### PR TITLE
Resolve #167: add schema validation adapters for zod and valibot

### DIFF
--- a/packages/dto-validator/README.ko.md
+++ b/packages/dto-validator/README.ko.md
@@ -5,7 +5,7 @@
 
 데코레이터 기반 TypeScript DTO 검증. 클래스 필드에 검증 규칙을 선언적으로 적고 구조화된 타입 에러를 얻습니다 — 별도 스키마 파일도, 수동 검사도 없습니다.
 
-현재 공개 계약은 decorator-first입니다. schema-object validation과 더 풍부한 validation-adapter 계약은 현재 지원되는 public surface에 포함되지 않습니다.
+이제 Zod, Valibot, 커스텀 스키마 엔진을 같은 `DtoValidationError` 이슈 형태로 연결하는 schema validation 확장 surface도 제공합니다.
 
 ## 관련 문서
 
@@ -92,6 +92,47 @@ interface Validator {
 ```
 
 커스텀 검증 전략을 제공하려면 이 인터페이스를 구현하면 됩니다.
+
+### 스키마 어댑터 (`@konekti/dto-validator/schema`)
+
+`emitDecoratorMetadata` 없이 스키마 기반 검증을 사용하면서 동일한 `DtoValidationError` 계약을 유지할 수 있습니다.
+
+```typescript
+import { z } from 'zod';
+import { object, pipe, safeParse, string, email } from 'valibot';
+import {
+  createSchemaValidator,
+  createValibotSchemaValidator,
+  createZodSchemaValidator,
+  type SchemaValidator,
+} from '@konekti/dto-validator/schema';
+
+const zodValidator = createZodSchemaValidator(
+  z.object({
+    email: z.string().email(),
+  }),
+);
+
+const valibotValidator = createValibotSchemaValidator(
+  object({
+    email: pipe(string(), email()),
+  }),
+  safeParse,
+);
+
+const customValidator: SchemaValidator<{ name: string }> = createSchemaValidator({
+  parse(value) {
+    if (typeof (value as { name?: unknown }).name === 'string') {
+      return { success: true, value: { name: (value as { name: string }).name } };
+    }
+
+    return {
+      success: false,
+      issues: [{ code: 'REQUIRED', field: 'name', message: 'name is required' }],
+    };
+  },
+});
+```
 
 ---
 

--- a/packages/dto-validator/README.md
+++ b/packages/dto-validator/README.md
@@ -5,7 +5,7 @@
 
 Decorator-based DTO validation for TypeScript. Declare validation rules directly on class fields and get structured, typed errors — no schema files, no manual checks.
 
-The current public contract is decorator-first. Schema-object validation and richer validation-adapter contracts are not part of the supported public surface today.
+The package now also includes a schema validation extension surface so Zod, Valibot, or custom schema engines can map into the same `DtoValidationError` issue shape.
 
 ## See also
 
@@ -92,6 +92,46 @@ interface Validator {
 ```
 
 Implement this interface to supply a custom validation strategy.
+
+### Schema adapters (`@konekti/dto-validator/schema`)
+
+Use schema-based validation without `emitDecoratorMetadata` while keeping the same `DtoValidationError` contract.
+
+```typescript
+import { z } from 'zod';
+import { object, pipe, safeParse, string, email } from 'valibot';
+import {
+  createSchemaValidator,
+  createValibotSchemaValidator,
+  createZodSchemaValidator,
+  type SchemaValidator,
+} from '@konekti/dto-validator/schema';
+
+const zodSchema = z.object({
+  email: z.string().email(),
+});
+
+const zodValidator = createZodSchemaValidator(zodSchema);
+
+const valibotSchema = object({
+  email: pipe(string(), email()),
+});
+
+const valibotValidator = createValibotSchemaValidator(valibotSchema, safeParse);
+
+const customValidator: SchemaValidator<{ name: string }> = createSchemaValidator({
+  parse(value) {
+    if (typeof (value as { name?: unknown }).name === 'string') {
+      return { success: true, value: { name: (value as { name: string }).name } };
+    }
+
+    return {
+      success: false,
+      issues: [{ code: 'REQUIRED', field: 'name', message: 'name is required' }],
+    };
+  },
+});
+```
 
 ---
 

--- a/packages/dto-validator/package.json
+++ b/packages/dto-validator/package.json
@@ -19,6 +19,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./schema": {
+      "types": "./dist/schema.d.ts",
+      "import": "./dist/schema.js"
     }
   },
   "main": "./dist/index.js",
