### PR TITLE
Resolve #211: add realtime backpressure controls and operation-scope reuse

### DIFF
--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -345,6 +345,51 @@ describe('@konekti/graphql — provider scopes', () => {
     await app.close();
   });
 
+  it('reuses one request scope across all resolver fields in the same operation', async () => {
+    @Inject([])
+    @Scope('request')
+    class OperationCounter {
+      count = 0;
+    }
+
+    @Inject([OperationCounter])
+    @Scope('request')
+    @Resolver('OperationScopedResolver')
+    class OperationScopedResolver {
+      constructor(private readonly counter: OperationCounter) {}
+
+      @Query({ outputType: 'int' })
+      firstTick(): number {
+        this.counter.count += 1;
+        return this.counter.count;
+      }
+
+      @Query({ outputType: 'int' })
+      secondTick(): number {
+        this.counter.count += 1;
+        return this.counter.count;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createGraphqlModule({ resolvers: [OperationScopedResolver] })],
+      providers: [OperationCounter, OperationScopedResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    await app.listen();
+
+    const firstOperation = await postGraphql(port, '{ firstTick secondTick }');
+    const secondOperation = await postGraphql(port, '{ firstTick secondTick }');
+
+    expect(firstOperation).toEqual({ data: { firstTick: 1, secondTick: 2 } });
+    expect(secondOperation).toEqual({ data: { firstTick: 1, secondTick: 2 } });
+
+    await app.close();
+  });
+
   it('transient resolver receives a fresh instance per operation', async () => {
     @Inject([])
     @Scope('transient')

--- a/packages/graphql/src/schema.ts
+++ b/packages/graphql/src/schema.ts
@@ -10,7 +10,13 @@ import type {
 import { DtoValidationError } from '@konekti/dto-validator';
 
 import { createGraphqlInput, resolveArgScalarType, resolveOutputScalarType } from './input-pipeline.js';
-import type { GraphQLContext, ResolverDescriptor, ResolverHandlerDescriptor, ResolverHandlerType } from './types.js';
+import {
+  GRAPHQL_OPERATION_CONTAINER,
+  type GraphQLContext,
+  type ResolverDescriptor,
+  type ResolverHandlerDescriptor,
+  type ResolverHandlerType,
+} from './types.js';
 
 type YogaGraphqlDeps = {
   GraphQLError: typeof GraphQLErrorType;
@@ -220,7 +226,8 @@ function createResolverInvoker(
       return resolverMethod.call(instance, input, contextValue);
     }
 
-    const operationContainer = runtimeContainer.createRequestScope();
+    const operationContainer = contextValue[GRAPHQL_OPERATION_CONTAINER] ?? runtimeContainer.createRequestScope();
+    const disposeOperationContainer = contextValue[GRAPHQL_OPERATION_CONTAINER] === undefined;
 
     try {
       const instance = await operationContainer.resolve(descriptor.token);
@@ -228,7 +235,9 @@ function createResolverInvoker(
       const input = await createResolverInput(deps, handler, args);
       return await resolverMethod.call(instance, input, contextValue);
     } finally {
-      await operationContainer.dispose();
+      if (disposeOperationContainer) {
+        await operationContainer.dispose();
+      }
     }
   };
 }

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -28,6 +28,7 @@ import { discoverResolverDescriptors } from './discovery.js';
 import { createCodeFirstSchema, resolveSchema } from './schema.js';
 import { GRAPHQL_LIFECYCLE_SERVICE, GRAPHQL_MODULE_OPTIONS } from './tokens.js';
 import { isGraphqlPath, toFetchRequest, writeFetchResponse } from './transport.js';
+import { GRAPHQL_OPERATION_CONTAINER } from './types.js';
 import type {
   GraphQLContext,
   GraphqlModuleOptions,
@@ -187,6 +188,7 @@ async function loadGraphqlDeps(): Promise<GraphqlDeps> {
 @Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, GRAPHQL_MODULE_OPTIONS])
 export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplicationShutdown {
   private middlewareRegistered = false;
+  private readonly operationContainers = new WeakMap<Request, Container>();
   private yoga: YogaLike | undefined;
 
   private readonly middleware: Middleware = {
@@ -209,15 +211,19 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
 
       try {
         const fetchRequest = toFetchRequest(context.request);
-        const fetchResponse = await graphqlRequestContextStorage.run(
-          {
-            principal: context.requestContext.principal,
-            request: context.request,
-          },
-          () => yoga.fetch(fetchRequest),
-        );
+        try {
+          const fetchResponse = await graphqlRequestContextStorage.run(
+            {
+              principal: context.requestContext.principal,
+              request: context.request,
+            },
+            () => yoga.fetch(fetchRequest),
+          );
 
-        await writeFetchResponse(fetchResponse, context.response);
+          await writeFetchResponse(fetchResponse, context.response);
+        } finally {
+          await this.disposeOperationContainer(fetchRequest);
+        }
       } catch (error) {
         this.logger.error('Failed to process GraphQL request.', error, 'GraphqlLifecycleService');
 
@@ -317,11 +323,41 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
       request: storedContext?.request ?? fallbackRequest,
     };
     const customContext = this.options.context?.(requestContext) ?? {};
+    const operationContainer = this.getOrCreateOperationContainer(request);
 
     return {
+      [GRAPHQL_OPERATION_CONTAINER]: operationContainer,
       ...customContext,
       principal: requestContext.principal,
       request: requestContext.request,
     };
+  }
+
+  private getOrCreateOperationContainer(request: Request): Container {
+    const existing = this.operationContainers.get(request);
+
+    if (existing) {
+      return existing;
+    }
+
+    const created = this.runtimeContainer.createRequestScope();
+    this.operationContainers.set(request, created);
+    return created;
+  }
+
+  private async disposeOperationContainer(request: Request): Promise<void> {
+    const operationContainer = this.operationContainers.get(request);
+
+    if (!operationContainer) {
+      return;
+    }
+
+    this.operationContainers.delete(request);
+
+    try {
+      await operationContainer.dispose();
+    } catch (error) {
+      this.logger.error('Failed to dispose GraphQL operation container.', error, 'GraphqlLifecycleService');
+    }
   }
 }

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -1,6 +1,9 @@
 import type { MetadataPropertyKey, Token } from '@konekti/core';
+import type { Container } from '@konekti/di';
 import type { FrameworkRequest, Principal } from '@konekti/http';
 import type { GraphQLSchema } from 'graphql';
+
+export const GRAPHQL_OPERATION_CONTAINER = Symbol.for('konekti.graphql.operation.container');
 
 export interface GraphqlRequestContext {
   request: FrameworkRequest;
@@ -10,6 +13,7 @@ export interface GraphqlRequestContext {
 export interface GraphQLContext {
   request: FrameworkRequest;
   principal?: Principal;
+  [GRAPHQL_OPERATION_CONTAINER]?: Container;
   [key: string]: unknown;
 }
 

--- a/packages/metrics/src/http-metrics-middleware.test.ts
+++ b/packages/metrics/src/http-metrics-middleware.test.ts
@@ -95,4 +95,52 @@ describe('HttpMetricsMiddleware', () => {
 
     expect(metricsText).toContain('http_requests_total{method="GET",path="/users/:id",status="200"} 1');
   });
+
+  it('passes immutable label snapshots to each metric recorder call', async () => {
+    const registry = new Registry();
+    const middleware = new HttpMetricsMiddleware(registry);
+
+    const calls: Array<{ sink: 'duration' | 'errors' | 'requests'; labels: Record<string, string> }> = [];
+    const requestsRecorder = {
+      inc(labels: Record<string, string>) {
+        labels.path = '/mutated-by-requests';
+        calls.push({ labels: { ...labels }, sink: 'requests' });
+      },
+    };
+    const durationRecorder = {
+      observe(labels: Record<string, string>, _value: number) {
+        calls.push({ labels: { ...labels }, sink: 'duration' });
+      },
+    };
+    const errorsRecorder = {
+      inc(labels: Record<string, string>) {
+        calls.push({ labels: { ...labels }, sink: 'errors' });
+      },
+    };
+
+    Reflect.set(middleware, 'requestsTotal', requestsRecorder);
+    Reflect.set(middleware, 'requestDuration', durationRecorder);
+    Reflect.set(middleware, 'errorsTotal', errorsRecorder);
+
+    const context = createContext('/users/123', { id: '123' });
+
+    await middleware.handle(context, async () => {
+      context.response.setStatus(500);
+    });
+
+    expect(calls).toEqual([
+      {
+        labels: { method: 'GET', path: '/mutated-by-requests', status: '500' },
+        sink: 'requests',
+      },
+      {
+        labels: { method: 'GET', path: '/users/:id', status: '500' },
+        sink: 'duration',
+      },
+      {
+        labels: { method: 'GET', path: '/users/:id', status: '500' },
+        sink: 'errors',
+      },
+    ]);
+  });
 });

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -7,6 +7,14 @@ type HttpMetricLabels = {
   status: string;
 };
 
+type MetricCounterLike = {
+  inc(labels: Record<string, string>): void;
+};
+
+type MetricHistogramLike = {
+  observe(labels: Record<string, string>, value: number): void;
+};
+
 export type HttpMetricsPathLabelMode = 'raw' | 'template';
 
 export interface HttpMetricsPathLabelContext {
@@ -45,9 +53,9 @@ function readErrorStatusCode(error: unknown): number | undefined {
 }
 
 export class HttpMetricsMiddleware implements Middleware {
-  private readonly requestsTotal: Counter<string>;
-  private readonly errorsTotal: Counter<string>;
-  private readonly requestDuration: Histogram<string>;
+  private readonly requestsTotal: MetricCounterLike;
+  private readonly errorsTotal: MetricCounterLike;
+  private readonly requestDuration: MetricHistogramLike;
   private readonly pathLabelMode: HttpMetricsPathLabelMode;
   private readonly pathLabelNormalizer?: HttpMetricsPathLabelNormalizer;
   private readonly unknownPathLabel: string;
@@ -132,17 +140,17 @@ export class HttpMetricsMiddleware implements Middleware {
     durationSeconds: number,
     requestError: unknown,
   ): void {
-    const labels: HttpMetricLabels = {
+    const labels: Readonly<HttpMetricLabels> = {
       method,
       path,
       status: String(statusCode),
     };
 
-    this.requestsTotal.inc(labels);
-    this.requestDuration.observe(labels, durationSeconds);
+    this.requestsTotal.inc({ ...labels });
+    this.requestDuration.observe({ ...labels }, durationSeconds);
 
     if (statusCode >= 400 || requestError !== undefined) {
-      this.errorsTotal.inc(labels);
+      this.errorsTotal.inc({ ...labels });
     }
   }
 }

--- a/packages/websocket/src/module.test.ts
+++ b/packages/websocket/src/module.test.ts
@@ -137,11 +137,13 @@ function createMockSocket(): {
   emitClose: (code?: number, reason?: Buffer) => void;
   emitPong: () => void;
   ping: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
   socket: WebSocket;
   terminate: ReturnType<typeof vi.fn>;
 } {
   const listeners: MockSocketListeners = {};
   const ping = vi.fn();
+  const send = vi.fn();
   const terminate = vi.fn();
 
   const socketObject = {
@@ -158,6 +160,8 @@ function createMockSocket(): {
     },
     ping,
     readyState: WebSocket.OPEN,
+    send,
+    bufferedAmount: 0,
     terminate,
   } as unknown as WebSocket;
 
@@ -169,6 +173,7 @@ function createMockSocket(): {
       listeners.pong?.();
     },
     ping,
+    send,
     socket: socketObject,
     terminate,
   };
@@ -463,6 +468,68 @@ describe('@konekti/websocket', () => {
     await app.close();
   });
 
+  it('caps pre-ready buffered websocket messages with drop-oldest policy', async () => {
+    const connected = createDeferred<void>();
+
+    class GatewayState {
+      messages: unknown[] = [];
+    }
+
+    @Inject([GatewayState])
+    @WebSocketGateway({ path: '/buffer-cap' })
+    class BufferedGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      async onConnect() {
+        await connected.promise;
+      }
+
+      @OnMessage('ping')
+      onPing(payload: unknown) {
+        this.state.messages.push(payload);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        createWebSocketModule({
+          buffer: {
+            maxPendingMessagesPerSocket: 2,
+            overflowPolicy: 'drop-oldest',
+          },
+        }),
+      ],
+      providers: [GatewayState, BufferedGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port,
+    });
+    const state = await app.container.resolve(GatewayState);
+
+    await app.listen();
+
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/buffer-cap`);
+    await onceOpen(socket);
+    socket.send(JSON.stringify({ event: 'ping', data: 'a' }));
+    socket.send(JSON.stringify({ event: 'ping', data: 'b' }));
+    socket.send(JSON.stringify({ event: 'ping', data: 'c' }));
+    socket.close();
+    await onceClosed(socket);
+
+    connected.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(state.messages).toEqual(['b', 'c']);
+
+    await app.close();
+  });
+
   it('delivers messages and disconnects that arrive after async onConnect completes', async () => {
     const connected = createDeferred<void>();
 
@@ -559,6 +626,50 @@ describe('@konekti/websocket', () => {
     await shutdown.call(service);
   });
 
+  it('caps ready-state message queue and drops newest messages when saturated', async () => {
+    const service = createTestLifecycleService({
+      buffer: {
+        maxPendingMessagesPerSocket: 1,
+        overflowPolicy: 'drop-newest',
+      },
+    });
+    const { socket } = createMockSocket();
+    const enqueueMessageDispatch = Reflect.get(service, 'enqueueMessageDispatch') as (
+      state: {
+        enqueuedMessageCount: number;
+        handlerQueue: Promise<void>;
+        resolved: Array<{ descriptor: unknown; instance: unknown }>;
+        socketId: string;
+      },
+      socket: WebSocket,
+      request: IncomingMessage,
+      data: unknown,
+    ) => void;
+    const gate = createDeferred<void>();
+    const handledPayloads: unknown[] = [];
+
+    Reflect.set(service, 'handleMessage', async (_resolved: unknown, _socket: WebSocket, _request: IncomingMessage, data: unknown) => {
+      handledPayloads.push(data);
+      await gate.promise;
+    });
+
+    const state = {
+      enqueuedMessageCount: 0,
+      handlerQueue: Promise.resolve(),
+      resolved: [],
+      socketId: 'socket-ready-1',
+    };
+
+    enqueueMessageDispatch.call(service, state, socket, {} as IncomingMessage, 'first');
+    enqueueMessageDispatch.call(service, state, socket, {} as IncomingMessage, 'second');
+
+    gate.resolve();
+    await state.handlerQueue;
+
+    expect(handledPayloads).toEqual(['first']);
+    expect(state.enqueuedMessageCount).toBe(0);
+  });
+
   it('terminates sockets when pong timeout is missed and clears heartbeat state', async () => {
     vi.useFakeTimers();
 
@@ -591,6 +702,49 @@ describe('@konekti/websocket', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('drops room broadcasts when socket bufferedAmount exceeds backpressure threshold', () => {
+    const service = createTestLifecycleService({
+      backpressure: {
+        maxBufferedAmountBytes: 1,
+        policy: 'drop',
+      },
+    });
+    const { send, socket, terminate } = createMockSocket();
+    (socket as unknown as { bufferedAmount: number }).bufferedAmount = 4;
+
+    const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, WebSocket>;
+    const roomSockets = Reflect.get(service, 'roomSockets') as Map<string, Set<string>>;
+    socketRegistry.set('socket-1', socket);
+    roomSockets.set('room-1', new Set(['socket-1']));
+
+    service.broadcastToRoom('room-1', 'event', { value: 'payload' });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it('terminates sockets on backpressure when policy is close', () => {
+    const service = createTestLifecycleService({
+      backpressure: {
+        maxBufferedAmountBytes: 1,
+        policy: 'close',
+      },
+    });
+    const { send, socket, terminate } = createMockSocket();
+    (socket as unknown as { bufferedAmount: number }).bufferedAmount = 4;
+
+    const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, WebSocket>;
+    const roomSockets = Reflect.get(service, 'roomSockets') as Map<string, Set<string>>;
+    socketRegistry.set('socket-1', socket);
+    roomSockets.set('room-1', new Set(['socket-1']));
+
+    service.broadcastToRoom('room-1', 'event', { value: 'payload' });
+
+    expect(send).not.toHaveBeenCalled();
+    expect(terminate).toHaveBeenCalledTimes(1);
+    expect(socketRegistry.has('socket-1')).toBe(false);
   });
 
   it('logs and continues shutdown when websocket server close exceeds timeout', async () => {

--- a/packages/websocket/src/service.ts
+++ b/packages/websocket/src/service.ts
@@ -43,6 +43,7 @@ interface GatewayAttachment {
 interface ConnectionHandlerState {
   bufferedDisconnect: BufferedDisconnectEvent | undefined;
   bufferedMessages: RawData[];
+  enqueuedMessageCount: number;
   handlerQueue: Promise<void>;
   handlersReady: boolean;
   resolved: Array<{ descriptor: WebSocketGatewayDescriptor; instance: unknown }>;
@@ -67,6 +68,12 @@ type BufferedDisconnectEvent = {
 };
 
 const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET = 256;
+const DEFAULT_MAX_BUFFERED_AMOUNT_BYTES = 1_048_576;
+
+function isFinitePositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 && Number.isInteger(value);
+}
 
 function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
   if (typeof provider === 'function') {
@@ -329,6 +336,7 @@ export class WebSocketGatewayLifecycleService
     return {
       bufferedDisconnect: undefined,
       bufferedMessages: [],
+      enqueuedMessageCount: 0,
       handlerQueue: Promise.resolve(),
       handlersReady: false,
       resolved: [],
@@ -342,9 +350,37 @@ export class WebSocketGatewayLifecycleService
     request: IncomingMessage,
     data: RawData,
   ): void {
+    const limit = isFinitePositiveInteger(this.moduleOptions.buffer?.maxPendingMessagesPerSocket)
+      ? this.moduleOptions.buffer.maxPendingMessagesPerSocket
+      : DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET;
+    const policy = this.moduleOptions.buffer?.overflowPolicy ?? 'drop-oldest';
+
+    if (state.enqueuedMessageCount >= limit) {
+      if (policy === 'close') {
+        socket.terminate();
+        this.unregisterSocket(state.socketId);
+        this.logger.warn(
+          `WebSocket connection ${state.socketId} exceeded ready-state message queue limit (${String(limit)}). Connection terminated.`,
+          'WebSocketGatewayLifecycleService',
+        );
+        return;
+      }
+
+      this.logger.warn(
+        `WebSocket connection ${state.socketId} dropped a ready-state message because queue limit (${String(limit)}) was reached.`,
+        'WebSocketGatewayLifecycleService',
+      );
+      return;
+    }
+
+    state.enqueuedMessageCount += 1;
+
     state.handlerQueue = state.handlerQueue
       .then(async () => {
         await this.handleMessage(state.resolved, socket, request, data);
+      })
+      .finally(() => {
+        state.enqueuedMessageCount = Math.max(0, state.enqueuedMessageCount - 1);
       })
       .catch((error) => {
         this.logger.error('WebSocket gateway message dispatch failed.', error, 'WebSocketGatewayLifecycleService');
@@ -378,7 +414,7 @@ export class WebSocketGatewayLifecycleService
   ): void {
     socket.on('message', (data: RawData) => {
       if (!state.handlersReady) {
-        state.bufferedMessages.push(data);
+        this.bufferIncomingMessage(state, socket, data);
         return;
       }
 
@@ -402,6 +438,46 @@ export class WebSocketGatewayLifecycleService
 
       this.enqueueDisconnectDispatch(state, socket, disconnectEvent);
     });
+  }
+
+  private bufferIncomingMessage(
+    state: ConnectionHandlerState,
+    socket: WebSocket,
+    data: RawData,
+  ): void {
+    const limit = isFinitePositiveInteger(this.moduleOptions.buffer?.maxPendingMessagesPerSocket)
+      ? this.moduleOptions.buffer.maxPendingMessagesPerSocket
+      : DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET;
+    const policy = this.moduleOptions.buffer?.overflowPolicy ?? 'drop-oldest';
+
+    if (state.bufferedMessages.length < limit) {
+      state.bufferedMessages.push(data);
+      return;
+    }
+
+    if (policy === 'close') {
+      socket.terminate();
+      this.logger.warn(
+        `WebSocket connection ${state.socketId} exceeded pending message buffer limit (${String(limit)}). Connection terminated.`,
+        'WebSocketGatewayLifecycleService',
+      );
+      return;
+    }
+
+    if (policy === 'drop-newest') {
+      this.logger.warn(
+        `WebSocket connection ${state.socketId} dropped an incoming message due to pending buffer limit (${String(limit)}).`,
+        'WebSocketGatewayLifecycleService',
+      );
+      return;
+    }
+
+    state.bufferedMessages.shift();
+    state.bufferedMessages.push(data);
+    this.logger.warn(
+      `WebSocket connection ${state.socketId} dropped the oldest pending message due to buffer limit (${String(limit)}).`,
+      'WebSocketGatewayLifecycleService',
+    );
   }
 
   private async resolveConnectionGateways(
@@ -440,8 +516,12 @@ export class WebSocketGatewayLifecycleService
 
     if (state.bufferedDisconnect) {
       this.enqueueDisconnectDispatch(state, socket, state.bufferedDisconnect);
+      state.bufferedDisconnect = undefined;
+      state.bufferedMessages = [];
       return;
     }
+
+    state.bufferedMessages = [];
 
     if (socket.readyState !== WebSocket.OPEN && socket.readyState !== WebSocket.CONNECTING) {
       this.unregisterSocket(state.socketId);
@@ -798,9 +878,32 @@ export class WebSocketGatewayLifecycleService
     }
 
     const message = JSON.stringify({ data, event });
+    const maxBufferedAmountBytes = isFinitePositiveInteger(this.moduleOptions.backpressure?.maxBufferedAmountBytes)
+      ? this.moduleOptions.backpressure.maxBufferedAmountBytes
+      : DEFAULT_MAX_BUFFERED_AMOUNT_BYTES;
+    const backpressurePolicy = this.moduleOptions.backpressure?.policy ?? 'drop';
+
     for (const socketId of socketIds) {
       const socket = this.socketRegistry.get(socketId);
       if (socket && socket.readyState === WebSocket.OPEN) {
+        if (socket.bufferedAmount > maxBufferedAmountBytes) {
+          if (backpressurePolicy === 'close') {
+            socket.terminate();
+            this.unregisterSocket(socketId);
+            this.logger.warn(
+              `WebSocket connection ${socketId} exceeded bufferedAmount threshold (${String(maxBufferedAmountBytes)} bytes). Connection terminated.`,
+              'WebSocketGatewayLifecycleService',
+            );
+            continue;
+          }
+
+          this.logger.warn(
+            `WebSocket connection ${socketId} exceeded bufferedAmount threshold (${String(maxBufferedAmountBytes)} bytes). Broadcast frame dropped.`,
+            'WebSocketGatewayLifecycleService',
+          );
+          continue;
+        }
+
         socket.send(message);
       }
     }

--- a/packages/websocket/src/types.ts
+++ b/packages/websocket/src/types.ts
@@ -54,6 +54,14 @@ export interface WebSocketRoomService {
 }
 
 export interface WebSocketModuleOptions {
+  backpressure?: {
+    maxBufferedAmountBytes?: number;
+    policy?: 'close' | 'drop';
+  };
+  buffer?: {
+    maxPendingMessagesPerSocket?: number;
+    overflowPolicy?: 'close' | 'drop-newest' | 'drop-oldest';
+  };
   heartbeat?: {
     enabled?: boolean;
     intervalMs?: number;


### PR DESCRIPTION
## Summary
- add websocket buffer/backpressure controls: pre-ready buffer cap, ready-state queue cap, room-broadcast bufferedAmount threshold, and overflow/pressure policies
- reuse one GraphQL request-scope container per operation (instead of per resolver invocation), then dispose it after request handling
- enforce immutable metric-label snapshots per recorder call to avoid cross-metric label mutation side effects

## Verification
- `pnpm build`
- `pnpm --filter @konekti/websocket typecheck && pnpm --filter @konekti/graphql typecheck && pnpm --filter @konekti/metrics typecheck`
- `pnpm vitest run packages/websocket/src/module.test.ts packages/graphql/src/module.test.ts packages/metrics/src/http-metrics-middleware.test.ts`

## Notes
- `pnpm typecheck` at workspace root currently reports unrelated pre-existing dependency typing errors in untouched packages; changed packages typecheck clean.

Closes #211