### PR TITLE
Resolve #73: fix event-bus edge cases — pre-bootstrap warn, cross-token dedup, lifecycle provider dedup

### DIFF
--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { Inject, Scope, defineControllerMetadata } from '@konekti/core';
+import { Container } from '@konekti/di';
 import { bootstrapApplication, defineModule, type ApplicationLogger } from '@konekti/runtime';
 
 import { OnEvent } from './decorators.js';
 import { getEventHandlerMetadataEntries } from './metadata.js';
 import { createEventBusModule } from './module.js';
+import { EventBusLifecycleService } from './service.js';
 import { EVENT_BUS } from './tokens.js';
 import type { EventBus } from './types.js';
 
@@ -387,6 +389,60 @@ describe('@konekti/event-bus', () => {
 
     expect(requestWarnings).toHaveLength(1);
     expect(controllerWarnings).toHaveLength(1);
+
+    await app.close();
+  });
+
+  it('warns when publish() is called before onApplicationBootstrap has run', async () => {
+    const loggerEvents: string[] = [];
+    const logger = createLogger(loggerEvents);
+    const container = new Container();
+    const service = new EventBusLifecycleService(container, [], logger);
+
+    await service.publish(new UserCreatedEvent('user-9'));
+
+    expect(
+      loggerEvents.some((e) =>
+        e.includes('warn:EventBusLifecycleService') &&
+        e.includes('called before onApplicationBootstrap'),
+      ),
+    ).toBe(true);
+  });
+
+  it('deduplicates handlers when the same class is registered under two different tokens', async () => {
+    class EventStore {
+      calls = 0;
+    }
+
+    const ALIAS_TOKEN = Symbol('AliasToken');
+
+    @Inject([EventStore])
+    class MultiTokenHandler {
+      constructor(private readonly store: EventStore) {}
+
+      @OnEvent(UserCreatedEvent)
+      onUserCreated(_event: UserCreatedEvent) {
+        this.store.calls += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createEventBusModule()],
+      providers: [
+        EventStore,
+        MultiTokenHandler,
+        { provide: ALIAS_TOKEN, useClass: MultiTokenHandler },
+      ],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+    const store = await app.container.resolve(EventStore);
+
+    await eventBus.publish(new UserCreatedEvent('user-10'));
+
+    expect(store.calls).toBe(1);
 
     await app.close();
   });

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -74,6 +74,13 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
       return;
     }
 
+    if (this.compiledModules.length === 0) {
+      this.logger.warn(
+        'EventBus.publish() was called before onApplicationBootstrap completed. Handlers may not yet be registered.',
+        'EventBusLifecycleService',
+      );
+    }
+
     this.discoverHandlers();
   }
 
@@ -83,7 +90,7 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
   }
 
   private discoverHandlerDescriptors(): EventHandlerDescriptor[] {
-    const seen = new Map<Token, Map<EventType, Set<string>>>();
+    const seen = new Set<string>();
     const descriptors: EventHandlerDescriptor[] = [];
 
     for (const candidate of this.discoveryCandidates()) {
@@ -103,16 +110,13 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
       for (const entry of entries) {
         const methodName = methodKeyToName(entry.propertyKey);
         const eventType = entry.metadata.eventType;
-        const seenByEvent = seen.get(candidate.token) ?? new Map<EventType, Set<string>>();
-        const seenMethods = seenByEvent.get(eventType) ?? new Set<string>();
+        const dedupKey = `${candidate.targetType.name}::${methodName}::${String(eventType)}`;
 
-        if (seenMethods.has(methodName)) {
+        if (seen.has(dedupKey)) {
           continue;
         }
 
-        seenMethods.add(methodName);
-        seenByEvent.set(eventType, seenMethods);
-        seen.set(candidate.token, seenByEvent);
+        seen.add(dedupKey);
 
         descriptors.push({
           eventType,

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -641,14 +641,6 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     resetReadinessState(bootstrapped.modules);
     const lifecycleProviders = [
       ...runtimeProviders,
-      {
-        provide: RUNTIME_CONTAINER,
-        useValue: bootstrapped.container,
-      },
-      {
-        provide: COMPILED_MODULES,
-        useValue: bootstrapped.modules,
-      },
       ...bootstrapped.modules.flatMap((compiledModule) => compiledModule.definition.providers ?? []),
     ];
     lifecycleInstances = await resolveLifecycleInstances(bootstrapped.container, lifecycleProviders);


### PR DESCRIPTION
## Summary

- **P1 — pre-bootstrap publish warning**: `EventBusLifecycleService.ensureDiscovered()` now emits a `logger.warn()` when `compiledModules` is empty, making the silent no-handler scenario visible instead of quietly discarding the event.
- **P2 — cross-token handler dedup**: dedup key changed from `token → eventType → methodName` to a flat `targetType.name::methodName::String(eventType)` composite, so registering the same class under two DI tokens no longer fires the same handler twice per event.
- **P2 — duplicate lifecycle providers**: removed the redundant `RUNTIME_CONTAINER` / `COMPILED_MODULES` re-entries from the `lifecycleProviders` array in `bootstrap.ts`; both tokens are already registered on the container earlier and were harmless but confusing duplicates.
- Two new tests cover the warning path and the dual-token dedup fix (13 total, all pass).

Closes #73