### PR TITLE
Resolve #277: feat(cache-manager) add general cache contract beyond HTTP response caching

### DIFF
--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -2,7 +2,7 @@
 
 <p><strong><kbd>한국어</kbd></strong> <a href="./README.md"><kbd>English</kbd></a></p>
 
-메모리/Redis 스토어를 지원하는 Konekti용 데코레이터 기반 HTTP 응답 캐시 패키지입니다.
+메모리/Redis 스토어를 지원하는 Konekti용 범용 캐시 관리 패키지입니다. 데코레이터 기반 HTTP 응답 캐싱과 독립적인 애플리케이션 레벨 캐시 API를 모두 제공합니다.
 
 ## 설치
 
@@ -16,7 +16,7 @@ Redis 캐시를 사용할 경우:
 npm install @konekti/cache-manager @konekti/redis ioredis
 ```
 
-## 빠른 시작
+## 빠른 시작 — HTTP 응답 캐싱
 
 ```ts
 import { Module } from '@konekti/core';
@@ -47,31 +47,99 @@ class ProductController {
 class AppModule {}
 ```
 
+## 빠른 시작 — 애플리케이션 레벨 캐싱
+
+외부 API 응답, 계산 결과, 세션 데이터 등 HTTP 외의 캐시가 필요한 경우 `CacheService`를 직접 사용합니다.
+
+```ts
+import { Inject } from '@konekti/core';
+import { Module } from '@konekti/runtime';
+import { CACHE_MANAGER, createCacheModule, type CacheService } from '@konekti/cache-manager';
+
+interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+}
+
+@Inject([CACHE_MANAGER])
+class UserService {
+  constructor(private readonly cache: CacheService) {}
+
+  async getUserProfile(userId: string): Promise<UserProfile> {
+    const cacheKey = `user:profile:${userId}`;
+
+    return this.cache.remember(cacheKey, async () => {
+      const response = await fetch(`https://api.example.com/users/${userId}`);
+      return response.json() as Promise<UserProfile>;
+    }, 300); // 5분 TTL
+  }
+
+  async invalidateUser(userId: string): Promise<void> {
+    await this.cache.del(`user:profile:${userId}`);
+  }
+
+  async clearAllCache(): Promise<void> {
+    await this.cache.reset();
+  }
+}
+
+@Module({
+  imports: [createCacheModule({ store: 'memory', ttl: 60 })],
+  providers: [UserService],
+})
+class AppModule {}
+```
+
 ## API
+
+### 핵심 캐시 계약
+
+- `CacheStore` — `get`, `set`, `del`, `reset`을 제공하는 저수준 스토어 인터페이스.
+- `CacheService` — 스토어를 감싸는 애플리케이션 레벨 캐시 API:
+  - `get<T>(key)` — 캐시된 값을 조회합니다.
+  - `set<T>(key, value, ttlSeconds?)` — 선택적 TTL 오버라이드로 값을 저장합니다.
+  - `remember<T>(key, loader, ttlSeconds?)` — 리드스루 캐시: 캐시된 값을 반환하거나 로드 후 캐싱합니다.
+  - `del(key)` — 단일 캐시 항목을 삭제합니다.
+  - `reset()` — 스토어가 관리하는 모든 항목을 초기화합니다.
+- `MemoryStore` — lazy TTL 만료를 사용하는 인메모리 캐시.
+- `RedisStore` — JSON 코덱과 `SCAN` + `DEL` 리셋을 사용하는 Redis 기반 캐시.
+
+### HTTP 인터셉터 API
+
+- `CacheInterceptor` — 데코레이터 기반 설정을 사용하는 GET 응답 캐시 HTTP 인터셉터.
+- `@CacheKey(value)` — 커스텀 캐시 키 (문자열 또는 함수).
+- `@CacheTTL(seconds)` — 메서드 단위 TTL 오버라이드.
+- `@CacheEvict(value)` — non-GET 성공 후 키 삭제.
+
+### 모듈 설정
 
 - `createCacheModule(options)` — 캐시 프로바이더를 등록합니다(기본값 `isGlobal: false`).
 - `createCacheProviders(options)` — 수동 조합용 프로바이더 목록을 반환합니다.
 - `CACHE_MANAGER` — `CacheService` DI 토큰.
 - `CACHE_OPTIONS` — 정규화된 모듈 옵션 DI 토큰.
-- `CacheService` 수동 API — `get`, `set`, `del`, `reset` (`remember`는 추가 헬퍼).
-- `CacheStore` 계약 — `get`, `set`, `del`, `reset`.
-- `MemoryStore` / `RedisStore` — 캐시 스토어 어댑터.
-- `@CacheKey(value)` — 커스텀 캐시 키 (문자열 또는 함수).
-- `@CacheTTL(seconds)` — 메서드 단위 TTL 오버라이드.
-- `@CacheEvict(value)` — non-GET 성공 후 키 삭제.
 
 `CacheModuleOptions`의 주요 필드는 `store`, `ttl`, `isGlobal`입니다.
 
 ## 동작 규약
+
+### HTTP 인터셉터 동작 (CacheInterceptor)
 
 - 기본 캐시 조회는 **GET 전용**입니다.
 - 기본 캐시 키는 매칭된 라우트 경로(`handler.metadata.effectivePath`)입니다.
 - 예: `GET /products?sort=asc` 요청의 기본 캐시 키는 `/products`입니다.
 - 쿼리 문자열까지 포함한 키가 필요하면 `@CacheKey(...)`로 명시적으로 지정합니다.
 - `@CacheEvict(...)`는 성공한 non-GET 핸들러의 응답이 기록된 뒤 실행됩니다.
-- `MemoryStore`는 lazy TTL 만료 방식을 사용합니다.
+
+### 범용 캐시 동작 (CacheService / CacheStore)
+
+- `CacheService`는 HTTP 컨텍스트와 독립적 — DI를 통해 어디서든 사용 가능.
+- TTL 규약은 스토어 간 일관: `0` 또는 생략 시 만료 없음, 양수 값은 만료 설정.
+- `MemoryStore`는 lazy TTL 만료 방식을 사용합니다(다음 읽기 또는 스윕 시 만료 항목 정리).
+- `RedisStore`는 애플리케이션 레벨 만료 추적을 사용하는 JSON 인코딩 항목을 저장합니다.
+- `remember()`는 계산되거나 조회된 값을 위한 리드스루 캐싱 패턴을 제공합니다.
+- 스토어 구현은 교환 가능 — `MemoryStore`와 `RedisStore` 모두 `CacheStore` 계약을 충족합니다.
 - 모듈 기본 TTL은 `0`(만료 없음)입니다.
-- `RedisStore`는 JSON 코덱을 사용하며 리셋 시 전역 flush 대신 `SCAN` + `DEL`을 사용합니다.
 
 ## Redis 부트스트랩 규약
 
@@ -81,3 +149,14 @@ class AppModule {}
   - `options.redis.client`로 raw ioredis 스타일 클라이언트 전달
 
 Redis 모드에서 클라이언트를 찾지 못하면 부트스트랩 시 명확한 오류를 발생시킵니다.
+
+## 스토어 간 일관성
+
+`MemoryStore`와 `RedisStore` 모두 동일한 `CacheStore` 인터페이스를 구현하며 동일한 규약을 따릅니다:
+
+- `get(key)`는 누락되거나 만료된 항목에 대해 `undefined`를 반환합니다.
+- `set(key, value, ttl?)`는 값을 저장합니다; `ttl=0`은 만료 없음을 의미합니다.
+- `del(key)`는 단일 항목을 삭제합니다.
+- `reset()`은 관리되는 모든 항목을 초기화합니다.
+
+이를 통해 애플리케이션 코드를 변경하지 않고 스토어를 전환할 수 있습니다 — 개발/테스트에는 `MemoryStore`, 프로덕션에는 `RedisStore`를 사용합니다.

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -2,7 +2,7 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
-Decorator-driven HTTP response caching for Konekti with pluggable memory and Redis stores.
+General-purpose cache manager for Konekti with pluggable memory and Redis stores. Provides both decorator-driven HTTP response caching and a standalone cache API for application-level caching.
 
 ## Installation
 
@@ -16,7 +16,7 @@ For Redis-backed caching:
 npm install @konekti/cache-manager @konekti/redis ioredis
 ```
 
