### PR TITLE
test: add gap-coverage tests from closed-issue audit

### DIFF
--- a/packages/http/src/rate-limit.test.ts
+++ b/packages/http/src/rate-limit.test.ts
@@ -82,4 +82,24 @@ describe('createRateLimitMiddleware', () => {
     expect(firstContext.response.statusCode).toBe(200);
     expect(secondContext.response.statusCode).toBe(200);
   });
+
+  it('uses an independent in-process store per middleware instance', async () => {
+    const first = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
+    const second = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
+    const context = createContext();
+    const next = vi.fn(async () => {});
+
+    await first.handle(context, next);
+    await first.handle(context, next);
+
+    expect(context.response.statusCode).toBe(429);
+
+    context.response.statusCode = 200;
+    context.response.committed = false;
+
+    await second.handle(context, next);
+
+    expect(context.response.statusCode).toBe(200);
+    expect(next).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -5,7 +5,7 @@ import type { FrameworkRequest, FrameworkResponse, GuardContext } from '@konekti
 import { Container } from '@konekti/di';
 
 import { RequireScopes, UseAuth } from './decorators.js';
-import { AuthenticationRequiredError } from './errors.js';
+import { AuthenticationExpiredError, AuthenticationFailedError, AuthenticationRequiredError } from './errors.js';
 import { createPassportProviders } from './module.js';
 import { createPassportJsStrategyBridge } from './passport-js.js';
 import type { AuthStrategy } from './types.js';
@@ -257,5 +257,89 @@ describe('AuthGuard', () => {
     expect(handlerCalled).toBe(false);
     expect(response.statusCode).toBe(302);
     expect(response.headers.Location).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+  });
+
+  it('maps authentication-failed errors to a canonical 401 response', async () => {
+    class FailingStrategy implements AuthStrategy {
+      async authenticate(_context: GuardContext): Promise<never> {
+        throw new AuthenticationFailedError();
+      }
+    }
+
+    @Controller('/profile')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth('mock')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      FailingStrategy,
+      ...createPassportProviders({ defaultStrategy: 'mock' }, [{ name: 'mock', token: FailingStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/profile', { 'x-request-id': 'req-failed' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-failed',
+        status: 401,
+      },
+    });
+  });
+
+  it('maps authentication-expired errors to a canonical 401 response', async () => {
+    class ExpiredStrategy implements AuthStrategy {
+      async authenticate(_context: GuardContext): Promise<never> {
+        throw new AuthenticationExpiredError();
+      }
+    }
+
+    @Controller('/profile')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth('mock')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      ExpiredStrategy,
+      ...createPassportProviders({ defaultStrategy: 'mock' }, [{ name: 'mock', token: ExpiredStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/profile', { 'x-request-id': 'req-expired' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-expired',
+        status: 401,
+      },
+    });
   });
 });

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -813,4 +813,57 @@ describe('bootstrapApplication', () => {
 
     await app.close();
   });
+
+  it('aborts the request signal when the response is closed before the handler commits', async () => {
+    const handlerReached = createDeferred();
+    const signalCapture = createDeferred<AbortSignal>();
+
+    @Controller('/slow')
+    class SlowController {
+      @Get('/')
+      async get(_input: unknown, ctx: RequestContext) {
+        signalCapture.resolve(ctx.request.signal!);
+        handlerReached.resolve();
+        await new Promise<void>(() => {});
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [SlowController] });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port,
+    });
+
+    await app.listen();
+
+    const net = await import('node:net');
+    const socket = net.createConnection(port, '127.0.0.1');
+
+    await new Promise<void>((resolve) => socket.once('connect', resolve));
+
+    socket.write('GET /slow HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n');
+
+    await handlerReached.promise;
+    socket.destroy();
+
+    const signal = await signalCapture.promise;
+
+    await new Promise<void>((resolve) => {
+      if (signal.aborted) {
+        resolve();
+        return;
+      }
+
+      signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+
+    expect(signal.aborted).toBe(true);
+
+    await app.close();
+  });
 });


### PR DESCRIPTION
## Summary

Closes the three test-coverage gaps identified in issue #41 from the closed-issue audit.

- **runtime (#21 gap)**: Add a test that verifies `FrameworkRequest.signal` is aborted when the client tears down the TCP connection before the handler commits a response. Uses a raw `net.Socket` to destroy the connection mid-request.
- **http (#23 gap)**: Add a test that verifies two independent `createRateLimitMiddleware()` instances maintain separate in-process counters — exhausting one does not affect the other.
- **passport (#24 gap)**: Add tests for `AuthenticationFailedError` and `AuthenticationExpiredError` mapping — both must produce a canonical 401 response with the expected error envelope. (The `AuthGuard.canActivate` return type was inspected and confirmed correct: `Promise<true>` is intentional per `AuthGuardContract`, auth guards must throw rather than return `false`.)

All 195 tests pass, typecheck is clean.

Closes #41