### PR TITLE
Resolve #441: remove class-name segments from throttler handler key

### DIFF
--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -97,7 +97,7 @@ class AppBootstrap {
 ## Behavior
 
 - Rate limit key defaults to `socket.remoteAddress`. Provide `keyGenerator` for header-based keying (e.g. `x-api-key`).
-- Store keys are composed as `throttler:<encoded-handler-key>:<encoded-client-key>`. Both key segments are encoded with `encodeURIComponent(...)`, so client keys containing `:` (for example IPv6 addresses) cannot collide with separator boundaries. The decoded `<handler-key>` still includes route method/path/version and deterministic controller/module class-name identities to prevent collisions between handlers that share class or method names across instances.
+- Store keys are composed as `throttler:<encoded-handler-key>:<encoded-client-key>`. Both key segments are encoded with `encodeURIComponent(...)`, so client keys containing `:` (for example IPv6 addresses) cannot collide with separator boundaries. The decoded `<handler-key>` is composed from route `method`, `path`, `version`, and `handler` method name — all stable under minification, since they are data values rather than class-name identifiers.
 - When the limit is exceeded, `ThrottlerGuard` throws `TooManyRequestsException` (HTTP 429) and sets the `Retry-After` response header to the seconds remaining in the current window.
 - Method-level `@Throttle` overrides class-level `@Throttle`, which overrides module-level defaults — in that priority order.
 - `@SkipThrottle()` at either level wins unconditionally.

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -42,24 +42,14 @@ function buildStoreKey(handlerKey: string, clientKey: string): string {
   return `throttler:${encodedHandlerKey}:${encodedClientKey}`;
 }
 
-function getTypeIdentity(value: Function): string {
-  return value.name || 'anonymous';
-}
-
 function buildHandlerKey(handler: GuardContext['handler']): string {
   const version = handler.route.version ?? handler.metadata.effectiveVersion ?? 'unversioned';
-  const moduleIdentity = handler.metadata.moduleType
-    ? `module:${getTypeIdentity(handler.metadata.moduleType)}`
-    : 'module:none';
-  const controllerIdentity = `controller:${getTypeIdentity(handler.controllerToken)}`;
 
   return [
     `method:${handler.route.method}`,
     `path:${encodeURIComponent(handler.route.path)}`,
     `version:${encodeURIComponent(version)}`,
     `handler:${encodeURIComponent(handler.methodName)}`,
-    moduleIdentity,
-    controllerIdentity,
   ].join('|');
 }
 


### PR DESCRIPTION
## Summary

Removes the `module:` and `controller:` segments from `buildHandlerKey()` in `packages/throttler/src/guard.ts`, which relied on `Function.name` (class constructor name) to build rate-limit store keys.

## Problem

Production bundlers (esbuild, Rollup, Webpack+terser) minify class names to single characters. Two unrelated controllers in different files could both receive the name `r`, causing cross-route key collisions and incorrect rate-limit enforcement in Redis-backed deployments.

## Fix

The route coordinates — `method`, `path`, `version`, and `handler` method name — already uniquely identify an endpoint. Method names on prototype chains are preserved by bundlers. Class-name segments are dropped entirely.

- `packages/throttler/src/guard.ts` — removed `getTypeIdentity()`, simplified `buildHandlerKey()`
- `packages/throttler/README.md` — updated Behavior bullet to reflect stable key composition

## Verification

- Existing keys in Redis will become stale on deploy (expected: new keys are more correct)
- No API surface changes

Closes #441