### PR TITLE
Resolve #236: make DI registration deterministic and streamline metadata traversal

### DIFF
--- a/docs/concepts/decorators-and-metadata.md
+++ b/docs/concepts/decorators-and-metadata.md
@@ -48,6 +48,7 @@ Current public boundary:
 - runtime and other packages should read normalized metadata through helper APIs
 - custom decorators should not depend on raw storage shape as a public contract
 - third-party metadata/decorator extension beyond framework-owned categories is not part of the current public contract
+- `ensureMetadataSymbol()` / helper exports are the supported compatibility boundary when `Symbol.metadata` needs to be present; consumers should not rely on incidental import order from internal helper modules
 
 ## practical mental model
 

--- a/docs/concepts/di-and-modules.md
+++ b/docs/concepts/di-and-modules.md
@@ -25,6 +25,7 @@ See also:
 - `useClass`
 - `useFactory`
 - `useValue`
+- tokens must choose one registration mode: single provider or multi provider collection
 
 ## scopes
 
@@ -95,6 +96,7 @@ In short:
 - constructor dependency metadata and constructor arity must agree
 - bootstrap errors should distinguish missing local provider, missing export, missing import, and malformed injection metadata
 - fail-fast diagnostics are part of the framework contract, not optional polish
+- mixed single-provider + multi-provider registration for the same token is a fail-fast container error, not a last-write or silent-shadowing case
 
 ## testing stance
 

--- a/docs/operations/third-party-extension-contract.md
+++ b/docs/operations/third-party-extension-contract.md
@@ -17,7 +17,7 @@ Custom metadata keys must use a namespaced `Symbol.for()` pattern:
 
 ### Authoring Custom Decorators
 
-Use the `metadata` property on the decorator context to store metadata. Access this via the `Symbol.metadata` primitive (shipped by `@konekti/core` if missing).
+Use the `metadata` property on the decorator context to store metadata. Access this via the `Symbol.metadata` primitive, using the `@konekti/core` compatibility boundary (`ensureMetadataSymbol()` / `metadataSymbol`) when you need to guarantee the symbol exists.
 
 ```typescript
 import { metadataSymbol } from '@konekti/core';

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,6 +113,8 @@ For DI metadata, `getOwnClassDiMetadata()` returns only metadata written on the 
 
 `@konekti/core` also re-exports additional metadata helpers and types from `src/metadata.ts`; treat this table as the most important helpers, not the full public surface.
 
+`ensureMetadataSymbol()` is the explicit compatibility boundary for standard-decorator metadata. `@konekti/core` still installs `Symbol.metadata` when missing so framework decorators and helper readers stay compatible, but extension code should treat the initializer/helper layer as the supported contract rather than depending on incidental import-order side effects.
+
 ## Architecture
 
 ```

--- a/packages/core/src/decorator-transform.test.ts
+++ b/packages/core/src/decorator-transform.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { ensureMetadataSymbol } from './metadata.js';
+
 const metadataSymbol =
   (Symbol as typeof Symbol & { metadata?: symbol }).metadata ??
   Symbol.for('konekti.test.metadata');
@@ -29,5 +31,10 @@ describe('decorator transform baseline', () => {
     const metadata = (Example as unknown as Record<symbol, Record<string, unknown>>)[metadataSymbol];
 
     expect(metadata.tag).toBe('ok');
+  });
+
+  it('keeps the metadata initializer idempotent', () => {
+    expect(ensureMetadataSymbol()).toBe(metadataSymbol);
+    expect(ensureMetadataSymbol()).toBe(metadataSymbol);
   });
 });

--- a/packages/core/src/metadata.test.ts
+++ b/packages/core/src/metadata.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  appendDtoFieldValidationRule,
   defineClassDiMetadata,
   defineControllerMetadata,
   defineDtoFieldBindingMetadata,
+  defineInjectionMetadata,
   defineModuleMetadata,
   defineRouteMetadata,
+  ensureMetadataSymbol,
   getClassDiMetadata,
   getControllerMetadata,
   getDtoBindingSchema,
+  getDtoValidationSchema,
   getDtoFieldBindingMetadata,
   getInheritedClassDiMetadata,
+  getInjectionSchema,
   getModuleMetadata,
   getOwnClassDiMetadata,
   getRouteMetadata,
@@ -135,6 +140,68 @@ describe('metadata helpers', () => {
     });
   });
 
