### PR TITLE
Resolve #301: add @konekti/mongoose integration package

### DIFF
--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -46,6 +46,7 @@ These packages are the current intended public release surface for the 0.x line:
 - `@konekti/redis`
 - `@konekti/prisma`
 - `@konekti/drizzle`
+- `@konekti/mongoose`
 - `@konekti/terminus`
 - `@konekti/testing`
 - `@konekti/cli`

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -20,6 +20,7 @@ This page provides an overview of the current public package family within the K
 - `@konekti/redis`
 - `@konekti/prisma`
 - `@konekti/drizzle`
+- `@konekti/mongoose`
 - `@konekti/terminus`
 - `@konekti/openapi`
 - `@konekti/graphql`
@@ -57,7 +58,7 @@ This page provides an overview of the current public package family within the K
 - **`@konekti/event-bus`**: In-process event publishing and discovery.
 - **`@konekti/websocket`**: Decorator-based WebSocket gateway discovery and Node upgrade wiring.
 - **`@konekti/queue`**: Redis-backed background jobs with worker discovery and DLQ support.
-- **Data Integrations**: `@konekti/redis`, `@konekti/prisma`, `@konekti/drizzle`.
+- **Data Integrations**: `@konekti/redis`, `@konekti/prisma`, `@konekti/drizzle`, `@konekti/mongoose`.
 - **`@konekti/terminus`**: Health indicator composition and enriched runtime health aggregation.
 - **`@konekti/testing`**: Testing module and helper utilities.
 - **`@konekti/cli`**: Application bootstrap and generation commands.

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -1,0 +1,100 @@
+# @konekti/mongoose
+
+<p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
+
+Konekti의 공식 Mongoose 통합 — 세션 인식 트랜잭션 시임과 선택적 dispose 훅으로 Mongoose 연결을 래핑합니다.
+
+## 같이 보기
+
+- `../../docs/concepts/transactions.md`
+- `../../docs/concepts/lifecycle-and-shutdown.md`
+
+## 이 패키지의 역할
+
+`@konekti/mongoose`는 Mongoose 연결을 Konekti의 모듈, DI, 라이프사이클 모델에 연결합니다. Prisma와 달리 Mongoose는 모델 작업에 세션을 자동으로 주입하지 않으므로, 이 통합은 애플리케이션 코드가 `{ session }` 전파를 담당하면서도 깔끔한 트랜잭션 컨텍스트를 제공합니다.
+
+주요 책임:
+- `MongooseConnection` 래퍼를 통해 `current()` / `currentSession()` / `transaction()` / `requestTransaction()` 제공
+- DI 컨테이너에 `MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, `MONGOOSE_OPTIONS` 토큰 등록
+- 선택적 `dispose` 훅을 `onApplicationShutdown`에 연결
+- 선택적 자동 요청 범위 트랜잭션을 위한 `MongooseTransactionInterceptor` 제공
+
+## 설치
+
+```bash
+npm install @konekti/mongoose
+```
+
+## 빠른 시작
+
+```typescript
+import { Module } from '@konekti/core';
+import { createMongooseModule } from '@konekti/mongoose';
+import mongoose from 'mongoose';
+
+const connection = mongoose.createConnection(process.env.MONGODB_URI);
+
+@Module({
+  imports: [
+    createMongooseModule({
+      connection,
+      dispose: async (conn) => {
+        await conn.close();
+      },
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### 저장소에서 연결 사용하기
+
+```typescript
+import { Inject } from '@konekti/core';
+import { MongooseConnection } from '@konekti/mongoose';
+
+export class UserRepository {
+  constructor(private conn: MongooseConnection) {}
+
+  async findById(id: string) {
+    // current()는 Mongoose 연결을 반환합니다
+    const connection = this.conn.current();
+    const User = connection.model('User');
+    return User.findById(id);
+  }
+}
+```
+
+### 명시적 트랜잭션
+
+```typescript
+await this.conn.transaction(async () => {
+  // currentSession()은 이 콜백 내에서 활성 세션을 반환합니다
+  const session = this.conn.currentSession();
+  
+  // 트랜잭션에 참여해야 하는 Mongoose 작업에는 { session }을 전달해야 합니다
+  await User.create([{ email: 'ada@example.com' }], { session });
+  await AuditLog.create([{ userId: user.id }], { session });
+});
+```
+
+## 주요 API
+
+| Export | 위치 | 설명 |
+|---|---|---|
+| `MongooseConnection` | `src/connection.ts` | `current()`, `currentSession()`, `transaction()`, `requestTransaction()`, `onApplicationShutdown()` 포함 래퍼 |
+| `createMongooseModule(options)` | `src/module.ts` | 모든 프로바이더가 포함된 import 가능한 Konekti 모듈 생성 |
+| `createMongooseProviders(options)` | `src/module.ts` | 수동 등록을 위한 원시 프로바이더 배열 반환 |
+| `MongooseTransactionInterceptor` | `src/transaction.ts` | 자동 요청 범위 트랜잭션을 위한 선택적 인터셉터 |
+
+## 트랜잭션 시맨틱스
+
+`MongooseConnection`는 활성 세션 컨텍스트를 추적하기 위해 `AsyncLocalStorage`를 사용합니다. 서비스와 저장소 코드는 `currentSession()`을 호출하여 세션을 얻은 후, 트랜잭션에 참여해야 하는 Mongoose 작업에 `{ session }`을 전달합니다.
+
+**중요**: Prisma와 달리 Mongoose 작업은 자동으로 앰비언트 세션을 사용하지 않습니다. 각 작업에 `{ session: mongooseConnection.currentSession() }`을 명시적으로 전달해야 합니다.
+
+## 관련 패키지
+
+- `@konekti/runtime` — 모듈 가져오기/내보내기 및 종료 라이프사이클
+- `@konekti/drizzle` — Drizzle을 위한 동일한 솔루션; 비교용
+- `@konekti/prisma` — Prisma를 위한 동일한 솔루션; 비교용

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -1,0 +1,169 @@
+# @konekti/mongoose
+
+<p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
+
+Official Mongoose integration for Konekti — wraps a Mongoose connection with a session-aware transaction seam and an optional dispose hook.
+
+## See also
+
+- `../../docs/concepts/transactions.md`
+- `../../docs/concepts/lifecycle-and-shutdown.md`
+
+## What this package does
+
+`@konekti/mongoose` connects a Mongoose connection to Konekti's module, DI, and lifecycle model. Unlike Prisma, Mongoose doesn't automatically inject sessions into model operations — so this integration provides a clean transaction context while keeping the `{ session }` propagation responsibility with application code.
+
+Key responsibilities:
+- Provide the `MongooseConnection` wrapper with `current()` / `currentSession()` / `transaction()` / `requestTransaction()`
+- Register `MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, and `MONGOOSE_OPTIONS` tokens in the DI container
+- Wire the optional `dispose` hook into `onApplicationShutdown`
+- Expose `MongooseTransactionInterceptor` for opt-in automatic request-scoped transactions
+
+## Installation
+
+```bash
+npm install @konekti/mongoose
+```
+
+## Quick Start
+
+```typescript
+import { Module } from '@konekti/core';
+import { createMongooseModule } from '@konekti/mongoose';
+import mongoose from 'mongoose';
+
+const connection = mongoose.createConnection(process.env.MONGODB_URI);
+
+@Module({
+  imports: [
+    createMongooseModule({
+      connection,
+      dispose: async (conn) => {
+        await conn.close();
+      },
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+### Using the connection in a repository
+
+```typescript
+import { Inject } from '@konekti/core';
+import { MongooseConnection } from '@konekti/mongoose';
+import { Model } from 'mongoose';
+
+export class UserRepository {
+  constructor(private conn: MongooseConnection) {}
+
+  async findById(id: string) {
+    // current() returns the Mongoose connection
+    const connection = this.conn.current();
+    const User = connection.model('User');
+    return User.findById(id);
+  }
+}
+```
+
+### Explicit transaction
+
+```typescript
+await this.conn.transaction(async () => {
+  // currentSession() returns the active session inside this callback
+  const session = this.conn.currentSession();
+  
+  // You must pass { session } to Mongoose operations that should participate
+  await User.create([{ email: 'ada@example.com' }], { session });
+  await AuditLog.create([{ userId: user.id }], { session });
+});
+```
+
+### Automatic request-scoped transaction (opt-in)
+
+```typescript
+import { UseInterceptor } from '@konekti/http';
+import { MongooseTransactionInterceptor } from '@konekti/mongoose';
+
+@UseInterceptor(MongooseTransactionInterceptor)
+class UsersController {}
+```
+
+## Key API
+
+| Export | Location | Description |
+|---|---|---|
+| `MongooseConnection` | `src/connection.ts` | Wrapper with `current()`, `currentSession()`, `transaction()`, `requestTransaction()`, `onApplicationShutdown()` |
+| `createMongooseModule(options)` | `src/module.ts` | Creates an importable Konekti module with all providers |
+| `createMongooseProviders(options)` | `src/module.ts` | Returns the raw provider array for manual registration |
+| `MongooseTransactionInterceptor` | `src/transaction.ts` | Opt-in interceptor for automatic per-request transactions |
+| `MONGOOSE_CONNECTION` | `src/tokens.ts` | DI token for the raw Mongoose connection |
+| `MONGOOSE_DISPOSE` | `src/tokens.ts` | DI token for the optional cleanup hook |
+| `MONGOOSE_OPTIONS` | `src/tokens.ts` | DI token for normalized Mongoose module options |
+| `MongooseConnectionLike` | `src/types.ts` | Seam type — any object with optional `startSession()` |
+| `MongooseSessionLike` | `src/types.ts` | Session contract with `startTransaction()`, `commitTransaction()`, `abortTransaction()`, `endSession()` |
+| `MongooseModuleOptions` | `src/types.ts` | `{ connection, dispose?, strictTransactions? }` |
+| `MongooseHandleProvider` | `src/types.ts` | Public connection-aware handle contract |
+
+## Architecture
+
+```
+createMongooseModule({ connection, dispose?, strictTransactions? })
+  → registers MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, and MONGOOSE_OPTIONS tokens
+  → registers MongooseConnection and MongooseTransactionInterceptor as exported providers
+
+service/repository code
+  → MongooseConnection.current()
+  → returns the Mongoose connection
+
+MongooseConnection.transaction(fn)
+  → calls connection.startSession() if available
+  → starts a transaction on the session
+  → AsyncLocalStorage stores the session
+  → currentSession() returns the session within the callback
+  → application code must pass { session: conn.currentSession() } to Mongoose operations
+
+app.close()
+  → onApplicationShutdown()
+  → aborts open request transactions
+  → calls dispose(connection) if provided
+```
+
+### Why MONGOOSE_DISPOSE is a separate token
+
+Separating the cleanup hook from the connection value means:
+- The connection object stays clean
+- Shutdown cleanup can be selectively wired without touching the connection handle
+- Tests can verify dispose behavior independently
+
+### Transaction semantics
+
+`MongooseConnection` uses `AsyncLocalStorage` to track the active session context. Service and repository code calls `currentSession()` to obtain the session, then passes `{ session }` to Mongoose operations that should participate in the transaction.
+
+**Important**: Unlike Prisma, Mongoose operations do not automatically use the ambient session. Application code must explicitly pass `{ session: mongooseConnection.currentSession() }` to each operation.
+
+### Nested transaction behavior
+
+When `transaction()` or `requestTransaction()` is called inside an existing transaction, the ambient session is reused rather than starting a new nested transaction. This matches Mongoose's actual nested transaction semantics.
+
+## File reading order for contributors
+
+1. `src/types.ts` — `MongooseConnectionLike`, `MongooseSessionLike`, `MongooseModuleOptions`, `MongooseHandleProvider`
+2. `src/tokens.ts` — `MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, `MONGOOSE_OPTIONS`
+3. `src/connection.ts` — `MongooseConnection` wrapper, ALS-based session context
+4. `src/module.ts` — `createMongooseProviders`, `createMongooseModule`
+5. `src/transaction.ts` — `MongooseTransactionInterceptor`
+6. `src/module.test.ts` — connection usage, session transactions, dispose hook
+
+## Related packages
+
+- `@konekti/runtime` — module import/export and shutdown lifecycle
+- `@konekti/drizzle` — the same problem solved for Drizzle; compare for perspective
+- `@konekti/prisma` — the same problem solved for Prisma; compare for perspective
+- `@konekti/cli` — scaffold includes this package when Mongoose is selected
+
+## One-liner mental model
+
+```text
+@konekti/mongoose = Mongoose connection → session-aware tx wrapper + optional cleanup hook → Konekti runtime
+```

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@konekti/mongoose",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/konektijs/konekti.git",
+    "directory": "packages/mongoose"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
+    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@konekti/core": "workspace:*",
+    "@konekti/http": "workspace:*",
+    "@konekti/di": "workspace:*",
+    "@konekti/runtime": "workspace:*"
+  },
+  "peerDependencies": {
+    "mongoose": ">=7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "mongoose": {
+      "optional": true
+    }
+  }
+}

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -1,0 +1,148 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import {
+  createRequestAbortContext,
+  raceWithAbort,
+  trackActiveRequestTransaction,
+  untrackActiveRequestTransaction,
+} from '@konekti/runtime';
+import type { OnApplicationShutdown } from '@konekti/runtime';
+import { Inject } from '@konekti/core';
+
+import { MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, MONGOOSE_OPTIONS } from './tokens.js';
+import type {
+  MongooseConnectionLike,
+  MongooseHandleProvider,
+  MongooseRuntimeOptions,
+  MongooseSessionLike,
+} from './types.js';
+
+const TRANSACTIONS_NOT_SUPPORTED_ERROR = 'Transaction not supported: Mongoose connection does not implement startSession.';
+
+type ActiveRequestTransaction = {
+  abort(reason?: unknown): void;
+  settled: Promise<void>;
+};
+
+type ActiveRequestTransactionHandle = {
+  active: ActiveRequestTransaction;
+  settle(): void;
+};
+
+async function executeSessionTransaction<T>(session: MongooseSessionLike, fn: () => Promise<T>): Promise<T> {
+  try {
+    await session.startTransaction();
+    const result = await fn();
+    await session.commitTransaction();
+    return result;
+  } catch (error) {
+    await session.abortTransaction();
+    throw error;
+  }
+}
+
+@Inject([MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, MONGOOSE_OPTIONS])
+export class MongooseConnection<TConnection extends MongooseConnectionLike = MongooseConnectionLike>
+  implements MongooseHandleProvider<TConnection>, OnApplicationShutdown
+{
+  private readonly sessions = new AsyncLocalStorage<MongooseSessionLike>();
+  private readonly activeRequestTransactions = new Set<ActiveRequestTransaction>();
+
+  constructor(
+    private readonly connection: TConnection,
+    private readonly dispose?: (connection: TConnection) => Promise<void> | void,
+    private readonly connectionOptions: MongooseRuntimeOptions = { strictTransactions: false },
+  ) {}
+
+  current(): TConnection {
+    return this.connection;
+  }
+
+  currentSession(): MongooseSessionLike | undefined {
+    return this.sessions.getStore();
+  }
+
+  async onApplicationShutdown(): Promise<void> {
+    for (const transaction of this.activeRequestTransactions) {
+      transaction.abort(new Error('Application shutdown interrupted an open request transaction.'));
+    }
+
+    await Promise.allSettled(Array.from(this.activeRequestTransactions, (transaction) => transaction.settled));
+
+    if (this.dispose) {
+      await this.dispose(this.connection);
+    }
+  }
+
+  async transaction<T>(fn: () => Promise<T>): Promise<T> {
+    const currentSession = this.sessions.getStore();
+    if (currentSession) {
+      return fn();
+    }
+
+    const session = await this.resolveSession();
+    if (!session) {
+      return fn();
+    }
+
+    try {
+      return await this.sessions.run(session, () =>
+        executeSessionTransaction(session, () => this.sessions.run(session, fn)),
+      );
+    } finally {
+      await session.endSession();
+    }
+  }
+
+  async requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    const currentSession = this.sessions.getStore();
+    if (currentSession) {
+      if (signal) {
+        return raceWithAbort(fn, signal);
+      }
+      return fn();
+    }
+
+    const abortContext = createRequestAbortContext(signal);
+    const active = this.trackActiveRequestTransaction(abortContext.controller);
+    let acquiredSession: MongooseSessionLike | undefined;
+
+    try {
+      const resolvedSession = await this.resolveSession();
+      if (!resolvedSession) {
+        return await raceWithAbort(fn, abortContext.signal);
+      }
+
+      acquiredSession = resolvedSession;
+      return await this.sessions.run(resolvedSession, () =>
+        executeSessionTransaction(resolvedSession, () =>
+          this.sessions.run(resolvedSession, () => raceWithAbort(fn, abortContext.signal)),
+        ),
+      );
+    } finally {
+      abortContext.cleanup();
+      this.untrackActiveRequestTransaction(active);
+      await acquiredSession?.endSession();
+    }
+  }
+
+  private trackActiveRequestTransaction(controller: AbortController): ActiveRequestTransactionHandle {
+    return trackActiveRequestTransaction(this.activeRequestTransactions, controller);
+  }
+
+  private untrackActiveRequestTransaction(handle: ActiveRequestTransactionHandle): void {
+    untrackActiveRequestTransaction(this.activeRequestTransactions, handle);
+  }
+
+  private async resolveSession(): Promise<MongooseSessionLike | undefined> {
+    if (typeof this.connection.startSession !== 'function') {
+      if (this.connectionOptions.strictTransactions) {
+        throw new Error(TRANSACTIONS_NOT_SUPPORTED_ERROR);
+      }
+
+      return undefined;
+    }
+
+    return this.connection.startSession();
+  }
+}

--- a/packages/mongoose/src/index.ts
+++ b/packages/mongoose/src/index.ts
@@ -1,0 +1,5 @@
+export * from './connection.js';
+export * from './module.js';
+export * from './tokens.js';
+export * from './transaction.js';
+export * from './types.js';

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Global, Inject, Module } from '@konekti/core';
+import { bootstrapApplication, defineModule } from '@konekti/runtime';
+
+import { createMongooseModule, createMongooseModuleAsync, MongooseConnection } from './index.js';
+import type { MongooseConnectionLike, MongooseSessionLike } from './types.js';
+
+function createFakeSession(events: string[]): MongooseSessionLike {
+  return {
+    async startTransaction() {
+      events.push('transaction:start');
+    },
+    async commitTransaction() {
+      events.push('transaction:commit');
+    },
+    async abortTransaction() {
+      events.push('transaction:abort');
+    },
+    async endSession() {
+      events.push('session:end');
+    },
+  };
+}
+
+describe('@konekti/mongoose', () => {
+  it('exposes current connection, session, and transaction callbacks with optional disposal', async () => {
+    const events: string[] = [];
+    const session = createFakeSession(events);
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    @Inject([MongooseConnection])
+    class UserService {
+      constructor(private readonly conn: MongooseConnection<typeof connection>) {}
+
+      async create(email: string) {
+        return this.conn.transaction(async () => {
+          const current = this.conn.current();
+          const currentSession = this.conn.currentSession();
+
+          events.push(`tx:create:${email}`);
+          events.push(`session:${currentSession !== undefined}`);
+
+          return { connection: current === connection, email };
+        });
+      }
+
+      async findById(id: string) {
+        events.push(`root:find:${id}`);
+        return { id };
+      }
+    }
+
+    const MongooseModule = createMongooseModule<typeof connection>({
+      connection,
+      dispose(current) {
+        events.push(`dispose:${current === connection}`);
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MongooseModule],
+      providers: [UserService],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+    const service = await app.container.resolve(UserService);
+
+    await expect(service.findById('user-1')).resolves.toEqual({ id: 'user-1' });
+    await expect(service.create('ada@example.com')).resolves.toEqual({ connection: true, email: 'ada@example.com' });
+
+    expect(events).toEqual([
+      'root:find:user-1',
+      'connection:startSession',
+      'transaction:start',
+      'tx:create:ada@example.com',
+      'session:true',
+      'transaction:commit',
+      'session:end',
+    ]);
+
+    await app.close();
+
+    expect(events).toEqual([
+      'root:find:user-1',
+      'connection:startSession',
+      'transaction:start',
+      'tx:create:ada@example.com',
+      'session:true',
+      'transaction:commit',
+      'session:end',
+      'dispose:true',
+    ]);
+  });
+
+  it('rolls back open request transactions before dispose on shutdown', async () => {
+    const events: string[] = [];
+    const session = createFakeSession(events);
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    const MongooseModule = createMongooseModule<typeof connection>({
+      connection,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MongooseModule],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
+
+    const openTransaction = mongoose.requestTransaction(
+      async () => new Promise<never>(() => undefined),
+    );
+
+    await app.close();
+
+    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'transaction:abort',
+      'session:end',
+      'dispose',
+    ]);
+  });
+
+  it('enforces strictTransactions for sync and async module builders', async () => {
+    const connection = {};
+
+    const StrictSyncModule = createMongooseModule({
+      connection,
+      strictTransactions: true,
+    });
+
+    class StrictSyncAppModule {}
+
+    defineModule(StrictSyncAppModule, {
+      imports: [StrictSyncModule],
+    });
+
+    const syncApp = await bootstrapApplication({
+      mode: 'test',
+      rootModule: StrictSyncAppModule,
+    });
+    const syncMongoose = await syncApp.container.resolve(MongooseConnection<typeof connection>);
+
+    await expect(syncMongoose.transaction(async () => 'ok')).rejects.toThrow(
+      'Transaction not supported: Mongoose connection does not implement startSession.',
+    );
+
+    await syncApp.close();
+
+    const StrictAsyncModule = createMongooseModuleAsync({
+      useFactory: () => ({
+        connection,
+        strictTransactions: true,
+      }),
+    });
+
+    class StrictAsyncAppModule {}
+
+    defineModule(StrictAsyncAppModule, {
+      imports: [StrictAsyncModule],
+    });
+
+    const asyncApp = await bootstrapApplication({
+      mode: 'test',
+      rootModule: StrictAsyncAppModule,
+    });
+    const asyncMongoose = await asyncApp.container.resolve(MongooseConnection<typeof connection>);
+
+    await expect(asyncMongoose.requestTransaction(async () => 'ok')).rejects.toThrow(
+      'Transaction not supported: Mongoose connection does not implement startSession.',
+    );
+
+    await asyncApp.close();
+  });
+
+  it('runs nested request and service transactions through a single session boundary', async () => {
+    let sessionCalls = 0;
+    const events: string[] = [];
+    const session = createFakeSession(events);
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        sessionCalls += 1;
+        return session;
+      },
+    };
+
+    const mongoose = new MongooseConnection<typeof connection>(connection);
+
+    await expect(
+      mongoose.requestTransaction(async () => mongoose.transaction(async () => 'ok')),
+    ).resolves.toBe('ok');
+    expect(sessionCalls).toBe(1);
+  });
+
+  it('handles transaction abort on error', async () => {
+    const events: string[] = [];
+    const session = createFakeSession(events);
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    const mongoose = new MongooseConnection<typeof connection>(connection);
+
+    await expect(
+      mongoose.transaction(async () => {
+        events.push('tx:work');
+        throw new Error('transaction failed');
+      }),
+    ).rejects.toThrow('transaction failed');
+
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'tx:work',
+      'transaction:abort',
+      'session:end',
+    ]);
+  });
+
+  it('handles connection without startSession gracefully', async () => {
+    const events: string[] = [];
+
+    const connection = {
+      someOtherMethod: async () => {
+        events.push('other:method');
+      },
+    } as unknown as MongooseConnectionLike;
+
+    const mongoose = new MongooseConnection<typeof connection>(connection);
+
+    await expect(mongoose.transaction(async () => {
+      events.push('tx:work');
+      return 'ok';
+    })).resolves.toBe('ok');
+
+    expect(events).toEqual(['tx:work']);
+  });
+});
+
+describe('createMongooseModuleAsync', () => {
+  function makeFakeConnection() {
+    const events: string[] = [];
+    const session = createFakeSession(events);
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    return { connection, events, session };
+  }
+
+  it('factory receives injected token and resolves MongooseConnection', async () => {
+    const { connection, events } = makeFakeConnection();
+
+    class ConfigService {
+      readonly url = 'mongodb://localhost/test';
+    }
+
+    @Global()
+    @Module({ providers: [ConfigService], exports: [ConfigService] })
+    class ConfigModule {}
+
+    const factory = vi.fn().mockResolvedValue({ connection });
+
+    const MongooseModule = createMongooseModuleAsync<typeof connection>({
+      inject: [ConfigService],
+      useFactory: factory,
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [ConfigModule, MongooseModule],
+    });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const conn = await app.container.resolve(MongooseConnection);
+
+    expect(factory).toHaveBeenCalledOnce();
+    expect(factory.mock.calls[0][0]).toBeInstanceOf(ConfigService);
+
+    void conn;
+    void events;
+
+    await app.close();
+  });
+
+  it('factory returning a promise resolves the connection correctly', async () => {
+    const { connection } = makeFakeConnection();
+
+    const MongooseModule = createMongooseModuleAsync<typeof connection>({
+      useFactory: () => Promise.resolve({ connection }),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [MongooseModule] });
+
+    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const conn = await app.container.resolve(MongooseConnection);
+
+    expect(conn).toBeInstanceOf(MongooseConnection);
+
+    await app.close();
+  });
+
+  it('propagates factory errors during module initialization', async () => {
+    const MongooseModule = createMongooseModuleAsync({
+      useFactory: () => Promise.reject(new Error('mongo config fetch failed')),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [MongooseModule] });
+
+    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow('mongo config fetch failed');
+  });
+});

--- a/packages/mongoose/src/module.ts
+++ b/packages/mongoose/src/module.ts
@@ -1,0 +1,127 @@
+import { type AsyncModuleOptions } from '@konekti/core';
+import type { Provider } from '@konekti/di';
+import { defineModule, type ModuleType } from '@konekti/runtime';
+
+import { MongooseConnection } from './connection.js';
+import { MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, MONGOOSE_OPTIONS } from './tokens.js';
+import { MongooseTransactionInterceptor } from './transaction.js';
+import type { MongooseConnectionLike, MongooseModuleOptions, MongooseRuntimeOptions } from './types.js';
+
+type ResolvedMongooseModuleOptions<TConnection extends MongooseConnectionLike> = Omit<
+  MongooseModuleOptions<TConnection>,
+  'strictTransactions'
+> & {
+  strictTransactions: boolean;
+};
+
+const MONGOOSE_NORMALIZED_OPTIONS = Symbol('konekti.mongoose.normalized-options');
+const MONGOOSE_MODULE_EXPORTS = [MongooseConnection, MongooseTransactionInterceptor];
+
+function normalizeMongooseModuleOptions<TConnection extends MongooseConnectionLike>(
+  options: MongooseModuleOptions<TConnection>,
+): ResolvedMongooseModuleOptions<TConnection> {
+  return {
+    ...options,
+    strictTransactions: options.strictTransactions ?? false,
+  };
+}
+
+function createRuntimeOptionsProviderValue(strictTransactions: boolean): MongooseRuntimeOptions {
+  return { strictTransactions };
+}
+
+function createMongooseRuntimeProviders<TConnection extends MongooseConnectionLike>(
+  normalizedOptionsProvider: Provider,
+): Provider[] {
+  return [
+    normalizedOptionsProvider,
+    {
+      inject: [MONGOOSE_NORMALIZED_OPTIONS],
+      provide: MONGOOSE_CONNECTION,
+      useFactory: (options: unknown) => (options as ResolvedMongooseModuleOptions<TConnection>).connection,
+    },
+    {
+      inject: [MONGOOSE_NORMALIZED_OPTIONS],
+      provide: MONGOOSE_DISPOSE,
+      useFactory: (options: unknown) => (options as ResolvedMongooseModuleOptions<TConnection>).dispose,
+    },
+    {
+      inject: [MONGOOSE_NORMALIZED_OPTIONS],
+      provide: MONGOOSE_OPTIONS,
+      useFactory: (options: unknown) =>
+        createRuntimeOptionsProviderValue(
+          (options as ResolvedMongooseModuleOptions<TConnection>).strictTransactions,
+        ),
+    },
+    MongooseConnection,
+    MongooseTransactionInterceptor,
+  ];
+}
+
+function createMemoizedMongooseOptionsResolver<TConnection extends MongooseConnectionLike>(
+  options: AsyncModuleOptions<MongooseModuleOptions<TConnection>>,
+): (...deps: unknown[]) => Promise<ResolvedMongooseModuleOptions<TConnection>> {
+  let cachedResult: Promise<ResolvedMongooseModuleOptions<TConnection>> | undefined;
+
+  return (...deps: unknown[]) => {
+    if (!cachedResult) {
+      cachedResult = Promise.resolve(options.useFactory(...deps)).then((resolved) =>
+        normalizeMongooseModuleOptions<TConnection>(resolved),
+      );
+    }
+
+    if (!cachedResult) {
+      throw new Error('Mongoose module options resolver initialization failed.');
+    }
+
+    return cachedResult;
+  };
+}
+
+function createMongooseProvidersAsync<TConnection extends MongooseConnectionLike>(
+  options: AsyncModuleOptions<MongooseModuleOptions<TConnection>>,
+): Provider[] {
+  const resolveOptions = createMemoizedMongooseOptionsResolver(options);
+
+  const normalizedOptionsProvider = {
+    inject: options.inject,
+    provide: MONGOOSE_NORMALIZED_OPTIONS,
+    scope: 'singleton' as const,
+    useFactory: async (...deps: unknown[]) => resolveOptions(...deps),
+  };
+
+  return createMongooseRuntimeProviders<TConnection>(normalizedOptionsProvider);
+}
+
+export function createMongooseProviders<TConnection extends MongooseConnectionLike>(
+  options: MongooseModuleOptions<TConnection>,
+): Provider[] {
+  const resolved = normalizeMongooseModuleOptions(options);
+
+  return createMongooseRuntimeProviders<TConnection>({
+    provide: MONGOOSE_NORMALIZED_OPTIONS,
+    useValue: resolved,
+  });
+}
+
+export function createMongooseModule<TConnection extends MongooseConnectionLike>(
+  options: MongooseModuleOptions<TConnection>,
+): ModuleType {
+  class MongooseModule {}
+
+  return defineModule(MongooseModule, {
+    exports: MONGOOSE_MODULE_EXPORTS,
+    providers: createMongooseProviders(options),
+  });
+}
+
+export function createMongooseModuleAsync<TConnection extends MongooseConnectionLike>(
+  options: AsyncModuleOptions<MongooseModuleOptions<TConnection>>,
+): ModuleType {
+  class MongooseAsyncModule {}
+
+  return defineModule(MongooseAsyncModule, {
+    exports: MONGOOSE_MODULE_EXPORTS,
+    providers: createMongooseProvidersAsync(options),
+  });
+}

--- a/packages/mongoose/src/tokens.ts
+++ b/packages/mongoose/src/tokens.ts
@@ -1,0 +1,4 @@
+export const MONGOOSE_CONNECTION = Symbol.for('konekti.mongoose.connection');
+export const MONGOOSE_DISPOSE = Symbol.for('konekti.mongoose.dispose');
+export const MONGOOSE_OPTIONS = Symbol.for('konekti.mongoose.options');
+export const MONGOOSE_SESSION = Symbol.for('konekti.mongoose.session');

--- a/packages/mongoose/src/transaction.ts
+++ b/packages/mongoose/src/transaction.ts
@@ -1,0 +1,14 @@
+import { Inject } from '@konekti/core';
+import type { Interceptor, InterceptorContext } from '@konekti/http';
+
+import { MongooseConnection } from './connection.js';
+import type { MongooseConnectionLike } from './types.js';
+
+@Inject([MongooseConnection])
+export class MongooseTransactionInterceptor implements Interceptor {
+  constructor(private readonly connection: MongooseConnection<MongooseConnectionLike>) {}
+
+  async intercept(context: InterceptorContext, next: { handle(): Promise<unknown> }): Promise<unknown> {
+    return this.connection.requestTransaction(async () => next.handle(), context.requestContext.request.signal);
+  }
+}

--- a/packages/mongoose/src/types.ts
+++ b/packages/mongoose/src/types.ts
@@ -1,0 +1,29 @@
+import type { MaybePromise } from '@konekti/core';
+
+export interface MongooseConnectionLike {
+  startSession?(): Promise<MongooseSessionLike>;
+}
+
+export interface MongooseSessionLike {
+  startTransaction(): Promise<void>;
+  commitTransaction(): Promise<void>;
+  abortTransaction(): Promise<void>;
+  endSession(): Promise<void>;
+}
+
+export interface MongooseRuntimeOptions {
+  strictTransactions: boolean;
+}
+
+export interface MongooseModuleOptions<TConnection extends MongooseConnectionLike = MongooseConnectionLike> {
+  connection: TConnection;
+  dispose?: (connection: TConnection) => MaybePromise<void>;
+  strictTransactions?: boolean;
+}
+
+export interface MongooseHandleProvider<TConnection extends MongooseConnectionLike = MongooseConnectionLike> {
+  current(): TConnection;
+  currentSession(): MongooseSessionLike | undefined;
+  transaction<T>(fn: () => Promise<T>): Promise<T>;
+  requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T>;
+}

--- a/packages/mongoose/src/vertical-slice.test.ts
+++ b/packages/mongoose/src/vertical-slice.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from 'vitest';
+
+import { Inject } from '@konekti/core';
+import { bootstrapApplication, defineModule } from '@konekti/runtime';
+import {
+  Controller,
+  FromBody,
+  FromPath,
+  Get,
+  NotFoundException,
+  Post,
+  RequestDto,
+  SuccessStatus,
+  UseInterceptor,
+  type FrameworkRequest,
+  type FrameworkResponse,
+} from '@konekti/http';
+
+import { createMongooseModule, MongooseConnection, MongooseTransactionInterceptor } from './index.js';
+import type { MongooseConnectionLike, MongooseSessionLike } from './types.js';
+
+function createResponse(events?: string[]): FrameworkResponse & { body?: unknown } {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      events?.push('response:send');
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string | string[]) {
+      const headers = this.headers as Record<string, string | string[]>;
+      headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+function createRequest(
+  path: string,
+  method: FrameworkRequest['method'],
+  body?: unknown,
+  signal?: AbortSignal,
+): FrameworkRequest {
+  return {
+    body,
+    cookies: {},
+    headers: {},
+    method,
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    signal,
+    url: path,
+  };
+}
+
+describe('@konekti/mongoose vertical slice', () => {
+  it('propagates session through the request interceptor path', async () => {
+    type UserRecord = {
+      email: string;
+      id: string;
+      name: string;
+    };
+
+    const users = new Map<string, UserRecord>();
+    const events: string[] = [];
+    let sequence = 0;
+    let resolveAbortCreate!: () => void;
+    const abortCreateReached = new Promise<void>((resolve) => {
+      resolveAbortCreate = resolve;
+    });
+
+    function createSession(events: string[]): MongooseSessionLike {
+      return {
+        async startTransaction() {
+          events.push('session:tx:start');
+        },
+        async commitTransaction() {
+          events.push('session:tx:commit');
+        },
+        async abortTransaction() {
+          events.push('session:tx:abort');
+        },
+        async endSession() {
+          events.push('session:end');
+        },
+      };
+    }
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return createSession(events);
+      },
+    };
+
+    class CreateUserRequest {
+      @FromBody('email')
+      email = '';
+
+      @FromBody('name')
+      name = '';
+    }
+
+    class GetUserRequest {
+      @FromPath('id')
+      id = '';
+    }
+
+    @Inject([MongooseConnection])
+    class UserRepository {
+      constructor(private readonly conn: MongooseConnection<typeof connection>) {}
+
+      async create(input: CreateUserRequest) {
+        events.push(`repo:insert:${input.email}`);
+
+        if (input.email === 'abort@example.com') {
+          resolveAbortCreate();
+          return new Promise<never>(() => undefined);
+        }
+
+        const record = {
+          ...input,
+          id: `user-${++sequence}`,
+        };
+        users.set(record.id, record);
+        return record;
+      }
+
+      async findById(id: string) {
+        events.push(`repo:find:${id}`);
+        return users.get(id) ?? null;
+      }
+    }
+
+    @Inject([UserRepository])
+    class UserService {
+      constructor(private readonly repo: UserRepository) {}
+
+      async create(input: CreateUserRequest) {
+        return this.repo.create(input);
+      }
+
+      async get(id: string) {
+        const user = await this.repo.findById(id);
+
+        if (!user) {
+          throw new NotFoundException(`User ${id} was not found.`);
+        }
+
+        return user;
+      }
+    }
+
+    @Controller('/users')
+    @Inject([UserService])
+    class UsersController {
+      constructor(private readonly users: UserService) {}
+
+      @RequestDto(CreateUserRequest)
+      @SuccessStatus(201)
+      @Post('/')
+      @UseInterceptor(MongooseTransactionInterceptor)
+      async create(input: CreateUserRequest) {
+        return this.users.create(input);
+      }
+
+      @RequestDto(GetUserRequest)
+      @Get('/:id')
+      @UseInterceptor(MongooseTransactionInterceptor)
+      async getOne(input: GetUserRequest) {
+        return this.users.get(input.id);
+      }
+    }
+
+    const MongooseModule = createMongooseModule<typeof connection>({
+      connection,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [UsersController],
+      imports: [MongooseModule],
+      providers: [UserRepository, UserService],
+    });
+
+    const app = await bootstrapApplication({
+      mode: 'test',
+      rootModule: AppModule,
+    });
+
+    const createResponseOk = createResponse(events);
+    await app.dispatch(createRequest('/users', 'POST', { email: 'ada@example.com', name: 'Ada' }), createResponseOk);
+
+    expect(createResponseOk.body).toEqual({ email: 'ada@example.com', id: 'user-1', name: 'Ada' });
+    expect(events).toEqual([
+      'connection:startSession',
+      'session:tx:start',
+      'repo:insert:ada@example.com',
+      'session:tx:commit',
+      'session:end',
+      'response:send',
+    ]);
+
+    const getResponseOk = createResponse(events);
+    await app.dispatch(createRequest('/users/user-1', 'GET'), getResponseOk);
+
+    expect(getResponseOk.body).toEqual({ email: 'ada@example.com', id: 'user-1', name: 'Ada' });
+    expect(events).toEqual([
+      'connection:startSession',
+      'session:tx:start',
+      'repo:insert:ada@example.com',
+      'session:tx:commit',
+      'session:end',
+      'response:send',
+      'connection:startSession',
+      'session:tx:start',
+      'repo:find:user-1',
+      'session:tx:commit',
+      'session:end',
+      'response:send',
+    ]);
+
+    const getResponseMissing = createResponse(events);
+    await app.dispatch(createRequest('/users/missing', 'GET'), getResponseMissing);
+
+    expect(getResponseMissing.statusCode).toBe(404);
+    expect(events).toEqual([
+      'connection:startSession',
+      'session:tx:start',
+      'repo:insert:ada@example.com',
+      'session:tx:commit',
+      'session:end',
+      'response:send',
+      'connection:startSession',
+      'session:tx:start',
+      'repo:find:user-1',
+      'session:tx:commit',
+      'session:end',
+      'response:send',
+      'connection:startSession',
+      'session:tx:start',
+      'repo:find:missing',
+      'session:tx:abort',
+      'session:end',
+      'response:send',
+    ]);
+
+    const abortController = new AbortController();
+    const abortResponse = createResponse(events);
+    const abortDispatch = app.dispatch(
+      createRequest('/users', 'POST', { email: 'abort@example.com', name: 'Ada' }, abortController.signal),
+      abortResponse,
+    );
+    await abortCreateReached;
+    abortController.abort(new Error('client aborted request'));
+    await abortDispatch;
+
+    expect(abortResponse.committed).toBe(false);
+    expect(users.get('user-1')).toEqual({
+      email: 'ada@example.com',
+      id: 'user-1',
+      name: 'Ada',
+    });
+
+    await app.close();
+
+    expect(events).toEqual([
+      'connection:startSession',
+      'session:tx:start',
+      'repo:insert:ada@example.com',
+      'session:tx:commit',
+      'session:end',
+      'response:send',
+      'connection:startSession',
+      'session:tx:start',
+      'repo:find:user-1',
+      'session:tx:commit',
+      'session:end',
+      'response:send',
+      'connection:startSession',
+      'session:tx:start',
+      'repo:find:missing',
+      'session:tx:abort',
+      'session:end',
+      'response:send',
+      'connection:startSession',
+      'session:tx:start',
+      'repo:insert:abort@example.com',
+      'session:tx:abort',
+      'session:end',
+      'dispose',
+    ]);
+  });
+});

--- a/packages/mongoose/tsconfig.build.json
+++ b/packages/mongoose/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/mongoose/tsconfig.json
+++ b/packages/mongoose/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,24 @@ importers:
         specifier: ^5.0.0
         version: 5.10.0
 
+  packages/mongoose:
+    dependencies:
+      '@konekti/core':
+        specifier: workspace:*
+        version: link:../core
+      '@konekti/di':
+        specifier: workspace:*
+        version: link:../di
+      '@konekti/http':
+        specifier: workspace:*
+        version: link:../http
+      '@konekti/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+      mongoose:
+        specifier: '>=7.0.0'
+        version: 9.3.2
+
   packages/openapi:
     dependencies:
       '@konekti/core':
@@ -1107,6 +1125,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mongodb-js/saslprep@1.4.6':
+    resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -1329,6 +1350,12 @@ packages:
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1460,6 +1487,10 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
 
   bullmq@5.71.0:
     resolution: {integrity: sha512-aeNWh4drsafSKnAJeiNH/nZP/5O8ZdtdMbnOPZmpjXj7NZUP5YC901U3bIH41iZValm7d1i3c34ojv7q31m30w==}
@@ -1861,6 +1892,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  kareem@3.2.0:
+    resolution: {integrity: sha512-VS8MWZz/cT+SqBCpVfNN4zoVz5VskR3N4+sTmUXme55e9avQHntpwpNq0yjnosISXqwJ3AQVjlbI4Dyzv//JtA==}
+    engines: {node: '>=18.0.0'}
+
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
@@ -1890,6 +1925,9 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -1904,6 +1942,49 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
+
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.1.1:
+    resolution: {integrity: sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
+
+  mongoose@9.3.2:
+    resolution: {integrity: sha512-4hMJA4vLAeNG6LnDwJImPYM+uJMVw+sFs7jtS/91OKOT7rzv19ytAAeswtAdWoinVBUVrzmClL/ZoPhcU5RL8w==}
+    engines: {node: '>=20.19.0'}
+
+  mpath@0.9.0:
+    resolution: {integrity: sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==}
+    engines: {node: '>=4.0.0'}
+
+  mquery@6.0.0:
+    resolution: {integrity: sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==}
+    engines: {node: '>=20.19.0'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1999,6 +2080,10 @@ packages:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
@@ -2081,6 +2166,9 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  sift@17.1.3:
+    resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -2109,6 +2197,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -2174,6 +2265,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2296,6 +2391,14 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -2851,6 +2954,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mongodb-js/saslprep@1.4.6':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -3009,6 +3116,12 @@ snapshots:
 
   '@types/validator@13.15.10': {}
 
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.15
@@ -3165,6 +3278,8 @@ snapshots:
       electron-to-chromium: 1.5.307
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  bson@7.2.0: {}
 
   bullmq@5.71.0:
     dependencies:
@@ -3571,6 +3686,8 @@ snapshots:
 
   json5@2.2.3: {}
 
+  kareem@3.2.0: {}
+
   light-my-request@6.6.0:
     dependencies:
       cookie: 1.1.1
@@ -3600,6 +3717,8 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
+  memory-pager@1.5.0: {}
+
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -3613,6 +3732,38 @@ snapshots:
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.0.2
+
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb@7.1.1:
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.6
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
+
+  mongoose@9.3.2:
+    dependencies:
+      kareem: 3.2.0
+      mongodb: 7.1.1
+      mpath: 0.9.0
+      mquery: 6.0.0
+      ms: 2.1.3
+      sift: 17.1.3
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+
+  mpath@0.9.0: {}
+
+  mquery@6.0.0: {}
 
   ms@2.1.3: {}
 
@@ -3706,6 +3857,8 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       tdigest: 0.1.2
 
+  punycode@2.3.1: {}
+
   quick-format-unescaped@4.0.4: {}
 
   raw-body@3.0.2:
@@ -3791,6 +3944,8 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sift@17.1.3: {}
+
   siginfo@2.0.0: {}
 
   slash@2.0.0: {}
@@ -3842,6 +3997,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
@@ -3889,6 +4048,10 @@ snapshots:
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
@@ -3997,6 +4160,13 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/tooling/release/verify-release-candidate.mjs
+++ b/tooling/release/verify-release-candidate.mjs
@@ -219,6 +219,7 @@ assertCheck(
     !quickStart.includes('Database') &&
     !scaffoldSource.includes('@konekti/prisma') &&
     !scaffoldSource.includes('@konekti/drizzle') &&
+    !scaffoldSource.includes('@konekti/mongoose') &&
     !scaffoldSource.includes('createTierNote'),
   'Bootstrap docs and scaffold source no longer encode ORM/DB prompts, support tiers, or starter-time ORM adapter injection.',
 );


### PR DESCRIPTION
## Summary

- Adds `packages/mongoose` as a new public workspace package following the same adapter conventions as `@konekti/prisma` and `@konekti/drizzle`.
- Provides `MongooseConnection` with ALS-backed session context, `transaction()`, `requestTransaction()`, `currentSession()`, and `onApplicationShutdown` lifecycle.
- Exposes `createMongooseModule` / `createMongooseModuleAsync` factories, `MongooseTransactionInterceptor` for opt-in per-request scope, and minimal DI tokens (`MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, `MONGOOSE_OPTIONS`).
- Registers `@konekti/mongoose` in `docs/reference/package-surface.md`, `docs/operations/release-governance.md`, and `tooling/release/verify-release-candidate.mjs`.

## Key implementation notes

- Request transactions are tracked **before** the async `resolveSession()` call to eliminate the shutdown race condition (where `onApplicationShutdown` could iterate an empty Set before the first `await` resolves).
- `session.endSession()` is called in the `finally` block of both `transaction()` (non-request-scoped) and `requestTransaction()` paths.
- Nested transaction reuse: when a session is already active in ALS, the ambient session is reused rather than starting a new one.

## Verification

```
pnpm typecheck   # clean
pnpm test        # 10/10 pass (module.test.ts × 9, vertical-slice.test.ts × 1)
pnpm build       # dist emitted successfully
```

Closes #301