### PR TITLE
Resolve #363: multi-provider scope caching, @All() fallback, cookie decode resilience

### DIFF
--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -111,6 +111,7 @@ export class Container {
   private readonly registrations = new Map<Token, NormalizedProvider>();
   private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
   private readonly requestCache = new Map<Token, Promise<unknown>>();
+  private readonly multiSingletonCache = new WeakMap<NormalizedProvider, Promise<unknown>>();
   private readonly staleDisposalTasks = new Set<Promise<void>>();
   private readonly staleDisposalErrors: unknown[] = [];
   private readonly singletonCache: Map<Token, Promise<unknown>>;
@@ -339,7 +340,25 @@ export class Container {
     const instances: unknown[] = [];
 
     for (const provider of providers) {
-      instances.push(await this.instantiate(provider, chain, activeTokens));
+      if (provider.type === 'existing') {
+        instances.push(await this.resolveWithChain(provider.useExisting as Token, chain, activeTokens));
+        continue;
+      }
+
+      if (provider.scope === 'transient') {
+        instances.push(await this.instantiate(provider, chain, activeTokens));
+        continue;
+      }
+
+      const rootCache = this.root().multiSingletonCache;
+
+      if (!rootCache.has(provider)) {
+        const promise = this.instantiate(provider, chain, activeTokens);
+        rootCache.set(provider, promise);
+        promise.catch(() => rootCache.delete(provider));
+      }
+
+      instances.push(await rootCache.get(provider)!);
     }
 
     return instances;
@@ -571,6 +590,8 @@ export class Container {
     switch (provider.type) {
       case 'value':
         return provider.useValue as T;
+      case 'existing':
+        return await this.resolveWithChain(provider.useExisting as Token<T>, [], new Set());
       case 'factory': {
         if (!provider.useFactory) {
           throw new InvariantError('Factory provider is missing useFactory.');

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -331,7 +331,10 @@ export function createHandlerMapping(sources: HandlerSource[], options?: CreateH
       const method = request.method.toUpperCase() as HttpMethod;
       const requestVersion = versioning.type === VersioningType.URI ? undefined : resolveRequestVersion(request, versioning);
       const incomingSegments = splitPathSegments(request.path);
-      const candidates = descriptorIndex.get(method)?.get(incomingSegments.length) ?? [];
+      const candidates = [
+        ...(descriptorIndex.get(method)?.get(incomingSegments.length) ?? []),
+        ...(descriptorIndex.get('ALL' as HttpMethod)?.get(incomingSegments.length) ?? []),
+      ];
       let firstUnversionedMatch: HandlerMatch | undefined;
 
       for (const candidate of candidates) {

--- a/packages/runtime/src/node-request.ts
+++ b/packages/runtime/src/node-request.ts
@@ -130,6 +130,14 @@ function readPrimaryHeaderValue(headerValue: string | string[] | undefined): str
   return headerValue;
 }
 
+function decodeCookieValue(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}
+
 function parseCookieHeader(cookieHeader: string | string[] | undefined): Record<string, string> {
   const normalizedCookieHeader = Array.isArray(cookieHeader) ? cookieHeader.join('; ') : cookieHeader;
 
@@ -149,7 +157,7 @@ function parseCookieHeader(cookieHeader: string | string[] | undefined): Record<
           return [pair.trim(), ''] as [string, string];
         }
 
-        return [pair.slice(0, index).trim(), decodeURIComponent(pair.slice(index + 1).trim())] as [string, string];
+        return [pair.slice(0, index).trim(), decodeCookieValue(pair.slice(index + 1).trim())] as [string, string];
       }),
   );
 }


### PR DESCRIPTION
## Summary

- **`@konekti/di`**: `resolveMultiProviderInstances` now respects scope. Singleton/request multi-providers are cached per-provider-object in a `WeakMap` so the same instance is returned on every resolve. Transient providers still instantiate fresh each time. `existing`-type multi-providers now correctly resolve their alias target instead of falling through to the unknown-type error.
- **`@konekti/http`**: `createHandlerMapping` match logic now falls back to the `'ALL'` method bucket after the exact-method lookup, making `@All()` routes actually reachable.
- **`@konekti/runtime`**: `parseCookieHeader` wraps `decodeURIComponent` in a try/catch via a `decodeCookieValue` helper, returning the raw value on `URIError` instead of crashing request parsing.

Closes #363