### PR TITLE
feat(@konekti/jwt): add RS256/ES256 asymmetric algorithm support

### DIFF
--- a/docs/concepts/auth-and-jwt.md
+++ b/docs/concepts/auth-and-jwt.md
@@ -41,9 +41,9 @@ HTTP request
 
 ## current shipped JWT scope
 
-- the built-in JWT core currently supports HMAC algorithms only: `HS256`, `HS384`, and `HS512`
-- asymmetric JWT verification/signing such as `RS256` or `ES256` is not part of the current shipped package surface
-- if a project needs asymmetric verification today, that should be treated as future product work rather than assumed built-in behavior
+- the built-in JWT core supports HMAC algorithms: `HS256`, `HS384`, and `HS512`
+- the built-in JWT core supports asymmetric algorithms: `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, and `ES512`
+- for asymmetric algorithms, pass `privateKey` and `publicKey` (PEM string or `KeyObject`) to `JwtVerifierOptions`; key-per-kid rotation is supported via the `keys` array
 
 ## official default auth story
 

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -17,6 +17,7 @@ The current official docs/examples path uses this package through bearer-token a
 `@konekti/jwt` knows nothing about routes or guards. It owns:
 
 - Signing access tokens with HMAC algorithms such as HS256, HS384, and HS512 (`DefaultJwtSigner.signAccessToken`)
+- Signing access tokens with asymmetric algorithms such as RS256, RS384, RS512, ES256, ES384, and ES512
 - Verifying tokens: shape → algorithm → signature → claims (`exp`, `nbf`, `iss`, `aud`)
 - Normalising verified claims to a `JwtPrincipal` (`subject`, `roles`, `scopes`, `claims`)
 - Exporting `JwtStrategy`, the reusable bearer-token strategy adapter for `@konekti/passport`
@@ -25,8 +26,7 @@ The current official docs/examples path uses this package through bearer-token a
 
 Current scope note:
 
-- shipped algorithms: `HS256`, `HS384`, `HS512`
-- not currently shipped: asymmetric JWT algorithms such as `RS256` / `ES256`
+- shipped algorithms: `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`
 - refresh-token issuance, rotation, and revoke/logout flows are outside this package and remain application-owned
 
 ## Installation
@@ -102,6 +102,47 @@ const token = await signer.signAccessToken({ sub: 'u1', roles: [] });
 const principal = await verifier.verifyAccessToken(token);
 ```
 
+### Asymmetric algorithms (RS256 / ES256)
+
+Pass `privateKey` and `publicKey` (PEM string or Node.js `KeyObject`) when using RS* or ES* algorithms:
+
+```typescript
+import { generateKeyPairSync } from 'node:crypto';
+import { DefaultJwtSigner, DefaultJwtVerifier } from '@konekti/jwt';
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+
+const signer = new DefaultJwtSigner({
+  algorithms: ['RS256'],
+  issuer: 'my-app',
+  audience: 'my-app-clients',
+  accessTokenTtlSeconds: 3600,
+  privateKey,
+});
+const verifier = new DefaultJwtVerifier({
+  algorithms: ['RS256'],
+  issuer: 'my-app',
+  audience: 'my-app-clients',
+  publicKey,
+});
+
+const token = await signer.signAccessToken({ sub: 'u1' });
+const principal = await verifier.verifyAccessToken(token);
+```
+
+For key rotation, use the `keys` array with `kid`:
+
+```typescript
+const signer = new DefaultJwtSigner({
+  algorithms: ['RS256'],
+  keys: [{ kid: 'v2', privateKey, publicKey }],
+});
+const verifier = new DefaultJwtVerifier({
+  algorithms: ['RS256'],
+  keys: [{ kid: 'v2', publicKey }],
+});
+```
+
 ## Key API
 
 | Export | Location | Description |
@@ -111,7 +152,7 @@ const principal = await verifier.verifyAccessToken(token);
 | `createJwtCoreProviders(options)` | `src/module.ts` | Registers options, verifier, and signer in one call |
 | `JwtPrincipal` | `src/types.ts` | `{ subject, issuer?, audience?, roles?, scopes?, claims }` |
 | `JwtClaims` | `src/types.ts` | Raw claims shape |
