### PR TITLE
Resolve #275: define account-linking policy contract for auth flows

### DIFF
--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -9,7 +9,7 @@ Konekti의 strategy-agnostic auth 실행 레이어 — 어떤 `AuthStrategy`든 
 - **Cookie auth preset**: HttpOnly 쿠키 JWT 추출 + `CookieManager` 유틸리티.
 - **Refresh token lifecycle**: 재생 감지(replay detection)를 포함한 refresh token 발급·로테이션·취소.
 
-계정 연결 정책이나 더 넓은 세션 스토어 관리는 애플리케이션 레벨 책임으로 남는다.
+`@konekti/passport`는 이제 공식 계정 연결 확장 계약(`AccountLinkPolicy`)을 제공하며, 최종 identity 정책 결정은 애플리케이션 레벨 책임으로 남는다.
 
 ## 관련 문서
 
@@ -29,8 +29,8 @@ Konekti의 strategy-agnostic auth 실행 레이어 — 어떤 `AuthStrategy`든 
 
 범위 정리:
 
-- `@konekti/passport`는 strategy 실행, refresh token lifecycle(발급·로테이션·취소), HttpOnly cookie auth preset을 소유한다
-- 로그인 자격 증명 검증, 세션 스토리지, 동의(consent), 계정 연결 등 더 넓은 account/session lifecycle은 애플리케이션 레벨 책임이다
+- `@konekti/passport`는 strategy 실행, refresh token lifecycle(발급·로테이션·취소), HttpOnly cookie auth preset, 계정 연결 정책 계약을 소유한다
+- 로그인 자격 증명 검증, 세션 스토리지, 동의(consent), 계정 upsert 소유권 등 더 넓은 account/session lifecycle은 애플리케이션 레벨 책임이다
 
 ## Refresh Token Lifecycle
 
@@ -247,6 +247,108 @@ Cookie auth preset은 보안 기본값을 사용한다:
 - 멀티 테넌트 쿠키 격리
 - 쿠키 동의 준수
 
