### PR TITLE
Resolve #136: formalize Redis facade codec and lifecycle edge handling

### DIFF
--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -3,7 +3,7 @@
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
 
-Konekti를 위한 공유 Redis 연결 레이어입니다. 한 번 등록하고, 어디서든 raw `ioredis` client를 주입받아 사용합니다.
+Konekti를 위한 공유 Redis 연결 레이어입니다. 한 번 등록하고, raw `ioredis` client 또는 선택적 Redis facade를 주입받아 사용합니다.
 
 ## 관련 문서
 
@@ -14,7 +14,7 @@ Konekti를 위한 공유 Redis 연결 레이어입니다. 한 번 등록하고, 
 
 `@konekti/redis`는 Konekti에서 앱 범위 Redis client lifecycle을 담당합니다. singleton `ioredis` client를 만들고, `REDIS_CLIENT` DI 토큰으로 노출하며, 모듈 초기화 시 연결하고, 애플리케이션 종료 시 정리합니다.
 
-이 패키지는 Redis 명령을 다른 추상화 뒤로 숨기지 **않습니다**. 그대로 raw `ioredis` API를 사용합니다.
+또한 `REDIS_SERVICE`로 노출되는 `RedisService`를 제공해 JSON 친화적인 `get`/`set`/`del` 사용을 지원하면서, 필요하면 raw `ioredis` 접근도 그대로 유지합니다.
 
 ## 설치
 
