### PR TITLE
Resolve #207: improve shutdown, routing, and config reload stability

### DIFF
--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -158,6 +158,41 @@ describe('loadConfig', () => {
     }
   });
 
+  it('isolates manual reload snapshots across listeners', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-reload-isolation-manual-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      mode: 'dev',
+      processEnv: {},
+    });
+
+    try {
+      let observedBySecondListener: string | undefined;
+
+      reloader.subscribe((snapshot) => {
+        snapshot['PORT'] = '9999';
+      });
+
+      reloader.subscribe((snapshot) => {
+        const port = snapshot['PORT'];
+        if (typeof port === 'string') {
+          observedBySecondListener = port;
+        }
+      });
+
+      writeFileSync(envPath, 'PORT=4100\n');
+      reloader.reload();
+
+      expect(observedBySecondListener).toBe('4100');
+    } finally {
+      reloader.close();
+    }
+  });
+
   it('keeps last valid snapshot and reports validation failures in watch mode', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-watch-validation-'));
     const envPath = join(cwd, '.env.dev');
@@ -250,6 +285,51 @@ describe('loadConfig', () => {
     await delay(150);
 
     expect(updates).toHaveLength(0);
+  });
+
+  it('isolates watch reload snapshots across listeners', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-reload-isolation-watch-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      mode: 'dev',
+      processEnv: {},
+      watch: true,
+    });
+
+    try {
+      let observedBySecondListener: string | undefined;
+
+      reloader.subscribe((snapshot, reason) => {
+        if (reason !== 'watch') {
+          return;
+        }
+
+        snapshot['PORT'] = '9999';
+      });
+
+      reloader.subscribe((snapshot, reason) => {
+        if (reason !== 'watch') {
+          return;
+        }
+
+        const port = snapshot['PORT'];
+        if (typeof port === 'string') {
+          observedBySecondListener = port;
+        }
+      });
+
+      await delay(100);
+      writeFileSync(envPath, 'PORT=4500\n');
+      await waitForCondition(() => observedBySecondListener !== undefined);
+
+      expect(observedBySecondListener).toBe('4500');
+    } finally {
+      reloader.close();
+    }
   });
 });
 

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -118,10 +118,8 @@ function notifyReloadListeners(
   snapshot: ConfigDictionary,
   reason: ConfigReloadReason,
 ): void {
-  const clonedSnapshot = cloneConfigDictionary(snapshot);
-
   for (const listener of listeners) {
-    listener(clonedSnapshot, reason);
+    listener(cloneConfigDictionary(snapshot), reason);
   }
 }
 

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -290,4 +290,70 @@ describe('handler mapping', () => {
 
     expect(v1Match?.descriptor.methodName).toBe('listV1');
   });
+
+  it('falls back to unversioned routes when request version is missing', () => {
+    @Controller('/users')
+    class UsersController {
+      @Get('/')
+      listDefault() {
+        return [{ id: 'default' }];
+      }
+
+      @Version('2')
+      @Get('/')
+      listV2() {
+        return [{ id: '2' }];
+      }
+    }
+
+    const mapping = createHandlerMapping(
+      [{ controllerToken: UsersController }],
+      { versioning: { header: 'x-api-version', type: VersioningType.HEADER } },
+    );
+
+    const fallbackMatch = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/users',
+      query: {},
+      raw: {},
+      url: '/users',
+    });
+
+    expect(fallbackMatch?.descriptor.methodName).toBe('listDefault');
+  });
+
+  it('preserves registration order among same method and segment count routes', () => {
+    @Controller('/users')
+    class UsersController {
+      @Get('/:id')
+      firstMatch() {
+        return { route: 'first' };
+      }
+
+      @Get('/:slug')
+      secondMatch() {
+        return { route: 'second' };
+      }
+    }
+
+    const mapping = createHandlerMapping([{ controllerToken: UsersController }]);
+    const match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/users/42',
+      query: {},
+      raw: {},
+      url: '/users/42',
+    });
+
+    expect(match?.descriptor.methodName).toBe('firstMatch');
+    expect(match?.params).toEqual({ id: '42' });
+  });
 });

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -25,6 +25,13 @@ interface CreateHandlerMappingOptions {
   versioning?: VersioningOptions;
 }
 
