### PR TITLE
Resolve #193: add ArkType schema adapter for dto-validator

### DIFF
--- a/packages/dto-validator/README.ko.md
+++ b/packages/dto-validator/README.ko.md
@@ -99,8 +99,10 @@ interface Validator {
 
 ```typescript
 import { z } from 'zod';
+import { type } from 'arktype';
 import { object, pipe, safeParse, string, email } from 'valibot';
 import {
+  createArkTypeAdapter,
   createSchemaValidator,
   createValibotSchemaValidator,
   createZodSchemaValidator,
@@ -118,6 +120,12 @@ const valibotValidator = createValibotSchemaValidator(
     email: pipe(string(), email()),
   }),
   safeParse,
+);
+
+const arkTypeValidator = createArkTypeAdapter(
+  type({
+    email: 'string.email',
+  }),
 );
 
 const customValidator: SchemaValidator<{ name: string }> = createSchemaValidator({

--- a/packages/dto-validator/README.md
+++ b/packages/dto-validator/README.md
@@ -99,8 +99,10 @@ Use schema-based validation without `emitDecoratorMetadata` while keeping the sa
 
 ```typescript
 import { z } from 'zod';
+import { type } from 'arktype';
 import { object, pipe, safeParse, string, email } from 'valibot';
 import {
+  createArkTypeAdapter,
   createSchemaValidator,
   createValibotSchemaValidator,
   createZodSchemaValidator,
@@ -118,6 +120,12 @@ const valibotSchema = object({
 });
 
 const valibotValidator = createValibotSchemaValidator(valibotSchema, safeParse);
+
+const arkTypeValidator = createArkTypeAdapter(
+  type({
+    email: 'string.email',
+  }),
+);
 
 const customValidator: SchemaValidator<{ name: string }> = createSchemaValidator({
   parse(value) {

--- a/packages/dto-validator/package.json
+++ b/packages/dto-validator/package.json
@@ -40,10 +40,14 @@
     "validator": "^13.15.26"
   },
   "peerDependencies": {
+    "arktype": "^2.2.0",
     "valibot": "^0.42.1",
     "zod": "^3.23.8 || ^4.0.0"
   },
   "peerDependenciesMeta": {
+    "arktype": {
+      "optional": true
+    },
     "valibot": {
       "optional": true
     },
@@ -53,6 +57,7 @@
   },
   "devDependencies": {
     "@types/validator": "^13.15.10",
+    "arktype": "^2.2.0",
     "valibot": "^0.42.1",
     "zod": "^4.1.11"
   }

--- a/packages/dto-validator/src/adapters/arktype.test.ts
+++ b/packages/dto-validator/src/adapters/arktype.test.ts
@@ -1,0 +1,83 @@
+import { type } from 'arktype';
+import { describe, expect, it } from 'vitest';
+
+import { DtoValidationError } from '../errors.js';
+import { createArkTypeAdapter } from './arktype.js';
+
+class RequestPayload {}
+
+describe('createArkTypeAdapter', () => {
+  it('maps ArkType failures to ValidationIssue[]', async () => {
+    const schema = type({
+      email: 'string.email',
+      tags: 'string[]',
+    });
+
+    const validator = createArkTypeAdapter(schema);
+
+    try {
+      await validator.validate(
+        {
+          email: 'invalid',
+          tags: [1],
+        },
+        RequestPayload,
+      );
+      throw new Error('Expected validation to fail for invalid payload');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(DtoValidationError);
+
+      const issues = (error as DtoValidationError).issues;
+      expect(issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'PATTERN', field: 'email' }),
+          expect.objectContaining({ code: 'DOMAIN', field: 'tags[0]' }),
+        ]),
+      );
+    }
+  });
+
+  it('passes valid input without errors', async () => {
+    const schema = type({
+      email: 'string.email',
+      tags: 'string[]',
+    });
+
+    const validator = createArkTypeAdapter(schema);
+
+    await expect(
+      validator.transform(
+        {
+          email: 'hello@konekti.dev',
+          tags: ['backend', 'framework'],
+        },
+        RequestPayload,
+      ),
+    ).resolves.toEqual({
+      email: 'hello@konekti.dev',
+      tags: ['backend', 'framework'],
+    });
+  });
+
+  it('returns field and message values for invalid input', async () => {
+    const schema = type({
+      email: 'string.email',
+    });
+
+    const validator = createArkTypeAdapter(schema);
+
+    try {
+      await validator.validate({ email: 'broken' }, RequestPayload);
+      throw new Error('Expected validation to fail for invalid email');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(DtoValidationError);
+
+      const issues = (error as DtoValidationError).issues;
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toMatchObject({
+        field: 'email',
+      });
+      expect(issues[0]?.message).toContain('email');
+    }
+  });
+});

