### PR TITLE
fix(runtime,di,testing): align override lifecycle and duplicate provider semantics

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -301,6 +301,35 @@ describe('Container', () => {
 
       expect(await container.resolve(token)).toBe('overridden');
     });
+
+    it('invalidates singleton cache when overriding a previously resolved provider', async () => {
+      const token = Symbol('cache-token');
+      const container = new Container().register({ provide: token, useValue: { value: 'first' } });
+
+      const first = await container.resolve<{ value: string }>(token);
+
+      container.override({ provide: token, useValue: { value: 'second' } });
+
+      const second = await container.resolve<{ value: string }>(token);
+
+      expect(first).toEqual({ value: 'first' });
+      expect(second).toEqual({ value: 'second' });
+      expect(first).not.toBe(second);
+    });
+
+    it('replaces existing multi providers when overriding a token', async () => {
+      const token = Symbol('plugins');
+      const container = new Container().register(
+        { provide: token, useValue: 'a', multi: true },
+        { provide: token, useValue: 'b', multi: true },
+      );
+
+      expect(await container.resolve<string[]>(token)).toEqual(['a', 'b']);
+
+      container.override({ provide: token, useValue: 'single' });
+
+      expect(await container.resolve<string>(token)).toBe('single');
+    });
   });
 
   describe('optional injection', () => {
@@ -501,6 +530,34 @@ describe('Container', () => {
       await container.resolve(SecondService);
 
       await expect(container.dispose()).rejects.toThrow('first failed');
+      expect(events).toEqual(['second', 'first']);
+    });
+
+    it('disposes stale overridden singleton instances exactly once', async () => {
+      const events: string[] = [];
+
+      class FirstService {
+        onDestroy() {
+          events.push('first');
+        }
+      }
+
+      class SecondService {
+        onDestroy() {
+          events.push('second');
+        }
+      }
+
+      const token = Symbol('disposable-token');
+      const container = new Container()
+        .register({ provide: token, useClass: FirstService });
+
+      await container.resolve(token);
+      container.override({ provide: token, useClass: SecondService });
+      await container.resolve(token);
+
+      await container.dispose();
+
       expect(events).toEqual(['second', 'first']);
     });
   });

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -112,6 +112,7 @@ export class Container {
   private readonly registrations = new Map<Token, NormalizedProvider>();
   private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
   private readonly requestCache = new Map<Token, Promise<unknown>>();
+  private readonly staleCache = new Map<Token, Promise<unknown>>();
   private readonly singletonCache: Map<Token, Promise<unknown>>;
   private disposePromise: Promise<void> | undefined;
   private disposed = false;
@@ -147,6 +148,15 @@ export class Container {
   override(...providers: Provider[]): this {
     for (const provider of providers) {
       const normalized = normalizeProvider(provider);
+
+      this.registrations.delete(normalized.provide);
+      this.multiRegistrations.delete(normalized.provide);
+      this.invalidateCachedEntry(normalized.provide);
+
+      if (normalized.multi) {
+        this.multiRegistrations.set(normalized.provide, [normalized]);
+        continue;
+      }
 
       this.registrations.set(normalized.provide, normalized);
     }
@@ -319,29 +329,31 @@ export class Container {
 
   private disposalCacheEntries(): Array<[Token, Promise<unknown>]> {
     if (this.parent) {
-      return Array.from(this.requestCache.entries());
+      return [...Array.from(this.staleCache.entries()), ...Array.from(this.requestCache.entries())];
     }
 
-    return Array.from(this.singletonCache.entries());
+    return [...Array.from(this.staleCache.entries()), ...Array.from(this.singletonCache.entries())];
   }
 
   private async disposeCache(entries: Array<[Token, Promise<unknown>]>): Promise<void> {
-    const disposables = new Map<Token, Disposable>();
+    const disposables: Disposable[] = [];
+    const seenInstances = new Set<unknown>();
     const errors: unknown[] = [];
 
-    for (const [token, instancePromise] of entries) {
+    for (const [, instancePromise] of entries) {
       try {
         const instance = await instancePromise;
 
-        if (this.isDisposable(instance)) {
-          disposables.set(token, instance);
+        if (this.isDisposable(instance) && !seenInstances.has(instance)) {
+          seenInstances.add(instance);
+          disposables.push(instance);
         }
       } catch (error) {
         errors.push(error);
       }
     }
 
-    for (const instance of Array.from(disposables.values()).reverse()) {
+    for (const instance of [...disposables].reverse()) {
       try {
         await instance.onDestroy();
       } catch (error) {
@@ -351,8 +363,10 @@ export class Container {
 
     if (this.parent) {
       this.requestCache.clear();
+      this.staleCache.clear();
     } else {
       this.singletonCache.clear();
+      this.staleCache.clear();
     }
 
     if (errors.length === 1) {
@@ -411,6 +425,30 @@ export class Container {
       }
       default:
         throw new InvariantError('Unknown provider type.');
+    }
+  }
+
+  private invalidateCachedEntry(token: Token): void {
+    if (this.requestCache.has(token)) {
+      const cached = this.requestCache.get(token);
+
+      if (cached) {
+        this.staleCache.set(token, cached);
+      }
+
+      this.requestCache.delete(token);
+    }
+
+    const singletonCache = this.root().singletonCache;
+
+    if (singletonCache.has(token)) {
+      const cached = singletonCache.get(token);
+
+      if (cached) {
+        this.root().staleCache.set(token, cached);
+      }
+
+      singletonCache.delete(token);
     }
   }
 }

--- a/packages/http/src/binding.test.ts
+++ b/packages/http/src/binding.test.ts
@@ -77,6 +77,7 @@ function createContext(request: FrameworkRequest): ArgumentResolverContext {
     },
     requestContext: {
       container: {
+        async dispose() {},
         resolve() {
           throw new Error('not used');
         },

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -257,6 +257,31 @@ describe('bootstrapApplication', () => {
     expect(events).toEqual(['adapter:listen', 'adapter:close:SIGTERM', 'adapter:close:SIGTERM']);
   });
 
+  it('disposes container-managed instances when the application closes', async () => {
+    class DisposableResource {
+      destroyed = false;
+
+      onDestroy() {
+        this.destroyed = true;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      providers: [DisposableResource],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const resource = await app.container.resolve(DisposableResource);
+
+    await app.close('SIGTERM');
+
+    expect(resource.destroyed).toBe(true);
+  });
+
   it('injects real runtime tokens before OnModuleInit runs', async () => {
     const adapter: HttpApplicationAdapter = {
       async close() {},
@@ -354,6 +379,40 @@ describe('bootstrapApplication', () => {
 
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual({ name: 'Ada' });
+
+    await app.close();
+  });
+
+  it('parses repeated query parameters as arrays in Node requests', async () => {
+    @Controller('/search')
+    class SearchController {
+      @Get('/')
+      list(_input: undefined, context: RequestContext) {
+        return context.request.query;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [SearchController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/search?page=1&tag=a&tag=b&tag=c`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      page: '1',
+      tag: ['a', 'b', 'c'],
+    });
 
     await app.close();
   });

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -267,6 +267,32 @@ describe('bootstrapModule duplicate provider detection', () => {
     expect(warnFn.mock.calls[0]![0]).toContain('SharedService');
   });
 
+  it('keeps the latest provider registration when policy is "warn"', async () => {
+    const SHARED = Symbol('shared-token');
+
+    class ModuleA {}
+    defineModuleMetadata(ModuleA, {
+      providers: [{ provide: SHARED, useValue: 'from-a' }],
+    });
+
+    class ModuleB {}
+    defineModuleMetadata(ModuleB, {
+      providers: [{ provide: SHARED, useValue: 'from-b' }],
+    });
+
+    class RootModule {}
+    defineModuleMetadata(RootModule, {
+      imports: [ModuleA, ModuleB],
+    });
+
+    const warnFn = vi.fn();
+    const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: warnFn };
+    const result = bootstrapModule(RootModule, { duplicateProviderPolicy: 'warn', logger });
+
+    await expect(result.container.resolve<string>(SHARED)).resolves.toBe('from-b');
+    expect(warnFn).toHaveBeenCalledOnce();
+  });
+
   it('warns when no policy is specified (default is "warn")', () => {
     class SharedService {}
 
@@ -342,6 +368,32 @@ describe('bootstrapModule duplicate provider detection', () => {
     const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: warnFn };
 
     expect(() => bootstrapModule(RootModule, { duplicateProviderPolicy: 'ignore', logger })).not.toThrow();
+    expect(warnFn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the latest provider registration when policy is "ignore"', async () => {
+    const SHARED = Symbol('shared-token');
+
+    class ModuleA {}
+    defineModuleMetadata(ModuleA, {
+      providers: [{ provide: SHARED, useValue: 'from-a' }],
+    });
+
+    class ModuleB {}
+    defineModuleMetadata(ModuleB, {
+      providers: [{ provide: SHARED, useValue: 'from-b' }],
+    });
+
+    class RootModule {}
+    defineModuleMetadata(RootModule, {
+      imports: [ModuleA, ModuleB],
+    });
+
+    const warnFn = vi.fn();
+    const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: warnFn };
+    const result = bootstrapModule(RootModule, { duplicateProviderPolicy: 'ignore', logger });
+
+    await expect(result.container.resolve<string>(SHARED)).resolves.toBe('from-b');
     expect(warnFn).not.toHaveBeenCalled();
   });
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -426,6 +426,7 @@ export function bootstrapModule(rootModule: ModuleType, options: BootstrapModule
     container.register(...options.providers);
   }
 
+  const runtimeProviderTokens = createRuntimeTokenSet(options.providers);
   const registeredProviderTokens = new Map<string | symbol | Function, string>();
 
   for (const compiledModule of modules) {
@@ -435,18 +436,30 @@ export function bootstrapModule(rootModule: ModuleType, options: BootstrapModule
       const tokenLabel = typeof token === 'function' ? token.name || '<anonymous>' : String(token);
       const existing = registeredProviderTokens.get(tokenKey);
 
-      if (existing !== undefined && policy !== 'ignore') {
+      if (runtimeProviderTokens.has(token)) {
+        registeredProviderTokens.set(tokenKey, compiledModule.type.name);
+        container.override(provider);
+        continue;
+      }
+
+      if (existing !== undefined) {
         const message = `Duplicate provider token "${tokenLabel}" registered in module "${compiledModule.type.name}". Previously registered in module "${existing}".`;
 
         if (policy === 'throw') {
           throw new DuplicateProviderError(message);
-        } else {
+        }
+
+        if (policy === 'warn') {
           options.logger?.warn(message, 'BootstrapModule');
         }
-      } else {
+
         registeredProviderTokens.set(tokenKey, compiledModule.type.name);
+
+        container.override(provider);
+        continue;
       }
 
+      registeredProviderTokens.set(tokenKey, compiledModule.type.name);
       container.register(provider);
     }
 
@@ -459,6 +472,10 @@ export function bootstrapModule(rootModule: ModuleType, options: BootstrapModule
         const token = (mw as { middleware: unknown; routes: unknown }).middleware;
 
         if (typeof token === 'function') {
+          if (container.has(token as Token)) {
+            continue;
+          }
+
           container.register(token as Parameters<typeof container.register>[0]);
         }
 
@@ -466,6 +483,10 @@ export function bootstrapModule(rootModule: ModuleType, options: BootstrapModule
       }
 
       if (typeof mw === 'function') {
+        if (container.has(mw as Token)) {
+          continue;
+        }
+
         container.register(mw as Parameters<typeof container.register>[0]);
         continue;
       }
@@ -561,6 +582,7 @@ class KonektiApplication implements Application {
     this.closingPromise = (async () => {
       await runShutdownHooks(this.lifecycleInstances, signal);
       await this.adapter.close(signal);
+      await this.container.dispose();
       this.closed = true;
       this.applicationState = 'closed';
     })();
@@ -693,6 +715,7 @@ function logRouteMappings(
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
   const logger = options.logger ?? createConsoleApplicationLogger();
   let lifecycleInstances: unknown[] = [];
+  let bootstrappedContainer: Container | undefined;
   const adapter = options.adapter ?? createNoopHttpApplicationAdapter();
 
   try {
@@ -730,6 +753,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
         useValue: bootstrapped.modules,
       },
     );
+    bootstrappedContainer = bootstrapped.container;
     resetReadinessState(bootstrapped.modules);
     const lifecycleProviders = [
       ...runtimeProviders,
@@ -771,6 +795,10 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
 
     if (lifecycleInstances.length > 0) {
       await runShutdownHooks(lifecycleInstances, 'bootstrap-failed');
+    }
+
+    if (bootstrappedContainer) {
+      await bootstrappedContainer.dispose();
     }
 
     throw error;

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -481,7 +481,7 @@ async function createFrameworkRequest(
     method: request.method ?? 'GET',
     params: {},
     path: url.pathname,
-    query: Object.fromEntries(url.searchParams.entries()),
+    query: parseQueryParams(url.searchParams),
     raw: request,
     signal,
     url: url.pathname + url.search,
@@ -496,6 +496,28 @@ async function createFrameworkRequest(
   }
 
   return frameworkRequest;
+}
+
+function parseQueryParams(searchParams: URLSearchParams): Record<string, string | string[]> {
+  const query: Record<string, string | string[]> = {};
+
+  for (const [key, value] of searchParams.entries()) {
+    const current = query[key];
+
+    if (current === undefined) {
+      query[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(current)) {
+      current.push(value);
+      continue;
+    }
+
+    query[key] = [current, value];
+  }
+
+  return query;
 }
 
 function createNodeMiddleware(options: BootstrapNodeApplicationOptions): MiddlewareLike[] {

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -125,6 +125,40 @@ describe('@konekti/testing', () => {
     expect(service.logger).toBeInstanceOf(FakeLogger);
     expect(service.logger.name).toBe('fake-logger');
   });
+
+  it('throws when overrideProvider token and provider.provide do not match', () => {
+    const EXPECTED = Symbol('expected-token');
+    const OTHER = Symbol('other-token');
+
+    expect(() =>
+      createTestingModule({ rootModule: AppModule }).overrideProvider(EXPECTED, {
+        provide: OTHER,
+        useValue: 'value',
+      }),
+    ).toThrow('overrideProvider token mismatch');
+  });
+
+  it('supports useExisting provider descriptors in overrideProvider', async () => {
+    const SOURCE = Symbol('source-token');
+    const TARGET = Symbol('target-token');
+
+    @Module({
+      providers: [
+        { provide: SOURCE, useValue: 'source-value' },
+        { provide: TARGET, useValue: 'target-value' },
+      ],
+    })
+    class AliasModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AliasModule })
+      .overrideProvider(TARGET, {
+        provide: TARGET,
+        useExisting: SOURCE,
+      })
+      .compile();
+
+    await expect(testingModule.resolve<string>(TARGET)).resolves.toBe('source-value');
+  });
 });
 
 describe('createMock', () => {
@@ -362,6 +396,49 @@ describe('TestingModuleRef.dispatch', () => {
       headers: { 'x-test-id': 'dispatch' },
       query: { scope: 'all' },
     });
+  });
+
+  it('shares singleton state between resolve() and dispatch()', async () => {
+    class CounterService {
+      count = 0;
+
+      next() {
+        this.count += 1;
+        return this.count;
+      }
+    }
+
+    @Inject([CounterService])
+    @Controller('/counter')
+    class CounterController {
+      constructor(private readonly counter: CounterService) {}
+
+      @Get('/')
+      read() {
+        return { count: this.counter.next() };
+      }
+    }
+
+    @Module({
+      controllers: [CounterController],
+      providers: [CounterService],
+    })
+    class CounterModule {}
+
+    const testingModule = await createTestingModule({ rootModule: CounterModule }).compile();
+    const service = await testingModule.resolve<CounterService>(CounterService);
+
+    expect(service.count).toBe(0);
+
+    const first = await testingModule.dispatch({ method: 'GET', path: '/counter' });
+    expect(first.status).toBe(200);
+    expect(first.body).toEqual({ count: 1 });
+    expect(service.count).toBe(1);
+
+    const second = await testingModule.dispatch({ method: 'GET', path: '/counter' });
+    expect(second.status).toBe(200);
+    expect(second.body).toEqual({ count: 2 });
+    expect(service.count).toBe(2);
   });
 });
 

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -29,8 +29,13 @@ function createTestingDispatcher(bootstrapped: BootstrapResult): ReturnType<type
   });
 }
 
-function isProviderDescriptor<T>(value: Provider<T> | T): value is Provider<T> {
-  return typeof value === 'object' && value !== null && ('useClass' in value || 'useFactory' in value || 'useValue' in value);
+function isProviderDescriptor<T>(value: Provider<T> | T): value is Exclude<Provider<T>, ClassType<T>> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'provide' in value &&
+    ('useClass' in value || 'useFactory' in value || 'useValue' in value || 'useExisting' in value)
+  );
 }
 
 function isClassConstructor<T>(value: Provider<T> | T): value is ClassType<T> {
@@ -44,6 +49,12 @@ function isClassConstructor<T>(value: Provider<T> | T): value is ClassType<T> {
 
 function normalizeOverride<T>(token: Token<T>, value: Provider<T> | T): Provider<T> {
   if (isProviderDescriptor(value)) {
+    if (value.provide !== token) {
+      throw new Error(
+        `overrideProvider token mismatch: expected ${String(token)} but received provider for ${String(value.provide)}.`,
+      );
+    }
+
     return { ...value, provide: token } as Provider<T>;
   }
 


### PR DESCRIPTION
## Summary
- align Container override behavior by invalidating cached entries and disposing stale overridden instances
- honor duplicate provider policies in runtime bootstrap and preserve runtime-provider precedence without duplicate middleware registrations
- preserve repeated Node query params as arrays and tighten testing override contracts (including useExisting)

## Verification
- pnpm vitest run packages/di/src/container.test.ts packages/runtime/src/bootstrap.test.ts packages/runtime/src/application.test.ts packages/testing/src/module.test.ts
- pnpm typecheck
- pnpm build

Closes #125
Closes #126
Closes #128