### PR TITLE
fix(jwt): RFC 7518 P1363 signatures, default exp enforcement, JWKS support, refresh token rotation

### DIFF
--- a/packages/jwt/src/index.ts
+++ b/packages/jwt/src/index.ts
@@ -1,5 +1,7 @@
 export * from './errors.js';
+export * from './jwks.js';
 export * from './module.js';
+export * from './refresh-token.js';
 export * from './signer.js';
 export * from './types.js';
 export * from './verifier.js';

--- a/packages/jwt/src/jwks.test.ts
+++ b/packages/jwt/src/jwks.test.ts
@@ -1,0 +1,122 @@
+import { createSign, generateKeyPairSync, type KeyObject } from 'node:crypto';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { JwksClient } from './jwks.js';
+import { DefaultJwtVerifier } from './verifier.js';
+
+function createRs256Token(privateKey: string | KeyObject, kid: string): string {
+  const headerSegment = Buffer.from(JSON.stringify({ alg: 'RS256', kid, typ: 'JWT' }), 'utf8').toString('base64url');
+  const payloadSegment = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 60, sub: 'jwks-user' }),
+    'utf8',
+  ).toString('base64url');
+  const signingInput = `${headerSegment}.${payloadSegment}`;
+  const signer = createSign('sha256');
+  signer.update(signingInput);
+  const signatureSegment = signer.sign(privateKey, 'base64url');
+
+  return `${headerSegment}.${payloadSegment}.${signatureSegment}`;
+}
+
+describe('JwksClient', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('fetches keys from jwks uri and finds key by kid', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const jwk = publicKey.export({ format: 'jwk' });
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ keys: [{ ...jwk, kid: 'key-1' }] }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = new JwksClient('https://example.test/.well-known/jwks.json');
+    const key = await client.getSigningKey('key-1');
+    const token = createRs256Token(privateKey, 'key-1');
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      publicKey: key,
+    });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'jwks-user',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches keys within ttl', async () => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const jwk = publicKey.export({ format: 'jwk' });
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ keys: [{ ...jwk, kid: 'key-1' }] }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = new JwksClient('https://example.test/.well-known/jwks.json', 30_000);
+    await client.getSigningKey('key-1');
+    await client.getSigningKey('key-1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after ttl expires', async () => {
+    const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const jwk = publicKey.export({ format: 'jwk' });
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ keys: [{ ...jwk, kid: 'key-1' }] }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const client = new JwksClient('https://example.test/.well-known/jwks.json', 1);
+    await client.getSigningKey('key-1');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await client.getSigningKey('key-1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('DefaultJwtVerifier with jwksUri', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('verifies RS256 token using jwksUri option', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const jwk = publicKey.export({ format: 'jwk' });
+    const token = createRs256Token(privateKey, 'key-1');
+
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ keys: [{ ...jwk, kid: 'key-1' }] }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }),
+    ) as typeof fetch;
+
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      jwksUri: 'https://example.test/.well-known/jwks.json',
+    });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'jwks-user',
+    });
+  });
+});

--- a/packages/jwt/src/jwks.ts
+++ b/packages/jwt/src/jwks.ts
@@ -1,0 +1,80 @@
+import { createPublicKey, type KeyObject } from 'node:crypto';
+
+import { JwtConfigurationError, JwtInvalidTokenError } from './errors.js';
+
+interface Jwk {
+  kid?: string;
+  [key: string]: unknown;
+}
+
+interface JwksResponse {
+  keys?: Jwk[];
+}
+
+export class JwksClient {
+  private readonly cache = new Map<string, { expiresAt: number; key: KeyObject }>();
+
+  constructor(
+    private readonly uri: string,
+    private readonly cacheTtl: number = 600_000,
+  ) {}
+
+  async getSigningKey(kid: string): Promise<KeyObject> {
+    const now = Date.now();
+    const cached = this.cache.get(kid);
+
+    if (cached && cached.expiresAt > now) {
+      return cached.key;
+    }
+
+    const keys = await this.fetchKeys();
+    const jwk = keys.find((entry) => entry.kid === kid);
+
+    if (!jwk) {
+      throw new JwtInvalidTokenError('JWT key id was not found in JWKS.');
+    }
+
+    let key: KeyObject;
+
+    try {
+      key = createPublicKey({ format: 'jwk', key: jwk });
+    } catch {
+      throw new JwtConfigurationError('Unable to parse JWKS key into a public key.');
+    }
+
+    this.cache.set(kid, {
+      expiresAt: now + this.cacheTtl,
+      key,
+    });
+
+    return key;
+  }
+
+  private async fetchKeys(): Promise<Jwk[]> {
+    let response: Response;
+
+    try {
+      response = await fetch(this.uri);
+    } catch {
+      throw new JwtConfigurationError(`Failed to fetch JWKS from "${this.uri}".`);
+    }
+
+    if (!response.ok) {
+      throw new JwtConfigurationError(`JWKS endpoint returned HTTP ${response.status}.`);
+    }
+
+    let body: JwksResponse;
+
+    try {
+      body = (await response.json()) as JwksResponse;
+    } catch {
+      throw new JwtConfigurationError('JWKS endpoint did not return valid JSON.');
+    }
+
+    if (!Array.isArray(body.keys)) {
+      throw new JwtConfigurationError('JWKS endpoint did not return a keys array.');
+    }
+
+    return body.keys;
+  }
+}

