### PR TITLE
Resolve #130: align OpenAPI binding contract and configurable default errors

### DIFF
--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -78,6 +78,7 @@ Registers two HTTP endpoints and returns a `ModuleType` to import into any modul
 interface OpenApiModuleOptions {
   title: string;
   version: string;
+  defaultErrorResponsesPolicy?: 'inject' | 'omit'; // default: 'inject'
   descriptors?: readonly HandlerDescriptor[];  // handler descriptors from createHandlerMapping()
   sources?: readonly HandlerSource[];          // same handler-source model consumed by createHandlerMapping()
   ui?: boolean;                                 // serve Swagger UI at /docs (default: false)
@@ -208,6 +209,8 @@ The generated document follows OpenAPI 3.1.0:
 - Request DTOs decorated with `@konekti/dto-validator` are emitted as `components.schemas` entries and linked through `requestBody`.
 - Cookie-bound DTO fields are emitted as `in: cookie` parameters.
 - Request bodies are only marked `required: true` when at least one body-bound DTO field is required.
+- Default error responses (`400`, `401`, `403`, `404`, `500`) are injected by default and can be disabled with `defaultErrorResponsesPolicy: 'omit'`.
+- Non-body parameter fields are emitted as runtime-compatible scalar/array shapes; nested object refs are not emitted for query/header/cookie/path params.
 
 ---
 
@@ -223,6 +226,7 @@ Builds the OpenAPI document directly from handler descriptors without mounting a
 
 ```typescript
 interface BuildOpenApiDocumentOptions {
+  defaultErrorResponsesPolicy?: 'inject' | 'omit'; // default: 'inject'
   descriptors: readonly HandlerDescriptor[];
   title: string;
   version: string;

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -684,6 +684,63 @@ describe('OpenApiModule', () => {
     expect((response.body as { paths: Record<string, { post?: { requestBody?: { required?: boolean } } }> }).paths['/partial/users']?.post?.requestBody?.required).toBeUndefined();
   });
 
+  it('omits requestBody when request DTO has no body-bound fields', async () => {
+    class SearchRequest {
+      @FromQuery('q')
+      @IsString()
+      query = '';
+
+      @IsString()
+      unboundHint = '';
+    }
+
+    @Controller('/implicit')
+    class ImplicitController {
+      @RequestDto(SearchRequest)
+      @Post('/search')
+      search() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: ImplicitController }],
+      title: 'Implicit DTO API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [ImplicitController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+
+    const document = response.body as {
+      paths: Record<string, { post?: { parameters?: unknown[]; requestBody?: unknown } }>;
+    };
+
+    expect(document.paths['/implicit/search']?.post?.parameters).toEqual([
+      {
+        in: 'query',
+        name: 'q',
+        required: true,
+        schema: { type: 'string' },
+      },
+    ]);
+    expect(document.paths['/implicit/search']?.post?.requestBody).toBeUndefined();
+  });
+
   it('emits correct response schemas when mapped DTO helpers are used with @ApiResponse', async () => {
     class UserResponseDto {
       @IsString()
@@ -824,7 +881,7 @@ describe('OpenApiModule', () => {
     );
   });
 
-  it('keeps nested parameter schema refs at field level', async () => {
+  it('does not emit nested parameter refs that runtime binding cannot consume', async () => {
     class FilterDto {
       @IsString()
       term = '';
@@ -869,11 +926,6 @@ describe('OpenApiModule', () => {
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual(
       expect.objectContaining({
-        components: expect.objectContaining({
-          schemas: expect.objectContaining({
-            FilterDto: expect.any(Object),
-          }),
-        }),
         paths: expect.objectContaining({
           '/search': {
             get: expect.objectContaining({
@@ -883,7 +935,7 @@ describe('OpenApiModule', () => {
                   name: 'filter',
                   required: true,
                   schema: {
-                    $ref: '#/components/schemas/FilterDto',
+                    type: 'string',
                   },
                 },
               ],
@@ -892,6 +944,12 @@ describe('OpenApiModule', () => {
         }),
       }),
     );
+
+    const document = response.body as {
+      components?: { schemas?: Record<string, unknown> };
+    };
+
+    expect(document.components?.schemas?.FilterDto).toBeUndefined();
   });
 
   it('adds default error responses when @ApiResponse is absent', async () => {
@@ -932,11 +990,40 @@ describe('OpenApiModule', () => {
             ErrorResponse: {
               additionalProperties: false,
               properties: {
-                error: { type: 'string' },
-                message: { type: 'string' },
-                statusCode: { type: 'integer' },
+                error: {
+                  additionalProperties: false,
+                  properties: {
+                    code: { type: 'string' },
+                    details: {
+                      items: {
+                        additionalProperties: false,
+                        properties: {
+                          code: { type: 'string' },
+                          field: { type: 'string' },
+                          message: { type: 'string' },
+                          source: {
+                            enum: ['path', 'query', 'header', 'cookie', 'body'],
+                            type: 'string',
+                          },
+                        },
+                        required: ['code', 'message'],
+                        type: 'object',
+                      },
+                      type: 'array',
+                    },
+                    message: { type: 'string' },
+                    meta: {
+                      additionalProperties: true,
+                      type: 'object',
+                    },
+                    requestId: { type: 'string' },
+                    status: { type: 'integer' },
+                  },
+                  required: ['code', 'status', 'message'],
+                  type: 'object',
+                },
               },
-              required: ['statusCode', 'message', 'error'],
+              required: ['error'],
               type: 'object',
             },
           }),
@@ -964,6 +1051,50 @@ describe('OpenApiModule', () => {
         }),
       }),
     );
+  });
+
+  it('omits default error response injection when policy is set to omit', async () => {
+    @Controller('/errors')
+    class ErrorsController {
+      @Get('/default')
+      defaultHandler() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      defaultErrorResponsesPolicy: 'omit',
+      sources: [{ controllerToken: ErrorsController }],
+      title: 'Errors API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [ErrorsController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+
+    const document = response.body as {
+      components?: { schemas?: Record<string, unknown> };
+      paths: Record<string, { get?: { responses?: Record<string, unknown> } }>;
+    };
+
+    expect(document.paths['/errors/default']?.get?.responses).toEqual({
+      '200': { description: 'OK' },
+    });
+    expect(document.components?.schemas?.ErrorResponse).toBeUndefined();
   });
 
   it('preserves explicit @ApiResponse and fills missing default error responses', async () => {

--- a/packages/openapi/src/openapi-module.ts
+++ b/packages/openapi/src/openapi-module.ts
@@ -11,9 +11,10 @@ import { Inject, type AsyncModuleOptions, type MaybePromise, type Token } from '
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { OpenApiHandlerRegistry } from './handler-registry.js';
-import { buildOpenApiDocument, type OpenApiDocument } from './schema-builder.js';
+import { buildOpenApiDocument, type DefaultErrorResponsesPolicy, type OpenApiDocument } from './schema-builder.js';
 
 export interface OpenApiModuleOptions {
+  defaultErrorResponsesPolicy?: DefaultErrorResponsesPolicy;
   title: string;
   version: string;
   ui?: boolean;
@@ -138,6 +139,7 @@ export class OpenApiModule {
             registry.setDescriptors(options.descriptors ?? createHandlerMapping([...(options.sources ?? [])]).descriptors);
 
             return buildOpenApiDocument({
+              defaultErrorResponsesPolicy: options.defaultErrorResponsesPolicy,
               descriptors: registry.getDescriptors(),
               title: options.title,
               version: options.version,

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -85,10 +85,13 @@ export interface OpenApiDocument {
 }
 
 export interface BuildOpenApiDocumentOptions {
+  defaultErrorResponsesPolicy?: DefaultErrorResponsesPolicy;
   descriptors: readonly HandlerDescriptor[];
   title: string;
   version: string;
 }
+
+export type DefaultErrorResponsesPolicy = 'inject' | 'omit';
 
 function expressPathToOpenApi(path: string): string {
   return path.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, '{$1}');
@@ -379,18 +382,8 @@ function createParameters(
     const source = entry.binding.metadata.source as 'cookie' | 'header' | 'path' | 'query';
     const rules = entry.validation?.rules ?? [];
     const inferred = inferPrimitiveTypeFromRules(rules) ?? { type: 'string' as const };
-    const schema = applyValidationConstraints(inferred, rules);
+    const schema = alignParameterSchemaWithRuntimeBindingContract(applyValidationConstraints(inferred, rules));
     const isRequired = source === 'path' ? true : isPropertyRequired(entry.binding, entry.validation);
-
-    if ('$ref' in schema) {
-      const nestedRule = rules.find(
-        (rule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
-      );
-
-      if (nestedRule) {
-        ensureComponentSchema(resolveNestedDto(nestedRule.dto), componentSchemas);
-      }
-    }
 
     return {
       in: source,
@@ -408,11 +401,40 @@ function ensureErrorResponseSchema(componentSchemas: Record<string, OpenApiSchem
     componentSchemas[schemaName] = {
       additionalProperties: false,
       properties: {
-        error: { type: 'string' },
-        message: { type: 'string' },
-        statusCode: { type: 'integer' },
+        error: {
+          additionalProperties: false,
+          properties: {
+            code: { type: 'string' },
+            details: {
+              items: {
+                additionalProperties: false,
+                properties: {
+                  code: { type: 'string' },
+                  field: { type: 'string' },
+                  message: { type: 'string' },
+                  source: {
+                    enum: ['path', 'query', 'header', 'cookie', 'body'],
+                    type: 'string',
+                  },
+                },
+                required: ['code', 'message'],
+                type: 'object',
+              },
+              type: 'array',
+            },
+            message: { type: 'string' },
+            meta: {
+              additionalProperties: true,
+              type: 'object',
+            },
+            requestId: { type: 'string' },
+            status: { type: 'integer' },
+          },
+          required: ['code', 'status', 'message'],
+          type: 'object',
+        },
       },
-      required: ['statusCode', 'message', 'error'],
+      required: ['error'],
       type: 'object',
     };
   }
@@ -457,7 +479,7 @@ function createRequestBody(
     return undefined;
   }
 
-  const entries = collectDtoEntries(dto).filter((entry) => entry.binding?.metadata.source === 'body' || entry.binding === undefined);
+  const entries = collectDtoEntries(dto).filter((entry) => entry.binding?.metadata.source === 'body');
 
   if (entries.length === 0) {
     return undefined;
@@ -474,6 +496,27 @@ function createRequestBody(
     },
     ...(entries.some((entry) => isPropertyRequired(entry.binding, entry.validation)) ? { required: true } : {}),
   };
+}
+
+function alignParameterSchemaWithRuntimeBindingContract(schema: OpenApiSchemaObject): OpenApiSchemaObject {
+  if (schema.$ref !== undefined) {
+    return { type: 'string' };
+  }
+
+  if (schema.type === 'object') {
+    return { type: 'string' };
+  }
+
+  if (schema.type === 'array' && schema.items) {
+    if (schema.items.$ref !== undefined || schema.items.type === 'object') {
+      return {
+        ...schema,
+        items: { type: 'string' },
+      };
+    }
+  }
+
+  return schema;
 }
 
 function createResponseObject(
@@ -504,6 +547,7 @@ export function buildOpenApiDocument(options: BuildOpenApiDocumentOptions): Open
   const paths: Record<string, OpenApiPathItemObject> = {};
   const componentSchemas: Record<string, OpenApiSchemaObject> = {};
   let hasBearerAuth = false;
+  const defaultErrorResponsesPolicy = options.defaultErrorResponsesPolicy ?? 'inject';
 
   for (const descriptor of options.descriptors) {
     const openApiPath = expressPathToOpenApi(descriptor.route.path);
@@ -523,7 +567,9 @@ export function buildOpenApiDocument(options: BuildOpenApiDocumentOptions): Open
       responses[String(descriptor.route.successStatus ?? 200)] = { description: 'OK' };
     }
 
-    addDefaultErrorResponses(responses, componentSchemas);
+    if (defaultErrorResponsesPolicy === 'inject') {
+      addDefaultErrorResponses(responses, componentSchemas);
+    }
 
     const security: OpenApiSecurityRequirementObject[] | undefined =
       methodMeta?.security && methodMeta.security.length > 0


### PR DESCRIPTION
## Summary
- align non-body parameter schemas with runtime binding contract by avoiding nested object refs for query/header/cookie/path inputs
- limit generated requestBody schemas to body-bound DTO fields and omit requestBody when no body bindings exist
- add configurable default error response injection policy (`inject` by default, `omit` opt-out) and align `ErrorResponse` schema with the runtime envelope

## Validation
- pnpm build
- pnpm vitest run packages/openapi/src/openapi-module.test.ts
- pnpm typecheck

Closes #130