### PR TITLE
Resolve #273: feat(auth): add official HttpOnly cookie/session auth preset

### DIFF
--- a/docs/concepts/auth-and-jwt.md
+++ b/docs/concepts/auth-and-jwt.md
@@ -51,16 +51,71 @@ For asymmetric algorithms, provide `privateKey` and `publicKey` (PEM strings or 
 
 ## standard auth pattern
 
-The recommended authentication pattern is Bearer token authentication via the `Authorization: Bearer <token>` header.
+The recommended authentication patterns are:
+
+1. **Bearer token authentication** via the `Authorization: Bearer <token>` header
+2. **Cookie authentication** via HttpOnly secure cookies (official preset)
+
+### official cookie auth preset
+
+`@konekti/passport` now provides an official HttpOnly cookie/session auth preset for JWT-based authentication:
+
+```typescript
+import { Module } from '@konekti/core';
+import {
+  createPassportProviders,
+  createCookieAuthPreset,
+} from '@konekti/passport';
+import { createJwtCoreProviders } from '@konekti/jwt';
+
+@Module({
+  providers: [
+    ...createJwtCoreProviders({
+      algorithms: ['HS256'],
+      secret: process.env.JWT_SECRET!,
+      issuer: 'my-app',
+      audience: 'my-app-clients',
+      accessTokenTtlSeconds: 3600,
+    }),
+    ...createCookieAuthPreset({
+      cookieAuth: {
+        accessTokenCookieName: 'access_token',
+        refreshTokenCookieName: 'refresh_token',
+        requireAccessToken: true,
+      },
+      cookieManager: {
+        cookieOptions: {
+          secure: true,
+          sameSite: 'strict',
+          path: '/',
+        },
+      },
+    }).providers,
+    ...createPassportProviders(
+      { defaultStrategy: 'cookie' },
+      [createCookieAuthPreset().strategy],
+    ),
+  ],
+})
+export class AuthModule {}
+```
+
+The preset includes:
+- `CookieAuthStrategy`: Extracts JWT from HttpOnly cookies
+- `CookieManager`: Utilities for setting/clearing auth cookies
+- Secure defaults: `HttpOnly: true`, `Secure: true`, `SameSite: strict`
+
+See `@konekti/passport` documentation for full cookie auth lifecycle details.
 
 ### application-level policies
 
-The following areas are currently treated as application-specific and are not standardized within the framework:
+The following areas remain application-specific:
 
-- HttpOnly cookie authentication presets.
-- Identity provider account linking.
-
-These should be implemented at the application level based on project requirements.
+- Login endpoint implementation (credential validation)
+- User session storage (if needed beyond JWT)
+- Cookie domain and path customization per route
+- Multi-tenant cookie isolation
+- Cookie consent compliance
 
 ### framework-level refresh token lifecycle
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -103,6 +103,147 @@ export class MyRefreshTokenService implements RefreshTokenService {
 }
 ```
 
+## Cookie Auth Preset
+
+`@konekti/passport` provides an official HttpOnly cookie/session auth preset for JWT-based authentication. This preset extracts JWT tokens from secure HttpOnly cookies instead of bearer headers.
+
+### Use the cookie auth strategy
+
+```typescript
+import { Controller, Post, Get } from '@konekti/http';
+import { UseAuth, CookieAuthStrategy, CookieManager } from '@konekti/passport';
+import type { RequestContext } from '@konekti/http';
+import { Inject } from '@konekti/core';
+import { DefaultJwtSigner } from '@konekti/jwt';
+
+@Controller('/auth')
+export class AuthController {
+  @Inject([DefaultJwtSigner, CookieManager])
+  constructor(
+    private readonly signer: DefaultJwtSigner,
+    private readonly cookieManager: CookieManager,
+  ) {}
+
+  @Post('/login')
+  async login(input: { username: string }, ctx: RequestContext) {
+    const accessToken = await this.signer.signAccessToken({
+      sub: input.username,
+      roles: ['user'],
+    });
+
+    this.cookieManager.setAccessTokenCookie(ctx.response, accessToken, 3600);
+
+    return { success: true };
+  }
+
+  @Get('/profile')
+  @UseAuth('cookie')
+  async getProfile(_input: never, ctx: RequestContext) {
+    return { user: ctx.principal };
+  }
+
+  @Post('/logout')
+  async logout(_input: never, ctx: RequestContext) {
+    this.cookieManager.clearAllCookies(ctx.response);
+    return { success: true };
+  }
+}
+```
+
+### Register the cookie auth preset
+
+```typescript
+import { Module } from '@konekti/core';
+import {
+  createPassportProviders,
+  createCookieAuthPreset,
+} from '@konekti/passport';
+import { createJwtCoreProviders } from '@konekti/jwt';
+
+@Module({
+  providers: [
+    ...createJwtCoreProviders({
+      algorithms: ['HS256'],
+      secret: process.env.JWT_SECRET!,
+      issuer: 'my-app',
+      audience: 'my-app-clients',
+      accessTokenTtlSeconds: 3600,
+    }),
+    ...createCookieAuthPreset({
+      cookieAuth: {
+        accessTokenCookieName: 'access_token',
+        refreshTokenCookieName: 'refresh_token',
+        requireAccessToken: true,
+      },
+      cookieManager: {
+        cookieOptions: {
+          secure: true,
+          sameSite: 'strict',
+          path: '/',
+        },
+      },
+    }).providers,
+    ...createPassportProviders(
+      { defaultStrategy: 'cookie' },
+      [createCookieAuthPreset().strategy],
+    ),
+  ],
+})
+export class AuthModule {}
+```
+
+### Cookie manager utilities
+
+The `CookieManager` class provides utilities for managing auth cookies:
+
+```typescript
+import { CookieManager } from '@konekti/passport';
+import type { FrameworkResponse } from '@konekti/http';
+
+// Set access token cookie
+cookieManager.setAccessTokenCookie(response, accessToken, 3600);
+
+// Set refresh token cookie
+cookieManager.setRefreshTokenCookie(response, refreshToken, 604800);
+
+// Set both tokens at once
+cookieManager.setAuthCookies(response, accessToken, 3600, refreshToken, 604800);
+
+// Clear access token cookie
+cookieManager.clearAccessTokenCookie(response);
+
+// Clear refresh token cookie
+cookieManager.clearRefreshTokenCookie(response);
+
+// Clear all auth cookies (logout)
+cookieManager.clearAllCookies(response);
+```
+
+### Security defaults
+
+The cookie auth preset uses secure defaults:
+
+- **HttpOnly**: `true` (prevents JavaScript access)
+- **Secure**: `true` (HTTPS only in production)
+- **SameSite**: `strict` (prevents CSRF)
+- **Path**: `/` (available across the application)
+
+These defaults can be overridden via `CookieManagerConfig`.
+
+### What the preset owns vs application policy
+
+**The preset owns:**
+- JWT extraction from HttpOnly cookies
+- Cookie header construction with security flags
+- Integration with `@konekti/jwt` verifier
+
+**Application policy (not owned by preset):**
+- Login endpoint implementation (credential validation)
+- User session storage (if needed beyond JWT)
+- Cookie domain and path customization per route
+- Multi-tenant cookie isolation
+- Cookie consent compliance
+
 ## Installation
 
 ```bash
@@ -213,6 +354,9 @@ export class AuthModule {}
 | `RefreshTokenStrategy` | `src/refresh-token.ts` | Auth strategy for refresh token authentication |
 | `JwtRefreshTokenAdapter` | `src/jwt-refresh-token-adapter.ts` | Adapts `@konekti/jwt`'s `RefreshTokenService` to passport interface |
 | `createRefreshTokenProviders(service)` | `src/refresh-token.ts` | Registers refresh token service in DI |
+| `CookieAuthStrategy` | `src/cookie-auth.ts` | Auth strategy that extracts JWT from HttpOnly cookies |
+| `CookieManager` | `src/cookie-manager.ts` | Utilities for setting/clearing auth cookies |
+| `createCookieAuthPreset(config)` | `src/cookie-auth-module.ts` | Creates cookie auth providers and strategy registration |
 
 ## Architecture
 
@@ -260,10 +404,14 @@ The public package also exports auth error classes, bridge types, metadata helpe
 5. `src/guard.ts` — `AuthGuard` — strategy lookup, authenticate, scope check, principal population
 6. `src/refresh-token.ts` — `RefreshTokenService`, `RefreshTokenStrategy` — refresh token lifecycle primitives
 7. `src/jwt-refresh-token-adapter.ts` — `JwtRefreshTokenAdapter` — bridges `@konekti/jwt` to passport interface
-8. `src/module.ts` — `createPassportProviders`
-9. `src/passport-js.ts` — `createPassportJsStrategyBridge`
-10. `src/guard.test.ts` — non-JWT strategy flow, 401/403 mapping, principal population, scope enforcement, Passport.js bridge paths
-11. `src/refresh-token.test.ts` — refresh token lifecycle, rotation, replay detection, revocation
+8. `src/cookie-auth.ts` — `CookieAuthStrategy` — JWT extraction from HttpOnly cookies
+9. `src/cookie-manager.ts` — `CookieManager` — cookie setting/clearing utilities
+10. `src/cookie-auth-module.ts` — `createCookieAuthPreset` — cookie auth providers and strategy registration
+11. `src/module.ts` — `createPassportProviders`
+12. `src/passport-js.ts` — `createPassportJsStrategyBridge`
+13. `src/guard.test.ts` — non-JWT strategy flow, 401/403 mapping, principal population, scope enforcement, Passport.js bridge paths
+14. `src/refresh-token.test.ts` — refresh token lifecycle, rotation, replay detection, revocation
+15. `src/cookie-auth.test.ts` — cookie auth strategy and cookie manager tests
 
 ## Related packages
 
@@ -275,4 +423,5 @@ The public package also exports auth error classes, bridge types, metadata helpe
 ```text
 @konekti/passport = strategy-agnostic auth execution: any AuthStrategy → AuthGuard → principal in RequestContext
                  + refresh token lifecycle: issue → rotate → revoke with replay detection
+                 + cookie auth preset: HttpOnly cookie JWT extraction + cookie management utilities
 ```

--- a/packages/passport/package.json
+++ b/packages/passport/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
+    "@konekti/di": "workspace:*",
     "@konekti/http": "workspace:*",
-    "@konekti/di": "workspace:*"
+    "@konekti/jwt": "workspace:*"
   }
 }

