### PR TITLE
feat(cron,metrics,websocket): distributed lock renewal, lifecycle hooks, MeterProvider, HTTP RED metrics, WebSocket rooms and heartbeat

### DIFF
--- a/packages/cron/src/decorators.ts
+++ b/packages/cron/src/decorators.ts
@@ -1,4 +1,5 @@
 import { metadataSymbol } from '@konekti/core';
+import { Cron as CronValidator } from 'croner';
 
 import type { CronTaskMetadata, CronTaskOptions } from './types.js';
 import { cronMetadataSymbol } from './metadata.js';
@@ -24,6 +25,12 @@ function defineStandardCronMetadata(metadata: unknown, propertyKey: string | sym
 }
 
 export function Cron(expression: string, options: CronTaskOptions = {}): MethodDecoratorLike {
+  try {
+    new CronValidator(expression, { maxRuns: 0 });
+  } catch {
+    throw new Error(`@Cron(): invalid cron expression "${expression}".`);
+  }
+
   const decorator = (_value: Function, context: ClassMethodDecoratorContext) => {
     if (context.private) {
       throw new Error('@Cron() cannot be used on private methods.');

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -36,8 +36,16 @@ class InMemoryLockRedisClient {
     return 'OK';
   }
 
-  async eval(_script: string, _keysLength: number, key: string, owner: string): Promise<number> {
+  async eval(script: string, _keysLength: number, key: string, owner: string, _ttl?: string): Promise<number> {
     if (this.locks.get(key) !== owner) {
+      return 0;
+    }
+
+    if (script.includes('PEXPIRE')) {
+      return 1;
+    }
+
+    if (!script.includes('DEL')) {
       return 0;
     }
 
@@ -548,5 +556,91 @@ describe('@konekti/cron', () => {
 
     await vi.advanceTimersByTimeAsync(2_000);
     expect(store.count).toBe(1);
+  });
+
+  it('throws during decoration when @Cron() expression is invalid', () => {
+    expect(() => {
+      class InvalidCronTask {
+        @Cron('not-a-cron')
+        run() {}
+      }
+
+      return InvalidCronTask;
+    }).toThrow('@Cron(): invalid cron expression "not-a-cron".');
+  });
+
+  it('runs lifecycle hooks around successful cron execution', async () => {
+    const scheduled = createManualScheduler();
+    const events: string[] = [];
+
+    class HookedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        afterRun: () => {
+          events.push('after');
+        },
+        beforeRun: () => {
+          events.push('before');
+        },
+        name: 'hooked-success-task',
+        onSuccess: () => {
+          events.push('success');
+        },
+      })
+      run() {
+        events.push('run');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCronModule({ scheduler: scheduled.scheduler })],
+      providers: [HookedTaskService],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+
+    await scheduled.records[0]!.tick();
+
+    expect(events).toEqual(['before', 'run', 'success', 'after']);
+
+    await app.close();
+  });
+
+  it('runs error lifecycle hooks when cron task fails', async () => {
+    const scheduled = createManualScheduler();
+    const events: string[] = [];
+
+    class HookedFailingTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        afterRun: () => {
+          events.push('after');
+        },
+        beforeRun: () => {
+          events.push('before');
+        },
+        name: 'hooked-failing-task',
+        onError: (error) => {
+          events.push(`error:${error instanceof Error ? error.message : 'unknown'}`);
+        },
+      })
+      run() {
+        events.push('run');
+        throw new Error('hook boom');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCronModule({ scheduler: scheduled.scheduler })],
+      providers: [HookedFailingTaskService],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+
+    await scheduled.records[0]!.tick();
+
+    expect(events).toEqual(['before', 'run', 'error:hook boom', 'after']);
+
+    await app.close();
   });
 });

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -21,6 +21,11 @@ interface RedisLockClient {
   set(key: string, value: string, mode: 'PX', ttl: number, existence: 'NX'): Promise<'OK' | null | undefined>;
 }
 