+## Account Linking Policy 계약
+
+`@konekti/passport`는 계정 소유권 자체를 프레임워크로 끌어오지 않으면서도, 애플리케이션이 일관되게 계정 연결을 구현할 수 있도록 최소 계약을 제공한다:
+
+- `AccountLinkPolicy.evaluate(context)`로 애플리케이션 정책 결정을 정의
+- `resolveAccountLinking(context, policy, options)`로 결과를 정규화하고 conflict/reject 시맨틱을 강제
+- `createConservativeAccountLinkPolicy()`는 모호한 후보 연결 시 명시적 확인을 요구하는 공식 baseline 정책
+
+### 프레임워크 동작 vs 애플리케이션 정책 경계
+
+**프레임워크 소유 동작:**
+- 계정 연결 계약 타입 및 DI 토큰(`ACCOUNT_LINKING_POLICY`)
+- 결정 정규화(`linked`, `create-account`, `skipped`)
+- 명시적 타입 에러(`AccountLinkConflictError`, `AccountLinkRejectedError`)
+
+**애플리케이션 소유 동작:**
+- 계정 후보 탐색(이메일/provider/메타데이터 기준 조회)
+- 동의 UI 및 명시적 링크 확인 UX
+- 계정 upsert/merge 트랜잭션 및 감사 로깅
+
+### 공통 플로우 매핑
+
+| 플로우 | 일반적인 입력 컨텍스트 | 기대 정책 결정 |
+|---|---|---|
+| 첫 외부 로그인 | `candidates: []` | `create-account` |
+| 기존 계정 매칭 | `candidates: [account]`, 아직 확인 없음 | `conflict` (명시적 확인 필요) |
+| 명시적 링크 확인 | `linkAttempt.confirmedByUser === true` 이고 대상이 후보에 포함 | `link` |
+| 링크 거절 | 사용자가 확인 거절 또는 대상 계정이 유효하지 않음 | `reject` |
+
+### 예시: 로컬 자격 증명 플로우 (외부 연결 없음)
+
+```typescript
+import { AuthenticationFailedError } from '@konekti/passport';
+
+export async function loginWithPassword(email: string, password: string) {
+  const account = await accountRepository.findByEmail(email);
+  if (!account || !(await passwordHasher.verify(password, account.passwordHash))) {
+    throw new AuthenticationFailedError('Invalid credentials.');
+  }
+
+  return account;
+}
+```
+
+### 예시: 외부 provider 플로우 + 명시적 링크 확인
+
+```typescript
+import {
+  AccountLinkConflictError,
+  AccountLinkRejectedError,
+  createConservativeAccountLinkPolicy,
+  resolveAccountLinking,
+} from '@konekti/passport';
+
+const policy = createConservativeAccountLinkPolicy();
+
+export async function handleGoogleCallback(identity: {
+  email?: string;
+  providerSubject: string;
+}) {
+  const candidates = await accountRepository.findCandidatesForExternalIdentity(identity);
+
+  try {
+    const resolution = await resolveAccountLinking(
+      {
+        candidates,
+        identity: {
+          email: identity.email,
+          emailVerified: true,
+          provider: 'google',
+          providerSubject: identity.providerSubject,
+        },
+      },
+      policy,
+    );
+
+    if (resolution.status === 'linked') {
+      return accountRepository.attachExternalIdentity(resolution.accountId, 'google', identity.providerSubject);
+    }
+
+    if (resolution.status === 'create-account') {
+      return accountRepository.createFromExternalIdentity('google', identity.providerSubject, identity.email);
+    }
+
+    return { next: 'manual-review' };
+  } catch (error) {
+    if (error instanceof AccountLinkConflictError) {
+      return {
+        candidateAccountIds: error.candidateAccountIds,
+        next: 'ask-link-confirmation',
+      };
+    }
+
+    if (error instanceof AccountLinkRejectedError) {
+      return { next: 'link-rejected' };
+    }
+
+    throw error;
+  }
+}
+```
+
 ## 설치
 
 ```bash
@@ -353,6 +455,12 @@ export class AuthModule {}
 | `createPassportProviders(opts)` | `src/module.ts` | strategy registry와 default strategy wiring 등록 |
 | `createPassportJsStrategyBridge(...)` | `src/passport-js.ts` | Passport.js strategy를 Konekti `AuthStrategy`로 감쌈 |
 | `AuthRequirement` | `src/types.ts` | `{ strategy?, scopes? }` — class + method 레벨에서 merge됨 |
+| `AccountLinkPolicy` | `src/account-linking.ts` | 애플리케이션이 제공한 후보 데이터로 identity-linking 결정을 내리는 확장 계약 |
+| `resolveAccountLinking(...)` | `src/account-linking.ts` | 정책 결과(`linked`, `create-account`, `skipped`) 정규화 + conflict/reject 타입 에러 처리 |
+| `createConservativeAccountLinkPolicy()` | `src/account-linking.ts` | 명시적 확인 전에는 모호한 연결을 허용하지 않는 기본 보수 정책 |
+| `ACCOUNT_LINKING_POLICY` | `src/account-linking.ts` | 정책 구현 연결을 위한 DI 토큰 |
+| `AccountLinkConflictError` | `src/account-linking.ts` | 하나 이상 후보가 매칭되어 명시적 확인이 필요한 경우 throw |
+| `AccountLinkRejectedError` | `src/account-linking.ts` | 정책에 의해 링크가 거절된 경우 throw |
 | `RefreshTokenService` | `src/refresh-token.ts` | refresh token lifecycle 작업을 위한 인터페이스 |
 | `RefreshTokenStrategy` | `src/refresh-token.ts` | refresh token 인증을 위한 auth strategy |
 | `JwtRefreshTokenAdapter` | `src/jwt-refresh-token-adapter.ts` | `@konekti/jwt`의 `RefreshTokenService`를 passport 인터페이스로 연결 |
@@ -394,27 +502,29 @@ export class AuthModule {}
 
 ### Passport.js bridge
 
-`createPassportJsStrategyBridge()`는 Passport.js의 `success`/`fail`/`redirect`/`error` callback 프로토콜을 Konekti의 `AuthStrategyResult`로 변환한다. `mapPrincipal` 인수는 passport user 객체를 Konekti `Principal` shape으로 정규화한다. bridge는 계정 upsert나 JWT 발급을 소유하지 않는다 — 그것들은 app service 코드의 책임이다.
+`createPassportJsStrategyBridge()`는 Passport.js의 `success`/`fail`/`redirect`/`error` callback 프로토콜을 Konekti의 `AuthStrategyResult`로 변환한다. `mapPrincipal` 인수는 passport user 객체를 Konekti `Principal` shape으로 정규화한다. bridge는 계정 upsert나 JWT 발급을 소유하지 않는다 — 그것들은 app service 코드의 책임이다. identity linking은 `AccountLinkPolicy` + `resolveAccountLinking` 계약 경계를 사용한다.
 
 public package는 auth error 클래스, bridge 타입, metadata helper, `AUTH_STRATEGY_REGISTRY`, `PASSPORT_OPTIONS`도 `src/index.ts`에서 함께 export한다.
 
 ## 파일 읽기 순서 (기여자용)
 
 1. `src/types.ts` — `AuthStrategy`, `AuthStrategyResult`, `AuthRequirement`, `GuardContext`
-2. `src/metadata.ts` — class + method requirement 저장과 merge
-3. `src/decorators.ts` — `UseAuth`, `RequireScopes` — 메타데이터 쓰기 + `AuthGuard` 부착
-4. `src/errors.ts` — auth-specific 에러 타입
-5. `src/guard.ts` — `AuthGuard` — strategy lookup, authenticate, scope 확인, principal 채우기
-6. `src/refresh-token.ts` — `RefreshTokenService`, `RefreshTokenStrategy` — refresh token lifecycle 기본 기능
-7. `src/jwt-refresh-token-adapter.ts` — `JwtRefreshTokenAdapter` — `@konekti/jwt`를 passport 인터페이스로 연결
-8. `src/cookie-auth.ts` — `CookieAuthStrategy` — HttpOnly 쿠키에서 JWT 추출
-9. `src/cookie-manager.ts` — `CookieManager` — 쿠키 설정/삭제 유틸리티
-10. `src/cookie-auth-module.ts` — `createCookieAuthPreset` — cookie auth provider와 strategy 등록
-11. `src/module.ts` — `createPassportProviders`
-12. `src/passport-js.ts` — `createPassportJsStrategyBridge`
-13. `src/guard.test.ts` — non-JWT strategy 흐름, 401/403 매핑, principal 채우기, scope 강제, Passport.js bridge 경로
-14. `src/refresh-token.test.ts` — refresh token lifecycle, 로테이션, 재생 감지, 취소
-15. `src/cookie-auth.test.ts` — cookie auth strategy 및 cookie manager 테스트
+2. `src/account-linking.ts` — 계정 연결 계약, conservative baseline 정책, conflict/reject 시맨틱
+3. `src/metadata.ts` — class + method requirement 저장과 merge
+4. `src/decorators.ts` — `UseAuth`, `RequireScopes` — 메타데이터 쓰기 + `AuthGuard` 부착
+5. `src/errors.ts` — auth-specific 에러 타입
+6. `src/guard.ts` — `AuthGuard` — strategy lookup, authenticate, scope 확인, principal 채우기
+7. `src/refresh-token.ts` — `RefreshTokenService`, `RefreshTokenStrategy` — refresh token lifecycle 기본 기능
+8. `src/jwt-refresh-token-adapter.ts` — `JwtRefreshTokenAdapter` — `@konekti/jwt`를 passport 인터페이스로 연결
+9. `src/cookie-auth.ts` — `CookieAuthStrategy` — HttpOnly 쿠키에서 JWT 추출
+10. `src/cookie-manager.ts` — `CookieManager` — 쿠키 설정/삭제 유틸리티
+11. `src/cookie-auth-module.ts` — `createCookieAuthPreset` — cookie auth provider와 strategy 등록
+12. `src/module.ts` — `createPassportProviders`
+13. `src/passport-js.ts` — `createPassportJsStrategyBridge`
+14. `src/account-linking.test.ts` — happy-path linking, conflict 처리, non-linking fallback, 명시적 거절 플로우 테스트
+15. `src/guard.test.ts` — non-JWT strategy 흐름, 401/403 매핑, principal 채우기, scope 강제, Passport.js bridge 경로
+16. `src/refresh-token.test.ts` — refresh token lifecycle, 로테이션, 재생 감지, 취소
+17. `src/cookie-auth.test.ts` — cookie auth strategy 및 cookie manager 테스트
 
 ## 관련 패키지
 
@@ -427,5 +537,6 @@ public package는 auth error 클래스, bridge 타입, metadata helper, `AUTH_ST
 @konekti/passport = strategy-agnostic auth 실행: 어떤 AuthStrategy든 → AuthGuard → RequestContext의 principal
                  + refresh token lifecycle: 발급 → 로테이션 → 취소 (재생 감지 포함)  (프레임워크 소유)
                  + cookie auth preset: HttpOnly 쿠키 JWT 추출 + 쿠키 관리 유틸리티   (프레임워크 소유)
