### PR TITLE
Resolve #137: harden cron startup and hook lifecycle contracts

### DIFF
--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -89,6 +89,36 @@ class LockLossOnRenewRedisClient {
   }
 }
 
+class RenewalErrorOnRenewRedisClient {
+  private readonly locks = new Map<string, string>();
+
+  async set(key: string, value: string, _mode: 'PX', _ttl: number, _existence: 'NX'): Promise<'OK' | null> {
+    if (this.locks.has(key)) {
+      return null;
+    }
+
+    this.locks.set(key, value);
+    return 'OK';
+  }
+
+  async eval(script: string, _keysLength: number, key: string, owner: string, _ttl?: string): Promise<number> {
+    if (script.includes('PEXPIRE')) {
+      throw new Error('renew failed');
+    }
+
+    if (!script.includes('DEL')) {
+      return 0;
+    }
+
+    if (this.locks.get(key) !== owner) {
+      return 0;
+    }
+
+    this.locks.delete(key);
+    return 1;
+  }
+}
+
 function createDeferred<T = void>(): Deferred<T> {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -293,6 +323,45 @@ describe('@konekti/cron', () => {
     await app.close();
 
     expect(scheduled.records[0]?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back partially scheduled jobs when startup fails', async () => {
+    const firstStop = vi.fn();
+    let scheduleCount = 0;
+    const scheduler: CronScheduler = (_expression, _options, _callback) => {
+      scheduleCount += 1;
+
+      if (scheduleCount === 1) {
+        return {
+          stop: firstStop,
+        };
+      }
+
+      throw new Error('scheduler boom');
+    };
+
+    class PartialScheduleTaskService {
+      @Cron(CronExpression.EVERY_SECOND, { name: 'partial-schedule-1' })
+      runOne() {}
+
+      @Cron(CronExpression.EVERY_SECOND, { name: 'partial-schedule-2' })
+      runTwo() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCronModule({ scheduler })],
+      providers: [PartialScheduleTaskService],
+    });
+
+    await expect(
+      bootstrapApplication({
+        mode: 'test',
+        rootModule: AppModule,
+      }),
+    ).rejects.toThrow('scheduler boom');
+
+    expect(firstStop).toHaveBeenCalledTimes(1);
   });
 
   it('warns when @Cron() is declared on a non-singleton provider and skips scheduling', async () => {
@@ -544,10 +613,9 @@ describe('@konekti/cron', () => {
     await closePromise;
     await secondScheduler.records[0]!.tick();
 
-    const firstStore = await appOne.container.resolve(SharedStore);
     const secondStore = await appTwo.container.resolve(SharedStore);
 
-    expect(firstStore.count + secondStore.count).toBe(2);
+    expect(secondStore.count).toBe(1);
 
     await appTwo.close();
   });
@@ -720,6 +788,49 @@ describe('@konekti/cron', () => {
     await app.close();
   });
 
+  it('keeps afterRun deterministic when onError throws', async () => {
+    const scheduled = createManualScheduler();
+    const events: string[] = [];
+    const loggerEvents: string[] = [];
+
+    class OnErrorThrowingTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        afterRun: () => {
+          events.push('after');
+        },
+        beforeRun: () => {
+          events.push('before');
+          throw new Error('before boom');
+        },
+        name: 'on-error-throwing-task',
+        onError: (error) => {
+          events.push(`error:${error instanceof Error ? error.message : 'unknown'}`);
+          throw new Error('onError boom');
+        },
+      })
+      run() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCronModule({ scheduler: scheduled.scheduler })],
+      providers: [OnErrorThrowingTaskService],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    await expect(scheduled.records[0]!.tick()).resolves.toBeUndefined();
+
+    expect(events).toEqual(['before', 'error:before boom', 'after']);
+    expect(loggerEvents.some((event) => event.includes('Cron onError hook on-error-throwing-task failed.'))).toBe(true);
+
+    await app.close();
+  });
+
   it('treats lock ownership loss during renewal as a failed tick', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-20T00:00:00.000Z'));
@@ -782,6 +893,74 @@ describe('@konekti/cron', () => {
     expect(events).toEqual([
       'run',
       'error:Distributed cron lock ownership lost for lock-loss-task.',
+      'after',
+    ]);
+
+    await app.close();
+  });
+
+  it('treats lock renewal errors as a failed tick', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-20T00:00:00.000Z'));
+
+    const scheduled = createManualScheduler();
+    const redis = new RenewalErrorOnRenewRedisClient();
+    const started = createDeferred<void>();
+    const release = createDeferred<void>();
+    const events: string[] = [];
+
+    class DistributedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        afterRun: () => {
+          events.push('after');
+        },
+        distributed: true,
+        lockTtlMs: 2_000,
+        name: 'lock-renew-error-task',
+        onError: (error) => {
+          events.push(`error:${error instanceof Error ? error.message : 'unknown'}`);
+        },
+        onSuccess: () => {
+          events.push('success');
+        },
+      })
+      async run() {
+        events.push('run');
+        started.resolve();
+        await release.promise;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        createCronModule({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-lock-renew-error',
+            lockTtlMs: 2_000,
+          },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    const tickPromise = scheduled.records[0]!.tick();
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(1_000);
+    release.resolve();
+    await tickPromise;
+
+    expect(events).toEqual([
+      'run',
+      'error:Distributed cron lock renewal failed for lock-renew-error-task.',
       'after',
     ]);
 

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -33,6 +33,8 @@ interface DiscoveryCandidate {
   token: Token;
 }
 
+type LockRenewalOutcome = 'renewed' | 'ownership-lost' | 'renewal-failed';
+
 function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
   if (typeof provider === 'function') {
     return getClassDiMetadata(provider)?.scope ?? 'singleton';
@@ -92,9 +94,15 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
       return;
     }
 
-    this.started = true;
-    await this.resolveDistributedClient();
-    this.scheduleTasks();
+    try {
+      await this.resolveDistributedClient();
+      this.scheduleTasks();
+      this.started = true;
+    } catch (error) {
+      this.stopAllJobs();
+      this.redisClient = undefined;
+      throw error;
+    }
   }
 
   async onApplicationShutdown(): Promise<void> {
@@ -280,17 +288,30 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     }
 
     const renewalIntervalMs = Math.max(1_000, Math.floor(descriptor.lockTtlMs / 2));
-    let lockOwnershipError: Error | undefined;
+    let lockPostRunError: Error | undefined;
+    let latestRenewalAttempt: Promise<void> | undefined;
     const renewalTimer = setInterval(() => {
-      void this.renewLock(descriptor).then((renewed) => {
-        if (!renewed && !lockOwnershipError) {
-          lockOwnershipError = new Error(`Distributed cron lock ownership lost for ${descriptor.taskName}.`);
+      latestRenewalAttempt = this.renewLock(descriptor).then((outcome) => {
+        if (lockPostRunError) {
+          return;
+        }
+
+        if (outcome === 'ownership-lost') {
+          lockPostRunError = new Error(`Distributed cron lock ownership lost for ${descriptor.taskName}.`);
+          return;
+        }
+
+        if (outcome === 'renewal-failed') {
+          lockPostRunError = new Error(`Distributed cron lock renewal failed for ${descriptor.taskName}.`);
         }
       });
     }, renewalIntervalMs);
 
     try {
-      await this.executeTask(descriptor, () => lockOwnershipError);
+      await this.executeTask(descriptor, async () => {
+        await latestRenewalAttempt;
+        return lockPostRunError;
+      });
     } finally {
       clearInterval(renewalTimer);
       await this.releaseLock(descriptor);
@@ -305,7 +326,7 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
 
   private async executeTask(
     descriptor: CronTaskDescriptor,
-    postRunErrorProvider?: () => Error | undefined,
+    postRunErrorProvider?: () => Error | Promise<Error | undefined> | undefined,
   ): Promise<void> {
     let instance: unknown;
 
@@ -330,6 +351,8 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
       return;
     }
 
+    let taskError: unknown;
+
     try {
       if (descriptor.beforeRun) {
         await Promise.resolve(descriptor.beforeRun());
@@ -337,7 +360,7 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
 
       await Promise.resolve((value as (this: unknown) => Promise<void>).call(instance));
 
-      const postRunError = postRunErrorProvider?.();
+      const postRunError = await postRunErrorProvider?.();
 
       if (postRunError) {
         throw postRunError;
@@ -347,14 +370,26 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
         await Promise.resolve(descriptor.onSuccess());
       }
     } catch (error) {
+      taskError = error;
       this.logger.error(`Cron task ${descriptor.taskName} failed.`, error, 'CronLifecycleService');
-      if (descriptor.onError) {
-        await Promise.resolve(descriptor.onError(error));
+    }
+
+    if (taskError && descriptor.onError) {
+      try {
+        await Promise.resolve(descriptor.onError(taskError));
+      } catch (hookError) {
+        this.logger.error(`Cron onError hook ${descriptor.taskName} failed.`, hookError, 'CronLifecycleService');
       }
-    } finally {
-      if (descriptor.afterRun) {
-        await Promise.resolve(descriptor.afterRun());
-      }
+    }
+
+    if (!descriptor.afterRun) {
+      return;
+    }
+
+    try {
+      await Promise.resolve(descriptor.afterRun());
+    } catch (hookError) {
+      this.logger.error(`Cron afterRun hook ${descriptor.taskName} failed.`, hookError, 'CronLifecycleService');
     }
   }
 
@@ -393,11 +428,11 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     await this.releaseLockKey(descriptor.lockKey, descriptor.taskName);
   }
 
-  private async renewLock(descriptor: CronTaskDescriptor): Promise<boolean> {
+  private async renewLock(descriptor: CronTaskDescriptor): Promise<LockRenewalOutcome> {
     const redis = this.redisClient;
 
     if (!redis) {
-      return true;
+      return 'renewed';
     }
 
     try {
@@ -414,17 +449,17 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
           `Distributed cron lock ownership was lost for ${descriptor.taskName}.`,
           'CronLifecycleService',
         );
-        return false;
+        return 'ownership-lost';
       }
 
-      return true;
+      return 'renewed';
     } catch (error) {
       this.logger.error(
         `Failed to renew distributed cron lock for ${descriptor.taskName}.`,
         error,
         'CronLifecycleService',
       );
-      return false;
+      return 'renewal-failed';
     }
   }
 


### PR DESCRIPTION
## Summary
- make cron bootstrap lifecycle-safe by deferring `started` until setup succeeds and rolling back partially scheduled jobs when scheduler setup fails
- make distributed lock renewal outcomes explicit (`ownership lost` vs `renewal failed`) and fail the tick deterministically before `onSuccess`
- harden hook guarantees so `onError`/`afterRun` failures are contained, plus add regression tests for startup rollback, hook failure ordering, and renewal-failure paths

## Verification
- `pnpm exec vitest run packages/cron/src/module.test.ts --project packages`
- `pnpm run typecheck` (in `packages/cron`)
- `pnpm run build` (in `packages/cron`)

Closes #137