### PR TITLE
Resolve #308: remove mode:'test' hardcode from testing and CLI

### DIFF
--- a/packages/cache-manager/src/module.test.ts
+++ b/packages/cache-manager/src/module.test.ts
@@ -112,7 +112,7 @@ describe('createCacheModule', () => {
       providers: [Consumer],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const consumer = await app.container.resolve(Consumer);
 
     await consumer.cache.set('/health', { ok: true });
@@ -128,7 +128,7 @@ describe('createCacheModule', () => {
       imports: [createCacheModule({ store: 'redis' })],
     });
 
-    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow(
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
       '@konekti/cache-manager redis store requires a Redis client at bootstrap.',
     );
   });
@@ -147,7 +147,6 @@ describe('createCacheModule', () => {
 
     const redisClient = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT_TOKEN, useValue: redisClient }],
       rootModule: AppModule,
     });
@@ -185,7 +184,7 @@ describe('createCacheModule', () => {
       imports: [createCacheModule({ store: 'memory' })],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     const firstGetResponse = createResponse();
     await app.dispatch(createRequest('/products', 'GET', '/products?page=1'), firstGetResponse);

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -408,9 +408,7 @@ function createMainFile(): string {
 
 import { AppModule } from './app';
 
-await runNodeApplication(AppModule, {
-  mode: 'dev',
-});
+await runNodeApplication(AppModule);
 `;
 }
 
@@ -463,7 +461,7 @@ function createResponse(): FrameworkResponse & { body?: unknown } {
 
 describe('AppModule', () => {
   it('dispatches the runtime health and readiness routes', async () => {
-    const app = await KonektiFactory.create(AppModule, { mode: 'test' });
+    const app = await KonektiFactory.create(AppModule);
     const healthResponse = createResponse();
     const readyResponse = createResponse();
 
@@ -477,7 +475,7 @@ describe('AppModule', () => {
   });
 
   it('dispatches the health-info route', async () => {
-    const app = await KonektiFactory.create(AppModule, { mode: 'test' });
+    const app = await KonektiFactory.create(AppModule);
     const response = createResponse();
 
     await app.dispatch(createRequest('/health-info/'), response);

--- a/packages/cqrs/src/module.test.ts
+++ b/packages/cqrs/src/module.test.ts
@@ -161,7 +161,7 @@ describe('@konekti/cqrs', () => {
       providers: [Store, CreateUserHandler, GetUserHandler],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
     const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
 
@@ -190,7 +190,7 @@ describe('@konekti/cqrs', () => {
       imports: [createCqrsModule()],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
     const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
 
@@ -221,7 +221,7 @@ describe('@konekti/cqrs', () => {
       providers: [FirstCreateUserHandler, SecondCreateUserHandler],
     });
 
-    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toBeInstanceOf(DuplicateCommandHandlerError);
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toBeInstanceOf(DuplicateCommandHandlerError);
   });
 
   it('fails bootstrap when duplicate query handlers are registered for one query type', async () => {
@@ -245,7 +245,7 @@ describe('@konekti/cqrs', () => {
       providers: [FirstGetUserHandler, SecondGetUserHandler],
     });
 
-    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toBeInstanceOf(DuplicateQueryHandlerError);
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toBeInstanceOf(DuplicateQueryHandlerError);
   });
 
   it('delegates publish and publishAll to the underlying event bus when no CQRS event handlers are registered', async () => {
@@ -279,7 +279,7 @@ describe('@konekti/cqrs', () => {
       imports: [createCqrsModule()],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const busByAlias = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
     const busByLegacy = await app.container.resolve<CqrsEventBus>(CQRS_EVENT_BUS);
 
@@ -324,7 +324,7 @@ describe('@konekti/cqrs', () => {
       ],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
     const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
     const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
@@ -448,7 +448,7 @@ describe('@konekti/cqrs', () => {
       ],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
     const store = await app.container.resolve(ProcessStore);
 
@@ -492,7 +492,7 @@ describe('@konekti/cqrs', () => {
       providers: [AccountActivationSaga],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
 
     await eventBus.publish(new AccountActivatedEvent('acct-1'));
@@ -520,7 +520,7 @@ describe('@konekti/cqrs', () => {
       providers: [FailingSaga],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
 
     await expect(eventBus.publish(new PaymentFailedEvent('order-2'))).rejects.toBeInstanceOf(SagaExecutionError);
@@ -558,7 +558,7 @@ describe('@konekti/cqrs', () => {
       providers: [SequenceStore, SequencingSaga],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
     const store = await app.container.resolve(SequenceStore);
 
@@ -601,7 +601,7 @@ describe('@konekti/cqrs', () => {
       providers: [ShutdownStore, ShutdownSaga],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
     const store = await app.container.resolve(ShutdownStore);
 
@@ -674,7 +674,7 @@ describe('@konekti/cqrs', () => {
       providers: [Store, CreateUserHandler, GetUserHandler, UserCreatedEventRecorder, UserCreatedOnEventProjection],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
     const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
     const eventBus = await app.container.resolve<CqrsEventBus>(CQRS_EVENT_BUS);

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -275,7 +275,7 @@ describe('@konekti/cron', () => {
       imports: [FeatureModule, createCronModule({ scheduler: scheduled.scheduler })],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const store = await app.container.resolve(TickStore);
 
     expect(scheduled.records).toHaveLength(1);
@@ -321,7 +321,6 @@ describe('@konekti/cron', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
     const store = await app.container.resolve(TickStore);
@@ -355,7 +354,7 @@ describe('@konekti/cron', () => {
       providers: [TaskService],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     expect(scheduled.records).toHaveLength(1);
 
@@ -395,7 +394,6 @@ describe('@konekti/cron', () => {
 
     await expect(
       bootstrapApplication({
-        mode: 'test',
         rootModule: AppModule,
       }),
     ).rejects.toThrow('scheduler boom');
@@ -426,7 +424,6 @@ describe('@konekti/cron', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -469,7 +466,6 @@ describe('@konekti/cron', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -546,12 +542,10 @@ describe('@konekti/cron', () => {
     });
 
     const appOne = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
     const appTwo = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: SecondAppModule,
     });
@@ -626,12 +620,10 @@ describe('@konekti/cron', () => {
     });
 
     const appOne = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
     const appTwo = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: SecondAppModule,
     });
@@ -683,7 +675,7 @@ describe('@konekti/cron', () => {
       providers: [TickStore, DefaultSchedulerTaskService],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const store = await app.container.resolve(TickStore);
 
     expect(store.count).toBe(0);
@@ -739,7 +731,7 @@ describe('@konekti/cron', () => {
       providers: [HookedTaskService],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     await scheduled.records[0]!.tick();
 
@@ -777,7 +769,7 @@ describe('@konekti/cron', () => {
       providers: [HookedFailingTaskService],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     await scheduled.records[0]!.tick();
 
@@ -818,7 +810,7 @@ describe('@konekti/cron', () => {
       providers: [BeforeRunFailingTaskService],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     await scheduled.records[0]!.tick();
 
@@ -858,7 +850,6 @@ describe('@konekti/cron', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -918,7 +909,6 @@ describe('@konekti/cron', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -986,7 +976,6 @@ describe('@konekti/cron', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -1045,7 +1034,6 @@ describe('@konekti/cron', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -1111,7 +1099,6 @@ describe('@konekti/cron', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -1181,7 +1168,6 @@ describe('@konekti/cron', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -73,7 +73,6 @@ describe('@konekti/drizzle', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const service = await app.container.resolve(UserService);
@@ -131,7 +130,6 @@ describe('@konekti/drizzle', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const drizzle = await app.container.resolve(DrizzleDatabase<typeof database, typeof transactionDatabase>);
@@ -166,7 +164,6 @@ describe('@konekti/drizzle', () => {
     });
 
     const syncApp = await bootstrapApplication({
-      mode: 'test',
       rootModule: StrictSyncAppModule,
     });
     const syncDrizzle = await syncApp.container.resolve(DrizzleDatabase<typeof database>);
@@ -191,7 +188,6 @@ describe('@konekti/drizzle', () => {
     });
 
     const asyncApp = await bootstrapApplication({
-      mode: 'test',
       rootModule: StrictAsyncAppModule,
     });
     const asyncDrizzle = await asyncApp.container.resolve(DrizzleDatabase<typeof database>);
@@ -325,7 +321,7 @@ describe('createDrizzleModuleAsync', () => {
       imports: [ConfigModule, DrizzleModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const db = await app.container.resolve(DrizzleDatabase);
 
     expect(factory).toHaveBeenCalledOnce();
@@ -348,7 +344,7 @@ describe('createDrizzleModuleAsync', () => {
 
     defineModule(AppModule, { imports: [DrizzleModule] });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const db = await app.container.resolve(DrizzleDatabase);
 
     expect(db).toBeInstanceOf(DrizzleDatabase);
@@ -365,6 +361,6 @@ describe('createDrizzleModuleAsync', () => {
 
     defineModule(AppModule, { imports: [DrizzleModule] });
 
-    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow('db config fetch failed');
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow('db config fetch failed');
   });
 });

--- a/packages/drizzle/src/vertical-slice.test.ts
+++ b/packages/drizzle/src/vertical-slice.test.ts
@@ -222,7 +222,6 @@ describe('@konekti/drizzle vertical slice', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -118,7 +118,7 @@ describe('@konekti/event-bus', () => {
       providers: [EventStore, UserCreatedHandler],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
     const store = await app.container.resolve(EventStore);
     const event = new UserCreatedEvent('user-1');
@@ -164,7 +164,6 @@ describe('@konekti/event-bus', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
@@ -224,7 +223,7 @@ describe('@konekti/event-bus', () => {
       providers: [EventStore, FirstHandler, SecondHandler],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
     const store = await app.container.resolve(EventStore);
 
@@ -278,7 +277,6 @@ describe('@konekti/event-bus', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
@@ -320,7 +318,7 @@ describe('@konekti/event-bus', () => {
       providers: [EventStore, SlowHandler],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
     const store = await app.container.resolve(EventStore);
 
@@ -368,7 +366,6 @@ describe('@konekti/event-bus', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
@@ -409,7 +406,6 @@ describe('@konekti/event-bus', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
@@ -471,7 +467,7 @@ describe('@konekti/event-bus', () => {
       imports: [FeatureModule, createEventBusModule()],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
     const store = await app.container.resolve(EventStore);
 
@@ -504,7 +500,7 @@ describe('@konekti/event-bus', () => {
       providers: [EventStore, BaseEventHandler],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
     const store = await app.container.resolve(EventStore);
 
@@ -525,7 +521,6 @@ describe('@konekti/event-bus', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
@@ -566,7 +561,7 @@ describe('@konekti/event-bus', () => {
       providers: [EventStore, UserCreatedHandler, UserPublisher],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const publisher = await app.container.resolve(UserPublisher);
     const store = await app.container.resolve(EventStore);
 
@@ -600,7 +595,7 @@ describe('@konekti/event-bus', () => {
       providers: [SharedHandler],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
 
     await eventBus.publish(new UserCreatedEvent('user-7'));
@@ -636,7 +631,6 @@ describe('@konekti/event-bus', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
@@ -703,7 +697,7 @@ describe('@konekti/event-bus', () => {
       ],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
     const store = await app.container.resolve(EventStore);
 
@@ -754,7 +748,7 @@ describe('@konekti/event-bus', () => {
       providers: [EventStore, FirstCollidingHandler, SecondCollidingHandler],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
     const store = await app.container.resolve(EventStore);
 
@@ -802,7 +796,7 @@ describe('@konekti/event-bus', () => {
         imports: [createEventBusModule({ transport })],
       });
 
-      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const app = await bootstrapApplication({ rootModule: AppModule });
       const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
 
       await eventBus.publish(new UserCreatedEvent('transport-user-1'));
@@ -838,7 +832,7 @@ describe('@konekti/event-bus', () => {
         providers: [HandlerA, HandlerB, HandlerC],
       });
 
-      await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      await bootstrapApplication({ rootModule: AppModule });
 
       const subscribedChannels = transport.subscribed.map((s) => s.channel).sort();
       expect(subscribedChannels).toEqual(['PasswordResetEvent', 'UserCreatedEvent']);
@@ -867,7 +861,7 @@ describe('@konekti/event-bus', () => {
         providers: [EventStore, TransportHandler],
       });
 
-      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const app = await bootstrapApplication({ rootModule: AppModule });
       const store = await app.container.resolve(EventStore);
 
       const incomingSubscription = transport.subscribed.find((s) => s.channel === 'UserCreatedEvent');
@@ -916,7 +910,7 @@ describe('@konekti/event-bus', () => {
         providers: [EventStore, BaseHandler, DerivedHandler],
       });
 
-      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const app = await bootstrapApplication({ rootModule: AppModule });
       const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
       const store = await app.container.resolve(EventStore);
 
@@ -969,7 +963,7 @@ describe('@konekti/event-bus', () => {
         providers: [EventStore, InventoryHandler],
       });
 
-      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const app = await bootstrapApplication({ rootModule: AppModule });
       const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
       const store = await app.container.resolve(EventStore);
 
@@ -1036,7 +1030,7 @@ describe('@konekti/event-bus', () => {
         providers: [EventStore, BaseHandler, DetailedHandler],
       });
 
-      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const app = await bootstrapApplication({ rootModule: AppModule });
       const store = await app.container.resolve(EventStore);
       const incomingSubscription = transport.subscribed.find((entry) => entry.channel === 'inventory.shared.v1');
 
@@ -1090,7 +1084,7 @@ describe('@konekti/event-bus', () => {
         providers: [EventStore, FirstHandler, SecondHandler],
       });
 
-      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const app = await bootstrapApplication({ rootModule: AppModule });
       const store = await app.container.resolve(EventStore);
       const incomingSubscription = transport.subscribed.find((s) => s.channel === 'MutableTransportEvent');
 
@@ -1111,7 +1105,7 @@ describe('@konekti/event-bus', () => {
         imports: [createEventBusModule({ transport })],
       });
 
-      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const app = await bootstrapApplication({ rootModule: AppModule });
 
       expect(transport.closeCalls).toBe(0);
       await app.close();
@@ -1139,7 +1133,7 @@ describe('@konekti/event-bus', () => {
         providers: [EventStore, LocalHandler],
       });
 
-      const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+      const app = await bootstrapApplication({ rootModule: AppModule });
       const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
       const store = await app.container.resolve(EventStore);
 

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -228,7 +228,6 @@ describe('@konekti/graphql', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -294,7 +293,6 @@ describe('@konekti/graphql', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -349,7 +347,6 @@ describe('@konekti/graphql', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -410,7 +407,6 @@ describe('@konekti/graphql', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -439,7 +435,6 @@ describe('@konekti/graphql', () => {
     const firstPort = await findAvailablePort();
     const firstApp = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port: firstPort,
     });
 
@@ -454,7 +449,6 @@ describe('@konekti/graphql', () => {
     const secondPort = await findAvailablePort();
     const secondApp = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port: secondPort,
     });
 
@@ -500,7 +494,6 @@ describe('@konekti/graphql', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -546,7 +539,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     const [op1, op2] = await Promise.all([
@@ -591,7 +584,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     const r1 = await postGraphql(port, '{ tick }');
@@ -636,7 +629,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     const firstOperation = await postGraphql(port, '{ firstTick secondTick }');
@@ -686,7 +679,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     const firstSocket = await connectGraphqlWebSocket(port);
@@ -751,7 +744,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     const r1 = await postGraphql(port, '{ transientTick }');
@@ -788,7 +781,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     const r1 = await postGraphql(port, '{ singletonTick }');
@@ -820,7 +813,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     await expect(postGraphql(port, '{ useValueHello }')).resolves.toEqual({
@@ -854,7 +847,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     await expect(postGraphql(port, '{ useFactoryGreeting }')).resolves.toEqual({
@@ -906,7 +899,7 @@ describe('@konekti/graphql — provider scopes', () => {
     });
 
     const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, { cors: false, mode: 'test', port });
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
     await app.listen();
 
     await expect(postGraphql(port, '{ classHello }')).resolves.toEqual({

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -60,7 +60,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -87,11 +86,9 @@ describe('MetricsModule', () => {
     });
 
     const firstApp = await bootstrapApplication({
-      mode: 'test',
       rootModule: FirstAppModule,
     });
     const secondApp = await bootstrapApplication({
-      mode: 'test',
       rootModule: SecondAppModule,
     });
 
@@ -130,7 +127,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -164,7 +160,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -194,7 +189,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -214,7 +208,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -257,7 +250,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -292,7 +284,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -324,7 +315,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -348,7 +338,6 @@ describe('MetricsModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -154,7 +154,6 @@ describe('@konekti/microservices', () => {
     });
 
     const microservice = await KonektiFactory.createMicroservice(AppModule, {
-      mode: 'test',
     });
 
     await microservice.listen();
@@ -185,7 +184,7 @@ describe('@konekti/microservices', () => {
       providers: [Handler],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const microservice = await app.container.resolve<{ listen(): Promise<void>; send(pattern: string, payload: unknown): Promise<unknown>; close(): Promise<void> }>(MICROSERVICE);
 
     await microservice.listen();
@@ -239,7 +238,7 @@ describe('@konekti/microservices', () => {
       providers: [Store, Handler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
 
     await microservice.listen();
 
@@ -280,7 +279,7 @@ describe('@konekti/microservices', () => {
       providers: [Store, Handler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
 
     await microservice.listen();
 
@@ -324,7 +323,6 @@ describe('@konekti/microservices', () => {
     });
 
     const microservice = await KonektiFactory.createMicroservice(AppModule, {
-      mode: 'test',
     });
 
     await microservice.listen();
@@ -374,7 +372,6 @@ describe('@konekti/microservices', () => {
     });
 
     const microservice = await KonektiFactory.createMicroservice(AppModule, {
-      mode: 'test',
     });
     const payload = { meta: { role: 'original' } };
 
@@ -413,7 +410,6 @@ describe('@konekti/microservices', () => {
     });
 
     const app = await KonektiFactory.create(AppModule, {
-      mode: 'test',
     });
     const microservice = await app.container.resolve<{
       emit(pattern: string, payload: unknown): Promise<void>;
@@ -455,7 +451,7 @@ describe('@konekti/microservices', () => {
       providers: [Handler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
 
     await Promise.all([microservice.listen(), microservice.listen()]);
 
@@ -487,7 +483,7 @@ describe('@konekti/microservices', () => {
       providers: [ExactHandler, RegexHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     await expect(microservice.send('user.lookup', {})).rejects.toThrow('Multiple message handlers matched pattern "user.lookup"');
@@ -522,7 +518,7 @@ describe('@konekti/microservices', () => {
       providers: [RequestState, RequestScopedHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     const [first, second] = await Promise.all([
@@ -568,7 +564,7 @@ describe('@konekti/microservices', () => {
       providers: [RequestState, RequestScopedHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     await expect(microservice.send('scope.dispose', {})).resolves.toBe(1);
@@ -608,7 +604,7 @@ describe('@konekti/microservices', () => {
       providers: [RequestState, RequestScopedHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     await expect(microservice.send('scope.error', {})).rejects.toThrow('request handler failed');
@@ -649,7 +645,7 @@ describe('@konekti/microservices', () => {
       providers: [EventContext, RequestScopedEventHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     await microservice.emit('scope.event', { id: 1 });
@@ -700,7 +696,7 @@ describe('@konekti/microservices', () => {
       providers: [SharedScope, FirstEventHandler, SecondEventHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     await microservice.emit('fanout.event', {});
@@ -743,7 +739,7 @@ describe('@konekti/microservices', () => {
       providers: [DisposableContext, DisposableHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     await microservice.emit('dispose.event', {});
@@ -787,7 +783,7 @@ describe('@konekti/microservices', () => {
       providers: [DisposableContext, FailingHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     await microservice.emit('fail.event', {});
@@ -819,7 +815,7 @@ describe('@konekti/microservices', () => {
       providers: [TransientHandler],
     });
 
-    const microservice = await KonektiFactory.createMicroservice(AppModule, { mode: 'test' });
+    const microservice = await KonektiFactory.createMicroservice(AppModule);
     await microservice.listen();
 
     await microservice.emit('transient.event', {});

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -72,7 +72,6 @@ describe('@konekti/mongoose', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const service = await app.container.resolve(UserService);
@@ -128,7 +127,7 @@ describe('@konekti/mongoose', () => {
       imports: [MongooseModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
 
     const openTransaction = mongoose.requestTransaction(
@@ -162,7 +161,6 @@ describe('@konekti/mongoose', () => {
     });
 
     const syncApp = await bootstrapApplication({
-      mode: 'test',
       rootModule: StrictSyncAppModule,
     });
     const syncMongoose = await syncApp.container.resolve(MongooseConnection<typeof connection>);
@@ -187,7 +185,6 @@ describe('@konekti/mongoose', () => {
     });
 
     const asyncApp = await bootstrapApplication({
-      mode: 'test',
       rootModule: StrictAsyncAppModule,
     });
     const asyncMongoose = await asyncApp.container.resolve(MongooseConnection<typeof connection>);
@@ -307,7 +304,7 @@ describe('createMongooseModuleAsync', () => {
       imports: [ConfigModule, MongooseModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const conn = await app.container.resolve(MongooseConnection);
 
     expect(factory).toHaveBeenCalledOnce();
@@ -330,7 +327,7 @@ describe('createMongooseModuleAsync', () => {
 
     defineModule(AppModule, { imports: [MongooseModule] });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const conn = await app.container.resolve(MongooseConnection);
 
     expect(conn).toBeInstanceOf(MongooseConnection);
@@ -347,6 +344,6 @@ describe('createMongooseModuleAsync', () => {
 
     defineModule(AppModule, { imports: [MongooseModule] });
 
-    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow('mongo config fetch failed');
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow('mongo config fetch failed');
   });
 });

--- a/packages/mongoose/src/vertical-slice.test.ts
+++ b/packages/mongoose/src/vertical-slice.test.ts
@@ -208,7 +208,6 @@ describe('@konekti/mongoose vertical slice', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -143,7 +143,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -286,7 +285,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -328,7 +326,6 @@ describe('OpenApiModule', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       globalPrefix: '/api',
-      mode: 'test',
       port,
     });
 
@@ -398,7 +395,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -473,7 +469,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -556,7 +551,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -700,7 +694,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -800,7 +793,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -875,7 +867,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -999,7 +990,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -1077,7 +1067,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -1143,7 +1132,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -1245,7 +1233,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -1295,7 +1282,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -1383,7 +1369,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -1451,7 +1436,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const response = createResponse();
@@ -1518,7 +1502,6 @@ describe('OpenApiModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: OPENAPI_TITLE, useValue: 'Async OpenAPI' }],
       rootModule: AppModule,
     });
@@ -1553,7 +1536,6 @@ describe('OpenApiModule', () => {
 
     await expect(
       bootstrapApplication({
-        mode: 'test',
         rootModule: AppModule,
       }),
     ).rejects.toThrow('openapi async options failed');

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -150,7 +150,6 @@ describe('@konekti/platform-fastify', () => {
     const port = await findAvailablePort();
     const app = await bootstrapFastifyApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       rawBody: true,
     });
@@ -206,7 +205,6 @@ describe('@konekti/platform-fastify', () => {
     const port = await findAvailablePort();
     const app = await bootstrapFastifyApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       rawBody: true,
     });
@@ -247,7 +245,6 @@ describe('@konekti/platform-fastify', () => {
     const port = await findAvailablePort();
     const app = await bootstrapFastifyApplication(AppModule, {
       cors: 'https://my-frontend.com',
-      mode: 'test',
       port,
     });
 
@@ -295,7 +292,6 @@ describe('@konekti/platform-fastify', () => {
       cors: false,
       host: '127.0.0.1',
       logger,
-      mode: 'test',
       port,
     });
 
@@ -334,7 +330,6 @@ describe('@konekti/platform-fastify', () => {
     const app = await bootstrapFastifyApplication(AppModule, {
       cors: false,
       globalPrefix: '/api',
-      mode: 'test',
       observers: [new PathObserver()],
       port,
     });
@@ -371,7 +366,6 @@ describe('@konekti/platform-fastify', () => {
     const app = await bootstrapFastifyApplication(AppModule, {
       cors: false,
       globalPrefix: '/api',
-      mode: 'test',
       port,
     });
 
@@ -427,7 +421,6 @@ describe('@konekti/platform-fastify', () => {
         key: TEST_TLS_PRIVATE_KEY,
       },
       logger,
-      mode: 'test',
       port,
     });
 

--- a/packages/platform-socket.io/src/module.test.ts
+++ b/packages/platform-socket.io/src/module.test.ts
@@ -98,7 +98,6 @@ describe('@konekti/platform-socket.io', () => {
 
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port: await findAvailablePort(),
     });
     const probe = await app.container.resolve(ServerProbe);
@@ -154,7 +153,6 @@ describe('@konekti/platform-socket.io', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -209,7 +207,6 @@ describe('@konekti/platform-socket.io', () => {
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
       logger: createLogger(loggerEvents),
-      mode: 'test',
       port: await findAvailablePort(),
     });
 
@@ -262,7 +259,6 @@ describe('@konekti/platform-socket.io', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -344,7 +340,6 @@ describe('@konekti/platform-socket.io', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -402,7 +397,6 @@ describe('@konekti/platform-socket.io', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       shutdownTimeoutMs: 200,
     });

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -76,7 +76,6 @@ describe('@konekti/prisma', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const service = await app.container.resolve(UserService);
@@ -141,7 +140,6 @@ describe('@konekti/prisma', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const prisma = await app.container.resolve(PrismaService<typeof client, typeof transactionClient>);
@@ -185,7 +183,6 @@ describe('@konekti/prisma', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const prisma = await app.container.resolve(PrismaService<typeof client, typeof transactionClient>);
@@ -271,7 +268,6 @@ describe('@konekti/prisma', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const prisma = await app.container.resolve(PrismaService<typeof client>);
@@ -300,7 +296,6 @@ describe('@konekti/prisma', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
     const prisma = await app.container.resolve(PrismaService<typeof client>);
@@ -364,7 +359,7 @@ describe('createPrismaModuleAsync', () => {
       imports: [ConfigModule, PrismaModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const prisma = await app.container.resolve(PrismaService);
     const rawClient = await app.container.resolve(PRISMA_CLIENT);
     const moduleOptions = await app.container.resolve(PRISMA_OPTIONS);
@@ -392,7 +387,7 @@ describe('createPrismaModuleAsync', () => {
 
     defineModule(AppModule, { imports: [PrismaModule] });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const prisma = await app.container.resolve(PrismaService);
 
     expect(prisma).toBeInstanceOf(PrismaService);
@@ -414,7 +409,7 @@ describe('createPrismaModuleAsync', () => {
 
     defineModule(AppModule, { imports: [PrismaModule] });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const prisma = await app.container.resolve(PrismaService<typeof client>);
 
     await expect(prisma.transaction(async () => 'never')).rejects.toThrow(
@@ -433,6 +428,6 @@ describe('createPrismaModuleAsync', () => {
 
     defineModule(AppModule, { imports: [PrismaModule] });
 
-    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow('secret fetch failed');
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow('secret fetch failed');
   });
 });

--- a/packages/prisma/src/vertical-slice.test.ts
+++ b/packages/prisma/src/vertical-slice.test.ts
@@ -237,7 +237,6 @@ describe('@konekti/prisma vertical slice', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -375,7 +375,6 @@ describe('@konekti/queue', () => {
 
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -422,7 +421,6 @@ describe('@konekti/queue', () => {
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -474,7 +472,6 @@ describe('@konekti/queue', () => {
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -532,7 +529,6 @@ describe('@konekti/queue', () => {
 
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -589,7 +585,6 @@ describe('@konekti/queue', () => {
 
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -632,7 +627,6 @@ describe('@konekti/queue', () => {
     };
 
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -685,7 +679,6 @@ describe('@konekti/queue', () => {
 
     await expect(
       bootstrapApplication({
-        mode: 'test',
         providers: [{ provide: REDIS_CLIENT, useValue: redis }],
         rootModule: AppModule,
       }),
@@ -715,7 +708,6 @@ describe('@konekti/queue', () => {
 
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -753,7 +745,6 @@ describe('@konekti/queue', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -790,7 +781,6 @@ describe('@konekti/queue', () => {
 
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -824,7 +814,6 @@ describe('@konekti/queue', () => {
 
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -858,7 +847,6 @@ describe('@konekti/queue', () => {
 
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });
@@ -898,7 +886,6 @@ describe('@konekti/queue', () => {
 
     const redis = new MockRedisClient();
     const app = await bootstrapApplication({
-      mode: 'test',
       providers: [{ provide: REDIS_CLIENT, useValue: redis }],
       rootModule: AppModule,
     });

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -96,7 +96,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
     });
 
-    await expect(bootstrapApplication({ mode: 'test', rootModule: AppModule })).rejects.toThrow('connect failed');
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow('connect failed');
 
     expect(mockRedisState.events).toEqual(['connect', 'disconnect']);
   });
@@ -117,7 +117,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 }), FeatureModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const cache = await app.container.resolve(CacheService);
 
     expect(mockRedisState.instances).toHaveLength(1);
@@ -142,7 +142,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     await expect(app.close()).resolves.toBeUndefined();
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
@@ -157,7 +157,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     await expect(app.close()).rejects.toThrow('quit failed');
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
@@ -169,7 +169,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const instance = mockRedisState.instances[0];
 
     expect(instance).toBeDefined();
@@ -189,7 +189,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 })],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const instance = mockRedisState.instances[0];
 
     expect(instance).toBeDefined();
@@ -219,7 +219,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 }), FeatureModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const cacheFacade = await app.container.resolve(CacheFacade);
 
     expect(cacheFacade.redisService).toBeInstanceOf(RedisService);
@@ -251,7 +251,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 }), FeatureModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const cacheFacade = await app.container.resolve(CacheFacade);
     const rawClient = cacheFacade.redisService.getRawClient();
 
@@ -278,7 +278,7 @@ describe('@konekti/redis', () => {
       imports: [createRedisModule({ host: '127.0.0.1', port: 6379 }), FeatureModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
     const cacheFacade = await app.container.resolve(CacheFacade);
     const rawClient = cacheFacade.redisService.getRawClient();
 

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -513,7 +513,6 @@ describe('KonektiFactory.createApplicationContext', () => {
     });
 
     const context = await KonektiFactory.createApplicationContext(AppModule, {
-      mode: 'test',
     });
 
     await expect(context.get(AppService)).resolves.toBeInstanceOf(AppService);
@@ -549,7 +548,6 @@ describe('KonektiFactory.createApplicationContext', () => {
     });
 
     const context = await KonektiFactory.createApplicationContext(AppModule, {
-      mode: 'test',
     });
 
     expect(events).toEqual(['module:init', 'app:bootstrap']);
@@ -587,7 +585,6 @@ describe('KonektiFactory.createMicroservice', () => {
     });
 
     const microservice = await KonektiFactory.createMicroservice(AppModule, {
-      mode: 'test',
     });
 
     await microservice.listen();
@@ -611,7 +608,7 @@ describe('KonektiFactory.createMicroservice', () => {
       ],
     });
 
-    await expect(KonektiFactory.createMicroservice(AppModule, { mode: 'test' })).rejects.toThrow(
+    await expect(KonektiFactory.createMicroservice(AppModule)).rejects.toThrow(
       'Resolved microservice token does not implement listen().',
     );
   });
@@ -637,7 +634,6 @@ describe('KonektiFactory.createMicroservice', () => {
     });
 
     const app = await KonektiFactory.create(AppModule, {
-      mode: 'test',
     });
     const microservice = await app.container.resolve<MicroserviceRuntime>(MICROSERVICE_TOKEN);
 

--- a/packages/runtime/src/health.test.ts
+++ b/packages/runtime/src/health.test.ts
@@ -62,7 +62,6 @@ describe('createHealthModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -94,7 +93,6 @@ describe('createHealthModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -126,7 +124,6 @@ describe('createHealthModule', () => {
     });
 
     const app = await bootstrapApplication({
-      mode: 'test',
       rootModule: AppModule,
     });
 

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -61,7 +61,7 @@ describe('createTerminusModule', () => {
       imports: [TerminusModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     const healthResponse = createResponse();
     await app.dispatch(createRequest('/health'), healthResponse);
@@ -107,7 +107,7 @@ describe('createTerminusModule', () => {
       imports: [TerminusModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     const healthResponse = createResponse();
     await app.dispatch(createRequest('/health'), healthResponse);
@@ -151,7 +151,7 @@ describe('createTerminusModule', () => {
       imports: [TerminusModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     const firstHealth = createResponse();
     await app.dispatch(createRequest('/health'), firstHealth);
@@ -199,7 +199,7 @@ describe('createTerminusModule', () => {
       imports: [TerminusModule],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     const healthResponse = createResponse();
     await app.dispatch(createRequest('/health'), healthResponse);
@@ -241,7 +241,7 @@ describe('createTerminusModule', () => {
       ],
     });
 
-    const app = await bootstrapApplication({ mode: 'test', rootModule: AppModule });
+    const app = await bootstrapApplication({ rootModule: AppModule });
 
     const healthResponse = createResponse();
     await app.dispatch(createRequest('/health'), healthResponse);

--- a/packages/testing/src/app.ts
+++ b/packages/testing/src/app.ts
@@ -44,7 +44,6 @@ function normalizeRequestInput(
 export async function createTestApp(options: TestingModuleOptions): Promise<TestApp> {
   const app = await bootstrapApplication({
     ...options,
-    mode: 'test',
     middleware: [createTestRequestContextMiddleware()],
   });
 

--- a/packages/websocket/src/module.test.ts
+++ b/packages/websocket/src/module.test.ts
@@ -241,7 +241,6 @@ describe('@konekti/websocket', () => {
 
     const app = await bootstrapApplication({
       logger: createLogger(loggerEvents),
-      mode: 'test',
       rootModule: AppModule,
     });
 
@@ -283,7 +282,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -319,7 +317,6 @@ describe('@konekti/websocket', () => {
           async close() {},
           async listen() {},
         },
-        mode: 'test',
         rootModule: AppModule,
       }),
     ).rejects.toThrow('WebSocket gateway bootstrap requires an HTTP adapter with getServer()');
@@ -333,7 +330,6 @@ describe('@konekti/websocket', () => {
 
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port: await findAvailablePort(),
     });
     const adapter = await app.container.resolve<HttpApplicationAdapter>(HTTP_APPLICATION_ADAPTER);
@@ -382,7 +378,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -446,7 +441,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapFastifyApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -510,7 +504,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -572,7 +565,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -633,7 +625,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(GatewayState);
@@ -696,7 +687,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
     const state = await app.container.resolve(SharedState);
@@ -990,7 +980,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
     });
 
@@ -1044,7 +1033,6 @@ describe('@konekti/websocket', () => {
     const port = await findAvailablePort();
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      mode: 'test',
       port,
       shutdownTimeoutMs: 200,
     });

--- a/tooling/benchmarks/manifest-decision.ts
+++ b/tooling/benchmarks/manifest-decision.ts
@@ -118,7 +118,6 @@ async function measureScenario(name: string, rootModule: ModuleType, iterations 
     const startedAt = performance.now();
     const app = await KonektiFactory.create(rootModule, {
       logger: silentLogger,
-      mode: 'test',
     });
     const bootstrapMs = performance.now() - startedAt;
 


### PR DESCRIPTION
Closes #308

## Summary
- Remove `mode: 'test'` from `createTestApp()` in `@konekti/testing`
- Remove `mode: 'dev'` from CLI scaffold template (`main.ts`)
- Remove `mode: 'test'` from all 24 test files across the monorepo
- Remove `mode: 'dev'` from CLI scaffold template

## Verification
- `pnpm vitest run packages/runtime packages/testing` — 119/119 tests pass
- No `mode: 'test'` references remain in any `.ts` files

## Migration
Tests that need config should:
1. Import `ConfigModule.forRoot({ envFile: '.env.test' })` in their test module, or
2. Use `overrideProvider(ConfigService, fakeConfigService)` for unit-style isolation