### PR TITLE
Resolve #429: docs(jwt): fix Key API async return types

### DIFF
--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -144,8 +144,8 @@ const verifier = new DefaultJwtVerifier({
 
 | 익스포트(Export) | 위치 | 설명 |
 |---|---|---|
-| `DefaultJwtVerifier` | `src/verifier.ts` | `verifyAccessToken(token) → JwtPrincipal` |
-| `DefaultJwtSigner` | `src/signer.ts` | `signAccessToken(claims) → string` |
+| `DefaultJwtVerifier` | `src/verifier.ts` | `verifyAccessToken(token) → Promise<JwtPrincipal>` |
+| `DefaultJwtSigner` | `src/signer.ts` | `signAccessToken(claims) → Promise<string>` |
 | `createJwtCoreProviders(options)` | `src/module.ts` | 옵션, 검증기, 서명기를 한 번에 등록 |
 | `JwtPrincipal` | `src/types.ts` | `{ subject, issuer?, audience?, roles?, scopes?, claims }` |
 | `JwtClaims` | `src/types.ts` | 로우(Raw) 클레임 형태 |

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -144,8 +144,8 @@ const verifier = new DefaultJwtVerifier({
 
 | Export | Location | Description |
 |---|---|---|
-| `DefaultJwtVerifier` | `src/verifier.ts` | `verifyAccessToken(token) → JwtPrincipal` |
-| `DefaultJwtSigner` | `src/signer.ts` | `signAccessToken(claims) → string` |
+| `DefaultJwtVerifier` | `src/verifier.ts` | `verifyAccessToken(token) → Promise<JwtPrincipal>` |
+| `DefaultJwtSigner` | `src/signer.ts` | `signAccessToken(claims) → Promise<string>` |
 | `createJwtCoreProviders(options)` | `src/module.ts` | Registers options, verifier, and signer in one call |
 | `JwtPrincipal` | `src/types.ts` | `{ subject, issuer?, audience?, roles?, scopes?, claims }` |
 | `JwtClaims` | `src/types.ts` | Raw claims shape |


### PR DESCRIPTION
Closes #429

## Summary
- update the JWT Key API table in the English README to show that `signAccessToken` and `verifyAccessToken` return `Promise<T>`
- mirror the same async return type fix in the Korean README
- keep the table aligned with the existing async examples and the actual signer/verifier interfaces

## Verification
- `git diff --check`
- confirmed the Key API tables in `packages/jwt/README.md` and `packages/jwt/README.ko.md` now show `Promise<string>` and `Promise<JwtPrincipal>`
- cross-checked the docs against `packages/jwt/src/signer.ts`, `packages/jwt/src/verifier.ts`, and `packages/jwt/src/types.ts`