### PR TITLE
Resolve #341: fix empty-string token silently dropped in injection schema

### DIFF
--- a/packages/core/src/metadata/injection.ts
+++ b/packages/core/src/metadata/injection.ts
@@ -26,7 +26,7 @@ export function getInjectionSchema(target: object): InjectionSchemaEntry[] {
     const metadata = stored.get(propertyKey);
     const standardMetadata = standard.get(propertyKey);
 
-    if (!metadata && !standardMetadata?.token) {
+    if (!metadata && standardMetadata?.token == null) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Replaces a truthiness check with an explicit `null`/`undefined` check in `getInjectionSchema`, so that `''` is treated as a valid injection token.

## Change

`packages/core/src/metadata/injection.ts:29`

```diff
- if (!metadata && !standardMetadata?.token) {
+ if (!metadata && standardMetadata?.token == null) {
```

## Verification

- `pnpm --filter @konekti/core exec tsc -p tsconfig.json --noEmit` — passes
- All test failures are pre-existing on `main` and unrelated to this change

Closes #341