### PR TITLE
Resolve #493: update config reloader current() before notifying listeners

### DIFF
--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -262,6 +262,43 @@ describe('loadConfig', () => {
     }
   });
 
+  it('updates current() before notifying manual reload listeners', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-reload-current-visibility-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      envFile: envPath,
+      processEnv: {},
+    });
+
+    try {
+      const observed: Array<{ callbackPort: string; currentPort: string | undefined }> = [];
+
+      reloader.subscribe((snapshot, reason) => {
+        if (reason !== 'manual') {
+          return;
+        }
+
+        const callbackPort = snapshot['PORT'];
+        const currentPort = reloader.current()['PORT'];
+
+        if (typeof callbackPort === 'string') {
+          observed.push({ callbackPort, currentPort: typeof currentPort === 'string' ? currentPort : undefined });
+        }
+      });
+
+      writeFileSync(envPath, 'PORT=4100\n');
+      reloader.reload();
+
+      expect(observed).toEqual([{ callbackPort: '4100', currentPort: '4100' }]);
+    } finally {
+      reloader.close();
+    }
+  });
+
   it('keeps last valid snapshot and reports validation failures in watch mode', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'konekti-config-watch-validation-'));
     const envPath = join(cwd, '.env.dev');

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -168,10 +168,17 @@ function applyReload(
   listeners: ReadonlySet<ConfigReloadListener>,
   reason: ConfigReloadReason,
 ): ConfigDictionary {
+  const previous = state.current;
   const next = resolveConfig(normalized);
 
-  notifyReloadListeners(listeners, next, reason);
   state.current = next;
+
+  try {
+    notifyReloadListeners(listeners, next, reason);
+  } catch (error) {
+    state.current = previous;
+    throw error;
+  }
 
   return cloneConfigDictionary(next);
 }


### PR DESCRIPTION
## Summary

- Reload listeners previously ran before `state.current` was updated, so a callback that called `reloader.current()` still observed the old snapshot.
- `applyReload()` now publishes the next snapshot before notification so `current()` and the callback snapshot stay consistent during reload callbacks.
- The previous rollback contract is preserved: if a listener throws, the reloader restores the previous snapshot before rethrowing.
- Added a regression test covering `current()` visibility inside a manual reload callback.

## Verification

- `../../node_modules/.bin/tsc -p packages/config/tsconfig.json --noEmit`
- `../../node_modules/.bin/vitest run packages/config/src/load.test.ts`

Closes #493