### PR TITLE
Resolve #393: reject handled:true guard pass when response is not committed

### DIFF
--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -413,6 +413,38 @@ describe('AuthGuard', () => {
     expect(subjects).toEqual(['alpha', 'beta']);
   });
 
+  it('rejects handled:true result when response is not committed and principal is absent', async () => {
+    class BrokenHandledStrategy implements AuthStrategy {
+      async authenticate(): Promise<{ handled: true }> {
+        return { handled: true };
+      }
+    }
+
+    @Controller('/protected')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth('broken')
+      getResource() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      BrokenHandledStrategy,
+      ...createPassportProviders({ defaultStrategy: 'broken' }, [{ name: 'broken', token: BrokenHandledStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/protected', { 'x-request-id': 'req-handled-bypass' }), response);
+
+    expect(response.statusCode).toBe(401);
+  });
+
   it('supports Passport.js redirect flow without executing the protected handler', async () => {
     let handlerCalled = false;
 

--- a/packages/passport/src/guard.ts
+++ b/packages/passport/src/guard.ts
@@ -87,6 +87,12 @@ export class AuthGuard implements AuthGuardContract {
       const principal = resolvePrincipal(result);
 
       if (isAuthHandledResult(result) && !principal) {
+        if (!context.requestContext.response.committed) {
+          throw new AuthenticationFailedError(
+            'Auth strategy returned handled:true without a principal but did not commit a response.',
+          );
+        }
+
         return true;
       }
 


### PR DESCRIPTION
## Summary

- Fixes authentication bypass where a strategy returning `{ handled: true }` without a principal could silently pass the guard when the response was not committed.
- The redirect short-circuit path (Passport.js OAuth redirect) is unaffected — it commits the response before returning `{ handled: true }`.
- Adds a regression test covering the bypass scenario.

## Root cause

`guard.ts:89-91` previously returned `true` for any `handled: true` result with no principal, regardless of whether the response was actually committed. A custom strategy that accidentally returns `{ handled: true }` without calling `redirect()` or `send()` would pass the guard.

## Fix

Added `response.committed` check before the early return. If the response is not committed and no principal is present, `AuthenticationFailedError` is thrown, which maps to a 401.

## Verification steps
1. `npx vitest run packages/passport/src/guard.test.ts`
2. All 13 tests pass including new: "rejects handled:true result when response is not committed and principal is absent"

Closes #393