### PR TITLE
Resolve #307: decouple config loading from runtime

### DIFF
--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -1,13 +1,9 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 import { Inject } from '@konekti/core';
-import { ConfigService } from '@konekti/config';
 import type { Container } from '@konekti/di';
 import {
   Controller,
@@ -67,24 +63,6 @@ function createDeferred<T = void>() {
   });
 
   return { promise, reject, resolve };
-}
-
-async function delay(milliseconds: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-async function waitForCondition(assertion: () => boolean, timeoutMs = 1_000): Promise<void> {
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < timeoutMs) {
-    if (assertion()) {
-      return;
-    }
-
-    await delay(25);
-  }
-
-  throw new Error('Timed out waiting for condition.');
 }
 
 const TEST_TLS_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
@@ -157,32 +135,6 @@ async function requestHttps(url: string): Promise<{ body: string; statusCode: nu
 }
 
 describe('bootstrapApplication', () => {
-  it('registers ConfigService as a bootstrap-level provider', async () => {
-    @Inject([ConfigService])
-    class AppService {
-      constructor(readonly config: ConfigService) {}
-    }
-
-    class AppModule {}
-    defineModule(AppModule, {
-      providers: [AppService],
-    });
-
-    const app = await bootstrapApplication({
-      mode: 'test',
-      rootModule: AppModule,
-      runtimeOverrides: { PORT: '3000' },
-    });
-
-    const service = await app.container.resolve(AppService);
-
-    expect(service.config.get<string>('PORT')).toBe('3000');
-    expect(app.mode).toBe('test');
-    expect(app.envFile.endsWith('.env.test')).toBe(true);
-
-    await expect(app.ready()).resolves.toBeUndefined();
-  });
-
   it('runs lifecycle hooks in deterministic order and supports explicit close', async () => {
     const events: string[] = [];
     const adapter: HttpApplicationAdapter = {
@@ -219,7 +171,6 @@ describe('bootstrapApplication', () => {
 
     const app = await bootstrapApplication({
       adapter,
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -268,7 +219,6 @@ describe('bootstrapApplication', () => {
 
     const app = await bootstrapApplication({
       adapter,
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -296,7 +246,6 @@ describe('bootstrapApplication', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const resource = await app.container.resolve(DisposableResource);
@@ -304,183 +253,6 @@ describe('bootstrapApplication', () => {
     await app.close('SIGTERM');
 
     expect(resource.destroyed).toBe(true);
-  });
-
-  it('applies watched config reloads in dev mode without replacing ConfigService identity', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'konekti-runtime-reload-dev-'));
-    const envPath = join(cwd, '.env.dev');
-
-    writeFileSync(envPath, 'PORT=3000\n');
-
-    @Inject([ConfigService])
-    class ReloadAwareService {
-      readonly ports: string[] = [];
-
-      constructor(readonly config: ConfigService) {}
-
-      onRuntimeReload(): void {
-        const port = this.config.get('PORT' as never);
-
-        if (typeof port === 'string') {
-          this.ports.push(port);
-        }
-      }
-    }
-
-    class AppModule {}
-    defineModule(AppModule, {
-      providers: [ReloadAwareService],
-    });
-
-    const app = await bootstrapApplication({
-      cwd,
-      mode: 'dev',
-      processEnv: {},
-      rootModule: AppModule,
-      watch: true,
-    });
-    const service = await app.container.resolve(ReloadAwareService);
-
-    await delay(100);
-    writeFileSync(envPath, 'PORT=3100\n');
-    await waitForCondition(() => service.ports.includes('3100'), 5_000);
-
-    expect(app.config.get('PORT')).toBe('3100');
-    expect(service.config).toBe(app.config);
-
-    await app.close();
-  });
-
-  it('keeps the previous runtime config snapshot when a watched update is invalid', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'konekti-runtime-reload-invalid-'));
-    const envPath = join(cwd, '.env.dev');
-
-    writeFileSync(envPath, 'PORT=3000\n');
-
-    class AppModule {}
-    defineModule(AppModule, {});
-
-    const app = await bootstrapApplication({
-      cwd,
-      mode: 'dev',
-      processEnv: {},
-      rootModule: AppModule,
-      validate: (raw: Record<string, unknown>) => {
-        const port = raw['PORT'];
-
-        if (typeof port !== 'string' || !/^\d+$/.test(port)) {
-          throw new Error('PORT must be numeric');
-        }
-
-        return raw;
-      },
-      watch: true,
-    });
-
-    writeFileSync(envPath, 'PORT=oops\n');
-    await delay(150);
-
-    expect(app.config.get('PORT')).toBe('3000');
-
-    await app.close();
-  });
-
-  it('restores the previous runtime config snapshot when a reload participant throws', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'konekti-runtime-reload-rollback-'));
-    const envPath = join(cwd, '.env.dev');
-
-    writeFileSync(envPath, 'PORT=3000\n');
-
-    @Inject([ConfigService])
-    class FailingReloadAwareService {
-      readonly seenPorts: string[] = [];
-
-      constructor(readonly config: ConfigService) {}
-
-      onRuntimeReload(): void {
-        const port = this.config.get('PORT' as never);
-
-        if (typeof port === 'string') {
-          this.seenPorts.push(port);
-        }
-
-        throw new Error('participant failure');
-      }
-    }
-
-    class AppModule {}
-    defineModule(AppModule, {
-      providers: [FailingReloadAwareService],
-    });
-
-    const app = await bootstrapApplication({
-      cwd,
-      mode: 'dev',
-      processEnv: {},
-      rootModule: AppModule,
-      watch: true,
-    });
-    const service = await app.container.resolve(FailingReloadAwareService);
-
-    await delay(100);
-    writeFileSync(envPath, 'PORT=3100\n');
-    await waitForCondition(() => service.seenPorts.includes('3100'), 5_000);
-    await delay(150);
-
-    expect(service.seenPorts).toContain('3100');
-    expect(app.config.get('PORT')).toBe('3000');
-    expect(service.config).toBe(app.config);
-
-    await app.close();
-  });
-
-  it('does not activate runtime config watch reload outside dev mode', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'konekti-runtime-reload-prod-'));
-    const envPath = join(cwd, '.env.prod');
-
-    writeFileSync(envPath, 'PORT=3000\n');
-
-    class AppModule {}
-    defineModule(AppModule, {});
-
-    const app = await bootstrapApplication({
-      cwd,
-      mode: 'prod',
-      processEnv: {},
-      rootModule: AppModule,
-      watch: true,
-    });
-
-    writeFileSync(envPath, 'PORT=3300\n');
-    await delay(150);
-
-    expect(app.config.get('PORT')).toBe('3000');
-
-    await app.close();
-  });
-
-  it('stops runtime config watch updates after application close', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'konekti-runtime-reload-close-'));
-    const envPath = join(cwd, '.env.dev');
-
-    writeFileSync(envPath, 'PORT=3000\n');
-
-    class AppModule {}
-    defineModule(AppModule, {});
-
-    const app = await bootstrapApplication({
-      cwd,
-      mode: 'dev',
-      processEnv: {},
-      rootModule: AppModule,
-      watch: true,
-    });
-
-    await app.close();
-    writeFileSync(envPath, 'PORT=3400\n');
-    await delay(150);
-
-    expect(app.config.get('PORT')).toBe('3000');
   });
 
   it('injects real runtime tokens before OnModuleInit runs', async () => {
@@ -520,7 +292,6 @@ describe('bootstrapApplication', () => {
 
     const app = await bootstrapApplication({
       adapter,
-      mode: 'test',
       rootModule: AppModule,
     });
     const probe = await app.container.resolve(RuntimeTokenProbe);
@@ -537,7 +308,6 @@ describe('bootstrapApplication', () => {
     defineModule(AppModule, {});
 
     const app = await KonektiFactory.create(AppModule, {
-      mode: 'test',
     });
 
     expect(app.rootModule).toBe(AppModule);
@@ -566,7 +336,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -601,7 +370,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -653,7 +421,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       rawBody: true,
     });
@@ -708,7 +475,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -750,7 +516,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       rawBody: true,
     });
@@ -803,7 +568,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -843,7 +607,6 @@ describe('bootstrapApplication', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       middleware: [createSecurityHeadersMiddleware()],
-      mode: 'test',
       port,
     });
 
@@ -889,7 +652,6 @@ describe('bootstrapApplication', () => {
 
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
-      mode: 'test',
       observers: [new StatusObserver()],
       port,
     });
@@ -929,7 +691,6 @@ describe('bootstrapApplication', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       maxBodySize: 8,
-      mode: 'test',
       port,
     });
 