@@ -35,7 +39,21 @@
     "@konekti/core": "workspace:*",
     "validator": "^13.15.26"
   },
+  "peerDependencies": {
+    "valibot": "^0.42.1",
+    "zod": "^3.23.8 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "valibot": {
+      "optional": true
+    },
+    "zod": {
+      "optional": true
+    }
+  },
   "devDependencies": {
-    "@types/validator": "^13.15.10"
+    "@types/validator": "^13.15.10",
+    "valibot": "^0.42.1",
+    "zod": "^4.1.11"
   }
 }

--- a/packages/dto-validator/src/index.ts
+++ b/packages/dto-validator/src/index.ts
@@ -1,4 +1,5 @@
 export * from './decorators.js';
 export * from './errors.js';
+export * from './schema.js';
 export * from './types.js';
 export * from './validation.js';

--- a/packages/dto-validator/src/schema.test.ts
+++ b/packages/dto-validator/src/schema.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { email, minLength, object, pipe, safeParse, string } from 'valibot';
+import { z } from 'zod';
+
+import { DtoValidationError } from './errors.js';
+import { createSchemaValidator, createValibotSchemaValidator, createZodSchemaValidator } from './schema.js';
+
+describe('schema validators', () => {
+  it('maps zod failures to DtoValidationError issues', async () => {
+    const schema = z.object({
+      email: z.string().email(),
+      tags: z.array(z.string().min(2)),
+    });
+
+    const validator = createZodSchemaValidator(schema);
+
+    await expect(
+      validator.transform({
+        email: 'invalid',
+        tags: ['ok', 'x'],
+      }),
+    ).rejects.toMatchObject({
+      issues: [
+        { code: 'INVALID_FORMAT', field: 'email' },
+        { code: 'TOO_SMALL', field: 'tags[1]' },
+      ],
+    });
+  });
+
+  it('maps valibot failures to DtoValidationError issues', async () => {
+    const schema = object({
+      email: pipe(string(), email()),
+      name: pipe(string(), minLength(2)),
+    });
+
+    const validator = createValibotSchemaValidator(schema, safeParse);
+
+    await expect(
+      validator.validate({
+        email: 'invalid',
+        name: 'x',
+      }),
+    ).rejects.toMatchObject({
+      issues: [
+        expect.objectContaining({ field: 'email', message: expect.stringContaining('Invalid email') }),
+        expect.objectContaining({ field: 'name', message: 'Invalid length: Expected >=2 but received 1' }),
+      ],
+    });
+  });
+
+  it('supports custom schema adapters via createSchemaValidator', async () => {
+    const validator = createSchemaValidator<{ name: string }>({
+      parse(value) {
+        const input = value as { name?: string };
+
+        if (typeof input?.name === 'string' && input.name.length > 0) {
+          return { success: true, value: { name: input.name } };
+        }
+
+        return {
+          success: false,
+          issues: [
+            {
+              code: 'REQUIRED',
+              field: 'name',
+              message: 'name is required',
+            },
+          ],
+        };
+      },
+    });
+
+    await expect(validator.transform({ name: 'jane' })).resolves.toEqual({ name: 'jane' });
+    await expect(validator.validate({})).rejects.toBeInstanceOf(DtoValidationError);
+  });
+});

