### PR TITLE
feat(event-bus): external transport interface and Redis Pub/Sub adapter

### DIFF
--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -3,15 +3,13 @@
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
 
-**In-process only.** In-process event publishing for Konekti applications with decorator-based handler discovery across singleton providers and controllers.
+In-process event publishing for Konekti applications with decorator-based handler discovery across singleton providers and controllers. Supports optional external transport adapters (e.g. Redis Pub/Sub) for cross-process fan-out.
 
 ## Installation
 
 ```bash
 npm install @konekti/event-bus
 ```
-
-> **⚠️ Scope: In-process only.** This package dispatches events within a single Node.js process. It provides no durability guarantees, no persistence, no cross-process delivery, and no replay capability. If your application crashes mid-dispatch, in-flight events are lost. For durable, distributed event processing, use `@konekti/queue` backed by Redis.
 
 ## Quick Start
 
@@ -52,6 +50,7 @@ export class AppModule {}
 - `createEventBusProviders()` - returns raw providers for manual composition
 - `EVENT_BUS` - DI token for the application event bus instance
 - `EventBus` - interface with `publish(event, options?)`
+- `EventBusTransport` - interface for external transport adapters
 - `@OnEvent(EventClass)` - marks provider/controller methods as event handlers
 
 ### Module options
@@ -60,19 +59,61 @@ export class AppModule {}
 
 - `publish.timeoutMs` - per-handler wait bound used when `publish()` waits for handlers (`waitForHandlers: true`)
 - `publish.waitForHandlers` - default waiting mode (`true` waits and applies timeout bounds, `false` dispatches fire-and-forget)
