### PR TITLE
Resolve #394: dispose multi-provider singleton instances on container teardown

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -735,5 +735,32 @@ describe('Container', () => {
 
       expect(events).toEqual(['v1', 'v2', 'v3']);
     });
+    it('calls onDestroy for resolved multi-provider singleton instances on dispose', async () => {
+      const events: string[] = [];
+      const token = Symbol('multi-disposable');
+
+      class PluginA {
+        onDestroy() {
+          events.push('plugin-a');
+        }
+      }
+
+      class PluginB {
+        onDestroy() {
+          events.push('plugin-b');
+        }
+      }
+
+      const container = new Container().register(
+        { provide: token, useClass: PluginA, multi: true },
+        { provide: token, useClass: PluginB, multi: true },
+      );
+
+      await container.resolve(token);
+      await container.dispose();
+
+      expect(events).toContain('plugin-a');
+      expect(events).toContain('plugin-b');
+    });
   });
 });

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -115,7 +115,7 @@ export class Container {
   private readonly registrations = new Map<Token, NormalizedProvider>();
   private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
   private readonly requestCache = new Map<Token, Promise<unknown>>();
-  private readonly multiSingletonCache = new WeakMap<NormalizedProvider, Promise<unknown>>();
+  private readonly multiSingletonCache = new Map<NormalizedProvider, Promise<unknown>>();
   private readonly staleDisposalTasks = new Set<Promise<void>>();
   private readonly staleDisposalErrors: unknown[] = [];
   private readonly singletonCache: Map<Token, Promise<unknown>>;
@@ -494,12 +494,16 @@ export class Container {
     return this.requestCache;
   }
 
-  private disposalCacheEntries(): Array<[Token, Promise<unknown>]> {
+  private disposalCacheEntries(): Array<[NormalizedProvider | Token, Promise<unknown>]> {
     if (this.parent) {
       return Array.from(this.requestCache.entries());
     }
 
-    return Array.from(this.singletonCache.entries());
+    const entries: Array<[NormalizedProvider | Token, Promise<unknown>]> = Array.from(this.singletonCache.entries());
+    for (const [provider, promise] of this.multiSingletonCache.entries()) {
+      entries.push([provider, promise]);
+    }
+    return entries;
   }
 
   private async disposeCache(entries: Array<[Token, Promise<unknown>]>): Promise<void> {
@@ -516,7 +520,7 @@ export class Container {
   }
 
   private async collectDisposableInstances(
-    entries: Array<[Token, Promise<unknown>]>,
+    entries: Array<[NormalizedProvider | Token, Promise<unknown>]>,
   ): Promise<{ disposables: Disposable[]; errors: unknown[] }> {
     const disposables: Disposable[] = [];
     const seenInstances = new Set<unknown>();
@@ -562,6 +566,7 @@ export class Container {
     }
 
     this.singletonCache.clear();
+    this.multiSingletonCache.clear();
   }
 
   private async waitForStaleDisposalTasks(): Promise<void> {


### PR DESCRIPTION
## Summary

- `multiSingletonCache` was a `WeakMap<NormalizedProvider, Promise<unknown>>`. `WeakMap` is not iterable, so `dispose()` skipped every multi-provider singleton — their `onDestroy()` hooks were never called.
- Converts `multiSingletonCache` to `Map` (iterable, same key type), then includes its entries in `disposalCacheEntries()` and clears it in `clearDisposalCaches()`.
- Adds regression test: two `onDestroy` multi-provider singletons are both called on `container.dispose()`.

## Verification steps
1. `npx vitest run packages/di/src/container.test.ts`
2. All 39 tests pass including new: "calls onDestroy for resolved multi-provider singleton instances on dispose"

Closes #394