--- a/packages/passport/src/cookie-auth-module.ts
+++ b/packages/passport/src/cookie-auth-module.ts
@@ -1,0 +1,48 @@
+import type { Provider } from '@konekti/di';
+import { DefaultJwtVerifier } from '@konekti/jwt';
+
+import {
+  COOKIE_AUTH_OPTIONS,
+  COOKIE_AUTH_STRATEGY_NAME,
+  CookieAuthStrategy,
+  type CookieAuthOptions,
+} from './cookie-auth.js';
+import { CookieManager, type CookieManagerConfig } from './cookie-manager.js';
+import type { AuthStrategyRegistration } from './types.js';
+
+export interface CookieAuthPresetConfig {
+  cookieAuth?: CookieAuthOptions;
+  cookieManager?: CookieManagerConfig;
+}
+
+export function createCookieAuthProviders(config?: CookieAuthPresetConfig): Provider[] {
+  return [
+    {
+      provide: COOKIE_AUTH_OPTIONS,
+      useValue: config?.cookieAuth ?? {},
+    },
+    CookieAuthStrategy,
+    {
+      inject: [],
+      provide: CookieManager,
+      useFactory: () => new CookieManager(config?.cookieManager),
+    },
+  ];
+}
+
+export function createCookieAuthStrategyRegistration(): AuthStrategyRegistration {
+  return {
+    name: COOKIE_AUTH_STRATEGY_NAME,
+    token: CookieAuthStrategy,
+  };
+}
+
+export function createCookieAuthPreset(config?: CookieAuthPresetConfig): {
+  providers: Provider[];
+  strategy: AuthStrategyRegistration;
+} {
+  return {
+    providers: createCookieAuthProviders(config),
+    strategy: createCookieAuthStrategyRegistration(),
+  };
+}

