### PR TITLE
Resolve #269: add request/reply parity for Redis Pub/Sub transport

### DIFF
--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -42,7 +42,7 @@ await microservice.listen();
 - `@MessagePattern(pattern)` - 요청/응답 핸들러를 등록합니다.
 - `@EventPattern(pattern)` - 이벤트 핸들러를 등록합니다.
 - `TcpMicroserviceTransport` - TCP 트랜스포트 어댑터입니다.
-- `RedisPubSubMicroserviceTransport` - Redis pub/sub 이벤트 트랜스포트 어댑터입니다.
+- `RedisPubSubMicroserviceTransport` - Redis pub/sub 트랜스포트 어댑터입니다 (요청/응답 + 이벤트).
 - `NatsMicroserviceTransport` - NATS 트랜스포트 어댑터입니다 (요청/응답 + 이벤트).
 - `KafkaMicroserviceTransport` - Kafka 트랜스포트 어댑터입니다 (이벤트, 인바운드 메시지 디스패치).
 - `RabbitMqMicroserviceTransport` - RabbitMQ 트랜스포트 어댑터입니다 (이벤트, 인바운드 메시지 디스패치).
@@ -91,19 +91,19 @@ class PaymentsHandler {
 ## 트랜스포트 참고 사항
 
 - `TcpMicroserviceTransport`는 `send()` (요청/응답)와 `emit()` (이벤트)를 모두 지원합니다.
-- `RedisPubSubMicroserviceTransport`는 `emit()` 팬아웃(fan-out)만 지원합니다. 요청/응답 `send()` 시맨틱이 필요한 경우 TCP 트랜스포트를 사용하세요.
+- `RedisPubSubMicroserviceTransport`는 Redis의 요청/응답 채널, 응답 채널, 이벤트 채널을 분리해 `send()`(요청/응답)와 `emit()`(이벤트)를 모두 지원합니다.
 - `NatsMicroserviceTransport`는 NATS 요청/응답 및 pub/sub 주제를 통해 `send()`와 `emit()`을 모두 지원합니다.
-- `KafkaMicroserviceTransport`와 `RabbitMqMicroserviceTransport`는 이벤트 전용 트랜스포트입니다. `emit()`과 인바운드 이벤트 디스패치를 지원합니다. 요청/응답 `send()`가 필요한 경우 TCP 또는 NATS 트랜스포트를 사용하세요.
+- `KafkaMicroserviceTransport`와 `RabbitMqMicroserviceTransport`는 이벤트 전용 트랜스포트입니다. `emit()`과 인바운드 이벤트 디스패치를 지원합니다. 요청/응답 `send()`가 필요한 경우 TCP, NATS 또는 Redis 트랜스포트를 사용하세요.
 
 ### Kafka
 
-- `KafkaMicroserviceTransport`는 현재 어댑터 계약에서 이벤트 전용입니다. `send()`는 항상 reject되므로 요청/응답 흐름은 TCP 또는 NATS를 사용해야 합니다.
+- `KafkaMicroserviceTransport`는 현재 어댑터 계약에서 이벤트 전용입니다. `send()`는 항상 reject되므로 요청/응답 흐름은 TCP, NATS 또는 Redis를 사용해야 합니다.
 - 인바운드 핸들러 실패는 트랜스포트 경계에서 격리되며 `emit()` 호출자에게 다시 전파되지 않습니다.
 - 순서 보장, 오프셋 커밋 정책, 컨슈머 그룹 복구, 브로커별 재연결 의미론은 현재 Konekti가 보장하지 않습니다. 별도 가이드가 나오기 전까지는 브로커/클라이언트 책임으로 취급하세요.
 
 ### RabbitMQ
 
-- `RabbitMqMicroserviceTransport`는 현재 어댑터 계약에서 이벤트 전용입니다. `send()`는 항상 reject되므로 요청/응답 흐름은 TCP 또는 NATS를 사용해야 합니다.
+- `RabbitMqMicroserviceTransport`는 현재 어댑터 계약에서 이벤트 전용입니다. `send()`는 항상 reject되므로 요청/응답 흐름은 TCP, NATS 또는 Redis를 사용해야 합니다.
 - 인바운드 핸들러 실패는 트랜스포트 경계에서 격리되며 `emit()` 호출자에게 다시 전파되지 않습니다.
 - ack/nack, 재큐잉(requeue), dead-letter, 채널 복구 정책은 현재 이 어댑터가 구성하지 않습니다. 별도 가이드가 나오기 전까지는 브로커/클라이언트 책임으로 취급하세요.
 
@@ -112,6 +112,17 @@ class PaymentsHandler {
 - `NatsMicroserviceTransport`는 별도의 요청/응답 subject와 이벤트 subject를 사용해 `send()`와 `emit()`을 모두 지원합니다.
 - `send()`는 `requestTimeoutMs`를 적용하며, 트랜스포트가 에러 메시지로 직렬화해 되돌릴 수 있는 핸들러 실패만 호출자에게 전파합니다.
 - 재연결, 버퍼링, responder 가용성은 여전히 클라이언트/서버 책임입니다. 운영상 요청/응답 보장이 중요하다면 선택한 NATS 클라이언트/runtime 조합에서 별도로 검증해야 합니다.
+
+### Redis
+
+- `RedisPubSubMicroserviceTransport`는 요청, 응답, 이벤트를 각각 다른 Redis 채널로 분리해 `send()`와 `emit()`을 모두 지원합니다.
+- `send()`는 고유한 `requestId`를 포함해 요청 채널로 publish하고, 응답 채널에서 같은 `requestId`를 가진 응답을 기다립니다.
+- 핸들러 실패는 에러 메시지로 직렬화되어 호출자 측 `send()`에서 reject됩니다.
+- `send()`는 `requestTimeoutMs`(기본값 3 000ms)를 적용하며, 타임아웃 또는 트랜스포트 종료 시 대기 중인 요청 Promise를 reject합니다.
+- `AbortSignal`을 지원합니다. 이미 abort된 시그널은 즉시 reject되고, 진행 중 abort는 해당 요청을 중단합니다.
+- `close()` 시점에는 대기 중인 요청 Promise를 모두 reject하고 구독을 정리합니다.
+- Redis Pub/Sub 요청/응답은 durable queue가 아닌 best-effort 전달 모델입니다. 타임아웃은 전송 계층 실패로 간주하고, 필요하면 idempotent 핸들러와 함께 재시도 전략을 적용하세요.
+- 트러블슈팅: Redis 타임아웃이 반복되면 패턴 responder 부재, 인스턴스 간 namespace 불일치, 응답 채널 구독 누락을 우선 확인하세요.
 
 ## 하이브리드 모드
 

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -162,6 +162,8 @@ In this example, `AuditHandler` and `NotificationHandler` receive the same `Even
 - `send()` applies `requestTimeoutMs` (default 3 000 ms) and rejects pending promises if the timeout expires or the transport closes.
 - `AbortSignal` is supported: passing an already-aborted signal rejects immediately; passing a signal that fires later aborts the in-flight request.
 - On `close()`, all pending request promises are rejected and subscriptions are removed cleanly.
+- Redis request/reply over Pub/Sub is best-effort (not durable queue semantics). Treat timeouts as transport-level failures and pair retries with idempotent handlers when needed.
+- Troubleshooting: repeated Redis timeouts usually mean no active responder for the pattern, namespace mismatch across instances, or missing response-channel subscriptions.
 
 ## Hybrid mode
 


### PR DESCRIPTION
## Summary
- Finalize Redis request/reply documentation for both English and Korean package READMEs.
- Document request correlation behavior, timeout/abort/close semantics, and best-effort delivery limits for Redis Pub/Sub request/reply mode.
- Add explicit troubleshooting guidance for common Redis timeout scenarios (missing responder, namespace mismatch, response subscription issues).

## Verification
- `npx vitest run packages/microservices/src/redis-transport.test.ts` (9/9 passing)
- `npx vitest run packages/microservices/src/` (transport tests pass; existing workspace module-resolution test failure is unrelated)

Closes #269