### PR TITLE
Resolve #448: recurse into class instances without metadata so child @Exclude/@Expose are respected

### DIFF
--- a/packages/serializer/src/serialize.test.ts
+++ b/packages/serializer/src/serialize.test.ts
@@ -91,6 +91,35 @@ describe('serialize', () => {
     });
   });
 
+  it('recurses into class instances without metadata so decorated child fields are respected', () => {
+    class Inner {
+      @Exclude()
+      secret: string;
+
+      public: string;
+
+      constructor(secret: string, pub: string) {
+        this.secret = secret;
+        this.public = pub;
+      }
+    }
+
+    class Outer {
+      inner: Inner;
+
+      constructor(inner: Inner) {
+        this.inner = inner;
+      }
+    }
+
+    const result = serialize(new Outer(new Inner('should-not-appear', 'visible'))) as {
+      inner: Record<string, unknown>;
+    };
+
+    expect(result.inner.public).toBe('visible');
+    expect(result.inner.secret).toBeUndefined();
+  });
+
   it('does not alter plain objects without serialization metadata', () => {
     const plain = {
       id: 'p-1',

--- a/packages/serializer/src/serialize.ts
+++ b/packages/serializer/src/serialize.ts
@@ -120,11 +120,7 @@ function serializeClassInstance(
   const hasMetadata = fieldMetadata.size > 0 || classOptions.excludeExtraneous === true;
 
   if (!hasMetadata) {
-    if (isPlainObject(value)) {
-      return serializeRecord(value, context);
-    }
-
-    return value;
+    return serializeRecord(value, context);
   }
 
   const serialized: Record<string | symbol, unknown> = {};


### PR DESCRIPTION
## Summary

Closes #448

`serializeClassInstance()` previously returned raw class instances unchanged when they had no serializer metadata (no `@Exclude`/`@Expose` on the outer class). Any decorated fields on a nested class were silently ignored, leaking sensitive values.

## Change

Removed the `isPlainObject` guard in the `!hasMetadata` branch so that metadata-less class instances fall through to `serializeRecord()`, which recursively processes all enumerable fields and applies each field value's own class metadata.

**Before:**
```typescript
if (!hasMetadata) {
  if (isPlainObject(value)) return serializeRecord(value, context);
  return value; // raw class instance returned — child @Exclude ignored
}
```

**After:**
```typescript
if (!hasMetadata) {
  return serializeRecord(value, context); // always recurse
}
```

## Verification

```
npx vitest run packages/serializer/src/serialize.test.ts
✓ packages/serializer/src/serialize.test.ts (9 tests) 4ms
```

New test: *"recurses into class instances without metadata so decorated child fields are respected"* confirms that `@Exclude` on an inner class is honoured even when the outer class has no metadata.