### PR TITLE
Resolve #112: add regression coverage for CLI ejs template rendering

### DIFF
--- a/packages/cli/src/generators.test.ts
+++ b/packages/cli/src/generators.test.ts
@@ -8,6 +8,7 @@ import { generateModuleFiles, registerInModule } from './generators/module.js';
 import { generateRepoFiles } from './generators/repository.js';
 import { generateRequestDtoFiles } from './generators/request-dto.js';
 import { generateResponseDtoFiles } from './generators/response-dto.js';
+import { renderTemplate } from './generators/render.js';
 import { generateServiceFiles } from './generators/service.js';
 import { GeneratorRegistry, defaultRegistry } from './registry.js';
 
@@ -95,6 +96,18 @@ describe('CLI generators', () => {
   it('generates middleware that registers into middleware array', () => {
     const content = generateMiddlewareFiles('Auth')[0]?.content ?? '';
     expect(content).toContain('handle(context: MiddlewareContext, next: Next)');
+  });
+
+  it('renders templates through ejs', () => {
+    const rendered = renderTemplate('service.ts.ejs', {
+      kebab: 'user',
+      pascal: 'UserService',
+      repo: 'UserRepo',
+      resource: 'User',
+    });
+
+    expect(rendered).toContain("import { UserRepo } from './user.repo';");
+    expect(rendered).toContain('export class UserService');
   });
 
   describe('registerInModule', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,15 +38,16 @@ importers:
 
   packages/cli:
     dependencies:
-      '@types/ejs':
-        specifier: ^3.1.5
-        version: 3.1.5
       ejs:
         specifier: ^3.1.10
         version: 3.1.10
       tsx:
         specifier: ^4.20.4
         version: 4.21.0
+    devDependencies:
+      '@types/ejs':
+        specifier: ^3.1.5
+        version: 3.1.5
 
   packages/config:
     dependencies:


### PR DESCRIPTION
## Summary
- add explicit regression test for `renderTemplate()` using `service.ts.ejs`
- assert generated template output so missing `ejs` resolution breaks tests immediately
- keep lockfile dependency classification consistent after workspace install

## Verification
- pnpm --filter @konekti/cli test --run

Closes #112