### PR TITLE
Resolve #127: introduce explicit config reload subscription API

### DIFF
--- a/packages/config/README.ko.md
+++ b/packages/config/README.ko.md
@@ -46,7 +46,7 @@ const config = loadConfig({
 const service = new ConfigService(config);
 service.get('DATABASE_URL');          // 없으면 throw
 service.getOptional('REDIS_URL');     // 없으면 undefined 반환
-service.snapshot();                   // 현재 값 복사본 반환
+service.snapshot();                   // 현재 값 deep clone 스냅샷 반환
 ```
 
 실제로는 `@konekti/runtime`의 `bootstrapApplication()`이 `loadConfig()`를 호출하고, 결과 `ConfigService`를 bootstrap-level provider로 등록합니다.
@@ -64,6 +64,23 @@ service.snapshot();                   // 현재 값 복사본 반환
 | `processEnv` | `NodeJS.ProcessEnv` | 실제 `process.env` 대신 사용할 소스 |
 | `runtimeOverrides` | `ConfigDictionary` | 가장 높은 우선순위 값 |
 | `validate` | `(raw) => T` | 유효하지 않으면 throw, 타입 딕셔너리 반환 |
+| `watch` | `boolean` | `createConfigReloader(options)`에서 env 파일 watch 리로드를 활성화할 때 사용 |
+
+### `createConfigReloader(options)`
+
+```typescript
+type ConfigReloadReason = 'manual' | 'watch';
+
+type ConfigReloader = {
+  current(): ConfigDictionary;
+  reload(): ConfigDictionary;
+  subscribe(listener: (snapshot: ConfigDictionary, reason: ConfigReloadReason) => void): { unsubscribe(): void };
+  subscribeError(listener: (error: unknown, reason: ConfigReloadReason) => void): { unsubscribe(): void };
+  close(): void;
+};
+```
+
+리로드 알림과 에러는 `subscribe(...)`, `subscribeError(...)`를 통해 명시적으로 전달됩니다. 전역 process 이벤트 사이드이펙트는 사용하지 않습니다.
 
 ### `ConfigService`
 
@@ -71,7 +88,7 @@ service.snapshot();                   // 현재 값 복사본 반환
 class ConfigService {
   get<T>(key: string): T              // 필수 — 없으면 throw
   getOptional<T>(key: string): T | undefined
-  snapshot(): ConfigDictionary        // 현재 정규화된 값 복사본 반환
+  snapshot(): ConfigDictionary        // 현재 정규화된 값을 deep clone으로 반환
 }
 ```
 
@@ -93,9 +110,16 @@ bootstrapApplication(options)
       → ConfigDictionary
   → new ConfigService(values)
   → bootstrap-level provider로 등록
+
+createConfigReloader(options)
+  → 스냅샷 로드 + 검증
+  → subscribe(listener) / subscribeError(listener)
+  → reload()로 수동 리로드
+  → `watch: true`면 env 파일 감시
+  → close()로 감시 중단 + 구독 정리
 ```
 
-`ConfigService`는 부트스트랩 이후 의도적으로 읽기 전용입니다 — 동적 리로드 없음, namespace API 없음.
+`ConfigService`는 부트스트랩 이후 의도적으로 읽기 전용입니다. 동적 리로드가 필요하면 `createConfigReloader()`를 명시적으로 사용합니다.
 
 ## 파일 읽기 순서 (기여자용)
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -46,7 +46,7 @@ const config = loadConfig({
 const service = new ConfigService(config);
 service.get('DATABASE_URL');          // throws if missing
 service.getOptional('REDIS_URL');     // returns undefined if missing
-service.snapshot();                   // returns a copy of all values
+service.snapshot();                   // returns a deep-cloned snapshot
 ```
 
 In practice you use `bootstrapApplication()` from `@konekti/runtime`, which calls `loadConfig()` for you and registers the resulting `ConfigService` as a bootstrap-level provider.
@@ -64,6 +64,23 @@ In practice you use `bootstrapApplication()` from `@konekti/runtime`, which call
 | `processEnv` | `NodeJS.ProcessEnv` | Override the source used instead of the live `process.env` |
 | `runtimeOverrides` | `ConfigDictionary` | Highest-precedence values |
 | `validate` | `(raw) => T` | Throws on invalid config, returns typed dictionary |
+| `watch` | `boolean` | Used by `createConfigReloader(options)` to enable env file watch reloads |
+
+### `createConfigReloader(options)`
+
+```typescript
+type ConfigReloadReason = 'manual' | 'watch';
+
+type ConfigReloader = {
+  current(): ConfigDictionary;
+  reload(): ConfigDictionary;
+  subscribe(listener: (snapshot: ConfigDictionary, reason: ConfigReloadReason) => void): { unsubscribe(): void };
+  subscribeError(listener: (error: unknown, reason: ConfigReloadReason) => void): { unsubscribe(): void };
+  close(): void;
+};
+```
+
+Use `createConfigReloader()` when you need explicit reload hooks. Reload notifications and errors are delivered via `subscribe(...)` and `subscribeError(...)`; no global process event side-effects are used.
 
 ### `ConfigService`
 
@@ -71,7 +88,7 @@ In practice you use `bootstrapApplication()` from `@konekti/runtime`, which call
 class ConfigService {
   get<T>(key: string): T              // required — throws if missing
   getOptional<T>(key: string): T | undefined
-  snapshot(): ConfigDictionary        // returns current normalized values copy
+  snapshot(): ConfigDictionary        // returns deep-cloned normalized values
 }
 ```
 
@@ -93,9 +110,16 @@ bootstrapApplication(options)
       → ConfigDictionary
   → new ConfigService(values)
   → register as bootstrap-level provider
+
+createConfigReloader(options)
+  → load + validate snapshot
+  → subscribe(listener) / subscribeError(listener)
+  → reload() for manual refresh
+  → watch env file when `watch: true`
+  → close() to stop watching and clear subscriptions
 ```
 
-`ConfigService` is intentionally read-only after bootstrap — no dynamic reload, no namespace API.
+`ConfigService` remains intentionally read-only after bootstrap. Dynamic reload is an explicit opt-in flow through `createConfigReloader()`.
 
 ## File reading order (for contributors)
 

--- a/packages/config/src/clone.ts
+++ b/packages/config/src/clone.ts
@@ -1,0 +1,26 @@
+function fallbackClone(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => fallbackClone(item));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const source = value as Record<string, unknown>;
+    const cloned: Record<string, unknown> = {};
+
+    for (const [key, item] of Object.entries(source)) {
+      cloned[key] = fallbackClone(item);
+    }
+
+    return cloned;
+  }
+
+  return value;
+}
+
+export function cloneConfigDictionary<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return fallbackClone(value) as T;
+  }
+}

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -4,8 +4,26 @@ import { tmpdir } from 'node:os';
 
 import { describe, expect, it } from 'vitest';
 
