### PR TITLE
feat(dto-validator, openapi): transform/pipe, lazy ValidateNested, parameter $ref fix, default error responses

### DIFF
--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -98,7 +98,7 @@ export type DtoFieldValidationRule =
   | ({ kind: 'length'; min: number; max?: number } & ValidationDecoratorOptions)
   | ({ kind: 'minLength'; value: number } & ValidationDecoratorOptions)
   | ({ kind: 'maxLength'; value: number } & ValidationDecoratorOptions)
-  | ({ kind: 'nested'; dto: Constructor } & ValidationDecoratorOptions)
+  | ({ kind: 'nested'; dto: Constructor | (() => Constructor) } & ValidationDecoratorOptions)
   | ({
       kind: 'validatorjs';
       validator:

--- a/packages/dto-validator/src/decorators.ts
+++ b/packages/dto-validator/src/decorators.ts
@@ -162,7 +162,7 @@ export function Length(min: number, max?: number, options?: ValidationDecoratorO
 
 export function ValidateNested(dto: Constructor | (() => Constructor), options?: ValidationDecoratorOptions): FieldDecoratorLike {
   return createValidationDecorator(() => ({
-    dto: typeof dto === 'function' && 'prototype' in dto && dto.prototype ? (dto as Constructor) : (dto as () => Constructor)(),
+    dto,
     kind: 'nested',
     ...options,
   }));

--- a/packages/dto-validator/src/types.ts
+++ b/packages/dto-validator/src/types.ts
@@ -9,4 +9,5 @@ export interface ValidationIssue {
 
 export interface Validator {
   validate(value: unknown, target: Constructor): MaybePromise<void>;
+  transform<T>(value: unknown, target: Constructor<T>): MaybePromise<T>;
 }

--- a/packages/dto-validator/src/validation.test.ts
+++ b/packages/dto-validator/src/validation.test.ts
@@ -59,4 +59,87 @@ describe('DefaultValidator', () => {
       ],
     });
   });
+
+  it('transform returns a typed DTO instance from plain object', async () => {
+    class CreateUserDto {
+      @IsEmail()
+      email = '';
+    }
+
+    const validator = new DefaultValidator();
+    const result = await validator.transform<CreateUserDto>({ email: 'hello@example.com' }, CreateUserDto);
+
+    expect(result).toBeInstanceOf(CreateUserDto);
+    expect(result.email).toBe('hello@example.com');
+  });
+
+  it('transform recursively transforms nested DTOs', async () => {
+    class AddressDto {
+      @MinLength(1)
+      city = '';
+    }
+
+    class CreateOrderDto {
+      @ValidateNested(() => AddressDto)
+      address = new AddressDto();
+
+      @ValidateNested(() => AddressDto, { each: true })
+      previousAddresses: AddressDto[] = [];
+    }
+
+    const validator = new DefaultValidator();
+    const result = await validator.transform<CreateOrderDto>(
+      {
+        address: { city: 'Seoul' },
+        previousAddresses: [{ city: 'Busan' }],
+      },
+      CreateOrderDto,
+    );
+
+    expect(result).toBeInstanceOf(CreateOrderDto);
+    expect(result.address).toBeInstanceOf(AddressDto);
+    expect(result.previousAddresses[0]).toBeInstanceOf(AddressDto);
+  });
+
+  it('transform throws DtoValidationError on invalid input', async () => {
+    class CreateUserDto {
+      @IsEmail()
+      email = '';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(validator.transform({ email: 'not-an-email' }, CreateUserDto)).rejects.toBeInstanceOf(DtoValidationError);
+  });
+
+  it('resolves lazy circular nested references at validation time', async () => {
+    class ParentDto {
+      @MinLength(1)
+      name = '';
+
+      @ValidateNested(() => ChildDto)
+      child!: ChildDto;
+    }
+
+    class ChildDto {
+      @ValidateNested(() => ParentDto, { each: true })
+      parents: ParentDto[] = [];
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(
+        Object.assign(new ParentDto(), {
+          child: {
+            parents: [{}],
+          },
+          name: 'ok',
+        }),
+        ParentDto,
+      ),
+    ).rejects.toMatchObject({
+      issues: [{ field: 'child.parents[0].name' }],
+    });
+  });
 });

--- a/packages/dto-validator/src/validation.ts
+++ b/packages/dto-validator/src/validation.ts
@@ -15,6 +15,14 @@ import {
 import { DtoValidationError } from './errors.js';
 import type { ValidationIssue, Validator } from './types.js';
 
+function resolveNestedDto(dto: Constructor | (() => Constructor)): Constructor {
+  if (typeof dto === 'function' && 'prototype' in dto && dto.prototype) {
+    return dto as Constructor;
+  }
+
+  return (dto as () => Constructor)();
+}
+
 function toFieldName(propertyKey: MetadataPropertyKey): string {
   return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
 }
@@ -104,6 +112,53 @@ function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown): 
     const sourceKey = bindingMap.get(propertyKey)?.key;
     if (!sourceKey) continue;
     instance[propertyKey] = rawValue[sourceKey];
+  }
+
+  for (const entry of getDtoValidationSchema(target)) {
+    const nestedRule = entry.rules.find(
+      (rule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
+    );
+
+    if (!nestedRule) {
+      continue;
+    }
+
+    const currentValue = instance[entry.propertyKey];
+    if (currentValue === undefined || currentValue === null) {
+      continue;
+    }
+
+    const resolvedDto = resolveNestedDto(nestedRule.dto);
+
+    if (nestedRule.each) {
+      if (Array.isArray(currentValue)) {
+        instance[entry.propertyKey] = currentValue.map((item) =>
+          item === undefined || item === null ? item : createNestedDtoInstance(resolvedDto, item),
+        );
+        continue;
+      }
+
+      if (currentValue instanceof Set) {
+        instance[entry.propertyKey] = new Set(
+          Array.from(currentValue.values(), (item) =>
+            item === undefined || item === null ? item : createNestedDtoInstance(resolvedDto, item),
+          ),
+        );
+        continue;
+      }
+
+      if (currentValue instanceof Map) {
+        instance[entry.propertyKey] = new Map(
+          Array.from(currentValue.entries(), ([key, item]) => [
+            key,
+            item === undefined || item === null ? item : createNestedDtoInstance(resolvedDto, item),
+          ]),
+        );
+        continue;
+      }
+    }
+
+    instance[entry.propertyKey] = createNestedDtoInstance(resolvedDto, currentValue);
   }
 
   return instance as T;
@@ -257,12 +312,13 @@ async function validateNestedRule(
 ): Promise<ValidationIssue[]> {
   const values = rule.each ? getIterableValues(value) ?? [value] : [value];
   const issues: ValidationIssue[] = [];
+  const resolvedDto = resolveNestedDto(rule.dto);
 
   for (const [index, entry] of values.entries()) {
     if (entry === undefined || entry === null) continue;
     const nestedPath = rule.each ? `${fieldPath}[${String(index)}]` : fieldPath;
-    const nestedDto = createNestedDtoInstance(rule.dto, entry);
-    issues.push(...(await collectValidationIssuesInternal(rule.dto, nestedDto, { fieldPrefix: nestedPath, inheritedSource })));
+    const nestedDto = createNestedDtoInstance(resolvedDto, entry);
+    issues.push(...(await collectValidationIssuesInternal(resolvedDto, nestedDto, { fieldPrefix: nestedPath, inheritedSource })));
   }
 
   return issues;
@@ -385,5 +441,16 @@ export class DefaultValidator implements Validator {
     const issues = await collectValidationIssues(target, value);
     if (issues.length === 0) return;
     throw new DtoValidationError('Validation failed.', issues);
+  }
+
+  async transform<T>(value: unknown, target: Constructor<T>): Promise<T> {
+    const instance = createNestedDtoInstance(target, value);
+    const issues = await collectValidationIssues(target, instance);
+
+    if (issues.length > 0) {
+      throw new DtoValidationError('Validation failed.', issues);
+    }
+
+    return instance;
   }
 }

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -186,7 +186,7 @@ describe('OpenApiModule', () => {
         paths: {
           '/users': {
             get: expect.objectContaining({
-              responses: {
+              responses: expect.objectContaining({
                 '201': {
                   content: {
                     'application/json': {
@@ -197,7 +197,7 @@ describe('OpenApiModule', () => {
                   },
                   description: 'Created',
                 },
-              },
+              }),
               security: [{ bearerAuth: [] }],
               summary: 'Create user',
               tags: ['users'],
@@ -213,7 +213,7 @@ describe('OpenApiModule', () => {
                 },
                 required: true,
               },
-              responses: {
+              responses: expect.objectContaining({
                 '201': {
                   content: {
                     'application/json': {
@@ -224,7 +224,7 @@ describe('OpenApiModule', () => {
                   },
                   description: 'Created',
                 },
-              },
+              }),
               summary: 'Create user',
               tags: ['users'],
             }),
@@ -779,7 +779,7 @@ describe('OpenApiModule', () => {
         paths: expect.objectContaining({
           '/users/summary': {
             get: expect.objectContaining({
-              responses: {
+              responses: expect.objectContaining({
                 '200': {
                   content: {
                     'application/json': {
@@ -788,12 +788,12 @@ describe('OpenApiModule', () => {
                   },
                   description: 'User summary',
                 },
-              },
+              }),
             }),
           },
           '/users/no-email': {
             get: expect.objectContaining({
-              responses: {
+              responses: expect.objectContaining({
                 '200': {
                   content: {
                     'application/json': {
@@ -802,12 +802,12 @@ describe('OpenApiModule', () => {
                   },
                   description: 'User without email',
                 },
-              },
+              }),
             }),
           },
           '/users/partial': {
             get: expect.objectContaining({
-              responses: {
+              responses: expect.objectContaining({
                 '200': {
                   content: {
                     'application/json': {
@@ -816,7 +816,216 @@ describe('OpenApiModule', () => {
                   },
                   description: 'Partial user',
                 },
+              }),
+            }),
+          },
+        }),
+      }),
+    );
+  });
+
+  it('keeps nested parameter schema refs at field level', async () => {
+    class FilterDto {
+      @IsString()
+      term = '';
+    }
+
+    class SearchRequest {
+      @FromQuery('filter')
+      @ValidateNested(() => FilterDto)
+      filter = new FilterDto();
+    }
+
+    @Controller('/search')
+    class SearchController {
+      @Get('/')
+      @RequestDto(SearchRequest)
+      search() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: SearchController }],
+      title: 'Search API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [SearchController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        components: expect.objectContaining({
+          schemas: expect.objectContaining({
+            FilterDto: expect.any(Object),
+          }),
+        }),
+        paths: expect.objectContaining({
+          '/search': {
+            get: expect.objectContaining({
+              parameters: [
+                {
+                  in: 'query',
+                  name: 'filter',
+                  required: true,
+                  schema: {
+                    $ref: '#/components/schemas/FilterDto',
+                  },
+                },
+              ],
+            }),
+          },
+        }),
+      }),
+    );
+  });
+
+  it('adds default error responses when @ApiResponse is absent', async () => {
+    @Controller('/errors')
+    class ErrorsController {
+      @Get('/default')
+      defaultHandler() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: ErrorsController }],
+      title: 'Errors API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [ErrorsController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        components: expect.objectContaining({
+          schemas: expect.objectContaining({
+            ErrorResponse: {
+              additionalProperties: false,
+              properties: {
+                error: { type: 'string' },
+                message: { type: 'string' },
+                statusCode: { type: 'integer' },
               },
+              required: ['statusCode', 'message', 'error'],
+              type: 'object',
+            },
+          }),
+        }),
+        paths: expect.objectContaining({
+          '/errors/default': {
+            get: expect.objectContaining({
+              responses: expect.objectContaining({
+                '200': { description: 'OK' },
+                '400': expect.objectContaining({
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/ErrorResponse' },
+                    },
+                  },
+                  description: 'Bad Request',
+                }),
+                '401': expect.objectContaining({ description: 'Unauthorized' }),
+                '403': expect.objectContaining({ description: 'Forbidden' }),
+                '404': expect.objectContaining({ description: 'Not Found' }),
+                '500': expect.objectContaining({ description: 'Internal Server Error' }),
+              }),
+            }),
+          },
+        }),
+      }),
+    );
+  });
+
+  it('preserves explicit @ApiResponse and fills missing default error responses', async () => {
+    class CreatedResponse {
+      @IsString()
+      id = '';
+    }
+
+    @Controller('/errors')
+    class ErrorsController {
+      @ApiResponse(201, { description: 'Created', type: CreatedResponse })
+      @ApiResponse(400, { description: 'Custom bad request' })
+      @Post('/custom')
+      create() {
+        return { id: '1' };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: ErrorsController }],
+      title: 'Errors API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [ErrorsController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        paths: expect.objectContaining({
+          '/errors/custom': {
+            post: expect.objectContaining({
+              responses: expect.objectContaining({
+                '201': {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: '#/components/schemas/CreatedResponse' },
+                    },
+                  },
+                  description: 'Created',
+                },
+                '400': {
+                  description: 'Custom bad request',
+                },
+                '401': expect.objectContaining({ description: 'Unauthorized' }),
+                '403': expect.objectContaining({ description: 'Forbidden' }),
+                '404': expect.objectContaining({ description: 'Not Found' }),
+                '500': expect.objectContaining({ description: 'Internal Server Error' }),
+              }),
             }),
           },
         }),

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -140,6 +140,14 @@ function createSchemaRef(name: string): OpenApiSchemaObject {
   };
 }
 