--- a/packages/dto-validator/src/schema.ts
+++ b/packages/dto-validator/src/schema.ts
@@ -1,0 +1,210 @@
+import type { MaybePromise } from '@konekti/core';
+
+import { DtoValidationError } from './errors.js';
+import type { ValidationIssue } from './types.js';
+
+export type SchemaValidationResult<T> =
+  | { success: true; value: T }
+  | { success: false; issues: readonly ValidationIssue[] };
+
+export interface SchemaValidationAdapter<T> {
+  parse(value: unknown): MaybePromise<SchemaValidationResult<T>>;
+}
+
+export interface SchemaValidator<T> {
+  validate(value: unknown): MaybePromise<void>;
+  transform(value: unknown): MaybePromise<T>;
+}
+
+interface ZodIssueLike {
+  readonly code: string;
+  readonly message: string;
+  readonly path?: readonly PropertyKey[];
+}
+
+interface ZodSafeParseFailureLike {
+  readonly success: false;
+  readonly error: {
+    readonly issues: readonly ZodIssueLike[];
+  };
+}
+
+interface ZodSafeParseSuccessLike<T> {
+  readonly success: true;
+  readonly data: T;
+}
+
+interface ZodSchemaLike<T> {
+  safeParse(value: unknown): ZodSafeParseSuccessLike<T> | ZodSafeParseFailureLike;
+}
+
+type ValibotPathLike =
+  | string
+  | number
+  | {
+      readonly key?: string | number;
+    };
+
+interface ValibotIssueLike {
+  readonly message: string;
+  readonly path?: readonly ValibotPathLike[];
+  readonly kind?: string;
+  readonly type?: string;
+}
+
+interface ValibotSafeParseFailureLike {
+  readonly success: false;
+  readonly issues: readonly ValibotIssueLike[];
+}
+
+interface ValibotSafeParseSuccessLike<T> {
+  readonly success: true;
+  readonly output: T;
+}
+
+function toFieldPath(path: readonly PropertyKey[] | undefined): string | undefined {
+  if (!path || path.length === 0) {
+    return undefined;
+  }
+
+  let result = '';
+
+  for (const segment of path) {
+    if (typeof segment === 'symbol') {
+      continue;
+    }
+
+    if (typeof segment === 'number') {
+      result += `[${String(segment)}]`;
+      continue;
+    }
+
+    result += result.length === 0 ? segment : `.${segment}`;
+  }
+
+  return result;
+}
+
+function normalizeCode(code: string | undefined, fallback: string): string {
+  if (!code || code.length === 0) {
+    return fallback;
+  }
+
+  return code.replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '').toUpperCase() || fallback;
+}
+
+function toValidationError(issues: readonly ValidationIssue[]): never {
+  throw new DtoValidationError('Validation failed.', issues);
+}
+
+function toValibotPath(path: readonly ValibotPathLike[] | undefined): readonly PropertyKey[] | undefined {
+  if (!path || path.length === 0) {
+    return undefined;
+  }
+
+  const segments: PropertyKey[] = [];
+
+  for (const segment of path) {
+    if (typeof segment === 'string' || typeof segment === 'number') {
+      segments.push(segment);
+      continue;
+    }
+
+    if (segment && (typeof segment.key === 'string' || typeof segment.key === 'number')) {
+      segments.push(segment.key);
+    }
+  }
+
+  return segments.length > 0 ? segments : undefined;
+}
+
+function toValibotIssue(issue: unknown): ValibotIssueLike {
+  const candidate = issue as {
+    kind?: unknown;
+    message?: unknown;
+    path?: unknown;
+    type?: unknown;
+  };
+
+  return {
+    kind: typeof candidate.kind === 'string' ? candidate.kind : undefined,
+    message: typeof candidate.message === 'string' ? candidate.message : 'Invalid value.',
+    path: Array.isArray(candidate.path) ? (candidate.path as readonly ValibotPathLike[]) : undefined,
+    type: typeof candidate.type === 'string' ? candidate.type : undefined,
+  };
+}
+
+export function createSchemaValidator<T>(adapter: SchemaValidationAdapter<T>): SchemaValidator<T> {
+  return {
+    async validate(value: unknown): Promise<void> {
+      const result = await adapter.parse(value);
+
+      if (!result.success) {
+        toValidationError(result.issues);
+      }
+    },
+
+    async transform(value: unknown): Promise<T> {
+      const result = await adapter.parse(value);
+
+      if (!result.success) {
+        toValidationError(result.issues);
+      }
+
+      return result.value;
+    },
+  };
+}
+
+export function createZodSchemaValidator<T>(schema: ZodSchemaLike<T>): SchemaValidator<T> {
+  return createSchemaValidator<T>({
+    parse(value: unknown): SchemaValidationResult<T> {
+      const result = schema.safeParse(value);
+
+      if (result.success) {
+        return { success: true, value: result.data };
+      }
+
+      return {
+        success: false,
+        issues: result.error.issues.map((issue) => ({
+          code: normalizeCode(issue.code, 'INVALID_FIELD'),
+          field: toFieldPath(issue.path),
+          message: issue.message,
+        })),
+      };
+    },
+  });
+}
+
+export function createValibotSchemaValidator<T, TSchema>(
+  schema: TSchema,
+  safeParse: (schema: TSchema, value: unknown) => {
+    readonly success: boolean;
+    readonly output?: unknown;
+    readonly issues?: readonly unknown[];
+  },
+): SchemaValidator<T> {
+  return createSchemaValidator<T>({
+    parse(value: unknown): SchemaValidationResult<T> {
+      const result = safeParse(schema, value);
+
+      if (result.success) {
+        return { success: true, value: result.output as T };
+      }
+
+      return {
+        success: false,
+        issues: (result.issues ?? []).map((rawIssue) => {
+          const issue = toValibotIssue(rawIssue);
+
+          return {
+          code: normalizeCode(issue.kind ?? issue.type, 'INVALID_FIELD'),
+          field: toFieldPath(toValibotPath(issue.path)),
+          message: issue.message,
+          };
+        }),
+      };
+    },
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,12 @@ importers:
       '@types/validator':
         specifier: ^13.15.10
         version: 13.15.10
+      valibot:
+        specifier: ^0.42.1
+        version: 0.42.1(typescript@5.9.3)
+      zod:
+        specifier: ^4.1.11
+        version: 4.3.6
 
   packages/event-bus:
     dependencies:
@@ -223,9 +229,6 @@ importers:
       '@konekti/http':
         specifier: workspace:*
         version: link:../http
-      '@konekti/jwt':
-        specifier: workspace:*
-        version: link:../jwt
 
   packages/prisma:
     dependencies:
@@ -1736,6 +1739,14 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
+  valibot@0.42.1:
+    resolution: {integrity: sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validator@13.15.26:
     resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
     engines: {node: '>= 0.10'}
@@ -1835,6 +1846,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -3067,6 +3081,10 @@ snapshots:
 
   uuid@11.1.0: {}
 
+  valibot@0.42.1(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   validator@13.15.26: {}
 
   vite-node@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
@@ -3154,3 +3172,5 @@ snapshots:
   ws@8.19.0: {}
 
   yallist@3.1.1: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary
- Add a schema-validation extension surface in `@konekti/dto-validator/schema` with `SchemaValidator<T>` and `createSchemaValidator`.
- Implement first-party adapters for Zod and Valibot that map parse failures to the standard `DtoValidationError` issue shape (`code`, `field`, `message`, `source`).
- Export the new schema module (root + subpath), add adapter tests, and document schema-based usage in both English/Korean README files.

## Verification
- `pnpm vitest run packages/dto-validator/src/schema.test.ts packages/dto-validator/src/validation.test.ts`
- `pnpm --filter @konekti/dto-validator run typecheck`
- `pnpm --filter @konekti/dto-validator run build`

Closes #167