--- a/packages/dto-validator/src/adapters/arktype.ts
+++ b/packages/dto-validator/src/adapters/arktype.ts
@@ -1,0 +1,120 @@
+import type { Constructor } from '@konekti/core';
+import type { Type } from 'arktype';
+
+import { DtoValidationError } from '../errors.js';
+import type { ValidationIssue, Validator } from '../types.js';
+
+interface ArkErrorLike {
+  readonly code?: string;
+  readonly message?: string;
+  readonly path?: readonly PropertyKey[];
+  readonly propString?: string;
+}
+
+interface ArkErrorsLike {
+  readonly issues: readonly unknown[];
+  readonly summary?: string;
+}
+
+type ArkTypeSchema<T> = Type<T>;
+
+function isPropertyKeyArray(value: unknown): value is readonly PropertyKey[] {
+  return Array.isArray(value) && value.every((segment) => typeof segment === 'string' || typeof segment === 'number');
+}
+
+function isArkErrorsLike(value: unknown): value is ArkErrorsLike {
+  return typeof value === 'object' && value !== null && Array.isArray((value as { issues?: unknown }).issues);
+}
+
+function toArkErrorLike(value: unknown): ArkErrorLike {
+  const candidate = value as {
+    code?: unknown;
+    message?: unknown;
+    path?: unknown;
+    propString?: unknown;
+  };
+
+  return {
+    code: typeof candidate.code === 'string' ? candidate.code : undefined,
+    message: typeof candidate.message === 'string' ? candidate.message : undefined,
+    path: isPropertyKeyArray(candidate.path) ? candidate.path : undefined,
+    propString: typeof candidate.propString === 'string' ? candidate.propString : undefined,
+  };
+}
+
+function toFieldPath(path: readonly PropertyKey[] | undefined): string | undefined {
+  if (!path || path.length === 0) {
+    return undefined;
+  }
+
+  let result = '';
+
+  for (const segment of path) {
+    if (typeof segment === 'symbol') {
+      continue;
+    }
+
+    if (typeof segment === 'number') {
+      result += `[${String(segment)}]`;
+      continue;
+    }
+
+    result += result.length === 0 ? segment : `.${segment}`;
+  }
+
+  return result.length > 0 ? result : undefined;
+}
+
+function normalizeCode(code: string | undefined, fallback: string): string {
+  if (!code || code.length === 0) {
+    return fallback;
+  }
+
+  return code.replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '').toUpperCase() || fallback;
+}
+
+function toIssues(errors: ArkErrorsLike): ValidationIssue[] {
+  const issues = errors.issues.map((rawIssue) => {
+    const issue = toArkErrorLike(rawIssue);
+
+    return {
+      code: normalizeCode(issue.code, 'INVALID_FIELD'),
+      field: toFieldPath(issue.path) ?? issue.propString,
+      message: issue.message ?? errors.summary ?? 'Invalid value.',
+    };
+  });
+
+  if (issues.length > 0) {
+    return issues;
+  }
+
+  return [
+    {
+      code: 'INVALID_FIELD',
+      message: errors.summary ?? 'Invalid value.',
+    },
+  ];
+}
+
+async function parseWithArkType<T>(schema: ArkTypeSchema<T>, value: unknown): Promise<unknown> {
+  const result = schema(value);
+
+  if (isArkErrorsLike(result)) {
+    throw new DtoValidationError('Validation failed.', toIssues(result));
+  }
+
+  return result;
+}
+
+export function createArkTypeAdapter<TSchema>(schema: ArkTypeSchema<TSchema>): Validator {
+  return {
+    async validate(value: unknown, _target: Constructor): Promise<void> {
+      await parseWithArkType(schema, value);
+    },
+
+    async transform<TOutput>(value: unknown, _target: Constructor<TOutput>): Promise<TOutput> {
+      const transformed = await parseWithArkType(schema, value);
+      return transformed as unknown as TOutput;
+    },
+  };
+}

