### PR TITLE
Resolve #238: tighten validation, schema generation, serialization, and throttler contracts

### DIFF
--- a/packages/dto-validator/README.md
+++ b/packages/dto-validator/README.md
@@ -267,6 +267,8 @@ class CreateOrderDto {
 
 Errors use dot-notation paths: `{ field: 'address.city', ... }`.
 
+When transforming nested DTOs, only plain-object payloads are copied into the nested instance; non-plain inputs are treated as invalid data and are not implicitly merged into DTO fields.
+
 ### Arrays of Nested Objects
 
 ```typescript

--- a/packages/dto-validator/src/validation.test.ts
+++ b/packages/dto-validator/src/validation.test.ts
@@ -131,6 +131,26 @@ describe('DefaultValidator', () => {
     expect(Array.from(result.previousAddressSet)[0]).toBeInstanceOf(AddressDto);
   });
 
+  it('does not copy non-plain nested input into DTO instances during transform', async () => {
+    class ChildDto {}
+
+    class ParentDto {
+      @ValidateNested(() => ChildDto)
+      child = new ChildDto();
+    }
+
+    const validator = new DefaultValidator();
+    const result = await validator.transform<ParentDto>(
+      {
+        child: 'unsafe-string-input',
+      },
+      ParentDto,
+    );
+
+    expect(result.child).toBeInstanceOf(ChildDto);
+    expect(Object.keys(result.child as object)).toEqual([]);
+  });
+
   it('transform throws DtoValidationError on invalid input', async () => {
     class CreateUserDto {
       @IsEmail()
@@ -170,6 +190,43 @@ describe('DefaultValidator', () => {
       ),
     ).rejects.toMatchObject({
       issues: [{ field: 'child.parents[0].name' }],
+    });
+  });
+
+  it('reports stable field paths for deeply nested DTO validation failures', async () => {
+    class Level3Dto {
+      @MinLength(2, { message: 'leaf must have length at least 2' })
+      leaf = '';
+    }
+
+    class Level2Dto {
+      @ValidateNested(() => Level3Dto)
+      level3 = new Level3Dto();
+    }
+
+    class Level1Dto {
+      @ValidateNested(() => Level2Dto, { each: true })
+      items: Level2Dto[] = [];
+    }
+
+    class RootDto {
+      @ValidateNested(() => Level1Dto)
+      level1 = new Level1Dto();
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(
+        Object.assign(new RootDto(), {
+          level1: {
+            items: [{ level3: { leaf: 'x' } }],
+          },
+        }),
+        RootDto,
+      ),
+    ).rejects.toMatchObject({
+      issues: [{ field: 'level1.items[0].level3.leaf', message: 'leaf must have length at least 2' }],
     });
   });
 

--- a/packages/dto-validator/src/validation.ts
+++ b/packages/dto-validator/src/validation.ts
@@ -70,7 +70,12 @@ function getIterableValues(value: unknown): unknown[] | undefined {
 }
 
 function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function isEmptyValue(value: unknown): boolean {
@@ -99,9 +104,36 @@ interface CachedDtoMetadata {
   classValidationRules: ReturnType<typeof getClassValidationRules>;
   dtoValidationSchema: DtoValidationSchema;
   mergedPropertyKeys: Set<MetadataPropertyKey>;
+  nestedDtoTransforms: readonly {
+    each: boolean;
+    propertyKey: MetadataPropertyKey;
+    target: Constructor;
+  }[];
 }
 
 const dtoMetadataCache = new WeakMap<Constructor, CachedDtoMetadata>();
+
+function collectNestedDtoTransforms(dtoValidationSchema: DtoValidationSchema): CachedDtoMetadata['nestedDtoTransforms'] {
+  const nestedEntries: CachedDtoMetadata['nestedDtoTransforms'][number][] = [];
+
+  for (const entry of dtoValidationSchema) {
+    const nestedRule = entry.rules.find(
+      (rule: DtoFieldValidationRule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
+    );
+
+    if (!nestedRule) {
+      continue;
+    }
+
+    nestedEntries.push({
+      each: nestedRule.each === true,
+      propertyKey: entry.propertyKey,
+      target: resolveNestedDto(nestedRule.dto),
+    });
+  }
+
+  return nestedEntries;
+}
 
 function getCachedDtoMetadata(target: Constructor): CachedDtoMetadata {
   const cached = dtoMetadataCache.get(target);
@@ -117,11 +149,13 @@ function getCachedDtoMetadata(target: Constructor): CachedDtoMetadata {
     ...bindingMap.keys(),
     ...dtoValidationSchema.map((entry: { propertyKey: MetadataPropertyKey }) => entry.propertyKey),
   ]);
+  const nestedDtoTransforms = collectNestedDtoTransforms(dtoValidationSchema);
   const next: CachedDtoMetadata = {
     bindingMap,
     classValidationRules,
     dtoValidationSchema,
     mergedPropertyKeys,
+    nestedDtoTransforms,
   };
 
   dtoMetadataCache.set(target, next);
@@ -348,7 +382,7 @@ function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown): 
   const instance = new target() as Record<PropertyKey, unknown>;
 
   if (!isPlainObject(rawValue)) {
-    return Object.assign(instance, rawValue) as T;
+    return instance as T;
   }
 
   Object.assign(instance, rawValue);
@@ -356,24 +390,15 @@ function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown): 
   const metadata = getCachedDtoMetadata(target);
   applyBindingValues(instance, rawValue, metadata.mergedPropertyKeys, metadata.bindingMap);
 
-  for (const entry of metadata.dtoValidationSchema) {
-    const nestedRule = entry.rules.find(
-      (rule: DtoFieldValidationRule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
-    );
-
-    if (!nestedRule) {
-      continue;
-    }
-
-    const currentValue = instance[entry.propertyKey];
+  for (const nestedEntry of metadata.nestedDtoTransforms) {
+    const currentValue = instance[nestedEntry.propertyKey];
     if (currentValue === undefined || currentValue === null) {
       continue;
     }
 
-    const resolvedDto = resolveNestedDto(nestedRule.dto);
-    instance[entry.propertyKey] = nestedRule.each
-      ? transformNestedEachValue(currentValue, resolvedDto)
-      : transformNestedValue(currentValue, resolvedDto);
+    instance[nestedEntry.propertyKey] = nestedEntry.each
+      ? transformNestedEachValue(currentValue, nestedEntry.target)
+      : transformNestedValue(currentValue, nestedEntry.target);
   }
 
   return instance as T;

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -244,6 +244,8 @@ function getControllerTags(target: Function): string[] | undefined;
 function getMethodApiMetadata(target: Function, propertyKey: MetadataPropertyKey): MethodApiMetadata | undefined;
 ```
 
+Both getters return defensive copies to prevent accidental external mutation of internal decorator metadata.
+
 ```typescript
 interface MethodApiMetadata {
   operation?: ApiOperationOptions;

--- a/packages/openapi/src/decorators.test.ts
+++ b/packages/openapi/src/decorators.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTag, getControllerTags, getMethodApiMetadata } from './decorators.js';
+
+describe('OpenAPI decorator metadata readers', () => {
+  it('returns defensive copies and preserves write-time snapshots', () => {
+    const responseSchema: Record<string, unknown> = {
+      properties: {
+        id: { type: 'string' },
+      },
+      type: 'object',
+    };
+
+    @ApiTag('users')
+    class UsersController {
+      @ApiOperation({ summary: 'List users' })
+      @ApiBearerAuth()
+      @ApiResponse(200, { description: 'OK', schema: responseSchema })
+      list() {
+        return [{ id: '1' }];
+      }
+    }
+
+    responseSchema.type = 'array';
+    responseSchema.properties = {
+      id: { type: 'number' },
+    };
+
+    const firstTags = getControllerTags(UsersController);
+    expect(firstTags).toEqual(['users']);
+
+    if (!firstTags) {
+      throw new Error('Expected controller tags to be present.');
+    }
+
+    firstTags.push('mutated');
+    expect(getControllerTags(UsersController)).toEqual(['users']);
+
+    const firstMeta = getMethodApiMetadata(UsersController, 'list');
+
+    if (!firstMeta) {
+      throw new Error('Expected method metadata to be present.');
+    }
+
+    expect(firstMeta.responses[0]?.schema).toEqual({
+      properties: {
+        id: { type: 'string' },
+      },
+      type: 'object',
+    });
+
+    firstMeta.operation = { summary: 'Mutated summary' };
+    firstMeta.responses[0] = {
+      ...firstMeta.responses[0],
+      description: 'Mutated description',
+      schema: { type: 'boolean' },
+      status: 500,
+    };
+
+    if (firstMeta.security) {
+      firstMeta.security.push('mutatedSecurity');
+    }
+
+    const secondMeta = getMethodApiMetadata(UsersController, 'list');
+
+    expect(secondMeta).toEqual({
+      operation: { summary: 'List users' },
+      responses: [
+        {
+          description: 'OK',
+          schema: {
+            properties: {
+              id: { type: 'string' },
+            },
+            type: 'object',
+          },
+          status: 200,
+          type: undefined,
+        },
+      ],
+      security: ['bearerAuth'],
+    });
+  });
+});

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -42,10 +42,53 @@ function getMetadataBag(target: object): MetadataBag | undefined {
   return (target as Record<symbol, MetadataBag | undefined>)[metadataSymbol];
 }
 
+function cloneUnknown<T>(value: T): T {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => cloneUnknown(entry)) as T;
+  }
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  const clone: Record<PropertyKey, unknown> = {};
+
+  for (const key of Reflect.ownKeys(value)) {
+    clone[key] = cloneUnknown((value as Record<PropertyKey, unknown>)[key]);
+  }
+
+  return clone as T;
+}
+
+function cloneApiOperationMetadata(operation: ApiOperationMetadata | undefined): ApiOperationMetadata | undefined {
+  if (!operation) {
+    return undefined;
+  }
+
+  return {
+    description: operation.description,
+    summary: operation.summary,
+  };
+}
+
+function cloneApiResponseMetadata(response: ApiResponseMetadata): ApiResponseMetadata {
+  return {
+    description: response.description,
+    schema: cloneUnknown(response.schema),
+    status: response.status,
+    type: response.type,
+  };
+}
+
 /** Read tags registered via `@ApiTag` on a controller class. */
 export function getControllerTags(target: Function): string[] | undefined {
   const bag = getMetadataBag(target);
-  return bag?.[openApiControllerTagsKey] as string[] | undefined;
+  const tags = bag?.[openApiControllerTagsKey] as string[] | undefined;
+  return tags ? [...tags] : undefined;
 }
 
 /** Read combined operation, response, and security metadata for a controller method. */
@@ -65,9 +108,9 @@ export function getMethodApiMetadata(target: Function, propertyKey: MetadataProp
   }
 
   return {
-    operation,
-    responses: responses ?? [],
-    security,
+    operation: cloneApiOperationMetadata(operation),
+    responses: (responses ?? []).map((response) => cloneApiResponseMetadata(response)),
+    security: security ? [...security] : undefined,
   };
 }
 
@@ -139,12 +182,12 @@ export function ApiResponse(
 
     map.set(context.name, [
       ...existing,
-      {
+      cloneApiResponseMetadata({
         description: normalized.description,
         schema: normalized.schema,
         status: normalized.status,
         type: normalized.type,
-      },
+      }),
     ]);
   };
 }

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { IsArray, IsOptional, IsString, MinLength, ValidateNested } from '@konekti/dto-validator';
+import { Controller, FromBody, Post, RequestDto, createHandlerMapping } from '@konekti/http';
+
+import { buildOpenApiDocument } from './schema-builder.js';
+
+describe('buildOpenApiDocument', () => {
+  it('keeps nested request-body schemas stable', () => {
+    class AuthorDto {
+      @IsString()
+      name = '';
+    }
+
+    class CreatePostRequest {
+      @FromBody('title')
+      @IsString()
+      @MinLength(3)
+      title = '';
+
+      @FromBody('author')
+      @ValidateNested(() => AuthorDto)
+      author = new AuthorDto();
+
+      @FromBody('tags')
+      @IsOptional()
+      @IsArray()
+      @IsString({ each: true })
+      tags: string[] = [];
+    }
+
+    @Controller('/posts')
+    class PostsController {
+      @RequestDto(CreatePostRequest)
+      @Post('/')
+      create() {
+        return { ok: true };
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: PostsController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Snapshot API',
+      version: '1.0.0',
+    });
+
+    expect(document.components?.schemas).toMatchInlineSnapshot(`
+      {
+        "AuthorDto": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string",
+            },
+          },
+          "required": [
+            "name",
+          ],
+          "type": "object",
+        },
+        "CreatePostRequest": {
+          "additionalProperties": false,
+          "properties": {
+            "author": {
+              "$ref": "#/components/schemas/AuthorDto",
+            },
+            "tags": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+            "title": {
+              "minLength": 3,
+              "type": "string",
+            },
+          },
+          "required": [
+            "title",
+            "author",
+          ],
+          "type": "object",
+        },
+      }
+    `);
+
+    expect(document.paths['/posts']?.post?.requestBody).toMatchInlineSnapshot(`
+      {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CreatePostRequest",
+            },
+          },
+        },
+        "required": true,
+      }
+    `);
+  });
+});

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -245,58 +245,237 @@ function inferNestedSchema(
   return createSchemaRef(schemaName);
 }
 
+interface RuleProfile {
+  enumEachRule: Extract<DtoFieldValidationRule, { kind: 'enum' }> | undefined;
+  enumRule: Extract<DtoFieldValidationRule, { kind: 'enum' }> | undefined;
+  hasArrayRule: boolean;
+  hasBooleanRule: boolean;
+  hasDateRule: boolean;
+  hasEachBooleanRule: boolean;
+  hasEachIntRule: boolean;
+  hasEachNumberRule: boolean;
+  hasIntRule: boolean;
+  hasNumberRule: boolean;
+  hasObjectRule: boolean;
+  hasStringRule: boolean;
+  hasStringRuleForEach: boolean;
+  maxLength: number | undefined;
+  maximum: number | undefined;
+  minLength: number | undefined;
+  minimum: number | undefined;
+  nestedEachRule: Extract<DtoFieldValidationRule, { kind: 'nested' }> | undefined;
+  nestedRule: Extract<DtoFieldValidationRule, { kind: 'nested' }> | undefined;
+  stringFormat: OpenApiSchemaObject['format'];
+}
+
+const ruleProfileCache = new WeakMap<readonly DtoFieldValidationRule[], RuleProfile>();
+
+function resolveValidatorStringFormat(
+  validatorRule: Extract<DtoFieldValidationRule, { kind: 'validatorjs' }>,
+): OpenApiSchemaObject['format'] {
+  if (validatorRule.validator === 'email') {
+    return 'email';
+  }
+
+  if (validatorRule.validator === 'uuid') {
+    return 'uuid';
+  }
+
+  if (validatorRule.validator === 'url') {
+    return 'uri';
+  }
+
+  if (validatorRule.validator === 'dateString' || validatorRule.validator === 'iso8601') {
+    return 'date-time';
+  }
+
+  return undefined;
+}
+
+function getRuleProfile(rules: readonly DtoFieldValidationRule[]): RuleProfile {
+  const cached = ruleProfileCache.get(rules);
+
+  if (cached) {
+    return cached;
+  }
+
+  const profile: RuleProfile = {
+    enumEachRule: undefined,
+    enumRule: undefined,
+    hasArrayRule: false,
+    hasBooleanRule: false,
+    hasDateRule: false,
+    hasEachBooleanRule: false,
+    hasEachIntRule: false,
+    hasEachNumberRule: false,
+    hasIntRule: false,
+    hasNumberRule: false,
+    hasObjectRule: false,
+    hasStringRule: false,
+    hasStringRuleForEach: false,
+    maxLength: undefined,
+    maximum: undefined,
+    minLength: undefined,
+    minimum: undefined,
+    nestedEachRule: undefined,
+    nestedRule: undefined,
+    stringFormat: undefined,
+  };
+
+  for (const rule of rules) {
+    if (rule.kind === 'nested') {
+      profile.nestedRule ??= rule;
+
+      if (rule.each) {
+        profile.nestedEachRule ??= rule;
+      }
+
+      continue;
+    }
+
+    if (rule.kind === 'array') {
+      profile.hasArrayRule = true;
+      continue;
+    }
+
+    if (rule.kind === 'enum') {
+      profile.enumRule ??= rule;
+
+      if (rule.each) {
+        profile.enumEachRule ??= rule;
+      }
+
+      continue;
+    }
+
+    if (rule.kind === 'int') {
+      profile.hasIntRule = true;
+
+      if (rule.each) {
+        profile.hasEachIntRule = true;
+      }
+
+      continue;
+    }
+
+    if (rule.kind === 'number') {
+      profile.hasNumberRule = true;
+
+      if (rule.each) {
+        profile.hasEachNumberRule = true;
+      }
+
+      continue;
+    }
+
+    if (rule.kind === 'boolean') {
+      profile.hasBooleanRule = true;
+
+      if (rule.each) {
+        profile.hasEachBooleanRule = true;
+      }
+
+      continue;
+    }
+
+    if (rule.kind === 'date') {
+      profile.hasDateRule = true;
+      continue;
+    }
+
+    if (rule.kind === 'object') {
+      profile.hasObjectRule = true;
+      continue;
+    }
+
+    if (rule.kind === 'string') {
+      profile.hasStringRule = true;
+      continue;
+    }
+
+    if (rule.kind === 'minLength') {
+      if (rule.each) {
+        profile.hasStringRuleForEach = true;
+      } else {
+        profile.minLength = rule.value;
+      }
+
+      continue;
+    }
+
+    if (rule.kind === 'maxLength') {
+      if (rule.each) {
+        profile.hasStringRuleForEach = true;
+      } else {
+        profile.maxLength = rule.value;
+      }
+
+      continue;
+    }
+
+    if (rule.kind === 'min' && !rule.each) {
+      profile.minimum = rule.value;
+      continue;
+    }
+
+    if (rule.kind === 'max' && !rule.each) {
+      profile.maximum = rule.value;
+      continue;
+    }
+
+    if (rule.kind === 'validatorjs') {
+      const nextFormat = resolveValidatorStringFormat(rule);
+
+      if (nextFormat) {
+        profile.stringFormat = nextFormat;
+      }
+    }
+  }
+
+  ruleProfileCache.set(rules, profile);
+  return profile;
+}
+
 function inferPrimitiveTypeFromRules(
   rules: readonly DtoFieldValidationRule[],
   context: BuildSchemaContext,
 ): OpenApiSchemaObject | undefined {
-  const hasRule = <TKind extends DtoFieldValidationRule['kind']>(kind: TKind) =>
-    rules.find((rule): rule is Extract<DtoFieldValidationRule, { kind: TKind }> => rule.kind === kind);
-
-  const nestedRule = hasRule('nested');
-  const arrayRule = hasRule('array');
-  const intRule = hasRule('int');
-  const numberRule = hasRule('number');
-  const booleanRule = hasRule('boolean');
-  const dateRule = hasRule('date');
-  const objectRule = hasRule('object');
-  const stringRule = hasRule('string');
-  const enumRule = hasRule('enum');
-
-  const nestedSchema = inferNestedSchema(nestedRule, context);
+  const profile = getRuleProfile(rules);
+  const nestedSchema = inferNestedSchema(profile.nestedRule, context);
 
   if (nestedSchema) {
     return nestedSchema;
   }
 
-  if (arrayRule) {
-    return { items: inferEachItemSchema(rules, context) ?? {}, type: 'array' };
+  if (profile.hasArrayRule) {
+    return { items: inferEachItemSchema(rules, context, profile) ?? {}, type: 'array' };
   }
 
-  if (enumRule) {
-    return createEnumSchema(enumRule.values);
+  if (profile.enumRule) {
+    return createEnumSchema(profile.enumRule.values);
   }
 
-  if (intRule) {
+  if (profile.hasIntRule) {
     return { type: 'integer' };
   }
 
-  if (numberRule) {
+  if (profile.hasNumberRule) {
     return { type: 'number' };
   }
 
-  if (booleanRule) {
+  if (profile.hasBooleanRule) {
     return { type: 'boolean' };
   }
 
-  if (dateRule) {
+  if (profile.hasDateRule) {
     return { format: 'date-time', type: 'string' };
   }
 
-  if (objectRule) {
+  if (profile.hasObjectRule) {
     return { additionalProperties: true, type: 'object' };
   }
 
-  if (stringRule) {
+  if (profile.hasStringRule) {
     return { type: 'string' };
   }
 
@@ -306,37 +485,30 @@ function inferPrimitiveTypeFromRules(
 function inferEachItemSchema(
   rules: readonly DtoFieldValidationRule[],
   context: BuildSchemaContext,
+  profile = getRuleProfile(rules),
 ): OpenApiSchemaObject | undefined {
-  const nestedRule = rules.find(
-    (rule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested' && Boolean(rule.each),
-  );
-
-  if (nestedRule) {
-    const resolvedDto = resolveNestedDto(nestedRule.dto);
+  if (profile.nestedEachRule) {
+    const resolvedDto = resolveNestedDto(profile.nestedEachRule.dto);
     return createSchemaRef(getDtoSchemaName(resolvedDto, context));
   }
 
-  const enumRule = rules.find(
-    (rule): rule is Extract<DtoFieldValidationRule, { kind: 'enum' }> => rule.kind === 'enum' && Boolean(rule.each),
-  );
-
-  if (enumRule) {
-    return createEnumSchema(enumRule.values);
+  if (profile.enumEachRule) {
+    return createEnumSchema(profile.enumEachRule.values);
   }
 
-  if (rules.some((rule) => rule.kind === 'string' || ((rule.kind === 'minLength' || rule.kind === 'maxLength') && rule.each))) {
+  if (profile.hasStringRule || profile.hasStringRuleForEach) {
     return { type: 'string' };
   }
 
-  if (rules.some((rule) => rule.kind === 'int' && Boolean(rule.each))) {
+  if (profile.hasEachIntRule) {
     return { type: 'integer' };
   }
 
-  if (rules.some((rule) => rule.kind === 'number' && Boolean(rule.each))) {
+  if (profile.hasEachNumberRule) {
     return { type: 'number' };
   }
 
-  if (rules.some((rule) => rule.kind === 'boolean' && Boolean(rule.each))) {
+  if (profile.hasEachBooleanRule) {
     return { type: 'boolean' };
   }
 
@@ -345,40 +517,29 @@ function inferEachItemSchema(
 
 function applyValidationConstraints(schema: OpenApiSchemaObject, rules: readonly DtoFieldValidationRule[]): OpenApiSchemaObject {
   const nextSchema: OpenApiSchemaObject = { ...schema };
+  const profile = getRuleProfile(rules);
 
-  for (const rule of rules) {
-    if (rule.kind === 'minLength' && !rule.each && nextSchema.type === 'string') {
-      nextSchema.minLength = rule.value;
+  if (nextSchema.type === 'string') {
+    if (profile.minLength !== undefined) {
+      nextSchema.minLength = profile.minLength;
     }
 
-    if (rule.kind === 'maxLength' && !rule.each && nextSchema.type === 'string') {
-      nextSchema.maxLength = rule.value;
+    if (profile.maxLength !== undefined) {
+      nextSchema.maxLength = profile.maxLength;
     }
 
-    if (rule.kind === 'min' && !rule.each && (nextSchema.type === 'number' || nextSchema.type === 'integer')) {
-      nextSchema.minimum = rule.value;
+    if (profile.stringFormat !== undefined) {
+      nextSchema.format = profile.stringFormat;
+    }
+  }
+
+  if (nextSchema.type === 'number' || nextSchema.type === 'integer') {
+    if (profile.minimum !== undefined) {
+      nextSchema.minimum = profile.minimum;
     }
 
-    if (rule.kind === 'max' && !rule.each && (nextSchema.type === 'number' || nextSchema.type === 'integer')) {
-      nextSchema.maximum = rule.value;
-    }
-
-    if (rule.kind === 'validatorjs' && nextSchema.type === 'string') {
-      if (rule.validator === 'email') {
-        nextSchema.format = 'email';
-      }
-
-      if (rule.validator === 'uuid') {
-        nextSchema.format = 'uuid';
-      }
-
-      if (rule.validator === 'url') {
-        nextSchema.format = 'uri';
-      }
-
-      if (rule.validator === 'dateString' || rule.validator === 'iso8601') {
-        nextSchema.format = 'date-time';
-      }
+    if (profile.maximum !== undefined) {
+      nextSchema.maximum = profile.maximum;
     }
   }
 

--- a/packages/serializer/README.md
+++ b/packages/serializer/README.md
@@ -70,3 +70,9 @@ await bootstrapApplication({
 - `Transform(fn: (value: unknown) => unknown): FieldDecorator`
 - `serialize(value: unknown): unknown`
 - `class SerializerInterceptor implements Interceptor`
+
+## Serialization contract
+
+- Cycles are cut to `undefined` at the cycle edge so output remains JSON-safe.
+- Shared references are preserved: revisiting an already-serialized object returns the same serialized node instead of dropping it.
+- Enumerable symbol-keyed properties on plain objects are serialized alongside string keys.

--- a/packages/serializer/src/serialize.test.ts
+++ b/packages/serializer/src/serialize.test.ts
@@ -123,4 +123,34 @@ describe('serialize', () => {
     expect(serialized.next).toBeUndefined();
     expect(() => JSON.stringify(serialized)).not.toThrow();
   });
+
+  it('preserves shared references instead of dropping revisited objects', () => {
+    const shared = { id: 'shared-node' };
+    const input = {
+      first: shared,
+      second: shared,
+    };
+
+    const serialized = serialize(input) as {
+      first?: { id: string };
+      second?: { id: string };
+    };
+
+    expect(serialized.first).toEqual({ id: 'shared-node' });
+    expect(serialized.second).toEqual({ id: 'shared-node' });
+    expect(serialized.second).toBe(serialized.first);
+  });
+
+  it('serializes enumerable symbol-keyed properties in plain objects', () => {
+    const token = Symbol('token');
+    const input: Record<string | symbol, unknown> = {
+      regular: 'value',
+      [token]: { nested: true },
+    };
+
+    const serialized = serialize(input) as Record<string | symbol, unknown>;
+
+    expect(serialized.regular).toBe('value');
+    expect(serialized[token]).toEqual({ nested: true });
+  });
 });

--- a/packages/serializer/src/serialize.ts
+++ b/packages/serializer/src/serialize.ts
@@ -4,7 +4,7 @@ import { getClassSerializationOptions, getFieldSerializationMetadata, type Seria
 
 interface SerializationContext {
   metadataCache: WeakMap<Function, { classOptions: ReturnType<typeof getClassSerializationOptions>; fieldMetadata: ReturnType<typeof getFieldSerializationMetadata> }>;
-  seen: WeakMap<object, unknown>;
+  references: WeakMap<object, { active: boolean; value: unknown }>;
 }
 
 function isObjectLike(value: unknown): value is Record<string | symbol, unknown> {
@@ -74,12 +74,45 @@ function getCachedMetadata(
   return next;
 }
 
+function getCircularOrSharedValue(value: object, context: SerializationContext): unknown {
+  const cached = context.references.get(value);
+
+  if (!cached) {
+    return undefined;
+  }
+
+  if (cached.active) {
+    return undefined;
+  }
+
+  return cached.value;
+}
+
+function markSerializationStart(value: object, serialized: unknown, context: SerializationContext): void {
+  context.references.set(value, {
+    active: true,
+    value: serialized,
+  });
+}
+
+function markSerializationComplete(value: object, context: SerializationContext): void {
+  const cached = context.references.get(value);
+
+  if (!cached) {
+    return;
+  }
+
+  cached.active = false;
+}
+
 function serializeClassInstance(
   value: Record<string | symbol, unknown>,
   context: SerializationContext,
 ): Record<string | symbol, unknown> {
-  if (context.seen.has(value)) {
-    return undefined as unknown as Record<string | symbol, unknown>;
+  const cachedValue = getCircularOrSharedValue(value, context);
+
+  if (context.references.has(value)) {
+    return cachedValue as Record<string | symbol, unknown>;
   }
 
   const constructor = value.constructor as Function;
@@ -95,7 +128,7 @@ function serializeClassInstance(
   }
 
   const serialized: Record<string | symbol, unknown> = {};
-  context.seen.set(value, serialized);
+  markSerializationStart(value, serialized, context);
   const candidateKeys = resolveCandidateKeys(value, fieldMetadata, classOptions.excludeExtraneous === true);
 
   for (const propertyKey of candidateKeys) {
@@ -115,6 +148,8 @@ function serializeClassInstance(
     serialized[propertyKey] = serializeInternal(transformed, context);
   }
 
+  markSerializationComplete(value, context);
+
   return serialized;
 }
 
@@ -122,16 +157,24 @@ function serializeRecord(
   value: Record<string | symbol, unknown>,
   context: SerializationContext,
 ): Record<string | symbol, unknown> {
-  if (context.seen.has(value)) {
-    return undefined as unknown as Record<string | symbol, unknown>;
+  const cachedValue = getCircularOrSharedValue(value, context);
+
+  if (context.references.has(value)) {
+    return cachedValue as Record<string | symbol, unknown>;
   }
 
   const serialized: Record<string | symbol, unknown> = {};
-  context.seen.set(value, serialized);
+  markSerializationStart(value, serialized, context);
 
-  for (const [propertyKey, propertyValue] of Object.entries(value)) {
+  const symbolKeys = Object.getOwnPropertySymbols(value).filter((key) => Object.prototype.propertyIsEnumerable.call(value, key));
+  const keys: Array<string | symbol> = [...Object.keys(value), ...symbolKeys];
+
+  for (const propertyKey of keys) {
+    const propertyValue = value[propertyKey];
     serialized[propertyKey] = serializeInternal(propertyValue, context);
   }
+
+  markSerializationComplete(value, context);
 
   return serialized;
 }
@@ -142,16 +185,20 @@ function serializeInternal<T = unknown>(value: T, context: SerializationContext)
   }
 
   if (Array.isArray(value)) {
-    if (context.seen.has(value)) {
-      return undefined;
+    const cachedValue = getCircularOrSharedValue(value, context);
+
+    if (context.references.has(value)) {
+      return cachedValue;
     }
 
     const serialized: unknown[] = [];
-    context.seen.set(value, serialized);
+    markSerializationStart(value, serialized, context);
 
     for (const item of value) {
       serialized.push(serializeInternal(item, context));
     }
+
+    markSerializationComplete(value, context);
 
     return serialized;
   }
@@ -170,7 +217,7 @@ function serializeInternal<T = unknown>(value: T, context: SerializationContext)
 export function serialize<T = unknown>(value: T): unknown {
   const context: SerializationContext = {
     metadataCache: new WeakMap(),
-    seen: new WeakMap(),
+    references: new WeakMap(),
   };
 
   return serializeInternal(value, context);

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -101,6 +101,8 @@ class AppBootstrap {
 - When the limit is exceeded, `ThrottlerGuard` throws `TooManyRequestsException` (HTTP 429) and sets the `Retry-After` response header to the seconds remaining in the current window.
 - Method-level `@Throttle` overrides class-level `@Throttle`, which overrides module-level defaults — in that priority order.
 - `@SkipThrottle()` at either level wins unconditionally.
+- `@Throttle()` options are copied when metadata is written/read, so mutating a shared options object later does not alter registered throttle policy.
+- The in-memory store sweeps expired keys whenever the earliest known reset time is reached, then updates the next sweep deadline from remaining active windows.
 - The in-memory store is per-`ThrottlerGuard` instance and is not shared across clustered workers. Use `RedisThrottlerStore` for cross-instance enforcement.
 
 ## Related packages

--- a/packages/throttler/src/decorators.ts
+++ b/packages/throttler/src/decorators.ts
@@ -1,6 +1,6 @@
 import type { ThrottlerHandlerOptions } from './types.js';
 
-const standardThrottleRouteKey = Symbol.for('konekti.standard.route');
+export const throttleRouteMetadataKey = Symbol.for('konekti.standard.route');
 const throttleKey = Symbol.for('konekti.throttler.throttle');
 const skipThrottleKey = Symbol.for('konekti.throttler.skip');
 const classThrottleKey = Symbol.for('konekti.throttler.class-throttle');
@@ -15,13 +15,20 @@ function getMetadataBag(metadata: unknown): StandardMetadataBag {
   return metadata as StandardMetadataBag;
 }
 
+function cloneThrottleOptions(options: ThrottlerHandlerOptions): ThrottlerHandlerOptions {
+  return {
+    limit: options.limit,
+    ttl: options.ttl,
+  };
+}
+
 function getRouteRecord(metadata: unknown, name: string | symbol): StandardMetadataBag {
   const bag = getMetadataBag(metadata);
-  let routeMap = bag[standardThrottleRouteKey] as Map<string | symbol, StandardMetadataBag> | undefined;
+  let routeMap = bag[throttleRouteMetadataKey] as Map<string | symbol, StandardMetadataBag> | undefined;
 
   if (!routeMap) {
     routeMap = new Map<string | symbol, StandardMetadataBag>();
-    bag[standardThrottleRouteKey] = routeMap;
+    bag[throttleRouteMetadataKey] = routeMap;
   }
 
   let record = routeMap.get(name);
@@ -37,9 +44,9 @@ function getRouteRecord(metadata: unknown, name: string | symbol): StandardMetad
 export function Throttle(options: ThrottlerHandlerOptions): ClassOrMethodDecoratorLike {
   const decorator = (_value: Function, context: ClassDecoratorContext | ClassMethodDecoratorContext) => {
     if (context.kind === 'class') {
-      getMetadataBag(context.metadata)[classThrottleKey] = options;
+      getMetadataBag(context.metadata)[classThrottleKey] = cloneThrottleOptions(options);
     } else {
-      getRouteRecord(context.metadata, context.name)[throttleKey] = options;
+      getRouteRecord(context.metadata, context.name)[throttleKey] = cloneThrottleOptions(options);
     }
   };
 
@@ -59,7 +66,8 @@ export function SkipThrottle(): ClassOrMethodDecoratorLike {
 }
 
 export function getThrottleMetadata(bag: StandardMetadataBag): ThrottlerHandlerOptions | undefined {
-  return bag[throttleKey] as ThrottlerHandlerOptions | undefined;
+  const metadata = bag[throttleKey] as ThrottlerHandlerOptions | undefined;
+  return metadata ? cloneThrottleOptions(metadata) : undefined;
 }
 
 export function getSkipThrottleMetadata(bag: StandardMetadataBag): boolean {
@@ -67,7 +75,8 @@ export function getSkipThrottleMetadata(bag: StandardMetadataBag): boolean {
 }
 
 export function getClassThrottleMetadata(bag: StandardMetadataBag): ThrottlerHandlerOptions | undefined {
-  return bag[classThrottleKey] as ThrottlerHandlerOptions | undefined;
+  const metadata = bag[classThrottleKey] as ThrottlerHandlerOptions | undefined;
+  return metadata ? cloneThrottleOptions(metadata) : undefined;
 }
 
 export function getClassSkipThrottleMetadata(bag: StandardMetadataBag): boolean {

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -6,6 +6,7 @@ import {
   getClassThrottleMetadata,
   getSkipThrottleMetadata,
   getThrottleMetadata,
+  throttleRouteMetadataKey,
 } from './decorators.js';
 import { createMemoryThrottlerStore } from './store.js';
 import { THROTTLER_OPTIONS } from './tokens.js';
@@ -27,7 +28,7 @@ function getMethodMetadataBag(controllerToken: Function, methodName: string): Me
     return undefined;
   }
 
-  const routeMap = classBag[Symbol.for('konekti.standard.route')] as Map<string | symbol, MetadataBag> | undefined;
+  const routeMap = classBag[throttleRouteMetadataKey] as Map<string | symbol, MetadataBag> | undefined;
 
   return routeMap?.get(methodName);
 }

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { metadataSymbol } from '@konekti/core';
 import type { GuardContext, HandlerDescriptor, RequestContext } from '@konekti/http';
 
-import { SkipThrottle, Throttle } from './decorators.js';
+import { SkipThrottle, Throttle, getThrottleMetadata } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
 import { createMemoryThrottlerStore } from './store.js';
 import type { ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
@@ -103,6 +103,43 @@ describe('@konekti/throttler decorators', () => {
     expect(bag[Symbol.for('konekti.throttler.class-throttle')]).toEqual({ limit: 100, ttl: 60 });
   });
 
+  it('captures @Throttle options by value to avoid shared mutable metadata', () => {
+    const options = { limit: 5, ttl: 60 };
+
+    class AuthController {
+      @Throttle(options)
+      login() {}
+    }
+
+    options.limit = 99;
+
+    const bag = (AuthController as unknown as Record<symbol, unknown>)[metadataSymbol] as Record<PropertyKey, unknown>;
+    const routeMap = bag[Symbol.for('konekti.standard.route')] as Map<string, Record<PropertyKey, unknown>>;
+    const loginRecord = routeMap?.get('login') ?? {};
+
+    expect(getThrottleMetadata(loginRecord)).toEqual({ limit: 5, ttl: 60 });
+  });
+
+  it('returns cloned throttle metadata so callers cannot mutate stored options', () => {
+    class AuthController {
+      @Throttle({ limit: 3, ttl: 60 })
+      login() {}
+    }
+
+    const bag = (AuthController as unknown as Record<symbol, unknown>)[metadataSymbol] as Record<PropertyKey, unknown>;
+    const routeMap = bag[Symbol.for('konekti.standard.route')] as Map<string, Record<PropertyKey, unknown>>;
+    const loginRecord = routeMap?.get('login') ?? {};
+    const firstRead = getThrottleMetadata(loginRecord);
+
+    if (!firstRead) {
+      throw new Error('Throttle metadata should be defined for @Throttle-decorated methods.');
+    }
+
+    firstRead.limit = 50;
+
+    expect(getThrottleMetadata(loginRecord)).toEqual({ limit: 3, ttl: 60 });
+  });
+
   it('writes @SkipThrottle method-level metadata into the route map', () => {
     class AuthController {
       @SkipThrottle()
@@ -191,6 +228,20 @@ describe('ThrottlerGuard — in-memory store', () => {
     const result = await guard.canActivate(createGuardContext(TestController, 'action', ctx));
 
     expect(result).toBe(true);
+  });
+
+  it('re-enters expired keys with a fresh window while keeping active key counters', async () => {
+    const store = createMemoryThrottlerStore();
+
+    const firstA = await store.consume('key-a', { now: 0, ttlSeconds: 1 });
+    const firstB = await store.consume('key-b', { now: 500, ttlSeconds: 10 });
+    const secondB = await store.consume('key-b', { now: 1500, ttlSeconds: 10 });
+    const secondA = await store.consume('key-a', { now: 1500, ttlSeconds: 1 });
+
+    expect(firstA.count).toBe(1);
+    expect(firstB.count).toBe(1);
+    expect(secondB.count).toBe(2);
+    expect(secondA.count).toBe(1);
   });
 
   it('skips throttling when method-level @SkipThrottle is present', async () => {

--- a/packages/throttler/src/store.ts
+++ b/packages/throttler/src/store.ts
@@ -19,6 +19,21 @@ function consumeWindow(
   };
 }
 
+function sweepExpiredEntries(map: Map<string, ThrottlerStoreEntry>, now: number): number {
+  let nextSweepAt = Number.POSITIVE_INFINITY;
+
+  for (const [entryKey, entry] of map) {
+    if (now >= entry.resetAt) {
+      map.delete(entryKey);
+      continue;
+    }
+
+    nextSweepAt = Math.min(nextSweepAt, entry.resetAt);
+  }
+
+  return Number.isFinite(nextSweepAt) ? nextSweepAt : 0;
+}
+
 export function createMemoryThrottlerStore(): ThrottlerStore {
   const map = new Map<string, ThrottlerStoreEntry>();
   let nextSweepAt = 0;
@@ -27,25 +42,9 @@ export function createMemoryThrottlerStore(): ThrottlerStore {
     consume(key, input) {
       const { now } = input;
 
-      if (now < nextSweepAt) {
-        const nextEntry = consumeWindow(map.get(key), input);
-        map.set(key, nextEntry);
-        nextSweepAt = Math.min(nextSweepAt, nextEntry.resetAt);
-        return nextEntry;
+      if (now >= nextSweepAt) {
+        nextSweepAt = sweepExpiredEntries(map, now);
       }
-
-      let next = Number.POSITIVE_INFINITY;
-
-      for (const [key, entry] of map) {
-        if (now >= entry.resetAt) {
-          map.delete(key);
-          continue;
-        }
-
-        next = Math.min(next, entry.resetAt);
-      }
-
-      nextSweepAt = Number.isFinite(next) ? next : 0;
 
       const nextEntry = consumeWindow(map.get(key), input);
       map.set(key, nextEntry);


### PR DESCRIPTION
## Summary
- Hardened DTO nested transform boundaries by only copying plain-object input into nested instances, precomputing nested transform metadata, and adding deeply nested/non-plain regression tests.
- Stabilized OpenAPI metadata and schema generation contracts by returning defensive copies from metadata getters, cloning response schema metadata at write-time, and caching per-field rule analysis to reduce repeated rule scans.
- Clarified serializer/throttler runtime contracts by distinguishing cycle vs shared-reference behavior, preserving shared references and symbol-keyed properties, cloning throttle options to avoid shared mutable state, and adding cleanup/mutation regression tests plus README updates.

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm exec vitest run packages/dto-validator/src/*.test.ts packages/openapi/src/*.test.ts packages/serializer/src/*.test.ts packages/throttler/src/*.test.ts`
- `pnpm test` *(fails on pre-existing `packages/jwt/src/jwks.test.ts` on both this branch and current `main` baseline)*

Closes #238