### PR TITLE
Resolve #142: replace regex module mutation and unify generator contracts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,8 @@
   },
   "dependencies": {
     "ejs": "^3.1.10",
-    "tsx": "^4.20.4"
+    "tsx": "^4.20.4",
+    "typescript": "^5.8.2"
   },
   "devDependencies": {
     "@types/ejs": "^3.1.5"

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -7,6 +7,7 @@ import { dirname, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { runCli } from './cli.js';
+import { generatorManifest } from './generators/manifest.js';
 
 const createdDirectories: string[] = [];
 
@@ -149,15 +150,13 @@ describe('CLI command runner', () => {
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Usage: konekti generate|g <kind> <name> [options]');
     expect(stdoutBuffer.join('')).toMatch(/\| Schematic\s+\| Aliases\s+\| Description\s+\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*controller\s*\|\s*co\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*guard\s*\|\s*gu\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*interceptor\s*\|\s*in\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*middleware\s*\|\s*mi\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*module\s*\|\s*mo\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*repository\s*\|\s*repo\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*request-dto\s*\|\s*req\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*response-dto\s*\|\s*res\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*service\s*\|\s*s\s*\|/);
+
+    for (const entry of generatorManifest) {
+      expect(stdoutBuffer.join('')).toContain(entry.schematic);
+      expect(stdoutBuffer.join('')).toContain(entry.aliases.join(', '));
+      expect(stdoutBuffer.join('')).toContain(entry.description);
+    }
+
     expect(stdoutBuffer.join('')).toContain('| Option                    | Aliases | Description');
     expect(stdoutBuffer.join('')).not.toContain('Usage: konekti new|create');
   });
@@ -173,8 +172,10 @@ describe('CLI command runner', () => {
 
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Usage: konekti generate|g <kind> <name> [options]');
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*repository\s*\|\s*repo\s*\|/);
-    expect(stdoutBuffer.join('')).toMatch(/\|\s*service\s*\|\s*s\s*\|/);
+
+    for (const entry of generatorManifest) {
+      expect(stdoutBuffer.join('')).toContain(entry.schematic);
+    }
   });
 
   it('places generated files under a domain subdirectory and auto-creates the module', async () => {
@@ -200,7 +201,7 @@ describe('CLI command runner', () => {
 
     const moduleContent = readFileSync(join(workspaceDirectory, 'src', 'posts', 'post.module.ts'), 'utf8');
     expect(moduleContent).toContain('PostService');
-    expect(moduleContent).toContain("from './post.service'");
+    expect(moduleContent).toContain('post.service');
   });
 
   it('accepts `repo` as the repository generator kind', async () => {
@@ -371,7 +372,7 @@ describe('CLI command runner', () => {
     expect(exitCode).toBe(0);
     const moduleContent = readFileSync(join(domainDir, 'order.module.ts'), 'utf8');
     expect(moduleContent).toContain('OrderController');
-    expect(moduleContent).toContain("from './order.controller'");
+    expect(moduleContent).toContain('order.controller');
   });
 
   it('creates a new starter project through the CLI', async () => {
@@ -486,6 +487,58 @@ describe('CLI command runner', () => {
     expect(exitCode).toBe(1);
     expect(stderrBuffer.join('')).toContain('Usage: konekti generate|g <kind> <name> [options]');
     expect(stderrBuffer.join('')).toMatch(/\|\s*service\s*\|\s*s\s*\|/);
+  });
+
+  it('rejects malformed generate names that start with a hyphen', async () => {
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['g', 'service', '-bad-name'], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('names cannot start with "-"');
+  });
+
+  it('rejects duplicate --force flags', async () => {
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['g', 'service', 'User', '--force', '--force'], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('Duplicate --force option.');
+  });
+
+  it('rejects duplicate --target-directory flags', async () => {
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['g', 'service', 'User', '--target-directory', 'src', '--target-directory', 'lib'], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('Duplicate --target-directory option.');
+  });
+
+  it('rejects --target-directory values that look like options', async () => {
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['g', 'service', 'User', '--target-directory', '--force'], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('Expected --target-directory to have a path value.');
   });
 
   it('resolves mi alias to middleware', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { runGenerateCommand } from './commands/generate.js';
 import { newUsage, runNewCommand, type NewCommandRuntimeOptions } from './commands/new.js';
+import { generatorManifest, resolveGeneratorKind } from './generators/manifest.js';
 import { renderAliasList, renderHelpTable } from './help.js';
 import type { GenerateOptions, GeneratorKind } from './types.js';
 
@@ -55,15 +56,12 @@ type TopLevelCommandHelpEntry = {
 };
 
 const GENERATE_KIND_HELP: GenerateKindHelpEntry[] = [
-  { aliases: ['co'], description: 'Generate a controller and register it in the module controllers array.', kind: 'controller', schematic: 'controller' },
-  { aliases: ['gu'], description: 'Generate a guard and register it as a provider.', kind: 'guard', schematic: 'guard' },
-  { aliases: ['in'], description: 'Generate an interceptor and register it as a provider.', kind: 'interceptor', schematic: 'interceptor' },
-  { aliases: ['mi'], description: 'Generate a middleware and register it in the module middleware array.', kind: 'middleware', schematic: 'middleware' },
-  { aliases: ['mo'], description: 'Generate a module.', kind: 'module', schematic: 'module' },
-  { aliases: ['repo'], description: 'Generate a repository.', kind: 'repo', schematic: 'repository' },
-  { aliases: ['req'], description: 'Generate a request DTO with body binding and validation.', kind: 'request-dto', schematic: 'request-dto' },
-  { aliases: ['res'], description: 'Generate a response DTO for typed response payloads.', kind: 'response-dto', schematic: 'response-dto' },
-  { aliases: ['s'], description: 'Generate a service and register it as a provider.', kind: 'service', schematic: 'service' },
+  ...generatorManifest.map((entry) => ({
+    aliases: [...entry.aliases],
+    description: entry.description,
+    kind: entry.kind,
+    schematic: entry.schematic,
+  })),
 ];
 
 const GENERATE_OPTION_HELP: GenerateOptionHelpEntry[] = [
@@ -79,12 +77,7 @@ const TOP_LEVEL_COMMAND_HELP: TopLevelCommandHelpEntry[] = [
 ];
 
 function normalizeGeneratorKind(value: string | undefined): GeneratorKind | undefined {
-  if (!value) {
-    return undefined;
-  }
-
-  const entry = GENERATE_KIND_HELP.find((item) => item.kind === value || item.schematic === value || item.aliases.includes(value));
-  return entry?.kind;
+  return resolveGeneratorKind(value);
 }
 
 function isHelpFlag(value: string | undefined): boolean {
@@ -159,25 +152,41 @@ function parseGenerateArgs(argv: string[]): ParsedCliArgs {
     throw new Error(generateUsage());
   }
 
+  if (name.startsWith('-')) {
+    throw new Error(`Invalid resource name "${name}": names cannot start with "-".`);
+  }
+
   const parsedOptions: GenerateOptions = {};
   let targetDirectory: string | undefined;
+  let seenForce = false;
+  let seenTargetDirectory = false;
 
   for (let index = 0; index < optionArgs.length; index += 1) {
     const option = optionArgs[index];
     const next = optionArgs[index + 1];
 
     if (option === '--target-directory' || option === '-o') {
-      if (!next) {
-        throw new Error('Expected --target-directory to have a value.');
+      if (seenTargetDirectory) {
+        throw new Error('Duplicate --target-directory option.');
+      }
+
+      if (!next || next.startsWith('-')) {
+        throw new Error('Expected --target-directory to have a path value.');
       }
 
       targetDirectory = next;
+      seenTargetDirectory = true;
       index += 1;
       continue;
     }
 
     if (option === '--force' || option === '-f') {
+      if (seenForce) {
+        throw new Error('Duplicate --force option.');
+      }
+
       parsedOptions.force = true;
+      seenForce = true;
       continue;
     }
 

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -1,0 +1,55 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runGenerateCommand } from './generate.js';
+
+const tempDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('runGenerateCommand', () => {
+  it('rejects empty resource names', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    expect(() => runGenerateCommand('service', '   ', workspaceDirectory)).toThrow('name must not be empty');
+  });
+
+  it('rejects traversal-style resource names', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    expect(() => runGenerateCommand('service', '../User', workspaceDirectory)).toThrow('path separators or traversal sequences');
+  });
+
+  it('updates existing module metadata and imports without duplication', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const domainDirectory = join(sourceDirectory, 'posts');
+    const modulePath = join(domainDirectory, 'post.module.ts');
+    mkdirSync(domainDirectory, { recursive: true });
+
+    writeFileSync(modulePath, `import { Module } from '@konekti/core';\nimport { ExistingService } from './existing.service';\n\n@Module({ providers:[ExistingService], controllers:[] })\nclass PostModule {}\n\nexport { PostModule };\n`);
+
+    runGenerateCommand('service', 'Post', sourceDirectory);
+    runGenerateCommand('service', 'Post', sourceDirectory);
+
+    const moduleContent = readFileSync(modulePath, 'utf8');
+    const occurrences = (moduleContent.match(/PostService/g) ?? []).length;
+
+    expect(existsSync(join(domainDirectory, 'post.service.ts'))).toBe(true);
+    expect(moduleContent).toContain('ExistingService');
+    expect(moduleContent).toContain('PostService');
+    expect(moduleContent).toContain('from "./post.service"');
+    expect(occurrences).toBe(2);
+  });
+});

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -2,27 +2,28 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, normalize, resolve } from 'node:path';
 
 import type { GenerateOptions, GeneratorKind } from '../types.js';
-import { defaultRegistry } from '../registry.js';
+import type { ModuleArrayKey } from '../generators/manifest.js';
+import { findGeneratorDefinition } from '../generators/manifest.js';
 
-import { generateModuleFiles, registerInModule } from '../generators/module.js';
+import { ensureModuleImport, generateModuleFiles, registerInModule } from '../generators/module.js';
 import { toKebabCase, toPascalCase, toPlural } from '../generators/utils.js';
 
-function moduleArrayKey(kind: GeneratorKind): 'controllers' | 'providers' | 'middleware' | null {
-  if (kind === 'controller') return 'controllers';
-  if (kind === 'service' || kind === 'repo' || kind === 'guard' || kind === 'interceptor') return 'providers';
-  if (kind === 'middleware') return 'middleware';
-  return null;
-}
+function assertValidResourceName(name: string): string {
+  const kebab = toKebabCase(name);
 
-function classNameForKind(name: string, kind: GeneratorKind): string {
-  const resource = toPascalCase(name);
-  if (kind === 'controller') return `${resource}Controller`;
-  if (kind === 'service') return `${resource}Service`;
-  if (kind === 'repo') return `${resource}Repo`;
-  if (kind === 'guard') return `${resource}Guard`;
-  if (kind === 'interceptor') return `${resource}Interceptor`;
-  if (kind === 'middleware') return `${resource}Middleware`;
-  return resource;
+  if (name.trim().length === 0) {
+    throw new Error('Invalid resource name: name must not be empty.');
+  }
+
+  if (kebab !== normalize(kebab) || kebab.includes('/') || kebab.includes('\\') || kebab.includes('..')) {
+    throw new Error(`Invalid resource name "${name}": must not contain path separators or traversal sequences.`);
+  }
+
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(kebab)) {
+    throw new Error(`Invalid resource name "${name}": use letters, numbers, spaces, underscores, or hyphens only.`);
+  }
+
+  return kebab;
 }
 
 function ensureModuleFile(domainDirectory: string, name: string): string {
@@ -40,41 +41,24 @@ function ensureModuleFile(domainDirectory: string, name: string): string {
   return modulePath;
 }
 
-function updateModuleFile(modulePath: string, arrayKey: 'controllers' | 'providers' | 'middleware', className: string, importPath: string): void {
+function updateModuleFile(modulePath: string, arrayKey: ModuleArrayKey, className: string, importPath: string): void {
   let source = readFileSync(modulePath, 'utf8');
-
-  const alreadyImported = /^import [^;]*;$/m.test(source) &&
-    new RegExp(`^import[^;]*\\b${className}\\b[^;]*;`, 'm').test(source);
-
-  if (!alreadyImported) {
-    const lastImportMatch = [...source.matchAll(/^import .+;$/gm)].at(-1);
-    const importLine = `import { ${className} } from './${importPath}';\n`;
-    if (lastImportMatch?.index !== undefined) {
-      const insertAt = lastImportMatch.index + lastImportMatch[0].length;
-      source = source.slice(0, insertAt) + '\n' + importLine + source.slice(insertAt);
-    } else {
-      source = importLine + source;
-    }
-  }
-
+  source = ensureModuleImport(source, className, importPath);
   source = registerInModule(source, arrayKey, className);
   writeFileSync(modulePath, source, 'utf8');
 }
 
 export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirectory: string, options: GenerateOptions = {}): string[] {
-  const kebab = toKebabCase(name);
-
-  if (kebab !== normalize(kebab) || kebab.includes('/') || kebab.includes('\\') || kebab.includes('..')) {
-    throw new Error(`Invalid resource name "${name}": must not contain path separators or traversal sequences.`);
-  }
+  const normalizedName = name.trim();
+  const kebab = assertValidResourceName(normalizedName);
+  const generator = findGeneratorDefinition(kind);
 
   const resolvedBase = resolve(baseDirectory);
   const domainDirectory = join(resolvedBase, toPlural(kebab));
 
   mkdirSync(domainDirectory, { recursive: true });
 
-  const factory = defaultRegistry.resolve(kind);
-  const files = factory ? factory(name, options) : [];
+  const files = generator.factory(normalizedName, options);
 
   const writtenPaths = files.map((file) => {
     const filePath = join(domainDirectory, file.path);
@@ -87,12 +71,12 @@ export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirect
     return filePath;
   }).filter((filePath): filePath is string => filePath !== null);
 
-  const arrayKey = moduleArrayKey(kind);
-  if (arrayKey !== null) {
-    const modulePath = ensureModuleFile(domainDirectory, name);
-    const className = classNameForKind(name, kind);
+  const moduleRegistration = 'moduleRegistration' in generator ? generator.moduleRegistration : undefined;
+  if (moduleRegistration) {
+    const modulePath = ensureModuleFile(domainDirectory, normalizedName);
+    const className = `${toPascalCase(normalizedName)}${moduleRegistration.classSuffix}`;
     const importPath = `${kebab}.${kind}`;
-    updateModuleFile(modulePath, arrayKey, className, importPath);
+    updateModuleFile(modulePath, moduleRegistration.arrayKey, className, importPath);
 
     if (!writtenPaths.includes(modulePath)) {
       writtenPaths.push(modulePath);

--- a/packages/cli/src/generator-types.ts
+++ b/packages/cli/src/generator-types.ts
@@ -1,0 +1,15 @@
+export interface GeneratedFile {
+  content: string;
+  path: string;
+}
+
+export interface GenerateOptions {
+  force?: boolean;
+}
+
+export type GeneratorFactory = (name: string, options?: GenerateOptions) => GeneratedFile[];
+
+export interface GeneratorRegistration {
+  factory: GeneratorFactory;
+  description?: string;
+}

--- a/packages/cli/src/generators.test.ts
+++ b/packages/cli/src/generators.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { generateControllerFiles } from './generators/controller.js';
 import { generateGuardFiles } from './generators/guard.js';
 import { generateInterceptorFiles } from './generators/interceptor.js';
+import { generatorManifest } from './generators/manifest.js';
 import { generateMiddlewareFiles } from './generators/middleware.js';
-import { generateModuleFiles, registerInModule } from './generators/module.js';
+import { ensureModuleImport, generateModuleFiles, registerInModule } from './generators/module.js';
 import { generateRepoFiles } from './generators/repository.js';
 import { generateRequestDtoFiles } from './generators/request-dto.js';
 import { generateResponseDtoFiles } from './generators/response-dto.js';
@@ -153,14 +154,52 @@ describe('CLI generators', () => {
       const result = registerInModule(withMiddlewareArray, 'middleware', 'AuthMiddleware');
       expect(result).toMatch(/middleware:\s*\[[\s\S]*AuthMiddleware/);
     });
+
+    it('throws when target metadata property is not an array', () => {
+      const malformedModule = baseModule.replace('providers: []', 'providers: UserService');
+      expect(() => registerInModule(malformedModule, 'providers', 'UserRepo')).toThrow('"providers" must be an array');
+    });
+  });
+
+  describe('ensureModuleImport', () => {
+    it('inserts a new import after the last import declaration', () => {
+      const source = `import { Module } from '@konekti/core';\n\n@Module({\n  controllers: [],\n  providers: [],\n})\nclass UserModule {}\n`;
+      const result = ensureModuleImport(source, 'UserService', 'user.service');
+
+      expect(result).toContain('import { UserService } from "./user.service";');
+      expect(result.indexOf('import { UserService } from "./user.service";')).toBeGreaterThan(result.indexOf("import { Module } from '@konekti/core';"));
+      expect(result.indexOf('@Module({')).toBeGreaterThan(result.indexOf('import { UserService } from "./user.service";'));
+    });
+
+    it('appends a class to an existing import from the same module path', () => {
+      const source = `import { ExistingService } from './user.service';\n\n@Module({\n  controllers: [],\n  providers: [],\n})\nclass UserModule {}\n`;
+      const result = ensureModuleImport(source, 'UserRepo', 'user.service');
+
+      expect(result).toContain('import { ExistingService, UserRepo } from');
+      expect(result).toContain('./user.service');
+    });
+
+    it('does not duplicate an existing named import', () => {
+      const source = `import { UserService } from './user.service';\n\n@Module({\n  controllers: [],\n  providers: [],\n})\nclass UserModule {}\n`;
+      const result = ensureModuleImport(source, 'UserService', 'user.service');
+      const occurrences = (result.match(/UserService/g) ?? []).length;
+
+      expect(occurrences).toBe(1);
+    });
   });
 });
 
 describe('GeneratorRegistry', () => {
   it('resolves all built-in generator kinds from defaultRegistry', () => {
-    const kinds = ['controller', 'guard', 'interceptor', 'middleware', 'module', 'repository', 'repo', 'request-dto', 'response-dto', 'service'] as const;
-    for (const kind of kinds) {
-      expect(defaultRegistry.has(kind), `expected defaultRegistry to have kind: ${kind}`).toBe(true);
+    for (const entry of generatorManifest) {
+      expect(defaultRegistry.has(entry.kind), `expected defaultRegistry to have kind: ${entry.kind}`).toBe(true);
+
+      const aliases = 'registryAliases' in entry ? entry.registryAliases : undefined;
+      if (aliases) {
+        for (const alias of aliases) {
+          expect(defaultRegistry.has(alias), `expected defaultRegistry to have alias: ${alias}`).toBe(true);
+        }
+      }
     }
   });
 

--- a/packages/cli/src/generators/manifest.ts
+++ b/packages/cli/src/generators/manifest.ts
@@ -1,0 +1,133 @@
+import type { GeneratorFactory } from '../generator-types.js';
+
+import { generateControllerFiles } from './controller.js';
+import { generateGuardFiles } from './guard.js';
+import { generateInterceptorFiles } from './interceptor.js';
+import { generateMiddlewareFiles } from './middleware.js';
+import { generateModuleFiles } from './module.js';
+import { generateRepoFiles } from './repository.js';
+import { generateRequestDtoFiles } from './request-dto.js';
+import { generateResponseDtoFiles } from './response-dto.js';
+import { generateServiceFiles } from './service.js';
+
+export type ModuleArrayKey = 'controllers' | 'providers' | 'middleware';
+
+type ModuleRegistrationDescriptor = {
+  arrayKey: ModuleArrayKey;
+  classSuffix: string;
+};
+
+export type GeneratorManifestEntry = {
+  aliases: readonly string[];
+  description: string;
+  factory: GeneratorFactory;
+  kind: string;
+  moduleRegistration?: ModuleRegistrationDescriptor;
+  registryAliases?: readonly string[];
+  schematic: string;
+};
+
+export const generatorManifest = [
+  {
+    aliases: ['co'],
+    description: 'Generate a controller and register it in the module controllers array.',
+    factory: (name) => generateControllerFiles(name),
+    kind: 'controller',
+    moduleRegistration: { arrayKey: 'controllers', classSuffix: 'Controller' },
+    schematic: 'controller',
+  },
+  {
+    aliases: ['gu'],
+    description: 'Generate a guard and register it as a provider.',
+    factory: (name) => generateGuardFiles(name),
+    kind: 'guard',
+    moduleRegistration: { arrayKey: 'providers', classSuffix: 'Guard' },
+    schematic: 'guard',
+  },
+  {
+    aliases: ['in'],
+    description: 'Generate an interceptor and register it as a provider.',
+    factory: (name) => generateInterceptorFiles(name),
+    kind: 'interceptor',
+    moduleRegistration: { arrayKey: 'providers', classSuffix: 'Interceptor' },
+    schematic: 'interceptor',
+  },
+  {
+    aliases: ['mi'],
+    description: 'Generate a middleware and register it in the module middleware array.',
+    factory: (name) => generateMiddlewareFiles(name),
+    kind: 'middleware',
+    moduleRegistration: { arrayKey: 'middleware', classSuffix: 'Middleware' },
+    schematic: 'middleware',
+  },
+  {
+    aliases: ['mo'],
+    description: 'Generate a module.',
+    factory: (name) => generateModuleFiles(name),
+    kind: 'module',
+    schematic: 'module',
+  },
+  {
+    aliases: ['repo'],
+    description: 'Generate a repository.',
+    factory: (name, options) => generateRepoFiles(name, options),
+    kind: 'repo',
+    moduleRegistration: { arrayKey: 'providers', classSuffix: 'Repo' },
+    registryAliases: ['repository'],
+    schematic: 'repository',
+  },
+  {
+    aliases: ['req'],
+    description: 'Generate a request DTO with body binding and validation.',
+    factory: (name) => generateRequestDtoFiles(name),
+    kind: 'request-dto',
+    schematic: 'request-dto',
+  },
+  {
+    aliases: ['res'],
+    description: 'Generate a response DTO for typed response payloads.',
+    factory: (name) => generateResponseDtoFiles(name),
+    kind: 'response-dto',
+    schematic: 'response-dto',
+  },
+  {
+    aliases: ['s'],
+    description: 'Generate a service and register it as a provider.',
+    factory: (name, options) => generateServiceFiles(name, options),
+    kind: 'service',
+    moduleRegistration: { arrayKey: 'providers', classSuffix: 'Service' },
+    schematic: 'service',
+  },
+] as const satisfies readonly GeneratorManifestEntry[];
+
+export type GeneratorKind = (typeof generatorManifest)[number]['kind'];
+export type GeneratorDefinition = (typeof generatorManifest)[number];
+
+const generatorByKind = new Map<GeneratorKind, GeneratorDefinition>();
+const tokenToKind = new Map<string, GeneratorKind>();
+
+for (const entry of generatorManifest) {
+  generatorByKind.set(entry.kind, entry);
+  tokenToKind.set(entry.kind, entry.kind);
+  tokenToKind.set(entry.schematic, entry.kind);
+  for (const alias of entry.aliases) {
+    tokenToKind.set(alias, entry.kind);
+  }
+}
+
+export function findGeneratorDefinition(kind: GeneratorKind): GeneratorDefinition {
+  const entry = generatorByKind.get(kind);
+  if (!entry) {
+    throw new Error(`Unknown generator kind: ${kind}`);
+  }
+
+  return entry;
+}
+
+export function resolveGeneratorKind(value: string | undefined): GeneratorKind | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return tokenToKind.get(value);
+}

--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -1,7 +1,146 @@
 import type { GeneratedFile } from '../types.js';
+import ts from 'typescript';
 
+import type { ModuleArrayKey } from './manifest.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
+
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+function parseSource(source: string): ts.SourceFile {
+  return ts.createSourceFile('generated.module.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function getPropertyNameText(name: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)) {
+    return name.text;
+  }
+
+  return undefined;
+}
+
+function replaceNodeText(source: string, sourceFile: ts.SourceFile, node: ts.Node, replacement: string): string {
+  return source.slice(0, node.getStart(sourceFile)) + replacement + source.slice(node.getEnd());
+}
+
+function findModuleDecoratorObject(sourceFile: ts.SourceFile): ts.ObjectLiteralExpression | undefined {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isClassDeclaration(statement)) {
+      continue;
+    }
+
+    if (!ts.canHaveDecorators(statement)) {
+      continue;
+    }
+
+    const decorators = ts.getDecorators(statement);
+    if (!decorators) {
+      continue;
+    }
+
+    for (const decorator of decorators) {
+      if (!ts.isCallExpression(decorator.expression)) {
+        continue;
+      }
+
+      if (!ts.isIdentifier(decorator.expression.expression) || decorator.expression.expression.text !== 'Module') {
+        continue;
+      }
+
+      const [firstArgument] = decorator.expression.arguments;
+      if (firstArgument && ts.isObjectLiteralExpression(firstArgument)) {
+        return firstArgument;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function hasNamedImport(sourceFile: ts.SourceFile, className: string): boolean {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+
+    const importClause = statement.importClause;
+    if (!importClause || !importClause.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
+      continue;
+    }
+
+    if (importClause.namedBindings.elements.some((element) => element.name.text === className)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function buildImportDeclaration(className: string, importPath: string): ts.ImportDeclaration {
+  return ts.factory.createImportDeclaration(
+    undefined,
+    ts.factory.createImportClause(
+      false,
+      undefined,
+      ts.factory.createNamedImports([
+        ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(className)),
+      ]),
+    ),
+    ts.factory.createStringLiteral(`./${importPath}`),
+  );
+}
+
+export function ensureModuleImport(source: string, className: string, importPath: string): string {
+  const sourceFile = parseSource(source);
+
+  if (hasNamedImport(sourceFile, className)) {
+    return source;
+  }
+
+  const moduleSpecifier = `./${importPath}`;
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)) {
+      continue;
+    }
+
+    if (!ts.isStringLiteral(statement.moduleSpecifier) || statement.moduleSpecifier.text !== moduleSpecifier) {
+      continue;
+    }
+
+    const importClause = statement.importClause;
+    if (!importClause || !importClause.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
+      continue;
+    }
+
+    const updatedImport = ts.factory.updateImportDeclaration(
+      statement,
+      statement.modifiers,
+      ts.factory.updateImportClause(
+        importClause,
+        importClause.isTypeOnly,
+        importClause.name,
+        ts.factory.updateNamedImports(importClause.namedBindings, [
+          ...importClause.namedBindings.elements,
+          ts.factory.createImportSpecifier(false, undefined, ts.factory.createIdentifier(className)),
+        ]),
+      ),
+      statement.moduleSpecifier,
+      statement.assertClause,
+    );
+
+    return replaceNodeText(source, sourceFile, statement, printer.printNode(ts.EmitHint.Unspecified, updatedImport, sourceFile));
+  }
+
+  const newImportLine = printer.printNode(ts.EmitHint.Unspecified, buildImportDeclaration(className, importPath), sourceFile);
+  const imports = sourceFile.statements.filter(ts.isImportDeclaration);
+
+  if (imports.length > 0) {
+    const lastImport = imports[imports.length - 1];
+    return source.slice(0, lastImport.getEnd()) + `\n${newImportLine}` + source.slice(lastImport.getEnd());
+  }
+
+  return `${newImportLine}\n${source}`;
+}
 
 export function generateModuleFiles(name: string): GeneratedFile[] {
   const kebab = toKebabCase(name);
@@ -16,30 +155,59 @@ export function generateModuleFiles(name: string): GeneratedFile[] {
 }
 
 function insertIntoModuleArray(source: string, arrayKey: 'controllers' | 'providers' | 'middleware', className: string): string {
-  const alreadyPresent = new RegExp(`\\b${className}\\b`).test(source);
+  const sourceFile = parseSource(source);
+  const moduleMetadata = findModuleDecoratorObject(sourceFile);
+
+  if (!moduleMetadata) {
+    throw new Error('Unable to locate @Module metadata object in module file.');
+  }
+
+  let alreadyPresent = false;
+  let hasTargetProperty = false;
+
+  const updatedProperties = moduleMetadata.properties.map((property) => {
+    if (!ts.isPropertyAssignment(property) || getPropertyNameText(property.name) !== arrayKey) {
+      return property;
+    }
+
+    hasTargetProperty = true;
+
+    if (!ts.isArrayLiteralExpression(property.initializer)) {
+      throw new Error(`Invalid @Module metadata: "${arrayKey}" must be an array.`);
+    }
+
+    if (property.initializer.elements.some((element) => element.getText(sourceFile) === className)) {
+      alreadyPresent = true;
+      return property;
+    }
+
+    return ts.factory.updatePropertyAssignment(
+      property,
+      property.name,
+      ts.factory.updateArrayLiteralExpression(property.initializer, [
+        ...property.initializer.elements,
+        ts.factory.createIdentifier(className),
+      ]),
+    );
+  });
+
   if (alreadyPresent) {
     return source;
   }
 
-  const emptyArrayPattern = new RegExp(`(${arrayKey}:\\s*\\[)(\\s*)(\\])`);
-  if (emptyArrayPattern.test(source)) {
-    return source.replace(emptyArrayPattern, `$1$2  ${className},$2$3`);
+  if (!hasTargetProperty) {
+    updatedProperties.push(
+      ts.factory.createPropertyAssignment(
+        ts.factory.createIdentifier(arrayKey),
+        ts.factory.createArrayLiteralExpression([ts.factory.createIdentifier(className)], true),
+      ),
+    );
   }
 
-  const nonEmptyArrayPattern = new RegExp(`(${arrayKey}:\\s*\\[)((?:[^\\]])*)(\\])`);
-  return source.replace(nonEmptyArrayPattern, (_, open, items, close) => {
-    const trimmed = items.trimEnd();
-    const separator = trimmed.endsWith(',') ? '' : ',';
-    return `${open}${trimmed}${separator}\n    ${className},\n  ${close}`;
-  });
+  const updatedModuleMetadata = ts.factory.updateObjectLiteralExpression(moduleMetadata, updatedProperties);
+  return replaceNodeText(source, sourceFile, moduleMetadata, printer.printNode(ts.EmitHint.Unspecified, updatedModuleMetadata, sourceFile));
 }
 
-export function registerInModule(source: string, arrayKey: 'controllers' | 'providers' | 'middleware', className: string): string {
-  let result = insertIntoModuleArray(source, arrayKey, className);
-  
-  if (arrayKey === 'middleware' && !new RegExp(`${arrayKey}:\\s*\\[`).test(result)) {
-    result = result.replace(/\}\)\nclass/, `})\n  middleware: [${className}],\nclass`);
-  }
-  
-  return result;
+export function registerInModule(source: string, arrayKey: ModuleArrayKey, className: string): string {
+  return insertIntoModuleArray(source, arrayKey, className);
 }

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,14 +1,6 @@
-import type { GenerateOptions, GeneratedFile, GeneratorFactory, GeneratorRegistration } from './types.js';
+import type { GeneratorFactory, GeneratorRegistration } from './types.js';
 
-import { generateControllerFiles } from './generators/controller.js';
-import { generateGuardFiles } from './generators/guard.js';
-import { generateInterceptorFiles } from './generators/interceptor.js';
-import { generateMiddlewareFiles } from './generators/middleware.js';
-import { generateModuleFiles } from './generators/module.js';
-import { generateRepoFiles } from './generators/repository.js';
-import { generateRequestDtoFiles } from './generators/request-dto.js';
-import { generateResponseDtoFiles } from './generators/response-dto.js';
-import { generateServiceFiles } from './generators/service.js';
+import { generatorManifest } from './generators/manifest.js';
 
 export class GeneratorRegistry {
   private readonly registry = new Map<string, GeneratorRegistration>();
@@ -31,15 +23,15 @@ export class GeneratorRegistry {
   }
 }
 
-export const defaultRegistry = new GeneratorRegistry()
-  .register('controller', (name) => generateControllerFiles(name))
-  .register('guard', (name) => generateGuardFiles(name))
-  .register('interceptor', (name) => generateInterceptorFiles(name))
-  .register('middleware', (name) => generateMiddlewareFiles(name))
-  .register('module', (name) => generateModuleFiles(name))
-  .register('repo', (name, options?: GenerateOptions) => generateRepoFiles(name, options))
-  .register('repository', (name, options?: GenerateOptions) => generateRepoFiles(name, options))
-  .register('request-dto', (name) => generateRequestDtoFiles(name))
-  .register('response-dto', (name) => generateResponseDtoFiles(name))
-  .register('service', (name, options?: GenerateOptions) => generateServiceFiles(name, options));
+export const defaultRegistry = new GeneratorRegistry();
 
+for (const entry of generatorManifest) {
+  defaultRegistry.register(entry.kind, entry.factory, entry.description);
+
+  const registryAliases = 'registryAliases' in entry ? entry.registryAliases : undefined;
+  if (registryAliases) {
+    for (const alias of registryAliases) {
+      defaultRegistry.register(alias, entry.factory, entry.description);
+    }
+  }
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,22 +1,10 @@
-export interface GeneratedFile {
-  content: string;
-  path: string;
-}
+import type { GeneratorKind as ManifestGeneratorKind } from './generators/manifest.js';
 
-export type GeneratorKind = 'controller' | 'guard' | 'interceptor' | 'middleware' | 'module' | 'repo' | 'request-dto' | 'response-dto' | 'service';
+export type { GenerateOptions, GeneratedFile, GeneratorFactory, GeneratorRegistration } from './generator-types.js';
 
-export interface GenerateOptions {
-  force?: boolean;
-}
+export type GeneratorKind = ManifestGeneratorKind;
 
 export interface ModuleRegistration {
   className: string;
   kind: 'controller' | 'provider';
-}
-
-export type GeneratorFactory = (name: string, options?: GenerateOptions) => GeneratedFile[];
-
-export interface GeneratorRegistration {
-  factory: GeneratorFactory;
-  description?: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       tsx:
         specifier: ^4.20.4
         version: 4.21.0
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
     devDependencies:
       '@types/ejs':
         specifier: ^3.1.5


### PR DESCRIPTION
## Summary
- Replace regex-based module file mutation with TypeScript AST-backed import and `@Module` metadata updates.
- Introduce a canonical generator manifest used by CLI kind parsing/help output, registry alias registration, and generator kind typing.
- Add targeted malformed-input and structural-edge test coverage for generate argument validation and module registration behavior.

## Verification
- `pnpm --dir packages/cli run test`
- `pnpm --dir packages/cli run typecheck`
- `pnpm --dir packages/cli run build`

Closes #142