### PR TITLE
Resolve #115: fix cron lock-loss handling and metrics error labeling

### DIFF
--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -54,6 +54,41 @@ class InMemoryLockRedisClient {
   }
 }
 
+class LockLossOnRenewRedisClient {
+  private readonly locks = new Map<string, string>();
+
+  async set(key: string, value: string, _mode: 'PX', _ttl: number, _existence: 'NX'): Promise<'OK' | null> {
+    if (this.locks.has(key)) {
+      return null;
+    }
+
+    this.locks.set(key, value);
+    return 'OK';
+  }
+
+  async eval(script: string, _keysLength: number, key: string, owner: string, _ttl?: string): Promise<number> {
+    if (script.includes('PEXPIRE')) {
+      if (this.locks.get(key) !== owner) {
+        return 0;
+      }
+
+      this.locks.delete(key);
+      return 0;
+    }
+
+    if (!script.includes('DEL')) {
+      return 0;
+    }
+
+    if (this.locks.get(key) !== owner) {
+      return 0;
+    }
+
+    this.locks.delete(key);
+    return 1;
+  }
+}
+
 function createDeferred<T = void>(): Deferred<T> {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -640,6 +675,115 @@ describe('@konekti/cron', () => {
     await scheduled.records[0]!.tick();
 
     expect(events).toEqual(['before', 'run', 'error:hook boom', 'after']);
+
+    await app.close();
+  });
+
+  it('runs onError and afterRun when beforeRun throws', async () => {
+    const scheduled = createManualScheduler();
+    const events: string[] = [];
+
+    class BeforeRunFailingTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        afterRun: () => {
+          events.push('after');
+        },
+        beforeRun: () => {
+          events.push('before');
+          throw new Error('before boom');
+        },
+        name: 'before-run-failing-task',
+        onError: (error) => {
+          events.push(`error:${error instanceof Error ? error.message : 'unknown'}`);
+        },
+        onSuccess: () => {
+          events.push('success');
+        },
+      })
+      run() {
+        events.push('run');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCronModule({ scheduler: scheduled.scheduler })],
+      providers: [BeforeRunFailingTaskService],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+
+    await scheduled.records[0]!.tick();
+
+    expect(events).toEqual(['before', 'error:before boom', 'after']);
+
+    await app.close();
+  });
+
+  it('treats lock ownership loss during renewal as a failed tick', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-20T00:00:00.000Z'));
+
+    const scheduled = createManualScheduler();
+    const redis = new LockLossOnRenewRedisClient();
+    const started = createDeferred<void>();
+    const release = createDeferred<void>();
+    const events: string[] = [];
+
+    class DistributedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        afterRun: () => {
+          events.push('after');
+        },
+        distributed: true,
+        lockTtlMs: 2_000,
+        name: 'lock-loss-task',
+        onError: (error) => {
+          events.push(`error:${error instanceof Error ? error.message : 'unknown'}`);
+        },
+        onSuccess: () => {
+          events.push('success');
+        },
+      })
+      async run() {
+        events.push('run');
+        started.resolve();
+        await release.promise;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        createCronModule({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-lock-loss',
+            lockTtlMs: 2_000,
+          },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    const tickPromise = scheduled.records[0]!.tick();
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(1_000);
+    release.resolve();
+    await tickPromise;
+
+    expect(events).toEqual([
+      'run',
+      'error:Distributed cron lock ownership lost for lock-loss-task.',
+      'after',
+    ]);
 
     await app.close();
   });

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -280,12 +280,17 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     }
 
     const renewalIntervalMs = Math.max(1_000, Math.floor(descriptor.lockTtlMs / 2));
+    let lockOwnershipError: Error | undefined;
     const renewalTimer = setInterval(() => {
-      void this.renewLock(descriptor);
+      void this.renewLock(descriptor).then((renewed) => {
+        if (!renewed && !lockOwnershipError) {
+          lockOwnershipError = new Error(`Distributed cron lock ownership lost for ${descriptor.taskName}.`);
+        }
+      });
     }, renewalIntervalMs);
 
     try {
-      await this.executeTask(descriptor);
+      await this.executeTask(descriptor, () => lockOwnershipError);
     } finally {
       clearInterval(renewalTimer);
       await this.releaseLock(descriptor);
@@ -298,7 +303,10 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     }
   }
 