@@ -66,13 +66,22 @@ export class CacheService {
 | `createRedisModule(options)` | `src/module.ts` | global singleton Redis client 모듈 등록 |
 | `createRedisProviders(options)` | `src/module.ts` | 수동 조합을 위한 raw provider 목록 반환 |
 | `REDIS_CLIENT` | `src/tokens.ts` | 공유 raw `ioredis` client용 DI 토큰 |
+| `REDIS_SERVICE` | `src/redis-service.ts` | Redis facade 서비스용 DI 토큰 |
+| `RedisService` | `src/redis-service.ts` | JSON codec 기반 `get`/`set`/`del` facade |
 | `RedisModuleOptions` | `src/types.ts` | `lazyConnect`를 제외한 `ioredis` 옵션 |
+
+## RedisService codec 동작
+
+- `get(key)`는 키가 없으면 `null`을 반환합니다.
+- `get(key)`는 유효한 JSON payload를 파싱해서 반환합니다.
+- `get(key)`는 non-JSON 또는 malformed JSON payload라면 저장된 raw 문자열을 그대로 반환합니다.
+- `set(key, value)`는 항상 `JSON.stringify(value)`로 저장하고, `ttlSeconds > 0`이면 Redis `EX`를 사용합니다.
 
 ## 라이프사이클 동작
 
 - `createRedisModule()`은 항상 `lazyConnect: true`로 client를 생성합니다.
-- `onModuleInit()`은 client가 아직 `wait` 상태이면 `connect()`를 호출해서 Redis가 필수인 경우 bootstrap 단계에서 바로 실패하게 합니다.
-- `onApplicationShutdown()`은 graceful shutdown을 위해 `quit()`을 우선 시도하고, 실패하면 `disconnect()`로 폴백합니다.
+- `onModuleInit()`은 `wait` 상태에서만 `connect()`를 호출하므로, Redis가 필수인 경우 connect 실패를 bootstrap 단계에서 바로 드러냅니다.
+- `onApplicationShutdown()`은 이미 `end`면 종료 작업을 건너뛰고, `quit` 불가능 상태에서는 `disconnect()`를 직접 호출하며, 그 외에는 `quit()` 우선 + 실패 시 `disconnect()` 폴백을 사용합니다.
 
 ## 구조
 
@@ -82,8 +91,8 @@ createRedisModule(options)
   -> connect/quit를 관리하는 lifecycle provider 등록
 
 service/repository 코드
-  -> @Inject([REDIS_CLIENT])
-  -> raw ioredis client
+  -> @Inject([REDIS_CLIENT]) 또는 @Inject([REDIS_SERVICE])
+  -> raw client 또는 facade codec helper
 
 app bootstrap
   -> onModuleInit()

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -3,7 +3,7 @@
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
 
-Shared Redis connection layer for Konekti. Register it once, inject the raw `ioredis` client anywhere.
+Shared Redis connection layer for Konekti. Register it once, inject either the raw `ioredis` client or the optional Redis facade.
 
 ## See also
 
@@ -14,7 +14,7 @@ Shared Redis connection layer for Konekti. Register it once, inject the raw `ior
 
 `@konekti/redis` owns the app-scoped Redis client lifecycle for Konekti. It creates a singleton `ioredis` client, exposes it through the `REDIS_CLIENT` DI token, connects it during module initialization, and closes it during application shutdown.
 
-The package does **not** wrap Redis commands behind another abstraction. You still use the raw `ioredis` client API.
+The package also exposes `RedisService` via `REDIS_SERVICE` for JSON-friendly `get`/`set`/`del` usage while still allowing direct raw `ioredis` access.
 
 ## Installation
 
@@ -66,13 +66,22 @@ export class CacheService {
 | `createRedisModule(options)` | `src/module.ts` | Registers a global singleton Redis client module |
 | `createRedisProviders(options)` | `src/module.ts` | Returns the raw provider list for manual composition |
 | `REDIS_CLIENT` | `src/tokens.ts` | DI token for the shared raw `ioredis` client |
+| `REDIS_SERVICE` | `src/redis-service.ts` | DI token for the Redis facade service |
+| `RedisService` | `src/redis-service.ts` | Facade with JSON codec `get`/`set`/`del` helpers |
 | `RedisModuleOptions` | `src/types.ts` | `ioredis` options without `lazyConnect` |
+
+## RedisService codec behavior
+
+- `get(key)` returns `null` when the key does not exist.
+- `get(key)` returns parsed JSON for valid JSON payloads.
+- `get(key)` returns the raw stored string for non-JSON or malformed JSON payloads.
+- `set(key, value)` always stores `JSON.stringify(value)` and uses Redis `EX` when `ttlSeconds > 0`.
 
 ## Lifecycle behavior
 
 - `createRedisModule()` always creates the client with `lazyConnect: true`.
-- `onModuleInit()` calls `connect()` when the client is still in `wait` state, so bootstrap fails early if Redis is required.
-- `onApplicationShutdown()` prefers `quit()` for graceful shutdown and falls back to `disconnect()` if `quit()` fails.
+- `onModuleInit()` calls `connect()` only in `wait` state, so bootstrap fails early if Redis is required and connect fails.
+- `onApplicationShutdown()` skips work when already `end`, disconnects directly for non-quittable states, and otherwise prefers `quit()` with `disconnect()` fallback.
 
 ## Architecture
 
@@ -82,8 +91,8 @@ createRedisModule(options)
   -> registers lifecycle provider that manages connect/quit
 
 service/repository code
-  -> @Inject([REDIS_CLIENT])
-  -> raw ioredis client
+  -> @Inject([REDIS_CLIENT]) or @Inject([REDIS_SERVICE])
+  -> raw client or facade codec helpers
 
 app bootstrap
   -> onModuleInit()

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -6,12 +6,17 @@ import { bootstrapApplication, defineModule } from '@konekti/runtime';
 interface MockRedisInstance {
   options: Record<string, unknown>;
   status: string;
+  connect(): Promise<void>;
+  disconnect(): void;
+  quit(): Promise<'OK'>;
   get(key: string): Promise<string | null>;
   set(key: string, value: string, ...args: unknown[]): Promise<'OK'>;
   del(key: string): Promise<number>;
 }
 
 const mockRedisState = vi.hoisted(() => ({
+  connectError: undefined as Error | undefined,
+  disconnectLeavesOpen: false,
   events: [] as string[],
   instances: [] as MockRedisInstance[],
   quitError: undefined as Error | undefined,
@@ -30,12 +35,19 @@ vi.mock('ioredis', () => ({
 
     async connect(): Promise<void> {
       mockRedisState.events.push('connect');
+
+      if (mockRedisState.connectError) {
+        throw mockRedisState.connectError;
+      }
+
       this.status = 'ready';
     }
 
     disconnect(): void {
       mockRedisState.events.push('disconnect');
-      this.status = 'end';
+      if (!mockRedisState.disconnectLeavesOpen) {
+        this.status = 'end';
+      }
     }
 
     async quit(): Promise<'OK'> {
@@ -69,9 +81,24 @@ import { createRedisModule, REDIS_CLIENT, REDIS_SERVICE, RedisService } from './
 
 describe('@konekti/redis', () => {
   beforeEach(() => {
+    mockRedisState.connectError = undefined;
+    mockRedisState.disconnectLeavesOpen = false;
     mockRedisState.events.length = 0;
     mockRedisState.instances.length = 0;
     mockRedisState.quitError = undefined;
+  });
+
+  it('fails bootstrap when connect throws and disconnects wait-state client', async () => {
+    mockRedisState.connectError = new Error('connect failed');
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
+    });
+
+    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow('connect failed');
+
+    expect(mockRedisState.events).toEqual(['connect', 'disconnect']);
   });
 
   it('registers a global Redis client, connects on bootstrap, and quits on shutdown', async () => {
@@ -119,6 +146,61 @@ describe('@konekti/redis', () => {
 
     await expect(app.close()).resolves.toBeUndefined();
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
+  });
+
+  it('rethrows quit failures when disconnect does not close the client', async () => {
+    mockRedisState.disconnectLeavesOpen = true;
+    mockRedisState.quitError = new Error('quit failed');
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+
+    await expect(app.close()).rejects.toThrow('quit failed');
+    expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
+  });
+
+  it('disconnects directly on shutdown when client is still waiting', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const instance = mockRedisState.instances[0];
+
+    expect(instance).toBeDefined();
+    if (!instance) {
+      throw new Error('Expected a Redis instance to be created.');
+    }
+
+    instance.status = 'wait';
+
+    await expect(app.close()).resolves.toBeUndefined();
+    expect(mockRedisState.events).toEqual(['connect', 'disconnect']);
+  });
+
+  it('skips shutdown work when client is already closed', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const instance = mockRedisState.instances[0];
+
+    expect(instance).toBeDefined();
+    if (!instance) {
+      throw new Error('Expected a Redis instance to be created.');
+    }
+
+    instance.status = 'end';
+
+    await expect(app.close()).resolves.toBeUndefined();
+    expect(mockRedisState.events).toEqual(['connect']);
   });
 
   it('provides a typed RedisService facade with get/set/del operations', async () => {
@@ -176,6 +258,33 @@ describe('@konekti/redis', () => {
     await rawClient.set('raw:key', 'plain-string');
 
     await expect(cacheFacade.redisService.get<string>('raw:key')).resolves.toBe('plain-string');
+
+    await app.close();
+  });
+
+  it('returns malformed JSON payload as raw string', async () => {
+    @Inject([REDIS_SERVICE])
+    class CacheFacade {
+      constructor(readonly redisService: RedisService) {}
+    }
+
+    class FeatureModule {}
+    defineModule(FeatureModule, {
+      providers: [CacheFacade],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createRedisModule({ host: '127.0.0.1', port: 6379 }), FeatureModule],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const cacheFacade = await app.container.resolve(CacheFacade);
+    const rawClient = cacheFacade.redisService.getRawClient();
+
+    await rawClient.set('malformed:key', '{"id": "u1"');
+
+    await expect(cacheFacade.redisService.get('malformed:key')).resolves.toBe('{"id": "u1"');
 
     await app.close();
   });

--- a/packages/redis/src/redis-service.ts
+++ b/packages/redis/src/redis-service.ts
@@ -5,21 +5,25 @@ import { REDIS_CLIENT } from './tokens.js';
 
 export const REDIS_SERVICE = Symbol.for('konekti.redis.service');
 
+function decodeRedisValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
 @Inject([REDIS_CLIENT])
 export class RedisService {
   constructor(private readonly client: Redis) {}
 
-  async get<T>(key: string): Promise<T | null> {
+  async get<T>(key: string): Promise<T | string | null> {
     const raw = await this.client.get(key);
     if (raw === null) {
       return null;
     }
 
-    try {
-      return JSON.parse(raw) as T;
-    } catch {
-      return raw as T;
-    }
+    return decodeRedisValue(raw) as T | string;
   }
 
   async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {

--- a/packages/redis/src/service.ts
+++ b/packages/redis/src/service.ts
@@ -4,8 +4,23 @@ import type { OnApplicationShutdown, OnModuleInit } from '@konekti/runtime';
 
 import { REDIS_CLIENT } from './tokens.js';
 
+const QUITTABLE_STATUSES = new Set(['connect', 'connecting', 'ready', 'reconnecting']);
+const DISCONNECTABLE_STATUSES = new Set(['close', 'connect', 'connecting', 'ready', 'reconnecting', 'wait']);
+
 function isClosed(status: string): boolean {
   return status === 'end';
+}
+
+function isConnectable(status: string): boolean {
+  return status === 'wait';
+}
+
+function isQuittable(status: string): boolean {
+  return QUITTABLE_STATUSES.has(status);
+}
+
+function isDisconnectable(status: string): boolean {
+  return DISCONNECTABLE_STATUSES.has(status);
 }
 
 @Inject([REDIS_CLIENT])
@@ -13,20 +28,34 @@ export class RedisLifecycleService implements OnModuleInit, OnApplicationShutdow
   constructor(private readonly client: Redis) {}
 
   async onModuleInit(): Promise<void> {
-    if (this.client.status === 'wait') {
-      await this.client.connect();
+    if (!isConnectable(this.client.status)) {
+      return;
     }
+
+    await this.client.connect();
   }
 
   async onApplicationShutdown(): Promise<void> {
-    if (isClosed(this.client.status)) {
+    const status = this.client.status;
+
+    if (isClosed(status)) {
+      return;
+    }
+
+    if (!isQuittable(status)) {
+      if (isDisconnectable(status)) {
+        this.client.disconnect();
+      }
+
       return;
     }
 
     try {
       await this.client.quit();
-    } catch (error) {
-      this.client.disconnect();
+    } catch (error: unknown) {
+      if (isDisconnectable(this.client.status)) {
+        this.client.disconnect();
+      }
 
       if (!isClosed(this.client.status)) {
         throw error;


### PR DESCRIPTION
## Summary
- formalize `RedisService.get()` decode behavior so keys resolve deterministically as `null`, parsed JSON, or raw string fallback for non-JSON/malformed payloads
- make `RedisLifecycleService` state transitions explicit for connect, quit, disconnect, and closed-state shutdown paths
- add regression coverage for bootstrap connect failure, malformed payload fallback, and lifecycle edge paths, and document the contract in `packages/redis/README*.md`

## Verification
- pnpm build
- pnpm vitest run packages/redis/src/module.test.ts
- pnpm --filter @konekti/redis typecheck
- pnpm --filter @konekti/redis build

Closes #136