### PR TITLE
Resolve #240: harden message delivery and realtime execution semantics

### DIFF
--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -1006,6 +1006,62 @@ describe('@konekti/cron', () => {
     await app.close();
   });
 
+  it('logs successful distributed lock renewals and releases for operational tracing', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-20T00:00:00.000Z'));
+
+    const scheduled = createManualScheduler();
+    const loggerEvents: string[] = [];
+    const redis = new InMemoryLockRedisClient();
+    const started = createDeferred<void>();
+    const release = createDeferred<void>();
+
+    class DistributedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        distributed: true,
+        lockTtlMs: 2_000,
+        name: 'lock-trace-task',
+      })
+      async run() {
+        started.resolve();
+        await release.promise;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        createCronModule({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-lock-trace',
+            lockTtlMs: 2_000,
+          },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      mode: 'test',
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    const tickPromise = scheduled.records[0]!.tick();
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(1_000);
+    release.resolve();
+    await tickPromise;
+
+    expect(loggerEvents.some((event) => event.includes('log:CronLifecycleService:Renewed distributed cron lock for lock-trace-task.'))).toBe(true);
+    expect(loggerEvents.some((event) => event.includes('log:CronLifecycleService:Released distributed cron lock for lock-trace-task.'))).toBe(true);
+
+    await app.close();
+  });
+
   it('awaits in-flight lock renewal attempts before deciding task success', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-20T00:00:00.000Z'));

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -621,6 +621,11 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
         return 'ownership-lost';
       }
 
