### PR TITLE
Resolve #473: JSON.stringify string body when Content-Type is application/json

### DIFF
--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -889,9 +889,11 @@ function serializeResponseBody(
   }
 
   if (typeof body === 'string') {
+    const isJson = isJsonContentType(contentType);
+
     return {
-      defaultContentType: isJsonContentType(contentType) ? undefined : 'text/plain; charset=utf-8',
-      payload: body,
+      defaultContentType: isJson ? undefined : 'text/plain; charset=utf-8',
+      payload: isJson ? JSON.stringify(body) : body,
     };
   }
 


### PR DESCRIPTION
## Summary

- When a controller action returns a `string` and the effective `Content-Type` is `application/json`, the Fastify adapter sent the raw string on the wire (unquoted). The Node adapter calls `JSON.stringify()` for the same case.
- Updated the string branch to call `JSON.stringify(body)` when the content-type is JSON, ensuring consistent cross-adapter wire format.

## Changes

- `packages/platform-fastify/src/adapter.ts`: string body branch now conditionally stringifies based on `isJsonContentType`.

## Verification

- `pnpm --filter @konekti/platform-fastify typecheck` — clean

Closes #473