### PR TITLE
Resolve #383: preserve symbol-keyed methods in createDeepMock

### DIFF
--- a/packages/testing/src/mock.ts
+++ b/packages/testing/src/mock.ts
@@ -52,7 +52,7 @@ export function createDeepMock<T extends object>(type: new (...args: unknown[]) 
 
       const descriptor = Object.getOwnPropertyDescriptor(proto, key);
       if (descriptor && typeof descriptor.value === 'function') {
-        spies[key as string] = vi.fn();
+        spies[key] = vi.fn();
       }
     }
     proto = Object.getPrototypeOf(proto) as object | null;

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -711,6 +711,23 @@ describe('createDeepMock', () => {
     const mock = createDeepMock(Child);
     expect(vi.isMockFunction(mock.method)).toBe(true);
   });
+
+  it('wraps symbol-keyed methods in a vi.fn() spy', () => {
+    const MY_METHOD = Symbol('myMethod');
+
+    class SymbolService {
+      [MY_METHOD]() {
+        return 42;
+      }
+    }
+
+    const mock = createDeepMock(SymbolService);
+
+    expect(vi.isMockFunction(mock[MY_METHOD])).toBe(true);
+
+    mock[MY_METHOD]();
+    expect(mock[MY_METHOD]).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('mockToken', () => {


### PR DESCRIPTION
## Summary
- stop coercing prototype keys to strings when building deep mock spies
- preserve symbol keys so symbol-named class methods resolve to `vi.fn()` as expected
- add a regression test that validates symbol-keyed methods are mocked and callable

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm exec vitest run packages/testing/src/module.test.ts`

Closes #383