### PR TITLE
Resolve #442: add principalScopeResolver for multi-tenant cache key control

### DIFF
--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -121,7 +121,7 @@ class AppModule {}
 - `CACHE_MANAGER` — DI token for `CacheService`.
 - `CACHE_OPTIONS` — DI token for normalized module options.
 
-`CacheModuleOptions` primary fields are `store`, `ttl`, `isGlobal`, and `httpKeyStrategy`.
+`CacheModuleOptions` primary fields are `store`, `ttl`, `isGlobal`, `httpKeyStrategy`, and `principalScopeResolver`.
 
 ## Behavior
 
@@ -133,6 +133,7 @@ class AppModule {}
   - `'route+query'` — route path + sorted query string, plus authenticated principal scope when present.
   - `'full'` — route path + sorted query string, plus authenticated principal scope when present; currently equivalent to `'route+query'`.
   - `function` — custom resolver `(context) => string`.
+- `principalScopeResolver` — optional function `(context) => string | undefined` that overrides the default `issuer:subject` principal scope segment. When provided, the returned string is appended verbatim as `|principal:<scope>`. Returning `undefined` skips the principal scope entirely for that request.
 - `@CacheKey(...)` decorator overrides the module-level strategy for individual handlers.
 - `@CacheEvict(...)` runs after the response write of successful non-GET handlers.
 