@@ -974,7 +735,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -1016,7 +776,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       versioning: {
         header: 'X-API-Version',
@@ -1069,7 +828,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       versioning: {
         key: 'v=',
@@ -1115,7 +873,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       versioning: {
         extractor: (request) => {
@@ -1169,7 +926,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await runNodeApplication(AppModule, {
       logger,
-      mode: 'test',
       port,
     });
 
@@ -1220,7 +976,6 @@ describe('bootstrapApplication', () => {
       cors: false,
       host: '127.0.0.1',
       logger,
-      mode: 'test',
       port,
     });
 
@@ -1268,7 +1023,6 @@ describe('bootstrapApplication', () => {
         key: TEST_TLS_PRIVATE_KEY,
       },
       logger,
-      mode: 'test',
       port,
     });
 
@@ -1312,7 +1066,6 @@ describe('bootstrapApplication', () => {
       cors: false,
       host: '0.0.0.0',
       logger,
-      mode: 'test',
       port,
     });
 
@@ -1367,7 +1120,6 @@ describe('bootstrapApplication', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       globalPrefix: '/api',
-      mode: 'test',
       port,
     });
 
@@ -1435,7 +1187,6 @@ describe('bootstrapApplication', () => {
       cors: false,
       globalPrefix: '/api',
       globalPrefixExclude: ['/health', '/ready'],
-      mode: 'test',
       port,
     });
 
@@ -1487,7 +1238,6 @@ describe('bootstrapApplication', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       globalPrefix: '/api',
-      mode: 'test',
       observers: [new PathObserver()],
       port,
     });
@@ -1530,7 +1280,6 @@ describe('bootstrapApplication', () => {
       cors: false,
       globalPrefix: '/api',
       globalPrefixExclude: ['/internal/*'],
-      mode: 'test',
       port,
     });
 
@@ -1580,7 +1329,6 @@ describe('bootstrapApplication', () => {
       cors: false,
       globalPrefix: '///api//',
       globalPrefixExclude: ['//internal//*'],
-      mode: 'test',
       port,
     });
 
@@ -1619,7 +1367,6 @@ describe('bootstrapApplication', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       globalPrefix: '/',
-      mode: 'test',
       port,
     });
 