+  it('round-trips injection schema metadata and returns fresh schema entries', () => {
+    class ExampleController {
+      service!: string;
+    }
+
+    defineInjectionMetadata(ExampleController.prototype, 'service', {
+      optional: true,
+      token: 'LOGGER',
+    });
+
+    const schema = getInjectionSchema(ExampleController.prototype);
+
+    expect(schema).toEqual([
+      {
+        propertyKey: 'service',
+        metadata: {
+          optional: true,
+          token: 'LOGGER',
+        },
+      },
+    ]);
+
+    schema[0]?.metadata && ((schema[0].metadata as unknown as { token: string }).token = 'MUTATED');
+
+    expect(getInjectionSchema(ExampleController.prototype)).toEqual([
+      {
+        propertyKey: 'service',
+        metadata: {
+          optional: true,
+          token: 'LOGGER',
+        },
+      },
+    ]);
+  });
+
+  it('preserves DTO validation append order while rebuilding fresh rule arrays', () => {
+    class ExampleDto {
+      name!: string;
+    }
+
+    appendDtoFieldValidationRule(ExampleDto.prototype, 'name', { kind: 'string' });
+    appendDtoFieldValidationRule(ExampleDto.prototype, 'name', { kind: 'minLength', value: 2 });
+
+    const schema = getDtoValidationSchema(ExampleDto);
+
+    expect(schema).toEqual([
+      {
+        propertyKey: 'name',
+        rules: [{ kind: 'string' }, { kind: 'minLength', value: 2 }],
+      },
+    ]);
+
+    (schema[0]?.rules as unknown as Array<{ kind: string }>).push({ kind: 'mutated' });
+
+    expect(getDtoValidationSchema(ExampleDto)).toEqual([
+      {
+        propertyKey: 'name',
+        rules: [{ kind: 'string' }, { kind: 'minLength', value: 2 }],
+      },
+    ]);
+  });
+
   it('round-trips class DI metadata', () => {
     class ExampleService {}
 
@@ -219,5 +286,9 @@ describe('metadata helpers', () => {
       inject: ['CACHE'],
       scope: 'request',
     });
+  });
+
+  it('ensures Symbol.metadata is available through the exported initializer', () => {
+    expect(ensureMetadataSymbol()).toBe((Symbol as typeof Symbol & { metadata?: symbol }).metadata);
   });
 });

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -2,7 +2,7 @@ export { getClassDiMetadata, getInheritedClassDiMetadata, getOwnClassDiMetadata,
 export { defineControllerMetadata, defineRouteMetadata, getControllerMetadata, getRouteMetadata } from './metadata/controller-route.js';
 export { defineInjectionMetadata, getInjectionSchema } from './metadata/injection.js';
 export { defineModuleMetadata, getModuleMetadata } from './metadata/module.js';
-export { metadataKeys, metadataSymbol } from './metadata/shared.js';
+export { ensureMetadataSymbol, metadataKeys, metadataSymbol } from './metadata/shared.js';
 export {
   appendClassValidationRule,
   appendDtoFieldValidationRule,

--- a/packages/core/src/metadata/class-di.ts
+++ b/packages/core/src/metadata/class-di.ts
@@ -14,9 +14,11 @@ function getClassMetadataLineage(target: Function): Function[] {
   let current: unknown = target;
 
   while (typeof current === 'function' && current !== Function.prototype) {
-    lineage.unshift(current);
+    lineage.push(current);
     current = Object.getPrototypeOf(current);
   }
+
+  lineage.reverse();
 
   return lineage;
 }

--- a/packages/core/src/metadata/controller-route.ts
+++ b/packages/core/src/metadata/controller-route.ts
@@ -1,4 +1,11 @@
-import { cloneCollection, getOrCreatePropertyMap, getStandardMetadataBag, mergeUnique, standardMetadataKeys } from './shared.js';
+import {
+  cloneCollection,
+  getOrCreatePropertyMap,
+  getStandardConstructorMetadataMap,
+  getStandardMetadataBag,
+  mergeUnique,
+  standardMetadataKeys,
+} from './shared.js';
 import type { ControllerMetadata, RouteMetadata, StandardRouteMetadataRecord } from './types.js';
 import type { MetadataPropertyKey } from '../types.js';
 
@@ -32,10 +39,7 @@ function getStandardControllerMetadata(target: Function): ControllerMetadata | u
 }
 
 function getStandardRouteMetadata(target: object, propertyKey: MetadataPropertyKey): RouteMetadata | undefined {
-  const constructor = (target as { constructor?: Function }).constructor;
-  const routeMap = constructor
-    ? (getStandardMetadataBag(constructor)?.[standardMetadataKeys.route] as Map<MetadataPropertyKey, StandardRouteMetadataRecord> | undefined)
-    : undefined;
+  const routeMap = getStandardConstructorMetadataMap<StandardRouteMetadataRecord>(target, standardMetadataKeys.route);
   const metadata = routeMap?.get(propertyKey);
 
   if (!metadata?.method || metadata.path === undefined) {

--- a/packages/core/src/metadata/injection.ts
+++ b/packages/core/src/metadata/injection.ts
@@ -1,15 +1,11 @@
-import { getOrCreatePropertyMap, getStandardMetadataBag, standardMetadataKeys } from './shared.js';
+import { getOrCreatePropertyMap, getStandardConstructorMetadataMap, mergeMetadataPropertyKeys, standardMetadataKeys } from './shared.js';
 import type { InjectionMetadata, InjectionSchemaEntry, StandardInjectionRecord } from './types.js';
 import type { MetadataPropertyKey } from '../types.js';
 
 const injectionMetadataStore = new WeakMap<object, Map<MetadataPropertyKey, InjectionMetadata>>();
 
 function getStandardInjectionMap(target: object): Map<MetadataPropertyKey, StandardInjectionRecord> | undefined {
-  const constructor = (target as { constructor?: Function }).constructor;
-
-  return constructor
-    ? (getStandardMetadataBag(constructor)?.[standardMetadataKeys.injection] as Map<MetadataPropertyKey, StandardInjectionRecord> | undefined)
-    : undefined;
+  return getStandardConstructorMetadataMap<StandardInjectionRecord>(target, standardMetadataKeys.injection);
 }
 
 export function defineInjectionMetadata(
@@ -23,7 +19,7 @@ export function defineInjectionMetadata(
 export function getInjectionSchema(target: object): InjectionSchemaEntry[] {
   const stored = injectionMetadataStore.get(target) ?? new Map<MetadataPropertyKey, InjectionMetadata>();
   const standard = getStandardInjectionMap(target) ?? new Map<MetadataPropertyKey, StandardInjectionRecord>();
-  const keys = new Set<MetadataPropertyKey>([...stored.keys(), ...standard.keys()]);
+  const keys = mergeMetadataPropertyKeys(stored, standard);
   const schema: InjectionSchemaEntry[] = [];
 
   for (const propertyKey of keys) {

--- a/packages/core/src/metadata/shared.ts
+++ b/packages/core/src/metadata/shared.ts
@@ -5,12 +5,18 @@ export type StandardMetadataBag = Record<PropertyKey, unknown>;
 const symbolWithMetadata = Symbol as typeof Symbol & { metadata?: symbol };
 export const metadataSymbol = symbolWithMetadata.metadata ?? Symbol.for('konekti.symbol.metadata');
 
-if (!symbolWithMetadata.metadata) {
-  Object.defineProperty(Symbol, 'metadata', {
-    configurable: true,
-    value: metadataSymbol,
-  });
+export function ensureMetadataSymbol(): symbol {
+  if (!symbolWithMetadata.metadata) {
+    Object.defineProperty(Symbol, 'metadata', {
+      configurable: true,
+      value: metadataSymbol,
+    });
+  }
+
+  return metadataSymbol;
 }
+
+void ensureMetadataSymbol();
 
 export const standardMetadataKeys = {
   classValidation: Symbol.for('konekti.standard.class-validation'),
@@ -56,9 +62,11 @@ export function mergeUnique<T>(existing: readonly T[] | undefined, values: reado
   }
 
   const merged = [...(existing ?? [])];
+  const seen = new Set(merged);
 
   for (const value of values ?? []) {
-    if (!merged.includes(value)) {
+    if (!seen.has(value)) {
+      seen.add(value);
       merged.push(value);
     }
   }
@@ -68,4 +76,69 @@ export function mergeUnique<T>(existing: readonly T[] | undefined, values: reado
 
 export function getStandardMetadataBag(target: object): StandardMetadataBag | undefined {
   return (target as Record<symbol, StandardMetadataBag | undefined>)[metadataSymbol];
+}
+
+export function getStandardConstructorMetadataBag(target: object): StandardMetadataBag | undefined {
+  const constructor = (target as { constructor?: Function }).constructor;
+
+  return constructor ? getStandardMetadataBag(constructor) : undefined;
+}
+
+export function getStandardConstructorMetadataRecord<T>(target: object, key: symbol): T | undefined {
+  return getStandardConstructorMetadataBag(target)?.[key] as T | undefined;
+}
+
+export function getStandardConstructorMetadataMap<T>(target: object, key: symbol): Map<MetadataPropertyKey, T> | undefined {
+  return getStandardConstructorMetadataRecord<Map<MetadataPropertyKey, T>>(target, key);
+}
+
+export function mergeMetadataPropertyKeys<TStored, TStandard>(
+  stored: ReadonlyMap<MetadataPropertyKey, TStored> | undefined,
+  standard: ReadonlyMap<MetadataPropertyKey, TStandard> | undefined,
+): MetadataPropertyKey[] {
+  const keys: MetadataPropertyKey[] = [];
+  const seen = new Set<MetadataPropertyKey>();
+
+  for (const source of [stored, standard]) {
+    if (!source) {
+      continue;
+    }
+
+    for (const key of source.keys()) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+      }
+    }
+  }
+
+  return keys;
+}
+
+export function appendPropertyMapValue<T>(
+  store: WeakMap<object, Map<MetadataPropertyKey, T[]>>,
+  target: object,
+  propertyKey: MetadataPropertyKey,
+  value: T,
+): void {
+  const map = getOrCreatePropertyMap(store, target);
+  const existing = map.get(propertyKey);
+
+  if (existing) {
+    existing.push(value);
+    return;
+  }
+
+  map.set(propertyKey, [value]);
+}
+
+export function appendWeakMapValue<T>(store: WeakMap<Function, T[]>, target: Function, value: T): void {
+  const existing = store.get(target);
+
+  if (existing) {
+    existing.push(value);
+    return;
+  }
+
+  store.set(target, [value]);
 }

--- a/packages/core/src/metadata/validation.ts
+++ b/packages/core/src/metadata/validation.ts
@@ -1,4 +1,12 @@
-import { getOrCreatePropertyMap, getStandardMetadataBag, standardMetadataKeys } from './shared.js';
+import {
+  appendPropertyMapValue,
+  appendWeakMapValue,
+  getOrCreatePropertyMap,
+  getStandardConstructorMetadataMap,
+  getStandardMetadataBag,
+  mergeMetadataPropertyKeys,
+  standardMetadataKeys,
+} from './shared.js';
 import type {
   ClassValidationRule,
   DtoBindingSchemaEntry,
@@ -15,23 +23,11 @@ const dtoFieldValidationStore = new WeakMap<object, Map<MetadataPropertyKey, Dto
 const classValidationStore = new WeakMap<Function, ClassValidationRule[]>();
 
 function getStandardDtoBindingMap(target: object): Map<MetadataPropertyKey, StandardDtoBindingRecord> | undefined {
-  const constructor = (target as { constructor?: Function }).constructor;
-
-  return constructor
-    ? (getStandardMetadataBag(constructor)?.[standardMetadataKeys.dtoFieldBinding] as
-        | Map<MetadataPropertyKey, StandardDtoBindingRecord>
-        | undefined)
-    : undefined;
+  return getStandardConstructorMetadataMap<StandardDtoBindingRecord>(target, standardMetadataKeys.dtoFieldBinding);
 }
 
 function getStandardDtoValidationMap(target: object): Map<MetadataPropertyKey, StandardDtoValidationRecord> | undefined {
-  const constructor = (target as { constructor?: Function }).constructor;
-
-  return constructor
-    ? (getStandardMetadataBag(constructor)?.[standardMetadataKeys.dtoFieldValidation] as
-        | Map<MetadataPropertyKey, StandardDtoValidationRecord>
-        | undefined)
-    : undefined;
+  return getStandardConstructorMetadataMap<StandardDtoValidationRecord>(target, standardMetadataKeys.dtoFieldValidation);
 }
 
 function getStandardClassValidationRules(target: Function): ClassValidationRule[] | undefined {
@@ -68,12 +64,11 @@ export function appendDtoFieldValidationRule(
   propertyKey: MetadataPropertyKey,
   rule: DtoFieldValidationRule,
 ): void {
-  const map = getOrCreatePropertyMap(dtoFieldValidationStore, target);
-  map.set(propertyKey, [...(map.get(propertyKey) ?? []), rule]);
+  appendPropertyMapValue(dtoFieldValidationStore, target, propertyKey, rule);
 }
 
 export function appendClassValidationRule(target: Function, rule: ClassValidationRule): void {
-  classValidationStore.set(target, [...(classValidationStore.get(target) ?? []), rule]);
+  appendWeakMapValue(classValidationStore, target, rule);
 }
 
 export function getDtoBindingSchema(dto: Constructor): DtoBindingSchemaEntry[] {
@@ -81,9 +76,9 @@ export function getDtoBindingSchema(dto: Constructor): DtoBindingSchemaEntry[] {
   const standard =
     (getStandardMetadataBag(dto)?.[standardMetadataKeys.dtoFieldBinding] as Map<MetadataPropertyKey, StandardDtoBindingRecord> | undefined) ??
     new Map<MetadataPropertyKey, StandardDtoBindingRecord>();
-  const keys = new Set<MetadataPropertyKey>([...stored.keys(), ...standard.keys()]);
+  const keys = mergeMetadataPropertyKeys(stored, standard);
 
-  return Array.from(keys)
+  return keys
     .map((propertyKey) => ({
       propertyKey,
       metadata: getDtoFieldBindingMetadata(dto.prototype, propertyKey),
@@ -101,9 +96,9 @@ export function getDtoFieldValidationRules(target: object, propertyKey: Metadata
 export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEntry[] {
   const stored = dtoFieldValidationStore.get(dto.prototype) ?? new Map<MetadataPropertyKey, DtoFieldValidationRule[]>();
   const standard = getStandardDtoValidationMap(dto.prototype) ?? new Map<MetadataPropertyKey, StandardDtoValidationRecord>();
-  const keys = new Set<MetadataPropertyKey>([...stored.keys(), ...standard.keys()]);
+  const keys = mergeMetadataPropertyKeys(stored, standard);
 
-  return Array.from(keys)
+  return keys
     .map((propertyKey) => ({
       propertyKey,
       rules: getDtoFieldValidationRules(dto.prototype, propertyKey),

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -85,6 +85,8 @@ Additional public exports include `Provider`, `RequestScopeContainer`, `Normaliz
 
 All incoming provider shapes — bare class, `useClass`, `useFactory`, `useValue` — are normalized to a `NormalizedProvider` before storage. This means the resolve path never branches on shape: it always knows which inject list to use, which scope applies, and which instantiation path to take.
 
+Provider registration is deterministic per token: a token must be registered either as a single provider or as a multi provider collection, never both. Attempting to mix those registration modes for the same token throws the same duplicate-provider diagnostic used for accidental double registration.
+
 ### Scope-aware caching
 
 The container separates **where to find a provider** from **where to cache its instance**:

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -281,6 +281,33 @@ describe('Container', () => {
       expect(a.b).toBeInstanceOf(ServiceB);
       expect(a.b.value).toBe('b');
     });
+
+    it('throws CircularDependencyError for a deep cycle (A -> B -> C -> A)', async () => {
+      class ServiceA {
+        constructor(public b: ServiceB) {}
+      }
+
+      class ServiceB {
+        constructor(public c: ServiceC) {}
+      }
+
+      class ServiceC {
+        constructor(public a: ServiceA) {}
+      }
+
+      const container = new Container().register(
+        { provide: ServiceA, useClass: ServiceA, inject: [ServiceB] },
+        { provide: ServiceB, useClass: ServiceB, inject: [ServiceC] },
+        { provide: ServiceC, useClass: ServiceC, inject: [ServiceA] },
+      );
+
+      const error = await container.resolve(ServiceA).catch((value: unknown) => value);
+
+      expect(error).toBeInstanceOf(CircularDependencyError);
+      expect((error as CircularDependencyError).message).toContain('ServiceA');
+      expect((error as CircularDependencyError).message).toContain('ServiceB');
+      expect((error as CircularDependencyError).message).toContain('ServiceC');
+    });
   });
 
   describe('duplicate provider detection', () => {
@@ -331,6 +358,26 @@ describe('Container', () => {
       expect(await container.resolve<string>(token)).toBe('single');
     });
 
+    it('throws DuplicateProviderError when registering a single provider after multi providers for the same token', () => {
+      const token = Symbol('plugins');
+
+      expect(() =>
+        new Container().register(
+          { provide: token, useValue: 'a', multi: true },
+          { provide: token, useValue: 'b' },
+        )).toThrow(DuplicateProviderError);
+    });
+
+    it('throws DuplicateProviderError when registering a multi provider after a single provider for the same token', () => {
+      const token = Symbol('plugins');
+
+      expect(() =>
+        new Container().register(
+          { provide: token, useValue: 'a' },
+          { provide: token, useValue: 'b', multi: true },
+        )).toThrow(DuplicateProviderError);
+    });
+  
     it('keeps root singleton cache isolated when overriding in a request scope', async () => {
       const token = Symbol('singleton-token');
       const rootSingleton = { value: 'root' };
@@ -432,6 +479,18 @@ describe('Container', () => {
       expect(plugins).toHaveLength(2);
       expect(plugins[0]).toBeInstanceOf(PluginA);
       expect(plugins[1]).toBeInstanceOf(PluginB);
+    });
+
+    it('collects parent and child multi providers without overriding parent registrations', async () => {
+      const PLUGINS = Symbol('Plugins');
+      const root = new Container().register(
+        { provide: PLUGINS, useValue: 'root-a', multi: true },
+        { provide: PLUGINS, useValue: 'root-b', multi: true },
+      );
+      const child = root.createRequestScope().register({ provide: PLUGINS, useValue: 'child-c', multi: true });
+
+      await expect(root.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b']);
+      await expect(child.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b', 'child-c']);
     });
   });
 

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -130,15 +130,18 @@ export class Container {
     for (const provider of providers) {
       const normalized = normalizeProvider(provider);
 
-      if (normalized.multi) {
-        const existing = this.multiRegistrations.get(normalized.provide) ?? [];
+      this.assertNoRegistrationConflict(normalized.provide, normalized.multi === true);
 
-        this.multiRegistrations.set(normalized.provide, [...existing, normalized]);
-      } else {
-        if (this.registrations.has(normalized.provide)) {
-          throw new DuplicateProviderError(normalized.provide);
+      if (normalized.multi) {
+        const existing = this.multiRegistrations.get(normalized.provide);
+
+        if (existing) {
+          existing.push(normalized);
+          continue;
         }
 
+        this.multiRegistrations.set(normalized.provide, [normalized]);
+      } else {
         this.registrations.set(normalized.provide, normalized);
       }
     }
@@ -183,7 +186,7 @@ export class Container {
       throw new ContainerResolutionError('Container has been disposed and can no longer resolve providers.');
     }
 
-    return this.resolveWithChain(token, []);
+    return this.resolveWithChain(token, [], new Set<Token>());
   }
 
   async dispose(): Promise<void> {
@@ -210,28 +213,58 @@ export class Container {
     return this.parent?.hasMulti(token) ?? false;
   }
 
-  private collectMultiProviders(token: Token): NormalizedProvider[] {
-    const parentProviders = this.parent?.collectMultiProviders(token) ?? [];
-    const local = this.multiRegistrations.get(token) ?? [];
+  private assertNoRegistrationConflict(token: Token, multi: boolean): void {
+    if (multi) {
+      if (this.registrations.has(token)) {
+        throw new DuplicateProviderError(token);
+      }
 
-    return [...parentProviders, ...local];
+      return;
+    }
+
+    if (this.registrations.has(token) || this.multiRegistrations.has(token)) {
+      throw new DuplicateProviderError(token);
+    }
   }
 
-  private async resolveWithChain<T>(token: Token<T>, chain: Token[], allowForwardRef = false): Promise<T> {
-    const cachedForwardRef = this.resolveForwardRefCircularDependency(token, chain, allowForwardRef);
+  private collectMultiProviders(token: Token): NormalizedProvider[] {
+    const providers: NormalizedProvider[] = [];
+
+    if (this.parent) {
+      providers.push(...this.parent.collectMultiProviders(token));
+    }
+
+    const local = this.multiRegistrations.get(token);
+
+    if (local) {
+      providers.push(...local);
+    }
+
+    return providers;
+  }
+
+  private async resolveWithChain<T>(
+    token: Token<T>,
+    chain: Token[],
+    activeTokens: Set<Token>,
+    allowForwardRef = false,
+  ): Promise<T> {
+    const cachedForwardRef = this.resolveForwardRefCircularDependency(token, chain, activeTokens, allowForwardRef);
 
     if (cachedForwardRef !== undefined) {
       return (await cachedForwardRef) as T;
     }
 
-    return await this.resolveFromRegisteredProviders(token, chain);
+    return await this.resolveFromRegisteredProviders(token, chain, activeTokens);
   }
 
-  private async resolveFromRegisteredProviders<T>(token: Token<T>, chain: Token[]): Promise<T> {
+  private async resolveFromRegisteredProviders<T>(token: Token<T>, chain: Token[], activeTokens: Set<Token>): Promise<T> {
     const multiProviders = this.collectMultiProviders(token);
 
     if (multiProviders.length > 0) {
-      const instances = await this.resolveMultiProviderInstances(multiProviders, chain, token);
+      const instances = await this.withTokenInChain(token, chain, activeTokens, async () =>
+        this.resolveMultiProviderInstances(multiProviders, chain, activeTokens),
+      );
 
       return instances as unknown as T;
     }
@@ -240,14 +273,16 @@ export class Container {
     const existingTarget = this.resolveExistingProviderTarget(provider);
 
     if (existingTarget !== undefined) {
-      return await this.resolveAliasTarget(existingTarget as Token<T>, token, chain);
+      return await this.resolveAliasTarget(existingTarget as Token<T>, token, chain, activeTokens);
     }
 
     if (provider.scope === 'transient') {
-      return (await this.instantiate(provider, [...chain, token])) as T;
+      return (await this.withTokenInChain(token, chain, activeTokens, async () => this.instantiate(provider, chain, activeTokens))) as T;
     }
 
-    return (await this.resolveScopedOrSingletonInstance(provider, [...chain, token])) as T;
+    return (await this.withTokenInChain(token, chain, activeTokens, async () =>
+      this.resolveScopedOrSingletonInstance(provider, chain, activeTokens),
+    )) as T;
   }
 
   private requireProvider(token: Token): NormalizedProvider {
@@ -260,16 +295,19 @@ export class Container {
     return provider;
   }
 
-  private async resolveAliasTarget<T>(existingTarget: Token<T>, token: Token, chain: Token[]): Promise<T> {
-    return await this.resolveWithChain(existingTarget, [...chain, token]);
+  private async resolveAliasTarget<T>(existingTarget: Token<T>, token: Token, chain: Token[], activeTokens: Set<Token>): Promise<T> {
+    return await this.withTokenInChain(token, chain, activeTokens, async () =>
+      this.resolveWithChain(existingTarget, chain, activeTokens),
+    );
   }
 
   private resolveForwardRefCircularDependency(
     token: Token,
     chain: Token[],
+    activeTokens: Set<Token>,
     allowForwardRef: boolean,
   ): Promise<unknown> | undefined {
-    if (!chain.includes(token)) {
+    if (!activeTokens.has(token)) {
       return undefined;
     }
 
@@ -289,9 +327,15 @@ export class Container {
   private async resolveMultiProviderInstances(
     providers: readonly NormalizedProvider[],
     chain: Token[],
-    token: Token,
+    activeTokens: Set<Token>,
   ): Promise<unknown[]> {
-    return Promise.all(providers.map((provider) => this.instantiate(provider, [...chain, token])));
+    const instances: unknown[] = [];
+
+    for (const provider of providers) {
+      instances.push(await this.instantiate(provider, chain, activeTokens));
+    }
+
+    return instances;
   }
 
   private resolveExistingProviderTarget(provider: NormalizedProvider): Token | undefined {
@@ -302,11 +346,15 @@ export class Container {
     return provider.useExisting;
   }
 
-  private async resolveScopedOrSingletonInstance(provider: NormalizedProvider, chain: Token[]): Promise<unknown> {
+  private async resolveScopedOrSingletonInstance(
+    provider: NormalizedProvider,
+    chain: Token[],
+    activeTokens: Set<Token>,
+  ): Promise<unknown> {
     const cache = this.cacheFor(provider);
 
     if (!cache.has(provider.provide)) {
-      const promise = this.instantiate(provider, chain);
+      const promise = this.instantiate(provider, chain, activeTokens);
 
       cache.set(provider.provide, promise);
       promise.catch(() => cache.delete(provider.provide));
@@ -330,6 +378,7 @@ export class Container {
   private async resolveDepToken(
     depEntry: Token | ForwardRefFn | OptionalToken,
     chain: Token[],
+    activeTokens: Set<Token>,
   ): Promise<unknown> {
     if (isOptionalToken(depEntry)) {
       const innerToken = depEntry.token;
@@ -338,16 +387,33 @@ export class Container {
         return undefined;
       }
 
-      return this.resolveWithChain(innerToken, chain);
+      return this.resolveWithChain(innerToken, chain, activeTokens);
     }
 
     if (isForwardRef(depEntry)) {
       const resolvedToken = depEntry.forwardRef();
 
-      return this.resolveWithChain(resolvedToken, chain, /* allowForwardRef */ true);
+      return this.resolveWithChain(resolvedToken, chain, activeTokens, /* allowForwardRef */ true);
     }
 
-    return this.resolveWithChain(depEntry as Token, chain);
+    return this.resolveWithChain(depEntry as Token, chain, activeTokens);
+  }
+
+  private async withTokenInChain<T>(
+    token: Token,
+    chain: Token[],
+    activeTokens: Set<Token>,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    chain.push(token);
+    activeTokens.add(token);
+
+    try {
+      return await run();
+    } finally {
+      activeTokens.delete(token);
+      chain.pop();
+    }
   }
 
   private root(): Container {
@@ -489,7 +555,7 @@ export class Container {
     return typeof value === 'object' && value !== null && 'onDestroy' in value && typeof value.onDestroy === 'function';
   }
 
-  private async instantiate<T>(provider: NormalizedProvider<T>, chain: Token[]): Promise<T> {
+  private async instantiate<T>(provider: NormalizedProvider<T>, chain: Token[], activeTokens: Set<Token>): Promise<T> {
     this.assertSingletonDependencyScopes(provider);
 
     switch (provider.type) {
@@ -500,7 +566,7 @@ export class Container {
           throw new InvariantError('Factory provider is missing useFactory.');
         }
 
-        const deps = await this.resolveProviderDeps(provider, chain);
+          const deps = await this.resolveProviderDeps(provider, chain, activeTokens);
 
         return provider.useFactory(...deps);
       }
@@ -509,7 +575,7 @@ export class Container {
           throw new InvariantError('Class provider is missing useClass.');
         }
 
-        const deps = await this.resolveProviderDeps(provider, chain);
+        const deps = await this.resolveProviderDeps(provider, chain, activeTokens);
 
         return new provider.useClass(...deps) as T;
       }
@@ -548,8 +614,14 @@ export class Container {
     return depEntry as Token;
   }
 
-  private async resolveProviderDeps(provider: NormalizedProvider, chain: Token[]): Promise<unknown[]> {
-    return Promise.all(provider.inject.map((entry) => this.resolveDepToken(entry, chain)));
+  private async resolveProviderDeps(provider: NormalizedProvider, chain: Token[], activeTokens: Set<Token>): Promise<unknown[]> {
+    const deps: unknown[] = [];
+
+    for (const entry of provider.inject) {
+      deps.push(await this.resolveDepToken(entry, chain, activeTokens));
+    }
+
+    return deps;
   }
 
   private invalidateCachedEntry(token: Token, scope: Scope): void {

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -1,5 +1,5 @@
 import type { Provider } from '@konekti/di';
-import { getOwnClassDiMetadata, getModuleMetadata, type Token } from '@konekti/core';
+import { getClassDiMetadata, getOwnClassDiMetadata, getModuleMetadata, type Token } from '@konekti/core';
 import type { MiddlewareLike } from '@konekti/http';
 
 import { ModuleGraphError, ModuleInjectionMetadataError, ModuleVisibilityError } from './errors.js';
@@ -22,34 +22,16 @@ type ClassDiMetadataView = {
   inject?: readonly InjectionToken[];
 };
 
-function getClassMetadataLineage(target: Function): Function[] {
-  const lineage: Function[] = [];
-  let current: unknown = target;
-
-  while (typeof current === 'function' && current !== Function.prototype) {
-    lineage.unshift(current);
-    current = Object.getPrototypeOf(current);
-  }
-
-  return lineage;
-}
-
 function getEffectiveClassDiMetadata(target: Function): ClassDiMetadataView | undefined {
-  let effective: ClassDiMetadataView | undefined;
+  const metadata = getClassDiMetadata(target);
 
-  for (const constructor of getClassMetadataLineage(target)) {
-    const metadata = getOwnClassDiMetadata(constructor);
-
-    if (!metadata) {
-      continue;
-    }
-
-    effective = {
-      inject: metadata.inject ? [...metadata.inject] as readonly InjectionToken[] : effective?.inject,
-    };
+  if (!metadata) {
+    return undefined;
   }
 
-  return effective;
+  return {
+    inject: metadata.inject ? [...metadata.inject] as readonly InjectionToken[] : undefined,
+  };
 }
 
 function isForwardRef(value: unknown): value is ForwardRefFn {


### PR DESCRIPTION
## Summary
- Make DI registration deterministic by rejecting mixed single-provider and multi-provider registration for the same token, and reduce deep-graph resolution overhead by reusing mutable chain state instead of repeatedly cloning token arrays.
- Consolidate constructor-to-standard-metadata lookup helpers in `@konekti/core`, simplify repeated metadata key merging/appending paths, and remove duplicate inherited DI traversal logic from runtime module-graph validation.
- Document the explicit metadata compatibility boundary (`ensureMetadataSymbol`) and add regressions covering mixed registrations, deep cycles, parent+child multi-provider collection, metadata schema cloning, and initializer stability.

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm vitest run packages/di/src/container.test.ts packages/core/src/metadata.test.ts packages/core/src/decorators.test.ts packages/core/src/decorator-transform.test.ts packages/runtime/src/bootstrap.test.ts`
- `lsp_diagnostics` on modified source files

Closes #236