### PR TITLE
Resolve #470: preserve multi-value request headers as arrays in Fastify adapter

### DIFF
--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -394,7 +394,7 @@ async function createFrameworkRequest(
 
   const frameworkRequest: FrameworkRequest = {
     body,
-    cookies: parseCookieHeader(headers.cookie),
+    cookies: parseCookieHeader(Array.isArray(headers.cookie) ? headers.cookie[0] : headers.cookie),
     headers,
     method: request.method,
     params: {},
@@ -474,12 +474,12 @@ function isFastifyMultipartTooLargeError(error: unknown): boolean {
   return error.name === 'FastifyError' || error.message.includes('toobig') || error.message.includes('File too large');
 }
 
-function normalizeHeaders(headers: FastifyRequest['headers']): Record<string, string | undefined> {
-  const normalized: Record<string, string | undefined> = {};
+function normalizeHeaders(headers: FastifyRequest['headers']): Record<string, string | string[] | undefined> {
+  const normalized: Record<string, string | string[] | undefined> = {};
 
   for (const [name, value] of Object.entries(headers)) {
     if (Array.isArray(value)) {
-      normalized[name] = value.join(', ');
+      normalized[name] = value;
       continue;
     }
 


### PR DESCRIPTION
## Summary

- `normalizeHeaders()` was joining array header values with `', '`, collapsing multi-value headers (e.g. `Set-Cookie`, custom multi-headers) into a single string. This made it impossible for downstream code to distinguish a comma in a value from multiple distinct values.
- Updated return type to `Record<string, string | string[] | undefined>` and removed the `join` branch so arrays pass through unchanged.
- Narrowed the `parseCookieHeader` call-site to take the first element if the cookie value is an array (cookie is a single-value header by spec).

## Changes

- `packages/platform-fastify/src/adapter.ts`: `normalizeHeaders` return type and array branch; cookie call-site guard.

## Verification

- `pnpm --filter @konekti/platform-fastify typecheck` — clean

Closes #470