### PR TITLE
Resolve #294: align auth/cache docs and validation gaps

### DIFF
--- a/docs/concepts/auth-and-jwt.md
+++ b/docs/concepts/auth-and-jwt.md
@@ -58,7 +58,7 @@ The recommended authentication patterns are:
 
 ### official cookie auth preset
 
-`@konekti/passport` now provides an official HttpOnly cookie/session auth preset for JWT-based authentication:
+`@konekti/passport` now provides an official HttpOnly cookie auth preset for JWT-based authentication:
 
 ```typescript
 import { Module } from '@konekti/core';

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -108,7 +108,7 @@ export class MyRefreshTokenService implements RefreshTokenService {
 
 ## Cookie Auth Preset
 
-`@konekti/passport` provides an official HttpOnly cookie/session auth preset for JWT-based authentication. This preset extracts JWT tokens from secure HttpOnly cookies instead of bearer headers.
+`@konekti/passport` provides an official HttpOnly cookie auth preset for JWT-based authentication. This preset extracts JWT tokens from secure HttpOnly cookies instead of bearer headers.
 
 ### Use the cookie auth strategy
 


### PR DESCRIPTION
## Summary

Closes #294

Fixes documentation terminology to match the actual implementation boundaries:

**Auth docs** (`packages/passport/README.md`, `docs/concepts/auth-and-jwt.md`):
- Removed "session" from "cookie/session auth preset" → "cookie auth preset"
- The implementation is a cookie-based JWT preset (JWT extraction + cookie management), not a full session framework with session stores or session lifecycle management

**Cache docs** (`packages/cache-manager`):
- Verified that types.ts, interceptor.ts, and README.md already agree that `'full'` is equivalent to `'route+query'` with sorted query strings
- Verified that test fixtures already include the required `httpKeyStrategy` field

## Changes

- `docs/concepts/auth-and-jwt.md`: `cookie/session auth preset` → `cookie auth preset`
- `packages/passport/README.md`: `cookie/session auth preset` → `cookie auth preset`

## Verification

- [x] Documentation terminology matches implementation (cookie-based JWT, not session framework)
- [x] Cache manager docs are internally consistent
- [x] Test fixtures include required type fields