### PR TITLE
Resolve #271: feat(microservices): add RabbitMQ request/reply parity

### DIFF
--- a/docs/reference/support-matrix.ko.md
+++ b/docs/reference/support-matrix.ko.md
@@ -26,7 +26,7 @@
 | Node.js | official | 첫 번째 공식 런타임 |
 | Fastify 어댑터 | preview | host/HTTPS/CORS/multipart/rawBody에 대해 Node 런타임 옵션 동등성을 갖춘 `@konekti/platform-fastify` 어댑터이며, `getServer()`가 노출하는 공용 Node `upgrade` 리스너 경로를 통해 WebSocket 게이트웨이도 검증됨 |
 | Socket.IO 어댑터 | preview | `@konekti/platform-socket.io`는 `@konekti/websocket` 게이트웨이 데코레이터와 메타데이터를 재사용하면서 공용 Node HTTP 서버 위에 Socket.IO v4 네임스페이스/room 바인딩을 추가함 |
-| 마이크로서비스 트랜스포트 | preview | TCP, Redis Pub/Sub, Kafka, NATS, RabbitMQ 트랜스포트 어댑터 및 `KonektiFactory.createMicroservice()`를 포함한 `@konekti/microservices`; 승격은 트랜스포트별로 평가되며 transport-specific 문서, 테스트, CI, 예제 커버리지, 트러블슈팅 가이드가 모두 필요함 |
+| 마이크로서비스 트랜스포트 | preview | TCP, Redis Pub/Sub, Kafka, NATS, RabbitMQ 트랜스포트 어댑터 및 `KonektiFactory.createMicroservice()`를 포함한 `@konekti/microservices`; RabbitMQ는 이제 요청/응답 `send()` 기능 동등성(`requestId` 상관관계, 응답 큐 라우팅, 타임아웃/에러 전파)을 출하했고 Kafka는 여전히 이벤트 중심 모델이며, 승격은 트랜스포트별로 평가되어 transport-specific 문서, 테스트, CI, 예제 커버리지, 트러블슈팅 가이드가 모두 필요함 |
 | Bun | preview | 코어 계약이 이 런타임으로 승격 가능하도록 유지되어야 함 |
 | Fetch 스타일 어댑터 | preview | 더 좁은 보장 범위를 가진 어댑터가 존재할 수 있음 |
 | Deno | experimental | 향후 후보 |

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -28,7 +28,7 @@ This file is the compact reference table for current support policy.
 | Socket.IO adapter | preview | `@konekti/platform-socket.io` adds Socket.IO v4 namespace and room wiring on the shared Node HTTP server while reusing `@konekti/websocket` gateway decorators and metadata |
 | GraphQL subscriptions (SSE) | official | available at `/graphql` through GraphQL Yoga server-sent events |
 | GraphQL subscriptions (`graphql-ws`) | preview | opt-in via `createGraphqlModule({ subscriptions: { websocket: { enabled: true } } })` on the shared Node HTTP adapter |
-| Microservices transport | preview | `@konekti/microservices` with TCP, Redis Pub/Sub, Kafka, NATS, and RabbitMQ transport adapters plus `KonektiFactory.createMicroservice()`; promotion is evaluated per transport and requires transport-specific docs, tests, CI, example coverage, and troubleshooting guidance |
+| Microservices transport | preview | `@konekti/microservices` with TCP, Redis Pub/Sub, Kafka, NATS, and RabbitMQ transport adapters plus `KonektiFactory.createMicroservice()`; RabbitMQ now ships request/reply `send()` parity (`requestId` correlation, reply queue routing, timeout/error propagation), while Kafka remains event-first; promotion is evaluated per transport and requires transport-specific docs, tests, CI, example coverage, and troubleshooting guidance |
 | Bun | preview | core contracts should remain promotable to this runtime |
 | Fetch-style adapter | preview | adapter may exist with narrower guarantees |
 | Deno | experimental | later candidate only |

--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -45,7 +45,7 @@ await microservice.listen();
 - `RedisPubSubMicroserviceTransport` - Redis pub/sub 트랜스포트 어댑터입니다 (요청/응답 + 이벤트).
 - `NatsMicroserviceTransport` - NATS 트랜스포트 어댑터입니다 (요청/응답 + 이벤트).
 - `KafkaMicroserviceTransport` - Kafka 트랜스포트 어댑터입니다 (이벤트, 인바운드 메시지 디스패치).
