### PR TITLE
Resolve #365: escape HTML in swagger UI title and fix schema fallback

### DIFF
--- a/packages/openapi/src/openapi-module.ts
+++ b/packages/openapi/src/openapi-module.ts
@@ -36,13 +36,22 @@ type OpenApiOptionsProvider =
       useFactory: (...deps: unknown[]) => MaybePromise<OpenApiModuleOptions>;
     };
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
 function createSwaggerUiHtml(title: string): string {
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>${title}</title>
+    <title>${escapeHtml(title)}</title>
     <link rel="stylesheet" href="${SWAGGER_UI_CSS_URL}" />
   </head>
   <body>

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -621,7 +621,7 @@ function buildComponentSchemaShape(
     const rules = entry.validation?.rules ?? [];
     ensureNestedSchemasFromRules(rules, componentSchemas, context);
 
-    const inferred = inferPrimitiveTypeFromRules(rules, context) ?? { type: 'string' };
+    const inferred = inferPrimitiveTypeFromRules(rules, context) ?? {};
     properties[entry.name] = applyValidationConstraints(inferred, rules);
 
     if (isPropertyRequired(entry.binding, entry.validation)) {
@@ -660,7 +660,7 @@ function createParameters(
   return entries.map((entry) => {
     const source = entry.binding.metadata.source as 'cookie' | 'header' | 'path' | 'query';
     const rules = entry.validation?.rules ?? [];
-    const inferred = inferPrimitiveTypeFromRules(rules, context) ?? { type: 'string' as const };
+    const inferred = inferPrimitiveTypeFromRules(rules, context) ?? {};
     const schema = alignParameterSchemaWithRuntimeBindingContract(applyValidationConstraints(inferred, rules), source);
     const isRequired = source === 'path' ? true : isPropertyRequired(entry.binding, entry.validation);
 


### PR DESCRIPTION
Closes #365

- Add `escapeHtml` helper in `openapi-module.ts` to sanitize the swagger UI page title, preventing XSS through user-controlled title values
- Change schema property fallback from `{ type: 'string' }` to `{}` in `schema-builder.ts` to avoid incorrectly coercing unknown property types