### PR TITLE
Resolve #455: reject first request when rate limit is 0

### DIFF
--- a/packages/http/src/rate-limit.ts
+++ b/packages/http/src/rate-limit.ts
@@ -86,6 +86,19 @@ export function createRateLimitMiddleware(options: RateLimitOptions): Middleware
         const resetAt = now + options.windowMs;
 
         await store.set(key, { count: 1, resetAt });
+
+        if (1 > options.limit) {
+          const retryAfter = Math.ceil(options.windowMs / 1000);
+          const error = new TooManyRequestsException('Too Many Requests', {
+            meta: { retryAfter },
+          });
+
+          context.response.setHeader('Retry-After', String(retryAfter));
+          context.response.setStatus(429);
+          await context.response.send(createErrorResponse(error, context.requestContext.requestId));
+          return;
+        }
+
         return next();
       }
 


### PR DESCRIPTION
## Summary

- The initialization branch previously set `count = 1` then called `next()` unconditionally
- Now after setting `count = 1`, the branch checks `1 > options.limit` before deciding to allow or reject
- When `limit === 0`, every request (including the first) is rejected with 429 and a `Retry-After` header
- Normal `limit > 0` behaviour is unchanged

## Verification

```typescript
app.use(rateLimit({ limit: 0, windowMs: 60_000 }));
// First request → 429 (previously 200)
// Second request → 429
```

Closes #455