### PR TITLE
Resolve #78: fix SSE edge cases

### DIFF
--- a/packages/http/src/sse.test.ts
+++ b/packages/http/src/sse.test.ts
@@ -4,17 +4,31 @@ import type { FrameworkResponse, RequestContext } from './types.js';
 import { SseResponse, encodeSseComment, encodeSseMessage } from './sse.js';
 
 interface MockSseStream {
+  backpressure: boolean;
+  closeListeners: Array<() => void>;
   flushHeadersCalls: number;
+  onCalls: number;
+  removeListenerCalls: number;
   writableEnded: boolean;
   writes: string[];
   endCalls: number;
   flushHeaders(): void;
+  on(event: 'close', listener: () => void): void;
+  removeListener(event: 'close', listener: () => void): void;
+  emitClose(): void;
   write(chunk: string): boolean;
   end(): void;
 }
 
 function createMockSseStream(): MockSseStream {
   return {
+    backpressure: false,
+    closeListeners: [],
+    emitClose() {
+      for (const listener of [...this.closeListeners]) {
+        listener();
+      }
+    },
     end() {
       this.endCalls += 1;
       this.writableEnded = true;
@@ -24,10 +38,26 @@ function createMockSseStream(): MockSseStream {
       this.flushHeadersCalls += 1;
     },
     flushHeadersCalls: 0,
+    on(event, listener) {
+      this.onCalls += 1;
+
+      if (event === 'close') {
+        this.closeListeners.push(listener);
+      }
+    },
+    onCalls: 0,
+    removeListener(event, listener) {
+      this.removeListenerCalls += 1;
+
+      if (event === 'close') {
+        this.closeListeners = this.closeListeners.filter((entry) => entry !== listener);
+      }
+    },
+    removeListenerCalls: 0,
     writableEnded: false,
     write(chunk: string) {
       this.writes.push(chunk);
-      return true;
+      return !this.backpressure;
     },
     writes: [],
   };
@@ -100,6 +130,17 @@ describe('SseResponse', () => {
     expect(encoded).toBe('event: keepalive\ndata: \n\n');
   });
 
+  it('throws for top-level non-serializable SSE payloads', () => {
+    expect(() => encodeSseMessage(Symbol('event'))).toThrow(TypeError);
+    expect(() => encodeSseMessage(() => 'ignored')).toThrow(TypeError);
+  });
+
+  it('keeps serializable object payloads even when some fields are skipped by JSON.stringify', () => {
+    const encoded = encodeSseMessage({ count: 1, ignore: () => 'ignored' });
+
+    expect(encoded).toBe('data: {"count":1}\n\n');
+  });
+
   it('commits SSE headers and keeps close idempotent', () => {
     const stream = createMockSseStream();
     const response = createMockResponse(stream);
@@ -121,6 +162,7 @@ describe('SseResponse', () => {
     expect(stream.flushHeadersCalls).toBe(1);
     expect(stream.writes).toEqual(['event: message\nid: 1\ndata: hello\n\n', ': note\n\n']);
     expect(stream.endCalls).toBe(1);
+    expect(stream.removeListenerCalls).toBe(1);
   });
 
   it('closes the stream when the request signal aborts', () => {
@@ -134,5 +176,64 @@ describe('SseResponse', () => {
 
     expect(stream.endCalls).toBe(1);
     expect(stream.writes).toEqual([]);
+    expect(stream.onCalls).toBe(0);
+  });
+
+  it('surfaces backpressure from send and comment calls', () => {
+    const stream = createMockSseStream();
+    const response = createMockResponse(stream);
+    const sse = new SseResponse(createContext(response));
+
+    stream.backpressure = true;
+
+    expect(sse.send('hello')).toBe(false);
+    expect(sse.comment('note')).toBe(false);
+    expect(stream.writes).toEqual(['data: hello\n\n', ': note\n\n']);
+  });
+
+  it('returns false when trying to send after the stream closes', () => {
+    const stream = createMockSseStream();
+    const response = createMockResponse(stream);
+    const sse = new SseResponse(createContext(response));
+
+    sse.close();
+
+    expect(sse.send('ignored')).toBe(false);
+    expect(sse.comment('ignored')).toBe(false);
+    expect(stream.writes).toEqual([]);
+  });
+
+  it('throws from send when the payload is not JSON-serializable', () => {
+    const stream = createMockSseStream();
+    const response = createMockResponse(stream);
+    const sse = new SseResponse(createContext(response));
+
+    expect(() => sse.send(Symbol('event'))).toThrow(TypeError);
+    expect(stream.writes).toEqual([]);
+  });
+
+  it('closes the stream from the raw close event when request signal is absent', () => {
+    const stream = createMockSseStream();
+    const response = createMockResponse(stream);
+    const sse = new SseResponse(createContext(response));
+
+    expect(stream.onCalls).toBe(1);
+
+    stream.emitClose();
+    sse.send('ignored-after-close');
+
+    expect(stream.endCalls).toBe(1);
+    expect(stream.removeListenerCalls).toBe(1);
+    expect(stream.writes).toEqual([]);
+  });
+
+  it('does not register a raw close listener when the request signal exists', () => {
+    const stream = createMockSseStream();
+    const response = createMockResponse(stream);
+    const controller = new AbortController();
+
+    new SseResponse(createContext(response, controller.signal));
+
+    expect(stream.onCalls).toBe(0);
   });
 });

--- a/packages/http/src/sse.ts
+++ b/packages/http/src/sse.ts
@@ -8,6 +8,8 @@ export interface SseSendOptions {
 
 interface WritableSseStream {
   flushHeaders?: () => void;
+  on?: (event: 'close', listener: () => void) => void;
+  removeListener?: (event: 'close', listener: () => void) => void;
   writableEnded: boolean;
   write(chunk: string): boolean;
   end(): void;
@@ -32,7 +34,11 @@ function toSseDataString(data: unknown): string {
 
   const serialized = JSON.stringify(data);
 
-  return serialized ?? '';
+  if (serialized === undefined) {
+    throw new TypeError(`SseResponse data must be JSON-serializable. Received ${typeof data}.`);
+  }
+
+  return serialized;
 }
 
 function isWritableSseStream(value: unknown): value is WritableSseStream {
@@ -120,14 +126,18 @@ export class SseResponse {
     }
 
     context.request.signal?.addEventListener('abort', this.onAbort, { once: true });
+
+    if (context.request.signal === undefined) {
+      this.stream.on?.('close', this.onAbort);
+    }
   }
 
-  send(data: unknown, options: SseSendOptions = {}): void {
-    this.writeFrame(encodeSseMessage(data, options));
+  send(data: unknown, options: SseSendOptions = {}): boolean {
+    return this.writeFrame(encodeSseMessage(data, options));
   }
 
-  comment(comment: string): void {
-    this.writeFrame(encodeSseComment(comment));
+  comment(comment: string): boolean {
+    return this.writeFrame(encodeSseComment(comment));
   }
 
   close(): void {
@@ -137,6 +147,7 @@ export class SseResponse {
 
     this.closed = true;
     this.context.request.signal?.removeEventListener('abort', this.onAbort);
+    this.stream.removeListener?.('close', this.onAbort);
 
     if (!this.stream.writableEnded) {
       this.stream.end();
@@ -145,16 +156,16 @@ export class SseResponse {
     this.context.response.committed = true;
   }
 
-  private writeFrame(frame: string): void {
+  private writeFrame(frame: string): boolean {
     if (this.closed) {
-      return;
+      return false;
     }
 
     if (this.stream.writableEnded) {
       this.close();
-      return;
+      return false;
     }
 
-    this.stream.write(frame);
+    return this.stream.write(frame);
   }
 }


### PR DESCRIPTION
## Summary
- surface SSE backpressure by returning the underlying `write()` boolean from `send()` and `comment()`
- throw for top-level non-serializable SSE payloads instead of silently emitting empty data frames
- close SSE streams on raw response `close` when no request `AbortSignal` is available, with focused regression tests

## Verification
- `pnpm exec vitest run packages/http/src/sse.test.ts`
- `pnpm exec vitest run packages/runtime/src/application.test.ts -t \"streams SSE frames over the Node adapter and closes on client disconnect\"`
- `pnpm --filter @konekti/http run typecheck`
- `pnpm exec vitest run packages/http/src/dispatcher.test.ts -t \"binds PartialType DTOs with optional runtime semantics\"` *(pre-existing failure on `main`, reproduced unchanged)*

Closes #78