### PR TITLE
Resolve #241: reduce data-access, CLI, and metrics drift

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -499,6 +499,54 @@ describe('CLI command runner', () => {
     expect(stderrBuffer.join('')).toContain('Usage: konekti <command> [options]');
   });
 
+  it('rejects unknown options for `new` before scaffolding side effects', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', 'starter-app', '--unknown-flag'], {
+      cwd: workspaceDirectory,
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('Unknown option for new command: --unknown-flag');
+    expect(existsSync(join(workspaceDirectory, 'starter-app'))).toBe(false);
+  });
+
+  it('rejects `new --package-manager` when the value is missing', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', 'starter-app', '--package-manager'], {
+      cwd: workspaceDirectory,
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('Expected --package-manager to have a value.');
+    expect(existsSync(join(workspaceDirectory, 'starter-app'))).toBe(false);
+  });
+
+  it('rejects unsupported package-manager values for `new`', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', 'starter-app', '--package-manager', 'bun'], {
+      cwd: workspaceDirectory,
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('Invalid --package-manager value "bun". Use one of: pnpm, npm, yarn.');
+    expect(existsSync(join(workspaceDirectory, 'starter-app'))).toBe(false);
+  });
+
   it('prints generate usage for an unknown schematic', async () => {
     const stderrBuffer: string[] = [];
 

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -52,4 +52,29 @@ describe('runGenerateCommand', () => {
     expect(moduleContent).toContain('from "./post.service"');
     expect(occurrences).toBe(2);
   });
+
+  it('does not write generated files when module rewrite preflight fails', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const domainDirectory = join(sourceDirectory, 'posts');
+    const modulePath = join(domainDirectory, 'post.module.ts');
+    mkdirSync(domainDirectory, { recursive: true });
+
+    writeFileSync(
+      modulePath,
+      `import { Module } from '@konekti/core';
+
+@Module({ providers: ExistingService })
+class PostModule {}
+
+export { PostModule };
+`,
+      'utf8',
+    );
+
+    expect(() => runGenerateCommand('service', 'Post', sourceDirectory)).toThrow('"providers" must be an array');
+    expect(existsSync(join(domainDirectory, 'post.service.ts'))).toBe(false);
+  });
 });

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -26,26 +26,53 @@ function assertValidResourceName(name: string): string {
   return kebab;
 }
 
