### PR TITLE
Resolve #276: feat(metrics): expose shared registry option for built-in and custom metrics

### DIFF
--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -55,6 +55,7 @@ interface MetricsModuleOptions {
   provider?: 'prometheus';    // only supported provider at this time
   defaultMetrics?: boolean;   // collect Node.js default metrics (default: true)
   middleware?: MiddlewareLike[];
+  registry?: Registry;        // external Prometheus registry to share with custom metrics
 }
 
 class MetricsModule {
@@ -135,7 +136,70 @@ Use `pathLabelMode: 'raw'` only when you intentionally accept higher cardinality
 
 ## Custom Metrics
 
-`MetricsModule` creates a dedicated `prom-client` `Registry` instance per `forRoot()` call. The current public API does not expose that internal registry, so sharing one registry between custom metrics and the built-in endpoint is not currently supported.
+`MetricsModule` creates a dedicated `prom-client` `Registry` instance per `forRoot()` call by default. You can either use the isolated default or provide a shared registry to emit both framework and application metrics from a single scrape endpoint.
+
+### Shared Registry (Recommended)
+
+Pass an external `Registry` to `forRoot()` so custom metrics and framework metrics share the same endpoint:
+
+```typescript
+import { Counter, Registry } from 'prom-client';
+import { MetricsModule } from '@konekti/metrics';
+
+const sharedRegistry = new Registry();
+
+// Register custom metrics on the shared registry
+const httpRequests = new Counter({
+  name: 'http_requests_total',
+  help: 'Total number of HTTP requests',
+  labelNames: ['method', 'status'],
+  registers: [sharedRegistry],
+});
+
+httpRequests.inc({ method: 'GET', status: '200' });
+
+@Module({
+  imports: [
+    MetricsModule.forRoot({ registry: sharedRegistry }),
+  ],
+})
+class AppModule {}
+// GET /metrics → framework metrics + http_requests_total from same registry
+```
+
+### Using MetricsService with Shared Registry
+
+After providing a shared registry, `MetricsService` and `METER_PROVIDER` both use it:
+
+```typescript
+import { METRICS_SERVICE, MetricsService } from '@konekti/metrics';
+
+@Inject([METRICS_SERVICE])
+class OrderService {
+  constructor(private readonly metrics: MetricsService) {
+    this.orderCounter = this.metrics.counter({
+      name: 'orders_created_total',
+      help: 'Total orders created',
+      labelNames: ['status'],
+    });
+  }
+}
+// All metrics appear on /metrics endpoint
+```
+
+### Accessing the Registry
+
+`MetricsService.getRegistry()` returns the underlying `prom-client` `Registry`:
+
+```typescript
+const metricsService = await app.container.resolve(METRICS_SERVICE);
+const registry = metricsService.getRegistry();
+// Use registry directly with prom-client APIs
+```
+
+### Isolated Registry (Default)
+
+Without a `registry` option, each `forRoot()` call creates a separate registry:
 
 ```typescript
 import { Counter } from 'prom-client';
@@ -150,7 +214,25 @@ const httpRequests = new Counter({
 httpRequests.inc({ method: 'GET', status: '200' });
 ```
 
-> **Note:** `MetricsModule` uses its own isolated `Registry`. If you need one endpoint backed by a shared registry, extend or wrap the module with your own registry plumbing.
+> **Note:** When using isolated registries, custom metrics registered outside the module won't appear on the built-in `/metrics` endpoint. Use a shared registry for unified scraping.
+
+### Duplicate Metric Names
+
+Prometheus requires unique metric names. When using a shared registry, registering the same name twice throws:
+
+```typescript
+import { Counter } from 'prom-client';
+
+const registry = new Registry();
+
+new Counter({ name: 'my_counter', help: 'help', registers: [registry] });
+
+// This throws: 'A metric with the name my_counter has already been registered.'
+MetricsModule.forRoot({ registry }).container.resolve(METRICS_SERVICE)
+  .counter({ name: 'my_counter', help: 'duplicate' });
+```
+
+This behavior matches `prom-client` and prevents silent metric collisions.
 
 ---
 

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,3 +1,4 @@
+export { Registry } from 'prom-client';
 export * from './metrics-module.js';
 export * from './metrics-service.js';
 export * from './meter-provider.js';

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { FrameworkRequest, FrameworkResponse } from '@konekti/http';
 import { bootstrapApplication, defineModule } from '@konekti/runtime';
+import { Counter, Registry } from 'prom-client';
 
 import { MetricsModule } from './metrics-module.js';
 import { METER_PROVIDER } from './meter-provider.js';
@@ -236,5 +237,132 @@ describe('MetricsModule', () => {
     expect(() => MetricsModule.forRoot({ provider: 'otel' as unknown as 'prometheus' })).toThrow(
       'MetricsModule provider "otel" is not supported. Use provider "prometheus".',
     );
+  });
+
+  it('uses shared registry when provided via options', async () => {
+    const sharedRegistry = new Registry();
+
+    const customCounter = new Counter({
+      name: 'app_custom_requests_total',
+      help: 'Custom application request counter',
+      labelNames: ['endpoint'],
+      registers: [sharedRegistry],
+    });
+    customCounter.inc({ endpoint: '/api' });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ registry: sharedRegistry, defaultMetrics: false })],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    const metricsService = await app.container.resolve(METRICS_SERVICE) as MetricsService;
+    const resolvedRegistry = metricsService.getRegistry();
+
+    expect(resolvedRegistry).toBe(sharedRegistry);
+
+    const response = createResponse();
+    await app.dispatch(createRequest('/metrics'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(String(response.body)).toContain('app_custom_requests_total{endpoint="/api"} 1');
+
+    await app.close();
+  });
+
+  it('emits both framework and custom metrics from shared registry', async () => {
+    const sharedRegistry = new Registry();
+
+    const customGauge = new Counter({
+      name: 'app_active_connections',
+      help: 'Active connection count',
+      registers: [sharedRegistry],
+    });
+    customGauge.inc(5);
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ registry: sharedRegistry })],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    const response = createResponse();
+    await app.dispatch(createRequest('/metrics'), response);
+
+    const metricsText = String(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(metricsText).toContain('app_active_connections');
+    expect(metricsText).toContain('process_cpu_seconds_total');
+
+    await app.close();
+  });
+
+  it('throws on duplicate metric names when using shared registry with MetricsService', async () => {
+    const sharedRegistry = new Registry();
+
+    new Counter({
+      name: 'shared_duplicate_counter',
+      help: 'First registration',
+      registers: [sharedRegistry],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ registry: sharedRegistry, defaultMetrics: false })],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    const metricsService = await app.container.resolve(METRICS_SERVICE) as MetricsService;
+
+    expect(() => {
+      metricsService.counter({
+        help: 'Duplicate registration',
+        name: 'shared_duplicate_counter',
+      });
+    }).toThrow('A metric with the name shared_duplicate_counter has already been registered.');
+
+    await app.close();
+  });
+
+  it('creates isolated registry by default when registry option is omitted', async () => {
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    const metricsService = await app.container.resolve(METRICS_SERVICE) as MetricsService;
+    const registry = metricsService.getRegistry();
+
+    metricsService.counter({
+      help: 'Isolated counter',
+      name: 'isolated_counter_total',
+    });
+
+    const metrics = await registry.metrics();
+    expect(metrics).toContain('isolated_counter_total');
+
+    await app.close();
   });
 });

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, type MiddlewareLike, type RequestContext } from '@konekti/http';
 import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
