### PR TITLE
Resolve #298: close remaining CQRS/cache/docs gaps

### DIFF
--- a/docs/concepts/cqrs.ko.md
+++ b/docs/concepts/cqrs.ko.md
@@ -24,10 +24,11 @@
 - `ICommandHandler<TCommand extends ICommand, TResult = void>`
 - `IQueryHandler<TQuery extends IQuery<TResult>, TResult = unknown>`
 - `IEventHandler<TEvent extends IEvent>`
+- `ISaga<TEvent extends IEvent>` — 이벤트 기반 오케스트레이션을 위한 saga/process-manager 계약
 
-`createCqrsModule({ commandHandlers?, queryHandlers?, eventHandlers?, eventBus? })`는 위 토큰들을 글로벌로 등록하고 `createEventBusModule()`을 자동으로 import하므로, CQRS 이벤트 발행에 추가 모듈 연결이 필요하지 않습니다.
+`createCqrsModule({ commandHandlers?, queryHandlers?, eventHandlers?, sagas?, eventBus? })`는 위 토큰들을 글로벌로 등록하고 `createEventBusModule()`을 자동으로 import하므로, CQRS 이벤트 발행에 추가 모듈 연결이 필요하지 않습니다.
 
-- `commandHandlers`, `queryHandlers`, `eventHandlers`: 생성되는 CQRS 모듈에 provider로 추가되는 선택적 편의 배열
+- `commandHandlers`, `queryHandlers`, `eventHandlers`, `sagas`: 생성되는 CQRS 모듈에 provider로 추가되는 선택적 편의 배열
 - `eventBus`: `createEventBusModule(eventBus)`로 그대로 전달되는 옵션
 
 ## 핸들러 등록 모델
