### PR TITLE
Resolve #138: bound event-bus publish and harden handler identity

### DIFF
--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -51,15 +51,22 @@ export class AppModule {}
 - `createEventBusModule()` - registers global `EVENT_BUS` and lifecycle discovery service
 - `createEventBusProviders()` - returns raw providers for manual composition
 - `EVENT_BUS` - DI token for the application event bus instance
-- `EventBus` - interface with `publish(event)`
+- `EventBus` - interface with `publish(event, options?)`
 - `@OnEvent(EventClass)` - marks provider/controller methods as event handlers
+
+### Module options
+
+`createEventBusModule(options)` and `createEventBusProviders(options)` accept:
+
+- `publish.timeoutMs` - bounds how long `publish()` waits per handler before moving on
+- `publish.waitForHandlers` - default waiting mode (`true` waits, `false` dispatches non-blocking)
 
 ## Runtime behavior
 
 - Handler discovery runs during application bootstrap using `COMPILED_MODULES`
-- Handler instances are resolved from `RUNTIME_CONTAINER` when events are published
+- Handler instances are pre-resolved from `RUNTIME_CONTAINER` during bootstrap and reused on publish
 - Events are matched by class using `instanceof`, so base-class handlers receive derived events
-- Publishing dispatches to every matching handler and waits for completion without throwing handler errors
+- Publishing dispatches to every matching handler and supports timeout, cancellation signal, and non-blocking dispatch options
 - Handler failures are isolated and logged through `ApplicationLogger`
 - Request/transient scoped classes with `@OnEvent()` are ignored with a warning
 

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -28,6 +28,17 @@ function createLogger(events: string[]): ApplicationLogger {
   };
 }
 
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
 class UserCreatedEvent {
   constructor(public readonly userId: string) {}
 }
