### PR TITLE
Resolve #364: fix passport security issues — verified JWT decode, required persistent store, configurable expiry and secret

### DIFF
--- a/packages/passport/src/jwt-refresh-token-adapter.ts
+++ b/packages/passport/src/jwt-refresh-token-adapter.ts
@@ -1,34 +1,137 @@
 import { Inject } from '@konekti/core';
-import { DefaultJwtSigner, DefaultJwtVerifier, JwtConfigurationError, RefreshTokenService as JwtRefreshTokenService } from '@konekti/jwt';
+import {
+  DefaultJwtSigner,
+  DefaultJwtVerifier,
+  JwtConfigurationError,
+  RefreshTokenService as JwtRefreshTokenService,
+  type RefreshTokenStore,
+} from '@konekti/jwt';
 
 import type { RefreshTokenService } from './refresh-token.js';
 
-@Inject([DefaultJwtSigner, DefaultJwtVerifier])
+export const REFRESH_TOKEN_MODULE_OPTIONS = Symbol.for('konekti.passport.refresh-token-module-options');
+
+export interface RefreshTokenModuleOptions {
+  /**
+   * Secret used to sign refresh tokens.
+   * Defaults to the `REFRESH_TOKEN_SECRET` environment variable if not provided.
+   */
+  secret?: string;
+  /**
+   * Refresh token lifetime in seconds.
+   * Defaults to 604800 (7 days) if not provided.
+   */
+  expiresInSeconds?: number;
+  /**
+   * Persistent store for refresh token records.
+   * Pass `'memory'` to explicitly opt into the in-memory store (development / single-instance only).
+   * Omitting this field causes a startup error, ensuring production deployments provide a real store.
+   */
+  store: RefreshTokenStore | 'memory';
+}
+
+function resolveSecret(options: RefreshTokenModuleOptions): string {
+  if (options.secret) {
+    return options.secret;
+  }
+
+  const envSecret = process.env.REFRESH_TOKEN_SECRET;
+  if (!envSecret) {
+    throw new JwtConfigurationError(
+      'Refresh token secret is not configured. Provide it via RefreshTokenModuleOptions.secret or the REFRESH_TOKEN_SECRET environment variable.',
+    );
+  }
+
+  return envSecret;
+}
+
+function createInMemoryStore(): RefreshTokenStore {
+  const records = new Map<string, {
+    id: string;
+    subject: string;
+    family: string;
+    expiresAt: Date;
+    used: boolean;
+    createdAt: Date;
+  }>();
+
+  return {
+    async save(token: {
+      id: string;
+      subject: string;
+      family: string;
+      expiresAt: Date;
+      used: boolean;
+      createdAt: Date;
+    }): Promise<void> {
+      records.set(token.id, token);
+    },
+
+    async find(tokenId: string) {
+      return records.get(tokenId);
+    },
+
+    async revoke(tokenId: string): Promise<void> {
+      records.delete(tokenId);
+    },
+
+    async revokeBySubject(subject: string): Promise<void> {
+      for (const [id, record] of records.entries()) {
+        if (record.subject === subject) {
+          records.delete(id);
+        }
+      }
+    },
+
+    async consume(input: { tokenId: string; subject: string; family: string; now: Date }) {
+      const record = records.get(input.tokenId);
+
+      if (!record) {
+        return 'not_found';
+      }
+
+      if (record.subject !== input.subject || record.family !== input.family) {
+        return 'mismatch';
+      }
+
+      if (record.expiresAt.getTime() <= input.now.getTime()) {
+        return 'expired';
+      }
+
+      if (record.used) {
+        return 'already_used';
+      }
+
+      records.set(input.tokenId, { ...record, used: true });
+      return 'consumed';
+    },
+  };
+}
+
+@Inject([DefaultJwtSigner, DefaultJwtVerifier, REFRESH_TOKEN_MODULE_OPTIONS])
 export class JwtRefreshTokenAdapter implements RefreshTokenService {
   private readonly service: JwtRefreshTokenService;
 
-  private static resolveSecret(): string {
-    const secret = process.env.REFRESH_TOKEN_SECRET;
-
-    if (!secret) {
+  constructor(
+    signer: DefaultJwtSigner,
+    verifier: DefaultJwtVerifier,
+    options: RefreshTokenModuleOptions,
+  ) {
+    if (!options.store) {
       throw new JwtConfigurationError(
-        'REFRESH_TOKEN_SECRET environment variable is required. Set it to a strong, random secret.',
+        'JwtRefreshTokenAdapter requires a persistent RefreshTokenStore. ' +
+        'Provide one via RefreshTokenModuleOptions.store, or pass store: \'memory\' to explicitly opt into the in-memory store (single-instance / development only).',
       );
     }
 
-    return secret;
-  }
+    const store = options.store === 'memory' ? createInMemoryStore() : options.store;
 
-  constructor(
-    private readonly signer: DefaultJwtSigner,
-    private readonly verifier: DefaultJwtVerifier,
-  ) {
     this.service = new JwtRefreshTokenService(
       {
-        expiresInSeconds: 3600,
+        expiresInSeconds: options.expiresInSeconds ?? 604800,
         rotation: true,
-        secret: JwtRefreshTokenAdapter.resolveSecret(),
-        store: this.createDefaultStore(),
+        secret: resolveSecret(options),
+        store,
       },
       signer,
       verifier,
@@ -49,68 +152,5 @@ export class JwtRefreshTokenAdapter implements RefreshTokenService {
 
   async revokeAllForSubject(subject: string): Promise<void> {
     return this.service.revokeAllForSubject(subject);
-  }
-
-  private createDefaultStore() {
-    const records = new Map<string, {
-      id: string;
-      subject: string;
-      family: string;
-      expiresAt: Date;
-      used: boolean;
-      createdAt: Date;
-    }>();
-
-    return {
-      async save(token: {
-        id: string;
-        subject: string;
-        family: string;
-        expiresAt: Date;
-        used: boolean;
-        createdAt: Date;
-      }): Promise<void> {
-        records.set(token.id, token);
-      },
-
-      async find(tokenId: string) {
-        return records.get(tokenId);
-      },
-
-      async revoke(tokenId: string): Promise<void> {
-        records.delete(tokenId);
-      },
-
-      async revokeBySubject(subject: string): Promise<void> {
-        for (const [id, record] of records.entries()) {
-          if (record.subject === subject) {
-            records.delete(id);
-          }
-        }
-      },
-
-      async consume(input: { tokenId: string; subject: string; family: string; now: Date }) {
-        const record = records.get(input.tokenId);
-
-        if (!record) {
-          return 'not_found';
-        }
-
-        if (record.subject !== input.subject || record.family !== input.family) {
-          return 'mismatch';
-        }
-
-        if (record.expiresAt.getTime() <= input.now.getTime()) {
-          return 'expired';
-        }
-
-        if (record.used) {
-          return 'already_used';
-        }
-
-        records.set(input.tokenId, { ...record, used: true });
-        return 'consumed';
-      },
-    };
   }
 }

--- a/packages/passport/src/refresh-token.test.ts
+++ b/packages/passport/src/refresh-token.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import type { DefaultJwtVerifier } from '@konekti/jwt';
 import { JwtExpiredTokenError, JwtInvalidTokenError } from '@konekti/jwt';
 
 import { AuthenticationExpiredError, AuthenticationFailedError, AuthenticationRequiredError } from './errors.js';
@@ -11,13 +12,20 @@ function createMockRefreshTokenService(overrides: Partial<RefreshTokenService> =
   return {
     issueRefreshToken: vi.fn().mockResolvedValue('mock-refresh-token'),
     rotateRefreshToken: vi.fn().mockResolvedValue({
-      accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyLTEiLCJpYXQiOjE1MTYyMzkwMjJ9.SflKxwRJSMeKKF2QT4fwpMfTLZfFJcKz6U6Jbc6GFcU',
+      accessToken: 'mock-access-token',
       refreshToken: 'new-refresh-token',
     }),
     revokeRefreshToken: vi.fn().mockResolvedValue(undefined),
     revokeAllForSubject: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
+}
+
+function createMockVerifier(subject = 'user-1'): DefaultJwtVerifier {
+  return {
+    verifyAccessToken: vi.fn().mockResolvedValue({ claims: { sub: subject } }),
+    verifyRefreshToken: vi.fn().mockResolvedValue({ claims: { sub: subject } }),
+  } as unknown as DefaultJwtVerifier;
 }
 
 function createGuardContext(body?: Record<string, unknown>, headers?: Record<string, string | string[]>): GuardContext {
@@ -46,7 +54,7 @@ describe('RefreshTokenStrategy', () => {
   describe('authenticate', () => {
     it('authenticates with refresh token from request body', async () => {
       const service = createMockRefreshTokenService();
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext({ refreshToken: 'valid-token' });
 
       const result = await strategy.authenticate(context);
@@ -63,7 +71,7 @@ describe('RefreshTokenStrategy', () => {
 
     it('authenticates with refresh token from authorization header', async () => {
       const service = createMockRefreshTokenService();
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext(undefined, { authorization: 'Bearer header-token' });
 
       const result = await strategy.authenticate(context);
@@ -76,7 +84,7 @@ describe('RefreshTokenStrategy', () => {
 
     it('authenticates with refresh token from custom header', async () => {
       const service = createMockRefreshTokenService();
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext(undefined, { 'x-refresh-token': 'custom-token' });
 
       const result = await strategy.authenticate(context);
@@ -89,7 +97,7 @@ describe('RefreshTokenStrategy', () => {
 
     it('handles array authorization header by using first element', async () => {
       const service = createMockRefreshTokenService();
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext(undefined, { authorization: ['Bearer array-token', 'Bearer second-token'] });
 
       const result = await strategy.authenticate(context);
@@ -102,7 +110,7 @@ describe('RefreshTokenStrategy', () => {
 
     it('handles array x-refresh-token header by using first element', async () => {
       const service = createMockRefreshTokenService();
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext(undefined, { 'x-refresh-token': ['custom-array-token'] });
 
       const result = await strategy.authenticate(context);
@@ -115,7 +123,7 @@ describe('RefreshTokenStrategy', () => {
 
     it('throws AuthenticationRequiredError when no token is provided', async () => {
       const service = createMockRefreshTokenService();
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext();
 
       await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
@@ -125,7 +133,7 @@ describe('RefreshTokenStrategy', () => {
       const service = createMockRefreshTokenService({
         rotateRefreshToken: vi.fn().mockRejectedValue(new JwtExpiredTokenError('Refresh token has expired.')),
       });
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext({ refreshToken: 'expired-token' });
 
       await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationExpiredError);
@@ -135,7 +143,7 @@ describe('RefreshTokenStrategy', () => {
       const service = createMockRefreshTokenService({
         rotateRefreshToken: vi.fn().mockRejectedValue(new JwtInvalidTokenError('Refresh token reuse detected.')),
       });
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext({ refreshToken: 'reused-token' });
 
       await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationFailedError);
@@ -145,7 +153,7 @@ describe('RefreshTokenStrategy', () => {
       const service = createMockRefreshTokenService({
         rotateRefreshToken: vi.fn().mockRejectedValue(new JwtInvalidTokenError('Invalid token')),
       });
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
       const context = createGuardContext({ refreshToken: 'invalid-token' });
 
       await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationFailedError);
@@ -155,7 +163,7 @@ describe('RefreshTokenStrategy', () => {
   describe('concurrent refresh attempts', () => {
     it('handles concurrent rotation attempts', async () => {
       const service = createMockRefreshTokenService();
-      const strategy = new RefreshTokenStrategy(service);
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
 
       const [first, second] = await Promise.allSettled([
         strategy.authenticate(createGuardContext({ refreshToken: 'token-1' })),

--- a/packages/passport/src/refresh-token.ts
+++ b/packages/passport/src/refresh-token.ts
@@ -1,6 +1,6 @@
 import type { GuardContext, RequestContext } from '@konekti/http';
 import { Inject, type Token } from '@konekti/core';
-import { JwtExpiredTokenError, JwtInvalidTokenError } from '@konekti/jwt';
+import { DefaultJwtVerifier, JwtExpiredTokenError, JwtInvalidTokenError } from '@konekti/jwt';
 
 import {
   AuthenticationExpiredError,
@@ -28,9 +28,12 @@ export interface RefreshTokenAuthResult {
   subject: string;
 }
 
-@Inject([REFRESH_TOKEN_SERVICE])
+@Inject([REFRESH_TOKEN_SERVICE, DefaultJwtVerifier])
 export class RefreshTokenStrategy implements AuthStrategy {
-  constructor(private readonly refreshTokenService: RefreshTokenService) {}
+  constructor(
+    private readonly refreshTokenService: RefreshTokenService,
+    private readonly verifier: DefaultJwtVerifier,
+  ) {}
 
   async authenticate(context: GuardContext): Promise<AuthStrategyResult> {
     const request = context.requestContext.request;
@@ -42,15 +45,21 @@ export class RefreshTokenStrategy implements AuthStrategy {
 
     try {
       const result = await this.refreshTokenService.rotateRefreshToken(refreshToken);
-      
+      const subject = await this.extractVerifiedSubject(result.accessToken);
+
       return {
         claims: {
           accessToken: result.accessToken,
           refreshToken: result.refreshToken,
         },
-        subject: this.extractSubjectFromToken(result.accessToken),
+        subject,
       };
     } catch (error: unknown) {
+      if (error instanceof AuthenticationRequiredError
+        || error instanceof AuthenticationExpiredError
+        || error instanceof AuthenticationFailedError) {
+        throw error;
+      }
       if (error instanceof JwtExpiredTokenError) {
         throw new AuthenticationExpiredError('Refresh token has expired.');
       }
@@ -76,14 +85,13 @@ export class RefreshTokenStrategy implements AuthStrategy {
     return Array.isArray(customHeader) ? customHeader[0] : customHeader;
   }
 
-  private extractSubjectFromToken(accessToken: string): string {
-    try {
-      const payload = accessToken.split('.')[1];
-      const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
-      return decoded.sub || 'unknown';
-    } catch {
-      return 'unknown';
+  private async extractVerifiedSubject(accessToken: string): Promise<string> {
+    const principal = await this.verifier.verifyAccessToken(accessToken);
+    const sub = principal.claims.sub;
+    if (typeof sub !== 'string' || sub.length === 0) {
+      throw new AuthenticationFailedError('Access token is missing a valid subject claim.');
     }
+    return sub;
   }
 }
 


### PR DESCRIPTION
Closes #364

Three P0 security issues fixed in `packages/passport`:

1. **Unverified JWT decode removed** (`refresh-token.ts`): `extractSubjectFromToken` previously base64-decoded the access token without signature verification. Now injects `DefaultJwtVerifier` and calls `verifyAccessToken()` to cryptographically verify the token before trusting the `sub` claim.

2. **In-memory store now requires explicit opt-in** (`jwt-refresh-token-adapter.ts`): The default `RefreshTokenStore` is no longer silently in-memory. Callers must pass `store: 'memory'` to explicitly opt into the in-memory store, or provide a persistent `RefreshTokenStore` via the new `REFRESH_TOKEN_MODULE_OPTIONS` DI token. A missing store throws at construction time.

3. **Configurable `expiresInSeconds` and `secret`** (`jwt-refresh-token-adapter.ts`): Both are now accepted via `RefreshTokenModuleOptions` injected through `REFRESH_TOKEN_MODULE_OPTIONS`. `expiresInSeconds` defaults to 604800 (7 days). `secret` falls back to `REFRESH_TOKEN_SECRET` env var, consistent with prior behavior.