### PR TITLE
feat(throttler): @konekti/throttler — rate limiting with in-memory and Redis store

### DIFF
--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -1,0 +1,108 @@
+# @konekti/throttler
+
+<p><strong><kbd>English</kbd></strong></p>
+
+Decorator-based rate limiting for Konekti applications with in-memory and Redis store adapters.
+
+## Installation
+
+```bash
+npm install @konekti/throttler
+```
+
+## Quick Start
+
+```typescript
+import { Module } from '@konekti/core';
+import { createThrottlerModule, Throttle, SkipThrottle } from '@konekti/throttler';
+import { Controller, Get, Post } from '@konekti/http';
+
+@Module({
+  imports: [
+    createThrottlerModule({
+      ttl: 60,
+      limit: 100,
+    }),
+  ],
+})
+class AppModule {}
+
+@Controller('/auth')
+class AuthController {
+  @Post('/login')
+  @Throttle({ ttl: 60, limit: 5 })
+  login() {}
+
+  @Post('/refresh')
+  @SkipThrottle()
+  refresh() {}
+}
+```
+
+## API
+
+### `createThrottlerModule(options)`
+
+Registers a global throttler guard. Options:
+
+| Option | Type | Description |
+|---|---|---|
+| `ttl` | `number` | Window length in seconds |
+| `limit` | `number` | Max requests per window |
+| `keyGenerator` | `(ctx) => string` | Custom key function. Defaults to remote IP |
+| `store` | `ThrottlerStore` | Store adapter. Defaults to in-memory |
+
+### `@Throttle({ ttl, limit })`
+
+Overrides module-level defaults for a specific controller class or handler method.
+
+### `@SkipThrottle()`
+
+Bypasses throttling entirely for a specific controller class or handler method.
+
+### `THROTTLER_GUARD`
+
+DI token for the registered `ThrottlerGuard`. Inject it to use it as an explicit guard:
+
+```typescript
+import { UseGuard } from '@konekti/http';
+import { THROTTLER_GUARD } from '@konekti/throttler';
+
+@UseGuard(THROTTLER_GUARD)
+@Controller('/api')
+class ApiController {}
+```
+
+## Redis store
+
+```typescript
+import { createThrottlerModule, RedisThrottlerStore } from '@konekti/throttler';
+import { REDIS_CLIENT } from '@konekti/redis';
+import type Redis from 'ioredis';
+
+@Inject([REDIS_CLIENT])
+class AppBootstrap {
+  constructor(private readonly redis: Redis) {}
+
+  buildModule() {
+    return createThrottlerModule({
+      ttl: 60,
+      limit: 100,
+      store: new RedisThrottlerStore(this.redis),
+    });
+  }
+}
+```
+
+## Behavior
+
+- Rate limit key defaults to `socket.remoteAddress`. Provide `keyGenerator` for header-based keying (e.g. `x-api-key`).
+- When the limit is exceeded, `ThrottlerGuard` throws `TooManyRequestsException` (HTTP 429) and sets the `Retry-After` response header to the seconds remaining in the current window.
+- Method-level `@Throttle` overrides class-level `@Throttle`, which overrides module-level defaults — in that priority order.
+- `@SkipThrottle()` at either level wins unconditionally.
+- The in-memory store is per-`ThrottlerGuard` instance and is not shared across clustered workers. Use `RedisThrottlerStore` for cross-instance enforcement.
+
+## Related packages
+
+- `@konekti/http` — provides `Guard`, `GuardContext`, `TooManyRequestsException`
+- `@konekti/redis` — Redis client, pass `REDIS_CLIENT` to `RedisThrottlerStore`

--- a/packages/throttler/package.json
+++ b/packages/throttler/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@konekti/throttler",
+  "description": "Decorator-based rate limiting for Konekti applications with in-memory and Redis store adapters.",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/konektijs/konekti.git",
+    "directory": "packages/throttler"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
+    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@konekti/core": "workspace:*",
+    "@konekti/di": "workspace:*",
+    "@konekti/http": "workspace:*",
+    "@konekti/runtime": "workspace:*"
+  },
+  "peerDependencies": {
+    "@konekti/redis": "workspace:*",
+    "ioredis": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@konekti/redis": {
+      "optional": true
+    },
+    "ioredis": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "ioredis": "^5.10.0"
+  }
+}