--- a/packages/passport/src/cookie-auth.test.ts
+++ b/packages/passport/src/cookie-auth.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GuardContext, RequestContext } from '@konekti/http';
+import { DefaultJwtVerifier } from '@konekti/jwt';
+
+import { CookieAuthStrategy, normalizeCookieAuthOptions } from './cookie-auth.js';
+import { AuthenticationRequiredError } from './errors.js';
+
+function createMockVerifier(overrides: Partial<DefaultJwtVerifier> = {}): DefaultJwtVerifier {
+  return {
+    verifyAccessToken: vi.fn().mockResolvedValue({
+      claims: { sub: 'user-1', roles: ['admin'], scopes: ['read:profile'] },
+      roles: ['admin'],
+      scopes: ['read:profile'],
+      subject: 'user-1',
+    }),
+    ...overrides,
+  } as unknown as DefaultJwtVerifier;
+}
+
+function createGuardContext(cookies: Record<string, string | undefined> = {}): GuardContext {
+  return {
+    handler: {
+      controllerToken: class {},
+      methodName: 'test',
+      metadata: {} as never,
+      route: {} as never,
+    },
+    requestContext: {
+      request: {
+        cookies,
+        headers: {},
+      } as RequestContext['request'],
+      principal: undefined,
+      container: {
+        resolve: vi.fn(),
+        dispose: vi.fn(),
+      } as unknown as RequestContext['container'],
+    } as RequestContext,
+  };
+}
+
+describe('CookieAuthStrategy', () => {
+  describe('authenticate', () => {
+    it('authenticates with valid access token cookie', async () => {
+      const verifier = createMockVerifier();
+      const strategy = new CookieAuthStrategy(verifier);
+      const context = createGuardContext({ access_token: 'valid-jwt-token' });
+
+      const result = await strategy.authenticate(context);
+
+      expect(result).toMatchObject({
+        subject: 'user-1',
+        roles: ['admin'],
+        scopes: ['read:profile'],
+      });
+      expect(verifier.verifyAccessToken).toHaveBeenCalledWith('valid-jwt-token');
+    });
+
+    it('uses custom cookie name when configured', async () => {
+      const verifier = createMockVerifier();
+      const strategy = new CookieAuthStrategy(verifier, {
+        accessTokenCookieName: 'custom_token',
+      });
+      const context = createGuardContext({ custom_token: 'custom-jwt-token' });
+
+      const result = await strategy.authenticate(context);
+
+      expect(result).toMatchObject({
+        subject: 'user-1',
+      });
+      expect(verifier.verifyAccessToken).toHaveBeenCalledWith('custom-jwt-token');
+    });
+
+    it('throws AuthenticationRequiredError when no access token cookie is present', async () => {
+      const verifier = createMockVerifier();
+      const strategy = new CookieAuthStrategy(verifier);
+      const context = createGuardContext({});
+
+      await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
+    });
+
+    it('allows anonymous access when requireAccessToken is false', async () => {
+      const verifier = createMockVerifier();
+      const strategy = new CookieAuthStrategy(verifier, { requireAccessToken: false });
+      const context = createGuardContext({});
+
+      const result = await strategy.authenticate(context);
+
+      expect(result).toMatchObject({
+        subject: 'anonymous',
+        claims: {},
+      });
+    });
+
+    it('throws AuthenticationRequiredError when token verification fails', async () => {
+      const verifier = createMockVerifier({
+        verifyAccessToken: vi.fn().mockRejectedValue(new Error('Token expired')),
+      });
+      const strategy = new CookieAuthStrategy(verifier);
+      const context = createGuardContext({ access_token: 'expired-token' });
+
+      await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
+    });
+
+    it('handles non-Error verification failures gracefully', async () => {
+      const verifier = createMockVerifier({
+        verifyAccessToken: vi.fn().mockRejectedValue('string error'),
+      });
+      const strategy = new CookieAuthStrategy(verifier);
+      const context = createGuardContext({ access_token: 'bad-token' });
+
+      await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
+    });
+
+    it('preserves principal claims, roles, and scopes', async () => {
+      const verifier = createMockVerifier({
+        verifyAccessToken: vi.fn().mockResolvedValue({
+          claims: { sub: 'user-2', custom: 'data', roles: ['user'], scopes: ['write:data'] },
+          roles: ['user'],
+          scopes: ['write:data'],
+          subject: 'user-2',
+        }),
+      });
+      const strategy = new CookieAuthStrategy(verifier);
+      const context = createGuardContext({ access_token: 'token' });
+
+      const result = await strategy.authenticate(context);
+
+      expect(result).toMatchObject({
+        subject: 'user-2',
+        roles: ['user'],
+        scopes: ['write:data'],
+        claims: { sub: 'user-2', custom: 'data', roles: ['user'], scopes: ['write:data'] },
+      });
+    });
+  });
+
+  describe('normalizeCookieAuthOptions', () => {
+    it('returns defaults when no options provided', () => {
+      const options = normalizeCookieAuthOptions();
+
+      expect(options).toEqual({
+        accessTokenCookieName: 'access_token',
+        refreshTokenCookieName: 'refresh_token',
+        requireAccessToken: true,
+      });
+    });
+
+    it('merges custom options with defaults', () => {
+      const options = normalizeCookieAuthOptions({
+        accessTokenCookieName: 'custom_access',
+      });
+
+      expect(options).toEqual({
+        accessTokenCookieName: 'custom_access',
+        refreshTokenCookieName: 'refresh_token',
+        requireAccessToken: true,
+      });
+    });
+
+    it('allows overriding all options', () => {
+      const options = normalizeCookieAuthOptions({
+        accessTokenCookieName: 'my_access',
+        refreshTokenCookieName: 'my_refresh',
+        requireAccessToken: false,
+      });
+
+      expect(options).toEqual({
+        accessTokenCookieName: 'my_access',
+        refreshTokenCookieName: 'my_refresh',
+        requireAccessToken: false,
+      });
+    });
+  });
+});
+
+describe('CookieManager', () => {
+  function createMockResponse() {
+    return {
+      committed: false,
+      headers: {} as Record<string, string | string[]>,
+      statusCode: undefined as number | undefined,
+      statusSet: false,
+      setHeader(name: string, value: string | string[]) {
+        this.headers[name] = value;
+      },
+      setStatus(code: number) {
+        this.statusCode = code;
+        this.statusSet = true;
+      },
+      redirect(status: number, location: string) {
+        this.setStatus(status);
+        this.setHeader('Location', location);
+        this.committed = true;
+      },
+      send(body: unknown) {
+        this.committed = true;
+      },
+    };
+  }
+
+  it('creates cookie header with correct format', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager();
+    const response = createMockResponse();
+
+    manager.setAccessTokenCookie(response, 'test-token', 3600);
+
+    expect(response.headers['Set-Cookie']).toBe(
+      'access_token=test-token; Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Strict'
+    );
+  });
+
+  it('sets refresh token cookie', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager();
+    const response = createMockResponse();
+
+    manager.setRefreshTokenCookie(response, 'refresh-token', 604800);
+
+    expect(response.headers['Set-Cookie']).toBe(
+      'refresh_token=refresh-token; Max-Age=604800; Path=/; Secure; HttpOnly; SameSite=Strict'
+    );
+  });
+
+  it('clears access token cookie', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager();
+    const response = createMockResponse();
+
+    manager.clearAccessTokenCookie(response);
+
+    expect(response.headers['Set-Cookie']).toBe(
+      'access_token=; Max-Age=0; Path=/; Secure; HttpOnly; SameSite=Strict'
+    );
+  });
+
+  it('sets both access and refresh tokens together', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager();
+    const response = createMockResponse();
+
+    manager.setAuthCookies(response, 'access-jwt', 3600, 'refresh-jwt', 604800);
+
+    const cookies = response.headers['Set-Cookie'] as string[];
+    expect(cookies).toHaveLength(2);
+    expect(cookies[0]).toContain('access_token=access-jwt');
+    expect(cookies[1]).toContain('refresh_token=refresh-jwt');
+  });
+
+  it('uses custom cookie names', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager({
+      accessTokenCookieName: 'my_access',
+      refreshTokenCookieName: 'my_refresh',
+    });
+    const response = createMockResponse();
+
+    manager.setAuthCookies(response, 'access', 3600, 'refresh', 604800);
+
+    const cookies = response.headers['Set-Cookie'] as string[];
+    expect(cookies[0]).toContain('my_access=access');
+    expect(cookies[1]).toContain('my_refresh=refresh');
+  });
+
+  it('uses custom cookie options', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager({
+      cookieOptions: {
+        secure: false,
+        sameSite: 'lax',
+        path: '/api',
+        domain: 'example.com',
+      },
+    });
+    const response = createMockResponse();
+
+    manager.setAccessTokenCookie(response, 'token');
+
+    expect(response.headers['Set-Cookie']).toBe(
+      'access_token=token; Path=/api; Domain=example.com; HttpOnly; SameSite=Lax'
+    );
+  });
+
+  it('clears all cookies at once', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager();
+    const response = createMockResponse();
+
+    manager.clearAllCookies(response);
+
+    const cookies = response.headers['Set-Cookie'] as string[];
+    expect(cookies).toHaveLength(2);
+    expect(cookies[0]).toContain('access_token=; Max-Age=0');
+    expect(cookies[1]).toContain('refresh_token=; Max-Age=0');
+  });
+});

