### PR TITLE
Resolve #472: clear message buffers when overflowPolicy=close terminates socket

### DIFF
--- a/packages/websocket/src/service.ts
+++ b/packages/websocket/src/service.ts
@@ -369,6 +369,7 @@ export class WebSocketGatewayLifecycleService
     if (state.queuedMessages.length >= limit) {
       if (policy === 'close') {
         socket.terminate();
+        state.queuedMessages = [];
         this.unregisterSocket(state.socketId);
         this.logger.warn(
           `WebSocket connection ${state.socketId} exceeded ready-state message queue limit (${String(limit)}). Connection terminated.`,
@@ -498,6 +499,7 @@ export class WebSocketGatewayLifecycleService
 
     if (policy === 'close') {
       socket.terminate();
+      state.bufferedMessages = [];
       this.logger.warn(
         `WebSocket connection ${state.socketId} exceeded pending message buffer limit (${String(limit)}). Connection terminated.`,
         'WebSocketGatewayLifecycleService',


### PR DESCRIPTION
## Summary

- When `overflowPolicy` is `'close'` and the socket is terminated due to overflow, the in-memory buffers were left intact. A subsequent call to `replayBufferedConnectionEvents` (or the queue drain path) would then attempt to deliver those stale messages to the already-terminated socket.
- Both overflow paths now explicitly clear their buffers immediately after `terminate()`.

## Changes

- `packages/websocket/src/service.ts`:
  - Pre-connect buffer path (`bufferIncomingMessage`): `state.bufferedMessages = []` after terminate
  - Ready-state queue path (`enqueueMessageDispatch`): `state.queuedMessages = []` after terminate

## Verification

- `pnpm --filter @konekti/websocket typecheck` — clean
- `npx vitest run packages/websocket` — 22/22 tests pass

Closes #472