@@ -199,6 +200,41 @@ To opt in per-handler while keeping the default globally:
   return query ? `${path}?${query}` : path;
 })
 ```
+
+#### Multi-Tenant and Role-Varied Caching
+
+When responses differ by tenant ID, subscription plan, or any other dimension beyond `issuer:subject`, use `principalScopeResolver` to control exactly what gets appended to the cache key.
+
+Scope responses by tenant only (ignores individual user):
+
+```ts
+createCacheModule({
+  store: 'redis',
+  ttl: 60,
+  principalScopeResolver: (context) => {
+    // context.requestContext.principal is available when the request is authenticated
+    const tenantId = context.requestContext.metadata['tenantId'] as string | undefined;
+    return tenantId; // undefined = skip principal scope entirely for anonymous requests
+  },
+})
+```
+
+Scope responses by subscription plan:
+
+```ts
+createCacheModule({
+  store: 'memory',
+  ttl: 120,
+  principalScopeResolver: (context) => {
+    const plan = context.requestContext.metadata['subscriptionPlan'] as string | undefined;
+    return plan ?? 'free';
+  },
+})
+```
+
+When `principalScopeResolver` returns `undefined`, no `|principal:…` segment is appended. When it returns a string, the cache key becomes `<base-key>|principal:<scope>`.
+
+> `principalScopeResolver` affects only the default key built by built-in string strategies (`'route'`, `'route+query'`, `'full'`). Handlers that use `@CacheKey(...)` or a custom `httpKeyStrategy` function are unaffected — those handlers own their own key construction and must include scope information themselves.
 
 ### General Cache Behavior (CacheService / CacheStore)
 

--- a/packages/cache-manager/src/cache-service.test.ts
+++ b/packages/cache-manager/src/cache-service.test.ts
@@ -11,6 +11,7 @@ const baseOptions: NormalizedCacheModuleOptions = {
   store: 'memory',
   ttl: 0,
   httpKeyStrategy: 'route',
+  principalScopeResolver: undefined,
 };
 
 class MockRedisClient {

--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -14,6 +14,7 @@ const cacheOptions: NormalizedCacheModuleOptions = {
   store: 'memory',
   ttl: 0,
   httpKeyStrategy: 'route',
+  principalScopeResolver: undefined,
 };
 
 function createRequestContext(

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -4,7 +4,7 @@ import { SseResponse, type CallHandler, type Interceptor, type InterceptorContex
 import { cacheRouteMetadataKey, getCacheEvictMetadata, getCacheKeyMetadata, getCacheTtlMetadata } from './decorators.js';
 import { CACHE_MANAGER, CACHE_OPTIONS } from './tokens.js';
 import { CacheService } from './service.js';
-import type { CacheEvictDecoratorValue, CacheKeyDecoratorValue, CacheKeyStrategy, NormalizedCacheModuleOptions } from './types.js';
+import type { CacheEvictDecoratorValue, CacheKeyDecoratorValue, CacheKeyStrategy, NormalizedCacheModuleOptions, PrincipalScopeResolver } from './types.js';
 
 type MetadataBag = Record<PropertyKey, unknown>;
 
@@ -49,11 +49,20 @@ function buildSortedQueryString(query: Record<string, unknown>): string {
   return entries.join('&');
 }
 
-function appendPrincipalScope(key: string, context: InterceptorContext): string {
+function appendPrincipalScope(
+  key: string,
+  context: InterceptorContext,
+  resolver: PrincipalScopeResolver | undefined,
+): string {
   const principal = context.requestContext.principal;
 
   if (!principal) {
     return key;
+  }
+
+  if (resolver) {
+    const scope = resolver(context);
+    return scope !== undefined ? `${key}|principal:${scope}` : key;
   }
 
   const issuer = encodeURIComponent(principal.issuer ?? 'unknown');
@@ -62,7 +71,11 @@ function appendPrincipalScope(key: string, context: InterceptorContext): string 
   return `${key}|principal:${issuer}:${subject}`;
 }
 
-function defaultCacheKey(context: InterceptorContext, strategy: CacheKeyStrategy): string {
+function defaultCacheKey(
+  context: InterceptorContext,
+  strategy: CacheKeyStrategy,
+  resolver: PrincipalScopeResolver | undefined,
+): string {
   if (typeof strategy === 'function') {
     return strategy(context);
   }
@@ -71,16 +84,16 @@ function defaultCacheKey(context: InterceptorContext, strategy: CacheKeyStrategy
   const query = context.requestContext.request.query;
 
   if (strategy === 'route') {
-    return appendPrincipalScope(path, context);
+    return appendPrincipalScope(path, context, resolver);
   }
 
   const queryString = buildSortedQueryString(query);
 
   if (!queryString) {
-    return appendPrincipalScope(path, context);
+    return appendPrincipalScope(path, context, resolver);
   }
 
-  return appendPrincipalScope(`${path}?${queryString}`, context);
+  return appendPrincipalScope(`${path}?${queryString}`, context, resolver);
 }
 
 function normalizeTtl(ttlSeconds: number | undefined, fallback: number): number | undefined {
@@ -109,9 +122,10 @@ async function resolveCacheKeyValue(
   metadata: CacheKeyDecoratorValue | undefined,
   context: InterceptorContext,
   strategy: CacheKeyStrategy,
+  resolver: PrincipalScopeResolver | undefined,
 ): Promise<string> {
   if (!metadata) {
-    return defaultCacheKey(context, strategy);
+    return defaultCacheKey(context, strategy, resolver);
   }
 
   if (typeof metadata === 'string') {
@@ -190,7 +204,7 @@ export class CacheInterceptor implements Interceptor {
     metadataBag: MetadataBag | undefined,
   ): Promise<unknown> {
     const keyMetadata = metadataBag ? getCacheKeyMetadata(metadataBag) : undefined;
-    const key = await resolveCacheKeyValue(keyMetadata, context, this.options.httpKeyStrategy);
+    const key = await resolveCacheKeyValue(keyMetadata, context, this.options.httpKeyStrategy, this.options.principalScopeResolver);
     const ttl = normalizeTtl(metadataBag ? getCacheTtlMetadata(metadataBag) : undefined, this.options.ttl);
 
     if (ttl !== undefined) {

--- a/packages/cache-manager/src/module.ts
+++ b/packages/cache-manager/src/module.ts
@@ -18,6 +18,7 @@ function normalizeCacheModuleOptions(options: CacheModuleOptions = {}): Normaliz
     store: options.store ?? 'memory',
     ttl: options.ttl ?? 0,
     httpKeyStrategy: options.httpKeyStrategy ?? 'route',
+    principalScopeResolver: options.principalScopeResolver,
   };
 }
 

--- a/packages/cache-manager/src/types.ts
+++ b/packages/cache-manager/src/types.ts
@@ -26,11 +26,14 @@ interface CacheModuleInternalOptions {
   redis?: RedisCacheOptions;
 }
 
+export type PrincipalScopeResolver = (context: InterceptorContext) => string | undefined;
+
 export interface CacheModuleOptions extends CacheModuleInternalOptions {
   isGlobal?: boolean;
   store?: 'memory' | 'redis' | CacheStore;
   ttl?: number;
   httpKeyStrategy?: CacheKeyStrategy;
+  principalScopeResolver?: PrincipalScopeResolver;
 }
 
 export interface NormalizedCacheModuleOptions {
@@ -40,6 +43,7 @@ export interface NormalizedCacheModuleOptions {
   store: 'memory' | 'redis' | CacheStore;
   ttl: number;
   httpKeyStrategy: CacheKeyStrategy;
+  principalScopeResolver: PrincipalScopeResolver | undefined;
 }
 
 export type CacheKeyFactory = (context: InterceptorContext) => Awaitable<string>;


### PR DESCRIPTION
## Summary

- Adds `PrincipalScopeResolver` type to `@konekti/cache-manager` — a module-level escape hatch for controlling the principal scope segment in default cache keys
- The built-in `issuer:subject` scope is too coarse for multi-tenant apps sharing an OIDC provider or needing per-role response isolation; `principalScopeResolver` lets callers return any string (tenant ID, plan, role) or `undefined` to skip the scope entirely
- Updates `appendPrincipalScope`, `defaultCacheKey`, and `resolveCacheKeyValue` to thread the resolver through; adds documentation with multi-tenant and role-varied caching examples

Closes #442