### PR TITLE
Resolve #478: move generated Babel ignore glob into babel.config.cjs

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -130,6 +130,29 @@ describe('CLI command runner', () => {
     expect(readFileSync(join(projectDirectory, '.env'), 'utf8')).toContain('PORT=3000');
   });
 
+  it('keeps Babel test-file ignore rules in babel.config.cjs instead of shell-quoted build args', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    const exitCode = await runCli(['new', 'starter-app'], {
+      cwd: workspaceDirectory,
+      env: {},
+      skipInstall: true,
+      stderr: { write: () => undefined },
+      stdout: { write: () => undefined },
+    });
+
+    const projectDirectory = join(workspaceDirectory, 'starter-app');
+    const packageJson = JSON.parse(readFileSync(join(projectDirectory, 'package.json'), 'utf8')) as {
+      scripts: { build: string };
+    };
+    const babelConfig = readFileSync(join(projectDirectory, 'babel.config.cjs'), 'utf8');
+
+    expect(exitCode).toBe(0);
+    expect(packageJson.scripts.build).not.toContain('--ignore');
+    expect(babelConfig).toContain("ignore: ['src/**/*.test.ts']");
+  });
+
   it('keeps explicit --target-directory when it appears before positional project name', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
     createdDirectories.push(workspaceDirectory);

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -130,7 +130,7 @@ function createProjectPackageJson(
       ...packageManagerField,
       ...localOverrideConfig,
       scripts: {
-        build: "babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ./babel.config.cjs && tsc -p tsconfig.build.json",
+        build: 'babel src --extensions .ts --out-dir dist --config-file ./babel.config.cjs && tsc -p tsconfig.build.json',
         dev: 'node --env-file=.env --watch --watch-preserve-output --import tsx src/main.ts',
         test: 'vitest run',
         'test:watch': 'vitest',
@@ -192,6 +192,7 @@ function createProjectTsconfigBuild(): string {
 
 function createBabelConfig(): string {
   return `module.exports = {
+  ignore: ['src/**/*.test.ts'],
   presets: [['@babel/preset-typescript', { allowDeclareFields: true }]],
   plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]],
 };


### PR DESCRIPTION
## Summary

- The scaffolded starter build script used a single-quoted `--ignore 'src/**/*.test.ts'` glob, which is not portable across Windows shells.
- The generated build script is now shell-neutral, and the ignore rule lives in `babel.config.cjs` instead.
- Added a CLI regression test that asserts the generated `package.json` no longer contains `--ignore` and the generated Babel config does contain the ignore rule.

## Verification

- `../../node_modules/.bin/tsc -p packages/cli/tsconfig.json --noEmit`
- `../../node_modules/.bin/vitest run packages/cli/src/cli.test.ts -t "keeps Babel test-file ignore rules in babel.config.cjs instead of shell-quoted build args"`

Closes #478