### PR TITLE
fix(http,openapi): align RequestDto validation and source-aware params

### DIFF
--- a/packages/http/src/binding.test.ts
+++ b/packages/http/src/binding.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   FromBody,
+  FromQuery,
   FromPath,
   Optional,
 } from './decorators.js';
@@ -77,7 +78,6 @@ function createContext(request: FrameworkRequest): ArgumentResolverContext {
     },
     requestContext: {
       container: {
-        async dispose() {},
         resolve() {
           throw new Error('not used');
         },
@@ -217,6 +217,7 @@ describe('HttpDtoValidationAdapter', () => {
       @IsString()
       nickname?: string;
 
+      @FromBody('enabled')
       enabled = false;
     }
 
@@ -248,6 +249,51 @@ describe('HttpDtoValidationAdapter', () => {
           field: 'password',
           message: 'password must have length at least 8',
           source: 'body',
+        },
+      ],
+      status: 400,
+    });
+  });
+
+  it('validates only bound DTO properties in HTTP RequestDto flow', async () => {
+    class SearchRequest {
+      @FromQuery('q')
+      @IsString()
+      @MinLength(1, { code: 'QUERY_REQUIRED', message: 'q is required' })
+      query = '';
+
+      @IsString()
+      @MinLength(1, { code: 'UNBOUND_REQUIRED', message: 'unbound hint is required' })
+      unboundHint = '';
+    }
+
+    const validator = new HttpDtoValidationAdapter();
+
+    await expect(
+      validator.validate(
+        Object.assign(new SearchRequest(), {
+          query: 'konekti',
+          unboundHint: '',
+        }),
+        SearchRequest,
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      validator.validate(
+        Object.assign(new SearchRequest(), {
+          query: '',
+          unboundHint: '',
+        }),
+        SearchRequest,
+      ),
+    ).rejects.toMatchObject({
+      details: [
+        {
+          code: 'QUERY_REQUIRED',
+          field: 'query',
+          message: 'q is required',
+          source: 'query',
         },
       ],
       status: 400,

--- a/packages/http/src/dispatch-routing-policy.test.ts
+++ b/packages/http/src/dispatch-routing-policy.test.ts
@@ -74,7 +74,6 @@ describe('dispatch routing policy', () => {
   it('updates request params in request context without mutating unrelated fields', () => {
     const context: RequestContext = {
       container: {
-        async dispose() {},
         resolve() {
           throw new Error('not used');
         },

--- a/packages/http/src/dto-validation-adapter.ts
+++ b/packages/http/src/dto-validation-adapter.ts
@@ -1,16 +1,38 @@
-import type { Constructor } from '@konekti/core';
+import { getDtoBindingSchema, type Constructor } from '@konekti/core';
 import { DefaultValidator as BaseDefaultValidator, DtoValidationError } from '@konekti/dto-validator';
 
 import { BadRequestException } from './exceptions.js';
 import { toInputErrorDetail } from './input-error-detail.js';
 import type { ValidationIssue, Validator } from './types.js';
 
+type TransformCapableValidator = {
+  transform<T>(value: unknown, target: Constructor<T>): Promise<T>;
+};
+
 export class HttpDtoValidationAdapter implements Validator {
   private readonly validator = new BaseDefaultValidator();
 
+  private filterUnboundRequestDtoFields(value: unknown, target: Constructor): unknown {
+    if (typeof value !== 'object' || value === null) {
+      return value;
+    }
+
+    const source = value as Record<PropertyKey, unknown>;
+    const filtered: Record<PropertyKey, unknown> = Object.create(Object.getPrototypeOf(value));
+
+    for (const binding of getDtoBindingSchema(target)) {
+      if (Object.prototype.hasOwnProperty.call(source, binding.propertyKey)) {
+        filtered[binding.propertyKey] = source[binding.propertyKey];
+      }
+    }
+
+    return filtered;
+  }
+
   async validate(value: unknown, target: Parameters<BaseDefaultValidator['validate']>[1]): Promise<void> {
     try {
-      await this.validator.validate(value, target);
+      const filteredValue = this.filterUnboundRequestDtoFields(value, target);
+      await this.validator.validate(filteredValue, target);
     } catch (error: unknown) {
       if (error instanceof DtoValidationError) {
         throw new BadRequestException(error.message, {
@@ -24,7 +46,8 @@ export class HttpDtoValidationAdapter implements Validator {
 
   async transform<T>(value: unknown, target: Constructor<T>): Promise<T> {
     try {
-      return await this.validator.transform(value, target);
+      const validator = this.validator as unknown as TransformCapableValidator;
+      return await validator.transform(value, target);
     } catch (error: unknown) {
       if (error instanceof DtoValidationError) {
         throw new BadRequestException(error.message, {

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { IsBoolean, IsOptional, IsString, MinLength, ValidateNested } from '@konekti/dto-validator';
+import { IsArray, IsBoolean, IsOptional, IsString, MinLength, ValidateNested } from '@konekti/dto-validator';
 import { Controller, Get, IntersectionType, OmitType, PartialType, PickType, Post, Version, createHandlerMapping, type FrameworkRequest, type FrameworkResponse } from '@konekti/http';
-import { FromBody, FromCookie, FromQuery, RequestDto } from '@konekti/http';
+import { FromBody, FromCookie, FromHeader, FromPath, FromQuery, RequestDto } from '@konekti/http';
 import { bootstrapApplication, defineModule } from '@konekti/runtime';
 
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTag } from './decorators.js';
@@ -950,6 +950,91 @@ describe('OpenApiModule', () => {
     };
 
     expect(document.components?.schemas?.FilterDto).toBeUndefined();
+  });
+
+  it('uses source-aware scalar schemas for path and cookie parameters', async () => {
+    class SearchRequest {
+      @FromPath('id')
+      @IsArray()
+      id: string[] = [];
+
+      @FromCookie('session')
+      @IsArray()
+      session: string[] = [];
+
+      @FromQuery('tags')
+      @IsArray()
+      tags: string[] = [];
+
+      @FromHeader('x-tags')
+      @IsArray()
+      headerTags: string[] = [];
+    }
+
+    @Controller('/search')
+    class SearchController {
+      @Get('/:id')
+      @RequestDto(SearchRequest)
+      search() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: SearchController }],
+      title: 'Search API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [SearchController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+
+    const document = response.body as {
+      paths: Record<string, { get?: { parameters?: Array<{ in: string; name: string; schema: { type?: string } }> } }>;
+    };
+
+    expect(document.paths['/search/{id}']?.get?.parameters).toEqual(
+      expect.arrayContaining([
+        {
+          in: 'path',
+          name: 'id',
+          required: true,
+          schema: { type: 'string' },
+        },
+        {
+          in: 'cookie',
+          name: 'session',
+          required: true,
+          schema: { type: 'string' },
+        },
+        {
+          in: 'query',
+          name: 'tags',
+          required: true,
+          schema: { items: {}, type: 'array' },
+        },
+        {
+          in: 'header',
+          name: 'x-tags',
+          required: true,
+          schema: { items: {}, type: 'array' },
+        },
+      ]),
+    );
   });
 
   it('adds default error responses when @ApiResponse is absent', async () => {

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -382,7 +382,7 @@ function createParameters(
     const source = entry.binding.metadata.source as 'cookie' | 'header' | 'path' | 'query';
     const rules = entry.validation?.rules ?? [];
     const inferred = inferPrimitiveTypeFromRules(rules) ?? { type: 'string' as const };
-    const schema = alignParameterSchemaWithRuntimeBindingContract(applyValidationConstraints(inferred, rules));
+    const schema = alignParameterSchemaWithRuntimeBindingContract(applyValidationConstraints(inferred, rules), source);
     const isRequired = source === 'path' ? true : isPropertyRequired(entry.binding, entry.validation);
 
     return {
@@ -498,25 +498,46 @@ function createRequestBody(
   };
 }
 
-function alignParameterSchemaWithRuntimeBindingContract(schema: OpenApiSchemaObject): OpenApiSchemaObject {
-  if (schema.$ref !== undefined) {
+function scalarizeArraySchemaItems(items: OpenApiSchemaObject | undefined): OpenApiSchemaObject {
+  if (!items || items.$ref !== undefined || items.type === undefined || items.type === 'array' || items.type === 'object') {
     return { type: 'string' };
   }
 
-  if (schema.type === 'object') {
-    return { type: 'string' };
+  return {
+    type: items.type,
+    ...(items.format !== undefined && { format: items.format }),
+    ...(items.enum !== undefined && { enum: items.enum }),
+  };
+}
+
+function alignParameterSchemaWithRuntimeBindingContract(
+  schema: OpenApiSchemaObject,
+  source: 'cookie' | 'header' | 'path' | 'query',
+): OpenApiSchemaObject {
+  let aligned = schema;
+
+  if (aligned.$ref !== undefined) {
+    aligned = { type: 'string' };
   }
 
-  if (schema.type === 'array' && schema.items) {
-    if (schema.items.$ref !== undefined || schema.items.type === 'object') {
-      return {
-        ...schema,
+  if (aligned.type === 'object') {
+    aligned = { type: 'string' };
+  }
+
+  if (aligned.type === 'array' && aligned.items) {
+    if (aligned.items.$ref !== undefined || aligned.items.type === 'object') {
+      aligned = {
+        ...aligned,
         items: { type: 'string' },
       };
     }
   }
 
-  return schema;
+  if ((source === 'path' || source === 'cookie') && aligned.type === 'array') {
+    return scalarizeArraySchemaItems(aligned.items);
+  }
+
+  return aligned;
 }
 
 function createResponseObject(


### PR DESCRIPTION
## Summary
- align OpenAPI non-body parameter shaping with runtime source contracts by forcing scalar schemas for `path` and `cookie` params while keeping `query/header` behavior
- align HTTP `RequestDto` validation with documented request contract by validating only bound DTO properties in `HttpDtoValidationAdapter`
- add regression tests for both behaviors and clean one stale request-scope test stub shape

## Validation
- pnpm vitest run packages/openapi/src/openapi-module.test.ts packages/http/src/binding.test.ts
- pnpm --filter @konekti/http --filter @konekti/openapi typecheck