### PR TITLE
Resolve #194: validate resolver request/transient scope across operations

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -143,6 +143,8 @@ GraphQL resolver는 HTTP provider와 동일한 `@Scope()` 시맨틱을 따릅니
 - **Request**: GraphQL operation마다 새 인스턴스를 생성합니다. GraphQL 모듈은 operation별로 child DI 컨테이너를 만들고, 그 컨테이너에서 resolver를 resolve한 뒤 operation 완료 후 컨테이너를 dispose합니다.
 - **Transient**: resolve할 때마다 새 인스턴스를 생성합니다. 각 GraphQL operation에서 별도의 child 컨테이너가 사용되므로 operation 경계에서는 request scope와 동일하게 동작합니다.
 
+동시에 실행되는 operation도 서로 완전히 격리되므로 request-scoped resolver 상태와 request-scoped 의존성이 겹치는 요청 사이에서 공유되지 않습니다.
+
 ```typescript
 import { Inject, Scope } from '@konekti/core';
 import { Resolver, Query } from '@konekti/graphql';

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -143,6 +143,8 @@ GraphQL resolvers respect the same `@Scope()` semantics as HTTP providers.
 - **Request**: a fresh instance per GraphQL operation. The GraphQL module creates a per-operation child DI container, resolves the resolver from it, and disposes the container after the operation completes.
 - **Transient**: a fresh instance on every resolution. Each GraphQL operation also gets its own child container, so transient resolvers behave identically to request scope at the operation boundary.
 
+Concurrent operations are isolated from each other, so request-scoped resolver state and request-scoped dependencies are never shared across overlapping GraphQL requests.
+
 ```typescript
 import { Inject, Scope } from '@konekti/core';
 import { Resolver, Query } from '@konekti/graphql';

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -259,6 +259,53 @@ describe('@konekti/graphql', () => {
 });
 
 describe('@konekti/graphql — provider scopes', () => {
+  it('isolates request-scoped resolver instances across concurrent operations', async () => {
+    let issued = 0;
+
+    @Inject([])
+    @Scope('request')
+    class RequestIdentity {
+      readonly id = `req-${String(++issued)}`;
+    }
+
+    @Inject([RequestIdentity])
+    @Scope('request')
+    @Resolver('ConcurrentRequestResolver')
+    class ConcurrentRequestResolver {
+      constructor(private readonly identity: RequestIdentity) {}
+
+      @Query()
+      async requestId(): Promise<string> {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        return this.identity.id;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createGraphqlModule({ resolvers: [ConcurrentRequestResolver] })],
+      providers: [RequestIdentity, ConcurrentRequestResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    await app.listen();
+
+    const [op1, op2] = await Promise.all([
+      postGraphql(port, '{ requestId }'),
+      postGraphql(port, '{ requestId }'),
+    ]);
+
+    const id1 = (op1 as { data?: { requestId?: string } }).data?.requestId;
+    const id2 = (op2 as { data?: { requestId?: string } }).data?.requestId;
+
+    expect(typeof id1).toBe('string');
+    expect(typeof id2).toBe('string');
+    expect(id1).not.toBe(id2);
+
+    await app.close();
+  });
+
   it('request-scoped resolver receives a fresh instance per operation', async () => {
     @Inject([])
     @Scope('request')


### PR DESCRIPTION
## Summary
- add GraphQL integration coverage to assert request-scoped resolver instances are isolated across concurrent operations
- keep existing singleton/request/transient scope integration coverage and document concurrent request isolation behavior in both English and Korean package docs
- confirm GraphQL scope behavior remains aligned with issue acceptance criteria for request/transient resolver resolution

## Verification
- `pnpm build`
- `pnpm exec vitest run /Users/playground/konekti/.worktrees/issue-194-resolver-request-transient-scope/packages/graphql/src/module.test.ts`
- `pnpm typecheck`

Closes #194