### PR TITLE
Resolve #222: align event-bus transport matching with local inheritance semantics

### DIFF
--- a/packages/event-bus/README.ko.md
+++ b/packages/event-bus/README.ko.md
@@ -3,7 +3,7 @@
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
 
-**인프로세스 전용.** Konekti 애플리케이션을 위한 인프로세스 이벤트 발행 패키지입니다. 데코레이터 기반으로 singleton provider/controller 핸들러를 찾아서 실행합니다.
+Konekti 애플리케이션을 위한 이벤트 발행 패키지입니다. 기본은 인프로세스 디스패치이며, 선택적으로 transport 어댑터를 연결해 프로세스 간 fan-out을 구성할 수 있습니다.
 
 ## 설치
 
@@ -11,7 +11,7 @@
 npm install @konekti/event-bus
 ```
 
-> **⚠️ 범위: 인프로세스 전용.** 이 패키지는 단일 Node.js 프로세스 내에서만 이벤트를 전달합니다. 내구성 보장, 영속성, 크로스 프로세스 전달, 재생 기능을 제공하지 않습니다. 디스패치 중 애플리케이션이 크래시되면 처리 중인 이벤트는 유실됩니다. 내구성 있는 분산 이벤트 처리가 필요하면 Redis 기반의 `@konekti/queue`를 사용하세요.
+> **⚠️ 내구성 보장은 없음.** transport를 연결하더라도 큐잉/재생/영속성은 제공하지 않습니다. 디스패치 중 애플리케이션이 크래시되면 처리 중인 이벤트는 유실될 수 있습니다. 내구성 있는 분산 처리에는 Redis 기반의 `@konekti/queue`를 사용하세요.
 
 ## 빠른 시작
 
@@ -60,13 +60,32 @@ export class AppModule {}
 
 - `publish.timeoutMs` - `waitForHandlers: true`일 때 `publish()`가 핸들러별로 대기하는 최대 시간(ms)
 - `publish.waitForHandlers` - 기본 대기 모드 (`true`는 대기 + timeout 적용, `false`는 비차단 fire-and-forget 디스패치)
+- `transport` - 선택적 외부 pub/sub 어댑터 (`EventBusTransport` 구현체)
+
+### event key 규약
+
+transport 채널 키는 이벤트 클래스에서 아래 순서로 결정됩니다.
+
+1. 이벤트 클래스에 `static eventKey = 'domain.event.v1'`가 있으면 해당 값을 사용
+2. 없으면 하위 호환을 위해 클래스 이름(`constructor.name`) 사용
+
+멀티 프로세스 환경에서는 클래스 이름 의존 대신 버전이 포함된 명시적 키를 권장합니다.
+
+```typescript
+class UserRegisteredEvent {
+  static readonly eventKey = 'user.registered.v1';
+
+  constructor(public readonly userId: string) {}
+}
+```
 
 ## 런타임 동작
 
 - 애플리케이션 부트스트랩에서 `COMPILED_MODULES` 기반 핸들러 탐색
 - 이벤트 발행 시 `RUNTIME_CONTAINER`에서 핸들러 인스턴스 해석
 - `instanceof` 기반 클래스 매칭으로 상속 이벤트까지 처리
-- 모든 매칭 핸들러에 디스패치하며, 두 모드 모두 cancellation signal을 지원
+- 모든 매칭 핸들러에 디스패치하며, transport 사용 시 매칭된 핸들러 이벤트 타입 채널로 fan-out
+- transport 수신 이벤트는 해당 채널에 등록된 핸들러에만 디스패치되어 로컬/원격 상속 매칭 결과를 일치
 - timeout 경계는 `waitForHandlers: true`일 때만 적용되며, `false`일 때는 대기 없이 디스패치
 - 핸들러 오류는 `ApplicationLogger`로 격리 로깅
 - `request`/`transient` 스코프의 `@OnEvent()` 핸들러는 경고 후 제외

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -73,6 +73,25 @@ interface EventBusTransport {
 
 Implement this interface to connect any external pub/sub system.
 
+### Event key convention
+
+Transport channels are resolved from event classes by the following rule:
+
+1. If the event class defines `static eventKey = 'domain.event.v1'`, that string is used.
+2. Otherwise, the fallback is the class constructor name (for backward compatibility).
+
+For multi-process deployments, prefer explicit, versioned keys:
+
+```typescript
+class UserRegisteredEvent {
+  static readonly eventKey = 'user.registered.v1';
+
+  constructor(public readonly userId: string) {}
+}
+```
+
+This avoids coupling transport contracts to class renames/minification and makes schema evolution explicit.
+
 ### Redis Pub/Sub adapter
 
 ```bash
