### PR TITLE
Resolve #208: make throttler atomic and reduce dto/openapi/serializer overhead

### DIFF
--- a/packages/dto-validator/src/validation.ts
+++ b/packages/dto-validator/src/validation.ts
@@ -92,6 +92,42 @@ function prefixIssues(
 
 type RuleKind = DtoFieldValidationRule['kind'];
 type NonCustomRule = Exclude<DtoFieldValidationRule, { kind: 'custom' | 'nested' }>;
+type DtoValidationSchema = ReturnType<typeof getDtoValidationSchema>;
+
+interface CachedDtoMetadata {
+  bindingMap: Map<MetadataPropertyKey, DtoFieldBindingMetadata>;
+  classValidationRules: ReturnType<typeof getClassValidationRules>;
+  dtoValidationSchema: DtoValidationSchema;
+  mergedPropertyKeys: Set<MetadataPropertyKey>;
+}
+
+const dtoMetadataCache = new WeakMap<Constructor, CachedDtoMetadata>();
+
+function getCachedDtoMetadata(target: Constructor): CachedDtoMetadata {
+  const cached = dtoMetadataCache.get(target);
+
+  if (cached) {
+    return cached;
+  }
+
+  const bindingMap = getDtoBindingMap(target);
+  const dtoValidationSchema = getDtoValidationSchema(target);
+  const classValidationRules = getClassValidationRules(target);
+  const mergedPropertyKeys = new Set<MetadataPropertyKey>([
+    ...bindingMap.keys(),
+    ...dtoValidationSchema.map((entry: { propertyKey: MetadataPropertyKey }) => entry.propertyKey),
+  ]);
+  const next: CachedDtoMetadata = {
+    bindingMap,
+    classValidationRules,
+    dtoValidationSchema,
+    mergedPropertyKeys,
+  };
+
+  dtoMetadataCache.set(target, next);
+  return next;
+}
+
 type RuleHandler<K extends RuleKind> = {
   defaultCode: string;
   describe: (field: string, rule: Extract<DtoFieldValidationRule, { kind: K }>) => string;
@@ -317,10 +353,10 @@ function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown): 
 
   Object.assign(instance, rawValue);
 
-  const bindingMap = getDtoBindingMap(target);
-  applyBindingValues(instance, rawValue, collectBoundAndValidatedPropertyKeys(target, bindingMap), bindingMap);
+  const metadata = getCachedDtoMetadata(target);
+  applyBindingValues(instance, rawValue, metadata.mergedPropertyKeys, metadata.bindingMap);
 
-  for (const entry of getDtoValidationSchema(target)) {
+  for (const entry of metadata.dtoValidationSchema) {
     const nestedRule = entry.rules.find(
       (rule: DtoFieldValidationRule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
     );
@@ -347,16 +383,6 @@ function getDtoBindingMap(target: Constructor): Map<MetadataPropertyKey, DtoFiel
   return new Map(
     getDtoBindingSchema(target).map((entry: { propertyKey: MetadataPropertyKey; metadata: DtoFieldBindingMetadata }) => [entry.propertyKey, entry.metadata]),
   );
-}
-
-function collectBoundAndValidatedPropertyKeys(
-  target: Constructor,
-  bindingMap: Map<MetadataPropertyKey, DtoFieldBindingMetadata>,
-): Set<MetadataPropertyKey> {
-  return new Set<MetadataPropertyKey>([
-    ...bindingMap.keys(),
-    ...getDtoValidationSchema(target).map((entry: { propertyKey: MetadataPropertyKey }) => entry.propertyKey),
-  ]);
 }
 
 function applyBindingValues(
@@ -621,17 +647,17 @@ async function collectValidationIssuesInternal<T>(
   value: T,
   context: { fieldPrefix?: string; inheritedSource?: ValidationIssue['source'] },
 ): Promise<readonly ValidationIssue[]> {
-  const bindingMetadata = getDtoBindingMap(target);
+  const metadata = getCachedDtoMetadata(target);
   const issues: ValidationIssue[] = [];
 
-  for (const entry of getDtoValidationSchema(target)) {
+  for (const entry of metadata.dtoValidationSchema) {
     const fieldValue = (value as Record<PropertyKey, unknown>)[entry.propertyKey];
-    const source = bindingMetadata.get(entry.propertyKey)?.source ?? context.inheritedSource;
+    const source = metadata.bindingMap.get(entry.propertyKey)?.source ?? context.inheritedSource;
     const fieldPath = context.fieldPrefix ? joinFieldPath(context.fieldPrefix, toFieldName(entry.propertyKey)) : toFieldName(entry.propertyKey);
     issues.push(...(await applyPropertyRules(entry.rules, fieldValue, value, entry.propertyKey, fieldPath, source)));
   }
 
-  for (const rule of getClassValidationRules(target)) {
+  for (const rule of metadata.classValidationRules) {
     const classIssues = await validateClassRule(rule, value);
     issues.push(...(context.fieldPrefix ? prefixIssues(classIssues, context.fieldPrefix, context.inheritedSource) : classIssues));
   }

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -1249,6 +1249,152 @@ describe('OpenApiModule', () => {
     );
   });
 
+  it('avoids component schema key collisions for DTOs with identical constructor names', async () => {
+    const makeNamedRequestDto = (name: string) => {
+      const generated = {
+        [name]: class {
+          @FromBody('value')
+          @IsString()
+          value = '';
+        },
+      };
+
+      return generated[name] as unknown as new () => { value: string };
+    };
+
+    const makeNamedResponseDto = (name: string) => {
+      const generated = {
+        [name]: class {
+          @IsString()
+          id = '';
+        },
+      };
+
+      return generated[name] as unknown as new () => { id: string };
+    };
+
+    const SharedRequestDto = makeNamedRequestDto('SharedDto');
+    const SharedResponseDto = makeNamedResponseDto('SharedDto');
+
+    @Controller('/collision')
+    class CollisionController {
+      @RequestDto(SharedRequestDto)
+      @ApiResponse(201, { description: 'Created', type: SharedResponseDto })
+      @Post('/create')
+      create() {
+        return { id: '1' };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: CollisionController }],
+      title: 'Collision API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [CollisionController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+
+    const document = response.body as {
+      components: { schemas: Record<string, unknown> };
+      paths: Record<string, { post?: { requestBody?: { content?: { 'application/json'?: { schema?: { $ref?: string } } } }; responses?: Record<string, { content?: { 'application/json'?: { schema?: { $ref?: string } } } }> } }>;
+    };
+
+    const requestSchemaRef = document.paths['/collision/create']?.post?.requestBody?.content?.['application/json']?.schema?.$ref;
+    const responseSchemaRef = document.paths['/collision/create']?.post?.responses?.['201']?.content?.['application/json']?.schema?.$ref;
+
+    expect(requestSchemaRef).toBeDefined();
+    expect(responseSchemaRef).toBeDefined();
+    expect(requestSchemaRef).not.toBe(responseSchemaRef);
+
+    const requestSchemaName = requestSchemaRef?.replace('#/components/schemas/', '');
+    const responseSchemaName = responseSchemaRef?.replace('#/components/schemas/', '');
+
+    expect(requestSchemaName).toBeDefined();
+    expect(responseSchemaName).toBeDefined();
+    expect(document.components.schemas[requestSchemaName as string]).toBeDefined();
+    expect(document.components.schemas[responseSchemaName as string]).toBeDefined();
+  });
+
+  it('keeps default ErrorResponse schema reserved when a DTO shares the same name', async () => {
+    const makeNamedRequestDto = (name: string) => {
+      const generated = {
+        [name]: class {
+          @FromBody('message')
+          @IsString()
+          message = '';
+        },
+      };
+
+      return generated[name] as unknown as new () => { message: string };
+    };
+
+    const ErrorResponseRequestDto = makeNamedRequestDto('ErrorResponse');
+
+    @Controller('/reserved')
+    class ReservedNameController {
+      @RequestDto(ErrorResponseRequestDto)
+      @Post('/create')
+      create() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: ReservedNameController }],
+      title: 'Reserved Name API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [ReservedNameController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+
+    const document = response.body as {
+      components: { schemas: Record<string, { properties?: Record<string, { type?: string }> }> };
+      paths: Record<string, { post?: { requestBody?: { content?: { 'application/json'?: { schema?: { $ref?: string } } } }; responses?: Record<string, { content?: { 'application/json'?: { schema?: { $ref?: string } } } }> } }>;
+    };
+
+    const requestSchemaRef = document.paths['/reserved/create']?.post?.requestBody?.content?.['application/json']?.schema?.$ref;
+    const defaultErrorSchemaRef = document.paths['/reserved/create']?.post?.responses?.['400']?.content?.['application/json']?.schema?.$ref;
+
+    expect(requestSchemaRef).toBeDefined();
+    expect(defaultErrorSchemaRef).toBe('#/components/schemas/ErrorResponse');
+    expect(requestSchemaRef).not.toBe(defaultErrorSchemaRef);
+
+    const requestSchemaName = requestSchemaRef?.replace('#/components/schemas/', '');
+    expect(requestSchemaName).toBeDefined();
+    expect(requestSchemaName).not.toBe('ErrorResponse');
+    expect(document.components.schemas[requestSchemaName as string]?.properties?.message?.type).toBe('string');
+  });
+
   it('resolves injected async options and serves the resulting document', async () => {
     const OPENAPI_TITLE = Symbol('openapi-title');
     const injectedTitles: string[] = [];

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -1,4 +1,4 @@
-import { getDtoBindingSchema, getDtoValidationSchema, type Constructor, type DtoFieldValidationRule } from '@konekti/core';
+import { getDtoBindingSchema, getDtoValidationSchema, type Constructor, type DtoFieldValidationRule, type MetadataPropertyKey } from '@konekti/core';
 import type { HandlerDescriptor, HttpMethod } from '@konekti/http';
 import {
   getControllerTags,
@@ -130,22 +130,68 @@ interface CollectedDtoEntry {
   validation: DtoValidationEntry | undefined;
 }
 
+interface BuildSchemaContext {
+  dtoEntries: WeakMap<Constructor, CollectedDtoEntry[]>;
+  dtoSchemaNames: WeakMap<Constructor, Map<string, string>>;
+  usedSchemaNames: Set<string>;
+}
+
 function propertyName(propertyKey: string | number | symbol): string {
   return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
 }
 
-function collectDtoEntries(dto: Constructor): CollectedDtoEntry[] {
+function collectDtoEntries(dto: Constructor, context: BuildSchemaContext): CollectedDtoEntry[] {
+  const cachedEntries = context.dtoEntries.get(dto);
+
+  if (cachedEntries) {
+    return cachedEntries;
+  }
+
   const bindingEntries = getDtoBindingSchema(dto);
   const validationEntries = getDtoValidationSchema(dto);
-  const bindingMap = new Map(bindingEntries.map((entry) => [entry.propertyKey, entry]));
-  const validationMap = new Map(validationEntries.map((entry) => [entry.propertyKey, entry]));
-  const propertyKeys = new Set([...bindingMap.keys(), ...validationMap.keys()]);
+  const bindingMap = new Map(bindingEntries.map((entry: DtoBindingEntry) => [entry.propertyKey, entry]));
+  const validationMap = new Map(validationEntries.map((entry: DtoValidationEntry) => [entry.propertyKey, entry]));
+  const propertyKeys = new Set<MetadataPropertyKey>([
+    ...(Array.from(bindingMap.keys()) as MetadataPropertyKey[]),
+    ...(Array.from(validationMap.keys()) as MetadataPropertyKey[]),
+  ]);
 
-  return Array.from(propertyKeys).map((propertyKey) => ({
+  const entries = Array.from(propertyKeys).map((propertyKey) => ({
     binding: bindingMap.get(propertyKey),
     name: propertyName(propertyKey),
     validation: validationMap.get(propertyKey),
   }));
+
+  context.dtoEntries.set(dto, entries);
+  return entries;
+}
+
+function getDtoSchemaName(dto: Constructor, context: BuildSchemaContext, suffix = ''): string {
+  let perDto = context.dtoSchemaNames.get(dto);
+
+  if (!perDto) {
+    perDto = new Map<string, string>();
+    context.dtoSchemaNames.set(dto, perDto);
+  }
+
+  const cached = perDto.get(suffix);
+
+  if (cached) {
+    return cached;
+  }
+
+  const baseName = `${dto.name || 'AnonymousDto'}${suffix}`;
+  let candidate = baseName;
+  let index = 2;
+
+  while (context.usedSchemaNames.has(candidate)) {
+    candidate = `${baseName}_${String(index)}`;
+    index++;
+  }
+
+  context.usedSchemaNames.add(candidate);
+  perDto.set(suffix, candidate);
+  return candidate;
 }
 
 function createSchemaRef(name: string): OpenApiSchemaObject {
@@ -183,21 +229,26 @@ function createEnumSchema(values: readonly unknown[]): OpenApiSchemaObject {
 
 function inferNestedSchema(
   nestedRule: Extract<DtoFieldValidationRule, { kind: 'nested' }> | undefined,
+  context: BuildSchemaContext,
 ): OpenApiSchemaObject | undefined {
   if (!nestedRule) {
     return undefined;
   }
 
   const resolvedDto = resolveNestedDto(nestedRule.dto);
+  const schemaName = getDtoSchemaName(resolvedDto, context);
 
   if (nestedRule.each) {
-    return { items: createSchemaRef(resolvedDto.name), type: 'array' };
+    return { items: createSchemaRef(schemaName), type: 'array' };
   }
 
-  return createSchemaRef(resolvedDto.name);
+  return createSchemaRef(schemaName);
 }
 
-function inferPrimitiveTypeFromRules(rules: readonly DtoFieldValidationRule[]): OpenApiSchemaObject | undefined {
+function inferPrimitiveTypeFromRules(
+  rules: readonly DtoFieldValidationRule[],
+  context: BuildSchemaContext,
+): OpenApiSchemaObject | undefined {
   const hasRule = <TKind extends DtoFieldValidationRule['kind']>(kind: TKind) =>
     rules.find((rule): rule is Extract<DtoFieldValidationRule, { kind: TKind }> => rule.kind === kind);
 
@@ -211,14 +262,14 @@ function inferPrimitiveTypeFromRules(rules: readonly DtoFieldValidationRule[]): 
   const stringRule = hasRule('string');
   const enumRule = hasRule('enum');
 
-  const nestedSchema = inferNestedSchema(nestedRule);
+  const nestedSchema = inferNestedSchema(nestedRule, context);
 
   if (nestedSchema) {
     return nestedSchema;
   }
 
   if (arrayRule) {
-    return { items: inferEachItemSchema(rules) ?? {}, type: 'array' };
+    return { items: inferEachItemSchema(rules, context) ?? {}, type: 'array' };
   }
 
   if (enumRule) {
@@ -252,14 +303,17 @@ function inferPrimitiveTypeFromRules(rules: readonly DtoFieldValidationRule[]): 
   return undefined;
 }
 
-function inferEachItemSchema(rules: readonly DtoFieldValidationRule[]): OpenApiSchemaObject | undefined {
+function inferEachItemSchema(
+  rules: readonly DtoFieldValidationRule[],
+  context: BuildSchemaContext,
+): OpenApiSchemaObject | undefined {
   const nestedRule = rules.find(
     (rule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested' && Boolean(rule.each),
   );
 
   if (nestedRule) {
     const resolvedDto = resolveNestedDto(nestedRule.dto);
-    return createSchemaRef(resolvedDto.name);
+    return createSchemaRef(getDtoSchemaName(resolvedDto, context));
   }
 
   const enumRule = rules.find(
@@ -336,7 +390,7 @@ function isPropertyRequired(binding: DtoBindingEntry | undefined, validation: Dt
     return false;
   }
 
-  if (validation?.rules.some((rule) => rule.kind === 'optional')) {
+  if (validation?.rules.some((rule: DtoFieldValidationRule) => rule.kind === 'optional')) {
     return false;
   }
 
@@ -347,6 +401,7 @@ function ensureComponentSchemaFromEntries(
   schemaName: string,
   entries: readonly CollectedDtoEntry[],
   componentSchemas: Record<string, OpenApiSchemaObject>,
+  context: BuildSchemaContext,
 ): OpenApiSchemaObject {
   if (componentSchemas[schemaName]) {
     return createSchemaRef(schemaName);
@@ -358,7 +413,7 @@ function ensureComponentSchemaFromEntries(
     type: 'object',
   };
 
-  const { properties, required } = buildComponentSchemaShape(entries, componentSchemas);
+  const { properties, required } = buildComponentSchemaShape(entries, componentSchemas, context);
 
   componentSchemas[schemaName] = {
     additionalProperties: false,
@@ -373,10 +428,11 @@ function ensureComponentSchemaFromEntries(
 function ensureNestedSchemasFromRules(
   rules: readonly DtoFieldValidationRule[],
   componentSchemas: Record<string, OpenApiSchemaObject>,
+  context: BuildSchemaContext,
 ): void {
   for (const rule of rules) {
     if (rule.kind === 'nested') {
-      ensureComponentSchema(resolveNestedDto(rule.dto), componentSchemas);
+      ensureComponentSchema(resolveNestedDto(rule.dto), componentSchemas, context);
     }
   }
 }
@@ -384,6 +440,7 @@ function ensureNestedSchemasFromRules(
 function buildComponentSchemaShape(
   entries: readonly CollectedDtoEntry[],
   componentSchemas: Record<string, OpenApiSchemaObject>,
+  context: BuildSchemaContext,
 ): {
   properties: Record<string, OpenApiSchemaObject>;
   required: string[];
@@ -393,9 +450,9 @@ function buildComponentSchemaShape(
 
   for (const entry of entries) {
     const rules = entry.validation?.rules ?? [];
-    ensureNestedSchemasFromRules(rules, componentSchemas);
+    ensureNestedSchemasFromRules(rules, componentSchemas, context);
 
-    const inferred = inferPrimitiveTypeFromRules(rules) ?? { type: 'string' };
+    const inferred = inferPrimitiveTypeFromRules(rules, context) ?? { type: 'string' };
     properties[entry.name] = applyValidationConstraints(inferred, rules);
 
     if (isPropertyRequired(entry.binding, entry.validation)) {
@@ -409,18 +466,21 @@ function buildComponentSchemaShape(
 function ensureComponentSchema(
   dto: Constructor,
   componentSchemas: Record<string, OpenApiSchemaObject>,
+  context: BuildSchemaContext,
 ): OpenApiSchemaObject {
-  return ensureComponentSchemaFromEntries(dto.name, collectDtoEntries(dto), componentSchemas);
+  const schemaName = getDtoSchemaName(dto, context);
+  return ensureComponentSchemaFromEntries(schemaName, collectDtoEntries(dto, context), componentSchemas, context);
 }
 
 function createParameters(
   dto: Constructor | undefined,
+  context: BuildSchemaContext,
 ): OpenApiParameterObject[] {
   if (!dto) {
     return [];
   }
 
-  const entries = collectDtoEntries(dto).filter(
+  const entries = collectDtoEntries(dto, context).filter(
     (entry): entry is typeof entry & { binding: DtoBindingEntry } =>
       entry.binding?.metadata.source === 'path'
       || entry.binding?.metadata.source === 'query'
@@ -431,7 +491,7 @@ function createParameters(
   return entries.map((entry) => {
     const source = entry.binding.metadata.source as 'cookie' | 'header' | 'path' | 'query';
     const rules = entry.validation?.rules ?? [];
-    const inferred = inferPrimitiveTypeFromRules(rules) ?? { type: 'string' as const };
+    const inferred = inferPrimitiveTypeFromRules(rules, context) ?? { type: 'string' as const };
     const schema = alignParameterSchemaWithRuntimeBindingContract(applyValidationConstraints(inferred, rules), source);
     const isRequired = source === 'path' ? true : isPropertyRequired(entry.binding, entry.validation);
 
@@ -524,20 +584,23 @@ function addDefaultErrorResponses(
 function createRequestBody(
   dto: Constructor | undefined,
   componentSchemas: Record<string, OpenApiSchemaObject>,
+  context: BuildSchemaContext,
 ): OpenApiRequestBodyObject | undefined {
   if (!dto) {
     return undefined;
   }
 
-  const dtoEntries = collectDtoEntries(dto);
+  const dtoEntries = collectDtoEntries(dto, context);
   const entries = dtoEntries.filter((entry) => entry.binding?.metadata.source === 'body');
 
   if (entries.length === 0) {
     return undefined;
   }
 
-  const schemaName = entries.length === dtoEntries.length ? dto.name : `${dto.name}RequestBody`;
-  ensureComponentSchemaFromEntries(schemaName, entries, componentSchemas);
+  const schemaName = entries.length === dtoEntries.length
+    ? getDtoSchemaName(dto, context)
+    : getDtoSchemaName(dto, context, 'RequestBody');
+  ensureComponentSchemaFromEntries(schemaName, entries, componentSchemas, context);
 
   return {
     content: {
@@ -594,11 +657,12 @@ function alignParameterSchemaWithRuntimeBindingContract(
 function createResponseObject(
   response: ApiResponseMetadata,
   componentSchemas: Record<string, OpenApiSchemaObject>,
+  context: BuildSchemaContext,
 ): OpenApiResponseObject {
   const schema = response.schema
     ? response.schema
     : response.type
-      ? ensureComponentSchema(response.type, componentSchemas)
+      ? ensureComponentSchema(response.type, componentSchemas, context)
       : undefined;
 
   return {
@@ -620,12 +684,13 @@ function createOperationResponses(
   methodMeta: MethodApiMetadata | undefined,
   componentSchemas: Record<string, OpenApiSchemaObject>,
   defaultErrorResponsesPolicy: DefaultErrorResponsesPolicy,
+  context: BuildSchemaContext,
 ): Record<string, OpenApiResponseObject> {
   const responses: Record<string, OpenApiResponseObject> = {};
 
   if (methodMeta?.responses && methodMeta.responses.length > 0) {
     for (const response of methodMeta.responses) {
-      responses[String(response.status)] = createResponseObject(response, componentSchemas);
+      responses[String(response.status)] = createResponseObject(response, componentSchemas, context);
     }
   } else {
     responses[String(descriptor.route.successStatus ?? 200)] = { description: 'OK' };
@@ -658,9 +723,10 @@ function createOperationObject(
   responses: Record<string, OpenApiResponseObject>,
   componentSchemas: Record<string, OpenApiSchemaObject>,
   security: OpenApiSecurityRequirementObject[] | undefined,
+  context: BuildSchemaContext,
 ): OpenApiOperationObject {
-  const parameters = createParameters(descriptor.route.request);
-  const requestBody = createRequestBody(descriptor.route.request, componentSchemas);
+  const parameters = createParameters(descriptor.route.request, context);
+  const requestBody = createRequestBody(descriptor.route.request, componentSchemas, context);
 
   return {
     operationId: normalizeOperationId(descriptor),
@@ -685,6 +751,7 @@ function buildOperationEntry(
   descriptor: HandlerDescriptor,
   componentSchemas: Record<string, OpenApiSchemaObject>,
   defaultErrorResponsesPolicy: DefaultErrorResponsesPolicy,
+  context: BuildSchemaContext,
 ): BuiltOperationEntry {
   const openApiPath = expressPathToOpenApi(descriptor.route.path);
   const method = descriptor.route.method.toLowerCase() as OpenApiOperationMethod;
@@ -695,9 +762,10 @@ function buildOperationEntry(
     methodMeta,
     componentSchemas,
     defaultErrorResponsesPolicy,
+    context,
   );
   const security = createOperationSecurity(methodMeta);
-  const operation = createOperationObject(descriptor, methodMeta, responses, componentSchemas, security);
+  const operation = createOperationObject(descriptor, methodMeta, responses, componentSchemas, security, context);
 
   return {
     method,
@@ -730,14 +798,20 @@ function createOpenApiComponents(
 export function buildOpenApiDocument(options: BuildOpenApiDocumentOptions): OpenApiDocument {
   const paths: Record<string, OpenApiPathItemObject> = {};
   const componentSchemas: Record<string, OpenApiSchemaObject> = {};
-  let hasBearerAuth = false;
   const defaultErrorResponsesPolicy = options.defaultErrorResponsesPolicy ?? 'inject';
+  const context: BuildSchemaContext = {
+    dtoEntries: new WeakMap(),
+    dtoSchemaNames: new WeakMap(),
+    usedSchemaNames: new Set(defaultErrorResponsesPolicy === 'inject' ? ['ErrorResponse'] : []),
+  };
+  let hasBearerAuth = false;
 
   for (const descriptor of options.descriptors) {
     const { method, openApiPath, operation, requiresBearerAuth } = buildOperationEntry(
       descriptor,
       componentSchemas,
       defaultErrorResponsesPolicy,
+      context,
     );
 
     if (requiresBearerAuth) {

--- a/packages/serializer/src/serialize.test.ts
+++ b/packages/serializer/src/serialize.test.ts
@@ -101,4 +101,26 @@ describe('serialize', () => {
 
     expect(serialize(plain)).toEqual(plain);
   });
+
+  it('serializes cyclic object graphs into JSON-safe output', () => {
+    class NodeView {
+      @Expose()
+      name: string;
+
+      @Expose()
+      next?: NodeView;
+
+      constructor(name: string) {
+        this.name = name;
+      }
+    }
+
+    const root = new NodeView('root');
+    root.next = root;
+    const serialized = serialize(root) as { name: string; next?: unknown };
+
+    expect(serialized.name).toBe('root');
+    expect(serialized.next).toBeUndefined();
+    expect(() => JSON.stringify(serialized)).not.toThrow();
+  });
 });

--- a/packages/serializer/src/serialize.ts
+++ b/packages/serializer/src/serialize.ts
@@ -2,6 +2,11 @@ import { type MetadataPropertyKey } from '@konekti/core';
 
 import { getClassSerializationOptions, getFieldSerializationMetadata, type SerializationFieldMetadata } from './metadata.js';
 
+interface SerializationContext {
+  metadataCache: WeakMap<Function, { classOptions: ReturnType<typeof getClassSerializationOptions>; fieldMetadata: ReturnType<typeof getFieldSerializationMetadata> }>;
+  seen: WeakMap<object, unknown>;
+}
+
 function isObjectLike(value: unknown): value is Record<string | symbol, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -50,21 +55,47 @@ function resolveCandidateKeys(
   return [...keys];
 }
 
-function serializeClassInstance(value: Record<string | symbol, unknown>): Record<string | symbol, unknown> {
+function getCachedMetadata(
+  constructor: Function,
+  context: SerializationContext,
+): { classOptions: ReturnType<typeof getClassSerializationOptions>; fieldMetadata: ReturnType<typeof getFieldSerializationMetadata> } {
+  const cached = context.metadataCache.get(constructor);
+
+  if (cached) {
+    return cached;
+  }
+
+  const next = {
+    classOptions: getClassSerializationOptions(constructor),
+    fieldMetadata: getFieldSerializationMetadata(constructor),
+  };
+
+  context.metadataCache.set(constructor, next);
+  return next;
+}
+
+function serializeClassInstance(
+  value: Record<string | symbol, unknown>,
+  context: SerializationContext,
+): Record<string | symbol, unknown> {
+  if (context.seen.has(value)) {
+    return undefined as unknown as Record<string | symbol, unknown>;
+  }
+
   const constructor = value.constructor as Function;
-  const classOptions = getClassSerializationOptions(constructor);
-  const fieldMetadata = getFieldSerializationMetadata(constructor);
+  const { classOptions, fieldMetadata } = getCachedMetadata(constructor, context);
   const hasMetadata = fieldMetadata.size > 0 || classOptions.excludeExtraneous === true;
 
   if (!hasMetadata) {
     if (isPlainObject(value)) {
-      return serializeRecord(value);
+      return serializeRecord(value, context);
     }
 
     return value;
   }
 
   const serialized: Record<string | symbol, unknown> = {};
+  context.seen.set(value, serialized);
   const candidateKeys = resolveCandidateKeys(value, fieldMetadata, classOptions.excludeExtraneous === true);
 
   for (const propertyKey of candidateKeys) {
@@ -81,29 +112,48 @@ function serializeClassInstance(value: Record<string | symbol, unknown>): Record
     }
 
     const transformed = metadata ? applyTransforms(raw, metadata) : raw;
-    serialized[propertyKey] = serialize(transformed);
+    serialized[propertyKey] = serializeInternal(transformed, context);
   }
 
   return serialized;
 }
 
-function serializeRecord(value: Record<string | symbol, unknown>): Record<string | symbol, unknown> {
+function serializeRecord(
+  value: Record<string | symbol, unknown>,
+  context: SerializationContext,
+): Record<string | symbol, unknown> {
+  if (context.seen.has(value)) {
+    return undefined as unknown as Record<string | symbol, unknown>;
+  }
+
   const serialized: Record<string | symbol, unknown> = {};
+  context.seen.set(value, serialized);
 
   for (const [propertyKey, propertyValue] of Object.entries(value)) {
-    serialized[propertyKey] = serialize(propertyValue);
+    serialized[propertyKey] = serializeInternal(propertyValue, context);
   }
 
   return serialized;
 }
 
-export function serialize<T = unknown>(value: T): unknown {
+function serializeInternal<T = unknown>(value: T, context: SerializationContext): unknown {
   if (value === null || value === undefined) {
     return value;
   }
 
   if (Array.isArray(value)) {
-    return value.map((item) => serialize(item));
+    if (context.seen.has(value)) {
+      return undefined;
+    }
+
+    const serialized: unknown[] = [];
+    context.seen.set(value, serialized);
+
+    for (const item of value) {
+      serialized.push(serializeInternal(item, context));
+    }
+
+    return serialized;
   }
 
   if (value instanceof Date) {
@@ -111,8 +161,17 @@ export function serialize<T = unknown>(value: T): unknown {
   }
 
   if (isObjectLike(value)) {
-    return serializeClassInstance(value);
+    return serializeClassInstance(value, context);
   }
 
   return value;
+}
+
+export function serialize<T = unknown>(value: T): unknown {
+  const context: SerializationContext = {
+    metadataCache: new WeakMap(),
+    seen: new WeakMap(),
+  };
+
+  return serializeInternal(value, context);
 }

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -78,24 +78,17 @@ export class ThrottlerGuard implements Guard {
     const handlerKey = `${handler.controllerToken.name}.${handler.methodName}`;
     const storeKey = buildStoreKey(handlerKey, clientKey);
     const now = Date.now();
+    const entry = await this.store.consume(storeKey, {
+      now,
+      ttlSeconds,
+    });
 
-    await this.store.evict(now);
-
-    const entry = await this.store.get(storeKey);
-
-    if (!entry || now >= entry.resetAt) {
-      const resetAt = now + ttlSeconds * 1000;
-      await this.store.set(storeKey, { count: 1, resetAt });
-      return true;
-    }
-
-    if (entry.count >= limit) {
+    if (entry.count > limit) {
       const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
       requestContext.response.setHeader('Retry-After', String(retryAfter));
       throw new TooManyRequestsException('Too Many Requests', { meta: { retryAfter } });
     }
 
-    await this.store.increment(storeKey);
     return true;
   }
 }

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -258,22 +258,26 @@ describe('ThrottlerGuard — in-memory store', () => {
 });
 
 describe('ThrottlerGuard — Redis store mock', () => {
-  it('delegates get/set/increment/evict to the provided store', async () => {
+  it('delegates atomic consume calls to the provided store', async () => {
     const entries = new Map<string, ThrottlerStoreEntry>();
     const store: ThrottlerStore = {
-      evict: vi.fn(),
-      get: vi.fn((key: string) => entries.get(key)),
-      increment: vi.fn((key: string) => {
+      consume: vi.fn((key: string, input) => {
+        const now = input.now;
+        const ttlMs = input.ttlSeconds * 1000;
         const entry = entries.get(key);
-        if (!entry) {
-          return 0;
+
+        if (!entry || now >= entry.resetAt) {
+          const next = { count: 1, resetAt: now + ttlMs };
+          entries.set(key, next);
+          return next;
         }
 
-        entry.count++;
-        return entry.count;
-      }),
-      set: vi.fn((key: string, entry: ThrottlerStoreEntry) => {
-        entries.set(key, entry);
+        const next = {
+          count: entry.count + 1,
+          resetAt: entry.resetAt,
+        };
+        entries.set(key, next);
+        return next;
       }),
     };
 
@@ -287,9 +291,6 @@ describe('ThrottlerGuard — Redis store mock', () => {
     await guard.canActivate(createGuardContext(TestController, 'action', ctx));
     await guard.canActivate(createGuardContext(TestController, 'action', ctx));
 
-    expect(store.get).toHaveBeenCalled();
-    expect(store.set).toHaveBeenCalled();
-    expect(store.increment).toHaveBeenCalled();
-    expect(store.evict).toHaveBeenCalled();
+    expect(store.consume).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/throttler/src/redis-store.ts
+++ b/packages/throttler/src/redis-store.ts
@@ -1,51 +1,63 @@
 import type Redis from 'ioredis';
 
-import type { ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+import type { ThrottlerConsumeInput, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+
+const CONSUME_LUA = [
+  "local key = KEYS[1]",
+  "local now = tonumber(ARGV[1])",
+  "local ttlMs = tonumber(ARGV[2])",
+  "local raw = redis.call('GET', key)",
+  "local count",
+  "local resetAt",
+  'if not raw then',
+  '  count = 1',
+  '  resetAt = now + ttlMs',
+  'else',
+  '  local decoded = cjson.decode(raw)',
+  "  count = tonumber(decoded['count']) or 0",
+  "  resetAt = tonumber(decoded['resetAt']) or (now + ttlMs)",
+  '  if now >= resetAt then',
+  '    count = 1',
+  '    resetAt = now + ttlMs',
+  '  else',
+  '    count = count + 1',
+  '  end',
+  'end',
+  'local ttlMsLeft = resetAt - now',
+  "if ttlMsLeft > 0 then",
+  '  local ttlSeconds = math.floor((ttlMsLeft + 999) / 1000)',
+  "  redis.call('SET', key, cjson.encode({ count = count, resetAt = resetAt }), 'EX', ttlSeconds)",
+  'end',
+  'return {count, resetAt}',
+].join('\n');
+
+function parseConsumeResult(result: unknown): ThrottlerStoreEntry {
+  if (!Array.isArray(result) || result.length < 2) {
+    throw new Error('Redis throttler consume script returned an invalid response.');
+  }
+
+  const count = Number(result[0]);
+  const resetAt = Number(result[1]);
+
+  if (!Number.isFinite(count) || !Number.isFinite(resetAt)) {
+    throw new Error('Redis throttler consume script returned non-numeric counters.');
+  }
+
+  return { count, resetAt };
+}
 
 export class RedisThrottlerStore implements ThrottlerStore {
   constructor(private readonly client: Redis) {}
 
-  async get(key: string): Promise<ThrottlerStoreEntry | undefined> {
-    const raw = await this.client.get(key);
+  async consume(key: string, input: ThrottlerConsumeInput): Promise<ThrottlerStoreEntry> {
+    const result = await this.client.eval(
+      CONSUME_LUA,
+      1,
+      key,
+      String(input.now),
+      String(input.ttlSeconds * 1000),
+    );
 
-    if (raw === null) {
-      return undefined;
-    }
-
-    return JSON.parse(raw) as ThrottlerStoreEntry;
-  }
-
-  async set(key: string, entry: ThrottlerStoreEntry): Promise<void> {
-    const ttlMs = entry.resetAt - Date.now();
-    const ttlSeconds = Math.ceil(ttlMs / 1000);
-
-    if (ttlSeconds <= 0) {
-      return;
-    }
-
-    await this.client.set(key, JSON.stringify(entry), 'EX', ttlSeconds);
-  }
-
-  async increment(key: string): Promise<number> {
-    const raw = await this.client.get(key);
-
-    if (raw === null) {
-      return 0;
-    }
-
-    const entry = JSON.parse(raw) as ThrottlerStoreEntry;
-    entry.count++;
-    const ttlMs = entry.resetAt - Date.now();
-    const ttlSeconds = Math.ceil(ttlMs / 1000);
-
-    if (ttlSeconds > 0) {
-      await this.client.set(key, JSON.stringify(entry), 'EX', ttlSeconds);
-    }
-
-    return entry.count;
-  }
-
-  async evict(_now: number): Promise<void> {
-    // Redis handles TTL-based expiry natively; no manual eviction needed.
+    return parseConsumeResult(result);
   }
 }

--- a/packages/throttler/src/store.ts
+++ b/packages/throttler/src/store.ts
@@ -1,29 +1,37 @@
-import type { ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+import type { ThrottlerConsumeInput, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+
+function consumeWindow(
+  entry: ThrottlerStoreEntry | undefined,
+  { now, ttlSeconds }: ThrottlerConsumeInput,
+): ThrottlerStoreEntry {
+  const resetAt = now + ttlSeconds * 1000;
+
+  if (!entry || now >= entry.resetAt) {
+    return {
+      count: 1,
+      resetAt,
+    };
+  }
+
+  return {
+    count: entry.count + 1,
+    resetAt: entry.resetAt,
+  };
+}
 
 export function createMemoryThrottlerStore(): ThrottlerStore {
   const map = new Map<string, ThrottlerStoreEntry>();
   let nextSweepAt = 0;
 
   return {
-    get(key) {
-      return map.get(key);
-    },
-    set(key, entry) {
-      map.set(key, entry);
-    },
-    increment(key) {
-      const entry = map.get(key);
+    consume(key, input) {
+      const { now } = input;
 
-      if (!entry) {
-        return 0;
-      }
-
-      entry.count++;
-      return entry.count;
-    },
-    evict(now) {
       if (now < nextSweepAt) {
-        return;
+        const nextEntry = consumeWindow(map.get(key), input);
+        map.set(key, nextEntry);
+        nextSweepAt = Math.min(nextSweepAt, nextEntry.resetAt);
+        return nextEntry;
       }
 
       let next = Number.POSITIVE_INFINITY;
@@ -38,6 +46,11 @@ export function createMemoryThrottlerStore(): ThrottlerStore {
       }
 
       nextSweepAt = Number.isFinite(next) ? next : 0;
+
+      const nextEntry = consumeWindow(map.get(key), input);
+      map.set(key, nextEntry);
+      nextSweepAt = nextSweepAt === 0 ? nextEntry.resetAt : Math.min(nextSweepAt, nextEntry.resetAt);
+      return nextEntry;
     },
   };
 }

--- a/packages/throttler/src/types.ts
+++ b/packages/throttler/src/types.ts
@@ -5,11 +5,13 @@ export interface ThrottlerStoreEntry {
   resetAt: number;
 }
 
+export interface ThrottlerConsumeInput {
+  now: number;
+  ttlSeconds: number;
+}
+
 export interface ThrottlerStore {
-  get(key: string): ThrottlerStoreEntry | undefined | Promise<ThrottlerStoreEntry | undefined>;
-  set(key: string, entry: ThrottlerStoreEntry): void | Promise<void>;
-  increment(key: string): number | Promise<number>;
-  evict(now: number): void | Promise<void>;
+  consume(key: string, input: ThrottlerConsumeInput): ThrottlerStoreEntry | Promise<ThrottlerStoreEntry>;
 }
 
 export interface ThrottlerHandlerOptions {


### PR DESCRIPTION
## Summary
- move throttler store contract to atomic `consume()` and update memory/redis adapters plus guard/tests to enforce consistent concurrent rate-limit decisions
- add constructor-scoped metadata caching in dto-validator and build-scoped DTO/schema caching in openapi to cut repeated metadata recomputation
- harden serialization/openapi edge cases: make cyclic serialization JSON-safe, avoid schema-name collisions, and reserve the default `ErrorResponse` component key

## Verification
- `pnpm --filter @konekti/dto-validator run build`
- `pnpm --filter @konekti/serializer run build`
- `pnpm --filter @konekti/throttler run build`
- `pnpm --filter @konekti/openapi run build`
- `pnpm --filter @konekti/dto-validator typecheck`
- `pnpm --filter @konekti/serializer typecheck`
- `pnpm --filter @konekti/throttler typecheck`
- `pnpm --filter @konekti/openapi typecheck`
- `pnpm exec vitest run packages/throttler/src/module.test.ts packages/serializer/src/serialize.test.ts packages/dto-validator/src/validation.test.ts packages/openapi/src/openapi-module.test.ts`

Closes #208