-                 + 로그인 흐름, 세션 스토어, 동의, 계정 연결                           (애플리케이션 소유)
+                 + 계정 연결 정책 계약: evaluate → resolve → conflict/reject 시맨틱   (프레임워크 경계 소유)
+                 + 로그인 흐름, 세션 스토어, 동의, 계정 upsert/merge 구현            (애플리케이션 소유)
 ```

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -9,7 +9,7 @@ The package ships two official presets beyond bearer-token JWT:
 - **Cookie auth preset**: HttpOnly cookie JWT extraction with `CookieManager` utilities.
 - **Refresh token lifecycle**: Issue, rotate, and revoke refresh tokens with replay detection.
 
-Account-linking policy and broader session store management remain application-level concerns.
+`@konekti/passport` now defines an official account-linking extension contract (`AccountLinkPolicy`), while final identity policy decisions remain application-level concerns.
 
 ## See also
 
@@ -29,8 +29,8 @@ Account-linking policy and broader session store management remain application-l
 
 Scope note:
 
-- `@konekti/passport` owns strategy execution, the refresh token lifecycle (issue / rotate / revoke), and the HttpOnly cookie auth preset
-- the broader account/session lifecycle (login credential validation, session storage, consent, account linking) remains application-level
+- `@konekti/passport` owns strategy execution, the refresh token lifecycle (issue / rotate / revoke), the HttpOnly cookie auth preset, and the account-linking policy contract
+- the broader account/session lifecycle (login credential validation, session storage, consent, account upsert ownership) remains application-level
 
 ## Refresh Token Lifecycle
 
@@ -247,6 +247,108 @@ These defaults can be overridden via `CookieManagerConfig`.
 - Multi-tenant cookie isolation
 - Cookie consent compliance
 
+## Account Linking Policy Contract
+
+`@konekti/passport` exposes a minimal account-linking policy surface so applications can implement linking consistently without pushing account ownership into the framework:
+
+- `AccountLinkPolicy.evaluate(context)` defines your linking decision logic.
+- `resolveAccountLinking(context, policy, options)` normalizes outcomes and enforces typed conflict/rejection semantics.
+- `createConservativeAccountLinkPolicy()` is an official baseline policy that requires explicit confirmation before linking ambiguous candidates.
+
+### Framework behavior vs application policy boundary
+
+**Framework-owned behavior:**
+- account-linking contract types and DI token (`ACCOUNT_LINKING_POLICY`)
+- decision normalization (`linked`, `create-account`, `skipped`)
+- explicit typed failures (`AccountLinkConflictError`, `AccountLinkRejectedError`)
+
+**Application-owned behavior:**
+- account candidate discovery (queries by email/provider/user metadata)
+- consent UI and explicit link confirmation UX
+- account upsert/merge transactions and audit logging
+
+### Common flow mapping
+
+| Flow | Typical input context | Expected policy decision |
+|---|---|---|
+| First external login | `candidates: []` | `create-account` |
+| Existing-account match | `candidates: [account]`, no confirmation yet | `conflict` (require explicit confirmation) |
+| Explicit link confirmation | `linkAttempt.confirmedByUser === true` and target in candidates | `link` |
+| Rejected link attempt | user denies confirmation or target is invalid | `reject` |
+
+### Example: local credential flow (no external linking)
+
+```typescript
+import { AuthenticationFailedError } from '@konekti/passport';
+
+export async function loginWithPassword(email: string, password: string) {
+  const account = await accountRepository.findByEmail(email);
+  if (!account || !(await passwordHasher.verify(password, account.passwordHash))) {
+    throw new AuthenticationFailedError('Invalid credentials.');
+  }
+
+  return account;
+}
+```
+
+### Example: external provider flow with explicit confirmation
+
+```typescript
+import {
+  AccountLinkConflictError,
+  AccountLinkRejectedError,
+  createConservativeAccountLinkPolicy,
+  resolveAccountLinking,
+} from '@konekti/passport';
+
+const policy = createConservativeAccountLinkPolicy();
+
+export async function handleGoogleCallback(identity: {
+  email?: string;
+  providerSubject: string;
+}) {
+  const candidates = await accountRepository.findCandidatesForExternalIdentity(identity);
+
+  try {
+    const resolution = await resolveAccountLinking(
+      {
+        candidates,
+        identity: {
+          email: identity.email,
+          emailVerified: true,
+          provider: 'google',
+          providerSubject: identity.providerSubject,
+        },
+      },
+      policy,
+    );
+
+    if (resolution.status === 'linked') {
+      return accountRepository.attachExternalIdentity(resolution.accountId, 'google', identity.providerSubject);
+    }
+
+    if (resolution.status === 'create-account') {
+      return accountRepository.createFromExternalIdentity('google', identity.providerSubject, identity.email);
+    }
+
+    return { next: 'manual-review' };
+  } catch (error) {
+    if (error instanceof AccountLinkConflictError) {
+      return {
+        candidateAccountIds: error.candidateAccountIds,
+        next: 'ask-link-confirmation',
+      };
+    }
+
+    if (error instanceof AccountLinkRejectedError) {
+      return { next: 'link-rejected' };
+    }
+
+    throw error;
+  }
+}
+```
+
 ## Installation
 
 ```bash
