### PR TITLE
Resolve #320: align JwtModule and JwtService API with NestJS

### DIFF
--- a/packages/jwt/src/index.ts
+++ b/packages/jwt/src/index.ts
@@ -2,6 +2,7 @@ export * from './errors.js';
 export * from './jwks.js';
 export * from './module.js';
 export * from './refresh-token.js';
+export * from './service.js';
 export * from './signer.js';
 export * from './types.js';
 export * from './verifier.js';

--- a/packages/jwt/src/module.test.ts
+++ b/packages/jwt/src/module.test.ts
@@ -5,6 +5,7 @@ import { Container, type Provider } from '@konekti/di';
 
 import { JwtModule } from './module.js';
 import { type RefreshTokenRecord, type RefreshTokenStore, RefreshTokenService } from './refresh-token.js';
+import { JwtService } from './service.js';
 import { DefaultJwtSigner } from './signer.js';
 import { DefaultJwtVerifier } from './verifier.js';
 
@@ -100,6 +101,34 @@ describe('JwtModule', () => {
     const service = await container.resolve(JwtRoundTripService);
 
     await expect(service.signAndVerify('sync-user')).resolves.toBe('sync-user');
+  });
+
+  it('supports NestJS-style register alias and resolves JwtService', async () => {
+    const container = new Container();
+    const moduleType = JwtModule.register({
+      algorithms: ['HS256'],
+      issuer: 'jwt-module-tests',
+      secret: 'register-secret',
+    });
+
+    container.register(...moduleProviders(moduleType));
+
+    const jwtService = await container.resolve(JwtService);
+    const token = await jwtService.sign({ sub: 'register-user' });
+
+    await expect(jwtService.verify<{ sub?: string }>(token)).resolves.toMatchObject({
+      sub: 'register-user',
+    });
+  });
+
+  it('registers JwtService provider in module metadata', () => {
+    const moduleType = JwtModule.forRoot({
+      algorithms: ['HS256'],
+      issuer: 'jwt-module-tests',
+      secret: 'metadata-secret',
+    });
+
+    expect(moduleProviders(moduleType).map((provider) => providerToken(provider))).toContain(JwtService);
   });
 
   it('resolves injected async options and wires them into jwt providers', async () => {

--- a/packages/jwt/src/module.ts
+++ b/packages/jwt/src/module.ts
@@ -3,6 +3,7 @@ import type { Provider } from '@konekti/di';
 
 import { JwtConfigurationError } from './errors.js';
 import { normalizeRefreshTokenOptions, RefreshTokenService } from './refresh-token.js';
+import { JwtService } from './service.js';
 import type { JwtVerifierOptions } from './types.js';
 import { DefaultJwtSigner } from './signer.js';
 import { DefaultJwtVerifier, JWT_OPTIONS } from './verifier.js';
@@ -35,7 +36,7 @@ function createJwtModuleProviders(
   includeRefreshTokenService: boolean,
   refreshTokenServiceScope: 'singleton' | 'transient',
 ): Provider[] {
-  const providers: Provider[] = [optionsProvider, DefaultJwtVerifier, DefaultJwtSigner];
+  const providers: Provider[] = [optionsProvider, DefaultJwtVerifier, DefaultJwtSigner, JwtService];
 
   if (includeRefreshTokenService) {
     providers.push({
@@ -67,6 +68,10 @@ export function createJwtCoreProviders(options: JwtVerifierOptions): Provider[] 
 }
 
 export class JwtModule {
+  static register(options: JwtVerifierOptions): ModuleType {
+    return this.forRoot(options);
+  }
+
   static forRoot(options: JwtVerifierOptions): ModuleType {
     return this.createModule({
       provide: JWT_OPTIONS,
@@ -92,7 +97,7 @@ export class JwtModule {
     class JwtRuntimeModule {}
 
     defineModuleMetadata(JwtRuntimeModule, {
-      exports: [DefaultJwtVerifier, DefaultJwtSigner, ...(includeRefreshTokenService ? [RefreshTokenService] : [])],
+      exports: [JwtService, DefaultJwtVerifier, DefaultJwtSigner, ...(includeRefreshTokenService ? [RefreshTokenService] : [])],
       providers: createJwtModuleProviders(optionsProvider, includeRefreshTokenService, refreshTokenServiceScope),
     });
 

--- a/packages/jwt/src/service.test.ts
+++ b/packages/jwt/src/service.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { JwtService } from './service.js';
+import { DefaultJwtSigner } from './signer.js';
+import type { JwtVerifierOptions } from './types.js';
+import { DefaultJwtVerifier } from './verifier.js';
+
+function createJwtService(options: JwtVerifierOptions): JwtService {
+  return new JwtService(options, new DefaultJwtSigner(options), new DefaultJwtVerifier(options));
+}
+
+describe('JwtService', () => {
+  it('signs and verifies payload claims with NestJS-style facade methods', async () => {
+    const service = createJwtService({
+      algorithms: ['HS256'],
+      issuer: 'jwt-service-tests',
+      secret: 'service-secret',
+    });
+    const token = await service.sign({ role: 'admin', sub: 'service-user' });
+
+    await expect(service.verify<{ role?: string; sub?: string }>(token)).resolves.toMatchObject({
+      role: 'admin',
+      sub: 'service-user',
+    });
+  });
+
+  it('applies sign and verify options overrides', async () => {
+    const service = createJwtService({
+      algorithms: ['HS256'],
+      issuer: 'jwt-service-tests',
+      secret: 'service-secret',
+    });
+    const token = await service.sign(
+      {
+        role: 'reader',
+      },
+      {
+        audience: 'konekti-users',
+        expiresIn: '60s',
+        issuer: 'jwt-service-tests',
+        subject: 'service-overrides-user',
+      },
+    );
+
+    await expect(
+      service.verify<{ aud?: string; role?: string; sub?: string }>(token, {
+        audience: 'konekti-users',
+        issuer: 'jwt-service-tests',
+      }),
+    ).resolves.toMatchObject({
+      aud: 'konekti-users',
+      role: 'reader',
+      sub: 'service-overrides-user',
+    });
+  });
+
+  it('decodes payload without signature verification', async () => {
+    const service = createJwtService({
+      algorithms: ['HS256'],
+      issuer: 'jwt-service-tests',
+      secret: 'service-secret',
+    });
+    const token = await service.sign({ sub: 'decoded-user' });
+
+    expect(service.decode(token)).toMatchObject({ sub: 'decoded-user' });
+    expect(service.decode('invalid-token')).toBeNull();
+  });
+});

--- a/packages/jwt/src/service.ts
+++ b/packages/jwt/src/service.ts
@@ -1,0 +1,138 @@
+import { Inject } from '@konekti/core';
+
+import { DefaultJwtSigner } from './signer.js';
+import type { JwtClaims, JwtVerifierOptions } from './types.js';
+import { DefaultJwtVerifier, JWT_OPTIONS } from './verifier.js';
+
+type DurationUnit = 's' | 'm' | 'h' | 'd';
+
+function decodeBase64Url(value: string): Buffer {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = normalized.length % 4 === 0 ? '' : '='.repeat(4 - (normalized.length % 4));
+
+  return Buffer.from(normalized + padding, 'base64');
+}
+
+function parseDurationUnitToSeconds(unit: DurationUnit): number {
+  switch (unit) {
+    case 's':
+      return 1;
+    case 'm':
+      return 60;
+    case 'h':
+      return 60 * 60;
+    case 'd':
+      return 60 * 60 * 24;
+  }
+}
+
+function parseExpiresInSeconds(expiresIn: SignOptions['expiresIn']): number | undefined {
+  if (expiresIn === undefined) {
+    return undefined;
+  }
+
+  if (typeof expiresIn === 'number') {
+    if (!Number.isFinite(expiresIn) || expiresIn < 0) {
+      throw new Error('JwtService.sign() options.expiresIn must be a non-negative finite number.');
+    }
+
+    return Math.floor(expiresIn);
+  }
+
+  const trimmed = expiresIn.trim();
+  const match = trimmed.match(/^(\d+)([smhd])$/i);
+
+  if (!match) {
+    throw new Error('JwtService.sign() options.expiresIn must be a number or duration string like "60s", "15m", "1h", "7d".');
+  }
+
+  const value = Number.parseInt(match[1] ?? '', 10);
+  const rawUnit = match[2]?.toLowerCase();
+
+  if (!rawUnit || !['s', 'm', 'h', 'd'].includes(rawUnit)) {
+    throw new Error('JwtService.sign() options.expiresIn uses an unsupported duration unit.');
+  }
+
+  return value * parseDurationUnitToSeconds(rawUnit as DurationUnit);
+}
+
+export interface SignOptions {
+  audience?: JwtVerifierOptions['audience'];
+  expiresIn?: number | `${number}${DurationUnit}`;
+  issuer?: string;
+  notBefore?: number;
+  subject?: string;
+}
+
+export interface VerifyOptions {
+  algorithms?: JwtVerifierOptions['algorithms'];
+  audience?: JwtVerifierOptions['audience'];
+  clockSkewSeconds?: number;
+  issuer?: string;
+  maxAge?: number;
+  requireExp?: boolean;
+}
+
+@Inject([JWT_OPTIONS, DefaultJwtSigner, DefaultJwtVerifier])
+export class JwtService {
+  constructor(
+    private readonly options: JwtVerifierOptions,
+    private readonly signer: DefaultJwtSigner,
+    private readonly verifier: DefaultJwtVerifier,
+  ) {}
+
+  async sign(payload: object, options?: SignOptions): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    const expiresInSeconds = parseExpiresInSeconds(options?.expiresIn);
+    const claims: JwtClaims = {
+      ...(payload as JwtClaims),
+      aud: options?.audience ?? (payload as JwtClaims).aud,
+      exp:
+        expiresInSeconds !== undefined
+          ? ((payload as JwtClaims).exp ?? now + expiresInSeconds)
+          : (payload as JwtClaims).exp,
+      iss: options?.issuer ?? (payload as JwtClaims).iss,
+      nbf: options?.notBefore ?? (payload as JwtClaims).nbf,
+      sub: options?.subject ?? (payload as JwtClaims).sub,
+    };
+
+    return this.signer.signAccessToken(claims);
+  }
+
+  async verify<T = unknown>(token: string, options?: VerifyOptions): Promise<T> {
+    const verifier = options
+      ? new DefaultJwtVerifier({
+          ...this.options,
+          algorithms: options.algorithms ?? this.options.algorithms,
+          audience: options.audience ?? this.options.audience,
+          clockSkewSeconds: options.clockSkewSeconds ?? this.options.clockSkewSeconds,
+          issuer: options.issuer ?? this.options.issuer,
+          maxAge: options.maxAge ?? this.options.maxAge,
+          requireExp: options.requireExp ?? this.options.requireExp,
+        })
+      : this.verifier;
+    const principal = await verifier.verifyAccessToken(token);
+
+    return principal.claims as T;
+  }
+
+  decode(token: string): unknown {
+    const segments = token.split('.');
+
+    if (segments.length !== 3) {
+      return null;
+    }
+
+    const [, payloadSegment] = segments;
+
+    if (!payloadSegment) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(decodeBase64Url(payloadSegment).toString('utf8')) as unknown;
+    } catch {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `JwtModule.register(options)` as a backward-compatible alias of `JwtModule.forRoot(options)`.
- Introduce injectable `JwtService` facade with `sign`, `verify`, and `decode` methods to provide a NestJS-style surface while preserving existing signer/verifier APIs.
- Wire `JwtService` into JWT module providers/exports and export it from package index; add module/service coverage tests.

## Verification
- `pnpm exec vitest run packages/jwt/src/module.test.ts packages/jwt/src/service.test.ts`
- `pnpm --filter @konekti/jwt run typecheck`
- `pnpm --filter @konekti/jwt run build`

## Notes
- Running `pnpm exec vitest run packages/jwt/src/*.test.ts` still reproduces an existing baseline failure in `packages/jwt/src/jwks.test.ts` (`JwksClient > fetches keys from jwks uri and finds key by kid`) on both this branch and current `main` checkout.

Closes #320