### PR TITLE
Resolve #418: document passport RefreshTokenJwtOptions.secret as required in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Breaking changes
+
+- `@konekti/passport`: `RefreshTokenJwtOptions.secret` is now required. Previously the field was optional and the adapter would fall back to reading `REFRESH_TOKEN_SECRET` from `process.env` directly; that fallback has been removed. Pass `secret` explicitly via DI-configured options (`REFRESH_TOKEN_MODULE_OPTIONS`).
+
 ### Added
 
 - `@konekti/terminus`: Terminus-style health indicators, structured `/health` aggregation, and runtime readiness integration layered on `createHealthModule()`.


### PR DESCRIPTION
## Summary

- Adds a `### Breaking changes` section to `[Unreleased]` in `CHANGELOG.md` documenting that `RefreshTokenJwtOptions.secret` is now required and the `process.env.REFRESH_TOKEN_SECRET` fallback has been removed
- The deployment docs (`docs/operations/deployment.md` and `deployment.ko.md`) were verified as already correct after PR #414 — no changes needed there

Closes #418