### PR TITLE
Resolve #492: guard resolveEffectiveProvider against cyclic alias chains

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -495,6 +495,62 @@ describe('Container', () => {
 
       expect(alias).toBe(original);
     });
+
+    it('resolves the original instance through a multi-hop alias chain', async () => {
+      class Logger {}
+
+      const LOGGER_ALIAS_A = Symbol('LoggerAliasA');
+      const LOGGER_ALIAS_B = Symbol('LoggerAliasB');
+
+      const container = new Container().register(
+        Logger,
+        { provide: LOGGER_ALIAS_A, useExisting: Logger },
+        { provide: LOGGER_ALIAS_B, useExisting: LOGGER_ALIAS_A },
+      );
+
+      const original = await container.resolve(Logger);
+      const alias = await container.resolve<Logger>(LOGGER_ALIAS_B);
+
+      expect(alias).toBe(original);
+    });
+
+    it('throws CircularDependencyError for cyclic useExisting chains during singleton scope checks', async () => {
+      const TOKEN_A = Symbol('TokenA');
+      const TOKEN_B = Symbol('TokenB');
+
+      class MyService {
+        constructor(readonly dependency: unknown) {}
+      }
+
+      const container = new Container().register(
+        { provide: TOKEN_A, useExisting: TOKEN_B },
+        { provide: TOKEN_B, useExisting: TOKEN_A },
+        { provide: MyService, useClass: MyService, inject: [TOKEN_A] },
+      );
+
+      await expect(container.resolve(MyService)).rejects.toThrow(CircularDependencyError);
+    });
+
+    it('applies singleton scope mismatch checks through alias chains', async () => {
+      const REQUEST_LOGGER = Symbol('RequestLogger');
+      const LOGGER_ALIAS_A = Symbol('LoggerAliasA');
+      const LOGGER_ALIAS_B = Symbol('LoggerAliasB');
+
+      class RequestLogger {}
+
+      class MyService {
+        constructor(readonly logger: RequestLogger) {}
+      }
+
+      const container = new Container().register(
+        { provide: REQUEST_LOGGER, useClass: RequestLogger, scope: Scope.REQUEST },
+        { provide: LOGGER_ALIAS_A, useExisting: REQUEST_LOGGER },
+        { provide: LOGGER_ALIAS_B, useExisting: LOGGER_ALIAS_A },
+        { provide: MyService, useClass: MyService, inject: [LOGGER_ALIAS_B] },
+      );
+
+      await expect(container.resolve(MyService)).rejects.toThrow(ScopeMismatchError);
+    });
   });
 
   describe('multi-provider', () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -701,7 +701,17 @@ export class Container {
     }
   }
 
-  private resolveEffectiveProvider(token: Token): NormalizedProvider | undefined {
+  private resolveEffectiveProvider(
+    token: Token,
+    visited = new Set<Token>(),
+    chain: Token[] = [],
+  ): NormalizedProvider | undefined {
+    if (visited.has(token)) {
+      throw new CircularDependencyError([...chain, token]);
+    }
+
+    visited.add(token);
+
     const provider = this.lookupProvider(token);
 
     if (!provider) {
@@ -709,7 +719,7 @@ export class Container {
     }
 
     if (provider.type === 'existing' && provider.useExisting !== undefined) {
-      return this.resolveEffectiveProvider(provider.useExisting);
+      return this.resolveEffectiveProvider(provider.useExisting, visited, [...chain, token]);
     }
 
     return provider;


### PR DESCRIPTION
## Summary

- `resolveEffectiveProvider()` could recurse forever through `useExisting` aliases when singleton scope validation walked a circular alias chain.
- Added a visited-token guard so the helper now throws the same circular dependency error shape as the main resolution path.
- Added regression coverage for multi-hop aliases, circular alias chains, and scope mismatch checks that traverse aliases.

## Verification

- `../../node_modules/.bin/tsc -p packages/di/tsconfig.json --noEmit`
- `../../node_modules/.bin/vitest run packages/di/src/container.test.ts`

Closes #492