### PR TITLE
Resolve #410: consolidate env access behind explicit runtime options

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -100,7 +100,7 @@ interface GraphQLContext {
 - `schema`: 스키마 우선 입력입니다. `GraphQLSchema` 인스턴스 또는 SDL 문자열을 받을 수 있습니다.
 - `resolvers`: 코드 우선 탐색 시 사용할 resolver allowlist입니다.
 - `context`: 요청 단위 커스텀 GraphQL context 값을 추가합니다.
-- `graphiql`: GraphiQL 표시 여부를 명시합니다. 기본값은 `NODE_ENV === 'production'`이 아닐 때 `true`입니다.
+- `graphiql`: GraphiQL 표시 여부를 명시합니다. 값을 지정하지 않으면 기본값은 `true`입니다.
 - `subscriptions.websocket.enabled`: 공유 Node HTTP 서버에 `graphql-ws` 전송 계층을 활성화하며, `/graphql`의 SSE 지원은 그대로 유지합니다.
 - `subscriptions.websocket.keepAliveMs`: `graphql-ws` keepalive용 websocket ping 간격을 조정합니다.
 - `subscriptions.websocket.connectionInitWaitTimeoutMs`: 초기 `connection_init` 메시지 대기 시간을 조정합니다.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -100,7 +100,7 @@ interface GraphQLContext {
 - `schema`: schema-first input. Accepts a `GraphQLSchema` instance or SDL string.
 - `resolvers`: optional allowlist for code-first discovery.
 - `context`: adds custom GraphQL context values for each request.
-- `graphiql`: explicit GraphiQL toggle. Default is `true` unless `NODE_ENV === 'production'`.
+- `graphiql`: explicit GraphiQL toggle. Default is `true` when not set.
 - `subscriptions.websocket.enabled`: enables `graphql-ws` transport on the shared Node HTTP server while keeping SSE support available on `/graphql`.
 - `subscriptions.websocket.keepAliveMs`: custom websocket ping interval for `graphql-ws` keepalive frames.
 - `subscriptions.websocket.connectionInitWaitTimeoutMs`: custom timeout for the initial `connection_init` message.

--- a/packages/graphql/src/service.test.ts
+++ b/packages/graphql/src/service.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import type { HttpApplicationAdapter } from '@konekti/http';
+import type { ApplicationLogger, CompiledModule } from '@konekti/runtime';
+import type { Container } from '@konekti/di';
+
+import { GraphqlLifecycleService } from './service.js';
+import type { GraphqlModuleOptions } from './types.js';
+
+function createService(options: GraphqlModuleOptions): GraphqlLifecycleService {
+  const logger: ApplicationLogger = {
+    debug() {},
+    error() {},
+    log() {},
+    warn() {},
+  };
+  const adapter: HttpApplicationAdapter = {
+    async close() {},
+    async listen() {},
+  };
+
+  return new GraphqlLifecycleService(
+    {} as unknown as Container,
+    [] as CompiledModule[],
+    logger,
+    adapter,
+    options,
+  );
+}
+
+function resolveGraphiqlEnabled(service: GraphqlLifecycleService): boolean {
+  const resolver = Reflect.get(service, 'resolveGraphiqlEnabled');
+
+  if (typeof resolver !== 'function') {
+    throw new Error('Expected resolveGraphiqlEnabled method to exist.');
+  }
+
+  return Reflect.apply(resolver, service, []) as boolean;
+}
+
+describe('GraphqlLifecycleService graphiql defaults', () => {
+  it('defaults to true even when NODE_ENV is production', () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      const service = createService({});
+
+      expect(resolveGraphiqlEnabled(service)).toBe(true);
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  it('respects explicit graphiql overrides', () => {
+    const disabled = createService({ graphiql: false });
+    const enabled = createService({ graphiql: true });
+
+    expect(resolveGraphiqlEnabled(disabled)).toBe(false);
+    expect(resolveGraphiqlEnabled(enabled)).toBe(true);
+  });
+});

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -389,7 +389,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
       return this.options.graphiql;
     }
 
-    return process.env.NODE_ENV !== 'production';
+    return true;
   }
 
   private resolveSchema(deps: GraphqlDeps): GraphQLSchemaType {

--- a/packages/passport/src/jwt-refresh-token-adapter.test.ts
+++ b/packages/passport/src/jwt-refresh-token-adapter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { JwtConfigurationError, type DefaultJwtSigner, type DefaultJwtVerifier } from '@konekti/jwt';
+
+import { JwtRefreshTokenAdapter } from './jwt-refresh-token-adapter.js';
+
+function createSigner(): DefaultJwtSigner {
+  return {
+    signAccessToken: async () => 'access-token',
+    signRefreshToken: async () => 'refresh-token',
+  } as unknown as DefaultJwtSigner;
+}
+
+function createVerifier(): DefaultJwtVerifier {
+  return {
+    verifyAccessToken: async () => ({ claims: { sub: 'user-1' } }),
+    verifyRefreshToken: async () => ({ claims: { family: 'family-1', jti: 'token-1', sub: 'user-1', type: 'refresh' } }),
+  } as unknown as DefaultJwtVerifier;
+}
+
+describe('JwtRefreshTokenAdapter', () => {
+  it('requires an explicit refresh token secret', () => {
+    expect(() =>
+      new JwtRefreshTokenAdapter(createSigner(), createVerifier(), {
+        secret: '',
+        store: 'memory',
+      }),
+    ).toThrow(JwtConfigurationError);
+  });
+
+  it('initializes when a refresh token secret is provided', () => {
+    expect(() =>
+      new JwtRefreshTokenAdapter(createSigner(), createVerifier(), {
+        secret: 'refresh-secret',
+        store: 'memory',
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/passport/src/jwt-refresh-token-adapter.ts
+++ b/packages/passport/src/jwt-refresh-token-adapter.ts
@@ -12,37 +12,19 @@ import type { RefreshTokenService } from './refresh-token.js';
 export const REFRESH_TOKEN_MODULE_OPTIONS = Symbol.for('konekti.passport.refresh-token-module-options');
 
 export interface RefreshTokenModuleOptions {
-  /**
-   * Secret used to sign refresh tokens.
-   * Defaults to the `REFRESH_TOKEN_SECRET` environment variable if not provided.
-   */
-  secret?: string;
-  /**
-   * Refresh token lifetime in seconds.
-   * Defaults to 604800 (7 days) if not provided.
-   */
+  secret: string;
   expiresInSeconds?: number;
-  /**
-   * Persistent store for refresh token records.
-   * Pass `'memory'` to explicitly opt into the in-memory store (development / single-instance only).
-   * Omitting this field causes a startup error, ensuring production deployments provide a real store.
-   */
   store: RefreshTokenStore | 'memory';
 }
 
 function resolveSecret(options: RefreshTokenModuleOptions): string {
-  if (options.secret) {
-    return options.secret;
-  }
-
-  const envSecret = process.env.REFRESH_TOKEN_SECRET;
-  if (!envSecret) {
+  if (!options.secret) {
     throw new JwtConfigurationError(
-      'Refresh token secret is not configured. Provide it via RefreshTokenModuleOptions.secret or the REFRESH_TOKEN_SECRET environment variable.',
+      'Refresh token secret is not configured. Provide it via RefreshTokenModuleOptions.secret.',
     );
   }
 
-  return envSecret;
+  return options.secret;
 }
 
 function createInMemoryStore(): RefreshTokenStore {

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -8,6 +8,7 @@ import { createHealthModule, defineModule, type ApplicationLogger } from '@konek
 
 import {
   bootstrapFastifyApplication,
+  createFastifyAdapter,
   FastifyHttpApplicationAdapter,
   runFastifyApplication,
 } from './adapter.js';
@@ -122,6 +123,42 @@ JNCDpGwh8us=
 -----END CERTIFICATE-----`;
 
 describe('@konekti/platform-fastify', () => {
+  it('uses the runtime default port instead of process.env.PORT', async () => {
+    const previousPort = process.env.PORT;
+    process.env.PORT = '4321';
+
+    try {
+      const adapter = createFastifyAdapter() as FastifyHttpApplicationAdapter;
+
+      expect(adapter.getListenTarget().url).toBe('http://localhost:3000');
+      await adapter.close();
+    } finally {
+      if (previousPort === undefined) {
+        delete process.env.PORT;
+      } else {
+        process.env.PORT = previousPort;
+      }
+    }
+  });
+
+  it('does not fail when process.env.PORT is invalid', async () => {
+    const previousPort = process.env.PORT;
+    process.env.PORT = 'not-a-number';
+
+    try {
+      const adapter = createFastifyAdapter() as FastifyHttpApplicationAdapter;
+
+      expect(adapter.getListenTarget().url).toBe('http://localhost:3000');
+      await adapter.close();
+    } finally {
+      if (previousPort === undefined) {
+        delete process.env.PORT;
+      } else {
+        process.env.PORT = previousPort;
+      }
+    }
+  });
+
   it('preserves raw body for JSON and text requests when enabled', async () => {
     @Controller('/webhooks')
     class WebhookController {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -758,10 +758,10 @@ function formatHostForAuthority(host: string): string {
 }
 
 function resolvePort(value: number | undefined): number {
-  const port = value ?? Number(process.env.PORT ?? 3000);
+  const port = value ?? 3000;
 
   if (!Number.isInteger(port) || port < 0 || port > 65535) {
-    throw new Error(`Invalid PORT value: ${String(value ?? process.env.PORT ?? 3000)}.`);
+    throw new Error(`Invalid PORT value: ${String(value ?? 3000)}.`);
   }
 
   return port;

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -3,7 +3,7 @@
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
 
-모듈 그래프를 컴파일하고 설정(config), DI, HTTP를 실행 가능한 애플리케이션 셸(shell)로 연결하는 조립 레이어입니다.
+모듈 그래프를 컴파일하고 DI, HTTP를 실행 가능한 애플리케이션 셸(shell)로 연결하는 조립 레이어입니다.
 
 ## 관련 문서
 
@@ -17,10 +17,9 @@
 
 1. 모듈 그래프 컴파일: `imports`/`exports` 가시성(visibility)을 검증하고, 순환 참조(circular imports)를 감지하며, 해결된 모든 토큰이 접근 가능한지 확인합니다.
 2. 루트 DI 컨테이너를 생성하고 모든 프로바이더와 컨트롤러를 등록합니다.
-3. `@konekti/config`를 통해 설정을 로드하고 `ConfigService`를 등록합니다.
-4. 싱글톤 프로바이더를 해결(resolve)하고 생명주기 훅(lifecycle hooks)을 실행합니다 (`onModuleInit` → `onApplicationBootstrap`).
-5. `@konekti/http`에서 `createHandlerMapping()`과 `createDispatcher()`를 호출합니다.
-6. `dispatch()`, `listen()`, `ready()`, `close()`를 포함하는 `KonektiApplication` 셸을 반환합니다.
+3. 싱글톤 프로바이더를 해결(resolve)하고 생명주기 훅(lifecycle hooks)을 실행합니다 (`onModuleInit` → `onApplicationBootstrap`).
+4. `@konekti/http`에서 `createHandlerMapping()`과 `createDispatcher()`를 호출합니다.
+5. `dispatch()`, `listen()`, `ready()`, `close()`를 포함하는 `KonektiApplication` 셸을 반환합니다.
 
 Node.js 앱의 경우 `runNodeApplication()`이 표준 시작 경로입니다. HTTP 어댑터, 기본 CORS, 시작 로깅, 그리고 정상 종료 시그널 연결(graceful shutdown signal wiring)을 처리합니다.
 
@@ -284,7 +283,7 @@ export class AppModule {}
 | `KonektiFactory.createMicroservice(rootModule, options)` | `src/bootstrap.ts` | DI/생명주기 컨텍스트를 부트스트랩하고 트랜스포트 기반 마이크로서비스 런타임 연결 |
 | `bootstrapModule(module)` | `src/bootstrap.ts` | 하위 레벨: 모듈 그래프 컴파일 + 컨테이너 빌드 |
 | `defineModule(cls, metadata)` | `src/bootstrap.ts` | 데코레이터 없이 모듈 메타데이터를 연결하는 하위 레벨 헬퍼 |
-| `Application` | `src/types.ts` | 인터페이스: `config`, `container`, `dispatcher`, `dispatch()`, `ready()`, `listen()`, `close()` |
+| `Application` | `src/types.ts` | 인터페이스: `container`, `modules`, `rootModule`, `state`, `dispatcher`, `dispatch()`, `ready()`, `listen()`, `close()` |
 | `@Module(metadata)` | `@konekti/core` | 모듈 프로바이더, 컨트롤러, 임포트, 익스포트 선언 |
 | `@Global()` | `@konekti/core` | 모듈을 전역적으로 가시성 있게 표시 |
 
@@ -294,8 +293,6 @@ export class AppModule {}
 
 ```text
 runNodeApplication(options)  [또는 bootstrapApplication]
-  → loadConfig(...)               (@konekti/config)
-  → ConfigService 프로바이더 등록
   → compileModuleGraph()
       → 임포트/익스포트 가시성 검증
       → 순환 참조 감지
@@ -342,7 +339,7 @@ runNodeApplication(options)  [또는 bootstrapApplication]
 `runNodeApplication()`은 애플리케이션 코드에 있어서는 안 될 Node 전용 시작 세부사항들을 통합합니다.
 - HTTP 어댑터 생성 및 바인딩
 - 기본 CORS 미들웨어
-- 설정으로부터 포트 해결
+- 런타임 옵션(`port`, 기본 `3000`)으로 포트 결정
 - 시작 로그
 - `SIGTERM`/`SIGINT` → `app.close()` 연결
 - 요청 중단 시그널 → `FrameworkRequest.signal` 브리지
@@ -361,12 +358,11 @@ Node 어댑터는 종료 시 새로운 연결 수락을 중단하고, 시작된 
 
 ## 관련 패키지
 
-- `@konekti/config` — 부트스트랩 중에 사용되는 `loadConfig`와 `ConfigService` 제공
 - `@konekti/di` — `bootstrapModule`이 프로바이더를 등록하는 `Container`
 - `@konekti/http` — `bootstrapApplication`에 의해 호출되는 `createHandlerMapping`과 `createDispatcher`
 
 ## 한 줄 멘탈 모델
 
 ```text
-@konekti/runtime = 메타데이터로 검증된 모듈 그래프 → 조립된 설정/DI/HTTP 애플리케이션 셸
+@konekti/runtime = 메타데이터로 검증된 모듈 그래프 → 조립된 DI/HTTP 애플리케이션 셸
 ```

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -3,7 +3,7 @@
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
 
-The assembly layer that compiles a module graph and wires config, DI, and HTTP into a runnable application shell.
+The assembly layer that compiles a module graph and wires DI and HTTP into a runnable application shell.
 
 ## See also
 
@@ -17,14 +17,11 @@ The assembly layer that compiles a module graph and wires config, DI, and HTTP i
 
 1. Compiles the module graph: validates `imports`/`exports` visibility, detects circular imports, and ensures every resolved token is accessible.
 2. Creates the root DI container and registers all providers and controllers.
-3. Loads config via `@konekti/config` and registers `ConfigService`.
-4. Resolves singleton providers and runs lifecycle hooks (`onModuleInit` → `onApplicationBootstrap`).
-5. Calls `createHandlerMapping()` and `createDispatcher()` from `@konekti/http`.
-6. Returns a `KonektiApplication` shell with `dispatch()`, `listen()`, `ready()`, and `close()`.
+3. Resolves singleton providers and runs lifecycle hooks (`onModuleInit` → `onApplicationBootstrap`).
+4. Calls `createHandlerMapping()` and `createDispatcher()` from `@konekti/http`.
+5. Returns a `KonektiApplication` shell with `dispatch()`, `listen()`, `ready()`, and `close()`.
 
 For Node.js apps, `runNodeApplication()` is the canonical startup path. It handles the HTTP adapter, default CORS, startup logging, and graceful shutdown signal wiring.
-
-In development, runtime also owns the in-process application of validated config reloads. Source-code edits still belong to runner-level process restart.
 
 ## Installation
 
@@ -74,17 +71,6 @@ await app.dispatch(req, res);
 // Graceful shutdown
 await app.close();
 ```
-
-### Dev-mode config reload
-
-```typescript
-const app = await bootstrapApplication({
-  rootModule: AppModule,
-  watch: true,
-});
-```
-
-With `watch: true`, runtime can subscribe to `createConfigReloader()` from `@konekti/config` and apply validated env-file updates to the existing `ConfigService` instance. This path is intentionally limited to config snapshots. It does not perform general code hot reload or module hot replacement.
 
 ### Standalone application context (no HTTP adapter)
 
@@ -297,7 +283,7 @@ export class AppModule {}
 | `KonektiFactory.createMicroservice(rootModule, options)` | `src/bootstrap.ts` | Bootstrap DI/lifecycle context and attach a transport-backed microservice runtime |
 | `bootstrapModule(module)` | `src/bootstrap.ts` | Lower-level: compile module graph + build container |
 | `defineModule(cls, metadata)` | `src/bootstrap.ts` | Low-level helper to attach module metadata without decorator |
-| `Application` | `src/types.ts` | Interface: `config`, `container`, `dispatcher`, `dispatch()`, `ready()`, `listen()`, `close()` |
+| `Application` | `src/types.ts` | Interface: `container`, `modules`, `rootModule`, `state`, `dispatcher`, `dispatch()`, `ready()`, `listen()`, `close()` |
 | `@Module(metadata)` | `@konekti/core` | Declares module providers, controllers, imports, exports |
 | `@Global()` | `@konekti/core` | Marks a module as globally visible |
 
@@ -307,9 +293,6 @@ export class AppModule {}
 
 ```text
 runNodeApplication(options)  [or bootstrapApplication]
-  → loadConfig(...)               (@konekti/config)
-  → register ConfigService provider
-  → optionally subscribe to dev-mode config reloads
   → compileModuleGraph()
       → validate imports/exports visibility
       → detect circular imports
@@ -356,7 +339,7 @@ Additional public exports also include helpers such as `KonektiFactory`, `create
 `runNodeApplication()` consolidates Node-specific startup details that should not live in application code:
 - HTTP adapter creation and binding
 - Default CORS middleware
-- Port resolution from config
+- Port resolution from runtime options (`port`, default `3000`)
 - Startup log
 - `SIGTERM`/`SIGINT` → `app.close()` wiring
 - Request abort signal → `FrameworkRequest.signal` bridge
@@ -375,12 +358,11 @@ The Node adapter stops accepting new connections on shutdown, drains started req
 
 ## Related packages
 
-- `@konekti/config` — provides `loadConfig` and `ConfigService` used during bootstrap
 - `@konekti/di` — `Container` that `bootstrapModule` registers providers into
 - `@konekti/http` — `createHandlerMapping` and `createDispatcher` called by `bootstrapApplication`
 
 ## One-liner mental model
 
 ```text
-@konekti/runtime = metadata-validated module graph → assembled config/DI/HTTP application shell
+@konekti/runtime = metadata-validated module graph → assembled DI/HTTP application shell
 ```

--- a/packages/runtime/src/node.test.ts
+++ b/packages/runtime/src/node.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { createNodeHttpAdapter, NodeHttpApplicationAdapter } from './node.js';
+
+describe('createNodeHttpAdapter', () => {
+  it('uses the runtime default port instead of process.env.PORT', async () => {
+    const previousPort = process.env.PORT;
+    process.env.PORT = '4321';
+
+    try {
+      const adapter = createNodeHttpAdapter() as NodeHttpApplicationAdapter;
+
+      expect(adapter.getListenTarget().url).toBe('http://localhost:3000');
+      await adapter.close();
+    } finally {
+      if (previousPort === undefined) {
+        delete process.env.PORT;
+      } else {
+        process.env.PORT = previousPort;
+      }
+    }
+  });
+
+  it('does not fail when process.env.PORT is invalid', async () => {
+    const previousPort = process.env.PORT;
+    process.env.PORT = 'not-a-number';
+
+    try {
+      const adapter = createNodeHttpAdapter() as NodeHttpApplicationAdapter;
+
+      expect(adapter.getListenTarget().url).toBe('http://localhost:3000');
+      await adapter.close();
+    } finally {
+      if (previousPort === undefined) {
+        delete process.env.PORT;
+      } else {
+        process.env.PORT = previousPort;
+      }
+    }
+  });
+});

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -554,10 +554,10 @@ function defaultShutdownSignals(): false | readonly NodeApplicationSignal[] {
 }
 
 function resolveNodePort(value: number | undefined): number {
-  const port = value ?? Number(process.env.PORT ?? 3000);
+  const port = value ?? 3000;
 
   if (!Number.isInteger(port) || port < 0 || port > 65535) {
-    throw new Error(`Invalid PORT value: ${String(value ?? process.env.PORT ?? 3000)}.`);
+    throw new Error(`Invalid PORT value: ${String(value ?? 3000)}.`);
   }
 
   return port;


### PR DESCRIPTION
## Summary
- Remove direct `process.env` fallbacks from runtime and fastify port resolution so these adapters now rely on explicit runtime options (`port`, default `3000`).
- Remove GraphQL's `NODE_ENV`-based GraphiQL default and make the default explicit (`graphiql` defaults to `true` when omitted).
- Require explicit refresh-token secrets in passport (`RefreshTokenModuleOptions.secret`) and update runtime/graphql docs to match current package boundaries.

## Verification
- `pnpm build`
- `pnpm exec vitest run -c vitest.config.ts packages/runtime/src/node.test.ts packages/platform-fastify/src/adapter.test.ts packages/graphql/src/service.test.ts packages/passport/src/jwt-refresh-token-adapter.test.ts`
- `pnpm --filter @konekti/runtime --filter @konekti/platform-fastify --filter @konekti/graphql --filter @konekti/passport run typecheck`
- `pnpm --filter @konekti/runtime --filter @konekti/platform-fastify --filter @konekti/graphql --filter @konekti/passport run build`

Closes #410