### PR TITLE
Resolve #349: refactor middleware pipeline and oversized helpers

### DIFF
--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -67,10 +67,6 @@ function defaultCacheKey(context: InterceptorContext, strategy: CacheKeyStrategy
     return path;
   }
 
-  if (strategy === 'route+query' || strategy === 'full') {
-    return `${path}?${queryString}`;
-  }
-
   return `${path}?${queryString}`;
 }
 

--- a/packages/http/src/middleware.test.ts
+++ b/packages/http/src/middleware.test.ts
@@ -149,4 +149,29 @@ describe('matchRoute behavior via runMiddlewareChain', () => {
 
     expect(events).toEqual(['terminal']);
   });
+
+  it('runs deep middleware stacks without recursive overflow', async () => {
+    const container = new Container();
+    const chainLength = 3_000;
+    let executed = 0;
+
+    const context = {
+      request: { path: '/health' },
+      requestContext: { container },
+      response: createResponse(),
+    } as unknown as MiddlewareContext;
+
+    const definitions: MiddlewareLike[] = Array.from({ length: chainLength }, () => ({
+      async handle(_context: MiddlewareContext, next: Next) {
+        executed += 1;
+        await next();
+      },
+    }));
+
+    await runMiddlewareChain(definitions, context, async () => {
+      executed += 1;
+    });
+
+    expect(executed).toBe(chainLength + 1);
+  });
 });

--- a/packages/http/src/middleware.ts
+++ b/packages/http/src/middleware.ts
@@ -10,16 +10,27 @@ export function isMiddlewareRouteConfig(value: MiddlewareLike): value is Middlew
   return typeof value === 'object' && value !== null && 'middleware' in value && 'routes' in value;
 }
 
