### PR TITLE
Resolve #471: fix duplicate @Cron() scheduling when class registered under multiple tokens

### DIFF
--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -193,7 +193,7 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
   }
 
   private discoverTaskDescriptors(): CronTaskDescriptor[] {
-    const seen = new Map<Token, Set<string>>();
+    const seen = new Map<Function, Set<string>>();
     const descriptors: CronTaskDescriptor[] = [];
 
     for (const candidate of this.discoveryCandidates()) {
@@ -213,14 +213,14 @@ export class CronLifecycleService implements OnApplicationBootstrap, OnApplicati
       for (const entry of entries) {
         const methodName = methodKeyToName(entry.propertyKey);
         const taskName = entry.metadata.options.name ?? buildDefaultTaskName(candidate.targetType.name, methodName);
-        const seenMethods = seen.get(candidate.token) ?? new Set<string>();
+        const seenMethods = seen.get(candidate.targetType) ?? new Set<string>();
 
         if (seenMethods.has(methodName)) {
           continue;
         }
 
         seenMethods.add(methodName);
-        seen.set(candidate.token, seenMethods);
+        seen.set(candidate.targetType, seenMethods);
         descriptors.push({
           afterRun: entry.metadata.options.afterRun,
           beforeRun: entry.metadata.options.beforeRun,


### PR DESCRIPTION
## Summary

- When a class is registered in the DI container under two or more tokens, `discoverTaskDescriptors` was keying the dedup map on `candidate.token`, so the same `@Cron()` method was scheduled once per token — causing it to fire multiple times per interval.
- Changed the dedup key to `candidate.targetType` (the class constructor), which has stable object identity across all token registrations.

## Changes

- `packages/cron/src/service.ts`: `seen` map type changed from `Map<Token, Set<string>>` to `Map<Function, Set<string>>`; lookup/insert keys updated to `candidate.targetType`.

## Verification

- `pnpm --filter @konekti/cron typecheck` — clean
- `npx vitest run packages/cron` — 22/22 tests pass

Closes #471