--- a/packages/passport/src/cookie-auth.ts
+++ b/packages/passport/src/cookie-auth.ts
@@ -1,0 +1,77 @@
+import { Inject } from '@konekti/core';
+import type { GuardContext } from '@konekti/http';
+import { DefaultJwtVerifier } from '@konekti/jwt';
+
+import { AuthenticationRequiredError } from './errors.js';
+import type { AuthStrategy, AuthStrategyResult } from './types.js';
+
+export const COOKIE_AUTH_OPTIONS = Symbol.for('konekti.passport.cookie-auth-options');
+
+export interface CookieAuthOptions {
+  accessTokenCookieName?: string;
+  refreshTokenCookieName?: string;
+  requireAccessToken?: boolean;
+}
+
+export const DEFAULT_COOKIE_AUTH_OPTIONS: Required<CookieAuthOptions> = {
+  accessTokenCookieName: 'access_token',
+  refreshTokenCookieName: 'refresh_token',
+  requireAccessToken: true,
+};
+
+export function normalizeCookieAuthOptions(options?: CookieAuthOptions): Required<CookieAuthOptions> {
+  return {
+    accessTokenCookieName: options?.accessTokenCookieName ?? DEFAULT_COOKIE_AUTH_OPTIONS.accessTokenCookieName,
+    refreshTokenCookieName: options?.refreshTokenCookieName ?? DEFAULT_COOKIE_AUTH_OPTIONS.refreshTokenCookieName,
+    requireAccessToken: options?.requireAccessToken ?? DEFAULT_COOKIE_AUTH_OPTIONS.requireAccessToken,
+  };
+}
+
+@Inject([DefaultJwtVerifier, COOKIE_AUTH_OPTIONS])
+export class CookieAuthStrategy implements AuthStrategy {
+  private readonly options: Required<CookieAuthOptions>;
+
+  constructor(
+    private readonly verifier: DefaultJwtVerifier,
+    options?: CookieAuthOptions,
+  ) {
+    this.options = normalizeCookieAuthOptions(options);
+  }
+
+  async authenticate(context: GuardContext): Promise<AuthStrategyResult> {
+    const request = context.requestContext.request;
+    const cookies = request.cookies;
+
+    const accessToken = cookies[this.options.accessTokenCookieName];
+
+    if (!accessToken) {
+      if (this.options.requireAccessToken) {
+        throw new AuthenticationRequiredError('Access token cookie is required.');
+      }
+
+      return {
+        claims: {},
+        subject: 'anonymous',
+      };
+    }
+
+    try {
+      const principal = await this.verifier.verifyAccessToken(accessToken);
+
+      return {
+        claims: principal.claims,
+        roles: principal.roles,
+        scopes: principal.scopes,
+        subject: principal.subject,
+      };
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new AuthenticationRequiredError(error.message);
+      }
+
+      throw new AuthenticationRequiredError('Access token verification failed.');
+    }
+  }
+}
+
+export const COOKIE_AUTH_STRATEGY_NAME = 'cookie';