+function resolveNestedDto(dto: Constructor | (() => Constructor)): Constructor {
+  if (typeof dto === 'function' && 'prototype' in dto && dto.prototype) {
+    return dto as Constructor;
+  }
+
+  return (dto as () => Constructor)();
+}
+
 function inferPrimitiveTypeFromRules(rules: readonly DtoFieldValidationRule[]): OpenApiSchemaObject | undefined {
   const hasRule = <TKind extends DtoFieldValidationRule['kind']>(kind: TKind) =>
     rules.find((rule): rule is Extract<DtoFieldValidationRule, { kind: TKind }> => rule.kind === kind);
@@ -155,11 +163,13 @@ function inferPrimitiveTypeFromRules(rules: readonly DtoFieldValidationRule[]): 
   const enumRule = hasRule('enum');
 
   if (nestedRule && nestedRule.each) {
-    return { items: createSchemaRef(nestedRule.dto.name), type: 'array' };
+    const resolvedDto = resolveNestedDto(nestedRule.dto);
+    return { items: createSchemaRef(resolvedDto.name), type: 'array' };
   }
 
   if (nestedRule) {
-    return createSchemaRef(nestedRule.dto.name);
+    const resolvedDto = resolveNestedDto(nestedRule.dto);
+    return createSchemaRef(resolvedDto.name);
   }
 
   if (arrayRule) {
@@ -208,7 +218,8 @@ function inferEachItemSchema(rules: readonly DtoFieldValidationRule[]): OpenApiS
   );
 
   if (nestedRule) {
-    return createSchemaRef(nestedRule.dto.name);
+    const resolvedDto = resolveNestedDto(nestedRule.dto);
+    return createSchemaRef(resolvedDto.name);
   }
 
   const enumRule = rules.find(
@@ -319,7 +330,7 @@ function ensureComponentSchemaFromEntries(
 
     for (const rule of rules) {
       if (rule.kind === 'nested') {
-        ensureComponentSchema(rule.dto, componentSchemas);
+        ensureComponentSchema(resolveNestedDto(rule.dto), componentSchemas);
       }
     }
 
@@ -371,15 +382,71 @@ function createParameters(
     const schema = applyValidationConstraints(inferred, rules);
     const isRequired = source === 'path' ? true : isPropertyRequired(entry.binding, entry.validation);
 
-    const ensuredSchema = '$ref' in schema ? ensureComponentSchema(dto, componentSchemas) : schema;
+    if ('$ref' in schema) {
+      const nestedRule = rules.find(
+        (rule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
+      );
+
+      if (nestedRule) {
+        ensureComponentSchema(resolveNestedDto(nestedRule.dto), componentSchemas);
+      }
+    }
 
     return {
       in: source,
       name: entry.binding.metadata.key ?? entry.name,
       required: isRequired,
-      schema: ensuredSchema,
+      schema,
     };
   });
+}
+
+function ensureErrorResponseSchema(componentSchemas: Record<string, OpenApiSchemaObject>): OpenApiSchemaObject {
+  const schemaName = 'ErrorResponse';
+
+  if (!componentSchemas[schemaName]) {
+    componentSchemas[schemaName] = {
+      additionalProperties: false,
+      properties: {
+        error: { type: 'string' },
+        message: { type: 'string' },
+        statusCode: { type: 'integer' },
+      },
+      required: ['statusCode', 'message', 'error'],
+      type: 'object',
+    };
+  }
+
+  return createSchemaRef(schemaName);
+}
+
+function addDefaultErrorResponses(
+  responses: Record<string, OpenApiResponseObject>,
+  componentSchemas: Record<string, OpenApiSchemaObject>,
+): void {
+  const errorSchema = ensureErrorResponseSchema(componentSchemas);
+  const defaultErrorResponses: Record<string, string> = {
+    '400': 'Bad Request',
+    '401': 'Unauthorized',
+    '403': 'Forbidden',
+    '404': 'Not Found',
+    '500': 'Internal Server Error',
+  };
+
+  for (const [status, description] of Object.entries(defaultErrorResponses)) {
+    if (responses[status]) {
+      continue;
+    }
+
+    responses[status] = {
+      content: {
+        'application/json': {
+          schema: errorSchema,
+        },
+      },
+      description,
+    };
+  }
 }
 
 function createRequestBody(
@@ -455,6 +522,8 @@ export function buildOpenApiDocument(options: BuildOpenApiDocumentOptions): Open
     } else {
       responses[String(descriptor.route.successStatus ?? 200)] = { description: 'OK' };
     }
+
+    addDefaultErrorResponses(responses, componentSchemas);
 
     const security: OpenApiSecurityRequirementObject[] | undefined =
       methodMeta?.security && methodMeta.security.length > 0


### PR DESCRIPTION
## Summary

Closes #93

### Changes

1. **Transform/pipe abstraction** (`@konekti/dto-validator`): Added `transform<T>(value, target)` method to `Validator` interface and `DefaultValidator` — creates a typed DTO instance, validates, and returns the result. `createNestedDtoInstance` enhanced to recursively instantiate nested DTOs including `each` collections.

2. **ValidateNested lazy evaluation fix** (`@konekti/core`, `@konekti/dto-validator`): Changed `ValidateNested` decorator from eagerly calling factory functions at decoration time to storing them as-is and resolving lazily via `resolveNestedDto()` at validation/schema-generation time. This fixes circular reference issues between DTOs.

3. **OpenAPI parameter `$ref` bug fix** (`@konekti/openapi`): Fixed `ensureComponentSchema()` call that incorrectly replaced field-level `$ref`s with the parent DTO's ref. Now keeps each field's own inferred schema and registers nested component schemas separately.

4. **Default error response schemas** (`@konekti/openapi`): Auto-injects standard HTTP error responses (400/401/403/404/500) with a shared `ErrorResponse` component schema when `@ApiResponse` is not explicitly provided. Explicit responses are preserved.

### Testing

- 26 tests pass across 5 test files (core: 8, dto-validator: 6, openapi: 12)
- 7 new regression tests added covering transform, nested transform, lazy circular references, parameter `$ref`, and default error responses