### PR TITLE
Resolve #381: passport strategy registry ignores inherited prototype keys

### DIFF
--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -87,6 +87,41 @@ describe('AuthGuard', () => {
     expect(response.body).toEqual({ subject: 'mock-user' });
   });
 
+  it('resolves strategies whose names shadow Object.prototype keys', async () => {
+    class ToStringStrategy implements AuthStrategy {
+      async authenticate() {
+        return {
+          claims: { source: 'prototype-safe' },
+          subject: 'prototype-safe-user',
+        };
+      }
+    }
+
+    @Controller('/profile')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth('toString')
+      getProfile(_input: unknown, ctx: { principal?: { subject: string } }) {
+        return { subject: ctx.principal?.subject };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      ToStringStrategy,
+      ...createPassportProviders({ defaultStrategy: 'toString' }, [{ name: 'toString', token: ToStringStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/profile'), response);
+
+    expect(response.body).toEqual({ subject: 'prototype-safe-user' });
+  });
+
   it('maps authentication-required failures to a canonical 401 response', async () => {
     class MissingCredentialsStrategy implements AuthStrategy {
       async authenticate(_context: GuardContext): Promise<never> {

--- a/packages/passport/src/guard.ts
+++ b/packages/passport/src/guard.ts
@@ -45,6 +45,10 @@ function isAuthenticationFailure(error: unknown): boolean {
   );
 }
 
+function hasRegisteredStrategy(registry: AuthStrategyRegistry, strategyName: string): boolean {
+  return Object.prototype.hasOwnProperty.call(registry, strategyName);
+}
+
 @Inject([AUTH_STRATEGY_REGISTRY, PASSPORT_OPTIONS])
 export class AuthGuard implements AuthGuardContract {
   constructor(
@@ -64,11 +68,11 @@ export class AuthGuard implements AuthGuardContract {
       return true;
     }
 
-    const strategyToken = this.strategies[strategyName];
-
-    if (!strategyToken) {
+    if (!hasRegisteredStrategy(this.strategies, strategyName)) {
       throw new AuthStrategyResolutionError(`No auth strategy registered for ${strategyName}.`);
     }
+
+    const strategyToken = this.strategies[strategyName];
 
     const strategy = await context.requestContext.container.resolve(strategyToken as Token<AuthStrategy>).catch((error: unknown) => {
       if (error instanceof ContainerResolutionError) {

--- a/packages/passport/src/module.test.ts
+++ b/packages/passport/src/module.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { AuthStrategyResolutionError } from './errors.js';
 import { createPassportProviders } from './module.js';
-import type { AuthStrategy } from './types.js';
+import { AUTH_STRATEGY_REGISTRY, type AuthStrategy } from './types.js';
 
 describe('createPassportProviders', () => {
   it('throws when duplicate strategy names are registered', () => {
@@ -24,6 +24,56 @@ describe('createPassportProviders', () => {
         [
           { name: 'jwt', token: FirstStrategy },
           { name: 'jwt', token: SecondStrategy },
+        ],
+      ),
+    ).toThrow(AuthStrategyResolutionError);
+  });
+
+  it('allows strategy names that shadow Object.prototype keys', () => {
+    class ToStringStrategy implements AuthStrategy {
+      async authenticate() {
+        return { claims: {}, subject: 'to-string' };
+      }
+    }
+
+    const providers = createPassportProviders(
+      { defaultStrategy: 'toString' },
+      [{ name: 'toString', token: ToStringStrategy }],
+    );
+
+    const strategyRegistryProvider = providers.find(
+      (provider) => typeof provider === 'object' && provider !== null && 'provide' in provider && provider.provide === AUTH_STRATEGY_REGISTRY,
+    );
+
+    if (!strategyRegistryProvider || !('useValue' in strategyRegistryProvider)) {
+      throw new Error('Expected strategy registry provider to be present.');
+    }
+
+    const registry = strategyRegistryProvider.useValue as Record<string, unknown>;
+
+    expect(Object.prototype.hasOwnProperty.call(registry, 'toString')).toBe(true);
+    expect(registry.toString).toBe(ToStringStrategy);
+  });
+
+  it('throws when duplicate prototype-shadowing strategy names are registered', () => {
+    class FirstStrategy implements AuthStrategy {
+      async authenticate() {
+        return { claims: {}, subject: 'first' };
+      }
+    }
+
+    class SecondStrategy implements AuthStrategy {
+      async authenticate() {
+        return { claims: {}, subject: 'second' };
+      }
+    }
+
+    expect(() =>
+      createPassportProviders(
+        { defaultStrategy: 'toString' },
+        [
+          { name: 'toString', token: FirstStrategy },
+          { name: 'toString', token: SecondStrategy },
         ],
       ),
     ).toThrow(AuthStrategyResolutionError);

--- a/packages/passport/src/module.ts
+++ b/packages/passport/src/module.ts
@@ -10,10 +10,10 @@ import {
 } from './types.js';
 
 function createStrategyRegistry(strategies: AuthStrategyRegistration[]): AuthStrategyRegistry {
-  const registry: Record<string, AuthStrategyRegistration['token']> = {};
+  const registry: Record<string, AuthStrategyRegistration['token']> = Object.create(null);
 
   for (const strategy of strategies) {
-    if (strategy.name in registry) {
+    if (Object.prototype.hasOwnProperty.call(registry, strategy.name)) {
       throw new AuthStrategyResolutionError(`Duplicate auth strategy registration for "${strategy.name}".`);
     }
 


### PR DESCRIPTION
## Summary
- Replace passport strategy registry creation with a null-prototype map and explicit own-key checks to block prototype-chain collisions.
- Harden `AuthGuard` strategy existence checks to only accept explicitly registered own keys.
- Add regression coverage for `toString`/prototype-shadowing strategy names in module and guard tests.

## Verification
- `pnpm exec vitest run --project packages packages/passport/src/module.test.ts packages/passport/src/guard.test.ts`
- `pnpm --filter @konekti/passport typecheck`
- `pnpm --filter @konekti/passport build`

Closes #381