### PR TITLE
Resolve #237: make request/bootstrap/config contracts explicit

### DIFF
--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -290,6 +290,34 @@ describe('loadConfig', () => {
     }
   });
 
+  it('keeps the previous snapshot when manual reload listeners throw', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-reload-ordering-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      mode: 'dev',
+      processEnv: {},
+    });
+
+    try {
+      reloader.subscribe((_snapshot, reason) => {
+        if (reason === 'manual') {
+          throw new Error('listener failed');
+        }
+      });
+
+      writeFileSync(envPath, 'PORT=4700\n');
+
+      expect(() => reloader.reload()).toThrow('listener failed');
+      expect(reloader.current()['PORT']).toBe('4000');
+    } finally {
+      reloader.close();
+    }
+  });
+
   it('stops watch notifications after close', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-watch-close-'));
     const envPath = join(cwd, '.env.dev');

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -20,22 +20,18 @@ import type {
 interface NormalizedLoadOptions {
   envFile: string;
   defaults: ConfigDictionary;
-  processEnv: NodeJS.ProcessEnv;
   safeProcessEnv: Record<string, string>;
   runtimeOverrides: ConfigDictionary;
   parse?: (content: string) => Record<string, string>;
   validate?: (raw: ConfigDictionary) => ConfigDictionary;
 }
 
-function parseEnvContent(content: string, processEnv: NodeJS.ProcessEnv, customParser?: (content: string) => Record<string, string>): Record<string, string> {
+function parseEnvContent(content: string, safeProcessEnv: Record<string, string>, customParser?: (content: string) => Record<string, string>): Record<string, string> {
   if (customParser) {
     return customParser(content);
   }
   const parsed = dotenvParse(content);
-  const safeProcessEnv: Record<string, string> = Object.fromEntries(
-    Object.entries(processEnv).filter((entry): entry is [string, string] => entry[1] !== undefined),
-  );
-  const result = dotenvExpand({ parsed, processEnv: safeProcessEnv });
+  const result = dotenvExpand({ parsed, processEnv: { ...safeProcessEnv } });
   return result.parsed ?? {};
 }
 
@@ -57,7 +53,6 @@ function normalizeLoadOptions(options: ConfigLoadOptions): NormalizedLoadOptions
     defaults,
     envFile,
     parse: options.parse,
-    processEnv,
     runtimeOverrides,
     safeProcessEnv,
     validate: options.validate,
@@ -69,7 +64,7 @@ function readEnvFileValues(options: NormalizedLoadOptions): ConfigDictionary {
     return {};
   }
 
-  return parseEnvContent(readFileSync(options.envFile, 'utf8'), options.processEnv, options.parse);
+  return parseEnvContent(readFileSync(options.envFile, 'utf8'), options.safeProcessEnv, options.parse);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -175,8 +170,8 @@ function applyReload(
 ): ConfigDictionary {
   const next = resolveConfig(normalized);
 
-  state.current = next;
   notifyReloadListeners(listeners, next, reason);
+  state.current = next;
 
   return cloneConfigDictionary(next);
 }

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -179,6 +179,8 @@ const UpdateUserRequest = PartialType(CreateUserRequest);
 
 > Validation decorators (`@IsString`, `@IsEmail`, etc.) come from `@konekti/dto-validator`, not this package.
 
+Binding keeps source value shape explicit. For example, repeated query/header values remain arrays (including single-element arrays) unless you provide an explicit converter that normalizes them.
+
 ### Runtime helpers
 
 | Export | Location | Description |

--- a/packages/http/src/binding.test.ts
+++ b/packages/http/src/binding.test.ts
@@ -142,6 +142,21 @@ describe('DefaultBinder', () => {
       ),
     ).rejects.toBeInstanceOf(BadRequestException);
   });
+
+  it('preserves single-element arrays for query bindings', async () => {
+    class SearchUsersRequest {
+      @FromQuery('tag')
+      tags: string[] = [];
+    }
+
+    const binder = new DefaultBinder();
+    const bound = (await binder.bind(
+      SearchUsersRequest,
+      createContext(createRequest({ query: { tag: ['admin'] } })),
+    )) as SearchUsersRequest;
+
+    expect(bound.tags).toEqual(['admin']);
+  });
 });
 
 describe('HttpDtoValidationAdapter', () => {

--- a/packages/http/src/binding.ts
+++ b/packages/http/src/binding.ts
@@ -91,10 +91,6 @@ function validateBodyKeys(
 
 export class DefaultConverter implements Converter {
   convert(value: unknown, _target: ConverterTarget): unknown {
-    if (Array.isArray(value) && value.length === 1) {
-      return value[0];
-    }
-
     return value;
   }
 }

--- a/packages/http/src/decorators.test.ts
+++ b/packages/http/src/decorators.test.ts
@@ -307,4 +307,70 @@ describe('http decorators', () => {
       },
     ]);
   });
