### PR TITLE
Resolve #266: feat(graphql): support useValue/useFactory provider discovery for GraphQL resolvers

### DIFF
--- a/packages/di/src/types.ts
+++ b/packages/di/src/types.ts
@@ -19,6 +19,7 @@ export interface FactoryProvider<T = unknown> {
   inject?: Array<Token | ForwardRefFn | OptionalToken>;
   scope?: Scope;
   multi?: boolean;
+  resolverClass?: ClassType;
 }
 
 export interface ValueProvider<T = unknown> {

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -147,7 +147,7 @@ Maps DTO fields to GraphQL argument names for input binding.
 - Reserved internal context keys are protected; custom context cannot override the per-operation DI container symbol.
 - Discovery: resolvers are discovered from compiled modules during bootstrap.
 - Scope model: singleton, request, and transient scopes are all supported in GraphQL resolvers.
-- Registration rule: class providers and controllers are discoverable; `useValue`/`useFactory` providers are not.
+- Registration rule: class providers, controllers, `useValue` providers (via instance constructor), and `useFactory` providers (with explicit `resolverClass`) are all discoverable.
 - Shutdown: Yoga state and any enabled GraphQL websocket listeners are released during application shutdown.
 
 ## Provider Scopes in Resolvers
@@ -178,6 +178,74 @@ class RequestScopedResolver {
 ```
 
 When a resolver is declared with `@Scope('request')`, all its dependencies must also use `'request'` or `'transient'` scope. The DI container enforces this at bootstrap and throws `ScopeMismatchError` if a request-scoped provider depends on a singleton.
+
+## Alternative Provider Registration
+
+In addition to plain class providers and `useClass` registrations, GraphQL resolver discovery supports `useValue` and `useFactory` providers.
+
+### useValue
+
+`useValue` providers register a pre-instantiated resolver. Discovery inspects the instance's constructor to find resolver decorators.
+
+```typescript
+import { Module } from '@konekti/core';
+import { Resolver, Query, createGraphqlModule } from '@konekti/graphql';
+
+@Resolver('ConfiguredResolver')
+class ConfiguredResolver {
+  constructor(private readonly greeting: string) {}
+
+  @Query()
+  hello(): string {
+    return this.greeting;
+  }
+}
+
+const configuredResolver = new ConfiguredResolver('Hello from useValue!');
+
+@Module({
+  imports: [
+    createGraphqlModule(),
+  ],
+  providers: [
+    { provide: ConfiguredResolver, useValue: configuredResolver },
+  ],
+})
+class AppModule {}
+```
+
+### useFactory
+
+`useFactory` providers use a factory function to create resolvers. Since the resolver class cannot be determined from the factory at discovery time, you must specify it explicitly via the `resolverClass` property.
+
+```typescript
+import { Module } from '@konekti/core';
+import { Resolver, Query, createGraphqlModule } from '@konekti/graphql';
+
+@Resolver('DynamicResolver')
+class DynamicResolver {
+  constructor(private readonly config: { prefix: string }) {}
+
+  @Query()
+  greeting(): string {
+    return `${this.config.prefix} World`;
+  }
+}
+
+@Module({
+  imports: [
+    createGraphqlModule(),
+  ],
+  providers: [
+    {
+      provide: DynamicResolver,
+      useFactory: () => new DynamicResolver({ prefix: 'Hello' }),
+      resolverClass: DynamicResolver,
+    },
+  ],
+})
+class AppModule {}
+```
 
 ## Validation and Errors
 

--- a/packages/graphql/src/discovery.ts
+++ b/packages/graphql/src/discovery.ts
@@ -1,5 +1,5 @@
 import { getClassDiMetadata, type MetadataPropertyKey, type Token } from '@konekti/core';
-import type { Provider } from '@konekti/di';
+import type { FactoryProvider, Provider, ValueProvider } from '@konekti/di';
 import type { CompiledModule } from '@konekti/runtime';
 
 import { getArgFieldMetadataEntries, getResolverHandlerMetadataEntries, getResolverMetadata } from './metadata.js';
@@ -26,6 +26,14 @@ function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'trans
 
 function isClassProvider(provider: Provider): provider is Extract<Provider, { provide: Token; useClass: Function }> {
   return typeof provider === 'object' && provider !== null && 'useClass' in provider;
+}
+
+function isValueProvider(provider: Provider): provider is ValueProvider {
+  return typeof provider === 'object' && provider !== null && 'useValue' in provider;
+}
+
+function isFactoryProvider(provider: Provider): provider is FactoryProvider {
+  return typeof provider === 'object' && provider !== null && 'useFactory' in provider;
 }
 
 function methodKeyToName(methodKey: MetadataPropertyKey): string {
@@ -62,6 +70,51 @@ function discoveryCandidates(compiledModules: readonly CompiledModule[]): Discov
           targetType: provider.useClass,
           token: provider.provide,
         });
+        continue;
+      }
+
+      if (isValueProvider(provider)) {
+        const value = provider.useValue;
+
+        if (typeof value === 'function') {
+          candidates.push({
+            moduleName: compiledModule.type.name,
+            scope: 'singleton',
+            targetType: value,
+            token: provider.provide,
+          });
+          continue;
+        }
+
+        if (typeof value === 'object' && value !== null) {
+          const constructor = value.constructor as Function | undefined;
+
+          if (constructor && constructor !== Object) {
+            candidates.push({
+              moduleName: compiledModule.type.name,
+              scope: 'singleton',
+              targetType: constructor,
+              token: provider.provide,
+            });
+          }
+        }
+
+        continue;
+      }
+
+      if (isFactoryProvider(provider)) {
+        const resolverClass = (provider as FactoryProvider & { resolverClass?: Function }).resolverClass;
+
+        if (resolverClass) {
+          candidates.push({
+            moduleName: compiledModule.type.name,
+            scope: scopeFromProvider(provider),
+            targetType: resolverClass,
+            token: provider.provide,
+          });
+        }
+
+        continue;
       }
     }
 

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -799,4 +799,128 @@ describe('@konekti/graphql — provider scopes', () => {
 
     await app.close();
   });
+
+  it('discovers resolvers from useValue providers via instance constructor', async () => {
+    @Resolver('UseValueResolver')
+    class UseValueResolver {
+      constructor(private readonly greeting: string) {}
+
+      @Query()
+      useValueHello(): string {
+        return this.greeting;
+      }
+    }
+
+    const resolverInstance = new UseValueResolver('Hello from useValue!');
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createGraphqlModule()],
+      providers: [{ provide: UseValueResolver, useValue: resolverInstance }],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    await app.listen();
+
+    await expect(postGraphql(port, '{ useValueHello }')).resolves.toEqual({
+      data: { useValueHello: 'Hello from useValue!' },
+    });
+
+    await app.close();
+  });
+
+  it('discovers resolvers from useFactory providers with resolverClass', async () => {
+    @Resolver('UseFactoryResolver')
+    class UseFactoryResolver {
+      constructor(private readonly config: { prefix: string }) {}
+
+      @Query()
+      useFactoryGreeting(): string {
+        return `${this.config.prefix} World`;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createGraphqlModule()],
+      providers: [
+        {
+          provide: UseFactoryResolver,
+          useFactory: () => new UseFactoryResolver({ prefix: 'Hello' }),
+          resolverClass: UseFactoryResolver,
+        },
+      ],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    await app.listen();
+
+    await expect(postGraphql(port, '{ useFactoryGreeting }')).resolves.toEqual({
+      data: { useFactoryGreeting: 'Hello World' },
+    });
+
+    await app.close();
+  });
+
+  it('handles mixed provider registrations (class, useValue, useFactory) in same module', async () => {
+    @Resolver('ClassResolver')
+    class ClassResolver {
+      @Query()
+      classHello(): string {
+        return 'from class';
+      }
+    }
+
+    @Resolver('ValueResolver')
+    class ValueResolver {
+      @Query()
+      valueHello(): string {
+        return 'from value';
+      }
+    }
+
+    @Resolver('FactoryResolver')
+    class FactoryResolver {
+      @Query()
+      factoryHello(): string {
+        return 'from factory';
+      }
+    }
+
+    const valueInstance = new ValueResolver();
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createGraphqlModule()],
+      providers: [
+        ClassResolver,
+        { provide: ValueResolver, useValue: valueInstance },
+        {
+          provide: FactoryResolver,
+          useFactory: () => new FactoryResolver(),
+          resolverClass: FactoryResolver,
+        },
+      ],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    await app.listen();
+
+    await expect(postGraphql(port, '{ classHello }')).resolves.toEqual({
+      data: { classHello: 'from class' },
+    });
+
+    await expect(postGraphql(port, '{ valueHello }')).resolves.toEqual({
+      data: { valueHello: 'from value' },
+    });
+
+    await expect(postGraphql(port, '{ factoryHello }')).resolves.toEqual({
+      data: { factoryHello: 'from factory' },
+    });
+
+    await app.close();
+  });
 });


### PR DESCRIPTION
## Summary
- Add support for `useValue` and `useFactory` provider discovery in `@konekti/graphql` resolvers
- `useValue` providers: discovered via `instance.constructor` to find resolver decorators
- `useFactory` providers: require explicit `resolverClass` property for discovery (since factory return type cannot be determined at discovery time)
- Add optional `resolverClass` property to `FactoryProvider` type in `@konekti/di`
- Update README with documentation for alternative provider registration

## Changes
- `packages/graphql/src/discovery.ts`: Add type guards and discovery logic for `useValue`/`useFactory` providers
- `packages/di/src/types.ts`: Add optional `resolverClass` property to `FactoryProvider` interface
- `packages/graphql/README.md`: Document `useValue` and `useFactory` resolver discovery
- `packages/graphql/src/module.test.ts`: Add 3 tests covering new provider types

## Verification
- All 19 tests pass in `@konekti/graphql` package
- Build succeeds for all packages

Closes #266