### PR TITLE
Resolve #139: harden websocket connect-phase and shutdown lifecycle

### DIFF
--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -48,6 +48,13 @@ export class AppModule {}
 - `@OnConnect()` - handles accepted socket connections
 - `@OnDisconnect()` - handles socket close events
 
+### Module options
+
+`createWebSocketModule(options)` and `createWebSocketProviders(options)` accept:
+
+- `heartbeat.enabled`, `heartbeat.intervalMs`, `heartbeat.timeoutMs`
+- `shutdown.timeoutMs` (default: `5000`)
+
 ## Runtime behavior
 
 - Discovery runs on `onApplicationBootstrap()` using `COMPILED_MODULES`
@@ -56,7 +63,8 @@ export class AppModule {}
 - Gateway path matching is exact and normalized (`/chat` != `/notifications`)
 - Non-singleton gateways are skipped with warnings
 - Shutdown removes the shared upgrade listener and terminates all active clients
-- `message` and `close` listeners are registered only after all `@OnConnect()` handlers have resolved, so messages or disconnects that arrive before `onConnect` completes are not delivered to gateway handlers
+- `message` and `close` events are buffered until `@OnConnect()` handlers complete, then replayed in order so connect-phase events are not silently dropped
+- Attachment server shutdown is timeout-aware and logs close timeout failures instead of hanging indefinitely
 
 ## Provider registration constraints
 

--- a/packages/websocket/src/module.test.ts
+++ b/packages/websocket/src/module.test.ts
@@ -1,15 +1,19 @@
 import { createConnection, createServer } from 'node:net';
+import type { IncomingMessage } from 'node:http';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { WebSocket } from 'ws';
 
 import { Inject, Scope } from '@konekti/core';
+import { Container } from '@konekti/di';
 import { bootstrapApplication, bootstrapNodeApplication, defineModule, type ApplicationLogger, HTTP_APPLICATION_ADAPTER } from '@konekti/runtime';
 import type { HttpApplicationAdapter } from '@konekti/http';
 
 import { OnConnect, OnDisconnect, OnMessage, WebSocketGateway } from './decorators.js';
 import { getWebSocketGatewayMetadata, getWebSocketHandlerMetadataEntries } from './metadata.js';
 import { createWebSocketModule } from './module.js';
