### PR TITLE
Resolve #398: unregister Fastify shutdown listeners and clarify metrics contract

### DIFF
--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -81,7 +81,7 @@ MetricsModule.forRoot({ path: '/internal/metrics' })
 
 ### 기본 메트릭 비활성화
 
-기본적으로 `prom-client`의 `collectDefaultMetrics()`가 호출되어 표준 Node.js 프로세스 및 GC 메트릭을 등록합니다. 내장 엔드포인트가 모듈이 등록한 메트릭만 노출하게 하려면 비활성화하세요:
+기본적으로 `prom-client`의 `collectDefaultMetrics()`가 호출되어 표준 Node.js 프로세스 및 GC 메트릭을 등록합니다. `prom-client` v15에서는 이 값들을 백그라운드 interval이 아니라 scrape 시점에 수집합니다. 내장 엔드포인트가 모듈이 등록한 메트릭만 노출하게 하려면 기본 메트릭을 비활성화하세요:
 
 ```typescript
 MetricsModule.forRoot({ defaultMetrics: false })

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -82,7 +82,7 @@ MetricsModule.forRoot({ path: '/internal/metrics' })
 
 ### Disable default metrics
 
-By default, `prom-client`'s `collectDefaultMetrics()` is called, which registers standard Node.js process and GC metrics. Disable it if you want the built-in endpoint to expose only metrics registered by the module itself:
+By default, `prom-client`'s `collectDefaultMetrics()` is called, which registers standard Node.js process and GC metrics. In `prom-client` v15 these values are collected on scrape rather than by a background interval. Disable default metrics if you want the built-in endpoint to expose only metrics registered by the module itself:
 
 ```typescript
 MetricsModule.forRoot({ defaultMetrics: false })

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -304,6 +304,44 @@ describe('@konekti/platform-fastify', () => {
     await app.close();
   });
 
+  it('removes registered shutdown signal listeners after close', async () => {
+    const logger: ApplicationLogger = {
+      debug() {},
+      error() {},
+      log() {},
+      warn() {},
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const signal = 'SIGTERM' as const;
+    const listenersBefore = process.listeners(signal).length;
+    const port = await findAvailablePort();
+    const app = await runFastifyApplication(AppModule, {
+      cors: false,
+      logger,
+      port,
+      shutdownSignals: [signal],
+    });
+
+    expect(process.listeners(signal).length).toBe(listenersBefore + 1);
+
+    await app.close();
+
+    expect(process.listeners(signal).length).toBe(listenersBefore);
+  });
+
   it('does not leak global-prefix path rewrites to request observers', async () => {
     const observedPaths: string[] = [];
 

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -305,7 +305,18 @@ export async function runFastifyApplication(
     throw error;
   }
 
-  registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals());
+  const unregisterShutdownSignals = registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals());
+  const close = app.close.bind(app);
+  let shutdownSignalsUnregistered = false;
+
+  app.close = async (signal?: string) => {
+    if (!shutdownSignalsUnregistered) {
+      unregisterShutdownSignals();
+      shutdownSignalsUnregistered = true;
+    }
+
+    await close(signal);
+  };
 
   return app;
 }
@@ -764,12 +775,13 @@ function registerShutdownSignals(
   app: Application,
   logger: ApplicationLogger,
   signals: false | readonly FastifyApplicationSignal[],
-): void {
+): () => void {
   if (signals === false || signals.length === 0) {
-    return;
+    return () => {};
   }
 
   const seen = new Set<FastifyApplicationSignal>();
+  const bindings: Array<{ signal: FastifyApplicationSignal; handler: () => void }> = [];
 
   for (const signal of signals) {
     if (seen.has(signal)) {
@@ -777,7 +789,7 @@ function registerShutdownSignals(
     }
 
     seen.add(signal);
-    process.once(signal, () => {
+    const handler = () => {
       void app.close(signal)
         .then(() => {
           logger.log(`Application closed after receiving ${signal}.`, 'KonektiFactory');
@@ -785,8 +797,17 @@ function registerShutdownSignals(
         .catch((error: unknown) => {
           logger.error(`Failed to close application after receiving ${signal}.`, error, 'KonektiFactory');
         });
-    });
+    };
+
+    bindings.push({ signal, handler });
+    process.once(signal, handler);
   }
+
+  return () => {
+    for (const binding of bindings) {
+      process.off(binding.signal, binding.handler);
+    }
+  };
 }
 
 function toHttpException(error: unknown): HttpException {


### PR DESCRIPTION
## Summary
- make `runFastifyApplication()` unregister its process shutdown listeners from `app.close()` so repeated lifecycles do not accumulate `SIGINT`/`SIGTERM` handlers
- add a regression test proving the Fastify listener count returns to baseline after explicit close
- clarify the metrics docs for the installed `prom-client@15` contract: default metrics are collected on scrape, so the reported interval leak does not apply to the current dependency version

## Why
The real runtime leak in this issue was the Fastify adapter: it registered shutdown handlers with no symmetric teardown path, unlike `runNodeApplication()`.

During verification, the metrics half turned out to be stale analysis for this repo’s dependency set. `prom-client@15.1.3` registers default collectors that run on scrape rather than through a background interval, so there is no runtime timer cleanup hook to add in the current version. The docs now say that explicitly to keep the package contract accurate.

## Verification
- `npx vitest run packages/platform-fastify/src/adapter.test.ts --reporter=verbose`
- `lsp_diagnostics` clean for `packages/platform-fastify/src/adapter.ts`
- `lsp_diagnostics` clean for `packages/platform-fastify/src/adapter.test.ts`
- inspected installed `prom-client@15.1.3` implementation and README: default metrics are scrape-based, not interval-based

Closes #398