### PR TITLE
Resolve #343: remove insecure secret default; use typed error classification in passport

### DIFF
--- a/packages/passport/src/jwt-refresh-token-adapter.ts
+++ b/packages/passport/src/jwt-refresh-token-adapter.ts
@@ -1,11 +1,23 @@
 import { Inject } from '@konekti/core';
-import { DefaultJwtSigner, DefaultJwtVerifier, RefreshTokenService as JwtRefreshTokenService } from '@konekti/jwt';
+import { DefaultJwtSigner, DefaultJwtVerifier, JwtConfigurationError, RefreshTokenService as JwtRefreshTokenService } from '@konekti/jwt';
 
 import type { RefreshTokenService } from './refresh-token.js';
 
 @Inject([DefaultJwtSigner, DefaultJwtVerifier])
 export class JwtRefreshTokenAdapter implements RefreshTokenService {
   private readonly service: JwtRefreshTokenService;
+
+  private static resolveSecret(): string {
+    const secret = process.env.REFRESH_TOKEN_SECRET;
+
+    if (!secret) {
+      throw new JwtConfigurationError(
+        'REFRESH_TOKEN_SECRET environment variable is required. Set it to a strong, random secret.',
+      );
+    }
+
+    return secret;
+  }
 
   constructor(
     private readonly signer: DefaultJwtSigner,
@@ -15,7 +27,7 @@ export class JwtRefreshTokenAdapter implements RefreshTokenService {
       {
         expiresInSeconds: 3600,
         rotation: true,
-        secret: process.env.REFRESH_TOKEN_SECRET || 'refresh-secret-change-me',
+        secret: JwtRefreshTokenAdapter.resolveSecret(),
         store: this.createDefaultStore(),
       },
       signer,

--- a/packages/passport/src/refresh-token.test.ts
+++ b/packages/passport/src/refresh-token.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { JwtExpiredTokenError, JwtInvalidTokenError } from '@konekti/jwt';
+
 import { AuthenticationExpiredError, AuthenticationFailedError, AuthenticationRequiredError } from './errors.js';
 import { RefreshTokenStrategy, type RefreshTokenService } from './refresh-token.js';
 import type { AuthStrategyResult } from './types.js';
@@ -121,7 +123,7 @@ describe('RefreshTokenStrategy', () => {
 
     it('throws AuthenticationExpiredError for expired tokens', async () => {
       const service = createMockRefreshTokenService({
-        rotateRefreshToken: vi.fn().mockRejectedValue(new Error('Refresh token has expired.')),
+        rotateRefreshToken: vi.fn().mockRejectedValue(new JwtExpiredTokenError('Refresh token has expired.')),
       });
       const strategy = new RefreshTokenStrategy(service);
       const context = createGuardContext({ refreshToken: 'expired-token' });
@@ -131,7 +133,7 @@ describe('RefreshTokenStrategy', () => {
 
     it('throws AuthenticationFailedError for reused tokens', async () => {
       const service = createMockRefreshTokenService({
-        rotateRefreshToken: vi.fn().mockRejectedValue(new Error('Refresh token reuse detected.')),
+        rotateRefreshToken: vi.fn().mockRejectedValue(new JwtInvalidTokenError('Refresh token reuse detected.')),
       });
       const strategy = new RefreshTokenStrategy(service);
       const context = createGuardContext({ refreshToken: 'reused-token' });
@@ -141,7 +143,7 @@ describe('RefreshTokenStrategy', () => {
 
     it('throws AuthenticationFailedError for invalid tokens', async () => {
       const service = createMockRefreshTokenService({
-        rotateRefreshToken: vi.fn().mockRejectedValue(new Error('Invalid token')),
+        rotateRefreshToken: vi.fn().mockRejectedValue(new JwtInvalidTokenError('Invalid token')),
       });
       const strategy = new RefreshTokenStrategy(service);
       const context = createGuardContext({ refreshToken: 'invalid-token' });

--- a/packages/passport/src/refresh-token.ts
+++ b/packages/passport/src/refresh-token.ts
@@ -1,5 +1,6 @@
 import type { GuardContext, RequestContext } from '@konekti/http';
 import { Inject, type Token } from '@konekti/core';
+import { JwtExpiredTokenError, JwtInvalidTokenError } from '@konekti/jwt';
 
 import {
   AuthenticationExpiredError,
@@ -50,13 +51,11 @@ export class RefreshTokenStrategy implements AuthStrategy {
         subject: this.extractSubjectFromToken(result.accessToken),
       };
     } catch (error: unknown) {
-      if (error instanceof Error) {
-        if (error.message.includes('expired')) {
-          throw new AuthenticationExpiredError('Refresh token has expired.');
-        }
-        if (error.message.includes('reuse') || error.message.includes('invalid')) {
-          throw new AuthenticationFailedError('Refresh token is invalid or has been reused.');
-        }
+      if (error instanceof JwtExpiredTokenError) {
+        throw new AuthenticationExpiredError('Refresh token has expired.');
+      }
+      if (error instanceof JwtInvalidTokenError) {
+        throw new AuthenticationFailedError('Refresh token is invalid or has been reused.');
       }
       throw new AuthenticationFailedError('Refresh token authentication failed.');
     }


### PR DESCRIPTION
## Summary

- **Hardcoded secret removed**: `JwtRefreshTokenAdapter` now calls a static `resolveSecret()` that throws `JwtConfigurationError` at construction time when `REFRESH_TOKEN_SECRET` is unset — no more publicly-known default key
- **Typed error classification**: `RefreshTokenStrategy.authenticate` now catches `JwtExpiredTokenError` and `JwtInvalidTokenError` by `instanceof` instead of `error.message.includes()` substring matching, making the mapping stable across library version changes
- Updated `refresh-token.test.ts` to use the correct typed error classes in mocks

Closes #343