### PR TITLE
Resolve #212: optimize local scaffold I/O and dedupe tx request lifecycle

### DIFF
--- a/packages/cli/src/generators/render.ts
+++ b/packages/cli/src/generators/render.ts
@@ -4,8 +4,16 @@ import { fileURLToPath } from 'node:url';
 import ejs from 'ejs';
 
 const templatesDir = join(dirname(fileURLToPath(import.meta.url)), 'templates');
+const templateCache = new Map<string, string>();
 
 export function renderTemplate(templateName: string, vars: Record<string, unknown>): string {
-  const template = readFileSync(join(templatesDir, templateName), 'utf8');
-  return ejs.render(template, vars, { escape: (s) => String(s) });
+  const templatePath = join(templatesDir, templateName);
+  let template = templateCache.get(templatePath);
+
+  if (!template) {
+    template = readFileSync(templatePath, 'utf8');
+    templateCache.set(templatePath, template);
+  }
+
+  return ejs.render(template, vars, { escape: (s: unknown) => String(s) });
 }

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -1,7 +1,9 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 
 import { installDependencies } from './install.js';
 import type { BootstrapOptions, PackageManager } from './types.js';
@@ -42,6 +44,15 @@ const LOCAL_PACKAGE_NAMES: readonly LocalPackageName[] = [
   '@konekti/runtime',
   '@konekti/testing',
 ];
