### PR TITLE
Resolve #386: persist refresh records only after sign succeeds

### DIFF
--- a/packages/jwt/src/refresh-token.test.ts
+++ b/packages/jwt/src/refresh-token.test.ts
@@ -136,6 +136,32 @@ describe('RefreshTokenService', () => {
     expect(typeof payload.family).toBe('string');
   });
 
+  it('does not persist a refresh token record when signing fails', async () => {
+    const store = new InMemoryRefreshTokenStore();
+    const refreshOptions = {
+      expiresInSeconds: 3600,
+      rotation: true,
+      secret: 'refresh-secret',
+      store,
+    };
+    const signer = new DefaultJwtSigner({
+      algorithms: ['HS256'],
+      refreshToken: refreshOptions,
+      secret: 'access-secret',
+    });
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      refreshToken: refreshOptions,
+      secret: 'access-secret',
+    });
+    const service = new RefreshTokenService(refreshOptions, signer, verifier);
+
+    vi.spyOn(signer, 'signRefreshToken').mockRejectedValueOnce(new Error('refresh signing failed'));
+
+    await expect(service.issueRefreshToken('user-1')).rejects.toThrow('refresh signing failed');
+    expect(store.countBySubject('user-1')).toBe(0);
+  });
+
   it('rotates refresh token and marks previous token as used', async () => {
     const store = new InMemoryRefreshTokenStore();
     const { service } = createService(store);

--- a/packages/jwt/src/refresh-token.ts
+++ b/packages/jwt/src/refresh-token.ts
@@ -166,15 +166,14 @@ export class RefreshTokenService {
     const now = Math.floor(Date.now() / 1000);
     const tokenId = randomUUID();
     const expiresAt = new Date((now + this.options.expiresInSeconds) * 1000);
-
-    await this.options.store.save({
+    const tokenRecord = {
       createdAt: new Date(now * 1000),
       expiresAt,
       family,
       id: tokenId,
       subject,
       used: false,
-    });
+    };
 
     const claims: RefreshTokenClaims = {
       exp: Math.floor(expiresAt.getTime() / 1000),
@@ -185,7 +184,11 @@ export class RefreshTokenService {
       type: 'refresh',
     };
 
-    return this.signer.signRefreshToken(claims);
+    const refreshToken = await this.signer.signRefreshToken(claims);
+
+    await this.options.store.save(tokenRecord);
+
+    return refreshToken;
   }
 
   private async verifyRefreshClaims(token: string): Promise<RefreshTokenClaims & { sub: string }> {


### PR DESCRIPTION
## Summary
- reorder refresh-token issuance to sign the JWT before writing the refresh-token record to storage
- keep persistence contingent on successful signing to prevent orphan refresh-token records
- add a regression test that forces `signRefreshToken` to throw and asserts the store remains unchanged

## Verification
- `pnpm build`
- `pnpm test packages/jwt/src/refresh-token.test.ts`
- `pnpm --filter @konekti/jwt typecheck`
- `pnpm --filter @konekti/jwt build`

Closes #386