### PR TITLE
Resolve #424: fix(throttler): use deterministic handler key identities

### DIFF
--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -97,7 +97,7 @@ class AppBootstrap {
 ## 동작 방식
 
 - 속도 제한 키의 기본값은 `socket.remoteAddress`입니다. 헤더 기반 키(예: `x-api-key`)를 사용하려면 `keyGenerator`를 제공하세요.
-- 저장소 키는 `throttler:<encoded-handler-key>:<encoded-client-key>` 형태로 구성됩니다. 두 키 세그먼트는 모두 `encodeURIComponent(...)`로 인코딩되므로 IPv6 주소처럼 `:`를 포함하는 클라이언트 키도 구분자 경계와 충돌하지 않습니다. 디코딩된 `<handler-key>`에는 클래스나 메서드 이름이 같은 핸들러 간의 충돌을 방지하기 위한 경로 메서드/경로/버전 및 컨트롤러/모듈 토큰 식별자가 포함됩니다.
+- 저장소 키는 `throttler:<encoded-handler-key>:<encoded-client-key>` 형태로 구성됩니다. 두 키 세그먼트는 모두 `encodeURIComponent(...)`로 인코딩되므로 IPv6 주소처럼 `:`를 포함하는 클라이언트 키도 구분자 경계와 충돌하지 않습니다. 디코딩된 `<handler-key>`에는 인스턴스가 달라도 같은 값을 유지하는 경로 메서드/경로/버전 및 결정적인 컨트롤러/모듈 클래스 이름 식별자가 포함되어, 클래스나 메서드 이름이 같은 핸들러 간 충돌을 방지합니다.
 - 제한을 초과하면 `ThrottlerGuard`는 `TooManyRequestsException` (HTTP 429)을 발생시키고, `Retry-After` 응답 헤더에 현재 윈도우에 남은 시간을 초 설정합니다.
 - 메서드 레벨의 `@Throttle`은 클래스 레벨의 `@Throttle`을 오버라이드하며, 클래스 레벨은 모듈 레벨의 기본값을 오버라이드합니다 (이 우선순위 순서대로 적용).
 - 어느 레벨에서든 `@SkipThrottle()`이 설정되면 무조건 우선권을 갖습니다.

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -97,7 +97,7 @@ class AppBootstrap {
 ## Behavior
 
 - Rate limit key defaults to `socket.remoteAddress`. Provide `keyGenerator` for header-based keying (e.g. `x-api-key`).
-- Store keys are composed as `throttler:<encoded-handler-key>:<encoded-client-key>`. Both key segments are encoded with `encodeURIComponent(...)`, so client keys containing `:` (for example IPv6 addresses) cannot collide with separator boundaries. The decoded `<handler-key>` still includes route method/path/version and controller/module token identities to prevent collisions between handlers that share class or method names.
+- Store keys are composed as `throttler:<encoded-handler-key>:<encoded-client-key>`. Both key segments are encoded with `encodeURIComponent(...)`, so client keys containing `:` (for example IPv6 addresses) cannot collide with separator boundaries. The decoded `<handler-key>` still includes route method/path/version and deterministic controller/module class-name identities to prevent collisions between handlers that share class or method names across instances.
 - When the limit is exceeded, `ThrottlerGuard` throws `TooManyRequestsException` (HTTP 429) and sets the `Retry-After` response header to the seconds remaining in the current window.
 - Method-level `@Throttle` overrides class-level `@Throttle`, which overrides module-level defaults — in that priority order.
 - `@SkipThrottle()` at either level wins unconditionally.

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -14,9 +14,6 @@ import type { ThrottlerModuleOptions, ThrottlerStore } from './types.js';
 
 type MetadataBag = Record<PropertyKey, unknown>;
 
-const functionIdentityMap = new WeakMap<Function, number>();
-let nextFunctionIdentity = 1;
-
 function getClassMetadataBag(target: object): MetadataBag | undefined {
   return (target as Record<symbol, MetadataBag | undefined>)[metadataSymbol];
 }
@@ -45,26 +42,16 @@ function buildStoreKey(handlerKey: string, clientKey: string): string {
   return `throttler:${encodedHandlerKey}:${encodedClientKey}`;
 }
 
-function getFunctionIdentity(value: Function): number {
-  const existing = functionIdentityMap.get(value);
-
-  if (existing !== undefined) {
-    return existing;
-  }
-
-  const assigned = nextFunctionIdentity;
-  nextFunctionIdentity += 1;
-  functionIdentityMap.set(value, assigned);
-
-  return assigned;
+function getTypeIdentity(value: Function): string {
+  return value.name || 'anonymous';
 }
 
 function buildHandlerKey(handler: GuardContext['handler']): string {
   const version = handler.route.version ?? handler.metadata.effectiveVersion ?? 'unversioned';
   const moduleIdentity = handler.metadata.moduleType
-    ? `module:${getFunctionIdentity(handler.metadata.moduleType)}`
+    ? `module:${getTypeIdentity(handler.metadata.moduleType)}`
     : 'module:none';
-  const controllerIdentity = `controller:${getFunctionIdentity(handler.controllerToken)}`;
+  const controllerIdentity = `controller:${getTypeIdentity(handler.controllerToken)}`;
 
   return [
     `method:${handler.route.method}`,

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -442,8 +442,73 @@ describe('ThrottlerGuard — Redis store mock', () => {
     expect(decodedHandler).toContain('path:%2Fv1%2Frate-limit');
     expect(decodedHandler).toContain('version:1');
     expect(decodedHandler).toContain('handler:hit');
-    expect(decodedHandler).toContain('module:');
-    expect(decodedHandler).toContain('controller:');
+    expect(decodedHandler).toContain('module:RateModule');
+    expect(decodedHandler).toContain('controller:RateController');
     expect(decodedClient).toBe('2001:db8::1');
+  });
+
+  it('builds the same store key even when handler discovery order differs across module instances', async () => {
+    const buildStore = (): ThrottlerStore => ({
+      consume: vi.fn(async (_key: string, input) => ({
+        count: 1,
+        resetAt: input.now + input.ttlSeconds * 1000,
+      })),
+    });
+
+    class WarmupController {
+      warmup() {}
+    }
+
+    class WarmupModule {}
+
+    class RateController {
+      hit() {}
+    }
+
+    class RateModule {}
+
+    vi.resetModules();
+    const { ThrottlerGuard: GuardA } = await import('./guard.js');
+    const storeA = buildStore();
+    const guardA = new GuardA({ limit: 2, store: storeA, ttl: 60 });
+
+    await guardA.canActivate(
+      createGuardContext(WarmupController, 'warmup', createRequestContext('2001:db8::10'), {
+        moduleType: WarmupModule,
+        routeMethod: 'GET',
+        routePath: '/warmup',
+        routeVersion: '1',
+      }),
+    );
+
+    await guardA.canActivate(
+      createGuardContext(RateController, 'hit', createRequestContext('2001:db8::1'), {
+        moduleType: RateModule,
+        routeMethod: 'POST',
+        routePath: '/v1/rate-limit',
+        routeVersion: '1',
+      }),
+    );
+
+    vi.resetModules();
+    const { ThrottlerGuard: GuardB } = await import('./guard.js');
+    const storeB = buildStore();
+    const guardB = new GuardB({ limit: 2, store: storeB, ttl: 60 });
+
+    await guardB.canActivate(
+      createGuardContext(RateController, 'hit', createRequestContext('2001:db8::1'), {
+        moduleType: RateModule,
+        routeMethod: 'POST',
+        routePath: '/v1/rate-limit',
+        routeVersion: '1',
+      }),
+    );
+
+    const keyA = vi.mocked(storeA.consume).mock.calls[1]?.[0];
+    const keyB = vi.mocked(storeB.consume).mock.calls[0]?.[0];
+
+    expect(keyA).toBeDefined();
+    expect(keyB).toBeDefined();
+    expect(keyA).toBe(keyB);
   });
 });


### PR DESCRIPTION
Closes #424

## Summary
- replace process-local WeakMap numeric identities in throttler handler keys with deterministic class-name identities
- add a regression test that proves handler discovery order no longer changes Redis store keys across module instances
- update the English and Korean throttler READMEs to describe the deterministic handler key composition

## Verification
- `pnpm -r --filter @konekti/core --filter @konekti/di --filter @konekti/dto-validator --filter @konekti/http --filter @konekti/runtime --filter @konekti/throttler run build`
- `pnpm exec vitest run packages/throttler/src/module.test.ts`
- `pnpm --filter @konekti/throttler run typecheck`
- `lsp_diagnostics` reported 0 errors in `packages/throttler`