+import { WebSocketGatewayLifecycleService } from './service.js';
+import type { WebSocketModuleOptions } from './types.js';
 
 function createLogger(events: string[]): ApplicationLogger {
   return {
@@ -99,6 +103,75 @@ function createDeferred<T = void>() {
   });
 
   return { promise, reject, resolve };
+}
+
+function createTestLifecycleService(
+  options: WebSocketModuleOptions = {},
+  loggerEvents: string[] = [],
+): WebSocketGatewayLifecycleService {
+  const adapter: HttpApplicationAdapter = {
+    async close() {},
+    getServer() {
+      return {
+        off() {
+          return this;
+        },
+        on() {
+          return this;
+        },
+      };
+    },
+    async listen() {},
+  };
+
+  return new WebSocketGatewayLifecycleService(new Container(), [], createLogger(loggerEvents), adapter, options);
+}
+
+type MockSocketListeners = {
+  close?: (code: number, reason: Buffer) => void;
+  message?: (data: unknown) => void;
+  pong?: () => void;
+};
+
+function createMockSocket(): {
+  emitClose: (code?: number, reason?: Buffer) => void;
+  emitPong: () => void;
+  ping: ReturnType<typeof vi.fn>;
+  socket: WebSocket;
+  terminate: ReturnType<typeof vi.fn>;
+} {
+  const listeners: MockSocketListeners = {};
+  const ping = vi.fn();
+  const terminate = vi.fn();
+
+  const socketObject = {
+    on(event: 'close' | 'message' | 'pong', listener: (...args: unknown[]) => void) {
+      if (event === 'close') {
+        listeners.close = listener as (code: number, reason: Buffer) => void;
+      } else if (event === 'message') {
+        listeners.message = listener as (data: unknown) => void;
+      } else {
+        listeners.pong = listener as () => void;
+      }
+
+      return this;
+    },
+    ping,
+    readyState: WebSocket.OPEN,
+    terminate,
+  } as unknown as WebSocket;
+
+  return {
+    emitClose(code = 1000, reason = Buffer.alloc(0)) {
+      listeners.close?.(code, reason);
+    },
+    emitPong() {
+      listeners.pong?.();
+    },
+    ping,
+    socket: socketObject,
+    terminate,
+  };
 }
 
 describe('@konekti/websocket', () => {
@@ -329,7 +402,7 @@ describe('@konekti/websocket', () => {
     await app.close();
   });
 
-  it('does not deliver messages or disconnects that arrive before async onConnect completes', async () => {
+  it('buffers messages and disconnects that arrive before async onConnect completes', async () => {
     const connected = createDeferred<void>();
 
     class GatewayState {
@@ -375,8 +448,6 @@ describe('@konekti/websocket', () => {
     await app.listen();
 
     // Connect, send a message, then close — all before onConnect resolves.
-    // message and close listeners are registered only after onConnect completes,
-    // so these events are not delivered to the gateway handlers.
     const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/async-connect`);
     await onceOpen(socket);
     socket.send(JSON.stringify({ event: 'ping', data: 'early' }));
@@ -386,8 +457,8 @@ describe('@konekti/websocket', () => {
     connected.resolve();
     await new Promise((resolve) => setTimeout(resolve, 25));
 
-    expect(state.messages).toEqual([]);
-    expect(state.disconnects).toBe(0);
+    expect(state.messages).toEqual(['early']);
+    expect(state.disconnects).toBe(1);
 
     await app.close();
   });
@@ -454,6 +525,107 @@ describe('@konekti/websocket', () => {
     expect(state.disconnects).toBe(1);
 
     await app.close();
+  });
+
+  it('clears heartbeat pending markers when pong is received', async () => {
+    const service = createTestLifecycleService();
+    const { emitPong, socket } = createMockSocket();
+    const bindConnectionHandlers = Reflect.get(service, 'bindConnectionHandlers') as (
+      descriptors: unknown[],
+      socket: WebSocket,
+      request: IncomingMessage,
+    ) => Promise<void>;
+
+    await bindConnectionHandlers.call(service, [], socket, {} as IncomingMessage);
+
+    const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, WebSocket>;
+    const socketId = Array.from(socketRegistry.keys())[0];
+
+    if (!socketId) {
+      throw new Error('Expected socket to be registered for heartbeat tracking.');
+    }
+
+    const pingPending = Reflect.get(service, 'pingPending') as Set<string>;
+    const pingSentAt = Reflect.get(service, 'pingSentAt') as Map<string, number>;
+    pingPending.add(socketId);
+    pingSentAt.set(socketId, Date.now());
+
+    emitPong();
+
+    expect(pingPending.has(socketId)).toBe(false);
+    expect(pingSentAt.has(socketId)).toBe(false);
+
+    const shutdown = Reflect.get(service, 'shutdown') as () => Promise<void>;
+    await shutdown.call(service);
+  });
+
+  it('terminates sockets when pong timeout is missed and clears heartbeat state', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const service = createTestLifecycleService();
+      const { ping, socket, terminate } = createMockSocket();
+      const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, WebSocket>;
+      socketRegistry.set('socket-1', socket);
+
+      const startHeartbeat = Reflect.get(service, 'startHeartbeat') as (intervalMs: number, timeoutMs: number) => void;
+      startHeartbeat.call(service, 100, 150);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(ping).toHaveBeenCalledTimes(1);
+
+      const pingPending = Reflect.get(service, 'pingPending') as Set<string>;
+      const pingSentAt = Reflect.get(service, 'pingSentAt') as Map<string, number>;
+      expect(pingPending.has('socket-1')).toBe(true);
+      expect(pingSentAt.has('socket-1')).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(terminate).toHaveBeenCalledTimes(1);
+      expect(socketRegistry.has('socket-1')).toBe(false);
+      expect(pingPending.has('socket-1')).toBe(false);
+      expect(pingSentAt.has('socket-1')).toBe(false);
+
+      const shutdown = Reflect.get(service, 'shutdown') as () => Promise<void>;
+      await shutdown.call(service);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('logs and continues shutdown when websocket server close exceeds timeout', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const loggerEvents: string[] = [];
+      const service = createTestLifecycleService({ shutdown: { timeoutMs: 25 } }, loggerEvents);
+      const hangingServer = {
+        clients: new Set<WebSocket>(),
+        close(_callback?: (error?: Error) => void) {},
+      };
+
+      Reflect.set(service, 'attachments', [
+        {
+          descriptors: [],
+          path: '/hang',
+          server: hangingServer,
+        },
+      ]);
+
+      const shutdown = Reflect.get(service, 'shutdown') as () => Promise<void>;
+      const shutdownPromise = shutdown.call(service);
+
+      await vi.advanceTimersByTimeAsync(25);
+      await shutdownPromise;
+
+      expect(
+        loggerEvents.some((event) =>
+          event.includes('error:WebSocketGatewayLifecycleService:Failed to close websocket server for path /hang within 25ms.'),
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('rejects websocket upgrade requests for unmatched gateway paths', async () => {

--- a/packages/websocket/src/service.ts
+++ b/packages/websocket/src/service.ts
@@ -52,6 +52,13 @@ type ParsedWebSocketMessage = {
   payload: unknown;
 };
 
+type BufferedDisconnectEvent = {
+  code: number;
+  reason: Buffer;
+};
+
+const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
+
 function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
   if (typeof provider === 'function') {
     return getClassDiMetadata(provider)?.scope ?? 'singleton';
@@ -256,6 +263,63 @@ export class WebSocketGatewayLifecycleService
     this.socketRegistry.set(socketId, socket);
 
     const resolved: Array<{ descriptor: WebSocketGatewayDescriptor; instance: unknown }> = [];
+    const bufferedMessages: RawData[] = [];
+    let bufferedDisconnect: BufferedDisconnectEvent | undefined;
+    let handlersReady = false;
+    let handlerQueue = Promise.resolve();
+
+    const queueMessage = (data: RawData): void => {
+      handlerQueue = handlerQueue
+        .then(async () => {
+          await this.handleMessage(resolved, socket, request, data);
+        })
+        .catch((error) => {
+          this.logger.error('WebSocket gateway message dispatch failed.', error, 'WebSocketGatewayLifecycleService');
+        });
+    };
+
+    const queueDisconnect = (disconnectEvent: BufferedDisconnectEvent): void => {
+      handlerQueue = handlerQueue
+        .then(async () => {
+          await this.handleDisconnect(
+            resolved,
+            socket,
+            disconnectEvent.code,
+            disconnectEvent.reason,
+            socketId,
+          );
+        })
+        .catch((error) => {
+          this.logger.error('WebSocket gateway disconnect dispatch failed.', error, 'WebSocketGatewayLifecycleService');
+        });
+    };
+
+    socket.on('message', (data: RawData) => {
+      if (!handlersReady) {
+        bufferedMessages.push(data);
+        return;
+      }
+
+      queueMessage(data);
+    });
+
+    socket.on('pong', () => {
+      this.pingPending.delete(socketId);
+      this.pingSentAt.delete(socketId);
+    });
+
+    socket.on('close', (code: number, reason: Buffer) => {
+      this.unregisterSocket(socketId);
+
+      const disconnectEvent: BufferedDisconnectEvent = { code, reason };
+
+      if (!handlersReady) {
+        bufferedDisconnect = disconnectEvent;
+        return;
+      }
+
+      queueDisconnect(disconnectEvent);
+    });
 
     for (const descriptor of descriptors) {
       const instance = await this.resolveGatewayInstance(descriptor);
@@ -271,24 +335,19 @@ export class WebSocketGatewayLifecycleService
       }),
     );
 
-    if (socket.readyState !== WebSocket.OPEN) {
-      this.unregisterSocket(socketId);
-      return;
+    handlersReady = true;
+
+    for (const message of bufferedMessages) {
+      queueMessage(message);
     }
 
-    socket.on('message', (data: RawData) => {
-      void this.handleMessage(resolved, socket, request, data);
-    });
-
-    socket.on('pong', () => {
-      this.pingPending.delete(socketId);
-      this.pingSentAt.delete(socketId);
-    });
-
-    socket.on('close', (code: number, reason: Buffer) => {
+    if (bufferedDisconnect) {
+      queueDisconnect(bufferedDisconnect);
+    } else if (socket.readyState !== WebSocket.OPEN && socket.readyState !== WebSocket.CONNECTING) {
       this.unregisterSocket(socketId);
-      void this.handleDisconnect(resolved, socket, code, reason, socketId);
-    });
+    }
+
+    await handlerQueue;
   }
 
   private async handleMessage(
@@ -460,6 +519,50 @@ export class WebSocketGatewayLifecycleService
     return candidates;
   }
 
+  private resolveShutdownTimeoutMs(): number {
+    const configured = this.moduleOptions.shutdown?.timeoutMs;
+
+    if (typeof configured !== 'number' || !Number.isFinite(configured) || configured <= 0) {
+      return DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS;
+    }
+
+    return Math.floor(configured);
+  }
+
+  private closeServerWithTimeout(attachment: GatewayAttachment, timeoutMs: number): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(
+          new Error(
+            `Timed out while closing websocket server for path "${attachment.path}" after ${String(timeoutMs)}ms.`,
+          ),
+        );
+      }, timeoutMs);
+
+      attachment.server.close((error?: Error) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimeout(timeout);
+
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve();
+      });
+    });
+  }
+
   private async shutdown(): Promise<void> {
     if (this.shutdownPromise) {
       await this.shutdownPromise;
@@ -480,6 +583,7 @@ export class WebSocketGatewayLifecycleService
       this.upgradeListener = undefined;
 
       const attachments = this.attachments.splice(0);
+      const shutdownTimeoutMs = this.resolveShutdownTimeoutMs();
 
       await Promise.all(
         attachments.map(async (attachment) => {
@@ -487,9 +591,15 @@ export class WebSocketGatewayLifecycleService
             client.terminate();
           }
 
-          await new Promise<void>((resolve) => {
-            attachment.server.close(() => resolve());
-          });
+          try {
+            await this.closeServerWithTimeout(attachment, shutdownTimeoutMs);
+          } catch (error) {
+            this.logger.error(
+              `Failed to close websocket server for path ${attachment.path} within ${String(shutdownTimeoutMs)}ms.`,
+              error,
+              'WebSocketGatewayLifecycleService',
+            );
+          }
         }),
       );
 

--- a/packages/websocket/src/types.ts
+++ b/packages/websocket/src/types.ts
@@ -59,4 +59,7 @@ export interface WebSocketModuleOptions {
     intervalMs?: number;
     timeoutMs?: number;
   };
+  shutdown?: {
+    timeoutMs?: number;
+  };
 }


### PR DESCRIPTION
## Summary
- buffer websocket message/close events while `@OnConnect()` handlers are running and replay them in order once connect-phase setup completes
- add `shutdown.timeoutMs` support and timeout-aware websocket attachment close handling so shutdown no longer waits indefinitely
- expand websocket tests with fake-timer heartbeat coverage for pong cleanup, missed-pong termination cleanup, and shutdown timeout logging

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run packages/websocket/src/module.test.ts`

Closes #139