### PR TITLE
Resolve #163: add createApplicationContext for standalone runtime bootstrap

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -74,6 +74,24 @@ await app.dispatch(req, res);
 await app.close();
 ```
 
+### Standalone application context (no HTTP adapter)
+
+```typescript
+import { KonektiFactory } from '@konekti/runtime';
+
+const context = await KonektiFactory.createApplicationContext(AppModule, {
+  mode: 'prod',
+});
+
+const service = await context.get(UserService);
+
+// ...run CLI task, migration, seed, or worker logic
+
+await context.close();
+```
+
+`createApplicationContext()` bootstraps the module graph and lifecycle hooks without creating the HTTP dispatcher/adapter. Use it for CLI scripts, background workers, migrations, and tests that only need DI.
+
 ### Raw webhook body (opt-in)
 
 ```typescript
@@ -218,6 +236,7 @@ export class AppModule {}
 | `runNodeApplication(rootModule, options)` | `src/node.ts` | Bootstrap + listen + shutdown wiring for Node |
 | `bootstrapNodeApplication(rootModule, options)` | `src/node.ts` | Bootstrap only (no listen) with Node defaults |
 | `bootstrapApplication(options)` | `src/bootstrap.ts` | Generic bootstrap — returns `Application` |
+| `KonektiFactory.createApplicationContext(rootModule, options)` | `src/bootstrap.ts` | Bootstrap DI/lifecycle context without HTTP runtime |
 | `bootstrapModule(module)` | `src/bootstrap.ts` | Lower-level: compile module graph + build container |
 | `defineModule(cls, metadata)` | `src/bootstrap.ts` | Low-level helper to attach module metadata without decorator |
 | `Application` | `src/types.ts` | Interface: `config`, `container`, `dispatcher`, `dispatch()`, `ready()`, `listen()`, `close()` |

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Global, Inject, Module, defineModuleMetadata } from '@konekti/core';
 
-import { bootstrapModule } from './bootstrap.js';
+import { bootstrapModule, KonektiFactory } from './bootstrap.js';
 import { DuplicateProviderError, ModuleInjectionMetadataError } from './errors.js';
