### PR TITLE
Clarify the current shipped auth scope across JWT and passport docs (#27)

### DIFF
--- a/docs/concepts/auth-and-jwt.md
+++ b/docs/concepts/auth-and-jwt.md
@@ -39,6 +39,12 @@ HTTP request
 - `@konekti/jwt` stays transport-agnostic except for its exported strategy adapter
 - app code should prefer normalized principals over raw JWT payloads
 
+## current shipped JWT scope
+
+- the built-in JWT core currently supports HMAC algorithms only: `HS256`, `HS384`, and `HS512`
+- asymmetric JWT verification/signing such as `RS256` or `ES256` is not part of the current shipped package surface
+- if a project needs asymmetric verification today, that should be treated as future product work rather than assumed built-in behavior
+
 ## official default auth story
 
 The current official docs/examples story is bearer-token auth with JWT verification through the `Authorization: Bearer <token>` header.
@@ -50,7 +56,7 @@ Explicitly not standardized as framework-wide defaults today:
 - logout/revoke semantics
 - account-linking policy across identity sources
 
-Those remain application-level policy choices until the product defines a broader official auth opinion.
+Those remain application-level policy choices. The current framework docs should describe them as app-owned behavior rather than implying a hidden default lifecycle.
 
 ## related package docs
 

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -23,6 +23,12 @@ The current official docs/examples path uses this package through bearer-token a
 
 `JwtStrategy` handles bearer-token extraction for the generic passport contract, while the token core stays reusable without HTTP framework coupling.
 
+Current scope note:
+
+- shipped algorithms: `HS256`, `HS384`, `HS512`
+- not currently shipped: asymmetric JWT algorithms such as `RS256` / `ES256`
+- refresh-token issuance, rotation, and revoke/logout flows are outside this package and remain application-owned
+
 ## Installation
 
 ```bash
@@ -140,6 +146,8 @@ If `iss`, `aud`, `iat`, or `exp` are absent from the claims passed to `signAcces
 ### Algorithm design
 
 Two separate checks exist: "is this algorithm in the allowlist?" and "does this implementation support it?". The current implementation supports HS256, HS384, and HS512, and the separation makes it safe to extend one without accidentally opening the other.
+
+This package should therefore be read as an HMAC-first JWT core today, not as a general-purpose JWT surface that already covers asymmetric verification.
 
 ## File reading order for contributors
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -23,6 +23,12 @@ The current official docs/examples path uses bearer-token JWT auth as the recomm
 
 `AuthGuard` follows the generic HTTP guard contract explicitly: it returns success to continue the pipeline, throws `UnauthorizedException` / `ForbiddenException` for auth failures, and allows committed-response flows such as redirects to short-circuit the handler.
 
+Scope note:
+
+- the current official example path is bearer-token JWT auth
+- refresh-token rotation, revoke/logout handling, and cookie/session policy remain application-level concerns
+- `@konekti/passport` owns strategy execution, not the broader account/session lifecycle
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
## Summary
- make the current shipped JWT scope explicit: HMAC-only today, not asymmetric JWT support
- clarify that refresh-token rotation, revoke/logout behavior, and cookie/session policy remain application-owned
- align the cross-package auth guide with the JWT and passport package READMEs

## Verification
- `lsp_diagnostics` clean on modified files

## Notes
- Closes #27