### PR TITLE
Resolve #116: fix config own-key resolution and testing override function handling

### DIFF
--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -28,6 +28,22 @@ describe('loadConfig', () => {
     });
   });
 
+  it('does not let undefined process env values overwrite file/default values', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-undefined-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const loaded = loadConfig({
+      cwd,
+      defaults: { PORT: '3000' },
+      mode: 'dev',
+      processEnv: { PORT: undefined },
+    });
+
+    expect(loaded).toMatchObject({ PORT: '4000' });
+  });
+
   it('fails when validation rejects the merged config', () => {
     expect(() =>
       loadConfig({
@@ -113,6 +129,22 @@ describe('ConfigService', () => {
     const service = new ConfigService({ db: { host: 'localhost' } });
 
     expect(service.getOptional('db.missing' as never)).toBeUndefined();
+  });
+
+  it('does not resolve inherited top-level keys', () => {
+    const values = Object.create({ PORT: '3000' }) as Record<string, unknown>;
+    const service = new ConfigService(values);
+
+    expect(service.getOptional('PORT' as never)).toBeUndefined();
+    expect(() => service.get('PORT' as never)).toThrow('Missing config key');
+  });
+
+  it('does not resolve inherited nested keys', () => {
+    const db = Object.create({ host: 'localhost' }) as Record<string, unknown>;
+    const service = new ConfigService({ db });
+
+    expect(service.getOptional('db.host' as never)).toBeUndefined();
+    expect(() => service.get('db.host' as never)).toThrow('Missing config key');
   });
 
   it('provides typed get/getOptional for generic ConfigService', () => {

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -19,11 +19,18 @@ function parseEnvContent(content: string, processEnv: NodeJS.ProcessEnv, customP
   return result.parsed ?? {};
 }
 
+function sanitizeProcessEnv(processEnv: NodeJS.ProcessEnv): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(processEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+}
+
 export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
   const cwd = options.cwd ?? process.cwd();
   const envFile = options.envFile ?? join(cwd, `.env.${options.mode}`);
   const defaults = options.defaults ?? {};
   const processEnv = options.processEnv ?? process.env;
+  const safeProcessEnv = sanitizeProcessEnv(processEnv);
   const runtimeOverrides = options.runtimeOverrides ?? {};
 
   const envFileValues = existsSync(envFile)
@@ -33,7 +40,7 @@ export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
   const merged: ConfigDictionary = {
     ...defaults,
     ...envFileValues,
-    ...processEnv,
+    ...safeProcessEnv,
     ...runtimeOverrides,
   };
 
@@ -55,7 +62,7 @@ export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
         const mergedReloaded: ConfigDictionary = {
           ...defaults,
           ...reloaded,
-          ...processEnv,
+          ...safeProcessEnv,
           ...runtimeOverrides,
         };
         const result = options.validate ? options.validate(mergedReloaded) : mergedReloaded;

--- a/packages/config/src/service.ts
+++ b/packages/config/src/service.ts
@@ -2,6 +2,10 @@ import { KonektiError } from '@konekti/core';
 
 import type { ConfigDictionary, DotPaths, DotValue } from './types.js';
 
+function hasOwn(value: unknown, key: string): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && Object.hasOwn(value, key);
+}
+
 export class ConfigService<T extends Record<string, unknown> = ConfigDictionary> {
   constructor(private readonly values: T) {}
 
@@ -24,16 +28,16 @@ export class ConfigService<T extends Record<string, unknown> = ConfigDictionary>
   }
 
   private _resolve(key: string): unknown {
-    if (key in this.values) {
+    if (hasOwn(this.values, key)) {
       return this.values[key];
     }
     const parts = key.split('.');
     let current: unknown = this.values;
     for (const part of parts) {
-      if (current === null || typeof current !== 'object' || !(part in (current as Record<string, unknown>))) {
+      if (!hasOwn(current, part)) {
         return undefined;
       }
-      current = (current as Record<string, unknown>)[part];
+      current = current[part];
     }
     return current;
   }

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -79,6 +79,52 @@ describe('@konekti/testing', () => {
 
     expect(service.logger).toEqual({ name: 'fake-logger' });
   });
+
+  it('treats direct function mocks in overrideProvider as useValue', async () => {
+    const FUNCTION_TOKEN = Symbol('function-token');
+    const mockFn = vi.fn().mockReturnValue('ok');
+
+    const testingModule = await createTestingModule({
+      rootModule: AppModule,
+    })
+      .overrideProvider(FUNCTION_TOKEN, mockFn)
+      .compile();
+
+    const resolved = await testingModule.resolve<typeof mockFn>(FUNCTION_TOKEN);
+
+    expect(resolved).toBe(mockFn);
+    expect(resolved()).toBe('ok');
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports class constructor overrides via overrideProvider', async () => {
+    class Logger {
+      readonly name: string = 'logger';
+    }
+
+    class FakeLogger {
+      readonly name: string = 'fake-logger';
+    }
+
+    @Inject([Logger])
+    class UserService {
+      constructor(readonly logger: Logger) {}
+    }
+
+    @Module({
+      providers: [Logger, UserService],
+    })
+    class ServiceModule {}
+
+    const testingModule = await createTestingModule({ rootModule: ServiceModule })
+      .overrideProvider(Logger, FakeLogger)
+      .compile();
+
+    const service = await testingModule.resolve(UserService);
+
+    expect(service.logger).toBeInstanceOf(FakeLogger);
+    expect(service.logger.name).toBe('fake-logger');
+  });
 });
 
 describe('createMock', () => {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -34,7 +34,12 @@ function isProviderDescriptor<T>(value: Provider<T> | T): value is Provider<T> {
 }
 
 function isClassConstructor<T>(value: Provider<T> | T): value is ClassType<T> {
-  return typeof value === 'function';
+  if (typeof value !== 'function') {
+    return false;
+  }
+
+  const source = Function.prototype.toString.call(value);
+  return source.startsWith('class ');
 }
 
 function normalizeOverride<T>(token: Token<T>, value: Provider<T> | T): Provider<T> {


### PR DESCRIPTION
## Summary
- prevent undefined entries from `processEnv` from overriding defaults/env-file values during config merge and reload paths
- switch `ConfigService` key resolution to own-property checks so prototype-chain keys are not treated as valid config
- classify direct function overrides in `@konekti/testing` as values unless they are actual class constructors
- add regression tests for undefined env precedence, inherited key access, function-mock overrides, and class override behavior

## Verification
- pnpm install
- pnpm -r --filter "./packages/*" --if-present run build
- pnpm exec vitest run packages/config/src/load.test.ts packages/testing/src/module.test.ts
- pnpm --filter @konekti/config typecheck
- pnpm --filter @konekti/config build
- pnpm --filter @konekti/testing typecheck *(fails due pre-existing `packages/testing/src/app.ts` TS2353 unrelated to this change)*
- pnpm --filter @konekti/testing build *(same pre-existing TS2353)*
- lsp_diagnostics on modified files: no errors

Closes #116