--- a/packages/jwt/src/module.test.ts
+++ b/packages/jwt/src/module.test.ts
@@ -4,8 +4,21 @@ import { Inject, getModuleMetadata, type Constructor, type Token } from '@konekt
 import { Container, type Provider } from '@konekti/di';
 
 import { JwtModule } from './module.js';
+import { type RefreshTokenRecord, type RefreshTokenStore, RefreshTokenService } from './refresh-token.js';
 import { DefaultJwtSigner } from './signer.js';
 import { DefaultJwtVerifier } from './verifier.js';
+
+class NoopRefreshTokenStore implements RefreshTokenStore {
+  async save(_: RefreshTokenRecord): Promise<void> {}
+
+  async find(_: string): Promise<RefreshTokenRecord | undefined> {
+    return undefined;
+  }
+
+  async revoke(_: string): Promise<void> {}
+
+  async revokeBySubject(_: string): Promise<void> {}
+}
 
 @Inject([DefaultJwtSigner, DefaultJwtVerifier])
 class JwtRoundTripService {
@@ -54,7 +67,7 @@ describe('JwtModule', () => {
     const container = new Container();
     const moduleType = JwtModule.forRootAsync({
       inject: [JWT_SECRET],
-      useFactory: async (...deps) => {
+      useFactory: async (...deps: unknown[]) => {
         const [secret] = deps;
 
         if (typeof secret !== 'string') {
@@ -94,5 +107,22 @@ describe('JwtModule', () => {
     container.register(...moduleProviders(moduleType));
 
     await expect(container.resolve(DefaultJwtSigner)).rejects.toThrow('jwt async options failed');
+  });
+
+  it('registers refresh token service when refresh options are provided', async () => {
+    const container = new Container();
+    const moduleType = JwtModule.forRoot({
+      algorithms: ['HS256'],
+      refreshToken: {
+        expiresInSeconds: 60,
+        rotation: true,
+        secret: 'refresh-secret',
+        store: new NoopRefreshTokenStore(),
+      },
+      secret: 'jwt-secret',
+    });
+
+    container.register(...moduleProviders(moduleType));
+    await expect(container.resolve(RefreshTokenService)).resolves.toBeInstanceOf(RefreshTokenService);
   });
 });

--- a/packages/jwt/src/module.ts
+++ b/packages/jwt/src/module.ts
@@ -1,6 +1,8 @@
 import { defineModuleMetadata, type AsyncModuleOptions, type Constructor, type MaybePromise, type Token } from '@konekti/core';
 import type { Provider } from '@konekti/di';
 
+import { JwtConfigurationError } from './errors.js';
+import { RefreshTokenService } from './refresh-token.js';
 import type { JwtVerifierOptions } from './types.js';
 import { DefaultJwtSigner } from './signer.js';
 import { DefaultJwtVerifier, JWT_OPTIONS } from './verifier.js';
@@ -20,8 +22,37 @@ type JwtOptionsProvider =
       useFactory: (...deps: unknown[]) => MaybePromise<JwtVerifierOptions>;
     };
 
-function createJwtModuleProviders(optionsProvider: JwtOptionsProvider): Provider[] {
-  return [optionsProvider, DefaultJwtVerifier, DefaultJwtSigner];
+function hasRefreshTokenOptions(
+  value: unknown,
+): value is JwtVerifierOptions & { refreshToken: NonNullable<JwtVerifierOptions['refreshToken']> } {
+  return typeof value === 'object' && value !== null && 'refreshToken' in value && Boolean(value.refreshToken);
+}
+
+function createJwtModuleProviders(optionsProvider: JwtOptionsProvider, includeRefreshTokenService: boolean): Provider[] {
+  const providers: Provider[] = [optionsProvider, DefaultJwtVerifier, DefaultJwtSigner];
+
+  if (includeRefreshTokenService) {
+    providers.push({
+      inject: [JWT_OPTIONS, DefaultJwtSigner, DefaultJwtVerifier],
+      provide: RefreshTokenService,
+      scope: 'singleton',
+      useFactory: (...deps: unknown[]) => {
+        const [options, signer, verifier] = deps;
+
+        if (!hasRefreshTokenOptions(options)) {
+          throw new JwtConfigurationError('JWT refresh token options are not configured.');
+        }
+
+        return new RefreshTokenService(
+          options.refreshToken,
+          signer as DefaultJwtSigner,
+          verifier as DefaultJwtVerifier,
+        );
+      },
+    });
+  }
+
+  return providers;
 }
 
 export function createJwtCoreProviders(options: JwtVerifierOptions): Provider[] {
@@ -29,7 +60,7 @@ export function createJwtCoreProviders(options: JwtVerifierOptions): Provider[] 
     provide: JWT_OPTIONS,
     scope: 'singleton',
     useValue: options,
-  });
+  }, Boolean(options.refreshToken));
 }
 
 export class JwtModule {
@@ -38,7 +69,7 @@ export class JwtModule {
       provide: JWT_OPTIONS,
       scope: 'singleton',
       useValue: options,
-    });
+    }, Boolean(options.refreshToken));
   }
 
   static forRootAsync(options: AsyncModuleOptions<JwtVerifierOptions>): ModuleType {
@@ -47,15 +78,15 @@ export class JwtModule {
       provide: JWT_OPTIONS,
       scope: 'singleton',
       useFactory: options.useFactory,
-    });
+    }, true);
   }
 
