### PR TITLE
Resolve #347: extract shared helpers to eliminate copy-paste duplication

### DIFF
--- a/packages/config/src/clone.ts
+++ b/packages/config/src/clone.ts
@@ -1,21 +1,4 @@
-function fallbackClone(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => fallbackClone(item));
-  }
-
-  if (typeof value === 'object' && value !== null) {
-    const source = value as Record<string, unknown>;
-    const cloned: Record<string, unknown> = {};
-
-    for (const [key, item] of Object.entries(source)) {
-      cloned[key] = fallbackClone(item);
-    }
-
-    return cloned;
-  }
-
-  return value;
-}
+import { fallbackClone } from '@konekti/core';
 
 export function cloneConfigDictionary<T>(value: T): T {
   try {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -31,3 +31,21 @@ export class InvariantError extends KonektiError {
     super(message, { ...options, code: 'INVARIANT_ERROR' });
   }
 }
+
+export abstract class KonektiCodeError extends KonektiError {
+  constructor(message: string, code: string, options: Omit<KonektiErrorOptions, 'code'> = {}) {
+    super(message, { ...options, code });
+  }
+}
+
+export function formatTokenName(token: unknown): string {
+  if (typeof token === 'function' && 'name' in token && token.name) {
+    return String(token.name);
+  }
+
+  if (typeof token === 'symbol') {
+    return token.toString();
+  }
+
+  return String(token);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from './decorators.js';
 export * from './errors.js';
 export * from './metadata.js';
 export * from './types.js';
+export * from './utils.js';

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -3,6 +3,7 @@ export { defineControllerMetadata, defineRouteMetadata, getControllerMetadata, g
 export { defineInjectionMetadata, getInjectionSchema } from './metadata/injection.js';
 export { defineModuleMetadata, getModuleMetadata } from './metadata/module.js';
 export { ensureMetadataSymbol, metadataKeys, metadataSymbol } from './metadata/shared.js';
+export { ensureSymbolMetadataPolyfill } from './metadata/symbol-metadata-polyfill.js';
 export {
   appendClassValidationRule,
   appendDtoFieldValidationRule,

--- a/packages/core/src/metadata/class-di.ts
+++ b/packages/core/src/metadata/class-di.ts
@@ -1,6 +1,7 @@
+import { createClonedWeakMapStore } from './store.js';
 import type { ClassDiMetadata } from './types.js';
 
-const classDiMetadataStore = new WeakMap<Function, ClassDiMetadata>();
+const classDiMetadataStore = createClonedWeakMapStore<Function, ClassDiMetadata>(cloneClassDiMetadata);
 
 function cloneClassDiMetadata(metadata: ClassDiMetadata): ClassDiMetadata {
   return {
@@ -24,28 +25,26 @@ function getClassMetadataLineage(target: Function): Function[] {
 }
 
 export function defineClassDiMetadata(target: Function, metadata: ClassDiMetadata): void {
-  const existing = classDiMetadataStore.get(target);
+  const existing = classDiMetadataStore.read(target);
 
-  classDiMetadataStore.set(
+  classDiMetadataStore.write(
     target,
-    cloneClassDiMetadata({
+    {
       inject: metadata.inject ?? existing?.inject,
       scope: metadata.scope ?? existing?.scope,
-    }),
+    },
   );
 }
 
 export function getOwnClassDiMetadata(target: Function): ClassDiMetadata | undefined {
-  const metadata = classDiMetadataStore.get(target);
-
-  return metadata ? cloneClassDiMetadata(metadata) : undefined;
+  return classDiMetadataStore.read(target);
 }
 
 export function getInheritedClassDiMetadata(target: Function): ClassDiMetadata | undefined {
   let effective: ClassDiMetadata | undefined;
 
   for (const constructor of getClassMetadataLineage(target)) {
-    const metadata = classDiMetadataStore.get(constructor);
+    const metadata = classDiMetadataStore.read(constructor);
 
     if (!metadata) {
       continue;

--- a/packages/core/src/metadata/controller-route.ts
+++ b/packages/core/src/metadata/controller-route.ts
@@ -6,10 +6,11 @@ import {
   mergeUnique,
   standardMetadataKeys,
 } from './shared.js';
+import { createClonedWeakMapStore } from './store.js';
 import type { ControllerMetadata, RouteMetadata, StandardRouteMetadataRecord } from './types.js';
 import type { MetadataPropertyKey } from '../types.js';
 
-const controllerMetadataStore = new WeakMap<Function, ControllerMetadata>();
+const controllerMetadataStore = createClonedWeakMapStore<Function, ControllerMetadata>(cloneControllerMetadata);
 const routeMetadataStore = new WeakMap<object, Map<MetadataPropertyKey, RouteMetadata>>();
 
 function cloneControllerMetadata(metadata: ControllerMetadata): ControllerMetadata {
@@ -60,11 +61,11 @@ function getStandardRouteMetadata(target: object, propertyKey: MetadataPropertyK
 }
 
 export function defineControllerMetadata(target: Function, metadata: ControllerMetadata): void {
-  controllerMetadataStore.set(target, cloneControllerMetadata(metadata));
+  controllerMetadataStore.write(target, metadata);
 }
 
 export function getControllerMetadata(target: Function): ControllerMetadata | undefined {
-  const stored = controllerMetadataStore.get(target);
+  const stored = controllerMetadataStore.read(target);
   const standard = getStandardControllerMetadata(target);
 
   if (!stored && !standard) {

--- a/packages/core/src/metadata/module.ts
+++ b/packages/core/src/metadata/module.ts
@@ -1,7 +1,8 @@
 import { cloneCollection } from './shared.js';
+import { createClonedWeakMapStore } from './store.js';
 import type { ModuleMetadata } from './types.js';
 
-const moduleMetadataStore = new WeakMap<Function, ModuleMetadata>();
+const moduleMetadataStore = createClonedWeakMapStore<Function, ModuleMetadata>(cloneModuleMetadata);
 
 function cloneModuleMetadata(metadata: ModuleMetadata): ModuleMetadata {
   return {
@@ -15,23 +16,21 @@ function cloneModuleMetadata(metadata: ModuleMetadata): ModuleMetadata {
 }
 
 export function defineModuleMetadata(target: Function, metadata: ModuleMetadata): void {
-  const existing = moduleMetadataStore.get(target);
+  const existing = moduleMetadataStore.read(target);
 
-  moduleMetadataStore.set(
+  moduleMetadataStore.write(
     target,
-    cloneModuleMetadata({
+    {
       controllers: metadata.controllers ?? existing?.controllers,
       exports: metadata.exports ?? existing?.exports,
       global: metadata.global ?? existing?.global,
       imports: metadata.imports ?? existing?.imports,
       middleware: metadata.middleware ?? existing?.middleware,
       providers: metadata.providers ?? existing?.providers,
-    }),
+    },
   );
 }
 
 export function getModuleMetadata(target: Function): ModuleMetadata | undefined {
-  const metadata = moduleMetadataStore.get(target);
-
-  return metadata ? cloneModuleMetadata(metadata) : undefined;
+  return moduleMetadataStore.read(target);
 }

--- a/packages/core/src/metadata/store.ts
+++ b/packages/core/src/metadata/store.ts
@@ -1,0 +1,20 @@
+export interface ClonedWeakMapStore<TKey extends object, TValue> {
+  read(target: TKey): TValue | undefined;
+  write(target: TKey, value: TValue): void;
+}
+
+export function createClonedWeakMapStore<TKey extends object, TValue>(
+  cloneValue: (value: TValue) => TValue,
+): ClonedWeakMapStore<TKey, TValue> {
+  const store = new WeakMap<TKey, TValue>();
+
+  return {
+    read(target: TKey): TValue | undefined {
+      const value = store.get(target);
+      return value ? cloneValue(value) : undefined;
+    },
+    write(target: TKey, value: TValue): void {
+      store.set(target, cloneValue(value));
+    },
+  };
+}

--- a/packages/core/src/metadata/symbol-metadata-polyfill.ts
+++ b/packages/core/src/metadata/symbol-metadata-polyfill.ts
@@ -1,0 +1,7 @@
+import { ensureMetadataSymbol } from './shared.js';
+
+export function ensureSymbolMetadataPolyfill(): symbol {
+  return ensureMetadataSymbol();
+}
+
+void ensureSymbolMetadataPolyfill();

--- a/packages/core/src/metadata/validation.ts
+++ b/packages/core/src/metadata/validation.ts
@@ -1,12 +1,12 @@
 import {
   appendPropertyMapValue,
-  appendWeakMapValue,
   getOrCreatePropertyMap,
   getStandardConstructorMetadataMap,
   getStandardMetadataBag,
   mergeMetadataPropertyKeys,
   standardMetadataKeys,
 } from './shared.js';
+import { createClonedWeakMapStore } from './store.js';
 import type {
   ClassValidationRule,
   DtoBindingSchemaEntry,
@@ -20,7 +20,7 @@ import type { Constructor, MetadataPropertyKey } from '../types.js';
 
 const dtoFieldBindingStore = new WeakMap<object, Map<MetadataPropertyKey, DtoFieldBindingMetadata>>();
 const dtoFieldValidationStore = new WeakMap<object, Map<MetadataPropertyKey, DtoFieldValidationRule[]>>();
-const classValidationStore = new WeakMap<Function, ClassValidationRule[]>();
+const classValidationStore = createClonedWeakMapStore<Function, ClassValidationRule[]>((rules) => [...rules]);
 
 function getStandardDtoBindingMap(target: object): Map<MetadataPropertyKey, StandardDtoBindingRecord> | undefined {
   return getStandardConstructorMetadataMap<StandardDtoBindingRecord>(target, standardMetadataKeys.dtoFieldBinding);
@@ -69,7 +69,9 @@ export function appendDtoFieldValidationRule(
 }
 
 export function appendClassValidationRule(target: Function, rule: ClassValidationRule): void {
-  appendWeakMapValue(classValidationStore, target, rule);
+  const rules = classValidationStore.read(target) ?? [];
+  rules.push(rule);
+  classValidationStore.write(target, rules);
 }
 
 export function getDtoBindingSchema(dto: Constructor): DtoBindingSchemaEntry[] {
@@ -108,5 +110,5 @@ export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEnt
 }
 
 export function getClassValidationRules(target: Function): readonly ClassValidationRule[] {
-  return [...(getStandardClassValidationRules(target) ?? []), ...(classValidationStore.get(target) ?? [])];
+  return [...(getStandardClassValidationRules(target) ?? []), ...(classValidationStore.read(target) ?? [])];
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,0 +1,18 @@
+export function fallbackClone<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => fallbackClone(item)) as T;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const source = value as Record<string, unknown>;
+    const cloned: Record<string, unknown> = {};
+
+    for (const [key, item] of Object.entries(source)) {
+      cloned[key] = fallbackClone(item);
+    }
+
+    return cloned as T;
+  }
+
+  return value;
+}

--- a/packages/cron/src/metadata.ts
+++ b/packages/cron/src/metadata.ts
@@ -1,18 +1,10 @@
-import type { MetadataPropertyKey } from '@konekti/core';
+import { ensureSymbolMetadataPolyfill, metadataSymbol, type MetadataPropertyKey } from '@konekti/core';
 
 import type { CronTaskMetadata } from './types.js';
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
-const symbolWithMetadata = Symbol as typeof Symbol & { metadata?: symbol };
-const metadataSymbol = symbolWithMetadata.metadata ?? Symbol.for('konekti.symbol.metadata');
-
-if (!symbolWithMetadata.metadata) {
-  Object.defineProperty(Symbol, 'metadata', {
-    configurable: true,
-    value: metadataSymbol,
-  });
-}
+void ensureSymbolMetadataPolyfill();
 
 const standardCronMetadataKey = Symbol.for('konekti.cron.standard.task');
 const cronMetadataStore = new WeakMap<object, Map<MetadataPropertyKey, CronTaskMetadata>>();

--- a/packages/di/src/errors.ts
+++ b/packages/di/src/errors.ts
@@ -1,59 +1,42 @@
-import { KonektiError } from '@konekti/core';
+import { KonektiCodeError, formatTokenName } from '@konekti/core';
 
-export class InvalidProviderError extends KonektiError {
+export class InvalidProviderError extends KonektiCodeError {
   constructor(message: string) {
-    super(message, { code: 'INVALID_PROVIDER' });
+    super(message, 'INVALID_PROVIDER');
   }
 }
 
-export class ContainerResolutionError extends KonektiError {
+export class ContainerResolutionError extends KonektiCodeError {
   constructor(message: string) {
-    super(message, { code: 'CONTAINER_RESOLUTION_ERROR' });
+    super(message, 'CONTAINER_RESOLUTION_ERROR');
   }
 }
 
-export class RequestScopeResolutionError extends KonektiError {
+export class RequestScopeResolutionError extends KonektiCodeError {
   constructor(message: string) {
-    super(message, { code: 'REQUEST_SCOPE_RESOLUTION_ERROR' });
+    super(message, 'REQUEST_SCOPE_RESOLUTION_ERROR');
   }
 }
 
-export class ScopeMismatchError extends KonektiError {
+export class ScopeMismatchError extends KonektiCodeError {
   constructor(message: string) {
-    super(message, { code: 'SCOPE_MISMATCH' });
+    super(message, 'SCOPE_MISMATCH');
   }
 }
 
-export class CircularDependencyError extends KonektiError {
+export class CircularDependencyError extends KonektiCodeError {
   constructor(chain: readonly unknown[]) {
-    const path = chain.map((t) => CircularDependencyError.tokenName(t)).join(' -> ');
-    super(`Circular dependency detected: ${path}`, { code: 'CIRCULAR_DEPENDENCY' });
-  }
-
-  private static tokenName(token: unknown): string {
-    if (typeof token === 'function' && 'name' in token && token.name) {
-      return String(token.name);
-    }
-
-    if (typeof token === 'symbol') {
-      return token.toString();
-    }
-
-    return String(token);
+    const path = chain.map((token) => formatTokenName(token)).join(' -> ');
+    super(`Circular dependency detected: ${path}`, 'CIRCULAR_DEPENDENCY');
   }
 }
 
-export class DuplicateProviderError extends KonektiError {
+export class DuplicateProviderError extends KonektiCodeError {
   constructor(token: unknown) {
-    const name =
-      typeof token === 'function' && 'name' in token && token.name
-        ? String(token.name)
-        : typeof token === 'symbol'
-          ? token.toString()
-          : String(token);
+    const name = formatTokenName(token);
     super(
       `Token "${name}" is already registered. Use container.override() for intentional overrides.`,
-      { code: 'DUPLICATE_PROVIDER' },
+      'DUPLICATE_PROVIDER',
     );
   }
 }

--- a/packages/event-bus/src/metadata.ts
+++ b/packages/event-bus/src/metadata.ts
@@ -1,18 +1,10 @@
-import type { MetadataPropertyKey } from '@konekti/core';
+import { ensureSymbolMetadataPolyfill, metadataSymbol, type MetadataPropertyKey } from '@konekti/core';
 
 import type { EventHandlerMetadata } from './types.js';
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
-const symbolWithMetadata = Symbol as typeof Symbol & { metadata?: symbol };
-const metadataSymbol = symbolWithMetadata.metadata ?? Symbol.for('konekti.symbol.metadata');
-
-if (!symbolWithMetadata.metadata) {
-  Object.defineProperty(Symbol, 'metadata', {
-    configurable: true,
-    value: metadataSymbol,
-  });
-}
+void ensureSymbolMetadataPolyfill();
 
 const standardEventHandlerMetadataKey = Symbol.for('konekti.event-bus.standard.handler');
 const eventHandlerMetadataStore = new WeakMap<object, Map<MetadataPropertyKey, EventHandlerMetadata>>();

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -1,4 +1,4 @@
-import { Inject, getClassDiMetadata, type MetadataPropertyKey, type Token } from '@konekti/core';
+import { Inject, fallbackClone, getClassDiMetadata, type MetadataPropertyKey, type Token } from '@konekti/core';
 import type { Container, Provider } from '@konekti/di';
 import {
   APPLICATION_LOGGER,
@@ -37,25 +37,6 @@ interface ResolvedPublishOptions {
 interface InvocationBound {
   cleanup(): void;
   promise: Promise<never>;
-}
-
-function fallbackClone(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => fallbackClone(item));
-  }
-
-  if (typeof value === 'object' && value !== null) {
-    const source = value as Record<string, unknown>;
-    const cloned: Record<string, unknown> = {};
-
-    for (const [key, item] of Object.entries(source)) {
-      cloned[key] = fallbackClone(item);
-    }
-
-    return cloned;
-  }
-
-  return value;
 }
 
 function cloneValue<T>(value: T): T {

--- a/packages/microservices/src/metadata.ts
+++ b/packages/microservices/src/metadata.ts
@@ -1,18 +1,10 @@
-import type { MetadataPropertyKey } from '@konekti/core';
+import { ensureSymbolMetadataPolyfill, metadataSymbol, type MetadataPropertyKey } from '@konekti/core';
 
 import type { HandlerMetadata } from './types.js';
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
-const symbolWithMetadata = Symbol as typeof Symbol & { metadata?: symbol };
-const metadataSymbol = symbolWithMetadata.metadata ?? Symbol.for('konekti.symbol.metadata');
-
-if (!symbolWithMetadata.metadata) {
-  Object.defineProperty(Symbol, 'metadata', {
-    configurable: true,
-    value: metadataSymbol,
-  });
-}
+void ensureSymbolMetadataPolyfill();
 
 const standardMicroserviceMetadataKey = Symbol.for('konekti.microservices.standard.handler');
 const handlerMetadataStore = new WeakMap<object, Map<MetadataPropertyKey, HandlerMetadata[]>>();

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -1,4 +1,4 @@
-import { Inject, getClassDiMetadata, type MetadataPropertyKey, type Token } from '@konekti/core';
+import { Inject, fallbackClone, getClassDiMetadata, type MetadataPropertyKey, type Token } from '@konekti/core';
 import type { Container, Provider } from '@konekti/di';
 import {
   APPLICATION_LOGGER,
@@ -26,25 +26,6 @@ interface DiscoveryCandidate {
   scope: 'request' | 'singleton' | 'transient';
   targetType: Function;
   token: Token;
-}
-
-function fallbackClone(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => fallbackClone(item));
-  }
-
-  if (typeof value === 'object' && value !== null) {
-    const source = value as Record<string, unknown>;
-    const cloned: Record<string, unknown> = {};
-
-    for (const [key, item] of Object.entries(source)) {
-      cloned[key] = fallbackClone(item);
-    }
-
-    return cloned;
-  }
-
-  return value;
 }
 
 function clonePayload<T>(payload: T): T {

--- a/packages/queue/src/metadata.ts
+++ b/packages/queue/src/metadata.ts
@@ -1,16 +1,10 @@
+import { ensureSymbolMetadataPolyfill, metadataSymbol } from '@konekti/core';
+
 import type { QueueWorkerMetadata } from './types.js';
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
-const symbolWithMetadata = Symbol as typeof Symbol & { metadata?: symbol };
-const metadataSymbol = symbolWithMetadata.metadata ?? Symbol.for('konekti.symbol.metadata');
-
-if (!symbolWithMetadata.metadata) {
-  Object.defineProperty(Symbol, 'metadata', {
-    configurable: true,
-    value: metadataSymbol,
-  });
-}
+void ensureSymbolMetadataPolyfill();
 
 const standardQueueWorkerMetadataKey = Symbol.for('konekti.queue.standard.worker');
 const queueWorkerMetadataStore = new WeakMap<Function, QueueWorkerMetadata>();

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -1,4 +1,4 @@
-import { Inject } from '@konekti/core';
+import { Inject, fallbackClone } from '@konekti/core';
 import type { Container } from '@konekti/di';
 import { REDIS_CLIENT } from '@konekti/redis';
 import {
@@ -92,25 +92,6 @@ function serializeJobPayload(job: object): QueuePayload {
   }
 
   return serialized;
-}
-
-function fallbackClone(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => fallbackClone(item));
-  }
-
-  if (typeof value === 'object' && value !== null) {
-    const source = value as Record<string, unknown>;
-    const cloned: Record<string, unknown> = {};
-
-    for (const [key, item] of Object.entries(source)) {
-      cloned[key] = fallbackClone(item);
-    }
-
-    return cloned;
-  }
-
-  return value;
 }
 
 function cloneQueuePayload(payload: QueuePayload): QueuePayload {

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -629,11 +629,15 @@ function createRuntimeProviders(
 }
 
 function registerRuntimeBootstrapTokens(bootstrapped: BootstrapResult, adapter: HttpApplicationAdapter): void {
+  registerRuntimeContextTokens(bootstrapped, {
+    provide: HTTP_APPLICATION_ADAPTER,
+    useValue: adapter,
+  });
+}
+
+function registerRuntimeContextTokens(bootstrapped: BootstrapResult, ...providers: Provider[]): void {
   bootstrapped.container.register(
-    {
-      provide: HTTP_APPLICATION_ADAPTER,
-      useValue: adapter,
-    },
+    ...providers,
     {
       provide: RUNTIME_CONTAINER,
       useValue: bootstrapped.container,
@@ -646,16 +650,7 @@ function registerRuntimeBootstrapTokens(bootstrapped: BootstrapResult, adapter: 
 }
 
 function registerRuntimeApplicationContextTokens(bootstrapped: BootstrapResult): void {
-  bootstrapped.container.register(
-    {
-      provide: RUNTIME_CONTAINER,
-      useValue: bootstrapped.container,
-    },
-    {
-      provide: COMPILED_MODULES,
-      useValue: bootstrapped.modules,
-    },
-  );
+  registerRuntimeContextTokens(bootstrapped);
 }
 
 async function resolveBootstrapLifecycleInstances(


### PR DESCRIPTION
## Summary
- Extracted shared `fallbackClone` and metadata store/polyfill helpers into `@konekti/core`, then replaced duplicated implementations across config, queue, microservices, event-bus, and cron.
- Consolidated repeated error-code/token-formatting patterns into core error helpers and updated `@konekti/di` to reuse them.
- Refactored runtime bootstrap token registration to remove duplicated registration logic while preserving behavior.

## Verification
- `pnpm --filter @konekti/core exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/di exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/queue exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/microservices exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/event-bus exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/cron exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/config exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @konekti/runtime exec tsc -p tsconfig.json --noEmit`

Closes #347
Closes #330
Closes #331
Closes #333
Closes #339
Closes #346