-import { loadConfig } from './load.js';
+import { createConfigReloader, loadConfig } from './load.js';
 import { ConfigService } from './service.js';
+
+async function waitForCondition(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+
+  throw new Error('Timed out waiting for condition.');
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 describe('loadConfig', () => {
   it('merges defaults, env file, process env, and runtime overrides in order', () => {
@@ -102,6 +120,137 @@ describe('loadConfig', () => {
 
     expect(loaded['KEY']).toBe('value');
   });
+
+  it('emits reload notifications through explicit subscriptions', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-reload-subscribe-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      mode: 'dev',
+      processEnv: {},
+    });
+
+    try {
+      const updates: Array<{ port: string; reason: string }> = [];
+      const subscription = reloader.subscribe((snapshot, reason) => {
+        const port = snapshot['PORT'];
+        if (typeof port === 'string') {
+          updates.push({ port, reason });
+        }
+      });
+
+      writeFileSync(envPath, 'PORT=4100\n');
+      const reloaded = reloader.reload();
+      expect(reloaded['PORT']).toBe('4100');
+      expect(updates).toHaveLength(1);
+      expect(updates[0]?.reason).toBe('manual');
+      expect(updates[0]?.port).toBe('4100');
+
+      subscription.unsubscribe();
+      writeFileSync(envPath, 'PORT=4200\n');
+      reloader.reload();
+      expect(updates).toHaveLength(1);
+    } finally {
+      reloader.close();
+    }
+  });
+
+  it('keeps last valid snapshot and reports validation failures in watch mode', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-watch-validation-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      mode: 'dev',
+      processEnv: {},
+      validate: (raw) => {
+        const port = raw['PORT'];
+
+        if (typeof port !== 'string' || !/^\d+$/.test(port)) {
+          throw new Error('PORT must be numeric');
+        }
+
+        return raw;
+      },
+      watch: true,
+    });
+
+    try {
+      const updates: string[] = [];
+      const errors: string[] = [];
+      const updateSubscription = reloader.subscribe((snapshot, reason) => {
+        if (reason !== 'watch') {
+          return;
+        }
+
+        const port = snapshot['PORT'];
+        if (typeof port === 'string') {
+          updates.push(port);
+        }
+      });
+      const errorSubscription = reloader.subscribeError((error, reason) => {
+        if (reason !== 'watch') {
+          return;
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+        errors.push(message);
+      });
+
+      await delay(100);
+      writeFileSync(envPath, 'PORT=oops\n');
+      await waitForCondition(() => errors.length > 0);
+      expect(reloader.current()['PORT']).toBe('4000');
+
+      await delay(100);
+      writeFileSync(envPath, 'PORT=4300\n');
+      await waitForCondition(() => updates.includes('4300'));
+      expect(reloader.current()['PORT']).toBe('4300');
+
+      updateSubscription.unsubscribe();
+      errorSubscription.unsubscribe();
+    } finally {
+      reloader.close();
+    }
+  });
+
+  it('stops watch notifications after close', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-watch-close-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      mode: 'dev',
+      processEnv: {},
+      watch: true,
+    });
+
+    const updates: string[] = [];
+    reloader.subscribe((snapshot, reason) => {
+      if (reason !== 'watch') {
+        return;
+      }
+
+      const port = snapshot['PORT'];
+      if (typeof port === 'string') {
+        updates.push(port);
+      }
+    });
+
+    reloader.close();
+
+    writeFileSync(envPath, 'PORT=4400\n');
+    await delay(150);
+
+    expect(updates).toHaveLength(0);
+  });
 });
 
 describe('ConfigService', () => {
@@ -156,5 +305,39 @@ describe('ConfigService', () => {
 
     expect(port).toBe('3000');
     expect(dbUrl).toBe('postgres://localhost');
+  });
+
+  it('returns deep-cloned snapshots', () => {
+    const service = new ConfigService({
+      db: { host: 'localhost' },
+      features: { flags: ['alpha'] },
+    });
+
+    const snapshot = service.snapshot() as {
+      db: { host: string };
+      features: { flags: string[] };
+    };
+
+    snapshot.db.host = 'remote';
+    snapshot.features.flags.push('beta');
+
+    const latest = service.snapshot() as {
+      db: { host: string };
+      features: { flags: string[] };
+    };
+
+    expect(latest.db.host).toBe('localhost');
+    expect(latest.features.flags).toEqual(['alpha']);
+  });
+
+  it('isolates internal state from caller mutations', () => {
+    const source = {
+      db: { host: 'localhost' },
+    };
+
+    const service = new ConfigService(source);
+    source.db.host = 'mutated';
+
+    expect(service.get('db.host')).toBe('localhost');
   });
 });

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -1,11 +1,31 @@
 import { existsSync, readFileSync, watch } from 'node:fs';