-function ensureModuleFile(domainDirectory: string, name: string): string {
+function resolveModulePath(domainDirectory: string, name: string): string {
   const kebab = toKebabCase(name);
-  const modulePath = join(domainDirectory, `${kebab}.module.ts`);
-
-  if (!existsSync(modulePath)) {
-    const [moduleFile] = generateModuleFiles(name);
-    if (moduleFile) {
-      mkdirSync(domainDirectory, { recursive: true });
-      writeFileSync(modulePath, moduleFile.content, 'utf8');
-    }
-  }
-
-  return modulePath;
+  return join(domainDirectory, `${kebab}.module.ts`);
 }
 
-function updateModuleFile(modulePath: string, arrayKey: ModuleArrayKey, className: string, importPath: string): void {
-  let source = readFileSync(modulePath, 'utf8');
+function readOrCreateModuleSource(modulePath: string, name: string): string {
+  if (existsSync(modulePath)) {
+    return readFileSync(modulePath, 'utf8');
+  }
+
+  const [moduleFile] = generateModuleFiles(name);
+  if (!moduleFile) {
+    throw new Error(`Unable to generate module file for resource "${name}".`);
+  }
+
+  return moduleFile.content;
+}
+
+function buildUpdatedModuleSource(moduleSource: string, arrayKey: ModuleArrayKey, className: string, importPath: string): string {
+  let source = moduleSource;
   source = ensureModuleImport(source, className, importPath);
   source = registerInModule(source, arrayKey, className);
-  writeFileSync(modulePath, source, 'utf8');
+  return source;
+}
+
+type ModuleUpdatePlan = {
+  modulePath: string;
+  source: string;
+};
+
+function prepareModuleUpdate(
+  domainDirectory: string,
+  normalizedName: string,
+  kind: GeneratorKind,
+  classSuffix: string,
+  arrayKey: ModuleArrayKey,
+): ModuleUpdatePlan {
+  const kebab = toKebabCase(normalizedName);
+  const modulePath = resolveModulePath(domainDirectory, normalizedName);
+  const className = `${toPascalCase(normalizedName)}${classSuffix}`;
+  const importPath = `${kebab}.${kind}`;
+  const moduleSource = readOrCreateModuleSource(modulePath, normalizedName);
+
+  return {
+    modulePath,
+    source: buildUpdatedModuleSource(moduleSource, arrayKey, className, importPath),
+  };
 }
 
 export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirectory: string, options: GenerateOptions = {}): string[] {
@@ -55,10 +82,14 @@ export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirect
 
   const resolvedBase = resolve(baseDirectory);
   const domainDirectory = join(resolvedBase, toPlural(kebab));
+  const files = generator.factory(normalizedName, options);
+  const moduleRegistration = 'moduleRegistration' in generator ? generator.moduleRegistration : undefined;
+
+  const moduleUpdate = moduleRegistration
+    ? prepareModuleUpdate(domainDirectory, normalizedName, kind, moduleRegistration.classSuffix, moduleRegistration.arrayKey)
+    : undefined;
 
   mkdirSync(domainDirectory, { recursive: true });
-
-  const files = generator.factory(normalizedName, options);
 
   const writtenPaths = files.map((file) => {
     const filePath = join(domainDirectory, file.path);
@@ -71,15 +102,11 @@ export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirect
     return filePath;
   }).filter((filePath): filePath is string => filePath !== null);
 
-  const moduleRegistration = 'moduleRegistration' in generator ? generator.moduleRegistration : undefined;
-  if (moduleRegistration) {
-    const modulePath = ensureModuleFile(domainDirectory, normalizedName);
-    const className = `${toPascalCase(normalizedName)}${moduleRegistration.classSuffix}`;
-    const importPath = `${kebab}.${kind}`;
-    updateModuleFile(modulePath, moduleRegistration.arrayKey, className, importPath);
+  if (moduleUpdate) {
+    writeFileSync(moduleUpdate.modulePath, moduleUpdate.source, 'utf8');
 
-    if (!writtenPaths.includes(modulePath)) {
-      writtenPaths.push(modulePath);
+    if (!writtenPaths.includes(moduleUpdate.modulePath)) {
+      writtenPaths.push(moduleUpdate.modulePath);
     }
   }
 

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -49,34 +49,68 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
   },
 ];
 
+const SUPPORTED_PACKAGE_MANAGERS = new Set<BootstrapAnswers['packageManager']>(['npm', 'pnpm', 'yarn']);
+
+function readOptionValue(argv: string[], index: number, option: '--name' | '--package-manager' | '--target-directory'): string {
+  const value = argv[index + 1];
+
+  if (!value || value.startsWith('-')) {
+    throw new Error(`Expected ${option} to have a value.`);
+  }
+
+  return value;
+}
+
 function parseArgs(argv: string[]): Partial<BootstrapAnswers> {
   const parsed: Partial<BootstrapAnswers> = {};
   let hasExplicitTargetDirectory = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    const next = argv[index + 1];
 
     switch (arg) {
       case '--name':
-        parsed.projectName = next;
+        if (parsed.projectName) {
+          throw new Error('Duplicate --name option.');
+        }
+
+        parsed.projectName = readOptionValue(argv, index, '--name');
         index += 1;
         break;
       case '--package-manager':
-        parsed.packageManager = next as BootstrapAnswers['packageManager'];
+        if (parsed.packageManager) {
+          throw new Error('Duplicate --package-manager option.');
+        }
+
+        parsed.packageManager = readOptionValue(argv, index, '--package-manager') as BootstrapAnswers['packageManager'];
+        if (!SUPPORTED_PACKAGE_MANAGERS.has(parsed.packageManager)) {
+          throw new Error(
+            `Invalid --package-manager value "${parsed.packageManager}". Use one of: pnpm, npm, yarn.`,
+          );
+        }
         index += 1;
         break;
       case '--target-directory':
-        parsed.targetDirectory = next;
+        if (hasExplicitTargetDirectory) {
+          throw new Error('Duplicate --target-directory option.');
+        }
+
+        parsed.targetDirectory = readOptionValue(argv, index, '--target-directory');
         hasExplicitTargetDirectory = true;
         index += 1;
         break;
       default:
-        if (!arg.startsWith('-') && !parsed.projectName) {
-          parsed.projectName = arg;
-          if (!hasExplicitTargetDirectory) {
-            parsed.targetDirectory = `./${arg}`;
-          }
+        if (arg.startsWith('-')) {
+          throw new Error(`Unknown option for new command: ${arg}`);
+        }
+
+        if (parsed.projectName) {
+          throw new Error(`Unexpected positional argument: ${arg}`);
+        }
+
+        parsed.projectName = arg;
+        if (!hasExplicitTargetDirectory) {
+          parsed.targetDirectory = `./${arg}`;
         }
         break;
     }

--- a/packages/cli/src/generators.test.ts
+++ b/packages/cli/src/generators.test.ts
@@ -186,6 +186,14 @@ describe('CLI generators', () => {
 
       expect(occurrences).toBe(1);
     });
+
+    it('throws when the same class is already imported from a different module path', () => {
+      const source = `import { UserService } from './legacy.service';\n\n@Module({\n  controllers: [],\n  providers: [],\n})\nclass UserModule {}\n`;
+
+      expect(() => ensureModuleImport(source, 'UserService', 'user.service')).toThrow(
+        'Import collision for UserService: already imported from "./legacy.service" but requested from "./user.service".',
+      );
+    });
   });
 });
 

--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -57,7 +57,7 @@ function findModuleDecoratorObject(sourceFile: ts.SourceFile): ts.ObjectLiteralE
   return undefined;
 }
 