-  private static createModule(optionsProvider: JwtOptionsProvider): ModuleType {
+  private static createModule(optionsProvider: JwtOptionsProvider, includeRefreshTokenService: boolean): ModuleType {
     class JwtRuntimeModule {}
 
     defineModuleMetadata(JwtRuntimeModule, {
-      exports: [DefaultJwtVerifier, DefaultJwtSigner],
-      providers: createJwtModuleProviders(optionsProvider),
+      exports: [DefaultJwtVerifier, DefaultJwtSigner, ...(includeRefreshTokenService ? [RefreshTokenService] : [])],
+      providers: createJwtModuleProviders(optionsProvider, includeRefreshTokenService),
     });
 
     return JwtRuntimeModule;

--- a/packages/jwt/src/refresh-token.test.ts
+++ b/packages/jwt/src/refresh-token.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+
+import { JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
+import { RefreshTokenService, type RefreshTokenRecord, type RefreshTokenStore } from './refresh-token.js';
+import { DefaultJwtSigner } from './signer.js';
+import { DefaultJwtVerifier } from './verifier.js';
+
+class InMemoryRefreshTokenStore implements RefreshTokenStore {
+  private readonly records = new Map<string, RefreshTokenRecord>();
+
+  async save(token: RefreshTokenRecord): Promise<void> {
+    this.records.set(token.id, token);
+  }
+
+  async find(tokenId: string): Promise<RefreshTokenRecord | undefined> {
+    return this.records.get(tokenId);
+  }
+
+  async revoke(tokenId: string): Promise<void> {
+    this.records.delete(tokenId);
+  }
+
+  async revokeBySubject(subject: string): Promise<void> {
+    for (const [id, record] of this.records.entries()) {
+      if (record.subject === subject) {
+        this.records.delete(id);
+      }
+    }
+  }
+
+  countBySubject(subject: string): number {
+    let count = 0;
+
+    for (const record of this.records.values()) {
+      if (record.subject === subject) {
+        count += 1;
+      }
+    }
+
+    return count;
+  }
+
+  markExpired(tokenId: string): void {
+    const record = this.records.get(tokenId);
+
+    if (!record) {
+      return;
+    }
+
+    this.records.set(tokenId, {
+      ...record,
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+  }
+}
+
+function readTokenPayload(token: string): Record<string, unknown> {
+  const [, payloadSegment] = token.split('.');
+  return JSON.parse(Buffer.from(payloadSegment, 'base64url').toString('utf8')) as Record<string, unknown>;
+}
+
+describe('RefreshTokenService', () => {
+  it('issues a refresh token with expected claims', async () => {
+    const store = new InMemoryRefreshTokenStore();
+    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const service = new RefreshTokenService(
+      {
+        expiresInSeconds: 3600,
+        rotation: true,
+        secret: 'refresh-secret',
+        store,
+      },
+      signer,
+      verifier,
+    );
+
+    const refreshToken = await service.issueRefreshToken('user-1');
+    const payload = readTokenPayload(refreshToken);
+
+    expect(payload.sub).toBe('user-1');
+    expect(payload.type).toBe('refresh');
+    expect(typeof payload.jti).toBe('string');
+    expect(typeof payload.family).toBe('string');
+  });
+
+  it('rotates refresh token and marks previous token as used', async () => {
+    const store = new InMemoryRefreshTokenStore();
+    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const service = new RefreshTokenService(
+      {
+        expiresInSeconds: 3600,
+        rotation: true,
+        secret: 'refresh-secret',
+        store,
+      },
+      signer,
+      verifier,
+    );
+    const firstToken = await service.issueRefreshToken('user-1');
+    const firstPayload = readTokenPayload(firstToken);
+    const firstRecord = await store.find(firstPayload.jti as string);
+
+    expect(firstRecord?.used).toBe(false);
+
+    const rotated = await service.rotateRefreshToken(firstToken);
+    const newPayload = readTokenPayload(rotated.refreshToken);
+    const updatedFirstRecord = await store.find(firstPayload.jti as string);
+    const newRecord = await store.find(newPayload.jti as string);
+
+    expect(rotated.accessToken).toContain('.');
+    expect(updatedFirstRecord?.used).toBe(true);
+    expect(newRecord?.used).toBe(false);
+    expect(newPayload.family).toBe(firstPayload.family);
+  });
+
+  it('detects refresh token reuse and revokes all tokens for the subject', async () => {
+    const store = new InMemoryRefreshTokenStore();
+    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const service = new RefreshTokenService(
+      {
+        expiresInSeconds: 3600,
+        rotation: true,
+        secret: 'refresh-secret',
+        store,
+      },
+      signer,
+      verifier,
+    );
+    const token = await service.issueRefreshToken('user-1');
+
+    await service.rotateRefreshToken(token);
+    await expect(service.rotateRefreshToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+    expect(store.countBySubject('user-1')).toBe(0);
+  });
+
+  it('revokeAllForSubject removes all subject tokens', async () => {
+    const store = new InMemoryRefreshTokenStore();
+    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const service = new RefreshTokenService(
+      {
+        expiresInSeconds: 3600,
+        rotation: true,
+        secret: 'refresh-secret',
+        store,
+      },
+      signer,
+      verifier,
+    );
+
+    await service.issueRefreshToken('user-1');
+    await service.issueRefreshToken('user-1');
+    expect(store.countBySubject('user-1')).toBe(2);
+
+    await service.revokeAllForSubject('user-1');
+    expect(store.countBySubject('user-1')).toBe(0);
+  });
+
+  it('rejects expired refresh token records', async () => {
+    const store = new InMemoryRefreshTokenStore();
+    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
+    const service = new RefreshTokenService(
+      {
+        expiresInSeconds: 3600,
+        rotation: true,
+        secret: 'refresh-secret',
+        store,
+      },
+      signer,
+      verifier,
+    );
+    const token = await service.issueRefreshToken('user-1');
+    const payload = readTokenPayload(token);
+
+    store.markExpired(payload.jti as string);
+
+    await expect(service.rotateRefreshToken(token)).rejects.toBeInstanceOf(JwtExpiredTokenError);
+  });
+});

--- a/packages/jwt/src/refresh-token.ts
+++ b/packages/jwt/src/refresh-token.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from 'node:crypto';
+
+import { JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
+import { DefaultJwtSigner } from './signer.js';
+import type { JwtClaims } from './types.js';
+import { DefaultJwtVerifier } from './verifier.js';
+
+export interface RefreshTokenStore {
+  save(token: RefreshTokenRecord): Promise<void>;
+  find(tokenId: string): Promise<RefreshTokenRecord | undefined>;
+  revoke(tokenId: string): Promise<void>;
+  revokeBySubject(subject: string): Promise<void>;
+}
+
+export interface RefreshTokenRecord {
+  id: string;
+  subject: string;
+  family: string;
+  expiresAt: Date;
+  used: boolean;
+  createdAt: Date;
+}
+
+export interface RefreshTokenOptions {
+  secret: string;
+  expiresInSeconds: number;
+  rotation: boolean;
+  store: RefreshTokenStore;
+}
+
+interface RefreshTokenClaims extends JwtClaims {
+  family: string;
+  jti: string;
+  type: 'refresh';
+}
+
+export class RefreshTokenService {
+  constructor(
+    private readonly options: RefreshTokenOptions,
+    private readonly signer: DefaultJwtSigner,
+    private readonly verifier: DefaultJwtVerifier,
+  ) {}
+
+  async issueRefreshToken(subject: string): Promise<string> {
+    const family = randomUUID();
+
+    return this.issueRefreshTokenWithFamily(subject, family);
+  }
+
+  async rotateRefreshToken(currentToken: string): Promise<{ accessToken: string; refreshToken: string }> {
+    const claims = await this.verifyRefreshClaims(currentToken);
+    const record = await this.options.store.find(claims.jti);
+
+    if (!record) {
+      throw new JwtInvalidTokenError('Refresh token record was not found.');
+    }
+
+    if (record.subject !== claims.sub || record.family !== claims.family) {
+      throw new JwtInvalidTokenError('Refresh token record does not match token claims.');
+    }
+
+    if (record.expiresAt.getTime() <= Date.now()) {
+      throw new JwtExpiredTokenError('Refresh token has expired.');
+    }
+
+    if (record.used) {
+      await this.options.store.revokeBySubject(record.subject);
+      throw new JwtInvalidTokenError('Refresh token reuse detected.');
+    }
+
+    if (this.options.rotation) {
+      await this.options.store.save({ ...record, used: true });
+      const refreshToken = await this.issueRefreshTokenWithFamily(record.subject, record.family);
+      const accessToken = await this.signer.signAccessToken({ sub: record.subject });
+
+      return { accessToken, refreshToken };
+    }
+
+    const accessToken = await this.signer.signAccessToken({ sub: record.subject });
+    return { accessToken, refreshToken: currentToken };
+  }
+
+  async revokeRefreshToken(tokenId: string): Promise<void> {
+    await this.options.store.revoke(tokenId);
+  }
+
+  async revokeAllForSubject(subject: string): Promise<void> {
+    await this.options.store.revokeBySubject(subject);
+  }
+
+  private async issueRefreshTokenWithFamily(subject: string, family: string): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    const tokenId = randomUUID();
+    const expiresAt = new Date((now + this.options.expiresInSeconds) * 1000);
+
+    await this.options.store.save({
+      createdAt: new Date(now * 1000),
+      expiresAt,
+      family,
+      id: tokenId,
+      subject,
+      used: false,
+    });
+
+    const claims: RefreshTokenClaims = {
+      exp: Math.floor(expiresAt.getTime() / 1000),
+      family,
+      iat: now,
+      jti: tokenId,
+      sub: subject,
+      type: 'refresh',
+    };
+
+    return this.signer.signAccessToken(claims);
+  }
+
+  private async verifyRefreshClaims(token: string): Promise<RefreshTokenClaims & { sub: string }> {
+    const principal = await this.verifier.verifyAccessToken(token);
+    const claims = principal.claims;
+
+    if (claims.type !== 'refresh') {
+      throw new JwtInvalidTokenError('JWT is not a refresh token.');
+    }
+
+    if (typeof claims.jti !== 'string' || claims.jti.length === 0) {
+      throw new JwtInvalidTokenError('Refresh token is missing jti.');
+    }
+
+    if (typeof claims.family !== 'string' || claims.family.length === 0) {
+      throw new JwtInvalidTokenError('Refresh token is missing family.');
+    }
+
+    if (typeof claims.sub !== 'string' || claims.sub.length === 0) {
+      throw new JwtInvalidTokenError('Refresh token is missing sub.');
+    }
+
+    return {
+      ...claims,
+      family: claims.family,
+      jti: claims.jti,
+      sub: claims.sub,
+      type: 'refresh',
+    };
+  }
+}

--- a/packages/jwt/src/signer.test.ts
+++ b/packages/jwt/src/signer.test.ts
@@ -1,9 +1,13 @@
-import { generateKeyPairSync } from 'node:crypto';
+import { generateKeyPairSync, sign, verify } from 'node:crypto';
 
 import { describe, expect, it } from 'vitest';
 
 import { DefaultJwtSigner } from './signer.js';
 import { DefaultJwtVerifier } from './verifier.js';
+
+function encodeBase64Url(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
 
 describe('DefaultJwtSigner', () => {
   it('creates an access token that the verifier accepts (HS256)', async () => {
@@ -136,6 +140,62 @@ describe('DefaultJwtSigner', () => {
         subject: 'user-es256',
       }),
     );
+  });
+
+  it('verifies ES256 token signed with raw crypto.sign using ieee-p1363', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const now = Math.floor(Date.now() / 1000);
+    const headerSegment = encodeBase64Url(JSON.stringify({ alg: 'ES256', typ: 'JWT' }));
+    const payloadSegment = encodeBase64Url(JSON.stringify({ exp: now + 60, iss: 'tests', sub: 'interop-es256' }));
+    const signingInput = `${headerSegment}.${payloadSegment}`;
+    const signatureSegment = sign('sha256', Buffer.from(signingInput), { dsaEncoding: 'ieee-p1363', key: privateKey }).toString(
+      'base64url',
+    );
+    const token = `${headerSegment}.${payloadSegment}.${signatureSegment}`;
+
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['ES256'],
+      issuer: 'tests',
+      publicKey,
+    });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'interop-es256',
+    });
+  });
+
+  it('creates ES256 token verifiable by raw crypto.verify using ieee-p1363', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const signer = new DefaultJwtSigner({
+      algorithms: ['ES256'],
+      issuer: 'tests',
+      privateKey,
+    });
+    const token = await signer.signAccessToken({ sub: 'interop-es256-signer' });
+    const [headerSegment, payloadSegment, signatureSegment] = token.split('.');
+    const signingInput = `${headerSegment}.${payloadSegment}`;
+    const signature = Buffer.from(signatureSegment, 'base64url');
+    const valid = verify('sha256', Buffer.from(signingInput), { dsaEncoding: 'ieee-p1363', key: publicKey }, signature);
+
+    expect(valid).toBe(true);
+  });
+
+  it('uses RFC7518 signature lengths for ES algorithms', async () => {
+    const es256 = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const es384 = generateKeyPairSync('ec', { namedCurve: 'P-384' });
+    const es512 = generateKeyPairSync('ec', { namedCurve: 'P-521' });
+
+    const signer256 = new DefaultJwtSigner({ algorithms: ['ES256'], privateKey: es256.privateKey });
+    const signer384 = new DefaultJwtSigner({ algorithms: ['ES384'], privateKey: es384.privateKey });
+    const signer512 = new DefaultJwtSigner({ algorithms: ['ES512'], privateKey: es512.privateKey });
+
+    const token256 = await signer256.signAccessToken({ sub: 'es256-len' });
+    const token384 = await signer384.signAccessToken({ sub: 'es384-len' });
+    const token512 = await signer512.signAccessToken({ sub: 'es512-len' });
+
+    expect(Buffer.from(token256.split('.')[2], 'base64url')).toHaveLength(64);
+    expect(Buffer.from(token384.split('.')[2], 'base64url')).toHaveLength(96);
+    expect(Buffer.from(token512.split('.')[2], 'base64url')).toHaveLength(132);
   });
 
   it('sign + verify roundtrip with RS256 using kid-keyed key entry', async () => {

--- a/packages/jwt/src/signer.ts
+++ b/packages/jwt/src/signer.ts
@@ -68,7 +68,10 @@ export class DefaultJwtSigner {
 
       const signer = createSign(hash);
       signer.update(signingInput);
-      signatureSegment = signer.sign(privateKey, 'base64url');
+      const isEc = algorithm.startsWith('ES');
+      signatureSegment = isEc
+        ? signer.sign({ dsaEncoding: 'ieee-p1363', key: privateKey } as Parameters<typeof signer.sign>[0], 'base64url')
+        : signer.sign(privateKey, 'base64url');
     } else {
       const secret = activeKey?.secret ?? this.options.secret;
 

--- a/packages/jwt/src/types.ts
+++ b/packages/jwt/src/types.ts
@@ -1,5 +1,7 @@
 import type { KeyObject } from 'node:crypto';
 
+import type { RefreshTokenOptions } from './refresh-token.js';
+
 export type JwtAlgorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256' | 'RS384' | 'RS512' | 'ES256' | 'ES384' | 'ES512';
 
 export interface JwtKeyEntry {
@@ -15,11 +17,16 @@ export interface JwtVerifierOptions {
   audience?: string | string[];
   clockSkewSeconds?: number;
   issuer?: string;
+  jwksCacheTtl?: number;
+  jwksUri?: string;
   keys?: JwtKeyEntry[];
+  maxAge?: number;
   requireExp?: boolean;
+  secretOrKeyProvider?: (header: { alg: string; kid?: string; [key: string]: unknown }) => Promise<string | KeyObject>;
   secret?: string;
   privateKey?: string | KeyObject;
   publicKey?: string | KeyObject;
+  refreshToken?: RefreshTokenOptions;
 }
 
 export interface JwtClaims extends Record<string, unknown> {

--- a/packages/jwt/src/verifier.test.ts
+++ b/packages/jwt/src/verifier.test.ts
@@ -1,6 +1,6 @@
 import { createHmac, createSign, generateKeyPairSync } from 'node:crypto';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
 import { DefaultJwtVerifier } from './verifier.js';
@@ -166,7 +166,7 @@ describe('DefaultJwtVerifier', () => {
     const payloadSegment = encodeBase64Url(JSON.stringify(payload));
     const signer = createSign('sha256');
     signer.update(`${headerSegment}.${payloadSegment}`);
-    const signatureSegment = signer.sign(privateKey, 'base64url');
+    const signatureSegment = signer.sign({ dsaEncoding: 'ieee-p1363', key: privateKey }, 'base64url');
     const token = `${headerSegment}.${payloadSegment}.${signatureSegment}`;
 
     const verifier = new DefaultJwtVerifier({
@@ -189,7 +189,7 @@ describe('DefaultJwtVerifier', () => {
     const payloadSegment = encodeBase64Url(JSON.stringify(payload));
     const signer = createSign('sha256');
     signer.update(`${headerSegment}.${payloadSegment}`);
-    const signatureSegment = signer.sign(privateKey, 'base64url');
+    const signatureSegment = signer.sign({ dsaEncoding: 'ieee-p1363', key: privateKey }, 'base64url');
     const token = `${headerSegment}.${payloadSegment}.${signatureSegment}`;
 
     const verifier = new DefaultJwtVerifier({
@@ -246,6 +246,16 @@ describe('DefaultJwtVerifier', () => {
     });
   });
 
+  it('rejects a token without exp by default', async () => {
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      secret: 'secret',
+    });
+    const token = signToken({ sub: 'user-no-exp' }, 'secret');
+
+    await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+  });
+
   it('rejects a token without exp when requireExp is true', async () => {
     const verifier = new DefaultJwtVerifier({
       algorithms: ['HS256'],
@@ -257,15 +267,103 @@ describe('DefaultJwtVerifier', () => {
     await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
   });
 
-  it('accepts a token without exp when requireExp is not set', async () => {
+  it('accepts a token without exp when requireExp is false', async () => {
     const verifier = new DefaultJwtVerifier({
       algorithms: ['HS256'],
+      requireExp: false,
       secret: 'secret',
     });
     const token = signToken({ sub: 'user-no-exp' }, 'secret');
 
     await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
       subject: 'user-no-exp',
+    });
+  });
+
+  it('accepts a token with exp under default requireExp behavior', async () => {
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      secret: 'secret',
+    });
+    const token = signToken({ exp: Math.floor(Date.now() / 1000) + 60, sub: 'user-with-exp' }, 'secret');
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'user-with-exp',
+    });
+  });
+
+  it('rejects tokens older than maxAge', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      maxAge: 10,
+      secret: 'secret',
+    });
+    const token = signToken({ exp: now + 60, iat: now - 30, sub: 'too-old' }, 'secret');
+
+    await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtExpiredTokenError);
+  });
+
+  it('accepts tokens within maxAge', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      maxAge: 30,
+      secret: 'secret',
+    });
+    const token = signToken({ exp: now + 60, iat: now - 10, sub: 'fresh-enough' }, 'secret');
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'fresh-enough',
+    });
+  });
+
+  it('calls secretOrKeyProvider with header and verifies token', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const token = signToken({ exp: now + 60, sub: 'provider-user' }, 'secret', { alg: 'HS256', kid: 'k1', typ: 'JWT' });
+    const provider = vi.fn(async (header: { alg: string; kid?: string }) => {
+      expect(header.alg).toBe('HS256');
+      expect(header.kid).toBe('k1');
+      return 'secret';
+    });
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      secretOrKeyProvider: provider,
+    });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'provider-user',
+    });
+    expect(provider).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects token when secretOrKeyProvider returns wrong key', async () => {
+    const token = signToken({ exp: Math.floor(Date.now() / 1000) + 60, sub: 'provider-user' }, 'secret');
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      secretOrKeyProvider: async () => 'wrong-secret',
+    });
+
+    await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+  });
+
+  it('verifies RS256 token when secretOrKeyProvider returns public key', async () => {
+    const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const headerSegment = encodeBase64Url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+    const payloadSegment = encodeBase64Url(JSON.stringify({ exp, sub: 'provider-rs-user' }));
+    const signer = createSign('sha256');
+    signer.update(`${headerSegment}.${payloadSegment}`);
+    const signatureSegment = signer.sign(privateKey, 'base64url');
+    const token = `${headerSegment}.${payloadSegment}.${signatureSegment}`;
+
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      secretOrKeyProvider: async () => publicKey,
+    });
+
+    await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
+      subject: 'provider-rs-user',
     });
   });
 });