--- a/packages/dto-validator/src/index.ts
+++ b/packages/dto-validator/src/index.ts
@@ -1,3 +1,4 @@
+export * from './adapters/arktype.js';
 export * from './decorators.js';
 export * from './errors.js';
 export * from './schema.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@types/validator':
         specifier: ^13.15.10
         version: 13.15.10
+      arktype:
+        specifier: ^2.2.0
+        version: 2.2.0
       valibot:
         specifier: ^0.42.1
         version: 0.42.1(typescript@5.9.3)
@@ -416,6 +419,12 @@ importers:
   tooling/vitest: {}
 
 packages:
+
+  '@ark/schema@0.56.0':
+    resolution: {integrity: sha512-ECg3hox/6Z/nLajxXqNhgPtNdHWC9zNsDyskwO28WinoFEnWow4IsERNz9AnXRhTZJnYIlAJ4uGn3nlLk65vZA==}
+
+  '@ark/util@0.56.0':
+    resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
 
   '@babel/cli@7.28.6':
     resolution: {integrity: sha512-6EUNcuBbNkj08Oj4gAZ+BUU8yLCgKzgVX4gaTh09Ya2C8ICM4P+G30g4m3akRxSYAp3A/gnWchrNst7px4/nUQ==}
@@ -1275,6 +1284,12 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  arkregex@0.0.5:
+    resolution: {integrity: sha512-ncYjBdLlh5/QnVsAA8De16Tc9EqmYM7y/WU9j+236KcyYNUXogpz3sC4ATIZYzzLxwI+0sEOaQLEmLmRleaEXw==}
+
+  arktype@2.2.0:
+    resolution: {integrity: sha512-t54MZ7ti5BhOEvzEkgKnWvqj+UbDfWig+DHr5I34xatymPusKLS0lQpNJd8M6DzmIto2QGszHfNKoFIT8tMCZQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2123,6 +2138,12 @@ packages:
 
 snapshots:
 
+  '@ark/schema@0.56.0':
+    dependencies:
+      '@ark/util': 0.56.0
+
+  '@ark/util@0.56.0': {}
+
   '@babel/cli@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -2876,6 +2897,16 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
     optional: true
+
+  arkregex@0.0.5:
+    dependencies:
+      '@ark/util': 0.56.0
+
+  arktype@2.2.0:
+    dependencies:
+      '@ark/schema': 0.56.0
+      '@ark/util': 0.56.0
+      arkregex: 0.0.5
 
   assertion-error@2.0.1: {}
 


### PR DESCRIPTION
## Summary
- Add `createArkTypeAdapter(schema: Type)` to `@konekti/dto-validator` and export it from the package root.
- Map ArkType validation failures to `DtoValidationError` issues with normalized `code`, `field`, and `message`.
- Add ArkType adapter unit tests, docs examples (EN/KO), and optional peer dependency wiring.

## Verification
- `pnpm vitest run packages/dto-validator/src/adapters/arktype.test.ts packages/dto-validator/src/schema.test.ts`
- `pnpm --filter @konekti/core run build`
- `pnpm --filter @konekti/dto-validator run typecheck`
- `pnpm --filter @konekti/dto-validator run build`

Closes #193