### PR TITLE
Resolve #225: eagerly dispose stale override instances

### DIFF
--- a/docs/concepts/di-and-modules.ko.md
+++ b/docs/concepts/di-and-modules.ko.md
@@ -32,6 +32,12 @@
 - `request`
 - `transient`
 
+## override 보존 정책
+
+- `override()`는 교체 대상 토큰의 singleton/request 캐시 엔트리를 무효화한다.
+- 축출된 stale 인스턴스가 `onDestroy()`를 구현했다면 즉시 정리한다.
+- override로 stale가 된 인스턴스를 전역 컨테이너 `dispose()` 시점까지 보관하지 않는다.
+
 ## app-facing injection strategy
 
 현재 공개되는 방식은 임시 static 프로퍼티가 아닌 데코레이터로 작성된 metadata입니다.

--- a/docs/concepts/di-and-modules.md
+++ b/docs/concepts/di-and-modules.md
@@ -32,6 +32,12 @@ See also:
 - `request`
 - `transient`
 
+## override retention policy
+
+- `override()` invalidates cached singleton/request entries for the token being replaced
+- evicted stale instances are disposed immediately when disposable (`onDestroy()`)
+- stale overridden instances are not retained until global container `dispose()`
+
 ## app-facing injection strategy
 
 The current public path is decorator-authored metadata rather than ad hoc static properties.

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -95,6 +95,14 @@ const handler = requestContainer.resolve<RequestHandler>(RequestHandler);
 
 provider는 root에 등록되지만 request child에 캐시될 수 있다. 이것이 request-scoped provider가 재등록 없이 요청마다 분리되는 메커니즘이다.
 
+### override 캐시 무효화 정책
+
+`override()`로 캐시된 singleton/request provider를 교체하면, 이전 캐시 인스턴스는 즉시 축출되고(`evict`) `onDestroy()`를 구현한 경우 즉시 정리된다.
+
+- override로 밀려난(stale) 인스턴스를 컨테이너 전체 `dispose()` 시점까지 보관하지 않는다.
+- 반복 override 시 stale 캐시 보존이 누적되지 않는다.
+- 컨테이너 `dispose()`는 여전히 현재 활성 캐시 엔트리를 생성 역순으로 정리한다.
+
 ### root에서 request-scoped provider를 resolve하면 왜 실패하나
 
 root 컨테이너에서 `request`-scoped provider를 직접 resolve하면 에러가 발생한다. 이것은 의도적인 안전장치다 — request scope에는 request boundary가 필요하고, root에서 resolve를 허용하면 request 의존성이 조용히 singleton처럼 동작하게 된다.

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -95,6 +95,14 @@ The container separates **where to find a provider** from **where to cache its i
 
 A provider can be registered in the root but cached in the request child. This is the mechanism that makes request-scoped providers per-request without re-registering them.
 
+### Override cache invalidation policy
+
+When `override()` replaces a cached singleton/request provider, the previous cached instance is evicted and disposed immediately (if it implements `onDestroy()`).
+
+- stale overridden instances are not retained until container-wide `dispose()`
+- repeated overrides do not accumulate stale cache retention
+- container `dispose()` still disposes currently active cache entries in reverse creation order
+
 ### Why resolving request-scoped providers from root fails
 
 Resolving a `request`-scoped provider directly from the root container throws an error. This is an intentional safeguard — a request scope needs a request boundary, and allowing root resolution would let request dependencies silently behave like singletons.

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -557,7 +557,7 @@ describe('Container', () => {
       expect(events).toEqual(['second', 'first']);
     });
 
