### PR TITLE
Resolve #407: invalidate stale multi singleton cache on override

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -698,6 +698,48 @@ describe('Container', () => {
       expect(events).toEqual(['first', 'second']);
     });
 
+    it('disposes stale overridden multi singleton instances immediately and exactly once', async () => {
+      const events: string[] = [];
+      const token = Symbol('multi-rotating-disposable-token');
+
+      class PluginA {
+        onDestroy() {
+          events.push('plugin-a');
+        }
+      }
+
+      class PluginB {
+        onDestroy() {
+          events.push('plugin-b');
+        }
+      }
+
+      class PluginC {
+        onDestroy() {
+          events.push('plugin-c');
+        }
+      }
+
+      const container = new Container().register(
+        { provide: token, useClass: PluginA, multi: true },
+        { provide: token, useClass: PluginB, multi: true },
+      );
+
+      await container.resolve(token);
+
+      container.override({ provide: token, useClass: PluginC, multi: true });
+      await Promise.resolve();
+
+      expect(events.slice().sort()).toEqual(['plugin-a', 'plugin-b']);
+
+      await container.resolve(token);
+      await container.dispose();
+
+      expect(events.filter((event) => event === 'plugin-a')).toHaveLength(1);
+      expect(events.filter((event) => event === 'plugin-b')).toHaveLength(1);
+      expect(events.filter((event) => event === 'plugin-c')).toHaveLength(1);
+    });
+
     it('does not retain stale singleton instances across repeated overrides', async () => {
       const events: string[] = [];
       const token = Symbol('rotating-disposable-token');

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -506,7 +506,7 @@ export class Container {
     return entries;
   }
 
-  private async disposeCache(entries: Array<[Token, Promise<unknown>]>): Promise<void> {
+  private async disposeCache(entries: Array<[NormalizedProvider | Token, Promise<unknown>]>): Promise<void> {
     await this.waitForStaleDisposalTasks();
 
     const { disposables, errors } = await this.collectDisposableInstances(entries);
@@ -719,6 +719,15 @@ export class Container {
       }
 
       singletonCache.delete(token);
+    }
+
+    for (const [provider, cached] of this.multiSingletonCache.entries()) {
+      if (provider.provide !== token) {
+        continue;
+      }
+
+      this.scheduleStaleDisposal(cached);
+      this.multiSingletonCache.delete(provider);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Invalidate `multiSingletonCache` entries for the overridden token inside `invalidateCachedEntry`.
- Schedule stale multi singleton disposal during override, matching singleton invalidation semantics.
- Add regression coverage proving stale multi singleton instances are destroyed on override and exactly once.

## Verification
- `pnpm --filter @konekti/core build`
- `pnpm --filter @konekti/di typecheck`
- `pnpm vitest run packages/di/src/container.test.ts`
- `pnpm --filter @konekti/di build`

Closes #407