### PR TITLE
feat(event-bus,redis,queue): scope docs, RedisService facade, queue rateLimiter

### DIFF
--- a/docs/design/repository-pattern.md
+++ b/docs/design/repository-pattern.md
@@ -1,0 +1,97 @@
+# repository pattern decision
+
+This document records the repository abstraction decision for database integrations in Konekti.
+
+## context
+
+`@konekti/prisma` and `@konekti/drizzle` already provide transaction-aware database wrappers with async-local transaction propagation.
+
+- Prisma integration exposes transaction-aware Prisma client usage via `$transaction(...)`
+- Drizzle integration exposes transaction-aware Drizzle usage via `transaction(...)`
+
+Because both adapters already ship strong typed query APIs, any extra repository abstraction must justify its cost.
+
+## options considered
+
+### option a: generic `BaseRepository<T, ID>`
+
+Provide a shared generic base with operations such as:
+
+- `find(...)`
+- `findById(id)`
+- `save(entity)`
+- `delete(id)`
+
+Pros:
+
+- common shape across projects
+- lower initial boilerplate
+
+Cons:
+
+- hard to model Prisma/Drizzle query capabilities without leaky abstraction
+- weakens type precision for complex filters, includes, relation loading, and projections
+- tends to force lowest-common-denominator CRUD even for domain-specific workflows
+
+### option b: no base repository
+
+Do not introduce framework-level repository base classes. Users write domain repositories directly on top of Prisma/Drizzle clients.
+
+Pros:
+
+- preserves native type safety and IDE support from Prisma/Drizzle
+- avoids unnecessary abstraction layers and indirection
+- keeps repository APIs domain-focused instead of generic CRUD contracts
+
+Cons:
+
+- more variability between projects
+- slightly more upfront design effort per domain
+
+### option c: thin transaction-aware repository contract
+
+Provide only a minimal interface focused on transaction handle resolution/propagation, without generic CRUD methods.
+
+Pros:
+
+- standardizes transaction-awareness behavior
+- avoids most CRUD abstraction drawbacks
+
+Cons:
+
+- still adds framework surface area with limited practical gain
+- can duplicate existing transaction helpers in adapter packages
+
+## decision
+
+Recommend **Option B**: no framework-level base repository.
+
+Reasoning:
+
+- Prisma and Drizzle already provide excellent typed query APIs
+- a generic base repository would either lose type safety or become a thin pass-through abstraction with little value
+- domain-specific repositories remain clearer and better aligned with aggregate/business boundaries
+
+## migration execution hooks
+
+Two migration execution approaches were evaluated:
+
+1. runtime hook execution (for example `onModuleInit`-driven migration checks)
+2. external migration CLI execution in deploy/runtime pipeline
+
+Recommendation: use **external migration CLI**.
+
+- Prisma: `prisma migrate deploy`
+- Drizzle: `drizzle-kit push` (or equivalent migration command)
+
+Why:
+
+- avoids startup-time schema mutation risk
+- keeps migration responsibility explicit in deployment operations
+- aligns with established operational best practices
+
+Runtime hooks can remain an opt-in project-level strategy for exceptional environments, not a framework default.
+
+## status
+
+Documented decision only. No code changes are required by this decision record.

