### PR TITLE
Resolve #423: fix(cache-manager): isolate authenticated cache keys by principal

### DIFF
--- a/docs/concepts/caching.ko.md
+++ b/docs/concepts/caching.ko.md
@@ -22,7 +22,7 @@
 ## 요청 동작 규약
 
 - 기본 read-through 캐시는 **GET 전용**입니다.
-- 기본 키는 매칭된 라우트 경로(`handler.metadata.effectivePath`)이며, 쿼리 문자열은 기본적으로 키에 포함되지 않습니다.
+- 기본 키는 매칭된 라우트 경로(`handler.metadata.effectivePath`)에서 시작합니다. `RequestContext.principal`이 있으면 내장 문자열 전략이 `principal.issuer` + `principal.subject`를 추가해 인증된 응답을 사용자 단위로 분리합니다. 쿼리 문자열은 query-aware 전략을 명시적으로 선택하지 않는 한 기본적으로 키에 포함되지 않습니다.
 - `@CacheKey(...)`는 핸들러 키를 오버라이드합니다.
 - `@CacheTTL(...)`는 모듈 기본 TTL을 핸들러 단위로 오버라이드합니다.
 - `@CacheEvict(...)`는 성공한 non-GET 핸들러의 응답이 기록된 뒤 실행되며 하나 이상의 키를 삭제할 수 있습니다.
@@ -66,7 +66,7 @@ await bootstrapApplication({
 });
 ```
 
-`CacheInterceptor`를 글로벌로 등록해도 기본 read-through 캐시는 GET 핸들러에만 적용됩니다. 쿼리 문자열까지 포함한 키가 필요하면 `@CacheKey(...)`로 명시적으로 지정하세요.
+`CacheInterceptor`를 글로벌로 등록해도 기본 read-through 캐시는 GET 핸들러에만 적용됩니다. 내장 문자열 전략은 인증된 principal을 자동으로 분리하지만, 쿼리 문자열까지 포함한 키가 필요하면 `httpKeyStrategy: 'route+query'` 또는 `@CacheKey(...)`를 명시적으로 지정하세요.
 
 ### 메모리 전용 구성
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -22,7 +22,7 @@ This guide explains Konekti's HTTP response caching model powered by `@konekti/c
 ## request behavior
 
 - **Read-through cache is GET-only by default**.
-- The default key is the matched route path (`handler.metadata.effectivePath`), so different query strings share the same key unless you override it.
+- The default key starts from the matched route path (`handler.metadata.effectivePath`). If `RequestContext.principal` is present, built-in string strategies append `principal.issuer` + `principal.subject` so authenticated responses are isolated by user. Different query strings still share the same key unless you opt into a query-aware strategy.
 - `@CacheKey(...)` overrides the key for a handler.
 - `@CacheTTL(...)` overrides module-level default TTL for a handler.
 - `@CacheEvict(...)` runs after the response write of successful non-GET handlers and can evict one or many keys.
