### PR TITLE
fix(http): fix three metadata correctness bugs in mapped-type helpers

### DIFF
--- a/packages/http/src/mapped-types.ts
+++ b/packages/http/src/mapped-types.ts
@@ -1,6 +1,8 @@
 import {
+  appendClassValidationRule,
   appendDtoFieldValidationRule,
   defineDtoFieldBindingMetadata,
+  getClassValidationRules,
   getDtoBindingSchema,
   getDtoValidationSchema,
   type Constructor,
@@ -55,6 +57,10 @@ function copyDtoMetadata(
     for (const rule of entry.rules) {
       appendDtoFieldValidationRule(target.prototype, entry.propertyKey, rule);
     }
+  }
+
+  for (const rule of getClassValidationRules(source)) {
+    appendClassValidationRule(target, rule);
   }
 }
 
@@ -128,7 +134,9 @@ export function IntersectionType<TBaseDtos extends readonly [DtoConstructor, Dto
 }
 
 export function PartialType<TBase extends DtoConstructor>(BaseDto: TBase): DtoConstructor<Partial<InstanceType<TBase>>> {
-  const PartialDto = createDerivedDto(`${BaseDto.name}PartialType`, (_instance) => {});
+  const PartialDto = createDerivedDto(`${BaseDto.name}PartialType`, (instance) => {
+    Object.assign(instance, new BaseDto());
+  });
 
   for (const entry of getDtoBindingSchema(BaseDto)) {
     defineDtoFieldBindingMetadata(PartialDto.prototype, entry.propertyKey, {
@@ -145,6 +153,10 @@ export function PartialType<TBase extends DtoConstructor>(BaseDto: TBase): DtoCo
     if (!hasOptionalRule(BaseDto, entry.propertyKey)) {
       appendDtoFieldValidationRule(PartialDto.prototype, entry.propertyKey, { kind: 'optional' });
     }
+  }
+
+  for (const rule of getClassValidationRules(BaseDto)) {
+    appendClassValidationRule(PartialDto, rule);
   }
 
   return PartialDto as DtoConstructor<Partial<InstanceType<TBase>>>;

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -683,4 +683,144 @@ describe('OpenApiModule', () => {
 
     expect((response.body as { paths: Record<string, { post?: { requestBody?: { required?: boolean } } }> }).paths['/partial/users']?.post?.requestBody?.required).toBeUndefined();
   });
+
+  it('emits correct response schemas when mapped DTO helpers are used with @ApiResponse', async () => {
+    class UserResponseDto {
+      @IsString()
+      id = '';
+
+      @IsString()
+      name = '';
+
+      @IsString()
+      email = '';
+    }
+
+    const UserSummaryResponse = PickType(UserResponseDto, ['id', 'name']);
+    const UserWithoutEmailResponse = OmitType(UserResponseDto, ['email']);
+    const PartialUserResponse = PartialType(UserResponseDto);
+
+    @Controller('/users')
+    class UsersController {
+      @ApiResponse(200, { description: 'User summary', type: UserSummaryResponse })
+      @Get('/summary')
+      getSummary() {
+        return { id: '1', name: 'Alice' };
+      }
+
+      @ApiResponse(200, { description: 'User without email', type: UserWithoutEmailResponse })
+      @Get('/no-email')
+      getWithoutEmail() {
+        return { id: '1', name: 'Alice' };
+      }
+
+      @ApiResponse(200, { description: 'Partial user', type: PartialUserResponse })
+      @Get('/partial')
+      getPartial() {
+        return { id: '1' };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: UsersController }],
+      title: 'Response Mapped Type API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [UsersController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        components: expect.objectContaining({
+          schemas: expect.objectContaining({
+            UserResponseDtoPickType: {
+              additionalProperties: false,
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+              },
+              required: ['id', 'name'],
+              type: 'object',
+            },
+            UserResponseDtoOmitType: {
+              additionalProperties: false,
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+              },
+              required: ['id', 'name'],
+              type: 'object',
+            },
+            UserResponseDtoPartialType: {
+              additionalProperties: false,
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+                email: { type: 'string' },
+              },
+              type: 'object',
+            },
+          }),
+        }),
+        paths: expect.objectContaining({
+          '/users/summary': {
+            get: expect.objectContaining({
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/UserResponseDtoPickType' },
+                    },
+                  },
+                  description: 'User summary',
+                },
+              },
+            }),
+          },
+          '/users/no-email': {
+            get: expect.objectContaining({
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/UserResponseDtoOmitType' },
+                    },
+                  },
+                  description: 'User without email',
+                },
+              },
+            }),
+          },
+          '/users/partial': {
+            get: expect.objectContaining({
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/UserResponseDtoPartialType' },
+                    },
+                  },
+                  description: 'Partial user',
+                },
+              },
+            }),
+          },
+        }),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes three bugs in `packages/http/src/mapped-types.ts` discovered during review of issues #35–#40.

- **`PartialType` did not copy BaseDto default values** — the initializer was a no-op (`(_instance) => {}`). Now calls `Object.assign(instance, new BaseDto())`, matching the pattern used by `PickType`, `OmitType`, and `IntersectionType`.
- **`copyDtoMetadata` dropped class-level validation rules** — the function only copied field binding metadata and field validation rules, silently discarding anything stored in `classValidationStore`. Now propagates all rules via `getClassValidationRules` / `appendClassValidationRule` for all four helpers.
- **No test coverage for mapped types in `@ApiResponse`** — added a test case in `packages/openapi/src/openapi-module.test.ts` that verifies `PickType`, `OmitType`, and `PartialType` produce correct OpenAPI response schemas when passed as the `type` option to `@ApiResponse`.

## Test results

All 7 tests in `openapi-module.test.ts` pass, all 3 tests in `decorators.test.ts` pass. No LSP errors.

Closes #51