### PR TITLE
Resolve #415: default GraphiQL to false to prevent production exposure

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -100,7 +100,7 @@ interface GraphQLContext {
 - `schema`: 스키마 우선 입력입니다. `GraphQLSchema` 인스턴스 또는 SDL 문자열을 받을 수 있습니다.
 - `resolvers`: 코드 우선 탐색 시 사용할 resolver allowlist입니다.
 - `context`: 요청 단위 커스텀 GraphQL context 값을 추가합니다.
-- `graphiql`: GraphiQL 표시 여부를 명시합니다. 값을 지정하지 않으면 기본값은 `true`입니다.
+- `graphiql`: GraphiQL 표시 여부를 명시합니다. 기본값은 `false`입니다. 개발 환경에서 활성화하려면 `graphiql: true`를 전달하세요.
 - `subscriptions.websocket.enabled`: 공유 Node HTTP 서버에 `graphql-ws` 전송 계층을 활성화하며, `/graphql`의 SSE 지원은 그대로 유지합니다.
 - `subscriptions.websocket.keepAliveMs`: `graphql-ws` keepalive용 websocket ping 간격을 조정합니다.
 - `subscriptions.websocket.connectionInitWaitTimeoutMs`: 초기 `connection_init` 메시지 대기 시간을 조정합니다.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -100,7 +100,7 @@ interface GraphQLContext {
 - `schema`: schema-first input. Accepts a `GraphQLSchema` instance or SDL string.
 - `resolvers`: optional allowlist for code-first discovery.
 - `context`: adds custom GraphQL context values for each request.
-- `graphiql`: explicit GraphiQL toggle. Default is `true` when not set.
+- `graphiql`: explicit GraphiQL toggle. Default is `false`. Set to `true` to enable GraphiQL (e.g. in development).
 - `subscriptions.websocket.enabled`: enables `graphql-ws` transport on the shared Node HTTP server while keeping SSE support available on `/graphql`.
 - `subscriptions.websocket.keepAliveMs`: custom websocket ping interval for `graphql-ws` keepalive frames.
 - `subscriptions.websocket.connectionInitWaitTimeoutMs`: custom timeout for the initial `connection_init` message.

--- a/packages/graphql/src/service.test.ts
+++ b/packages/graphql/src/service.test.ts
@@ -39,14 +39,20 @@ function resolveGraphiqlEnabled(service: GraphqlLifecycleService): boolean {
 }
 
 describe('GraphqlLifecycleService graphiql defaults', () => {
-  it('defaults to true even when NODE_ENV is production', () => {
+  it('defaults to false when graphiql option is not set', () => {
+    const service = createService({});
+
+    expect(resolveGraphiqlEnabled(service)).toBe(false);
+  });
+
+  it('defaults to false regardless of NODE_ENV', () => {
     const previousNodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    process.env.NODE_ENV = 'development';
 
     try {
       const service = createService({});
 
-      expect(resolveGraphiqlEnabled(service)).toBe(true);
+      expect(resolveGraphiqlEnabled(service)).toBe(false);
     } finally {
       if (previousNodeEnv === undefined) {
         delete process.env.NODE_ENV;

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -385,11 +385,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   }
 
   private resolveGraphiqlEnabled(): boolean {
-    if (this.options.graphiql !== undefined) {
-      return this.options.graphiql;
-    }
-
-    return true;
+    return this.options.graphiql ?? false;
   }
 
   private resolveSchema(deps: GraphqlDeps): GraphQLSchemaType {


### PR DESCRIPTION
## Summary

- Changes `graphiql` default from `true` to `false` in `GraphqlLifecycleService.isGraphiqlEnabled()`
- Updates tests to assert `false` is the correct default behavior
- Updates both English and Korean READMEs to document the new default

Closes #415