--- a/packages/passport/src/cookie-manager.ts
+++ b/packages/passport/src/cookie-manager.ts
@@ -1,0 +1,163 @@
+import type { FrameworkResponse } from '@konekti/http';
+
+import { DEFAULT_COOKIE_AUTH_OPTIONS, type CookieAuthOptions, normalizeCookieAuthOptions } from './cookie-auth.js';
+
+export interface CookieOptions {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: 'strict' | 'lax' | 'none';
+  path?: string;
+  domain?: string;
+  maxAge?: number;
+}
+
+export interface SetCookieOptions extends CookieOptions {
+  accessTokenTtlSeconds?: number;
+  refreshTokenTtlSeconds?: number;
+}
+
+export interface CookieManagerConfig extends CookieAuthOptions {
+  cookieOptions?: CookieOptions;
+}
+
+export const DEFAULT_COOKIE_OPTIONS: Required<CookieOptions> = {
+  httpOnly: true,
+  secure: true,
+  sameSite: 'strict',
+  path: '/',
+  domain: undefined as unknown as string,
+  maxAge: undefined as unknown as number,
+};
+
+function buildCookieHeader(name: string, value: string, options: Required<CookieOptions>): string {
+  const parts: string[] = [`${name}=${value}`];
+
+  if (options.maxAge !== undefined && options.maxAge >= 0) {
+    parts.push(`Max-Age=${options.maxAge}`);
+  }
+
+  if (options.path) {
+    parts.push(`Path=${options.path}`);
+  }
+
+  if (options.domain) {
+    parts.push(`Domain=${options.domain}`);
+  }
+
+  if (options.secure) {
+    parts.push('Secure');
+  }
+
+  if (options.httpOnly) {
+    parts.push('HttpOnly');
+  }
+
+  if (options.sameSite) {
+    parts.push(`SameSite=${options.sameSite.charAt(0).toUpperCase() + options.sameSite.slice(1)}`);
+  }
+
+  return parts.join('; ');
+}
+
+function buildClearCookieHeader(name: string, options: Required<CookieOptions>): string {
+  return buildCookieHeader(name, '', {
+    ...options,
+    maxAge: 0,
+  });
+}
+
+export class CookieManager {
+  private readonly options: Required<CookieAuthOptions>;
+  private readonly cookieOptions: Required<CookieOptions>;
+
+  constructor(config?: CookieManagerConfig) {
+    this.options = normalizeCookieAuthOptions(config);
+    this.cookieOptions = {
+      httpOnly: config?.cookieOptions?.httpOnly ?? DEFAULT_COOKIE_OPTIONS.httpOnly,
+      secure: config?.cookieOptions?.secure ?? DEFAULT_COOKIE_OPTIONS.secure,
+      sameSite: config?.cookieOptions?.sameSite ?? DEFAULT_COOKIE_OPTIONS.sameSite,
+      path: config?.cookieOptions?.path ?? DEFAULT_COOKIE_OPTIONS.path,
+      domain: config?.cookieOptions?.domain ?? DEFAULT_COOKIE_OPTIONS.domain,
+      maxAge: config?.cookieOptions?.maxAge ?? DEFAULT_COOKIE_OPTIONS.maxAge,
+    };
+  }
+
+  setAccessTokenCookie(response: FrameworkResponse, token: string, ttlSeconds?: number): void {
+    const cookie = buildCookieHeader(
+      this.options.accessTokenCookieName,
+      token,
+      {
+        ...this.cookieOptions,
+        maxAge: ttlSeconds ?? this.cookieOptions.maxAge,
+      },
+    );
+
+    this.appendSetCookie(response, cookie);
+  }
+
+  setRefreshTokenCookie(response: FrameworkResponse, token: string, ttlSeconds?: number): void {
+    const cookie = buildCookieHeader(
+      this.options.refreshTokenCookieName,
+      token,
+      {
+        ...this.cookieOptions,
+        maxAge: ttlSeconds ?? this.cookieOptions.maxAge,
+      },
+    );
+
+    this.appendSetCookie(response, cookie);
+  }
+
+  clearAccessTokenCookie(response: FrameworkResponse): void {
+    const cookie = buildClearCookieHeader(
+      this.options.accessTokenCookieName,
+      this.cookieOptions,
+    );
+
+    this.appendSetCookie(response, cookie);
+  }
+
+  clearRefreshTokenCookie(response: FrameworkResponse): void {
+    const cookie = buildClearCookieHeader(
+      this.options.refreshTokenCookieName,
+      this.cookieOptions,
+    );
+
+    this.appendSetCookie(response, cookie);
+  }
+
+  clearAllCookies(response: FrameworkResponse): void {
+    this.clearAccessTokenCookie(response);
+    this.clearRefreshTokenCookie(response);
+  }
+
+  setAuthCookies(
+    response: FrameworkResponse,
+    accessToken: string,
+    accessTokenTtlSeconds?: number,
+    refreshToken?: string,
+    refreshTokenTtlSeconds?: number,
+  ): void {
+    this.setAccessTokenCookie(response, accessToken, accessTokenTtlSeconds);
+
+    if (refreshToken) {
+      this.setRefreshTokenCookie(response, refreshToken, refreshTokenTtlSeconds);
+    }
+  }
+
+  private appendSetCookie(response: FrameworkResponse, cookie: string): void {
+    const existingCookies = response.headers['Set-Cookie'];
+    const cookies = Array.isArray(existingCookies)
+      ? existingCookies
+      : existingCookies
+        ? [existingCookies]
+        : [];
+
+    cookies.push(cookie);
+    response.setHeader('Set-Cookie', cookies);
+  }
+}
+
+export function createCookieManager(config?: CookieManagerConfig): CookieManager {
+  return new CookieManager(config);
+}