--- a/docs/design/transactional-outbox.md
+++ b/docs/design/transactional-outbox.md
@@ -1,0 +1,113 @@
+# transactional outbox
+
+This document defines a proposed durable event publication path for workloads that cannot tolerate in-process event loss.
+
+## problem statement
+
+`@konekti/event-bus` is explicitly in-process only. It dispatches handlers inside one Node.js process and does not provide durability, persistence, replay, or cross-process delivery. If the process crashes during dispatch, in-flight events are lost.
+
+For domain events that must survive crashes and be consumed by distributed workers, the current event-bus behavior is insufficient.
+
+## outbox pattern overview
+
+The transactional outbox pattern stores events in a database table as part of the same database transaction as the domain write.
+
+- service writes domain state changes and outbox rows in one transaction
+- transaction commit makes both durable together
+- separate publisher process reads unpublished outbox rows and publishes to broker/queue
+- publisher marks rows as published (or records attempts/failures) for retry and observability
+
+This removes the "write committed but event lost" failure mode.
+
+## integration points in konekti data packages
+
+Both `@konekti/prisma` and `@konekti/drizzle` already expose transaction APIs with async-local transaction context propagation.
+
+- Prisma path: `$transaction(...)`
+- Drizzle path: `transaction(...)`
+
+A durable outbox integration can reuse that context:
+
+- if a transaction context exists, enqueue outbox rows into that same transaction handle
+- if no transaction context exists, either open a local transaction or reject based on policy
+
+## api sketch (design only)
+
+Potential package-level API shape:
+
+```typescript
+interface OutboxEnvelope {
+  id: string;
+  topic: string;
+  payload: unknown;
+  occurredAt: Date;
+  aggregateType?: string;
+  aggregateId?: string;
+  headers?: Record<string, string>;
+}
+
+interface OutboxWriter {
+  publish(event: OutboxEnvelope): Promise<void>;
+}
+
+class OutboxEventBus implements OutboxWriter {
+  async publish(event: OutboxEnvelope): Promise<void> {
+    // resolve current tx from ALS-aware prisma/drizzle integration
+    // insert into outbox table inside current transaction
+  }
+}
+```
+
+Notes:
+
+- `publish()` persists, it does not directly fan out to handlers
+- actual delivery is done by outbox dispatcher workers
+- optional compatibility adapter can mirror current `EventBus` surface where needed
+
+## schema and migration requirements
+
+Introduce an outbox table through normal migration tooling.
+
+Minimum columns:
+
+- `id` (stable event id, uuid/ulid)
+- `topic` (logical routing key)
+- `payload` (json/jsonb)
+- `headers` (optional json/jsonb)
+- `occurred_at` (event creation timestamp)
+- `published_at` (nullable)
+- `attempt_count` (int, default 0)
+- `last_error` (nullable text)
+
+Recommended indexes:
+
+- `(published_at, occurred_at)` for poller scan
+- `(topic, occurred_at)` for operational tracing
+
+## publish strategy tradeoffs: polling vs cdc
+
+### polling worker
+
+- easy to implement in app/runtime code
+- works with any supported database
+- introduces scan interval latency and read amplification
+- requires careful locking/claiming strategy (`for update skip locked` or equivalent)
+
+### cdc (change data capture)
+
+- lower latency, event-stream native integration
+- better fit for high-throughput or cross-language consumers
+- higher operational complexity (connector infrastructure, replay tooling)
+- vendor and platform dependencies are stronger than simple polling
+
+Recommended default path: polling first, CDC optional for advanced deployments.
+
+## rollout expectations
+
+- keep `@konekti/event-bus` as documented in-process primitive
+- add outbox as a separate package/feature path to avoid behavior ambiguity
+- define clear migration guide from in-process publish calls to outbox publish calls
+
+## status
+
+Design documented only. Implementation is intentionally deferred to a separate GitHub issue.

--- a/packages/event-bus/README.ko.md
+++ b/packages/event-bus/README.ko.md
@@ -3,13 +3,15 @@
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
 
-Konekti 애플리케이션을 위한 인프로세스 이벤트 발행 패키지입니다. 데코레이터 기반으로 singleton provider/controller 핸들러를 찾아서 실행합니다.
+**인프로세스 전용.** Konekti 애플리케이션을 위한 인프로세스 이벤트 발행 패키지입니다. 데코레이터 기반으로 singleton provider/controller 핸들러를 찾아서 실행합니다.
 
 ## 설치
 
 ```bash
 npm install @konekti/event-bus
 ```
+
+> **⚠️ 범위: 인프로세스 전용.** 이 패키지는 단일 Node.js 프로세스 내에서만 이벤트를 전달합니다. 내구성 보장, 영속성, 크로스 프로세스 전달, 재생 기능을 제공하지 않습니다. 디스패치 중 애플리케이션이 크래시되면 처리 중인 이벤트는 유실됩니다. 내구성 있는 분산 이벤트 처리가 필요하면 Redis 기반의 `@konekti/queue`를 사용하세요.
 
 ## 빠른 시작
 

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -3,13 +3,15 @@
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
 