+const RELEASE_LOCK_SCRIPT =
+  'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end';
+const RENEW_LOCK_SCRIPT =
+  'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("PEXPIRE", KEYS[1], ARGV[2]) else return 0 end';
+
 interface DiscoveryCandidate {
   moduleName: string;
   scope: 'request' | 'singleton' | 'transient';
@@ -189,6 +194,8 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
         seenMethods.add(methodName);
         seen.set(candidate.token, seenMethods);
         descriptors.push({
+          afterRun: entry.metadata.options.afterRun,
+          beforeRun: entry.metadata.options.beforeRun,
           distributed: entry.metadata.options.distributed ?? true,
           expression: entry.metadata.expression,
           lockKey: createLockKey(this.options.distributed.keyPrefix, entry.metadata.options.key ?? taskName),
@@ -196,6 +203,8 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
           methodKey: entry.propertyKey,
           methodName,
           moduleName: candidate.moduleName,
+          onError: entry.metadata.options.onError,
+          onSuccess: entry.metadata.options.onSuccess,
           targetName: candidate.targetType.name,
           taskName,
           timezone: entry.metadata.options.timezone,
@@ -270,9 +279,15 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
       return;
     }
 
+    const renewalIntervalMs = Math.max(1_000, Math.floor(descriptor.lockTtlMs / 2));
+    const renewalTimer = setInterval(() => {
+      void this.renewLock(descriptor);
+    }, renewalIntervalMs);
+
     try {
       await this.executeTask(descriptor);
     } finally {
+      clearInterval(renewalTimer);
       await this.releaseLock(descriptor);
     }
   }
@@ -307,10 +322,24 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
       return;
     }
 
+    if (descriptor.beforeRun) {
+      await Promise.resolve(descriptor.beforeRun());
+    }
+
     try {
       await Promise.resolve((value as (this: unknown) => Promise<void>).call(instance));
+      if (descriptor.onSuccess) {
+        await Promise.resolve(descriptor.onSuccess());
+      }
     } catch (error) {
       this.logger.error(`Cron task ${descriptor.taskName} failed.`, error, 'CronLifecycleService');
+      if (descriptor.onError) {
+        await Promise.resolve(descriptor.onError(error));
+      }
+    } finally {
+      if (descriptor.afterRun) {
+        await Promise.resolve(descriptor.afterRun());
+      }
     }
   }
 
@@ -349,6 +378,30 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     await this.releaseLockKey(descriptor.lockKey, descriptor.taskName);
   }
 
