### PR TITLE
Resolve #362: preserve useValue identity and await transport in non-blocking publish

### DIFF
--- a/packages/core/src/metadata/module.ts
+++ b/packages/core/src/metadata/module.ts
@@ -1,8 +1,27 @@
-import { cloneCollection } from './shared.js';
+import { cloneCollection, cloneMutableValue } from './shared.js';
 import { createClonedWeakMapStore } from './store.js';
 import type { ModuleMetadata } from './types.js';
 
 const moduleMetadataStore = createClonedWeakMapStore<Function, ModuleMetadata>(cloneModuleMetadata);
+
+function isValueProvider(provider: unknown): provider is { useValue: unknown } {
+  return typeof provider === 'object' && provider !== null && 'useValue' in provider;
+}
+
+function cloneProvider(provider: unknown): unknown {
+  if (isValueProvider(provider)) {
+    // Shallow-copy the provider descriptor but preserve the useValue reference.
+    // Deep-cloning useValue would sever object identity for externally supplied
+    // instances (e.g. transport adapters) that callers hold references to.
+    return { ...provider };
+  }
+
+  return cloneMutableValue(provider);
+}
+
+function cloneProviders(providers: readonly unknown[] | undefined): unknown[] | undefined {
+  return providers ? providers.map(cloneProvider) : undefined;
+}
 
 function cloneModuleMetadata(metadata: ModuleMetadata): ModuleMetadata {
   return {
@@ -11,7 +30,7 @@ function cloneModuleMetadata(metadata: ModuleMetadata): ModuleMetadata {
     global: metadata.global,
     imports: cloneCollection(metadata.imports),
     middleware: cloneCollection(metadata.middleware),
-    providers: cloneCollection(metadata.providers),
+    providers: cloneProviders(metadata.providers),
   };
 }
 

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -137,7 +137,7 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     if (!publishOptions.waitForHandlers) {
       const backgroundTasks = this.createBackgroundInvocationTasks(matchingDescriptors, event, publishOptions.signal);
       this.runInvocationTasksInBackground(backgroundTasks);
-      this.runInvocationTasksInBackground([transportPublish]);
+      await transportPublish;
 
       return;
     }


### PR DESCRIPTION
## Summary

- Shallow-copies `useValue` provider descriptors in `cloneModuleMetadata` to preserve object identity for externally supplied instances (e.g. transport adapters). Previously, deep-cloning `useValue` caused the service and the test to hold references to different transport objects, so published events were invisible to the test.
- Awaits `transportPublish` directly in the non-blocking (`waitForHandlers: false`) code path instead of wrapping it in `runInvocationTasksInBackground`, ensuring transport publish completes before the publish call returns.

Closes #362