### PR TITLE
Resolve #319: align @konekti/testing module API with NestJS

### DIFF
--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,5 +1,5 @@
 export * from './http.js';
 export * from './app.js';
 export * from './mock.js';
-export { createTestingModule, extractModuleProviders, extractModuleControllers, extractModuleImports } from './module.js';
+export { Test, createTestingModule, extractModuleProviders, extractModuleControllers, extractModuleImports } from './module.js';
 export * from './types.js';

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -15,6 +15,7 @@ import {
   extractModuleProviders,
   makeRequest,
   mockToken,
+  Test,
 } from './index.js';
 
 @Controller('/users')
@@ -40,6 +41,21 @@ class UserController {
 class AppModule {}
 
 describe('@konekti/testing', () => {
+  it('exposes Test.createTestingModule for NestJS-style module builder access', async () => {
+    const TOKEN = Symbol('token');
+
+    @Module({
+      providers: [{ provide: TOKEN, useValue: 'from-test-namespace' }],
+    })
+    class NamespaceModule {}
+
+    const testingModule = await Test.createTestingModule({
+      rootModule: NamespaceModule,
+    }).compile();
+
+    expect(testingModule.get<string>(TOKEN)).toBe('from-test-namespace');
+  });
+
   it('creates a testing module and resolves providers from the module graph', async () => {
     class Logger {
       readonly name = 'logger';
@@ -59,7 +75,7 @@ describe('@konekti/testing', () => {
       rootModule: ServiceModule,
     }).compile();
 
-    const service = await testingModule.resolve(UserService);
+    const service = await testingModule.resolve<UserService>(UserService);
 
     expect(testingModule.has(UserService)).toBe(true);
     expect(service.logger.name).toBe('logger');
@@ -89,6 +105,55 @@ describe('@konekti/testing', () => {
     const service = await testingModule.resolve(UserService);
 
     expect(service.logger).toEqual({ name: 'fake-logger' });
+  });
+
+  it('supports NestJS-style overrideProvider(token).useValue(value) chain', async () => {
+    class Logger {
+      readonly name: string = 'logger';
+    }
+
+    @Inject([Logger])
+    class UserService {
+      constructor(readonly logger: Logger) {}
+    }
+
+    @Module({
+      providers: [Logger, UserService],
+    })
+    class ServiceModule {}
+
+    const testingModule = await createTestingModule({
+      rootModule: ServiceModule,
+    })
+      .overrideProvider(Logger)
+      .useValue({ name: 'nest-style-fake' })
+      .compile();
+
+    const service = await testingModule.resolve(UserService);
+
+    expect(service.logger).toEqual({ name: 'nest-style-fake' });
+    expect(testingModule.get<Logger>(Logger)).toEqual({ name: 'nest-style-fake' });
+  });
+
+  it('throws from get() for async providers and guides to resolve()', async () => {
+    const TOKEN = Symbol('async-token');
+
+    @Module({
+      providers: [
+        {
+          provide: TOKEN,
+          useFactory: async () => 'async-value',
+        },
+      ],
+    })
+    class AsyncProviderModule {}
+
+    const testingModule = await createTestingModule({
+      rootModule: AsyncProviderModule,
+    }).compile();
+
+    expect(() => testingModule.get<string>(TOKEN)).toThrow(/requires async resolution/);
+    await expect(testingModule.resolve<string>(TOKEN)).resolves.toBe('async-value');
   });
 
   it('treats direct function mocks in overrideProvider as useValue', async () => {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -1,13 +1,21 @@
-import type { Token } from '@konekti/core';
+import type { MaybePromise, Token } from '@konekti/core';
 import { getModuleMetadata } from '@konekti/core';
-import type { ClassType, Provider } from '@konekti/di';
+import {
+  isForwardRef,
+  isOptionalToken,
+  type ClassType,
+  type ForwardRefFn,
+  type NormalizedProvider,
+  type OptionalToken,
+  type Provider,
+} from '@konekti/di';
 import type { BootstrapResult, ModuleDefinition, ModuleType } from '@konekti/runtime';
 import { bootstrapModule, defineModule } from '@konekti/runtime';
 
 import { createDispatcher, createHandlerMapping } from '@konekti/http';
 import type { Guard, HandlerSource, Interceptor } from '@konekti/http';
 import { createTestRequestContextMiddleware, makeRequest, type TestRequestWithOptions } from './http.js';
-import type { TestingModuleBuilder, TestingModuleOptions, TestingModuleRef } from './types.js';
+import type { OverrideProviderBuilder, TestingModuleBuilder, TestingModuleOptions, TestingModuleRef } from './types.js';
 
 export function extractModuleProviders(moduleType: ModuleType): Provider[] {
   const metadata = getModuleMetadata(moduleType);
@@ -95,13 +103,199 @@ function normalizeOverride<T>(token: Token<T>, value: Provider<T> | T): Provider
   return { provide: token, useValue: value };
 }
 
+interface ContainerIntrospection {
+  parent?: ContainerIntrospection;
+  registrations: Map<Token, NormalizedProvider>;
+  multiRegistrations: Map<Token, NormalizedProvider[]>;
+  requestScopeEnabled?: boolean;
+}
+
+function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+  return (
+    (typeof value === 'object' || typeof value === 'function') &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+function createSyncResolver(
+  container: BootstrapResult['container'],
+): <T>(token: Token<T>) => T {
+  const introspection = container as unknown as ContainerIntrospection;
+  const singletonCache = new Map<Token, unknown>();
+  const resolutionChain = new Set<Token>();
+
+  const collectMultiProviders = (target: ContainerIntrospection, token: Token): NormalizedProvider[] => {
+    const fromParent = target.parent ? collectMultiProviders(target.parent, token) : [];
+    const local = target.multiRegistrations.get(token) ?? [];
+    return [...fromParent, ...local];
+  };
+
+  const lookupProvider = (target: ContainerIntrospection, token: Token): NormalizedProvider | undefined => {
+    const local = target.registrations.get(token);
+    if (local) {
+      return local;
+    }
+
+    return target.parent ? lookupProvider(target.parent, token) : undefined;
+  };
+
+  const hasToken = (token: Token): boolean => {
+    return lookupProvider(introspection, token) !== undefined || collectMultiProviders(introspection, token).length > 0;
+  };
+
+  const resolveDep = (entry: Token | ForwardRefFn | OptionalToken): unknown => {
+    if (isOptionalToken(entry)) {
+      if (!hasToken(entry.token)) {
+        return undefined;
+      }
+
+      return resolveToken(entry.token);
+    }
+
+    if (isForwardRef(entry)) {
+      return resolveToken(entry.forwardRef());
+    }
+
+    return resolveToken(entry as Token);
+  };
+
+  const instantiateProvider = (provider: NormalizedProvider): unknown => {
+    switch (provider.type) {
+      case 'value': {
+        return provider.useValue;
+      }
+      case 'existing': {
+        if (!provider.useExisting) {
+          throw new Error('Existing provider is missing useExisting token.');
+        }
+
+        return resolveToken(provider.useExisting);
+      }
+      case 'factory': {
+        if (!provider.useFactory) {
+          throw new Error('Factory provider is missing useFactory.');
+        }
+
+        const deps = provider.inject.map((entry) => resolveDep(entry));
+        const value = provider.useFactory(...deps) as MaybePromise<unknown>;
+
+        if (isPromiseLike(value)) {
+          throw new Error(
+            `Token ${String(provider.provide)} requires async resolution. Use resolve() instead of get() for async providers.`,
+          );
+        }
+
+        return value;
+      }
+      case 'class': {
+        if (!provider.useClass) {
+          throw new Error('Class provider is missing useClass.');
+        }
+
+        const deps = provider.inject.map((entry) => resolveDep(entry));
+        return new provider.useClass(...deps);
+      }
+      default: {
+        throw new Error('Unknown provider type.');
+      }
+    }
+  };
+
+  const resolveProvider = (provider: NormalizedProvider): unknown => {
+    if (provider.scope === 'request' && !introspection.requestScopeEnabled) {
+      throw new Error(`Request-scoped provider ${String(provider.provide)} cannot be resolved outside request scope.`);
+    }
+
+    if (provider.scope === 'transient') {
+      return instantiateProvider(provider);
+    }
+
+    if (singletonCache.has(provider.provide)) {
+      return singletonCache.get(provider.provide);
+    }
+
+    const instance = instantiateProvider(provider);
+    singletonCache.set(provider.provide, instance);
+    return instance;
+  };
+
+  const resolveToken = (token: Token): unknown => {
+    if (resolutionChain.has(token)) {
+      throw new Error(`Circular dependency detected while resolving token ${String(token)} via get().`);
+    }
+
+    resolutionChain.add(token);
+
+    try {
+      const multiProviders = collectMultiProviders(introspection, token);
+      if (multiProviders.length > 0) {
+        return multiProviders.map((provider) => instantiateProvider(provider));
+      }
+
+      const provider = lookupProvider(introspection, token);
+
+      if (!provider) {
+        throw new Error(`No provider registered for token ${String(token)}.`);
+      }
+
+      return resolveProvider(provider);
+    } finally {
+      resolutionChain.delete(token);
+    }
+  };
+
+  return <T>(token: Token<T>): T => resolveToken(token) as T;
+}
+
+class DefaultOverrideProviderBuilder<T> implements OverrideProviderBuilder<T> {
+  constructor(
+    private readonly builder: DefaultTestingModuleBuilder,
+    private readonly token: Token<T>,
+  ) {}
+
+  useValue(value: T): TestingModuleBuilder {
+    this.builder.addOverride(normalizeOverride(this.token, value));
+    return this.builder;
+  }
+
+  useClass(cls: ClassType<T>): TestingModuleBuilder {
+    this.builder.addOverride({ provide: this.token, useClass: cls });
+    return this.builder;
+  }
+
+  useFactory(
+    factory: (...args: unknown[]) => MaybePromise<T>,
+    inject?: Array<Token | ForwardRefFn | OptionalToken>,
+  ): TestingModuleBuilder {
+    this.builder.addOverride({ provide: this.token, useFactory: factory, inject });
+    return this.builder;
+  }
+
+  useExisting(token: Token<T>): TestingModuleBuilder {
+    this.builder.addOverride({ provide: this.token, useExisting: token });
+    return this.builder;
+  }
+}
+
 class DefaultTestingModuleBuilder implements TestingModuleBuilder {
   private readonly overrides: Provider[] = [];
   private readonly moduleReplacements = new Map<ModuleType, ModuleType>();
 
   constructor(private readonly options: TestingModuleOptions) {}
 
-  overrideProvider<T>(token: Token<T>, value: Provider<T> | T): this {
+  addOverride(provider: Provider): void {
+    this.overrides.push(provider);
+  }
+
+  overrideProvider<T>(token: Token<T>): OverrideProviderBuilder<T>;
+  overrideProvider<T>(token: Token<T>, provider: Provider<T>): this;
+  overrideProvider<T>(token: Token<T>, value: T): this;
+  overrideProvider<T>(token: Token<T>, value?: Provider<T> | T): this | OverrideProviderBuilder<T> {
+    if (value === undefined) {
+      return new DefaultOverrideProviderBuilder(this, token);
+    }
+
     this.overrides.push(normalizeOverride(token, value));
     return this;
   }
@@ -158,10 +352,12 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
 
   private createTestingModuleRef(bootstrapped: BootstrapResult): TestingModuleRef {
     const dispatcher = createTestingDispatcher(bootstrapped);
+    const getSync = createSyncResolver(bootstrapped.container);
 
     return {
       ...bootstrapped,
       has: (token) => bootstrapped.container.has(token),
+      get: (token) => getSync(token),
       resolve: (token) => bootstrapped.container.resolve(token),
       resolveAll: async <T>(tokens: Token<T>[]): Promise<T[]> => {
         const results: T[] = [];
@@ -230,3 +426,7 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
 export function createTestingModule(options: TestingModuleOptions): TestingModuleBuilder {
   return new DefaultTestingModuleBuilder(options);
 }
+
+export const Test = {
+  createTestingModule,
+};

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -1,7 +1,7 @@
 import type { Mock } from 'vitest';
 
-import type { Token } from '@konekti/core';
-import type { Container, Provider } from '@konekti/di';
+import type { MaybePromise, Token } from '@konekti/core';
+import type { ClassType, Container, ForwardRefFn, OptionalToken, Provider } from '@konekti/di';
 import type { BootstrapResult, BootstrapModuleOptions, ModuleType } from '@konekti/runtime';
 import type { Guard, Interceptor } from '@konekti/http';
 import type { RequestBuilder, TestPrincipal, TestRequest, TestRequestWithOptions, TestResponse } from './http.js';
@@ -16,13 +16,25 @@ export interface TestRequestOptions {
 
 export interface TestingModuleRef extends BootstrapResult {
   has(token: Token): boolean;
+  get<T>(token: Token<T>): T;
   resolve<T>(token: Token<T>): Promise<T>;
   resolveAll<T>(tokens: Token<T>[]): Promise<T[]>;
   dispatch(request: TestRequestWithOptions): Promise<TestResponse>;
 }
 
+export interface OverrideProviderBuilder<T> {
+  useValue(value: T): TestingModuleBuilder;
+  useClass(cls: ClassType<T>): TestingModuleBuilder;
+  useFactory(
+    factory: (...args: unknown[]) => MaybePromise<T>,
+    inject?: Array<Token | ForwardRefFn | OptionalToken>,
+  ): TestingModuleBuilder;
+  useExisting(token: Token<T>): TestingModuleBuilder;
+}
+
 export interface TestingModuleBuilder {
   compile(): Promise<TestingModuleRef>;
+  overrideProvider<T>(token: Token<T>): OverrideProviderBuilder<T>;
   overrideProvider<T>(token: Token<T>, provider: Provider<T>): this;
   overrideProvider<T>(token: Token<T>, value: T): this;
   overrideProviders(overrides: Array<[Token, unknown]>): this;


### PR DESCRIPTION
## Summary
- Added a NestJS-style `Test` namespace export with `Test.createTestingModule(...)` while keeping the existing `createTestingModule(...)` API intact.
- Added `TestingModuleRef#get<T>(token)` for synchronous token access with clear errors for async/request-scoped resolution paths, while preserving existing async `resolve()` behavior.
- Added `overrideProvider(token).useValue(...)` builder chaining alongside the existing two-argument `overrideProvider(token, value)` form.
- Added regression tests covering `Test.createTestingModule`, fluent `overrideProvider(...).useValue(...)`, and `get()` async-provider guard behavior.

## Verification
- `pnpm --filter @konekti/testing run typecheck`
- `pnpm exec vitest run packages/testing/src/module.test.ts`
- `pnpm --filter @konekti/testing run build`

Closes #319