### PR TITLE
Resolve #385: encode throttler store-key segments

### DIFF
--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -97,7 +97,7 @@ class AppBootstrap {
 ## 동작 방식
 
 - 속도 제한 키의 기본값은 `socket.remoteAddress`입니다. 헤더 기반 키(예: `x-api-key`)를 사용하려면 `keyGenerator`를 제공하세요.
-- 저장소 키는 `throttler:<handler-key>:<client-key>` 형태로 구성됩니다. 여기서 `<handler-key>`는 클래스나 메서드 이름이 같은 핸들러 간의 충돌을 방지하기 위해 경로 메서드/경로/버전 및 컨트롤러/모듈 토큰 식별자를 포함합니다.
+- 저장소 키는 `throttler:<encoded-handler-key>:<encoded-client-key>` 형태로 구성됩니다. 두 키 세그먼트는 모두 `encodeURIComponent(...)`로 인코딩되므로 IPv6 주소처럼 `:`를 포함하는 클라이언트 키도 구분자 경계와 충돌하지 않습니다. 디코딩된 `<handler-key>`에는 클래스나 메서드 이름이 같은 핸들러 간의 충돌을 방지하기 위한 경로 메서드/경로/버전 및 컨트롤러/모듈 토큰 식별자가 포함됩니다.
 - 제한을 초과하면 `ThrottlerGuard`는 `TooManyRequestsException` (HTTP 429)을 발생시키고, `Retry-After` 응답 헤더에 현재 윈도우에 남은 시간을 초 설정합니다.
 - 메서드 레벨의 `@Throttle`은 클래스 레벨의 `@Throttle`을 오버라이드하며, 클래스 레벨은 모듈 레벨의 기본값을 오버라이드합니다 (이 우선순위 순서대로 적용).
 - 어느 레벨에서든 `@SkipThrottle()`이 설정되면 무조건 우선권을 갖습니다.

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -97,7 +97,7 @@ class AppBootstrap {
 ## Behavior
 
 - Rate limit key defaults to `socket.remoteAddress`. Provide `keyGenerator` for header-based keying (e.g. `x-api-key`).
-- Store keys are composed as `throttler:<handler-key>:<client-key>`, where `<handler-key>` includes route method/path/version and controller/module token identities to prevent collisions between handlers that share class or method names.
+- Store keys are composed as `throttler:<encoded-handler-key>:<encoded-client-key>`. Both key segments are encoded with `encodeURIComponent(...)`, so client keys containing `:` (for example IPv6 addresses) cannot collide with separator boundaries. The decoded `<handler-key>` still includes route method/path/version and controller/module token identities to prevent collisions between handlers that share class or method names.
 - When the limit is exceeded, `ThrottlerGuard` throws `TooManyRequestsException` (HTTP 429) and sets the `Retry-After` response header to the seconds remaining in the current window.
 - Method-level `@Throttle` overrides class-level `@Throttle`, which overrides module-level defaults — in that priority order.
 - `@SkipThrottle()` at either level wins unconditionally.

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -39,7 +39,10 @@ function defaultKeyGenerator(ctx: MiddlewareContext): string {
 }
 
 function buildStoreKey(handlerKey: string, clientKey: string): string {
-  return `throttler:${handlerKey}:${clientKey}`;
+  const encodedHandlerKey = encodeURIComponent(handlerKey);
+  const encodedClientKey = encodeURIComponent(clientKey);
+
+  return `throttler:${encodedHandlerKey}:${encodedClientKey}`;
 }
 
 function getFunctionIdentity(value: Function): number {

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -407,7 +407,7 @@ describe('ThrottlerGuard — Redis store mock', () => {
     };
 
     const guard = new ThrottlerGuard({ limit: 2, store, ttl: 60 });
-    const ctx = createRequestContext('10.0.0.9');
+    const ctx = createRequestContext('2001:db8::1');
     class RateController {
       hit() {}
     }
@@ -424,12 +424,26 @@ describe('ThrottlerGuard — Redis store mock', () => {
 
     const key = vi.mocked(store.consume).mock.calls[0]?.[0];
 
-    expect(key).toContain('method:POST');
-    expect(key).toContain('path:%2Fv1%2Frate-limit');
-    expect(key).toContain('version:1');
-    expect(key).toContain('handler:hit');
-    expect(key).toContain('module:');
-    expect(key).toContain('controller:');
-    expect(key).toContain(':10.0.0.9');
+    expect(key).toBeDefined();
+
+    const delimiterCount = (key?.match(/:/g) ?? []).length;
+    expect(delimiterCount).toBe(2);
+
+    const [prefix, encodedHandler, encodedClient] = key?.split(':', 3) ?? [];
+
+    expect(prefix).toBe('throttler');
+    expect(encodedHandler).toBeTruthy();
+    expect(encodedClient).toBeTruthy();
+
+    const decodedHandler = decodeURIComponent(encodedHandler ?? '');
+    const decodedClient = decodeURIComponent(encodedClient ?? '');
+
+    expect(decodedHandler).toContain('method:POST');
+    expect(decodedHandler).toContain('path:%2Fv1%2Frate-limit');
+    expect(decodedHandler).toContain('version:1');
+    expect(decodedHandler).toContain('handler:hit');
+    expect(decodedHandler).toContain('module:');
+    expect(decodedHandler).toContain('controller:');
+    expect(decodedClient).toBe('2001:db8::1');
   });
 });


### PR DESCRIPTION
## Summary
- encode both `handlerKey` and `clientKey` with `encodeURIComponent(...)` before composing throttler store keys
- add a regression assertion that IPv6 client keys keep only two raw `:` delimiters in composed store keys
- update throttler README docs (EN/KO) to document the encoded key format

## Verification
- `pnpm build`
- `pnpm test packages/throttler/src/module.test.ts`
- `pnpm --filter @konekti/throttler typecheck`

Closes #385