+  private async renewLock(descriptor: CronTaskDescriptor): Promise<void> {
+    const redis = this.redisClient;
+
+    if (!redis) {
+      return;
+    }
+
+    try {
+      await redis.eval(
+        RENEW_LOCK_SCRIPT,
+        1,
+        descriptor.lockKey,
+        this.options.distributed.ownerId,
+        String(descriptor.lockTtlMs),
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to renew distributed cron lock for ${descriptor.taskName}.`,
+        error,
+        'CronLifecycleService',
+      );
+    }
+  }
+
   private async releaseOwnedLocks(): Promise<void> {
     if (!this.redisClient || this.ownedLockKeys.size === 0) {
       return;
@@ -371,12 +424,7 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     }
 
     try {
-      await redis.eval(
-        'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end',
-        1,
-        lockKey,
-        this.options.distributed.ownerId,
-      );
+      await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, this.options.distributed.ownerId);
     } catch (error) {
       this.logger.error(
         `Failed to release distributed cron lock for ${taskName}.`,

--- a/packages/cron/src/types.ts
+++ b/packages/cron/src/types.ts
@@ -1,10 +1,14 @@
 import type { MetadataPropertyKey, Token } from '@konekti/core';
 
 export interface CronTaskOptions {
+  afterRun?: () => void | Promise<void>;
+  beforeRun?: () => void | Promise<void>;
   distributed?: boolean;
   key?: string;
   lockTtlMs?: number;
   name?: string;
+  onError?: (error: unknown) => void | Promise<void>;
+  onSuccess?: () => void | Promise<void>;
   timezone?: string;
 }
 
@@ -47,6 +51,8 @@ export interface NormalizedCronModuleOptions {
 }
 
 export interface CronTaskDescriptor {
+  afterRun?: () => void | Promise<void>;
+  beforeRun?: () => void | Promise<void>;
   distributed: boolean;
   expression: string;
   lockKey: string;
@@ -54,6 +60,8 @@ export interface CronTaskDescriptor {
   methodKey: MetadataPropertyKey;
   methodName: string;
   moduleName: string;
+  onError?: (error: unknown) => void | Promise<void>;
+  onSuccess?: () => void | Promise<void>;
   taskName: string;
   timezone?: string;
   targetName: string;

--- a/packages/http/src/dto-validation-adapter.ts
+++ b/packages/http/src/dto-validation-adapter.ts
@@ -1,3 +1,4 @@
+import type { Constructor } from '@konekti/core';
 import { DefaultValidator as BaseDefaultValidator, DtoValidationError } from '@konekti/dto-validator';
 
 import { BadRequestException, type HttpExceptionDetail } from './exceptions.js';
@@ -18,6 +19,20 @@ export class HttpDtoValidationAdapter implements Validator {
   async validate(value: unknown, target: Parameters<BaseDefaultValidator['validate']>[1]): Promise<void> {
     try {
       await this.validator.validate(value, target);
+    } catch (error: unknown) {
+      if (error instanceof DtoValidationError) {
+        throw new BadRequestException(error.message, {
+          details: error.issues.map(toDetail),
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  async transform<T>(value: unknown, target: Constructor<T>): Promise<T> {
+    try {
+      return await this.validator.transform(value, target);
     } catch (error: unknown) {
       if (error instanceof DtoValidationError) {
         throw new BadRequestException(error.message, {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -32,6 +32,7 @@
     "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@konekti/di": "workspace:*",
     "@konekti/http": "workspace:*",
     "@konekti/runtime": "workspace:*",
     "prom-client": "^15.1.3"

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -1,0 +1,57 @@
+import type { Middleware, MiddlewareContext, Next } from '@konekti/http';
+import { Counter, Histogram, type Registry } from 'prom-client';
+
+type HttpMetricLabels = {
+  method: string;
+  path: string;
+  status: string;
+};
+
+export class HttpMetricsMiddleware implements Middleware {
+  private readonly requestsTotal: Counter<string>;
+  private readonly errorsTotal: Counter<string>;
+  private readonly requestDuration: Histogram<string>;
+
+  constructor(registry: Registry) {
+    this.requestsTotal = new Counter({
+      help: 'Total number of HTTP requests',
+      labelNames: ['method', 'path', 'status'],
+      name: 'http_requests_total',
+      registers: [registry],
+    });
+    this.errorsTotal = new Counter({
+      help: 'Total number of HTTP error responses (4xx/5xx)',
+      labelNames: ['method', 'path', 'status'],
+      name: 'http_errors_total',
+      registers: [registry],
+    });
+    this.requestDuration = new Histogram({
+      help: 'HTTP request duration in seconds',
+      labelNames: ['method', 'path', 'status'],
+      name: 'http_request_duration_seconds',
+      registers: [registry],
+    });
+  }
+
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    const start = performance.now();
+    const method = context.request.method;
+    const path = context.request.path;
+
+    try {
+      await next();
+    } finally {
+      const status = String(context.response.statusCode ?? 200);
+      const durationSeconds = (performance.now() - start) / 1000;
+      const labels: HttpMetricLabels = { method, path, status };
+
+      this.requestsTotal.inc(labels);
+      this.requestDuration.observe(labels, durationSeconds);
+
+      const statusCode = Number(status);
+      if (statusCode >= 400) {
+        this.errorsTotal.inc(labels);
+      }
+    }
+  }
+}

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,1 +1,5 @@
 export * from './metrics-module.js';
+export * from './metrics-service.js';
+export * from './meter-provider.js';
+export * from './prometheus-meter-provider.js';
+export * from './http-metrics-middleware.js';

--- a/packages/metrics/src/meter-provider.ts
+++ b/packages/metrics/src/meter-provider.ts
@@ -1,0 +1,20 @@
+export interface MeterCounter {
+  inc(labels?: Record<string, string | number>, value?: number): void;
+}
+
+export interface MeterGauge {
+  set(value: number, labels?: Record<string, string | number>): void;
+}
+
+export interface MeterHistogram {
+  observe(value: number, labels?: Record<string, string | number>): void;
+}
+
+export interface MeterProvider {
+  readonly type: 'prometheus' | 'otel' | string;
+  createCounter(name: string, help: string, labelNames?: string[]): MeterCounter;
+  createGauge(name: string, help: string, labelNames?: string[]): MeterGauge;
+  createHistogram(name: string, help: string, labelNames?: string[], buckets?: number[]): MeterHistogram;
+}
+
+export const METER_PROVIDER = Symbol.for('konekti.metrics.meter-provider');

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -1,9 +1,17 @@
 import { Controller, Get, type MiddlewareLike, type RequestContext } from '@konekti/http';
+import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 import { Registry, collectDefaultMetrics } from 'prom-client';
 
+import { HttpMetricsMiddleware } from './http-metrics-middleware.js';
+import { METER_PROVIDER } from './meter-provider.js';
+import { METRICS_SERVICE, MetricsService } from './metrics-service.js';
+import { PrometheusMeterProvider } from './prometheus-meter-provider.js';
+
 export interface MetricsModuleOptions {
+  http?: boolean;
   path?: string;
+  provider?: 'prometheus' | 'otel';
   defaultMetrics?: boolean;
   middleware?: MiddlewareLike[];
 }
@@ -14,11 +22,28 @@ export class MetricsModule {
   static forRoot(options: MetricsModuleOptions = {}): ModuleType {
     const metricsPath = options.path ?? '/metrics';
     const registry = new Registry();
+    const metricsService = new MetricsService(registry);
+    const meterProvider = options.provider === 'otel'
+      ? new PrometheusMeterProvider(registry)
+      : new PrometheusMeterProvider(registry);
 
     if (options.defaultMetrics !== false && !MetricsModule.registeredRegistries.has(registry)) {
       MetricsModule.registeredRegistries.add(registry);
       collectDefaultMetrics({ register: registry });
     }
+
+    const middleware = options.http === true ? [new HttpMetricsMiddleware(registry), ...(options.middleware ?? [])] : (options.middleware ?? []);
+
+    const providers: Provider[] = [
+      {
+        provide: METRICS_SERVICE,
+        useValue: metricsService,
+      },
+      {
+        provide: METER_PROVIDER,
+        useValue: meterProvider,
+      },
+    ];
 
     @Controller('')
     class MetricsController {
@@ -33,7 +58,8 @@ export class MetricsModule {
 
     defineModule(MetricsRuntimeModule, {
       controllers: [MetricsController],
-      middleware: options.middleware ?? [],
+      middleware,
+      providers,
     });
 
     return MetricsRuntimeModule;

--- a/packages/metrics/src/metrics-service.ts
+++ b/packages/metrics/src/metrics-service.ts
@@ -1,0 +1,31 @@
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  Registry,
+  type CounterConfiguration,
+  type GaugeConfiguration,
+  type HistogramConfiguration,
+} from 'prom-client';
+
+export const METRICS_SERVICE = Symbol.for('konekti.metrics.service');
+
+export class MetricsService {
+  constructor(private readonly registry: Registry) {}
+
+  counter<T extends string = string>(config: CounterConfiguration<T>): Counter<T> {
+    return new Counter({ ...config, registers: [this.registry] });
+  }
+
+  gauge<T extends string = string>(config: GaugeConfiguration<T>): Gauge<T> {
+    return new Gauge({ ...config, registers: [this.registry] });
+  }
+
+  histogram<T extends string = string>(config: HistogramConfiguration<T>): Histogram<T> {
+    return new Histogram({ ...config, registers: [this.registry] });
+  }
+
+  getRegistry(): Registry {
+    return this.registry;
+  }
+}

--- a/packages/metrics/src/prometheus-meter-provider.ts
+++ b/packages/metrics/src/prometheus-meter-provider.ts
@@ -1,0 +1,70 @@
+import { Counter, Gauge, Histogram, type Registry } from 'prom-client';
+
+import type { MeterCounter, MeterGauge, MeterHistogram, MeterProvider } from './meter-provider.js';
+
+export class PrometheusMeterProvider implements MeterProvider {
+  readonly type = 'prometheus' as const;
+
+  constructor(private readonly registry: Registry) {}
+
+  createCounter(name: string, help: string, labelNames: string[] = []): MeterCounter {
+    const counter = new Counter({
+      help,
+      labelNames,
+      name,
+      registers: [this.registry],
+    });
+
+    return {
+      inc(labels?: Record<string, string | number>, value = 1): void {
+        if (labels) {
+          counter.inc(labels, value);
+          return;
+        }
+
+        counter.inc(value);
+      },
+    };
+  }
+
+  createGauge(name: string, help: string, labelNames: string[] = []): MeterGauge {
+    const gauge = new Gauge({
+      help,
+      labelNames,
+      name,
+      registers: [this.registry],
+    });
+
+    return {
+      set(value: number, labels?: Record<string, string | number>): void {
+        if (labels) {
+          gauge.set(labels, value);
+          return;
+        }
+
+        gauge.set(value);
+      },
+    };
+  }
+
+  createHistogram(name: string, help: string, labelNames: string[] = [], buckets?: number[]): MeterHistogram {
+    const histogram = new Histogram({
+      buckets,
+      help,
+      labelNames,
+      name,
+      registers: [this.registry],
+    });
+
+    return {
+      observe(value: number, labels?: Record<string, string | number>): void {
+        if (labels) {
+          histogram.observe(labels, value);
+          return;
+        }
+
+        histogram.observe(value);
+      },
+    };
+  }
+}

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import { Container, type Provider } from '@konekti/di';
+import { Container, isForwardRef, isOptionalToken, type ForwardRefFn, type OptionalToken, type Provider } from '@konekti/di';
 import { ConfigService, loadConfig } from '@konekti/config';
 import { InvariantError, defineModuleMetadata, getClassDiMetadata, getOwnClassDiMetadata, getModuleMetadata, type Token } from '@konekti/core';
 import {
@@ -44,7 +44,15 @@ function providerToken(provider: Provider): Token {
   return provider.provide;
 }
 
-function providerDependencies(provider: Provider): Token[] {
+type InjectionToken = Token | ForwardRefFn | OptionalToken;
+
+function resolveInjectionToken(t: InjectionToken): Token {
+  if (isForwardRef(t)) return t.forwardRef();
+  if (isOptionalToken(t)) return t.token;
+  return t;
+}
+
+function providerDependencies(provider: Provider): InjectionToken[] {
   if (typeof provider === 'function') {
     return getClassDiMetadata(provider)?.inject ?? [];
   }
@@ -95,7 +103,11 @@ function providerScope(provider: Provider): 'singleton' | 'request' | 'transient
     return provider.scope ?? getClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
   }
 
-  return provider.scope ?? 'singleton';
+  if ('useFactory' in provider) {
+    return provider.scope ?? 'singleton';
+  }
+
+  return 'singleton';
 }
 
 function createRuntimeTokenSet(providers: Provider[] = []): Set<Token> {
@@ -120,7 +132,7 @@ function requiredConstructorParameters(target: Function): number {
 function validateClassInjectionMetadata(
   subject: string,
   implementation: Function,
-  inject: readonly Token[],
+  inject: readonly InjectionToken[],
   scope: string,
   remedy: string,
 ): void {
@@ -343,7 +355,9 @@ function validateCompiledModules(
     for (const provider of compiledModule.definition.providers ?? []) {
       validateProviderInjectionMetadata(provider, scope);
 
-      for (const token of providerDependencies(provider)) {
+      for (const rawToken of providerDependencies(provider)) {
+        const token = resolveInjectionToken(rawToken);
+
         if (!accessibleTokens.has(token)) {
           throw new ModuleVisibilityError(
             `Provider ${String(providerToken(provider))} in module ${compiledModule.type.name} cannot access token ${String(

--- a/packages/websocket/src/decorators.ts
+++ b/packages/websocket/src/decorators.ts
@@ -1,7 +1,7 @@
 import { metadataSymbol } from '@konekti/core';
 
 import { webSocketGatewayMetadataSymbol, webSocketHandlerMetadataSymbol } from './metadata.js';
-import type { WebSocketGatewayHandlerMetadata, WebSocketGatewayOptions } from './types.js';
+import type { WebSocketEventMap, WebSocketGatewayHandlerMetadata, WebSocketGatewayOptions } from './types.js';
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 type StandardClassDecoratorFn = (value: Function, context: ClassDecoratorContext) => void;
@@ -63,7 +63,9 @@ function createMethodDecorator(metadata: WebSocketGatewayHandlerMetadata): Metho
   return decorator as MethodDecoratorLike;
 }
 
-export function WebSocketGateway(options: WebSocketGatewayOptions = {}): ClassDecoratorLike {
+export function WebSocketGateway<TEvents extends WebSocketEventMap = WebSocketEventMap>(
+  options: WebSocketGatewayOptions<TEvents> = {},
+): ClassDecoratorLike {
   const decorator = (_value: Function, context: ClassDecoratorContext) => {
     defineStandardGatewayMetadata(context.metadata, options);
   };
@@ -71,7 +73,10 @@ export function WebSocketGateway(options: WebSocketGatewayOptions = {}): ClassDe
   return decorator as ClassDecoratorLike;
 }
 
-export function OnMessage(event?: string): MethodDecoratorLike {
+export function OnMessage<
+  TEvents extends WebSocketEventMap = WebSocketEventMap,
+  K extends keyof TEvents = keyof TEvents,
+>(event?: K & string): MethodDecoratorLike {
   return createMethodDecorator({
     event,
     type: 'message',

--- a/packages/websocket/src/module.ts
+++ b/packages/websocket/src/module.ts
@@ -2,10 +2,15 @@ import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { WebSocketGatewayLifecycleService } from './service.js';
-import { WEBSOCKET_GATEWAY_SERVICE } from './tokens.js';
+import { WEBSOCKET_GATEWAY_SERVICE, WEBSOCKET_OPTIONS } from './tokens.js';
+import type { WebSocketModuleOptions } from './types.js';
 
-export function createWebSocketProviders(): Provider[] {
+export function createWebSocketProviders(options: WebSocketModuleOptions = {}): Provider[] {
   return [
+    {
+      provide: WEBSOCKET_OPTIONS,
+      useValue: options,
+    },
     {
       provide: WEBSOCKET_GATEWAY_SERVICE,
       useClass: WebSocketGatewayLifecycleService,
@@ -13,10 +18,10 @@ export function createWebSocketProviders(): Provider[] {
   ];
 }
 
-export function createWebSocketModule(): ModuleType {
+export function createWebSocketModule(options: WebSocketModuleOptions = {}): ModuleType {
   class WebSocketModule {}
 
   return defineModule(WebSocketModule, {
-    providers: createWebSocketProviders(),
+    providers: createWebSocketProviders(options),
   });
 }

--- a/packages/websocket/src/service.ts
+++ b/packages/websocket/src/service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 
@@ -18,7 +19,13 @@ import type { HttpApplicationAdapter } from '@konekti/http';
 import { WebSocket, WebSocketServer, type RawData } from 'ws';
 
 import { getWebSocketGatewayMetadata, getWebSocketHandlerMetadataEntries } from './metadata.js';
-import type { WebSocketGatewayDescriptor, WebSocketGatewayHandlerDescriptor } from './types.js';
+import { WEBSOCKET_OPTIONS } from './tokens.js';
+import type {
+  WebSocketGatewayDescriptor,
+  WebSocketGatewayHandlerDescriptor,
+  WebSocketModuleOptions,
+  WebSocketRoomService,
+} from './types.js';
 
 interface DiscoveryCandidate {
   moduleName: string;
@@ -129,10 +136,18 @@ function rejectUpgradeRequest(socket: Duplex): void {
   socket.destroy();
 }
 
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER])
-export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy {
+@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS])
+export class WebSocketGatewayLifecycleService
+  implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
+{
   private attachments: GatewayAttachment[] = [];
+  private heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  private readonly pingPending = new Set<string>();
+  private readonly pingSentAt = new Map<string, number>();
+  private readonly roomSockets = new Map<string, Set<string>>();
   private shutdownPromise: Promise<void> | undefined;
+  private readonly socketRegistry = new Map<string, WebSocket>();
+  private readonly socketRooms = new Map<string, Set<string>>();
   private upgradeListener: NodeUpgradeListener | undefined;
   private upgradeServer: NodeUpgradeServer | undefined;
 
@@ -141,6 +156,7 @@ export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap,
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
     private readonly adapter: HttpApplicationAdapter,
+    private readonly moduleOptions: WebSocketModuleOptions,
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
@@ -197,6 +213,12 @@ export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap,
     this.upgradeServer = upgradeServer;
     this.upgradeListener = listener;
     this.attachments = Array.from(attachmentsByPath.values());
+
+    if (this.moduleOptions.heartbeat?.enabled === true) {
+      const intervalMs = this.moduleOptions.heartbeat.intervalMs ?? 30_000;
+      const timeoutMs = this.moduleOptions.heartbeat.timeoutMs ?? intervalMs;
+      this.startHeartbeat(intervalMs, timeoutMs);
+    }
   }
 
   async onApplicationShutdown(): Promise<void> {
@@ -230,6 +252,9 @@ export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap,
     socket: WebSocket,
     request: IncomingMessage,
   ): Promise<void> {
+    const socketId = randomUUID();
+    this.socketRegistry.set(socketId, socket);
+
     const resolved: Array<{ descriptor: WebSocketGatewayDescriptor; instance: unknown }> = [];
 
     for (const descriptor of descriptors) {
@@ -242,11 +267,12 @@ export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap,
 
     await Promise.all(
       resolved.map(async ({ descriptor, instance }) => {
-        await this.runHandlers(instance, descriptor, 'connect', socket, request);
+        await this.runHandlers(instance, descriptor, 'connect', socket, request, socketId);
       }),
     );
 
     if (socket.readyState !== WebSocket.OPEN) {
+      this.unregisterSocket(socketId);
       return;
     }
 
@@ -254,8 +280,14 @@ export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap,
       void this.handleMessage(resolved, socket, request, data);
     });
 
+    socket.on('pong', () => {
+      this.pingPending.delete(socketId);
+      this.pingSentAt.delete(socketId);
+    });
+
     socket.on('close', (code: number, reason: Buffer) => {
-      void this.handleDisconnect(resolved, socket, code, reason);
+      this.unregisterSocket(socketId);
+      void this.handleDisconnect(resolved, socket, code, reason, socketId);
     });
   }
 
@@ -287,10 +319,11 @@ export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap,
     socket: WebSocket,
     code: number,
     reason: Buffer,
+    socketId: string,
   ): Promise<void> {
     await Promise.all(
       resolved.map(async ({ descriptor, instance }) => {
-        await this.runHandlers(instance, descriptor, 'disconnect', socket, code, reason.toString('utf8'));
+        await this.runHandlers(instance, descriptor, 'disconnect', socket, code, reason.toString('utf8'), socketId);
       }),
     );
   }
@@ -434,6 +467,11 @@ export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap,
     }
 
     this.shutdownPromise = (async () => {
+      if (this.heartbeatTimer) {
+        clearInterval(this.heartbeatTimer);
+        this.heartbeatTimer = undefined;
+      }
+
       if (this.upgradeServer && this.upgradeListener) {
         this.upgradeServer.off('upgrade', this.upgradeListener);
       }
@@ -454,8 +492,114 @@ export class WebSocketGatewayLifecycleService implements OnApplicationBootstrap,
           });
         }),
       );
+
+      this.socketRegistry.clear();
+      this.socketRooms.clear();
+      this.roomSockets.clear();
+      this.pingPending.clear();
+      this.pingSentAt.clear();
     })();
 
     await this.shutdownPromise;
+  }
+
+  joinRoom(socketId: string, room: string): void {
+    let rooms = this.socketRooms.get(socketId);
+
+    if (!rooms) {
+      rooms = new Set<string>();
+      this.socketRooms.set(socketId, rooms);
+    }
+
+    rooms.add(room);
+
+    let sockets = this.roomSockets.get(room);
+    if (!sockets) {
+      sockets = new Set<string>();
+      this.roomSockets.set(room, sockets);
+    }
+
+    sockets.add(socketId);
+  }
+
+  leaveRoom(socketId: string, room: string): void {
+    const rooms = this.socketRooms.get(socketId);
+    rooms?.delete(room);
+    if (rooms && rooms.size === 0) {
+      this.socketRooms.delete(socketId);
+    }
+
+    const sockets = this.roomSockets.get(room);
+    sockets?.delete(socketId);
+    if (sockets && sockets.size === 0) {
+      this.roomSockets.delete(room);
+    }
+  }
+
+  broadcastToRoom(room: string, event: string, data: unknown): void {
+    const socketIds = this.roomSockets.get(room);
+
+    if (!socketIds) {
+      return;
+    }
+
+    const message = JSON.stringify({ data, event });
+    for (const socketId of socketIds) {
+      const socket = this.socketRegistry.get(socketId);
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        socket.send(message);
+      }
+    }
+  }
+
+  getRooms(socketId: string): ReadonlySet<string> {
+    return this.socketRooms.get(socketId) ?? new Set<string>();
+  }
+
+  private startHeartbeat(intervalMs: number, timeoutMs: number): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+    }
+
+    this.heartbeatTimer = setInterval(() => {
+      const now = Date.now();
+
+      for (const [socketId, socket] of this.socketRegistry) {
+        if (this.pingPending.has(socketId)) {
+          const pingAt = this.pingSentAt.get(socketId);
+          const elapsed = pingAt === undefined ? timeoutMs : now - pingAt;
+
+          if (elapsed >= timeoutMs) {
+            socket.terminate();
+            this.unregisterSocket(socketId);
+          }
+          continue;
+        }
+
+        if (socket.readyState === WebSocket.OPEN) {
+          this.pingPending.add(socketId);
+          this.pingSentAt.set(socketId, now);
+          socket.ping();
+        }
+      }
+    }, intervalMs);
+  }
+
+  private unregisterSocket(socketId: string): void {
+    this.socketRegistry.delete(socketId);
+    this.pingPending.delete(socketId);
+    this.pingSentAt.delete(socketId);
+
+    const rooms = this.socketRooms.get(socketId);
+    if (rooms) {
+      for (const room of rooms) {
+        const sockets = this.roomSockets.get(room);
+        sockets?.delete(socketId);
+        if (sockets && sockets.size === 0) {
+          this.roomSockets.delete(room);
+        }
+      }
+      this.socketRooms.delete(socketId);
+    }
   }
 }