@@ -353,6 +455,12 @@ export class AuthModule {}
 | `createPassportProviders(opts)` | `src/module.ts` | Registers strategy registry and default strategy wiring |
 | `createPassportJsStrategyBridge(...)` | `src/passport-js.ts` | Wraps a Passport.js strategy as a Konekti `AuthStrategy` |
 | `AuthRequirement` | `src/types.ts` | `{ strategy?, scopes? }` — merged from class + method level |
+| `AccountLinkPolicy` | `src/account-linking.ts` | Extension contract: evaluate identity-linking decisions from app-provided candidate data |
+| `resolveAccountLinking(...)` | `src/account-linking.ts` | Normalizes policy outcomes (`linked`, `create-account`, `skipped`) and throws typed conflict/reject errors |
+| `createConservativeAccountLinkPolicy()` | `src/account-linking.ts` | Built-in baseline policy requiring explicit confirmation before linking non-explicit matches |
+| `ACCOUNT_LINKING_POLICY` | `src/account-linking.ts` | DI token for wiring a policy implementation |
+| `AccountLinkConflictError` | `src/account-linking.ts` | Thrown when one or more candidate matches require explicit link confirmation |
+| `AccountLinkRejectedError` | `src/account-linking.ts` | Thrown when linking is denied by policy |
 | `RefreshTokenService` | `src/refresh-token.ts` | Interface for refresh token lifecycle operations |
 | `RefreshTokenStrategy` | `src/refresh-token.ts` | Auth strategy for refresh token authentication |
 | `JwtRefreshTokenAdapter` | `src/jwt-refresh-token-adapter.ts` | Adapts `@konekti/jwt`'s `RefreshTokenService` to passport interface |