-function matchRoute(pattern: string, path: string): boolean {
-  const normPath = path.endsWith('/') && path.length > 1 ? path.slice(0, -1) : path;
-  const normPattern = pattern.endsWith('/') && pattern.length > 1 ? pattern.slice(0, -1) : pattern;
-
-  if (normPattern.endsWith('/*')) {
-    const prefix = normPattern.slice(0, -2);
-    return normPath === prefix || normPath.startsWith(`${prefix}/`);
+export function normalizeRoutePattern(path: string): string {
+  if (path.endsWith('/*')) {
+    return `${normalizeRoutePattern(path.slice(0, -2))}/*`;
   }
 
-  return normPath === normPattern;
+  const segments = path.split('/').filter(Boolean);
+  const normalized = `/${segments.join('/')}`;
+
+  return normalized === '' ? '/' : normalized;
+}
+
+export function matchRoutePattern(pattern: string, path: string): boolean {
+  const normalizedPath = normalizeRoutePattern(path);
+  const normalizedPattern = normalizeRoutePattern(pattern);
+
+  if (normalizedPattern.endsWith('/*')) {
+    const prefix = normalizedPattern.slice(0, -2);
+    return normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`);
+  }
+
+  return normalizedPath === normalizedPattern;
 }
 
 export function forRoutes<T extends Constructor<Middleware>>(
@@ -37,34 +48,51 @@ async function resolveMiddleware(definition: MiddlewareLike, requestContext: Req
   return requestContext.container.resolve(definition as Token<Middleware>);
 }
 
+async function resolveActiveMiddlewareDefinitions(
+  definitions: MiddlewareLike[],
+  context: MiddlewareContext,
+): Promise<Middleware[]> {
+  const requestPath = context.request.path;
+  const middlewareChain: Middleware[] = [];
+
+  for (const definition of definitions) {
+    if (isMiddlewareRouteConfig(definition)) {
+      const matches = definition.routes.length === 0 || definition.routes.some((route) => matchRoutePattern(route, requestPath));
+
+      if (!matches) {
+        continue;
+      }
+
+      const middleware = await context.requestContext.container.resolve(definition.middleware);
+      middlewareChain.push(middleware);
+      continue;
+    }
+
+    middlewareChain.push(await resolveMiddleware(definition, context.requestContext));
+  }
+
+  return middlewareChain;
+}
+
+function deferNext(next: Next): Next {
+  return async () => {
+    await Promise.resolve();
+    await next();
+  };
+}
+
 export async function runMiddlewareChain(
   definitions: MiddlewareLike[],
   context: MiddlewareContext,
   terminal: Next,
 ): Promise<void> {
-  const dispatch = async (index: number): Promise<void> => {
-    if (index === definitions.length) {
-      await terminal();
-      return;
-    }
+  const middlewareChain = await resolveActiveMiddlewareDefinitions(definitions, context);
+  const composed = middlewareChain.reduceRight<Next>(
+    (next, middleware) => deferNext(async () => {
+      await middleware.handle(context, next);
+    }),
+    deferNext(terminal),
+  );
 
-    const definition = definitions[index];
-    if (isMiddlewareRouteConfig(definition)) {
-      const requestPath = context.request.path;
-      const matches = definition.routes.length === 0 || definition.routes.some((route) => matchRoute(route, requestPath));
-      if (!matches) {
-        await dispatch(index + 1);
-        return;
-      }
-
-      const middleware = await context.requestContext.container.resolve(definition.middleware);
-      await middleware.handle(context, () => dispatch(index + 1));
-      return;
-    }
-
-    const middleware = await resolveMiddleware(definition, context.requestContext);
-    await middleware.handle(context, () => dispatch(index + 1));
-  };
-
-  await dispatch(0);
+  await composed();
 }

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -292,14 +292,8 @@ function resolveValidatorStringFormat(
   return undefined;
 }
 
-function getRuleProfile(rules: readonly DtoFieldValidationRule[]): RuleProfile {
-  const cached = ruleProfileCache.get(rules);
-
-  if (cached) {
-    return cached;
-  }
-
-  const profile: RuleProfile = {
+function createRuleProfile(): RuleProfile {
+  return {
     enumEachRule: undefined,
     enumRule: undefined,
     hasArrayRule: false,
@@ -321,115 +315,129 @@ function getRuleProfile(rules: readonly DtoFieldValidationRule[]): RuleProfile {
     nestedRule: undefined,
     stringFormat: undefined,
   };
+}
+
+function applyRuleToProfile(profile: RuleProfile, rule: DtoFieldValidationRule): void {
+  if (rule.kind === 'nested') {
+    profile.nestedRule ??= rule;
+
+    if (rule.each) {
+      profile.nestedEachRule ??= rule;
+    }
+
+    return;
+  }
+
+  if (rule.kind === 'array') {
+    profile.hasArrayRule = true;
+    return;
+  }
+
+  if (rule.kind === 'enum') {
+    profile.enumRule ??= rule;
+
+    if (rule.each) {
+      profile.enumEachRule ??= rule;
+    }
+
+    return;
+  }
+
+  if (rule.kind === 'int') {
+    profile.hasIntRule = true;
+
+    if (rule.each) {
+      profile.hasEachIntRule = true;
+    }
+
+    return;
+  }
+
+  if (rule.kind === 'number') {
+    profile.hasNumberRule = true;
+
+    if (rule.each) {
+      profile.hasEachNumberRule = true;
+    }
+
+    return;
+  }
+
+  if (rule.kind === 'boolean') {
+    profile.hasBooleanRule = true;
+
+    if (rule.each) {
+      profile.hasEachBooleanRule = true;
+    }
+
+    return;
+  }
+
+  if (rule.kind === 'date') {
+    profile.hasDateRule = true;
+    return;
+  }
+
+  if (rule.kind === 'object') {
+    profile.hasObjectRule = true;
+    return;
+  }
+
+  if (rule.kind === 'string') {
+    profile.hasStringRule = true;
+    return;
+  }
+
+  if (rule.kind === 'minLength') {
+    if (rule.each) {
+      profile.hasStringRuleForEach = true;
+      return;
+    }
+
+    profile.minLength = rule.value;
+    return;
+  }
+
+  if (rule.kind === 'maxLength') {
+    if (rule.each) {
+      profile.hasStringRuleForEach = true;
+      return;
+    }
+
+    profile.maxLength = rule.value;
+    return;
+  }
+
+  if (rule.kind === 'min' && !rule.each) {
+    profile.minimum = rule.value;
+    return;
+  }
+
+  if (rule.kind === 'max' && !rule.each) {
+    profile.maximum = rule.value;
+    return;
+  }
+
+  if (rule.kind === 'validatorjs') {
+    const nextFormat = resolveValidatorStringFormat(rule);
+
+    if (nextFormat) {
+      profile.stringFormat = nextFormat;
+    }
+  }
+}
+
+function getRuleProfile(rules: readonly DtoFieldValidationRule[]): RuleProfile {
+  const cached = ruleProfileCache.get(rules);
+
+  if (cached) {
+    return cached;
+  }
+
+  const profile = createRuleProfile();
 
   for (const rule of rules) {
-    if (rule.kind === 'nested') {
-      profile.nestedRule ??= rule;
-
-      if (rule.each) {
-        profile.nestedEachRule ??= rule;
-      }
-
-      continue;
-    }
-
-    if (rule.kind === 'array') {
-      profile.hasArrayRule = true;
-      continue;
-    }
-
-    if (rule.kind === 'enum') {
-      profile.enumRule ??= rule;
-
-      if (rule.each) {
-        profile.enumEachRule ??= rule;
-      }
-
-      continue;
-    }
-
-    if (rule.kind === 'int') {
-      profile.hasIntRule = true;
-
-      if (rule.each) {
-        profile.hasEachIntRule = true;
-      }
-
-      continue;
-    }
-
-    if (rule.kind === 'number') {
-      profile.hasNumberRule = true;
-
-      if (rule.each) {
-        profile.hasEachNumberRule = true;
-      }
-
-      continue;
-    }
-
-    if (rule.kind === 'boolean') {
-      profile.hasBooleanRule = true;
-
-      if (rule.each) {
-        profile.hasEachBooleanRule = true;
-      }
-
-      continue;
-    }
-
-    if (rule.kind === 'date') {
-      profile.hasDateRule = true;
-      continue;
-    }
-
-    if (rule.kind === 'object') {
-      profile.hasObjectRule = true;
-      continue;
-    }
-
-    if (rule.kind === 'string') {
-      profile.hasStringRule = true;
-      continue;
-    }
-
-    if (rule.kind === 'minLength') {
-      if (rule.each) {
-        profile.hasStringRuleForEach = true;
-      } else {
-        profile.minLength = rule.value;
-      }
-
-      continue;
-    }
-
-    if (rule.kind === 'maxLength') {
-      if (rule.each) {
-        profile.hasStringRuleForEach = true;
-      } else {
-        profile.maxLength = rule.value;
-      }
-
-      continue;
-    }
-
-    if (rule.kind === 'min' && !rule.each) {
-      profile.minimum = rule.value;
-      continue;
-    }
-
-    if (rule.kind === 'max' && !rule.each) {
-      profile.maximum = rule.value;
-      continue;
-    }
-
-    if (rule.kind === 'validatorjs') {
-      const nextFormat = resolveValidatorStringFormat(rule);
-
-      if (nextFormat) {
-        profile.stringFormat = nextFormat;
-      }
-    }
+    applyRuleToProfile(profile, rule);
   }
 
   ruleProfileCache.set(rules, profile);

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -12,7 +12,9 @@ import {
   createSecurityHeadersMiddleware,
   HttpException,
   InternalServerErrorException,
+  matchRoutePattern,
   NotFoundException,
+  normalizeRoutePattern,
   PayloadTooLargeException,
   type CorsOptions,
   type Dispatcher,
@@ -594,7 +596,7 @@ function createFastifyMiddleware(options: BootstrapFastifyApplicationOptions): M
 }
 
 function createGlobalPrefixMiddleware(prefix: string, exclude: readonly string[] | undefined): MiddlewareLike {
-  const normalizedPrefix = normalizePathPattern(prefix);
+  const normalizedPrefix = normalizeRoutePattern(prefix);
 
   if (normalizedPrefix === '/') {
     return {
@@ -604,45 +606,72 @@ function createGlobalPrefixMiddleware(prefix: string, exclude: readonly string[]
     };
   }
 
-  const exclusions = [...(exclude ?? [])].map((path) => normalizePathPattern(path));
+  const exclusions = [...(exclude ?? [])].map((path) => normalizeRoutePattern(path));
 
   return {
     async handle(context: MiddlewareContext, next: Next) {
-      const requestPath = normalizePathPattern(context.request.path);
+      const requestPath = normalizeRoutePattern(context.request.path);
 
       if (matchesExcludedPath(requestPath, exclusions)) {
         await next();
         return;
       }
 
-      if (!matchesPrefix(requestPath, normalizedPrefix)) {
+      if (shouldRejectGlobalPrefixRequest(requestPath, normalizedPrefix, exclusions)) {
         await writeGlobalPrefixNotFound(context.requestContext.requestId, context.response);
         return;
       }
 
       const strippedPath = stripGlobalPrefix(requestPath, normalizedPrefix);
-
-      if (matchesExcludedPath(strippedPath, exclusions)) {
-        await writeGlobalPrefixNotFound(context.requestContext.requestId, context.response);
-        return;
-      }
-
-      const originalRequest = context.requestContext.request;
-      const scopedRequest = {
-        ...originalRequest,
-        path: strippedPath,
-        url: rewritePrefixedUrl(originalRequest.url, requestPath, strippedPath),
-      };
-      context.request = scopedRequest;
-      context.requestContext.request = scopedRequest;
+      const restore = applyScopedGlobalPrefixRequest(context, requestPath, strippedPath);
 
       try {
         await next();
       } finally {
-        context.request = originalRequest;
-        context.requestContext.request = originalRequest;
+        restore();
       }
     },
+  };
+}
+
+function shouldRejectGlobalPrefixRequest(
+  requestPath: string,
+  normalizedPrefix: string,
+  exclusions: readonly string[],
+): boolean {
+  if (!matchesPrefix(requestPath, normalizedPrefix)) {
+    return true;
+  }
+
+  return matchesExcludedPath(stripGlobalPrefix(requestPath, normalizedPrefix), exclusions);
+}
+
+function rewriteGlobalPrefixRequest(
+  request: MiddlewareContext['request'],
+  requestPath: string,
+  strippedPath: string,
+): MiddlewareContext['request'] {
+  return {
+    ...request,
+    path: strippedPath,
+    url: rewritePrefixedUrl(request.url, requestPath, strippedPath),
+  };
+}
+
+function applyScopedGlobalPrefixRequest(
+  context: MiddlewareContext,
+  requestPath: string,
+  strippedPath: string,
+): () => void {
+  const originalRequest = context.requestContext.request;
+  const scopedRequest = rewriteGlobalPrefixRequest(originalRequest, requestPath, strippedPath);
+
+  context.request = scopedRequest;
+  context.requestContext.request = scopedRequest;
+
+  return () => {
+    context.request = originalRequest;
+    context.requestContext.request = originalRequest;
   };
 }
 
@@ -664,17 +693,6 @@ function writeGlobalPrefixNotFound(requestId: string | undefined, response: Fram
   return Promise.resolve(response.send(createErrorResponse(error, requestId)));
 }
 
-function normalizePathPattern(path: string): string {
-  if (path.endsWith('/*')) {
-    return `${normalizePathPattern(path.slice(0, -2))}/*`;
-  }
-
-  const segments = path.split('/').filter(Boolean);
-  const normalized = `/${segments.join('/')}`;
-
-  return normalized === '' ? '/' : normalized;
-}
-
 function matchesPrefix(path: string, prefix: string): boolean {
   return path === prefix || path.startsWith(`${prefix}/`);
 }
@@ -684,20 +702,11 @@ function stripGlobalPrefix(path: string, prefix: string): string {
     return '/';
   }
 
-  return normalizePathPattern(path.slice(prefix.length));
+  return normalizeRoutePattern(path.slice(prefix.length));
 }
 
 function matchesExcludedPath(path: string, exclusions: readonly string[]): boolean {
   return exclusions.some((pattern) => matchRoutePattern(pattern, path));
-}
-
-function matchRoutePattern(pattern: string, path: string): boolean {
-  if (pattern.endsWith('/*')) {
-    const prefix = pattern.slice(0, -2);
-    return path === prefix || path.startsWith(`${prefix}/`);
-  }
-
-  return path === pattern;
 }
 
 function rewritePrefixedUrl(url: string, originalPath: string, rewrittenPath: string): string {

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -6,12 +6,16 @@ import {
   createCorsMiddleware,
   createErrorResponse,
   createSecurityHeadersMiddleware,
+  matchRoutePattern,
+  normalizeRoutePattern,
   NotFoundException,
   type CorsOptions,
   type Dispatcher,
   type FrameworkResponse,
   type HttpApplicationAdapter,
+  type MiddlewareContext,
   type MiddlewareLike,
+  type Next,
   type SecurityHeadersOptions,
 } from '@konekti/http';
 
@@ -419,55 +423,82 @@ function createNodeMiddleware(options: BootstrapNodeApplicationOptions): Middlew
 }
 
 function createGlobalPrefixMiddleware(prefix: string, exclude: readonly string[] | undefined): MiddlewareLike {
-  const normalizedPrefix = normalizePathPattern(prefix);
+  const normalizedPrefix = normalizeRoutePattern(prefix);
 
   if (normalizedPrefix === '/') {
     return {
-      async handle(_context, next) {
+      async handle(_context: MiddlewareContext, next: Next) {
         await next();
       },
     };
   }
 
-  const exclusions = [...(exclude ?? [])].map((path) => normalizePathPattern(path));
+  const exclusions = [...(exclude ?? [])].map((path) => normalizeRoutePattern(path));
 
   return {
-    async handle(context, next) {
-      const requestPath = normalizePathPattern(context.request.path);
+    async handle(context: MiddlewareContext, next: Next) {
+      const requestPath = normalizeRoutePattern(context.request.path);
 
       if (matchesExcludedPath(requestPath, exclusions)) {
         await next();
         return;
       }
 
-      if (!matchesPrefix(requestPath, normalizedPrefix)) {
+      if (shouldRejectGlobalPrefixRequest(requestPath, normalizedPrefix, exclusions)) {
         await writeGlobalPrefixNotFound(context.requestContext.requestId, context.response);
         return;
       }
 
       const strippedPath = stripGlobalPrefix(requestPath, normalizedPrefix);
-
-      if (matchesExcludedPath(strippedPath, exclusions)) {
-        await writeGlobalPrefixNotFound(context.requestContext.requestId, context.response);
-        return;
-      }
-
-      const originalRequest = context.requestContext.request;
-      const scopedRequest = {
-        ...originalRequest,
-        path: strippedPath,
-        url: rewritePrefixedUrl(originalRequest.url, requestPath, strippedPath),
-      };
-      context.request = scopedRequest;
-      context.requestContext.request = scopedRequest;
+      const restore = applyScopedGlobalPrefixRequest(context, requestPath, strippedPath);
 
       try {
         await next();
       } finally {
-        context.request = originalRequest;
-        context.requestContext.request = originalRequest;
+        restore();
       }
     },
+  };
+}
+
+function shouldRejectGlobalPrefixRequest(
+  requestPath: string,
+  normalizedPrefix: string,
+  exclusions: readonly string[],
+): boolean {
+  if (!matchesPrefix(requestPath, normalizedPrefix)) {
+    return true;
+  }
+
+  return matchesExcludedPath(stripGlobalPrefix(requestPath, normalizedPrefix), exclusions);
+}
+
+function rewriteGlobalPrefixRequest(
+  request: MiddlewareContext['request'],
+  requestPath: string,
+  strippedPath: string,
+): MiddlewareContext['request'] {
+  return {
+    ...request,
+    path: strippedPath,
+    url: rewritePrefixedUrl(request.url, requestPath, strippedPath),
+  };
+}
+
+function applyScopedGlobalPrefixRequest(
+  context: MiddlewareContext,
+  requestPath: string,
+  strippedPath: string,
+): () => void {
+  const originalRequest = context.requestContext.request;
+  const scopedRequest = rewriteGlobalPrefixRequest(originalRequest, requestPath, strippedPath);
+
+  context.request = scopedRequest;
+  context.requestContext.request = scopedRequest;
+
+  return () => {
+    context.request = originalRequest;
+    context.requestContext.request = originalRequest;
   };
 }
 
@@ -475,17 +506,6 @@ function writeGlobalPrefixNotFound(requestId: string | undefined, response: Fram
   const error = new NotFoundException('Resource not found.');
   response.setStatus(error.status);
   return Promise.resolve(response.send(createErrorResponse(error, requestId)));
-}
-
-function normalizePathPattern(path: string): string {
-  if (path.endsWith('/*')) {
-    return `${normalizePathPattern(path.slice(0, -2))}/*`;
-  }
-
-  const segments = path.split('/').filter(Boolean);
-  const normalized = `/${segments.join('/')}`;
-
-  return normalized === '' ? '/' : normalized;
 }
 
 function matchesPrefix(path: string, prefix: string): boolean {
@@ -497,20 +517,11 @@ function stripGlobalPrefix(path: string, prefix: string): string {
     return '/';
   }
 
-  return normalizePathPattern(path.slice(prefix.length));
+  return normalizeRoutePattern(path.slice(prefix.length));
 }
 
 function matchesExcludedPath(path: string, exclusions: readonly string[]): boolean {
-  return exclusions.some((pattern) => matchNodeRoutePattern(pattern, path));
-}
-
-function matchNodeRoutePattern(pattern: string, path: string): boolean {
-  if (pattern.endsWith('/*')) {
-    const prefix = pattern.slice(0, -2);
-    return path === prefix || path.startsWith(`${prefix}/`);
-  }
-
-  return path === pattern;
+  return exclusions.some((pattern) => matchRoutePattern(pattern, path));
 }
 
 function rewritePrefixedUrl(url: string, originalPath: string, rewrittenPath: string): string {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -144,134 +144,144 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
   );
 }
 
+interface SyncResolverState {
+  introspection: ContainerIntrospection;
+  resolutionChain: Set<Token>;
+  singletonCache: Map<Token, unknown>;
+}
+
+function collectMultiProviders(target: ContainerIntrospection, token: Token): NormalizedProvider[] {
+  const fromParent = target.parent ? collectMultiProviders(target.parent, token) : [];
+  const local = target.multiRegistrations.get(token) ?? [];
+  return [...fromParent, ...local];
+}
+
+function lookupProvider(target: ContainerIntrospection, token: Token): NormalizedProvider | undefined {
+  const local = target.registrations.get(token);
+
+  if (local) {
+    return local;
+  }
+
+  return target.parent ? lookupProvider(target.parent, token) : undefined;
+}
+
+function hasToken(state: SyncResolverState, token: Token): boolean {
+  return lookupProvider(state.introspection, token) !== undefined || collectMultiProviders(state.introspection, token).length > 0;
+}
+
+function resolveSyncDependency(entry: Token | ForwardRefFn | OptionalToken, state: SyncResolverState): unknown {
+  if (isOptionalToken(entry)) {
+    if (!hasToken(state, entry.token)) {
+      return undefined;
+    }
+
+    return resolveSyncToken(entry.token, state);
+  }
+
+  if (isForwardRef(entry)) {
+    return resolveSyncToken(entry.forwardRef(), state);
+  }
+
+  return resolveSyncToken(entry as Token, state);
+}
+
+function instantiateSyncProvider(provider: NormalizedProvider, state: SyncResolverState): unknown {
+  switch (provider.type) {
+    case 'value': {
+      return provider.useValue;
+    }
+    case 'existing': {
+      if (!provider.useExisting) {
+        throw new Error('Existing provider is missing useExisting token.');
+      }
+
+      return resolveSyncToken(provider.useExisting, state);
+    }
+    case 'factory': {
+      if (!provider.useFactory) {
+        throw new Error('Factory provider is missing useFactory.');
+      }
+
+      const deps = provider.inject.map((entry) => resolveSyncDependency(entry, state));
+      const value = provider.useFactory(...deps) as MaybePromise<unknown>;
+
+      if (isPromiseLike(value)) {
+        throw new Error(
+          `Token ${String(provider.provide)} requires async resolution. Use resolve() instead of get() for async providers.`,
+        );
+      }
+
+      return value;
+    }
+    case 'class': {
+      if (!provider.useClass) {
+        throw new Error('Class provider is missing useClass.');
+      }
+
+      const deps = provider.inject.map((entry) => resolveSyncDependency(entry, state));
+      return new provider.useClass(...deps);
+    }
+    default: {
+      throw new Error('Unknown provider type.');
+    }
+  }
+}
+
+function resolveSyncProvider(provider: NormalizedProvider, state: SyncResolverState): unknown {
+  if (provider.scope === 'request' && !state.introspection.requestScopeEnabled) {
+    throw new Error(`Request-scoped provider ${String(provider.provide)} cannot be resolved outside request scope.`);
+  }
+
+  if (provider.scope === 'transient') {
+    return instantiateSyncProvider(provider, state);
+  }
+
+  if (state.singletonCache.has(provider.provide)) {
+    return state.singletonCache.get(provider.provide);
+  }
+
+  const instance = instantiateSyncProvider(provider, state);
+  state.singletonCache.set(provider.provide, instance);
+  return instance;
+}
+
+function resolveSyncToken(token: Token, state: SyncResolverState): unknown {
+  if (state.resolutionChain.has(token)) {
+    throw new Error(`Circular dependency detected while resolving token ${String(token)} via get().`);
+  }
+
+  state.resolutionChain.add(token);
+
+  try {
+    const multiProviders = collectMultiProviders(state.introspection, token);
+
+    if (multiProviders.length > 0) {
+      return multiProviders.map((provider) => instantiateSyncProvider(provider, state));
+    }
+
+    const provider = lookupProvider(state.introspection, token);
+
+    if (!provider) {
+      throw new Error(`No provider registered for token ${String(token)}.`);
+    }
+
+    return resolveSyncProvider(provider, state);
+  } finally {
+    state.resolutionChain.delete(token);
+  }
+}
+
 function createSyncResolver(
   container: BootstrapResult['container'],
 ): <T>(token: Token<T>) => T {
-  const introspection = toContainerIntrospection(container);
-  const singletonCache = new Map<Token, unknown>();
-  const resolutionChain = new Set<Token>();
-
-  const collectMultiProviders = (target: ContainerIntrospection, token: Token): NormalizedProvider[] => {
-    const fromParent = target.parent ? collectMultiProviders(target.parent, token) : [];
-    const local = target.multiRegistrations.get(token) ?? [];
-    return [...fromParent, ...local];
+  const state: SyncResolverState = {
+    introspection: toContainerIntrospection(container),
+    resolutionChain: new Set<Token>(),
+    singletonCache: new Map<Token, unknown>(),
   };
 
-  const lookupProvider = (target: ContainerIntrospection, token: Token): NormalizedProvider | undefined => {
-    const local = target.registrations.get(token);
-    if (local) {
-      return local;
-    }
-
-    return target.parent ? lookupProvider(target.parent, token) : undefined;
-  };
-
-  const hasToken = (token: Token): boolean => {
-    return lookupProvider(introspection, token) !== undefined || collectMultiProviders(introspection, token).length > 0;
-  };
-
-  const resolveDep = (entry: Token | ForwardRefFn | OptionalToken): unknown => {
-    if (isOptionalToken(entry)) {
-      if (!hasToken(entry.token)) {
-        return undefined;
-      }
-
-      return resolveToken(entry.token);
-    }
-
-    if (isForwardRef(entry)) {
-      return resolveToken(entry.forwardRef());
-    }
-
-    return resolveToken(entry as Token);
-  };
-
-  const instantiateProvider = (provider: NormalizedProvider): unknown => {
-    switch (provider.type) {
-      case 'value': {
-        return provider.useValue;
-      }
-      case 'existing': {
-        if (!provider.useExisting) {
-          throw new Error('Existing provider is missing useExisting token.');
-        }
-
-        return resolveToken(provider.useExisting);
-      }
-      case 'factory': {
-        if (!provider.useFactory) {
-          throw new Error('Factory provider is missing useFactory.');
-        }
-
-        const deps = provider.inject.map((entry) => resolveDep(entry));
-        const value = provider.useFactory(...deps) as MaybePromise<unknown>;
-
-        if (isPromiseLike(value)) {
-          throw new Error(
-            `Token ${String(provider.provide)} requires async resolution. Use resolve() instead of get() for async providers.`,
-          );
-        }
-
-        return value;
-      }
-      case 'class': {
-        if (!provider.useClass) {
-          throw new Error('Class provider is missing useClass.');
-        }
-
-        const deps = provider.inject.map((entry) => resolveDep(entry));
-        return new provider.useClass(...deps);
-      }
-      default: {
-        throw new Error('Unknown provider type.');
-      }
-    }
-  };
-
-  const resolveProvider = (provider: NormalizedProvider): unknown => {
-    if (provider.scope === 'request' && !introspection.requestScopeEnabled) {
-      throw new Error(`Request-scoped provider ${String(provider.provide)} cannot be resolved outside request scope.`);
-    }
-
-    if (provider.scope === 'transient') {
-      return instantiateProvider(provider);
-    }
-
-    if (singletonCache.has(provider.provide)) {
-      return singletonCache.get(provider.provide);
-    }
-
-    const instance = instantiateProvider(provider);
-    singletonCache.set(provider.provide, instance);
-    return instance;
-  };
-
-  const resolveToken = (token: Token): unknown => {
-    if (resolutionChain.has(token)) {
-      throw new Error(`Circular dependency detected while resolving token ${String(token)} via get().`);
-    }
-
-    resolutionChain.add(token);
-
-    try {
-      const multiProviders = collectMultiProviders(introspection, token);
-      if (multiProviders.length > 0) {
-        return multiProviders.map((provider) => instantiateProvider(provider));
-      }
-
-      const provider = lookupProvider(introspection, token);
-
-      if (!provider) {
-        throw new Error(`No provider registered for token ${String(token)}.`);
-      }
-
-      return resolveProvider(provider);
-    } finally {
-      resolutionChain.delete(token);
-    }
-  };
-
-  return <T>(token: Token<T>): T => resolveToken(token) as T;
+  return <T>(token: Token<T>): T => resolveSyncToken(token, state) as T;
 }
 
 class DefaultOverrideProviderBuilder<T> implements OverrideProviderBuilder<T> {

--- a/packages/testing/src/vitest.ts
+++ b/packages/testing/src/vitest.ts
@@ -5,6 +5,16 @@ import { transformAsync } from '@babel/core';
 
 const babelConfigFileCache = new Map<string, string>();
 
+interface BabelDecoratorsTransformResult {
+  code: string;
+  map: unknown;
+}
+
+interface KonektiBabelDecoratorsPlugin {
+  name: string;
+  transform(code: string, id: string): Promise<BabelDecoratorsTransformResult | null>;
+}
+
 function resolveBabelConfigFile(filePath: string): string {
   let currentDirectory = dirname(filePath);
 
@@ -32,7 +42,7 @@ function resolveBabelConfigFile(filePath: string): string {
   }
 }
 
-export function konektiBabelDecoratorsPlugin() {
+export function konektiBabelDecoratorsPlugin(): KonektiBabelDecoratorsPlugin {
   return {
     name: 'konekti-babel-decorators',
     async transform(code: string, id: string) {


### PR DESCRIPTION
## Summary
- unify route-pattern normalization/matching in `@konekti/http` and reuse it from runtime + fastify global-prefix middleware to remove duplicated logic
- make middleware chain execution stack-safe for deep middleware stacks and add regression coverage for large chains
- split oversized helper logic in testing/openapi/runtime/fastify and clean up redundant cache-key branching + explicit Vitest plugin return typing

## Verification
- `pnpm exec vitest run packages/http/src/middleware.test.ts packages/http/src/dispatcher.test.ts packages/runtime/src/application.test.ts packages/platform-fastify/src/adapter.test.ts packages/openapi/src/schema-builder.test.ts packages/testing/src/module.test.ts packages/cache-manager/src/interceptor.test.ts`
- `pnpm typecheck`
- `pnpm build`

Closes #349