--- a/packages/throttler/src/decorators.ts
+++ b/packages/throttler/src/decorators.ts
@@ -1,0 +1,75 @@
+import type { ThrottlerHandlerOptions } from './types.js';
+
+const standardThrottleRouteKey = Symbol.for('konekti.standard.route');
+const throttleKey = Symbol.for('konekti.throttler.throttle');
+const skipThrottleKey = Symbol.for('konekti.throttler.skip');
+const classThrottleKey = Symbol.for('konekti.throttler.class-throttle');
+const classSkipThrottleKey = Symbol.for('konekti.throttler.class-skip');
+
+type StandardMetadataBag = Record<PropertyKey, unknown>;
+type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecoratorContext) => void;
+type StandardClassDecoratorFn = (value: Function, context: ClassDecoratorContext) => void;
+type ClassOrMethodDecoratorLike = StandardClassDecoratorFn & StandardMethodDecoratorFn;
+
+function getMetadataBag(metadata: unknown): StandardMetadataBag {
+  return metadata as StandardMetadataBag;
+}
+
+function getRouteRecord(metadata: unknown, name: string | symbol): StandardMetadataBag {
+  const bag = getMetadataBag(metadata);
+  let routeMap = bag[standardThrottleRouteKey] as Map<string | symbol, StandardMetadataBag> | undefined;
+
+  if (!routeMap) {
+    routeMap = new Map<string | symbol, StandardMetadataBag>();
+    bag[standardThrottleRouteKey] = routeMap;
+  }
+
+  let record = routeMap.get(name);
+
+  if (!record) {
+    record = {};
+    routeMap.set(name, record);
+  }
+
+  return record;
+}
+
+export function Throttle(options: ThrottlerHandlerOptions): ClassOrMethodDecoratorLike {
+  const decorator = (_value: Function, context: ClassDecoratorContext | ClassMethodDecoratorContext) => {
+    if (context.kind === 'class') {
+      getMetadataBag(context.metadata)[classThrottleKey] = options;
+    } else {
+      getRouteRecord(context.metadata, context.name)[throttleKey] = options;
+    }
+  };
+
+  return decorator as ClassOrMethodDecoratorLike;
+}
+
+export function SkipThrottle(): ClassOrMethodDecoratorLike {
+  const decorator = (_value: Function, context: ClassDecoratorContext | ClassMethodDecoratorContext) => {
+    if (context.kind === 'class') {
+      getMetadataBag(context.metadata)[classSkipThrottleKey] = true;
+    } else {
+      getRouteRecord(context.metadata, context.name)[skipThrottleKey] = true;
+    }
+  };
+
+  return decorator as ClassOrMethodDecoratorLike;
+}
+
+export function getThrottleMetadata(bag: StandardMetadataBag): ThrottlerHandlerOptions | undefined {
+  return bag[throttleKey] as ThrottlerHandlerOptions | undefined;
+}
+
+export function getSkipThrottleMetadata(bag: StandardMetadataBag): boolean {
+  return bag[skipThrottleKey] === true;
+}
+
+export function getClassThrottleMetadata(bag: StandardMetadataBag): ThrottlerHandlerOptions | undefined {
+  return bag[classThrottleKey] as ThrottlerHandlerOptions | undefined;
+}
+
+export function getClassSkipThrottleMetadata(bag: StandardMetadataBag): boolean {
+  return bag[classSkipThrottleKey] === true;
+}

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -1,0 +1,101 @@
+import { Inject, metadataSymbol } from '@konekti/core';
+import { TooManyRequestsException, type Guard, type GuardContext, type MiddlewareContext } from '@konekti/http';
+
+import {
+  getClassSkipThrottleMetadata,
+  getClassThrottleMetadata,
+  getSkipThrottleMetadata,
+  getThrottleMetadata,
+} from './decorators.js';
+import { createMemoryThrottlerStore } from './store.js';
+import { THROTTLER_OPTIONS } from './tokens.js';
+import type { ThrottlerModuleOptions, ThrottlerStore } from './types.js';
+
+type MetadataBag = Record<PropertyKey, unknown>;
+
+function getClassMetadataBag(target: object): MetadataBag | undefined {
+  return (target as Record<symbol, MetadataBag | undefined>)[metadataSymbol];
+}
+
+function getMethodMetadataBag(controllerToken: Function, methodName: string): MetadataBag | undefined {
+  const classBag = getClassMetadataBag(controllerToken);
+
+  if (!classBag) {
+    return undefined;
+  }
+
+  const routeMap = classBag[Symbol.for('konekti.standard.route')] as Map<string | symbol, MetadataBag> | undefined;
+
+  return routeMap?.get(methodName);
+}
+
+function defaultKeyGenerator(ctx: MiddlewareContext): string {
+  const raw = ctx.request.raw as { socket?: { remoteAddress?: string } } | undefined;
+  return raw?.socket?.remoteAddress ?? 'unknown';
+}
+
+function buildStoreKey(handlerKey: string, clientKey: string): string {
+  return `throttler:${handlerKey}:${clientKey}`;
+}
+
+@Inject([THROTTLER_OPTIONS])
+export class ThrottlerGuard implements Guard {
+  private readonly store: ThrottlerStore;
+
+  constructor(private readonly options: ThrottlerModuleOptions) {
+    this.store = options.store ?? createMemoryThrottlerStore();
+  }
+
+  async canActivate(context: GuardContext): Promise<boolean> {
+    const { handler, requestContext } = context;
+
+    const classBag = getClassMetadataBag(handler.controllerToken);
+    const methodBag = getMethodMetadataBag(handler.controllerToken, handler.methodName);
+
+    const classSkip = classBag ? getClassSkipThrottleMetadata(classBag) : false;
+    const methodSkip = methodBag ? getSkipThrottleMetadata(methodBag) : false;
+
+    if (classSkip || methodSkip) {
+      return true;
+    }
+
+    const methodThrottle = methodBag ? getThrottleMetadata(methodBag) : undefined;
+    const classThrottle = classBag ? getClassThrottleMetadata(classBag) : undefined;
+
+    const ttlSeconds = methodThrottle?.ttl ?? classThrottle?.ttl ?? this.options.ttl;
+    const limit = methodThrottle?.limit ?? classThrottle?.limit ?? this.options.limit;
+
+    const middlewareCtx: MiddlewareContext = {
+      request: requestContext.request,
+      requestContext,
+      response: requestContext.response,
+    };
+
+    const clientKey = this.options.keyGenerator
+      ? this.options.keyGenerator(middlewareCtx)
+      : defaultKeyGenerator(middlewareCtx);
+
+    const handlerKey = `${handler.controllerToken.name}.${handler.methodName}`;
+    const storeKey = buildStoreKey(handlerKey, clientKey);
+    const now = Date.now();
+
+    await this.store.evict(now);
+
+    const entry = await this.store.get(storeKey);
+
+    if (!entry || now >= entry.resetAt) {
+      const resetAt = now + ttlSeconds * 1000;
+      await this.store.set(storeKey, { count: 1, resetAt });
+      return true;
+    }
+
+    if (entry.count >= limit) {
+      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+      requestContext.response.setHeader('Retry-After', String(retryAfter));
+      throw new TooManyRequestsException('Too Many Requests', { meta: { retryAfter } });
+    }
+
+    await this.store.increment(storeKey);
+    return true;
+  }
+}