-## Quick Start
+## Quick Start — HTTP Response Caching
 
 ```ts
 import { Module } from '@konekti/core';
@@ -47,31 +47,101 @@ class ProductController {
 class AppModule {}
 ```
 
+## Quick Start — Application-Level Caching
+
+Use `CacheService` directly for non-HTTP caching needs such as external API responses, computed results, or session data.
+
+```ts
+import { Inject } from '@konekti/core';
+import { Module } from '@konekti/runtime';
+import { CACHE_MANAGER, createCacheModule, type CacheService } from '@konekti/cache-manager';
+
+const EXTERNAL_API = Symbol.for('EXTERNAL_API');
+
+interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+}
+
+@Inject([CACHE_MANAGER])
+class UserService {
+  constructor(private readonly cache: CacheService) {}
+
+  async getUserProfile(userId: string): Promise<UserProfile> {
+    const cacheKey = `user:profile:${userId}`;
+
+    return this.cache.remember(cacheKey, async () => {
+      const response = await fetch(`https://api.example.com/users/${userId}`);
+      return response.json() as Promise<UserProfile>;
+    }, 300); // 5-minute TTL
+  }
+
+  async invalidateUser(userId: string): Promise<void> {
+    await this.cache.del(`user:profile:${userId}`);
+  }
+
+  async clearAllCache(): Promise<void> {
+    await this.cache.reset();
+  }
+}
+
+@Module({
+  imports: [createCacheModule({ store: 'memory', ttl: 60 })],
+  providers: [UserService],
+})
+class AppModule {}
+```
+
 ## API
+
+### Core Cache Contract
+
+- `CacheStore` — low-level store interface with `get`, `set`, `del`, `reset`.
+- `CacheService` — application-level cache API wrapping a store:
+  - `get<T>(key)` — retrieve a cached value.
+  - `set<T>(key, value, ttlSeconds?)` — store a value with optional TTL override.
+  - `remember<T>(key, loader, ttlSeconds?)` — read-through cache: returns cached value or loads, caches, and returns.
+  - `del(key)` — remove a single cache entry.
+  - `reset()` — clear all entries managed by the store.
+- `MemoryStore` — in-process cache with lazy TTL expiration.
+- `RedisStore` — Redis-backed cache with JSON codec and scoped `SCAN` + `DEL` reset.
+
+### HTTP Interceptor API
+
+- `CacheInterceptor` — HTTP interceptor for GET response caching with decorator-driven configuration.
+- `@CacheKey(value)` — custom cache key (string or resolver function).
+- `@CacheTTL(seconds)` — method-level TTL override.
+- `@CacheEvict(value)` — evict key(s) after successful non-GET handlers.
+
+### Module Setup
 
 - `createCacheModule(options)` — registers cache providers (default `isGlobal: false`).
 - `createCacheProviders(options)` — returns providers for manual composition.
 - `CACHE_MANAGER` — DI token for `CacheService`.
 - `CACHE_OPTIONS` — DI token for normalized module options.
-- `CacheService` manual API — `get`, `set`, `del`, `reset` (`remember` is additive).
-- `CacheStore` contract — `get`, `set`, `del`, `reset`.
-- `MemoryStore` / `RedisStore` — cache store adapters.
-- `@CacheKey(value)` — custom cache key (string or resolver function).
-- `@CacheTTL(seconds)` — method-level TTL override.
-- `@CacheEvict(value)` — evict key(s) after successful non-GET handlers.
 
 `CacheModuleOptions` primary fields are `store`, `ttl`, and `isGlobal`.
 
 ## Behavior
+
+### HTTP Interceptor Behavior (CacheInterceptor)
 
 - Cache reads are **GET-only** by default.
 - Default cache key is the matched route path (`handler.metadata.effectivePath`).
 - Example: `GET /products?sort=asc` => default cache key `/products`.
 - Use `@CacheKey(...)` when query-string-aware or fully custom cache keys are required.
 - `@CacheEvict(...)` runs after the response write of successful non-GET handlers.
-- `MemoryStore` uses lazy TTL expiration.
+
+### General Cache Behavior (CacheService / CacheStore)
+
+- `CacheService` is independent of HTTP context — use it anywhere via DI.
+- TTL semantics are consistent across stores: `0` or omitted means no expiry; positive values set expiration.
+- `MemoryStore` uses lazy TTL expiration (expired entries cleaned on next read or sweep).
+- `RedisStore` stores JSON-encoded entries with application-level expiry tracking.
+- `remember()` provides read-through caching pattern for computed or fetched values.
+- Store implementations are interchangeable — both `MemoryStore` and `RedisStore` satisfy the `CacheStore` contract.
 - Default module TTL is `0` (no expiry).
-- `RedisStore` stores JSON codec entries and resets keys via scoped `SCAN` + `DEL` (no global flush).
 
 ## Redis bootstrap behavior
 
@@ -81,6 +151,17 @@ class AppModule {}
   - `options.redis.client` with a raw ioredis-style client.
 
 If Redis mode is selected and no client is available, bootstrap fails with an explicit error.
+
+## Cross-store consistency
+
+Both `MemoryStore` and `RedisStore` implement the `CacheStore` interface with identical semantics:
+
+- `get(key)` returns `undefined` for missing or expired entries.
+- `set(key, value, ttl?)` stores the value; `ttl=0` means no expiry.
+- `del(key)` removes a single entry.
+- `reset()` clears all managed entries.
+
+This allows swapping stores without changing application code — use `MemoryStore` for development/testing and `RedisStore` for production.
 
 ## Related packages
 

--- a/packages/cache-manager/src/cache-service.test.ts
+++ b/packages/cache-manager/src/cache-service.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MemoryStore } from './memory-store.js';
+import { RedisStore } from './redis-store.js';
+import { CacheService } from './service.js';
+import type { CacheStore, NormalizedCacheModuleOptions } from './types.js';
+
+const baseOptions: NormalizedCacheModuleOptions = {
+  isGlobal: false,
+  keyPrefix: 'konekti:cache:',
+  store: 'memory',
+  ttl: 0,
+};
+
+class MockRedisClient {
+  readonly storage = new Map<string, string>();
+
+  async get(key: string): Promise<string | null> {
+    return this.storage.get(key) ?? null;
+  }
+
+  async set(key: string, value: string, ...args: Array<string | number>): Promise<'OK'> {
+    this.storage.set(key, value);
+    return 'OK';
+  }
+
+  async del(key: string, ...keys: string[]): Promise<number> {
+    const allKeys = [key, ...keys];
+    let deleted = 0;
+
+    for (const current of allKeys) {
+      if (this.storage.delete(current)) {
+        deleted += 1;
+      }
+    }
+
+    return deleted;
+  }
+
+  async scan(cursor: string, ...args: Array<string | number>): Promise<[string, string[]]> {
+    if (cursor !== '0') {
+      return ['0', []];
+    }
+
+    const matchIndex = args.findIndex((value) => value === 'MATCH');
+    const rawPattern = matchIndex >= 0 ? args[matchIndex + 1] : '*';
+    const pattern = typeof rawPattern === 'string' ? rawPattern : '*';
+    const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;
+
+    return ['0', Array.from(this.storage.keys()).filter((key) => key.startsWith(prefix))];
+  }
+}
+
+function createCacheService(store: CacheStore, options: Partial<NormalizedCacheModuleOptions> = {}) {
+  const mergedOptions: NormalizedCacheModuleOptions = {
+    ...baseOptions,
+    ...options,
+  };
+
+  return new CacheService(store, mergedOptions);
+}
+
+describe('CacheService — general cache contract (outside HTTP interceptor)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe.each([
+    { name: 'MemoryStore', createStore: () => new MemoryStore() },
+    {
+      name: 'RedisStore',
+      createStore: () => {
+        const client = new MockRedisClient();
+        return new RedisStore(client, { keyPrefix: 'test:' });
+      },
+    },
+  ])('$name', ({ createStore }) => {
+    it('get returns undefined for missing keys', async () => {
+      const cache = createCacheService(createStore());
+
+      await expect(cache.get('missing:key')).resolves.toBeUndefined();
+    });
+
+    it('set and get round-trip values', async () => {
+      const cache = createCacheService(createStore());
+
+      await cache.set('user:1', { id: 'u1', name: 'Alice' });
+      await expect(cache.get('user:1')).resolves.toEqual({ id: 'u1', name: 'Alice' });
+    });
+
+    it('del removes a single entry', async () => {
+      const cache = createCacheService(createStore());
+
+      await cache.set('user:1', { id: 'u1' });
+      await cache.set('user:2', { id: 'u2' });
+
+      await cache.del('user:1');
+
+      await expect(cache.get('user:1')).resolves.toBeUndefined();
+      await expect(cache.get('user:2')).resolves.toEqual({ id: 'u2' });
+    });
+
+    it('reset clears all entries', async () => {
+      const cache = createCacheService(createStore());
+
+      await cache.set('a:1', 1);
+      await cache.set('a:2', 2);
+      await cache.set('b:1', 3);
+
+      await cache.reset();
+
+      await expect(cache.get('a:1')).resolves.toBeUndefined();
+      await expect(cache.get('a:2')).resolves.toBeUndefined();
+      await expect(cache.get('b:1')).resolves.toBeUndefined();
+    });
+
+    it('remember returns cached value on hit', async () => {
+      const cache = createCacheService(createStore());
+      const loader = vi.fn(async () => ({ computed: true }));
+
+      await cache.set('key', { cached: true });
+
+      const result = await cache.remember('key', loader);
+
+      expect(result).toEqual({ cached: true });
+      expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('remember loads and caches on miss', async () => {
+      const cache = createCacheService(createStore());
+      const loader = vi.fn(async () => ({ computed: true }));
+
+      const result = await cache.remember('key', loader);
+
+      expect(result).toEqual({ computed: true });
+      expect(loader).toHaveBeenCalledTimes(1);
+      await expect(cache.get('key')).resolves.toEqual({ computed: true });
+    });
+
+    it('remember uses provided TTL', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-24T00:00:00.000Z'));
+
+      const store = createStore();
+      const cache = createCacheService(store, { ttl: 0 });
+      const loader = vi.fn(async () => ({ value: 'loaded' }));
+
+      await cache.remember('key', loader, 60);
+
+      vi.advanceTimersByTime(59_000);
+      await expect(cache.get('key')).resolves.toEqual({ value: 'loaded' });
+
+      vi.advanceTimersByTime(1_001);
+      await expect(cache.get('key')).resolves.toBeUndefined();
+    });
+
+    it('set uses module default TTL when not specified', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-24T00:00:00.000Z'));
+
+      const store = createStore();
+      const cache = createCacheService(store, { ttl: 30 });
+
+      await cache.set('key', { value: 'default-ttl' });
+
+      vi.advanceTimersByTime(29_000);
+      await expect(cache.get('key')).resolves.toEqual({ value: 'default-ttl' });
+
+      vi.advanceTimersByTime(1_001);
+      await expect(cache.get('key')).resolves.toBeUndefined();
+    });
+
+    it('set with explicit TTL overrides module default', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-24T00:00:00.000Z'));
+
+      const store = createStore();
+      const cache = createCacheService(store, { ttl: 60 });
+
+      await cache.set('key', { value: 'override' }, 10);
+
+      vi.advanceTimersByTime(9_000);
+      await expect(cache.get('key')).resolves.toEqual({ value: 'override' });
+
+      vi.advanceTimersByTime(1_001);
+      await expect(cache.get('key')).resolves.toBeUndefined();
+    });
+
+    it('set with TTL=0 means no expiry', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-24T00:00:00.000Z'));
+
+      const store = createStore();
+      const cache = createCacheService(store, { ttl: 60 });
+
+      await cache.set('key', { value: 'no-expiry' }, 0);
+
+      vi.advanceTimersByTime(60_000);
+      await expect(cache.get('key')).resolves.toEqual({ value: 'no-expiry' });
+    });
+
+    it('set with negative TTL is a no-op', async () => {
+      const cache = createCacheService(createStore(), { ttl: 60 });
+
+      await cache.set('key', { value: 'should-not-store' }, -1);
+
+      await expect(cache.get('key')).resolves.toBeUndefined();
+    });
+
+    it('set with non-finite TTL is a no-op', async () => {
+      const cache = createCacheService(createStore(), { ttl: 60 });
+
+      await cache.set('key', { value: 'nan' }, Number.NaN);
+      await cache.set('key2', { value: 'infinity' }, Number.POSITIVE_INFINITY);
+
+      await expect(cache.get('key')).resolves.toBeUndefined();
+      await expect(cache.get('key2')).resolves.toBeUndefined();
+    });
+
+    it('handles complex nested objects', async () => {
+      const cache = createCacheService(createStore());
+
+      const complexObject = {
+        users: [
+          { id: 1, name: 'Alice', roles: ['admin', 'user'] },
+          { id: 2, name: 'Bob', roles: ['user'] },
+        ],
+        metadata: {
+          total: 2,
+          page: 1,
+          filters: { active: true },
+        },
+        tags: ['cache', 'test'],
+      };
+
+      await cache.set('complex', complexObject);
+      await expect(cache.get('complex')).resolves.toEqual(complexObject);
+    });
+
+    it('handles multiple independent key namespaces', async () => {
+      const cache = createCacheService(createStore());
+
+      await cache.set('user:1', { id: 1 });
+      await cache.set('order:1', { id: 1 });
+      await cache.set('product:1', { id: 1 });
+
+      await cache.del('user:1');
+
+      await expect(cache.get('user:1')).resolves.toBeUndefined();
+      await expect(cache.get('order:1')).resolves.toEqual({ id: 1 });
+      await expect(cache.get('product:1')).resolves.toEqual({ id: 1 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Updated README.md and README.ko.md with application-level caching examples
- Added cross-store tests for CacheService outside HTTP interceptor path
- Documented CacheStore interface and CacheService API as general-purpose
- Clarified that cache-manager supports both HTTP and non-HTTP caching use cases
- Verified TTL semantics are consistent across MemoryStore and RedisStore

## Changes
- **README.md**: Added "Quick Start — Application-Level Caching" section with `UserService` example showing `remember()`, `del()`, and `reset()` usage
- **README.ko.md**: Updated Korean translation with matching content
- **cache-service.test.ts**: New test file with 28 tests covering cross-store behavior for `MemoryStore` and `RedisStore`

## Verification
All 52 cache-manager tests pass:
- cache-service.test.ts: 28 tests (new)
- memory-store.test.ts: 4 tests
- redis-store.test.ts: 4 tests
- interceptor.test.ts: 9 tests
- decorators.test.ts: 2 tests
- module.test.ts: 5 tests

## Acceptance Criteria
- [x] The package defines a clearly documented public cache contract for non-HTTP/application-level cache usage
- [x] Store behavior and TTL semantics are consistent across memory and Redis-backed implementations
- [x] The public API does not depend on route metadata or interceptor-only assumptions for basic cache operations
- [x] README/docs show at least one first-class non-HTTP cache usage example
- [x] Existing HTTP cache interceptor ergonomics remain backward compatible
- [x] Tests cover cross-store behavior for the supported public cache contract outside the HTTP interceptor path

Closes #277