### PR TITLE
Resolve #476: remove TCP abort listener on normal request cleanup

### DIFF
--- a/packages/microservices/src/tcp-transport.test.ts
+++ b/packages/microservices/src/tcp-transport.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { TcpMicroserviceTransport } from './tcp-transport.js';
+
+describe('TcpMicroserviceTransport', () => {
+  it('removes abort listener after a request completes normally', async () => {
+    const port = 40_000 + Math.floor(Math.random() * 10_000);
+    const transport = new TcpMicroserviceTransport({ port, requestTimeoutMs: 1_000 });
+
+    await transport.listen(async () => 'ok');
+
+    const controller = new AbortController();
+    const removeEventListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+
+    await expect(transport.send('success.pattern', {}, controller.signal)).resolves.toBe('ok');
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+
+    await transport.close();
+  });
+});

--- a/packages/microservices/src/tcp-transport.ts
+++ b/packages/microservices/src/tcp-transport.ts
@@ -124,10 +124,15 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
       const socket = new Socket();
       let settled = false;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      let onAbort: (() => void) | undefined;
 
       const cleanup = () => {
         if (timeoutId) {
           clearTimeout(timeoutId);
+        }
+
+        if (signal && onAbort) {
+          signal.removeEventListener('abort', onAbort);
         }
 
         socket.removeAllListeners();
@@ -156,9 +161,10 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
           return;
         }
 
-        signal.addEventListener('abort', () => {
+        onAbort = () => {
           fail(new Error('Microservice send aborted.'));
-        }, { once: true });
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
       }
 
       timeoutId = setTimeout(() => {


### PR DESCRIPTION
## Summary

- TCP transport registered an anonymous abort listener that could never be removed on normal completion.
- The send path now stores a named abort handler and unregisters it from `cleanup()`.
- Added a regression test proving a successfully completed request removes the listener.

## Verification

- `pnpm --filter @konekti/microservices typecheck` (root workspace)
- `../../node_modules/.bin/vitest run packages/microservices/src/tcp-transport.test.ts` (worktree)

Closes #476