### PR TITLE
Resolve #329: replace unsafe as-unknown-as casts with typed alternatives

### DIFF
--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -8,16 +8,26 @@ import type { CacheEvictDecoratorValue, CacheKeyDecoratorValue, CacheKeyStrategy
 
 type MetadataBag = Record<PropertyKey, unknown>;
 
-function getMethodMetadataBag(controllerToken: Function, methodName: string): MetadataBag | undefined {
-  const classBag = (controllerToken as unknown as Record<symbol, MetadataBag | undefined>)[metadataSymbol];
+function isMetadataBag(value: unknown): value is MetadataBag {
+  return typeof value === 'object' && value !== null;
+}
 
-  if (!classBag) {
+function getMethodMetadataBag(controllerToken: Function, methodName: string): MetadataBag | undefined {
+  const classBag = Reflect.get(controllerToken, metadataSymbol);
+
+  if (!isMetadataBag(classBag)) {
     return undefined;
   }
 
-  const routeMap = classBag[cacheRouteMetadataKey] as Map<string | symbol, MetadataBag> | undefined;
+  const routeMap = classBag[cacheRouteMetadataKey];
 
-  return routeMap?.get(methodName);
+  if (!(routeMap instanceof Map)) {
+    return undefined;
+  }
+
+  const methodMetadata = routeMap.get(methodName);
+
+  return isMetadataBag(methodMetadata) ? methodMetadata : undefined;
 }
 
 function normalizeCacheMethod(method: string): string {

--- a/packages/core/src/metadata/shared.ts
+++ b/packages/core/src/metadata/shared.ts
@@ -75,7 +75,13 @@ export function mergeUnique<T>(existing: readonly T[] | undefined, values: reado
 }
 
 export function getStandardMetadataBag(target: object): StandardMetadataBag | undefined {
-  return (target as Record<symbol, StandardMetadataBag | undefined>)[metadataSymbol];
+  const metadata = Reflect.get(target, metadataSymbol);
+
+  if (typeof metadata !== 'object' || metadata === null) {
+    return undefined;
+  }
+
+  return metadata as StandardMetadataBag;
 }
 
 export function getStandardConstructorMetadataBag(target: object): StandardMetadataBag | undefined {

--- a/packages/core/src/metadata/validation.ts
+++ b/packages/core/src/metadata/validation.ts
@@ -39,15 +39,16 @@ function getStandardClassValidationRules(target: Function): ClassValidationRule[
 export function getDtoFieldBindingMetadata(target: object, propertyKey: MetadataPropertyKey): DtoFieldBindingMetadata | undefined {
   const stored = dtoFieldBindingStore.get(target)?.get(propertyKey);
   const standard = getStandardDtoBindingMap(target)?.get(propertyKey);
+  const source = stored?.source ?? standard?.source;
 
-  if (!stored && !standard?.source) {
+  if (!source) {
     return undefined;
   }
 
   return {
     key: stored?.key ?? standard?.key,
     optional: stored?.optional ?? standard?.optional,
-    source: stored?.source ?? (standard as { source: DtoFieldBindingMetadata['source'] }).source,
+    source,
   };
 }
 

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -265,7 +265,7 @@ export class Container {
         this.resolveMultiProviderInstances(multiProviders, chain, activeTokens),
       );
 
-      return instances as unknown as T;
+      return instances as T;
     }
 
     const provider = this.requireProvider(token);

--- a/packages/passport/src/cookie-manager.ts
+++ b/packages/passport/src/cookie-manager.ts
@@ -20,16 +20,19 @@ export interface CookieManagerConfig extends CookieAuthOptions {
   cookieOptions?: CookieOptions;
 }
 
-export const DEFAULT_COOKIE_OPTIONS: Required<CookieOptions> = {
+type NormalizedCookieOptions = Omit<Required<CookieOptions>, 'domain' | 'maxAge'> &
+  Pick<CookieOptions, 'domain' | 'maxAge'>;
+
+export const DEFAULT_COOKIE_OPTIONS: NormalizedCookieOptions = {
   httpOnly: true,
   secure: true,
   sameSite: 'strict',
   path: '/',
-  domain: undefined as unknown as string,
-  maxAge: undefined as unknown as number,
+  domain: undefined,
+  maxAge: undefined,
 };
 
-function buildCookieHeader(name: string, value: string, options: Required<CookieOptions>): string {
+function buildCookieHeader(name: string, value: string, options: NormalizedCookieOptions): string {
   const parts: string[] = [`${name}=${value}`];
 
   if (options.maxAge !== undefined && options.maxAge >= 0) {
@@ -59,7 +62,7 @@ function buildCookieHeader(name: string, value: string, options: Required<Cookie
   return parts.join('; ');
 }
 
-function buildClearCookieHeader(name: string, options: Required<CookieOptions>): string {
+function buildClearCookieHeader(name: string, options: NormalizedCookieOptions): string {
   return buildCookieHeader(name, '', {
     ...options,
     maxAge: 0,
@@ -68,7 +71,7 @@ function buildClearCookieHeader(name: string, options: Required<CookieOptions>):
 
 export class CookieManager {
   private readonly options: Required<CookieAuthOptions>;
-  private readonly cookieOptions: Required<CookieOptions>;
+  private readonly cookieOptions: NormalizedCookieOptions;
 
   constructor(config?: CookieManagerConfig) {
     this.options = normalizeCookieAuthOptions(config);

--- a/packages/passport/src/passport-js.ts
+++ b/packages/passport/src/passport-js.ts
@@ -171,12 +171,12 @@ export class PassportJsAuthStrategy implements AuthStrategy {
   }
 
   private createExecutableStrategy(): PassportJsExecutableStrategy {
-    const template = this.strategyTemplate as unknown as Record<PropertyKey, unknown>;
+    const template = this.strategyTemplate;
     const strategy = Object.create(Object.getPrototypeOf(this.strategyTemplate)) as PassportJsExecutableStrategy &
       Record<PropertyKey, unknown>;
 
     for (const key of Reflect.ownKeys(template)) {
-      const value = template[key];
+      const value = Reflect.get(template, key);
 
       if (typeof value === 'function') {
         strategy[key] = value;

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -37,12 +37,12 @@ const DEAD_LETTER_DRAIN_TIMEOUT_MS = 5_000;
 
 type QueueLifecycleState = 'idle' | 'starting' | 'started' | 'stopping' | 'stopped';
 
-interface QueueOwnedConnection {
+type QueueOwnedConnection = ConnectionOptions & {
   connect(): Promise<unknown>;
   disconnect(): void;
   quit(): Promise<unknown>;
   status?: string;
-}
+};
 
 interface QueueRedisClient {
   duplicate(): QueueOwnedConnection;
@@ -382,7 +382,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     queueConnection: QueueOwnedConnection,
   ): QueueInstance {
     return new BullQueue(descriptor.jobName, {
-      connection: queueConnection as unknown as ConnectionOptions,
+      connection: queueConnection,
     });
   }
 
@@ -412,7 +412,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   } {
     return {
       concurrency: descriptor.concurrency,
-      connection: workerConnection as unknown as ConnectionOptions,
+      connection: workerConnection,
       ...this.createWorkerLimiterOptions(descriptor),
     };
   }

--- a/packages/testing/src/mock.ts
+++ b/packages/testing/src/mock.ts
@@ -29,7 +29,7 @@ export function createMock<T extends object>(partial: Partial<MockedMethods<T>> 
 }
 
 export function asMock<T extends (...args: never[]) => unknown>(fn: T): Mock<T> {
-  return fn as unknown as Mock<T>;
+  return vi.mocked(fn);
 }
 
 export function createDeepMock<T extends object>(type: new (...args: unknown[]) => T): DeepMocked<T> {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -110,6 +110,32 @@ interface ContainerIntrospection {
   requestScopeEnabled?: boolean;
 }
 
+function isContainerIntrospection(value: unknown): value is ContainerIntrospection {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as {
+    multiRegistrations?: unknown;
+    parent?: unknown;
+    registrations?: unknown;
+    requestScopeEnabled?: unknown;
+  };
+
+  const parentValid = candidate.parent === undefined || isContainerIntrospection(candidate.parent);
+  const requestScopeValid = candidate.requestScopeEnabled === undefined || typeof candidate.requestScopeEnabled === 'boolean';
+
+  return candidate.registrations instanceof Map && candidate.multiRegistrations instanceof Map && parentValid && requestScopeValid;
+}
+
+function toContainerIntrospection(container: BootstrapResult['container']): ContainerIntrospection {
+  if (!isContainerIntrospection(container)) {
+    throw new Error('Testing container introspection is unavailable for the current container implementation.');
+  }
+
+  return container;
+}
+
 function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
   return (
     (typeof value === 'object' || typeof value === 'function') &&
@@ -121,7 +147,7 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
 function createSyncResolver(
   container: BootstrapResult['container'],
 ): <T>(token: Token<T>) => T {
-  const introspection = container as unknown as ContainerIntrospection;
+  const introspection = toContainerIntrospection(container);
   const singletonCache = new Map<Token, unknown>();
   const resolutionChain = new Set<Token>();
 
@@ -410,12 +436,14 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
     }
 
     class PatchedModule {}
-    defineModule(PatchedModule as unknown as ModuleType, {
+    const patchedModule: ModuleType = PatchedModule;
+
+    defineModule(patchedModule, {
       ...(metadata as ModuleDefinition),
       imports: rewrittenImports,
     });
 
-    return PatchedModule as unknown as ModuleType;
+    return patchedModule;
   }
 
   private rewriteModuleImports(imports: ModuleType[]): ModuleType[] {


### PR DESCRIPTION
## Summary
- Replaced all unsafe `as unknown as` casts listed in issue #329 across core, di, queue, testing, passport, and cache-manager.
- Introduced typed narrowing/type-guard-based alternatives for metadata access, testing container introspection, and cookie option normalization.
- Updated queue connection typing and testing/passport helper paths to remove double-cast escapes while preserving existing behavior and API contracts.

## Validation
- `pnpm --filter @konekti/core exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/di exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/queue exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/testing exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/passport exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/cache-manager exec tsc -p tsconfig.json --noEmit`