### PR TITLE
Resolve #113: harden refresh token rotation and refresh-secret flow

### DIFF
--- a/packages/jwt/src/module.test.ts
+++ b/packages/jwt/src/module.test.ts
@@ -18,6 +18,10 @@ class NoopRefreshTokenStore implements RefreshTokenStore {
   async revoke(_: string): Promise<void> {}
 
   async revokeBySubject(_: string): Promise<void> {}
+
+  async consume(): Promise<'consumed' | 'already_used' | 'expired' | 'not_found' | 'mismatch'> {
+    return 'not_found';
+  }
 }
 
 @Inject([DefaultJwtSigner, DefaultJwtVerifier])

--- a/packages/jwt/src/refresh-token.test.ts
+++ b/packages/jwt/src/refresh-token.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
+import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
 import { RefreshTokenService, type RefreshTokenRecord, type RefreshTokenStore } from './refresh-token.js';
 import { DefaultJwtSigner } from './signer.js';
 import { DefaultJwtVerifier } from './verifier.js';
@@ -26,6 +26,33 @@ class InMemoryRefreshTokenStore implements RefreshTokenStore {
         this.records.delete(id);
       }
     }
+  }
+
+  async consume(input: { tokenId: string; subject: string; family: string; now: Date }): Promise<'consumed' | 'already_used' | 'expired' | 'not_found' | 'mismatch'> {
+    const record = this.records.get(input.tokenId);
+
+    if (!record) {
+      return 'not_found';
+    }
+
+    if (record.subject !== input.subject || record.family !== input.family) {
+      return 'mismatch';
+    }
+
+    if (record.expiresAt.getTime() <= input.now.getTime()) {
+      return 'expired';
+    }
+
+    if (record.used) {
+      return 'already_used';
+    }
+
+    this.records.set(input.tokenId, {
+      ...record,
+      used: true,
+    });
+
+    return 'consumed';
   }
 
   countBySubject(subject: string): number {
@@ -59,21 +86,38 @@ function readTokenPayload(token: string): Record<string, unknown> {
   return JSON.parse(Buffer.from(payloadSegment, 'base64url').toString('utf8')) as Record<string, unknown>;
 }
 
+function createService(
+  store: RefreshTokenStore,
+  options: { expiresInSeconds?: number; rotation?: boolean; refreshSecret?: string } = {},
+): { service: RefreshTokenService; verifier: DefaultJwtVerifier } {
+  const refreshOptions = {
+    expiresInSeconds: options.expiresInSeconds ?? 3600,
+    rotation: options.rotation ?? true,
+    secret: options.refreshSecret ?? 'refresh-secret',
+    store,
+  };
+
+  const signer = new DefaultJwtSigner({
+    algorithms: ['HS256'],
+    refreshToken: refreshOptions,
+    secret: 'access-secret',
+  });
+  const verifier = new DefaultJwtVerifier({
+    algorithms: ['HS256'],
+    refreshToken: refreshOptions,
+    secret: 'access-secret',
+  });
+
+  return {
+    service: new RefreshTokenService(refreshOptions, signer, verifier),
+    verifier,
+  };
+}
+
 describe('RefreshTokenService', () => {
   it('issues a refresh token with expected claims', async () => {
     const store = new InMemoryRefreshTokenStore();
-    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const service = new RefreshTokenService(
-      {
-        expiresInSeconds: 3600,
-        rotation: true,
-        secret: 'refresh-secret',
-        store,
-      },
-      signer,
-      verifier,
-    );
+    const { service } = createService(store);
 
     const refreshToken = await service.issueRefreshToken('user-1');
     const payload = readTokenPayload(refreshToken);
@@ -86,18 +130,7 @@ describe('RefreshTokenService', () => {
 
   it('rotates refresh token and marks previous token as used', async () => {
     const store = new InMemoryRefreshTokenStore();
-    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const service = new RefreshTokenService(
-      {
-        expiresInSeconds: 3600,
-        rotation: true,
-        secret: 'refresh-secret',
-        store,
-      },
-      signer,
-      verifier,
-    );
+    const { service } = createService(store);
     const firstToken = await service.issueRefreshToken('user-1');
     const firstPayload = readTokenPayload(firstToken);
     const firstRecord = await store.find(firstPayload.jti as string);
@@ -117,18 +150,7 @@ describe('RefreshTokenService', () => {
 
   it('detects refresh token reuse and revokes all tokens for the subject', async () => {
     const store = new InMemoryRefreshTokenStore();
-    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const service = new RefreshTokenService(
-      {
-        expiresInSeconds: 3600,
-        rotation: true,
-        secret: 'refresh-secret',
-        store,
-      },
-      signer,
-      verifier,
-    );
+    const { service } = createService(store);
     const token = await service.issueRefreshToken('user-1');
 
     await service.rotateRefreshToken(token);
@@ -138,18 +160,7 @@ describe('RefreshTokenService', () => {
 
   it('revokeAllForSubject removes all subject tokens', async () => {
     const store = new InMemoryRefreshTokenStore();
-    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const service = new RefreshTokenService(
-      {
-        expiresInSeconds: 3600,
-        rotation: true,
-        secret: 'refresh-secret',
-        store,
-      },
-      signer,
-      verifier,
-    );
+    const { service } = createService(store);
 
     await service.issueRefreshToken('user-1');
     await service.issueRefreshToken('user-1');
@@ -161,23 +172,68 @@ describe('RefreshTokenService', () => {
 
   it('rejects expired refresh token records', async () => {
     const store = new InMemoryRefreshTokenStore();
-    const signer = new DefaultJwtSigner({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const verifier = new DefaultJwtVerifier({ algorithms: ['HS256'], secret: 'refresh-secret' });
-    const service = new RefreshTokenService(
-      {
-        expiresInSeconds: 3600,
-        rotation: true,
-        secret: 'refresh-secret',
-        store,
-      },
-      signer,
-      verifier,
-    );
+    const { service } = createService(store);
     const token = await service.issueRefreshToken('user-1');
     const payload = readTokenPayload(token);
 
     store.markExpired(payload.jti as string);
 
     await expect(service.rotateRefreshToken(token)).rejects.toBeInstanceOf(JwtExpiredTokenError);
+  });
+
+  it('uses refreshToken.secret to sign and verify refresh tokens', async () => {
+    const store = new InMemoryRefreshTokenStore();
+    const { service, verifier } = createService(store, { refreshSecret: 'refresh-secret' });
+    const token = await service.issueRefreshToken('user-1');
+
+    await expect(verifier.verifyRefreshToken(token)).resolves.toMatchObject({ subject: 'user-1' });
+    await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+  });
+
+  it('allows only one successful rotation under concurrent requests', async () => {
+    const store = new InMemoryRefreshTokenStore();
+    const { service } = createService(store);
+    const token = await service.issueRefreshToken('user-1');
+
+    const [first, second] = await Promise.allSettled([
+      service.rotateRefreshToken(token),
+      service.rotateRefreshToken(token),
+    ]);
+
+    const fulfilled = [first, second].filter((result): result is PromiseFulfilledResult<{ accessToken: string; refreshToken: string }> => result.status === 'fulfilled');
+    const rejected = [first, second].filter((result): result is PromiseRejectedResult => result.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.reason).toBeInstanceOf(JwtInvalidTokenError);
+  });
+
+  it('fails fast when rotation is enabled with a legacy store lacking consume()', () => {
+    const legacyStore: RefreshTokenStore = {
+      async save(_token: RefreshTokenRecord): Promise<void> {},
+      async find(_tokenId: string): Promise<RefreshTokenRecord | undefined> {
+        return undefined;
+      },
+      async revoke(_tokenId: string): Promise<void> {},
+      async revokeBySubject(_subject: string): Promise<void> {},
+    };
+    const refreshOptions = {
+      expiresInSeconds: 3600,
+      rotation: true,
+      secret: 'refresh-secret',
+      store: legacyStore,
+    };
+    const signer = new DefaultJwtSigner({
+      algorithms: ['HS256'],
+      refreshToken: refreshOptions,
+      secret: 'access-secret',
+    });
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      refreshToken: refreshOptions,
+      secret: 'access-secret',
+    });
+
+    expect(() => new RefreshTokenService(refreshOptions, signer, verifier)).toThrow(JwtConfigurationError);
   });
 });

--- a/packages/jwt/src/refresh-token.ts
+++ b/packages/jwt/src/refresh-token.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
+import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
 import { DefaultJwtSigner } from './signer.js';
 import type { JwtClaims } from './types.js';
 import { DefaultJwtVerifier } from './verifier.js';
@@ -10,7 +10,17 @@ export interface RefreshTokenStore {
   find(tokenId: string): Promise<RefreshTokenRecord | undefined>;
   revoke(tokenId: string): Promise<void>;
   revokeBySubject(subject: string): Promise<void>;
+  consume?(input: RefreshTokenConsumeInput): Promise<RefreshTokenConsumeResult>;
 }
+
+export interface RefreshTokenConsumeInput {
+  tokenId: string;
+  subject: string;
+  family: string;
+  now: Date;
+}
+
+export type RefreshTokenConsumeResult = 'consumed' | 'already_used' | 'expired' | 'not_found' | 'mismatch';
 
 export interface RefreshTokenRecord {
   id: string;
@@ -39,7 +49,13 @@ export class RefreshTokenService {
     private readonly options: RefreshTokenOptions,
     private readonly signer: DefaultJwtSigner,
     private readonly verifier: DefaultJwtVerifier,
-  ) {}
+  ) {
+    if (this.options.rotation && typeof this.options.store.consume !== 'function') {
+      throw new JwtConfigurationError(
+        'Refresh token rotation requires an atomic store.consume() implementation.',
+      );
+    }
+  }
 
   async issueRefreshToken(subject: string): Promise<string> {
     const family = randomUUID();
@@ -49,6 +65,44 @@ export class RefreshTokenService {
 
   async rotateRefreshToken(currentToken: string): Promise<{ accessToken: string; refreshToken: string }> {
     const claims = await this.verifyRefreshClaims(currentToken);
+
+    if (this.options.rotation) {
+      if (!this.options.store.consume) {
+        throw new JwtConfigurationError(
+          'Refresh token rotation requires an atomic store.consume() implementation.',
+        );
+      }
+
+      const consumeResult = await this.options.store.consume({
+        family: claims.family,
+        now: new Date(),
+        subject: claims.sub,
+        tokenId: claims.jti,
+      });
+
+      if (consumeResult === 'consumed') {
+        const refreshToken = await this.issueRefreshTokenWithFamily(claims.sub, claims.family);
+        const accessToken = await this.signer.signAccessToken({ sub: claims.sub });
+
+        return { accessToken, refreshToken };
+      }
+
+      if (consumeResult === 'already_used') {
+        await this.options.store.revokeBySubject(claims.sub);
+        throw new JwtInvalidTokenError('Refresh token reuse detected.');
+      }
+
+      if (consumeResult === 'expired') {
+        throw new JwtExpiredTokenError('Refresh token has expired.');
+      }
+
+      if (consumeResult === 'not_found') {
+        throw new JwtInvalidTokenError('Refresh token record was not found.');
+      }
+
+      throw new JwtInvalidTokenError('Refresh token record does not match token claims.');
+    }
+
     const record = await this.options.store.find(claims.jti);
 
     if (!record) {
@@ -66,14 +120,6 @@ export class RefreshTokenService {
     if (record.used) {
       await this.options.store.revokeBySubject(record.subject);
       throw new JwtInvalidTokenError('Refresh token reuse detected.');
-    }
-
-    if (this.options.rotation) {
-      await this.options.store.save({ ...record, used: true });
-      const refreshToken = await this.issueRefreshTokenWithFamily(record.subject, record.family);
-      const accessToken = await this.signer.signAccessToken({ sub: record.subject });
-
-      return { accessToken, refreshToken };
     }
 
     const accessToken = await this.signer.signAccessToken({ sub: record.subject });
@@ -111,11 +157,11 @@ export class RefreshTokenService {
       type: 'refresh',
     };
 
-    return this.signer.signAccessToken(claims);
+    return this.signer.signRefreshToken(claims);
   }
 
   private async verifyRefreshClaims(token: string): Promise<RefreshTokenClaims & { sub: string }> {
-    const principal = await this.verifier.verifyAccessToken(token);
+    const principal = await this.verifier.verifyRefreshToken(token);
     const claims = principal.claims;
 
     if (claims.type !== 'refresh') {

--- a/packages/jwt/src/signer.ts
+++ b/packages/jwt/src/signer.ts
@@ -19,11 +19,47 @@ export class DefaultJwtSigner {
   constructor(private readonly options: JwtVerifierOptions) {}
 
   async signAccessToken(claims: JwtClaims): Promise<string> {
-    const algorithm: JwtAlgorithm | undefined = this.options.algorithms.find(
-      (alg) => alg in HMAC_HASH || alg in ASYMMETRIC_HASH,
-    );
+    return this.signToken(claims, this.options, false);
+  }
+
+  async signRefreshToken(claims: JwtClaims): Promise<string> {
+    const refreshOptions = this.resolveRefreshSigningOptions();
+    return this.signToken(claims, refreshOptions, true);
+  }
+
+  private resolveRefreshSigningOptions(): JwtVerifierOptions {
+    const refreshToken = this.options.refreshToken;
+
+    if (!refreshToken) {
+      throw new JwtConfigurationError('JWT refresh token options are not configured.');
+    }
+
+    return {
+      ...this.options,
+      accessTokenTtlSeconds: refreshToken.expiresInSeconds,
+      algorithms: this.options.algorithms.filter((algorithm) => algorithm in HMAC_HASH),
+      keys: undefined,
+      privateKey: undefined,
+      secret: refreshToken.secret,
+    };
+  }
+
+  private async signToken(claims: JwtClaims, options: JwtVerifierOptions, hmacOnly: boolean): Promise<string> {
+    const algorithm: JwtAlgorithm | undefined = options.algorithms.find((alg) => {
+      if (hmacOnly) {
+        return alg in HMAC_HASH;
+      }
+
+      return alg in HMAC_HASH || alg in ASYMMETRIC_HASH;
+    });
 
     if (!algorithm) {
+      if (hmacOnly) {
+        throw new JwtConfigurationError(
+          'JWT refresh token signer requires at least one HMAC algorithm (HS256/HS384/HS512) in the allowed algorithms list.',
+        );
+      }
+
       throw new JwtConfigurationError(
         'JWT signer requires at least one supported algorithm (HS256/HS384/HS512/RS256/RS384/RS512/ES256/ES384/ES512) in the allowed algorithms list.',
       );
@@ -32,16 +68,16 @@ export class DefaultJwtSigner {
     const isAsymmetric = algorithm in ASYMMETRIC_HASH;
 
     const now = Math.floor(Date.now() / 1000);
-    const ttl = this.options.accessTokenTtlSeconds ?? 3600;
+    const ttl = options.accessTokenTtlSeconds ?? 3600;
     const payload: JwtClaims = {
       ...claims,
-      aud: claims.aud ?? this.options.audience,
+      aud: claims.aud ?? options.audience,
       exp: claims.exp ?? now + ttl,
       iat: claims.iat ?? now,
-      iss: claims.iss ?? this.options.issuer,
+      iss: claims.iss ?? options.issuer,
     };
 
-    const activeKey = this.options.keys?.[0];
+    const activeKey = options.keys?.[0];
     const header: Record<string, string> = {
       alg: algorithm,
       typ: 'JWT',
@@ -54,7 +90,7 @@ export class DefaultJwtSigner {
     let signatureSegment: string;
 
     if (isAsymmetric) {
-      const privateKey = activeKey?.privateKey ?? this.options.privateKey;
+      const privateKey = activeKey?.privateKey ?? options.privateKey;
 
       if (!privateKey) {
         throw new JwtConfigurationError('JWT private key is not configured.');
@@ -73,7 +109,7 @@ export class DefaultJwtSigner {
         ? signer.sign({ dsaEncoding: 'ieee-p1363', key: privateKey } as Parameters<typeof signer.sign>[0], 'base64url')
         : signer.sign(privateKey, 'base64url');
     } else {
-      const secret = activeKey?.secret ?? this.options.secret;
+      const secret = activeKey?.secret ?? options.secret;
 
       if (!secret) {
         throw new JwtConfigurationError('JWT secret is not configured.');

--- a/packages/jwt/src/verifier.ts
+++ b/packages/jwt/src/verifier.ts
@@ -132,6 +132,38 @@ export class DefaultJwtVerifier {
   }
 
   async verifyAccessToken(token: string): Promise<JwtPrincipal> {
+    return this.verifyToken(token, this.options, this.jwksClient);
+  }
+
+  async verifyRefreshToken(token: string): Promise<JwtPrincipal> {
+    return this.verifyToken(token, this.resolveRefreshVerificationOptions(), undefined);
+  }
+
+  private resolveRefreshVerificationOptions(): JwtVerifierOptions {
+    const refreshToken = this.options.refreshToken;
+
+    if (!refreshToken) {
+      throw new JwtConfigurationError('JWT refresh token options are not configured.');
+    }
+
+    return {
+      ...this.options,
+      algorithms: this.options.algorithms.filter((algorithm) => algorithm in HMAC_HASH),
+      jwksUri: undefined,
+      keys: undefined,
+      privateKey: undefined,
+      publicKey: undefined,
+      requireExp: true,
+      secret: refreshToken.secret,
+      secretOrKeyProvider: undefined,
+    };
+  }
+
+  private async verifyToken(
+    token: string,
+    options: JwtVerifierOptions,
+    jwksClient: JwksClient | undefined,
+  ): Promise<JwtPrincipal> {
     const segments = token.split('.');
 
     if (segments.length !== 3) {
@@ -141,7 +173,7 @@ export class DefaultJwtVerifier {
     const [headerSegment, payloadSegment, signatureSegment] = segments;
     const header = parseJwtPart<{ [key: string]: unknown; alg?: string; kid?: string; typ?: string }>(headerSegment);
     const payload = parseJwtPart<JwtClaims>(payloadSegment);
-    const algorithms = this.options.algorithms;
+    const algorithms = options.algorithms;
 
     if (!isAllowedAlgorithm(header.alg, algorithms)) {
       throw new JwtInvalidTokenError('JWT algorithm is not allowed.');
@@ -150,8 +182,8 @@ export class DefaultJwtVerifier {
     const signingInput = `${headerSegment}.${payloadSegment}`;
 
     if (header.alg in HMAC_HASH) {
-      const providerKey = this.options.secretOrKeyProvider
-        ? await this.options.secretOrKeyProvider({ alg: header.alg, ...header })
+      const providerKey = options.secretOrKeyProvider
+        ? await options.secretOrKeyProvider({ alg: header.alg, ...header })
         : undefined;
 
       if (providerKey !== undefined && typeof providerKey !== 'string') {
@@ -161,8 +193,8 @@ export class DefaultJwtVerifier {
       const secret =
         providerKey ??
         ((header.kid !== undefined && header.kid !== ''
-          ? this.options.keys?.find((k) => k.kid === header.kid)?.secret
-          : undefined) ?? this.options.secret);
+          ? options.keys?.find((k) => k.kid === header.kid)?.secret
+          : undefined) ?? options.secret);
 
       if (!secret) {
         throw new JwtConfigurationError('JWT secret is not configured.');
@@ -170,16 +202,16 @@ export class DefaultJwtVerifier {
 
       verifyHmacSignature(header.alg, secret, signingInput, signatureSegment);
     } else {
-      const providerKey = this.options.secretOrKeyProvider
-        ? await this.options.secretOrKeyProvider({ alg: header.alg, ...header })
+      const providerKey = options.secretOrKeyProvider
+        ? await options.secretOrKeyProvider({ alg: header.alg, ...header })
         : undefined;
       const publicKey =
         providerKey ??
-        (this.jwksClient
-          ? await this.resolveJwksPublicKey(header.kid)
+        (jwksClient
+          ? await this.resolveJwksPublicKey(header.kid, jwksClient)
           : ((header.kid !== undefined && header.kid !== ''
-              ? this.options.keys?.find((k) => k.kid === header.kid)?.publicKey
-              : undefined) ?? this.options.publicKey));
+              ? options.keys?.find((k) => k.kid === header.kid)?.publicKey
+              : undefined) ?? options.publicKey));
 
       if (!publicKey) {
         throw new JwtConfigurationError('JWT public key is not configured.');
@@ -189,13 +221,13 @@ export class DefaultJwtVerifier {
     }
 
     const now = Math.floor(Date.now() / 1000);
-    const clockSkew = this.options.clockSkewSeconds ?? 0;
+    const clockSkew = options.clockSkewSeconds ?? 0;
 
-    if (this.options.requireExp !== false && typeof payload.exp !== 'number') {
+    if (options.requireExp !== false && typeof payload.exp !== 'number') {
       throw new JwtInvalidTokenError('JWT is missing a required expiration claim.');
     }
 
-    if (typeof this.options.maxAge === 'number' && typeof payload.iat === 'number' && now - payload.iat > this.options.maxAge) {
+    if (typeof options.maxAge === 'number' && typeof payload.iat === 'number' && now - payload.iat > options.maxAge) {
       throw new JwtExpiredTokenError('JWT exceeds maxAge.');
     }
 
@@ -207,12 +239,12 @@ export class DefaultJwtVerifier {
       throw new JwtInvalidTokenError('JWT is not active yet.');
     }
 
-    if (this.options.issuer && payload.iss !== this.options.issuer) {
+    if (options.issuer && payload.iss !== options.issuer) {
       throw new JwtInvalidTokenError('JWT issuer does not match.');
     }
 
-    if (this.options.audience) {
-      const expectedAudience = Array.isArray(this.options.audience) ? this.options.audience : [this.options.audience];
+    if (options.audience) {
+      const expectedAudience = Array.isArray(options.audience) ? options.audience : [options.audience];
       const actualAudience = Array.isArray(payload.aud) ? payload.aud : payload.aud ? [payload.aud] : [];
 
       if (!expectedAudience.some((audience) => actualAudience.includes(audience))) {
@@ -223,15 +255,11 @@ export class DefaultJwtVerifier {
     return normalizePrincipal(payload);
   }
 
-  private async resolveJwksPublicKey(kid: string | undefined): Promise<KeyObject> {
-    if (!this.jwksClient) {
-      throw new JwtConfigurationError('JWKS client is not configured.');
-    }
-
+  private async resolveJwksPublicKey(kid: string | undefined, jwksClient: JwksClient): Promise<KeyObject> {
     if (typeof kid !== 'string' || kid.length === 0) {
       throw new JwtInvalidTokenError('JWT is missing key id (kid) for JWKS resolution.');
     }
 
-    return this.jwksClient.getSigningKey(kid);
+    return jwksClient.getSigningKey(kid);
   }
 }


### PR DESCRIPTION
## Summary
- add atomic `store.consume()` contract for refresh token rotation and remove insecure `find() -> save()` race path
- require refresh service rotation mode to use atomic consume and map consume outcomes to explicit token errors
- introduce refresh-specific signer/verifier methods so refresh tokens are signed and verified with `refreshToken.secret`
- extend JWT refresh tests to cover concurrency, refresh-secret separation, and legacy-store misconfiguration

## Verification
- pnpm -r --filter "./packages/*" --if-present run build
- pnpm exec vitest run packages/jwt/src/*.test.ts
- pnpm --filter @konekti/jwt typecheck
- pnpm --filter @konekti/jwt build

Closes #113