### PR TITLE
Resolve #166: add header, media-type, and custom versioning

### DIFF
--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -104,14 +104,14 @@ const dispatcher = createDispatcher({ handlerMapping, rootContainer: container, 
 | `@Get(path)` / `@Post(path)` / `@Put(path)` / `@Patch(path)` / `@Delete(path)` | HTTP method route |
 | `@Version(value)` | Applies URI versioning such as `/v1/...`; handler-level version overrides controller-level version |
 
-### URI versioning
+### Versioning strategies
 
-Konekti currently supports URI versioning only.
+`@Version()` on controllers and handlers stays the same. The active strategy is selected by `@konekti/runtime` bootstrap options.
 
 ```typescript
 @Version('1')
 @Controller('/users')
-class UsersV1Controller {
+class UsersController {
   @Get('/')
   listUsers() {
     return [];
@@ -125,9 +125,12 @@ class UsersV1Controller {
 }
 ```
 
-- controller-level `@Version('1')` produces routes such as `/v1/users`
-- handler-level `@Version('2')` overrides the controller version for that specific route
-- unversioned controllers keep their normal paths
+- `VersioningType.URI` (default): `/v1/users`
+- `VersioningType.HEADER`: version from a configured request header such as `X-API-Version: 1`
+- `VersioningType.MEDIA_TYPE`: version extracted from `Accept` using a key such as `v=` (`Accept: application/json;v=1`)
+- `VersioningType.CUSTOM`: user-supplied extractor function
+
+URI behavior remains the default when no runtime `versioning` option is provided.
 
 ### Mapped DTO helpers
 

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { Controller, Get, Version } from './decorators.js';
 import { RouteConflictError } from './errors.js';
 import { createHandlerMapping } from './mapping.js';
+import { VersioningType } from './types.js';
 
 describe('handler mapping', () => {
   it('normalizes paths and extracts path params', () => {
@@ -146,5 +147,147 @@ describe('handler mapping', () => {
       params: { id: '42' },
     });
     expect(unversionedMatch).toBeUndefined();
+  });
+
+  it('resolves versions from configured request headers', () => {
+    @Controller('/users')
+    class UsersController {
+      @Version('1')
+      @Get('/')
+      listV1() {
+        return [{ id: '1' }];
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return [{ id: '2' }];
+      }
+    }
+
+    const mapping = createHandlerMapping(
+      [{ controllerToken: UsersController }],
+      { versioning: { header: 'x-api-version', type: VersioningType.HEADER } },
+    );
+
+    const v1Match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: { 'x-api-version': '1' },
+      method: 'GET',
+      params: {},
+      path: '/users',
+      query: {},
+      raw: {},
+      url: '/users',
+    });
+
+    const v2Match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: { 'X-API-Version': '2' },
+      method: 'GET',
+      params: {},
+      path: '/users',
+      query: {},
+      raw: {},
+      url: '/users',
+    });
+
+    const missingVersionMatch = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/users',
+      query: {},
+      raw: {},
+      url: '/users',
+    });
+
+    expect(v1Match?.descriptor.methodName).toBe('listV1');
+    expect(v2Match?.descriptor.methodName).toBe('listV2');
+    expect(missingVersionMatch).toBeUndefined();
+  });
+
+  it('resolves versions from Accept media type parameters', () => {
+    @Controller('/users')
+    class UsersController {
+      @Version('1')
+      @Get('/')
+      listV1() {
+        return [{ id: '1' }];
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return [{ id: '2' }];
+      }
+    }
+
+    const mapping = createHandlerMapping(
+      [{ controllerToken: UsersController }],
+      { versioning: { key: 'v=', type: VersioningType.MEDIA_TYPE } },
+    );
+
+    const v2Match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: { accept: 'application/json;v=2' },
+      method: 'GET',
+      params: {},
+      path: '/users',
+      query: {},
+      raw: {},
+      url: '/users',
+    });
+
+    expect(v2Match?.descriptor.methodName).toBe('listV2');
+  });
+
+  it('resolves versions from custom extractor functions', () => {
+    @Controller('/users')
+    class UsersController {
+      @Version('1')
+      @Get('/')
+      listV1() {
+        return [{ id: '1' }];
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return [{ id: '2' }];
+      }
+    }
+
+    const mapping = createHandlerMapping(
+      [{ controllerToken: UsersController }],
+      {
+        versioning: {
+          extractor: (request) => {
+            const raw = request.headers['x-custom-version'];
+            return Array.isArray(raw) ? raw[0] : raw;
+          },
+          type: VersioningType.CUSTOM,
+        },
+      },
+    );
+
+    const v1Match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: { 'x-custom-version': '1' },
+      method: 'GET',
+      params: {},
+      path: '/users',
+      query: {},
+      raw: {},
+      url: '/users',
+    });
+
+    expect(v1Match?.descriptor.methodName).toBe('listV1');
   });
 });

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -2,6 +2,7 @@ import { getControllerMetadata, getRouteMetadata, type Constructor, type Metadat
 
 import { getRouteProducesMetadata } from './decorators.js';
 import { RouteConflictError } from './errors.js';
+import { VersioningType } from './types.js';
 import type {
   FrameworkRequest,
   GuardLike,
@@ -11,7 +12,18 @@ import type {
   HandlerSource,
   InterceptorLike,
   HttpMethod,
+  VersioningExtractor,
+  VersioningOptions,
 } from './types.js';
+
+interface ResolvedVersioning {
+  extractor: VersioningExtractor;
+  type: VersioningType;
+}
+
+interface CreateHandlerMappingOptions {
+  versioning?: VersioningOptions;
+}
 
 function normalizePath(path: string): string {
   const segments = path.split('/').filter(Boolean);
@@ -36,6 +48,136 @@ function applyVersionPrefix(path: string, version: string | undefined): string {
   }
 
   return joinPaths(`/${normalizeVersionSegment(version)}`, path);
+}
+
+function normalizeVersionValue(version: string): string {
+  return version.trim().replace(/^v/i, '');
+}
+
+function readHeaderValue(request: FrameworkRequest, headerName: string): string | undefined {
+  const normalizedHeaderName = headerName.trim().toLowerCase();
+
+  if (!normalizedHeaderName) {
+    return undefined;
+  }
+
+  for (const [key, raw] of Object.entries(request.headers)) {
+    if (key.toLowerCase() !== normalizedHeaderName) {
+      continue;
+    }
+
+    const values = Array.isArray(raw) ? raw : [raw];
+
+    for (const value of values) {
+      const normalized = value?.trim();
+
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractVersionFromMediaType(request: FrameworkRequest, key: string): string | undefined {
+  const accept = readHeaderValue(request, 'accept');
+
+  if (!accept) {
+    return undefined;
+  }
+
+  const escapedKey = escapeRegExp(key);
+  const matcher = new RegExp(`${escapedKey}([^;,+\\s]+)`, 'i');
+  const mediaTypes = accept.split(',').map((value) => value.trim()).filter(Boolean);
+
+  for (const mediaType of mediaTypes) {
+    const match = mediaType.match(matcher);
+    const extracted = match?.[1]?.trim();
+
+    if (extracted) {
+      return extracted;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveVersioning(options: CreateHandlerMappingOptions | undefined): ResolvedVersioning {
+  const versioning = options?.versioning;
+
+  if (!versioning || versioning.type === undefined || versioning.type === VersioningType.URI) {
+    return {
+      extractor: () => undefined,
+      type: VersioningType.URI,
+    };
+  }
+
+  if (versioning.type === VersioningType.HEADER) {
+    return {
+      extractor: (request) => readHeaderValue(request, versioning.header),
+      type: VersioningType.HEADER,
+    };
+  }
+
+  if (versioning.type === VersioningType.MEDIA_TYPE) {
+    return {
+      extractor: (request) => extractVersionFromMediaType(request, versioning.key ?? 'v='),
+      type: VersioningType.MEDIA_TYPE,
+    };
+  }
+
+  if (versioning.type === VersioningType.CUSTOM) {
+    return {
+      extractor: versioning.extractor,
+      type: VersioningType.CUSTOM,
+    };
+  }
+
+  return {
+    extractor: () => undefined,
+    type: VersioningType.URI,
+  };
+}
+
+function resolveRequestVersion(request: FrameworkRequest, versioning: ResolvedVersioning): string | undefined {
+  const raw = versioning.extractor(request);
+  const values = Array.isArray(raw) ? raw : [raw];
+
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      continue;
+    }
+
+    const normalized = normalizeVersionValue(value);
+
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return undefined;
+}
+
+function matchesRouteVersion(
+  descriptor: HandlerDescriptor,
+  requestVersion: string | undefined,
+): boolean {
+  const routeVersion = descriptor.route.version;
+
+  if (!routeVersion) {
+    return requestVersion === undefined;
+  }
+
+  if (!requestVersion) {
+    return false;
+  }
+
+  return normalizeVersionValue(routeVersion) === requestVersion;
 }
 
 function getControllerMethodNames(controllerToken: Constructor): MetadataPropertyKey[] {
@@ -76,7 +218,7 @@ function matchPath(registeredPath: string, incomingPath: string): Readonly<Recor
   return params;
 }
 
-function createHandlerDescriptors(source: HandlerSource): HandlerDescriptor[] {
+function createHandlerDescriptors(source: HandlerSource, versioning: ResolvedVersioning): HandlerDescriptor[] {
   const controllerMetadata = getControllerMetadata(source.controllerToken) ?? { basePath: '' };
   const descriptors: HandlerDescriptor[] = [];
 
@@ -88,7 +230,8 @@ function createHandlerDescriptors(source: HandlerSource): HandlerDescriptor[] {
     }
 
     const effectiveVersion = routeMetadata.version ?? controllerMetadata.version;
-    const effectivePath = applyVersionPrefix(joinPaths(controllerMetadata.basePath, routeMetadata.path), effectiveVersion);
+    const routePath = joinPaths(controllerMetadata.basePath, routeMetadata.path);
+    const effectivePath = versioning.type === VersioningType.URI ? applyVersionPrefix(routePath, effectiveVersion) : routePath;
     const produces = getRouteProducesMetadata(source.controllerToken, propertyKey);
 
     descriptors.push({
@@ -122,12 +265,12 @@ function createHandlerDescriptors(source: HandlerSource): HandlerDescriptor[] {
   return descriptors;
 }
 
-function buildDescriptorList(sources: HandlerSource[]): HandlerDescriptor[] {
-  const descriptors = sources.flatMap((source) => createHandlerDescriptors(source));
+function buildDescriptorList(sources: HandlerSource[], versioning: ResolvedVersioning): HandlerDescriptor[] {
+  const descriptors = sources.flatMap((source) => createHandlerDescriptors(source, versioning));
   const seen = new Set<string>();
 
   for (const descriptor of descriptors) {
-    const routeKey = `${descriptor.route.method}:${descriptor.route.path}`;
+    const routeKey = `${descriptor.route.method}:${descriptor.route.path}:${descriptor.route.version ?? '<none>'}`;
 
     if (seen.has(routeKey)) {
       throw new RouteConflictError(`Duplicate route registration detected for ${routeKey}.`);
@@ -139,13 +282,16 @@ function buildDescriptorList(sources: HandlerSource[]): HandlerDescriptor[] {
   return descriptors;
 }
 
-export function createHandlerMapping(sources: HandlerSource[]): HandlerMapping {
-  const descriptors = buildDescriptorList(sources);
+export function createHandlerMapping(sources: HandlerSource[], options?: CreateHandlerMappingOptions): HandlerMapping {
+  const versioning = resolveVersioning(options);
+  const descriptors = buildDescriptorList(sources, versioning);
 
   return {
     descriptors,
     match(request: FrameworkRequest): HandlerMatch | undefined {
       const method = request.method.toUpperCase() as HttpMethod;
+      const requestVersion = versioning.type === VersioningType.URI ? undefined : resolveRequestVersion(request, versioning);
+      const matchedDescriptors: Array<{ descriptor: HandlerDescriptor; params: Readonly<Record<string, string>> }> = [];
 
       for (const descriptor of descriptors) {
         if (descriptor.route.method !== method) {
@@ -158,10 +304,38 @@ export function createHandlerMapping(sources: HandlerSource[]): HandlerMapping {
           continue;
         }
 
-        return {
-          descriptor,
-          params,
-        };
+        matchedDescriptors.push({ descriptor, params });
+
+        if (versioning.type === VersioningType.URI) {
+          return {
+            descriptor,
+            params,
+          };
+        }
+      }
+
+      if (versioning.type !== VersioningType.URI) {
+        for (const match of matchedDescriptors) {
+          if (!matchesRouteVersion(match.descriptor, requestVersion)) {
+            continue;
+          }
+
+          return {
+            descriptor: match.descriptor,
+            params: match.params,
+          };
+        }
+
+        for (const match of matchedDescriptors) {
+          if (match.descriptor.route.version !== undefined) {
+            continue;
+          }
+
+          return {
+            descriptor: match.descriptor,
+            params: match.params,
+          };
+        }
       }
 
       return undefined;

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -4,6 +4,13 @@ export type { ValidationIssue, Validator } from '@konekti/dto-validator';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
 
+export enum VersioningType {
+  URI = 'URI',
+  HEADER = 'HEADER',
+  MEDIA_TYPE = 'MEDIA_TYPE',
+  CUSTOM = 'CUSTOM',
+}
+
 export interface FrameworkRequest {
   method: HttpMethod | string;
   path: string;
@@ -112,6 +119,26 @@ export interface HandlerSource {
   moduleMiddleware?: MiddlewareLike[];
   moduleType?: Constructor;
 }
+
+export type VersioningExtractorResult = string | readonly string[] | undefined;
+export type VersioningExtractor = (request: FrameworkRequest) => VersioningExtractorResult;
+
+export type VersioningOptions =
+  | {
+      type?: VersioningType.URI;
+    }
+  | {
+      type: VersioningType.HEADER;
+      header: string;
+    }
+  | {
+      type: VersioningType.MEDIA_TYPE;
+      key?: string;
+    }
+  | {
+      type: VersioningType.CUSTOM;
+      extractor: VersioningExtractor;
+    };
 
 export interface Dispatcher {
   dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void>;

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -191,10 +191,10 @@ await bootstrapApplication({
 
 `duplicateProviderPolicy` controls what happens when multiple modules register the same provider token during bootstrap. Use `'warn'` to log and continue, `'throw'` to fail fast with `DuplicateProviderError`, or `'ignore'` to preserve the existing last-registration-wins behavior.
 
-### URI versioning
+### Versioning strategies
 
 ```typescript
-import { Controller, Get, Version } from '@konekti/http';
+import { Controller, Get, Version, VersioningType } from '@konekti/http';
 
 @Version('1')
 @Controller('/users')
@@ -204,9 +204,24 @@ class UsersController {
     return [];
   }
 }
+
+await runNodeApplication(AppModule, {
+  mode: 'prod',
+  versioning: {
+    header: 'X-API-Version',
+    type: VersioningType.HEADER,
+  },
+});
 ```
 
-Konekti currently supports URI versioning only. `@Version('1')` turns `/users` into `/v1/users`, and handler-level versions override controller-level versions for specific routes.
+Runtime supports four versioning strategies:
+
+- `VersioningType.URI` (default): `/v1/users`
+- `VersioningType.HEADER`: read from a configured header
+- `VersioningType.MEDIA_TYPE`: parse `Accept` using a key such as `v=`
+- `VersioningType.CUSTOM`: use a custom extractor function
+
+`@Version()` decorator usage does not change across strategies. If `versioning` is omitted, URI versioning remains the default (no breaking change).
 
 ### Module with imports and exports
 

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -12,6 +12,8 @@ import {
   FromCookie,
   Get,
   Post,
+  Version,
+  VersioningType,
   SseResponse,
   createSecurityHeadersMiddleware,
   type RequestContext,
@@ -751,6 +753,190 @@ describe('bootstrapApplication', () => {
         status: 413,
       },
     });
+
+    await app.close();
+  });
+
+  it('defaults to URI versioning when no versioning option is provided', async () => {
+    @Version('1')
+    @Controller('/users')
+    class UsersController {
+      @Get('/')
+      listUsers() {
+        return { version: 'v1' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UsersController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port,
+    });
+
+    await app.listen();
+
+    const [versioned, unversioned] = await Promise.all([
+      fetch(`http://127.0.0.1:${String(port)}/v1/users`),
+      fetch(`http://127.0.0.1:${String(port)}/users`),
+    ]);
+
+    expect(versioned.status).toBe(200);
+    await expect(versioned.json()).resolves.toEqual({ version: 'v1' });
+    expect(unversioned.status).toBe(404);
+
+    await app.close();
+  });
+
+  it('supports header-based versioning in bootstrap options', async () => {
+    @Controller('/users')
+    class UsersController {
+      @Version('1')
+      @Get('/')
+      listV1() {
+        return { version: 'v1' };
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return { version: 'v2' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UsersController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port,
+      versioning: {
+        header: 'X-API-Version',
+        type: VersioningType.HEADER,
+      },
+    });
+
+    await app.listen();
+
+    const [v1, v2, missing] = await Promise.all([
+      fetch(`http://127.0.0.1:${String(port)}/users`, {
+        headers: { 'x-api-version': '1' },
+      }),
+      fetch(`http://127.0.0.1:${String(port)}/users`, {
+        headers: { 'X-API-Version': '2' },
+      }),
+      fetch(`http://127.0.0.1:${String(port)}/users`),
+    ]);
+
+    expect(v1.status).toBe(200);
+    await expect(v1.json()).resolves.toEqual({ version: 'v1' });
+    expect(v2.status).toBe(200);
+    await expect(v2.json()).resolves.toEqual({ version: 'v2' });
+    expect(missing.status).toBe(404);
+
+    await app.close();
+  });
+
+  it('supports media-type versioning in bootstrap options', async () => {
+    @Controller('/users')
+    class UsersController {
+      @Version('1')
+      @Get('/')
+      listV1() {
+        return { version: 'v1' };
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return { version: 'v2' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UsersController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port,
+      versioning: {
+        key: 'v=',
+        type: VersioningType.MEDIA_TYPE,
+      },
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/users`, {
+      headers: {
+        accept: 'application/json;v=2',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ version: 'v2' });
+
+    await app.close();
+  });
+
+  it('supports custom version extractors in bootstrap options', async () => {
+    @Controller('/users')
+    class UsersController {
+      @Version('1')
+      @Get('/')
+      listV1() {
+        return { version: 'v1' };
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return { version: 'v2' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UsersController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port,
+      versioning: {
+        extractor: (request) => {
+          const raw = request.headers['x-custom-version'];
+          return Array.isArray(raw) ? raw[0] : raw;
+        },
+        type: VersioningType.CUSTOM,
+      },
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/users`, {
+      headers: {
+        'x-custom-version': '2',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ version: 'v2' });
 
     await app.close();
   });

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -646,7 +646,9 @@ function createRuntimeDispatcher(
   options: BootstrapApplicationOptions,
   logger: ApplicationLogger,
 ): Dispatcher {
-  const handlerMapping = createHandlerMapping(createHandlerSources(bootstrapped.modules));
+  const handlerMapping = createHandlerMapping(createHandlerSources(bootstrapped.modules), {
+    versioning: options.versioning,
+  });
   logRouteMappings(logger, handlerMapping.descriptors);
 
   const errorHandler = createFilterErrorHandler(options.filters);

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,7 +1,15 @@
 import type { ConfigLoadOptions, ConfigMode, ConfigService } from '@konekti/config';
 import type { Constructor, MaybePromise, Token } from '@konekti/core';
 import type { Container, Provider } from '@konekti/di';
-import type { Dispatcher, FrameworkRequest, FrameworkResponse, HttpApplicationAdapter, MiddlewareLike, RequestObserverLike } from '@konekti/http';
+import type {
+  Dispatcher,
+  FrameworkRequest,
+  FrameworkResponse,
+  HttpApplicationAdapter,
+  MiddlewareLike,
+  RequestObserverLike,
+  VersioningOptions,
+} from '@konekti/http';
 
 export type ModuleType = Constructor & { definition?: ModuleDefinition };
 export type ControllerType = Constructor;
@@ -96,6 +104,7 @@ export interface BootstrapApplicationOptions extends ConfigLoadOptions {
   observers?: RequestObserverLike[];
   providers?: Provider[];
   rootModule: ModuleType;
+  versioning?: VersioningOptions;
 }
 
 export type CreateApplicationOptions = Omit<BootstrapApplicationOptions, 'rootModule'>;


### PR DESCRIPTION
## Summary
- add `VersioningType` and `versioning` options so `@Version()` works with `URI` (default), `HEADER`, `MEDIA_TYPE`, and `CUSTOM` extraction strategies
- update HTTP route mapping to resolve request versions by strategy while preserving existing URI path behavior when no option is provided
- add integration coverage for default URI + new header/media/custom strategies and document both package surfaces

Closes #166

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm exec vitest run packages/http/src/mapping.test.ts packages/runtime/src/application.test.ts`