### PR TITLE
Resolve #117: fix RedisService.get fallback and queue rateLimiter normalization

### DIFF
--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -619,6 +619,74 @@ describe('@konekti/queue', () => {
     await app.close();
   });
 
+  it('normalizes invalid decorator rate limiter values before creating Bull worker', async () => {
+    class InvalidRateLimitedJob {
+      constructor(public readonly value: string) {}
+    }
+
+    @QueueWorker(InvalidRateLimitedJob, { rateLimiter: { duration: -500, max: 0 } })
+    class InvalidRateLimitedWorker {
+      async handle(_job: InvalidRateLimitedJob): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createQueueModule()],
+      providers: [InvalidRateLimitedWorker],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      mode: 'test',
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    await app.container.resolve<Queue>(QUEUE);
+
+    const worker = bullmqState.workers.get('InvalidRateLimitedJob');
+    expect(worker?.workerOpts.limiter).toEqual({
+      duration: 1_000,
+      max: 1,
+    });
+
+    await app.close();
+  });
+
+  it('normalizes invalid module defaultRateLimiter values before creating Bull worker', async () => {
+    class DefaultRateLimitedJob {
+      constructor(public readonly value: string) {}
+    }
+
+    @QueueWorker(DefaultRateLimitedJob)
+    class DefaultRateLimitedWorker {
+      async handle(_job: DefaultRateLimitedJob): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createQueueModule({ defaultRateLimiter: { duration: Number.NaN, max: -3 } })],
+      providers: [DefaultRateLimitedWorker],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      mode: 'test',
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    await app.container.resolve<Queue>(QUEUE);
+
+    const worker = bullmqState.workers.get('DefaultRateLimitedJob');
+    expect(worker?.workerOpts.limiter).toEqual({
+      duration: 1_000,
+      max: 1,
+    });
+
+    await app.close();
+  });
+
   it('applies module defaults for attempts/concurrency and shuts down idempotently', async () => {
     class DefaultedJob {
       constructor(public readonly value: string) {}

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -3,7 +3,7 @@ import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { QueueLifecycleService } from './service.js';
 import { QUEUE, QUEUE_OPTIONS } from './tokens.js';
-import type { NormalizedQueueModuleOptions, QueueModuleOptions } from './types.js';
+import type { NormalizedQueueModuleOptions, QueueModuleOptions, QueueRateLimiterOptions } from './types.js';
 
 function normalizePositiveInteger(value: number | undefined, fallback: number): number {
   if (value === undefined) {
@@ -24,6 +24,8 @@ function normalizePositiveInteger(value: number | undefined, fallback: number): 
 }
 
 function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): NormalizedQueueModuleOptions {
+  const defaultRateLimiter = normalizeRateLimiter(options.defaultRateLimiter);
+
   return {
     defaultAttempts: normalizePositiveInteger(options.defaultAttempts, 1),
     defaultBackoff: options.defaultBackoff
@@ -33,7 +35,18 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
         }
       : undefined,
     defaultConcurrency: normalizePositiveInteger(options.defaultConcurrency, 1),
-    defaultRateLimiter: options.defaultRateLimiter,
+    defaultRateLimiter,
+  };
+}
+
+function normalizeRateLimiter(rateLimiter: QueueRateLimiterOptions | undefined): QueueRateLimiterOptions | undefined {
+  if (!rateLimiter) {
+    return undefined;
+  }
+
+  return {
+    duration: normalizePositiveInteger(rateLimiter.duration, 1_000),
+    max: normalizePositiveInteger(rateLimiter.max, 1),
   };
 }
 

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -20,6 +20,7 @@ import type {
   Queue,
   QueueBackoffOptions,
   QueueJobType,
+  QueueRateLimiterOptions,
   QueueWorkerDescriptor,
 } from './types.js';
 
@@ -118,6 +119,17 @@ function toBullBackoff(backoff: QueueBackoffOptions | undefined): JobsOptions['b
 
 function deadLetterKey(jobName: string): string {
   return `konekti:queue:dead-letter:${jobName}`;
+}
+
+function normalizeRateLimiter(rateLimiter: QueueRateLimiterOptions | undefined): QueueRateLimiterOptions | undefined {
+  if (!rateLimiter) {
+    return undefined;
+  }
+
+  return {
+    duration: normalizePositiveInteger(rateLimiter.duration, 1_000),
+    max: normalizePositiveInteger(rateLimiter.max, 1),
+  };
 }
 
 async function closeConnection(connection: QueueOwnedConnection): Promise<void> {
@@ -267,7 +279,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
         jobName,
         jobType,
         moduleName: candidate.moduleName,
-        rateLimiter: metadata.options.rateLimiter ?? this.options.defaultRateLimiter,
+        rateLimiter: normalizeRateLimiter(metadata.options.rateLimiter ?? this.options.defaultRateLimiter),
         token: candidate.token,
         workerName: candidate.targetType.name,
       });

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -152,4 +152,31 @@ describe('@konekti/redis', () => {
 
     await app.close();
   });
+
+  it('returns raw string when stored value is not JSON', async () => {
+    @Inject([REDIS_SERVICE])
+    class CacheFacade {
+      constructor(readonly redisService: RedisService) {}
+    }
+
+    class FeatureModule {}
+    defineModule(FeatureModule, {
+      providers: [CacheFacade],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createRedisModule({ host: '127.0.0.1', port: 6379 }), FeatureModule],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const cacheFacade = await app.container.resolve(CacheFacade);
+    const rawClient = cacheFacade.redisService.getRawClient();
+
+    await rawClient.set('raw:key', 'plain-string');
+
+    await expect(cacheFacade.redisService.get<string>('raw:key')).resolves.toBe('plain-string');
+
+    await app.close();
+  });
 });

--- a/packages/redis/src/redis-service.ts
+++ b/packages/redis/src/redis-service.ts
@@ -15,7 +15,11 @@ export class RedisService {
       return null;
     }
 
-    return JSON.parse(raw) as T;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return raw as T;
+    }
   }
 
   async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {


### PR DESCRIPTION
## Summary
- make `RedisService.get()` resilient to non-JSON values by falling back to raw string when parsing fails
- normalize queue rate limiter values for both module defaults and `@QueueWorker()` overrides before passing limiter config to Bull workers
- add redis regression coverage for plain-string retrieval and queue regressions for invalid limiter inputs

## Verification
- pnpm install
- pnpm -r --filter "./packages/*" --if-present run build
- pnpm exec vitest run packages/redis/src/module.test.ts packages/queue/src/module.test.ts
- pnpm --filter @konekti/redis typecheck
- pnpm --filter @konekti/queue typecheck
- lsp_diagnostics on modified files: no errors

Closes #117