--- a/packages/jwt/src/verifier.ts
+++ b/packages/jwt/src/verifier.ts
@@ -4,6 +4,7 @@ import type { KeyObject } from 'node:crypto';
 import { Inject } from '@konekti/core';
 
 import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
+import { JwksClient } from './jwks.js';
 import type { JwtAlgorithm, JwtClaims, JwtPrincipal, JwtVerifierOptions } from './types.js';
 
 export const JWT_OPTIONS = Symbol.for('konekti.jwt.options');
@@ -62,7 +63,14 @@ function verifyAsymmetricSignature(
 
   const verifier = createVerify(hash);
   verifier.update(signingInput);
-  const valid = verifier.verify(publicKey, signatureSegment, 'base64url');
+  const isEc = algorithm.startsWith('ES');
+  const valid = verifier.verify(
+    isEc
+      ? ({ dsaEncoding: 'ieee-p1363', key: publicKey } as Parameters<typeof verifier.verify>[0])
+      : publicKey,
+    signatureSegment,
+    'base64url',
+  );
   if (!valid) {
     throw new JwtInvalidTokenError();
   }
@@ -117,7 +125,11 @@ function normalizePrincipal(claims: JwtClaims): JwtPrincipal {
 
 @Inject([JWT_OPTIONS])
 export class DefaultJwtVerifier {
-  constructor(private readonly options: JwtVerifierOptions) {}
+  private readonly jwksClient: JwksClient | undefined;
+
+  constructor(private readonly options: JwtVerifierOptions) {
+    this.jwksClient = options.jwksUri ? new JwksClient(options.jwksUri, options.jwksCacheTtl) : undefined;
+  }
 
   async verifyAccessToken(token: string): Promise<JwtPrincipal> {
     const segments = token.split('.');
@@ -127,7 +139,7 @@ export class DefaultJwtVerifier {
     }
 
     const [headerSegment, payloadSegment, signatureSegment] = segments;
-    const header = parseJwtPart<{ alg?: string; typ?: string; kid?: string }>(headerSegment);
+    const header = parseJwtPart<{ [key: string]: unknown; alg?: string; kid?: string; typ?: string }>(headerSegment);
     const payload = parseJwtPart<JwtClaims>(payloadSegment);
     const algorithms = this.options.algorithms;
 
@@ -138,10 +150,19 @@ export class DefaultJwtVerifier {
     const signingInput = `${headerSegment}.${payloadSegment}`;
 
     if (header.alg in HMAC_HASH) {
+      const providerKey = this.options.secretOrKeyProvider
+        ? await this.options.secretOrKeyProvider({ alg: header.alg, ...header })
+        : undefined;
+
+      if (providerKey !== undefined && typeof providerKey !== 'string') {
+        throw new JwtConfigurationError('secretOrKeyProvider must return a string for HMAC algorithms.');
+      }
+
       const secret =
-        (header.kid !== undefined && header.kid !== ''
+        providerKey ??
+        ((header.kid !== undefined && header.kid !== ''
           ? this.options.keys?.find((k) => k.kid === header.kid)?.secret
-          : undefined) ?? this.options.secret;
+          : undefined) ?? this.options.secret);
 
       if (!secret) {
         throw new JwtConfigurationError('JWT secret is not configured.');
@@ -149,10 +170,16 @@ export class DefaultJwtVerifier {
 
       verifyHmacSignature(header.alg, secret, signingInput, signatureSegment);
     } else {
+      const providerKey = this.options.secretOrKeyProvider
+        ? await this.options.secretOrKeyProvider({ alg: header.alg, ...header })
+        : undefined;
       const publicKey =
-        (header.kid !== undefined && header.kid !== ''
-          ? this.options.keys?.find((k) => k.kid === header.kid)?.publicKey
-          : undefined) ?? this.options.publicKey;
+        providerKey ??
+        (this.jwksClient
+          ? await this.resolveJwksPublicKey(header.kid)
+          : ((header.kid !== undefined && header.kid !== ''
+              ? this.options.keys?.find((k) => k.kid === header.kid)?.publicKey
+              : undefined) ?? this.options.publicKey));
 
       if (!publicKey) {
         throw new JwtConfigurationError('JWT public key is not configured.');
@@ -164,8 +191,12 @@ export class DefaultJwtVerifier {
     const now = Math.floor(Date.now() / 1000);
     const clockSkew = this.options.clockSkewSeconds ?? 0;
 
-    if (this.options.requireExp && typeof payload.exp !== 'number') {
+    if (this.options.requireExp !== false && typeof payload.exp !== 'number') {
       throw new JwtInvalidTokenError('JWT is missing a required expiration claim.');
+    }
+
+    if (typeof this.options.maxAge === 'number' && typeof payload.iat === 'number' && now - payload.iat > this.options.maxAge) {
+      throw new JwtExpiredTokenError('JWT exceeds maxAge.');
     }
 
     if (typeof payload.exp === 'number' && payload.exp + clockSkew < now) {
@@ -190,5 +221,17 @@ export class DefaultJwtVerifier {
     }
 
     return normalizePrincipal(payload);
+  }
+
+  private async resolveJwksPublicKey(kid: string | undefined): Promise<KeyObject> {
+    if (!this.jwksClient) {
+      throw new JwtConfigurationError('JWKS client is not configured.');
+    }
+
+    if (typeof kid !== 'string' || kid.length === 0) {
+      throw new JwtInvalidTokenError('JWT is missing key id (kid) for JWKS resolution.');
+    }
+
+    return this.jwksClient.getSigningKey(kid);
   }
 }


### PR DESCRIPTION
## Summary

Closes #94

### Changes

1. **ES256/384/512 IEEE-P1363 signature format** (RFC 7518 §3.4): EC algorithms now use `dsaEncoding: 'ieee-p1363'` for both signing and verification, producing standard R‖S format signatures (64/96/132 bytes). Tokens are now interoperable with jose, jsonwebtoken, Auth0, and other standard JWT libraries.

2. **`exp` claim enforcement by default**: `requireExp` now defaults to `true` — tokens without an `exp` claim are rejected unless `requireExp: false` is explicitly set. Also added `maxAge` option to enforce absolute token age from `iat`.

3. **JWKS / remote key provider support**: 
   - `secretOrKeyProvider` callback for dynamic key resolution based on token header (kid, alg)
   - `jwksUri` + `jwksCacheTtl` options for automatic JWKS endpoint fetching with TTL-based caching
   - New `JwksClient` class handles fetch, JWK→KeyObject conversion, and cache management

4. **Refresh token rotation**: New `RefreshTokenService` with `RefreshTokenStore` interface for:
   - Token issuance with family-based tracking
   - Rotation (each use issues new refresh + access token)
   - Reuse detection (used token triggers full family revocation)
   - Per-subject revocation (logout everywhere)
   - Module integration via `JwtModule.forRoot({ refreshToken: {...} })`

### Testing

- 42 tests pass across 5 test files (verifier: 19, signer: 10, jwks: 4, refresh-token: 5, module: 4)
- New tests cover P1363 interop with raw crypto, signature byte lengths, default exp rejection, maxAge enforcement, secretOrKeyProvider scenarios, JWKS fetch/cache/TTL, and full refresh token lifecycle