+
+  it('does not execute base DTO constructors while creating mapped DTO helpers', () => {
+    const constructorCalls: string[] = [];
+
+    class BaseRequest {
+      @FromBody('name')
+      @IsString()
+      name = '';
+
+      constructor() {
+        constructorCalls.push('base');
+      }
+    }
+
+    class SecondaryRequest {
+      @FromBody('city')
+      @IsString()
+      city = '';
+
+      constructor() {
+        constructorCalls.push('secondary');
+      }
+    }
+
+    const Picked = PickType(BaseRequest, ['name']);
+    const Omitted = OmitType(BaseRequest, []);
+    const Partial = PartialType(BaseRequest);
+    const Intersected = IntersectionType(BaseRequest, SecondaryRequest);
+
+    expect(constructorCalls).toEqual([]);
+
+    expect(new Picked()).toEqual({ name: undefined });
+    expect(new Omitted()).toEqual({ name: undefined });
+    expect(new Partial()).toEqual({ name: undefined });
+    expect(new Intersected()).toEqual({ city: undefined, name: undefined });
+  });
+
+  it('adds at most one optional validation rule per field in PartialType', () => {
+    class UpdateUserRequest {
+      @FromBody('name')
+      @IsString()
+      @Optional()
+      @MinLength(2)
+      name = '';
+    }
+
+    const PartialUpdateUserRequest = PartialType(UpdateUserRequest);
+    const schema = getDtoValidationSchema(PartialUpdateUserRequest);
+    let nameRules: Array<{ kind: string }> = [];
+
+    for (const entry of schema) {
+      if (entry.propertyKey === 'name') {
+        nameRules = entry.rules as Array<{ kind: string }>;
+        break;
+      }
+    }
+
+    const optionalRules: Array<{ kind: string }> = [];
+    for (const rule of nameRules) {
+      if (rule.kind === 'optional') {
+        optionalRules.push(rule);
+      }
+    }
+
+    expect(optionalRules).toHaveLength(1);
+  });
 });

--- a/packages/http/src/dispatcher.test.ts
+++ b/packages/http/src/dispatcher.test.ts
@@ -13,6 +13,7 @@ import type {
 } from '@konekti/http';
 import {
   FromBody,
+  FromQuery,
   createDispatcher,
   createHandlerMapping,
   Controller,
@@ -1222,6 +1223,47 @@ describe('dispatcher runtime', () => {
         status: 400,
       },
     });
