### PR TITLE
Resolve #328: reject register/override on disposed container

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -626,6 +626,24 @@ describe('Container', () => {
       expect(() => container.createRequestScope()).toThrow('Container has been disposed');
     });
 
+    it('rejects register() after dispose', async () => {
+      class SomeService {}
+      const container = new Container();
+
+      await container.dispose();
+
+      expect(() => container.register(SomeService)).toThrow('Container has been disposed');
+    });
+
+    it('rejects override() after dispose', async () => {
+      class SomeService {}
+      const container = new Container().register(SomeService);
+
+      await container.dispose();
+
+      expect(() => container.override(SomeService)).toThrow('Container has been disposed');
+    });
+
     it('continues disposal when one onDestroy fails', async () => {
       const events: string[] = [];
 

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -126,6 +126,10 @@ export class Container {
   }
 
   register(...providers: Provider[]): this {
+    if (this.disposed) {
+      throw new ContainerResolutionError('Container has been disposed and can no longer register providers.');
+    }
+
     for (const provider of providers) {
       const normalized = normalizeProvider(provider);
 
@@ -149,6 +153,10 @@ export class Container {
   }
 
   override(...providers: Provider[]): this {
+    if (this.disposed) {
+      throw new ContainerResolutionError('Container has been disposed and can no longer override providers.');
+    }
+
     for (const provider of providers) {
       const normalized = normalizeProvider(provider);
       const existing = this.lookupProvider(normalized.provide);


### PR DESCRIPTION
## Summary

- `register()` and `override()` now throw `ContainerResolutionError` when called on a disposed container, matching the existing guards on `resolve()` and `createRequestScope()`
- Added two test cases to `container.test.ts` covering both post-disposal mutation guards

Closes #328