### PR TITLE
Resolve #361: fix single cookie set-header regression

### DIFF
--- a/packages/passport/src/cookie-manager.ts
+++ b/packages/passport/src/cookie-manager.ts
@@ -157,7 +157,7 @@ export class CookieManager {
         : [];
 
     cookies.push(cookie);
-    response.setHeader('Set-Cookie', cookies);
+    response.setHeader('Set-Cookie', cookies.length === 1 ? cookies[0] : cookies);
   }
 }
 


### PR DESCRIPTION
## Summary

- `CookieManager.appendSetCookie` now passes a scalar `string` (not `string[]`) when exactly one cookie is being set, restoring the expected `Set-Cookie: <value>` behaviour.

## Root Cause

After the #349 structural refactor, `appendSetCookie` unconditionally passed the accumulated `cookies` array to `setHeader`, even when the array held only one entry. Four single-cookie tests expected `response.headers['Set-Cookie']` to be a plain `string`, but received `string[]`.

## Fix

```ts
// before
response.setHeader('Set-Cookie', cookies);

// after
response.setHeader('Set-Cookie', cookies.length === 1 ? cookies[0] : cookies);
```

## Verification

`packages/passport/src/cookie-auth.test.ts` — 17 tests all pass (4 previously failing single-cookie assertions now pass; multi-cookie array tests remain unchanged).

Closes #361