### PR TITLE
Resolve #209: split refresh verification policy and make passport bridge state explicit

### DIFF
--- a/packages/jwt/src/refresh-token.test.ts
+++ b/packages/jwt/src/refresh-token.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { JwtConfigurationError, JwtExpiredTokenError, JwtInvalidTokenError } from './errors.js';
 import { RefreshTokenService, type RefreshTokenRecord, type RefreshTokenStore } from './refresh-token.js';
@@ -88,12 +88,19 @@ function readTokenPayload(token: string): Record<string, unknown> {
 
 function createService(
   store: RefreshTokenStore,
-  options: { expiresInSeconds?: number; rotation?: boolean; refreshSecret?: string } = {},
+  options: {
+    accessMaxAgeSeconds?: number;
+    expiresInSeconds?: number;
+    refreshSecret?: string;
+    refreshVerifyMaxAgeSeconds?: number;
+    rotation?: boolean;
+  } = {},
 ): { service: RefreshTokenService; verifier: DefaultJwtVerifier } {
   const refreshOptions = {
     expiresInSeconds: options.expiresInSeconds ?? 3600,
     rotation: options.rotation ?? true,
     secret: options.refreshSecret ?? 'refresh-secret',
+    verifyMaxAgeSeconds: options.refreshVerifyMaxAgeSeconds,
     store,
   };
 
@@ -104,6 +111,7 @@ function createService(
   });
   const verifier = new DefaultJwtVerifier({
     algorithms: ['HS256'],
+    maxAge: options.accessMaxAgeSeconds,
     refreshToken: refreshOptions,
     secret: 'access-secret',
   });
@@ -188,6 +196,41 @@ describe('RefreshTokenService', () => {
 
     await expect(verifier.verifyRefreshToken(token)).resolves.toMatchObject({ subject: 'user-1' });
     await expect(verifier.verifyAccessToken(token)).rejects.toBeInstanceOf(JwtInvalidTokenError);
+  });
+
+  it('does not apply access maxAge to refresh verification by default', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const store = new InMemoryRefreshTokenStore();
+      const { service, verifier } = createService(store, { accessMaxAgeSeconds: 1 });
+      const token = await service.issueRefreshToken('user-1');
+
+      vi.advanceTimersByTime(5_000);
+
+      await expect(verifier.verifyRefreshToken(token)).resolves.toMatchObject({ subject: 'user-1' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('applies refresh verifyMaxAgeSeconds independently from access maxAge', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const store = new InMemoryRefreshTokenStore();
+      const { service, verifier } = createService(store, {
+        accessMaxAgeSeconds: 600,
+        refreshVerifyMaxAgeSeconds: 1,
+      });
+      const token = await service.issueRefreshToken('user-1');
+
+      vi.advanceTimersByTime(5_000);
+
+      await expect(verifier.verifyRefreshToken(token)).rejects.toBeInstanceOf(JwtExpiredTokenError);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('allows only one successful rotation under concurrent requests', async () => {

--- a/packages/jwt/src/refresh-token.ts
+++ b/packages/jwt/src/refresh-token.ts
@@ -34,6 +34,7 @@ export interface RefreshTokenRecord {
 export interface RefreshTokenOptions {
   secret: string;
   expiresInSeconds: number;
+  verifyMaxAgeSeconds?: number;
   rotation: boolean;
   store: RefreshTokenStore;
 }

--- a/packages/jwt/src/verifier.ts
+++ b/packages/jwt/src/verifier.ts
@@ -236,7 +236,7 @@ export class DefaultJwtVerifier {
       audience: this.options.audience,
       clockSkewSeconds: this.options.clockSkewSeconds,
       issuer: this.options.issuer,
-      maxAge: this.options.maxAge,
+      maxAge: refreshToken.verifyMaxAgeSeconds,
       requireExp: true,
       secret: refreshToken.secret,
     };

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -264,6 +264,60 @@ describe('AuthGuard', () => {
     });
   });
 
+  it('isolates Passport.js bridge request state across concurrent authentications', async () => {
+    let sequence = 0;
+
+    class PassportLikeConcurrentStrategy {
+      success?: (user: unknown, info?: unknown) => void;
+
+      authenticate() {
+        const current = ++sequence;
+        const delay = current === 1 ? 10 : 0;
+
+        setTimeout(() => {
+          this.success?.({
+            id: `google-user-${current}`,
+          });
+        }, delay);
+      }
+    }
+
+    const bridge = createPassportJsStrategyBridge('google-concurrent', PassportLikeConcurrentStrategy);
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-concurrent')
+      getProfile(_input: unknown, ctx: { principal?: { subject: string } }) {
+        return { subject: ctx.principal?.subject };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikeConcurrentStrategy,
+      ...bridge.providers,
+      ...createPassportProviders({ defaultStrategy: 'google-concurrent' }, [bridge.strategy]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+
+    const [firstResponse, secondResponse] = [createResponse(), createResponse()];
+
+    await Promise.all([
+      dispatcher.dispatch(createRequest('/oauth/profile'), firstResponse),
+      dispatcher.dispatch(createRequest('/oauth/profile'), secondResponse),
+    ]);
+
+    const subjects = [firstResponse.body, secondResponse.body]
+      .map((body) => (body as { subject?: string }).subject)
+      .sort();
+
+    expect(subjects).toEqual(['google-user-1', 'google-user-2']);
+  });
+
   it('supports Passport.js redirect flow without executing the protected handler', async () => {
     let handlerCalled = false;
 

--- a/packages/passport/src/passport-js.ts
+++ b/packages/passport/src/passport-js.ts
@@ -20,6 +20,15 @@ export interface PassportJsStrategyLike {
 
 type PassportJsExecutableStrategy = PassportJsStrategyLike & PassportJsActionBindings;
 
+interface PassportJsRequestState {
+  context: GuardContext;
+  mapPrincipal: PassportJsPrincipalMapper;
+  reject: (reason?: unknown) => void;
+  resolve: (value: Principal | AuthHandledResult) => void;
+  response: GuardContext['requestContext']['response'];
+  settled: boolean;
+}
+
 export interface PassportJsPrincipalMapperInput {
   context: GuardContext;
   info?: unknown;
@@ -112,6 +121,8 @@ function extractChallengeMessage(challenge: unknown): string | undefined {
 }
 
 export class PassportJsAuthStrategy implements AuthStrategy {
+  private readonly requestState = new WeakMap<PassportJsExecutableStrategy, PassportJsRequestState>();
+
   constructor(
     private readonly strategyTemplate: PassportJsStrategyLike,
     private readonly options: PassportJsAuthStrategyOptions = {},
@@ -124,51 +135,44 @@ export class PassportJsAuthStrategy implements AuthStrategy {
     const mapPrincipal = this.options.mapPrincipal ?? defaultPrincipalMapper;
 
     return new Promise((resolve, reject) => {
-      const settle = this.createSettleGuard();
-
-      this.bindStrategyActions(strategy, {
+      this.requestState.set(strategy, {
         context,
         mapPrincipal,
         reject,
         resolve,
         response,
-        settle,
+        settled: false,
       });
+
+      this.bindStrategyActions(strategy);
 
       try {
         strategy.authenticate(request, this.options.authenticateOptions);
       } catch (error: unknown) {
-        settle(() => reject(error));
+        this.settle(strategy, () => reject(error));
       }
     });
   }
 
-  private createSettleGuard(): (handler: () => void) => void {
-    let settled = false;
+  private settle(strategy: PassportJsExecutableStrategy, handler: (state: PassportJsRequestState) => void): void {
+    const state = this.requestState.get(strategy);
 
-    return (handler: () => void) => {
-      if (settled) {
-        return;
-      }
+    if (!state || state.settled) {
+      return;
+    }
 
-      settled = true;
-      handler();
-    };
+    state.settled = true;
+
+    try {
+      handler(state);
+    } finally {
+      this.requestState.delete(strategy);
+    }
   }
 
-  private bindStrategyActions(
-    strategy: PassportJsExecutableStrategy,
-    state: {
-      context: GuardContext;
-      mapPrincipal: PassportJsPrincipalMapper;
-      reject: (reason?: unknown) => void;
-      resolve: (value: Principal | AuthHandledResult) => void;
-      response: GuardContext['requestContext']['response'];
-      settle: (handler: () => void) => void;
-    },
-  ): void {
+  private bindStrategyActions(strategy: PassportJsExecutableStrategy): void {
     strategy.success = (user, info) => {
-      state.settle(() => {
+      this.settle(strategy, (state) => {
         try {
           state.resolve(state.mapPrincipal({ context: state.context, info, user }));
         } catch (error: unknown) {
@@ -178,26 +182,26 @@ export class PassportJsAuthStrategy implements AuthStrategy {
     };
 
     strategy.fail = (challenge, status) => {
-      state.settle(() => {
+      this.settle(strategy, (state) => {
         state.reject(this.createFailureError(challenge, status));
       });
     };
 
     strategy.redirect = (url, status = 302) => {
-      state.settle(() => {
+      this.settle(strategy, (state) => {
         state.response.redirect(status, url);
         state.resolve({ handled: true });
       });
     };
 
     strategy.pass = () => {
-      state.settle(() => {
+      this.settle(strategy, (state) => {
         state.reject(new AuthenticationRequiredError());
       });
     };
 
     strategy.error = (error) => {
-      state.settle(() => {
+      this.settle(strategy, (state) => {
         state.reject(error);
       });
     };


### PR DESCRIPTION
## Summary
- decouple refresh token verification maxAge from access token maxAge by introducing `refreshToken.verifyMaxAgeSeconds`
- add refresh-token tests proving access maxAge no longer bleeds into refresh verification and refresh maxAge can be configured independently
- make Passport.js bridge request state explicit with request-scoped `WeakMap` state and add concurrent authentication isolation test

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run packages/jwt/src/refresh-token.test.ts packages/passport/src/guard.test.ts`

Closes #209