+
+const LOCAL_PACKAGE_CACHE_DIR = join(tmpdir(), 'konekti-cli-local-packages');
+const LOCAL_PACKAGE_CACHE_STAMP_FILE = 'cache-stamp.json';
+
+type LocalPackageCacheStamp = {
+  dirtyFingerprint: string;
+  headCommit: string;
+  packageVersions: Record<LocalPackageName, string>;
+};
 
 function packageRootFromImportMeta(importMetaUrl: string): string {
   return resolve(dirname(fileURLToPath(importMetaUrl)), '..', '..');
@@ -514,7 +525,7 @@ export async function scaffoldBootstrapApp(
 ): Promise<void> {
   const targetDirectory = resolve(options.targetDirectory);
   const releaseVersion = readOwnPackageVersion(importMetaUrl);
-  const packageSpecs = await resolvePackageSpecs(targetDirectory, options);
+  const packageSpecs = await resolvePackageSpecs(options);
 
   mkdirSync(targetDirectory, { recursive: true });
 
@@ -601,6 +612,120 @@ function getPackageVersionOrThrow(
   return packageVersion;
 }
 
+function toPackageVersionRecord(
+  packageVersions: ReadonlyMap<LocalPackageName, string>,
+): Record<LocalPackageName, string> {
+  const packageVersionRecord = {} as Record<LocalPackageName, string>;
+
+  for (const packageName of LOCAL_PACKAGE_NAMES) {
+    packageVersionRecord[packageName] = getPackageVersionOrThrow(packageVersions, packageName);
+  }
+
+  return packageVersionRecord;
+}
+
+function runGitCommand(repoRoot: string, args: string[]): string | undefined {
+  try {
+    return execFileSync('git', args, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function createPackagePathArguments(packageNames: readonly LocalPackageName[]): string[] {
+  const packagePaths = new Set<string>();
+
+  for (const packageName of packageNames) {
+    const packageDirectory = PACKAGE_DIRECTORY_BY_NAME[packageName];
+    const packageRoot = join('packages', packageDirectory);
+    packagePaths.add(packageRoot);
+    packagePaths.add(join(packageRoot, 'src'));
+    packagePaths.add(join(packageRoot, 'package.json'));
+    packagePaths.add(join(packageRoot, 'tsconfig.json'));
+    packagePaths.add(join(packageRoot, 'tsconfig.build.json'));
+  }
+
+  return Array.from(packagePaths);
+}
+
+function computeLocalPackageCacheStamp(
+  repoRoot: string,
+  packageNames: readonly LocalPackageName[],
+  packageVersions: ReadonlyMap<LocalPackageName, string>,
+): LocalPackageCacheStamp | undefined {
+  const headCommit = runGitCommand(repoRoot, ['rev-parse', 'HEAD']);
+
+  if (!headCommit) {
+    return undefined;
+  }
+
+  const packagePaths = createPackagePathArguments(packageNames);
+  const dirtyFingerprint = runGitCommand(repoRoot, ['status', '--porcelain', '--', ...packagePaths]);
+
+  if (dirtyFingerprint === undefined) {
+    return undefined;
+  }
+
+  return {
+    dirtyFingerprint,
+    headCommit,
+    packageVersions: toPackageVersionRecord(packageVersions),
+  };
+}
+
+function readLocalPackageCacheStamp(stampPath: string): LocalPackageCacheStamp | undefined {
+  if (!existsSync(stampPath)) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(readFileSync(stampPath, 'utf8')) as LocalPackageCacheStamp;
+  } catch {
+    return undefined;
+  }
+}
+
+function cacheStampMatches(expected: LocalPackageCacheStamp, actual: LocalPackageCacheStamp | undefined): boolean {
+  if (!actual) {
+    return false;
+  }
+
+  if (actual.headCommit !== expected.headCommit || actual.dirtyFingerprint !== expected.dirtyFingerprint) {
+    return false;
+  }
+
+  for (const packageName of LOCAL_PACKAGE_NAMES) {
+    if (actual.packageVersions[packageName] !== expected.packageVersions[packageName]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function cacheContainsTarballs(
+  outputDirectory: string,
+  packageNames: readonly LocalPackageName[],
+  packageVersions: ReadonlyMap<LocalPackageName, string>,
+): boolean {
+  const packedFiles = new Set(readdirSync(outputDirectory));
+
+  return packageNames.every((packageName) => {
+    const packageVersion = getPackageVersionOrThrow(packageVersions, packageName);
+    const tarball = expectedTarballName(packageName, packageVersion);
+    return packedFiles.has(tarball);
+  });
+}
+
+function createLocalPackageCachePath(repoRoot: string): string {
+  const repoCacheKey = createHash('sha1').update(resolve(repoRoot)).digest('hex').slice(0, 12);
+  return join(LOCAL_PACKAGE_CACHE_DIR, repoCacheKey);
+}
+
 function latestModifiedTimeMs(path: string): number {
   const stats = statSync(path);
 
@@ -665,14 +790,14 @@ async function packLocalPackages(
 ): Promise<void> {
   for (const packageName of packageNames) {
     const packageVersion = getPackageVersionOrThrow(packageVersions, packageName);
+    const tarballName = expectedTarballName(packageName, packageVersion);
 
     await runPackCommand(repoRoot, PACKAGE_DIRECTORY_BY_NAME[packageName], outputDirectory);
-    await normalizePackedPackageManifest(outputDirectory, expectedTarballName(packageName, packageVersion), packageVersions);
+    await normalizePackedPackageManifest(outputDirectory, tarballName, packageVersions);
   }
 }
 
 function createLocalTarballSpecs(
-  targetDirectory: string,
   outputDirectory: string,
   packageNames: readonly LocalPackageName[],
   packageVersions: ReadonlyMap<LocalPackageName, string>,
@@ -688,7 +813,7 @@ function createLocalTarballSpecs(
       throw new Error(`Unable to locate packed tarball for ${packageName}.`);
     }
 
-    tarballs.set(packageName, `file:${relative(targetDirectory, join(outputDirectory, tarball))}`);
+    tarballs.set(packageName, `file:${join(outputDirectory, tarball)}`);
   }
 
   return Object.fromEntries(tarballs);
@@ -772,22 +897,37 @@ async function normalizePackedPackageManifest(
   rmSync(temporaryDirectory, { force: true, recursive: true });
 }
 
-async function resolvePackageSpecs(targetDirectory: string, options: BootstrapOptions): Promise<Record<string, string>> {
+async function resolvePackageSpecs(options: BootstrapOptions): Promise<Record<string, string>> {
   if (options.dependencySource !== 'local' || !options.repoRoot) {
     return {};
   }
 
   const repoRoot = resolve(options.repoRoot);
-  const outputDirectory = join(targetDirectory, '.konekti', 'packages');
+  const outputDirectory = createLocalPackageCachePath(repoRoot);
+  const cacheStampPath = join(outputDirectory, LOCAL_PACKAGE_CACHE_STAMP_FILE);
   mkdirSync(outputDirectory, { recursive: true });
 
   const packageNames = LOCAL_PACKAGE_NAMES;
   const packageVersions = collectLocalPackageVersions(repoRoot, packageNames);
+  const expectedCacheStamp = computeLocalPackageCacheStamp(repoRoot, packageNames, packageVersions);
+  const currentCacheStamp = readLocalPackageCacheStamp(cacheStampPath);
+  const canReuseCachedTarballs = expectedCacheStamp
+    ? cacheStampMatches(expectedCacheStamp, currentCacheStamp)
+      && cacheContainsTarballs(outputDirectory, packageNames, packageVersions)
+    : false;
 
-  await ensureWorkspaceBuildOutput(repoRoot, packageNames);
-  await packLocalPackages(repoRoot, outputDirectory, packageNames, packageVersions);
+  if (!canReuseCachedTarballs) {
+    await ensureWorkspaceBuildOutput(repoRoot, packageNames);
+    await packLocalPackages(repoRoot, outputDirectory, packageNames, packageVersions);
 
-  return createLocalTarballSpecs(targetDirectory, outputDirectory, packageNames, packageVersions);
+    if (expectedCacheStamp) {
+      writeFileSync(cacheStampPath, `${JSON.stringify(expectedCacheStamp, null, 2)}\n`, 'utf8');
+    } else {
+      rmSync(cacheStampPath, { force: true });
+    }
+  }
+
+  return createLocalTarballSpecs(outputDirectory, packageNames, packageVersions);
 }
 
 export const scaffoldKonektiApp = scaffoldBootstrapApp;

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -1,6 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import { raceWithAbort } from '@konekti/runtime';
+import {
+  createRequestAbortContext,
+  raceWithAbort,
+  trackActiveRequestTransaction,
+  untrackActiveRequestTransaction,
+} from '@konekti/runtime';
 import type { OnApplicationShutdown } from '@konekti/runtime';
 import { Inject } from '@konekti/core';
 
@@ -17,12 +22,6 @@ const TRANSACTION_NOT_SUPPORTED_ERROR = 'Transaction not supported: Drizzle data
 type ActiveRequestTransaction = {
   abort(reason?: unknown): void;
   settled: Promise<void>;
-};
-
-type RequestAbortContext = {
-  controller: AbortController;
-  cleanup(): void;
-  signal: AbortSignal;
 };
 
 type ActiveRequestTransactionHandle = {
@@ -100,7 +99,7 @@ export class DrizzleDatabase<
     options: TTransactionOptions | undefined,
     signal?: AbortSignal,
   ): Promise<T> {
-    const abortContext = this.createRequestAbortContext(signal);
+    const abortContext = createRequestAbortContext(signal);
     const active = this.trackActiveRequestTransaction(abortContext.controller);
 
     try {
@@ -114,46 +113,12 @@ export class DrizzleDatabase<
     }
   }
 
-  private createRequestAbortContext(signal?: AbortSignal): RequestAbortContext {
-    const controller = new AbortController();
-    const forwardAbort = () => controller.abort(signal?.reason);
-
-    if (signal?.aborted) {
-      forwardAbort();
-    } else {
-      signal?.addEventListener('abort', forwardAbort, { once: true });
-    }
-
-    return {
-      controller,
-      cleanup: () => {
-        signal?.removeEventListener('abort', forwardAbort);
-      },
-      signal: controller.signal,
-    };
-  }
-
   private trackActiveRequestTransaction(controller: AbortController): ActiveRequestTransactionHandle {
-    let settle!: () => void;
-    const settled = new Promise<void>((resolve) => {
-      settle = resolve;
-    });
-
-    const active: ActiveRequestTransaction = {
-      abort(reason?: unknown) {
-        controller.abort(reason);
-      },
-      settled,
-    };
-
-    this.activeRequestTransactions.add(active);
-
-    return { active, settle };
+    return trackActiveRequestTransaction(this.activeRequestTransactions, controller);
   }
 
   private untrackActiveRequestTransaction(handle: ActiveRequestTransactionHandle): void {
-    this.activeRequestTransactions.delete(handle.active);
-    handle.settle();
+    untrackActiveRequestTransaction(this.activeRequestTransactions, handle);
   }
 
   private resolveTransactionRunner(): DrizzleTransactionRunner<TTransactionDatabase, TTransactionOptions> | undefined {

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -1,6 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-import { raceWithAbort } from '@konekti/runtime';
+import {
+  createRequestAbortContext,
+  raceWithAbort,
+  trackActiveRequestTransaction,
+  untrackActiveRequestTransaction,
+} from '@konekti/runtime';
 import type { OnApplicationShutdown, OnModuleInit } from '@konekti/runtime';
 import { Inject } from '@konekti/core';
 
@@ -10,12 +15,6 @@ import type { PrismaClientLike, PrismaHandleProvider } from './types.js';
 interface PrismaServiceOptions {
   strictTransactions: boolean;
 }
-
-type RequestAbortContext = {
-  controller: AbortController;
-  cleanup(): void;
-  signal: AbortSignal;
-};
 
 type ActiveRequestTransaction = {
   abort(reason?: unknown): void;
@@ -85,7 +84,7 @@ export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>,
   }
 
   async requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
-    const abortContext = this.createRequestAbortContext(signal);
+    const abortContext = createRequestAbortContext(signal);
     const active = this.trackActiveRequestTransaction(abortContext.controller);
 
     try {
@@ -99,45 +98,11 @@ export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>,
     }
   }
 
-  private createRequestAbortContext(signal?: AbortSignal): RequestAbortContext {
-    const controller = new AbortController();
-    const forwardAbort = () => controller.abort(signal?.reason);
-
-    if (signal?.aborted) {
-      forwardAbort();
-    } else {
-      signal?.addEventListener('abort', forwardAbort, { once: true });
-    }
-
-    return {
-      controller,
-      cleanup: () => {
-        signal?.removeEventListener('abort', forwardAbort);
-      },
-      signal: controller.signal,
-    };
-  }
-
   private trackActiveRequestTransaction(controller: AbortController): ActiveRequestTransactionHandle {
-    let settle!: () => void;
-    const settled = new Promise<void>((resolve) => {
-      settle = resolve;
-    });
-
-    const active: ActiveRequestTransaction = {
-      abort(reason?: unknown) {
-        controller.abort(reason);
-      },
-      settled,
-    };
-
-    this.activeRequestTransactions.add(active);
-
-    return { active, settle };
+    return trackActiveRequestTransaction(this.activeRequestTransactions, controller);
   }
 
   private untrackActiveRequestTransaction(handle: ActiveRequestTransactionHandle): void {
-    this.activeRequestTransactions.delete(handle.active);
-    handle.settle();
+    untrackActiveRequestTransaction(this.activeRequestTransactions, handle);
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,5 +7,6 @@ export * from './json-logger.js';
 export * from './logger.js';
 export * from './multipart.js';
 export * from './node.js';
+export * from './request-transaction.js';
 export * from './tokens.js';
 export * from './types.js';

--- a/packages/runtime/src/request-transaction.ts
+++ b/packages/runtime/src/request-transaction.ts
@@ -1,0 +1,63 @@
+export type RequestAbortContext = {
+  controller: AbortController;
+  cleanup(): void;
+  signal: AbortSignal;
+};
+
+export type ActiveRequestTransaction = {
+  abort(reason?: unknown): void;
+  settled: Promise<void>;
+};
+
+export type ActiveRequestTransactionHandle = {
+  active: ActiveRequestTransaction;
+  settle(): void;
+};
+
+export function createRequestAbortContext(signal?: AbortSignal): RequestAbortContext {
+  const controller = new AbortController();
+  const forwardAbort = () => controller.abort(signal?.reason);
+
+  if (signal?.aborted) {
+    forwardAbort();
+  } else {
+    signal?.addEventListener('abort', forwardAbort, { once: true });
+  }
+
+  return {
+    controller,
+    cleanup: () => {
+      signal?.removeEventListener('abort', forwardAbort);
+    },
+    signal: controller.signal,
+  };
+}
+
+export function trackActiveRequestTransaction(
+  activeRequestTransactions: Set<ActiveRequestTransaction>,
+  controller: AbortController,
+): ActiveRequestTransactionHandle {
+  let settle!: () => void;
+  const settled = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+
+  const active: ActiveRequestTransaction = {
+    abort(reason?: unknown) {
+      controller.abort(reason);
+    },
+    settled,
+  };
+
+  activeRequestTransactions.add(active);
+
+  return { active, settle };
+}
+
+export function untrackActiveRequestTransaction(
+  activeRequestTransactions: Set<ActiveRequestTransaction>,
+  handle: ActiveRequestTransactionHandle,
+): void {
+  activeRequestTransactions.delete(handle.active);
+  handle.settle();
+}


### PR DESCRIPTION
## Summary
- introduce reusable local tarball cache with git-backed change stamp in CLI scaffold, reducing repeated workspace scan/pack-repack cost for local dependency bootstraps
- add in-memory template cache for generator rendering to avoid repeat synchronous template reads
- extract shared request transaction abort/active tracking helpers into runtime and reuse them from both drizzle and prisma integrations

## Verification
- pnpm --filter @konekti/cli test
- pnpm exec vitest run packages/drizzle/src/module.test.ts packages/prisma/src/module.test.ts

Closes #212