### PR TITLE
Resolve #430: fix(event-bus): fail bootstrap on transport subscribe errors

### DIFF
--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -878,6 +878,36 @@ describe('@konekti/event-bus', () => {
       expect(subscribedChannels).toEqual(['PasswordResetEvent', 'UserCreatedEvent']);
     });
 
+    it('fails bootstrap when transport subscription wiring fails', async () => {
+      const loggerEvents: string[] = [];
+      const transport = {
+        async publish(_channel: string, _payload: unknown) {},
+        async subscribe(_channel: string, _handler: (payload: unknown) => Promise<void>) {
+          throw new Error('subscribe failed');
+        },
+        async close() {},
+      } satisfies EventBusTransport;
+
+      class Handler {
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {}
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+        providers: [Handler],
+      });
+
+      await expect(
+        bootstrapApplication({ logger: createLogger(loggerEvents), rootModule: AppModule }),
+      ).rejects.toThrow('subscribe failed');
+
+      expect(
+        loggerEvents.some((event) => event.includes('EventBusTransport failed to subscribe to channel "UserCreatedEvent".')),
+      ).toBe(true);
+    });
+
     it('dispatches incoming transport messages to local handlers', async () => {
       const transport = createMockTransport();
 

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -343,6 +343,8 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
         error,
         'EventBusLifecycleService',
       );
+
+      throw error;
     }
   }
 


### PR DESCRIPTION
Closes #430

## Summary
- rethrow transport subscribe failures during event-bus bootstrap after logging them instead of swallowing the error
- make application bootstrap fail fast when external event transport wiring cannot be established
- add a regression test that proves `bootstrapApplication()` rejects when `transport.subscribe()` fails

## Verification
- `pnpm -r --filter @konekti/core --filter @konekti/di --filter @konekti/dto-validator --filter @konekti/http --filter @konekti/config --filter @konekti/runtime --filter @konekti/event-bus run build`
- `pnpm exec vitest run packages/event-bus/src/module.test.ts`
- `pnpm --filter @konekti/event-bus run typecheck`
- `lsp_diagnostics` reported 0 errors in `packages/event-bus`