### PR TITLE
Resolve #226: honor explicit target-directory precedence

### DIFF
--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -40,6 +40,8 @@ konekti new my-app
 #   --target-directory <path>
 ```
 
+`--target-directory`는 인자 순서와 무관하게 positional 프로젝트 이름보다 항상 우선합니다.
+
 한 번만 실행하는 zero-install 부트스트랩에는 `pnpm dlx @konekti/cli new my-app`도 계속 지원됩니다.
 
 ### 기존 프로젝트에 파일 생성

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,6 +40,8 @@ konekti new my-app
 #   --target-directory <path>
 ```
 
+`--target-directory` always wins over the positional project name, regardless of argument order.
+
 For a one-off no-install bootstrap, `pnpm dlx @konekti/cli new my-app` remains supported.
 
 ### Generate a file inside an existing project

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -93,6 +93,44 @@ describe('CLI command runner', () => {
     expect(stdoutBuffer.join('')).toContain('pnpm dev');
   });
 
+  it('keeps explicit --target-directory when it appears before positional project name', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', '--target-directory', 'custom-app', 'starter-app'], {
+      cwd: workspaceDirectory,
+      env: {},
+      skipInstall: true,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'custom-app', 'package.json'))).toBe(true);
+    expect(existsSync(join(workspaceDirectory, 'starter-app', 'package.json'))).toBe(false);
+    expect(stdoutBuffer.join('')).toContain('cd custom-app');
+  });
+
+  it('keeps explicit --target-directory when it appears after positional project name', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', 'starter-app', '--target-directory', 'custom-app'], {
+      cwd: workspaceDirectory,
+      env: {},
+      skipInstall: true,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'custom-app', 'package.json'))).toBe(true);
+    expect(existsSync(join(workspaceDirectory, 'starter-app', 'package.json'))).toBe(false);
+    expect(stdoutBuffer.join('')).toContain('cd custom-app');
+  });
+
   it('prints top-level usage for `help`', async () => {
     const stdoutBuffer: string[] = [];
 

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -39,7 +39,7 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
   },
   {
     aliases: [],
-    description: 'Write the new app to a custom target directory.',
+    description: 'Write the new app to a custom target directory (always overrides positional name path).',
     option: '--target-directory <path>',
   },
   {
@@ -51,6 +51,7 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
 
 function parseArgs(argv: string[]): Partial<BootstrapAnswers> {
   const parsed: Partial<BootstrapAnswers> = {};
+  let hasExplicitTargetDirectory = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -67,12 +68,15 @@ function parseArgs(argv: string[]): Partial<BootstrapAnswers> {
         break;
       case '--target-directory':
         parsed.targetDirectory = next;
+        hasExplicitTargetDirectory = true;
         index += 1;
         break;
       default:
         if (!arg.startsWith('-') && !parsed.projectName) {
           parsed.projectName = arg;
-          parsed.targetDirectory = `./${arg}`;
+          if (!hasExplicitTargetDirectory) {
+            parsed.targetDirectory = `./${arg}`;
+          }
         }
         break;
     }


### PR DESCRIPTION
Closes #226

## Summary
- Preserve explicit `--target-directory` when parsing `konekti new` args even if positional project name appears later.
- Add regression tests proving option precedence is stable regardless of argument order.
- Document `--target-directory` precedence rule in CLI package docs (EN/KO).

## Verification
- pnpm build
- pnpm test packages/cli/src/cli.test.ts
- pnpm typecheck