-    it('disposes stale overridden singleton instances exactly once', async () => {
+    it('disposes stale overridden singleton instances immediately and exactly once', async () => {
       const events: string[] = [];
 
       class FirstService {
@@ -578,11 +578,50 @@ describe('Container', () => {
 
       await container.resolve(token);
       container.override({ provide: token, useClass: SecondService });
+      await Promise.resolve();
       await container.resolve(token);
 
       await container.dispose();
 
-      expect(events).toEqual(['second', 'first']);
+      expect(events).toEqual(['first', 'second']);
+    });
+
+    it('does not retain stale singleton instances across repeated overrides', async () => {
+      const events: string[] = [];
+      const token = Symbol('rotating-disposable-token');
+
+      class VersionedService {
+        constructor(private readonly name: string) {}
+
+        onDestroy() {
+          events.push(this.name);
+        }
+      }
+
+      const container = new Container().register({
+        provide: token,
+        useFactory: () => new VersionedService('v1'),
+      });
+
+      await container.resolve(token);
+
+      container.override({
+        provide: token,
+        useFactory: () => new VersionedService('v2'),
+      });
+      await Promise.resolve();
+      await container.resolve(token);
+
+      container.override({
+        provide: token,
+        useFactory: () => new VersionedService('v3'),
+      });
+      await Promise.resolve();
+      await container.resolve(token);
+
+      await container.dispose();
+
+      expect(events).toEqual(['v1', 'v2', 'v3']);
     });
   });
 });

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -112,7 +112,8 @@ export class Container {
   private readonly registrations = new Map<Token, NormalizedProvider>();
   private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
   private readonly requestCache = new Map<Token, Promise<unknown>>();
-  private readonly staleCache = new Map<Token, Promise<unknown>>();
+  private readonly staleDisposalTasks = new Set<Promise<void>>();
+  private readonly staleDisposalErrors: unknown[] = [];
   private readonly singletonCache: Map<Token, Promise<unknown>>;
   private disposePromise: Promise<void> | undefined;
   private disposed = false;
@@ -383,14 +384,18 @@ export class Container {
 
   private disposalCacheEntries(): Array<[Token, Promise<unknown>]> {
     if (this.parent) {
-      return [...Array.from(this.staleCache.entries()), ...Array.from(this.requestCache.entries())];
+      return Array.from(this.requestCache.entries());
     }
 
-    return [...Array.from(this.staleCache.entries()), ...Array.from(this.singletonCache.entries())];
+    return Array.from(this.singletonCache.entries());
   }
 
   private async disposeCache(entries: Array<[Token, Promise<unknown>]>): Promise<void> {
+    await this.waitForStaleDisposalTasks();
+
     const { disposables, errors } = await this.collectDisposableInstances(entries);
+
+    errors.push(...this.staleDisposalErrors.splice(0, this.staleDisposalErrors.length));
 
     errors.push(...(await this.disposeInstancesInReverseOrder(disposables)));
 
@@ -438,12 +443,36 @@ export class Container {
   private clearDisposalCaches(): void {
     if (this.parent) {
       this.requestCache.clear();
-      this.staleCache.clear();
       return;
     }
 
     this.singletonCache.clear();
-    this.staleCache.clear();
+  }
+
+  private async waitForStaleDisposalTasks(): Promise<void> {
+    while (this.staleDisposalTasks.size > 0) {
+      await Promise.all(Array.from(this.staleDisposalTasks));
+    }
+  }
+
+  private scheduleStaleDisposal(instancePromise: Promise<unknown>): void {
+    let task: Promise<void>;
+
+    task = (async () => {
+      try {
+        const instance = await instancePromise;
+
+        if (this.isDisposable(instance)) {
+          await instance.onDestroy();
+        }
+      } catch (error) {
+        this.staleDisposalErrors.push(error);
+      }
+    })().finally(() => {
+      this.staleDisposalTasks.delete(task);
+    });
+
+    this.staleDisposalTasks.add(task);
   }
 
   private throwDisposalErrors(errors: unknown[]): void {
@@ -528,7 +557,7 @@ export class Container {
       const cached = this.requestCache.get(token);
 
       if (cached) {
-        this.staleCache.set(token, cached);
+        this.scheduleStaleDisposal(cached);
       }
 
       this.requestCache.delete(token);
@@ -544,7 +573,7 @@ export class Container {
       const cached = singletonCache.get(token);
 
       if (cached) {
-        this.staleCache.set(token, cached);
+        this.scheduleStaleDisposal(cached);
       }
 
       singletonCache.delete(token);


### PR DESCRIPTION
Closes #225

## Summary
- Replace stale cache retention with immediate disposal tasks when override invalidates cached request/singleton instances.
- Await pending stale disposal tasks during container dispose and surface stale disposal errors.
- Add regression tests for repeated override churn and document override retention policy (EN/KO).

## Verification
- pnpm build
- pnpm test packages/di/src/container.test.ts
- pnpm typecheck