--- a/packages/throttler/src/index.ts
+++ b/packages/throttler/src/index.ts
@@ -1,0 +1,6 @@
+export * from './decorators.js';
+export { RedisThrottlerStore } from './redis-store.js';
+export * from './module.js';
+export { createMemoryThrottlerStore } from './store.js';
+export { THROTTLER_GUARD, THROTTLER_OPTIONS } from './tokens.js';
+export type { ThrottlerHandlerOptions, ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { metadataSymbol } from '@konekti/core';
+import type { GuardContext, HandlerDescriptor, RequestContext } from '@konekti/http';
+
+import { SkipThrottle, Throttle } from './decorators.js';
+import { ThrottlerGuard } from './guard.js';
+import { createMemoryThrottlerStore } from './store.js';
+import type { ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+
+function createRequestContext(remoteAddress = '127.0.0.1'): RequestContext {
+  const headers: Record<string, string | string[]> = {};
+  const response = {
+    committed: false,
+    headers,
+    redirect() {},
+    send: vi.fn(async function send(this: { committed: boolean }) {
+      this.committed = true;
+    }),
+    setHeader(name: string, value: string | string[]) {
+      headers[name] = value;
+    },
+    setStatus(_code: number) {},
+    statusCode: 200,
+  };
+
+  return {
+    container: {} as RequestContext['container'],
+    metadata: {},
+    request: {
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/test',
+      query: {},
+      raw: { socket: { remoteAddress } },
+      url: '/test',
+    },
+    response: response as unknown as RequestContext['response'],
+  };
+}
+
+function createGuardContext(
+  controllerToken: Function,
+  methodName: string,
+  requestContext: RequestContext,
+): GuardContext {
+  return {
+    handler: {
+      controllerToken: controllerToken as HandlerDescriptor['controllerToken'],
+      metadata: {} as HandlerDescriptor['metadata'],
+      methodName,
+      route: {
+        method: 'GET',
+        path: '/test',
+      },
+    },
+    requestContext,
+  };
+}
+
+describe('@konekti/throttler decorators', () => {
+  it('writes @Throttle method-level metadata into the route map', () => {
+    class AuthController {
+      @Throttle({ limit: 5, ttl: 60 })
+      login() {}
+    }
+
+    const bag = (AuthController as unknown as Record<symbol, unknown>)[metadataSymbol] as Record<PropertyKey, unknown>;
+    const routeMap = bag[Symbol.for('konekti.standard.route')] as Map<string, Record<PropertyKey, unknown>>;
+    const loginRecord = routeMap?.get('login');
+
+    expect(loginRecord?.[Symbol.for('konekti.throttler.throttle')]).toEqual({ limit: 5, ttl: 60 });
+  });
+
+  it('writes @Throttle class-level metadata into the class bag', () => {
+    @Throttle({ limit: 100, ttl: 60 })
+    class ApiController {
+      list() {}
+    }
+
+    const bag = (ApiController as unknown as Record<symbol, unknown>)[metadataSymbol] as Record<PropertyKey, unknown>;
+
+    expect(bag[Symbol.for('konekti.throttler.class-throttle')]).toEqual({ limit: 100, ttl: 60 });
+  });
+
+  it('writes @SkipThrottle method-level metadata into the route map', () => {
+    class AuthController {
+      @SkipThrottle()
+      refresh() {}
+    }
+
+    const bag = (AuthController as unknown as Record<symbol, unknown>)[metadataSymbol] as Record<PropertyKey, unknown>;
+    const routeMap = bag[Symbol.for('konekti.standard.route')] as Map<string, Record<PropertyKey, unknown>>;
+    const refreshRecord = routeMap?.get('refresh');
+
+    expect(refreshRecord?.[Symbol.for('konekti.throttler.skip')]).toBe(true);
+  });
+
+  it('writes @SkipThrottle class-level metadata into the class bag', () => {
+    @SkipThrottle()
+    class PublicController {
+      get() {}
+    }
+
+    const bag = (PublicController as unknown as Record<symbol, unknown>)[metadataSymbol] as Record<PropertyKey, unknown>;
+
+    expect(bag[Symbol.for('konekti.throttler.class-skip')]).toBe(true);
+  });
+});
+
+describe('ThrottlerGuard — in-memory store', () => {
+  let options: ThrottlerModuleOptions;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-17T00:00:00.000Z'));
+
+    options = {
+      limit: 2,
+      store: createMemoryThrottlerStore(),
+      ttl: 60,
+    };
+  });
+
+  it('allows requests up to the limit', async () => {
+    class TestController {
+      @Throttle({ limit: 2, ttl: 60 })
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard(options);
+    const ctx = createRequestContext();
+
+    const result1 = await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+    const result2 = await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+  });
+
+  it('throws TooManyRequestsException on limit exceeded with Retry-After header', async () => {
+    class TestController {
+      @Throttle({ limit: 1, ttl: 60 })
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard(options);
+    const ctx = createRequestContext();
+
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', ctx))).rejects.toThrow(
+      'Too Many Requests',
+    );
+
+    expect(ctx.response.headers['Retry-After']).toBeDefined();
+  });
+
+  it('resets the counter after the window expires', async () => {
+    class TestController {
+      @Throttle({ limit: 1, ttl: 1 })
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard(options);
+    const ctx = createRequestContext();
+
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+    vi.advanceTimersByTime(1_001);
+
+    const result = await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+
+    expect(result).toBe(true);
+  });
+
+  it('skips throttling when method-level @SkipThrottle is present', async () => {
+    class TestController {
+      @SkipThrottle()
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1 });
+    const ctx = createRequestContext();
+
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+    const result = await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+
+    expect(result).toBe(true);
+  });
+
+  it('skips throttling when class-level @SkipThrottle is present', async () => {
+    @SkipThrottle()
+    class PublicController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1 });
+    const ctx = createRequestContext();
+
+    await guard.canActivate(createGuardContext(PublicController, 'action', ctx));
+    const result = await guard.canActivate(createGuardContext(PublicController, 'action', ctx));
+
+    expect(result).toBe(true);
+  });
+
+  it('method-level @Throttle overrides module-level defaults', async () => {
+    class TestController {
+      @Throttle({ limit: 5, ttl: 60 })
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1 });
+    const ctx = createRequestContext();
+
+    for (let i = 0; i < 5; i++) {
+      await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+    }
+
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', ctx))).rejects.toThrow(
+      'Too Many Requests',
+    );
+  });
+
+  it('uses module-level defaults when no handler-level @Throttle', async () => {
+    class TestController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1 });
+    const ctx = createRequestContext();
+
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', ctx))).rejects.toThrow(
+      'Too Many Requests',
+    );
+  });
+
+  it('keeps separate counters per handler and per client IP', async () => {
+    class TestController {
+      action() {}
+      other() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1 });
+    const ctx1 = createRequestContext('10.0.0.1');
+    const ctx2 = createRequestContext('10.0.0.2');
+
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx1));
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx2));
+    await guard.canActivate(createGuardContext(TestController, 'other', ctx1));
+
+    expect(true).toBe(true);
+  });
+});
+
+describe('ThrottlerGuard — Redis store mock', () => {
+  it('delegates get/set/increment/evict to the provided store', async () => {
+    const entries = new Map<string, ThrottlerStoreEntry>();
+    const store: ThrottlerStore = {
+      evict: vi.fn(),
+      get: vi.fn((key: string) => entries.get(key)),
+      increment: vi.fn((key: string) => {
+        const entry = entries.get(key);
+        if (!entry) {
+          return 0;
+        }
+
+        entry.count++;
+        return entry.count;
+      }),
+      set: vi.fn((key: string, entry: ThrottlerStoreEntry) => {
+        entries.set(key, entry);
+      }),
+    };
+
+    class TestController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ limit: 2, store, ttl: 60 });
+    const ctx = createRequestContext();
+
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+
+    expect(store.get).toHaveBeenCalled();
+    expect(store.set).toHaveBeenCalled();
+    expect(store.increment).toHaveBeenCalled();
+    expect(store.evict).toHaveBeenCalled();
+  });
+});

