### PR TITLE
Resolve #409: add Yarn fallback when corepack is unavailable

### DIFF
--- a/packages/cli/src/new/install.test.ts
+++ b/packages/cli/src/new/install.test.ts
@@ -14,10 +14,17 @@ describe('resolveInstallCommand', () => {
     });
   });
 
-  it('uses the corepack yarn install path only when yarn is selected', () => {
-    expect(resolveInstallCommand('yarn')).toEqual({
-      args: ['yarn', 'install', '--no-cache'],
+  it('uses the corepack yarn install path when corepack is available', () => {
+    expect(resolveInstallCommand('yarn', { isCorepackAvailable: true })).toEqual({
+      args: ['yarn', 'install'],
       command: 'corepack',
+    });
+  });
+
+  it('falls back to direct yarn install when corepack is unavailable', () => {
+    expect(resolveInstallCommand('yarn', { isCorepackAvailable: false })).toEqual({
+      args: ['install'],
+      command: 'yarn',
     });
   });
 });

--- a/packages/cli/src/new/install.ts
+++ b/packages/cli/src/new/install.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 import type { PackageManager } from './types.js';
 
@@ -7,10 +7,35 @@ export interface InstallCommand {
   command: string;
 }
 
-export function resolveInstallCommand(packageManager: PackageManager): InstallCommand {
+export interface ResolveInstallCommandOptions {
+  isCorepackAvailable?: boolean;
+}
+
+const COREPACK_DOCS_URL = 'https://nodejs.org/api/corepack.html';
+
+function checkCommandAvailability(command: string): boolean {
+  const checker = process.platform === 'win32' ? 'where' : 'which';
+  const result = spawnSync(checker, [command], { stdio: 'ignore' });
+
+  return result.status === 0;
+}
+
+export function resolveInstallCommand(
+  packageManager: PackageManager,
+  options: ResolveInstallCommandOptions = {},
+): InstallCommand {
   if (packageManager === 'yarn') {
+    const isCorepackAvailable = options.isCorepackAvailable ?? checkCommandAvailability('corepack');
+
+    if (!isCorepackAvailable) {
+      return {
+        args: ['install'],
+        command: 'yarn',
+      };
+    }
+
     return {
-      args: ['yarn', 'install', '--no-cache'],
+      args: ['yarn', 'install'],
       command: 'corepack',
     };
   }
@@ -22,7 +47,14 @@ export function resolveInstallCommand(packageManager: PackageManager): InstallCo
 }
 
 export async function installDependencies(targetDirectory: string, packageManager: PackageManager): Promise<void> {
-  const { args, command } = resolveInstallCommand(packageManager);
+  const hasCorepack = packageManager === 'yarn' ? checkCommandAvailability('corepack') : undefined;
+  const { args, command } = resolveInstallCommand(packageManager, { isCorepackAvailable: hasCorepack });
+
+  if (packageManager === 'yarn' && hasCorepack === false) {
+    console.warn(
+      `[konekti] corepack was not found in PATH, falling back to "yarn install". See ${COREPACK_DOCS_URL}`,
+    );
+  }
 
   await new Promise<void>((resolve, reject) => {
     const child = spawn(command, args, {


### PR DESCRIPTION
## Summary
- Add a Corepack availability preflight for Yarn installs in `@konekti/cli`.
- Fall back to direct `yarn install` (with a one-line Corepack guidance warning) when Corepack is missing from PATH.
- Remove Yarn-only `--no-cache` usage and add unit coverage for the fallback behavior.

## Verification
- `pnpm --dir packages/cli exec vitest run -c vitest.config.ts src/new/install.test.ts`
- `pnpm --dir packages/cli run typecheck`
- `pnpm --dir packages/cli run build`

Closes #409