### PR TITLE
Resolve #452: tear down partial subscriptions on listen() failure

### DIFF
--- a/packages/microservices/src/kafka-transport.test.ts
+++ b/packages/microservices/src/kafka-transport.test.ts
@@ -280,4 +280,35 @@ describe('KafkaMicroserviceTransport', () => {
 
     await transport.close();
   });
+
+  it('unsubscribes already-subscribed topics when a later subscribe fails during listen()', async () => {
+    const subscribed: string[] = [];
+    const unsubscribed: string[] = [];
+    let callCount = 0;
+
+    const transport = new KafkaMicroserviceTransport({
+      consumer: {
+        subscribe: async (topic) => {
+          callCount++;
+
+          if (callCount === 2) {
+            throw new Error('subscribe failed on second topic');
+          }
+
+          subscribed.push(topic);
+        },
+        unsubscribe: async (topic) => {
+          unsubscribed.push(topic);
+        },
+      },
+      producer: {
+        publish: async () => {},
+      },
+    });
+
+    await expect(transport.listen(() => Promise.resolve(undefined))).rejects.toThrow('subscribe failed on second topic');
+
+    expect(subscribed).toHaveLength(1);
+    expect(unsubscribed).toEqual(subscribed);
+  });
 });

--- a/packages/microservices/src/kafka-transport.ts
+++ b/packages/microservices/src/kafka-transport.ts
@@ -64,15 +64,30 @@ export class KafkaMicroserviceTransport implements MicroserviceTransport {
     }
 
     this.listenPromise = (async () => {
-      await this.options.consumer.subscribe(this.eventTopic, (message) => {
-        void this.handleInboundEvent(message).catch(() => undefined);
-      });
-      await this.options.consumer.subscribe(this.messageTopic, (message) => {
-        void this.handleInboundRequest(message).catch(() => undefined);
-      });
-      await this.options.consumer.subscribe(this.responseTopic, (message) => {
-        void this.handleInboundResponse(message).catch(() => undefined);
-      });
+      const subscribed: string[] = [];
+
+      try {
+        await this.options.consumer.subscribe(this.eventTopic, (message) => {
+          void this.handleInboundEvent(message).catch(() => undefined);
+        });
+        subscribed.push(this.eventTopic);
+
+        await this.options.consumer.subscribe(this.messageTopic, (message) => {
+          void this.handleInboundRequest(message).catch(() => undefined);
+        });
+        subscribed.push(this.messageTopic);
+
+        await this.options.consumer.subscribe(this.responseTopic, (message) => {
+          void this.handleInboundResponse(message).catch(() => undefined);
+        });
+        subscribed.push(this.responseTopic);
+      } catch (error) {
+        for (const topic of subscribed) {
+          await this.options.consumer.unsubscribe(topic).catch(() => undefined);
+        }
+
+        throw error;
+      }
 
       this.listening = true;
     })();

--- a/packages/microservices/src/rabbitmq-transport.test.ts
+++ b/packages/microservices/src/rabbitmq-transport.test.ts
@@ -343,4 +343,35 @@ describe('RabbitMqMicroserviceTransport', () => {
 
     await transport.close();
   });
+
+  it('cancels already-subscribed queues when a later consume fails during listen()', async () => {
+    const subscribed: string[] = [];
+    const cancelled: string[] = [];
+    let callCount = 0;
+
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        consume: async (queue) => {
+          callCount++;
+
+          if (callCount === 2) {
+            throw new Error('consume failed on second queue');
+          }
+
+          subscribed.push(queue);
+        },
+        cancel: async (queue) => {
+          cancelled.push(queue);
+        },
+      },
+      publisher: {
+        publish: async () => {},
+      },
+    });
+
+    await expect(transport.listen(() => Promise.resolve(undefined))).rejects.toThrow('consume failed on second queue');
+
+    expect(subscribed).toHaveLength(1);
+    expect(cancelled).toEqual(subscribed);
+  });
 });

--- a/packages/microservices/src/rabbitmq-transport.ts
+++ b/packages/microservices/src/rabbitmq-transport.ts
@@ -64,12 +64,22 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
     this.listenPromise = (async () => {
       const queues = new Set([this.eventQueue, this.messageQueue, this.responseQueue]);
 
-      for (const queue of queues) {
-        await this.options.consumer.consume(queue, (message) => {
-          void this.handleInboundMessage(message).catch(() => undefined);
-        });
+      try {
+        for (const queue of queues) {
+          await this.options.consumer.consume(queue, (message) => {
+            void this.handleInboundMessage(message).catch(() => undefined);
+          });
 
-        this.subscribedQueues.add(queue);
+          this.subscribedQueues.add(queue);
+        }
+      } catch (error) {
+        for (const queue of this.subscribedQueues) {
+          await this.options.consumer.cancel(queue).catch(() => undefined);
+        }
+
+        this.subscribedQueues.clear();
+
+        throw error;
       }
 
       this.listening = true;


### PR DESCRIPTION
## Summary

- `KafkaMicroserviceTransport.listen()` subscribed 3 topics sequentially; if the 2nd or 3rd `subscribe()` failed, the already-subscribed topics were never cleaned up, leaving orphaned partition consumers
- `RabbitMqMicroserviceTransport.listen()` tracked subscribed queues in `subscribedQueues` but did not cancel them on failure before propagating the error
- Both transports now wrap the subscription loop in a try/catch: on any failure they cancel all previously established subscriptions (cancel errors are suppressed), clear state, and rethrow the original error

## Changes

- `packages/microservices/src/kafka-transport.ts` — `listen()` tracks successfully subscribed topics and unsubscribes them all on failure
- `packages/microservices/src/rabbitmq-transport.ts` — `listen()` cancels all queues in `subscribedQueues` and clears the set on failure
- `packages/microservices/src/kafka-transport.test.ts` — new test: partial topic cleanup on second subscribe failure
- `packages/microservices/src/rabbitmq-transport.test.ts` — new test: partial queue cleanup on second consume failure

## Verification

All 47 microservices tests pass (2 new tests added).

Closes #452