### PR TITLE
Resolve #350: remove implicit shared-state mutation paths

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,7 +113,7 @@ For DI metadata, `getOwnClassDiMetadata()` returns only metadata written on the 
 
 `@konekti/core` also re-exports additional metadata helpers and types from `src/metadata.ts`; treat this table as the most important helpers, not the full public surface.
 
-`ensureMetadataSymbol()` is the explicit compatibility boundary for standard-decorator metadata. `@konekti/core` still installs `Symbol.metadata` when missing so framework decorators and helper readers stay compatible, but extension code should treat the initializer/helper layer as the supported contract rather than depending on incidental import-order side effects.
+`ensureMetadataSymbol()` is the explicit compatibility boundary for standard-decorator metadata. Call it during bootstrap when your runtime does not provide `Symbol.metadata`; framework extensions should depend on this explicit initializer instead of import-order side effects.
 
 ## Architecture
 

--- a/packages/core/src/metadata.test.ts
+++ b/packages/core/src/metadata.test.ts
@@ -115,6 +115,44 @@ describe('metadata helpers', () => {
     });
   });
 
+  it('returns cloned nested route metadata objects', () => {
+    class ExampleController {
+      getUser() {
+        return { ok: true };
+      }
+    }
+
+    defineRouteMetadata(ExampleController.prototype, 'getUser', {
+      headers: [{ name: 'x-test', value: 'v1' }],
+      method: 'GET',
+      path: '/users',
+      redirect: {
+        statusCode: 302,
+        url: '/moved',
+      },
+    });
+
+    const metadata = getRouteMetadata(ExampleController.prototype, 'getUser');
+
+    if (metadata?.headers?.[0]) {
+      metadata.headers[0].value = 'mutated';
+    }
+
+    if (metadata?.redirect) {
+      metadata.redirect.url = '/mutated';
+    }
+
+    expect(getRouteMetadata(ExampleController.prototype, 'getUser')).toEqual({
+      headers: [{ name: 'x-test', value: 'v1' }],
+      method: 'GET',
+      path: '/users',
+      redirect: {
+        statusCode: 302,
+        url: '/moved',
+      },
+    });
+  });
+
   it('builds DTO binding schema from field metadata', () => {
     class GetUserRequest {
       id!: string;
@@ -198,6 +236,31 @@ describe('metadata helpers', () => {
       {
         propertyKey: 'name',
         rules: [{ kind: 'string' }, { kind: 'minLength', value: 2 }],
+      },
+    ]);
+  });
+
+  it('returns cloned DTO validation rule payloads for nested rule objects', () => {
+    class ExampleDto {
+      tags!: string[];
+    }
+
+    appendDtoFieldValidationRule(ExampleDto.prototype, 'tags', {
+      kind: 'in',
+      values: ['a', 'b'],
+    });
+
+    const schema = getDtoValidationSchema(ExampleDto);
+    const firstRule = schema[0]?.rules[0];
+
+    if (firstRule && firstRule.kind === 'in') {
+      (firstRule.values as string[]).push('mutated');
+    }
+
+    expect(getDtoValidationSchema(ExampleDto)).toEqual([
+      {
+        propertyKey: 'tags',
+        rules: [{ kind: 'in', values: ['a', 'b'] }],
       },
     ]);
   });

--- a/packages/core/src/metadata/controller-route.ts
+++ b/packages/core/src/metadata/controller-route.ts
@@ -1,4 +1,5 @@
 import {
+  cloneMutableValue,
   cloneCollection,
   getOrCreatePropertyMap,
   getStandardConstructorMetadataMap,
@@ -13,6 +14,14 @@ import type { MetadataPropertyKey } from '../types.js';
 const controllerMetadataStore = createClonedWeakMapStore<Function, ControllerMetadata>(cloneControllerMetadata);
 const routeMetadataStore = new WeakMap<object, Map<MetadataPropertyKey, RouteMetadata>>();
 
+function cloneRouteHeaders(headers: RouteMetadata['headers']): RouteMetadata['headers'] {
+  return headers?.map((header) => ({ ...header }));
+}
+
+function cloneRouteRedirect(redirect: RouteMetadata['redirect']): RouteMetadata['redirect'] {
+  return redirect ? { ...redirect } : undefined;
+}
+
 function cloneControllerMetadata(metadata: ControllerMetadata): ControllerMetadata {
   return {
     ...metadata,
@@ -24,6 +33,8 @@ function cloneControllerMetadata(metadata: ControllerMetadata): ControllerMetada
 function cloneRouteMetadata(metadata: RouteMetadata): RouteMetadata {
   return {
     ...metadata,
+    headers: cloneRouteHeaders(metadata.headers),
+    redirect: cloneRouteRedirect(metadata.redirect),
     guards: cloneCollection(metadata.guards),
     interceptors: cloneCollection(metadata.interceptors),
   };
@@ -108,13 +119,16 @@ function mergeRouteMetadata(
   standard: RouteMetadata | undefined,
   required: Pick<RouteMetadata, 'method' | 'path'>,
 ): RouteMetadata {
+  const mergedHeaders = stored?.headers ?? standard?.headers;
+  const mergedRedirect = stored?.redirect ?? standard?.redirect;
+
   return {
     guards: mergeUnique(stored?.guards, standard?.guards),
-    headers: stored?.headers ?? standard?.headers,
+    headers: cloneMutableValue(mergedHeaders),
     interceptors: mergeUnique(stored?.interceptors, standard?.interceptors),
     method: required.method,
     path: required.path,
-    redirect: stored?.redirect ?? standard?.redirect,
+    redirect: cloneMutableValue(mergedRedirect),
     request: stored?.request ?? standard?.request,
     successStatus: stored?.successStatus ?? standard?.successStatus,
     version: stored?.version ?? standard?.version,

--- a/packages/core/src/metadata/shared.ts
+++ b/packages/core/src/metadata/shared.ts
@@ -3,9 +3,14 @@ import type { MetadataPropertyKey } from '../types.js';
 export type StandardMetadataBag = Record<PropertyKey, unknown>;
 
 const symbolWithMetadata = Symbol as typeof Symbol & { metadata?: symbol };
-export const metadataSymbol = symbolWithMetadata.metadata ?? Symbol.for('konekti.symbol.metadata');
+export let metadataSymbol = symbolWithMetadata.metadata ?? Symbol.for('konekti.symbol.metadata');
 
 export function ensureMetadataSymbol(): symbol {
+  if (symbolWithMetadata.metadata) {
+    metadataSymbol = symbolWithMetadata.metadata;
+    return metadataSymbol;
+  }
+
   if (!symbolWithMetadata.metadata) {
     Object.defineProperty(Symbol, 'metadata', {
       configurable: true,
@@ -17,6 +22,48 @@ export function ensureMetadataSymbol(): symbol {
 }
 
 void ensureMetadataSymbol();
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function cloneMutableValue<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneMutableValue(item)) as T;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime()) as T;
+  }
+
+  if (value instanceof Map) {
+    return new Map(
+      Array.from(value.entries(), ([key, entryValue]) => [key, cloneMutableValue(entryValue)]),
+    ) as T;
+  }
+
+  if (value instanceof Set) {
+    return new Set(Array.from(value.values(), (entryValue) => cloneMutableValue(entryValue))) as T;
+  }
+
+  if (isPlainObject(value)) {
+    const cloned: Record<string, unknown> = {};
+
+    for (const [key, entryValue] of Object.entries(value)) {
+      cloned[key] = cloneMutableValue(entryValue);
+    }
+
+    return cloned as T;
+  }
+
+  return value;
+}
 
 export const standardMetadataKeys = {
   classValidation: Symbol.for('konekti.standard.class-validation'),
@@ -39,7 +86,7 @@ export const metadataKeys = {
 } as const;
 
 export function cloneCollection<T>(collection: readonly T[] | undefined): T[] | undefined {
-  return collection ? [...collection] : undefined;
+  return collection ? collection.map((value) => cloneMutableValue(value)) : undefined;
 }
 
 export function getOrCreatePropertyMap<T>(

--- a/packages/core/src/metadata/symbol-metadata-polyfill.ts
+++ b/packages/core/src/metadata/symbol-metadata-polyfill.ts
@@ -3,5 +3,3 @@ import { ensureMetadataSymbol } from './shared.js';
 export function ensureSymbolMetadataPolyfill(): symbol {
   return ensureMetadataSymbol();
 }
-
-void ensureSymbolMetadataPolyfill();

--- a/packages/core/src/metadata/validation.ts
+++ b/packages/core/src/metadata/validation.ts
@@ -1,5 +1,6 @@
 import {
   appendPropertyMapValue,
+  cloneMutableValue,
   getOrCreatePropertyMap,
   getStandardConstructorMetadataMap,
   getStandardMetadataBag,
@@ -20,7 +21,9 @@ import type { Constructor, MetadataPropertyKey } from '../types.js';
 
 const dtoFieldBindingStore = new WeakMap<object, Map<MetadataPropertyKey, DtoFieldBindingMetadata>>();
 const dtoFieldValidationStore = new WeakMap<object, Map<MetadataPropertyKey, DtoFieldValidationRule[]>>();
-const classValidationStore = createClonedWeakMapStore<Function, ClassValidationRule[]>((rules) => [...rules]);
+const classValidationStore = createClonedWeakMapStore<Function, ClassValidationRule[]>((rules) =>
+  rules.map((rule) => cloneMutableValue(rule))
+);
 
 function getStandardDtoBindingMap(target: object): Map<MetadataPropertyKey, StandardDtoBindingRecord> | undefined {
   return getStandardConstructorMetadataMap<StandardDtoBindingRecord>(target, standardMetadataKeys.dtoFieldBinding);
@@ -33,7 +36,7 @@ function getStandardDtoValidationMap(target: object): Map<MetadataPropertyKey, S
 function getStandardClassValidationRules(target: Function): ClassValidationRule[] | undefined {
   const rules = getStandardMetadataBag(target)?.[standardMetadataKeys.classValidation] as ClassValidationRule[] | undefined;
 
-  return rules ? [...rules] : undefined;
+  return rules ? rules.map((rule) => cloneMutableValue(rule)) : undefined;
 }
 
 export function getDtoFieldBindingMetadata(target: object, propertyKey: MetadataPropertyKey): DtoFieldBindingMetadata | undefined {
@@ -65,12 +68,12 @@ export function appendDtoFieldValidationRule(
   propertyKey: MetadataPropertyKey,
   rule: DtoFieldValidationRule,
 ): void {
-  appendPropertyMapValue(dtoFieldValidationStore, target, propertyKey, rule);
+  appendPropertyMapValue(dtoFieldValidationStore, target, propertyKey, cloneMutableValue(rule));
 }
 
 export function appendClassValidationRule(target: Function, rule: ClassValidationRule): void {
   const rules = classValidationStore.read(target) ?? [];
-  rules.push(rule);
+  rules.push(cloneMutableValue(rule));
   classValidationStore.write(target, rules);
 }
 
@@ -107,7 +110,10 @@ export function getDtoFieldValidationRules(target: object, propertyKey: Metadata
   const stored = dtoFieldValidationStore.get(target)?.get(propertyKey) ?? [];
   const standard = getStandardDtoValidationMap(target)?.get(propertyKey) ?? [];
 
-  return [...standard, ...stored];
+  return [
+    ...standard.map((rule) => cloneMutableValue(rule)),
+    ...stored.map((rule) => cloneMutableValue(rule)),
+  ];
 }
 
 export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEntry[] {
@@ -117,8 +123,8 @@ export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEnt
 
   return keys.flatMap((propertyKey) => {
     const rules: DtoFieldValidationRule[] = [
-      ...(standard.get(propertyKey) ?? []),
-      ...(stored.get(propertyKey) ?? []),
+      ...(standard.get(propertyKey) ?? []).map((rule) => cloneMutableValue(rule)),
+      ...(stored.get(propertyKey) ?? []).map((rule) => cloneMutableValue(rule)),
     ];
 
     if (rules.length === 0) {

--- a/packages/http/src/dispatcher.ts
+++ b/packages/http/src/dispatcher.ts
@@ -20,6 +20,7 @@ import type {
   HandlerMapping,
   InterceptorLike,
   InterceptorContext,
+  MiddlewareContext,
   MiddlewareLike,
   RequestContext,
   RequestObservationContext,
@@ -214,34 +215,38 @@ async function notifyRequestFinish(context: DispatchPhaseContext): Promise<void>
 async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void> {
   ensureRequestNotAborted(context.requestContext.request);
 
-  await runMiddlewareChain(context.options.appMiddleware ?? [], {
+  const appMiddlewareContext: MiddlewareContext = {
     request: context.requestContext.request,
     requestContext: context.requestContext,
     response: context.response,
-  }, async () => {
+  };
+
+  await runMiddlewareChain(context.options.appMiddleware ?? [], appMiddlewareContext, async () => {
     if (context.response.committed) {
       return;
     }
 
-    const match = matchHandlerOrThrow(context.options.handlerMapping, context.requestContext.request);
+    const match = matchHandlerOrThrow(context.options.handlerMapping, appMiddlewareContext.request);
     context.matchedHandler = match.descriptor;
     updateRequestParams(context.requestContext, match.params);
     await notifyHandlerMatched(context, match.descriptor);
 
-      await runMiddlewareChain(match.descriptor.metadata.moduleMiddleware ?? [], {
-        request: context.requestContext.request,
-        requestContext: context.requestContext,
-        response: context.response,
-      }, async () => {
-        await dispatchMatchedHandler(
-          match.descriptor,
-          context.requestContext,
-          context.observers,
-          context.contentNegotiation,
-          context.options.interceptors,
-        );
-      });
+    const moduleMiddlewareContext: MiddlewareContext = {
+      request: appMiddlewareContext.request,
+      requestContext: context.requestContext,
+      response: context.response,
+    };
+
+    await runMiddlewareChain(match.descriptor.metadata.moduleMiddleware ?? [], moduleMiddlewareContext, async () => {
+      await dispatchMatchedHandler(
+        match.descriptor,
+        context.requestContext,
+        context.observers,
+        context.contentNegotiation,
+        context.options.interceptors,
+      );
     });
+  });
 }
 
 async function handleDispatchError(context: DispatchPhaseContext, error: unknown): Promise<void> {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -623,13 +623,8 @@ function createGlobalPrefixMiddleware(prefix: string, exclude: readonly string[]
       }
 
       const strippedPath = stripGlobalPrefix(requestPath, normalizedPrefix);
-      const restore = applyScopedGlobalPrefixRequest(context, requestPath, strippedPath);
-
-      try {
-        await next();
-      } finally {
-        restore();
-      }
+      context.request = rewriteGlobalPrefixRequest(context.request, requestPath, strippedPath);
+      await next();
     },
   };
 }
@@ -655,23 +650,6 @@ function rewriteGlobalPrefixRequest(
     ...request,
     path: strippedPath,
     url: rewritePrefixedUrl(request.url, requestPath, strippedPath),
-  };
-}
-
-function applyScopedGlobalPrefixRequest(
-  context: MiddlewareContext,
-  requestPath: string,
-  strippedPath: string,
-): () => void {
-  const originalRequest = context.requestContext.request;
-  const scopedRequest = rewriteGlobalPrefixRequest(originalRequest, requestPath, strippedPath);
-
-  context.request = scopedRequest;
-  context.requestContext.request = scopedRequest;
-
-  return () => {
-    context.request = originalRequest;
-    context.requestContext.request = originalRequest;
   };
 }
 

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -988,6 +988,44 @@ describe('bootstrapApplication', () => {
     await app.close();
   });
 
+  it('removes registered shutdown signal listeners after close', async () => {
+    const logger: ApplicationLogger = {
+      debug() {},
+      error() {},
+      log() {},
+      warn() {},
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const signal = 'SIGTERM' as const;
+    const listenersBefore = process.listeners(signal).length;
+    const port = await findAvailablePort();
+    const app = await runNodeApplication(AppModule, {
+      cors: false,
+      logger,
+      port,
+      shutdownSignals: [signal],
+    });
+
+    expect(process.listeners(signal).length).toBe(listenersBefore + 1);
+
+    await app.close();
+
+    expect(process.listeners(signal).length).toBe(listenersBefore);
+  });
+
   it('supports https startup and reports the https listen URL', async () => {
     const loggerEvents: string[] = [];
     const logger: ApplicationLogger = {

--- a/packages/runtime/src/node-request.test.ts
+++ b/packages/runtime/src/node-request.test.ts
@@ -1,0 +1,78 @@
+import type { IncomingMessage } from 'node:http';
+
+import { describe, expect, it } from 'vitest';
+
+import { createFrameworkRequest } from './node-request.js';
+
+function createIncomingMessage(options: {
+  body?: string | Uint8Array;
+  headers: Record<string, string | string[] | undefined>;
+  method?: string;
+  url?: string;
+}): IncomingMessage {
+  const chunks: Uint8Array[] = [];
+
+  if (options.body !== undefined) {
+    chunks.push(typeof options.body === 'string' ? Buffer.from(options.body, 'utf8') : options.body);
+  }
+
+  return {
+    headers: options.headers,
+    method: options.method ?? 'GET',
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    },
+    url: options.url ?? '/',
+  } as unknown as IncomingMessage;
+}
+
+describe('node request adapter', () => {
+  it('preserves multi-value header arrays without flattening them', async () => {
+    const upstreamValues = ['v1', 'v2'];
+    const request = createIncomingMessage({
+      headers: {
+        'x-multi': upstreamValues,
+      },
+      url: '/headers',
+    });
+
+    const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+
+    upstreamValues.push('v3');
+
+    expect(frameworkRequest.headers['x-multi']).toEqual(['v1', 'v2']);
+  });
+
+  it('parses cookie header arrays without losing cookie boundaries', async () => {
+    const request = createIncomingMessage({
+      headers: {
+        cookie: ['session=abc', 'theme=dark'],
+      },
+      url: '/cookies',
+    });
+
+    const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+
+    expect(frameworkRequest.cookies).toEqual({
+      session: 'abc',
+      theme: 'dark',
+    });
+  });
+
+  it('uses the primary content-type value when duplicate content-type headers are present', async () => {
+    const request = createIncomingMessage({
+      body: '{"ok":true}',
+      headers: {
+        'content-type': ['application/json', 'text/plain'],
+      },
+      method: 'POST',
+      url: '/body',
+    });
+
+    const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+
+    expect(frameworkRequest.body).toEqual({ ok: true });
+  });
+});

--- a/packages/runtime/src/node-request.ts
+++ b/packages/runtime/src/node-request.ts
@@ -30,11 +30,8 @@ export async function createFrameworkRequest(
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
   const url = new URL(request.url ?? '/', 'http://localhost');
-  const headers = Object.fromEntries(
-    Object.entries(request.headers).map(([name, value]) => [name, Array.isArray(value) ? value.join(', ') : value]),
-  );
-
-  const contentType = headers['content-type'];
+  const headers = cloneRequestHeaders(request.headers);
+  const contentType = readPrimaryHeaderValue(headers['content-type']);
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
 
   let body: unknown;
@@ -119,13 +116,29 @@ function parseQueryParams(searchParams: URLSearchParams): Record<string, string 
   return query;
 }
 
-function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
-  if (!cookieHeader) {
+function cloneRequestHeaders(headers: IncomingHttpHeaders): FrameworkRequest['headers'] {
+  const clonedEntries = Object.entries(headers).map(([name, value]) => [name, Array.isArray(value) ? [...value] : value]);
+
+  return Object.fromEntries(clonedEntries);
+}
+
+function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {
+  if (Array.isArray(headerValue)) {
+    return headerValue[0];
+  }
+
+  return headerValue;
+}
+
+function parseCookieHeader(cookieHeader: string | string[] | undefined): Record<string, string> {
+  const normalizedCookieHeader = Array.isArray(cookieHeader) ? cookieHeader.join('; ') : cookieHeader;
+
+  if (!normalizedCookieHeader) {
     return {};
   }
 
   return Object.fromEntries(
-    cookieHeader
+    normalizedCookieHeader
       .split(';')
       .map((pair) => pair.trim())
       .filter(Boolean)

--- a/packages/runtime/src/node-shutdown.ts
+++ b/packages/runtime/src/node-shutdown.ts
@@ -6,16 +6,27 @@ export function registerShutdownSignals(
   app: Application,
   logger: ApplicationLogger,
   signals: false | readonly NodeShutdownSignal[],
-): void {
+): () => void {
   if (signals === false) {
-    return;
+    return () => {};
   }
 
+  const bindings: Array<{ signal: NodeShutdownSignal; handler: () => void }> = [];
+
   for (const signal of signals) {
-    process.once(signal, () => {
+    const handler = () => {
       void closeFromSignal(app, logger, signal);
-    });
+    };
+
+    bindings.push({ signal, handler });
+    process.once(signal, handler);
   }
+
+  return () => {
+    for (const binding of bindings) {
+      process.off(binding.signal, binding.handler);
+    }
+  };
 }
 
 async function closeFromSignal(app: Application, logger: ApplicationLogger, signal: NodeShutdownSignal): Promise<void> {

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -269,7 +269,18 @@ export async function runNodeApplication(
     throw error;
   }
 
-  registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals());
+  const unregisterShutdownSignals = registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals());
+  const close = app.close.bind(app);
+  let shutdownSignalsUnregistered = false;
+
+  app.close = async (signal?: string) => {
+    if (!shutdownSignalsUnregistered) {
+      unregisterShutdownSignals();
+      shutdownSignalsUnregistered = true;
+    }
+
+    await close(signal);
+  };
 
   return app;
 }
@@ -450,13 +461,8 @@ function createGlobalPrefixMiddleware(prefix: string, exclude: readonly string[]
       }
 
       const strippedPath = stripGlobalPrefix(requestPath, normalizedPrefix);
-      const restore = applyScopedGlobalPrefixRequest(context, requestPath, strippedPath);
-
-      try {
-        await next();
-      } finally {
-        restore();
-      }
+      context.request = rewriteGlobalPrefixRequest(context.request, requestPath, strippedPath);
+      await next();
     },
   };
 }
@@ -482,23 +488,6 @@ function rewriteGlobalPrefixRequest(
     ...request,
     path: strippedPath,
     url: rewritePrefixedUrl(request.url, requestPath, strippedPath),
-  };
-}
-
-function applyScopedGlobalPrefixRequest(
-  context: MiddlewareContext,
-  requestPath: string,
-  strippedPath: string,
-): () => void {
-  const originalRequest = context.requestContext.request;
-  const scopedRequest = rewriteGlobalPrefixRequest(originalRequest, requestPath, strippedPath);
-
-  context.request = scopedRequest;
-  context.requestContext.request = scopedRequest;
-
-  return () => {
-    context.request = originalRequest;
-    context.requestContext.request = originalRequest;
   };
 }
 


### PR DESCRIPTION
## Summary
- eliminate implicit/shared mutable metadata behavior by deep-cloning mutable metadata values and synchronizing `metadataSymbol` resolution while preserving `Symbol.metadata` availability for standard decorators
- prevent request/state leakage by scoping global-prefix request rewrites to middleware context, preserving header array semantics in Node request adaptation, and adding explicit runtime tests for header/cookie array behavior
- harden runtime shutdown lifecycle by returning and invoking signal unregistration on application close to avoid listener leaks

## Verification
- `pnpm test packages/core/src/metadata.test.ts packages/core/src/decorator-transform.test.ts packages/http/src/dispatcher.test.ts packages/runtime/src/node-request.test.ts packages/runtime/src/application.test.ts packages/platform-fastify/src/adapter.test.ts`
- `pnpm typecheck`
- `pnpm build`

Closes #350