### PR TITLE
Resolve #129: decompose HTTP dispatcher policies and unify input error mapping

### DIFF
--- a/packages/http/src/binding.ts
+++ b/packages/http/src/binding.ts
@@ -1,6 +1,7 @@
 import { getDtoBindingSchema, type Constructor, type MetadataPropertyKey, type MetadataSource } from '@konekti/core';
 
 import { BadRequestException, type HttpExceptionDetail } from './exceptions.js';
+import { toInputErrorDetail } from './input-error-detail.js';
 import type { ArgumentResolverContext, Binder, Converter, ConverterTarget, FrameworkRequest } from './types.js';
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
@@ -17,15 +18,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function toFieldName(propertyKey: MetadataPropertyKey): string {
   return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
-}
-
-function toDetail(code: string, message: string, field?: string, source?: MetadataSource): HttpExceptionDetail {
-  return {
-    code,
-    field,
-    message,
-    source,
-  };
 }
 
 function resolveSourceKey(propertyKey: MetadataPropertyKey, key?: string): string {
@@ -73,7 +65,7 @@ function validateBodyKeys(
 
   if (!isPlainObject(request.body)) {
     throw new BadRequestException('Request body must be a plain object.', {
-      details: [toDetail('INVALID_BODY', 'Request body must be a plain object.', undefined, 'body')],
+      details: [toInputErrorDetail({ code: 'INVALID_BODY', message: 'Request body must be a plain object.', source: 'body' })],
     });
   }
 
@@ -81,12 +73,12 @@ function validateBodyKeys(
 
   for (const key of Object.keys(request.body)) {
     if (DANGEROUS_KEYS.has(key)) {
-      details.push(toDetail('DANGEROUS_KEY', `Dangerous body key ${key} is not allowed.`, key, 'body'));
+      details.push(toInputErrorDetail({ code: 'DANGEROUS_KEY', field: key, message: `Dangerous body key ${key} is not allowed.`, source: 'body' }));
       continue;
     }
 
     if (!bodyKeys.has(key)) {
-      details.push(toDetail('UNKNOWN_FIELD', `Unknown body field ${key}.`, key, 'body'));
+      details.push(toInputErrorDetail({ code: 'UNKNOWN_FIELD', field: key, message: `Unknown body field ${key}.`, source: 'body' }));
     }
   }
 
@@ -112,11 +104,12 @@ export class DefaultBinder implements Binder {
 
   async bind(dto: Constructor, context: ArgumentResolverContext): Promise<unknown> {
     const schema = getDtoBindingSchema(dto);
+    type BindingSchemaEntry = (typeof schema)[number];
     const value = new dto() as Record<string | symbol, unknown>;
-    const bodyKeys = new Set(
+    const bodyKeys = new Set<string>(
       schema
-        .filter((entry) => entry.metadata.source === 'body')
-        .map((entry) => resolveSourceKey(entry.propertyKey, entry.metadata.key)),
+        .filter((entry: BindingSchemaEntry) => entry.metadata.source === 'body')
+        .map((entry: BindingSchemaEntry) => resolveSourceKey(entry.propertyKey, entry.metadata.key)),
     );
 
     validateBodyKeys(context.requestContext.request, bodyKeys);
@@ -137,12 +130,12 @@ export class DefaultBinder implements Binder {
         }
 
         details.push(
-          toDetail(
-            'MISSING_FIELD',
-            `Missing required ${entry.metadata.source} field ${resolveSourceKey(entry.propertyKey, entry.metadata.key)}.`,
-            toFieldName(entry.propertyKey),
-            entry.metadata.source,
-          ),
+          toInputErrorDetail({
+            code: 'MISSING_FIELD',
+            field: toFieldName(entry.propertyKey),
+            message: `Missing required ${entry.metadata.source} field ${resolveSourceKey(entry.propertyKey, entry.metadata.key)}.`,
+            source: entry.metadata.source,
+          }),
         );
         continue;
       }

--- a/packages/http/src/dispatch-handler-policy.ts
+++ b/packages/http/src/dispatch-handler-policy.ts
@@ -1,0 +1,33 @@
+import { InvariantError, type Token } from '@konekti/core';
+
+import { DefaultBinder } from './binding.js';
+import { HttpDtoValidationAdapter } from './dto-validation-adapter.js';
+import type { ArgumentResolverContext, HandlerDescriptor, RequestContext } from './types.js';
+
+const defaultBinder = new DefaultBinder();
+const defaultValidator = new HttpDtoValidationAdapter();
+
+export async function invokeControllerHandler(handler: HandlerDescriptor, requestContext: RequestContext): Promise<unknown> {
+  const controller = await requestContext.container.resolve(handler.controllerToken as Token<object>);
+  const method = (controller as Record<string, unknown>)[handler.methodName];
+
+  if (typeof method !== 'function') {
+    throw new InvariantError(
+      `Controller ${handler.controllerToken.name} does not expose handler method ${handler.methodName}.`,
+    );
+  }
+
+  const argumentResolverContext: ArgumentResolverContext = {
+    handler,
+    requestContext,
+  };
+  const input = handler.route.request
+    ? await defaultBinder.bind(handler.route.request, argumentResolverContext)
+    : undefined;
+
+  if (handler.route.request) {
+    await defaultValidator.validate(input, handler.route.request);
+  }
+
+  return method.call(controller, input, requestContext);
+}

--- a/packages/http/src/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch-response-policy.ts
@@ -1,0 +1,292 @@
+import { HandlerNotFoundError } from './errors.js';
+import {
+  HttpException,
+  InternalServerException,
+  NotAcceptableException,
+  NotFoundException,
+  createErrorResponse,
+} from './exceptions.js';
+import type {
+  ContentNegotiationOptions,
+  FrameworkRequest,
+  FrameworkResponse,
+  HandlerDescriptor,
+  ResponseFormatter,
+} from './types.js';
+
+interface AcceptToken {
+  mediaRange: string;
+  quality: number;
+  specificity: number;
+}
+
+export interface ResolvedContentNegotiation {
+  defaultFormatter: ResponseFormatter;
+  formatters: ResponseFormatter[];
+}
+
+function normalizeMediaType(value: string): string {
+  return value.split(';')[0]?.trim().toLowerCase() ?? '';
+}
+
+function readAcceptHeader(request: FrameworkRequest): string | undefined {
+  const raw = request.headers.accept ?? request.headers.Accept;
+  const value = Array.isArray(raw) ? raw.join(',') : raw;
+  const normalized = value?.trim();
+
+  return normalized ? normalized : undefined;
+}
+
+function parseQuality(value: string | undefined): number {
+  if (!value) {
+    return 1;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return 0;
+  }
+
+  if (parsed > 1) {
+    return 1;
+  }
+
+  return parsed;
+}
+
+function getMediaRangeSpecificity(mediaRange: string): number {
+  if (mediaRange === '*/*') {
+    return 0;
+  }
+
+  if (mediaRange.endsWith('/*')) {
+    return 1;
+  }
+
+  return 2;
+}
+
+function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
+  const tokens: AcceptToken[] = [];
+
+  for (const token of acceptHeader.split(',')) {
+    const [rawMediaRange, ...parameterParts] = token.trim().split(';');
+    const mediaRange = normalizeMediaType(rawMediaRange ?? '');
+
+    if (!mediaRange || !mediaRange.includes('/')) {
+      continue;
+    }
+
+    let quality = 1;
+
+    for (const parameterPart of parameterParts) {
+      const [name, value] = parameterPart.trim().split('=');
+
+      if (name?.toLowerCase() === 'q') {
+        quality = parseQuality(value?.trim());
+        break;
+      }
+    }
+
+    if (quality <= 0) {
+      continue;
+    }
+
+    tokens.push({
+      mediaRange,
+      quality,
+      specificity: getMediaRangeSpecificity(mediaRange),
+    });
+  }
+
+  return tokens.sort((left, right) => {
+    if (right.quality !== left.quality) {
+      return right.quality - left.quality;
+    }
+
+    return right.specificity - left.specificity;
+  });
+}
+
+function matchesMediaRange(mediaRange: string, mediaType: string): boolean {
+  if (mediaRange === '*/*') {
+    return true;
+  }
+
+  const [rangeType, rangeSubtype] = mediaRange.split('/');
+  const [mediaTypeType, mediaTypeSubtype] = mediaType.split('/');
+
+  if (!rangeType || !rangeSubtype || !mediaTypeType || !mediaTypeSubtype) {
+    return false;
+  }
+
+  if (rangeType !== '*' && rangeType !== mediaTypeType) {
+    return false;
+  }
+
+  return rangeSubtype === '*' || rangeSubtype === mediaTypeSubtype;
+}
+
+export function resolveContentNegotiation(options: ContentNegotiationOptions | undefined): ResolvedContentNegotiation | undefined {
+  if (!options?.formatters?.length) {
+    return undefined;
+  }
+
+  const formatters = options.formatters.filter((formatter, index, all) => {
+    const mediaType = normalizeMediaType(formatter.mediaType);
+
+    if (!mediaType) {
+      return false;
+    }
+
+    return all.findIndex((item) => normalizeMediaType(item.mediaType) === mediaType) === index;
+  });
+
+  if (!formatters.length) {
+    return undefined;
+  }
+
+  const defaultMediaType = normalizeMediaType(options.defaultMediaType ?? '');
+  const defaultFormatter = defaultMediaType
+    ? formatters.find((formatter) => normalizeMediaType(formatter.mediaType) === defaultMediaType) ?? formatters[0]
+    : formatters[0];
+
+  return {
+    defaultFormatter,
+    formatters,
+  };
+}
+
+function resolveAllowedFormatters(
+  handler: HandlerDescriptor,
+  contentNegotiation: ResolvedContentNegotiation,
+): ResponseFormatter[] {
+  if (!handler.route.produces?.length) {
+    return contentNegotiation.formatters;
+  }
+
+  const allowed = new Set(handler.route.produces.map((mediaType) => normalizeMediaType(mediaType)));
+  return contentNegotiation.formatters.filter((formatter) => allowed.has(normalizeMediaType(formatter.mediaType)));
+}
+
+function resolveDefaultFormatter(
+  allowedFormatters: ResponseFormatter[],
+  contentNegotiation: ResolvedContentNegotiation,
+): ResponseFormatter {
+  const defaultMediaType = normalizeMediaType(contentNegotiation.defaultFormatter.mediaType);
+
+  return allowedFormatters.find((formatter) => normalizeMediaType(formatter.mediaType) === defaultMediaType)
+    ?? allowedFormatters[0]
+    ?? contentNegotiation.defaultFormatter;
+}
+
+function selectResponseFormatter(
+  handler: HandlerDescriptor,
+  request: FrameworkRequest,
+  contentNegotiation: ResolvedContentNegotiation,
+): ResponseFormatter {
+  const allowedFormatters = resolveAllowedFormatters(handler, contentNegotiation);
+
+  if (!allowedFormatters.length) {
+    throw new NotAcceptableException('No acceptable response representation found.');
+  }
+
+  const defaultFormatter = resolveDefaultFormatter(allowedFormatters, contentNegotiation);
+  const acceptHeader = readAcceptHeader(request);
+
+  if (!acceptHeader) {
+    return defaultFormatter;
+  }
+
+  const acceptTokens = parseAcceptHeader(acceptHeader);
+
+  if (!acceptTokens.length) {
+    throw new NotAcceptableException('No acceptable response representation found.');
+  }
+
+  for (const token of acceptTokens) {
+    if (token.mediaRange === '*/*') {
+      return defaultFormatter;
+    }
+
+    const matchedFormatter = allowedFormatters.find((formatter) => {
+      return matchesMediaRange(token.mediaRange, normalizeMediaType(formatter.mediaType));
+    });
+
+    if (matchedFormatter) {
+      return matchedFormatter;
+    }
+  }
+
+  throw new NotAcceptableException('No acceptable response representation found.');
+}
+
+function resolveDefaultSuccessStatus(handler: HandlerDescriptor, value: unknown): number {
+  switch (handler.route.method) {
+    case 'POST':
+      return 201;
+    case 'DELETE':
+    case 'OPTIONS':
+      return value === undefined ? 204 : 200;
+    default:
+      return 200;
+  }
+}
+
+export async function writeSuccessResponse(
+  handler: HandlerDescriptor,
+  request: FrameworkRequest,
+  response: FrameworkResponse,
+  value: unknown,
+  contentNegotiation: ResolvedContentNegotiation | undefined,
+): Promise<void> {
+  if (response.committed) {
+    return;
+  }
+
+  const formatter = contentNegotiation
+    ? selectResponseFormatter(handler, request, contentNegotiation)
+    : undefined;
+
+  if (formatter) {
+    response.setHeader('Content-Type', formatter.mediaType);
+  }
+
+  if (handler.route.successStatus !== undefined) {
+    response.setStatus(handler.route.successStatus);
+  } else if (response.statusSet !== true) {
+    response.setStatus(resolveDefaultSuccessStatus(handler, value));
+  }
+
+  const responseBody = formatter
+    ? formatter.format(value)
+    : value;
+  await response.send(responseBody);
+}
+
+function toHttpException(error: unknown): HttpException {
+  if (error instanceof HttpException) {
+    return error;
+  }
+
+  if (error instanceof HandlerNotFoundError) {
+    const message = error instanceof Error ? error.message : 'Resource not found.';
+
+    return new NotFoundException(message, { cause: error });
+  }
+
+  return new InternalServerException('Internal server error.', {
+    cause: error,
+  });
+}
+
+export async function writeErrorResponse(error: unknown, response: FrameworkResponse, requestId?: string): Promise<void> {
+  if (response.committed) {
+    return;
+  }
+
+  const httpError = toHttpException(error);
+  response.setStatus(httpError.status);
+  await response.send(createErrorResponse(httpError, requestId));
+}

--- a/packages/http/src/dispatch-routing-policy.test.ts
+++ b/packages/http/src/dispatch-routing-policy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { HandlerNotFoundError } from './errors.js';
+import { matchHandlerOrThrow, updateRequestParams } from './dispatch-routing-policy.js';
+import type { FrameworkRequest, HandlerDescriptor, HandlerMapping, RequestContext } from './types.js';
+
+function createRequest(path: string, method: FrameworkRequest['method']): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method,
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createDescriptor(): HandlerDescriptor {
+  class ExampleController {
+    list() {
+      return { ok: true };
+    }
+  }
+
+  return {
+    controllerToken: ExampleController,
+    metadata: {
+      controllerPath: '/users',
+      effectivePath: '/users/:id',
+      moduleMiddleware: [],
+      pathParams: ['id'],
+    },
+    methodName: 'list',
+    route: {
+      method: 'GET',
+      path: '/users/:id',
+    },
+  };
+}
+
+describe('dispatch routing policy', () => {
+  it('returns the matched handler descriptor and params', () => {
+    const descriptor = createDescriptor();
+    const mapping: HandlerMapping = {
+      descriptors: [descriptor],
+      match() {
+        return {
+          descriptor,
+          params: { id: '42' },
+        };
+      },
+    };
+
+    const match = matchHandlerOrThrow(mapping, createRequest('/users/42', 'GET'));
+
+    expect(match.descriptor).toBe(descriptor);
+    expect(match.params).toEqual({ id: '42' });
+  });
+
+  it('throws HandlerNotFoundError when no route matches', () => {
+    const mapping: HandlerMapping = {
+      descriptors: [],
+      match() {
+        return undefined;
+      },
+    };
+
+    expect(() => matchHandlerOrThrow(mapping, createRequest('/missing', 'GET'))).toThrow(HandlerNotFoundError);
+  });
+
+  it('updates request params in request context without mutating unrelated fields', () => {
+    const context: RequestContext = {
+      container: {
+        async dispose() {},
+        resolve() {
+          throw new Error('not used');
+        },
+      },
+      metadata: {},
+      request: createRequest('/users/1', 'GET'),
+      response: {
+        committed: false,
+        headers: {},
+        redirect() {},
+        send() {},
+        setHeader() {},
+        setStatus() {},
+      },
+    };
+
+    updateRequestParams(context, { id: '1' });
+
+    expect(context.request.path).toBe('/users/1');
+    expect(context.request.params).toEqual({ id: '1' });
+  });
+});

--- a/packages/http/src/dispatch-routing-policy.ts
+++ b/packages/http/src/dispatch-routing-policy.ts
@@ -1,0 +1,19 @@
+import { HandlerNotFoundError } from './errors.js';
+import type { FrameworkRequest, HandlerMapping, HandlerMatch, RequestContext } from './types.js';
+
+export function matchHandlerOrThrow(handlerMapping: HandlerMapping, request: FrameworkRequest): HandlerMatch {
+  const match = handlerMapping.match(request);
+
+  if (!match) {
+    throw new HandlerNotFoundError(`No handler registered for ${request.method} ${request.path}.`);
+  }
+
+  return match;
+}
+
+export function updateRequestParams(requestContext: RequestContext, params: Readonly<Record<string, string>>): void {
+  requestContext.request = {
+    ...requestContext.request,
+    params,
+  };
+}

--- a/packages/http/src/dispatcher.test.ts
+++ b/packages/http/src/dispatcher.test.ts
@@ -636,6 +636,78 @@ describe('dispatcher runtime', () => {
     ]);
   });
 
+  it('isolates request start and handler matched observer failures from request execution', async () => {
+    const events: string[] = [];
+
+    const observer = {
+      onHandlerMatched() {
+        events.push('match');
+        throw new Error('match observer failed');
+      },
+      onRequestFinish() {
+        events.push('finish');
+      },
+      onRequestStart() {
+        events.push('start');
+        throw new Error('start observer failed');
+      },
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        events.push('handler');
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(HealthController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: HealthController }]),
+      observers: [observer],
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/health', 'GET', { 'x-request-id': 'req-observer-isolation' }), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(events).toEqual(['start', 'match', 'handler', 'finish']);
+  });
+
+  it('passes matched handler metadata to request error observers', async () => {
+    const events: string[] = [];
+
+    class RequestLogger {
+      onRequestError(context: RequestObservationContext) {
+        events.push(`error:${context.handler?.methodName ?? 'none'}`);
+      }
+    }
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/boom')
+      fail() {
+        throw new Error('boom');
+      }
+    }
+
+    const root = new Container().register(RequestLogger, HealthController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: HealthController }]),
+      observers: [RequestLogger],
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/health/boom', 'GET', { 'x-request-id': 'req-observer-handler' }), response);
+
+    expect(response.statusCode).toBe(500);
+    expect(events).toEqual(['error:fail']);
+  });
+
   it('returns a canonical 403 response when a guard denies the request', async () => {
     class DenyGuard {
       canActivate() {

--- a/packages/http/src/dispatcher.ts
+++ b/packages/http/src/dispatcher.ts
@@ -1,17 +1,17 @@
-import { InvariantError, type Token } from '@konekti/core';
+import type { Token } from '@konekti/core';
 import type { Container } from '@konekti/di';
 
-import { HandlerNotFoundError, RequestAbortedError } from './errors.js';
-import { HttpException, InternalServerException, NotAcceptableException, NotFoundException, createErrorResponse } from './exceptions.js';
-import { DefaultBinder } from './binding.js';
-import { HttpDtoValidationAdapter } from './dto-validation-adapter.js';
+import { invokeControllerHandler } from './dispatch-handler-policy.js';
+import { resolveContentNegotiation, writeErrorResponse, writeSuccessResponse, type ResolvedContentNegotiation } from './dispatch-response-policy.js';
+import { matchHandlerOrThrow, updateRequestParams } from './dispatch-routing-policy.js';
+import { RequestAbortedError } from './errors.js';
 import { runGuardChain } from './guards.js';
 import { runInterceptorChain } from './interceptors.js';
 import { runMiddlewareChain } from './middleware.js';
 import { createRequestContext, runWithRequestContext } from './request-context.js';
 import { SseResponse } from './sse.js';
 import type {
-  ArgumentResolverContext,
+  ContentNegotiationOptions,
   Dispatcher,
   FrameworkRequest,
   FrameworkResponse,
@@ -20,16 +20,11 @@ import type {
   HandlerMapping,
   InterceptorContext,
   MiddlewareLike,
-  ResponseFormatter,
-  ContentNegotiationOptions,
+  RequestContext,
+  RequestObservationContext,
   RequestObserver,
   RequestObserverLike,
-  RequestObservationContext,
-  RequestContext,
 } from './types.js';
-
-const defaultBinder = new DefaultBinder();
-const defaultValidator = new HttpDtoValidationAdapter();
 
 export type ErrorHandler = (error: unknown, request: FrameworkRequest, response: FrameworkResponse, requestId?: string) => Promise<boolean | void> | boolean | void;
 
@@ -40,214 +35,6 @@ export interface CreateDispatcherOptions {
   observers?: RequestObserverLike[];
   onError?: ErrorHandler;
   rootContainer: Container;
-}
-
-interface AcceptToken {
-  mediaRange: string;
-  quality: number;
-  specificity: number;
-}
-
-interface ResolvedContentNegotiation {
-  defaultFormatter: ResponseFormatter;
-  formatters: ResponseFormatter[];
-}
-
-function normalizeMediaType(value: string): string {
-  return value.split(';')[0]?.trim().toLowerCase() ?? '';
-}
-
-function readAcceptHeader(request: FrameworkRequest): string | undefined {
-  const raw = request.headers.accept ?? request.headers.Accept;
-  const value = Array.isArray(raw) ? raw.join(',') : raw;
-  const normalized = value?.trim();
-
-  return normalized ? normalized : undefined;
-}
-
-function parseQuality(value: string | undefined): number {
-  if (!value) {
-    return 1;
-  }
-
-  const parsed = Number(value);
-
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return 0;
-  }
-
-  if (parsed > 1) {
-    return 1;
-  }
-
-  return parsed;
-}
-
-function getMediaRangeSpecificity(mediaRange: string): number {
-  if (mediaRange === '*/*') {
-    return 0;
-  }
-
-  if (mediaRange.endsWith('/*')) {
-    return 1;
-  }
-
-  return 2;
-}
-
-function parseAcceptHeader(acceptHeader: string): AcceptToken[] {
-  const tokens: AcceptToken[] = [];
-
-  for (const token of acceptHeader.split(',')) {
-    const [rawMediaRange, ...parameterParts] = token.trim().split(';');
-    const mediaRange = normalizeMediaType(rawMediaRange ?? '');
-
-    if (!mediaRange || !mediaRange.includes('/')) {
-      continue;
-    }
-
-    let quality = 1;
-
-    for (const parameterPart of parameterParts) {
-      const [name, value] = parameterPart.trim().split('=');
-
-      if (name?.toLowerCase() === 'q') {
-        quality = parseQuality(value?.trim());
-        break;
-      }
-    }
-
-    if (quality <= 0) {
-      continue;
-    }
-
-    tokens.push({
-      mediaRange,
-      quality,
-      specificity: getMediaRangeSpecificity(mediaRange),
-    });
-  }
-
-  return tokens.sort((left, right) => {
-    if (right.quality !== left.quality) {
-      return right.quality - left.quality;
-    }
-
-    return right.specificity - left.specificity;
-  });
-}
-
-function matchesMediaRange(mediaRange: string, mediaType: string): boolean {
-  if (mediaRange === '*/*') {
-    return true;
-  }
-
-  const [rangeType, rangeSubtype] = mediaRange.split('/');
-  const [mediaTypeType, mediaTypeSubtype] = mediaType.split('/');
-
-  if (!rangeType || !rangeSubtype || !mediaTypeType || !mediaTypeSubtype) {
-    return false;
-  }
-
-  if (rangeType !== '*' && rangeType !== mediaTypeType) {
-    return false;
-  }
-
-  return rangeSubtype === '*' || rangeSubtype === mediaTypeSubtype;
-}
-
-function resolveContentNegotiation(options: ContentNegotiationOptions | undefined): ResolvedContentNegotiation | undefined {
-  if (!options?.formatters?.length) {
-    return undefined;
-  }
-
-  const formatters = options.formatters.filter((formatter, index, all) => {
-    const mediaType = normalizeMediaType(formatter.mediaType);
-
-    if (!mediaType) {
-      return false;
-    }
-
-    return all.findIndex((item) => normalizeMediaType(item.mediaType) === mediaType) === index;
-  });
-
-  if (!formatters.length) {
-    return undefined;
-  }
-
-  const defaultMediaType = normalizeMediaType(options.defaultMediaType ?? '');
-  const defaultFormatter = defaultMediaType
-    ? formatters.find((formatter) => normalizeMediaType(formatter.mediaType) === defaultMediaType) ?? formatters[0]
-    : formatters[0];
-
-  return {
-    defaultFormatter,
-    formatters,
-  };
-}
-
-function resolveAllowedFormatters(
-  handler: HandlerDescriptor,
-  contentNegotiation: ResolvedContentNegotiation,
-): ResponseFormatter[] {
-  if (!handler.route.produces?.length) {
-    return contentNegotiation.formatters;
-  }
-
-  const allowed = new Set(handler.route.produces.map((mediaType) => normalizeMediaType(mediaType)));
-  return contentNegotiation.formatters.filter((formatter) => allowed.has(normalizeMediaType(formatter.mediaType)));
-}
-
-function resolveDefaultFormatter(
-  allowedFormatters: ResponseFormatter[],
-  contentNegotiation: ResolvedContentNegotiation,
-): ResponseFormatter {
-  const defaultMediaType = normalizeMediaType(contentNegotiation.defaultFormatter.mediaType);
-
-  return allowedFormatters.find((formatter) => normalizeMediaType(formatter.mediaType) === defaultMediaType)
-    ?? allowedFormatters[0]
-    ?? contentNegotiation.defaultFormatter;
-}
-
-function selectResponseFormatter(
-  handler: HandlerDescriptor,
-  request: FrameworkRequest,
-  contentNegotiation: ResolvedContentNegotiation,
-): ResponseFormatter {
-  const allowedFormatters = resolveAllowedFormatters(handler, contentNegotiation);
-
-  if (!allowedFormatters.length) {
-    throw new NotAcceptableException('No acceptable response representation found.');
-  }
-
-  const defaultFormatter = resolveDefaultFormatter(allowedFormatters, contentNegotiation);
-  const acceptHeader = readAcceptHeader(request);
-
-  if (!acceptHeader) {
-    return defaultFormatter;
-  }
-
-  const acceptTokens = parseAcceptHeader(acceptHeader);
-
-  if (!acceptTokens.length) {
-    throw new NotAcceptableException('No acceptable response representation found.');
-  }
-
-  for (const token of acceptTokens) {
-    if (token.mediaRange === '*/*') {
-      return defaultFormatter;
-    }
-
-    const matchedFormatter = allowedFormatters.find((formatter) => {
-      return matchesMediaRange(token.mediaRange, normalizeMediaType(formatter.mediaType));
-    });
-
-    if (matchedFormatter) {
-      return matchedFormatter;
-    }
-  }
-
-  throw new NotAcceptableException('No acceptable response representation found.');
 }
 
 function createDispatchRequest(request: FrameworkRequest): FrameworkRequest {
@@ -279,112 +66,10 @@ function createDispatchContext(
   });
 }
 
-function updateRequestParams(context: RequestContext, params: Readonly<Record<string, string>>): void {
-  context.request = {
-    ...context.request,
-    params,
-  };
-}
-
-async function invokeControllerHandler(
-  handler: HandlerDescriptor,
-  requestContext: RequestContext,
-): Promise<unknown> {
-  const controller = await requestContext.container.resolve(handler.controllerToken as Token<object>);
-  const method = (controller as Record<string, unknown>)[handler.methodName];
-
-  if (typeof method !== 'function') {
-    throw new InvariantError(
-      `Controller ${handler.controllerToken.name} does not expose handler method ${handler.methodName}.`,
-    );
-  }
-
-  const argumentResolverContext: ArgumentResolverContext = {
-    handler,
-    requestContext,
-  };
-  const input = handler.route.request
-    ? await defaultBinder.bind(handler.route.request, argumentResolverContext)
-    : undefined;
-
-  if (handler.route.request) {
-    await defaultValidator.validate(input, handler.route.request);
-  }
-
-  return method.call(controller, input, requestContext);
-}
-
-function resolveDefaultSuccessStatus(handler: HandlerDescriptor, value: unknown): number {
-  switch (handler.route.method) {
-    case 'POST':
-      return 201;
-    case 'DELETE':
-    case 'OPTIONS':
-      return value === undefined ? 204 : 200;
-    default:
-      return 200;
-  }
-}
-
-async function writeSuccessResponse(
-  handler: HandlerDescriptor,
-  request: FrameworkRequest,
-  response: FrameworkResponse,
-  value: unknown,
-  contentNegotiation: ResolvedContentNegotiation | undefined,
-): Promise<void> {
-  if (response.committed) {
-    return;
-  }
-
-  const formatter = contentNegotiation
-    ? selectResponseFormatter(handler, request, contentNegotiation)
-    : undefined;
-
-  if (formatter) {
-    response.setHeader('Content-Type', formatter.mediaType);
-  }
-
-  if (handler.route.successStatus !== undefined) {
-    response.setStatus(handler.route.successStatus);
-  } else if (response.statusSet !== true) {
-    response.setStatus(resolveDefaultSuccessStatus(handler, value));
-  }
-
-  const responseBody = formatter
-    ? formatter.format(value)
-    : value;
-  await response.send(responseBody);
-}
-
 function ensureRequestNotAborted(request: FrameworkRequest): void {
   if (request.signal?.aborted) {
     throw new RequestAbortedError();
   }
-}
-
-function toHttpException(error: unknown): HttpException {
-  if (error instanceof HttpException) {
-    return error;
-  }
-
-  if (error instanceof HandlerNotFoundError) {
-    return new NotFoundException(error.message, { cause: error });
-  }
-
-  return new InternalServerException('Internal server error.', {
-    cause: error,
-  });
-}
-
-async function writeErrorResponse(error: unknown, response: FrameworkResponse, requestId?: string): Promise<void> {
-  if (response.committed) {
-    return;
-  }
-
-  const httpError = toHttpException(error);
-  response.setStatus(httpError.status);
-  await response.send(createErrorResponse(httpError, requestId));
 }
 
 function isRequestObserver(value: RequestObserverLike): value is RequestObserver {
@@ -460,7 +145,6 @@ async function dispatchMatchedHandler(
       handler,
     );
   } catch {
-    // Observer errors must not mask a successful request.
   }
 }
 
@@ -471,13 +155,17 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
       const requestContext = createDispatchContext(createDispatchRequest(request), response, options.rootContainer);
       const observers = options.observers ?? [];
+      let matchedHandler: HandlerDescriptor | undefined;
 
       await runWithRequestContext(requestContext, async () => {
-        await notifyObservers(observers, requestContext, async (observer, context) => {
-          await observer.onRequestStart?.(context);
-        });
-
         try {
+          try {
+            await notifyObservers(observers, requestContext, async (observer, context) => {
+              await observer.onRequestStart?.(context);
+            });
+          } catch {
+          }
+
           ensureRequestNotAborted(requestContext.request);
           await runMiddlewareChain(options.appMiddleware ?? [], {
             request: requestContext.request,
@@ -488,21 +176,20 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
               return;
             }
 
-            const match = options.handlerMapping.match(requestContext.request);
-
-            if (!match) {
-              throw new HandlerNotFoundError(`No handler registered for ${request.method} ${request.path}.`);
-            }
-
+            const match = matchHandlerOrThrow(options.handlerMapping, requestContext.request);
+            matchedHandler = match.descriptor;
             updateRequestParams(requestContext, match.params);
-            await notifyObservers(
-              observers,
-              requestContext,
-              async (observer, context) => {
-                await observer.onHandlerMatched?.(context);
-              },
-              match.descriptor,
-            );
+            try {
+              await notifyObservers(
+                observers,
+                requestContext,
+                async (observer, context) => {
+                  await observer.onHandlerMatched?.(context);
+                },
+                match.descriptor,
+              );
+            } catch {
+            }
 
             await runMiddlewareChain(match.descriptor.metadata.moduleMiddleware ?? [], {
               request: requestContext.request,
@@ -524,9 +211,9 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
               async (observer, context) => {
                 await observer.onRequestError?.(context, error);
               },
+              matchedHandler,
             );
           } catch {
-            // Observer errors must not mask the original request error.
           }
 
           const handled = await options.onError?.(error, requestContext.request, response, requestContext.requestId);
@@ -540,9 +227,8 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
           try {
             await notifyObservers(observers, requestContext, async (observer, context) => {
               await observer.onRequestFinish?.(context);
-            });
+            }, matchedHandler);
           } catch {
-            // Observer errors in the finally block must not mask earlier errors.
           }
         }
       });

--- a/packages/http/src/dto-validation-adapter.ts
+++ b/packages/http/src/dto-validation-adapter.ts
@@ -1,17 +1,9 @@
 import type { Constructor } from '@konekti/core';
 import { DefaultValidator as BaseDefaultValidator, DtoValidationError } from '@konekti/dto-validator';
 
-import { BadRequestException, type HttpExceptionDetail } from './exceptions.js';
+import { BadRequestException } from './exceptions.js';
+import { toInputErrorDetail } from './input-error-detail.js';
 import type { ValidationIssue, Validator } from './types.js';
-
-function toDetail(issue: ValidationIssue): HttpExceptionDetail {
-  return {
-    code: issue.code,
-    field: issue.field,
-    message: issue.message,
-    source: issue.source,
-  };
-}
 
 export class HttpDtoValidationAdapter implements Validator {
   private readonly validator = new BaseDefaultValidator();
@@ -22,7 +14,7 @@ export class HttpDtoValidationAdapter implements Validator {
     } catch (error: unknown) {
       if (error instanceof DtoValidationError) {
         throw new BadRequestException(error.message, {
-          details: error.issues.map(toDetail),
+          details: error.issues.map((issue: ValidationIssue) => toInputErrorDetail(issue)),
         });
       }
 
@@ -36,7 +28,7 @@ export class HttpDtoValidationAdapter implements Validator {
     } catch (error: unknown) {
       if (error instanceof DtoValidationError) {
         throw new BadRequestException(error.message, {
-          details: error.issues.map(toDetail),
+          details: error.issues.map((issue: ValidationIssue) => toInputErrorDetail(issue)),
         });
       }
 

--- a/packages/http/src/input-error-detail.test.ts
+++ b/packages/http/src/input-error-detail.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { toInputErrorDetail } from './input-error-detail.js';
+
+describe('input error detail mapping', () => {
+  it('maps input issue shape to HTTP exception detail contract', () => {
+    const detail = toInputErrorDetail({
+      code: 'MISSING_FIELD',
+      field: 'name',
+      message: 'name is required',
+      source: 'body',
+    });
+
+    expect(detail).toEqual({
+      code: 'MISSING_FIELD',
+      field: 'name',
+      message: 'name is required',
+      source: 'body',
+    });
+  });
+});

--- a/packages/http/src/input-error-detail.ts
+++ b/packages/http/src/input-error-detail.ts
@@ -1,0 +1,19 @@
+import type { MetadataSource } from '@konekti/core';
+
+import type { HttpExceptionDetail } from './exceptions.js';
+
+export interface InputErrorDetail {
+  code: string;
+  field?: string;
+  message: string;
+  source?: MetadataSource;
+}
+
+export function toInputErrorDetail(detail: InputErrorDetail): HttpExceptionDetail {
+  return {
+    code: detail.code,
+    field: detail.field,
+    message: detail.message,
+    source: detail.source,
+  };
+}


### PR DESCRIPTION
## Summary
- split dispatcher responsibilities into dedicated policy modules for routing, handler input orchestration, and response/error writing
- centralize binding/validation detail conversion through a shared input-error detail contract
- add focused policy tests and observer regression coverage to keep route matching and error observer contracts stable

## Verification
- pnpm build
- pnpm vitest run packages/http/src/*.test.ts
- pnpm typecheck
- lsp_diagnostics on packages/http/src (.ts, errors only)

Closes #129