### PR TITLE
Resolve #449: child container override() now shadows parent multi-providers

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -527,6 +527,18 @@ describe('Container', () => {
       await expect(root.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b']);
       await expect(child.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b', 'child-c']);
     });
+
+    it('child override() replaces parent multi providers for that token', async () => {
+      const PLUGINS = Symbol('Plugins');
+      const root = new Container().register(
+        { provide: PLUGINS, useValue: 'root-a', multi: true },
+        { provide: PLUGINS, useValue: 'root-b', multi: true },
+      );
+      const child = root.createRequestScope().override({ provide: PLUGINS, useValue: 'child-only', multi: true });
+
+      await expect(root.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b']);
+      await expect(child.resolve<string[]>(PLUGINS)).resolves.toEqual(['child-only']);
+    });
   });
 
   describe('dispose', () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -114,6 +114,7 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
 export class Container {
   private readonly registrations = new Map<Token, NormalizedProvider>();
   private readonly multiRegistrations = new Map<Token, NormalizedProvider[]>();
+  private readonly multiOverriddenTokens = new Set<Token>();
   private readonly requestCache = new Map<Token, Promise<unknown>>();
   private readonly multiSingletonCache = new Map<NormalizedProvider, Promise<unknown>>();
   private readonly staleDisposalTasks = new Set<Promise<void>>();
@@ -181,6 +182,7 @@ export class Container {
 
       if (normalized.multi) {
         this.multiRegistrations.set(normalized.provide, [normalized]);
+        this.multiOverriddenTokens.add(normalized.provide);
         continue;
       }
 
@@ -248,19 +250,19 @@ export class Container {
   }
 
   private collectMultiProviders(token: Token): NormalizedProvider[] {
-    const providers: NormalizedProvider[] = [];
-
-    if (this.parent) {
-      providers.push(...this.parent.collectMultiProviders(token));
-    }
-
     const local = this.multiRegistrations.get(token);
 
-    if (local) {
-      providers.push(...local);
+    if (this.multiOverriddenTokens.has(token)) {
+      return local ?? [];
     }
 
-    return providers;
+    const fromParent = this.parent ? this.parent.collectMultiProviders(token) : [];
+
+    if (local) {
+      return [...fromParent, ...local];
+    }
+
+    return fromParent;
   }
 
   private async resolveWithChain<T>(


### PR DESCRIPTION
## Summary

Closes #449

`collectMultiProviders()` accumulated parent multi-providers before appending local ones unconditionally. This made `override()` in a child container **add** to the parent set rather than replace it, because the parent's entries were always collected first.

## Root Cause

```typescript
private collectMultiProviders(token: Token): NormalizedProvider[] {
  const providers: NormalizedProvider[] = [];
  if (this.parent) {
    providers.push(...this.parent.collectMultiProviders(token)); // always merged
  }
  const local = this.multiRegistrations.get(token);
  if (local) providers.push(...local);
  return providers;
}
```

## Fix

Added a `multiOverriddenTokens: Set<Token>` field. When `override()` registers a multi-provider, the token is added to that set. `collectMultiProviders()` skips parent traversal when the current container has an override for that token.

The normal `register()` path is unaffected — child `register()` still accumulates parent entries, matching the documented extension behaviour.

## Verification

```
npx vitest run packages/di/src/container.test.ts
✓ packages/di/src/container.test.ts (42 tests) 9ms
```

New test: *"child override() replaces parent multi providers for that token"* validates the fix. Existing accumulation test at line 519 continues to pass.