### PR TITLE
Resolve #431: fix(microservices): remove redis pubsub listener on close

### DIFF
--- a/packages/microservices/src/redis-transport.test.ts
+++ b/packages/microservices/src/redis-transport.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { RedisPubSubMicroserviceTransport } from './redis-transport.js';
 
 interface RedisLike {
+  off?(event: 'message', listener: (channel: string, message: string) => void): unknown;
   on(event: 'message', listener: (channel: string, message: string) => void): unknown;
   publish(channel: string, message: string): Promise<unknown>;
   subscribe(...channels: string[]): Promise<unknown>;
@@ -11,6 +12,10 @@ interface RedisLike {
 
 class InMemoryRedisBus {
   private readonly subscriberHandlers = new Set<(channel: string, message: string) => void>();
+
+  listenerCount(): number {
+    return this.subscriberHandlers.size;
+  }
 
   createClient(): {
     publishClient: RedisLike;
@@ -33,6 +38,11 @@ class InMemoryRedisBus {
         on: (event: 'message', listener: (channel: string, message: string) => void) => {
           if (event === 'message') {
             this.subscriberHandlers.add(listener);
+          }
+        },
+        off: (event: 'message', listener: (channel: string, message: string) => void) => {
+          if (event === 'message') {
+            this.subscriberHandlers.delete(listener);
           }
         },
         publish: async () => {},
@@ -245,6 +255,43 @@ describe('RedisPubSubMicroserviceTransport', () => {
     expect(subscribeClient.subscriptions.has('test-ns:requests')).toBe(false);
     expect(subscribeClient.subscriptions.has('test-ns:responses')).toBe(false);
     expect(subscribeClient.subscriptions.has('test-ns:events')).toBe(false);
+  });
+
+  it('removes the message listener on close so reconnect does not duplicate dispatch', async () => {
+    const bus = new InMemoryRedisBus();
+    const { publishClient, subscribeClient } = bus.createClient();
+
+    const transport = new RedisPubSubMicroserviceTransport({
+      publishClient,
+      subscribeClient,
+      requestTimeoutMs: 1_000,
+    });
+
+    let handled = 0;
+
+    const handler = async (packet: Parameters<typeof transport.listen>[0] extends (arg: infer T) => unknown ? T : never) => {
+      if (packet.kind === 'message' && packet.pattern === 'math.sum') {
+        handled += 1;
+        return 7;
+      }
+
+      return undefined;
+    };
+
+    await transport.listen(handler);
+    expect(bus.listenerCount()).toBe(1);
+
+    await transport.close();
+    expect(bus.listenerCount()).toBe(0);
+
+    await transport.listen(handler);
+    expect(bus.listenerCount()).toBe(1);
+
+    await expect(transport.send('math.sum', { a: 2, b: 5 })).resolves.toBe(7);
+    expect(handled).toBe(1);
+
+    await transport.close();
+    expect(bus.listenerCount()).toBe(0);
   });
 
   it('does not send before listen() is called', async () => {

--- a/packages/microservices/src/redis-transport.ts
+++ b/packages/microservices/src/redis-transport.ts
@@ -9,6 +9,7 @@ interface RedisPubSubMessage {
 }
 
 interface RedisLike {
+  off?(event: 'message', listener: (channel: string, message: string) => void): unknown;
   on(event: 'message', listener: (channel: string, message: string) => void): unknown;
   publish(channel: string, message: string): Promise<unknown>;
   subscribe(...channels: string[]): Promise<unknown>;
@@ -26,6 +27,9 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
   private handler: TransportHandler | undefined;
   private listening = false;
   private listenPromise: Promise<void> | undefined;
+  private readonly messageListener = (channel: string, message: string) => {
+    void this.handleIncoming(channel, message);
+  };
   private readonly namespace: string;
   private readonly pending = new Map<string, { reject: (error: unknown) => void; resolve: (value: unknown) => void; timeout: ReturnType<typeof setTimeout> }>();
   private readonly requestTimeoutMs: number;
@@ -48,16 +52,19 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
     }
 
     this.listenPromise = (async () => {
-      this.options.subscribeClient.on('message', (channel, message) => {
-        void this.handleIncoming(channel, message);
-      });
+      this.options.subscribeClient.on('message', this.messageListener);
 
-      await this.options.subscribeClient.subscribe(
-        this.requestChannel,
-        this.responseChannel,
-        this.eventChannel,
-      );
-      this.listening = true;
+      try {
+        await this.options.subscribeClient.subscribe(
+          this.requestChannel,
+          this.responseChannel,
+          this.eventChannel,
+        );
+        this.listening = true;
+      } catch (error) {
+        this.options.subscribeClient.off?.('message', this.messageListener);
+        throw error;
+      }
     })();
 
     try {
@@ -147,6 +154,8 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
         this.eventChannel,
       );
     }
+
+    this.options.subscribeClient.off?.('message', this.messageListener);
 
     this.listening = false;
     this.handler = undefined;


### PR DESCRIPTION
Closes #431

## Summary
- store the Redis Pub/Sub `message` listener on the transport instance instead of recreating an anonymous closure on every `listen()`
- remove the listener on `close()` and also clean it up if the initial Redis subscription setup fails
- add a regression test that proves `listen() -> close() -> listen()` no longer duplicates request dispatch

## Verification
- `pnpm exec vitest run packages/microservices/src/redis-transport.test.ts`
- `pnpm -r --filter @konekti/core --filter @konekti/di --filter @konekti/dto-validator --filter @konekti/http --filter @konekti/config --filter @konekti/runtime --filter @konekti/microservices run build`
- `pnpm --filter @konekti/microservices run typecheck`
- `lsp_diagnostics` reported 0 errors in `packages/microservices`