### PR TITLE
Resolve #417: strip v-prefix from _clientVersion before major version parse

### DIFF
--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -345,6 +345,32 @@ describe('@konekti/prisma', () => {
     expect(optionsCalls).toEqual([{ isolationLevel: 'repeatable read' }]);
   });
 
+  it('injects request signal when _clientVersion uses a v-prefixed format', async () => {
+    const optionsCalls: Array<{ signal?: AbortSignal } | undefined> = [];
+    const transactionClient = {};
+    const client = {
+      _clientVersion: 'v5.0.0',
+      async $connect() {},
+      async $disconnect() {},
+      async $transaction<T>(
+        callback: (value: typeof transactionClient) => Promise<T>,
+        options?: { signal?: AbortSignal },
+      ): Promise<T> {
+        optionsCalls.push(options);
+        return callback(transactionClient);
+      },
+    };
+
+    const prisma = new PrismaService<typeof client, typeof transactionClient, { signal?: AbortSignal }>(client);
+    const requestAbortController = new AbortController();
+
+    await expect(
+      prisma.requestTransaction(async () => prisma.current(), requestAbortController.signal),
+    ).resolves.toBe(transactionClient);
+
+    expect(optionsCalls[0]?.signal).toBeDefined();
+  });
+
   it('rejects nested transaction options to avoid silent option drops', async () => {
     const transactionClient = {
       kind: 'transaction' as const,

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -147,7 +147,8 @@ export class PrismaService<
       return false;
     }
 
-    const majorVersion = Number.parseInt(clientVersion.split('.')[0] ?? '', 10);
+    const rawSegment = clientVersion.split('.')[0] ?? '';
+    const majorVersion = Number.parseInt(rawSegment.replace(/^v/i, ''), 10);
 
     return Number.isInteger(majorVersion) && majorVersion >= 5;
   }


### PR DESCRIPTION
## Summary

- Strips an optional leading `v` or `V` from `_clientVersion` before calling `parseInt` so that version strings like `v5.0.0` are correctly parsed as major version 5
- Without the fix, `parseInt('v5', 10)` returns `NaN`, causing `supportsTransactionAbortSignalOption` to return `false` and the abort signal to be silently dropped on Prisma v5 clients whose version string carries a prefix
- Adds a regression test with `_clientVersion: 'v5.0.0'` asserting that the signal is forwarded

Closes #417