-| `JwtVerifierOptions` | `src/types.ts` | `{ secret, issuer?, audience?, algorithms?, accessTokenTtlSeconds? }` |
+| `JwtVerifierOptions` | `src/types.ts` | `{ secret?, privateKey?, publicKey?, issuer?, audience?, algorithms?, accessTokenTtlSeconds?, keys? }` |
 | `JwtVerifier` | `src/types.ts` | Interface for custom verifier implementations |
 | `JwtSigner` | `src/types.ts` | Interface for custom signer implementations |
 | `JwtStrategy` | `src/strategy.ts` | Passport-compatible bearer-token strategy backed by `DefaultJwtVerifier` |
@@ -124,7 +165,7 @@ const principal = await verifier.verifyAccessToken(token);
 verifyAccessToken(token)
   1. Split and base64url-decode header + payload + signature
   2. Check algorithm is in the allowed list
-  3. Verify the matching HMAC signature implementation
+  3. Verify the signature — HMAC (createHmac) for HS* or asymmetric (createVerify) for RS*/ES*
   4. Validate claims: exp, nbf, iss, aud
   5. normalizePrincipal(payload) → JwtPrincipal
 ```
@@ -145,9 +186,7 @@ If `iss`, `aud`, `iat`, or `exp` are absent from the claims passed to `signAcces
 
 ### Algorithm design
 
-Two separate checks exist: "is this algorithm in the allowlist?" and "does this implementation support it?". The current implementation supports HS256, HS384, and HS512, and the separation makes it safe to extend one without accidentally opening the other.
-
-This package should therefore be read as an HMAC-first JWT core today, not as a general-purpose JWT surface that already covers asymmetric verification.
+Two separate checks exist: "is this algorithm in the allowlist?" and "does this implementation support it?". HMAC algorithms (HS*) use `createHmac` with a shared secret; asymmetric algorithms (RS*, ES*) use `createVerify`/`createSign` with a key pair. The separation makes it safe to extend the allowlist without accidentally opening unsupported paths.
 
 ## File reading order for contributors
 

--- a/packages/jwt/src/signer.test.ts
+++ b/packages/jwt/src/signer.test.ts
@@ -1,3 +1,5 @@
+import { generateKeyPairSync } from 'node:crypto';
+
 import { describe, expect, it } from 'vitest';
 
 import { DefaultJwtSigner } from './signer.js';
@@ -83,6 +85,75 @@ describe('DefaultJwtSigner', () => {
     // Token must be signed with HS384 (first in list) — HS384-only verifier must accept it
     await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
       subject: 'user-first-alg',
+    });
+  });
+
+  it('sign + verify roundtrip with RS256', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const signer = new DefaultJwtSigner({
+      accessTokenTtlSeconds: 120,
+      algorithms: ['RS256'],
+      audience: 'konekti',
+      issuer: 'tests',
+      privateKey,
+    });
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      audience: 'konekti',
+      issuer: 'tests',
+      publicKey,
+    });
+    const token = await signer.signAccessToken({ sub: 'user-rs256', scopes: ['read'] });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toEqual(
+      expect.objectContaining({
+        scopes: ['read'],
+        subject: 'user-rs256',
+      }),
+    );
+  });
+
+  it('sign + verify roundtrip with ES256', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const signer = new DefaultJwtSigner({
+      accessTokenTtlSeconds: 120,
+      algorithms: ['ES256'],
+      audience: 'konekti',
+      issuer: 'tests',
+      privateKey,
+    });
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['ES256'],
+      audience: 'konekti',
+      issuer: 'tests',
+      publicKey,
+    });
+    const token = await signer.signAccessToken({ sub: 'user-es256', scopes: ['write'] });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toEqual(
+      expect.objectContaining({
+        scopes: ['write'],
+        subject: 'user-es256',
+      }),
+    );
+  });
+
+  it('sign + verify roundtrip with RS256 using kid-keyed key entry', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const signer = new DefaultJwtSigner({
+      algorithms: ['RS256'],
+      issuer: 'tests',
+      keys: [{ kid: 'key-1', privateKey, publicKey }],
+    });
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      issuer: 'tests',
+      keys: [{ kid: 'key-1', publicKey }],
+    });
+    const token = await signer.signAccessToken({ sub: 'user-kid-rs256' });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'user-kid-rs256',
     });
   });
 });

--- a/packages/jwt/src/signer.ts
+++ b/packages/jwt/src/signer.ts
@@ -1,10 +1,10 @@
-import { createHmac } from 'node:crypto';
+import { createHmac, createSign } from 'node:crypto';
 
 import { Inject } from '@konekti/core';
 
 import { JwtConfigurationError } from './errors.js';
 import type { JwtAlgorithm, JwtClaims, JwtVerifierOptions } from './types.js';
