### PR TITLE
Resolve #143: align drizzle module contracts and transaction lifecycle flow

### DIFF
--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -5,11 +5,19 @@ import type { OnApplicationShutdown } from '@konekti/runtime';
 import { Inject } from '@konekti/core';
 
 import { DRIZZLE_DATABASE, DRIZZLE_DISPOSE, DRIZZLE_OPTIONS } from './tokens.js';
-import type { DrizzleDatabaseLike, DrizzleHandleProvider } from './types.js';
+import type {
+  DrizzleDatabaseLike,
+  DrizzleHandleProvider,
+  DrizzleRuntimeOptions,
+  DrizzleTransactionRunner,
+} from './types.js';
 
-interface DrizzleDatabaseOptions {
-  strictTransactions: boolean;
-}
+const TRANSACTION_NOT_SUPPORTED_ERROR = 'Transaction not supported: Drizzle database does not implement transaction.';
+
+type ActiveRequestTransaction = {
+  abort(reason?: unknown): void;
+  settled: Promise<void>;
+};
 
 @Inject([DRIZZLE_DATABASE, DRIZZLE_DISPOSE, DRIZZLE_OPTIONS])
 export class DrizzleDatabase<
@@ -19,15 +27,12 @@ export class DrizzleDatabase<
 > implements DrizzleHandleProvider<TDatabase, TTransactionDatabase, TTransactionOptions>, OnApplicationShutdown
 {
   private readonly transactions = new AsyncLocalStorage<TTransactionDatabase>();
-  private readonly activeRequestTransactions = new Set<{
-    abort(reason?: unknown): void;
-    settled: Promise<void>;
-  }>();
+  private readonly activeRequestTransactions = new Set<ActiveRequestTransaction>();
 
   constructor(
     private readonly database: TDatabase,
     private readonly dispose?: (database: TDatabase) => Promise<void> | void,
-    private readonly databaseOptions: DrizzleDatabaseOptions = { strictTransactions: false },
+    private readonly databaseOptions: DrizzleRuntimeOptions = { strictTransactions: false },
   ) {}
 
   current(): TDatabase | TTransactionDatabase {
@@ -47,40 +52,50 @@ export class DrizzleDatabase<
   }
 
   async transaction<T>(fn: () => Promise<T>, options?: TTransactionOptions): Promise<T> {
-    const current = this.transactions.getStore();
-
-    if (current) {
-      return fn();
-    }
-
-    if (typeof this.database.transaction !== 'function') {
-      if (this.databaseOptions.strictTransactions) {
-        throw new Error('Transaction not supported: Drizzle database does not implement transaction.');
-      }
-      return fn();
-    }
-
-    return this.database.transaction((transactionDatabase) => this.transactions.run(transactionDatabase, fn), options);
+    return this.executeTransaction(fn, options, false);
   }
 
   async requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal, options?: TTransactionOptions): Promise<T> {
+    return this.executeTransaction(fn, options, true, signal);
+  }
+
+  private async executeTransaction<T>(
+    fn: () => Promise<T>,
+    options: TTransactionOptions | undefined,
+    requestScoped: boolean,
+    signal?: AbortSignal,
+  ): Promise<T> {
     const current = this.transactions.getStore();
 
     if (current) {
       return fn();
     }
 
-    if (typeof this.database.transaction !== 'function') {
-      if (this.databaseOptions.strictTransactions) {
-        throw new Error('Transaction not supported: Drizzle database does not implement transaction.');
-      }
+    const transactionRunner = this.resolveTransactionRunner();
+    if (!transactionRunner) {
       return fn();
     }
 
+    if (!requestScoped) {
+      return transactionRunner((transactionDatabase) => this.transactions.run(transactionDatabase, fn), options);
+    }
+
+    return this.executeRequestTransaction(transactionRunner, fn, options, signal);
+  }
+
+  private async executeRequestTransaction<T>(
+    transactionRunner: DrizzleTransactionRunner<TTransactionDatabase, TTransactionOptions>,
+    fn: () => Promise<T>,
+    options: TTransactionOptions | undefined,
+    signal?: AbortSignal,
+  ): Promise<T> {
     const controller = new AbortController();
     const forwardAbort = () => controller.abort(signal?.reason);
-
-    signal?.addEventListener('abort', forwardAbort, { once: true });
+    if (signal?.aborted) {
+      forwardAbort();
+    } else {
+      signal?.addEventListener('abort', forwardAbort, { once: true });
+    }
 
     let settle!: () => void;
     const settled = new Promise<void>((resolve) => {
@@ -96,7 +111,7 @@ export class DrizzleDatabase<
     this.activeRequestTransactions.add(active);
 
     try {
-      return await this.database.transaction(
+      return await transactionRunner(
         (transactionDatabase) => this.transactions.run(transactionDatabase, () => raceWithAbort(fn, controller.signal)),
         options,
       );
@@ -105,5 +120,17 @@ export class DrizzleDatabase<
       this.activeRequestTransactions.delete(active);
       settle();
     }
+  }
+
+  private resolveTransactionRunner(): DrizzleTransactionRunner<TTransactionDatabase, TTransactionOptions> | undefined {
+    if (typeof this.database.transaction !== 'function') {
+      if (this.databaseOptions.strictTransactions) {
+        throw new Error(TRANSACTION_NOT_SUPPORTED_ERROR);
+      }
+
+      return undefined;
+    }
+
+    return this.database.transaction.bind(this.database) as DrizzleTransactionRunner<TTransactionDatabase, TTransactionOptions>;
   }
 }

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -150,6 +150,87 @@ describe('@konekti/drizzle', () => {
       'dispose',
     ]);
   });
+
+  it('enforces strictTransactions for sync and async module builders', async () => {
+    const database = {};
+
+    const StrictSyncModule = createDrizzleModule({
+      database,
+      strictTransactions: true,
+    });
+
+    class StrictSyncAppModule {}
+
+    defineModule(StrictSyncAppModule, {
+      imports: [StrictSyncModule],
+    });
+
+    const syncApp = await bootstrapApplication({
+      mode: 'test',
+      rootModule: StrictSyncAppModule,
+    });
+    const syncDrizzle = await syncApp.container.resolve(DrizzleDatabase<typeof database>);
+
+    await expect(syncDrizzle.transaction(async () => 'ok')).rejects.toThrow(
+      'Transaction not supported: Drizzle database does not implement transaction.',
+    );
+
+    await syncApp.close();
+
+    const StrictAsyncModule = createDrizzleModuleAsync({
+      useFactory: () => ({
+        database,
+        strictTransactions: true,
+      }),
+    });
+
+    class StrictAsyncAppModule {}
+
+    defineModule(StrictAsyncAppModule, {
+      imports: [StrictAsyncModule],
+    });
+
+    const asyncApp = await bootstrapApplication({
+      mode: 'test',
+      rootModule: StrictAsyncAppModule,
+    });
+    const asyncDrizzle = await asyncApp.container.resolve(DrizzleDatabase<typeof database>);
+
+    await expect(asyncDrizzle.requestTransaction(async () => 'ok')).rejects.toThrow(
+      'Transaction not supported: Drizzle database does not implement transaction.',
+    );
+
+    await asyncApp.close();
+  });
+
+  it('forwards transaction options for explicit and request-scoped transactions', async () => {
+    const optionsCalls: Array<{ isolationLevel: string } | undefined> = [];
+    const transactionDatabase = { kind: 'transaction' };
+    const database = {
+      async transaction<T>(
+        callback: (value: typeof transactionDatabase) => Promise<T>,
+        options?: { isolationLevel: string },
+      ): Promise<T> {
+        optionsCalls.push(options);
+        return callback(transactionDatabase);
+      },
+    };
+
+    const drizzle = new DrizzleDatabase<typeof database, typeof transactionDatabase, { isolationLevel: string }>(database);
+
+    await expect(drizzle.transaction(async () => drizzle.current(), { isolationLevel: 'serializable' })).resolves.toBe(
+      transactionDatabase,
+    );
+
+    await expect(
+      drizzle.requestTransaction(async () => drizzle.current(), undefined, { isolationLevel: 'read committed' }),
+    ).resolves.toBe(transactionDatabase);
+
+    expect(optionsCalls).toEqual([
+      { isolationLevel: 'serializable' },
+      { isolationLevel: 'read committed' },
+    ]);
+  });
 });
 
 describe('createDrizzleModuleAsync', () => {
@@ -164,11 +245,11 @@ describe('createDrizzleModuleAsync', () => {
         return result;
       },
     };
-    return { database, events };
+    return { database, events, transactionDatabase };
   }
 
   it('factory receives injected token and resolves DrizzleDatabase', async () => {
-    const { database, events } = makeFakeDatabase();
+    const { database, events, transactionDatabase } = makeFakeDatabase();
 
     class ConfigService {
       readonly url = 'postgres://localhost/test';
@@ -180,7 +261,7 @@ describe('createDrizzleModuleAsync', () => {
 
     const factory = vi.fn().mockResolvedValue({ database });
 
-    const DrizzleModule = createDrizzleModuleAsync({
+    const DrizzleModule = createDrizzleModuleAsync<typeof database, typeof transactionDatabase>({
       inject: [ConfigService],
       useFactory: factory,
     });
@@ -204,9 +285,9 @@ describe('createDrizzleModuleAsync', () => {
   });
 
   it('factory returning a promise resolves the database correctly', async () => {
-    const { database } = makeFakeDatabase();
+    const { database, transactionDatabase } = makeFakeDatabase();
 
-    const DrizzleModule = createDrizzleModuleAsync({
+    const DrizzleModule = createDrizzleModuleAsync<typeof database, typeof transactionDatabase>({
       useFactory: () => Promise.resolve({ database }),
     });
 

--- a/packages/drizzle/src/module.ts
+++ b/packages/drizzle/src/module.ts
@@ -1,29 +1,122 @@
-import { type AsyncModuleOptions, type MaybePromise } from '@konekti/core';
+import { type AsyncModuleOptions } from '@konekti/core';
 import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { DrizzleDatabase } from './database.js';
 import { DRIZZLE_DATABASE, DRIZZLE_DISPOSE, DRIZZLE_OPTIONS } from './tokens.js';
 import { DrizzleTransactionInterceptor } from './transaction.js';
-import type { DrizzleDatabaseLike, DrizzleModuleOptions } from './types.js';
+import type { DrizzleDatabaseLike, DrizzleModuleOptions, DrizzleRuntimeOptions } from './types.js';
+
+type ResolvedDrizzleModuleOptions<
+  TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
+  TTransactionDatabase,
+  TTransactionOptions,
+> = Omit<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>, 'strictTransactions'> & {
+  strictTransactions: boolean;
+};
+
+function normalizeDrizzleModuleOptions<
+  TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
+  TTransactionDatabase,
+  TTransactionOptions,
+>(
+  options: DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>,
+): ResolvedDrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions> {
+  return {
+    ...options,
+    strictTransactions: options.strictTransactions ?? false,
+  };
+}
+
+function createRuntimeOptionsProviderValue(strictTransactions: boolean): DrizzleRuntimeOptions {
+  return { strictTransactions };
+}
+
+function createMemoizedDrizzleOptionsResolver<
+  TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
+  TTransactionDatabase,
+  TTransactionOptions,
+>(
+  options: AsyncModuleOptions<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>>,
+): (...deps: unknown[]) => Promise<ResolvedDrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>> {
+  let cachedResult: Promise<ResolvedDrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>> | undefined;
+
+  return (...deps: unknown[]) => {
+    if (!cachedResult) {
+      cachedResult = Promise.resolve(options.useFactory(...deps)).then((resolved) =>
+        normalizeDrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>(resolved),
+      );
+    }
+
+    if (!cachedResult) {
+      throw new Error('Drizzle module options resolver initialization failed.');
+    }
+
+    return cachedResult;
+  };
+}
+
+function createDrizzleProvidersAsync<
+  TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
+  TTransactionDatabase,
+  TTransactionOptions,
+>(
+  options: AsyncModuleOptions<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>>,
+): Provider[] {
+  const resolveOptions = createMemoizedDrizzleOptionsResolver(options);
+
+  const databaseProvider = {
+    inject: options.inject,
+    provide: DRIZZLE_DATABASE,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => {
+      const resolved = await resolveOptions(...deps);
+      return resolved.database;
+    },
+  };
+
+  const disposeProvider = {
+    inject: options.inject,
+    provide: DRIZZLE_DISPOSE,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => {
+      const resolved = await resolveOptions(...deps);
+      return resolved.dispose;
+    },
+  };
+
+  const optionsProvider = {
+    inject: options.inject,
+    provide: DRIZZLE_OPTIONS,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => {
+      const resolved = await resolveOptions(...deps);
+      return createRuntimeOptionsProviderValue(resolved.strictTransactions);
+    },
+  };
+
+  return [databaseProvider, disposeProvider, optionsProvider, DrizzleDatabase, DrizzleTransactionInterceptor];
+}
 
 export function createDrizzleProviders<
   TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
   TTransactionDatabase = TDatabase,
   TTransactionOptions = unknown,
 >(options: DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>): Provider[] {
+  const resolved = normalizeDrizzleModuleOptions(options);
+
   return [
     {
       provide: DRIZZLE_DATABASE,
-      useValue: options.database,
+      useValue: resolved.database,
     },
     {
       provide: DRIZZLE_DISPOSE,
-      useValue: options.dispose,
+      useValue: resolved.dispose,
     },
     {
       provide: DRIZZLE_OPTIONS,
-      useValue: { strictTransactions: options.strictTransactions ?? false },
+      useValue: createRuntimeOptionsProviderValue(resolved.strictTransactions),
     },
     DrizzleDatabase,
     DrizzleTransactionInterceptor,
@@ -45,53 +138,13 @@ export function createDrizzleModule<
 
 export function createDrizzleModuleAsync<
   TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
-  TTransactionDatabase = unknown,
+  TTransactionDatabase = TDatabase,
   TTransactionOptions = unknown,
 >(options: AsyncModuleOptions<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>>): ModuleType {
   class DrizzleAsyncModule {}
 
-  const factory = options.useFactory as (...args: unknown[]) => MaybePromise<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>>;
-
-  let cachedResult: Promise<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>> | undefined;
-  const memoizedFactory = (...deps: unknown[]): Promise<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>> => {
-    if (!cachedResult) {
-      cachedResult = Promise.resolve(factory(...deps));
-    }
-    return cachedResult;
-  };
-
-  const databaseProvider = {
-    inject: options.inject,
-    provide: DRIZZLE_DATABASE,
-    scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => {
-      const resolved = await memoizedFactory(...deps);
-      return resolved.database;
-    },
-  };
-
-  const disposeProvider = {
-    inject: options.inject,
-    provide: DRIZZLE_DISPOSE,
-    scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => {
-      const resolved = await memoizedFactory(...deps);
-      return resolved.dispose;
-    },
-  };
-
-  const optionsProvider = {
-    inject: options.inject,
-    provide: DRIZZLE_OPTIONS,
-    scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => {
-      const resolved = await memoizedFactory(...deps);
-      return { strictTransactions: resolved.strictTransactions ?? false };
-    },
-  };
-
   return defineModule(DrizzleAsyncModule, {
     exports: [DrizzleDatabase, DrizzleTransactionInterceptor],
-    providers: [databaseProvider, disposeProvider, optionsProvider, DrizzleDatabase, DrizzleTransactionInterceptor],
+    providers: createDrizzleProvidersAsync(options),
   });
 }

--- a/packages/drizzle/src/types.ts
+++ b/packages/drizzle/src/types.ts
@@ -1,7 +1,18 @@
 import type { MaybePromise } from '@konekti/core';
 
+export type DrizzleTransactionCallback<TTransactionDatabase, TResult> = (database: TTransactionDatabase) => Promise<TResult>;
+
+export type DrizzleTransactionRunner<TTransactionDatabase, TTransactionOptions> = <T>(
+  callback: DrizzleTransactionCallback<TTransactionDatabase, T>,
+  options?: TTransactionOptions,
+) => Promise<T>;
+
 export interface DrizzleDatabaseLike<TTransactionDatabase = unknown, TTransactionOptions = unknown> {
-  transaction?<T>(callback: (database: TTransactionDatabase) => Promise<T>, options?: TTransactionOptions): Promise<T>;
+  transaction?: DrizzleTransactionRunner<TTransactionDatabase, TTransactionOptions>;
+}
+
+export interface DrizzleRuntimeOptions {
+  strictTransactions: boolean;
 }
 
 export interface DrizzleModuleOptions<TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>, TTransactionDatabase = TDatabase, TTransactionOptions = unknown> {


### PR DESCRIPTION
## Summary
- Align sync/async Drizzle module builders around a shared options normalization path and consistent generic defaults.
- Deduplicate `DrizzleDatabase` transaction/requestTransaction execution via shared helper boundaries while preserving request-scoped abort/shutdown behavior.
- Add strict transaction and transaction-option forwarding coverage to lock in edge-case behavior for both module builders and runtime execution.

## Verification
- `pnpm build`
- `pnpm --dir packages/drizzle run typecheck`
- `pnpm --dir packages/drizzle run build`
- `pnpm exec vitest run packages/drizzle/src/module.test.ts packages/drizzle/src/vertical-slice.test.ts`

Closes #143