### PR TITLE
feat(@konekti/config): introduce ConfigModule.forRoot() and ConfigReloadModule

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,5 @@
 export * from './load.js';
+export * from './module.js';
+export * from './reload-module.js';
 export * from './service.js';
 export * from './types.js';

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -35,7 +35,7 @@ describe('loadConfig', () => {
     const loaded = loadConfig({
       cwd,
       defaults: { NAME: 'from-default', PORT: '3000' },
-      mode: 'dev',
+      envFile: envPath,
       processEnv: { NAME: 'from-process' },
       runtimeOverrides: { NAME: 'from-runtime' },
     });
@@ -55,7 +55,7 @@ describe('loadConfig', () => {
     const loaded = loadConfig({
       cwd,
       defaults: { PORT: '3000' },
-      mode: 'dev',
+      envFile: envPath,
       processEnv: { PORT: undefined },
     });
 
@@ -74,7 +74,6 @@ describe('loadConfig', () => {
           },
         },
       },
-      mode: 'test',
       processEnv: {},
       runtimeOverrides: {
         db: {
@@ -101,7 +100,6 @@ describe('loadConfig', () => {
   it('fails when validation rejects the merged config', () => {
     expect(() =>
       loadConfig({
-        mode: 'test',
         validate: () => {
           throw new Error('PORT is required');
         },
@@ -115,7 +113,7 @@ describe('loadConfig', () => {
 
     writeFileSync(envPath, 'PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\\nMIIEowIBAAKCAQ\\n-----END RSA PRIVATE KEY-----"\n');
 
-    const loaded = loadConfig({ cwd, mode: 'dev', processEnv: {} });
+    const loaded = loadConfig({ cwd, envFile: envPath, processEnv: {} });
 
     expect(loaded['PRIVATE_KEY']).toContain('BEGIN RSA PRIVATE KEY');
     expect(loaded['PRIVATE_KEY']).toContain('\n');
@@ -127,7 +125,7 @@ describe('loadConfig', () => {
 
     writeFileSync(envPath, 'DB_HOST=localhost\nDB_PORT=5432\nDATABASE_URL=${DB_HOST}:${DB_PORT}/mydb\n');
 
-    const loaded = loadConfig({ cwd, mode: 'dev', processEnv: {} });
+    const loaded = loadConfig({ cwd, envFile: envPath, processEnv: {} });
 
     expect(loaded['DATABASE_URL']).toBe('localhost:5432/mydb');
   });
@@ -140,7 +138,7 @@ describe('loadConfig', () => {
 
     const loaded = loadConfig({
       cwd,
-      mode: 'dev',
+      envFile: envPath,
       processEnv: {},
       parse: (content) => {
         const result: Record<string, string> = {};
@@ -165,7 +163,7 @@ describe('loadConfig', () => {
 
     const reloader = createConfigReloader({
       cwd,
-      mode: 'dev',
+      envFile: envPath,
       processEnv: {},
     });
 
@@ -202,7 +200,7 @@ describe('loadConfig', () => {
 
     const reloader = createConfigReloader({
       cwd,
-      mode: 'dev',
+      envFile: envPath,
       processEnv: {},
     });
 
@@ -237,7 +235,7 @@ describe('loadConfig', () => {
 
     const reloader = createConfigReloader({
       cwd,
-      mode: 'dev',
+      envFile: envPath,
       processEnv: {},
       validate: (raw) => {
         const port = raw['PORT'];
@@ -298,7 +296,7 @@ describe('loadConfig', () => {
 
     const reloader = createConfigReloader({
       cwd,
-      mode: 'dev',
+      envFile: envPath,
       processEnv: {},
     });
 
@@ -326,7 +324,7 @@ describe('loadConfig', () => {
 
     const reloader = createConfigReloader({
       cwd,
-      mode: 'dev',
+      envFile: envPath,
       processEnv: {},
       watch: true,
     });
@@ -359,7 +357,7 @@ describe('loadConfig', () => {
 
     const reloader = createConfigReloader({
       cwd,
-      mode: 'dev',
+      envFile: envPath,
       processEnv: {},
       watch: true,
     });

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -43,7 +43,7 @@ function sanitizeProcessEnv(processEnv: NodeJS.ProcessEnv): Record<string, strin
 
 function normalizeLoadOptions(options: ConfigLoadOptions): NormalizedLoadOptions {
   const cwd = options.cwd ?? process.cwd();
-  const envFile = options.envFile ?? join(cwd, `.env.${options.mode}`);
+  const envFile = options.envFile ?? join(cwd, '.env');
   const defaults = options.defaults ?? {};
   const processEnv = options.processEnv ?? process.env;
   const safeProcessEnv = sanitizeProcessEnv(processEnv);

--- a/packages/config/src/module.ts
+++ b/packages/config/src/module.ts
@@ -1,0 +1,24 @@
+import { defineModuleMetadata } from '@konekti/core';
+
+import { loadConfig } from './load.js';
+import { ConfigService } from './service.js';
+import type { ConfigModuleOptions } from './types.js';
+
+export class ConfigModule {
+  static forRoot(options?: ConfigModuleOptions): new () => ConfigModule {
+    class ConfigModuleImpl extends ConfigModule {}
+
+    defineModuleMetadata(ConfigModuleImpl, {
+      global: true,
+      exports: [ConfigService],
+      providers: [
+        {
+          provide: ConfigService,
+          useFactory: () => new ConfigService(loadConfig(options ?? {})),
+        },
+      ],
+    });
+
+    return ConfigModuleImpl;
+  }
+}

--- a/packages/config/src/reload-module.ts
+++ b/packages/config/src/reload-module.ts
@@ -1,0 +1,140 @@
+import { Inject, defineModuleMetadata } from '@konekti/core';
+
+import { cloneConfigDictionary } from './clone.js';
+import { createConfigReloader } from './load.js';
+import { ConfigService } from './service.js';
+import type {
+  ConfigDictionary,
+  ConfigLoadOptions,
+  ConfigReloadErrorListener,
+  ConfigReloader,
+  ConfigReloadListener,
+  ConfigReloadSubscription,
+} from './types.js';
+
+const CONFIG_RELOAD_OPTIONS = Symbol('konekti.config.reload-options');
+
+export const CONFIG_RELOADER = Symbol('konekti.config.reloader');
+
+function createSubscription<T>(listeners: Set<T>, listener: T): ConfigReloadSubscription {
+  listeners.add(listener);
+
+  return {
+    unsubscribe(): void {
+      listeners.delete(listener);
+    },
+  };
+}
+
+@Inject([ConfigService, CONFIG_RELOAD_OPTIONS])
+class ConfigReloadManager implements ConfigReloader {
+  private reloader: ConfigReloader | undefined;
+  private reloadForwarder: ConfigReloadSubscription | undefined;
+  private errorForwarder: ConfigReloadSubscription | undefined;
+  private readonly reloadListeners = new Set<ConfigReloadListener>();
+  private readonly errorListeners = new Set<ConfigReloadErrorListener>();
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly options: ConfigLoadOptions,
+  ) {}
+
+  current(): ConfigDictionary {
+    return this.ensureReloader().current();
+  }
+
+  reload(): ConfigDictionary {
+    return this.ensureReloader().reload();
+  }
+
+  subscribe(listener: ConfigReloadListener): ConfigReloadSubscription {
+    return createSubscription(this.reloadListeners, listener);
+  }
+
+  subscribeError(listener: ConfigReloadErrorListener): ConfigReloadSubscription {
+    return createSubscription(this.errorListeners, listener);
+  }
+
+  close(): void {
+    this.reloadForwarder?.unsubscribe();
+    this.reloadForwarder = undefined;
+    this.errorForwarder?.unsubscribe();
+    this.errorForwarder = undefined;
+
+    if (this.reloader) {
+      this.reloader.close();
+      this.reloader = undefined;
+    }
+
+    this.reloadListeners.clear();
+    this.errorListeners.clear();
+  }
+
+  onApplicationBootstrap(): void {
+    if (!this.options.watch) {
+      return;
+    }
+
+    this.ensureReloader();
+  }
+
+  onModuleDestroy(): void {
+    this.close();
+  }
+
+  private ensureReloader(): ConfigReloader {
+    if (this.reloader) {
+      return this.reloader;
+    }
+
+    const reloader = createConfigReloader(this.options);
+
+    this.reloadForwarder = reloader.subscribe((nextConfig, reason) => {
+      const previousConfig = this.config.snapshot();
+
+      try {
+        this.config._replaceSnapshot(nextConfig);
+
+        for (const listener of this.reloadListeners) {
+          listener(cloneConfigDictionary(nextConfig), reason);
+        }
+      } catch (error: unknown) {
+        this.config._replaceSnapshot(previousConfig);
+        throw error;
+      }
+    });
+    this.errorForwarder = reloader.subscribeError((error, reason) => {
+      for (const listener of this.errorListeners) {
+        listener(error, reason);
+      }
+    });
+    this.reloader = reloader;
+
+    return reloader;
+  }
+}
+
+export class ConfigReloadModule {
+  static forRoot(options?: ConfigLoadOptions): new () => ConfigReloadModule {
+    const loadOptions = options ?? {};
+
+    class ConfigReloadModuleImpl extends ConfigReloadModule {}
+
+    defineModuleMetadata(ConfigReloadModuleImpl, {
+      exports: [CONFIG_RELOADER],
+      providers: [
+        {
+          provide: CONFIG_RELOAD_OPTIONS,
+          useValue: loadOptions,
+        },
+        ConfigReloadManager,
+        {
+          provide: CONFIG_RELOADER,
+          useExisting: ConfigReloadManager,
+        },
+      ],
+    });
+
+    return ConfigReloadModuleImpl;
+  }
+}

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated Use `envFile` option instead. Mode-based env file selection is removed.
+ */
 export type ConfigMode = 'dev' | 'prod' | 'test';
 
 export type ConfigDictionary = Record<string, unknown>;
@@ -26,7 +29,6 @@ export type DotValue<T, K extends string> = K extends keyof T
     : never;
 
 export interface ConfigModuleOptions {
-  mode: ConfigMode;
   envFile?: string;
   validate?: (raw: ConfigDictionary) => ConfigDictionary;
   defaults?: ConfigDictionary;

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 
 import { Container, type Provider } from '@konekti/di';
-import { ConfigService, createConfigReloader, loadConfig, type ConfigDictionary, type ConfigReloadReason } from '@konekti/config';
+import { ConfigService, createConfigReloader, loadConfig, type ConfigDictionary, type ConfigMode, type ConfigReloadReason } from '@konekti/config';
 import { InvariantError, defineModuleMetadata, getClassDiMetadata, type Token } from '@konekti/core';
 import {
   createDispatcher,
@@ -312,7 +312,7 @@ class KonektiApplication implements Application {
     readonly config: ConfigService,
     readonly container: Container,
     readonly envFile: string,
-    readonly mode: BootstrapApplicationOptions['mode'],
+    readonly mode: ConfigMode,
     readonly modules: CompiledModule[],
     readonly rootModule: ModuleType,
     readonly dispatcher: Dispatcher,
@@ -407,7 +407,7 @@ class KonektiApplicationContext implements ApplicationContext {
     readonly config: ConfigService,
     readonly container: Container,
     readonly envFile: string,
-    readonly mode: BootstrapApplicationOptions['mode'],
+    readonly mode: ConfigMode,
     readonly modules: CompiledModule[],
     readonly rootModule: ModuleType,
     private readonly lifecycleInstances: unknown[],
@@ -470,7 +470,7 @@ class KonektiMicroserviceApplication implements MicroserviceApplication {
     return this.context.envFile;
   }
 
-  get mode(): BootstrapApplicationOptions['mode'] {
+  get mode(): ConfigMode {
     return this.context.mode;
   }
 
@@ -610,7 +610,11 @@ async function runShutdownHooks(instances: unknown[], signal?: string): Promise<
  * 모드와 작업 디렉터리를 기준으로 실제로 사용될 env 파일 경로를 결정한다.
  */
 function resolveEnvFile(options: BootstrapApplicationOptions): string {
-  return options.envFile ?? join(options.cwd ?? process.cwd(), `.env.${options.mode}`);
+  return options.envFile ?? join(options.cwd ?? process.cwd(), `.env.${options.mode ?? 'prod'}`);
+}
+
+function resolveApplicationMode(mode: ConfigMode | undefined): ConfigMode {
+  return mode ?? 'prod';
 }
 
 function createHandlerSources(modules: CompiledModule[]): HandlerSource[] {
@@ -860,20 +864,27 @@ function setupRuntimeConfigReload(
  * 런타임 애플리케이션 셸을 만든다.
  */
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
+  const mode = resolveApplicationMode(options.mode);
+  const envFile = resolveEnvFile({ ...options, mode });
+  const bootstrapOptions: BootstrapApplicationOptions = {
+    ...options,
+    envFile,
+    mode,
+  };
   const logger = options.logger ?? createConsoleApplicationLogger();
   let lifecycleInstances: unknown[] = [];
   let bootstrappedContainer: Container | undefined;
-  const adapter = options.adapter ?? createNoopHttpApplicationAdapter();
+  const adapter = bootstrapOptions.adapter ?? createNoopHttpApplicationAdapter();
   const runtimeCleanup: Array<() => void> = [];
 
   try {
     logger.log('Starting Konekti application...', 'KonektiFactory');
-    const configValues = loadConfig(options);
+    const configValues = loadConfig(bootstrapOptions);
     const config = new ConfigService(configValues);
-    const runtimeProviders = createRuntimeProviders(options, config, logger);
+    const runtimeProviders = createRuntimeProviders(bootstrapOptions, config, logger);
 
-    const bootstrapped = bootstrapModule(options.rootModule, {
-      duplicateProviderPolicy: options.duplicateProviderPolicy,
+    const bootstrapped = bootstrapModule(bootstrapOptions.rootModule, {
+      duplicateProviderPolicy: bootstrapOptions.duplicateProviderPolicy,
       logger,
       providers: runtimeProviders,
       validationTokens: [RUNTIME_CONTAINER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER],
@@ -884,21 +895,20 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
     await runBootstrapLifecycle(bootstrapped.modules, lifecycleInstances, logger);
 
-    const envFile = resolveEnvFile(options);
-    const configReloadCleanup = setupRuntimeConfigReload(options, config, lifecycleInstances, envFile, logger);
+    const configReloadCleanup = setupRuntimeConfigReload(bootstrapOptions, config, lifecycleInstances, envFile, logger);
     if (configReloadCleanup) {
       runtimeCleanup.push(configReloadCleanup);
     }
 
-    const dispatcher = createRuntimeDispatcher(bootstrapped, options, logger);
+    const dispatcher = createRuntimeDispatcher(bootstrapped, bootstrapOptions, logger);
 
     return new KonektiApplication(
       config,
       bootstrapped.container,
       envFile,
-      options.mode,
+      mode,
       bootstrapped.modules,
-      options.rootModule,
+      bootstrapOptions.rootModule,
       dispatcher,
       adapter,
       lifecycleInstances,
@@ -936,7 +946,14 @@ export class KonektiFactory {
     rootModule: ModuleType,
     options: CreateApplicationContextOptions = {},
   ): Promise<ApplicationContext> {
-    const mode = options.mode ?? 'prod';
+    const mode = resolveApplicationMode(options.mode);
+    const envFile = resolveEnvFile({ ...options, mode, rootModule });
+    const bootstrapOptions: BootstrapApplicationOptions = {
+      ...options,
+      envFile,
+      mode,
+      rootModule,
+    };
     const logger = options.logger ?? createConsoleApplicationLogger();
     let lifecycleInstances: unknown[] = [];
     let bootstrappedContainer: Container | undefined;
@@ -944,16 +961,9 @@ export class KonektiFactory {
 
     try {
       logger.log('Starting Konekti application context...', 'KonektiFactory');
-      const configValues = loadConfig({
-        ...options,
-        mode,
-      });
+      const configValues = loadConfig(bootstrapOptions);
       const config = new ConfigService(configValues);
-      const runtimeProviders = createRuntimeProviders({
-        ...options,
-        mode,
-        rootModule,
-      }, config, logger);
+      const runtimeProviders = createRuntimeProviders(bootstrapOptions, config, logger);
 
       const bootstrapped = bootstrapModule(rootModule, {
         duplicateProviderPolicy: options.duplicateProviderPolicy,
@@ -967,12 +977,6 @@ export class KonektiFactory {
       lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
       await runBootstrapLifecycle(bootstrapped.modules, lifecycleInstances, logger);
 
-      const bootstrapOptions = {
-        ...options,
-        mode,
-        rootModule,
-      } as BootstrapApplicationOptions;
-      const envFile = resolveEnvFile(bootstrapOptions);
       const configReloadCleanup = setupRuntimeConfigReload(bootstrapOptions, config, lifecycleInstances, envFile, logger);
       if (configReloadCleanup) {
         runtimeCleanup.push(configReloadCleanup);

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -103,6 +103,7 @@ export interface BootstrapApplicationOptions extends ConfigLoadOptions {
   interceptors?: InterceptorLike[];
   logger?: ApplicationLogger;
   middleware?: MiddlewareLike[];
+  mode?: ConfigMode;
   observers?: RequestObserverLike[];
   providers?: Provider[];
   rootModule: ModuleType;
@@ -112,8 +113,7 @@ export interface BootstrapApplicationOptions extends ConfigLoadOptions {
 export type CreateApplicationOptions = Omit<BootstrapApplicationOptions, 'rootModule'>;
 
 export interface CreateApplicationContextOptions
-  extends Omit<BootstrapApplicationOptions, 'adapter' | 'filters' | 'middleware' | 'mode' | 'observers' | 'rootModule'> {
-  mode?: ConfigMode;
+  extends Omit<BootstrapApplicationOptions, 'adapter' | 'filters' | 'middleware' | 'observers' | 'rootModule'> {
 }
 
 export interface MicroserviceRuntime {


### PR DESCRIPTION
## Summary

- `ConfigModule.forRoot()` 도입: NestJS ConfigModule 패턴으로 config 소유권을 AppModule로 이전
- `ConfigReloadModule.forRoot()` 분리: watch/reload 기능을 독립 모듈로 분리, `ConfigModule` 순수 유지
- `ConfigMode` deprecated re-export 유지, `mode` 파라미터를 공개 API에서 제거 시작
- `load.ts` 기본 envFile을 `.env`로 변경 (mode 기반 파일명 컨벤션 제거)

## Related

Closes #306
Part of #305