### PR TITLE
feat(@konekti/http): content negotiation, unified error envelope, and typed request context

### DIFF
--- a/packages/http/src/decorators.test.ts
+++ b/packages/http/src/decorators.test.ts
@@ -8,10 +8,12 @@ import {
   FromPath,
   Get,
   Optional,
+  Produces,
   RequestDto,
   SuccessStatus,
   UseGuard,
   UseInterceptor,
+  getRouteProducesMetadata,
 } from './decorators.js';
 import { IntersectionType, OmitType, PartialType, PickType } from './mapped-types.js';
 import { IsString, MinLength, ValidateClass } from '@konekti/dto-validator';
@@ -121,6 +123,19 @@ describe('http decorators', () => {
     ]);
 
     expect(getClassValidationRules(ExampleController)).toHaveLength(1);
+  });
+
+  it('stores handler-level produced media types', () => {
+    @Controller('/feeds')
+    class FeedController {
+      @Produces('application/json', 'text/plain', 'application/json')
+      @Get('/')
+      getFeed() {
+        return { ok: true };
+      }
+    }
+
+    expect(getRouteProducesMetadata(FeedController, 'getFeed')).toEqual(['application/json', 'text/plain']);
   });
 
   it('preserves binding and validator metadata for PickType, OmitType, and IntersectionType', () => {

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -27,9 +27,26 @@ interface StandardRouteMetadataRecord {
   interceptors?: InterceptorLike[];
   method?: HttpMethod;
   path?: string;
+  produces?: string[];
   request?: Constructor;
   successStatus?: number;
   version?: string;
+}
+
+function normalizeProducesMediaTypes(mediaTypes: readonly string[]): string[] {
+  const normalized: string[] = [];
+
+  for (const mediaType of mediaTypes) {
+    const value = mediaType.trim();
+
+    if (!value || normalized.includes(value)) {
+      continue;
+    }
+
+    normalized.push(value);
+  }
+
+  return normalized;
 }
 
 function mergeUnique<T>(existing: T[] | undefined, values: T[]): T[] {
@@ -181,9 +198,23 @@ export const RequestDto = createRouteValueDecorator<Constructor>((record, dto) =
   record.request = dto;
 });
 
+export function Produces(...mediaTypes: string[]): MethodDecoratorLike {
+  return createRouteValueDecorator<string[]>((record, value) => {
+    record.produces = normalizeProducesMediaTypes(value);
+  })(mediaTypes);
+}
+
 export const SuccessStatus = createRouteValueDecorator<number>((record, status) => {
   record.successStatus = status;
 });
+
+export function getRouteProducesMetadata(controllerToken: Constructor, propertyKey: MetadataPropertyKey): string[] | undefined {
+  const bag = (controllerToken as unknown as Record<PropertyKey, unknown>)[metadataSymbol] as StandardMetadataBag | undefined;
+  const routeMap = bag?.[standardRouteMetadataKey] as Map<MetadataPropertyKey, StandardRouteMetadataRecord> | undefined;
+  const produces = routeMap?.get(propertyKey)?.produces;
+
+  return produces ? [...produces] : undefined;
+}
 
 export const FromPath = createDtoFieldDecorator('path');
 export const FromQuery = createDtoFieldDecorator('query');

--- a/packages/http/src/dispatcher.test.ts
+++ b/packages/http/src/dispatcher.test.ts
@@ -18,6 +18,7 @@ import {
   Controller,
   Get,
   Post,
+  Produces,
   RequestDto,
   SseResponse,
   SuccessStatus,
@@ -75,6 +76,152 @@ function createRequest(
 }
 
 describe('dispatcher runtime', () => {
+  it('keeps JSON response behavior when no formatters are configured', async () => {
+    @Controller('/negotiation')
+    class NegotiationController {
+      @Get('/default')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/negotiation/default', 'GET', { accept: 'text/plain' }), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(response.headers['Content-Type']).toBeUndefined();
+  });
+
+  it('selects formatter by Accept header when content negotiation is configured', async () => {
+    @Controller('/negotiation')
+    class NegotiationController {
+      @Produces('application/json', 'text/plain')
+      @Get('/formatted')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        formatters: [
+          {
+            format(body) {
+              return JSON.stringify(body);
+            },
+            mediaType: 'application/json',
+          },
+          {
+            format(body) {
+              return `plain:${JSON.stringify(body)}`;
+            },
+            mediaType: 'text/plain',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/negotiation/formatted', 'GET', { accept: 'text/plain' }), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('text/plain');
+    expect(response.body).toBe('plain:{"ok":true}');
+  });
+
+  it('returns 406 when Accept does not match available formatters', async () => {
+    @Controller('/negotiation')
+    class NegotiationController {
+      @Produces('application/json')
+      @Get('/json-only')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        formatters: [
+          {
+            format(body) {
+              return JSON.stringify(body);
+            },
+            mediaType: 'application/json',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/negotiation/json-only', 'GET', { accept: 'text/plain' }), response);
+
+    expect(response.statusCode).toBe(406);
+    expect(response.body).toEqual({
+      error: {
+        code: 'NOT_ACCEPTABLE',
+        details: undefined,
+        message: 'No acceptable response representation found.',
+        meta: undefined,
+        requestId: undefined,
+        status: 406,
+      },
+    });
+  });
+
+  it('falls back to default formatter for wildcard Accept header', async () => {
+    @Controller('/negotiation')
+    class NegotiationController {
+      @Produces('application/json', 'text/plain')
+      @Get('/wildcard')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        defaultMediaType: 'text/plain',
+        formatters: [
+          {
+            format(body) {
+              return JSON.stringify(body);
+            },
+            mediaType: 'application/json',
+          },
+          {
+            format(body) {
+              return `plain:${JSON.stringify(body)}`;
+            },
+            mediaType: 'text/plain',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/negotiation/wildcard', 'GET', { accept: '*/*' }), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['Content-Type']).toBe('text/plain');
+    expect(response.body).toBe('plain:{"ok":true}');
+  });
+
   describe('runMiddlewareChain with forRoutes filtering', () => {
     it('runs middleware with matching forRoutes path', async () => {
       const events: string[] = [];

--- a/packages/http/src/dispatcher.ts
+++ b/packages/http/src/dispatcher.ts
@@ -2,7 +2,7 @@ import { InvariantError, type Token } from '@konekti/core';
 import type { Container } from '@konekti/di';
 
 import { HandlerNotFoundError, RequestAbortedError } from './errors.js';
-import { HttpException, InternalServerException, NotFoundException, createErrorResponse } from './exceptions.js';
+import { HttpException, InternalServerException, NotAcceptableException, NotFoundException, createErrorResponse } from './exceptions.js';
 import { DefaultBinder } from './binding.js';
 import { HttpDtoValidationAdapter } from './dto-validation-adapter.js';
 import { runGuardChain } from './guards.js';
@@ -20,6 +20,8 @@ import type {
   HandlerMapping,
   InterceptorContext,
   MiddlewareLike,
+  ResponseFormatter,
+  ContentNegotiationOptions,
   RequestObserver,
   RequestObserverLike,
   RequestObservationContext,
@@ -33,10 +35,219 @@ export type ErrorHandler = (error: unknown, request: FrameworkRequest, response:
 
 export interface CreateDispatcherOptions {
   appMiddleware?: MiddlewareLike[];
+  contentNegotiation?: ContentNegotiationOptions;
   handlerMapping: HandlerMapping;
   observers?: RequestObserverLike[];
   onError?: ErrorHandler;
   rootContainer: Container;
+}
+
+interface AcceptToken {
+  mediaRange: string;
+  quality: number;
+  specificity: number;
+}
+
+interface ResolvedContentNegotiation {
+  defaultFormatter: ResponseFormatter;
+  formatters: ResponseFormatter[];
+}
+
+function normalizeMediaType(value: string): string {
+  return value.split(';')[0]?.trim().toLowerCase() ?? '';
+}
+
+function readAcceptHeader(request: FrameworkRequest): string | undefined {
+  const raw = request.headers.accept ?? request.headers.Accept;
+  const value = Array.isArray(raw) ? raw.join(',') : raw;
+  const normalized = value?.trim();
+
+  return normalized ? normalized : undefined;
+}
+
+function parseQuality(value: string | undefined): number {
+  if (!value) {
+    return 1;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+
+  if (parsed > 1) {
+    return 1;
+  }
+
+  return parsed;
+}
+
+function getMediaRangeSpecificity(mediaRange: string): number {
+  if (mediaRange === '*/*') {
+    return 0;
+  }
+
+  if (mediaRange.endsWith('/*')) {
+    return 1;
+  }
+
+  return 2;
+}
+
+function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
+  const tokens: AcceptToken[] = [];
+
+  for (const token of acceptHeader.split(',')) {
+    const [rawMediaRange, ...parameterParts] = token.trim().split(';');
+    const mediaRange = normalizeMediaType(rawMediaRange ?? '');
+
+    if (!mediaRange || !mediaRange.includes('/')) {
+      continue;
+    }
+
+    let quality = 1;
+
+    for (const parameterPart of parameterParts) {
+      const [name, value] = parameterPart.trim().split('=');
+
+      if (name?.toLowerCase() === 'q') {
+        quality = parseQuality(value?.trim());
+        break;
+      }
+    }
+
+    if (quality <= 0) {
+      continue;
+    }
+
+    tokens.push({
+      mediaRange,
+      quality,
+      specificity: getMediaRangeSpecificity(mediaRange),
+    });
+  }
+
+  return tokens.sort((left, right) => {
+    if (right.quality !== left.quality) {
+      return right.quality - left.quality;
+    }
+
+    return right.specificity - left.specificity;
+  });
+}
+
+function matchesMediaRange(mediaRange: string, mediaType: string): boolean {
+  if (mediaRange === '*/*') {
+    return true;
+  }
+
+  const [rangeType, rangeSubtype] = mediaRange.split('/');
+  const [mediaTypeType, mediaTypeSubtype] = mediaType.split('/');
+
+  if (!rangeType || !rangeSubtype || !mediaTypeType || !mediaTypeSubtype) {
+    return false;
+  }
+
+  if (rangeType !== '*' && rangeType !== mediaTypeType) {
+    return false;
+  }
+
+  return rangeSubtype === '*' || rangeSubtype === mediaTypeSubtype;
+}
+
+function resolveContentNegotiation(options: ContentNegotiationOptions | undefined): ResolvedContentNegotiation | undefined {
+  if (!options?.formatters?.length) {
+    return undefined;
+  }
+
+  const formatters = options.formatters.filter((formatter, index, all) => {
+    const mediaType = normalizeMediaType(formatter.mediaType);
+
+    if (!mediaType) {
+      return false;
+    }
+
+    return all.findIndex((item) => normalizeMediaType(item.mediaType) === mediaType) === index;
+  });
+
+  if (!formatters.length) {
+    return undefined;
+  }
+
+  const defaultMediaType = normalizeMediaType(options.defaultMediaType ?? '');
+  const defaultFormatter = defaultMediaType
+    ? formatters.find((formatter) => normalizeMediaType(formatter.mediaType) === defaultMediaType) ?? formatters[0]
+    : formatters[0];
+
+  return {
+    defaultFormatter,
+    formatters,
+  };
+}
+
+function resolveAllowedFormatters(
+  handler: HandlerDescriptor,
+  contentNegotiation: ResolvedContentNegotiation,
+): ResponseFormatter[] {
+  if (!handler.route.produces?.length) {
+    return contentNegotiation.formatters;
+  }
+
+  const allowed = new Set(handler.route.produces.map((mediaType) => normalizeMediaType(mediaType)));
+  return contentNegotiation.formatters.filter((formatter) => allowed.has(normalizeMediaType(formatter.mediaType)));
+}
+
+function resolveDefaultFormatter(
+  allowedFormatters: ResponseFormatter[],
+  contentNegotiation: ResolvedContentNegotiation,
+): ResponseFormatter {
+  const defaultMediaType = normalizeMediaType(contentNegotiation.defaultFormatter.mediaType);
+
+  return allowedFormatters.find((formatter) => normalizeMediaType(formatter.mediaType) === defaultMediaType)
+    ?? allowedFormatters[0]
+    ?? contentNegotiation.defaultFormatter;
+}
+
+function selectResponseFormatter(
+  handler: HandlerDescriptor,
+  request: FrameworkRequest,
+  contentNegotiation: ResolvedContentNegotiation,
+): ResponseFormatter {
+  const allowedFormatters = resolveAllowedFormatters(handler, contentNegotiation);
+
+  if (!allowedFormatters.length) {
+    throw new NotAcceptableException('No acceptable response representation found.');
+  }
+
+  const defaultFormatter = resolveDefaultFormatter(allowedFormatters, contentNegotiation);
+  const acceptHeader = readAcceptHeader(request);
+
+  if (!acceptHeader) {
+    return defaultFormatter;
+  }
+
+  const acceptTokens = parseAcceptHeader(acceptHeader);
+
+  if (!acceptTokens.length) {
+    return defaultFormatter;
+  }
+
+  for (const token of acceptTokens) {
+    if (token.mediaRange === '*/*') {
+      return defaultFormatter;
+    }
+
+    const matchedFormatter = allowedFormatters.find((formatter) => {
+      return matchesMediaRange(token.mediaRange, normalizeMediaType(formatter.mediaType));
+    });
+
+    if (matchedFormatter) {
+      return matchedFormatter;
+    }
+  }
+
+  throw new NotAcceptableException('No acceptable response representation found.');
 }
 
 function createDispatchRequest(request: FrameworkRequest): FrameworkRequest {
@@ -115,9 +326,23 @@ function resolveDefaultSuccessStatus(handler: HandlerDescriptor, value: unknown)
   }
 }
 
-async function writeSuccessResponse(handler: HandlerDescriptor, response: FrameworkResponse, value: unknown): Promise<void> {
+async function writeSuccessResponse(
+  handler: HandlerDescriptor,
+  request: FrameworkRequest,
+  response: FrameworkResponse,
+  value: unknown,
+  contentNegotiation: ResolvedContentNegotiation | undefined,
+): Promise<void> {
   if (response.committed) {
     return;
+  }
+
+  const formatter = contentNegotiation
+    ? selectResponseFormatter(handler, request, contentNegotiation)
+    : undefined;
+
+  if (formatter) {
+    response.setHeader('Content-Type', formatter.mediaType);
   }
 
   if (handler.route.successStatus !== undefined) {
@@ -126,7 +351,10 @@ async function writeSuccessResponse(handler: HandlerDescriptor, response: Framew
     response.setStatus(resolveDefaultSuccessStatus(handler, value));
   }
 
-  await response.send(value);
+  const responseBody = formatter
+    ? formatter.format(value)
+    : value;
+  await response.send(responseBody);
 }
 
 function ensureRequestNotAborted(request: FrameworkRequest): void {
@@ -195,6 +423,7 @@ async function dispatchMatchedHandler(
   handler: HandlerDescriptor,
   requestContext: RequestContext,
   observers: RequestObserverLike[],
+  contentNegotiation: ResolvedContentNegotiation | undefined,
 ): Promise<void> {
   const guardContext: GuardContext = {
     handler,
@@ -218,7 +447,7 @@ async function dispatchMatchedHandler(
   ensureRequestNotAborted(requestContext.request);
 
   if (!(result instanceof SseResponse) && !requestContext.response.committed) {
-    await writeSuccessResponse(handler, requestContext.response, result);
+    await writeSuccessResponse(handler, requestContext.request, requestContext.response, result, contentNegotiation);
   }
 
   try {
@@ -236,6 +465,8 @@ async function dispatchMatchedHandler(
 }
 
 export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
+  const contentNegotiation = resolveContentNegotiation(options.contentNegotiation);
+
   return {
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
       const requestContext = createDispatchContext(createDispatchRequest(request), response, options.rootContainer);
@@ -278,7 +509,7 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
               requestContext,
               response,
             }, async () => {
-              await dispatchMatchedHandler(match.descriptor, requestContext, observers);
+              await dispatchMatchedHandler(match.descriptor, requestContext, observers, contentNegotiation);
             });
           });
         } catch (error: unknown) {

--- a/packages/http/src/exceptions.ts
+++ b/packages/http/src/exceptions.ts
@@ -71,6 +71,18 @@ export class ConflictException extends HttpException {
   }
 }
 
+export class NotAcceptableException extends HttpException {
+  constructor(message = 'Not acceptable.', options: Omit<HttpExceptionOptions, 'code'> = {}) {
+    super(406, message, { ...options, code: 'NOT_ACCEPTABLE' });
+  }
+}
+
+export class TooManyRequestsException extends HttpException {
+  constructor(message = 'Too many requests.', options: Omit<HttpExceptionOptions, 'code'> = {}) {
+    super(429, message, { ...options, code: 'TOO_MANY_REQUESTS' });
+  }
+}
+
 export class PayloadTooLargeException extends HttpException {
   constructor(message = 'Payload too large.', options: Omit<HttpExceptionOptions, 'code'> = {}) {
     super(413, message, { ...options, code: 'PAYLOAD_TOO_LARGE' });

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -1,5 +1,6 @@
 import { getControllerMetadata, getRouteMetadata, type Constructor, type MetadataPropertyKey } from '@konekti/core';
 
+import { getRouteProducesMetadata } from './decorators.js';
 import { RouteConflictError } from './errors.js';
 import type {
   FrameworkRequest,
@@ -88,6 +89,7 @@ function createHandlerDescriptors(source: HandlerSource): HandlerDescriptor[] {
 
     const effectiveVersion = routeMetadata.version ?? controllerMetadata.version;
     const effectivePath = applyVersionPrefix(joinPaths(controllerMetadata.basePath, routeMetadata.path), effectiveVersion);
+    const produces = getRouteProducesMetadata(source.controllerToken, propertyKey);
 
     descriptors.push({
       controllerToken: source.controllerToken,
@@ -102,6 +104,7 @@ function createHandlerDescriptors(source: HandlerSource): HandlerDescriptor[] {
       methodName: String(propertyKey),
       route: {
         ...routeMetadata,
+        ...(produces ? { produces } : {}),
         guards: [
           ...((controllerMetadata.guards ?? []) as GuardLike[]),
           ...((routeMetadata.guards ?? []) as GuardLike[]),

--- a/packages/http/src/rate-limit.test.ts
+++ b/packages/http/src/rate-limit.test.ts
@@ -51,7 +51,16 @@ describe('createRateLimitMiddleware', () => {
     expect(next).toHaveBeenCalledTimes(2);
     expect(context.response.statusCode).toBe(429);
     expect(context.response.headers['Retry-After']).toBe('1');
-    expect(context.response.send).toHaveBeenCalledWith({ message: 'Too Many Requests' });
+    expect(context.response.send).toHaveBeenCalledWith({
+      error: {
+        code: 'TOO_MANY_REQUESTS',
+        details: undefined,
+        message: 'Too Many Requests',
+        meta: { retryAfter: 1 },
+        requestId: undefined,
+        status: 429,
+      },
+    });
   });
 
   it('resets the counter after the window expires', async () => {

--- a/packages/http/src/rate-limit.ts
+++ b/packages/http/src/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { MiddlewareContext, Middleware } from './types.js';
+import { TooManyRequestsException, createErrorResponse } from './exceptions.js';
 
 export interface RateLimitStoreEntry {
   count: number;
@@ -90,10 +91,13 @@ export function createRateLimitMiddleware(options: RateLimitOptions): Middleware
 
       if (entry.count >= options.limit) {
         const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+        const error = new TooManyRequestsException('Too Many Requests', {
+          meta: { retryAfter },
+        });
 
         context.response.setHeader('Retry-After', String(retryAfter));
         context.response.setStatus(429);
-        await context.response.send({ message: 'Too Many Requests' });
+        await context.response.send(createErrorResponse(error, context.requestContext.requestId));
         return;
       }
 

--- a/packages/http/src/request-context.test.ts
+++ b/packages/http/src/request-context.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import { Container } from '@konekti/di';
 
-import { assertRequestContext, createRequestContext, getCurrentRequestContext, runWithRequestContext } from './request-context.js';
+import {
+  assertRequestContext,
+  createContextKey,
+  createRequestContext,
+  getContextValue,
+  getCurrentRequestContext,
+  runWithRequestContext,
+  setContextValue,
+} from './request-context.js';
 import type { RequestContext } from './types.js';
 
 function createMockContext(): RequestContext {
@@ -95,5 +103,48 @@ describe('request context store', () => {
     });
 
     expect(requestA).not.toBe(requestB);
+  });
+
+  describe('typed context keys', () => {
+    it('stores and retrieves typed values via ContextKey', async () => {
+      const TENANT_KEY = createContextKey<string>('tenantId');
+      const TRACE_KEY = createContextKey<string>('traceId');
+      const context = createRequestContext(createMockContext());
+
+      setContextValue(context, TENANT_KEY, 'acme');
+      setContextValue(context, TRACE_KEY, 'trace-123');
+
+      expect(getContextValue(context, TENANT_KEY)).toBe('acme');
+      expect(getContextValue(context, TRACE_KEY)).toBe('trace-123');
+    });
+
+    it('returns undefined for unset context keys', () => {
+      const KEY = createContextKey<number>('counter');
+      const context = createRequestContext(createMockContext());
+
+      expect(getContextValue(context, KEY)).toBeUndefined();
+    });
+
+    it('isolates context keys between requests via ALS', async () => {
+      const LOCALE_KEY = createContextKey<string>('locale');
+      const contextA = createRequestContext(createMockContext());
+      const contextB = createRequestContext(createMockContext());
+
+      setContextValue(contextA, LOCALE_KEY, 'en-US');
+      setContextValue(contextB, LOCALE_KEY, 'ko-KR');
+
+      const resultA = await runWithRequestContext(contextA, async () => {
+        const ctx = assertRequestContext();
+        return getContextValue(ctx, LOCALE_KEY);
+      });
+
+      const resultB = await runWithRequestContext(contextB, async () => {
+        const ctx = assertRequestContext();
+        return getContextValue(ctx, LOCALE_KEY);
+      });
+
+      expect(resultA).toBe('en-US');
+      expect(resultB).toBe('ko-KR');
+    });
   });
 });

--- a/packages/http/src/request-context.ts
+++ b/packages/http/src/request-context.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 import { KonektiError } from '@konekti/core';
 
-import type { RequestContext } from './types.js';
+import type { ContextKey, RequestContext } from './types.js';
 
 const requestContextStore = new AsyncLocalStorage<RequestContext>();
 
@@ -43,4 +43,19 @@ export function createRequestContext(context: RequestContext): RequestContext {
     ...context,
     metadata: { ...context.metadata },
   };
+}
+
+export function createContextKey<T>(description: string): ContextKey<T> {
+  return {
+    description,
+    id: Symbol(description),
+  };
+}
+
+export function getContextValue<T>(context: RequestContext, key: ContextKey<T>): T | undefined {
+  return context.metadata[key.id] as T | undefined;
+}
+
+export function setContextValue<T>(context: RequestContext, key: ContextKey<T>, value: T): void {
+  context.metadata[key.id] = value;
 }

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -30,6 +30,16 @@ export interface FrameworkResponse {
   send(body: unknown): MaybePromise<void>;
 }
 
+export interface ResponseFormatter {
+  readonly mediaType: string;
+  format(body: unknown): string | Buffer;
+}
+
+export interface ContentNegotiationOptions {
+  defaultMediaType?: string;
+  formatters?: ResponseFormatter[];
+}
+
 export interface Principal {
   subject: string;
   issuer?: string;
@@ -44,8 +54,14 @@ export interface RequestContext {
   response: FrameworkResponse;
   requestId?: string;
   principal?: Principal;
-  metadata: Record<string, unknown>;
+  metadata: Record<string | symbol, unknown>;
   container: RequestScopeContainer;
+}
+
+export interface ContextKey<T> {
+  readonly id: symbol;
+  readonly description: string;
+  readonly __type?: T;
 }
 
 export type ControllerHandler<Input = unknown, Result = unknown> = (
@@ -56,6 +72,7 @@ export type ControllerHandler<Input = unknown, Result = unknown> = (
 export interface RouteDefinition {
   method: HttpMethod;
   path: string;
+  produces?: string[];
   request?: Constructor;
   guards?: GuardLike[];
   interceptors?: InterceptorLike[];


### PR DESCRIPTION
## Summary
- Add `ResponseFormatter` interface and `Accept` header content negotiation in the dispatcher
- Add `@Produces()` decorator for per-handler media type restrictions with `406 Not Acceptable` support
- Add `NotAcceptableException` (406) and `TooManyRequestsException` (429) exception classes
- Unify rate-limit middleware error response to use the canonical error envelope with `requestId`
- Add `createContextKey<T>()`, `getContextValue()`, `setContextValue()` for typed request context baggage
- Widen `RequestContext.metadata` to `Record<string | symbol, unknown>` for symbol-based typed keys

## Test Results
All 81 tests pass across 11 test files.

Closes #92