### PR TITLE
feat(prisma,drizzle): add createPrismaModuleAsync and createDrizzleModuleAsync

### DIFF
--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { Inject } from '@konekti/core';
+import { Global, Inject, Module } from '@konekti/core';
 import { bootstrapApplication, defineModule } from '@konekti/runtime';
 
-import { createDrizzleModule, DrizzleDatabase } from './index.js';
+import { createDrizzleModule, createDrizzleModuleAsync, DrizzleDatabase } from './index.js';
 
 describe('@konekti/drizzle', () => {
   it('exposes current database handles, transaction callbacks, and optional disposal', async () => {
@@ -149,5 +149,88 @@ describe('@konekti/drizzle', () => {
       'transaction:end',
       'dispose',
     ]);
+  });
+});
+
+describe('createDrizzleModuleAsync', () => {
+  function makeFakeDatabase() {
+    const events: string[] = [];
+    const transactionDatabase = {};
+    const database = {
+      async transaction<T>(callback: (tx: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        events.push('transaction:start');
+        const result = await callback(transactionDatabase);
+        events.push('transaction:end');
+        return result;
+      },
+    };
+    return { database, events };
+  }
+
+  it('factory receives injected token and resolves DrizzleDatabase', async () => {
+    const { database, events } = makeFakeDatabase();
+
+    class ConfigService {
+      readonly url = 'postgres://localhost/test';
+    }
+
+    @Global()
+    @Module({ providers: [ConfigService], exports: [ConfigService] })
+    class ConfigModule {}
+
+    const factory = vi.fn().mockResolvedValue({ database });
+
+    const DrizzleModule = createDrizzleModuleAsync({
+      inject: [ConfigService],
+      useFactory: factory,
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [ConfigModule, DrizzleModule],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const db = await app.container.resolve(DrizzleDatabase);
+
+    expect(factory).toHaveBeenCalledOnce();
+    expect(factory.mock.calls[0][0]).toBeInstanceOf(ConfigService);
+
+    void db;
+    void events;
+
+    await app.close();
+  });
+
+  it('factory returning a promise resolves the database correctly', async () => {
+    const { database } = makeFakeDatabase();
+
+    const DrizzleModule = createDrizzleModuleAsync({
+      useFactory: () => Promise.resolve({ database }),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [DrizzleModule] });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const db = await app.container.resolve(DrizzleDatabase);
+
+    expect(db).toBeInstanceOf(DrizzleDatabase);
+
+    await app.close();
+  });
+
+  it('propagates factory errors during module initialization', async () => {
+    const DrizzleModule = createDrizzleModuleAsync({
+      useFactory: () => Promise.reject(new Error('db config fetch failed')),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [DrizzleModule] });
+
+    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow('db config fetch failed');
   });
 });

--- a/packages/drizzle/src/module.ts
+++ b/packages/drizzle/src/module.ts
@@ -1,3 +1,4 @@
+import { type AsyncModuleOptions, type MaybePromise } from '@konekti/core';
 import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
@@ -39,5 +40,58 @@ export function createDrizzleModule<
   return defineModule(DrizzleModule, {
     exports: [DrizzleDatabase, DrizzleTransactionInterceptor],
     providers: createDrizzleProviders(options),
+  });
+}
+
+export function createDrizzleModuleAsync<
+  TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
+  TTransactionDatabase = unknown,
+  TTransactionOptions = unknown,
+>(options: AsyncModuleOptions<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>>): ModuleType {
+  class DrizzleAsyncModule {}
+
+  const factory = options.useFactory as (...args: unknown[]) => MaybePromise<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>>;
+
+  let cachedResult: Promise<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>> | undefined;
+  const memoizedFactory = (...deps: unknown[]): Promise<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>> => {
+    if (!cachedResult) {
+      cachedResult = Promise.resolve(factory(...deps));
+    }
+    return cachedResult;
+  };
+
+  const databaseProvider = {
+    inject: options.inject,
+    provide: DRIZZLE_DATABASE,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => {
+      const resolved = await memoizedFactory(...deps);
+      return resolved.database;
+    },
+  };
+
+  const disposeProvider = {
+    inject: options.inject,
+    provide: DRIZZLE_DISPOSE,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => {
+      const resolved = await memoizedFactory(...deps);
+      return resolved.dispose;
+    },
+  };
+
+  const optionsProvider = {
+    inject: options.inject,
+    provide: DRIZZLE_OPTIONS,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => {
+      const resolved = await memoizedFactory(...deps);
+      return { strictTransactions: resolved.strictTransactions ?? false };
+    },
+  };
+
+  return defineModule(DrizzleAsyncModule, {
+    exports: [DrizzleDatabase, DrizzleTransactionInterceptor],
+    providers: [databaseProvider, disposeProvider, optionsProvider, DrizzleDatabase, DrizzleTransactionInterceptor],
   });
 }

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Inject } from '@konekti/core';
 import { bootstrapApplication, defineModule } from '@konekti/runtime';
+import { Global, Module } from '@konekti/core';
 
-import { createPrismaModule, PrismaService } from './index.js';
+import { createPrismaModule, createPrismaModuleAsync, PrismaService } from './index.js';
 
 describe('@konekti/prisma', () => {
   it('connects, reuses transaction-scoped handles, and disconnects through lifecycle hooks', async () => {
@@ -159,5 +160,98 @@ describe('@konekti/prisma', () => {
       'transaction:end',
       'disconnect',
     ]);
+  });
+});
+
+describe('createPrismaModuleAsync', () => {
+  function makeFakeClient() {
+    const events: string[] = [];
+    const transactionClient = {
+      async $connect() {},
+      async $disconnect() {},
+      async $transaction<T>(callback: (tx: Record<string, never>) => Promise<T>): Promise<T> {
+        return callback({});
+      },
+    };
+    const client = {
+      async $connect() {
+        events.push('connect');
+      },
+      async $disconnect() {
+        events.push('disconnect');
+      },
+      async $transaction<T>(callback: (tx: typeof transactionClient) => Promise<T>): Promise<T> {
+        return callback(transactionClient);
+      },
+    };
+    return { client, events };
+  }
+
+  it('factory receives injected token and resolves PrismaService', async () => {
+    const { client, events } = makeFakeClient();
+
+    class ConfigService {
+      readonly url = 'postgres://localhost/test';
+    }
+
+    @Global()
+    @Module({ providers: [ConfigService], exports: [ConfigService] })
+    class ConfigModule {}
+
+    const factory = vi.fn().mockResolvedValue({ client });
+
+    const PrismaModule = createPrismaModuleAsync({
+      inject: [ConfigService],
+      useFactory: factory,
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [ConfigModule, PrismaModule],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const prisma = await app.container.resolve(PrismaService);
+
+    expect(factory).toHaveBeenCalledOnce();
+    expect(factory.mock.calls[0][0]).toBeInstanceOf(ConfigService);
+    expect(events).toEqual(['connect']);
+
+    await app.close();
+    expect(events).toEqual(['connect', 'disconnect']);
+
+    void prisma;
+  });
+
+  it('factory returning a promise resolves the client correctly', async () => {
+    const { client } = makeFakeClient();
+
+    const PrismaModule = createPrismaModuleAsync({
+      useFactory: () => Promise.resolve({ client }),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [PrismaModule] });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const prisma = await app.container.resolve(PrismaService);
+
+    expect(prisma).toBeInstanceOf(PrismaService);
+
+    await app.close();
+  });
+
+  it('propagates factory errors during module initialization', async () => {
+    const PrismaModule = createPrismaModuleAsync({
+      useFactory: () => Promise.reject(new Error('secret fetch failed')),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [PrismaModule] });
+
+    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow('secret fetch failed');
   });
 });

--- a/packages/prisma/src/module.ts
+++ b/packages/prisma/src/module.ts
@@ -1,10 +1,11 @@
+import { type AsyncModuleOptions, type MaybePromise } from '@konekti/core';
 import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { PrismaService } from './service.js';
 import { PRISMA_CLIENT, PRISMA_OPTIONS } from './tokens.js';
 import { PrismaTransactionInterceptor } from './transaction.js';
-import type { PrismaClientLike, PrismaModuleOptions } from './types.js';
+import type { PrismaClientLike, PrismaModuleOptions, PrismaTransactionClient } from './types.js';
 
 export function createPrismaProviders<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient>(
   options: PrismaModuleOptions<TClient, TTransactionClient>,
@@ -31,5 +32,47 @@ export function createPrismaModule<TClient extends PrismaClientLike<TTransaction
   return defineModule(PrismaModule, {
     exports: [PrismaService, PrismaTransactionInterceptor],
     providers: createPrismaProviders(options),
+  });
+}
+
+export function createPrismaModuleAsync<
+  TClient extends PrismaClientLike<TTransactionClient>,
+  TTransactionClient = PrismaTransactionClient,
+>(options: AsyncModuleOptions<PrismaModuleOptions<TClient, TTransactionClient>>): ModuleType {
+  class PrismaAsyncModule {}
+
+  const factory = options.useFactory as (...args: unknown[]) => MaybePromise<PrismaModuleOptions<TClient, TTransactionClient>>;
+
+  let cachedResult: Promise<PrismaModuleOptions<TClient, TTransactionClient>> | undefined;
+  const memoizedFactory = (...deps: unknown[]): Promise<PrismaModuleOptions<TClient, TTransactionClient>> => {
+    if (!cachedResult) {
+      cachedResult = Promise.resolve(factory(...deps));
+    }
+    return cachedResult;
+  };
+
+  const clientProvider = {
+    inject: options.inject,
+    provide: PRISMA_CLIENT,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => {
+      const resolved = await memoizedFactory(...deps);
+      return resolved.client;
+    },
+  };
+
+  const optionsProvider = {
+    inject: options.inject,
+    provide: PRISMA_OPTIONS,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => {
+      const resolved = await memoizedFactory(...deps);
+      return { strictTransactions: resolved.strictTransactions ?? false };
+    },
+  };
+
+  return defineModule(PrismaAsyncModule, {
+    exports: [PrismaService, PrismaTransactionInterceptor],
+    providers: [clientProvider, optionsProvider, PrismaService, PrismaTransactionInterceptor],
   });
 }


### PR DESCRIPTION
## Summary

- `@konekti/prisma`에 `createPrismaModuleAsync(options)` 추가 — `useFactory` + `inject`로 비동기 모듈 등록 지원
- `@konekti/drizzle`에 `createDrizzleModuleAsync(options)` 추가 — 동일한 패턴으로 Drizzle 비동기 등록 지원
- 두 함수 모두 factory 결과를 memoize하여 `useFactory`가 정확히 한 번만 호출되도록 보장

## Details

`AsyncModuleOptions<T>` (`@konekti/core`)를 받아 `inject` 배열의 DI 토큰을 주입하고, `useFactory(...deps)` 결과를 각각의 DI 토큰(`PRISMA_CLIENT`, `PRISMA_OPTIONS`, `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_OPTIONS`)에 분배합니다.

generic 타입 파라미터 기본값을 `TClient` 자기 자신 대신 각 패키지의 베이스 타입(`PrismaTransactionClient`, `unknown`)으로 변경하여 재귀 타입 추론 문제를 해결했습니다.

## Tests

- Prisma: factory inject + connect/disconnect lifecycle, async promise 해석, 에러 전파 (3 케이스)
- Drizzle: factory inject, async promise 해석, 에러 전파 (3 케이스)
- 전체 10/10 통과

Closes #63