### PR TITLE
Resolve #469: detect cross-container single/multi registration conflicts

### DIFF
--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -254,12 +254,40 @@ export class Container {
         throw new DuplicateProviderError(token);
       }
 
+      if (this.hasAncestorSingleRegistration(token)) {
+        throw new DuplicateProviderError(token);
+      }
+
       return;
     }
 
     if (this.registrations.has(token) || this.multiRegistrations.has(token)) {
       throw new DuplicateProviderError(token);
     }
+
+    if (this.hasAncestorMultiRegistration(token)) {
+      throw new DuplicateProviderError(token);
+    }
+  }
+
+  private hasAncestorSingleRegistration(token: Token): boolean {
+    return this.parent?.hasSingleRegistration(token) ?? false;
+  }
+
+  private hasSingleRegistration(token: Token): boolean {
+    if (this.registrations.has(token)) return true;
+
+    return this.parent?.hasSingleRegistration(token) ?? false;
+  }
+
+  private hasAncestorMultiRegistration(token: Token): boolean {
+    return this.parent?.hasMultiRegistration(token) ?? false;
+  }
+
+  private hasMultiRegistration(token: Token): boolean {
+    if (this.multiRegistrations.has(token)) return true;
+
+    return this.parent?.hasMultiRegistration(token) ?? false;
   }
 
   private collectMultiProviders(token: Token): NormalizedProvider[] {


### PR DESCRIPTION
## Summary

- `assertNoRegistrationConflict` previously only checked the local container maps, allowing a child container to register a single provider for a token that a parent had registered as multi (and vice-versa), producing undefined resolution behaviour.
- Added ancestor traversal so the check walks the parent chain before allowing a registration.

## Changes

- `packages/di/src/container.ts`:
  - `assertNoRegistrationConflict`: when registering a multi provider, also checks ancestors for a single registration; when registering single, also checks ancestors for a multi registration.
  - Added private helpers `hasAncestorSingleRegistration`, `hasSingleRegistration`, `hasAncestorMultiRegistration`, `hasMultiRegistration`.

## Verification

- `pnpm --filter @konekti/di typecheck` — clean
- `npx vitest run packages/di` — 42/42 tests pass

Closes #469