### PR TITLE
Resolve #396: run CQRS local handlers before bus fan-out

### DIFF
--- a/packages/cqrs/src/event-bus.ts
+++ b/packages/cqrs/src/event-bus.ts
@@ -44,7 +44,6 @@ export class CqrsEventBusService extends CqrsBusBase implements CqrsEventBus, On
 
   async publish<TEvent extends IEvent>(event: TEvent): Promise<void> {
     await this.ensureDiscovered();
-    await this.eventBus.publish(event);
 
     for (const descriptor of this.matchEventDescriptors(event)) {
       const instance = await this.resolveHandlerInstance(descriptor.token);
@@ -57,6 +56,7 @@ export class CqrsEventBusService extends CqrsBusBase implements CqrsEventBus, On
     }
 
     await this.sagaService.dispatch(event);
+    await this.eventBus.publish(event);
   }
 
   async publishAll<TEvent extends IEvent>(events: readonly TEvent[]): Promise<void> {

--- a/packages/cqrs/src/module.test.ts
+++ b/packages/cqrs/src/module.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Inject } from '@konekti/core';
 import { Container } from '@konekti/di';
-import { OnEvent } from '@konekti/event-bus';
+import { OnEvent, type EventBusTransport } from '@konekti/event-bus';
 import { bootstrapApplication, defineModule, type ApplicationLogger } from '@konekti/runtime';
 
 import { CommandHandler, EventHandler, QueryHandler, Saga } from './decorators.js';
@@ -529,6 +529,40 @@ describe('@konekti/cqrs', () => {
     await app.close();
   });
 
+  it('does not publish to transport when a CQRS event handler fails', async () => {
+    const transport = {
+      published: [] as Array<{ channel: string; payload: unknown }>,
+      async publish(channel: string, payload: unknown) {
+        this.published.push({ channel, payload });
+      },
+      async subscribe(_channel: string, _handler: (payload: unknown) => Promise<void>) {},
+      async close() {},
+    } satisfies EventBusTransport & {
+      published: Array<{ channel: string; payload: unknown }>;
+    };
+
+    @EventHandler(UserCreatedEvent)
+    class FailingEventHandler implements IEventHandler<UserCreatedEvent> {
+      handle(_event: UserCreatedEvent): void {
+        throw new Error('handler exploded');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCqrsModule({ eventBus: { transport } })],
+      providers: [FailingEventHandler],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
+
+    await expect(eventBus.publish(new UserCreatedEvent('alice'))).rejects.toThrow('handler exploded');
+    expect(transport.published).toEqual([]);
+
+    await app.close();
+  });
+
   it('processes saga events in a deterministic order under concurrent publish calls', async () => {
     class SequenceStore {
       seen: number[] = [];
@@ -687,7 +721,7 @@ describe('@konekti/cqrs', () => {
 
     expect(commandCount).toBe(1);
     expect(store.commandCount).toBe(1);
-    expect(store.eventNames).toEqual(['on:alice', 'alice', 'on:bob', 'bob']);
+    expect(store.eventNames).toEqual(['alice', 'on:alice', 'bob', 'on:bob']);
 
     await app.close();
   });


### PR DESCRIPTION
## Summary
- reorder `CqrsEventBusService.publish()` so CQRS `@EventHandler()` handlers and sagas complete before delegating to the underlying event bus
- add a regression test proving transport publish is skipped when a CQRS event handler fails
- update the CQRS bootstrap test to reflect the safer local-before-`@OnEvent` ordering

## Why
The previous order delegated to the underlying event bus first. Because that bus can fan out to external transport, a later CQRS local failure could leave an externally published event with no matching local success path.

This change keeps the CQRS layer honest: local CQRS work must succeed before the event leaves the CQRS boundary.

## Verification
- `npx vitest run packages/cqrs/src/module.test.ts --reporter=verbose`
- `lsp_diagnostics` clean for `packages/cqrs/src/event-bus.ts`
- `lsp_diagnostics` clean for `packages/cqrs/src/module.test.ts`

Closes #396