### PR TITLE
Resolve #369: CORS Vary append, busboy stop on maxFiles, array body rejection, forced-exit timeout

### DIFF
--- a/packages/http/src/binding.ts
+++ b/packages/http/src/binding.ts
@@ -47,6 +47,11 @@ function readSourceValue(
       return request.cookies[resolvedKey];
     case 'body': {
       if (!isPlainObject(request.body)) {
+        if (request.body !== undefined && request.body !== null) {
+          throw new BadRequestException('Request body must be a plain object.', {
+            details: [toInputErrorDetail({ code: 'INVALID_BODY', message: 'Request body must be a plain object.', source: 'body' })],
+          });
+        }
         return undefined;
       }
 

--- a/packages/http/src/cors.ts
+++ b/packages/http/src/cors.ts
@@ -69,7 +69,12 @@ export function createCorsMiddleware(options: CorsOptions = {}): Middleware {
       );
 
       if (origin && origin !== '*') {
-        context.response.setHeader('Vary', 'Origin');
+        const existingVary = context.response.headers['vary'] ?? context.response.headers['Vary'];
+        const varyValues = existingVary ? (Array.isArray(existingVary) ? existingVary : String(existingVary).split(',').map((v) => v.trim())) : [];
+        if (!varyValues.some((v) => v.toLowerCase() === 'origin')) {
+          varyValues.push('Origin');
+        }
+        context.response.setHeader('Vary', varyValues.join(', '));
       }
 
       if (context.request.method === 'OPTIONS') {

--- a/packages/runtime/src/multipart.ts
+++ b/packages/runtime/src/multipart.ts
@@ -64,6 +64,8 @@ export function parseMultipart(request: IncomingMessage, options: MultipartOptio
       if (fileCount > maxFiles) {
         fileStream.resume();
         rejectOnce(new PayloadTooLargeException(`Exceeded maximum file count of ${String(maxFiles)}.`));
+        request.unpipe(bb);
+        bb.destroy();
         return;
       }
 

--- a/packages/runtime/src/node-shutdown.ts
+++ b/packages/runtime/src/node-shutdown.ts
@@ -2,10 +2,13 @@ import type { Application, ApplicationLogger } from './types.js';
 
 type NodeShutdownSignal = 'SIGINT' | 'SIGTERM';
 
+const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
+
 export function registerShutdownSignals(
   app: Application,
   logger: ApplicationLogger,
   signals: false | readonly NodeShutdownSignal[],
+  forceExitTimeoutMs: number = DEFAULT_FORCE_EXIT_TIMEOUT_MS,
 ): () => void {
   if (signals === false) {
     return () => {};
@@ -15,7 +18,7 @@ export function registerShutdownSignals(
 
   for (const signal of signals) {
     const handler = () => {
-      void closeFromSignal(app, logger, signal);
+      void closeFromSignal(app, logger, signal, forceExitTimeoutMs);
     };
 
     bindings.push({ signal, handler });
@@ -29,16 +32,27 @@ export function registerShutdownSignals(
   };
 }
 
-async function closeFromSignal(app: Application, logger: ApplicationLogger, signal: NodeShutdownSignal): Promise<void> {
+async function closeFromSignal(app: Application, logger: ApplicationLogger, signal: NodeShutdownSignal, forceExitTimeoutMs: number): Promise<void> {
   if (app.state === 'closed') {
     process.exitCode = 0;
     return;
   }
 
+  const forceExitTimer = setTimeout(() => {
+    logger.error(`Forced exit after ${String(forceExitTimeoutMs)}ms shutdown timeout.`, undefined, 'KonektiFactory');
+    process.exit(1);
+  }, forceExitTimeoutMs);
+
+  if (forceExitTimer.unref) {
+    forceExitTimer.unref();
+  }
+
   try {
     await app.close(signal);
+    clearTimeout(forceExitTimer);
     process.exitCode = 0;
   } catch (error: unknown) {
+    clearTimeout(forceExitTimer);
     logger.error('Failed to shut down the application cleanly.', error, 'KonektiFactory');
     process.exitCode = 1;
   }

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -79,6 +79,7 @@ export interface BootstrapNodeApplicationOptions extends Omit<CreateApplicationO
 }
 
 export interface RunNodeApplicationOptions extends BootstrapNodeApplicationOptions {
+  forceExitTimeoutMs?: number;
   shutdownSignals?: false | readonly NodeApplicationSignal[];
 }
 
@@ -269,7 +270,7 @@ export async function runNodeApplication(
     throw error;
   }
 
-  const unregisterShutdownSignals = registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals());
+  const unregisterShutdownSignals = registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals(), options.forceExitTimeoutMs);
   const close = app.close.bind(app);
   let shutdownSignalsUnregistered = false;
 


### PR DESCRIPTION
## Summary

- Append `Origin` to existing `Vary` header instead of overwriting it to prevent CDN caching bugs
- Unpipe request and destroy busboy after `maxFiles` limit to prevent memory exhaustion
- Throw `BadRequestException` in `readSourceValue` when request body is a non-plain-object (e.g. arrays) instead of silently returning `undefined`
- Add configurable `forceExitTimeoutMs` to `RunNodeApplicationOptions`; if shutdown hangs past the timeout, log a warning and call `process.exit(1)`

Closes #369