### PR TITLE
Resolve #286: fix refresh-token header handling and align auth docs

### DIFF
--- a/docs/concepts/auth-and-jwt.md
+++ b/docs/concepts/auth-and-jwt.md
@@ -58,11 +58,19 @@ The recommended authentication pattern is Bearer token authentication via the `A
 The following areas are currently treated as application-specific and are not standardized within the framework:
 
 - HttpOnly cookie authentication presets.
-- Refresh token lifecycles and rotation.
-- Logout and token revocation.
 - Identity provider account linking.
 
 These should be implemented at the application level based on project requirements.
+
+### framework-level refresh token lifecycle
+
+`@konekti/passport` provides framework-level primitives for refresh token operations via `RefreshTokenService`:
+
+- **Issue**: Create new refresh tokens for subjects.
+- **Rotate**: Exchange refresh tokens for new access + refresh tokens with replay detection.
+- **Revoke**: Invalidate specific tokens or all tokens for a subject (logout).
+
+The `RefreshTokenStrategy` extracts refresh tokens from request body (`refreshToken`), `Authorization: Bearer` header, or a custom `x-refresh-token` header. The framework handles header shape normalization (string or string array) internally.
 
 ## further reading
 

--- a/packages/passport/src/refresh-token.test.ts
+++ b/packages/passport/src/refresh-token.test.ts
@@ -17,7 +17,7 @@ function createMockRefreshTokenService(overrides: Partial<RefreshTokenService> =
   };
 }
 
-function createGuardContext(body?: Record<string, unknown>, headers?: Record<string, string>): GuardContext {
+function createGuardContext(body?: Record<string, unknown>, headers?: Record<string, string | string[]>): GuardContext {
   return {
     handler: {
       controllerToken: class {},
@@ -79,6 +79,32 @@ describe('RefreshTokenStrategy', () => {
         subject: 'user-1',
       });
       expect(service.rotateRefreshToken).toHaveBeenCalledWith('custom-token');
+    });
+
+    it('handles array authorization header by using first element', async () => {
+      const service = createMockRefreshTokenService();
+      const strategy = new RefreshTokenStrategy(service);
+      const context = createGuardContext(undefined, { authorization: ['Bearer array-token', 'Bearer second-token'] });
+
+      const result = await strategy.authenticate(context);
+
+      expect(result).toMatchObject({
+        subject: 'user-1',
+      });
+      expect(service.rotateRefreshToken).toHaveBeenCalledWith('array-token');
+    });
+
+    it('handles array x-refresh-token header by using first element', async () => {
+      const service = createMockRefreshTokenService();
+      const strategy = new RefreshTokenStrategy(service);
+      const context = createGuardContext(undefined, { 'x-refresh-token': ['custom-array-token'] });
+
+      const result = await strategy.authenticate(context);
+
+      expect(result).toMatchObject({
+        subject: 'user-1',
+      });
+      expect(service.rotateRefreshToken).toHaveBeenCalledWith('custom-array-token');
     });
 
     it('throws AuthenticationRequiredError when no token is provided', async () => {

--- a/packages/passport/src/refresh-token.ts
+++ b/packages/passport/src/refresh-token.ts
@@ -67,12 +67,14 @@ export class RefreshTokenStrategy implements AuthStrategy {
       return (request.body as { refreshToken: string }).refreshToken;
     }
 
-    const authHeader = request.headers?.authorization;
+    const authHeaderRaw = request.headers?.authorization;
+    const authHeader = Array.isArray(authHeaderRaw) ? authHeaderRaw[0] : authHeaderRaw;
     if (authHeader?.startsWith('Bearer ')) {
       return authHeader.slice(7);
     }
 
-    return request.headers?.['x-refresh-token'] as string | undefined;
+    const customHeader = request.headers?.['x-refresh-token'];
+    return Array.isArray(customHeader) ? customHeader[0] : customHeader;
   }
 
   private extractSubjectFromToken(accessToken: string): string {


### PR DESCRIPTION
## Summary

- Fix `RefreshTokenStrategy.extractRefreshToken` to handle `string | string[]` header shapes safely
- Update `docs/concepts/auth-and-jwt.md` to align with actual framework behavior for refresh token lifecycle

## Changes

### Implementation fix
The `extractRefreshToken` method in `packages/passport/src/refresh-token.ts` assumed authorization headers were always strings, but framework request headers can be `string | string[]`. This fix normalizes both `authorization` and `x-refresh-token` headers by using `Array.isArray()` and taking the first element when an array is received.

### Documentation alignment
Updated `docs/concepts/auth-and-jwt.md` to reflect that refresh token lifecycle (issue, rotate, revoke) is now framework-level via `@konekti/passport`, not application-specific as previously documented.

### Tests added
- Test for array `authorization` header handling
- Test for array `x-refresh-token` header handling

## Verification

- [x] All 14 tests pass in `packages/passport/src/refresh-token.test.ts`
- [x] Typecheck passes for modified files

Closes #286