+import { HTTP_APPLICATION_ADAPTER } from './tokens.js';
 
 describe('bootstrapModule', () => {
   it('boots a simple module graph deterministically', () => {
@@ -496,5 +497,69 @@ describe('bootstrapModule requiredConstructorParameters fix', () => {
     });
 
     expect(() => bootstrapModule(AppModule)).not.toThrow();
+  });
+});
+
+describe('KonektiFactory.createApplicationContext', () => {
+  it('boots providers without creating the HTTP application adapter', async () => {
+    class AppService {
+      readonly marker = 'ok';
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const context = await KonektiFactory.createApplicationContext(AppModule, {
+      mode: 'test',
+    });
+
+    await expect(context.get(AppService)).resolves.toBeInstanceOf(AppService);
+    await expect(context.get(HTTP_APPLICATION_ADAPTER)).rejects.toThrow('No provider registered');
+
+    await context.close();
+  });
+
+  it('runs startup and shutdown lifecycle hooks around close()', async () => {
+    const events: string[] = [];
+
+    class AppService {
+      onApplicationBootstrap() {
+        events.push('app:bootstrap');
+      }
+
+      onApplicationShutdown(signal?: string) {
+        events.push(`app:shutdown:${signal ?? 'none'}`);
+      }
+
+      onModuleDestroy() {
+        events.push('module:destroy');
+      }
+
+      onModuleInit() {
+        events.push('module:init');
+      }
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const context = await KonektiFactory.createApplicationContext(AppModule, {
+      mode: 'test',
+    });
+
+    expect(events).toEqual(['module:init', 'app:bootstrap']);
+    await context.close('SIGTERM');
+    await context.close('SIGTERM');
+
+    expect(events).toEqual([
+      'module:init',
+      'app:bootstrap',
+      'module:destroy',
+      'app:shutdown:SIGTERM',
+    ]);
   });
 });

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -20,6 +20,7 @@ import { createConsoleApplicationLogger } from './logger.js';
 import { compileModuleGraph, createRuntimeTokenSet, providerToken } from './module-graph.js';
 import { APPLICATION_LOGGER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, RUNTIME_CONTAINER } from './tokens.js';
 import type {
+  ApplicationContext,
   Application,
   ApplicationLogger,
   ApplicationState,
@@ -28,6 +29,7 @@ import type {
   BootstrapResult,
   CompiledModule,
   CreateApplicationOptions,
+  CreateApplicationContextOptions,
   ExceptionFilterHandler,
   ModuleDefinition,
   ModuleType,
@@ -368,6 +370,49 @@ class KonektiApplication implements Application {
   }
 }
 
+class KonektiApplicationContext implements ApplicationContext {
+  private closed = false;
+  private closingPromise: Promise<void> | undefined;
+
+  constructor(
+    readonly config: ConfigService,
+    readonly container: Container,
+    readonly envFile: string,
+    readonly mode: BootstrapApplicationOptions['mode'],
+    readonly modules: CompiledModule[],
+    readonly rootModule: ModuleType,
+    private readonly lifecycleInstances: unknown[],
+  ) {}
+
+  async get<T>(token: Token<T>): Promise<T> {
+    return this.container.resolve(token);
+  }
+
+  async close(signal?: string): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
+    if (this.closingPromise) {
+      await this.closingPromise;
+      return;
+    }
+
+    this.closingPromise = (async () => {
+      await runShutdownHooks(this.lifecycleInstances, signal);
+      await disposeContainer(this.container);
+      this.closed = true;
+    })();
+
+    try {
+      await this.closingPromise;
+    } catch (error) {
+      this.closingPromise = undefined;
+      throw error;
+    }
+  }
+}
+
 /**
  * lifecycle hook이 있는 singleton provider 인스턴스를 미리 해석해 둔다.
  */
@@ -506,6 +551,19 @@ function registerRuntimeBootstrapTokens(bootstrapped: BootstrapResult, adapter: 
       provide: HTTP_APPLICATION_ADAPTER,
       useValue: adapter,
     },
+    {
+      provide: RUNTIME_CONTAINER,
+      useValue: bootstrapped.container,
+    },
+    {
+      provide: COMPILED_MODULES,
+      useValue: bootstrapped.modules,
+    },
+  );
+}
+
+function registerRuntimeApplicationContextTokens(bootstrapped: BootstrapResult): void {
+  bootstrapped.container.register(
     {
       provide: RUNTIME_CONTAINER,
       useValue: bootstrapped.container,
@@ -665,5 +723,67 @@ export class KonektiFactory {
       ...options,
       rootModule,
     });
+  }
+
+  static async createApplicationContext(
+    rootModule: ModuleType,
+    options: CreateApplicationContextOptions = {},
+  ): Promise<ApplicationContext> {
+    const mode = options.mode ?? 'prod';
+    const logger = options.logger ?? createConsoleApplicationLogger();
+    let lifecycleInstances: unknown[] = [];
+    let bootstrappedContainer: Container | undefined;
+
+    try {
+      logger.log('Starting Konekti application context...', 'KonektiFactory');
+      const configValues = loadConfig({
+        ...options,
+        mode,
+      });
+      const config = new ConfigService(configValues);
+      const runtimeProviders = createRuntimeProviders({
+        ...options,
+        mode,
+        rootModule,
+      }, config, logger);
+
+      const bootstrapped = bootstrapModule(rootModule, {
+        duplicateProviderPolicy: options.duplicateProviderPolicy,
+        logger,
+        providers: runtimeProviders,
+        validationTokens: [RUNTIME_CONTAINER, COMPILED_MODULES],
+      });
+      registerRuntimeApplicationContextTokens(bootstrapped);
+
+      bootstrappedContainer = bootstrapped.container;
+      lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
+      await runBootstrapLifecycle(bootstrapped.modules, lifecycleInstances, logger);
+
+      return new KonektiApplicationContext(
+        config,
+        bootstrapped.container,
+        resolveEnvFile({
+          ...options,
+          mode,
+          rootModule,
+        }),
+        mode,
+        bootstrapped.modules,
+        rootModule,
+        lifecycleInstances,
+      );
+    } catch (error: unknown) {
+      logger.error('Failed to bootstrap application context.', error, 'KonektiFactory');
+
+      if (lifecycleInstances.length > 0) {
+        await runShutdownHooks(lifecycleInstances, 'bootstrap-failed');
+      }
+
+      if (bootstrappedContainer) {
+        await disposeContainer(bootstrappedContainer);
+      }
+
+      throw error;
+    }
   }
 }

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -100,6 +100,23 @@ export interface BootstrapApplicationOptions extends ConfigLoadOptions {
 
 export type CreateApplicationOptions = Omit<BootstrapApplicationOptions, 'rootModule'>;
 
+export interface CreateApplicationContextOptions
+  extends Omit<BootstrapApplicationOptions, 'adapter' | 'filters' | 'middleware' | 'mode' | 'observers' | 'rootModule'> {
+  mode?: ConfigMode;
+}
+
+export interface ApplicationContext {
+  readonly config: ConfigService;
+  readonly container: Container;
+  readonly envFile: string;
+  readonly mode: ConfigMode;
+  readonly modules: CompiledModule[];
+  readonly rootModule: ModuleType;
+
+  close(signal?: string): Promise<void>;
+  get<T>(token: Token<T>): Promise<T>;
+}
+
 export interface Application {
   readonly config: ConfigService;
   readonly container: Container;


### PR DESCRIPTION
## Summary
- add `KonektiFactory.createApplicationContext()` to bootstrap module graph + lifecycle without creating HTTP dispatcher/adapter
- add `ApplicationContext` and `CreateApplicationContextOptions` runtime types with `get()` and `close()` for standalone DI use cases
- cover behavior with runtime unit tests and document usage in `packages/runtime/README.md`

## Verification
- `pnpm --filter @konekti/runtime run build`
- `pnpm --filter @konekti/runtime run typecheck`
- `pnpm exec vitest run packages/runtime/src/bootstrap.test.ts`

Closes #163