### PR TITLE
Resolve #456: fix module middleware receiving stale request before params are populated

### DIFF
--- a/packages/http/src/dispatcher.ts
+++ b/packages/http/src/dispatcher.ts
@@ -232,7 +232,7 @@ async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void>
     await notifyHandlerMatched(context, match.descriptor);
 
     const moduleMiddlewareContext: MiddlewareContext = {
-      request: appMiddlewareContext.request,
+      request: context.requestContext.request,
       requestContext: context.requestContext,
       response: context.response,
     };

--- a/packages/metrics/src/http-metrics-middleware.test.ts
+++ b/packages/metrics/src/http-metrics-middleware.test.ts
@@ -96,6 +96,24 @@ describe('HttpMetricsMiddleware', () => {
     expect(metricsText).toContain('http_requests_total{method="GET",path="/users/:id",status="200"} 1');
   });
 
+  it('does not reuse a param key when multiple params share the same value', async () => {
+    const registry = new Registry();
+    const middleware = new HttpMetricsMiddleware(registry);
+
+    const context = createContext('/users/foo/orders/foo', {
+      orderId: 'foo',
+      userId: 'foo',
+    });
+
+    await middleware.handle(context, async () => {
+      context.response.setStatus(200);
+    });
+
+    const metricsText = await registry.metrics();
+
+    expect(metricsText).toContain('http_requests_total{method="GET",path="/users/:userId/orders/:orderId",status="200"} 1');
+  });
+
   it('passes immutable label snapshots to each metric recorder call', async () => {
     const registry = new Registry();
     const middleware = new HttpMetricsMiddleware(registry);

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -163,6 +163,7 @@ function normalizePathToTemplate(path: string, params: Readonly<Record<string, s
 
   const normalizedSegments: string[] = [];
   const paramEntries = Object.entries(params);
+  const usedParamKeys = new Set<string>();
 
   for (const segment of path.split('/')) {
     if (!segment) {
@@ -173,8 +174,13 @@ function normalizePathToTemplate(path: string, params: Readonly<Record<string, s
     let normalizedSegment = segment;
 
     for (const [paramKey, paramValue] of paramEntries) {
+      if (usedParamKeys.has(paramKey)) {
+        continue;
+      }
+
       if (segment === paramValue || decoded === paramValue) {
         normalizedSegment = `:${paramKey}`;
+        usedParamKeys.add(paramKey);
         break;
       }
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `moduleMiddlewareContext` was built with `appMiddlewareContext.request`, which is captured before `updateRequestParams` replaces `requestContext.request` with the route-param-populated version. As a result, all module middleware — including `HttpMetricsMiddleware` — saw `request.params === {}` regardless of route parameters, causing path labels to never be normalized.
- **Fix 1** (`packages/http/src/dispatcher.ts`): Build `moduleMiddlewareContext.request` from `context.requestContext.request` instead of `appMiddlewareContext.request`. This reference is assigned after `updateRequestParams` and carries the matched route params.
- **Fix 2** (`packages/metrics/src/http-metrics-middleware.ts`): Add a `usedParamKeys` Set in `normalizePathToTemplate` so that when multiple path segments share an identical value, each param key is used at most once, preventing label collisions like `/users/:userId/orders/:userId` for routes with distinct parameter names.

## Verification

- All existing `packages/metrics` and `packages/http` tests pass.
- New test case added: `does not reuse a param key when multiple params share the same value`.

Closes #456