@@ -90,6 +91,48 @@ class GetUserHandler implements IQueryHandler<GetUserQuery, { id: string }> {
 - `publishAll(events)`는 각 이벤트에 대해 순차적으로 `publish(event)`를 호출합니다.
 
 즉, 같은 이벤트 타입에 대해 클래스 레벨 `@EventHandler()`와 메서드 레벨 `@OnEvent(...)`를 함께 사용할 수 있습니다.
+
+## saga / process-manager 모델
+
+`@Saga(EventClass | EventClass[])`는 하나 이상의 이벤트 타입에 반응하는 saga/process-manager 클래스를 지정합니다.
+
+```typescript
+import { Inject } from '@konekti/core';
+import {
+  CommandBus,
+  COMMAND_BUS,
+  createCqrsModule,
+  IEvent,
+  ISaga,
+  Saga,
+} from '@konekti/cqrs';
+
+class OrderSubmittedEvent implements IEvent {
+  constructor(public readonly orderId: string) {}
+}
+
+class StartPaymentCommand {
+  constructor(public readonly orderId: string) {}
+}
+
+@Inject([COMMAND_BUS])
+@Saga(OrderSubmittedEvent)
+class OrderSaga implements ISaga<OrderSubmittedEvent> {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  async handle(event: OrderSubmittedEvent): Promise<void> {
+    await this.commandBus.execute(new StartPaymentCommand(event.orderId));
+  }
+}
+```
+
+- `@Saga()`는 단일 이벤트 클래스 또는 배열을 허용합니다.
+- saga 클래스는 singleton 스코프여야 하며 `handle(event)`를 구현해야 합니다.
+- 서로 다른 saga 클래스는 같은 이벤트 타입을 함께 구독할 수 있고, 같은 saga 클래스의 중복 등록은 자동으로 dedupe됩니다.
+- saga 디스패치는 saga 인스턴스 단위 실행 체인으로 처리되어, 동시 `publish()` 상황에서도 saga별 처리 순서가 결정적으로 유지됩니다.
+- saga 내부에서 예상치 못한 예외가 발생하면 `publish()`는 `SagaExecutionError`를 throw합니다.
+- 애플리케이션 종료 시 진행 중인 saga 실행은 drain됩니다.
+- saga는 `createCqrsModule({ sagas: [...] })`의 `sagas` 옵션으로 등록하거나, 부트스트랩 시점 데코레이터 탐색에 맡길 수 있습니다.
 
 ## 한 줄 모델
 

--- a/docs/concepts/cqrs.md
+++ b/docs/concepts/cqrs.md
@@ -24,10 +24,11 @@ It also publishes issue-aligned base contracts:
 - `ICommandHandler<TCommand extends ICommand, TResult = void>`
 - `IQueryHandler<TQuery extends IQuery<TResult>, TResult = unknown>`
 - `IEventHandler<TEvent extends IEvent>`
+- `ISaga<TEvent extends IEvent>` — saga/process-manager contract for event-driven orchestration
 
-`createCqrsModule({ commandHandlers?, queryHandlers?, eventHandlers?, eventBus? })` registers those global tokens and imports `createEventBusModule()` automatically, so CQRS event publishing works without extra module wiring.
+`createCqrsModule({ commandHandlers?, queryHandlers?, eventHandlers?, sagas?, eventBus? })` registers those global tokens and imports `createEventBusModule()` automatically, so CQRS event publishing works without extra module wiring.
 
-- `commandHandlers`, `queryHandlers`, `eventHandlers`: optional convenience arrays that are added as providers in the generated CQRS module.
+- `commandHandlers`, `queryHandlers`, `eventHandlers`, `sagas`: optional convenience arrays that are added as providers in the generated CQRS module.
 - `eventBus`: forwarded to `createEventBusModule(eventBus)`.
 
 ## handler registration model
@@ -90,6 +91,48 @@ class GetUserHandler implements IQueryHandler<GetUserQuery, { id: string }> {
 - `publishAll(events)` calls `publish(event)` for each event in order.
 
 This means class-level `@EventHandler()` and method-level `@OnEvent(...)` handlers can coexist for the same event type.
+
+## saga / process-manager model
+
+`@Saga(EventClass | EventClass[])` marks a class as a saga/process-manager that reacts to one or more event types:
+
+```typescript
+import { Inject } from '@konekti/core';
+import {
+  CommandBus,
+  COMMAND_BUS,
+  createCqrsModule,
+  IEvent,
+  ISaga,
+  Saga,
+} from '@konekti/cqrs';
+
+class OrderSubmittedEvent implements IEvent {
+  constructor(public readonly orderId: string) {}
+}
+
+class StartPaymentCommand {
+  constructor(public readonly orderId: string) {}
+}
+
+@Inject([COMMAND_BUS])
+@Saga(OrderSubmittedEvent)
+class OrderSaga implements ISaga<OrderSubmittedEvent> {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  async handle(event: OrderSubmittedEvent): Promise<void> {
+    await this.commandBus.execute(new StartPaymentCommand(event.orderId));
+  }
+}
+```
+
+- `@Saga()` accepts a single event class or an array of event classes.
+- Saga classes must be singleton-scoped and implement `handle(event)`.
+- Different saga classes can observe the same event type; duplicate registration of the same saga class is deduplicated.
+- Saga dispatches run through per-saga execution chains, so concurrent `publish()` calls are applied in deterministic order for each saga instance.
+- Unexpected saga failures throw `SagaExecutionError` from `publish()`.
+- In-flight saga executions are drained during application shutdown.
+- Register sagas via the `sagas` option in `createCqrsModule({ sagas: [...] })` or rely on decorator discovery at bootstrap.
 
 ## mental model
 

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -53,7 +53,7 @@
 - **`@konekti/cache-manager`**: 메모리/Redis 스토어를 지원하는 데코레이터 기반 HTTP 응답 캐시.
 - **`@konekti/metrics`**: Prometheus 메트릭 노출.
 - **`@konekti/cron`**: 분산 락을 지원하는 데코레이터 기반 작업 스케줄링.
-- **`@konekti/cqrs`**: 부트스트랩 시점 핸들러 탐색과 event-bus 위임을 제공하는 command/query 버스.
+- **`@konekti/cqrs`**: 부트스트랩 시점 핸들러 탐색, saga/process-manager 지원, event-bus 위임을 제공하는 command/query 버스.
 - **`@konekti/event-bus`**: 프로세스 내 이벤트 발행 및 탐색.
 - **`@konekti/websocket`**: 데코레이터 기반 WebSocket 게이트웨이 탐색 및 Node 업그레이드 연결.
 - **`@konekti/queue`**: 워커 탐색과 DLQ(Dead Letter Queue)를 지원하는 Redis 기반 백그라운드 작업.

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -53,7 +53,7 @@ This page provides an overview of the current public package family within the K
 - **`@konekti/cache-manager`**: Decorator-driven HTTP response caching with memory and Redis stores.
 - **`@konekti/metrics`**: Prometheus metrics exposure.
 - **`@konekti/cron`**: Decorator-based task scheduling with distributed lock support.
-- **`@konekti/cqrs`**: Command/query buses with bootstrap-time handler discovery and event-bus delegation.
+- **`@konekti/cqrs`**: Command/query buses with bootstrap-time handler discovery, saga/process-manager support, and event-bus delegation.
 - **`@konekti/event-bus`**: In-process event publishing and discovery.
 - **`@konekti/websocket`**: Decorator-based WebSocket gateway discovery and Node upgrade wiring.
 - **`@konekti/queue`**: Redis-backed background jobs with worker discovery and DLQ support.

--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -16,8 +16,7 @@ const cacheOptions: NormalizedCacheModuleOptions = {
   httpKeyStrategy: 'route',
 };
 
-function createRequestContext(method: string, url: string, path = url): RequestContext {
-  const headers: Record<string, string | string[]> = {};
+function createRequestContext(method: string, url: string, path = url, headers: Record<string, string | string[]> = {}): RequestContext {
   const queryStart = url.indexOf('?');
   const query: Record<string, string> = {};
 
@@ -44,7 +43,7 @@ function createRequestContext(method: string, url: string, path = url): RequestC
     request: {
       body: undefined,
       cookies: {},
-      headers: {},
+      headers,
       method,
       params: {},
       path,
@@ -380,10 +379,8 @@ describe('CacheInterceptor', () => {
       };
 
       const { interceptor, cacheService } = createInterceptor({ httpKeyStrategy: customStrategy });
-      const firstContext = createContext(ProductController, 'list', createRequestContext('GET', '/products', '/products'));
-      firstContext.requestContext.request.headers['x-tenant-id'] = 'tenant-a';
-      const secondContext = createContext(ProductController, 'list', createRequestContext('GET', '/products', '/products'));
-      secondContext.requestContext.request.headers['x-tenant-id'] = 'tenant-b';
+      const firstContext = createContext(ProductController, 'list', createRequestContext('GET', '/products', '/products', { 'x-tenant-id': 'tenant-a' }));
+      const secondContext = createContext(ProductController, 'list', createRequestContext('GET', '/products', '/products', { 'x-tenant-id': 'tenant-b' }));
       const next: CallHandler = {
         handle: vi.fn(async () => ({ data: 'response' })),
       };
@@ -434,6 +431,29 @@ describe('CacheInterceptor', () => {
       await interceptor.intercept(secondContext, next);
 
       expect(next.handle).toHaveBeenCalledTimes(1);
+    });
+
+    it('strategy "full" includes sorted query in cache key (equivalent to route+query)', async () => {
+      class ProductController {
+        @CacheTTL(120)
+        list() {}
+      }
+
+      const { interceptor, cacheService } = createInterceptor({ httpKeyStrategy: 'full' });
+      const firstContext = createContext(ProductController, 'list', createRequestContext('GET', '/products?page=1&sort=asc', '/products'));
+      const secondContext = createContext(ProductController, 'list', createRequestContext('GET', '/products?sort=asc&page=1', '/products'));
+      const thirdContext = createContext(ProductController, 'list', createRequestContext('GET', '/products?page=2&sort=asc', '/products'));
+      const next: CallHandler = {
+        handle: vi.fn(async () => ({ data: 'response' })),
+      };
+
+      await interceptor.intercept(firstContext, next);
+      await interceptor.intercept(secondContext, next);
+      await interceptor.intercept(thirdContext, next);
+
+      expect(next.handle).toHaveBeenCalledTimes(2);
+      expect(await cacheService.get('/products?page=1&sort=asc')).toEqual({ data: 'response' });
+      expect(await cacheService.get('/products?page=2&sort=asc')).toEqual({ data: 'response' });
     });
   });
 });

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -57,7 +57,7 @@ function defaultCacheKey(context: InterceptorContext, strategy: CacheKeyStrategy
     return path;
   }
 
-  if (strategy === 'route+query') {
+  if (strategy === 'route+query' || strategy === 'full') {
     return `${path}?${queryString}`;
   }
 


### PR DESCRIPTION
## Summary
Closes remaining CQRS/cache/docs gaps after #279, #286, and #294.

Closes #298

## Changes

### CQRS cross-package docs
- Updated `docs/concepts/cqrs.md` and `docs/concepts/cqrs.ko.md` to describe saga/process-manager support with `ISaga<TEvent>` contract and `@Saga()` decorator
- Updated `docs/reference/package-surface.md` and `docs/reference/package-surface.ko.md` to mention saga/process-manager in CQRS package description

### Cache-manager httpKeyStrategy 'full' semantics
- Added explicit `'full'` branch in `packages/cache-manager/src/interceptor.ts` (currently equivalent to `'route+query'`)
- Added dedicated test for `httpKeyStrategy: 'full'` behavior in `packages/cache-manager/src/interceptor.test.ts`
- Fixed readonly request headers mutation in test by passing headers as parameter to `createRequestContext()`

## Verification
- ✅ `pnpm --filter @konekti/cqrs --filter @konekti/passport --filter @konekti/cache-manager run typecheck` passes
- ✅ `pnpm exec vitest run packages/cqrs/src/module.test.ts packages/cache-manager/src/cache-service.test.ts packages/passport/src/refresh-token.test.ts` passes
- ✅ `pnpm exec vitest run packages/cache-manager/src/interceptor.test.ts` passes (17 tests including new 'full' strategy test)