-import { Registry, collectDefaultMetrics } from 'prom-client';
+import { type Registry, Registry as PrometheusRegistry, collectDefaultMetrics } from 'prom-client';
 
 import {
   HttpMetricsMiddleware,
@@ -25,6 +25,8 @@ export interface MetricsModuleOptions {
   provider?: 'prometheus';
   defaultMetrics?: boolean;
   middleware?: MiddlewareLike[];
+  /** External Prometheus registry to share between built-in and custom metrics. */
+  registry?: Registry;
 }
 
 export class MetricsModule {
@@ -38,7 +40,7 @@ export class MetricsModule {
 
     const httpOptions = resolveHttpOptions(options.http);
     const metricsPath = options.path ?? '/metrics';
-    const registry = new Registry();
+    const registry = options.registry ?? new PrometheusRegistry();
     const metricsService = new MetricsService(registry);
     const meterProvider = new PrometheusMeterProvider(registry);
 


### PR DESCRIPTION
## Summary

Resolves #276

Adds a `registry` option to `MetricsModuleOptions` that lets applications provide an external `prom-client` `Registry`. When supplied, the module reuses that registry for framework metrics, the built-in `/metrics` endpoint, and any custom metrics registered on the same instance — enabling unified scraping without workarounds.

## Changes

- **`MetricsModuleOptions.registry`** — optional `prom-client` `Registry`. When omitted, behavior is unchanged (isolated registry per `forRoot()` call).
- **Public API** — re-exports `Registry` from `prom-client` so consumers can import it directly from `@konekti/metrics`.
- **README** — documents shared registry setup, `MetricsService.getRegistry()`, duplicate-name behavior, and isolated default.
- **Tests** — 4 new cases covering shared registry wiring, mixed framework+custom metrics, duplicate-name errors, and default isolation.

## Verification

```bash
pnpm --filter @konekti/metrics test
```

All 11 tests pass (7 existing + 4 new).