### PR TITLE
Resolve #468: track request-scope children and dispose on root dispose

### DIFF
--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -120,6 +120,7 @@ export class Container {
   private readonly staleDisposalTasks = new Set<Promise<void>>();
   private readonly staleDisposalErrors: unknown[] = [];
   private readonly singletonCache: Map<Token, Promise<unknown>>;
+  private readonly childScopes = new Set<Container>();
   private disposePromise: Promise<void> | undefined;
   private disposed = false;
 
@@ -201,7 +202,9 @@ export class Container {
       throw new ContainerResolutionError('Container has been disposed and can no longer create request scopes.');
     }
 
-    return new Container(this, true, this.root().singletonCache);
+    const child = new Container(this, true, this.root().singletonCache);
+    this.root().childScopes.add(child);
+    return child;
   }
 
   async resolve<T>(token: Token<T>): Promise<T> {
@@ -219,7 +222,7 @@ export class Container {
     }
 
     this.disposed = true;
-    this.disposePromise = this.disposeCache(this.disposalCacheEntries());
+    this.disposePromise = this.disposeAll();
 
     try {
       await this.disposePromise;
@@ -227,6 +230,16 @@ export class Container {
       this.disposePromise = undefined;
       throw error;
     }
+  }
+
+  private async disposeAll(): Promise<void> {
+    // Dispose all live request-scope children first (root only)
+    if (!this.parent && this.childScopes.size > 0) {
+      await Promise.all(Array.from(this.childScopes).map((child) => child.dispose()));
+      this.childScopes.clear();
+    }
+
+    await this.disposeCache(this.disposalCacheEntries());
   }
 
   private hasMulti(token: Token): boolean {


### PR DESCRIPTION
## Summary

- Root container now maintains a `childScopes: Set<Container>` tracking all containers created by `createRequestScope()`.
- When the root is disposed, all live child scopes are disposed first (in parallel), ensuring request-scoped disposable instances are cleaned up.
- After children are disposed, the root proceeds with its normal singleton cache disposal.

## Changes

- `packages/di/src/container.ts`:
  - Added `private readonly childScopes = new Set<Container>()` field on `Container`
  - `createRequestScope()` now registers the new child on `this.root().childScopes`
  - `dispose()` delegates to new private `disposeAll()` which cascades to children before root caches

## Verification

- `pnpm --filter @konekti/di typecheck` — clean
- `npx vitest run packages/di` — 42/42 tests pass

Closes #468