-import { HMAC_HASH, JWT_OPTIONS } from './verifier.js';
+import { ASYMMETRIC_HASH, HMAC_HASH, JWT_OPTIONS } from './verifier.js';
 
 function encodeBase64Url(value: Buffer | string): string {
   return Buffer.from(value)
@@ -19,18 +19,17 @@ export class DefaultJwtSigner {
   constructor(private readonly options: JwtVerifierOptions) {}
 
   async signAccessToken(claims: JwtClaims): Promise<string> {
-    const algorithm: JwtAlgorithm | undefined = this.options.algorithms.find((alg) => alg in HMAC_HASH);
+    const algorithm: JwtAlgorithm | undefined = this.options.algorithms.find(
+      (alg) => alg in HMAC_HASH || alg in ASYMMETRIC_HASH,
+    );
 
     if (!algorithm) {
-      throw new JwtConfigurationError('JWT signer requires at least one HMAC algorithm (HS256, HS384, or HS512) in the allowed algorithms list.');
+      throw new JwtConfigurationError(
+        'JWT signer requires at least one supported algorithm (HS256/HS384/HS512/RS256/RS384/RS512/ES256/ES384/ES512) in the allowed algorithms list.',
+      );
     }
 
-    const activeKey = this.options.keys?.[0];
-    const secret = activeKey?.secret ?? this.options.secret;
-
-    if (!secret) {
-      throw new JwtConfigurationError('JWT secret is not configured.');
-    }
+    const isAsymmetric = algorithm in ASYMMETRIC_HASH;
 
     const now = Math.floor(Date.now() / 1000);
     const ttl = this.options.accessTokenTtlSeconds ?? 3600;
@@ -41,6 +40,8 @@ export class DefaultJwtSigner {
       iat: claims.iat ?? now,
       iss: claims.iss ?? this.options.issuer,
     };
+
+    const activeKey = this.options.keys?.[0];
     const header: Record<string, string> = {
       alg: algorithm,
       typ: 'JWT',
@@ -48,10 +49,31 @@ export class DefaultJwtSigner {
     };
     const headerSegment = encodeBase64Url(JSON.stringify(header));
     const payloadSegment = encodeBase64Url(JSON.stringify(payload));
-    const hash = HMAC_HASH[algorithm];
-    const signatureSegment = encodeBase64Url(
-      createHmac(hash, secret).update(`${headerSegment}.${payloadSegment}`).digest(),
-    );
+    const signingInput = `${headerSegment}.${payloadSegment}`;
+
+    let signatureSegment: string;
+
+    if (isAsymmetric) {
+      const privateKey = activeKey?.privateKey ?? this.options.privateKey;
+
+      if (!privateKey) {
+        throw new JwtConfigurationError('JWT private key is not configured.');
+      }
+
+      const hash = ASYMMETRIC_HASH[algorithm]!;
+      const signer = createSign(hash);
+      signer.update(signingInput);
+      signatureSegment = signer.sign(privateKey, 'base64url');
+    } else {
+      const secret = activeKey?.secret ?? this.options.secret;
+
+      if (!secret) {
+        throw new JwtConfigurationError('JWT secret is not configured.');
+      }
+
+      const hash = HMAC_HASH[algorithm]!;
+      signatureSegment = encodeBase64Url(createHmac(hash, secret).update(signingInput).digest());
+    }
 
     return `${headerSegment}.${payloadSegment}.${signatureSegment}`;
   }

--- a/packages/jwt/src/types.ts
+++ b/packages/jwt/src/types.ts
@@ -1,8 +1,12 @@
-export type JwtAlgorithm = 'HS256' | 'HS384' | 'HS512';
+import type { KeyObject } from 'node:crypto';
+
+export type JwtAlgorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256' | 'RS384' | 'RS512' | 'ES256' | 'ES384' | 'ES512';
 
 export interface JwtKeyEntry {
   kid: string;
-  secret: string;
+  secret?: string;
+  privateKey?: string | KeyObject;
+  publicKey?: string | KeyObject;
 }
 
 export interface JwtVerifierOptions {
@@ -13,6 +17,8 @@ export interface JwtVerifierOptions {
   issuer?: string;
   keys?: JwtKeyEntry[];
   secret?: string;
+  privateKey?: string | KeyObject;
+  publicKey?: string | KeyObject;
 }
 
 export interface JwtClaims extends Record<string, unknown> {

--- a/packages/jwt/src/verifier.test.ts
+++ b/packages/jwt/src/verifier.test.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'node:crypto';
+import { createHmac, createSign, generateKeyPairSync } from 'node:crypto';
 
 import { describe, expect, it } from 'vitest';
 
@@ -155,5 +155,94 @@ describe('DefaultJwtVerifier', () => {
     );
 
     await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+  });
+
+  it('verifies a valid RS256 token', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const header = { alg: 'RS256', typ: 'JWT' };
+    const payload = { exp, iss: 'tests', sub: 'user-rs256' };
+    const headerSegment = encodeBase64Url(JSON.stringify(header));
+    const payloadSegment = encodeBase64Url(JSON.stringify(payload));
+    const signer = createSign('sha256');
+    signer.update(`${headerSegment}.${payloadSegment}`);
+    const signatureSegment = signer.sign(privateKey, 'base64url');
+    const token = `${headerSegment}.${payloadSegment}.${signatureSegment}`;
+
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      issuer: 'tests',
+      publicKey,
+    });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'user-rs256',
+    });
+  });
+
+  it('verifies a valid ES256 token', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const header = { alg: 'ES256', typ: 'JWT' };
+    const payload = { exp, iss: 'tests', sub: 'user-es256' };
+    const headerSegment = encodeBase64Url(JSON.stringify(header));
+    const payloadSegment = encodeBase64Url(JSON.stringify(payload));
+    const signer = createSign('sha256');
+    signer.update(`${headerSegment}.${payloadSegment}`);
+    const signatureSegment = signer.sign(privateKey, 'base64url');
+    const token = `${headerSegment}.${payloadSegment}.${signatureSegment}`;
+
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['ES256'],
+      issuer: 'tests',
+      publicKey,
+    });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'user-es256',
+    });
+  });
+
+  it('rejects an RS256 token verified with the wrong public key', async () => {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const { publicKey: wrongPublicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const header = { alg: 'RS256', typ: 'JWT' };
+    const payload = { exp, sub: 'user-rs256' };
+    const headerSegment = encodeBase64Url(JSON.stringify(header));
+    const payloadSegment = encodeBase64Url(JSON.stringify(payload));
+    const signer = createSign('sha256');
+    signer.update(`${headerSegment}.${payloadSegment}`);
+    const signatureSegment = signer.sign(privateKey, 'base64url');
+    const token = `${headerSegment}.${payloadSegment}.${signatureSegment}`;
+
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      publicKey: wrongPublicKey,
+    });
+
+    await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+  });
+
+  it('verifies a valid RS256 token using a kid-keyed key entry', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const header = { alg: 'RS256', kid: 'key-1', typ: 'JWT' };
+    const payload = { exp, sub: 'user-kid-rs256' };
+    const headerSegment = encodeBase64Url(JSON.stringify(header));
+    const payloadSegment = encodeBase64Url(JSON.stringify(payload));
+    const signer = createSign('sha256');
+    signer.update(`${headerSegment}.${payloadSegment}`);
+    const signatureSegment = signer.sign(privateKey, 'base64url');
+    const token = `${headerSegment}.${payloadSegment}.${signatureSegment}`;
+
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      keys: [{ kid: 'key-1', publicKey }],
+    });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'user-kid-rs256',
+    });
   });
 });

