### PR TITLE
Resolve #453: abort scaffold when target directory is non-empty

### DIFF
--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -43,6 +43,11 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
     option: '--target-directory <path>',
   },
   {
+    aliases: [],
+    description: 'Overwrite files in a non-empty target directory without prompting.',
+    option: '--force',
+  },
+  {
     aliases: ['-h'],
     description: 'Show help for the new command.',
     option: '--help',
@@ -61,8 +66,8 @@ function readOptionValue(argv: string[], index: number, option: '--name' | '--pa
   return value;
 }
 
-function parseArgs(argv: string[]): Partial<BootstrapAnswers> {
-  const parsed: Partial<BootstrapAnswers> = {};
+function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolean } {
+  const parsed: Partial<BootstrapAnswers> & { force?: boolean } = {};
   let hasExplicitTargetDirectory = false;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -98,6 +103,9 @@ function parseArgs(argv: string[]): Partial<BootstrapAnswers> {
         parsed.targetDirectory = readOptionValue(argv, index, '--target-directory');
         hasExplicitTargetDirectory = true;
         index += 1;
+        break;
+      case '--force':
+        parsed.force = true;
         break;
       default:
         if (arg.startsWith('-')) {
@@ -161,6 +169,7 @@ export async function runNewCommand(argv: string[], runtime: NewCommandRuntimeOp
     const options = {
       ...answers,
       dependencySource: runtime.dependencySource,
+      force: parsed.force ?? runtime.force,
       repoRoot: runtime.repoRoot,
       skipInstall: runtime.skipInstall,
       targetDirectory: resolve(runtime.cwd ?? process.cwd(), answers.targetDirectory),

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -572,6 +572,16 @@ export async function scaffoldBootstrapApp(
 
   mkdirSync(targetDirectory, { recursive: true });
 
+  if (!options.force) {
+    const existingFiles = readdirSync(targetDirectory);
+    if (existingFiles.length > 0) {
+      throw new Error(
+        `Target directory "${targetDirectory}" is not empty. ` +
+        'Remove the existing files or use --force to overwrite.',
+      );
+    }
+  }
+
   for (const file of buildScaffoldFiles(options, releaseVersion, packageSpecs)) {
     writeTextFile(join(targetDirectory, file.path), file.content);
   }

--- a/packages/cli/src/new/types.ts
+++ b/packages/cli/src/new/types.ts
@@ -3,6 +3,7 @@ export type DependencySource = 'local' | 'published';
 
 export interface BootstrapOptions {
   dependencySource?: DependencySource;
+  force?: boolean;
   packageManager: PackageManager;
   projectName: string;
   repoRoot?: string;
@@ -23,6 +24,7 @@ export interface BootstrapAnswers {
 
 export interface NewCommandOptions {
   dependencySource?: DependencySource;
+  force?: boolean;
   repoRoot?: string;
   skipInstall?: boolean;
 }


### PR DESCRIPTION
## Summary

- Add a non-empty directory guard in `scaffoldBootstrapApp` that throws an actionable error before writing any files
- Add `force?: boolean` to `BootstrapOptions` and `NewCommandOptions` to allow opting out of the guard
- Add `--force` CLI flag to `konekti new` and update help output

## Verification

```bash
# Should fail with clear error
mkdir my-app && echo '{}' > my-app/package.json
konekti new my-app  # → error: "Target directory ... is not empty. Use --force to overwrite."

# Should succeed
konekti new my-app --force  # overwrites as before
```

Closes #453