### PR TITLE
Resolve #210: prevent listener accumulation and payload mutation bleed

### DIFF
--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -97,7 +97,7 @@ describe('@konekti/event-bus', () => {
     }).toThrow('@OnEvent() cannot be used on static methods.');
   });
 
-  it('dispatches a published event to a single provider handler with the exact event instance', async () => {
+  it('dispatches a published event to a single provider handler with a rehydrated event instance', async () => {
     class EventStore {
       received: UserCreatedEvent | undefined;
     }
@@ -125,7 +125,9 @@ describe('@konekti/event-bus', () => {
 
     await eventBus.publish(event);
 
-    expect(store.received).toBe(event);
+    expect(store.received).toBeInstanceOf(UserCreatedEvent);
+    expect(store.received).not.toBe(event);
+    expect(store.received?.userId).toBe(event.userId);
 
     await app.close();
   });
@@ -172,6 +174,66 @@ describe('@konekti/event-bus', () => {
 
     expect(store.successCalls).toBe(1);
     expect(loggerEvents.some((event) => event.includes('Event handler FailingHandler.handle failed.'))).toBe(true);
+
+    await app.close();
+  });
+
+  it('isolates payload mutations between local handlers and transport publish', async () => {
+    const transport = {
+      published: [] as Array<{ channel: string; payload: unknown }>,
+      async publish(channel: string, payload: unknown) {
+        this.published.push({ channel, payload });
+      },
+      async subscribe(_channel: string, _handler: (payload: unknown) => Promise<void>) {},
+      async close() {},
+    } satisfies EventBusTransport & { published: Array<{ channel: string; payload: unknown }> };
+
+    class MutableEvent {
+      constructor(public readonly meta: { role: string }) {}
+    }
+
+    class EventStore {
+      firstSeen = '';
+      secondSeen = '';
+    }
+
+    @Inject([EventStore])
+    class FirstHandler {
+      constructor(private readonly store: EventStore) {}
+
+      @OnEvent(MutableEvent)
+      handle(event: MutableEvent) {
+        this.store.firstSeen = event.meta.role;
+        event.meta.role = 'mutated';
+      }
+    }
+
+    @Inject([EventStore])
+    class SecondHandler {
+      constructor(private readonly store: EventStore) {}
+
+      @OnEvent(MutableEvent)
+      handle(event: MutableEvent) {
+        this.store.secondSeen = event.meta.role;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createEventBusModule({ transport })],
+      providers: [EventStore, FirstHandler, SecondHandler],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+    const store = await app.container.resolve(EventStore);
+
+    await eventBus.publish(new MutableEvent({ role: 'original' }));
+
+    expect(store.firstSeen).toBe('original');
+    expect(store.secondSeen).toBe('original');
+    expect(transport.published).toHaveLength(1);
+    expect((transport.published[0]?.payload as { meta: { role: string } }).meta.role).toBe('original');
 
     await app.close();
   });
@@ -816,6 +878,58 @@ describe('@konekti/event-bus', () => {
       expect(store.received).toBeDefined();
       expect(store.received).toBeInstanceOf(UserCreatedEvent);
       expect(store.received!.userId).toBe('transport-user-2');
+
+      await app.close();
+    });
+
+    it('isolates payload mutations between handlers for incoming transport messages', async () => {
+      const transport = createMockTransport();
+
+      class MutableTransportEvent {
+        constructor(public readonly meta: { role: string }) {}
+      }
+
+      class EventStore {
+        firstSeen = '';
+        secondSeen = '';
+      }
+
+      @Inject([EventStore])
+      class FirstHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(MutableTransportEvent)
+        handle(event: MutableTransportEvent) {
+          this.store.firstSeen = event.meta.role;
+          event.meta.role = 'changed';
+        }
+      }
+
+      @Inject([EventStore])
+      class SecondHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(MutableTransportEvent)
+        handle(event: MutableTransportEvent) {
+          this.store.secondSeen = event.meta.role;
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+        providers: [EventStore, FirstHandler, SecondHandler],
+      });
+
+      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const store = await app.container.resolve(EventStore);
+      const incomingSubscription = transport.subscribed.find((s) => s.channel === 'MutableTransportEvent');
+
+      expect(incomingSubscription).toBeDefined();
+      await incomingSubscription!.handler({ meta: { role: 'original' } });
+
+      expect(store.firstSeen).toBe('original');
+      expect(store.secondSeen).toBe('original');
 
       await app.close();
     });

--- a/packages/event-bus/src/redis-transport.test.ts
+++ b/packages/event-bus/src/redis-transport.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RedisEventBusTransport } from './redis-transport.js';
+
+class MockRedisClient {
+  readonly messageListeners: Array<(channel: string, message: string) => void> = [];
+  readonly publishes: Array<{ channel: string; message: string }> = [];
+  readonly subscribedChannels: string[] = [];
+  disconnectCalls = 0;
+
+  on(event: string, listener: (channel: string, message: string) => void): this {
+    if (event === 'message') {
+      this.messageListeners.push(listener);
+    }
+
+    return this;
+  }
+
+  async publish(channel: string, message: string): Promise<number> {
+    this.publishes.push({ channel, message });
+    return 1;
+  }
+
+  async subscribe(channel: string): Promise<void> {
+    this.subscribedChannels.push(channel);
+  }
+
+  emitMessage(channel: string, payload: string): void {
+    for (const listener of this.messageListeners) {
+      listener(channel, payload);
+    }
+  }
+
+  disconnect(): void {
+    this.disconnectCalls += 1;
+  }
+}
+
+describe('RedisEventBusTransport', () => {
+  it('attaches a single message listener and dispatches by channel', async () => {
+    const publishClient = new MockRedisClient();
+    const subscribeClient = new MockRedisClient();
+    const transport = new RedisEventBusTransport({
+      publishClient: publishClient as never,
+      subscribeClient: subscribeClient as never,
+    });
+    const onUserCreated = vi.fn(async (_payload: unknown) => undefined);
+    const onPasswordReset = vi.fn(async (_payload: unknown) => undefined);
+
+    await transport.subscribe('UserCreatedEvent', onUserCreated);
+    await transport.subscribe('PasswordResetEvent', onPasswordReset);
+
+    expect(subscribeClient.subscribedChannels).toEqual(['UserCreatedEvent', 'PasswordResetEvent']);
+    expect(subscribeClient.messageListeners).toHaveLength(1);
+
+    subscribeClient.emitMessage('UserCreatedEvent', JSON.stringify({ userId: 'u1' }));
+    subscribeClient.emitMessage('PasswordResetEvent', JSON.stringify({ userId: 'u2' }));
+    subscribeClient.emitMessage('UnknownEvent', JSON.stringify({ ignored: true }));
+
+    expect(onUserCreated).toHaveBeenCalledTimes(1);
+    expect(onUserCreated).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(onPasswordReset).toHaveBeenCalledTimes(1);
+    expect(onPasswordReset).toHaveBeenCalledWith({ userId: 'u2' });
+  });
+
+  it('ignores invalid JSON payloads', async () => {
+    const transport = new RedisEventBusTransport({
+      publishClient: new MockRedisClient() as never,
+      subscribeClient: new MockRedisClient() as never,
+    });
+    const handler = vi.fn(async (_payload: unknown) => undefined);
+    const subscribeClient = (transport as unknown as { subscribeClient: MockRedisClient }).subscribeClient;
+
+    await transport.subscribe('InvalidJsonEvent', handler);
+    subscribeClient.emitMessage('InvalidJsonEvent', '{not-json');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('serializes publish payloads and disconnects both clients on close', async () => {
+    const publishClient = new MockRedisClient();
+    const subscribeClient = new MockRedisClient();
+    const transport = new RedisEventBusTransport({
+      publishClient: publishClient as never,
+      subscribeClient: subscribeClient as never,
+    });
+
+    await transport.publish('AuditEvent', { ok: true });
+
+    expect(publishClient.publishes).toEqual([{ channel: 'AuditEvent', message: '{"ok":true}' }]);
+
+    await transport.close();
+
+    expect(publishClient.disconnectCalls).toBe(1);
+    expect(subscribeClient.disconnectCalls).toBe(1);
+  });
+});

--- a/packages/event-bus/src/redis-transport.ts
+++ b/packages/event-bus/src/redis-transport.ts
@@ -10,37 +10,48 @@ export interface RedisEventBusTransportOptions {
 export class RedisEventBusTransport implements EventBusTransport {
   private readonly publishClient: Redis;
   private readonly subscribeClient: Redis;
+  private readonly handlersByChannel = new Map<string, (payload: unknown) => Promise<void>>();
+  private messageListenerAttached = false;
 
   constructor(options: RedisEventBusTransportOptions) {
     this.publishClient = options.publishClient;
     this.subscribeClient = options.subscribeClient;
   }
 
+  private readonly onMessage = (receivedChannel: string, message: string): void => {
+    const handler = this.handlersByChannel.get(receivedChannel);
+
+    if (!handler) {
+      return;
+    }
+
+    let payload: unknown;
+
+    try {
+      payload = JSON.parse(message) as unknown;
+    } catch {
+      return;
+    }
+
+    void handler(payload);
+  };
+
   async publish(channel: string, payload: unknown): Promise<void> {
     await this.publishClient.publish(channel, JSON.stringify(payload));
   }
 
   async subscribe(channel: string, handler: (payload: unknown) => Promise<void>): Promise<void> {
+    this.handlersByChannel.set(channel, handler);
     await this.subscribeClient.subscribe(channel);
 
-    this.subscribeClient.on('message', (receivedChannel: string, message: string) => {
-      if (receivedChannel !== channel) {
-        return;
-      }
-
-      let payload: unknown;
-
-      try {
-        payload = JSON.parse(message) as unknown;
-      } catch {
-        return;
-      }
-
-      void handler(payload);
-    });
+    if (!this.messageListenerAttached) {
+      this.subscribeClient.on('message', this.onMessage);
+      this.messageListenerAttached = true;
+    }
   }
 
   async close(): Promise<void> {
+    this.handlersByChannel.clear();
     this.subscribeClient.disconnect();
     this.publishClient.disconnect();
   }

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -39,6 +39,43 @@ interface InvocationBound {
   promise: Promise<never>;
 }
 
+function fallbackClone(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => fallbackClone(item));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const source = value as Record<string, unknown>;
+    const cloned: Record<string, unknown> = {};
+
+    for (const [key, item] of Object.entries(source)) {
+      cloned[key] = fallbackClone(item);
+    }
+
+    return cloned;
+  }
+
+  return value;
+}
+
+function cloneValue<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return fallbackClone(value) as T;
+  }
+}
+
+function createIsolatedEvent<TEvent extends object>(eventType: EventType<TEvent>, source: unknown): TEvent {
+  const clonedPayload = cloneValue(source);
+
+  if (typeof clonedPayload !== 'object' || clonedPayload === null) {
+    return clonedPayload as TEvent;
+  }
+
+  return Object.assign(Object.create(eventType.prototype) as object, clonedPayload) as TEvent;
+}
+
 class EventPublishTimeoutError extends Error {
   constructor(readonly timeoutMs: number) {
     super(`Event publish timed out after ${String(timeoutMs)}ms.`);
@@ -107,7 +144,8 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     await this.ensureDiscovered();
     const matchingDescriptors = this.matchEventDescriptors(event);
 
-    const transportPublish = this.publishToTransport(event);
+    const transportPayload = createIsolatedEvent(event.constructor as EventType, event);
+    const transportPublish = this.publishToTransport(transportPayload);
 
     if (matchingDescriptors.length === 0) {
       await transportPublish;
@@ -137,7 +175,10 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     event: object,
     publishOptions: ResolvedPublishOptions,
   ): Promise<void>[] {
-    return descriptors.map((descriptor) => this.invokeHandlerWithBounds(descriptor, event, publishOptions));
+    return descriptors.map((descriptor) => {
+      const isolatedEvent = createIsolatedEvent(event.constructor as EventType, event);
+      return this.invokeHandlerWithBounds(descriptor, isolatedEvent, publishOptions);
+    });
   }
 
   private createBackgroundInvocationTasks(
@@ -145,7 +186,10 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     event: object,
     signal: AbortSignal | undefined,
   ): Promise<void>[] {
-    return descriptors.map((descriptor) => this.invokeHandlerInBackground(descriptor, event, signal));
+    return descriptors.map((descriptor) => {
+      const isolatedEvent = createIsolatedEvent(event.constructor as EventType, event);
+      return this.invokeHandlerInBackground(descriptor, isolatedEvent, signal);
+    });
   }
 
   private runInvocationTasksInBackground(invocationTasks: Promise<void>[]): void {
@@ -264,7 +308,7 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
   private async subscribeTransportChannel(channel: string, eventType: EventType): Promise<void> {
     try {
       await this.transport!.subscribe(channel, async (payload) => {
-        const event = Object.assign(Object.create(eventType.prototype) as object, payload);
+        const event = createIsolatedEvent(eventType, payload);
         const matchingDescriptors = this.matchEventDescriptors(event);
 
         if (matchingDescriptors.length === 0) {

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -253,6 +253,57 @@ describe('@konekti/microservices', () => {
     await microservice.close();
   });
 
+  it('isolates payload mutations across event handlers and caller payloads', async () => {
+    class Store {
+      firstSeen = '';
+      secondSeen = '';
+    }
+
+    @Inject([Store])
+    class FirstHandler {
+      constructor(private readonly store: Store) {}
+
+      @EventPattern('audit.mutation')
+      onAudit(input: { meta: { role: string } }) {
+        this.store.firstSeen = input.meta.role;
+        input.meta.role = 'changed';
+      }
+    }
+
+    @Inject([Store])
+    class SecondHandler {
+      constructor(private readonly store: Store) {}
+
+      @EventPattern('audit.mutation')
+      onAudit(input: { meta: { role: string } }) {
+        this.store.secondSeen = input.meta.role;
+      }
+    }
+
+    const transport = new InMemoryLoopbackTransport();
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [createMicroservicesModule({ transport })],
+      providers: [Store, FirstHandler, SecondHandler],
+    });
+
+    const microservice = await KonektiFactory.createMicroservice(AppModule, {
+      mode: 'test',
+    });
+    const payload = { meta: { role: 'original' } };
+
+    await microservice.listen();
+    await microservice.emit('audit.mutation', payload);
+
+    const store = await microservice.get(Store);
+    expect(store.firstSeen).toBe('original');
+    expect(store.secondSeen).toBe('original');
+    expect(payload.meta.role).toBe('original');
+
+    await microservice.close();
+  });
+
   it('shares singleton provider state in hybrid app + microservice composition', async () => {
     class SharedState {
       count = 0;

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -28,6 +28,33 @@ interface DiscoveryCandidate {
   token: Token;
 }
 
+function fallbackClone(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => fallbackClone(item));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const source = value as Record<string, unknown>;
+    const cloned: Record<string, unknown> = {};
+
+    for (const [key, item] of Object.entries(source)) {
+      cloned[key] = fallbackClone(item);
+    }
+
+    return cloned;
+  }
+
+  return value;
+}
+
+function clonePayload<T>(payload: T): T {
+  try {
+    return structuredClone(payload);
+  } catch {
+    return fallbackClone(payload) as T;
+  }
+}
+
 function methodKeyToName(methodKey: MetadataPropertyKey): string {
   return typeof methodKey === 'symbol' ? methodKey.toString() : methodKey;
 }
@@ -82,11 +109,11 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
   }
 
   async send(pattern: string, payload: unknown, signal?: AbortSignal): Promise<unknown> {
-    return this.moduleOptions.transport.send(pattern, payload, signal);
+    return this.moduleOptions.transport.send(pattern, clonePayload(payload), signal);
   }
 
   async emit(pattern: string, payload: unknown): Promise<void> {
-    await this.moduleOptions.transport.emit(pattern, payload);
+    await this.moduleOptions.transport.emit(pattern, clonePayload(payload));
   }
 
   private async dispatchPacket(packet: TransportPacket): Promise<unknown> {
@@ -100,10 +127,10 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
         throw new Error(`No message handler registered for pattern "${packet.pattern}".`);
       }
 
-      return await this.invokeHandler(first, packet.payload);
+      return await this.invokeHandler(first, clonePayload(packet.payload));
     }
 
-    await Promise.allSettled(matches.map((descriptor) => this.invokeHandler(descriptor, packet.payload)));
+    await Promise.allSettled(matches.map((descriptor) => this.invokeHandler(descriptor, clonePayload(packet.payload))));
     return undefined;
   }
 

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -508,6 +508,51 @@ describe('@konekti/queue', () => {
     await app.close();
   });
 
+  it('keeps dead-letter payload immutable when worker mutates nested payload fields', async () => {
+    class MutableFailingJob {
+      constructor(public readonly meta: { role: string }) {}
+    }
+
+    @QueueWorker(MutableFailingJob, {
+      attempts: 1,
+      jobName: 'mutable-failing-job',
+    })
+    class MutableFailingWorker {
+      async handle(job: MutableFailingJob): Promise<void> {
+        job.meta.role = 'mutated';
+        throw new Error('mutated and failed');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createQueueModule()],
+      providers: [MutableFailingWorker],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      mode: 'test',
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const queue = await app.container.resolve<Queue>(QUEUE);
+
+    await queue.enqueue(new MutableFailingJob({ role: 'original' }));
+
+    const deadLetters = redis.deadLetters.get('konekti:queue:dead-letter:mutable-failing-job') ?? [];
+    expect(deadLetters).toHaveLength(1);
+    expect(JSON.parse(deadLetters[0]!)).toMatchObject({
+      payload: {
+        meta: {
+          role: 'original',
+        },
+      },
+    });
+
+    await app.close();
+  });
+
   it('allows enqueue during another provider onApplicationBootstrap', async () => {
     class BootstrapJob {
       constructor(public readonly value: string) {}

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -94,8 +94,35 @@ function serializeJobPayload(job: object): QueuePayload {
   return serialized;
 }
 
+function fallbackClone(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => fallbackClone(item));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const source = value as Record<string, unknown>;
+    const cloned: Record<string, unknown> = {};
+
+    for (const [key, item] of Object.entries(source)) {
+      cloned[key] = fallbackClone(item);
+    }
+
+    return cloned;
+  }
+
+  return value;
+}
+
+function cloneQueuePayload(payload: QueuePayload): QueuePayload {
+  try {
+    return structuredClone(payload);
+  } catch {
+    return fallbackClone(payload) as QueuePayload;
+  }
+}
+
 function rehydrateJobPayload<TJob extends object>(jobType: QueueJobType<TJob>, payload: QueuePayload): TJob {
-  return Object.assign(Object.create(jobType.prototype), payload) as TJob;
+  return Object.assign(Object.create(jobType.prototype), cloneQueuePayload(payload)) as TJob;
 }
 
 function toBullBackoff(backoff: QueueBackoffOptions | undefined): JobsOptions['backoff'] {


### PR DESCRIPTION
## Summary
- refactor `RedisEventBusTransport` to use a single Redis `message` listener with channel→handler dispatch map so subscriptions no longer accumulate one listener per channel
- isolate payload boundaries in event-bus, microservices, and queue lifecycles by cloning before handler invocation/transport fan-out to prevent cross-handler mutation bleed
- add regression tests for redis transport listener behavior and payload mutation isolation across event-bus, microservices, and queue dead-letter flow

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm exec vitest run packages/event-bus/src/module.test.ts packages/event-bus/src/redis-transport.test.ts packages/microservices/src/module.test.ts packages/queue/src/module.test.ts`

Closes #210