--- a/packages/throttler/src/module.ts
+++ b/packages/throttler/src/module.ts
@@ -1,0 +1,29 @@
+import type { Provider } from '@konekti/di';
+import { defineModule, type ModuleType } from '@konekti/runtime';
+
+import { ThrottlerGuard } from './guard.js';
+import { THROTTLER_GUARD, THROTTLER_OPTIONS } from './tokens.js';
+import type { ThrottlerModuleOptions } from './types.js';
+
+export function createThrottlerProviders(options: ThrottlerModuleOptions): Provider[] {
+  return [
+    {
+      provide: THROTTLER_OPTIONS,
+      useValue: options,
+    },
+    {
+      provide: THROTTLER_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ];
+}
+
+export function createThrottlerModule(options: ThrottlerModuleOptions): ModuleType {
+  class ThrottlerModule {}
+
+  return defineModule(ThrottlerModule, {
+    exports: [THROTTLER_GUARD],
+    global: true,
+    providers: createThrottlerProviders(options),
+  });
+}

--- a/packages/throttler/src/redis-store.ts
+++ b/packages/throttler/src/redis-store.ts
@@ -1,0 +1,51 @@
+import type Redis from 'ioredis';
+
+import type { ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+
+export class RedisThrottlerStore implements ThrottlerStore {
+  constructor(private readonly client: Redis) {}
+
+  async get(key: string): Promise<ThrottlerStoreEntry | undefined> {
+    const raw = await this.client.get(key);
+
+    if (raw === null) {
+      return undefined;
+    }
+
+    return JSON.parse(raw) as ThrottlerStoreEntry;
+  }
+
+  async set(key: string, entry: ThrottlerStoreEntry): Promise<void> {
+    const ttlMs = entry.resetAt - Date.now();
+    const ttlSeconds = Math.ceil(ttlMs / 1000);
+
+    if (ttlSeconds <= 0) {
+      return;
+    }
+
+    await this.client.set(key, JSON.stringify(entry), 'EX', ttlSeconds);
+  }
+
+  async increment(key: string): Promise<number> {
+    const raw = await this.client.get(key);
+
+    if (raw === null) {
+      return 0;
+    }
+
+    const entry = JSON.parse(raw) as ThrottlerStoreEntry;
+    entry.count++;
+    const ttlMs = entry.resetAt - Date.now();
+    const ttlSeconds = Math.ceil(ttlMs / 1000);
+
+    if (ttlSeconds > 0) {
+      await this.client.set(key, JSON.stringify(entry), 'EX', ttlSeconds);
+    }
+
+    return entry.count;
+  }
+
+  async evict(_now: number): Promise<void> {
+    // Redis handles TTL-based expiry natively; no manual eviction needed.
+  }
+}

--- a/packages/throttler/src/store.ts
+++ b/packages/throttler/src/store.ts
@@ -1,0 +1,43 @@
+import type { ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+
+export function createMemoryThrottlerStore(): ThrottlerStore {
+  const map = new Map<string, ThrottlerStoreEntry>();
+  let nextSweepAt = 0;
+
+  return {
+    get(key) {
+      return map.get(key);
+    },
+    set(key, entry) {
+      map.set(key, entry);
+    },
+    increment(key) {
+      const entry = map.get(key);
+
+      if (!entry) {
+        return 0;
+      }
+
+      entry.count++;
+      return entry.count;
+    },
+    evict(now) {
+      if (now < nextSweepAt) {
+        return;
+      }
+
+      let next = Number.POSITIVE_INFINITY;
+
+      for (const [key, entry] of map) {
+        if (now >= entry.resetAt) {
+          map.delete(key);
+          continue;
+        }
+
+        next = Math.min(next, entry.resetAt);
+      }
+
+      nextSweepAt = Number.isFinite(next) ? next : 0;
+    },
+  };
+}

--- a/packages/throttler/src/tokens.ts
+++ b/packages/throttler/src/tokens.ts
@@ -1,0 +1,2 @@
+export const THROTTLER_OPTIONS = Symbol.for('konekti.throttler.options');
+export const THROTTLER_GUARD = Symbol.for('konekti.throttler.guard');

--- a/packages/throttler/src/types.ts
+++ b/packages/throttler/src/types.ts
@@ -1,0 +1,34 @@
+import type { MiddlewareContext } from '@konekti/http';
+
+export interface ThrottlerStoreEntry {
+  count: number;
+  resetAt: number;
+}
+
+export interface ThrottlerStore {
+  get(key: string): ThrottlerStoreEntry | undefined | Promise<ThrottlerStoreEntry | undefined>;
+  set(key: string, entry: ThrottlerStoreEntry): void | Promise<void>;
+  increment(key: string): number | Promise<number>;
+  evict(now: number): void | Promise<void>;
+}
+
+export interface ThrottlerHandlerOptions {
+  /** Seconds in the rate-limit window. */
+  ttl: number;
+  /** Maximum number of requests allowed within the window. */
+  limit: number;
+}
+
+export interface ThrottlerModuleOptions {
+  /** Seconds in the rate-limit window (module-wide default). */
+  ttl: number;
+  /** Maximum number of requests allowed within the window (module-wide default). */
+  limit: number;
+  /**
+   * Key generator function. Defaults to remote IP.
+   * Receives the raw middleware context so custom headers (e.g. x-api-key) can be used.
+   */
+  keyGenerator?: (ctx: MiddlewareContext) => string;
+  /** Store adapter. Defaults to the built-in in-memory store. */
+  store?: ThrottlerStore;
+}

--- a/packages/throttler/tsconfig.build.json
+++ b/packages/throttler/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/throttler/tsconfig.json
+++ b/packages/throttler/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,28 @@ importers:
         specifier: workspace:*
         version: link:../runtime
 
+  packages/throttler:
+    dependencies:
+      '@konekti/core':
+        specifier: workspace:*
+        version: link:../core
+      '@konekti/di':
+        specifier: workspace:*
+        version: link:../di
+      '@konekti/http':
+        specifier: workspace:*
+        version: link:../http
+      '@konekti/redis':
+        specifier: workspace:*
+        version: link:../redis
+      '@konekti/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+    devDependencies:
+      ioredis:
+        specifier: ^5.10.0
+        version: 5.10.0
+
   packages/websocket:
     dependencies:
       '@konekti/core':


### PR DESCRIPTION
## Summary

- Adds new `@konekti/throttler` package with decorator-based rate limiting using TC39 standard decorators
- `@Throttle({ ttl, limit })` and `@SkipThrottle()` can be applied at class or method level; method-level overrides class-level which overrides module defaults
- In-memory store (default) for single-process use; `RedisThrottlerStore` for cluster-wide enforcement via `@konekti/redis`
- `ThrottlerGuard` throws `TooManyRequestsException` (HTTP 429) with `Retry-After` header on limit exceeded
- 13 unit tests covering: decorator metadata writes, limit enforcement, window reset, `@SkipThrottle`, override priority, Redis store mock, and per-handler/per-client key isolation

## Related

Closes #169