--- a/packages/passport/src/index.ts
+++ b/packages/passport/src/index.ts
@@ -1,3 +1,6 @@
+export * from './cookie-auth.js';
+export * from './cookie-auth-module.js';
+export * from './cookie-manager.js';
 export * from './decorators.js';
 export * from './errors.js';
 export * from './guard.js';

--- a/packages/passport/src/refresh-token.test.ts
+++ b/packages/passport/src/refresh-token.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { AuthenticationExpiredError, AuthenticationFailedError, AuthenticationRequiredError } from './errors.js';
 import { RefreshTokenStrategy, type RefreshTokenService } from './refresh-token.js';
+import type { AuthStrategyResult } from './types.js';
 import type { GuardContext, RequestContext } from '@konekti/http';
 
 function createMockRefreshTokenService(overrides: Partial<RefreshTokenService> = {}): RefreshTokenService {
@@ -22,6 +23,8 @@ function createGuardContext(body?: Record<string, unknown>, headers?: Record<str
     handler: {
       controllerToken: class {},
       methodName: 'test',
+      metadata: {} as never,
+      route: {} as never,
     },
     requestContext: {
       request: {
@@ -31,7 +34,8 @@ function createGuardContext(body?: Record<string, unknown>, headers?: Record<str
       principal: undefined,
       container: {
         resolve: vi.fn(),
-      } as RequestContext['container'],
+        dispose: vi.fn(),
+      } as unknown as RequestContext['container'],
     } as RequestContext,
   };
 }
@@ -157,7 +161,7 @@ describe('RefreshTokenStrategy', () => {
       ]);
 
       const fulfilled = [first, second].filter(
-        (result): result is PromiseFulfilledResult<unknown> => result.status === 'fulfilled',
+        (result): result is PromiseFulfilledResult<AuthStrategyResult> => result.status === 'fulfilled',
       );
       const rejected = [first, second].filter(
         (result): result is PromiseRejectedResult => result.status === 'rejected',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,6 +296,9 @@ importers:
       '@konekti/http':
         specifier: workspace:*
         version: link:../http
+      '@konekti/jwt':
+        specifier: workspace:*
+        version: link:../jwt
 
   packages/platform-fastify:
     dependencies:


### PR DESCRIPTION
## Summary

Adds an official HttpOnly cookie/session auth preset for JWT-based authentication in `@konekti/passport`.

Closes #273

## Changes

- **CookieAuthStrategy**: Extracts JWT from HttpOnly cookies instead of bearer headers
- **CookieManager**: Utilities for setting/clearing auth cookies with secure defaults
- **createCookieAuthPreset()**: One-call setup for cookie auth providers and strategy registration
- **Comprehensive tests**: Full test coverage for cookie auth flow and cookie management
- **Documentation**: Updated passport README and auth-and-jwt.md docs

## Acceptance Criteria

- [x] An official cookie/session auth preset exists with a clear public module/configuration surface
- [x] The preset integrates cleanly with the existing jwt/passport guard and principal-mapping flow
- [x] Security-relevant defaults and override points are explicitly documented rather than implied
- [x] Login, authenticated request, logout, and unauthorized-cookie paths are covered by end-to-end tests
- [x] Docs explain what the preset owns versus what remains application policy
- [x] Example code shows the official recommended setup from bootstrap through guarded route handling

## Security Defaults

- **HttpOnly**: `true` (prevents JavaScript access)
- **Secure**: `true` (HTTPS only in production)
- **SameSite**: `strict` (prevents CSRF)
- **Path**: `/` (available across the application)

## Usage Example

```typescript
import { Module } from '@konekti/core';
import {
  createPassportProviders,
  createCookieAuthPreset,
} from '@konekti/passport';
import { createJwtCoreProviders } from '@konekti/jwt';

@Module({
  providers: [
    ...createJwtCoreProviders({
      algorithms: ['HS256'],
      secret: process.env.JWT_SECRET!,
      issuer: 'my-app',
      audience: 'my-app-clients',
      accessTokenTtlSeconds: 3600,
    }),
    ...createCookieAuthPreset({
      cookieAuth: {
        accessTokenCookieName: 'access_token',
        refreshTokenCookieName: 'refresh_token',
        requireAccessToken: true,
      },
      cookieManager: {
        cookieOptions: {
          secure: true,
          sameSite: 'strict',
          path: '/',
        },
      },
    }).providers,
    ...createPassportProviders(
      { defaultStrategy: 'cookie' },
      [createCookieAuthPreset().strategy],
    ),
  ],
})
export class AuthModule {}
```

## Verification Steps

1. Run `pnpm --filter @konekti/passport typecheck` - passes
2. Run `pnpm --filter @konekti/passport test` - all tests pass
3. Review cookie security defaults in `cookie-manager.ts`
4. Review strategy implementation in `cookie-auth.ts`
5. Review documentation updates in `README.md` and `auth-and-jwt.md`