@@ -394,27 +502,29 @@ This means adding a new auth strategy requires only implementing `AuthStrategy` 
 
 ### Passport.js bridge
 
-`createPassportJsStrategyBridge()` adapts Passport.js's `success`/`fail`/`redirect`/`error` callback protocol to Konekti's `AuthStrategyResult`. The `mapPrincipal` argument normalizes the passport user object to a Konekti `Principal` shape. The bridge does not own account upsert or JWT issuance — those remain in app service code.
+`createPassportJsStrategyBridge()` adapts Passport.js's `success`/`fail`/`redirect`/`error` callback protocol to Konekti's `AuthStrategyResult`. The `mapPrincipal` argument normalizes the passport user object to a Konekti `Principal` shape. The bridge does not own account upsert or JWT issuance — those remain in app service code. For identity linking, use `AccountLinkPolicy` + `resolveAccountLinking` as the framework contract boundary.
 
 The public package also exports auth error classes, bridge types, metadata helpers, `AUTH_STRATEGY_REGISTRY`, and `PASSPORT_OPTIONS` from `src/index.ts`.
 
 ## File reading order for contributors
 
 1. `src/types.ts` — `AuthStrategy`, `AuthStrategyResult`, `AuthRequirement`, `GuardContext`
-2. `src/metadata.ts` — class + method requirement storage and merge
-3. `src/decorators.ts` — `UseAuth`, `RequireScopes` — metadata write + `AuthGuard` attachment
-4. `src/errors.ts` — auth-specific error types
-5. `src/guard.ts` — `AuthGuard` — strategy lookup, authenticate, scope check, principal population
-6. `src/refresh-token.ts` — `RefreshTokenService`, `RefreshTokenStrategy` — refresh token lifecycle primitives
-7. `src/jwt-refresh-token-adapter.ts` — `JwtRefreshTokenAdapter` — bridges `@konekti/jwt` to passport interface
-8. `src/cookie-auth.ts` — `CookieAuthStrategy` — JWT extraction from HttpOnly cookies
-9. `src/cookie-manager.ts` — `CookieManager` — cookie setting/clearing utilities
-10. `src/cookie-auth-module.ts` — `createCookieAuthPreset` — cookie auth providers and strategy registration
-11. `src/module.ts` — `createPassportProviders`
-12. `src/passport-js.ts` — `createPassportJsStrategyBridge`
-13. `src/guard.test.ts` — non-JWT strategy flow, 401/403 mapping, principal population, scope enforcement, Passport.js bridge paths
-14. `src/refresh-token.test.ts` — refresh token lifecycle, rotation, replay detection, revocation
-15. `src/cookie-auth.test.ts` — cookie auth strategy and cookie manager tests
+2. `src/account-linking.ts` — account-linking contract, conservative policy baseline, conflict/reject semantics
+3. `src/metadata.ts` — class + method requirement storage and merge
+4. `src/decorators.ts` — `UseAuth`, `RequireScopes` — metadata write + `AuthGuard` attachment
+5. `src/errors.ts` — auth-specific error types
+6. `src/guard.ts` — `AuthGuard` — strategy lookup, authenticate, scope check, principal population
+7. `src/refresh-token.ts` — `RefreshTokenService`, `RefreshTokenStrategy` — refresh token lifecycle primitives
+8. `src/jwt-refresh-token-adapter.ts` — `JwtRefreshTokenAdapter` — bridges `@konekti/jwt` to passport interface
+9. `src/cookie-auth.ts` — `CookieAuthStrategy` — JWT extraction from HttpOnly cookies
+10. `src/cookie-manager.ts` — `CookieManager` — cookie setting/clearing utilities
+11. `src/cookie-auth-module.ts` — `createCookieAuthPreset` — cookie auth providers and strategy registration
+12. `src/module.ts` — `createPassportProviders`
+13. `src/passport-js.ts` — `createPassportJsStrategyBridge`
+14. `src/account-linking.test.ts` — happy-path linking, conflict handling, non-linking fallback, explicit rejection flows
+15. `src/guard.test.ts` — non-JWT strategy flow, 401/403 mapping, principal population, scope enforcement, Passport.js bridge paths
+16. `src/refresh-token.test.ts` — refresh token lifecycle, rotation, replay detection, revocation
+17. `src/cookie-auth.test.ts` — cookie auth strategy and cookie manager tests
 
 ## Related packages
 
