### PR TITLE
Resolve #397: fail startup when distributed cron Redis backend is missing

### DIFF
--- a/packages/cron/README.ko.md
+++ b/packages/cron/README.ko.md
@@ -53,7 +53,7 @@ createCronModule({
 export class AppModule {}
 ```
 
-분산 모드를 실제로 사용하려면 `createRedisModule(...)`로 `REDIS_CLIENT`를 함께 등록해야 합니다. 이때만 락을 획득한 인스턴스가 tick 작업을 실행하며, 실행 중에는 락 갱신을 시도합니다. `REDIS_CLIENT`가 없으면 런타임은 경고를 남기고 인프로세스 스케줄링으로 fallback합니다.
+분산 모드를 실제로 사용하려면 `createRedisModule(...)`로 `REDIS_CLIENT`를 함께 등록해야 합니다. 이때만 락을 획득한 인스턴스가 tick 작업을 실행하며, 실행 중에는 락 갱신을 시도합니다. `REDIS_CLIENT`가 없거나 필요한 `set`/`eval` 락 연산을 구현하지 않으면, 런타임은 인프로세스 스케줄링으로 조용히 fallback하지 않고 애플리케이션 부트스트랩을 실패시킵니다.
 
 ## API
 

--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -53,7 +53,7 @@ import { createRedisModule } from '@konekti/redis';
 export class AppModule {}
 ```
 
-To run in distributed mode, register `REDIS_CLIENT` (for example via `createRedisModule(...)`) alongside `createCronModule(...)`. In distributed mode each tick acquires a Redis lock before running and attempts lock renewal while work is in progress; if lock ownership is lost or renewal fails before completion, the tick is treated as failed. When `REDIS_CLIENT` is missing, runtime logs a warning and falls back to in-process scheduling.
+To run in distributed mode, register `REDIS_CLIENT` (for example via `createRedisModule(...)`) alongside `createCronModule(...)`. In distributed mode each tick acquires a Redis lock before running and attempts lock renewal while work is in progress; if lock ownership is lost or renewal fails before completion, the tick is treated as failed. If `REDIS_CLIENT` is missing or does not implement the required `set`/`eval` lock operations, application bootstrap fails instead of silently falling back to in-process scheduling.
 
 ## API
 

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -566,6 +566,67 @@ describe('@konekti/cron', () => {
     await appTwo.close();
   });
 
+  it('fails bootstrap before scheduling jobs when distributed mode is enabled without REDIS_CLIENT', async () => {
+    const scheduler = createManualScheduler();
+
+    class DistributedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, { name: 'distributed-missing-redis' })
+      async run() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        createCronModule({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-missing-redis',
+            lockTtlMs: 60_000,
+          },
+          scheduler: scheduler.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService],
+    });
+
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
+      'Cron distributed mode requires REDIS_CLIENT to be registered.',
+    );
+    expect(scheduler.records).toHaveLength(0);
+  });
+
+  it('fails bootstrap before scheduling jobs when REDIS_CLIENT cannot perform lock operations', async () => {
+    const scheduler = createManualScheduler();
+
+    class DistributedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, { name: 'distributed-invalid-redis' })
+      async run() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        createCronModule({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-invalid-redis',
+            lockTtlMs: 60_000,
+          },
+          scheduler: scheduler.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService],
+    });
+
+    await expect(
+      bootstrapApplication({
+        providers: [{ provide: REDIS_CLIENT, useValue: {} }],
+        rootModule: AppModule,
+      }),
+    ).rejects.toThrow('Cron distributed mode requires REDIS_CLIENT to implement set/eval lock operations.');
+    expect(scheduler.records).toHaveLength(0);
+  });
+
   it('releases owned distributed locks during shutdown so another node can continue', async () => {
     const firstScheduler = createManualScheduler();
     const secondScheduler = createManualScheduler();

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -162,21 +162,13 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
     }
 
     if (!this.runtimeContainer.has(REDIS_CLIENT)) {
-      this.logger.warn(
-        'Cron distributed mode is enabled but REDIS_CLIENT is not registered. Falling back to in-process scheduling.',
-        'CronLifecycleService',
-      );
-      return;
+      throw new Error('Cron distributed mode requires REDIS_CLIENT to be registered.');
     }
 
     const redisClient = await this.runtimeContainer.resolve(REDIS_CLIENT);
 
     if (!hasRedisLockClient(redisClient)) {
-      this.logger.warn(
-        'REDIS_CLIENT is registered but does not implement set/eval lock operations. Falling back to in-process scheduling.',
-        'CronLifecycleService',
-      );
-      return;
+      throw new Error('Cron distributed mode requires REDIS_CLIENT to implement set/eval lock operations.');
     }
 
     this.redisClient = redisClient;


### PR DESCRIPTION
## Summary
- make distributed cron startup fail fast when `REDIS_CLIENT` is missing or cannot perform the required lock operations
- add bootstrap regressions proving cron jobs are not scheduled under that misconfiguration
- update the cron package docs to describe the new hard dependency instead of the old in-process fallback

## Why
Distributed cron mode relies on Redis-backed locking to prevent duplicate execution across instances. Falling back to in-process scheduling kept startup green while removing the very protection operators enabled distributed mode for.

## Verification
- `npx vitest run packages/cron/src/module.test.ts --reporter=verbose`
- `lsp_diagnostics` clean for `packages/cron/src/service.ts`
- `lsp_diagnostics` clean for `packages/cron/src/module.test.ts`

Closes #397