### PR TITLE
Resolve #416: evict multi singleton cache when override scope is non-default

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -804,5 +804,37 @@ describe('Container', () => {
       expect(events).toContain('plugin-a');
       expect(events).toContain('plugin-b');
     });
+
+    it('evicts multi singleton cache when override uses non-default scope', async () => {
+      const events: string[] = [];
+      const token = Symbol('multi-non-default-scope-override');
+
+      class PluginA {
+        onDestroy() {
+          events.push('plugin-a');
+        }
+      }
+
+      class PluginB {
+        onDestroy() {
+          events.push('plugin-b');
+        }
+      }
+
+      const container = new Container().register(
+        { provide: token, useClass: PluginA, multi: true },
+      );
+
+      await container.resolve(token);
+
+      container.override({ provide: token, useClass: PluginB, multi: true, scope: 'transient' });
+      await Promise.resolve();
+
+      expect(events).toContain('plugin-a');
+
+      await container.dispose();
+
+      expect(events.filter((e) => e === 'plugin-a')).toHaveLength(1);
+    });
   });
 });

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -705,29 +705,29 @@ export class Container {
       this.requestCache.delete(token);
     }
 
-    if (this.parent || scope !== Scope.DEFAULT) {
-      return;
+    if (!this.parent && scope === Scope.DEFAULT) {
+      const singletonCache = this.singletonCache;
+
+      if (singletonCache.has(token)) {
+        const cached = singletonCache.get(token);
+
+        if (cached) {
+          this.scheduleStaleDisposal(cached);
+        }
+
+        singletonCache.delete(token);
+      }
     }
 
-    const singletonCache = this.singletonCache;
+    if (!this.parent) {
+      for (const [provider, cached] of this.multiSingletonCache.entries()) {
+        if (provider.provide !== token) {
+          continue;
+        }
 
-    if (singletonCache.has(token)) {
-      const cached = singletonCache.get(token);
-
-      if (cached) {
         this.scheduleStaleDisposal(cached);
+        this.multiSingletonCache.delete(provider);
       }
-
-      singletonCache.delete(token);
-    }
-
-    for (const [provider, cached] of this.multiSingletonCache.entries()) {
-      if (provider.provide !== token) {
-        continue;
-      }
-
-      this.scheduleStaleDisposal(cached);
-      this.multiSingletonCache.delete(provider);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Splits the early-return guard in `invalidateCachedEntry` so the `multiSingletonCache` loop runs regardless of provider scope
- Previously, overriding a multi provider with `scope: 'transient'` or `scope: 'request'` would skip cache eviction, leaving stale instances in the cache
- Adds a regression test that overrides a resolved multi provider with a transient-scoped replacement and asserts the previous instance is disposed exactly once

Closes #416