### PR TITLE
Resolve #141: unify prisma module wiring and transaction orchestration

### DIFF
--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -4,7 +4,7 @@ import { Inject } from '@konekti/core';
 import { bootstrapApplication, defineModule } from '@konekti/runtime';
 import { Global, Module } from '@konekti/core';
 
-import { createPrismaModule, createPrismaModuleAsync, PrismaService } from './index.js';
+import { PRISMA_CLIENT, PRISMA_OPTIONS, createPrismaModule, createPrismaModuleAsync, PrismaService } from './index.js';
 
 describe('@konekti/prisma', () => {
   it('connects, reuses transaction-scoped handles, and disconnects through lifecycle hooks', async () => {
@@ -161,6 +161,104 @@ describe('@konekti/prisma', () => {
       'disconnect',
     ]);
   });
+
+  it('runs nested request and service transactions through a single transaction boundary', async () => {
+    let transactionCalls = 0;
+    const transactionClient = {
+      kind: 'transaction' as const,
+    };
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+      async $transaction<T>(callback: (value: typeof transactionClient) => Promise<T>): Promise<T> {
+        transactionCalls += 1;
+        return callback(transactionClient);
+      },
+    };
+
+    const PrismaModule = createPrismaModule<typeof client, typeof transactionClient>({ client });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [PrismaModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const prisma = await app.container.resolve(PrismaService<typeof client, typeof transactionClient>);
+
+    await expect(
+      prisma.requestTransaction(async () => prisma.transaction(async () => 'ok')),
+    ).resolves.toBe('ok');
+    expect(transactionCalls).toBe(1);
+
+    await app.close();
+  });
+
+  it('falls back when transaction client is unsupported and strictTransactions is false', async () => {
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+    };
+
+    const PrismaModule = createPrismaModule<typeof client>({
+      client,
+      strictTransactions: false,
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [PrismaModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const prisma = await app.container.resolve(PrismaService<typeof client>);
+
+    await expect(prisma.transaction(async () => 'fallback-transaction')).resolves.toBe('fallback-transaction');
+    await expect(prisma.requestTransaction(async () => 'fallback-request')).resolves.toBe('fallback-request');
+
+    await app.close();
+  });
+
+  it('throws when transaction client is unsupported and strictTransactions is true', async () => {
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+    };
+
+    const PrismaModule = createPrismaModule<typeof client>({
+      client,
+      strictTransactions: true,
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [PrismaModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const prisma = await app.container.resolve(PrismaService<typeof client>);
+
+    await expect(prisma.transaction(async () => 'never')).rejects.toThrow(
+      'Transaction not supported: Prisma client does not implement $transaction.',
+    );
+    await expect(prisma.requestTransaction(async () => 'never')).rejects.toThrow(
+      'Transaction not supported: Prisma client does not implement $transaction.',
+    );
+
+    await app.close();
+  });
 });
 
 describe('createPrismaModuleAsync', () => {
@@ -184,11 +282,11 @@ describe('createPrismaModuleAsync', () => {
         return callback(transactionClient);
       },
     };
-    return { client, events };
+    return { client, events, transactionClient };
   }
 
   it('factory receives injected token and resolves PrismaService', async () => {
-    const { client, events } = makeFakeClient();
+    const { client, events, transactionClient } = makeFakeClient();
 
     class ConfigService {
       readonly url = 'postgres://localhost/test';
@@ -200,7 +298,7 @@ describe('createPrismaModuleAsync', () => {
 
     const factory = vi.fn().mockResolvedValue({ client });
 
-    const PrismaModule = createPrismaModuleAsync({
+    const PrismaModule = createPrismaModuleAsync<typeof client, typeof transactionClient>({
       inject: [ConfigService],
       useFactory: factory,
     });
@@ -213,9 +311,13 @@ describe('createPrismaModuleAsync', () => {
 
     const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
     const prisma = await app.container.resolve(PrismaService);
+    const rawClient = await app.container.resolve(PRISMA_CLIENT);
+    const moduleOptions = await app.container.resolve(PRISMA_OPTIONS);
 
     expect(factory).toHaveBeenCalledOnce();
     expect(factory.mock.calls[0][0]).toBeInstanceOf(ConfigService);
+    expect(rawClient).toBe(client);
+    expect(moduleOptions).toEqual({ strictTransactions: false });
     expect(events).toEqual(['connect']);
 
     await app.close();
@@ -225,9 +327,9 @@ describe('createPrismaModuleAsync', () => {
   });
 
   it('factory returning a promise resolves the client correctly', async () => {
-    const { client } = makeFakeClient();
+    const { client, transactionClient } = makeFakeClient();
 
-    const PrismaModule = createPrismaModuleAsync({
+    const PrismaModule = createPrismaModuleAsync<typeof client, typeof transactionClient>({
       useFactory: () => Promise.resolve({ client }),
     });
 
@@ -239,6 +341,30 @@ describe('createPrismaModuleAsync', () => {
     const prisma = await app.container.resolve(PrismaService);
 
     expect(prisma).toBeInstanceOf(PrismaService);
+
+    await app.close();
+  });
+
+  it('applies strictTransactions from async options for unsupported clients', async () => {
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+    };
+
+    const PrismaModule = createPrismaModuleAsync({
+      useFactory: () => Promise.resolve({ client, strictTransactions: true }),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [PrismaModule] });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const prisma = await app.container.resolve(PrismaService<typeof client>);
+
+    await expect(prisma.transaction(async () => 'never')).rejects.toThrow(
+      'Transaction not supported: Prisma client does not implement $transaction.',
+    );
 
     await app.close();
   });

--- a/packages/prisma/src/module.ts
+++ b/packages/prisma/src/module.ts
@@ -5,23 +5,54 @@ import { defineModule, type ModuleType } from '@konekti/runtime';
 import { PrismaService } from './service.js';
 import { PRISMA_CLIENT, PRISMA_OPTIONS } from './tokens.js';
 import { PrismaTransactionInterceptor } from './transaction.js';
-import type { PrismaClientLike, PrismaModuleOptions, PrismaTransactionClient } from './types.js';
+import type { PrismaClientLike, PrismaModuleOptions } from './types.js';
 
-export function createPrismaProviders<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient>(
+interface NormalizedPrismaModuleOptions<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient> {
+  client: TClient;
+  strictTransactions: boolean;
+}
+
+const PRISMA_NORMALIZED_OPTIONS = Symbol('konekti.prisma.normalized-options');
+const PRISMA_MODULE_EXPORTS = [PrismaService, PrismaTransactionInterceptor];
+
+function normalizePrismaModuleOptions<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient>(
   options: PrismaModuleOptions<TClient, TTransactionClient>,
+): NormalizedPrismaModuleOptions<TClient, TTransactionClient> {
+  return {
+    client: options.client,
+    strictTransactions: options.strictTransactions ?? false,
+  };
+}
+
+function createPrismaRuntimeProviders<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient>(
+  normalizedOptionsProvider: Provider,
 ): Provider[] {
   return [
+    normalizedOptionsProvider,
     {
+      inject: [PRISMA_NORMALIZED_OPTIONS],
       provide: PRISMA_CLIENT,
-      useValue: options.client,
+      useFactory: (options: unknown) => (options as NormalizedPrismaModuleOptions<TClient, TTransactionClient>).client,
     },
     {
+      inject: [PRISMA_NORMALIZED_OPTIONS],
       provide: PRISMA_OPTIONS,
-      useValue: { strictTransactions: options.strictTransactions ?? false },
+      useFactory: (options: unknown) => ({
+        strictTransactions: (options as NormalizedPrismaModuleOptions<TClient, TTransactionClient>).strictTransactions,
+      }),
     },
     PrismaService,
     PrismaTransactionInterceptor,
   ];
+}
+
+export function createPrismaProviders<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient>(
+  options: PrismaModuleOptions<TClient, TTransactionClient>,
+): Provider[] {
+  return createPrismaRuntimeProviders({
+    provide: PRISMA_NORMALIZED_OPTIONS,
+    useValue: normalizePrismaModuleOptions(options),
+  });
 }
 
 export function createPrismaModule<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient>(
@@ -30,49 +61,36 @@ export function createPrismaModule<TClient extends PrismaClientLike<TTransaction
   class PrismaModule {}
 
   return defineModule(PrismaModule, {
-    exports: [PrismaService, PrismaTransactionInterceptor],
+    exports: PRISMA_MODULE_EXPORTS,
     providers: createPrismaProviders(options),
   });
 }
 
 export function createPrismaModuleAsync<
   TClient extends PrismaClientLike<TTransactionClient>,
-  TTransactionClient = PrismaTransactionClient,
+  TTransactionClient = TClient,
 >(options: AsyncModuleOptions<PrismaModuleOptions<TClient, TTransactionClient>>): ModuleType {
   class PrismaAsyncModule {}
 
   const factory = options.useFactory as (...args: unknown[]) => MaybePromise<PrismaModuleOptions<TClient, TTransactionClient>>;
 
-  let cachedResult: Promise<PrismaModuleOptions<TClient, TTransactionClient>> | undefined;
-  const memoizedFactory = (...deps: unknown[]): Promise<PrismaModuleOptions<TClient, TTransactionClient>> => {
+  let cachedResult: Promise<NormalizedPrismaModuleOptions<TClient, TTransactionClient>> | undefined;
+  const memoizedFactory = (...deps: unknown[]): Promise<NormalizedPrismaModuleOptions<TClient, TTransactionClient>> => {
     if (!cachedResult) {
-      cachedResult = Promise.resolve(factory(...deps));
+      cachedResult = Promise.resolve(factory(...deps)).then((resolved) => normalizePrismaModuleOptions(resolved));
     }
     return cachedResult;
   };
 
-  const clientProvider = {
+  const normalizedOptionsProvider = {
     inject: options.inject,
-    provide: PRISMA_CLIENT,
+    provide: PRISMA_NORMALIZED_OPTIONS,
     scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => {
-      const resolved = await memoizedFactory(...deps);
-      return resolved.client;
-    },
-  };
-
-  const optionsProvider = {
-    inject: options.inject,
-    provide: PRISMA_OPTIONS,
-    scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => {
-      const resolved = await memoizedFactory(...deps);
-      return { strictTransactions: resolved.strictTransactions ?? false };
-    },
+    useFactory: (...deps: unknown[]) => memoizedFactory(...deps),
   };
 
   return defineModule(PrismaAsyncModule, {
-    exports: [PrismaService, PrismaTransactionInterceptor],
-    providers: [clientProvider, optionsProvider, PrismaService, PrismaTransactionInterceptor],
+    exports: PRISMA_MODULE_EXPORTS,
+    providers: createPrismaRuntimeProviders(normalizedOptionsProvider),
   });
 }

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -30,6 +30,25 @@ export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>,
     return this.transactions.getStore() ?? this.client;
   }
 
+  private async runWithTransactionClient<T>(
+    fn: () => Promise<T>,
+    run: (callback: (transactionClient: TTransactionClient) => Promise<T>) => Promise<T>,
+  ): Promise<T> {
+    if (this.transactions.getStore()) {
+      return fn();
+    }
+
+    if (typeof this.client.$transaction !== 'function') {
+      if (this.serviceOptions.strictTransactions) {
+        throw new Error('Transaction not supported: Prisma client does not implement $transaction.');
+      }
+
+      return fn();
+    }
+
+    return run((transactionClient) => this.transactions.run(transactionClient, fn));
+  }
+
   async onModuleInit(): Promise<void> {
     if (typeof this.client.$connect === 'function') {
       await this.client.$connect();
@@ -49,36 +68,10 @@ export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>,
   }
 
   async transaction<T>(fn: () => Promise<T>): Promise<T> {
-    const current = this.transactions.getStore();
-
-    if (current) {
-      return fn();
-    }
-
-    if (typeof this.client.$transaction !== 'function') {
-      if (this.serviceOptions.strictTransactions) {
-        throw new Error('Transaction not supported: Prisma client does not implement $transaction.');
-      }
-      return fn();
-    }
-
-    return this.client.$transaction((transactionClient) => this.transactions.run(transactionClient, fn));
+    return this.runWithTransactionClient(fn, (callback) => this.client.$transaction!(callback));
   }
 
   async requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
-    const current = this.transactions.getStore();
-
-    if (current) {
-      return fn();
-    }
-
-    if (typeof this.client.$transaction !== 'function') {
-      if (this.serviceOptions.strictTransactions) {
-        throw new Error('Transaction not supported: Prisma client does not implement $transaction.');
-      }
-      return fn();
-    }
-
     const controller = new AbortController();
     const forwardAbort = () => controller.abort(signal?.reason);
 
@@ -98,8 +91,9 @@ export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>,
     this.activeRequestTransactions.add(active);
 
     try {
-      return await this.client.$transaction((transactionClient) =>
-        this.transactions.run(transactionClient, () => raceWithAbort(fn, controller.signal)),
+      return await this.runWithTransactionClient(
+        () => raceWithAbort(fn, controller.signal),
+        (callback) => this.client.$transaction!(callback),
       );
     } finally {
       signal?.removeEventListener('abort', forwardAbort);

--- a/packages/prisma/src/types.ts
+++ b/packages/prisma/src/types.ts
@@ -4,10 +4,12 @@ export interface PrismaTransactionClient {
   [key: string]: unknown;
 }
 
+export type PrismaTransactionCallback<TTransactionClient, TResult> = (client: TTransactionClient) => Promise<TResult>;
+
 export interface PrismaClientLike<TTransactionClient = PrismaTransactionClient> {
   $connect?(): MaybePromise<void>;
   $disconnect?(): MaybePromise<void>;
-  $transaction?<T>(callback: (client: TTransactionClient) => Promise<T>): Promise<T>;
+  $transaction?<T>(callback: PrismaTransactionCallback<TTransactionClient, T>): Promise<T>;
 }
 
 export interface PrismaModuleOptions<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient> {


### PR DESCRIPTION
## Summary
- unify sync/async Prisma module wiring through one normalized provider assembly path with aligned generic defaults
- deduplicate transaction and requestTransaction preflight orchestration while preserving request abort/shutdown handling
- add strictTransactions and unsupported transaction-client coverage, plus async provider wiring assertions

## Verification
- pnpm --filter @konekti/prisma typecheck
- pnpm --filter @konekti/prisma build
- pnpm vitest run packages/prisma/src/module.test.ts packages/prisma/src/vertical-slice.test.ts

Closes #141