+import type { FSWatcher } from 'node:fs';
 import { join } from 'node:path';
 
 import { KonektiError } from '@konekti/core';
 import { parse as dotenvParse } from 'dotenv';
 import { expand as dotenvExpand } from 'dotenv-expand';
 
-import type { ConfigDictionary, ConfigLoadOptions } from './types.js';
+import { cloneConfigDictionary } from './clone.js';
+import type {
+  ConfigDictionary,
+  ConfigLoadOptions,
+  ConfigReloadErrorListener,
+  ConfigReloader,
+  ConfigReloadListener,
+  ConfigReloadReason,
+  ConfigReloadSubscription,
+} from './types.js';
+
+interface NormalizedLoadOptions {
+  envFile: string;
+  defaults: ConfigDictionary;
+  processEnv: NodeJS.ProcessEnv;
+  safeProcessEnv: Record<string, string>;
+  runtimeOverrides: ConfigDictionary;
+  parse?: (content: string) => Record<string, string>;
+  validate?: (raw: ConfigDictionary) => ConfigDictionary;
+}
 
 function parseEnvContent(content: string, processEnv: NodeJS.ProcessEnv, customParser?: (content: string) => Record<string, string>): Record<string, string> {
   if (customParser) {
@@ -25,7 +45,7 @@ function sanitizeProcessEnv(processEnv: NodeJS.ProcessEnv): Record<string, strin
   );
 }
 
