### PR TITLE
feat(config,testing,cli): key-safe config access, extended override surface, pluggable generator architecture

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
-    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
+    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json && node -e \"require('fs').cpSync('src/generators/templates', 'dist/generators/templates', {recursive: true})\"",
     "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
     "test": "pnpm exec vitest run -c vitest.config.ts",
     "test:watch": "pnpm exec vitest -c vitest.config.ts",
@@ -42,6 +42,10 @@
     "sandbox:clean": "node ./scripts/local-test-env.mjs clean"
   },
   "dependencies": {
+    "ejs": "^3.1.10",
     "tsx": "^4.20.4"
+  },
+  "devDependencies": {
+    "@types/ejs": "^3.1.5"
   }
 }

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,43 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, normalize, resolve } from 'node:path';
 
-import type { GenerateOptions, GeneratedFile, GeneratorKind } from '../types.js';
+import type { GenerateOptions, GeneratorKind } from '../types.js';
+import { defaultRegistry } from '../registry.js';
 
-import { generateControllerFiles } from '../generators/controller.js';
-import { generateGuardFiles } from '../generators/guard.js';
-import { generateInterceptorFiles } from '../generators/interceptor.js';
-import { generateMiddlewareFiles } from '../generators/middleware.js';
 import { generateModuleFiles, registerInModule } from '../generators/module.js';
-import { generateRepoFiles } from '../generators/repository.js';
-import { generateRequestDtoFiles } from '../generators/request-dto.js';
-import { generateResponseDtoFiles } from '../generators/response-dto.js';
-import { generateServiceFiles } from '../generators/service.js';
 import { toKebabCase, toPascalCase, toPlural } from '../generators/utils.js';
