### PR TITLE
Resolve #114: fix Accept q=0 negotiation and memory store sweep scheduling

### DIFF
--- a/packages/http/src/dispatcher.test.ts
+++ b/packages/http/src/dispatcher.test.ts
@@ -181,6 +181,57 @@ describe('dispatcher runtime', () => {
     });
   });
 
+  it('returns 406 when Accept tokens are all q=0', async () => {
+    @Controller('/negotiation')
+    class NegotiationController {
+      @Produces('application/json', 'text/plain')
+      @Get('/q-zero')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        formatters: [
+          {
+            format(body) {
+              return JSON.stringify(body);
+            },
+            mediaType: 'application/json',
+          },
+          {
+            format(body) {
+              return `plain:${JSON.stringify(body)}`;
+            },
+            mediaType: 'text/plain',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(
+      createRequest('/negotiation/q-zero', 'GET', { accept: 'application/json;q=0, text/plain;q=0' }),
+      response,
+    );
+
+    expect(response.statusCode).toBe(406);
+    expect(response.body).toEqual({
+      error: {
+        code: 'NOT_ACCEPTABLE',
+        details: undefined,
+        message: 'No acceptable response representation found.',
+        meta: undefined,
+        requestId: undefined,
+        status: 406,
+      },
+    });
+  });
+
   it('falls back to default formatter for wildcard Accept header', async () => {
     @Controller('/negotiation')
     class NegotiationController {

--- a/packages/http/src/dispatcher.ts
+++ b/packages/http/src/dispatcher.ts
@@ -230,7 +230,7 @@ function selectResponseFormatter(
   const acceptTokens = parseAcceptHeader(acceptHeader);
 
   if (!acceptTokens.length) {
-    return defaultFormatter;
+    throw new NotAcceptableException('No acceptable response representation found.');
   }
 
   for (const token of acceptTokens) {

--- a/packages/http/src/rate-limit.test.ts
+++ b/packages/http/src/rate-limit.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createRateLimitMiddleware } from './rate-limit.js';
+import { createMemoryRateLimitStore, createRateLimitMiddleware } from './rate-limit.js';
 import type { MiddlewareContext } from './types.js';
 
 function createContext(remoteAddress = '127.0.0.1') {
@@ -160,5 +160,20 @@ describe('createRateLimitMiddleware', () => {
 
     expect(context.response.statusCode).toBe(200);
     expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps eviction active after an initial empty sweep', async () => {
+    const store = createMemoryRateLimitStore();
+    const now = Date.now();
+
+    await store.evict(now);
+    await store.set('client-1', {
+      count: 1,
+      resetAt: now - 1,
+    });
+
+    await store.evict(now + 1);
+
+    expect(store.get('client-1')).toBeUndefined();
   });
 });

--- a/packages/http/src/rate-limit.ts
+++ b/packages/http/src/rate-limit.ts
@@ -62,7 +62,7 @@ export function createMemoryRateLimitStore(): RateLimitStore {
         next = Math.min(next, entry.resetAt);
       }
 
-      nextSweepAt = next;
+      nextSweepAt = Number.isFinite(next) ? next : 0;
     },
   };
 }


### PR DESCRIPTION
## Summary
- treat an explicit `Accept` header with no acceptable media tokens (e.g. all `q=0`) as `406 Not Acceptable` instead of falling back to default formatter
- fix memory rate-limit store sweep scheduling so an initial empty sweep does not freeze future evictions
- add regression tests for both scenarios in dispatcher and rate-limit suites

## Verification
- pnpm -r --filter "./packages/*" --if-present run build
- pnpm exec vitest run packages/http/src/dispatcher.test.ts packages/http/src/rate-limit.test.ts
- pnpm --filter @konekti/http build
- lsp_diagnostics: no errors on modified files

## Notes
- `pnpm --filter @konekti/http typecheck` currently fails due pre-existing test typing issues in this package on main (unrelated to this change)

Closes #114