--- a/packages/jwt/src/verifier.ts
+++ b/packages/jwt/src/verifier.ts
@@ -1,4 +1,5 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createHmac, createVerify, timingSafeEqual } from 'node:crypto';
+import type { KeyObject } from 'node:crypto';
 
 import { Inject } from '@konekti/core';
 
@@ -7,14 +8,23 @@ import type { JwtAlgorithm, JwtClaims, JwtPrincipal, JwtVerifierOptions } from '
 
 export const JWT_OPTIONS = Symbol.for('konekti.jwt.options');
 
-export const HMAC_HASH: Record<JwtAlgorithm, string> = {
+export const HMAC_HASH: Partial<Record<JwtAlgorithm, string>> = {
   HS256: 'sha256',
   HS384: 'sha384',
   HS512: 'sha512',
 };
 
+export const ASYMMETRIC_HASH: Partial<Record<JwtAlgorithm, string>> = {
+  RS256: 'sha256',
+  RS384: 'sha384',
+  RS512: 'sha512',
+  ES256: 'sha256',
+  ES384: 'sha384',
+  ES512: 'sha512',
+};
+
 function isAllowedAlgorithm(alg: string | undefined, allowed: JwtAlgorithm[]): alg is JwtAlgorithm {
-  return typeof alg === 'string' && (allowed as string[]).includes(alg) && alg in HMAC_HASH;
+  return typeof alg === 'string' && (allowed as string[]).includes(alg) && (alg in HMAC_HASH || alg in ASYMMETRIC_HASH);
 }
 
 function verifyHmacSignature(
@@ -23,12 +33,27 @@ function verifyHmacSignature(
   signingInput: string,
   signatureSegment: string,
 ): void {
-  const hash = HMAC_HASH[algorithm];
+  const hash = HMAC_HASH[algorithm]!;
   const expected = encodeBase64Url(createHmac(hash, secret).update(signingInput).digest());
   const expectedBuf = Buffer.from(expected, 'base64url');
   const actualBuf = Buffer.from(signatureSegment, 'base64url');
 
   if (expectedBuf.length !== actualBuf.length || !timingSafeEqual(expectedBuf, actualBuf)) {
+    throw new JwtInvalidTokenError();
+  }
+}
+
+function verifyAsymmetricSignature(
+  algorithm: JwtAlgorithm,
+  publicKey: string | KeyObject,
+  signingInput: string,
+  signatureSegment: string,
+): void {
+  const hash = ASYMMETRIC_HASH[algorithm]!;
+  const verifier = createVerify(hash);
+  verifier.update(signingInput);
+  const valid = verifier.verify(publicKey, signatureSegment, 'base64url');
+  if (!valid) {
     throw new JwtInvalidTokenError();
   }
 }
@@ -96,20 +121,35 @@ export class DefaultJwtVerifier {
     const payload = parseJwtPart<JwtClaims>(payloadSegment);
     const algorithms = this.options.algorithms;
 
-    const secret =
-      (header.kid !== undefined && header.kid !== ''
-        ? this.options.keys?.find((k) => k.kid === header.kid)?.secret
-        : undefined) ?? this.options.secret;
-
-    if (!secret) {
-      throw new JwtConfigurationError('JWT secret is not configured.');
-    }
-
     if (!isAllowedAlgorithm(header.alg, algorithms)) {
       throw new JwtInvalidTokenError('JWT algorithm is not allowed.');
     }
 
-    verifyHmacSignature(header.alg, secret, `${headerSegment}.${payloadSegment}`, signatureSegment);
+    const signingInput = `${headerSegment}.${payloadSegment}`;
+
+    if (header.alg in HMAC_HASH) {
+      const secret =
+        (header.kid !== undefined && header.kid !== ''
+          ? this.options.keys?.find((k) => k.kid === header.kid)?.secret
+          : undefined) ?? this.options.secret;
+
+      if (!secret) {
+        throw new JwtConfigurationError('JWT secret is not configured.');
+      }
+
+      verifyHmacSignature(header.alg, secret, signingInput, signatureSegment);
+    } else {
+      const publicKey =
+        (header.kid !== undefined && header.kid !== ''
+          ? this.options.keys?.find((k) => k.kid === header.kid)?.publicKey
+          : undefined) ?? this.options.publicKey;
+
+      if (!publicKey) {
+        throw new JwtConfigurationError('JWT public key is not configured.');
+      }
+
+      verifyAsymmetricSignature(header.alg, publicKey, signingInput, signatureSegment);
+    }
 
     const now = Math.floor(Date.now() / 1000);
     const clockSkew = this.options.clockSkewSeconds ?? 0;


### PR DESCRIPTION
## Summary

- Extends `JwtAlgorithm` with RS256/RS384/RS512 and ES256/ES384/ES512
- `DefaultJwtVerifier` now selects `createVerify` (node:crypto) for RS*/ES* tokens, `createHmac` path unchanged for HS* tokens
- `DefaultJwtSigner` now selects `createSign` for RS*/ES* tokens; both paths support `kid`-based key rotation via the `keys` array
- `privateKey` / `publicKey` fields added to `JwtKeyEntry` and `JwtVerifierOptions`
- 5 new tests: RS256 verify, ES256 verify, wrong-key rejection, kid-keyed RS256 verify, RS256/ES256 sign+verify roundtrips, kid-keyed roundtrip
- Updated `packages/jwt/README.md` and `docs/concepts/auth-and-jwt.md` to reflect shipped status

Closes #42