### PR TITLE
Resolve #447: validate CORS allowCredentials+wildcard for omitted and function-based allowOrigin

### DIFF
--- a/packages/http/src/cors.test.ts
+++ b/packages/http/src/cors.test.ts
@@ -92,4 +92,55 @@ describe('createCorsMiddleware', () => {
     expect(response.statusCode).toBe(204);
     expect(response.headers['Access-Control-Allow-Origin']).toBe('*');
   });
+
+  it('throws at config time when allowCredentials is true and allowOrigin is "*"', () => {
+    expect(() => createCorsMiddleware({ allowCredentials: true, allowOrigin: '*' })).toThrow(
+      'allowCredentials cannot be true',
+    );
+  });
+
+  it('throws at config time when allowCredentials is true and allowOrigin is omitted (defaults to "*")', () => {
+    expect(() => createCorsMiddleware({ allowCredentials: true })).toThrow(
+      'allowCredentials cannot be true',
+    );
+  });
+
+  it('throws at request time when allowCredentials is true and allowOrigin function returns "*"', async () => {
+    const middleware = createCorsMiddleware({
+      allowCredentials: true,
+      allowOrigin: () => '*',
+    });
+    const response = createResponse();
+
+    await expect(
+      middleware.handle(
+        {
+          request: createRequest('GET', 'https://app.example.com'),
+          requestContext: {} as never,
+          response,
+        },
+        async () => {},
+      ),
+    ).rejects.toThrow('allowCredentials cannot be true');
+  });
+
+  it('allows allowCredentials with an explicit list of origins', async () => {
+    const middleware = createCorsMiddleware({
+      allowCredentials: true,
+      allowOrigin: ['https://trusted.example.com'],
+    });
+    const response = createResponse();
+
+    await middleware.handle(
+      {
+        request: createRequest('GET', 'https://trusted.example.com'),
+        requestContext: {} as never,
+        response,
+      },
+      async () => {},
+    );
+
+    expect(response.headers['Access-Control-Allow-Credentials']).toBe('true');
+    expect(response.headers['Access-Control-Allow-Origin']).toBe('https://trusted.example.com');
+  });
 });

--- a/packages/http/src/cors.ts
+++ b/packages/http/src/cors.ts
@@ -36,10 +36,12 @@ function setHeaderIfValue(
 }
 
 export function createCorsMiddleware(options: CorsOptions = {}): Middleware {
-  if (options.allowCredentials === true && options.allowOrigin === '*') {
-    throw new Error(
-      'CORS misconfiguration: allowCredentials cannot be true when allowOrigin is "*". Specify explicit origins instead.',
-    );
+  if (options.allowCredentials === true) {
+    if (options.allowOrigin === '*' || options.allowOrigin === undefined) {
+      throw new Error(
+        'CORS misconfiguration: allowCredentials cannot be true when allowOrigin is "*" or unset (defaults to "*"). Specify explicit origins instead.',
+      );
+    }
   }
 
   const allowMethods = options.allowMethods ?? ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'];
@@ -51,6 +53,11 @@ export function createCorsMiddleware(options: CorsOptions = {}): Middleware {
       const origin = resolveOrigin(options, requestOrigin);
 
       if (origin) {
+        if (options.allowCredentials === true && origin === '*') {
+          throw new Error(
+            'CORS misconfiguration: allowCredentials cannot be true when allowOrigin function returns "*". Specify explicit origins instead.',
+          );
+        }
         context.response.setHeader('Access-Control-Allow-Origin', origin);
       }
 


### PR DESCRIPTION
## Summary

Closes #447

`createCorsMiddleware()` previously only validated the `allowCredentials: true` + wildcard origin combination when `allowOrigin` was explicitly set to `'*'`. Two equivalent misconfigurations were missed:

1. **`allowOrigin` omitted** — the default resolves to `'*'`, producing the same spec-invalid `ACAO: * + ACAC: true` combination.
2. **`allowOrigin` is a function returning `'*'`** — the config-time guard never fires for dynamic origin resolvers.

## Changes

- `cors.ts`: Extend the config-time guard to also reject `allowOrigin === undefined` when `allowCredentials` is true.
- `cors.ts`: Add a request-time guard that throws when a function-based `allowOrigin` returns `'*'` with credentials enabled.
- `cors.test.ts`: Add 4 new test cases covering the two missing paths (config-time rejection for omitted origin, request-time rejection for function returning wildcard, and a passing case confirming explicit array origins still work).

## Verification

```
npx vitest run packages/http/src/cors.test.ts
✓ packages/http/src/cors.test.ts (6 tests) 3ms
```