-- `RabbitMqMicroserviceTransport` - RabbitMQ 트랜스포트 어댑터입니다 (이벤트, 인바운드 메시지 디스패치).
+- `RabbitMqMicroserviceTransport` - RabbitMQ 트랜스포트 어댑터입니다 (요청/응답 + 이벤트).
 
 ## 런타임 동작
 
@@ -93,19 +93,25 @@ class PaymentsHandler {
 - `TcpMicroserviceTransport`는 `send()` (요청/응답)와 `emit()` (이벤트)를 모두 지원합니다.
 - `RedisPubSubMicroserviceTransport`는 Redis의 요청/응답 채널, 응답 채널, 이벤트 채널을 분리해 `send()`(요청/응답)와 `emit()`(이벤트)를 모두 지원합니다.
 - `NatsMicroserviceTransport`는 NATS 요청/응답 및 pub/sub 주제를 통해 `send()`와 `emit()`을 모두 지원합니다.
-- `KafkaMicroserviceTransport`와 `RabbitMqMicroserviceTransport`는 이벤트 전용 트랜스포트입니다. `emit()`과 인바운드 이벤트 디스패치를 지원합니다. 요청/응답 `send()`가 필요한 경우 TCP, NATS 또는 Redis 트랜스포트를 사용하세요.
+- `KafkaMicroserviceTransport`는 이벤트 전용 트랜스포트입니다. `emit()`과 인바운드 이벤트 디스패치를 지원합니다.
+- `RabbitMqMicroserviceTransport`는 요청/응답 상관관계(request/reply correlation)와 전용 요청/응답 큐를 사용해 `send()`와 `emit()`을 모두 지원합니다.
 
 ### Kafka
 
-- `KafkaMicroserviceTransport`는 현재 어댑터 계약에서 이벤트 전용입니다. `send()`는 항상 reject되므로 요청/응답 흐름은 TCP, NATS 또는 Redis를 사용해야 합니다.
+- `KafkaMicroserviceTransport`는 현재 어댑터 계약에서 이벤트 전용입니다. `send()`는 항상 reject되므로 요청/응답 흐름은 TCP, NATS, Redis 또는 RabbitMQ를 사용해야 합니다.
 - 인바운드 핸들러 실패는 트랜스포트 경계에서 격리되며 `emit()` 호출자에게 다시 전파되지 않습니다.
 - 순서 보장, 오프셋 커밋 정책, 컨슈머 그룹 복구, 브로커별 재연결 의미론은 현재 Konekti가 보장하지 않습니다. 별도 가이드가 나오기 전까지는 브로커/클라이언트 책임으로 취급하세요.
 
 ### RabbitMQ
 
-- `RabbitMqMicroserviceTransport`는 현재 어댑터 계약에서 이벤트 전용입니다. `send()`는 항상 reject되므로 요청/응답 흐름은 TCP, NATS 또는 Redis를 사용해야 합니다.
-- 인바운드 핸들러 실패는 트랜스포트 경계에서 격리되며 `emit()` 호출자에게 다시 전파되지 않습니다.
-- ack/nack, 재큐잉(requeue), dead-letter, 채널 복구 정책은 현재 이 어댑터가 구성하지 않습니다. 별도 가이드가 나오기 전까지는 브로커/클라이언트 책임으로 취급하세요.
+- `RabbitMqMicroserviceTransport`는 전용 이벤트(`eventQueue`), 요청(`messageQueue`), 응답(`responseQueue`) 큐를 사용해 `send()`와 `emit()`을 모두 지원합니다.
+- `send()`는 `{ kind: 'message', pattern, payload, requestId, replyTo }`를 `messageQueue`에 publish하고, `responseQueue`에서 `{ kind: 'response', requestId, payload | error }`를 기다립니다.
+- 상관관계는 `requestId` 기준으로 처리되며, 요청이 종료된 뒤 도착한 알 수 없는/지연/중복 응답은 무시됩니다.
+- `send()`는 `requestTimeoutMs`(기본 3 000ms)를 적용합니다. 타임아웃, abort, 트랜스포트 종료 시 대기 중인 요청 Promise는 결정적으로 reject됩니다.
+- 핸들러 실패는 응답 `error` 문자열로 직렬화되어 호출자 쪽 `send()`에서 reject됩니다.
+- 생명주기 동작: startup 시 이벤트/요청/응답 큐를 구독하고, reconnect는 `close()` 이후 `listen()`을 다시 호출해 지원하며, shutdown 시 큐 소비를 해제하고 진행 중 요청을 모두 reject합니다.
+- ack/nack, 재큐잉(requeue), dead-letter, 브로커 관리 채널 복구는 별도 가이드가 나오기 전까지 브로커/클라이언트 책임입니다.
+- 트러블슈팅: RabbitMQ 요청 타임아웃이 반복되면 `messageQueue` responder 부재, 서비스 간 `responseQueue` 이름 불일치, 브로커 재연결 이후 consumer 재구독 누락을 우선 확인하세요.
 
 ### NATS
 

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -45,7 +45,7 @@ await microservice.listen();
 - `RedisPubSubMicroserviceTransport` - Redis pub/sub event transport adapter
 - `NatsMicroserviceTransport` - NATS transport adapter (request/reply + event)
 - `KafkaMicroserviceTransport` - Kafka transport adapter (event, inbound message dispatch)
-- `RabbitMqMicroserviceTransport` - RabbitMQ transport adapter (event, inbound message dispatch)
+- `RabbitMqMicroserviceTransport` - RabbitMQ transport adapter (request/reply + event)
 
 ## Runtime behavior
 
@@ -134,19 +134,25 @@ In this example, `AuditHandler` and `NotificationHandler` receive the same `Even
 - `TcpMicroserviceTransport` supports both `send()` (request/reply) and `emit()` (event).
 - `RedisPubSubMicroserviceTransport` supports both `send()` (request/reply) and `emit()` (event) via separate request, response, and event channels with correlation-based reply routing.
 - `NatsMicroserviceTransport` supports both `send()` and `emit()` via NATS request/reply and pub/sub subjects.
-- `KafkaMicroserviceTransport` and `RabbitMqMicroserviceTransport` are event-only transports: they support `emit()` plus inbound event dispatch. For request/reply `send()`, use TCP, NATS, or Redis transport.
+- `KafkaMicroserviceTransport` is event-only: it supports `emit()` plus inbound event dispatch.
+- `RabbitMqMicroserviceTransport` supports both `send()` and `emit()` using request/reply correlation with dedicated message and response queues.
 
 ### Kafka
 
-- `KafkaMicroserviceTransport` is event-only in the current adapter contract. `send()` always rejects, so request/reply flows should use TCP, NATS, or Redis instead.
+- `KafkaMicroserviceTransport` is event-only in the current adapter contract. `send()` always rejects, so request/reply flows should use TCP, NATS, Redis, or RabbitMQ instead.
 - Inbound handler failures are isolated at the transport boundary and do not round-trip back to the caller of `emit()`.
 - Ordering, offset commit policy, consumer group recovery, and broker-specific reconnect semantics are not guaranteed by Konekti itself; treat them as broker/client concerns unless a future guide says otherwise.
 
 ### RabbitMQ
 
-- `RabbitMqMicroserviceTransport` is event-only in the current adapter contract. `send()` always rejects, so request/reply flows should use TCP, NATS, or Redis instead.
-- Inbound handler failures are isolated at the transport boundary and do not round-trip back to the caller of `emit()`.
-- Ack/nack, requeue, dead-letter, and channel recovery policies are not configured by this adapter today. Treat them as broker/client concerns unless a future guide says otherwise.
+- `RabbitMqMicroserviceTransport` supports both `send()` and `emit()` using dedicated event (`eventQueue`), request (`messageQueue`), and response (`responseQueue`) queues.
+- `send()` publishes `{ kind: 'message', pattern, payload, requestId, replyTo }` to `messageQueue` and waits for `{ kind: 'response', requestId, payload | error }` on `responseQueue`.
+- Correlation is `requestId`-based. Unknown, late, or duplicate responses are ignored once a request is settled.
+- `send()` applies `requestTimeoutMs` (default 3 000 ms). On timeout, abort, or transport close, pending request promises reject deterministically.
+- Handler failures are serialized back as response `error` strings and rejected at the caller side.
+- Lifecycle behavior: startup subscribes event/request/response queues; reconnect is supported by calling `listen()` again after `close()`; shutdown cancels queue consumers and rejects in-flight pending requests.
+- Ack/nack, requeue, dead-letter, and broker-managed channel recovery remain broker/client concerns unless a future guide says otherwise.
+- Troubleshooting: repeated RabbitMQ request timeouts usually mean no active responder on `messageQueue`, mismatched `responseQueue` names across services, or missing consumer resubscription after broker reconnect.
 
 ### NATS
 

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -200,7 +200,7 @@ describe('@konekti/microservices', () => {
     await microservice.listen();
 
     await expect(microservice.send('calc.double', { value: 21 })).rejects.toThrow(
-      'does not support request/reply send()',
+      'No message handler registered for pattern "calc.double".',
     );
     await microservice.emit('audit.login', { message: 'ok' });
 

--- a/packages/microservices/src/rabbitmq-transport.test.ts
+++ b/packages/microservices/src/rabbitmq-transport.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { RabbitMqMicroserviceTransport } from './rabbitmq-transport.js';
 
-class InMemoryTopicBus {
+class InMemoryQueueBus {
   private readonly listeners = new Map<string, Set<(message: string) => Promise<void> | void>>();
 
-  async publish(topic: string, message: string): Promise<void> {
-    const handlers = this.listeners.get(topic);
+  async publish(queue: string, message: string): Promise<void> {
+    const handlers = this.listeners.get(queue);
 
     if (!handlers) {
       return;
@@ -17,21 +17,21 @@ class InMemoryTopicBus {
     }
   }
 
-  async subscribe(topic: string, handler: (message: string) => Promise<void> | void): Promise<void> {
-    const handlers = this.listeners.get(topic) ?? new Set<(message: string) => Promise<void> | void>();
+  async subscribe(queue: string, handler: (message: string) => Promise<void> | void): Promise<void> {
+    const handlers = this.listeners.get(queue) ?? new Set<(message: string) => Promise<void> | void>();
     handlers.add(handler);
-    this.listeners.set(topic, handlers);
+    this.listeners.set(queue, handlers);
   }
 
-  async unsubscribe(topic: string): Promise<void> {
-    this.listeners.delete(topic);
+  async unsubscribe(queue: string): Promise<void> {
+    this.listeners.delete(queue);
   }
 }
 
 describe('RabbitMqMicroserviceTransport', () => {
-  it('supports event emit and rejects send()', async () => {
-    const bus = new InMemoryTopicBus();
-    const received: string[] = [];
+  it('supports request/reply send() and event dispatch', async () => {
+    const bus = new InMemoryQueueBus();
+    const events: string[] = [];
     const transport = new RabbitMqMicroserviceTransport({
       consumer: {
         async cancel(queue) {
@@ -50,22 +50,23 @@ describe('RabbitMqMicroserviceTransport', () => {
 
     await transport.listen(async (packet) => {
       if (packet.kind === 'event') {
-        received.push((packet.payload as { message: string }).message);
+        events.push((packet.payload as { value: string }).value);
+        return undefined;
       }
-      return undefined;
+
+      const input = packet.payload as { a: number; b: number };
+      return input.a + input.b;
     });
 
-    await transport.emit('audit.logout', { message: 'bye' });
-    expect(received).toEqual(['bye']);
-    await expect(transport.send('math.sum', { a: 3, b: 3 })).rejects.toThrow(
-      'does not support request/reply send()',
-    );
+    await expect(transport.send('math.sum', { a: 2, b: 5 })).resolves.toBe(7);
+    await transport.emit('audit.event', { value: 'ok' });
+    expect(events).toEqual(['ok']);
 
     await transport.close();
   });
 
-  it('captures async callback rejections without leaking them to emit()', async () => {
-    const bus = new InMemoryTopicBus();
+  it('round-trips handler failures to send() caller', async () => {
+    const bus = new InMemoryQueueBus();
     const transport = new RabbitMqMicroserviceTransport({
       consumer: {
         async cancel(queue) {
@@ -82,11 +83,263 @@ describe('RabbitMqMicroserviceTransport', () => {
       },
     });
 
-    await transport.listen(async () => {
-      throw new Error('rabbit handler failed');
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'message') {
+        throw new Error('rabbit handler failed');
+      }
+
+      return undefined;
     });
 
-    await expect(transport.emit('audit.logout', { message: 'bye' })).resolves.toBeUndefined();
+    await expect(transport.send('math.sum', { a: 1, b: 2 })).rejects.toThrow('rabbit handler failed');
+
+    await transport.close();
+  });
+
+  it('rejects pending requests on timeout', async () => {
+    const bus = new InMemoryQueueBus();
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+      requestTimeoutMs: 50,
+    });
+
+    await transport.listen(async () => {
+      await new Promise<void>(() => {});
+    });
+
+    await expect(transport.send('slow.pattern', {})).rejects.toThrow(
+      /RabbitMQ request timed out after 50ms waiting for pattern "slow.pattern"/,
+    );
+
+    await transport.close();
+  });
+
+  it('supports concurrent request/reply flows with deterministic correlation', async () => {
+    const bus = new InMemoryQueueBus();
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+      requestTimeoutMs: 1_000,
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind !== 'message') {
+        return undefined;
+      }
+
+      const input = packet.payload as { delayMs: number; value: number };
+      await new Promise((resolve) => setTimeout(resolve, input.delayMs));
+      return input.value;
+    });
+
+    const first = transport.send('math.delayed', { delayMs: 40, value: 1 });
+    const second = transport.send('math.delayed', { delayMs: 5, value: 2 });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([1, 2]);
+
+    await transport.close();
+  });
+
+  it('ignores late replies after timeout and keeps later requests healthy', async () => {
+    const bus = new InMemoryQueueBus();
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+      requestTimeoutMs: 20,
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind !== 'message') {
+        return undefined;
+      }
+
+      if (packet.pattern === 'slow.once') {
+        await new Promise((resolve) => setTimeout(resolve, 80));
+        return 'late';
+      }
+
+      return 'fast';
+    });
+
+    await expect(transport.send('slow.once', {})).rejects.toThrow(
+      /RabbitMQ request timed out after 20ms waiting for pattern "slow.once"/,
+    );
+    await expect(transport.send('fast.next', {})).resolves.toBe('fast');
+
+    await transport.close();
+  });
+
+  it('rejects all pending requests on shutdown', async () => {
+    const bus = new InMemoryQueueBus();
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+      requestTimeoutMs: 5_000,
+    });
+
+    await transport.listen(async () => {
+      await new Promise<void>(() => {});
+    });
+
+    const first = transport.send('never.one', {});
+    const second = transport.send('never.two', {});
+
+    await transport.close();
+
+    await expect(first).rejects.toThrow('RabbitMQ microservice transport closed before response.');
+    await expect(second).rejects.toThrow('RabbitMQ microservice transport closed before response.');
+  });
+
+  it('documents startup/reconnect/shutdown queue lifecycle behavior', async () => {
+    const bus = new InMemoryQueueBus();
+    const consumedQueues: string[] = [];
+    const cancelledQueues: string[] = [];
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          cancelledQueues.push(queue);
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          consumedQueues.push(queue);
+          await bus.subscribe(queue, handler);
+        },
+      },
+      eventQueue: 'test.events',
+      messageQueue: 'test.messages',
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+      responseQueue: 'test.responses',
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'message') {
+        return 'pong';
+      }
+
+      return undefined;
+    });
+
+    expect(consumedQueues.sort()).toEqual(['test.events', 'test.messages', 'test.responses']);
+    await expect(transport.send('health.ping', {})).resolves.toBe('pong');
+
+    await transport.close();
+
+    expect(cancelledQueues.sort()).toEqual(['test.events', 'test.messages', 'test.responses']);
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'message') {
+        return 'reconnected';
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.send('health.ping', {})).resolves.toBe('reconnected');
+    await transport.close();
+
+    expect(consumedQueues).toHaveLength(6);
+    expect(cancelledQueues).toHaveLength(6);
+  });
+
+  it('rejects send() before listen()', async () => {
+    const bus = new InMemoryQueueBus();
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+    });
+
+    await expect(transport.send('math.sum', { a: 1, b: 2 })).rejects.toThrow(
+      'RabbitMqMicroserviceTransport is not listening. Call listen() before send().',
+    );
+  });
+
+  it('captures async event-handler failures without leaking them to emit()', async () => {
+    const bus = new InMemoryQueueBus();
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'event') {
+        throw new Error('rabbit event handler failed');
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.emit('audit.logout', { value: 'bye' })).resolves.toBeUndefined();
 
     await transport.close();
   });

--- a/packages/microservices/src/rabbitmq-transport.ts
+++ b/packages/microservices/src/rabbitmq-transport.ts
@@ -10,9 +10,12 @@ interface RabbitMqPublisherLike {
 }
 
 interface RabbitMqTransportMessage {
-  readonly kind: 'event' | 'message';
+  readonly error?: string;
+  readonly kind: 'event' | 'message' | 'response';
   readonly pattern: string;
-  readonly payload: unknown;
+  readonly payload?: unknown;
+  readonly replyTo?: string;
+  readonly requestId?: string;
 }
 
 export interface RabbitMqMicroserviceTransportOptions {
@@ -20,6 +23,8 @@ export interface RabbitMqMicroserviceTransportOptions {
   eventQueue?: string;
   messageQueue?: string;
   publisher: RabbitMqPublisherLike;
+  requestTimeoutMs?: number;
+  responseQueue?: string;
 }
 
 export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
@@ -27,9 +32,21 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
   private listening = false;
   private listenPromise: Promise<void> | undefined;
   private readonly eventQueue: string;
+  private readonly messageQueue: string;
+  private readonly pending = new Map<string, {
+    reject: (error: unknown) => void;
+    resolve: (value: unknown) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }>();
+  private readonly requestTimeoutMs: number;
+  private readonly responseQueue: string;
+  private readonly subscribedQueues = new Set<string>();
 
   constructor(private readonly options: RabbitMqMicroserviceTransportOptions) {
     this.eventQueue = options.eventQueue ?? 'konekti.microservices.events';
+    this.messageQueue = options.messageQueue ?? 'konekti.microservices.messages';
+    this.responseQueue = options.responseQueue ?? 'konekti.microservices.responses';
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 3_000;
   }
 
   async listen(handler: TransportHandler): Promise<void> {
@@ -45,9 +62,15 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
     }
 
     this.listenPromise = (async () => {
-      await this.options.consumer.consume(this.eventQueue, (message) => {
-        void this.handleInboundMessage(message, 'event').catch(() => undefined);
-      });
+      const queues = new Set([this.eventQueue, this.messageQueue, this.responseQueue]);
+
+      for (const queue of queues) {
+        await this.options.consumer.consume(queue, (message) => {
+          void this.handleInboundMessage(message).catch(() => undefined);
+        });
+
+        this.subscribedQueues.add(queue);
+      }
 
       this.listening = true;
     })();
@@ -59,10 +82,72 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
     }
   }
 
-  async send(_pattern: string, _payload: unknown): Promise<unknown> {
-    throw new Error(
-      'RabbitMqMicroserviceTransport does not support request/reply send(). Use TCP or NATS transport for send().',
-    );
+  async send(pattern: string, payload: unknown, signal?: AbortSignal): Promise<unknown> {
+    if (this.listenPromise) {
+      await this.listenPromise;
+    }
+
+    if (!this.listening) {
+      throw new Error('RabbitMqMicroserviceTransport is not listening. Call listen() before send().');
+    }
+
+    const requestId = crypto.randomUUID();
+    const message: RabbitMqTransportMessage = {
+      kind: 'message',
+      pattern,
+      payload,
+      replyTo: this.responseQueue,
+      requestId,
+    };
+
+    return await new Promise<unknown>((resolve, reject) => {
+      let abortHandler: (() => void) | undefined;
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error(`RabbitMQ request timed out after ${this.requestTimeoutMs}ms waiting for pattern "${pattern}".`));
+      }, this.requestTimeoutMs);
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        this.pending.delete(requestId);
+
+        if (abortHandler && signal) {
+          signal.removeEventListener('abort', abortHandler);
+        }
+      };
+
+      this.pending.set(requestId, {
+        reject: (error: unknown) => {
+          cleanup();
+          reject(error);
+        },
+        resolve: (value: unknown) => {
+          cleanup();
+          resolve(value);
+        },
+        timeout,
+      });
+
+      if (signal) {
+        if (signal.aborted) {
+          cleanup();
+          reject(new Error('RabbitMQ request aborted before publish.'));
+          return;
+        }
+
+        abortHandler = () => {
+          cleanup();
+          reject(new Error('RabbitMQ request aborted.'));
+        };
+
+        signal.addEventListener('abort', abortHandler, { once: true });
+      }
+
+      void this.options.publisher.publish(this.messageQueue, JSON.stringify(message)).catch((error: unknown) => {
+        cleanup();
+        reject(error instanceof Error ? error : new Error('Failed to publish RabbitMQ request.'));
+      });
+    });
   }
 
   async emit(pattern: string, payload: unknown): Promise<void> {
@@ -81,17 +166,18 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
     }
 
     if (this.listening) {
-      await this.options.consumer.cancel(this.eventQueue);
+      for (const queue of this.subscribedQueues) {
+        await this.options.consumer.cancel(queue);
+      }
     }
 
+    this.subscribedQueues.clear();
+    this.rejectPendingRequests(new Error('RabbitMQ microservice transport closed before response.'));
     this.listening = false;
     this.handler = undefined;
   }
 
-  private async handleInboundMessage(rawMessage: string, expectedKind: 'event' | 'message'): Promise<void> {
-    if (!this.handler) {
-      return;
-    }
+  private async handleInboundMessage(rawMessage: string): Promise<void> {
 
     let message: RabbitMqTransportMessage;
 
@@ -101,14 +187,90 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
       return;
     }
 
-    if (message.kind !== expectedKind) {
+    if (message.kind === 'response') {
+      this.handleResponse(message);
       return;
     }
 
-    await this.handler({
-      kind: message.kind,
-      pattern: message.pattern,
-      payload: message.payload,
-    });
+    if (!this.handler) {
+      return;
+    }
+
+    if (message.kind === 'event') {
+      await this.handler({
+        kind: 'event',
+        pattern: message.pattern,
+        payload: message.payload,
+      });
+      return;
+    }
+
+    if (message.kind === 'message' && message.requestId) {
+      await this.handleRequest(message);
+    }
+  }
+
+  private async handleRequest(message: RabbitMqTransportMessage): Promise<void> {
+    if (!this.handler || !message.requestId) {
+      return;
+    }
+
+    const replyQueue = typeof message.replyTo === 'string' && message.replyTo.length > 0
+      ? message.replyTo
+      : this.responseQueue;
+
+    try {
+      const payload = await this.handler({
+        kind: 'message',
+        pattern: message.pattern,
+        payload: message.payload,
+        requestId: message.requestId,
+      });
+
+      await this.options.publisher.publish(replyQueue, JSON.stringify({
+        kind: 'response',
+        pattern: message.pattern,
+        payload,
+        requestId: message.requestId,
+      } satisfies RabbitMqTransportMessage));
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Unhandled microservice error';
+
+      await this.options.publisher.publish(replyQueue, JSON.stringify({
+        error: errorMessage,
+        kind: 'response',
+        pattern: message.pattern,
+        requestId: message.requestId,
+      } satisfies RabbitMqTransportMessage));
+    }
+  }
+
+  private handleResponse(message: RabbitMqTransportMessage): void {
+    if (!message.requestId) {
+      return;
+    }
+
+    const pending = this.pending.get(message.requestId);
+
+    if (!pending) {
+      return;
+    }
+
+    this.pending.delete(message.requestId);
+
+    if (message.error) {
+      pending.reject(new Error(message.error));
+      return;
+    }
+
+    pending.resolve(message.payload);
+  }
+
+  private rejectPendingRequests(error: Error): void {
+    for (const [requestId, entry] of this.pending) {
+      clearTimeout(entry.timeout);
+      this.pending.delete(requestId);
+      entry.reject(error);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add request/reply `send()` support to `RabbitMqMicroserviceTransport` with `requestId` correlation, reply queue routing (`replyTo`/`responseQueue`), deterministic timeout handling, and pending-request cleanup on shutdown
- add deterministic transport tests for success, timeout, remote failure, concurrent request/reply, late-response ignore behavior, and startup/reconnect/shutdown queue lifecycle
- update microservices docs and support matrix (EN/KO) to reflect RabbitMQ request/reply support, explicit operational boundaries, and troubleshooting guidance

Closes #271

## Request/Reply Contract (RabbitMQ)
- Request envelope: `{ kind: 'message', pattern, payload, requestId, replyTo }`
- Response envelope: `{ kind: 'response', requestId, payload | error }`
- Correlation: `requestId`
- Timeout: `requestTimeoutMs` (default `3000` ms)
- Error propagation: handler exceptions are serialized as `error` and rejected by `send()` caller

## Lifecycle Behavior
- **Startup**: `listen()` subscribes `eventQueue`, `messageQueue`, `responseQueue`
- **Reconnect**: supported by calling `listen()` again after `close()` (queues are re-subscribed)
- **Shutdown**: `close()` cancels queue consumers and rejects all in-flight pending requests

## Verification
- `pnpm --filter @konekti/microservices typecheck`
- `pnpm test packages/microservices/src`
- `pnpm --filter @konekti/microservices build`