### PR TITLE
Resolve #382: apply waitForHandlers=false to transport dispatch

### DIFF
--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -808,6 +808,46 @@ describe('@konekti/event-bus', () => {
       await app.close();
     });
 
+    it('does not block on transport.publish() when waitForHandlers is false', async () => {
+      const gate = createDeferred<void>();
+      const transport = {
+        publishCompleted: false,
+        published: [] as Array<{ channel: string; payload: unknown }>,
+        async publish(channel: string, payload: unknown) {
+          this.published.push({ channel, payload });
+          await gate.promise;
+          this.publishCompleted = true;
+        },
+        async subscribe(_channel: string, _handler: (payload: unknown) => Promise<void>) {},
+        async close() {},
+      } satisfies EventBusTransport & {
+        publishCompleted: boolean;
+        published: Array<{ channel: string; payload: unknown }>;
+      };
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+      });
+
+      const app = await bootstrapApplication({ rootModule: AppModule });
+      const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+
+      await expect(
+        eventBus.publish(new UserCreatedEvent('transport-user-nowait'), { waitForHandlers: false }),
+      ).resolves.toBeUndefined();
+
+      expect(transport.published).toHaveLength(1);
+      expect(transport.publishCompleted).toBe(false);
+
+      gate.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(transport.publishCompleted).toBe(true);
+
+      await app.close();
+    });
+
     it('subscribes to a channel per discovered local handler event type on bootstrap', async () => {
       const transport = createMockTransport();
 

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -124,19 +124,19 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
   async publish(event: object, options?: EventPublishOptions): Promise<void> {
     await this.ensureDiscovered();
     const matchingDescriptors = this.matchEventDescriptors(event);
+    const publishOptions = this.resolvePublishOptions(options);
 
     const transportPayload = createIsolatedEvent(event.constructor as EventType, event);
     const transportPublish = this.publishToTransport(transportPayload, matchingDescriptors);
 
-    if (matchingDescriptors.length === 0) {
-      await transportPublish;
+    if (!publishOptions.waitForHandlers) {
+      const backgroundTasks = this.createBackgroundInvocationTasks(matchingDescriptors, event, publishOptions.signal);
+      this.runInvocationTasksInBackground([...backgroundTasks, transportPublish]);
+
       return;
     }
 
-    const publishOptions = this.resolvePublishOptions(options);
-    if (!publishOptions.waitForHandlers) {
-      const backgroundTasks = this.createBackgroundInvocationTasks(matchingDescriptors, event, publishOptions.signal);
-      this.runInvocationTasksInBackground(backgroundTasks);
+    if (matchingDescriptors.length === 0) {
       await transportPublish;
 
       return;


### PR DESCRIPTION
## Summary
- Respect `waitForHandlers` before any publish waiting logic so non-blocking mode applies to transport dispatch too.
- In non-blocking mode, run local handler invocations and transport publish as background tasks.
- Add a transport regression test that verifies `publish()` returns before a delayed transport publish completes when `waitForHandlers: false` is used.

## Verification
- `pnpm exec vitest run packages/event-bus/src/module.test.ts packages/event-bus/src/redis-transport.test.ts`
- `pnpm --filter @konekti/event-bus run typecheck`
- `pnpm --filter @konekti/event-bus run build`

Closes #382