-export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
+function normalizeLoadOptions(options: ConfigLoadOptions): NormalizedLoadOptions {
   const cwd = options.cwd ?? process.cwd();
   const envFile = options.envFile ?? join(cwd, `.env.${options.mode}`);
   const defaults = options.defaults ?? {};
@@ -33,45 +53,124 @@ export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
   const safeProcessEnv = sanitizeProcessEnv(processEnv);
   const runtimeOverrides = options.runtimeOverrides ?? {};
 
-  const envFileValues = existsSync(envFile)
-    ? parseEnvContent(readFileSync(envFile, 'utf8'), processEnv, options.parse)
-    : {};
-
-  const merged: ConfigDictionary = {
-    ...defaults,
-    ...envFileValues,
-    ...safeProcessEnv,
-    ...runtimeOverrides,
+  return {
+    defaults,
+    envFile,
+    parse: options.parse,
+    processEnv,
+    runtimeOverrides,
+    safeProcessEnv,
+    validate: options.validate,
   };
+}
 
-  let validated: ConfigDictionary;
+function readEnvFileValues(options: NormalizedLoadOptions): ConfigDictionary {
+  if (!existsSync(options.envFile)) {
+    return {};
+  }
 
+  return parseEnvContent(readFileSync(options.envFile, 'utf8'), options.processEnv, options.parse);
+}
+
+function buildMergedConfig(options: NormalizedLoadOptions): ConfigDictionary {
+  const envFileValues = readEnvFileValues(options);
+
+  return {
+    ...options.defaults,
+    ...envFileValues,
+    ...options.safeProcessEnv,
+    ...options.runtimeOverrides,
+  };
+}
+
+function validateConfig(options: NormalizedLoadOptions, merged: ConfigDictionary): ConfigDictionary {
   try {
-    validated = options.validate ? options.validate(merged) : merged;
+    return options.validate ? options.validate(merged) : merged;
   } catch (error: unknown) {
     throw new KonektiError('Invalid configuration.', {
       code: 'INVALID_CONFIG',
       cause: error,
     });
   }
+}
 
-  if (options.watch && existsSync(envFile)) {
-    watch(envFile, { persistent: false }, () => {
+function resolveConfig(options: NormalizedLoadOptions): ConfigDictionary {
+  return validateConfig(options, buildMergedConfig(options));
+}
+
+function createSubscription<T>(listeners: Set<T>, listener: T): ConfigReloadSubscription {
+  listeners.add(listener);
+
+  return {
+    unsubscribe(): void {
+      listeners.delete(listener);
+    },
+  };
+}
+
+export function createConfigReloader(options: ConfigLoadOptions): ConfigReloader {
+  const normalized = normalizeLoadOptions(options);
+  let current = resolveConfig(normalized);
+  let watcher: FSWatcher | undefined;
+  const listeners = new Set<ConfigReloadListener>();
+  const errorListeners = new Set<ConfigReloadErrorListener>();
+
+  const notifyReload = (snapshot: ConfigDictionary, reason: ConfigReloadReason): void => {
+    const clonedSnapshot = cloneConfigDictionary(snapshot);
+
+    for (const listener of listeners) {
+      listener(clonedSnapshot, reason);
+    }
+  };
+
+  const notifyError = (error: unknown, reason: ConfigReloadReason): void => {
+    for (const listener of errorListeners) {
+      listener(error, reason);
+    }
+  };
+
+  const applyReload = (reason: ConfigReloadReason): ConfigDictionary => {
+    const next = resolveConfig(normalized);
+    current = next;
+    notifyReload(next, reason);
+    return cloneConfigDictionary(next);
+  };
+
+  if (options.watch && existsSync(normalized.envFile)) {
+    watcher = watch(normalized.envFile, { persistent: false }, () => {
       try {
-        const reloaded = parseEnvContent(readFileSync(envFile, 'utf8'), processEnv, options.parse);
-        const mergedReloaded: ConfigDictionary = {
-          ...defaults,
-          ...reloaded,
-          ...safeProcessEnv,
-          ...runtimeOverrides,
-        };
-        const result = options.validate ? options.validate(mergedReloaded) : mergedReloaded;
-        process.emit('CONFIG_RELOADED' as never, result as never);
-      } catch {
-        // silently skip reload errors — watch mode is best-effort
+        applyReload('watch');
+      } catch (error: unknown) {
+        notifyError(error, 'watch');
       }
     });
   }
 
-  return validated;
+  return {
+    close(): void {
+      if (watcher) {
+        watcher.close();
+        watcher = undefined;
+      }
+
+      listeners.clear();
+      errorListeners.clear();
+    },
+    current(): ConfigDictionary {
+      return cloneConfigDictionary(current);
+    },
+    reload(): ConfigDictionary {
+      return applyReload('manual');
+    },
+    subscribe(listener: ConfigReloadListener): ConfigReloadSubscription {
+      return createSubscription(listeners, listener);
+    },
+    subscribeError(listener: ConfigReloadErrorListener): ConfigReloadSubscription {
+      return createSubscription(errorListeners, listener);
+    },
+  };
+}
+
+export function loadConfig(options: ConfigLoadOptions): ConfigDictionary {
+  return cloneConfigDictionary(resolveConfig(normalizeLoadOptions(options)));
 }

--- a/packages/config/src/service.ts
+++ b/packages/config/src/service.ts
@@ -1,5 +1,6 @@
 import { KonektiError } from '@konekti/core';
 
+import { cloneConfigDictionary } from './clone.js';
 import type { ConfigDictionary, DotPaths, DotValue } from './types.js';
 
 function hasOwn(value: unknown, key: string): value is Record<string, unknown> {
@@ -7,7 +8,11 @@ function hasOwn(value: unknown, key: string): value is Record<string, unknown> {
 }
 
 export class ConfigService<T extends Record<string, unknown> = ConfigDictionary> {
-  constructor(private readonly values: T) {}
+  private readonly values: T;
+
+  constructor(values: T) {
+    this.values = cloneConfigDictionary(values);
+  }
 
   get<K extends DotPaths<T>>(key: K): DotValue<T, K & string> {
     const value = this._resolve(key as string);
@@ -24,7 +29,7 @@ export class ConfigService<T extends Record<string, unknown> = ConfigDictionary>
   }
 
   snapshot(): ConfigDictionary {
-    return { ...this.values };
+    return cloneConfigDictionary(this.values);
   }
 
   private _resolve(key: string): unknown {

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -33,8 +33,6 @@ export interface ConfigModuleOptions {
   /** Supply a custom file parser (e.g. for YAML or TOML). Receives raw file content,
    *  returns a flat key-value record. Defaults to dotenv parsing. */
   parse?: (content: string) => Record<string, string>;
-  /** When true, watch the env file for changes and emit CONFIG_RELOADED on the
-   *  internal event bus whenever the file is modified. */
   watch?: boolean;
 }
 
@@ -42,4 +40,22 @@ export interface ConfigLoadOptions extends ConfigModuleOptions {
   cwd?: string;
   processEnv?: NodeJS.ProcessEnv;
   runtimeOverrides?: ConfigDictionary;
+}
+
+export type ConfigReloadReason = 'manual' | 'watch';
+
+export type ConfigReloadListener = (snapshot: ConfigDictionary, reason: ConfigReloadReason) => void;
+
+export type ConfigReloadErrorListener = (error: unknown, reason: ConfigReloadReason) => void;
+
+export interface ConfigReloadSubscription {
+  unsubscribe(): void;
+}
+
+export interface ConfigReloader {
+  current(): ConfigDictionary;
+  reload(): ConfigDictionary;
+  subscribe(listener: ConfigReloadListener): ConfigReloadSubscription;
+  subscribeError(listener: ConfigReloadErrorListener): ConfigReloadSubscription;
+  close(): void;
 }


### PR DESCRIPTION
## Summary
- replace the implicit `process.emit('CONFIG_RELOADED')` side-effect with an explicit `createConfigReloader()` API (`reload`, `subscribe`, `subscribeError`, `close`)
- preserve last valid config snapshot on watch reload failures and expose watch failures through explicit error subscriptions
- enforce deep-cloned snapshot semantics in `ConfigService` and document reload/snapshot behavior in `packages/config/README*.md`

## Verification
- pnpm --filter @konekti/core build
- pnpm vitest run packages/config/src/load.test.ts
- pnpm --filter @konekti/config typecheck
- pnpm --filter @konekti/config build
- pnpm build

Closes #127