+      this.logger.log(
+        `Renewed distributed cron lock for ${descriptor.taskName}.`,
+        'CronLifecycleService',
+      );
+
       return 'renewed';
     } catch (error) {
       this.logger.error(
@@ -654,7 +659,20 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     }
 
     try {
-      await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, this.options.distributed.ownerId);
+      const result = await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, this.options.distributed.ownerId);
+
+      if (typeof result === 'number' && result <= 0) {
+        this.logger.warn(
+          `Distributed cron lock for ${taskName} was already released or owned by another node.`,
+          'CronLifecycleService',
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Released distributed cron lock for ${taskName}.`,
+        'CronLifecycleService',
+      );
     } catch (error) {
       this.logger.error(
         `Failed to release distributed cron lock for ${taskName}.`,

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -988,6 +988,69 @@ describe('@konekti/event-bus', () => {
       await app.close();
     });
 
+    it('rehydrates incoming shared-channel payloads with each handler event type', async () => {
+      const transport = createMockTransport();
+
+      class BaseInventoryEvent {
+        static readonly eventKey = 'inventory.shared.v1';
+
+        constructor(public readonly sku: string) {}
+      }
+
+      class DetailedInventoryEvent extends BaseInventoryEvent {
+        static readonly eventKey = 'inventory.shared.v1';
+
+        constructor(sku: string, public readonly warehouse: string) {
+          super(sku);
+        }
+      }
+
+      class EventStore {
+        baseEvent: BaseInventoryEvent | undefined;
+        detailedEvent: DetailedInventoryEvent | undefined;
+      }
+
+      @Inject([EventStore])
+      class BaseHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(BaseInventoryEvent)
+        onBase(event: BaseInventoryEvent) {
+          this.store.baseEvent = event;
+        }
+      }
+
+      @Inject([EventStore])
+      class DetailedHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(DetailedInventoryEvent)
+        onDetailed(event: DetailedInventoryEvent) {
+          this.store.detailedEvent = event;
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+        providers: [EventStore, BaseHandler, DetailedHandler],
+      });
+
+      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const store = await app.container.resolve(EventStore);
+      const incomingSubscription = transport.subscribed.find((entry) => entry.channel === 'inventory.shared.v1');
+
+      expect(incomingSubscription).toBeDefined();
+
+      await incomingSubscription!.handler({ sku: 'sku-2', warehouse: 'icn' });
+
+      expect(store.baseEvent).toBeInstanceOf(BaseInventoryEvent);
+      expect(store.detailedEvent).toBeInstanceOf(DetailedInventoryEvent);
+      expect(store.detailedEvent?.warehouse).toBe('icn');
+
+      await app.close();
+    });
+
     it('isolates payload mutations between handlers for incoming transport messages', async () => {
       const transport = createMockTransport();
 

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -176,7 +176,7 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     publishOptions: ResolvedPublishOptions,
   ): Promise<void>[] {
     return descriptors.map((descriptor) => {
-      const isolatedEvent = createIsolatedEvent(event.constructor as EventType, event);
+      const isolatedEvent = createIsolatedEvent(descriptor.eventType, event);
       return this.invokeHandlerWithBounds(descriptor, isolatedEvent, publishOptions);
     });
   }
@@ -187,7 +187,7 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     signal: AbortSignal | undefined,
   ): Promise<void>[] {
     return descriptors.map((descriptor) => {
-      const isolatedEvent = createIsolatedEvent(event.constructor as EventType, event);
+      const isolatedEvent = createIsolatedEvent(descriptor.eventType, event);
       return this.invokeHandlerInBackground(descriptor, isolatedEvent, signal);
     });
   }
@@ -328,33 +328,31 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     }
 
     for (const [channel, channelDescriptors] of descriptorsByChannel) {
-      const eventType = channelDescriptors[0]?.eventType;
-
-      if (!eventType) {
-        continue;
-      }
-
-      await this.subscribeTransportChannel(channel, eventType, channelDescriptors);
+      await this.subscribeTransportChannel(channel, channelDescriptors);
     }
   }
 
   private async subscribeTransportChannel(
     channel: string,
-    eventType: EventType,
     channelDescriptors: EventHandlerDescriptor[],
   ): Promise<void> {
     try {
       await this.transport!.subscribe(channel, async (payload) => {
-        const event = createIsolatedEvent(eventType, payload);
         if (channelDescriptors.length === 0) {
           return;
         }
 
-        const invocationTasks = this.createInvocationTasks(channelDescriptors, event, {
-          signal: undefined,
-          timeoutMs: this.normalizeTimeoutMs(this.moduleOptions.publish?.timeoutMs),
-          waitForHandlers: this.moduleOptions.publish?.waitForHandlers ?? true,
-        });
+        const invocationTasks = channelDescriptors.map((descriptor) =>
+          this.invokeHandlerWithBounds(
+            descriptor,
+            createIsolatedEvent(descriptor.eventType, payload),
+            {
+              signal: undefined,
+              timeoutMs: this.normalizeTimeoutMs(this.moduleOptions.publish?.timeoutMs),
+              waitForHandlers: this.moduleOptions.publish?.waitForHandlers ?? true,
+            },
+          ),
+        );
 
         await Promise.allSettled(invocationTasks);
       });

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -258,6 +258,48 @@ describe('@konekti/graphql', () => {
     await app.close();
   });
 
+  it('boots the same GraphQL module repeatedly without leaking middleware registration across app instances', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        createGraphqlModule({
+          resolvers: [GraphqlResolver],
+        }),
+      ],
+      providers: [ResolverState, GraphqlResolver],
+    });
+
+    const firstPort = await findAvailablePort();
+    const firstApp = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port: firstPort,
+    });
+
+    await firstApp.listen();
+    await expect(postGraphql(firstPort, '{ echo(value: "first") }')).resolves.toEqual({
+      data: {
+        echo: 'first',
+      },
+    });
+    await firstApp.close();
+
+    const secondPort = await findAvailablePort();
+    const secondApp = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port: secondPort,
+    });
+
+    await secondApp.listen();
+    await expect(postGraphql(secondPort, '{ echo(value: "second") }')).resolves.toEqual({
+      data: {
+        echo: 'second',
+      },
+    });
+    await secondApp.close();
+  });
+
   it('keeps internal operation container when custom context includes reserved symbol key', async () => {
     const poisonedOperationContainer = {
       async dispose() {},

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -166,8 +166,6 @@ function patchGraphqlInstanceOf(): void {
 }
 
 async function loadGraphqlDeps(): Promise<GraphqlDeps> {
-  patchGraphqlInstanceOf();
-
   const graphqlMod = runtimeRequire('graphql') as typeof import('graphql');
   const yogaMod = runtimeRequire('graphql-yoga') as typeof import('graphql-yoga');
 
@@ -264,6 +262,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   }
 
   async onApplicationShutdown(): Promise<void> {
+    this.unregisterMiddleware();
     this.middlewareRegistered = false;
     this.yoga = undefined;
   }
@@ -277,6 +276,10 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   }
 
   private resolveSchema(deps: GraphqlDeps): GraphQLSchemaType {
+    if (this.options.schema && typeof this.options.schema === 'object') {
+      patchGraphqlInstanceOf();
+    }
+
     return resolveSchema(deps, this.options.schema, () => this.createCodeFirstSchema(deps), markAllowedCrossRealmGraphqlObjects);
   }
 
@@ -297,10 +300,30 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
       const middleware = compiledModule.definition.middleware ?? [];
 
       if (!middleware.includes(this.middleware)) {
-        middleware.push(this.middleware);
+        compiledModule.definition.middleware = [...middleware, this.middleware];
+        continue;
       }
 
-      compiledModule.definition.middleware = middleware;
+      compiledModule.definition.middleware = [...middleware];
+    }
+  }
+
+  private unregisterMiddleware(): void {
+    for (const compiledModule of this.compiledModules) {
+      if (!compiledModule.providerTokens.has(GRAPHQL_LIFECYCLE_SERVICE)) {
+        continue;
+      }
+
+      const middleware = compiledModule.definition.middleware ?? [];
+      const remaining = [];
+
+      for (const entry of middleware) {
+        if (entry !== this.middleware) {
+          remaining.push(entry);
+        }
+      }
+
+      compiledModule.definition.middleware = remaining;
     }
   }
 

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -52,6 +52,7 @@ await microservice.listen();
 - handlers are discovered from providers/controllers in compiled modules
 - only singleton-scoped handlers are registered
 - `@MessagePattern` matches one handler and returns its value to the caller
+- if multiple `@MessagePattern` handlers match the same incoming pattern, dispatch fails explicitly instead of silently picking the first match
 - `@EventPattern` dispatches to all matching handlers
 - pattern supports exact string or `RegExp` matching
 - transport lifecycle is managed through app startup/shutdown
@@ -61,7 +62,7 @@ await microservice.listen();
 - `TcpMicroserviceTransport` supports both `send()` (request/reply) and `emit()` (event).
 - `RedisPubSubMicroserviceTransport` supports `emit()` fan-out only. Use TCP transport for request/reply `send()` semantics.
 - `NatsMicroserviceTransport` supports both `send()` and `emit()` via NATS request/reply and pub/sub subjects.
-- `KafkaMicroserviceTransport` and `RabbitMqMicroserviceTransport` support `emit()` and inbound handler dispatch. For request/reply `send()`, use TCP or NATS transport.
+- `KafkaMicroserviceTransport` and `RabbitMqMicroserviceTransport` are event-only transports: they support `emit()` plus inbound event dispatch. For request/reply `send()`, use TCP or NATS transport.
 
 ## Hybrid mode
 

--- a/packages/microservices/src/kafka-transport.ts
+++ b/packages/microservices/src/kafka-transport.ts
@@ -25,12 +25,11 @@ export interface KafkaMicroserviceTransportOptions {
 export class KafkaMicroserviceTransport implements MicroserviceTransport {
   private handler: TransportHandler | undefined;
   private listening = false;
+  private listenPromise: Promise<void> | undefined;
   private readonly eventTopic: string;
-  private readonly messageTopic: string;
 
   constructor(private readonly options: KafkaMicroserviceTransportOptions) {
     this.eventTopic = options.eventTopic ?? 'konekti.microservices.events';
-    this.messageTopic = options.messageTopic ?? 'konekti.microservices.messages';
   }
 
   async listen(handler: TransportHandler): Promise<void> {
@@ -40,14 +39,24 @@ export class KafkaMicroserviceTransport implements MicroserviceTransport {
       return;
     }
 
-    await this.options.consumer.subscribe(this.eventTopic, async (message) => {
-      await this.handleInboundMessage(message, 'event');
-    });
-    await this.options.consumer.subscribe(this.messageTopic, async (message) => {
-      await this.handleInboundMessage(message, 'message');
-    });
+    if (this.listenPromise) {
+      await this.listenPromise;
+      return;
+    }
 
-    this.listening = true;
+    this.listenPromise = (async () => {
+      await this.options.consumer.subscribe(this.eventTopic, (message) => {
+        void this.handleInboundMessage(message, 'event').catch(() => undefined);
+      });
+
+      this.listening = true;
+    })();
+
+    try {
+      await this.listenPromise;
+    } finally {
+      this.listenPromise = undefined;
+    }
   }
 
   async send(_pattern: string, _payload: unknown): Promise<unknown> {
@@ -67,9 +76,12 @@ export class KafkaMicroserviceTransport implements MicroserviceTransport {
   }
 
   async close(): Promise<void> {
+    if (this.listenPromise) {
+      await this.listenPromise;
+    }
+
     if (this.listening) {
       await this.options.consumer.unsubscribe(this.eventTopic);
-      await this.options.consumer.unsubscribe(this.messageTopic);
     }
 
     this.handler = undefined;

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -343,4 +343,70 @@ describe('@konekti/microservices', () => {
 
     await app.close();
   });
+
+  it('deduplicates concurrent listen() calls against the underlying transport subscription', async () => {
+    let listenCalls = 0;
+
+    const transport: MicroserviceTransport = {
+      async close() {},
+      async emit() {},
+      async listen(_handler) {
+        listenCalls += 1;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      },
+      async send() {
+        return undefined;
+      },
+    };
+
+    class Handler {
+      @EventPattern('listen.once')
+      onEvent() {}
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [createMicroservicesModule({ transport })],
+      providers: [Handler],
+    });
+
+    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+
+    await Promise.all([microservice.listen(), microservice.listen()]);
+
+    expect(listenCalls).toBe(1);
+
+    await microservice.close();
+  });
+
+  it('fails deterministically when multiple message handlers match the same pattern', async () => {
+    class ExactHandler {
+      @MessagePattern('user.lookup')
+      handle() {
+        return 'exact';
+      }
+    }
+
+    class RegexHandler {
+      @MessagePattern(/^user\./)
+      handle() {
+        return 'regex';
+      }
+    }
+
+    const transport = new InMemoryLoopbackTransport();
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [createMicroservicesModule({ transport })],
+      providers: [ExactHandler, RegexHandler],
+    });
+
+    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    await microservice.listen();
+
+    await expect(microservice.send('user.lookup', {})).rejects.toThrow('Multiple message handlers matched pattern "user.lookup"');
+
+    await microservice.close();
+  });
 });

--- a/packages/microservices/src/rabbitmq-transport.ts
+++ b/packages/microservices/src/rabbitmq-transport.ts
@@ -25,12 +25,11 @@ export interface RabbitMqMicroserviceTransportOptions {
 export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
   private handler: TransportHandler | undefined;
   private listening = false;
+  private listenPromise: Promise<void> | undefined;
   private readonly eventQueue: string;
-  private readonly messageQueue: string;
 
   constructor(private readonly options: RabbitMqMicroserviceTransportOptions) {
     this.eventQueue = options.eventQueue ?? 'konekti.microservices.events';
-    this.messageQueue = options.messageQueue ?? 'konekti.microservices.messages';
   }
 
   async listen(handler: TransportHandler): Promise<void> {
@@ -40,14 +39,24 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
       return;
     }
 
-    await this.options.consumer.consume(this.eventQueue, async (message) => {
-      await this.handleInboundMessage(message, 'event');
-    });
-    await this.options.consumer.consume(this.messageQueue, async (message) => {
-      await this.handleInboundMessage(message, 'message');
-    });
+    if (this.listenPromise) {
+      await this.listenPromise;
+      return;
+    }
 
-    this.listening = true;
+    this.listenPromise = (async () => {
+      await this.options.consumer.consume(this.eventQueue, (message) => {
+        void this.handleInboundMessage(message, 'event').catch(() => undefined);
+      });
+
+      this.listening = true;
+    })();
+
+    try {
+      await this.listenPromise;
+    } finally {
+      this.listenPromise = undefined;
+    }
   }
 
   async send(_pattern: string, _payload: unknown): Promise<unknown> {
@@ -67,9 +76,12 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
   }
 
   async close(): Promise<void> {
+    if (this.listenPromise) {
+      await this.listenPromise;
+    }
+
     if (this.listening) {
       await this.options.consumer.cancel(this.eventQueue);
-      await this.options.consumer.cancel(this.messageQueue);
     }
 
     this.listening = false;

--- a/packages/microservices/src/redis-transport.ts
+++ b/packages/microservices/src/redis-transport.ts
@@ -25,6 +25,7 @@ export interface RedisPubSubMicroserviceTransportOptions {
 export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
   private handler: TransportHandler | undefined;
   private listening = false;
+  private listenPromise: Promise<void> | undefined;
   private readonly namespace: string;
   private readonly pending = new Map<string, { reject: (error: unknown) => void; resolve: (value: unknown) => void }>();
 
@@ -39,16 +40,29 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
       return;
     }
 
-    this.options.subscribeClient.on('message', (channel, message) => {
-      void this.handleIncoming(channel, message);
-    });
+    if (this.listenPromise) {
+      await this.listenPromise;
+      return;
+    }
 
-    await this.options.subscribeClient.subscribe(
-      this.requestChannel,
-      this.responseChannel,
-      this.eventChannel,
-    );
-    this.listening = true;
+    this.listenPromise = (async () => {
+      this.options.subscribeClient.on('message', (channel, message) => {
+        void this.handleIncoming(channel, message);
+      });
+
+      await this.options.subscribeClient.subscribe(
+        this.requestChannel,
+        this.responseChannel,
+        this.eventChannel,
+      );
+      this.listening = true;
+    })();
+
+    try {
+      await this.listenPromise;
+    } finally {
+      this.listenPromise = undefined;
+    }
   }
 
   async emit(pattern: string, payload: unknown): Promise<void> {
@@ -69,6 +83,10 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
   }
 
   async close(): Promise<void> {
+    if (this.listenPromise) {
+      await this.listenPromise;
+    }
+
     if (this.listening) {
       await this.options.subscribeClient.unsubscribe(
         this.requestChannel,

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -80,6 +80,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
   private readonly descriptors: HandlerDescriptor[] = [];
   private readonly handlerInstances = new Map<Token, Promise<unknown>>();
   private listening = false;
+  private listenPromise: Promise<void> | undefined;
 
   constructor(
     private readonly runtimeContainer: Container,
@@ -93,13 +94,30 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
       return;
     }
 
-    this.descriptors.length = 0;
-    this.descriptors.push(...this.discoverHandlerDescriptors());
-    await this.moduleOptions.transport.listen(async (packet) => this.dispatchPacket(packet));
-    this.listening = true;
+    if (this.listenPromise) {
+      await this.listenPromise;
+      return;
+    }
+
+    this.listenPromise = (async () => {
+      this.descriptors.length = 0;
+      this.descriptors.push(...this.discoverHandlerDescriptors());
+      await this.moduleOptions.transport.listen(async (packet) => this.dispatchPacket(packet));
+      this.listening = true;
+    })();
+
+    try {
+      await this.listenPromise;
+    } finally {
+      this.listenPromise = undefined;
+    }
   }
 
   async close(): Promise<void> {
+    if (this.listenPromise) {
+      await this.listenPromise;
+    }
+
     await this.moduleOptions.transport.close();
     this.listening = false;
   }
@@ -121,6 +139,14 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
       descriptor.kind === packet.kind && this.matchesPattern(descriptor.pattern, packet.pattern));
 
     if (packet.kind === 'message') {
+      if (matches.length > 1) {
+        throw new Error(
+          `Multiple message handlers matched pattern "${packet.pattern}": ${matches
+            .map((descriptor) => `${descriptor.targetName}.${descriptor.methodName}`)
+            .join(', ')}.`,
+        );
+      }
+
       const first = matches[0];
 
       if (!first) {
@@ -162,6 +188,10 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
         const dedupeKey = this.dedupeKey(entry.metadata.kind, entry.metadata.pattern);
 
         if (this.isDuplicate(seen, candidate.targetType, entry.propertyKey, dedupeKey)) {
+          this.logger.warn(
+            `Duplicate microservice handler registration for ${dedupeKey} on ${candidate.targetType.name}.${methodKeyToName(entry.propertyKey)} was ignored.`,
+            'MicroserviceLifecycleService',
+          );
           continue;
         }
 

--- a/packages/microservices/src/tcp-transport.ts
+++ b/packages/microservices/src/tcp-transport.ts
@@ -16,6 +16,7 @@ interface TcpMicroserviceTransportOptions {
 
 export class TcpMicroserviceTransport implements MicroserviceTransport {
   private handler: TransportHandler | undefined;
+  private listenPromise: Promise<void> | undefined;
   private readonly sockets = new Set<Socket>();
   private readonly host: string;
   private readonly requestTimeoutMs: number;
@@ -37,13 +38,24 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
       return;
     }
 
-    await new Promise<void>((resolve, reject) => {
+    if (this.listenPromise) {
+      await this.listenPromise;
+      return;
+    }
+
+    this.listenPromise = new Promise<void>((resolve, reject) => {
       this.server.once('error', reject);
       this.server.listen(this.options.port, this.host, () => {
         this.server.off('error', reject);
         resolve();
       });
     });
+
+    try {
+      await this.listenPromise;
+    } finally {
+      this.listenPromise = undefined;
+    }
   }
 
   async emit(pattern: string, payload: unknown): Promise<void> {
@@ -56,6 +68,10 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
   }
 
   async close(): Promise<void> {
+    if (this.listenPromise) {
+      await this.listenPromise;
+    }
+
     for (const socket of this.sockets) {
       socket.destroy();
     }
@@ -199,7 +215,7 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
 
         if (line.length > 0) {
           try {
-            onPacket(JSON.parse(line) as TPacket);
+            void Promise.resolve(onPacket(JSON.parse(line) as TPacket)).catch(() => undefined);
           } catch {
             return;
           }

--- a/packages/microservices/src/transports.test.ts
+++ b/packages/microservices/src/transports.test.ts
@@ -204,4 +204,58 @@ describe('broker transport adapters', () => {
 
     await transport.close();
   });
+
+  it('captures Kafka async callback rejections without leaking them to emit()', async () => {
+    const bus = new InMemoryTopicBus();
+    const transport = new KafkaMicroserviceTransport({
+      consumer: {
+        subscribe: async (topic, handler) => {
+          await bus.subscribe(topic, handler);
+        },
+        unsubscribe: async (topic) => {
+          await bus.unsubscribe(topic);
+        },
+      },
+      producer: {
+        publish: async (topic, message) => {
+          await bus.publish(topic, message);
+        },
+      },
+    });
+
+    await transport.listen(async () => {
+      throw new Error('kafka handler failed');
+    });
+
+    await expect(transport.emit('audit.login', { message: 'ok' })).resolves.toBeUndefined();
+
+    await transport.close();
+  });
+
+  it('captures RabbitMQ async callback rejections without leaking them to emit()', async () => {
+    const bus = new InMemoryTopicBus();
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+    });
+
+    await transport.listen(async () => {
+      throw new Error('rabbit handler failed');
+    });
+
+    await expect(transport.emit('audit.logout', { message: 'bye' })).resolves.toBeUndefined();
+
+    await transport.close();
+  });
 });

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -550,7 +550,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
         failedAt: new Date(job.finishedOn ?? Date.now()).toISOString(),
         jobId: job.id ?? '',
         jobName: descriptor.jobName,
-        payload: job.data,
+        payload: isQueuePayload(job.data) ? cloneQueuePayload(job.data) : job.data,
       };
 
       await this.getRedisClient().rpush(deadLetterKey(descriptor.jobName), JSON.stringify(deadLetter));

--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -62,6 +62,7 @@ export class AppModule {}
 - Uses `ws` in `noServer` mode with one shared Node server `upgrade` listener
 - Gateway path matching is exact and normalized (`/chat` != `/notifications`)
 - Non-singleton gateways are skipped with warnings
+- Handlers for gateways sharing the same socket/path execute in discovery order, not `Promise.all` parallel fan-out
 - Shutdown removes the shared upgrade listener and terminates all active clients
 - `message` and `close` events are buffered until `@OnConnect()` handlers complete, then replayed in order so connect-phase events are not silently dropped
 - Attachment server shutdown is timeout-aware and logs close timeout failures instead of hanging indefinitely

--- a/packages/websocket/src/module.test.ts
+++ b/packages/websocket/src/module.test.ts
@@ -594,6 +594,61 @@ describe('@konekti/websocket', () => {
     await app.close();
   });
 
+  it('runs same-socket gateway handlers in deterministic registration order', async () => {
+    class SharedState {
+      steps: string[] = [];
+    }
+
+    @Inject([SharedState])
+    @WebSocketGateway({ path: '/ordered' })
+    class FirstGateway {
+      constructor(private readonly state: SharedState) {}
+
+      @OnConnect()
+      async onConnect() {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        this.state.steps.push('first');
+      }
+    }
+
+    @Inject([SharedState])
+    @WebSocketGateway({ path: '/ordered' })
+    class SecondGateway {
+      constructor(private readonly state: SharedState) {}
+
+      @OnConnect()
+      onConnect() {
+        this.state.steps.push(`second-after-${this.state.steps.join('|') || 'none'}`);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createWebSocketModule()],
+      providers: [SharedState, FirstGateway, SecondGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      mode: 'test',
+      port,
+    });
+    const state = await app.container.resolve(SharedState);
+
+    await app.listen();
+
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/ordered`);
+    await onceOpen(socket);
+    socket.close();
+    await onceClosed(socket);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(state.steps).toEqual(['first', 'second-after-first']);
+
+    await app.close();
+  });
+
   it('clears heartbeat pending markers when pong is received', async () => {
     const service = createTestLifecycleService();
     const { emitPong, socket } = createMockSocket();
@@ -626,7 +681,7 @@ describe('@konekti/websocket', () => {
     await shutdown.call(service);
   });
 
-  it('caps ready-state message queue and drops newest messages when saturated', async () => {
+  it('caps ready-state message queue and drops newest queued messages when saturated', async () => {
     const service = createTestLifecycleService({
       buffer: {
         maxPendingMessagesPerSocket: 1,
@@ -638,6 +693,8 @@ describe('@konekti/websocket', () => {
       state: {
         enqueuedMessageCount: number;
         handlerQueue: Promise<void>;
+        processingMessageQueue: boolean;
+        queuedMessages: unknown[];
         resolved: Array<{ descriptor: unknown; instance: unknown }>;
         socketId: string;
       },
@@ -656,17 +713,72 @@ describe('@konekti/websocket', () => {
     const state = {
       enqueuedMessageCount: 0,
       handlerQueue: Promise.resolve(),
+      processingMessageQueue: false,
+      queuedMessages: [] as unknown[],
       resolved: [],
       socketId: 'socket-ready-1',
     };
 
     enqueueMessageDispatch.call(service, state, socket, {} as IncomingMessage, 'first');
     enqueueMessageDispatch.call(service, state, socket, {} as IncomingMessage, 'second');
+    enqueueMessageDispatch.call(service, state, socket, {} as IncomingMessage, 'third');
 
     gate.resolve();
     await state.handlerQueue;
 
-    expect(handledPayloads).toEqual(['first']);
+    expect(handledPayloads).toEqual(['first', 'second']);
+    expect(state.enqueuedMessageCount).toBe(0);
+  });
+
+  it('caps ready-state message queue and drops the oldest queued message when configured', async () => {
+    const service = createTestLifecycleService({
+      buffer: {
+        maxPendingMessagesPerSocket: 1,
+        overflowPolicy: 'drop-oldest',
+      },
+    });
+    const { socket } = createMockSocket();
+    const enqueueMessageDispatch = Reflect.get(service, 'enqueueMessageDispatch') as (
+      state: {
+        enqueuedMessageCount: number;
+        handlerQueue: Promise<void>;
+        processingMessageQueue: boolean;
+        queuedMessages: unknown[];
+        resolved: Array<{ descriptor: unknown; instance: unknown }>;
+        socketId: string;
+      },
+      socket: WebSocket,
+      request: IncomingMessage,
+      data: unknown,
+    ) => void;
+    const gate = createDeferred<void>();
+    const handledPayloads: unknown[] = [];
+
+    Reflect.set(service, 'handleMessage', async (_resolved: unknown, _socket: WebSocket, _request: IncomingMessage, data: unknown) => {
+      handledPayloads.push(data);
+
+      if (data === 'first') {
+        await gate.promise;
+      }
+    });
+
+    const state = {
+      enqueuedMessageCount: 0,
+      handlerQueue: Promise.resolve(),
+      processingMessageQueue: false,
+      queuedMessages: [] as unknown[],
+      resolved: [],
+      socketId: 'socket-ready-drop-oldest',
+    };
+
+    enqueueMessageDispatch.call(service, state, socket, {} as IncomingMessage, 'first');
+    enqueueMessageDispatch.call(service, state, socket, {} as IncomingMessage, 'second');
+    enqueueMessageDispatch.call(service, state, socket, {} as IncomingMessage, 'third');
+
+    gate.resolve();
+    await state.handlerQueue;
+
+    expect(handledPayloads).toEqual(['first', 'third']);
     expect(state.enqueuedMessageCount).toBe(0);
   });
 

--- a/packages/websocket/src/service.ts
+++ b/packages/websocket/src/service.ts
@@ -46,6 +46,8 @@ interface ConnectionHandlerState {
   enqueuedMessageCount: number;
   handlerQueue: Promise<void>;
   handlersReady: boolean;
+  processingMessageQueue: boolean;
+  queuedMessages: RawData[];
   resolved: Array<{ descriptor: WebSocketGatewayDescriptor; instance: unknown }>;
   socketId: string;
 }
@@ -53,6 +55,12 @@ interface ConnectionHandlerState {
 interface NodeUpgradeServer {
   off(event: 'upgrade', listener: NodeUpgradeListener): this;
   on(event: 'upgrade', listener: NodeUpgradeListener): this;
+}
+
+interface ClassProviderLike {
+  provide: Token;
+  scope?: 'request' | 'singleton' | 'transient';
+  useClass: new (...args: any[]) => unknown;
 }
 
 type NodeUpgradeListener = (request: IncomingMessage, socket: Duplex, head: Buffer) => void;
@@ -81,7 +89,8 @@ function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'trans
   }
 
   if ('useClass' in provider) {
-    return provider.scope ?? getClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
+    const classProvider = provider as ClassProviderLike;
+    return classProvider.scope ?? getClassDiMetadata(classProvider.useClass)?.scope ?? 'singleton';
   }
 
   return 'scope' in provider ? provider.scope ?? 'singleton' : 'singleton';
@@ -91,7 +100,7 @@ function methodKeyToName(methodKey: MetadataPropertyKey): string {
   return typeof methodKey === 'symbol' ? methodKey.toString() : methodKey;
 }
 
-function isClassProvider(provider: Provider): provider is Extract<Provider, { provide: Token; useClass: Function }> {
+function isClassProvider(provider: Provider): provider is ClassProviderLike {
   return typeof provider === 'object' && provider !== null && 'useClass' in provider;
 }
 
@@ -339,6 +348,8 @@ export class WebSocketGatewayLifecycleService
       enqueuedMessageCount: 0,
       handlerQueue: Promise.resolve(),
       handlersReady: false,
+      processingMessageQueue: false,
+      queuedMessages: [],
       resolved: [],
       socketId: randomUUID(),
     };
@@ -355,7 +366,7 @@ export class WebSocketGatewayLifecycleService
       : DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET;
     const policy = this.moduleOptions.buffer?.overflowPolicy ?? 'drop-oldest';
 
-    if (state.enqueuedMessageCount >= limit) {
+    if (state.queuedMessages.length >= limit) {
       if (policy === 'close') {
         socket.terminate();
         this.unregisterSocket(state.socketId);
@@ -366,25 +377,55 @@ export class WebSocketGatewayLifecycleService
         return;
       }
 
-      this.logger.warn(
-        `WebSocket connection ${state.socketId} dropped a ready-state message because queue limit (${String(limit)}) was reached.`,
-        'WebSocketGatewayLifecycleService',
-      );
+      if (policy === 'drop-oldest') {
+        state.queuedMessages.shift();
+        this.logger.warn(
+          `WebSocket connection ${state.socketId} dropped the oldest ready-state message because queue limit (${String(limit)}) was reached.`,
+          'WebSocketGatewayLifecycleService',
+        );
+      } else {
+        this.logger.warn(
+          `WebSocket connection ${state.socketId} dropped a ready-state message because queue limit (${String(limit)}) was reached.`,
+          'WebSocketGatewayLifecycleService',
+        );
+        return;
+      }
+    }
+
+    state.queuedMessages.push(data);
+    state.enqueuedMessageCount = state.queuedMessages.length;
+
+    if (state.processingMessageQueue) {
       return;
     }
 
-    state.enqueuedMessageCount += 1;
-
-    state.handlerQueue = state.handlerQueue
-      .then(async () => {
-        await this.handleMessage(state.resolved, socket, request, data);
-      })
+    state.processingMessageQueue = true;
+    state.handlerQueue = this.drainMessageQueue(state, socket, request)
       .finally(() => {
-        state.enqueuedMessageCount = Math.max(0, state.enqueuedMessageCount - 1);
+        state.processingMessageQueue = false;
+        state.enqueuedMessageCount = state.queuedMessages.length;
       })
       .catch((error) => {
         this.logger.error('WebSocket gateway message dispatch failed.', error, 'WebSocketGatewayLifecycleService');
       });
+  }
+
+  private async drainMessageQueue(
+    state: ConnectionHandlerState,
+    socket: WebSocket,
+    request: IncomingMessage,
+  ): Promise<void> {
+    while (state.queuedMessages.length > 0) {
+      const nextMessage = state.queuedMessages.shift();
+
+      state.enqueuedMessageCount = state.queuedMessages.length;
+
+      if (nextMessage === undefined) {
+        continue;
+      }
+
+      await this.handleMessage(state.resolved, socket, request, nextMessage);
+    }
   }
 
   private enqueueDisconnectDispatch(
@@ -498,11 +539,9 @@ export class WebSocketGatewayLifecycleService
     socket: WebSocket,
     request: IncomingMessage,
   ): Promise<void> {
-    await Promise.all(
-      state.resolved.map(async ({ descriptor, instance }) => {
-        await this.runHandlers(instance, descriptor, 'connect', socket, request, state.socketId);
-      }),
-    );
+    for (const { descriptor, instance } of state.resolved) {
+      await this.runHandlers(instance, descriptor, 'connect', socket, request, state.socketId);
+    }
   }
 
   private replayBufferedConnectionEvents(
@@ -536,15 +575,13 @@ export class WebSocketGatewayLifecycleService
   ): Promise<void> {
     const parsed = parseIncomingMessage(data);
 
-    await Promise.all(
-      resolved.map(async ({ descriptor, instance }) => {
-        const handlers = this.selectMessageHandlers(descriptor, parsed.event);
+    for (const { descriptor, instance } of resolved) {
+      const handlers = this.selectMessageHandlers(descriptor, parsed.event);
 
-        for (const handler of handlers) {
-          await this.invokeGatewayMethod(instance, descriptor, handler, [parsed.payload, socket, request]);
-        }
-      }),
-    );
+      for (const handler of handlers) {
+        await this.invokeGatewayMethod(instance, descriptor, handler, [parsed.payload, socket, request]);
+      }
+    }
   }
 
   private selectMessageHandlers(
@@ -565,11 +602,9 @@ export class WebSocketGatewayLifecycleService
     reason: Buffer,
     socketId: string,
   ): Promise<void> {
-    await Promise.all(
-      resolved.map(async ({ descriptor, instance }) => {
-        await this.runHandlers(instance, descriptor, 'disconnect', socket, code, reason.toString('utf8'), socketId);
-      }),
-    );
+    for (const { descriptor, instance } of resolved) {
+      await this.runHandlers(instance, descriptor, 'disconnect', socket, code, reason.toString('utf8'), socketId);
+    }
   }
 
   private async runHandlers(
@@ -684,7 +719,7 @@ export class WebSocketGatewayLifecycleService
             moduleName: compiledModule.type.name,
             scope: scopeFromProvider(provider),
             targetType: provider,
-            token: provider,
+            token: provider as Token,
           });
           continue;
         }


### PR DESCRIPTION
## Summary
- Make cross-process/event delivery deterministic by rehydrating event-bus transport payloads per handler event type, guarding microservice listen paths against concurrent double subscription, and surfacing duplicate message-handler matches explicitly.
- Tighten realtime execution ownership by serializing same-socket websocket gateway handlers, making ready-state overflow policies explicit, and removing GraphQL bootstrap middleware mutation leakage across repeated app boots.
- Improve operational semantics by tracing distributed cron lock renew/release outcomes, preserving dead-letter payload isolation, and clarifying Kafka/RabbitMQ as event-only transports.

## Verification
- `pnpm build`
- `pnpm vitest run packages/event-bus/src/module.test.ts`
- `pnpm vitest run packages/microservices/src/module.test.ts packages/microservices/src/transports.test.ts`
- `pnpm vitest run packages/queue/src/module.test.ts packages/cron/src/module.test.ts`
- `pnpm vitest run packages/websocket/src/module.test.ts`
- `pnpm vitest run packages/graphql/src/module.test.ts`
- `lsp_diagnostics` on all modified source files

## Notes
- `pnpm typecheck` still fails in this worktree due to pre-existing unresolved `@konekti/core` workspace module resolution errors under `packages/runtime/src/*`; those failures were present outside the issue-specific changes, so verification used package builds plus focused regression suites.

Closes #240