### PR TITLE
Resolve #197 #198: sharpen TC39 and TypeScript positioning docs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,69 @@
 
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
-Konekti는 **TC39 표준 데코레이터** 기반으로, 명시적 DI와 예측 가능한 런타임 흐름을 빠르게 시작할 수 있게 만든 TypeScript 백엔드 프레임워크입니다.
+Konekti는 **TC39 표준 데코레이터**를 전면 사용하는 TypeScript 백엔드 프레임워크로, NestJS의 레거시 데코레이터 경로와 명확히 구분됩니다.
+
+## 왜 표준 데코레이터인가?
+
+Konekti는 TypeScript의 현재 표준 데코레이터 모델을 기준으로 동작하므로, 스타터 앱에서 레거시 컴파일러 동작을 요구하지 않습니다.
+
+- `experimentalDecorators`: 레거시(표준 이전) 데코레이터 동작을 활성화하는 플래그입니다.
+- `emitDecoratorMetadata`: 리플렉션 기반 주입에 쓰이는 런타임 타입 메타데이터를 생성하는 플래그입니다.
+- NestJS: 암묵적 생성자 주입을 위해 레거시 데코레이터 + 메타데이터 생성이 필요합니다.
+- Konekti: 토큰 기반 명시적 주입을 사용하므로 메타데이터 생성에 의존하지 않습니다.
+
+즉, 프로젝트 `tsconfig.json`에서 표준 TypeScript 기본값을 유지하고 레거시 데코레이터 플래그를 피할 수 있습니다.
+
+## TypeScript-first, 검증 가능한 차이
+
+Konekti의 TypeScript-first는 마케팅 문구가 아니라, 레거시 데코레이터 플래그 불필요성과 명시적 DI라는 검증 가능한 동작 차이를 뜻합니다.
+
+### `tsconfig.json` 비교
+
+NestJS식 레거시 데코레이터 설정:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+Konekti 표준 데코레이터 설정:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": false
+  }
+}
+```
+
+Konekti 앱에서는 `experimentalDecorators`를 아예 생략해도 됩니다.
+
+### DI 스타일 비교
+
+NestJS 암묵적 메타데이터 주입:
+
+```ts
+@Injectable()
+export class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+}
+```
+
+Konekti 명시적 토큰 주입:
+
+```ts
+const USERS_REPOSITORY = Symbol('USERS_REPOSITORY');
+
+@Inject([USERS_REPOSITORY])
+class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+}
+```
 
 ## 빠른 시작
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,69 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
-Konekti is a TypeScript backend framework built on **TC39 standard decorators**, explicit DI, and a predictable runtime path you can run in minutes.
+Konekti is a TypeScript backend framework built on **TC39 standard decorators** as an explicit alternative to NestJS legacy decorator mode.
+
+## Why Standard Decorators?
+
+Konekti ships on the current TypeScript standard decorator model, so starter apps do not need legacy compiler behavior.
+
+- `experimentalDecorators`: enables legacy (pre-standard) decorator emit and type behavior.
+- `emitDecoratorMetadata`: emits runtime design-type metadata for reflection-based injection.
+- NestJS: depends on legacy decorators plus emitted metadata for implicit constructor injection.
+- Konekti: does not require emitted metadata because dependencies are declared explicitly with tokens.
+
+For project config, that means you can keep standard TypeScript defaults and avoid legacy decorator flags.
+
+## TypeScript-first, with Verifiable Differences
+
+TypeScript-first in Konekti means no legacy decorator compiler flags and no reflection-driven DI.
+
+### `tsconfig.json` comparison
+
+NestJS-style legacy decorator setup:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
+
+Konekti standard decorator setup:
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": false
+  }
+}
+```
+
+You can also omit `experimentalDecorators` entirely in Konekti apps.
+
+### DI style comparison
+
+NestJS implicit metadata injection:
+
+```ts
+@Injectable()
+export class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+}
+```
+
+Konekti explicit token injection:
+
+```ts
+const USERS_REPOSITORY = Symbol('USERS_REPOSITORY');
+
+@Inject([USERS_REPOSITORY])
+class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+}
+```
 
 ## Quick Start
 

--- a/docs/getting-started/quick-start.ko.md
+++ b/docs/getting-started/quick-start.ko.md
@@ -5,6 +5,14 @@
 
 이 가이드는 현재 Konekti의 공개 부트스트랩 경로를 설명합니다.
 
+> [!NOTE]
+> Konekti는 TC39 표준 데코레이터(TypeScript 5.0+)를 사용합니다.
+> 스타터 앱의 `tsconfig.json`에서 레거시 데코레이터 플래그를 켜지 마세요:
+> - `"experimentalDecorators": true`를 설정하지 마세요
+> - `"emitDecoratorMetadata": true`를 설정하지 마세요
+> NestJS는 현재 레거시 데코레이터 + 메타데이터 경로에 의존하지만, Konekti는 그렇지 않습니다.
+> Konekti에서는 표준 설정(`"experimentalDecorators": false` 또는 생략)만으로 충분합니다.
+
 ## 표준 부트스트랩 경로
 
 ```sh

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -9,6 +9,7 @@ This guide describes the current public bootstrap path for Konekti.
 > Konekti uses TC39 standard decorators (TypeScript 5.0+). Starter apps should not enable legacy decorator flags in `tsconfig.json`:
 > - do not set `"experimentalDecorators": true`
 > - do not set `"emitDecoratorMetadata": true`
+> NestJS currently relies on the legacy decorator + metadata path; Konekti does not.
 > Standard configuration is enough (`"experimentalDecorators": false` or omitting it).
 
 ## canonical bootstrap path


### PR DESCRIPTION
## Summary
- lead the root README messaging with explicit TC39 standard decorators positioning against NestJS legacy decorator mode
- add a concrete "Why standard decorators?" explanation and verifiable TypeScript-first claims with side-by-side `tsconfig.json` and DI examples in both English and Korean READMEs
- add/strengthen top-level quick-start callouts for standard decorators in both English and Korean docs

## Verification
- `pnpm install`
- `pnpm typecheck` *(fails due to pre-existing repository baseline errors unrelated to this docs change; same failure pattern on current main)*
- `pnpm build`

Closes #197
Closes #198