### PR TITLE
Resolve #206: isolate request override cache invalidation

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -330,6 +330,30 @@ describe('Container', () => {
 
       expect(await container.resolve<string>(token)).toBe('single');
     });
+
+    it('keeps root singleton cache isolated when overriding in a request scope', async () => {
+      const token = Symbol('singleton-token');
+      const rootSingleton = { value: 'root' };
+      const requestOverride = { value: 'request' };
+
+      const root = new Container().register({ provide: token, useValue: rootSingleton });
+      const requestScope = root.createRequestScope();
+
+      const rootBeforeOverride = await root.resolve<{ value: string }>(token);
+
+      requestScope.override({ provide: token, useValue: requestOverride });
+
+      const requestResolved = await requestScope.resolve<{ value: string }>(token);
+      const rootAfterOverride = await root.resolve<{ value: string }>(token);
+      const secondRequestScope = root.createRequestScope();
+      const secondRequestResolved = await secondRequestScope.resolve<{ value: string }>(token);
+
+      expect(rootBeforeOverride).toBe(rootSingleton);
+      expect(rootAfterOverride).toBe(rootBeforeOverride);
+      expect(requestResolved).toBe(requestOverride);
+      expect(requestResolved).not.toBe(rootAfterOverride);
+      expect(secondRequestResolved).toBe(rootAfterOverride);
+    });
   });
 
   describe('optional injection', () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -148,10 +148,11 @@ export class Container {
   override(...providers: Provider[]): this {
     for (const provider of providers) {
       const normalized = normalizeProvider(provider);
+      const existing = this.lookupProvider(normalized.provide);
 
       this.registrations.delete(normalized.provide);
       this.multiRegistrations.delete(normalized.provide);
-      this.invalidateCachedEntry(normalized.provide);
+      this.invalidateCachedEntry(normalized.provide, existing?.scope ?? normalized.scope);
 
       if (normalized.multi) {
         this.multiRegistrations.set(normalized.provide, [normalized]);
@@ -301,7 +302,7 @@ export class Container {
   }
 
   private async resolveScopedOrSingletonInstance(provider: NormalizedProvider, chain: Token[]): Promise<unknown> {
-    const cache = this.cacheFor(provider.scope, provider.provide);
+    const cache = this.cacheFor(provider);
 
     if (!cache.has(provider.provide)) {
       const promise = this.instantiate(provider, chain);
@@ -317,6 +318,10 @@ export class Container {
     const provider = this.lookupProvider(token);
 
     if (!provider || provider.scope !== 'singleton') return undefined;
+
+    if (this.requestScopeEnabled && this.registrations.has(token)) {
+      return this.requestCache;
+    }
 
     return this.root().singletonCache;
   }
@@ -358,14 +363,18 @@ export class Container {
     return this.parent?.lookupProvider(token);
   }
 
-  private cacheFor(scope: Scope, token: Token) {
-    if (scope === 'singleton') {
+  private cacheFor(provider: NormalizedProvider): Map<Token, Promise<unknown>> {
+    if (provider.scope === 'singleton') {
+      if (this.requestScopeEnabled && this.registrations.has(provider.provide)) {
+        return this.requestCache;
+      }
+
       return this.root().singletonCache;
     }
 
     if (!this.requestScopeEnabled) {
       throw new RequestScopeResolutionError(
-        `Request-scoped provider ${String(token)} cannot be resolved outside request scope.`,
+        `Request-scoped provider ${String(provider.provide)} cannot be resolved outside request scope.`,
       );
     }
 
@@ -514,7 +523,7 @@ export class Container {
     return Promise.all(provider.inject.map((entry) => this.resolveDepToken(entry, chain)));
   }
 
-  private invalidateCachedEntry(token: Token): void {
+  private invalidateCachedEntry(token: Token, scope: Scope): void {
     if (this.requestCache.has(token)) {
       const cached = this.requestCache.get(token);
 
@@ -525,13 +534,17 @@ export class Container {
       this.requestCache.delete(token);
     }
 
-    const singletonCache = this.root().singletonCache;
+    if (this.parent || scope !== 'singleton') {
+      return;
+    }
+
+    const singletonCache = this.singletonCache;
 
     if (singletonCache.has(token)) {
       const cached = singletonCache.get(token);
 
       if (cached) {
-        this.root().staleCache.set(token, cached);
+        this.staleCache.set(token, cached);
       }
 
       singletonCache.delete(token);


### PR DESCRIPTION
## Summary
- restrict override cache invalidation so request-scope overrides do not clear the root singleton cache
- keep request-local singleton overrides isolated in request cache when registered inside request-scope containers
- add regression coverage proving request override does not mutate root singleton instance sharing across requests

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run packages/di/src/container.test.ts`

Closes #206