+  });
+
+  it('keeps single-element query arrays intact in RequestDto binding', async () => {
+    class SearchRequest {
+      @FromQuery('tag')
+      tags: string[] = [];
+    }
+
+    @Controller('/search')
+    class SearchController {
+      @RequestDto(SearchRequest)
+      @Get('/')
+      search(input: SearchRequest) {
+        return input;
+      }
+    }
+
+    const root = new Container().register(SearchController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: SearchController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(
+      {
+        body: undefined,
+        cookies: {},
+        headers: {},
+        method: 'GET',
+        params: {},
+        path: '/search',
+        query: { tag: ['one'] },
+        raw: {},
+        url: '/search?tag=one',
+      },
+      response,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ tags: ['one'] });
   });
 
   it('returns nested validation field paths through the canonical error envelope', async () => {

--- a/packages/http/src/mapped-types.ts
+++ b/packages/http/src/mapped-types.ts
@@ -32,8 +32,18 @@ function createDerivedDto(
   return DerivedDto;
 }
 
-function ownKeysOf(dto: DtoConstructor): MetadataPropertyKey[] {
-  return Reflect.ownKeys(new dto() as object);
+function collectDtoKeys(dto: DtoConstructor): MetadataPropertyKey[] {
+  const keys = new Set<MetadataPropertyKey>();
+
+  for (const entry of getDtoBindingSchema(dto)) {
+    keys.add(entry.propertyKey);
+  }
+
+  for (const entry of getDtoValidationSchema(dto)) {
+    keys.add(entry.propertyKey);
+  }
+
+  return [...keys];
 }
 
 function copyDtoMetadata(
@@ -64,22 +74,16 @@ function copyDtoMetadata(
   }
 }
 
-function hasOptionalRule(source: DtoConstructor, propertyKey: MetadataPropertyKey): boolean {
-  return getDtoValidationSchema(source)
-    .find((entry) => entry.propertyKey === propertyKey)
-    ?.rules.some((rule) => rule.kind === 'optional') ?? false;
-}
-
 export function PickType<TBase extends DtoConstructor, TKey extends Extract<keyof InstanceType<TBase>, string>>(
   BaseDto: TBase,
   keys: readonly TKey[],
 ): DtoConstructor<Pick<InstanceType<TBase>, TKey>> {
   const selected = new Set<MetadataPropertyKey>(keys);
+  const baseKeys = collectDtoKeys(BaseDto);
   const PickedDto = createDerivedDto(`${BaseDto.name}PickType`, (instance) => {
-    const base = new BaseDto() as Record<PropertyKey, unknown>;
-    for (const key of ownKeysOf(BaseDto)) {
+    for (const key of baseKeys) {
       if (selected.has(key)) {
-        instance[key] = base[key];
+        instance[key] = undefined;
       }
     }
   });
@@ -94,11 +98,11 @@ export function OmitType<TBase extends DtoConstructor, TKey extends Extract<keyo
   keys: readonly TKey[],
 ): DtoConstructor<Omit<InstanceType<TBase>, TKey>> {
   const omitted = new Set<MetadataPropertyKey>(keys);
+  const baseKeys = collectDtoKeys(BaseDto);
   const OmittedDto = createDerivedDto(`${BaseDto.name}OmitType`, (instance) => {
-    const base = new BaseDto() as Record<PropertyKey, unknown>;
-    for (const key of ownKeysOf(BaseDto)) {
+    for (const key of baseKeys) {
       if (!omitted.has(key)) {
-        instance[key] = base[key];
+        instance[key] = undefined;
       }
     }
   });
@@ -117,11 +121,14 @@ type IntersectionInstance<TBaseDtos extends readonly DtoConstructor[]> = UnionTo
 export function IntersectionType<TBaseDtos extends readonly [DtoConstructor, DtoConstructor, ...DtoConstructor[]]>(
   ...baseDtos: TBaseDtos
 ): DtoConstructor<IntersectionInstance<TBaseDtos>> {
+  const baseKeySets = baseDtos.map((dto) => collectDtoKeys(dto));
   const IntersectionDto = createDerivedDto(
     `${baseDtos.map((dto) => dto.name).join('') || 'Anonymous'}IntersectionType`,
     (instance) => {
-      for (const BaseDto of baseDtos) {
-        Object.assign(instance, new BaseDto());
+      for (const baseKeys of baseKeySets) {
+        for (const key of baseKeys) {
+          instance[key] = undefined;
+        }
       }
     },
   );
@@ -134,8 +141,9 @@ export function IntersectionType<TBaseDtos extends readonly [DtoConstructor, Dto
 }
 
 export function PartialType<TBase extends DtoConstructor>(BaseDto: TBase): DtoConstructor<Partial<InstanceType<TBase>>> {
+  const baseKeys = collectDtoKeys(BaseDto);
   const PartialDto = createDerivedDto(`${BaseDto.name}PartialType`, (instance) => {
-    for (const key of ownKeysOf(BaseDto)) {
+    for (const key of baseKeys) {
       instance[key] = undefined;
     }
   });
@@ -147,12 +155,29 @@ export function PartialType<TBase extends DtoConstructor>(BaseDto: TBase): DtoCo
     });
   }
 
-  for (const entry of getDtoValidationSchema(BaseDto)) {
+  const validationSchema = getDtoValidationSchema(BaseDto);
+  const optionalProperties = new Set<MetadataPropertyKey>();
+
+  for (const entry of validationSchema) {
+    let hasOptional = false;
+    for (const rule of entry.rules) {
+      if (rule.kind === 'optional') {
+        hasOptional = true;
+        break;
+      }
+    }
+
+    if (hasOptional) {
+      optionalProperties.add(entry.propertyKey);
+    }
+  }
+
+  for (const entry of validationSchema) {
     for (const rule of entry.rules) {
       appendDtoFieldValidationRule(PartialDto.prototype, entry.propertyKey, rule);
     }
 
-    if (!hasOptionalRule(BaseDto, entry.propertyKey)) {
+    if (!optionalProperties.has(entry.propertyKey)) {
       appendDtoFieldValidationRule(PartialDto.prototype, entry.propertyKey, { kind: 'optional' });
     }
   }

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -3,7 +3,7 @@ import { request as httpsRequest } from 'node:https';
 
 import { describe, expect, it } from 'vitest';
 
-import { Controller, Get, Post, type RequestContext } from '@konekti/http';
+import { Controller, Get, Post, type FrameworkRequest, type RequestContext } from '@konekti/http';
 import { defineModule, type ApplicationLogger } from '@konekti/runtime';
 
 import {
@@ -304,6 +304,48 @@ describe('@konekti/platform-fastify', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
     expect(loggerEvents).toContain(`log:KonektiFactory:Listening on http://127.0.0.1:${String(port)}`);
+
+    await app.close();
+  });
+
+  it('does not leak global-prefix path rewrites to request observers', async () => {
+    const observedPaths: string[] = [];
+
+    class PathObserver {
+      onRequestFinish(context: { requestContext: { request: FrameworkRequest } }) {
+        observedPaths.push(context.requestContext.request.path);
+      }
+    }
+
+    @Controller('/app')
+    class AppController {
+      @Get('/info')
+      getInfo() {
+        return { ok: true, route: 'app-info' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [AppController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      globalPrefix: '/api',
+      mode: 'test',
+      observers: [new PathObserver()],
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/api/app/info`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, route: 'app-info' });
+    expect(observedPaths).toEqual(['/api/app/info']);
 
     await app.close();
   });

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -61,7 +61,6 @@ const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 const DEFAULT_GLOBAL_PREFIX_EXCLUDE = ['/health', '/ready', '/openapi.json', '/docs', '/metrics'] as const;
 
 export interface BootstrapFastifyApplicationOptions extends Omit<CreateApplicationOptions, 'adapter' | 'logger' | 'middleware'> {
-  compression?: boolean;
   cors?: CorsInput;
   globalPrefix?: string;
   globalPrefixExclude?: readonly string[];
@@ -248,7 +247,6 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
 
 export function createFastifyAdapter(
   options: FastifyAdapterOptions = {},
-  _compression = false,
   multipartOptions?: MultipartOptions,
 ): HttpApplicationAdapter {
   return new FastifyHttpApplicationAdapter(
@@ -272,7 +270,7 @@ export async function bootstrapFastifyApplication(
 
   return bootstrapApplication({
     ...options,
-    adapter: createFastifyAdapter(options, options.compression ?? false, options.multipart),
+    adapter: createFastifyAdapter(options, options.multipart),
     logger,
     middleware: createFastifyMiddleware(options),
     rootModule,
@@ -284,7 +282,7 @@ export async function runFastifyApplication(
   options: RunFastifyApplicationOptions,
 ): Promise<Application> {
   const logger = options.logger ?? createConsoleApplicationLogger();
-  const adapter = createFastifyAdapter(options, options.compression ?? false, options.multipart) as FastifyHttpApplicationAdapter;
+  const adapter = createFastifyAdapter(options, options.multipart) as FastifyHttpApplicationAdapter;
   const app = await bootstrapApplication({
     ...options,
     adapter,
@@ -630,9 +628,21 @@ function createGlobalPrefixMiddleware(prefix: string, exclude: readonly string[]
         return;
       }
 
-      context.request.path = strippedPath;
-      context.request.url = rewritePrefixedUrl(context.request.url, requestPath, strippedPath);
-      await next();
+      const originalRequest = context.requestContext.request;
+      const scopedRequest = {
+        ...originalRequest,
+        path: strippedPath,
+        url: rewritePrefixedUrl(originalRequest.url, requestPath, strippedPath),
+      };
+      context.request = scopedRequest;
+      context.requestContext.request = scopedRequest;
+
+      try {
+        await next();
+      } finally {
+        context.request = originalRequest;
+        context.requestContext.request = originalRequest;
+      }
     },
   };
 }

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -1207,6 +1207,48 @@ describe('bootstrapApplication', () => {
     await app.close();
   });
 
+  it('does not leak global-prefix path rewrites to request observers', async () => {
+    const observedPaths: string[] = [];
+
+    class PathObserver {
+      onRequestFinish(context: { requestContext: { request: FrameworkRequest } }) {
+        observedPaths.push(context.requestContext.request.path);
+      }
+    }
+
+    @Controller('/app')
+    class AppController {
+      @Get('/info')
+      getInfo() {
+        return { ok: true, route: 'app-info' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [AppController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      globalPrefix: '/api',
+      mode: 'test',
+      observers: [new PathObserver()],
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/api/app/info`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, route: 'app-info' });
+    expect(observedPaths).toEqual(['/api/app/info']);
+
+    await app.close();
+  });
+
   it('supports additional global prefix exclusion patterns', async () => {
     @Controller('/internal')
     class InternalController {

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -454,9 +454,21 @@ function createGlobalPrefixMiddleware(prefix: string, exclude: readonly string[]
         return;
       }
 
-      context.request.path = strippedPath;
-      context.request.url = rewritePrefixedUrl(context.request.url, requestPath, strippedPath);
-      await next();
+      const originalRequest = context.requestContext.request;
+      const scopedRequest = {
+        ...originalRequest,
+        path: strippedPath,
+        url: rewritePrefixedUrl(originalRequest.url, requestPath, strippedPath),
+      };
+      context.request = scopedRequest;
+      context.requestContext.request = scopedRequest;
+
+      try {
+        await next();
+      } finally {
+        context.request = originalRequest;
+        context.requestContext.request = originalRequest;
+      }
     },
   };
 }

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -95,7 +95,7 @@ Fluent builder returned by `createTestingModule`.
 
 | Method | Description |
 |---|---|
-| `.overrideProvider(token, implementation)` | Replace a DI token's provider with `implementation` before the graph is compiled. Chainable. |
+| `.overrideProvider(token, implementation)` | Replace a DI token's provider with `implementation` before any provider resolution in the compiled test container. Chainable. |
 | `.compile()` | Compile the module graph with all overrides applied. Returns a `Promise<TestingModuleRef>`. |
 
 ### `TestingModuleRef`
@@ -207,7 +207,7 @@ TestingModuleRef
 createTestApp({ rootModule })  → bootstrapped test app with request()
 ```
 
-Overrides are applied **after** the module graph is constructed, replacing the real providers with the fakes you supplied. The rest of the graph remains intact, so only the tokens you explicitly override are substituted.
+Overrides are applied immediately after module graph construction and before any provider resolution, replacing the real providers with the fakes you supplied. The rest of the graph remains intact, so only the tokens you explicitly override are substituted.
 
 ## File Reading Order (for contributors)
 

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -159,6 +159,43 @@ describe('@konekti/testing', () => {
 
     await expect(testingModule.resolve<string>(TARGET)).resolves.toBe('source-value');
   });
+
+  it('applies provider overrides before first provider resolution side effects', async () => {
+    const TOKEN = Symbol('expensive-token');
+    let factoryCallCount = 0;
+
+    class ConsumerService {
+      constructor(readonly value: string) {}
+    }
+
+    @Module({
+      providers: [
+        {
+          provide: TOKEN,
+          useFactory: () => {
+            factoryCallCount += 1;
+            return 'real';
+          },
+        },
+        {
+          provide: ConsumerService,
+          inject: [TOKEN],
+          useFactory: (value: string) => new ConsumerService(value),
+        },
+      ],
+    })
+    class ServiceModule {}
+
+    const testingModule = await createTestingModule({ rootModule: ServiceModule })
+      .overrideProvider(TOKEN, 'fake')
+      .compile();
+
+    expect(factoryCallCount).toBe(0);
+
+    const consumer = await testingModule.resolve<ConsumerService>(ConsumerService);
+    expect(consumer.value).toBe('fake');
+    expect(factoryCallCount).toBe(0);
+  });
 });
 
 describe('createMock', () => {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -101,23 +101,21 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
   async compile(): Promise<TestingModuleRef> {
     const bootstrapped = this.bootstrapTestingModule();
 
-    this.applyOverrides(bootstrapped);
-
     return this.createTestingModuleRef(bootstrapped);
   }
 
   private bootstrapTestingModule(): BootstrapResult {
     const rootModule = this._applyModuleReplacements(this.options.rootModule);
 
-    return bootstrapModule(rootModule, {
+    const bootstrapped = bootstrapModule(rootModule, {
       providers: this.options.providers,
     });
-  }
 
-  private applyOverrides(bootstrapped: BootstrapResult): void {
     if (this.overrides.length > 0) {
       bootstrapped.container.override(...this.overrides);
     }
+
+    return bootstrapped;
   }
 
   private createTestingModuleRef(bootstrapped: BootstrapResult): TestingModuleRef {


### PR DESCRIPTION
## Summary
- Remove implicit HTTP single-element array-to-scalar coercion and rework mapped DTO helpers to avoid executing base DTO constructors while keeping metadata-derived fields explicit.
- Isolate global-prefix rewrites to scoped request objects (Node/Fastify), preserve external request contracts, and add regression coverage for observer-visible path behavior.
- Reduce config reload contract drift by avoiding shared dotenv-expand env mutation, committing reload state only after listener notification succeeds, and remove the unused Fastify `compression` option from the public API.

## Verification
- `pnpm build`
- `pnpm vitest run packages/http/src/binding.test.ts packages/http/src/decorators.test.ts packages/http/src/dispatcher.test.ts`
- `pnpm vitest run packages/config/src/load.test.ts`
- `pnpm vitest run packages/testing/src/module.test.ts`
- `pnpm vitest run packages/runtime/src/application.test.ts packages/platform-fastify/src/adapter.test.ts`

Closes #237