+type IndexedDescriptor = {
+  descriptor: HandlerDescriptor;
+  segments: readonly string[];
+};
+
+type DescriptorIndex = Map<HttpMethod, Map<number, IndexedDescriptor[]>>;
+
 function normalizePath(path: string): string {
   const segments = path.split('/').filter(Boolean);
   const normalized = `/${segments.join('/')}`;
@@ -192,9 +199,11 @@ function extractPathParams(path: string): string[] {
     .map((segment) => segment.slice(1));
 }
 
-function matchPath(registeredPath: string, incomingPath: string): Readonly<Record<string, string>> | undefined {
-  const registeredSegments = normalizePath(registeredPath).split('/').filter(Boolean);
-  const incomingSegments = normalizePath(incomingPath).split('/').filter(Boolean);
+function splitPathSegments(path: string): string[] {
+  return normalizePath(path).split('/').filter(Boolean);
+}
+
+function matchPath(registeredSegments: readonly string[], incomingSegments: readonly string[]): Readonly<Record<string, string>> | undefined {
 
   if (registeredSegments.length !== incomingSegments.length) {
     return undefined;
@@ -216,6 +225,35 @@ function matchPath(registeredPath: string, incomingPath: string): Readonly<Recor
   }
 
   return params;
+}
+
+function buildDescriptorIndex(descriptors: HandlerDescriptor[]): DescriptorIndex {
+  const index: DescriptorIndex = new Map();
+
+  for (const descriptor of descriptors) {
+    const method = descriptor.route.method;
+    const segments = splitPathSegments(descriptor.route.path);
+    const segmentCount = segments.length;
+
+    let methodMap = index.get(method);
+    if (!methodMap) {
+      methodMap = new Map();
+      index.set(method, methodMap);
+    }
+
+    let bucket = methodMap.get(segmentCount);
+    if (!bucket) {
+      bucket = [];
+      methodMap.set(segmentCount, bucket);
+    }
+
+    bucket.push({
+      descriptor,
+      segments,
+    });
+  }
+
+  return index;
 }
 
 function createHandlerDescriptors(source: HandlerSource, versioning: ResolvedVersioning): HandlerDescriptor[] {
@@ -285,55 +323,51 @@ function buildDescriptorList(sources: HandlerSource[], versioning: ResolvedVersi
 export function createHandlerMapping(sources: HandlerSource[], options?: CreateHandlerMappingOptions): HandlerMapping {
   const versioning = resolveVersioning(options);
   const descriptors = buildDescriptorList(sources, versioning);
+  const descriptorIndex = buildDescriptorIndex(descriptors);
 
   return {
     descriptors,
     match(request: FrameworkRequest): HandlerMatch | undefined {
       const method = request.method.toUpperCase() as HttpMethod;
       const requestVersion = versioning.type === VersioningType.URI ? undefined : resolveRequestVersion(request, versioning);
-      const matchedDescriptors: Array<{ descriptor: HandlerDescriptor; params: Readonly<Record<string, string>> }> = [];
+      const incomingSegments = splitPathSegments(request.path);
+      const candidates = descriptorIndex.get(method)?.get(incomingSegments.length) ?? [];
+      let firstUnversionedMatch: HandlerMatch | undefined;
 
-      for (const descriptor of descriptors) {
-        if (descriptor.route.method !== method) {
-          continue;
-        }
-
-        const params = matchPath(descriptor.route.path, request.path);
+      for (const candidate of candidates) {
+        const params = matchPath(candidate.segments, incomingSegments);
 
         if (!params) {
           continue;
         }
 
-        matchedDescriptors.push({ descriptor, params });
-
         if (versioning.type === VersioningType.URI) {
           return {
-            descriptor,
+            descriptor: candidate.descriptor,
+            params,
+          };
+        }
+
+        if (matchesRouteVersion(candidate.descriptor, requestVersion)) {
+          return {
+            descriptor: candidate.descriptor,
+            params,
+          };
+        }
+
+        if (candidate.descriptor.route.version === undefined && !firstUnversionedMatch) {
+          firstUnversionedMatch = {
+            descriptor: candidate.descriptor,
             params,
           };
         }
       }
 
       if (versioning.type !== VersioningType.URI) {
-        for (const match of matchedDescriptors) {
-          if (!matchesRouteVersion(match.descriptor, requestVersion)) {
-            continue;
-          }
-
+        if (firstUnversionedMatch) {
           return {
-            descriptor: match.descriptor,
-            params: match.params,
-          };
-        }
-
-        for (const match of matchedDescriptors) {
-          if (match.descriptor.route.version !== undefined) {
-            continue;
-          }
-
-          return {
-            descriptor: match.descriptor,
-            params: match.params,
+            descriptor: firstUnversionedMatch.descriptor,
+            params: firstUnversionedMatch.params,
           };
         }
       }

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -6,7 +6,26 @@ import { describe, expect, it } from 'vitest';
 import { Controller, Get, Post, type RequestContext } from '@konekti/http';
 import { defineModule, type ApplicationLogger } from '@konekti/runtime';
 
-import { bootstrapFastifyApplication, runFastifyApplication } from './adapter.js';
+import {
+  bootstrapFastifyApplication,
+  FastifyHttpApplicationAdapter,
+  runFastifyApplication,
+} from './adapter.js';
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
 
 async function findAvailablePort(): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
@@ -335,5 +354,37 @@ describe('@konekti/platform-fastify', () => {
     expect(loggerEvents).toContain(`log:KonektiFactory:Listening on https://127.0.0.1:${String(port)}`);
 
     await app.close();
+  });
+
+  it('clears dispatcher only after fastify close settles when timeout wins', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
+    const app = {
+      close: () => Promise.resolve(),
+      server: {
+        listening: true,
+      },
+    };
+    const dispatcher = {
+      async dispatch() {},
+    };
+    const deferred = createDeferred<void>();
+    let closeCallCount = 0;
+
+    Reflect.set(adapter, 'app', app);
+    Reflect.set(adapter, 'dispatcher', dispatcher);
+    app.close = () => {
+      closeCallCount += 1;
+      return deferred.promise;
+    };
+
+    await adapter.close();
+
+    expect(closeCallCount).toBe(1);
+    expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
+
+    deferred.resolve();
+    await Promise.resolve();
+
+    expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
   });
 });

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -94,6 +94,7 @@ type FastifyFrameworkResponse = FrameworkResponse & {
 };
 
 export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
+  private closeInFlight?: Promise<void>;
   private dispatcher?: Dispatcher;
   private pluginsReady = false;
   private readonly app: ReturnType<typeof fastify>;
@@ -132,13 +133,23 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
       return;
     }
 
-    await Promise.race([
-      this.app.close(),
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, this.shutdownTimeoutMs);
-      }),
-    ]);
-    this.dispatcher = undefined;
+    if (!this.closeInFlight) {
+      const closePromise = this.app.close();
+      const closeInFlight = closePromise.finally(() => {
+        this.closeInFlight = undefined;
+        this.dispatcher = undefined;
+      });
+      this.closeInFlight = closeInFlight;
+      void closeInFlight.catch(() => {});
+    }
+
+    const closeInFlight = this.closeInFlight;
+
+    if (!closeInFlight) {
+      return;
+    }
+
+    await waitForCloseWithTimeout(closeInFlight, this.shutdownTimeoutMs);
   }
 
   private async registerPluginsAndRoute(): Promise<void> {
@@ -805,6 +816,15 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number): Promise<void> {
+  return Promise.race([
+    closePromise,
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, timeoutMs);
+    }),
+  ]);
 }
 
 function mergeSetCookieHeader(


### PR DESCRIPTION
## Summary
- Keep Fastify dispatcher bound until actual close settlement so shutdown timeout no longer clears dispatch state too early.
- Build method + segment-count route index in handler mapping to reduce request-time linear scans while preserving matching order semantics.
- Clone reload snapshots per config listener to prevent listener-to-listener snapshot contamination in manual and watch reload paths.

## Verification
- `pnpm exec vitest run packages/config/src/load.test.ts packages/http/src/mapping.test.ts packages/platform-fastify/src/adapter.test.ts`
- `pnpm typecheck`
- `pnpm build`

Closes #207