@@ -1655,7 +1402,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       shutdownTimeoutMs: 1_000,
     });
@@ -1704,7 +1450,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       shutdownTimeoutMs: 50,
     });
@@ -1716,21 +1461,6 @@ describe('bootstrapApplication', () => {
 
     await expect(app.close()).resolves.toBeUndefined();
     await expect(responsePromise).rejects.toThrow();
-  });
-
-  it('fails before listen when config validation rejects bootstrap config', async () => {
-    class AppModule {}
-    defineModule(AppModule, {});
-
-    await expect(
-      bootstrapApplication({
-        mode: 'test',
-        rootModule: AppModule,
-        validate: () => {
-          throw new Error('PORT is required');
-        },
-      }),
-    ).rejects.toThrow('Invalid configuration.');
   });
 
   it('fails during bootstrap when a provider omits required injection metadata', async () => {
@@ -1747,7 +1477,6 @@ describe('bootstrapApplication', () => {
 
     await expect(
       bootstrapApplication({
-        mode: 'test',
         rootModule: AppModule,
       }),
     ).rejects.toThrow(ModuleInjectionMetadataError);
@@ -1777,7 +1506,6 @@ describe('bootstrapApplication', () => {
 
     const app = await bootstrapApplication({
       adapter,
-      mode: 'test',
       rootModule: AppModule,
     });
     const request: FrameworkRequest = {
@@ -1855,7 +1583,6 @@ describe('bootstrapApplication', () => {
 
     const app = await bootstrapApplication({
       interceptors: [SerializerInterceptor],
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -1971,7 +1698,6 @@ describe('bootstrapApplication', () => {
     await expect(
       bootstrapApplication({
         logger,
-        mode: 'test',
         rootModule: AppModule,
       }),
     ).rejects.toThrow('boom');
@@ -2021,7 +1747,6 @@ describe('bootstrapApplication', () => {
     const app = await bootstrapApplication({
       adapter,
       logger,
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -2059,7 +1784,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -2089,7 +1813,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: 'https://my-frontend.com',
-      mode: 'test',
       port,
     });
 
@@ -2121,7 +1844,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: ['https://a.com', 'https://b.com'],
-      mode: 'test',
       port,
     });
 
@@ -2156,7 +1878,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: { allowOrigin: 'https://my-frontend.com', maxAge: 600 },
-      mode: 'test',
       port,
     });
 
@@ -2194,7 +1915,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -2266,7 +1986,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -2338,7 +2057,6 @@ describe('exception filter pipeline', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       filters: [filter],
-      mode: 'test',
       port,
     });
 
@@ -2377,7 +2095,6 @@ describe('exception filter pipeline', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       filters: [filter],
-      mode: 'test',
       port,
     });
 
@@ -2427,7 +2144,6 @@ describe('exception filter pipeline', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       filters: [firstFilter, secondFilter],
-      mode: 'test',
       port,
     });
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1,7 +1,4 @@
-import { join } from 'node:path';
-
 import { Container, type Provider } from '@konekti/di';
-import { ConfigService, createConfigReloader, loadConfig, type ConfigDictionary, type ConfigMode, type ConfigReloadReason } from '@konekti/config';
 import { InvariantError, defineModuleMetadata, getClassDiMetadata, type Token } from '@konekti/core';
 import {
   createDispatcher,
@@ -116,10 +113,6 @@ function isOnApplicationShutdown(value: unknown): value is OnApplicationShutdown
   return hasMethod(value, 'onApplicationShutdown');
 }
 
-function isRuntimeReloadParticipant(value: unknown): value is RuntimeReloadParticipant {
-  return hasMethod(value, 'onRuntimeReload');
-}
-
 function hasReadinessStateMethods(value: unknown): value is { markReady(): void; markStarting(): void } {
   if (typeof value !== 'function') {
     return false;
@@ -157,18 +150,6 @@ interface SelectedProviderEntry {
   provider: Provider;
   source: 'module' | 'runtime';
   token: Token;
-}
-
-interface RuntimeReloadEvent {
-  envFile: string;
-  kind: 'config';
-  nextConfig: ConfigDictionary;
-  previousConfig: ConfigDictionary;
-  reason: ConfigReloadReason;
-}
-
-interface RuntimeReloadParticipant {
-  onRuntimeReload(event: RuntimeReloadEvent): void | Promise<void>;
 }
 
 function createDuplicateProviderMessage(token: Token, moduleName: string, existingModuleName: string): string {
@@ -309,10 +290,7 @@ class KonektiApplication implements Application {
   private readonly lifecycleInstances: unknown[];
 
   constructor(
-    readonly config: ConfigService,
     readonly container: Container,
-    readonly envFile: string,
-    readonly mode: ConfigMode,
     readonly modules: CompiledModule[],
     readonly rootModule: ModuleType,
     readonly dispatcher: Dispatcher,
@@ -404,10 +382,7 @@ class KonektiApplicationContext implements ApplicationContext {
   private closingPromise: Promise<void> | undefined;
 
   constructor(
-    readonly config: ConfigService,
     readonly container: Container,
-    readonly envFile: string,
-    readonly mode: ConfigMode,
     readonly modules: CompiledModule[],
     readonly rootModule: ModuleType,
     private readonly lifecycleInstances: unknown[],
@@ -458,20 +433,8 @@ class KonektiMicroserviceApplication implements MicroserviceApplication {
     private readonly runtime: MicroserviceRuntime,
   ) {}
 
-  get config(): ConfigService {
-    return this.context.config;
-  }
-
   get container(): Container {
     return this.context.container;
-  }
-
-  get envFile(): string {
-    return this.context.envFile;
-  }
-
-  get mode(): ConfigMode {
-    return this.context.mode;
   }
 
   get modules(): CompiledModule[] {
@@ -606,17 +569,6 @@ async function runShutdownHooks(instances: unknown[], signal?: string): Promise<
   }
 }
 
-/**
- * 모드와 작업 디렉터리를 기준으로 실제로 사용될 env 파일 경로를 결정한다.
- */
-function resolveEnvFile(options: BootstrapApplicationOptions): string {
-  return options.envFile ?? join(options.cwd ?? process.cwd(), `.env.${options.mode ?? 'prod'}`);
-}
-
-function resolveApplicationMode(mode: ConfigMode | undefined): ConfigMode {
-  return mode ?? 'prod';
-}
-
 function createHandlerSources(modules: CompiledModule[]): HandlerSource[] {
   return modules.flatMap((compiledModule) =>
     (compiledModule.definition.controllers ?? []).map((controllerToken) => ({
@@ -664,16 +616,11 @@ function logRouteMappings(
 }
 
 function createRuntimeProviders(
-  options: BootstrapApplicationOptions,
-  config: ConfigService,
+  options: { readonly providers?: Provider[] },
   logger: ApplicationLogger,
 ): Provider[] {
   return [
     ...(options.providers ?? []),
-    {
-      provide: ConfigService,
-      useValue: config,
-    },
     {
       provide: APPLICATION_LOGGER,
       useValue: logger,
@@ -799,92 +746,23 @@ function createRuntimeDispatcher(
   return createDispatcher(dispatcherOptions);
 }
 
-function shouldEnableRuntimeConfigReload(options: BootstrapApplicationOptions): boolean {
-  return options.mode === 'dev' && options.watch === true;
-}
-
-async function notifyRuntimeReloadParticipants(
-  lifecycleInstances: readonly unknown[],
-  event: RuntimeReloadEvent,
-): Promise<void> {
-  for (const instance of lifecycleInstances) {
-    if (!isRuntimeReloadParticipant(instance)) {
-      continue;
-    }
-
-    await instance.onRuntimeReload(event);
-  }
-}
-
-function setupRuntimeConfigReload(
-  options: BootstrapApplicationOptions,
-  config: ConfigService,
-  lifecycleInstances: readonly unknown[],
-  envFile: string,
-  logger: ApplicationLogger,
-): (() => void) | undefined {
-  if (!shouldEnableRuntimeConfigReload(options)) {
-    return undefined;
-  }
-
-  const reloader = createConfigReloader(options);
-  const subscription = reloader.subscribe((nextConfig: ConfigDictionary, reason: ConfigReloadReason) => {
-    void (async () => {
-      const previousConfig = config.snapshot();
-
-      try {
-        config._replaceSnapshot(nextConfig);
-        await notifyRuntimeReloadParticipants(lifecycleInstances, {
-          envFile,
-          kind: 'config',
-          nextConfig,
-          previousConfig,
-          reason,
-        });
-        logger.log(`Applied config reload from ${envFile}.`, 'KonektiFactory');
-      } catch (error: unknown) {
-        config._replaceSnapshot(previousConfig);
-        logger.error('Failed to apply runtime config reload. Restored previous configuration snapshot.', error, 'KonektiFactory');
-      }
-    })();
-  });
-  const errorSubscription = reloader.subscribeError((error: unknown, reason: ConfigReloadReason) => {
-    logger.error(`Config reload failed during ${reason}.`, error, 'KonektiFactory');
-  });
-
-  return () => {
-    subscription.unsubscribe();
-    errorSubscription.unsubscribe();
-    reloader.close();
-  };
-}
-
 /**
- * config 로딩, bootstrap-level provider 등록, 모듈 부트스트랩, lifecycle hook 실행까지를 묶어
+ * bootstrap-level provider 등록, 모듈 부트스트랩, lifecycle hook 실행까지를 묶어
  * 런타임 애플리케이션 셸을 만든다.
  */
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
-  const mode = resolveApplicationMode(options.mode);
-  const envFile = resolveEnvFile({ ...options, mode });
-  const bootstrapOptions: BootstrapApplicationOptions = {
-    ...options,
-    envFile,
-    mode,
-  };
   const logger = options.logger ?? createConsoleApplicationLogger();
   let lifecycleInstances: unknown[] = [];
   let bootstrappedContainer: Container | undefined;
-  const adapter = bootstrapOptions.adapter ?? createNoopHttpApplicationAdapter();
+  const adapter = options.adapter ?? createNoopHttpApplicationAdapter();
   const runtimeCleanup: Array<() => void> = [];
 
   try {
     logger.log('Starting Konekti application...', 'KonektiFactory');
-    const configValues = loadConfig(bootstrapOptions);
-    const config = new ConfigService(configValues);
-    const runtimeProviders = createRuntimeProviders(bootstrapOptions, config, logger);
+    const runtimeProviders = createRuntimeProviders(options, logger);
 
-    const bootstrapped = bootstrapModule(bootstrapOptions.rootModule, {
-      duplicateProviderPolicy: bootstrapOptions.duplicateProviderPolicy,
+    const bootstrapped = bootstrapModule(options.rootModule, {
+      duplicateProviderPolicy: options.duplicateProviderPolicy,
       logger,
       providers: runtimeProviders,
       validationTokens: [RUNTIME_CONTAINER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER],
@@ -895,20 +773,12 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
     await runBootstrapLifecycle(bootstrapped.modules, lifecycleInstances, logger);
 
-    const configReloadCleanup = setupRuntimeConfigReload(bootstrapOptions, config, lifecycleInstances, envFile, logger);
-    if (configReloadCleanup) {
-      runtimeCleanup.push(configReloadCleanup);
-    }
-
-    const dispatcher = createRuntimeDispatcher(bootstrapped, bootstrapOptions, logger);
+    const dispatcher = createRuntimeDispatcher(bootstrapped, options, logger);
 
     return new KonektiApplication(
-      config,
       bootstrapped.container,
-      envFile,
-      mode,
       bootstrapped.modules,
-      bootstrapOptions.rootModule,
+      options.rootModule,
       dispatcher,
       adapter,
       lifecycleInstances,
@@ -946,14 +816,6 @@ export class KonektiFactory {
     rootModule: ModuleType,
     options: CreateApplicationContextOptions = {},
   ): Promise<ApplicationContext> {
-    const mode = resolveApplicationMode(options.mode);
-    const envFile = resolveEnvFile({ ...options, mode, rootModule });
-    const bootstrapOptions: BootstrapApplicationOptions = {
-      ...options,
-      envFile,
-      mode,
-      rootModule,
-    };
     const logger = options.logger ?? createConsoleApplicationLogger();
     let lifecycleInstances: unknown[] = [];
     let bootstrappedContainer: Container | undefined;
@@ -961,9 +823,7 @@ export class KonektiFactory {
 
     try {
       logger.log('Starting Konekti application context...', 'KonektiFactory');
-      const configValues = loadConfig(bootstrapOptions);
-      const config = new ConfigService(configValues);
-      const runtimeProviders = createRuntimeProviders(bootstrapOptions, config, logger);
+      const runtimeProviders = createRuntimeProviders(options, logger);
 
       const bootstrapped = bootstrapModule(rootModule, {
         duplicateProviderPolicy: options.duplicateProviderPolicy,
@@ -977,16 +837,8 @@ export class KonektiFactory {
       lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
       await runBootstrapLifecycle(bootstrapped.modules, lifecycleInstances, logger);
 
-      const configReloadCleanup = setupRuntimeConfigReload(bootstrapOptions, config, lifecycleInstances, envFile, logger);
-      if (configReloadCleanup) {
-        runtimeCleanup.push(configReloadCleanup);
-      }
-
       return new KonektiApplicationContext(
-        config,
         bootstrapped.container,
-        envFile,
-        mode,
         bootstrapped.modules,
         rootModule,
         lifecycleInstances,

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -9,7 +9,6 @@ import {
   NotFoundException,
   type CorsOptions,
   type Dispatcher,
-  type FrameworkRequest,
   type FrameworkResponse,
   type HttpApplicationAdapter,
   type MiddlewareLike,
@@ -266,7 +265,7 @@ export async function runNodeApplication(
     throw error;
   }
 
-  registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals(options.mode));
+  registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals());
 
   return app;
 }
@@ -549,8 +548,8 @@ function forceCloseConnections(server: import('node:http').Server, sockets: Read
   }
 }
 
-function defaultShutdownSignals(mode: RunNodeApplicationOptions['mode']): false | readonly NodeApplicationSignal[] {
-  return mode === 'test' ? false : ['SIGINT', 'SIGTERM'];
+function defaultShutdownSignals(): false | readonly NodeApplicationSignal[] {
+  return ['SIGINT', 'SIGTERM'];
 }
 
 function resolveNodePort(value: number | undefined): number {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,4 +1,3 @@
-import type { ConfigLoadOptions, ConfigMode, ConfigService } from '@konekti/config';
 import type { Constructor, MaybePromise, Token } from '@konekti/core';
 import type { Container, Provider } from '@konekti/di';
 import type {
@@ -84,7 +83,7 @@ export interface ExceptionFilterHandler {
   catch(error: unknown, context: ExceptionFilterContext): MaybePromise<boolean | void>;
 }
 
-export interface BootstrapApplicationOptions extends ConfigLoadOptions {
+export interface BootstrapApplicationOptions {
   adapter?: HttpApplicationAdapter;
   /**
    * Policy for duplicate provider tokens across modules.
@@ -103,7 +102,6 @@ export interface BootstrapApplicationOptions extends ConfigLoadOptions {
   interceptors?: InterceptorLike[];
   logger?: ApplicationLogger;
   middleware?: MiddlewareLike[];
-  mode?: ConfigMode;
   observers?: RequestObserverLike[];
   providers?: Provider[];
   rootModule: ModuleType;
@@ -127,10 +125,7 @@ export interface CreateMicroserviceOptions extends CreateApplicationContextOptio
 }
 
 export interface ApplicationContext {
-  readonly config: ConfigService;
   readonly container: Container;
-  readonly envFile: string;
-  readonly mode: ConfigMode;
   readonly modules: CompiledModule[];
   readonly rootModule: ModuleType;
 
@@ -139,10 +134,7 @@ export interface ApplicationContext {
 }
 
 export interface Application {
-  readonly config: ConfigService;
   readonly container: Container;
-  readonly envFile: string;
-  readonly mode: ConfigMode;
   readonly modules: CompiledModule[];
   readonly rootModule: ModuleType;
   readonly state: ApplicationState;


### PR DESCRIPTION
Closes #307

## Summary
- Remove `ConfigLoadOptions` inheritance and config-related fields (`mode`, `envFile`, `config`) from `@konekti/runtime` public API
- Remove `loadConfig()`, config reload setup, and `ConfigService` registration from bootstrap flow
- Remove `mode` dependency from `defaultShutdownSignals()`
- Update tests to remove config-loading coverage (now owned by `@konekti/config`)

## Verification
- `pnpm run --filter @konekti/runtime build` passes
- `pnpm vitest run packages/runtime/src/application.test.ts` — 45/45 tests pass
- `lsp_diagnostics` clean on all changed files

## Migration note for users
```ts
// Before
const app = await KonektiFactory.create(AppModule, { mode: 'dev' });
const service = app.config.get('DATABASE_URL');  // ❌

// After
const app = await KonektiFactory.create(AppModule);
const service = await app.container.resolve(ConfigService);
const dbUrl = service.get('DATABASE_URL');        // ✅
```

## Note
`@konekti/platform-fastify` will need a follow-up to remove its `mode` references (separate cleanup per issue scope).