-  private async executeTask(descriptor: CronTaskDescriptor): Promise<void> {
+  private async executeTask(
+    descriptor: CronTaskDescriptor,
+    postRunErrorProvider?: () => Error | undefined,
+  ): Promise<void> {
     let instance: unknown;
 
     try {
@@ -322,12 +330,19 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
       return;
     }
 
-    if (descriptor.beforeRun) {
-      await Promise.resolve(descriptor.beforeRun());
-    }
-
     try {
+      if (descriptor.beforeRun) {
+        await Promise.resolve(descriptor.beforeRun());
+      }
+
       await Promise.resolve((value as (this: unknown) => Promise<void>).call(instance));
+
+      const postRunError = postRunErrorProvider?.();
+
+      if (postRunError) {
+        throw postRunError;
+      }
+
       if (descriptor.onSuccess) {
         await Promise.resolve(descriptor.onSuccess());
       }
@@ -378,27 +393,38 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     await this.releaseLockKey(descriptor.lockKey, descriptor.taskName);
   }
 
-  private async renewLock(descriptor: CronTaskDescriptor): Promise<void> {
+  private async renewLock(descriptor: CronTaskDescriptor): Promise<boolean> {
     const redis = this.redisClient;
 
     if (!redis) {
-      return;
+      return true;
     }
 
     try {
-      await redis.eval(
+      const result = await redis.eval(
         RENEW_LOCK_SCRIPT,
         1,
         descriptor.lockKey,
         this.options.distributed.ownerId,
         String(descriptor.lockTtlMs),
       );
+
+      if (typeof result === 'number' && result <= 0) {
+        this.logger.warn(
+          `Distributed cron lock ownership was lost for ${descriptor.taskName}.`,
+          'CronLifecycleService',
+        );
+        return false;
+      }
+
+      return true;
     } catch (error) {
       this.logger.error(
         `Failed to renew distributed cron lock for ${descriptor.taskName}.`,
         error,
         'CronLifecycleService',
       );
+      return false;
     }
   }
 

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -7,6 +7,26 @@ type HttpMetricLabels = {
   status: string;
 };
 
+function readErrorStatusCode(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+
+  const candidate = error as { status?: unknown; statusCode?: unknown };
+  const fromStatus = typeof candidate.status === 'number' ? candidate.status : undefined;
+  const fromStatusCode = typeof candidate.statusCode === 'number' ? candidate.statusCode : undefined;
+
+  if (fromStatus !== undefined && Number.isFinite(fromStatus)) {
+    return fromStatus;
+  }
+
+  if (fromStatusCode !== undefined && Number.isFinite(fromStatusCode)) {
+    return fromStatusCode;
+  }
+
+  return undefined;
+}
+
 export class HttpMetricsMiddleware implements Middleware {
   private readonly requestsTotal: Counter<string>;
   private readonly errorsTotal: Counter<string>;
@@ -37,19 +57,28 @@ export class HttpMetricsMiddleware implements Middleware {
     const start = performance.now();
     const method = context.request.method;
     const path = context.request.path;
+    let requestError: unknown;
 
     try {
       await next();
+    } catch (error) {
+      requestError = error;
+      throw error;
     } finally {
-      const status = String(context.response.statusCode ?? 200);
+      const responseStatusCode = context.response.statusCode;
+      const statusCode =
+        responseStatusCode
+        ?? (requestError
+          ? (readErrorStatusCode(requestError) ?? 500)
+          : 200);
+      const status = String(statusCode);
       const durationSeconds = (performance.now() - start) / 1000;
       const labels: HttpMetricLabels = { method, path, status };
 
       this.requestsTotal.inc(labels);
       this.requestDuration.observe(labels, durationSeconds);
 
-      const statusCode = Number(status);
-      if (statusCode >= 400) {
+      if (statusCode >= 400 || requestError !== undefined) {
         this.errorsTotal.inc(labels);
       }
     }

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -104,4 +104,50 @@ describe('MetricsModule', () => {
     await firstApp.close();
     await secondApp.close();
   });
+
+  it('records thrown middleware errors with 500 status labels', async () => {
+    let failNextRequest = true;
+
+    const failingMiddleware = {
+      async handle(_context: unknown, next: () => Promise<void>): Promise<void> {
+        if (failNextRequest) {
+          failNextRequest = false;
+          throw new Error('metrics route boom');
+        }
+
+        await next();
+      },
+    };
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, http: true, middleware: [failingMiddleware] })],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    const errorResponse = createResponse();
+    await app.dispatch(createRequest('/metrics'), errorResponse);
+    expect(errorResponse.statusCode).toBe(500);
+
+    const metricsResponse = createResponse();
+    await app.dispatch(createRequest('/metrics'), metricsResponse);
+
+    const metricsText = String(metricsResponse.body);
+
+    expect(metricsResponse.statusCode).toBe(200);
+    expect(metricsText).toContain('http_requests_total{method="GET",path="/metrics",status="500"} 1');
+    expect(metricsText).toContain('http_errors_total{method="GET",path="/metrics",status="500"} 1');
+
+    await app.close();
+  });
+
+  it('throws when otel provider is requested', () => {
+    expect(() => MetricsModule.forRoot({ provider: 'otel' })).toThrow(
+      'MetricsModule provider "otel" is not implemented yet. Use provider "prometheus".',
+    );
+  });
 });

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -20,12 +20,14 @@ export class MetricsModule {
   private static registeredRegistries = new WeakSet<Registry>();
 
   static forRoot(options: MetricsModuleOptions = {}): ModuleType {
+    if (options.provider === 'otel') {
+      throw new Error('MetricsModule provider "otel" is not implemented yet. Use provider "prometheus".');
+    }
+
     const metricsPath = options.path ?? '/metrics';
     const registry = new Registry();
     const metricsService = new MetricsService(registry);
-    const meterProvider = options.provider === 'otel'
-      ? new PrometheusMeterProvider(registry)
-      : new PrometheusMeterProvider(registry);
+    const meterProvider = new PrometheusMeterProvider(registry);
 
     if (options.defaultMetrics !== false && !MetricsModule.registeredRegistries.has(registry)) {
       MetricsModule.registeredRegistries.add(registry);


### PR DESCRIPTION
## Summary
- treat distributed cron lock-renew ownership loss as a task failure signal so `onSuccess` is skipped and `onError`/`afterRun` still run
- move `beforeRun` hook inside cron execution `try/catch/finally` so hook exceptions consistently trigger error and finally hooks
- update HTTP metrics middleware to classify thrown downstream failures as non-200 (fallback 500) and increment error counters correctly
- fail fast when `MetricsModule.forRoot({ provider: "otel" })` is requested because otel provider wiring is not implemented

## Verification
- pnpm install
- pnpm -r --filter "./packages/*" --if-present run build
- pnpm exec vitest run packages/cron/src/module.test.ts packages/metrics/src/metrics-module.test.ts
- pnpm --filter @konekti/cron typecheck
- pnpm --filter @konekti/metrics typecheck
- pnpm --filter @konekti/cron build
- pnpm --filter @konekti/metrics build
- lsp_diagnostics on modified files: no errors

Closes #115