@@ -427,5 +537,6 @@ The public package also exports auth error classes, bridge types, metadata helpe
 @konekti/passport = strategy-agnostic auth execution: any AuthStrategy → AuthGuard → principal in RequestContext
                  + refresh token lifecycle: issue → rotate → revoke with replay detection        (framework-owned)
                  + cookie auth preset: HttpOnly cookie JWT extraction + cookie management        (framework-owned)
-                 + login flow, session store, consent, account linking                          (application-owned)
+                 + account-linking policy contract: evaluate → resolve → conflict/reject semantics (framework-owned boundary)
+                 + login flow, session store, consent, account upsert/merge implementation        (application-owned)
 ```

--- a/packages/passport/src/account-linking.test.ts
+++ b/packages/passport/src/account-linking.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AccountLinkConflictError,
+  AccountLinkRejectedError,
+  createConservativeAccountLinkPolicy,
+  resolveAccountLinking,
+  type AccountLinkContext,
+} from './account-linking.js';
+
+function createContext(overrides: Partial<AccountLinkContext> = {}): AccountLinkContext {
+  return {
+    candidates: [],
+    identity: {
+      claims: {
+        hd: 'example.com',
+      },
+      email: 'user@example.com',
+      emailVerified: true,
+      provider: 'google',
+      providerSubject: 'google-user-1',
+    },
+    ...overrides,
+  };
+}
+
+describe('resolveAccountLinking', () => {
+  it('links a candidate after explicit user confirmation (happy path)', async () => {
+    const policy = createConservativeAccountLinkPolicy();
+    const result = await resolveAccountLinking(
+      createContext({
+        candidates: [
+          {
+            accountId: 'account-1',
+            reason: 'email-match',
+          },
+        ],
+        linkAttempt: {
+          confirmedByUser: true,
+          targetAccountId: 'account-1',
+        },
+      }),
+      policy,
+    );
+
+    expect(result).toEqual({
+      accountId: 'account-1',
+      reason: 'Identity linked after explicit user confirmation.',
+      status: 'linked',
+    });
+  });
+
+  it('throws AccountLinkConflictError when multiple candidates match', async () => {
+    const policy = createConservativeAccountLinkPolicy();
+
+    await expect(
+      resolveAccountLinking(
+        createContext({
+          candidates: [
+            {
+              accountId: 'account-1',
+              reason: 'email-match',
+            },
+            {
+              accountId: 'account-2',
+              reason: 'username-match',
+            },
+          ],
+        }),
+        policy,
+      ),
+    ).rejects.toThrow(AccountLinkConflictError);
+
+    try {
+      await resolveAccountLinking(
+        createContext({
+          candidates: [
+            {
+              accountId: 'account-1',
+              reason: 'email-match',
+            },
+            {
+              accountId: 'account-2',
+              reason: 'username-match',
+            },
+          ],
+        }),
+        policy,
+      );
+      expect.unreachable('Expected conflict error to be thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AccountLinkConflictError);
+      expect((error as AccountLinkConflictError).candidateAccountIds).toEqual(['account-1', 'account-2']);
+    }
+  });
+
+  it('returns skipped when no policy is configured (non-linking fallback)', async () => {
+    const result = await resolveAccountLinking(
+      createContext({
+        candidates: [
+          {
+            accountId: 'account-1',
+            reason: 'email-match',
+          },
+        ],
+      }),
+      undefined,
+    );
+
+    expect(result).toEqual({
+      reason:
+        'No account-linking policy was configured. The framework leaves identity linking to the application.',
+      status: 'skipped',
+    });
+  });
+
+  it('throws AccountLinkRejectedError when a link attempt is not confirmed', async () => {
+    const policy = createConservativeAccountLinkPolicy();
+
+    await expect(
+      resolveAccountLinking(
+        createContext({
+          candidates: [
+            {
+              accountId: 'account-1',
+              reason: 'email-match',
+            },
+          ],
+          linkAttempt: {
+            confirmedByUser: false,
+            targetAccountId: 'account-1',
+          },
+        }),
+        policy,
+      ),
+    ).rejects.toThrow(AccountLinkRejectedError);
+  });
+});

--- a/packages/passport/src/account-linking.ts
+++ b/packages/passport/src/account-linking.ts
@@ -1,0 +1,202 @@
+import { KonektiError, type MaybePromise } from '@konekti/core';
+
+export const ACCOUNT_LINKING_POLICY = Symbol.for('konekti.passport.account-linking-policy');
+
+export interface AccountIdentity {
+  provider: string;
+  providerSubject: string;
+  email?: string;
+  emailVerified?: boolean;
+  claims?: Record<string, unknown>;
+}
+
+export interface AccountLinkCandidate {
+  accountId: string;
+  reason: 'existing-link' | 'email-match' | 'username-match' | string;
+}
+
+export interface AccountLinkAttempt {
+  targetAccountId: string;
+  confirmedByUser: boolean;
+}
+
+export interface AccountLinkContext {
+  identity: AccountIdentity;
+  candidates: AccountLinkCandidate[];
+  linkAttempt?: AccountLinkAttempt;
+}
+
+export type AccountLinkPolicyDecision =
+  | {
+      action: 'link';
+      accountId: string;
+      reason: string;
+    }
+  | {
+      action: 'create-account';
+      reason: string;
+    }
+  | {
+      action: 'reject';
+      reason: string;
+      code?: string;
+    }
+  | {
+      action: 'conflict';
+      reason: string;
+      candidateAccountIds: string[];
+    };
+
+export interface AccountLinkPolicy {
+  evaluate(context: AccountLinkContext): MaybePromise<AccountLinkPolicyDecision>;
+}
+
+export interface AccountLinkingOptions {
+  fallback?: 'create-account' | 'skip';
+}
+
+export type AccountLinkingResolution =
+  | {
+      status: 'linked';
+      accountId: string;
+      reason: string;
+    }
+  | {
+      status: 'create-account';
+      reason: string;
+    }
+  | {
+      status: 'skipped';
+      reason: string;
+    };
+
+export class AccountLinkConflictError extends KonektiError {
+  readonly candidateAccountIds: string[];
+
+  constructor(
+    candidateAccountIds: string[],
+    message = 'Multiple account candidates require explicit link confirmation.',
+  ) {
+    super(message, {
+      code: 'ACCOUNT_LINK_CONFLICT',
+      meta: {
+        candidateAccountIds: [...candidateAccountIds],
+      },
+    });
+
+    this.candidateAccountIds = [...candidateAccountIds];
+  }
+}
+
+export class AccountLinkRejectedError extends KonektiError {
+  constructor(message = 'Account-linking attempt was rejected.', code = 'ACCOUNT_LINK_REJECTED') {
+    super(message, { code });
+  }
+}
+
+export function createConservativeAccountLinkPolicy(): AccountLinkPolicy {
+  return {
+    evaluate(context) {
+      const existingLink = context.candidates.find((candidate) => candidate.reason === 'existing-link');
+      if (existingLink) {
+        return {
+          action: 'link',
+          accountId: existingLink.accountId,
+          reason: 'Existing identity link found.',
+        };
+      }
+
+      const linkAttempt = context.linkAttempt;
+      if (linkAttempt) {
+        if (!linkAttempt.confirmedByUser) {
+          return {
+            action: 'reject',
+            code: 'ACCOUNT_LINK_CONFIRMATION_REQUIRED',
+            reason: 'Explicit link confirmation is required before linking identities.',
+          };
+        }
+
+        if (context.candidates.some((candidate) => candidate.accountId === linkAttempt.targetAccountId)) {
+          return {
+            action: 'link',
+            accountId: linkAttempt.targetAccountId,
+            reason: 'Identity linked after explicit user confirmation.',
+          };
+        }
+
+        return {
+          action: 'reject',
+          code: 'ACCOUNT_LINK_TARGET_NOT_FOUND',
+          reason: 'Requested account for linking is not a valid candidate.',
+        };
+      }
+
+      if (context.candidates.length === 0) {
+        return {
+          action: 'create-account',
+          reason: 'No matching account candidate found for this external identity.',
+        };
+      }
+
+      return {
+        action: 'conflict',
+        candidateAccountIds: context.candidates.map((candidate) => candidate.accountId),
+        reason:
+          context.candidates.length === 1
+            ? 'A single account candidate matched. Explicit confirmation is required before linking.'
+            : 'Multiple account candidates matched. Explicit confirmation is required before linking.',
+      };
+    },
+  };
+}
+
+const DEFAULT_SKIP_REASON =
+  'No account-linking policy was configured. The framework leaves identity linking to the application.';
+
+export async function resolveAccountLinking(
+  context: AccountLinkContext,
+  policy?: AccountLinkPolicy,
+  options: AccountLinkingOptions = {},
+): Promise<AccountLinkingResolution> {
+  if (!policy) {
+    if (options.fallback === 'create-account') {
+      return {
+        reason: 'No policy configured. Falling back to account creation.',
+        status: 'create-account',
+      };
+    }
+
+    return {
+      reason: DEFAULT_SKIP_REASON,
+      status: 'skipped',
+    };
+  }
+
+  const decision = await policy.evaluate(context);
+
+  switch (decision.action) {
+    case 'link':
+      return {
+        accountId: decision.accountId,
+        reason: decision.reason,
+        status: 'linked',
+      };
+
+    case 'create-account':
+      return {
+        reason: decision.reason,
+        status: 'create-account',
+      };
+
+    case 'reject':
+      throw new AccountLinkRejectedError(decision.reason, decision.code);
+
+    case 'conflict':
+      throw new AccountLinkConflictError(decision.candidateAccountIds, decision.reason);
+
+    default: {
+      const exhaustiveCheck: never = decision;
+      return exhaustiveCheck;
+    }
+  }
+}

--- a/packages/passport/src/index.ts
+++ b/packages/passport/src/index.ts
@@ -1,3 +1,4 @@
+export * from './account-linking.js';
 export * from './cookie-auth.js';
 export * from './cookie-auth-module.js';
 export * from './cookie-manager.js';


### PR DESCRIPTION
## Summary
- Add an official `@konekti/passport` account-linking extension contract (`AccountLinkPolicy`) with framework-level resolver semantics.
- Introduce typed conflict/rejection behavior (`AccountLinkConflictError`, `AccountLinkRejectedError`) and a conservative baseline policy requiring explicit confirmation before linking.
- Document the framework/application boundary and common account-linking flows in both English and Korean package READMEs, including local + external integration examples.

## Verification
- `pnpm --filter @konekti/passport typecheck`
- `pnpm exec vitest run packages/passport/src/account-linking.test.ts`
- `pnpm --filter @konekti/passport build`
- `pnpm exec vitest run packages/passport/src` *(contains 4 pre-existing failures in `cookie-auth.test.ts`, reproducible on `main`)*

Closes #275