@@ -104,9 +123,10 @@ Two separate Redis clients are required because a client in subscribe mode canno
 - Handler discovery runs during application bootstrap using `COMPILED_MODULES`
 - Handler instances are pre-resolved from `RUNTIME_CONTAINER` during bootstrap and reused on publish
 - Events are matched by class using `instanceof`, so base-class handlers receive derived events
-- Publishing dispatches to every matching local handler and, when a transport is configured, fans out to the transport in parallel
+- Publishing dispatches to every matching local handler and, when a transport is configured, fans out to transport channels for all matched handler event types in parallel
 - When a transport is configured, the event bus subscribes to one channel per discovered event type on bootstrap; incoming messages are deserialized with `JSON.parse` and dispatched to matching local handlers
-- The channel name for a given event type is the class constructor name (e.g. `UserRegisteredEvent`)
+- Incoming transport messages are dispatched only to handlers registered for that subscribed channel, keeping local/remote inheritance matching outcomes consistent
+- The channel name for a given event type uses `eventType.eventKey` when present, otherwise falls back to the class constructor name (e.g. `UserRegisteredEvent`)
 - Transport `close()` is called during `onApplicationShutdown`
 - Timeout bounds apply only when waiting mode is enabled (`waitForHandlers: true`); non-blocking mode (`false`) dispatches without waiting
 - Handler failures are isolated and logged through `ApplicationLogger`

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -882,6 +882,112 @@ describe('@konekti/event-bus', () => {
       await app.close();
     });
 
