### PR TITLE
Resolve #474: accept case-insensitive Bearer scheme in refresh token auth

### DIFF
--- a/packages/passport/src/refresh-token.test.ts
+++ b/packages/passport/src/refresh-token.test.ts
@@ -82,6 +82,19 @@ describe('RefreshTokenStrategy', () => {
       expect(service.rotateRefreshToken).toHaveBeenCalledWith('header-token');
     });
 
+    it('accepts lowercase bearer scheme in authorization header', async () => {
+      const service = createMockRefreshTokenService();
+      const strategy = new RefreshTokenStrategy(service, createMockVerifier());
+      const context = createGuardContext(undefined, { authorization: 'bearer lowercase-token' });
+
+      const result = await strategy.authenticate(context);
+
+      expect(result).toMatchObject({
+        subject: 'user-1',
+      });
+      expect(service.rotateRefreshToken).toHaveBeenCalledWith('lowercase-token');
+    });
+
     it('authenticates with refresh token from custom header', async () => {
       const service = createMockRefreshTokenService();
       const strategy = new RefreshTokenStrategy(service, createMockVerifier());

--- a/packages/passport/src/refresh-token.ts
+++ b/packages/passport/src/refresh-token.ts
@@ -77,7 +77,7 @@ export class RefreshTokenStrategy implements AuthStrategy {
 
     const authHeaderRaw = request.headers?.authorization;
     const authHeader = Array.isArray(authHeaderRaw) ? authHeaderRaw[0] : authHeaderRaw;
-    if (authHeader?.startsWith('Bearer ')) {
+    if (authHeader?.toLowerCase().startsWith('bearer ')) {
       return authHeader.slice(7);
     }
 


### PR DESCRIPTION
## Summary

- Refresh token extraction was matching the Authorization scheme with a case-sensitive `startsWith('Bearer ')`, rejecting valid lowercase or uppercase variants.
- The extractor now checks the scheme case-insensitively while preserving the original token slice.
- Added a regression test covering lowercase `bearer` input.

## Verification

- `pnpm --filter @konekti/passport typecheck`
- `npx vitest run packages/passport/src/refresh-token.test.ts`

Closes #474