### PR TITLE
Resolve #224: protect websocket room state from external mutation

### DIFF
--- a/packages/websocket/README.ko.md
+++ b/packages/websocket/README.ko.md
@@ -65,6 +65,7 @@ export class AppModule {}
 - 종료 시 업그레이드 리스너 제거 및 활성 소켓 정리
 - `message`/`close` 이벤트는 `@OnConnect()` 핸들러가 끝날 때까지 버퍼링되며, 이후 순서대로 재생되어 connect 단계 이벤트가 조용히 유실되지 않습니다
 - attachment server 종료는 timeout 인지 방식으로 처리되며, 제한 시간 안에 close가 끝나지 않으면 무기한 대기하지 않고 로그를 남깁니다
+- `getRooms(socketId)`는 방 목록의 방어적 스냅샷(`ReadonlySet`)을 반환하므로 외부에서 내부 room 인덱스를 오염시킬 수 없습니다
 
 ## 프로바이더 등록 제약
 

--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -65,6 +65,7 @@ export class AppModule {}
 - Shutdown removes the shared upgrade listener and terminates all active clients
 - `message` and `close` events are buffered until `@OnConnect()` handlers complete, then replayed in order so connect-phase events are not silently dropped
 - Attachment server shutdown is timeout-aware and logs close timeout failures instead of hanging indefinitely
+- `getRooms(socketId)` returns a defensive snapshot (`ReadonlySet`) so callers cannot mutate internal room indexes
 
 ## Provider registration constraints
 

--- a/packages/websocket/src/module.test.ts
+++ b/packages/websocket/src/module.test.ts
@@ -747,6 +747,21 @@ describe('@konekti/websocket', () => {
     expect(socketRegistry.has('socket-1')).toBe(false);
   });
 
+  it('returns room snapshots so external mutation cannot corrupt internal room indexes', () => {
+    const service = createTestLifecycleService();
+
+    service.joinRoom('socket-1', 'room-a');
+    service.joinRoom('socket-1', 'room-b');
+
+    const snapshot = service.getRooms('socket-1') as Set<string>;
+    snapshot.delete('room-a');
+    snapshot.add('room-c');
+
+    const nextSnapshot = service.getRooms('socket-1');
+
+    expect(Array.from(nextSnapshot).sort()).toEqual(['room-a', 'room-b']);
+  });
+
   it('logs and continues shutdown when websocket server close exceeds timeout', async () => {
     vi.useFakeTimers();
 

--- a/packages/websocket/src/service.ts
+++ b/packages/websocket/src/service.ts
@@ -910,7 +910,13 @@ export class WebSocketGatewayLifecycleService
   }
 
   getRooms(socketId: string): ReadonlySet<string> {
-    return this.socketRooms.get(socketId) ?? new Set<string>();
+    const rooms = this.socketRooms.get(socketId);
+
+    if (!rooms) {
+      return new Set<string>();
+    }
+
+    return new Set<string>(rooms);
   }
 
   private startHeartbeat(intervalMs: number, timeoutMs: number): void {


### PR DESCRIPTION
## Summary
- Change `getRooms(socketId)` to return a defensive `Set` snapshot instead of the internal mutable reference.
- Add integration coverage proving external mutation of returned room sets cannot corrupt internal room indexes.
- Document read-only snapshot behavior in websocket package docs (English/Korean).

## Verification
- `pnpm exec vitest run --project packages packages/websocket/src/module.test.ts`
- `pnpm --filter @konekti/websocket run typecheck`
- `pnpm --filter @konekti/websocket run build`

Closes #224