@@ -66,7 +66,7 @@ await bootstrapApplication({
 });
 ```
 
-When you register `CacheInterceptor` globally, only GET handlers are read-through cached by default. Use `@CacheKey(...)` to opt into query-aware keys.
+When you register `CacheInterceptor` globally, only GET handlers are read-through cached by default. Built-in string strategies isolate authenticated principals automatically, but query-sensitive routes still need `httpKeyStrategy: 'route+query'` or an explicit `@CacheKey(...)` override.
 
 ### memory-only setup
 

--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -127,12 +127,14 @@ class AppModule {}
 
 - 기본 캐시 조회는 **GET 전용**입니다.
 - 기본 캐시 키는 `httpKeyStrategy`에 따라 결정됩니다:
-  - `'route'` (기본값) — 매칭된 라우트 경로만 사용, 쿼리 파라미터 무시.
-  - `'route+query'` — 라우트 경로 + 정렬된 쿼리 문자열 (쿼리 민감 엔드포인트에 권장).
-  - `'full'` — 라우트 경로 + 정렬된 쿼리 문자열; 현재 `'route+query'`와 동일.
+  - `'route'` (기본값) — 비인증 요청에서는 매칭된 라우트 경로만 사용하고, 인증 요청에서는 `principal.issuer` + `principal.subject` 범위를 추가합니다.
+  - `'route+query'` — 라우트 경로 + 정렬된 쿼리 문자열에, 인증된 principal 범위를 함께 포함합니다.
+  - `'full'` — 라우트 경로 + 정렬된 쿼리 문자열에, 인증된 principal 범위를 함께 포함합니다. 현재 `'route+query'`와 동일합니다.
   - `function` — 커스텀 resolver `(context) => string`.
 - `@CacheKey(...)` 데코레이터는 개별 핸들러에 대해 모듈 레벨 전략을 재정의합니다.
 - `@CacheEvict(...)`는 성공한 non-GET 핸들러의 응답이 기록된 뒤 실행됩니다.
+
+> 내장 문자열 전략은 기본적으로 principal-aware 입니다. `@CacheKey(...)`나 커스텀 함수로 키를 직접 덮어쓰면, 해당 라우트에 필요한 인증/테넌트/로케일/헤더 변이를 직접 키에 포함해야 합니다.
 
 ### 범용 캐시 동작 (CacheService / CacheStore)
 

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -129,12 +129,14 @@ class AppModule {}
 
 - Cache reads are **GET-only** by default.
 - Default cache key depends on `httpKeyStrategy`:
-  - `'route'` (default) — matched route path only, query params ignored.
-  - `'route+query'` — route path + sorted query string (recommended for query-sensitive endpoints).
-  - `'full'` — route path + sorted query string; currently equivalent to `'route+query'`.
+  - `'route'` (default) — matched route path only for unauthenticated requests; authenticated requests append `principal.issuer` + `principal.subject`.
+  - `'route+query'` — route path + sorted query string, plus authenticated principal scope when present.
+  - `'full'` — route path + sorted query string, plus authenticated principal scope when present; currently equivalent to `'route+query'`.
   - `function` — custom resolver `(context) => string`.
 - `@CacheKey(...)` decorator overrides the module-level strategy for individual handlers.
 - `@CacheEvict(...)` runs after the response write of successful non-GET handlers.
+
+> Built-in string strategies are principal-aware by default. If you override the key with `@CacheKey(...)` or a custom function, you are responsible for including any auth, tenant, locale, or header variance required by the route.
 
 #### Query-Sensitive Caching Example
 
@@ -169,9 +171,10 @@ class ProductController {
 
 #### Migration Note
 
-The default `httpKeyStrategy` is `'route'` for backward compatibility. This means:
+The default `httpKeyStrategy` is `'route'`. This means:
 - Existing applications continue to work without changes.
 - Query parameters are ignored in cache keys by default.
+- Authenticated requests are isolated by `principal.issuer` + `principal.subject` when `RequestContext.principal` is present.
 - For new projects or query-sensitive endpoints, set `httpKeyStrategy: 'route+query'`.
 
 To opt in to query-aware caching globally:

--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { CallHandler, HttpMethod, InterceptorContext, RequestContext } from '@konekti/http';
+import type { CallHandler, HttpMethod, InterceptorContext, Principal, RequestContext } from '@konekti/http';
 
 import { CacheEvict, CacheKey, CacheTTL } from './decorators.js';
 import { CacheInterceptor } from './interceptor.js';
@@ -16,7 +16,13 @@ const cacheOptions: NormalizedCacheModuleOptions = {
   httpKeyStrategy: 'route',
 };
 
-function createRequestContext(method: string, url: string, path = url, headers: Record<string, string | string[]> = {}): RequestContext {
+function createRequestContext(
+  method: string,
+  url: string,
+  path = url,
+  headers: Record<string, string | string[]> = {},
+  principal?: Principal,
+): RequestContext {
   const queryStart = url.indexOf('?');
   const query: Record<string, string> = {};
 
@@ -40,6 +46,7 @@ function createRequestContext(method: string, url: string, path = url, headers: 
       },
     },
     metadata: {},
+    principal,
     request: {
       body: undefined,
       cookies: {},
@@ -303,6 +310,40 @@ describe('CacheInterceptor', () => {
       expect(await cacheService.get('/products')).toEqual({ page: 1 });
     });
 
+    it('strategy "route" isolates authenticated principals by default', async () => {
+      class ProductController {
+        @CacheTTL(120)
+        list() {}
+      }
+
+      const { interceptor, cacheService } = createInterceptor({ httpKeyStrategy: 'route' });
+      const alice: Principal = { subject: 'alice', issuer: 'issuer-a', claims: {} };
+      const bob: Principal = { subject: 'bob', issuer: 'issuer-a', claims: {} };
+      const firstContext = createContext(
+        ProductController,
+        'list',
+        createRequestContext('GET', '/products', '/products', {}, alice),
+      );
+      const secondContext = createContext(
+        ProductController,
+        'list',
+        createRequestContext('GET', '/products', '/products', {}, bob),
+      );
+      const next: CallHandler = {
+        handle: vi
+          .fn<CallHandler['handle']>()
+          .mockResolvedValueOnce({ owner: 'alice' })
+          .mockResolvedValueOnce({ owner: 'bob' }),
+      };
+
+      await interceptor.intercept(firstContext, next);
+      await interceptor.intercept(secondContext, next);
+
+      expect(next.handle).toHaveBeenCalledTimes(2);
+      expect(await cacheService.get('/products|principal:issuer-a:alice')).toEqual({ owner: 'alice' });
+      expect(await cacheService.get('/products|principal:issuer-a:bob')).toEqual({ owner: 'bob' });
+    });
+
     it('strategy "route+query" includes sorted query in cache key', async () => {
       class ProductController {
         @CacheTTL(120)
@@ -414,7 +455,7 @@ describe('CacheInterceptor', () => {
       expect(await cacheService.get('/products?page=1')).toBeUndefined();
     });
 
-    it('default strategy is "route" for backward compatibility', async () => {
+    it('default strategy still ignores query parameters for unauthenticated requests', async () => {
       class ProductController {
         @CacheTTL(120)
         list() {}

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -49,6 +49,19 @@ function buildSortedQueryString(query: Record<string, unknown>): string {
   return entries.join('&');
 }
 
+function appendPrincipalScope(key: string, context: InterceptorContext): string {
+  const principal = context.requestContext.principal;
+
+  if (!principal) {
+    return key;
+  }
+
+  const issuer = encodeURIComponent(principal.issuer ?? 'unknown');
+  const subject = encodeURIComponent(principal.subject);
+
+  return `${key}|principal:${issuer}:${subject}`;
+}
+
 function defaultCacheKey(context: InterceptorContext, strategy: CacheKeyStrategy): string {
   if (typeof strategy === 'function') {
     return strategy(context);
@@ -58,16 +71,16 @@ function defaultCacheKey(context: InterceptorContext, strategy: CacheKeyStrategy
   const query = context.requestContext.request.query;
 
   if (strategy === 'route') {
-    return path;
+    return appendPrincipalScope(path, context);
   }
 
   const queryString = buildSortedQueryString(query);
 
   if (!queryString) {
-    return path;
+    return appendPrincipalScope(path, context);
   }
 
-  return `${path}?${queryString}`;
+  return appendPrincipalScope(`${path}?${queryString}`, context);
 }
 
 function normalizeTtl(ttlSeconds: number | undefined, fallback: number): number | undefined {

--- a/packages/cache-manager/src/types.ts
+++ b/packages/cache-manager/src/types.ts
@@ -52,12 +52,4 @@ export type CacheEvictFactory = (
 
 export type CacheEvictDecoratorValue = string | readonly string[] | CacheEvictFactory;
 
-/**
- * Strategy for computing default HTTP cache keys.
- *
- * - `'route'` — key is the matched route path only (legacy default).
- * - `'route+query'` — route path + sorted query string (recommended).
- * - `'full'` — route path + sorted query string; currently equivalent to `'route+query'`.
- * - `function` — custom resolver receiving the interceptor context.
- */
 export type CacheKeyStrategy = 'route' | 'route+query' | 'full' | ((context: InterceptorContext) => string);


### PR DESCRIPTION
Closes #423

## Summary
- make built-in cache-manager string key strategies append `principal.issuer` and `principal.subject` when an authenticated principal is present
- add regression coverage for authenticated route-key isolation while preserving legacy unauthenticated route-only query behavior
- update the cache-manager package docs and caching concept docs in English and Korean to document principal-aware default keys and explicit override responsibilities

## Verification
- `pnpm -r --filter @konekti/core --filter @konekti/di --filter @konekti/dto-validator --filter @konekti/http --filter @konekti/runtime --filter @konekti/cache-manager run build`
- `pnpm --filter @konekti/cache-manager run typecheck`
- `lsp_diagnostics` reported 0 errors in `packages/cache-manager`
- manually executed the built cache interceptor to confirm authenticated requests produce distinct cache entries while unauthenticated route-only requests still share the legacy key