-
-function generateFiles(kind: GeneratorKind, name: string, options: GenerateOptions = {}): GeneratedFile[] {
-  switch (kind) {
-    case 'controller':
-      return generateControllerFiles(name);
-    case 'guard':
-      return generateGuardFiles(name);
-    case 'interceptor':
-      return generateInterceptorFiles(name);
-    case 'middleware':
-      return generateMiddlewareFiles(name);
-    case 'module':
-      return generateModuleFiles(name);
-    case 'repo':
-      return generateRepoFiles(name, options);
-    case 'request-dto':
-      return generateRequestDtoFiles(name);
-    case 'response-dto':
-      return generateResponseDtoFiles(name);
-    case 'service':
-      return generateServiceFiles(name, options);
-    default:
-      return [];
-  }
-}
 
 function moduleArrayKey(kind: GeneratorKind): 'controllers' | 'providers' | 'middleware' | null {
   if (kind === 'controller') return 'controllers';
@@ -105,7 +73,8 @@ export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirect
 
   mkdirSync(domainDirectory, { recursive: true });
 
-  const files = generateFiles(kind, name, options);
+  const factory = defaultRegistry.resolve(kind);
+  const files = factory ? factory(name, options) : [];
 
   const writtenPaths = files.map((file) => {
     const filePath = join(domainDirectory, file.path);

--- a/packages/cli/src/generators.test.ts
+++ b/packages/cli/src/generators.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { generateControllerFiles } from './generators/controller.js';
 import { generateGuardFiles } from './generators/guard.js';
@@ -9,6 +9,7 @@ import { generateRepoFiles } from './generators/repository.js';
 import { generateRequestDtoFiles } from './generators/request-dto.js';
 import { generateResponseDtoFiles } from './generators/response-dto.js';
 import { generateServiceFiles } from './generators/service.js';
+import { GeneratorRegistry, defaultRegistry } from './registry.js';
 
 describe('CLI generators', () => {
   it('follow naming conventions for default generators', () => {
@@ -139,5 +140,45 @@ describe('CLI generators', () => {
       const result = registerInModule(withMiddlewareArray, 'middleware', 'AuthMiddleware');
       expect(result).toMatch(/middleware:\s*\[[\s\S]*AuthMiddleware/);
     });
+  });
+});
+
+describe('GeneratorRegistry', () => {
+  it('resolves all built-in generator kinds from defaultRegistry', () => {
+    const kinds = ['controller', 'guard', 'interceptor', 'middleware', 'module', 'repository', 'repo', 'request-dto', 'response-dto', 'service'] as const;
+    for (const kind of kinds) {
+      expect(defaultRegistry.has(kind), `expected defaultRegistry to have kind: ${kind}`).toBe(true);
+    }
+  });
+
+  it('returns undefined for unknown kind', () => {
+    expect(defaultRegistry.resolve('unknown')).toBeUndefined();
+  });
+
+  it('allows registering and invoking custom generators', () => {
+    const registry = new GeneratorRegistry();
+    const factory = vi.fn().mockReturnValue([{ path: 'foo.ts', content: 'bar' }]);
+    registry.register('custom', factory);
+    expect(registry.has('custom')).toBe(true);
+    const result = registry.resolve('custom')?.('Foo');
+    expect(factory).toHaveBeenCalledWith('Foo');
+    expect(result).toEqual([{ path: 'foo.ts', content: 'bar' }]);
+  });
+
+  it('overrides an existing registration', () => {
+    const registry = new GeneratorRegistry();
+    const original = vi.fn().mockReturnValue([]);
+    const replacement = vi.fn().mockReturnValue([{ path: 'replaced.ts', content: '' }]);
+    registry.register('controller', original);
+    registry.register('controller', replacement);
+    registry.resolve('controller')?.('User');
+    expect(replacement).toHaveBeenCalledOnce();
+    expect(original).not.toHaveBeenCalled();
+  });
+
+  it('lists all registered kinds', () => {
+    const registry = new GeneratorRegistry();
+    registry.register('a', vi.fn()).register('b', vi.fn());
+    expect(registry.kinds()).toEqual(['a', 'b']);
   });
 });

--- a/packages/cli/src/generators/controller.ts
+++ b/packages/cli/src/generators/controller.ts
@@ -1,5 +1,6 @@
 import type { GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
 export function generateControllerFiles(name: string): GeneratedFile[] {
@@ -8,45 +9,15 @@ export function generateControllerFiles(name: string): GeneratedFile[] {
   const pascal = `${resource}Controller`;
   const service = `${resource}Service`;
 
+  const vars = { kebab, resource, pascal, service };
+
   return [
     {
-      content: `import { Inject } from '@konekti/core';
-import { Controller, Get } from '@konekti/http';
-
-import { ${service} } from './${kebab}.service';
-
-@Controller('/${kebab}')
-@Inject([${service}])
-class ${pascal} {
-  constructor(private readonly service: ${service}) {}
-
-  @Get('/')
-  async list${resource}s() {
-    return this.service.list${resource}s();
-  }
-}
-
-export { ${pascal} };
-`,
+      content: renderTemplate('controller.ts.ejs', vars),
       path: `${kebab}.controller.ts`,
     },
     {
-      content: `import { describe, expect, it } from 'vitest';
-
-import { ${pascal} } from './${kebab}.controller';
-
-class Fake${service} {
-  async list${resource}s() {
-    return [{ id: '${kebab}-1' }];
-  }
-}
-
-describe('${pascal}', () => {
-  it('delegates to the service', async () => {
-    await expect(new ${pascal}(new Fake${service}() as never).list${resource}s()).resolves.toEqual([{ id: '${kebab}-1' }]);
-  });
-});
-`,
+      content: renderTemplate('controller.test.ts.ejs', vars),
       path: `${kebab}.controller.test.ts`,
     },
   ];

--- a/packages/cli/src/generators/guard.ts
+++ b/packages/cli/src/generators/guard.ts
@@ -1,5 +1,6 @@
 import type { GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
 export function generateGuardFiles(name: string): GeneratedFile[] {
@@ -8,14 +9,7 @@ export function generateGuardFiles(name: string): GeneratedFile[] {
   const pascal = `${resource}Guard`;
 
   return [{
-    content: `import type { Guard, GuardContext } from '@konekti/http';
-
-export class ${pascal} implements Guard {
-  canActivate(context: GuardContext): boolean {
-    return true;
-  }
-}
-`,
+    content: renderTemplate('guard.ts.ejs', { kebab, resource, pascal }),
     path: `${kebab}.guard.ts`,
   }];
 }

--- a/packages/cli/src/generators/interceptor.ts
+++ b/packages/cli/src/generators/interceptor.ts
@@ -1,5 +1,6 @@
 import type { GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
 export function generateInterceptorFiles(name: string): GeneratedFile[] {
@@ -8,14 +9,7 @@ export function generateInterceptorFiles(name: string): GeneratedFile[] {
   const pascal = `${resource}Interceptor`;
 
   return [{
-    content: `import type { CallHandler, Interceptor, InterceptorContext } from '@konekti/http';
-
-export class ${pascal} implements Interceptor {
-  async intercept(context: InterceptorContext, next: CallHandler): Promise<unknown> {
-    return next.handle();
-  }
-}
-`,
+    content: renderTemplate('interceptor.ts.ejs', { kebab, resource, pascal }),
     path: `${kebab}.interceptor.ts`,
   }];
 }

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -1,5 +1,6 @@
 import type { GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
 export function generateMiddlewareFiles(name: string): GeneratedFile[] {
@@ -8,18 +9,7 @@ export function generateMiddlewareFiles(name: string): GeneratedFile[] {
   const pascal = `${resource}Middleware`;
 
   return [{
-    content: `import type { Middleware, MiddlewareContext, MiddlewareRouteConfig, Next } from '@konekti/http';
-
-export class ${pascal} implements Middleware {
-  static forRoutes(...routes: string[]): MiddlewareRouteConfig {
-    return { middleware: ${pascal}, routes };
-  }
-
-  async handle(context: MiddlewareContext, next: Next): Promise<void> {
-    await next();
-  }
-}
-`,
+    content: renderTemplate('middleware.ts.ejs', { kebab, resource, pascal }),
     path: `${kebab}.middleware.ts`,
   }];
 }

--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -1,5 +1,6 @@
 import type { GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
 export function generateModuleFiles(name: string): GeneratedFile[] {
@@ -8,16 +9,7 @@ export function generateModuleFiles(name: string): GeneratedFile[] {
 
   return [
     {
-      content: `import { Module } from '@konekti/core';
-
-@Module({
-  controllers: [],
-  providers: [],
-})
-class ${pascal} {}
-
-export { ${pascal} };
-`,
+      content: renderTemplate('module.ts.ejs', { kebab, pascal }),
       path: `${kebab}.module.ts`,
     },
   ];

--- a/packages/cli/src/generators/render.ts
+++ b/packages/cli/src/generators/render.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ejs from 'ejs';
+
+const templatesDir = join(dirname(fileURLToPath(import.meta.url)), 'templates');
+
+export function renderTemplate(templateName: string, vars: Record<string, unknown>): string {
+  const template = readFileSync(join(templatesDir, templateName), 'utf8');
+  return ejs.render(template, vars, { escape: (s) => String(s) });
+}

--- a/packages/cli/src/generators/repository.ts
+++ b/packages/cli/src/generators/repository.ts
@@ -1,20 +1,7 @@
 import type { GenerateOptions, GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
-
-function createRepoImplementation(resource: string): string {
-  return `
-type ${resource}Record = {
-  id: string;
-};
-
-export class ${resource}Repo {
-  async list${resource}s(): Promise<${resource}Record[]> {
-    return [];
-  }
-}
-`;
-}
 
 export function generateRepoFiles(name: string, _options: GenerateOptions = {}): GeneratedFile[] {
   const kebab = toKebabCase(name);
@@ -23,20 +10,11 @@ export function generateRepoFiles(name: string, _options: GenerateOptions = {}):
 
   return [
     {
-      content: createRepoImplementation(resource),
+      content: renderTemplate('repository.ts.ejs', { kebab, resource, pascal }),
       path: `${kebab}.repo.ts`,
     },
     {
-      content: `import { describe, expect, it } from 'vitest';
-
-import { ${pascal} } from './${kebab}.repo';
-
-describe('${pascal}', () => {
-  it('exposes a list method', () => {
-    expect(typeof ${pascal}.prototype.list${resource}s).toBe('function');
-  });
-});
-`,
+      content: renderTemplate('repository.test.ts.ejs', { kebab, resource, pascal }),
       path: `${kebab}.repo.test.ts`,
     },
   ];

--- a/packages/cli/src/generators/request-dto.ts
+++ b/packages/cli/src/generators/request-dto.ts
@@ -1,5 +1,6 @@
 import type { GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
 export function generateRequestDtoFiles(name: string): GeneratedFile[] {
@@ -10,16 +11,7 @@ export function generateRequestDtoFiles(name: string): GeneratedFile[] {
 
   return [
     {
-      content: `import { IsString, MinLength } from '@konekti/dto-validator';
-import { FromBody } from '@konekti/http';
-
-export class ${pascal} {
-  @FromBody('${bodyField}')
-  @IsString()
-  @MinLength(1, { message: '${bodyField} is required' })
-  ${bodyField} = '';
-}
-`,
+      content: renderTemplate('request-dto.ts.ejs', { kebab, resource, pascal, bodyField }),
       path: `${kebab}.request.dto.ts`,
     },
   ];

--- a/packages/cli/src/generators/response-dto.ts
+++ b/packages/cli/src/generators/response-dto.ts
@@ -1,5 +1,6 @@
 import type { GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
 export function generateResponseDtoFiles(name: string): GeneratedFile[] {
@@ -10,10 +11,7 @@ export function generateResponseDtoFiles(name: string): GeneratedFile[] {
 
   return [
     {
-      content: `export class ${pascal} {
-  ${field}!: string;
-}
-`,
+      content: renderTemplate('response-dto.ts.ejs', { kebab, resource, pascal, field }),
       path: `${kebab}.response.dto.ts`,
     },
   ];

--- a/packages/cli/src/generators/service.ts
+++ b/packages/cli/src/generators/service.ts
@@ -1,5 +1,6 @@
 import type { GenerateOptions, GeneratedFile } from '../types.js';
 
+import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
 export function generateServiceFiles(name: string, _options: GenerateOptions = {}): GeneratedFile[] {
@@ -8,40 +9,15 @@ export function generateServiceFiles(name: string, _options: GenerateOptions = {
   const pascal = `${resource}Service`;
   const repo = `${resource}Repo`;
 
+  const vars = { kebab, resource, pascal, repo };
+
   return [
     {
-      content: `import { Inject } from '@konekti/core';
-
-import { ${repo} } from './${kebab}.repo';
-
-@Inject([${repo}])
-export class ${pascal} {
-  constructor(private readonly repo: ${repo}) {}
-
-  async list${resource}s() {
-    return this.repo.list${resource}s();
-  }
-}
-`,
+      content: renderTemplate('service.ts.ejs', vars),
       path: `${kebab}.service.ts`,
     },
     {
-      content: `import { describe, expect, it } from 'vitest';
-
-import { ${pascal} } from './${kebab}.service';
-
-class Fake${repo} {
-  list${resource}s() {
-    return [{ id: '${kebab}-1' }];
-  }
-}
-
-describe('${pascal}', () => {
-  it('delegates to the repo', async () => {
-    await expect(new ${pascal}(new Fake${repo}() as never).list${resource}s()).resolves.toEqual([{ id: '${kebab}-1' }]);
-  });
-});
-`,
+      content: renderTemplate('service.test.ts.ejs', vars),
       path: `${kebab}.service.test.ts`,
     },
   ];

--- a/packages/cli/src/generators/templates/controller.test.ts.ejs
+++ b/packages/cli/src/generators/templates/controller.test.ts.ejs
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { <%- pascal %> } from './<%- kebab %>.controller';
+
+class Fake<%- service %> {
+  async list<%- resource %>s() {
+    return [{ id: '<%- kebab %>-1' }];
+  }
+}
+
+describe('<%- pascal %>', () => {
+  it('delegates to the service', async () => {
+    await expect(new <%- pascal %>(new Fake<%- service %>() as never).list<%- resource %>s()).resolves.toEqual([{ id: '<%- kebab %>-1' }]);
+  });
+});

--- a/packages/cli/src/generators/templates/controller.ts.ejs
+++ b/packages/cli/src/generators/templates/controller.ts.ejs
@@ -1,0 +1,17 @@
+import { Inject } from '@konekti/core';
+import { Controller, Get } from '@konekti/http';
+
+import { <%- service %> } from './<%- kebab %>.service';
+
+@Controller('/<%- kebab %>')
+@Inject([<%- service %>])
+class <%- pascal %> {
+  constructor(private readonly service: <%- service %>) {}
+
+  @Get('/')
+  async list<%- resource %>s() {
+    return this.service.list<%- resource %>s();
+  }
+}
+
+export { <%- pascal %> };

--- a/packages/cli/src/generators/templates/guard.ts.ejs
+++ b/packages/cli/src/generators/templates/guard.ts.ejs
@@ -1,0 +1,7 @@
+import type { Guard, GuardContext } from '@konekti/http';
+
+export class <%- pascal %> implements Guard {
+  canActivate(context: GuardContext): boolean {
+    return true;
+  }
+}

--- a/packages/cli/src/generators/templates/interceptor.ts.ejs
+++ b/packages/cli/src/generators/templates/interceptor.ts.ejs
@@ -1,0 +1,7 @@
+import type { CallHandler, Interceptor, InterceptorContext } from '@konekti/http';
+
+export class <%- pascal %> implements Interceptor {
+  async intercept(context: InterceptorContext, next: CallHandler): Promise<unknown> {
+    return next.handle();
+  }
+}

--- a/packages/cli/src/generators/templates/middleware.ts.ejs
+++ b/packages/cli/src/generators/templates/middleware.ts.ejs
@@ -1,0 +1,11 @@
+import type { Middleware, MiddlewareContext, MiddlewareRouteConfig, Next } from '@konekti/http';
+
+export class <%- pascal %> implements Middleware {
+  static forRoutes(...routes: string[]): MiddlewareRouteConfig {
+    return { middleware: <%- pascal %>, routes };
+  }
+
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    await next();
+  }
+}

--- a/packages/cli/src/generators/templates/module.ts.ejs
+++ b/packages/cli/src/generators/templates/module.ts.ejs
@@ -1,0 +1,9 @@
+import { Module } from '@konekti/core';
+
+@Module({
+  controllers: [],
+  providers: [],
+})
+class <%- pascal %> {}
+
+export { <%- pascal %> };

--- a/packages/cli/src/generators/templates/repository.test.ts.ejs
+++ b/packages/cli/src/generators/templates/repository.test.ts.ejs
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { <%- pascal %> } from './<%- kebab %>.repo';
+
+describe('<%- pascal %>', () => {
+  it('exposes a list method', () => {
+    expect(typeof <%- pascal %>.prototype.list<%- resource %>s).toBe('function');
+  });
+});

--- a/packages/cli/src/generators/templates/repository.ts.ejs
+++ b/packages/cli/src/generators/templates/repository.ts.ejs
@@ -1,0 +1,10 @@
+
+type <%- resource %>Record = {
+  id: string;
+};
+
+export class <%- resource %>Repo {
+  async list<%- resource %>s(): Promise<<%- resource %>Record[]> {
+    return [];
+  }
+}

--- a/packages/cli/src/generators/templates/request-dto.ts.ejs
+++ b/packages/cli/src/generators/templates/request-dto.ts.ejs
@@ -1,0 +1,9 @@
+import { IsString, MinLength } from '@konekti/dto-validator';
+import { FromBody } from '@konekti/http';
+
+export class <%- pascal %> {
+  @FromBody('<%- bodyField %>')
+  @IsString()
+  @MinLength(1, { message: '<%- bodyField %> is required' })
+  <%- bodyField %> = '';
+}

--- a/packages/cli/src/generators/templates/response-dto.ts.ejs
+++ b/packages/cli/src/generators/templates/response-dto.ts.ejs
@@ -1,0 +1,3 @@
+export class <%- pascal %> {
+  <%- field %>!: string;
+}

--- a/packages/cli/src/generators/templates/service.test.ts.ejs
+++ b/packages/cli/src/generators/templates/service.test.ts.ejs
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { <%- pascal %> } from './<%- kebab %>.service';
+
+class Fake<%- repo %> {
+  list<%- resource %>s() {
+    return [{ id: '<%- kebab %>-1' }];
+  }
+}
+
+describe('<%- pascal %>', () => {
+  it('delegates to the repo', async () => {
+    await expect(new <%- pascal %>(new Fake<%- repo %>() as never).list<%- resource %>s()).resolves.toEqual([{ id: '<%- kebab %>-1' }]);
+  });
+});

--- a/packages/cli/src/generators/templates/service.ts.ejs
+++ b/packages/cli/src/generators/templates/service.ts.ejs
@@ -1,0 +1,12 @@
+import { Inject } from '@konekti/core';
+
+import { <%- repo %> } from './<%- kebab %>.repo';
+
+@Inject([<%- repo %>])
+export class <%- pascal %> {
+  constructor(private readonly repo: <%- repo %>) {}
+
+  async list<%- resource %>s() {
+    return this.repo.list<%- resource %>s();
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,3 +1,4 @@
 export * from './cli.js';
 export * from './commands/new.js';
+export * from './registry.js';
 export * from './types.js';

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,0 +1,45 @@
+import type { GenerateOptions, GeneratedFile, GeneratorFactory, GeneratorRegistration } from './types.js';
+
+import { generateControllerFiles } from './generators/controller.js';
+import { generateGuardFiles } from './generators/guard.js';
+import { generateInterceptorFiles } from './generators/interceptor.js';
+import { generateMiddlewareFiles } from './generators/middleware.js';
+import { generateModuleFiles } from './generators/module.js';
+import { generateRepoFiles } from './generators/repository.js';
+import { generateRequestDtoFiles } from './generators/request-dto.js';
+import { generateResponseDtoFiles } from './generators/response-dto.js';
+import { generateServiceFiles } from './generators/service.js';
+
+export class GeneratorRegistry {
+  private readonly registry = new Map<string, GeneratorRegistration>();
+
+  register(kind: string, factory: GeneratorFactory, description?: string): this {
+    this.registry.set(kind, { factory, description });
+    return this;
+  }
+
+  resolve(kind: string): GeneratorFactory | undefined {
+    return this.registry.get(kind)?.factory;
+  }
+
+  has(kind: string): boolean {
+    return this.registry.has(kind);
+  }
+
+  kinds(): string[] {
+    return Array.from(this.registry.keys());
+  }
+}
+
+export const defaultRegistry = new GeneratorRegistry()
+  .register('controller', (name) => generateControllerFiles(name))
+  .register('guard', (name) => generateGuardFiles(name))
+  .register('interceptor', (name) => generateInterceptorFiles(name))
+  .register('middleware', (name) => generateMiddlewareFiles(name))
+  .register('module', (name) => generateModuleFiles(name))
+  .register('repo', (name, options?: GenerateOptions) => generateRepoFiles(name, options))
+  .register('repository', (name, options?: GenerateOptions) => generateRepoFiles(name, options))
+  .register('request-dto', (name) => generateRequestDtoFiles(name))
+  .register('response-dto', (name) => generateResponseDtoFiles(name))
+  .register('service', (name, options?: GenerateOptions) => generateServiceFiles(name, options));
+

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,3 +13,10 @@ export interface ModuleRegistration {
   className: string;
   kind: 'controller' | 'provider';
 }
+
+export type GeneratorFactory = (name: string, options?: GenerateOptions) => GeneratedFile[];
+
+export interface GeneratorRegistration {
+  factory: GeneratorFactory;
+  description?: string;
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -32,6 +32,8 @@
     "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@konekti/core": "workspace:*"
+    "@konekti/core": "workspace:*",
+    "dotenv": "^16.0.0",
+    "dotenv-expand": "^11.0.0"
   }
 }

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -38,13 +38,91 @@ describe('loadConfig', () => {
       }),
     ).toThrow('Invalid configuration.');
   });
+
+  it('parses multiline values from env files using dotenv', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-multiline-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\\nMIIEowIBAAKCAQ\\n-----END RSA PRIVATE KEY-----"\n');
+
+    const loaded = loadConfig({ cwd, mode: 'dev', processEnv: {} });
+
+    expect(loaded['PRIVATE_KEY']).toContain('BEGIN RSA PRIVATE KEY');
+    expect(loaded['PRIVATE_KEY']).toContain('\n');
+  });
+
+  it('expands variable interpolation in env files', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-expand-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'DB_HOST=localhost\nDB_PORT=5432\nDATABASE_URL=${DB_HOST}:${DB_PORT}/mydb\n');
+
+    const loaded = loadConfig({ cwd, mode: 'dev', processEnv: {} });
+
+    expect(loaded['DATABASE_URL']).toBe('localhost:5432/mydb');
+  });
+
+  it('uses a custom parse function when provided', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-custom-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'KEY: value\n');
+
+    const loaded = loadConfig({
+      cwd,
+      mode: 'dev',
+      processEnv: {},
+      parse: (content) => {
+        const result: Record<string, string> = {};
+        for (const line of content.split('\n')) {
+          const colonIdx = line.indexOf(':');
+          if (colonIdx !== -1) {
+            result[line.slice(0, colonIdx).trim()] = line.slice(colonIdx + 1).trim();
+          }
+        }
+        return result;
+      },
+    });
+
+    expect(loaded['KEY']).toBe('value');
+  });
 });
 
 describe('ConfigService', () => {
   it('reads required and optional keys', () => {
     const service = new ConfigService({ PORT: '3000' });
 
-    expect(service.get<string>('PORT')).toBe('3000');
-    expect(service.getOptional<string>('MISSING')).toBeUndefined();
+    expect(service.get('PORT')).toBe('3000');
+    expect(service.getOptional('MISSING' as never)).toBeUndefined();
+  });
+
+  it('resolves nested dot-path keys', () => {
+    const service = new ConfigService({ db: { host: 'localhost', port: 5432 } });
+
+    expect(service.get('db.host')).toBe('localhost');
+    expect(service.get('db.port')).toBe(5432);
+  });
+
+  it('throws on missing required key', () => {
+    const service = new ConfigService({ PORT: '3000' });
+
+    expect(() => service.get('MISSING' as never)).toThrow('Missing config key');
+  });
+
+  it('returns undefined for missing optional nested key', () => {
+    const service = new ConfigService({ db: { host: 'localhost' } });
+
+    expect(service.getOptional('db.missing' as never)).toBeUndefined();
+  });
+
+  it('provides typed get/getOptional for generic ConfigService', () => {
+    type AppConfig = { PORT: string; DB_URL: string };
+    const service = new ConfigService<AppConfig>({ PORT: '3000', DB_URL: 'postgres://localhost' });
+
+    const port = service.get('PORT');
+    const dbUrl = service.getOptional('DB_URL');
+
+    expect(port).toBe('3000');
+    expect(dbUrl).toBe('postgres://localhost');
   });
 });

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -1,48 +1,24 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, watch } from 'node:fs';
 import { join } from 'node:path';
 
 import { KonektiError } from '@konekti/core';
+import { parse as dotenvParse } from 'dotenv';
+import { expand as dotenvExpand } from 'dotenv-expand';
 
 import type { ConfigDictionary, ConfigLoadOptions } from './types.js';
 
-/**
- * `.env` 파일 내용을 단순한 key-value 맵으로 파싱한다.
- */
-function parseEnvFile(content: string): Record<string, string> {
-  const parsed: Record<string, string> = {};
-
-  for (const line of content.split(/\r?\n/)) {
-    const trimmed = line.trim();
-
-    if (!trimmed || trimmed.startsWith('#')) {
-      continue;
-    }
-
-    const equalsIndex = trimmed.indexOf('=');
-
-    if (equalsIndex === -1) {
-      console.warn(`[config] Skipping malformed .env line (missing '='): ${trimmed}`);
-      continue;
-    }
-
-    const key = trimmed.slice(0, equalsIndex).trim();
-    const rawValue = trimmed.slice(equalsIndex + 1).trim();
-
-    const value =
-      (rawValue.startsWith('"') && rawValue.endsWith('"')) ||
-      (rawValue.startsWith("'") && rawValue.endsWith("'"))
-        ? rawValue.slice(1, -1)
-        : rawValue;
-
-    parsed[key] = value;
+function parseEnvContent(content: string, processEnv: NodeJS.ProcessEnv, customParser?: (content: string) => Record<string, string>): Record<string, string> {
+  if (customParser) {
+    return customParser(content);
   }
-
-  return parsed;
+  const parsed = dotenvParse(content);
+  const safeProcessEnv: Record<string, string> = Object.fromEntries(
+    Object.entries(processEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+  const result = dotenvExpand({ parsed, processEnv: safeProcessEnv });
+  return result.parsed ?? {};
 }
 
-/**
- * 정해진 우선순서에 따라 설정을 병합하고 검증한다.
- */
 export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
   const cwd = options.cwd ?? process.cwd();
   const envFile = options.envFile ?? join(cwd, `.env.${options.mode}`);
@@ -50,7 +26,9 @@ export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
   const processEnv = options.processEnv ?? process.env;
   const runtimeOverrides = options.runtimeOverrides ?? {};
 
-  const envFileValues = existsSync(envFile) ? parseEnvFile(readFileSync(envFile, 'utf8')) : {};
+  const envFileValues = existsSync(envFile)
+    ? parseEnvContent(readFileSync(envFile, 'utf8'), processEnv, options.parse)
+    : {};
 
   const merged: ConfigDictionary = {
     ...defaults,
@@ -59,12 +37,34 @@ export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
     ...runtimeOverrides,
   };
 
+  let validated: ConfigDictionary;
+
   try {
-    return options.validate ? options.validate(merged) : merged;
+    validated = options.validate ? options.validate(merged) : merged;
   } catch (error: unknown) {
     throw new KonektiError('Invalid configuration.', {
       code: 'INVALID_CONFIG',
       cause: error,
     });
   }
+
+  if (options.watch && existsSync(envFile)) {
+    watch(envFile, { persistent: false }, () => {
+      try {
+        const reloaded = parseEnvContent(readFileSync(envFile, 'utf8'), processEnv, options.parse);
+        const mergedReloaded: ConfigDictionary = {
+          ...defaults,
+          ...reloaded,
+          ...processEnv,
+          ...runtimeOverrides,
+        };
+        const result = options.validate ? options.validate(mergedReloaded) : mergedReloaded;
+        process.emit('CONFIG_RELOADED' as never, result as never);
+      } catch {
+        // silently skip reload errors — watch mode is best-effort
+      }
+    });
+  }
+
+  return validated;
 }

--- a/packages/config/src/service.ts
+++ b/packages/config/src/service.ts
@@ -1,26 +1,40 @@
 import { KonektiError } from '@konekti/core';
 
-import type { ConfigDictionary } from './types.js';
+import type { ConfigDictionary, DotPaths, DotValue } from './types.js';
 
-/**
- * 정규화된 설정 값을 읽기 위한 최소한의 typed accessor다.
- */
-export class ConfigService {
-  constructor(private readonly values: ConfigDictionary) {}
+export class ConfigService<T extends Record<string, unknown> = ConfigDictionary> {
+  constructor(private readonly values: T) {}
 
-  get<T>(key: string): T {
-    if (!(key in this.values)) {
-      throw new KonektiError(`Missing config key: ${key}`, { code: 'CONFIG_KEY_MISSING' });
+  get<K extends DotPaths<T>>(key: K): DotValue<T, K & string> {
+    const value = this._resolve(key as string);
+
+    if (value === undefined) {
+      throw new KonektiError(`Missing config key: ${String(key)}`, { code: 'CONFIG_KEY_MISSING' });
     }
 
-    return this.values[key] as T;
+    return value as DotValue<T, K & string>;
   }
 
-  getOptional<T>(key: string): T | undefined {
-    return this.values[key] as T | undefined;
+  getOptional<K extends DotPaths<T>>(key: K): DotValue<T, K & string> | undefined {
+    return this._resolve(key as string) as DotValue<T, K & string> | undefined;
   }
 
   snapshot(): ConfigDictionary {
     return { ...this.values };
+  }
+
+  private _resolve(key: string): unknown {
+    if (key in this.values) {
+      return this.values[key];
+    }
+    const parts = key.split('.');
+    let current: unknown = this.values;
+    for (const part of parts) {
+      if (current === null || typeof current !== 'object' || !(part in (current as Record<string, unknown>))) {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[part];
+    }
+    return current;
   }
 }

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -2,11 +2,40 @@ export type ConfigMode = 'dev' | 'prod' | 'test';
 
 export type ConfigDictionary = Record<string, unknown>;
 
+/**
+ * Nested dot-path key helper.
+ * Produces "a" | "a.b" | "a.b.c" keys from a Record type.
+ */
+export type DotPaths<T, Prefix extends string = ''> = T extends Record<string, unknown>
+  ? {
+      [K in keyof T & string]:
+        | `${Prefix}${K}`
+        | DotPaths<T[K], `${Prefix}${K}.`>;
+    }[keyof T & string]
+  : never;
+
+/**
+ * Resolves a dot-path key to its leaf value type.
+ */
+export type DotValue<T, K extends string> = K extends keyof T
+  ? T[K]
+  : K extends `${infer Head}.${infer Tail}`
+    ? Head extends keyof T
+      ? DotValue<T[Head], Tail>
+      : never
+    : never;
+
 export interface ConfigModuleOptions {
   mode: ConfigMode;
   envFile?: string;
   validate?: (raw: ConfigDictionary) => ConfigDictionary;
   defaults?: ConfigDictionary;
+  /** Supply a custom file parser (e.g. for YAML or TOML). Receives raw file content,
+   *  returns a flat key-value record. Defaults to dotenv parsing. */
+  parse?: (content: string) => Record<string, string>;
+  /** When true, watch the env file for changes and emit CONFIG_RELOADED on the
+   *  internal event bus whenever the file is modified. */
+  watch?: boolean;
 }
 
 export interface ConfigLoadOptions extends ConfigModuleOptions {

--- a/packages/testing/src/mock.ts
+++ b/packages/testing/src/mock.ts
@@ -1,6 +1,11 @@
 import { vi } from 'vitest';
 import type { Mock } from 'vitest';
 
+import type { Token } from '@konekti/core';
+import type { ValueProvider } from '@konekti/di';
+
+import type { DeepMocked } from './types.js';
+
 export type MockedMethods<T> = {
   [K in keyof T]: T[K] extends (...args: never[]) => unknown ? Mock<T[K]> : T[K];
 };
@@ -25,4 +30,28 @@ export function createMock<T extends object>(partial: Partial<MockedMethods<T>> 
 
 export function asMock<T extends (...args: never[]) => unknown>(fn: T): Mock<T> {
   return fn as unknown as Mock<T>;
+}
+
+export function createDeepMock<T extends object>(type: new (...args: unknown[]) => T): DeepMocked<T> {
+  const spies: Record<string | symbol, unknown> = {};
+
+  let proto: object | null = type.prototype as object | null;
+  while (proto !== null && proto !== Object.prototype) {
+    for (const key of Reflect.ownKeys(proto)) {
+      if (key === 'constructor') continue;
+      if (key in spies) continue;
+
+      const descriptor = Object.getOwnPropertyDescriptor(proto, key);
+      if (descriptor && typeof descriptor.value === 'function') {
+        spies[key as string] = vi.fn();
+      }
+    }
+    proto = Object.getPrototypeOf(proto) as object | null;
+  }
+
+  return spies as DeepMocked<T>;
+}
+
+export function mockToken<T>(token: Token<T>, partial: Partial<T> = {}): ValueProvider<T> {
+  return { provide: token, useValue: partial as T };
 }

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -4,7 +4,7 @@ import { Inject, Module } from '@konekti/core';
 import { Controller, Get, Post, type RequestContext } from '@konekti/http';
 import type { Dispatcher } from '@konekti/http';
 
-import { asMock, createMock, createTestApp, createTestingModule, makeRequest } from './index.js';
+import { asMock, createDeepMock, createMock, createTestApp, createTestingModule, makeRequest, mockToken } from './index.js';
 
 @Controller('/users')
 class UserController {
@@ -316,5 +316,217 @@ describe('TestingModuleRef.dispatch', () => {
       headers: { 'x-test-id': 'dispatch' },
       query: { scope: 'all' },
     });
+  });
+});
+
+describe('overrideGuard', () => {
+  it('replaces a guard with a passthrough that always allows access', async () => {
+    const GUARD_TOKEN = Symbol('AuthGuard');
+
+    const builder = createTestingModule({ rootModule: AppModule });
+    builder.overrideGuard(GUARD_TOKEN);
+
+    const testingModule = await builder.compile();
+    const guard = await testingModule.resolve<{ canActivate(): boolean }>(GUARD_TOKEN);
+
+    expect(guard.canActivate()).toBe(true);
+  });
+
+  it('merges partial guard override with the passthrough default', async () => {
+    const GUARD_TOKEN = Symbol('RoleGuard');
+    const canActivate = vi.fn().mockReturnValue(false);
+
+    const builder = createTestingModule({ rootModule: AppModule });
+    builder.overrideGuard(GUARD_TOKEN, { canActivate });
+
+    const testingModule = await builder.compile();
+    const guard = await testingModule.resolve<{ canActivate(): boolean }>(GUARD_TOKEN);
+
+    expect(guard.canActivate()).toBe(false);
+    expect(canActivate).toHaveBeenCalledOnce();
+  });
+});
+
+describe('overrideInterceptor', () => {
+  it('replaces an interceptor with a passthrough that calls next.handle()', async () => {
+    const INTERCEPTOR_TOKEN = Symbol('LoggingInterceptor');
+
+    const builder = createTestingModule({ rootModule: AppModule });
+    builder.overrideInterceptor(INTERCEPTOR_TOKEN);
+
+    const testingModule = await builder.compile();
+    const interceptor = await testingModule.resolve<{
+      intercept(_ctx: unknown, next: { handle(): unknown }): unknown;
+    }>(INTERCEPTOR_TOKEN);
+
+    const next = { handle: vi.fn().mockReturnValue('result') };
+    const result = interceptor.intercept({}, next);
+
+    expect(result).toBe('result');
+    expect(next.handle).toHaveBeenCalledOnce();
+  });
+});
+
+describe('overrideFilter', () => {
+  it('replaces a filter token with a provided fake value', async () => {
+    const FILTER_TOKEN = Symbol('ErrorFilter');
+    const fakeFilter = { catch: vi.fn() };
+
+    const builder = createTestingModule({ rootModule: AppModule });
+    builder.overrideFilter(FILTER_TOKEN, fakeFilter);
+
+    const testingModule = await builder.compile();
+    const filter = await testingModule.resolve<typeof fakeFilter>(FILTER_TOKEN);
+
+    expect(filter).toBe(fakeFilter);
+  });
+});
+
+describe('overrideModule', () => {
+  it('swaps an imported module with a replacement before compilation', async () => {
+    class RealService {
+      value() {
+        return 'real';
+      }
+    }
+
+    class FakeService {
+      value() {
+        return 'fake';
+      }
+    }
+
+    @Inject([RealService])
+    class ConsumerService {
+      constructor(readonly dep: RealService) {}
+    }
+
+    @Module({ providers: [RealService], exports: [RealService] })
+    class RealModule {}
+
+    @Module({ providers: [{ provide: RealService, useClass: FakeService }], exports: [RealService] })
+    class FakeModule {}
+
+    @Module({ imports: [RealModule], providers: [ConsumerService] })
+    class RootModule {}
+
+    const testingModule = await createTestingModule({ rootModule: RootModule })
+      .overrideModule(RealModule, FakeModule)
+      .compile();
+
+    const consumer = await testingModule.resolve(ConsumerService);
+    expect(consumer.dep.value()).toBe('fake');
+  });
+});
+
+describe('createDeepMock', () => {
+  it('wraps every class method in a vi.fn() spy', () => {
+    class MailService {
+      send(_to: string) {
+        return true;
+      }
+      queue(_msg: string) {
+        return 0;
+      }
+    }
+
+    const mock = createDeepMock(MailService);
+
+    expect(typeof mock.send).toBe('function');
+    expect(typeof mock.queue).toBe('function');
+
+    mock.send('test@example.com');
+    expect(vi.isMockFunction(mock.send)).toBe(true);
+    expect((mock.send as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
+  it('includes inherited methods from parent classes', () => {
+    class Base {
+      baseMethod() {
+        return 'base';
+      }
+    }
+
+    class Child extends Base {
+      childMethod() {
+        return 'child';
+      }
+    }
+
+    const mock = createDeepMock(Child);
+
+    expect(vi.isMockFunction(mock.baseMethod)).toBe(true);
+    expect(vi.isMockFunction(mock.childMethod)).toBe(true);
+  });
+
+  it('child method overrides parent method with a single spy', () => {
+    class Base {
+      method() {
+        return 'base';
+      }
+    }
+
+    class Child extends Base {
+      override method() {
+        return 'child';
+      }
+    }
+
+    const mock = createDeepMock(Child);
+    expect(vi.isMockFunction(mock.method)).toBe(true);
+  });
+});
+
+describe('mockToken', () => {
+  it('produces a ValueProvider for the given token and partial', () => {
+    const MY_TOKEN = Symbol('MyService');
+
+    interface MyService {
+      find(id: string): string;
+    }
+
+    const find = vi.fn().mockReturnValue('found');
+    const provider = mockToken<MyService>(MY_TOKEN, { find });
+
+    expect(provider.provide).toBe(MY_TOKEN);
+    expect(provider.useValue.find('1')).toBe('found');
+  });
+
+  it('defaults to an empty object when no partial is given', () => {
+    const TOKEN = Symbol('Token');
+    const provider = mockToken(TOKEN);
+
+    expect(provider.provide).toBe(TOKEN);
+    expect(provider.useValue).toEqual({});
+  });
+
+  it('can be passed directly to overrideProvider', async () => {
+    const TOKEN = Symbol('Greeter');
+
+    interface Greeter {
+      greet(): string;
+    }
+
+    class Logger {
+      readonly name = 'logger';
+    }
+
+    @Inject([Logger])
+    class UserService {
+      constructor(readonly logger: Logger) {}
+    }
+
+    @Module({ providers: [Logger, UserService] })
+    class ServiceModule {}
+
+    const greet = vi.fn().mockReturnValue('hello from mock');
+    const provider = mockToken<Greeter>(TOKEN, { greet });
+
+    const testingModule = await createTestingModule({ rootModule: ServiceModule })
+      .overrideProvider(TOKEN, provider)
+      .compile();
+
+    const greeter = await testingModule.resolve<Greeter>(TOKEN);
+    expect(greeter.greet()).toBe('hello from mock');
   });
 });

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -1,10 +1,11 @@
 import type { Token } from '@konekti/core';
+import { getModuleMetadata } from '@konekti/core';
 import type { ClassType, Provider } from '@konekti/di';
-import type { BootstrapResult } from '@konekti/runtime';
-import { bootstrapModule } from '@konekti/runtime';
+import type { BootstrapResult, ModuleDefinition, ModuleType } from '@konekti/runtime';
+import { bootstrapModule, defineModule } from '@konekti/runtime';
 
 import { createDispatcher, createHandlerMapping } from '@konekti/http';
-import type { HandlerSource } from '@konekti/http';
+import type { Guard, HandlerSource, Interceptor } from '@konekti/http';
 import { createTestRequestContextMiddleware, makeRequest, type TestRequestWithOptions } from './http.js';
 import type { TestingModuleBuilder, TestingModuleOptions, TestingModuleRef } from './types.js';
 
@@ -50,6 +51,7 @@ function normalizeOverride<T>(token: Token<T>, value: Provider<T> | T): Provider
 
 class DefaultTestingModuleBuilder implements TestingModuleBuilder {
   private readonly overrides: Provider[] = [];
+  private readonly moduleReplacements = new Map<ModuleType, ModuleType>();
 
   constructor(private readonly options: TestingModuleOptions) {}
 
@@ -58,13 +60,37 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
     return this;
   }
 
+  overrideGuard(guard: Token<Guard>, fake: Partial<Guard> = {}): this {
+    const passthrough: Guard = { canActivate: () => true, ...fake };
+    this.overrides.push({ provide: guard as Token<Guard>, useValue: passthrough });
+    return this;
+  }
+
+  overrideInterceptor(interceptor: Token<Interceptor>, fake: Partial<Interceptor> = {}): this {
+    const passthrough: Interceptor = { intercept: (_ctx, next) => next.handle(), ...fake };
+    this.overrides.push({ provide: interceptor as Token<Interceptor>, useValue: passthrough });
+    return this;
+  }
+
+  overrideFilter(filter: Token<unknown>, fake: unknown = {}): this {
+    this.overrides.push({ provide: filter, useValue: fake });
+    return this;
+  }
+
+  overrideModule(module: ModuleType, replacement: ModuleType): this {
+    this.moduleReplacements.set(module, replacement);
+    return this;
+  }
+
   async compile(): Promise<TestingModuleRef> {
-    const bootstrapped = bootstrapModule(this.options.rootModule, {
+    const rootModule = this._applyModuleReplacements(this.options.rootModule);
+
+    const bootstrapped = bootstrapModule(rootModule, {
       providers: this.options.providers,
     });
 
     if (this.overrides.length > 0) {
-      bootstrapped.container.register(...this.overrides);
+      bootstrapped.container.override(...this.overrides);
     }
 
     const dispatcher = createTestingDispatcher(bootstrapped);
@@ -75,6 +101,41 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
       resolve: (token) => bootstrapped.container.resolve(token),
       dispatch: (request: TestRequestWithOptions) => makeRequest(dispatcher, request),
     };
+  }
+
+  private _applyModuleReplacements(module: ModuleType): ModuleType {
+    if (this.moduleReplacements.size === 0) {
+      return module;
+    }
+
+    const replacement = this.moduleReplacements.get(module);
+    if (replacement) {
+      return replacement;
+    }
+
+    const metadata = getModuleMetadata(module);
+    if (!metadata?.imports || metadata.imports.length === 0) {
+      return module;
+    }
+
+    const rewrittenImports = (metadata.imports as ModuleType[]).map(
+      (imp) => this._applyModuleReplacements(imp),
+    );
+    const hasChange = rewrittenImports.some(
+      (imp, i) => imp !== (metadata.imports as ModuleType[])[i],
+    );
+
+    if (!hasChange) {
+      return module;
+    }
+
+    class PatchedModule {}
+    defineModule(PatchedModule as unknown as ModuleType, {
+      ...(metadata as ModuleDefinition),
+      imports: rewrittenImports,
+    });
+
+    return PatchedModule as unknown as ModuleType;
   }
 }
 

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -1,6 +1,9 @@
+import type { Mock } from 'vitest';
+
 import type { Token } from '@konekti/core';
 import type { Container, Provider } from '@konekti/di';
 import type { BootstrapResult, BootstrapModuleOptions, ModuleType } from '@konekti/runtime';
+import type { Guard, Interceptor } from '@konekti/http';
 import type { RequestBuilder, TestPrincipal, TestRequest, TestRequestWithOptions, TestResponse } from './http.js';
 
 export interface TestingModuleOptions extends BootstrapModuleOptions {
@@ -21,6 +24,10 @@ export interface TestingModuleBuilder {
   compile(): Promise<TestingModuleRef>;
   overrideProvider<T>(token: Token<T>, provider: Provider<T>): this;
   overrideProvider<T>(token: Token<T>, value: T): this;
+  overrideGuard(guard: Token<Guard>, fake?: Partial<Guard>): this;
+  overrideInterceptor(interceptor: Token<Interceptor>, fake?: Partial<Interceptor>): this;
+  overrideFilter(filter: Token<unknown>, fake?: unknown): this;
+  overrideModule(module: ModuleType, replacement: ModuleType): this;
 }
 
 export interface TestingBootstrapResult {
@@ -36,3 +43,9 @@ export interface TestApp {
   dispatch(request: TestRequestWithOptions): Promise<TestResponse>;
   close(): Promise<void>;
 }
+
+export type DeepMocked<T> = {
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? Mock<(...args: A) => R> & T[K]
+    : T[K];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,12 @@ importers:
 
   packages/cli:
     dependencies:
+      '@types/ejs':
+        specifier: ^3.1.5
+        version: 3.1.5
+      ejs:
+        specifier: ^3.1.10
+        version: 3.1.10
       tsx:
         specifier: ^4.20.4
         version: 4.21.0
@@ -47,6 +53,12 @@ importers:
       '@konekti/core':
         specifier: workspace:*
         version: link:../core
+      dotenv:
+        specifier: ^16.0.0
+        version: 16.6.1
+      dotenv-expand:
+        specifier: ^11.0.0
+        version: 11.0.7
 
   packages/core: {}
 
@@ -1082,6 +1094,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/ejs@3.1.5':
+    resolution: {integrity: sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1155,6 +1170,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1172,6 +1190,9 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1254,6 +1275,14 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dotenv-expand@11.0.7:
+    resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
 
   drizzle-orm@0.45.1:
     resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
@@ -1347,6 +1376,11 @@ packages:
       sqlite3:
         optional: true
 
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   electron-to-chromium@1.5.307:
     resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
 
@@ -1382,6 +1416,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  filelist@1.0.6:
+    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1454,6 +1491,11 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1498,6 +1540,10 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2396,6 +2442,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/ejs@3.1.5': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.15':
@@ -2491,6 +2539,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  async@3.2.6: {}
+
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.10.0: {}
@@ -2504,6 +2554,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
@@ -2590,10 +2644,20 @@ snapshots:
   detect-libc@2.1.2:
     optional: true
 
+  dotenv-expand@11.0.7:
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}
+
   drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@7.5.0(typescript@5.9.3)):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@prisma/client': 7.5.0(typescript@5.9.3)
+
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.4
 
   electron-to-chromium@1.5.307: {}
 
@@ -2668,6 +2732,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  filelist@1.0.6:
+    dependencies:
+      minimatch: 5.1.9
 
   fill-range@7.1.1:
     dependencies:
@@ -2770,6 +2838,12 @@ snapshots:
   is-number@7.0.0:
     optional: true
 
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.6
+      picocolors: 1.1.1
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -2804,6 +2878,10 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Summary

- `@konekti/config`: adds typed key-safe `get()` access on `ConfigService` with dot-notation support and strong return types
- `@konekti/testing`: extends `TestingModuleBuilder` with `overrideGuard`, `overrideInterceptor`, `overrideFilter`, and `overrideModule`; adds `createDeepMock<T>` and `mockToken<T>` helpers
- `@konekti/cli`: migrates all code generators to EJS templates, introduces `GeneratorRegistry` for pluggable third-party generator registration

Closes #97