### PR TITLE
Resolve #317: add Scope constants alongside literal scope type

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { Inject, Scope } from '@konekti/core';
+import { Inject, Scope as ScopeDecorator } from '@konekti/core';
 
 import { Container } from './container.js';
 import { CircularDependencyError, DuplicateProviderError, ScopeMismatchError } from './errors.js';
-import { forwardRef, optional } from './types.js';
+import { Scope, forwardRef, optional } from './types.js';
 
 describe('Container', () => {
   it('caches singleton providers', async () => {
@@ -69,7 +69,7 @@ describe('Container', () => {
     class Logger {}
 
     @Inject([Logger])
-    @Scope('request')
+    @ScopeDecorator('request')
     class RequestService {
       constructor(readonly logger: Logger) {}
     }
@@ -84,6 +84,41 @@ describe('Container', () => {
 
     expect(first).toBe(second);
     expect(first.logger).toBeInstanceOf(Logger);
+  });
+
+  it('accepts Scope constants in both decorator and provider registrations', async () => {
+    class Logger {}
+
+    @Inject([Logger])
+    @ScopeDecorator(Scope.REQUEST)
+    class RequestService {
+      constructor(readonly logger: Logger) {}
+    }
+
+    let created = 0;
+    class TransientService {
+      readonly id = ++created;
+    }
+
+    const root = new Container().register(
+      Logger,
+      RequestService,
+      {
+        provide: TransientService,
+        scope: Scope.TRANSIENT,
+        useClass: TransientService,
+      },
+    );
+
+    await expect(root.resolve(RequestService)).rejects.toThrow('outside request scope');
+
+    const requestScope = root.createRequestScope();
+    const requestScoped = await requestScope.resolve(RequestService);
+    const firstTransient = await requestScope.resolve(TransientService);
+    const secondTransient = await requestScope.resolve(TransientService);
+
+    expect(requestScoped.logger).toBeInstanceOf(Logger);
+    expect(firstTransient).not.toBe(secondTransient);
   });
 
   describe('transient scope', () => {
@@ -111,7 +146,7 @@ describe('Container', () => {
     it('supports @Scope decorator for transient services', async () => {
       let created = 0;
 
-      @Scope('transient')
+      @ScopeDecorator('transient')
       class TransientCounter {
         readonly id = ++created;
       }

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -18,10 +18,9 @@ import type {
   NormalizedProvider,
   OptionalToken,
   Provider,
-  Scope,
   ValueProvider,
 } from './types.js';
-import { isForwardRef, isOptionalToken } from './types.js';
+import { Scope, isForwardRef, isOptionalToken } from './types.js';
 
 function isClassConstructor(value: Provider): value is ClassType {
   return typeof value === 'function';
@@ -54,7 +53,7 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
     return {
       inject: (metadata?.inject ?? []).map(normalizeInjectToken),
       provide: provider,
-      scope: metadata?.scope ?? 'singleton',
+      scope: metadata?.scope ?? Scope.DEFAULT,
       type: 'class',
       useClass: provider,
     };
@@ -65,7 +64,7 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
       inject: [],
       multi: provider.multi,
       provide: provider.provide,
-      scope: 'singleton',
+      scope: Scope.DEFAULT,
       type: 'value',
       useValue: provider.useValue,
     };
@@ -76,7 +75,7 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
       inject: (provider.inject ?? []).map(normalizeInjectToken),
       multi: provider.multi,
       provide: provider.provide,
-      scope: provider.scope ?? 'singleton',
+      scope: provider.scope ?? Scope.DEFAULT,
       type: 'factory',
       useFactory: provider.useFactory,
     };
@@ -89,7 +88,7 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
       inject: (provider.inject ?? metadata?.inject ?? []).map(normalizeInjectToken),
       multi: provider.multi,
       provide: provider.provide,
-      scope: provider.scope ?? metadata?.scope ?? 'singleton',
+      scope: provider.scope ?? metadata?.scope ?? Scope.DEFAULT,
       type: 'class',
       useClass: provider.useClass,
     };
@@ -99,7 +98,7 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
     return {
       inject: [],
       provide: provider.provide,
-      scope: 'singleton',
+      scope: Scope.DEFAULT,
       type: 'existing',
       useExisting: provider.useExisting,
     };
@@ -366,7 +365,7 @@ export class Container {
   private singletonCacheFor(token: Token): Map<Token, Promise<unknown>> | undefined {
     const provider = this.lookupProvider(token);
 
-    if (!provider || provider.scope !== 'singleton') return undefined;
+    if (!provider || provider.scope !== Scope.DEFAULT) return undefined;
 
     if (this.requestScopeEnabled && this.registrations.has(token)) {
       return this.requestCache;
@@ -431,7 +430,7 @@ export class Container {
   }
 
   private cacheFor(provider: NormalizedProvider): Map<Token, Promise<unknown>> {
-    if (provider.scope === 'singleton') {
+    if (provider.scope === Scope.DEFAULT) {
       if (this.requestScopeEnabled && this.registrations.has(provider.provide)) {
         return this.requestCache;
       }
@@ -585,7 +584,7 @@ export class Container {
   }
 
   private assertSingletonDependencyScopes(provider: NormalizedProvider): void {
-    if (provider.scope !== 'singleton') {
+    if (provider.scope !== Scope.DEFAULT) {
       return;
     }
 
@@ -635,7 +634,7 @@ export class Container {
       this.requestCache.delete(token);
     }
 
-    if (this.parent || scope !== 'singleton') {
+    if (this.parent || scope !== Scope.DEFAULT) {
       return;
     }
 

--- a/packages/di/src/types.ts
+++ b/packages/di/src/types.ts
@@ -2,6 +2,12 @@ import type { Constructor, MaybePromise, Token } from '@konekti/core';
 
 export type Scope = 'singleton' | 'request' | 'transient';
 
+export namespace Scope {
+  export const DEFAULT: Scope = 'singleton';
+  export const REQUEST: Scope = 'request';
+  export const TRANSIENT: Scope = 'transient';
+}
+
 export interface ClassType<T = unknown> extends Constructor<T> {
 }
 


### PR DESCRIPTION
## Summary
- Added `Scope.DEFAULT`, `Scope.REQUEST`, and `Scope.TRANSIENT` exports in `@konekti/di` while preserving existing string-literal scope typing for backward compatibility.
- Updated DI container internals to use the new `Scope` constants for defaulting/comparisons without changing runtime behavior.
- Added regression coverage to verify `@Scope()` decorator and provider registrations both accept the new `Scope` constants.

## Verification
- `pnpm --filter @konekti/core build`
- `pnpm --filter @konekti/di build`
- `pnpm --filter @konekti/di typecheck`
- `pnpm build`
- `pnpm exec vitest run packages/di/src/container.test.ts`

## Notes
- `pnpm typecheck` currently fails due pre-existing unrelated errors in `packages/http/src/dispatcher.test.ts` (`Cannot find name '$$$'`).

Closes #317