### PR TITLE
Resolve #451: clone nested objects returned by get() and getOrThrow()

### DIFF
--- a/packages/config/src/service.test.ts
+++ b/packages/config/src/service.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { ConfigService } from './service.js';
+
+describe('ConfigService – get() isolation (issue #451)', () => {
+  it('returns a copy of nested objects, not the internal reference', () => {
+    const service = new ConfigService({ db: { host: 'localhost', port: 5432 } });
+
+    const first = service.get('db') as Record<string, unknown>;
+    expect(first).toEqual({ host: 'localhost', port: 5432 });
+
+    // Mutating the returned object must NOT affect subsequent reads
+    first['host'] = 'mutated';
+
+    const second = service.get('db') as Record<string, unknown>;
+    expect(second).toEqual({ host: 'localhost', port: 5432 });
+  });
+
+  it('returns a copy via dot-path traversal', () => {
+    const service = new ConfigService({ app: { options: { retries: 3 } } });
+
+    const options = service.get('app.options') as Record<string, unknown>;
+    expect(options).toEqual({ retries: 3 });
+
+    options['retries'] = 999;
+
+    expect(service.get('app.options')).toEqual({ retries: 3 });
+  });
+
+  it('returns scalar values directly without cloning', () => {
+    const service = new ConfigService({ port: 3000, name: 'app' });
+
+    expect(service.get('port')).toBe(3000);
+    expect(service.get('name')).toBe('app');
+  });
+
+  it('returns undefined for missing keys', () => {
+    const service = new ConfigService({ port: 3000 });
+
+    expect(service.get('missing' as never)).toBeUndefined();
+    expect(service.get('a.b.c' as never)).toBeUndefined();
+  });
+});

--- a/packages/config/src/service.ts
+++ b/packages/config/src/service.ts
@@ -44,17 +44,26 @@ export class ConfigService<T extends Record<string, unknown> = ConfigDictionary>
   }
 
   private _resolve(key: string): unknown {
+    let resolved: unknown;
+
     if (hasOwn(this.values, key)) {
-      return this.values[key];
-    }
-    const parts = key.split('.');
-    let current: unknown = this.values;
-    for (const part of parts) {
-      if (!hasOwn(current, part)) {
-        return undefined;
+      resolved = this.values[key];
+    } else {
+      const parts = key.split('.');
+      let current: unknown = this.values;
+      for (const part of parts) {
+        if (!hasOwn(current, part)) {
+          return undefined;
+        }
+        current = current[part];
       }
-      current = current[part];
+      resolved = current;
     }
-    return current;
+
+    if (typeof resolved === 'object' && resolved !== null) {
+      return cloneConfigDictionary(resolved);
+    }
+
+    return resolved;
   }
 }


### PR DESCRIPTION
## Summary

- `ConfigService._resolve()` previously returned raw references to internal nested objects, allowing callers to mutate service state through the returned reference
- Fix: any non-primitive value resolved by `_resolve()` is now passed through `cloneConfigDictionary()` before being returned to the caller
- Scalar values (string, number, boolean, null, undefined) are returned as-is since they are immutable by value

## Changes

- `packages/config/src/service.ts` — `_resolve()` now clones object/array results via `cloneConfigDictionary()` before returning
- `packages/config/src/service.test.ts` — new unit test file covering: top-level nested object isolation, dot-path nested object isolation, scalar passthrough, and missing key behavior

## Verification

New test suite `ConfigService – get() isolation` passes (4 tests). All existing config tests remain green.

Closes #451