### PR TITLE
Resolve #351: header leak, swallowed observer errors, rate-limit race

### DIFF
--- a/packages/http/src/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch-response-policy.ts
@@ -33,10 +33,6 @@ export async function writeSuccessResponse(
     return;
   }
 
-  for (const header of handler.route.headers ?? []) {
-    response.setHeader(header.name, header.value);
-  }
-
   if (handler.route.redirect) {
     const { url, statusCode = 302 } = handler.route.redirect;
     response.redirect(statusCode, url);
@@ -46,6 +42,13 @@ export async function writeSuccessResponse(
   const formatter = contentNegotiation
     ? selectResponseFormatter(handler, request, contentNegotiation)
     : undefined;
+
+  // Write route-level headers only after successful formatter negotiation so
+  // that a negotiation failure does not leak success-only headers onto the
+  // error response.
+  for (const header of handler.route.headers ?? []) {
+    response.setHeader(header.name, header.value);
+  }
 
   if (formatter) {
     response.setHeader('Content-Type', formatter.mediaType);

--- a/packages/http/src/dispatcher.test.ts
+++ b/packages/http/src/dispatcher.test.ts
@@ -235,6 +235,40 @@ describe('dispatcher runtime', () => {
     });
   });
 
+  it('does not leak @Header values onto 406 negotiation error responses', async () => {
+    @Controller('/negotiation')
+    class NegotiationController {
+      @Header('X-Secret', 'sensitive')
+      @Produces('application/json')
+      @Get('/secret-header')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(NegotiationController);
+    const dispatcher = createDispatcher({
+      contentNegotiation: {
+        formatters: [
+          {
+            format(body) {
+              return JSON.stringify(body);
+            },
+            mediaType: 'application/json',
+          },
+        ],
+      },
+      handlerMapping: createHandlerMapping([{ controllerToken: NegotiationController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/negotiation/secret-header', 'GET', { accept: 'text/plain' }), response);
+
+    expect(response.statusCode).toBe(406);
+    expect((response.headers as Record<string, unknown>)['X-Secret']).toBeUndefined();
+  });
+
   it('falls back to default formatter for wildcard Accept header', async () => {
     @Controller('/negotiation')
     class NegotiationController {

--- a/packages/http/src/dispatcher.ts
+++ b/packages/http/src/dispatcher.ts
@@ -114,7 +114,8 @@ async function notifyObserversSafely(
 ): Promise<void> {
   try {
     await notifyObservers(observers, requestContext, callback, handler);
-  } catch {
+  } catch (error) {
+    console.error('[konekti] request observer threw an unhandled error:', error);
   }
 }
 

--- a/packages/http/src/rate-limit.ts
+++ b/packages/http/src/rate-limit.ts
@@ -89,7 +89,9 @@ export function createRateLimitMiddleware(options: RateLimitOptions): Middleware
         return next();
       }
 
-      if (entry.count >= options.limit) {
+      const count = await store.increment(key);
+
+      if (count > options.limit) {
         const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
         const error = new TooManyRequestsException('Too Many Requests', {
           meta: { retryAfter },
@@ -101,7 +103,6 @@ export function createRateLimitMiddleware(options: RateLimitOptions): Middleware
         return;
       }
 
-      await store.increment(key);
       return next();
     },
   };


### PR DESCRIPTION
## Summary

- **Header leak** (`dispatch-response-policy.ts`): route-level headers from `@Header()` are now written after successful formatter negotiation, so a 406 failure no longer leaks success-only headers onto the error response
- **Observer errors** (`dispatcher.ts`): `notifyObserversSafely` now emits to `console.error` instead of silently discarding failures; broken observers are now visible in logs
- **Rate-limit race** (`rate-limit.ts`): `increment` is now called before the limit check so concurrent requests that both pass the `get` check are correctly counted; the check is now `count > limit` against the post-increment value

Closes #351, closes #327, closes #336