### PR TITLE
Resolve #399: ignore generated .env and preserve selected package manager

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -93,6 +93,43 @@ describe('CLI command runner', () => {
     expect(stdoutBuffer.join('')).toContain('pnpm dev');
   });
 
+  it('honors explicit yarn selection without changing the stable scaffold shape', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', 'starter-app', '--package-manager', 'yarn'], {
+      cwd: workspaceDirectory,
+      env: {},
+      skipInstall: true,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdoutBuffer.join('')).toContain('Installing dependencies with yarn');
+    expect(stdoutBuffer.join('')).toContain('yarn dev');
+  });
+
+  it('scaffolds a local .env file while ignoring it from git by default', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    const exitCode = await runCli(['new', 'starter-app'], {
+      cwd: workspaceDirectory,
+      env: {},
+      skipInstall: true,
+      stderr: { write: () => undefined },
+      stdout: { write: () => undefined },
+    });
+
+    const projectDirectory = join(workspaceDirectory, 'starter-app');
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(projectDirectory, '.gitignore'), 'utf8')).toContain('.env');
+    expect(readFileSync(join(projectDirectory, '.env'), 'utf8')).toContain('PORT=3000');
+  });
+
   it('keeps explicit --target-directory when it appears before positional project name', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
     createdDirectories.push(workspaceDirectory);
@@ -433,6 +470,8 @@ describe('CLI command runner', () => {
     expect(readFileSync(join(projectDirectory, 'package.json'), 'utf8')).toContain('@konekti/runtime');
     expect(readFileSync(join(projectDirectory, 'package.json'), 'utf8')).not.toContain('@konekti/prisma');
     expect(readFileSync(join(projectDirectory, 'package.json'), 'utf8')).not.toContain('@konekti/drizzle');
+    expect(readFileSync(join(projectDirectory, '.gitignore'), 'utf8')).toContain('.env');
+    expect(readFileSync(join(projectDirectory, '.env'), 'utf8')).toContain('PORT=3000');
     expect(stdoutBuffer.join('')).toContain('Installing dependencies with pnpm');
     expect(existsSync(join(projectDirectory, 'node_modules'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'health', 'health.repo.ts'))).toBe(true);

--- a/packages/cli/src/new/install.test.ts
+++ b/packages/cli/src/new/install.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveInstallCommand } from './install.js';
+
+describe('resolveInstallCommand', () => {
+  it('uses direct install commands for pnpm and npm', () => {
+    expect(resolveInstallCommand('pnpm')).toEqual({
+      args: ['install'],
+      command: 'pnpm',
+    });
+    expect(resolveInstallCommand('npm')).toEqual({
+      args: ['install'],
+      command: 'npm',
+    });
+  });
+
+  it('uses the corepack yarn install path only when yarn is selected', () => {
+    expect(resolveInstallCommand('yarn')).toEqual({
+      args: ['yarn', 'install', '--no-cache'],
+      command: 'corepack',
+    });
+  });
+});

--- a/packages/cli/src/new/install.ts
+++ b/packages/cli/src/new/install.ts
@@ -2,9 +2,27 @@ import { spawn } from 'node:child_process';
 
 import type { PackageManager } from './types.js';
 
+export interface InstallCommand {
+  args: string[];
+  command: string;
+}
+
+export function resolveInstallCommand(packageManager: PackageManager): InstallCommand {
+  if (packageManager === 'yarn') {
+    return {
+      args: ['yarn', 'install', '--no-cache'],
+      command: 'corepack',
+    };
+  }
+
+  return {
+    args: ['install'],
+    command: packageManager,
+  };
+}
+
 export async function installDependencies(targetDirectory: string, packageManager: PackageManager): Promise<void> {
-  const command = packageManager === 'yarn' ? 'corepack' : packageManager;
-  const args = packageManager === 'yarn' ? ['yarn', 'install', '--no-cache'] : ['install'];
+  const { args, command } = resolveInstallCommand(packageManager);
 
   await new Promise<void>((resolve, reject) => {
     const child = spawn(command, args, {

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -217,6 +217,7 @@ function createGitignore(): string {
   return `node_modules
 dist
 .konekti
+.env
 .env.local
 coverage
 `;


### PR DESCRIPTION
## Summary
- add `.env` to the scaffolded `.gitignore` so the generated starter keeps working out of the box without making local secrets easy to commit
- extract the install-command mapping into a small helper and pin the contract with tests: npm/pnpm install directly, Yarn uses the existing corepack path only when Yarn is actually selected
- add focused CLI regressions for package-manager detection/output and generated `.env`/`.gitignore` content

## Why
The starter currently generates a local `.env` file and loads it by default, so deleting that file or replacing it with `.env.example` would make onboarding worse. The real bug was that the generated `.gitignore` did not exclude `.env`.

On the install side, the CLI already detects the package manager from the caller context before scaffolding. This change keeps that behavior but makes the final spawn command explicit and testable, so Yarn/corepack is only used on the Yarn path instead of being an unverified inline branch.

## Verification
Focused issue-399 tests passed:
- `npx vitest run packages/cli/src/new/install.test.ts packages/cli/src/cli.test.ts -t "uses direct install commands|uses the corepack yarn install path|auto-detects the package manager|falls back to pnpm|honors explicit yarn selection|scaffolds a local .env file" --reporter=verbose`
- `lsp_diagnostics` clean for `packages/cli/src/new/scaffold.ts`
- `lsp_diagnostics` clean for `packages/cli/src/new/install.ts`
- `lsp_diagnostics` clean for `packages/cli/src/new/install.test.ts`
- `lsp_diagnostics` clean for `packages/cli/src/cli.test.ts`

Note: the existing long-form `packages/cli/src/cli.test.ts` local-dependency scaffold test currently fails on `main` because rebuilding workspace packages hits an unrelated TypeScript error in `packages/di/src/container.ts`. That blocker predates this CLI patch and is outside the files changed here.

Closes #399