### PR TITLE
Resolve #395: fail fast for unsupported request transactions

### DIFF
--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -93,6 +93,10 @@ export class DrizzleDatabase<
 
     const transactionRunner = this.resolveTransactionRunner();
     if (!transactionRunner) {
+      if (requestScoped) {
+        throw new Error(TRANSACTION_NOT_SUPPORTED_ERROR);
+      }
+
       return fn();
     }
 

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -199,6 +199,24 @@ describe('@konekti/drizzle', () => {
     await asyncApp.close();
   });
 
+  it('rejects requestTransaction when transaction support is unavailable even if strictTransactions is false', async () => {
+    const database = {};
+    const drizzle = new DrizzleDatabase<typeof database>(database, undefined, {
+      strictTransactions: false,
+    });
+    let invoked = false;
+
+    await expect(
+      drizzle.requestTransaction(async () => {
+        invoked = true;
+        return 'never';
+      }),
+    ).rejects.toThrow('Transaction not supported: Drizzle database does not implement transaction.');
+
+    await expect(drizzle.transaction(async () => 'fallback-transaction')).resolves.toBe('fallback-transaction');
+    expect(invoked).toBe(false);
+  });
+
   it('runs nested request and service transactions through a single transaction boundary', async () => {
     let transactionCalls = 0;
     const transactionDatabase = {


### PR DESCRIPTION
## Summary
- make `DrizzleDatabase.requestTransaction()` reject when the underlying database does not implement `transaction()` instead of silently executing outside a transaction
- keep the existing non-strict fallback for plain `transaction()` so the change stays scoped to the request-bound contract break
- add a regression test proving the unsupported request path rejects before invoking the callback

## Why
`requestTransaction()` is used by the Drizzle request interceptor and advertises request-scoped transaction + abort semantics. Falling back to `fn()` made that contract false and could silently skip rollback/abort behavior.

## Verification
- `npx vitest run packages/drizzle/src/module.test.ts --reporter=verbose`
- `npx vitest run packages/drizzle/src/vertical-slice.test.ts --reporter=verbose`
- `lsp_diagnostics` clean for `packages/drizzle/src/database.ts`
- `lsp_diagnostics` clean for `packages/drizzle/src/module.test.ts`

Closes #395