+- `transport` - optional `EventBusTransport` adapter for cross-process fan-out
+
+### Transport interface
+
+```typescript
+interface EventBusTransport {
+  publish(channel: string, payload: unknown): Promise<void>;
+  subscribe(channel: string, handler: (payload: unknown) => Promise<void>): Promise<void>;
+  close(): Promise<void>;
+}
+```
+
+Implement this interface to connect any external pub/sub system.
+
+### Redis Pub/Sub adapter
+
+```bash
+npm install ioredis
+```
+
+```typescript
+import Redis from 'ioredis';
+import { createEventBusModule } from '@konekti/event-bus';
+import { RedisEventBusTransport } from '@konekti/event-bus/redis';
+
+const publishClient = new Redis();
+const subscribeClient = new Redis();
+
+@Module({
+  imports: [
+    createEventBusModule({
+      transport: new RedisEventBusTransport({ publishClient, subscribeClient }),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+Two separate Redis clients are required because a client in subscribe mode cannot issue other commands.
 
 ## Runtime behavior
 
 - Handler discovery runs during application bootstrap using `COMPILED_MODULES`
 - Handler instances are pre-resolved from `RUNTIME_CONTAINER` during bootstrap and reused on publish
 - Events are matched by class using `instanceof`, so base-class handlers receive derived events
-- Publishing dispatches to every matching handler and supports cancellation signals in both modes
+- Publishing dispatches to every matching local handler and, when a transport is configured, fans out to the transport in parallel
+- When a transport is configured, the event bus subscribes to one channel per discovered event type on bootstrap; incoming messages are deserialized with `JSON.parse` and dispatched to matching local handlers
+- The channel name for a given event type is the class constructor name (e.g. `UserRegisteredEvent`)
+- Transport `close()` is called during `onApplicationShutdown`
 - Timeout bounds apply only when waiting mode is enabled (`waitForHandlers: true`); non-blocking mode (`false`) dispatches without waiting
 - Handler failures are isolated and logged through `ApplicationLogger`
 - Request/transient scoped classes with `@OnEvent()` are ignored with a warning
 
 ## Non-goals
 
-- no transport abstraction, queueing, replay, wildcards, or ordering guarantees
-- no external pub/sub adapter integration
+- no queueing, replay, wildcards, or ordering guarantees
 - no imperative `subscribe()` or `unsubscribe()` API
+- no durability or persistence (events lost on crash)

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -20,6 +20,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./redis": {
+      "types": "./dist/redis-transport.d.ts",
+      "import": "./dist/redis-transport.js"
     }
   },
   "main": "./dist/index.js",
@@ -36,5 +40,13 @@
     "@konekti/core": "workspace:*",
     "@konekti/di": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "peerDependencies": {
+    "ioredis": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ioredis": {
+      "optional": true
+    }
   }
 }

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -9,7 +9,7 @@ import { getEventHandlerMetadataEntries } from './metadata.js';
 import { createEventBusModule } from './module.js';
 import { EventBusLifecycleService } from './service.js';
 import { EVENT_BUS } from './tokens.js';
-import type { EventBus } from './types.js';
+import type { EventBus, EventBusTransport } from './types.js';
 
 function createLogger(events: string[]): ApplicationLogger {
   return {
@@ -702,5 +702,169 @@ describe('@konekti/event-bus', () => {
     expect(store.secondCalls).toBe(1);
 
     await app.close();
+  });
+
+  describe('transport', () => {
+    function createMockTransport(): EventBusTransport & {
+      published: Array<{ channel: string; payload: unknown }>;
+      subscribed: Array<{ channel: string; handler: (payload: unknown) => Promise<void> }>;
+      closeCalls: number;
+    } {
+      const published: Array<{ channel: string; payload: unknown }> = [];
+      const subscribed: Array<{ channel: string; handler: (payload: unknown) => Promise<void> }> = [];
+      let closeCalls = 0;
+
+      return {
+        published,
+        subscribed,
+        get closeCalls() {
+          return closeCalls;
+        },
+        async publish(channel, payload) {
+          published.push({ channel, payload });
+        },
+        async subscribe(channel, handler) {
+          subscribed.push({ channel, handler });
+        },
+        async close() {
+          closeCalls += 1;
+        },
+      };
+    }
+
+    it('fans out to transport.publish() when transport is configured', async () => {
+      const transport = createMockTransport();
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+      });
+
+      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+
+      await eventBus.publish(new UserCreatedEvent('transport-user-1'));
+
+      expect(transport.published).toHaveLength(1);
+      expect(transport.published[0]!.channel).toBe('UserCreatedEvent');
+      expect((transport.published[0]!.payload as { userId: string }).userId).toBe('transport-user-1');
+
+      await app.close();
+    });
+
+    it('subscribes to a channel per discovered local handler event type on bootstrap', async () => {
+      const transport = createMockTransport();
+
+      class HandlerA {
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {}
+      }
+
+      class HandlerB {
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {}
+      }
+
+      class HandlerC {
+        @OnEvent(PasswordResetEvent)
+        onPasswordReset(_event: PasswordResetEvent) {}
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+        providers: [HandlerA, HandlerB, HandlerC],
+      });
+
+      await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+
+      const subscribedChannels = transport.subscribed.map((s) => s.channel).sort();
+      expect(subscribedChannels).toEqual(['PasswordResetEvent', 'UserCreatedEvent']);
+    });
+
+    it('dispatches incoming transport messages to local handlers', async () => {
+      const transport = createMockTransport();
+
+      class EventStore {
+        received: UserCreatedEvent | undefined;
+      }
+
+      @Inject([EventStore])
+      class TransportHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(event: UserCreatedEvent) {
+          this.store.received = event;
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+        providers: [EventStore, TransportHandler],
+      });
+
+      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const store = await app.container.resolve(EventStore);
+
+      const incomingSubscription = transport.subscribed.find((s) => s.channel === 'UserCreatedEvent');
+      expect(incomingSubscription).toBeDefined();
+
+      await incomingSubscription!.handler({ userId: 'transport-user-2' });
+
+      expect(store.received).toBeDefined();
+      expect(store.received).toBeInstanceOf(UserCreatedEvent);
+      expect(store.received!.userId).toBe('transport-user-2');
+
+      await app.close();
+    });
+
+    it('calls transport.close() on application shutdown', async () => {
+      const transport = createMockTransport();
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+      });
+
+      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+
+      expect(transport.closeCalls).toBe(0);
+      await app.close();
+      expect(transport.closeCalls).toBe(1);
+    });
+
+    it('does not call transport when no transport is configured (backward compat)', async () => {
+      class EventStore {
+        calls = 0;
+      }
+
+      @Inject([EventStore])
+      class LocalHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {
+          this.store.calls += 1;
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule()],
+        providers: [EventStore, LocalHandler],
+      });
+
+      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+      const store = await app.container.resolve(EventStore);
+
+      await eventBus.publish(new UserCreatedEvent('local-user'));
+
+      expect(store.calls).toBe(1);
+
+      await app.close();
+    });
   });
 });

--- a/packages/event-bus/src/redis-transport.ts
+++ b/packages/event-bus/src/redis-transport.ts
@@ -1,0 +1,47 @@
+import type { Redis } from 'ioredis';
+
+import type { EventBusTransport } from './types.js';
+
+export interface RedisEventBusTransportOptions {
+  publishClient: Redis;
+  subscribeClient: Redis;
+}
+
+export class RedisEventBusTransport implements EventBusTransport {
+  private readonly publishClient: Redis;
+  private readonly subscribeClient: Redis;
+
+  constructor(options: RedisEventBusTransportOptions) {
+    this.publishClient = options.publishClient;
+    this.subscribeClient = options.subscribeClient;
+  }
+
+  async publish(channel: string, payload: unknown): Promise<void> {
+    await this.publishClient.publish(channel, JSON.stringify(payload));
+  }
+
+  async subscribe(channel: string, handler: (payload: unknown) => Promise<void>): Promise<void> {
+    await this.subscribeClient.subscribe(channel);
+
+    this.subscribeClient.on('message', (receivedChannel: string, message: string) => {
+      if (receivedChannel !== channel) {
+        return;
+      }
+
+      let payload: unknown;
+
+      try {
+        payload = JSON.parse(message) as unknown;
+      } catch {
+        return;
+      }
+
+      void handler(payload);
+    });
+  }
+
+  async close(): Promise<void> {
+    this.subscribeClient.disconnect();
+    this.publishClient.disconnect();
+  }
+}

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -7,6 +7,7 @@ import {
   type ApplicationLogger,
   type CompiledModule,
   type OnApplicationBootstrap,
+  type OnApplicationShutdown,
 } from '@konekti/runtime';
 
 import { getEventHandlerMetadataEntries } from './metadata.js';
@@ -14,6 +15,7 @@ import { EVENT_BUS_OPTIONS } from './tokens.js';
 import type {
   EventBus,
   EventBusModuleOptions,
+  EventBusTransport,
   EventHandlerDescriptor,
   EventPublishOptions,
   EventType,
@@ -70,28 +72,45 @@ function isClassProvider(provider: Provider): provider is Extract<Provider, { pr
 }
 
 @Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, EVENT_BUS_OPTIONS])
-export class EventBusLifecycleService implements EventBus, OnApplicationBootstrap {
+export class EventBusLifecycleService implements EventBus, OnApplicationBootstrap, OnApplicationShutdown {
   private descriptors: EventHandlerDescriptor[] = [];
   private discoveryPromise: Promise<void> | undefined;
   private discovered = false;
   private readonly handlerInstances = new Map<Token, Promise<unknown>>();
+  private readonly transport: EventBusTransport | undefined;
 
   constructor(
     private readonly runtimeContainer: Container,
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
     private readonly moduleOptions: EventBusModuleOptions,
-  ) {}
+  ) {
+    this.transport = moduleOptions.transport;
+  }
 
   async onApplicationBootstrap(): Promise<void> {
     await this.ensureDiscovered();
+    await this.subscribeTransportChannels();
+  }
+
+  async onApplicationShutdown(): Promise<void> {
+    if (this.transport) {
+      try {
+        await this.transport.close();
+      } catch (error) {
+        this.logger.error('EventBusTransport failed to close.', error, 'EventBusLifecycleService');
+      }
+    }
   }
 
   async publish(event: object, options?: EventPublishOptions): Promise<void> {
     await this.ensureDiscovered();
     const matchingDescriptors = this.matchEventDescriptors(event);
 
+    const transportPublish = this.publishToTransport(event);
+
     if (matchingDescriptors.length === 0) {
+      await transportPublish;
       return;
     }
 
@@ -99,13 +118,14 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     if (!publishOptions.waitForHandlers) {
       const backgroundTasks = this.createBackgroundInvocationTasks(matchingDescriptors, event, publishOptions.signal);
       this.runInvocationTasksInBackground(backgroundTasks);
+      this.runInvocationTasksInBackground([transportPublish]);
 
       return;
     }
 
     const invocationTasks = this.createInvocationTasks(matchingDescriptors, event, publishOptions);
 
-    await Promise.allSettled(invocationTasks);
+    await Promise.allSettled([...invocationTasks, transportPublish]);
   }
 
   private matchEventDescriptors(event: object): EventHandlerDescriptor[] {
@@ -196,6 +216,75 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
       this.discovered = true;
     } finally {
       this.discoveryPromise = undefined;
+    }
+  }
+
+  private channelFromEventType(eventType: EventType): string {
+    return eventType.name;
+  }
+
+  private async publishToTransport(event: object): Promise<void> {
+    if (!this.transport) {
+      return;
+    }
+
+    const channel = this.channelFromEventType(event.constructor as EventType);
+
+    try {
+      await this.transport.publish(channel, event);
+    } catch (error) {
+      this.logger.error(
+        `EventBusTransport failed to publish to channel "${channel}".`,
+        error,
+        'EventBusLifecycleService',
+      );
+    }
+  }
+
+  private async subscribeTransportChannels(): Promise<void> {
+    if (!this.transport) {
+      return;
+    }
+
+    const subscribedChannels = new Set<string>();
+
+    for (const descriptor of this.descriptors) {
+      const channel = this.channelFromEventType(descriptor.eventType);
+
+      if (subscribedChannels.has(channel)) {
+        continue;
+      }
+
+      subscribedChannels.add(channel);
+
+      await this.subscribeTransportChannel(channel, descriptor.eventType);
+    }
+  }
+
+  private async subscribeTransportChannel(channel: string, eventType: EventType): Promise<void> {
+    try {
+      await this.transport!.subscribe(channel, async (payload) => {
+        const event = Object.assign(Object.create(eventType.prototype) as object, payload);
+        const matchingDescriptors = this.matchEventDescriptors(event);
+
+        if (matchingDescriptors.length === 0) {
+          return;
+        }
+
+        const invocationTasks = this.createInvocationTasks(matchingDescriptors, event, {
+          signal: undefined,
+          timeoutMs: this.normalizeTimeoutMs(this.moduleOptions.publish?.timeoutMs),
+          waitForHandlers: this.moduleOptions.publish?.waitForHandlers ?? true,
+        });
+
+        await Promise.allSettled(invocationTasks);
+      });
+    } catch (error) {
+      this.logger.error(
+        `EventBusTransport failed to subscribe to channel "${channel}".`,
+        error,
+        'EventBusLifecycleService',
+      );
     }
   }
 

--- a/packages/event-bus/src/types.ts
+++ b/packages/event-bus/src/types.ts
@@ -23,11 +23,37 @@ export interface EventPublishOptions {
   waitForHandlers?: boolean;
 }
 
+export interface EventBusTransport {
+  /**
+   * Publish an event payload to the external transport under the given channel name.
+   * Called by the event bus on every local `publish()` invocation when a transport is configured.
+   */
+  publish(channel: string, payload: unknown): Promise<void>;
+
+  /**
+   * Subscribe to incoming messages on the given channel from the external transport.
+   * The event bus calls this once per discovered local handler during bootstrap.
+   * Received messages are deserialized and dispatched to matching local handlers.
+   */
+  subscribe(channel: string, handler: (payload: unknown) => Promise<void>): Promise<void>;
+
+  /**
+   * Tear down any open connections. Called during application shutdown.
+   */
+  close(): Promise<void>;
+}
+
 export interface EventBusModuleOptions {
   publish?: {
     timeoutMs?: number;
     waitForHandlers?: boolean;
   };
+  /**
+   * Optional external transport adapter (e.g. Redis Pub/Sub).
+   * When provided, `publish()` fans out to the transport in addition to local handlers,
+   * and incoming transport messages are dispatched to local handlers on bootstrap.
+   */
+  transport?: EventBusTransport;
 }
 
 export interface EventBus {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+      ioredis:
+        specifier: ^5.0.0
+        version: 5.10.0
 
   packages/graphql:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `EventBusTransport` interface to `@konekti/event-bus` so applications can plug in any external pub/sub system alongside in-process dispatch
- `EventBusLifecycleService` now subscribes to one channel per discovered event type on bootstrap, fans out to the transport on every `publish()`, and calls `transport.close()` on shutdown
- Ships `RedisEventBusTransport` as an optional `@konekti/event-bus/redis` subpath export backed by ioredis (optional peer dependency)

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | `EventBusTransport` interface + `transport?` field on `EventBusModuleOptions` |
| `src/service.ts` | Transport wiring in `onApplicationBootstrap`, `publish`, `onApplicationShutdown` |
| `src/redis-transport.ts` | New `RedisEventBusTransport` class |
| `package.json` | `./redis` subpath export, `ioredis` optional peer dependency |
| `src/module.test.ts` | 5 new integration tests for transport behaviour |
| `README.md` | Transport section, Redis usage example, updated non-goals |

## Test results

23 tests pass (18 existing + 5 new transport tests), full typecheck clean.

Closes #170