### PR TITLE
Resolve #69: warn on non-singleton cron tasks

### DIFF
--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Inject } from '@konekti/core';
+import { Inject, Scope, defineControllerMetadata } from '@konekti/core';
 import { REDIS_CLIENT } from '@konekti/redis';
 import { bootstrapApplication, defineModule, type ApplicationLogger } from '@konekti/runtime';
 
@@ -250,6 +250,95 @@ describe('@konekti/cron', () => {
     await app.close();
 
     expect(scheduled.records[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns when @Cron() is declared on a non-singleton provider and skips scheduling', async () => {
+    const scheduled = createManualScheduler();
+    const loggerEvents: string[] = [];
+
+    class ReportService {
+      @Cron('0 0 2 * * *')
+      generateDailyReport() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCronModule({ scheduler: scheduled.scheduler })],
+      providers: [
+        {
+          provide: ReportService,
+          scope: 'transient',
+          useClass: ReportService,
+        },
+      ],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    expect(scheduled.records).toHaveLength(0);
+    expect(
+      loggerEvents.some((event) =>
+        event.includes(
+          'warn:CronLifecycleService:ReportService in module AppModule declares @Cron() methods but is registered with transient scope.',
+        ),
+      ),
+    ).toBe(true);
+
+    await app.close();
+  });
+
+  it('warns when @Cron() is declared on non-singleton controllers and skips scheduling', async () => {
+    const scheduled = createManualScheduler();
+    const loggerEvents: string[] = [];
+
+    @Scope('request')
+    class RequestScopedReportController {
+      @Cron('0 0 2 * * *')
+      generateRequestScopedReport() {}
+    }
+
+    @Scope('transient')
+    class TransientExportController {
+      @Cron('0 30 2 * * *')
+      generateTransientExport() {}
+    }
+
+    defineControllerMetadata(RequestScopedReportController, { basePath: '/reports' });
+    defineControllerMetadata(TransientExportController, { basePath: '/exports' });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [RequestScopedReportController, TransientExportController],
+      imports: [createCronModule({ scheduler: scheduled.scheduler })],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    expect(scheduled.records).toHaveLength(0);
+    expect(
+      loggerEvents.some((event) =>
+        event.includes(
+          'warn:CronLifecycleService:RequestScopedReportController in module AppModule declares @Cron() methods but is registered with request scope.',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      loggerEvents.some((event) =>
+        event.includes(
+          'warn:CronLifecycleService:TransientExportController in module AppModule declares @Cron() methods but is registered with transient scope.',
+        ),
+      ),
+    ).toBe(true);
+
+    await app.close();
   });
 
   it('uses distributed Redis locking so only one app executes the same task tick', async () => {

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -164,11 +164,20 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     const descriptors: CronTaskDescriptor[] = [];
 
     for (const candidate of this.discoveryCandidates()) {
+      const entries = getCronTaskMetadataEntries(candidate.targetType.prototype);
+
       if (candidate.scope !== 'singleton') {
+        if (entries.length > 0) {
+          this.logger.warn(
+            `${candidate.targetType.name} in module ${candidate.moduleName} declares @Cron() methods but is registered with ${candidate.scope} scope. Cron tasks are scheduled only for singleton providers.`,
+            'CronLifecycleService',
+          );
+        }
+
         continue;
       }
 
-      for (const entry of getCronTaskMetadataEntries(candidate.targetType.prototype)) {
+      for (const entry of entries) {
         const methodName = methodKeyToName(entry.propertyKey);
         const taskName = entry.metadata.options.name ?? buildDefaultTaskName(candidate.targetType.name, methodName);
         const seenMethods = seen.get(candidate.token) ?? new Set<string>();
@@ -226,7 +235,7 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
       for (const controller of compiledModule.definition.controllers ?? []) {
         candidates.push({
           moduleName: compiledModule.type.name,
-          scope: 'singleton',
+          scope: scopeFromProvider(controller),
           targetType: controller,
           token: controller,
         });


### PR DESCRIPTION
## Summary
- warn and skip when `@Cron()` metadata is found on non-singleton providers instead of silently doing nothing
- apply the same scope-aware warning behavior to controllers so request-scoped and transient controllers do not get scheduled accidentally
- add cron regression coverage for transient providers plus request-scoped and transient controllers that declare cron tasks

## Verification
- `pnpm exec vitest run packages/cron/src/module.test.ts`
- `pnpm --filter @konekti/cron run typecheck`
- `pnpm --filter @konekti/cron run build`
- `lsp_diagnostics` clean for changed cron files

Closes #69