@@ -161,6 +172,157 @@ describe('@konekti/event-bus', () => {
 
     expect(store.successCalls).toBe(1);
     expect(loggerEvents.some((event) => event.includes('Event handler FailingHandler.handle failed.'))).toBe(true);
+
+    await app.close();
+  });
+
+  it('keeps publish bounded and predictable with mixed success, failure, and hanging handlers', async () => {
+    const loggerEvents: string[] = [];
+    const gate = createDeferred<void>();
+
+    class EventStore {
+      successCalls = 0;
+    }
+
+    @Inject([EventStore])
+    class SuccessHandler {
+      constructor(private readonly store: EventStore) {}
+
+      @OnEvent(UserCreatedEvent)
+      onUserCreated(_event: UserCreatedEvent) {
+        this.store.successCalls += 1;
+      }
+    }
+
+    class FailingHandler {
+      @OnEvent(UserCreatedEvent)
+      onUserCreated(_event: UserCreatedEvent) {
+        throw new Error('handler failed');
+      }
+    }
+
+    class HangingHandler {
+      @OnEvent(UserCreatedEvent)
+      async onUserCreated(_event: UserCreatedEvent) {
+        await gate.promise;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createEventBusModule({ publish: { timeoutMs: 20 } })],
+      providers: [EventStore, SuccessHandler, FailingHandler, HangingHandler],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+    const store = await app.container.resolve(EventStore);
+
+    await expect(eventBus.publish(new UserCreatedEvent('user-2-timeout'))).resolves.toBeUndefined();
+
+    expect(store.successCalls).toBe(1);
+    expect(loggerEvents.some((event) => event.includes('Event handler FailingHandler.onUserCreated failed.'))).toBe(true);
+    expect(loggerEvents.some((event) => event.includes('exceeded publish timeout of 20ms.'))).toBe(true);
+
+    gate.resolve();
+    await app.close();
+  });
+
+  it('supports non-blocking publish option without waiting for handler completion', async () => {
+    const gate = createDeferred<void>();
+
+    class EventStore {
+      completedCalls = 0;
+      startedCalls = 0;
+    }
+
+    @Inject([EventStore])
+    class SlowHandler {
+      constructor(private readonly store: EventStore) {}
+
+      @OnEvent(UserCreatedEvent)
+      async onUserCreated(_event: UserCreatedEvent) {
+        this.store.startedCalls += 1;
+        await gate.promise;
+        this.store.completedCalls += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createEventBusModule()],
+      providers: [EventStore, SlowHandler],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+    const store = await app.container.resolve(EventStore);
+
+    await expect(
+      eventBus.publish(new UserCreatedEvent('user-non-blocking'), { waitForHandlers: false }),
+    ).resolves.toBeUndefined();
+
+    await Promise.resolve();
+
+    expect(store.startedCalls).toBe(1);
+    expect(store.completedCalls).toBe(0);
+
+    gate.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(store.completedCalls).toBe(1);
+
+    await app.close();
+  });
+
+  it('supports publish cancellation signal before handler dispatch', async () => {
+    const loggerEvents: string[] = [];
+
+    class EventStore {
+      calls = 0;
+    }
+
+    @Inject([EventStore])
+    class Handler {
+      constructor(private readonly store: EventStore) {}
+
+      @OnEvent(UserCreatedEvent)
+      onUserCreated(_event: UserCreatedEvent) {
+        this.store.calls += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createEventBusModule()],
+      providers: [EventStore, Handler],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+    const store = await app.container.resolve(EventStore);
+    const controller = new AbortController();
+
+    controller.abort();
+
+    await expect(
+      eventBus.publish(new UserCreatedEvent('user-cancelled'), { signal: controller.signal }),
+    ).resolves.toBeUndefined();
+
+    expect(store.calls).toBe(0);
+    expect(
+      loggerEvents.some((event) =>
+        event.includes('Event publish was cancelled before dispatching handler Handler.onUserCreated.'),
+      ),
+    ).toBe(true);
 
     await app.close();
   });
@@ -397,7 +559,7 @@ describe('@konekti/event-bus', () => {
     const loggerEvents: string[] = [];
     const logger = createLogger(loggerEvents);
     const container = new Container();
-    const service = new EventBusLifecycleService(container, [], logger);
+    const service = new EventBusLifecycleService(container, [], logger, {});
 
     await service.publish(new UserCreatedEvent('user-9'));
 
@@ -443,6 +605,58 @@ describe('@konekti/event-bus', () => {
     await eventBus.publish(new UserCreatedEvent('user-10'));
 
     expect(store.calls).toBe(1);
+
+    await app.close();
+  });
+
+  it('keeps distinct handlers with colliding class and method names', async () => {
+    class EventStore {
+      firstCalls = 0;
+      secondCalls = 0;
+    }
+
+    const FirstCollidingHandler = (() => {
+      @Inject([EventStore])
+      class CollidingHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {
+          this.store.firstCalls += 1;
+        }
+      }
+
+      return CollidingHandler;
+    })();
+
+    const SecondCollidingHandler = (() => {
+      @Inject([EventStore])
+      class CollidingHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {
+          this.store.secondCalls += 1;
+        }
+      }
+
+      return CollidingHandler;
+    })();
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createEventBusModule()],
+      providers: [EventStore, FirstCollidingHandler, SecondCollidingHandler],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+    const store = await app.container.resolve(EventStore);
+
+    await eventBus.publish(new UserCreatedEvent('user-11'));
+
+    expect(store.firstCalls).toBe(1);
+    expect(store.secondCalls).toBe(1);
 
     await app.close();
   });

--- a/packages/event-bus/src/module.ts
+++ b/packages/event-bus/src/module.ts
@@ -2,10 +2,15 @@ import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { EventBusLifecycleService } from './service.js';
-import { EVENT_BUS } from './tokens.js';
+import { EVENT_BUS, EVENT_BUS_OPTIONS } from './tokens.js';
+import type { EventBusModuleOptions } from './types.js';
 
-export function createEventBusProviders(): Provider[] {
+export function createEventBusProviders(options: EventBusModuleOptions = {}): Provider[] {
   return [
+    {
+      provide: EVENT_BUS_OPTIONS,
+      useValue: options,
+    },
     {
       provide: EVENT_BUS,
       useClass: EventBusLifecycleService,
@@ -13,12 +18,12 @@ export function createEventBusProviders(): Provider[] {
   ];
 }
 
-export function createEventBusModule(): ModuleType {
+export function createEventBusModule(options: EventBusModuleOptions = {}): ModuleType {
   class EventBusModule {}
 
   return defineModule(EventBusModule, {
     exports: [EVENT_BUS],
     global: true,
-    providers: createEventBusProviders(),
+    providers: createEventBusProviders(options),
   });
 }

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -10,13 +10,38 @@ import {
 } from '@konekti/runtime';
 
 import { getEventHandlerMetadataEntries } from './metadata.js';
-import type { EventBus, EventHandlerDescriptor, EventType } from './types.js';
+import { EVENT_BUS_OPTIONS } from './tokens.js';
+import type {
+  EventBus,
+  EventBusModuleOptions,
+  EventHandlerDescriptor,
+  EventPublishOptions,
+  EventType,
+} from './types.js';
 
 interface DiscoveryCandidate {
   moduleName: string;
   scope: 'request' | 'singleton' | 'transient';
   targetType: Function;
   token: Token;
+}
+
+interface ResolvedPublishOptions {
+  signal: AbortSignal | undefined;
+  timeoutMs: number | undefined;
+  waitForHandlers: boolean;
+}
+
+class EventPublishTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Event publish timed out after ${String(timeoutMs)}ms.`);
+  }
+}
+
+class EventPublishAbortError extends Error {
+  constructor() {
+    super('Event publish was aborted.');
+  }
 }
 
 function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
@@ -39,38 +64,55 @@ function isClassProvider(provider: Provider): provider is Extract<Provider, { pr
   return typeof provider === 'object' && provider !== null && 'useClass' in provider;
 }
 
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER])
+@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, EVENT_BUS_OPTIONS])
 export class EventBusLifecycleService implements EventBus, OnApplicationBootstrap {
   private descriptors: EventHandlerDescriptor[] = [];
+  private discoveryPromise: Promise<void> | undefined;
   private discovered = false;
+  private readonly handlerInstances = new Map<Token, Promise<unknown>>();
 
   constructor(
     private readonly runtimeContainer: Container,
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
+    private readonly moduleOptions: EventBusModuleOptions,
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
-    this.discoverHandlers();
+    await this.ensureDiscovered();
   }
 
-  async publish(event: object): Promise<void> {
-    this.ensureDiscovered();
+  async publish(event: object, options?: EventPublishOptions): Promise<void> {
+    await this.ensureDiscovered();
     const matchingDescriptors = this.descriptors.filter((descriptor) => event instanceof descriptor.eventType);
 
     if (matchingDescriptors.length === 0) {
       return;
     }
 
-    await Promise.allSettled(
-      matchingDescriptors.map(async (descriptor) => {
-        await this.invokeHandler(descriptor, event);
-      }),
+    const publishOptions = this.resolvePublishOptions(options);
+    const invocationTasks = matchingDescriptors.map((descriptor) =>
+      this.invokeHandlerWithBounds(descriptor, event, publishOptions),
     );
+
+    if (!publishOptions.waitForHandlers) {
+      for (const task of invocationTasks) {
+        void task;
+      }
+
+      return;
+    }
+
+    await Promise.allSettled(invocationTasks);
   }
 
-  private ensureDiscovered(): void {
+  private async ensureDiscovered(): Promise<void> {
     if (this.discovered) {
+      return;
+    }
+
+    if (this.discoveryPromise) {
+      await this.discoveryPromise;
       return;
     }
 
@@ -81,16 +123,149 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
       );
     }
 
-    this.discoverHandlers();
+    this.discoveryPromise = this.discoverHandlers();
+    await this.discoveryPromise;
   }
 
-  private discoverHandlers(): void {
-    this.descriptors = this.discoverHandlerDescriptors();
-    this.discovered = true;
+  private resolvePublishOptions(options?: EventPublishOptions): ResolvedPublishOptions {
+    const defaults = this.moduleOptions.publish;
+    const timeoutMs = this.normalizeTimeoutMs(options?.timeoutMs ?? defaults?.timeoutMs);
+    const waitForHandlers = options?.waitForHandlers ?? defaults?.waitForHandlers ?? true;
+
+    return {
+      signal: options?.signal,
+      timeoutMs,
+      waitForHandlers,
+    };
+  }
+
+  private normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
+    if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      return undefined;
+    }
+
+    return Math.floor(timeoutMs);
+  }
+
+  private async discoverHandlers(): Promise<void> {
+    try {
+      this.descriptors = this.discoverHandlerDescriptors();
+      this.handlerInstances.clear();
+      await this.preloadHandlerInstances(this.descriptors);
+      this.discovered = true;
+    } finally {
+      this.discoveryPromise = undefined;
+    }
+  }
+
+  private async preloadHandlerInstances(descriptors: EventHandlerDescriptor[]): Promise<void> {
+    for (const descriptor of descriptors) {
+      if (this.handlerInstances.has(descriptor.token)) {
+        continue;
+      }
+
+      await this.resolveHandlerInstance(descriptor);
+    }
+  }
+
+  private async invokeHandlerWithBounds(
+    descriptor: EventHandlerDescriptor,
+    event: object,
+    publishOptions: ResolvedPublishOptions,
+  ): Promise<void> {
+    if (publishOptions.signal?.aborted) {
+      this.logger.warn(
+        `Event publish was cancelled before dispatching handler ${descriptor.targetName}.${descriptor.methodName}.`,
+        'EventBusLifecycleService',
+      );
+      return;
+    }
+
+    const invocation = this.invokeHandler(descriptor, event);
+
+    try {
+      await this.awaitInvocationBounds(invocation, publishOptions);
+    } catch (error) {
+      if (error instanceof EventPublishTimeoutError) {
+        this.logger.warn(
+          `Event handler ${descriptor.targetName}.${descriptor.methodName} exceeded publish timeout of ${String(error.timeoutMs)}ms.`,
+          'EventBusLifecycleService',
+        );
+        return;
+      }
+
+      if (error instanceof EventPublishAbortError) {
+        this.logger.warn(
+          `Event publish was cancelled while waiting for handler ${descriptor.targetName}.${descriptor.methodName}.`,
+          'EventBusLifecycleService',
+        );
+        return;
+      }
+
+      this.logger.error(
+        `Event handler ${descriptor.targetName}.${descriptor.methodName} failed while applying publish bounds.`,
+        error,
+        'EventBusLifecycleService',
+      );
+    }
+  }
+
+  private async awaitInvocationBounds(
+    invocation: Promise<void>,
+    publishOptions: ResolvedPublishOptions,
+  ): Promise<void> {
+    const timeoutMs = publishOptions.timeoutMs;
+    const signal = publishOptions.signal;
+
+    if (timeoutMs === undefined && !signal) {
+      await invocation;
+      return;
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let abortListener: (() => void) | undefined;
+    const bounds: Array<Promise<never>> = [];
+
+    if (timeoutMs !== undefined) {
+      bounds.push(
+        new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(new EventPublishTimeoutError(timeoutMs));
+          }, timeoutMs);
+        }),
+      );
+    }
+
+    if (signal) {
+      if (signal.aborted) {
+        throw new EventPublishAbortError();
+      }
+
+      bounds.push(
+        new Promise<never>((_resolve, reject) => {
+          abortListener = () => {
+            reject(new EventPublishAbortError());
+          };
+          signal.addEventListener('abort', abortListener, { once: true });
+        }),
+      );
+    }
+
+    try {
+      await Promise.race([invocation, ...bounds]);
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
+      if (signal && abortListener) {
+        signal.removeEventListener('abort', abortListener);
+      }
+    }
   }
 
   private discoverHandlerDescriptors(): EventHandlerDescriptor[] {
-    const seen = new Set<string>();
+    const seen = new WeakMap<Function, Map<MetadataPropertyKey, Set<EventType>>>();
     const descriptors: EventHandlerDescriptor[] = [];
 
     for (const candidate of this.discoveryCandidates()) {
@@ -110,13 +285,25 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
       for (const entry of entries) {
         const methodName = methodKeyToName(entry.propertyKey);
         const eventType = entry.metadata.eventType;
-        const dedupKey = `${candidate.targetType.name}::${methodName}::${String(eventType)}`;
+        let methodsByKey = seen.get(candidate.targetType);
 
-        if (seen.has(dedupKey)) {
+        if (!methodsByKey) {
+          methodsByKey = new Map<MetadataPropertyKey, Set<EventType>>();
+          seen.set(candidate.targetType, methodsByKey);
+        }
+
+        let seenEventTypes = methodsByKey.get(entry.propertyKey);
+
+        if (!seenEventTypes) {
+          seenEventTypes = new Set<EventType>();
+          methodsByKey.set(entry.propertyKey, seenEventTypes);
+        }
+
+        if (seenEventTypes.has(eventType)) {
           continue;
         }
 
-        seen.add(dedupKey);
+        seenEventTypes.add(eventType);
 
         descriptors.push({
           eventType,
@@ -171,16 +358,9 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
   }
 
   private async invokeHandler(descriptor: EventHandlerDescriptor, event: object): Promise<void> {
-    let instance: unknown;
+    const instance = await this.resolveHandlerInstance(descriptor);
 
-    try {
-      instance = await this.runtimeContainer.resolve(descriptor.token);
-    } catch (error) {
-      this.logger.error(
-        `Failed to resolve event handler target ${descriptor.targetName} from module ${descriptor.moduleName}.`,
-        error,
-        'EventBusLifecycleService',
-      );
+    if (instance === undefined) {
       return;
     }
 
@@ -202,6 +382,29 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
         error,
         'EventBusLifecycleService',
       );
+    }
+  }
+
+  private async resolveHandlerInstance(descriptor: EventHandlerDescriptor): Promise<unknown | undefined> {
+    const cached = this.handlerInstances.get(descriptor.token);
+
+    if (cached) {
+      return await cached;
+    }
+
+    const resolving = this.runtimeContainer.resolve(descriptor.token);
+    this.handlerInstances.set(descriptor.token, resolving);
+
+    try {
+      return await resolving;
+    } catch (error) {
+      this.handlerInstances.delete(descriptor.token);
+      this.logger.error(
+        `Failed to resolve event handler target ${descriptor.targetName} from module ${descriptor.moduleName}.`,
+        error,
+        'EventBusLifecycleService',
+      );
+      return undefined;
     }
   }
 }

--- a/packages/event-bus/src/tokens.ts
+++ b/packages/event-bus/src/tokens.ts
@@ -1,5 +1,6 @@
 import type { Token } from '@konekti/core';
 
-import type { EventBus } from './types.js';
+import type { EventBus, EventBusModuleOptions } from './types.js';
 
 export const EVENT_BUS: Token<EventBus> = Symbol.for('konekti.event-bus');
+export const EVENT_BUS_OPTIONS: Token<EventBusModuleOptions> = Symbol.for('konekti.event-bus.options');

--- a/packages/event-bus/src/types.ts
+++ b/packages/event-bus/src/types.ts
@@ -17,6 +17,19 @@ export interface EventHandlerDescriptor {
   token: Token;
 }
 
+export interface EventPublishOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  waitForHandlers?: boolean;
+}
+
+export interface EventBusModuleOptions {
+  publish?: {
+    timeoutMs?: number;
+    waitForHandlers?: boolean;
+  };
+}
+
 export interface EventBus {
-  publish(event: object): Promise<void>;
+  publish(event: object, options?: EventPublishOptions): Promise<void>;
 }


### PR DESCRIPTION
## Summary
- add bounded publish controls to `@konekti/event-bus` via timeout, cancellation signal, and non-blocking dispatch options
- replace string-based handler dedupe with stable identity-based semantics and preload singleton handler instances during bootstrap
- expand event-bus tests to cover mixed success/failure/timeout behavior, non-blocking publish, cancellation, and class-name collision dedupe safety

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run packages/event-bus/src/module.test.ts`

Closes #138