### PR TITLE
Resolve #450: throw on duplicate resolver fieldName at schema build time

### DIFF
--- a/packages/graphql/src/schema.test.ts
+++ b/packages/graphql/src/schema.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GraphQLBoolean,
+  GraphQLError,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  buildSchema,
+} from 'graphql';
+
+import type { Container } from '@konekti/di';
+
+import { createCodeFirstSchema } from './schema.js';
+import type { ResolverDescriptor } from './types.js';
+
+const deps = {
+  GraphQLBoolean,
+  GraphQLError,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  buildSchema,
+};
+
+const fakeContainer = {} as unknown as Container;
+
+function makeDescriptor(targetName: string, fieldName: string): ResolverDescriptor {
+  return {
+    handlers: [
+      {
+        argFields: [],
+        fieldName,
+        methodKey: 'resolve',
+        methodName: 'resolve',
+        type: 'query',
+      },
+    ],
+    moduleName: 'TestModule',
+    scope: 'singleton',
+    targetName,
+    token: Symbol(targetName),
+    typeName: 'Query',
+  };
+}
+
+describe('createCodeFirstSchema – duplicate fieldName detection', () => {
+  it('throws when two resolvers register the same query fieldName', () => {
+    const descriptors: ResolverDescriptor[] = [
+      makeDescriptor('QueryA', 'user'),
+      makeDescriptor('QueryB', 'user'),
+    ];
+
+    expect(() => createCodeFirstSchema(deps, fakeContainer, descriptors)).toThrow(
+      /field "user" on query type is registered more than once/,
+    );
+  });
+
+  it('throws when two resolvers register the same mutation fieldName', () => {
+    const descriptors: ResolverDescriptor[] = [
+      {
+        ...makeDescriptor('MutationA', 'createUser'),
+        handlers: [{ argFields: [], fieldName: 'createUser', methodKey: 'exec', methodName: 'exec', type: 'mutation' }],
+      },
+      {
+        ...makeDescriptor('MutationB', 'createUser'),
+        handlers: [{ argFields: [], fieldName: 'createUser', methodKey: 'exec', methodName: 'exec', type: 'mutation' }],
+      },
+    ];
+
+    expect(() => createCodeFirstSchema(deps, fakeContainer, descriptors)).toThrow(
+      /field "createUser" on mutation type is registered more than once/,
+    );
+  });
+
+  it('allows distinct fieldNames across multiple resolvers', () => {
+    const descriptors: ResolverDescriptor[] = [
+      makeDescriptor('QueryA', 'user'),
+      makeDescriptor('QueryB', 'post'),
+    ];
+
+    expect(() => createCodeFirstSchema(deps, fakeContainer, descriptors)).not.toThrow();
+  });
+});

--- a/packages/graphql/src/schema.ts
+++ b/packages/graphql/src/schema.ts
@@ -141,6 +141,13 @@ function pickFieldsByType(
 
       const outputType = scalarByName(deps, resolveOutputScalarType(handler));
 
+      if (Object.prototype.hasOwnProperty.call(fields, handler.fieldName)) {
+        throw new Error(
+          `GraphQL schema conflict: field "${handler.fieldName}" on ${handlerType} type is registered more than once. ` +
+            `Found duplicate in resolver "${descriptor.targetName}". Each field name must be unique across all resolvers.`,
+        );
+      }
+
       if (handler.type === 'subscription') {
         fields[handler.fieldName] = createSubscriptionField(descriptor, handler, args, outputType, invokeResolver);
 


### PR DESCRIPTION
## Summary

- Adds duplicate fieldName detection in `pickFieldsByType` inside `packages/graphql/src/schema.ts`
- When two resolvers register the same `fieldName` for the same operation type (query/mutation/subscription), an `Error` is thrown at schema-build time with a clear message naming the conflicting field, type, and resolver class
- Previously the second registration silently overwrote the first, invisibly dropping one handler

## Changes

- `packages/graphql/src/schema.ts` — added `Object.prototype.hasOwnProperty` guard before field assignment in `pickFieldsByType`
- `packages/graphql/src/schema.test.ts` — new unit test file covering: duplicate query fieldName throws, duplicate mutation fieldName throws, distinct fieldNames across resolvers does not throw

## Verification

New test suite `createCodeFirstSchema – duplicate fieldName detection` passes (3 tests). All existing graphql tests remain green.

Closes #450