### PR TITLE
Resolve #475: remove Redis abort listener on normal request cleanup

### DIFF
--- a/packages/microservices/src/redis-transport.test.ts
+++ b/packages/microservices/src/redis-transport.test.ts
@@ -211,6 +211,27 @@ describe('RedisPubSubMicroserviceTransport', () => {
     await transport.close();
   });
 
+  it('removes abort listener after a request completes normally', async () => {
+    const bus = new InMemoryRedisBus();
+    const { publishClient, subscribeClient } = bus.createClient();
+
+    const transport = new RedisPubSubMicroserviceTransport({
+      publishClient,
+      subscribeClient,
+    });
+
+    await transport.listen(async () => 'ok');
+
+    const controller = new AbortController();
+    const removeEventListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+
+    await expect(transport.send('success.pattern', {}, controller.signal)).resolves.toBe('ok');
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+
+    await transport.close();
+  });
+
   it('rejects all pending requests on close', async () => {
     const bus = new InMemoryRedisBus();
     const { publishClient, subscribeClient } = bus.createClient();

--- a/packages/microservices/src/redis-transport.ts
+++ b/packages/microservices/src/redis-transport.ts
@@ -103,9 +103,15 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
         reject(new Error(`Redis request timed out after ${this.requestTimeoutMs}ms waiting for pattern "${pattern}".`));
       }, this.requestTimeoutMs);
 
+      let onAbort: (() => void) | undefined;
+
       const cleanup = () => {
         clearTimeout(timeout);
         this.pending.delete(requestId);
+
+        if (signal && onAbort) {
+          signal.removeEventListener('abort', onAbort);
+        }
       };
 
       this.pending.set(requestId, {
@@ -127,7 +133,7 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
           return;
         }
 
-        const onAbort = () => {
+        onAbort = () => {
           cleanup();
           reject(new Error('Redis request aborted.'));
         };


### PR DESCRIPTION
## Summary

- Redis transport registered an abort listener with `{ once: true }`, but the listener remained attached when the request resolved or rejected normally.
- `cleanup()` now removes the abort listener when present.
- Added a regression test verifying normal completion unregisters the listener.

## Verification

- `pnpm --filter @konekti/microservices typecheck`
- `npx vitest run packages/microservices/src/redis-transport.test.ts`

Closes #475