+    it('keeps inherited handler matching consistent for transport messages', async () => {
+      const transport = createMockTransport();
+
+      class EventStore {
+        baseCalls = 0;
+        derivedCalls = 0;
+      }
+
+      @Inject([EventStore])
+      class BaseHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(UserCreatedEvent)
+        onBase(_event: UserCreatedEvent) {
+          this.store.baseCalls += 1;
+        }
+      }
+
+      @Inject([EventStore])
+      class DerivedHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(UserPromotedEvent)
+        onDerived(_event: UserPromotedEvent) {
+          this.store.derivedCalls += 1;
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+        providers: [EventStore, BaseHandler, DerivedHandler],
+      });
+
+      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+      const store = await app.container.resolve(EventStore);
+
+      await eventBus.publish(new UserPromotedEvent('transport-user-3', 'admin'));
+
+      const publishedChannels = transport.published.map((entry) => entry.channel).sort();
+      expect(publishedChannels).toEqual(['UserCreatedEvent', 'UserPromotedEvent']);
+
+      const baseSubscription = transport.subscribed.find((entry) => entry.channel === 'UserCreatedEvent');
+      const derivedSubscription = transport.subscribed.find((entry) => entry.channel === 'UserPromotedEvent');
+
+      expect(baseSubscription).toBeDefined();
+      expect(derivedSubscription).toBeDefined();
+
+      await derivedSubscription!.handler({ userId: 'remote-derived', role: 'admin' });
+      await baseSubscription!.handler({ userId: 'remote-derived', role: 'admin' });
+
+      expect(store.baseCalls).toBe(2);
+      expect(store.derivedCalls).toBe(2);
+
+      await app.close();
+    });
+
+    it('uses explicit static eventKey values for transport channels', async () => {
+      const transport = createMockTransport();
+
+      class InventoryAdjustedEvent {
+        static readonly eventKey = 'inventory.adjusted.v1';
+
+        constructor(public readonly sku: string) {}
+      }
+
+      class EventStore {
+        receivedSku = '';
+      }
+
+      @Inject([EventStore])
+      class InventoryHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(InventoryAdjustedEvent)
+        onAdjusted(event: InventoryAdjustedEvent) {
+          this.store.receivedSku = event.sku;
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+        providers: [EventStore, InventoryHandler],
+      });
+
+      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+      const store = await app.container.resolve(EventStore);
+
+      await eventBus.publish(new InventoryAdjustedEvent('sku-1'));
+
+      expect(transport.published).toHaveLength(1);
+      expect(transport.published[0]!.channel).toBe('inventory.adjusted.v1');
+
+      const incomingSubscription = transport.subscribed.find((entry) => entry.channel === 'inventory.adjusted.v1');
+      expect(incomingSubscription).toBeDefined();
+
+      await incomingSubscription!.handler({ sku: 'sku-2' });
+
+      expect(store.receivedSku).toBe('sku-2');
+
+      await app.close();
+    });
+
     it('isolates payload mutations between handlers for incoming transport messages', async () => {
       const transport = createMockTransport();
 

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -145,7 +145,7 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     const matchingDescriptors = this.matchEventDescriptors(event);
 
     const transportPayload = createIsolatedEvent(event.constructor as EventType, event);
-    const transportPublish = this.publishToTransport(transportPayload);
+    const transportPublish = this.publishToTransport(transportPayload, matchingDescriptors);
 
     if (matchingDescriptors.length === 0) {
       await transportPublish;
@@ -264,25 +264,53 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
   }
 
   private channelFromEventType(eventType: EventType): string {
+    if (typeof eventType.eventKey === 'string') {
+      const eventKey = eventType.eventKey.trim();
+
+      if (eventKey.length > 0) {
+        return eventKey;
+      }
+    }
+
     return eventType.name;
   }
 
-  private async publishToTransport(event: object): Promise<void> {
+  private channelsForTransportPublish(event: object, descriptors: EventHandlerDescriptor[]): string[] {
+    const channels = new Set<string>();
+
+    for (const descriptor of descriptors) {
+      channels.add(this.channelFromEventType(descriptor.eventType));
+    }
+
+    if (channels.size === 0) {
+      channels.add(this.channelFromEventType(event.constructor as EventType));
+    }
+
+    return Array.from(channels);
+  }
+
+  private async publishToTransport(event: object, descriptors: EventHandlerDescriptor[]): Promise<void> {
     if (!this.transport) {
       return;
     }
 
-    const channel = this.channelFromEventType(event.constructor as EventType);
+    const channels = this.channelsForTransportPublish(event, descriptors);
 
-    try {
-      await this.transport.publish(channel, event);
-    } catch (error) {
-      this.logger.error(
-        `EventBusTransport failed to publish to channel "${channel}".`,
-        error,
-        'EventBusLifecycleService',
-      );
-    }
+    const publishTasks = channels.map(async (channel) => {
+      const payload = createIsolatedEvent(event.constructor as EventType, event);
+
+      try {
+        await this.transport!.publish(channel, payload);
+      } catch (error) {
+        this.logger.error(
+          `EventBusTransport failed to publish to channel "${channel}".`,
+          error,
+          'EventBusLifecycleService',
+        );
+      }
+    });
+
+    await Promise.allSettled(publishTasks);
   }
 
   private async subscribeTransportChannels(): Promise<void> {
@@ -290,32 +318,39 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
       return;
     }
 
-    const subscribedChannels = new Set<string>();
+    const descriptorsByChannel = new Map<string, EventHandlerDescriptor[]>();
 
     for (const descriptor of this.descriptors) {
       const channel = this.channelFromEventType(descriptor.eventType);
+      const channelDescriptors = descriptorsByChannel.get(channel) ?? [];
+      channelDescriptors.push(descriptor);
+      descriptorsByChannel.set(channel, channelDescriptors);
+    }
 
-      if (subscribedChannels.has(channel)) {
+    for (const [channel, channelDescriptors] of descriptorsByChannel) {
+      const eventType = channelDescriptors[0]?.eventType;
+
+      if (!eventType) {
         continue;
       }
 
-      subscribedChannels.add(channel);
-
-      await this.subscribeTransportChannel(channel, descriptor.eventType);
+      await this.subscribeTransportChannel(channel, eventType, channelDescriptors);
     }
   }
 
-  private async subscribeTransportChannel(channel: string, eventType: EventType): Promise<void> {
+  private async subscribeTransportChannel(
+    channel: string,
+    eventType: EventType,
+    channelDescriptors: EventHandlerDescriptor[],
+  ): Promise<void> {
     try {
       await this.transport!.subscribe(channel, async (payload) => {
         const event = createIsolatedEvent(eventType, payload);
-        const matchingDescriptors = this.matchEventDescriptors(event);
-
-        if (matchingDescriptors.length === 0) {
+        if (channelDescriptors.length === 0) {
           return;
         }
 
-        const invocationTasks = this.createInvocationTasks(matchingDescriptors, event, {
+        const invocationTasks = this.createInvocationTasks(channelDescriptors, event, {
           signal: undefined,
           timeoutMs: this.normalizeTimeoutMs(this.moduleOptions.publish?.timeoutMs),
           waitForHandlers: this.moduleOptions.publish?.waitForHandlers ?? true,

--- a/packages/event-bus/src/types.ts
+++ b/packages/event-bus/src/types.ts
@@ -2,6 +2,7 @@ import type { MetadataPropertyKey, Token } from '@konekti/core';
 
 export interface EventType<TEvent extends object = object> {
   new (...args: never[]): TEvent;
+  readonly eventKey?: string;
 }
 
 export interface EventHandlerMetadata {


### PR DESCRIPTION
## Summary
- Align transport delivery with local `instanceof` semantics by publishing to channels for all matched handler event types.
- Dispatch incoming transport messages only to handlers registered for the subscribed channel to avoid duplicate inherited handler execution.
- Add explicit event key support via `static eventKey` (fallback to class name), document the key convention, and add integration tests for inheritance + keyed channels.

## Verification
- `pnpm --filter @konekti/event-bus exec vitest run --project packages packages/event-bus/src/module.test.ts`
- `pnpm --filter @konekti/event-bus run typecheck`
- `pnpm --filter @konekti/event-bus run build`

Closes #222