### PR TITLE
Resolve #366: runtime lifecycle fixes

### DIFF
--- a/packages/http/src/dispatcher.ts
+++ b/packages/http/src/dispatcher.ts
@@ -291,6 +291,7 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
           await handleDispatchError(phaseContext, error);
         } finally {
           await notifyRequestFinish(phaseContext);
+          await phaseContext.requestContext.container.dispose();
         }
       });
     },

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -361,7 +361,11 @@ class KonektiApplication implements Application {
         cleanup();
       }
 
-      await runShutdownHooks(this.lifecycleInstances, signal);
+      try {
+        await runShutdownHooks(this.lifecycleInstances, signal);
+      } catch (error) {
+        console.error('[konekti] shutdown hook threw an error:', error);
+      }
       await this.adapter.close(signal);
       await disposeContainer(this.container);
       this.closed = true;

--- a/packages/runtime/src/node-response.ts
+++ b/packages/runtime/src/node-response.ts
@@ -65,13 +65,11 @@ export function createFrameworkResponse(response: ServerResponse, acceptEncoding
       if (acceptEncoding && payload.byteLength >= 256) {
         this.committed = true;
 
-        compressResponse(response, payload, acceptEncoding, contentType).catch(() => {
+        return compressResponse(response, payload, acceptEncoding, contentType).catch(() => {
           if (!response.writableEnded) {
             response.end();
           }
         });
-
-        return;
       }
 
       response.end(payload);


### PR DESCRIPTION
## Summary

- Await compressed response so the HTTP response is not cut short
- Dispose request-scoped DI container in dispatcher `finally` block to prevent memory leaks
- Wrap `runShutdownHooks` in try/catch so `adapter.close()` and `disposeContainer()` always run even if a shutdown hook throws

Closes #366