### PR TITLE
Resolve #88: fix graphql handler metadata symbols and remove unused adapter injection

### DIFF
--- a/packages/graphql/src/decorators.ts
+++ b/packages/graphql/src/decorators.ts
@@ -2,10 +2,8 @@ import { metadataSymbol } from '@konekti/core';
 
 import {
   argMetadataSymbol,
-  mutationMetadataSymbol,
-  queryMetadataSymbol,
+  handlerMetadataSymbol,
   resolverMetadataSymbol,
-  subscriptionMetadataSymbol,
 } from './metadata.js';
 import type { ArgFieldMetadata, ResolverHandlerMetadata, ResolverMetadata } from './types.js';
 
@@ -71,13 +69,7 @@ function defineStandardResolverMetadata(metadata: unknown, resolverMetadata: Res
 
 function defineStandardHandlerMetadata(metadata: unknown, propertyKey: string | symbol, handlerMetadata: ResolverHandlerMetadata): void {
   const bag = getStandardMetadataBag(metadata);
-  const key =
-    handlerMetadata.type === 'query'
-      ? queryMetadataSymbol
-      : handlerMetadata.type === 'mutation'
-        ? mutationMetadataSymbol
-        : subscriptionMetadataSymbol;
-  const current = bag[key] as Map<string | symbol, ResolverHandlerMetadata> | undefined;
+  const current = bag[handlerMetadataSymbol] as Map<string | symbol, ResolverHandlerMetadata> | undefined;
   const map = current ?? new Map<string | symbol, ResolverHandlerMetadata>();
 
   map.set(propertyKey, {
@@ -86,7 +78,7 @@ function defineStandardHandlerMetadata(metadata: unknown, propertyKey: string | 
     topics: handlerMetadata.topics,
     type: handlerMetadata.type,
   });
-  bag[key] = map;
+  bag[handlerMetadataSymbol] = map;
 }
 
 function defineStandardArgFieldMetadata(metadata: unknown, propertyKey: string | symbol, argFieldMetadata: ArgFieldMetadata): void {

--- a/packages/graphql/src/metadata.ts
+++ b/packages/graphql/src/metadata.ts
@@ -187,7 +187,5 @@ export function getArgFieldMetadataEntries(
 }
 
 export const resolverMetadataSymbol = standardResolverMetadataKey;
-export const queryMetadataSymbol = standardHandlerMetadataKey;
-export const mutationMetadataSymbol = standardHandlerMetadataKey;
-export const subscriptionMetadataSymbol = standardHandlerMetadataKey;
+export const handlerMetadataSymbol = standardHandlerMetadataKey;
 export const argMetadataSymbol = standardArgFieldMetadataKey;

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -7,14 +7,12 @@ import type { Container, Provider } from '@konekti/di';
 import {
   APPLICATION_LOGGER,
   COMPILED_MODULES,
-  HTTP_APPLICATION_ADAPTER,
   RUNTIME_CONTAINER,
   type ApplicationLogger,
   type CompiledModule,
   type OnApplicationBootstrap,
   type OnApplicationShutdown,
 } from '@konekti/runtime';
-import type { HttpApplicationAdapter } from '@konekti/http';
 import type {
   GraphQLFieldConfigMap,
   GraphQLObjectType as GraphQLObjectTypeType,
@@ -423,7 +421,7 @@ async function loadGraphqlDeps(): Promise<GraphqlDeps> {
   };
 }
 
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, GRAPHQL_MODULE_OPTIONS])
+@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, GRAPHQL_MODULE_OPTIONS])
 export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplicationShutdown {
   private middlewareRegistered = false;
   private yoga: YogaLike | undefined;
@@ -473,7 +471,6 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     private readonly runtimeContainer: Container,
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
-    private readonly _adapter: HttpApplicationAdapter,
     private readonly options: GraphqlModuleOptions,
   ) {}
 


### PR DESCRIPTION
## Summary

- Unify three redundant metadata symbols (`queryMetadataSymbol`, `mutationMetadataSymbol`, `subscriptionMetadataSymbol`) into a single `handlerMetadataSymbol`, all of which were already backed by the same `standardHandlerMetadataKey`.
- Remove the dead-code key conditional in `defineStandardHandlerMetadata` and use `handlerMetadataSymbol` directly.
- Drop `HTTP_APPLICATION_ADAPTER` from the `@Inject` token list and remove the unused `_adapter: HttpApplicationAdapter` constructor parameter from `GraphqlLifecycleService` — the field was injected but never referenced.

## Verification

- `pnpm exec tsc -p packages/graphql/tsconfig.json --noEmit` — exit 0
- `pnpm test` — 301/301 tests pass

Closes #88