### PR TITLE
Resolve #348: eliminate per-request allocations and redundant scans

### DIFF
--- a/packages/core/src/metadata/validation.ts
+++ b/packages/core/src/metadata/validation.ts
@@ -81,12 +81,26 @@ export function getDtoBindingSchema(dto: Constructor): DtoBindingSchemaEntry[] {
     new Map<MetadataPropertyKey, StandardDtoBindingRecord>();
   const keys = mergeMetadataPropertyKeys(stored, standard);
 
-  return keys
-    .map((propertyKey) => ({
-      propertyKey,
-      metadata: getDtoFieldBindingMetadata(dto.prototype, propertyKey),
-    }))
-    .filter((entry): entry is DtoBindingSchemaEntry => entry.metadata !== undefined);
+  return keys.flatMap((propertyKey) => {
+    const storedEntry = stored.get(propertyKey);
+    const standardEntry = standard.get(propertyKey);
+    const source = storedEntry?.source ?? standardEntry?.source;
+
+    if (!source) {
+      return [];
+    }
+
+    return [
+      {
+        propertyKey,
+        metadata: {
+          key: storedEntry?.key ?? standardEntry?.key,
+          optional: storedEntry?.optional ?? standardEntry?.optional,
+          source,
+        },
+      },
+    ];
+  });
 }
 
 export function getDtoFieldValidationRules(target: object, propertyKey: MetadataPropertyKey): readonly DtoFieldValidationRule[] {
@@ -101,12 +115,18 @@ export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEnt
   const standard = getStandardDtoValidationMap(dto.prototype) ?? new Map<MetadataPropertyKey, StandardDtoValidationRecord>();
   const keys = mergeMetadataPropertyKeys(stored, standard);
 
-  return keys
-    .map((propertyKey) => ({
-      propertyKey,
-      rules: getDtoFieldValidationRules(dto.prototype, propertyKey),
-    }))
-    .filter((entry) => entry.rules.length > 0);
+  return keys.flatMap((propertyKey) => {
+    const rules: DtoFieldValidationRule[] = [
+      ...(standard.get(propertyKey) ?? []),
+      ...(stored.get(propertyKey) ?? []),
+    ];
+
+    if (rules.length === 0) {
+      return [];
+    }
+
+    return [{ propertyKey, rules }];
+  });
 }
 
 export function getClassValidationRules(target: Function): readonly ClassValidationRule[] {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -483,16 +483,19 @@ export class Container {
     const seenInstances = new Set<unknown>();
     const errors: unknown[] = [];
 
-    for (const [, instancePromise] of entries) {
-      try {
-        const instance = await instancePromise;
+    const settled = await Promise.allSettled(entries.map(([, p]) => p));
 
-        if (this.isDisposable(instance) && !seenInstances.has(instance)) {
-          seenInstances.add(instance);
-          disposables.push(instance);
-        }
-      } catch (error) {
-        errors.push(error);
+    for (const result of settled) {
+      if (result.status === 'rejected') {
+        errors.push(result.reason);
+        continue;
+      }
+
+      const instance = result.value;
+
+      if (this.isDisposable(instance) && !seenInstances.has(instance)) {
+        seenInstances.add(instance);
+        disposables.push(instance);
       }
     }
 

--- a/packages/http/src/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch-content-negotiation.ts
@@ -15,6 +15,7 @@ interface AcceptToken {
 export interface ResolvedContentNegotiation {
   defaultFormatter: ResponseFormatter;
   formatters: ResponseFormatter[];
+  normalizedMediaTypes: string[];
 }
 
 const NO_ACCEPTABLE_REPRESENTATION_MESSAGE = 'No acceptable response representation found.';
@@ -127,14 +128,16 @@ export function resolveContentNegotiation(options: ContentNegotiationOptions | u
     return undefined;
   }
 
-  const formatters = options.formatters.filter((formatter, index, all) => {
+  const seen = new Set<string>();
+  const formatters = options.formatters.filter((formatter) => {
     const mediaType = normalizeMediaType(formatter.mediaType);
 
-    if (!mediaType) {
+    if (!mediaType || seen.has(mediaType)) {
       return false;
     }
 
-    return all.findIndex((item) => normalizeMediaType(item.mediaType) === mediaType) === index;
+    seen.add(mediaType);
+    return true;
   });
 
   if (!formatters.length) {
@@ -149,30 +152,43 @@ export function resolveContentNegotiation(options: ContentNegotiationOptions | u
   return {
     defaultFormatter,
     formatters,
+    normalizedMediaTypes: formatters.map((f) => normalizeMediaType(f.mediaType)),
   };
 }
 
 function resolveAllowedFormatters(
   handler: HandlerDescriptor,
   contentNegotiation: ResolvedContentNegotiation,
-): ResponseFormatter[] {
+): { formatters: ResponseFormatter[]; normalizedMediaTypes: string[] } {
   if (!handler.route.produces?.length) {
-    return contentNegotiation.formatters;
+    return { formatters: contentNegotiation.formatters, normalizedMediaTypes: contentNegotiation.normalizedMediaTypes };
   }
 
   const allowed = new Set(handler.route.produces.map((mediaType) => normalizeMediaType(mediaType)));
-  return contentNegotiation.formatters.filter((formatter) => allowed.has(normalizeMediaType(formatter.mediaType)));
+  const formatters: ResponseFormatter[] = [];
+  const normalizedMediaTypes: string[] = [];
+
+  for (let i = 0; i < contentNegotiation.formatters.length; i++) {
+    const normalized = contentNegotiation.normalizedMediaTypes[i]!;
+
+    if (allowed.has(normalized)) {
+      formatters.push(contentNegotiation.formatters[i]!);
+      normalizedMediaTypes.push(normalized);
+    }
+  }
+
+  return { formatters, normalizedMediaTypes };
 }
 
 function resolveDefaultFormatter(
   allowedFormatters: ResponseFormatter[],
+  allowedNormalizedMediaTypes: string[],
   contentNegotiation: ResolvedContentNegotiation,
 ): ResponseFormatter {
   const defaultMediaType = normalizeMediaType(contentNegotiation.defaultFormatter.mediaType);
+  const idx = allowedNormalizedMediaTypes.indexOf(defaultMediaType);
 
-  return allowedFormatters.find((formatter) => normalizeMediaType(formatter.mediaType) === defaultMediaType)
-    ?? allowedFormatters[0]
-    ?? contentNegotiation.defaultFormatter;
+  return idx >= 0 ? allowedFormatters[idx]! : (allowedFormatters[0] ?? contentNegotiation.defaultFormatter);
 }
 
 export function selectResponseFormatter(
@@ -180,13 +196,16 @@ export function selectResponseFormatter(
   request: FrameworkRequest,
   contentNegotiation: ResolvedContentNegotiation,
 ): ResponseFormatter {
-  const allowedFormatters = resolveAllowedFormatters(handler, contentNegotiation);
+  const { formatters: allowedFormatters, normalizedMediaTypes: allowedNormalizedMediaTypes } = resolveAllowedFormatters(
+    handler,
+    contentNegotiation,
+  );
 
   if (!allowedFormatters.length) {
     throw new NotAcceptableException(NO_ACCEPTABLE_REPRESENTATION_MESSAGE);
   }
 
-  const defaultFormatter = resolveDefaultFormatter(allowedFormatters, contentNegotiation);
+  const defaultFormatter = resolveDefaultFormatter(allowedFormatters, allowedNormalizedMediaTypes, contentNegotiation);
   const acceptHeader = readAcceptHeader(request);
 
   if (!acceptHeader) {
@@ -204,9 +223,14 @@ export function selectResponseFormatter(
       return defaultFormatter;
     }
 
-    const matchedFormatter = allowedFormatters.find((formatter) => {
-      return matchesMediaRange(token.mediaRange, normalizeMediaType(formatter.mediaType));
-    });
+    let matchedFormatter: ResponseFormatter | undefined;
+
+    for (let i = 0; i < allowedFormatters.length; i++) {
+      if (matchesMediaRange(token.mediaRange, allowedNormalizedMediaTypes[i]!)) {
+        matchedFormatter = allowedFormatters[i];
+        break;
+      }
+    }
 
     if (matchedFormatter) {
       return matchedFormatter;


### PR DESCRIPTION
## Summary

- **di/container**: `collectDisposableInstances` now uses `Promise.allSettled` to concurrently await all cached instance promises instead of sequential `await` in a loop.
- **http/dispatch-content-negotiation**: `resolveContentNegotiation` replaces O(n²) `findIndex`-based deduplication with a `Set`; adds a `normalizedMediaTypes` field to `ResolvedContentNegotiation` so per-request `selectResponseFormatter` never calls `normalizeMediaType` redundantly on the same formatter list.
- **core/metadata/validation**: `getDtoBindingSchema` and `getDtoValidationSchema` rewritten with `flatMap` to eliminate the second store lookup per key that the previous `map + filter` approach performed.

Note: dependency resolution (`resolveProviderDeps`) and multi-provider instantiation (`resolveMultiProviderInstances`) were not parallelized — both share a mutable `activeTokens` set used for circular dependency detection, so concurrent execution would produce false positive cycle errors (confirmed by a failing test).

Closes #348