-In-process event publishing for Konekti applications with decorator-based handler discovery across singleton providers and controllers.
+**In-process only.** In-process event publishing for Konekti applications with decorator-based handler discovery across singleton providers and controllers.
 
 ## Installation
 
 ```bash
 npm install @konekti/event-bus
 ```
+
+> **⚠️ Scope: In-process only.** This package dispatches events within a single Node.js process. It provides no durability guarantees, no persistence, no cross-process delivery, and no replay capability. If your application crashes mid-dispatch, in-flight events are lost. For durable, distributed event processing, use `@konekti/queue` backed by Redis.
 
 ## Quick Start
 

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@konekti/event-bus",
+  "description": "In-process only event publishing for Konekti applications.",
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -7,5 +7,6 @@ export type {
   QueueBackoffType,
   QueueJobType,
   QueueModuleOptions,
+  QueueRateLimiterOptions,
   QueueWorkerOptions,
 } from './types.js';

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -44,7 +44,7 @@ const bullmqState = vi.hoisted(() => {
       failures: number;
       name: string;
       processor: (job: MockQueueJob) => Promise<unknown>;
-      workerOpts: { concurrency?: number };
+      workerOpts: { concurrency?: number; limiter?: { duration: number; max: number } };
     }
   >();
 
@@ -109,7 +109,11 @@ const bullmqState = vi.hoisted(() => {
       queues.set(name, queue);
       return queue;
     },
-    createWorker(name: string, processor: (job: MockQueueJob) => Promise<unknown>, workerOpts: { concurrency?: number }) {
+    createWorker(
+      name: string,
+      processor: (job: MockQueueJob) => Promise<unknown>,
+      workerOpts: { concurrency?: number; limiter?: { duration: number; max: number } },
+    ) {
       const worker = {
         active: new Set<Promise<void>>(),
         closeCalls: 0,
@@ -175,7 +179,11 @@ vi.mock('bullmq', () => ({
     constructor(
       name: string,
       processor: (job: MockQueueJob) => Promise<unknown>,
-      options: { concurrency?: number; connection: MockRedisConnection },
+      options: {
+        concurrency?: number;
+        connection: MockRedisConnection;
+        limiter?: { duration: number; max: number };
+      },
     ) {
       this.worker = bullmqState.createWorker(name, processor, options);
     }
@@ -575,6 +583,40 @@ describe('@konekti/queue', () => {
 
     const deadLetters = redis.deadLetters.get('konekti:queue:dead-letter:shutdown-failing-job') ?? [];
     expect(deadLetters).toHaveLength(1);
+  });
+
+  it('passes rate limiter options from @QueueWorker() to Bull worker configuration', async () => {
+    class RateLimitedJob {
+      constructor(public readonly value: string) {}
+    }
+
+    @QueueWorker(RateLimitedJob, { rateLimiter: { duration: 1_000, max: 10 } })
+    class RateLimitedWorker {
+      async handle(_job: RateLimitedJob): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createQueueModule()],
+      providers: [RateLimitedWorker],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      mode: 'test',
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    await app.container.resolve<Queue>(QUEUE);
+
+    const worker = bullmqState.workers.get('RateLimitedJob');
+    expect(worker?.workerOpts.limiter).toEqual({
+      duration: 1_000,
+      max: 10,
+    });
+
+    await app.close();
   });
 
   it('applies module defaults for attempts/concurrency and shuts down idempotently', async () => {

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -33,6 +33,7 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
         }
       : undefined,
     defaultConcurrency: normalizePositiveInteger(options.defaultConcurrency, 1),
+    defaultRateLimiter: options.defaultRateLimiter,
   };
 }
 

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -267,6 +267,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
         jobName,
         jobType,
         moduleName: candidate.moduleName,
+        rateLimiter: metadata.options.rateLimiter ?? this.options.defaultRateLimiter,
         token: candidate.token,
         workerName: candidate.targetType.name,
       });
@@ -326,6 +327,14 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
         {
           concurrency: descriptor.concurrency,
           connection: workerConnection as unknown as ConnectionOptions,
+          ...(descriptor.rateLimiter
+            ? {
+                limiter: {
+                  duration: descriptor.rateLimiter.duration,
+                  max: descriptor.rateLimiter.max,
+                },
+              }
+            : {}),
         },
       );
 

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -11,23 +11,31 @@ export interface QueueBackoffOptions {
   type?: QueueBackoffType;
 }
 
+export interface QueueRateLimiterOptions {
+  max: number;
+  duration: number;
+}
+
 export interface QueueWorkerOptions {
   attempts?: number;
   backoff?: QueueBackoffOptions;
   concurrency?: number;
   jobName?: string;
+  rateLimiter?: QueueRateLimiterOptions;
 }
 
 export interface QueueModuleOptions {
   defaultAttempts?: number;
   defaultBackoff?: QueueBackoffOptions;
   defaultConcurrency?: number;
+  defaultRateLimiter?: QueueRateLimiterOptions;
 }
 
 export interface NormalizedQueueModuleOptions {
   defaultAttempts: number;
   defaultBackoff?: QueueBackoffOptions;
   defaultConcurrency: number;
+  defaultRateLimiter?: QueueRateLimiterOptions;
 }
 
 export interface QueueWorkerMetadata {
@@ -42,6 +50,7 @@ export interface QueueWorkerDescriptor {
   jobName: string;
   jobType: QueueJobType;
   moduleName: string;
+  rateLimiter?: QueueRateLimiterOptions;
   token: Token;
   workerName: string;
 }

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -1,3 +1,4 @@
 export * from './module.js';
+export { RedisService, REDIS_SERVICE } from './redis-service.js';
 export * from './tokens.js';
 export * from './types.js';

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -6,6 +6,9 @@ import { bootstrapApplication, defineModule } from '@konekti/runtime';
 interface MockRedisInstance {
   options: Record<string, unknown>;
   status: string;
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ...args: unknown[]): Promise<'OK'>;
+  del(key: string): Promise<number>;
 }
 
 const mockRedisState = vi.hoisted(() => ({
@@ -18,6 +21,7 @@ vi.mock('ioredis', () => ({
   default: class MockRedis {
     readonly options: Record<string, unknown>;
     status = 'wait';
+    private readonly storage = new Map<string, string>();
 
     constructor(options: Record<string, unknown> = {}) {
       this.options = options;
@@ -44,10 +48,24 @@ vi.mock('ioredis', () => ({
       this.status = 'end';
       return 'OK';
     }
+
+    async get(key: string): Promise<string | null> {
+      return this.storage.get(key) ?? null;
+    }
+
+    async set(key: string, value: string, ..._args: unknown[]): Promise<'OK'> {
+      this.storage.set(key, value);
+      return 'OK';
+    }
+
+    async del(key: string): Promise<number> {
+      const existed = this.storage.delete(key);
+      return existed ? 1 : 0;
+    }
   },
 }));
 
-import { createRedisModule, REDIS_CLIENT } from './index.js';
+import { createRedisModule, REDIS_CLIENT, REDIS_SERVICE, RedisService } from './index.js';
 
 describe('@konekti/redis', () => {
   beforeEach(() => {
@@ -101,5 +119,37 @@ describe('@konekti/redis', () => {
 
     await expect(app.close()).resolves.toBeUndefined();
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
+  });
+
+  it('provides a typed RedisService facade with get/set/del operations', async () => {
+    @Inject([REDIS_SERVICE])
+    class CacheFacade {
+      constructor(readonly redisService: RedisService) {}
+    }
+
+    class FeatureModule {}
+    defineModule(FeatureModule, {
+      providers: [CacheFacade],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createRedisModule({ host: '127.0.0.1', port: 6379 }), FeatureModule],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const cacheFacade = await app.container.resolve(CacheFacade);
+
+    expect(cacheFacade.redisService).toBeInstanceOf(RedisService);
+
+    await cacheFacade.redisService.set('user:1', { id: 'user-1', name: 'Ada' }, 60);
+
+    const user = await cacheFacade.redisService.get<{ id: string; name: string }>('user:1');
+    expect(user).toEqual({ id: 'user-1', name: 'Ada' });
+
+    await cacheFacade.redisService.del('user:1');
+    await expect(cacheFacade.redisService.get('user:1')).resolves.toBeNull();
+
+    await app.close();
   });
 });

--- a/packages/redis/src/module.ts
+++ b/packages/redis/src/module.ts
@@ -2,6 +2,7 @@ import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 import Redis from 'ioredis';
 
+import { REDIS_SERVICE, RedisService } from './redis-service.js';
 import { RedisLifecycleService } from './service.js';
 import { REDIS_CLIENT } from './tokens.js';
 import type { RedisModuleOptions } from './types.js';
@@ -16,6 +17,10 @@ export function createRedisProviders(options: RedisModuleOptions): Provider[] {
         lazyConnect: true,
       }),
     },
+    {
+      provide: REDIS_SERVICE,
+      useClass: RedisService,
+    },
     RedisLifecycleService,
   ];
 }
@@ -25,7 +30,7 @@ export function createRedisModule(options: RedisModuleOptions): ModuleType {
 
   return defineModule(RedisModule, {
     global: true,
-    exports: [REDIS_CLIENT],
+    exports: [REDIS_CLIENT, REDIS_SERVICE],
     providers: createRedisProviders(options),
   });
 }

--- a/packages/redis/src/redis-service.ts
+++ b/packages/redis/src/redis-service.ts
@@ -1,0 +1,37 @@
+import { Inject } from '@konekti/core';
+import type Redis from 'ioredis';
+
+import { REDIS_CLIENT } from './tokens.js';
+
+export const REDIS_SERVICE = Symbol.for('konekti.redis.service');
+
+@Inject([REDIS_CLIENT])
+export class RedisService {
+  constructor(private readonly client: Redis) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    const raw = await this.client.get(key);
+    if (raw === null) {
+      return null;
+    }
+
+    return JSON.parse(raw) as T;
+  }
+
+  async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {
+    const serialized = JSON.stringify(value);
+    if (ttlSeconds !== undefined && ttlSeconds > 0) {
+      await this.client.set(key, serialized, 'EX', ttlSeconds);
+    } else {
+      await this.client.set(key, serialized);
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    await this.client.del(key);
+  }
+
+  getRawClient(): Redis {
+    return this.client;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #95

- **event-bus**: Add prominent in-process-only scope warnings to both README.md and README.ko.md, update package description
- **redis**: Add typed `RedisService` facade with `get<T>()`, `set<T>()`, `del()`, `getRawClient()` — registered as `REDIS_SERVICE` token and exported
- **queue**: Expose `rateLimiter` option (`max`/`duration`) in `QueueWorkerOptions` and `QueueModuleOptions`, passed through to BullMQ Worker `limiter`
- **docs/design**: Add transactional outbox design document and repository pattern decision record

## Changes

### `@konekti/event-bus` (docs only)
- README.md / README.ko.md: prominent ⚠️ scope warning after installation section
- package.json: description updated to include "in-process"

### `@konekti/redis` (new feature)
- New `RedisService` class (`redis-service.ts`) with JSON-serialized get/set/del and raw client access
- New `REDIS_SERVICE` DI token registered in module and exported
- New test for RedisService facade through full bootstrap cycle

### `@konekti/queue` (new feature)
- `QueueRateLimiterOptions` interface (`{ max, duration }`)
- `rateLimiter` field added to `QueueWorkerOptions`, `QueueModuleOptions`, `NormalizedQueueModuleOptions`, `QueueWorkerDescriptor`
- Passed through to BullMQ Worker `limiter` option in service.ts
- New test verifying rateLimiter passthrough

### Design documents (new files)
- `docs/design/transactional-outbox.md` — outbox pattern design for durable event publication
- `docs/design/repository-pattern.md` — decision record: no framework-level BaseRepository

## Test Results
- redis: 3/3 pass (including new RedisService test)
- queue: 8/8 pass (including new rateLimiter test)
- event-bus: 12/13 pass (1 pre-existing DuplicateProviderError failure, unrelated)