### PR TITLE
Resolve #367: cache-manager stampede, redis TTL race, eviction fallback

### DIFF
--- a/packages/cache-manager/src/cache-service.test.ts
+++ b/packages/cache-manager/src/cache-service.test.ts
@@ -15,13 +15,35 @@ const baseOptions: NormalizedCacheModuleOptions = {
 
 class MockRedisClient {
   readonly storage = new Map<string, string>();
+  private readonly expiry = new Map<string, number>();
 
   async get(key: string): Promise<string | null> {
+    const expiresAt = this.expiry.get(key);
+
+    if (expiresAt !== undefined && Date.now() >= expiresAt) {
+      this.storage.delete(key);
+      this.expiry.delete(key);
+      return null;
+    }
+
     return this.storage.get(key) ?? null;
   }
 
   async set(key: string, value: string, ...args: Array<string | number>): Promise<'OK'> {
     this.storage.set(key, value);
+
+    const exIndex = args.findIndex((a) => a === 'EX');
+
+    if (exIndex >= 0) {
+      const ttlSeconds = Number(args[exIndex + 1]);
+
+      if (Number.isFinite(ttlSeconds) && ttlSeconds > 0) {
+        this.expiry.set(key, Date.now() + ttlSeconds * 1000);
+      }
+    } else {
+      this.expiry.delete(key);
+    }
+
     return 'OK';
   }
 

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -108,6 +108,8 @@ async function resolveCacheKeyValue(
   return metadata(context);
 }
 
+const EVICTION_FALLBACK_TIMEOUT_MS = 5_000;
+
 function installDeferredEviction(
   response: InterceptorContext['requestContext']['response'],
   evict: () => Promise<void>,
@@ -116,23 +118,33 @@ function installDeferredEviction(
   let restored = false;
   let completed = false;
 
+  const runEviction = () => {
+    if (completed) {
+      return;
+    }
+
+    completed = true;
+    void evict();
+  };
+
   const restore = () => {
     if (restored) {
       return;
     }
 
+    clearTimeout(fallbackTimer);
     response.send = originalSend;
     restored = true;
   };
 
+  const fallbackTimer = setTimeout(() => {
+    runEviction();
+    restore();
+  }, EVICTION_FALLBACK_TIMEOUT_MS);
+
   response.send = async (body: unknown) => {
     await originalSend(body);
-
-    if (!completed) {
-      completed = true;
-      await evict();
-    }
-
+    runEviction();
     restore();
   };
 

--- a/packages/cache-manager/src/redis-store.test.ts
+++ b/packages/cache-manager/src/redis-store.test.ts
@@ -68,14 +68,14 @@ describe('RedisStore', () => {
     expect(cached).toEqual({ id: 'u1' });
   });
 
-  it('deletes malformed payloads on read', async () => {
+  it('returns undefined for malformed payloads without deleting', async () => {
     const client = new MockRedisClient();
     const store = new RedisStore(client, { keyPrefix: 'cache:' });
 
     client.storage.set('cache:bad', '{"expiresAt": "not-number"}');
 
     await expect(store.get('bad')).resolves.toBeUndefined();
-    expect(client.deletedKeys).toContainEqual(['cache:bad']);
+    expect(client.deletedKeys).not.toContainEqual(['cache:bad']);
   });
 
   it('uses scoped scan+del reset instead of flush-all behavior', async () => {

--- a/packages/cache-manager/src/redis-store.ts
+++ b/packages/cache-manager/src/redis-store.ts
@@ -60,7 +60,6 @@ export class RedisStore implements CacheStore {
   }
 
   async get<T = unknown>(key: string): Promise<T | undefined> {
-    const now = Date.now();
     const redisKey = this.toRedisKey(key);
     const raw = await this.client.get(redisKey);
 
@@ -70,8 +69,7 @@ export class RedisStore implements CacheStore {
 
     const decoded = parseEntry(raw);
 
-    if (!decoded || (decoded.expiresAt !== undefined && now >= decoded.expiresAt)) {
-      await this.client.del(redisKey);
+    if (!decoded) {
       return undefined;
     }
 

--- a/packages/cache-manager/src/service.ts
+++ b/packages/cache-manager/src/service.ts
@@ -5,6 +5,8 @@ import type { CacheStore, NormalizedCacheModuleOptions } from './types.js';
 
 @Inject([CACHE_STORE, CACHE_OPTIONS])
 export class CacheService {
+  private readonly inflight = new Map<string, Promise<unknown>>();
+
   constructor(
     private readonly store: CacheStore,
     private readonly options: NormalizedCacheModuleOptions,
@@ -35,9 +37,21 @@ export class CacheService {
       return cached;
     }
 
-    const value = await loader();
-    await this.set(key, value, ttlSeconds);
-    return value;
+    const existing = this.inflight.get(key) as Promise<T> | undefined;
+
+    if (existing) {
+      return existing;
+    }
+
+    const promise = loader().then(async (value) => {
+      await this.set(key, value, ttlSeconds);
+      return value;
+    }).finally(() => {
+      this.inflight.delete(key);
+    });
+
+    this.inflight.set(key, promise);
+    return promise;
   }
 
   async del(key: string): Promise<void> {


### PR DESCRIPTION
## Summary

- **Fix 1** (`service.ts`): Add singleflight pattern to `remember()` using an `inflight` Map — prevents cache stampede when multiple concurrent requests miss the cache for the same key
- **Fix 2** (`redis-store.ts`): Remove app-level `expiresAt` check + `del` in `get()` — rely solely on Redis native TTL (`EX`) to avoid a non-atomic read-check-delete race condition
- **Fix 3** (`interceptor.ts`): Add 5 s timeout-based fallback in `installDeferredEviction` — ensures eviction always fires even on non-send code paths (e.g. streaming or early return)
- Update tests to reflect new contracts: mock Redis client honours `EX` TTL via fake timers; malformed payload test no longer expects a proactive `del`

Closes #367