### PR TITLE
Resolve #223: prevent throttler handler key collisions

### DIFF
--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -97,6 +97,7 @@ class AppBootstrap {
 ## Behavior
 
 - Rate limit key defaults to `socket.remoteAddress`. Provide `keyGenerator` for header-based keying (e.g. `x-api-key`).
+- Store keys are composed as `throttler:<handler-key>:<client-key>`, where `<handler-key>` includes route method/path/version and controller/module token identities to prevent collisions between handlers that share class or method names.
 - When the limit is exceeded, `ThrottlerGuard` throws `TooManyRequestsException` (HTTP 429) and sets the `Retry-After` response header to the seconds remaining in the current window.
 - Method-level `@Throttle` overrides class-level `@Throttle`, which overrides module-level defaults — in that priority order.
 - `@SkipThrottle()` at either level wins unconditionally.

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -13,6 +13,9 @@ import type { ThrottlerModuleOptions, ThrottlerStore } from './types.js';
 
 type MetadataBag = Record<PropertyKey, unknown>;
 
+const functionIdentityMap = new WeakMap<Function, number>();
+let nextFunctionIdentity = 1;
+
 function getClassMetadataBag(target: object): MetadataBag | undefined {
   return (target as Record<symbol, MetadataBag | undefined>)[metadataSymbol];
 }
@@ -36,6 +39,37 @@ function defaultKeyGenerator(ctx: MiddlewareContext): string {
 
 function buildStoreKey(handlerKey: string, clientKey: string): string {
   return `throttler:${handlerKey}:${clientKey}`;
+}
+
+function getFunctionIdentity(value: Function): number {
+  const existing = functionIdentityMap.get(value);
+
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const assigned = nextFunctionIdentity;
+  nextFunctionIdentity += 1;
+  functionIdentityMap.set(value, assigned);
+
+  return assigned;
+}
+
+function buildHandlerKey(handler: GuardContext['handler']): string {
+  const version = handler.route.version ?? handler.metadata.effectiveVersion ?? 'unversioned';
+  const moduleIdentity = handler.metadata.moduleType
+    ? `module:${getFunctionIdentity(handler.metadata.moduleType)}`
+    : 'module:none';
+  const controllerIdentity = `controller:${getFunctionIdentity(handler.controllerToken)}`;
+
+  return [
+    `method:${handler.route.method}`,
+    `path:${encodeURIComponent(handler.route.path)}`,
+    `version:${encodeURIComponent(version)}`,
+    `handler:${encodeURIComponent(handler.methodName)}`,
+    moduleIdentity,
+    controllerIdentity,
+  ].join('|');
 }
 
 @Inject([THROTTLER_OPTIONS])
@@ -75,7 +109,7 @@ export class ThrottlerGuard implements Guard {
       ? this.options.keyGenerator(middlewareCtx)
       : defaultKeyGenerator(middlewareCtx);
 
-    const handlerKey = `${handler.controllerToken.name}.${handler.methodName}`;
+    const handlerKey = buildHandlerKey(handler);
     const storeKey = buildStoreKey(handlerKey, clientKey);
     const now = Date.now();
     const entry = await this.store.consume(storeKey, {

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -46,15 +46,32 @@ function createGuardContext(
   controllerToken: Function,
   methodName: string,
   requestContext: RequestContext,
+  options?: {
+    moduleType?: HandlerDescriptor['metadata']['moduleType'];
+    routeMethod?: HandlerDescriptor['route']['method'];
+    routePath?: string;
+    routeVersion?: string;
+  },
 ): GuardContext {
+  const routePath = options?.routePath ?? '/test';
+  const routeMethod = options?.routeMethod ?? 'GET';
+
   return {
     handler: {
       controllerToken: controllerToken as HandlerDescriptor['controllerToken'],
-      metadata: {} as HandlerDescriptor['metadata'],
+      metadata: {
+        controllerPath: '',
+        effectivePath: routePath,
+        effectiveVersion: options?.routeVersion,
+        moduleMiddleware: [],
+        moduleType: options?.moduleType,
+        pathParams: [],
+      },
       methodName,
       route: {
-        method: 'GET',
-        path: '/test',
+        method: routeMethod,
+        path: routePath,
+        version: options?.routeVersion,
       },
     },
     requestContext,
@@ -255,6 +272,42 @@ describe('ThrottlerGuard — in-memory store', () => {
 
     expect(true).toBe(true);
   });
+
+  it('separates throttling state for handlers with identical class and method names', async () => {
+    const AuthController = class DuplicateController {
+      action() {}
+    };
+    const AdminController = class DuplicateController {
+      action() {}
+    };
+    class AuthModule {}
+    class AdminModule {}
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1 });
+    const ctx = createRequestContext('10.0.0.1');
+
+    await expect(
+      guard.canActivate(
+        createGuardContext(AuthController, 'action', ctx, {
+          moduleType: AuthModule,
+          routeMethod: 'POST',
+          routePath: '/auth/login',
+          routeVersion: '1',
+        }),
+      ),
+    ).resolves.toBe(true);
+
+    await expect(
+      guard.canActivate(
+        createGuardContext(AdminController, 'action', ctx, {
+          moduleType: AdminModule,
+          routeMethod: 'POST',
+          routePath: '/admin/login',
+          routeVersion: '1',
+        }),
+      ),
+    ).resolves.toBe(true);
+  });
 });
 
 describe('ThrottlerGuard — Redis store mock', () => {
@@ -292,5 +345,40 @@ describe('ThrottlerGuard — Redis store mock', () => {
     await guard.canActivate(createGuardContext(TestController, 'action', ctx));
 
     expect(store.consume).toHaveBeenCalledTimes(2);
+  });
+
+  it('builds store keys from route and token identity context', async () => {
+    const store: ThrottlerStore = {
+      consume: vi.fn(async (_key: string, input) => ({
+        count: 1,
+        resetAt: input.now + input.ttlSeconds * 1000,
+      })),
+    };
+
+    const guard = new ThrottlerGuard({ limit: 2, store, ttl: 60 });
+    const ctx = createRequestContext('10.0.0.9');
+    class RateController {
+      hit() {}
+    }
+    class RateModule {}
+
+    await guard.canActivate(
+      createGuardContext(RateController, 'hit', ctx, {
+        moduleType: RateModule,
+        routeMethod: 'POST',
+        routePath: '/v1/rate-limit',
+        routeVersion: '1',
+      }),
+    );
+
+    const key = vi.mocked(store.consume).mock.calls[0]?.[0];
+
+    expect(key).toContain('method:POST');
+    expect(key).toContain('path:%2Fv1%2Frate-limit');
+    expect(key).toContain('version:1');
+    expect(key).toContain('handler:hit');
+    expect(key).toContain('module:');
+    expect(key).toContain('controller:');
+    expect(key).toContain(':10.0.0.9');
   });
 });


### PR DESCRIPTION
## Summary
- replace class/method-name-based throttler handler keys with route/method/version plus controller/module token identity components to avoid collisions
- keep client key composition unchanged while preserving per-handler separation semantics via method component in handler keys
- add regression tests for identical class/method-name handlers and document the key-generation rule in package README

Closes #223

## Verification
- `pnpm vitest run packages/throttler/src/*.test.ts`
- `pnpm --filter @konekti/throttler run typecheck`
- `pnpm --filter @konekti/throttler run build`