-function hasNamedImport(sourceFile: ts.SourceFile, className: string): boolean {
+function findNamedImportSource(sourceFile: ts.SourceFile, className: string): string | undefined {
   for (const statement of sourceFile.statements) {
     if (!ts.isImportDeclaration(statement)) {
       continue;
@@ -68,12 +68,16 @@ function hasNamedImport(sourceFile: ts.SourceFile, className: string): boolean {
       continue;
     }
 
-    if (importClause.namedBindings.elements.some((element) => element.name.text === className)) {
-      return true;
+    if (!importClause.namedBindings.elements.some((element) => element.name.text === className)) {
+      continue;
+    }
+
+    if (ts.isStringLiteral(statement.moduleSpecifier)) {
+      return statement.moduleSpecifier.text;
     }
   }
 
-  return false;
+  return undefined;
 }
 
 function buildImportDeclaration(className: string, importPath: string): ts.ImportDeclaration {
@@ -92,12 +96,19 @@ function buildImportDeclaration(className: string, importPath: string): ts.Impor
 
 export function ensureModuleImport(source: string, className: string, importPath: string): string {
   const sourceFile = parseSource(source);
+  const moduleSpecifier = `./${importPath}`;
+  const existingImportSource = findNamedImportSource(sourceFile, className);
 
-  if (hasNamedImport(sourceFile, className)) {
-    return source;
+  if (existingImportSource) {
+    if (existingImportSource === moduleSpecifier) {
+      return source;
+    }
+
+    throw new Error(
+      `Import collision for ${className}: already imported from "${existingImportSource}" but requested from "${moduleSpecifier}".`,
+    );
   }
 
-  const moduleSpecifier = `./${importPath}`;
   for (const statement of sourceFile.statements) {
     if (!ts.isImportDeclaration(statement)) {
       continue;

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -18,6 +18,8 @@ import type {
 } from './types.js';
 
 const TRANSACTION_NOT_SUPPORTED_ERROR = 'Transaction not supported: Drizzle database does not implement transaction.';
+const NESTED_TRANSACTION_OPTIONS_NOT_SUPPORTED_ERROR =
+  'Nested Drizzle transaction options are not supported because the active transaction context is reused.';
 
 type ActiveRequestTransaction = {
   abort(reason?: unknown): void;
@@ -78,6 +80,14 @@ export class DrizzleDatabase<
     const current = this.transactions.getStore();
 
     if (current) {
+      if (options !== undefined) {
+        throw new Error(NESTED_TRANSACTION_OPTIONS_NOT_SUPPORTED_ERROR);
+      }
+
+      if (requestScoped && signal) {
+        return raceWithAbort(fn, signal);
+      }
+
       return fn();
     }
 

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -203,6 +203,26 @@ describe('@konekti/drizzle', () => {
     await asyncApp.close();
   });
 
+  it('runs nested request and service transactions through a single transaction boundary', async () => {
+    let transactionCalls = 0;
+    const transactionDatabase = {
+      kind: 'transaction' as const,
+    };
+    const database = {
+      async transaction<T>(callback: (value: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        transactionCalls += 1;
+        return callback(transactionDatabase);
+      },
+    };
+
+    const drizzle = new DrizzleDatabase<typeof database, typeof transactionDatabase>(database);
+
+    await expect(
+      drizzle.requestTransaction(async () => drizzle.transaction(async () => 'ok')),
+    ).resolves.toBe('ok');
+    expect(transactionCalls).toBe(1);
+  });
+
   it('forwards transaction options for explicit and request-scoped transactions', async () => {
     const optionsCalls: Array<{ isolationLevel: string } | undefined> = [];
     const transactionDatabase = { kind: 'transaction' };
@@ -230,6 +250,39 @@ describe('@konekti/drizzle', () => {
       { isolationLevel: 'serializable' },
       { isolationLevel: 'read committed' },
     ]);
+  });
+
+  it('rejects nested transaction options and still honors nested request abort signals', async () => {
+    const transactionDatabase = {
+      kind: 'transaction' as const,
+    };
+    const database = {
+      async transaction<T>(
+        callback: (value: typeof transactionDatabase) => Promise<T>,
+        _options?: { isolationLevel: string },
+      ): Promise<T> {
+        return callback(transactionDatabase);
+      },
+    };
+
+    const drizzle = new DrizzleDatabase<typeof database, typeof transactionDatabase, { isolationLevel: string }>(database);
+
+    await expect(
+      drizzle.transaction(
+        async () => drizzle.transaction(async () => 'never', { isolationLevel: 'serializable' }),
+      ),
+    ).rejects.toThrow(
+      'Nested Drizzle transaction options are not supported because the active transaction context is reused.',
+    );
+
+    const controller = new AbortController();
+    controller.abort(new Error('nested request aborted'));
+
+    await expect(
+      drizzle.transaction(
+        async () => drizzle.requestTransaction(async () => new Promise<never>(() => undefined), controller.signal),
+      ),
+    ).rejects.toThrow('nested request aborted');
   });
 });
 

--- a/packages/drizzle/src/module.ts
+++ b/packages/drizzle/src/module.ts
@@ -15,6 +15,9 @@ type ResolvedDrizzleModuleOptions<
   strictTransactions: boolean;
 };
 
+const DRIZZLE_NORMALIZED_OPTIONS = Symbol('konekti.drizzle.normalized-options');
+const DRIZZLE_MODULE_EXPORTS = [DrizzleDatabase, DrizzleTransactionInterceptor];
+
 function normalizeDrizzleModuleOptions<
   TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
   TTransactionDatabase,
@@ -30,6 +33,38 @@ function normalizeDrizzleModuleOptions<
 
 function createRuntimeOptionsProviderValue(strictTransactions: boolean): DrizzleRuntimeOptions {
   return { strictTransactions };
+}
+
+function createDrizzleRuntimeProviders<
+  TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
+  TTransactionDatabase,
+  TTransactionOptions,
+>(normalizedOptionsProvider: Provider): Provider[] {
+  return [
+    normalizedOptionsProvider,
+    {
+      inject: [DRIZZLE_NORMALIZED_OPTIONS],
+      provide: DRIZZLE_DATABASE,
+      useFactory: (options: unknown) =>
+        (options as ResolvedDrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>).database,
+    },
+    {
+      inject: [DRIZZLE_NORMALIZED_OPTIONS],
+      provide: DRIZZLE_DISPOSE,
+      useFactory: (options: unknown) =>
+        (options as ResolvedDrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>).dispose,
+    },
+    {
+      inject: [DRIZZLE_NORMALIZED_OPTIONS],
+      provide: DRIZZLE_OPTIONS,
+      useFactory: (options: unknown) =>
+        createRuntimeOptionsProviderValue(
+          (options as ResolvedDrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>).strictTransactions,
+        ),
+    },
+    DrizzleDatabase,
+    DrizzleTransactionInterceptor,
+  ];
 }
 
 function createMemoizedDrizzleOptionsResolver<
@@ -65,37 +100,14 @@ function createDrizzleProvidersAsync<
 ): Provider[] {
   const resolveOptions = createMemoizedDrizzleOptionsResolver(options);
 
-  const databaseProvider = {
+  const normalizedOptionsProvider = {
     inject: options.inject,
-    provide: DRIZZLE_DATABASE,
+    provide: DRIZZLE_NORMALIZED_OPTIONS,
     scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => {
-      const resolved = await resolveOptions(...deps);
-      return resolved.database;
-    },
+    useFactory: async (...deps: unknown[]) => resolveOptions(...deps),
   };
 
-  const disposeProvider = {
-    inject: options.inject,
-    provide: DRIZZLE_DISPOSE,
-    scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => {
-      const resolved = await resolveOptions(...deps);
-      return resolved.dispose;
-    },
-  };
-
-  const optionsProvider = {
-    inject: options.inject,
-    provide: DRIZZLE_OPTIONS,
-    scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => {
-      const resolved = await resolveOptions(...deps);
-      return createRuntimeOptionsProviderValue(resolved.strictTransactions);
-    },
-  };
-
-  return [databaseProvider, disposeProvider, optionsProvider, DrizzleDatabase, DrizzleTransactionInterceptor];
+  return createDrizzleRuntimeProviders<TDatabase, TTransactionDatabase, TTransactionOptions>(normalizedOptionsProvider);
 }
 
 export function createDrizzleProviders<
@@ -105,22 +117,10 @@ export function createDrizzleProviders<
 >(options: DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>): Provider[] {
   const resolved = normalizeDrizzleModuleOptions(options);
 
-  return [
-    {
-      provide: DRIZZLE_DATABASE,
-      useValue: resolved.database,
-    },
-    {
-      provide: DRIZZLE_DISPOSE,
-      useValue: resolved.dispose,
-    },
-    {
-      provide: DRIZZLE_OPTIONS,
-      useValue: createRuntimeOptionsProviderValue(resolved.strictTransactions),
-    },
-    DrizzleDatabase,
-    DrizzleTransactionInterceptor,
-  ];
+  return createDrizzleRuntimeProviders<TDatabase, TTransactionDatabase, TTransactionOptions>({
+    provide: DRIZZLE_NORMALIZED_OPTIONS,
+    useValue: resolved,
+  });
 }
 
 export function createDrizzleModule<
@@ -131,7 +131,7 @@ export function createDrizzleModule<
   class DrizzleModule {}
 
   return defineModule(DrizzleModule, {
-    exports: [DrizzleDatabase, DrizzleTransactionInterceptor],
+    exports: DRIZZLE_MODULE_EXPORTS,
     providers: createDrizzleProviders(options),
   });
 }
@@ -144,7 +144,7 @@ export function createDrizzleModuleAsync<
   class DrizzleAsyncModule {}
 
   return defineModule(DrizzleAsyncModule, {
-    exports: [DrizzleDatabase, DrizzleTransactionInterceptor],
+    exports: DRIZZLE_MODULE_EXPORTS,
     providers: createDrizzleProvidersAsync(options),
   });
 }

--- a/packages/drizzle/src/vertical-slice.test.ts
+++ b/packages/drizzle/src/vertical-slice.test.ts
@@ -49,6 +49,7 @@ function createRequest(
   path: string,
   method: FrameworkRequest['method'],
   body?: unknown,
+  signal?: AbortSignal,
 ): FrameworkRequest {
   return {
     body,
@@ -59,6 +60,7 @@ function createRequest(
     path,
     query: {},
     raw: {},
+    signal,
     url: path,
   };
 }
@@ -74,6 +76,10 @@ describe('@konekti/drizzle vertical slice', () => {
     const users = new Map<string, UserRecord>();
     const events: string[] = [];
     let sequence = 0;
+    let resolveAbortCreate!: () => void;
+    const abortCreateReached = new Promise<void>((resolve) => {
+      resolveAbortCreate = resolve;
+    });
 
     const transactionDatabase = {
       users: {
@@ -83,6 +89,12 @@ describe('@konekti/drizzle vertical slice', () => {
         },
         async insert(value: { email: string; name: string }) {
           events.push(`tx:insert:${value.email}`);
+
+          if (value.email === 'abort@example.com') {
+            resolveAbortCreate();
+            return new Promise<never>(() => undefined);
+          }
+
           const record = {
             ...value,
             id: `user-${++sequence}`,
@@ -255,8 +267,44 @@ describe('@konekti/drizzle vertical slice', () => {
       'response:send',
     ]);
 
+    const abortController = new AbortController();
+    const abortResponse = createResponse(events);
+    const abortDispatch = app.dispatch(
+      createRequest('/users', 'POST', { email: 'abort@example.com', name: 'Ada' }, abortController.signal),
+      abortResponse,
+    );
+    await abortCreateReached;
+    abortController.abort(new Error('client aborted request'));
+    await abortDispatch;
+
+    expect(abortResponse.committed).toBe(false);
+    expect(users.get('user-1')).toEqual({
+      email: 'ada@example.com',
+      id: 'user-1',
+      name: 'Ada',
+    });
+
     await app.close();
 
-    expect(events).toContain('dispose');
+    expect(events).toEqual([
+      'transaction:start',
+      'tx:insert:ada@example.com',
+      'transaction:end',
+      'response:send',
+      'transaction:start',
+      'tx:find:user-1',
+      'transaction:end',
+      'response:send',
+      'transaction:start',
+      'tx:find:missing',
+      'transaction:rollback',
+      'transaction:end',
+      'response:send',
+      'transaction:start',
+      'tx:insert:abort@example.com',
+      'transaction:rollback',
+      'transaction:end',
+      'dispose',
+    ]);
   });
 });

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -1,5 +1,7 @@
 import type { FrameworkRequest, Middleware, MiddlewareContext, Next } from '@konekti/http';
-import { Counter, Histogram, type Registry } from 'prom-client';
+import type { Registry } from 'prom-client';
+
+import { createPrometheusCounter, createPrometheusHistogram } from './prometheus-metrics-factory.js';
 
 type HttpMetricLabels = {
   method: string;
@@ -64,23 +66,20 @@ export class HttpMetricsMiddleware implements Middleware {
     this.pathLabelMode = options.pathLabelMode ?? 'template';
     this.pathLabelNormalizer = options.pathLabelNormalizer;
     this.unknownPathLabel = options.unknownPathLabel ?? 'UNKNOWN';
-    this.requestsTotal = new Counter({
+    this.requestsTotal = createPrometheusCounter(registry, {
       help: 'Total number of HTTP requests',
       labelNames: ['method', 'path', 'status'],
       name: 'http_requests_total',
-      registers: [registry],
     });
-    this.errorsTotal = new Counter({
+    this.errorsTotal = createPrometheusCounter(registry, {
       help: 'Total number of HTTP error responses (4xx/5xx)',
       labelNames: ['method', 'path', 'status'],
       name: 'http_errors_total',
-      registers: [registry],
     });
-    this.requestDuration = new Histogram({
+    this.requestDuration = createPrometheusHistogram(registry, {
       help: 'HTTP request duration in seconds',
       labelNames: ['method', 'path', 'status'],
       name: 'http_request_duration_seconds',
-      registers: [registry],
     });
   }
 
@@ -140,17 +139,19 @@ export class HttpMetricsMiddleware implements Middleware {
     durationSeconds: number,
     requestError: unknown,
   ): void {
-    const labels: Readonly<HttpMetricLabels> = {
+    const baseLabels: HttpMetricLabels = {
       method,
       path,
       status: String(statusCode),
     };
+    const requestLabels: HttpMetricLabels = { ...baseLabels };
+    const errorLabels = statusCode >= 400 || requestError !== undefined ? { ...baseLabels } : undefined;
 
-    this.requestsTotal.inc({ ...labels });
-    this.requestDuration.observe({ ...labels }, durationSeconds);
+    this.requestsTotal.inc(requestLabels);
+    this.requestDuration.observe(baseLabels, durationSeconds);
 
-    if (statusCode >= 400 || requestError !== undefined) {
-      this.errorsTotal.inc({ ...labels });
+    if (errorLabels) {
+      this.errorsTotal.inc(errorLabels);
     }
   }
 }
@@ -160,19 +161,26 @@ function normalizePathToTemplate(path: string, params: Readonly<Record<string, s
     return '/';
   }
 
-  const normalizedSegments = path
-    .split('/')
-    .filter((segment) => segment.length > 0)
-    .map((segment) => {
-      const decoded = safeDecodeURIComponent(segment);
-      for (const [paramKey, paramValue] of Object.entries(params)) {
-        if (segment === paramValue || decoded === paramValue) {
-          return `:${paramKey}`;
-        }
-      }
+  const normalizedSegments: string[] = [];
+  const paramEntries = Object.entries(params);
 
-      return segment;
-    });
+  for (const segment of path.split('/')) {
+    if (!segment) {
+      continue;
+    }
+
+    const decoded = safeDecodeURIComponent(segment);
+    let normalizedSegment = segment;
+
+    for (const [paramKey, paramValue] of paramEntries) {
+      if (segment === paramValue || decoded === paramValue) {
+        normalizedSegment = `:${paramKey}`;
+        break;
+      }
+    }
+
+    normalizedSegments.push(normalizedSegment);
+  }
 
   if (normalizedSegments.length === 0) {
     return '/';

--- a/packages/metrics/src/metrics-service.ts
+++ b/packages/metrics/src/metrics-service.ts
@@ -1,28 +1,27 @@
 import {
-  Counter,
-  Gauge,
-  Histogram,
   Registry,
   type CounterConfiguration,
   type GaugeConfiguration,
   type HistogramConfiguration,
 } from 'prom-client';
 
+import { createPrometheusCounter, createPrometheusGauge, createPrometheusHistogram } from './prometheus-metrics-factory.js';
+
 export const METRICS_SERVICE = Symbol.for('konekti.metrics.service');
 
 export class MetricsService {
   constructor(private readonly registry: Registry) {}
 
-  counter<T extends string = string>(config: CounterConfiguration<T>): Counter<T> {
-    return new Counter({ ...config, registers: [this.registry] });
+  counter<T extends string = string>(config: CounterConfiguration<T>) {
+    return createPrometheusCounter(this.registry, config);
   }
 
-  gauge<T extends string = string>(config: GaugeConfiguration<T>): Gauge<T> {
-    return new Gauge({ ...config, registers: [this.registry] });
+  gauge<T extends string = string>(config: GaugeConfiguration<T>) {
+    return createPrometheusGauge(this.registry, config);
   }
 
-  histogram<T extends string = string>(config: HistogramConfiguration<T>): Histogram<T> {
-    return new Histogram({ ...config, registers: [this.registry] });
+  histogram<T extends string = string>(config: HistogramConfiguration<T>) {
+    return createPrometheusHistogram(this.registry, config);
   }
 
   getRegistry(): Registry {

--- a/packages/metrics/src/prometheus-meter-provider.ts
+++ b/packages/metrics/src/prometheus-meter-provider.ts
@@ -1,6 +1,7 @@
-import { Counter, Gauge, Histogram, type Registry } from 'prom-client';
+import type { Registry } from 'prom-client';
 
 import type { MeterCounter, MeterGauge, MeterHistogram, MeterProvider } from './meter-provider.js';
+import { createPrometheusCounter, createPrometheusGauge, createPrometheusHistogram } from './prometheus-metrics-factory.js';
 
 export class PrometheusMeterProvider implements MeterProvider {
   readonly type = 'prometheus' as const;
@@ -8,11 +9,10 @@ export class PrometheusMeterProvider implements MeterProvider {
   constructor(private readonly registry: Registry) {}
 
   createCounter(name: string, help: string, labelNames: string[] = []): MeterCounter {
-    const counter = new Counter({
+    const counter = createPrometheusCounter(this.registry, {
       help,
       labelNames,
       name,
-      registers: [this.registry],
     });
 
     return {
@@ -28,11 +28,10 @@ export class PrometheusMeterProvider implements MeterProvider {
   }
 
   createGauge(name: string, help: string, labelNames: string[] = []): MeterGauge {
-    const gauge = new Gauge({
+    const gauge = createPrometheusGauge(this.registry, {
       help,
       labelNames,
       name,
-      registers: [this.registry],
     });
 
     return {
@@ -48,12 +47,11 @@ export class PrometheusMeterProvider implements MeterProvider {
   }
 
   createHistogram(name: string, help: string, labelNames: string[] = [], buckets?: number[]): MeterHistogram {
-    const histogram = new Histogram({
+    const histogram = createPrometheusHistogram(this.registry, {
       buckets,
       help,
       labelNames,
       name,
-      registers: [this.registry],
     });
 
     return {

--- a/packages/metrics/src/prometheus-metrics-factory.ts
+++ b/packages/metrics/src/prometheus-metrics-factory.ts
@@ -1,0 +1,30 @@
+import {
+  Counter,
+  Gauge,
+  Histogram,
+  type CounterConfiguration,
+  type GaugeConfiguration,
+  type HistogramConfiguration,
+  type Registry,
+} from 'prom-client';
+
+export function createPrometheusCounter<T extends string = string>(
+  registry: Registry,
+  config: CounterConfiguration<T>,
+): Counter<T> {
+  return new Counter({ ...config, registers: [registry] });
+}
+
+export function createPrometheusGauge<T extends string = string>(
+  registry: Registry,
+  config: GaugeConfiguration<T>,
+): Gauge<T> {
+  return new Gauge({ ...config, registers: [registry] });
+}
+
+export function createPrometheusHistogram<T extends string = string>(
+  registry: Registry,
+  config: HistogramConfiguration<T>,
+): Histogram<T> {
+  return new Histogram({ ...config, registers: [registry] });
+}

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -198,6 +198,61 @@ describe('@konekti/prisma', () => {
     await app.close();
   });
 
+  it('forwards transaction options for explicit and request-scoped transactions', async () => {
+    const optionsCalls: Array<{ isolationLevel: string } | undefined> = [];
+    const transactionClient = {
+      kind: 'transaction' as const,
+    };
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+      async $transaction<T>(
+        callback: (value: typeof transactionClient) => Promise<T>,
+        options?: { isolationLevel: string },
+      ): Promise<T> {
+        optionsCalls.push(options);
+        return callback(transactionClient);
+      },
+    };
+
+    const prisma = new PrismaService<typeof client, typeof transactionClient, { isolationLevel: string }>(client);
+
+    await expect(prisma.transaction(async () => prisma.current(), { isolationLevel: 'serializable' })).resolves.toBe(
+      transactionClient,
+    );
+    await expect(
+      prisma.requestTransaction(async () => prisma.current(), undefined, { isolationLevel: 'read committed' }),
+    ).resolves.toBe(transactionClient);
+
+    expect(optionsCalls).toEqual([
+      { isolationLevel: 'serializable' },
+      { isolationLevel: 'read committed' },
+    ]);
+  });
+
+  it('rejects nested transaction options to avoid silent option drops', async () => {
+    const transactionClient = {
+      kind: 'transaction' as const,
+    };
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+      async $transaction<T>(callback: (value: typeof transactionClient) => Promise<T>): Promise<T> {
+        return callback(transactionClient);
+      },
+    };
+
+    const prisma = new PrismaService<typeof client, typeof transactionClient, { isolationLevel: string }>(client);
+
+    await expect(
+      prisma.transaction(
+        async () => prisma.transaction(async () => 'never', { isolationLevel: 'serializable' }),
+      ),
+    ).rejects.toThrow(
+      'Nested Prisma transaction options are not supported because the active transaction context is reused.',
+    );
+  });
+
   it('falls back when transaction client is unsupported and strictTransactions is false', async () => {
     const client = {
       async $connect() {},

--- a/packages/prisma/src/module.ts
+++ b/packages/prisma/src/module.ts
@@ -7,7 +7,11 @@ import { PRISMA_CLIENT, PRISMA_OPTIONS } from './tokens.js';
 import { PrismaTransactionInterceptor } from './transaction.js';
 import type { PrismaClientLike, PrismaModuleOptions } from './types.js';
 
-interface NormalizedPrismaModuleOptions<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient> {
+interface NormalizedPrismaModuleOptions<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient,
+  TTransactionOptions,
+> {
   client: TClient;
   strictTransactions: boolean;
 }
@@ -15,16 +19,24 @@ interface NormalizedPrismaModuleOptions<TClient extends PrismaClientLike<TTransa
 const PRISMA_NORMALIZED_OPTIONS = Symbol('konekti.prisma.normalized-options');
 const PRISMA_MODULE_EXPORTS = [PrismaService, PrismaTransactionInterceptor];
 
-function normalizePrismaModuleOptions<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient>(
-  options: PrismaModuleOptions<TClient, TTransactionClient>,
-): NormalizedPrismaModuleOptions<TClient, TTransactionClient> {
+function normalizePrismaModuleOptions<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient,
+  TTransactionOptions,
+>(
+  options: PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>,
+): NormalizedPrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions> {
   return {
     client: options.client,
     strictTransactions: options.strictTransactions ?? false,
   };
 }
 
-function createPrismaRuntimeProviders<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient>(
+function createPrismaRuntimeProviders<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient,
+  TTransactionOptions,
+>(
   normalizedOptionsProvider: Provider,
 ): Provider[] {
   return [
@@ -32,13 +44,15 @@ function createPrismaRuntimeProviders<TClient extends PrismaClientLike<TTransact
     {
       inject: [PRISMA_NORMALIZED_OPTIONS],
       provide: PRISMA_CLIENT,
-      useFactory: (options: unknown) => (options as NormalizedPrismaModuleOptions<TClient, TTransactionClient>).client,
+      useFactory: (options: unknown) =>
+        (options as NormalizedPrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>).client,
     },
     {
       inject: [PRISMA_NORMALIZED_OPTIONS],
       provide: PRISMA_OPTIONS,
       useFactory: (options: unknown) => ({
-        strictTransactions: (options as NormalizedPrismaModuleOptions<TClient, TTransactionClient>).strictTransactions,
+        strictTransactions:
+          (options as NormalizedPrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>).strictTransactions,
       }),
     },
     PrismaService,
@@ -46,17 +60,25 @@ function createPrismaRuntimeProviders<TClient extends PrismaClientLike<TTransact
   ];
 }
 
-export function createPrismaProviders<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient>(
-  options: PrismaModuleOptions<TClient, TTransactionClient>,
+export function createPrismaProviders<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient = TClient,
+  TTransactionOptions = unknown,
+>(
+  options: PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>,
 ): Provider[] {
-  return createPrismaRuntimeProviders({
+  return createPrismaRuntimeProviders<TClient, TTransactionClient, TTransactionOptions>({
     provide: PRISMA_NORMALIZED_OPTIONS,
     useValue: normalizePrismaModuleOptions(options),
   });
 }
 
-export function createPrismaModule<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient>(
-  options: PrismaModuleOptions<TClient, TTransactionClient>,
+export function createPrismaModule<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient = TClient,
+  TTransactionOptions = unknown,
+>(
+  options: PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>,
 ): ModuleType {
   class PrismaModule {}
 
@@ -67,17 +89,24 @@ export function createPrismaModule<TClient extends PrismaClientLike<TTransaction
 }
 
 export function createPrismaModuleAsync<
-  TClient extends PrismaClientLike<TTransactionClient>,
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
   TTransactionClient = TClient,
->(options: AsyncModuleOptions<PrismaModuleOptions<TClient, TTransactionClient>>): ModuleType {
+  TTransactionOptions = unknown,
+>(options: AsyncModuleOptions<PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>>): ModuleType {
   class PrismaAsyncModule {}
 
-  const factory = options.useFactory as (...args: unknown[]) => MaybePromise<PrismaModuleOptions<TClient, TTransactionClient>>;
+  const factory = options.useFactory as (
+    ...args: unknown[]
+  ) => MaybePromise<PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>>;
 
-  let cachedResult: Promise<NormalizedPrismaModuleOptions<TClient, TTransactionClient>> | undefined;
-  const memoizedFactory = (...deps: unknown[]): Promise<NormalizedPrismaModuleOptions<TClient, TTransactionClient>> => {
+  let cachedResult: Promise<NormalizedPrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>> | undefined;
+  const memoizedFactory = (
+    ...deps: unknown[]
+  ): Promise<NormalizedPrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>> => {
     if (!cachedResult) {
-      cachedResult = Promise.resolve(factory(...deps)).then((resolved) => normalizePrismaModuleOptions(resolved));
+      cachedResult = Promise.resolve(factory(...deps)).then((resolved) =>
+        normalizePrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>(resolved),
+      );
     }
     return cachedResult;
   };
@@ -91,6 +120,6 @@ export function createPrismaModuleAsync<
 
   return defineModule(PrismaAsyncModule, {
     exports: PRISMA_MODULE_EXPORTS,
-    providers: createPrismaRuntimeProviders(normalizedOptionsProvider),
+    providers: createPrismaRuntimeProviders<TClient, TTransactionClient, TTransactionOptions>(normalizedOptionsProvider),
   });
 }

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -12,6 +12,9 @@ import { Inject } from '@konekti/core';
 import { PRISMA_CLIENT, PRISMA_OPTIONS } from './tokens.js';
 import type { PrismaClientLike, PrismaHandleProvider } from './types.js';
 
+const NESTED_TRANSACTION_OPTIONS_NOT_SUPPORTED_ERROR =
+  'Nested Prisma transaction options are not supported because the active transaction context is reused.';
+
 interface PrismaServiceOptions {
   strictTransactions: boolean;
 }
@@ -27,8 +30,12 @@ type ActiveRequestTransactionHandle = {
 };
 
 @Inject([PRISMA_CLIENT, PRISMA_OPTIONS])
-export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient>
-  implements PrismaHandleProvider<TClient, TTransactionClient>, OnModuleInit, OnApplicationShutdown
+export class PrismaService<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient = TClient,
+  TTransactionOptions = unknown,
+>
+  implements PrismaHandleProvider<TClient, TTransactionClient, TTransactionOptions>, OnModuleInit, OnApplicationShutdown
 {
   private readonly transactions = new AsyncLocalStorage<TTransactionClient>();
   private readonly activeRequestTransactions = new Set<ActiveRequestTransaction>();
@@ -44,9 +51,17 @@ export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>,
 
   private async runWithTransactionClient<T>(
     fn: () => Promise<T>,
-    run: (callback: (transactionClient: TTransactionClient) => Promise<T>) => Promise<T>,
+    run: (
+      callback: (transactionClient: TTransactionClient) => Promise<T>,
+      options?: TTransactionOptions,
+    ) => Promise<T>,
+    options?: TTransactionOptions,
   ): Promise<T> {
     if (this.transactions.getStore()) {
+      if (options !== undefined) {
+        throw new Error(NESTED_TRANSACTION_OPTIONS_NOT_SUPPORTED_ERROR);
+      }
+
       return fn();
     }
 
@@ -58,7 +73,7 @@ export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>,
       return fn();
     }
 
-    return run((transactionClient) => this.transactions.run(transactionClient, fn));
+    return run((transactionClient) => this.transactions.run(transactionClient, fn), options);
   }
 
   async onModuleInit(): Promise<void> {
@@ -79,18 +94,23 @@ export class PrismaService<TClient extends PrismaClientLike<TTransactionClient>,
     }
   }
 
-  async transaction<T>(fn: () => Promise<T>): Promise<T> {
-    return this.runWithTransactionClient(fn, (callback) => this.client.$transaction!(callback));
+  async transaction<T>(fn: () => Promise<T>, options?: TTransactionOptions): Promise<T> {
+    return this.runWithTransactionClient(
+      fn,
+      (callback, transactionOptions) => this.client.$transaction!(callback, transactionOptions),
+      options,
+    );
   }
 
-  async requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  async requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal, options?: TTransactionOptions): Promise<T> {
     const abortContext = createRequestAbortContext(signal);
     const active = this.trackActiveRequestTransaction(abortContext.controller);
 
     try {
       return await this.runWithTransactionClient(
         () => raceWithAbort(fn, abortContext.signal),
-        (callback) => this.client.$transaction!(callback),
+        (callback, transactionOptions) => this.client.$transaction!(callback, transactionOptions),
+        options,
       );
     } finally {
       abortContext.cleanup();

--- a/packages/prisma/src/types.ts
+++ b/packages/prisma/src/types.ts
@@ -6,19 +6,27 @@ export interface PrismaTransactionClient {
 
 export type PrismaTransactionCallback<TTransactionClient, TResult> = (client: TTransactionClient) => Promise<TResult>;
 
-export interface PrismaClientLike<TTransactionClient = PrismaTransactionClient> {
+export interface PrismaClientLike<TTransactionClient = PrismaTransactionClient, TTransactionOptions = unknown> {
   $connect?(): MaybePromise<void>;
   $disconnect?(): MaybePromise<void>;
-  $transaction?<T>(callback: PrismaTransactionCallback<TTransactionClient, T>): Promise<T>;
+  $transaction?<T>(callback: PrismaTransactionCallback<TTransactionClient, T>, options?: TTransactionOptions): Promise<T>;
 }
 
-export interface PrismaModuleOptions<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient> {
+export interface PrismaModuleOptions<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient = TClient,
+  TTransactionOptions = unknown,
+> {
   client: TClient;
   strictTransactions?: boolean;
 }
 
-export interface PrismaHandleProvider<TClient extends PrismaClientLike<TTransactionClient>, TTransactionClient = TClient> {
+export interface PrismaHandleProvider<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient = TClient,
+  TTransactionOptions = unknown,
+> {
   current(): TClient | TTransactionClient;
-  requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T>;
-  transaction<T>(fn: () => Promise<T>): Promise<T>;
+  requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal, options?: TTransactionOptions): Promise<T>;
+  transaction<T>(fn: () => Promise<T>, options?: TTransactionOptions): Promise<T>;
 }


### PR DESCRIPTION
## Summary
- Tightened drizzle/prisma transaction contracts by making nested behavior explicit (no silent option drops), forwarding supported options, and reusing shared provider-wiring patterns.
- Hardened CLI generation/new-command behavior by adding source-aware import collision detection, preflighting module rewrites before file writes, and enforcing strict `new` argument validation before side effects.
- Reduced metrics drift/hot-path overhead by extracting shared Prometheus metric factories and reducing repeated per-request normalization/allocation work while preserving label snapshot safety.

## Verification
- `pnpm vitest run packages/metrics/src/http-metrics-middleware.test.ts packages/metrics/src/metrics-module.test.ts packages/drizzle/src/module.test.ts packages/drizzle/src/vertical-slice.test.ts packages/prisma/src/module.test.ts packages/prisma/src/vertical-slice.test.ts packages/cli/src/generators.test.ts packages/cli/src/commands/generate.test.ts packages/cli/src/cli.test.ts`
- `pnpm vitest run packages/metrics/src/metrics-module.test.ts packages/drizzle/src/module.test.ts packages/drizzle/src/vertical-slice.test.ts packages/prisma/src/module.test.ts packages/prisma/src/vertical-slice.test.ts`
- `pnpm typecheck`
- `pnpm build`

Closes #241