--- a/packages/websocket/src/tokens.ts
+++ b/packages/websocket/src/tokens.ts
@@ -1,5 +1,8 @@
 import type { Token } from '@konekti/core';
 
 import type { WebSocketGatewayLifecycleService } from './service.js';
+import type { WebSocketModuleOptions } from './types.js';
 
 export const WEBSOCKET_GATEWAY_SERVICE: Token<WebSocketGatewayLifecycleService> = Symbol.for('konekti.websocket.gateway-service');
+export const WEBSOCKET_OPTIONS: Token<WebSocketModuleOptions> = Symbol.for('konekti.websocket.options');
+export const WEBSOCKET_SERVICE = WEBSOCKET_GATEWAY_SERVICE;

--- a/packages/websocket/src/types.ts
+++ b/packages/websocket/src/types.ts
@@ -3,7 +3,15 @@ import type { IncomingMessage } from 'node:http';
 import type { MetadataPropertyKey, Token } from '@konekti/core';
 import type { WebSocket } from 'ws';
 
-export interface WebSocketGatewayOptions {
+export type WebSocketEventMap = Record<string, unknown>;
+
+export type TypedOnMessageHandler<TEvents extends WebSocketEventMap, K extends keyof TEvents> = (
+  payload: TEvents[K],
+  socket: WebSocket,
+  request: IncomingMessage,
+) => void | Promise<void>;
+
+export interface WebSocketGatewayOptions<TEvents extends WebSocketEventMap = WebSocketEventMap> {
   path?: string;
 }
 
@@ -36,4 +44,19 @@ export interface WebSocketGatewayDescriptor {
 export interface WebSocketGatewayContext {
   request: IncomingMessage;
   socket: WebSocket;
+}
+
+export interface WebSocketRoomService {
+  joinRoom(socketId: string, room: string): void;
+  leaveRoom(socketId: string, room: string): void;
+  broadcastToRoom(room: string, event: string, data: unknown): void;
+  getRooms(socketId: string): ReadonlySet<string>;
+}
+
+export interface WebSocketModuleOptions {
+  heartbeat?: {
+    enabled?: boolean;
+    intervalMs?: number;
+    timeoutMs?: number;
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+      drizzle-orm:
+        specifier: '>=0.30.0'
+        version: 0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@7.5.0(typescript@5.9.3))
 
   packages/dto-validator:
     dependencies:
@@ -158,6 +161,9 @@ importers:
 
   packages/metrics:
     dependencies:
+      '@konekti/di':
+        specifier: workspace:*
+        version: link:../di
       '@konekti/http':
         specifier: workspace:*
         version: link:../http
@@ -219,6 +225,9 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+      '@prisma/client':
+        specifier: '>=5.0.0'
+        version: 7.5.0(typescript@5.9.3)
 
   packages/queue:
     dependencies:
@@ -909,6 +918,21 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@prisma/client-runtime-utils@7.5.0':
+    resolution: {integrity: sha512-KnJ2b4Si/pcWEtK68uM+h0h1oh80CZt2suhLTVuLaSKg4n58Q9jBF/A42Kw6Ma+aThy1yAhfDeTC0JvEmeZnFQ==}
+
+  '@prisma/client@7.5.0':
+    resolution: {integrity: sha512-h4hF9ctp+kSRs7ENHGsFQmHAgHcfkOCxbYt6Ti9Xi8x7D+kP4tTi9x51UKmiTH/OqdyJAO+8V+r+JA5AWdav7w==}
+    engines: {node: ^20.19 || ^22.12 || >=24.0}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
   '@repeaterjs/repeater@3.0.6':
     resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
 
@@ -1230,6 +1254,98 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  drizzle-orm@0.45.1:
+    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
 
   electron-to-chromium@1.5.307:
     resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
@@ -2163,6 +2279,14 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@prisma/client-runtime-utils@7.5.0': {}
+
+  '@prisma/client@7.5.0(typescript@5.9.3)':
+    dependencies:
+      '@prisma/client-runtime-utils': 7.5.0
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@repeaterjs/repeater@3.0.6': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -2465,6 +2589,11 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@7.5.0(typescript@5.9.3)):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@prisma/client': 7.5.0(typescript@5.9.3)
 
   electron-to-chromium@1.5.307: {}
 


### PR DESCRIPTION
## Summary

- **cron**: lock renewal heartbeat at `lockTtlMs/2`, `beforeRun`/`afterRun`/`onSuccess`/`onError` lifecycle hooks, `@Cron()` expression validation via croner
- **metrics**: `MetricsService` + `METRICS_SERVICE` token, `MeterProvider`/`MeterCounter`/`MeterGauge`/`MeterHistogram` interfaces + `METER_PROVIDER` token, `PrometheusMeterProvider` implementation, `HttpMetricsMiddleware` with RED metrics (`http_requests_total`, `http_errors_total`, `http_request_duration_seconds`)
- **websocket**: `WEBSOCKET_OPTIONS`/`WEBSOCKET_SERVICE` tokens, `WebSocketRoomService`/`WebSocketEventMap`/`TypedOnMessageHandler` types, full room support (`joinRoom`/`leaveRoom`/`broadcastToRoom`/`getRooms`), heartbeat/ping-pong
- **http**: add `transform<T>()` to `DtoValidationAdapter` to match updated `Validator` interface
- **runtime**: fix pre-existing tsc errors — widen inject array types to include `ForwardRefFn`/`OptionalToken`, guard `ExistingProvider` scope access
- **metrics**: add missing `@konekti/di` peer dependency

Closes #96