### PR TITLE
Resolve #220: prevent forRootAsync refresh bootstrap crashes

### DIFF
--- a/packages/jwt/src/module.test.ts
+++ b/packages/jwt/src/module.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { Inject, getModuleMetadata, type Constructor, type Token } from '@konekti/core';
+import { Inject, getClassDiMetadata, getModuleMetadata, type Constructor, type Token } from '@konekti/core';
 import { Container, type Provider } from '@konekti/di';
 
 import { JwtModule } from './module.js';
@@ -47,6 +47,44 @@ function moduleProviders(moduleType: Constructor): Provider[] {
   }
 
   return metadata.providers as Provider[];
+}
+
+function providerScope(provider: Provider): 'singleton' | 'request' | 'transient' {
+  if (typeof provider === 'function') {
+    return getClassDiMetadata(provider)?.scope ?? 'singleton';
+  }
+
+  if ('useValue' in provider) {
+    return 'singleton';
+  }
+
+  if ('useClass' in provider) {
+    return provider.scope ?? getClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
+  }
+
+  if ('useFactory' in provider) {
+    return provider.scope ?? 'singleton';
+  }
+
+  return 'singleton';
+}
+
+function providerToken(provider: Provider): Token {
+  if (typeof provider === 'function') {
+    return provider;
+  }
+
+  return provider.provide;
+}
+
+async function resolveSingletonProviders(container: Container, providers: Provider[]): Promise<void> {
+  for (const provider of providers) {
+    if (providerScope(provider) !== 'singleton') {
+      continue;
+    }
+
+    await container.resolve(providerToken(provider));
+  }
 }
 
 describe('JwtModule', () => {
@@ -111,6 +149,43 @@ describe('JwtModule', () => {
     container.register(...moduleProviders(moduleType));
 
     await expect(container.resolve(DefaultJwtSigner)).rejects.toThrow('jwt async options failed');
+  });
+
+  it('does not fail singleton provider resolution when async options omit refreshToken', async () => {
+    const container = new Container();
+    const moduleType = JwtModule.forRootAsync({
+      useFactory: async () => ({
+        algorithms: ['HS256'],
+        issuer: 'jwt-module-tests',
+        secret: 'async-secret-without-refresh',
+      }),
+    });
+
+    const providers = moduleProviders(moduleType);
+
+    container.register(...providers);
+
+    await expect(resolveSingletonProviders(container, providers)).resolves.toBeUndefined();
+  });
+
+  it('resolves refresh token service for async options when refreshToken is configured', async () => {
+    const container = new Container();
+    const moduleType = JwtModule.forRootAsync({
+      useFactory: async () => ({
+        algorithms: ['HS256'],
+        refreshToken: {
+          expiresInSeconds: 60,
+          rotation: true,
+          secret: 'refresh-secret',
+          store: new NoopRefreshTokenStore(),
+        },
+        secret: 'jwt-secret',
+      }),
+    });
+
+    container.register(...moduleProviders(moduleType));
+
+    await expect(container.resolve(RefreshTokenService)).resolves.toBeInstanceOf(RefreshTokenService);
   });
 
   it('registers refresh token service when refresh options are provided', async () => {

--- a/packages/jwt/src/module.ts
+++ b/packages/jwt/src/module.ts
@@ -28,14 +28,18 @@ function hasRefreshTokenOptions(
   return typeof value === 'object' && value !== null && 'refreshToken' in value && Boolean(value.refreshToken);
 }
 
-function createJwtModuleProviders(optionsProvider: JwtOptionsProvider, includeRefreshTokenService: boolean): Provider[] {
+function createJwtModuleProviders(
+  optionsProvider: JwtOptionsProvider,
+  includeRefreshTokenService: boolean,
+  refreshTokenServiceScope: 'singleton' | 'transient',
+): Provider[] {
   const providers: Provider[] = [optionsProvider, DefaultJwtVerifier, DefaultJwtSigner];
 
   if (includeRefreshTokenService) {
     providers.push({
       inject: [JWT_OPTIONS, DefaultJwtSigner, DefaultJwtVerifier],
       provide: RefreshTokenService,
-      scope: 'singleton',
+      scope: refreshTokenServiceScope,
       useFactory: (...deps: unknown[]) => {
         const [options, signer, verifier] = deps;
 
@@ -60,7 +64,7 @@ export function createJwtCoreProviders(options: JwtVerifierOptions): Provider[] 
     provide: JWT_OPTIONS,
     scope: 'singleton',
     useValue: options,
-  }, Boolean(options.refreshToken));
+  }, Boolean(options.refreshToken), 'singleton');
 }
 
 export class JwtModule {
@@ -69,7 +73,7 @@ export class JwtModule {
       provide: JWT_OPTIONS,
       scope: 'singleton',
       useValue: options,
-    }, Boolean(options.refreshToken));
+    }, Boolean(options.refreshToken), 'singleton');
   }
 
   static forRootAsync(options: AsyncModuleOptions<JwtVerifierOptions>): ModuleType {
@@ -78,15 +82,19 @@ export class JwtModule {
       provide: JWT_OPTIONS,
       scope: 'singleton',
       useFactory: options.useFactory,
-    }, true);
+    }, true, 'transient');
   }
 
-  private static createModule(optionsProvider: JwtOptionsProvider, includeRefreshTokenService: boolean): ModuleType {
+  private static createModule(
+    optionsProvider: JwtOptionsProvider,
+    includeRefreshTokenService: boolean,
+    refreshTokenServiceScope: 'singleton' | 'transient',
+  ): ModuleType {
     class JwtRuntimeModule {}
 
     defineModuleMetadata(JwtRuntimeModule, {
       exports: [DefaultJwtVerifier, DefaultJwtSigner, ...(includeRefreshTokenService ? [RefreshTokenService] : [])],
-      providers: createJwtModuleProviders(optionsProvider, includeRefreshTokenService),
+      providers: createJwtModuleProviders(optionsProvider, includeRefreshTokenService, refreshTokenServiceScope),
     });
 
     return JwtRuntimeModule;


### PR DESCRIPTION
## Summary
- make `JwtModule.forRootAsync()` register `RefreshTokenService` as transient so bootstrap lifecycle singleton resolution no longer fails when `refreshToken` is omitted
- keep refresh-token behavior intact when async options include `refreshToken`, and preserve existing synchronous registration behavior
- add regression tests for async options without `refreshToken` and async options with `refreshToken`

Closes #220

## Verification
- `pnpm build`
- `pnpm --filter @konekti/jwt run typecheck`
- `pnpm vitest run packages/jwt/src/*.test.ts`