### PR TITLE
Resolve #467: fix @IsDefined() validate always returning true

### DIFF
--- a/packages/dto-validator/src/validation.ts
+++ b/packages/dto-validator/src/validation.ts
@@ -181,7 +181,7 @@ const RULE_HANDLERS: { [K in RuleKind]: RuleHandler<K> } = {
   defined: {
     defaultCode: 'REQUIRED',
     describe: (field) => `${field} is required.`,
-    validate: () => true,
+    validate: (_rule, value) => value !== undefined && value !== null,
   },
   optional: {
     defaultCode: 'OPTIONAL',


### PR DESCRIPTION
## Summary

- Fixes the `defined` rule handler's `validate` function which unconditionally returned `true`, rendering `@IsDefined()` a no-op.
- Now returns `false` when the value is `undefined` or `null`, as documented.

## Changes

- `packages/dto-validator/src/validation.ts`: change `validate: () => true` → `validate: (_rule, value) => value !== undefined && value !== null`

## Verification

- `pnpm --filter @konekti/dto-validator typecheck` passes with no errors.
- Fields decorated with `@IsDefined()` now correctly fail validation when the value is absent.

Closes #467