### PR TITLE
Resolve #491: document non-rotation refresh token semantics explicitly

### DIFF
--- a/docs/concepts/auth-and-jwt.md
+++ b/docs/concepts/auth-and-jwt.md
@@ -127,6 +127,11 @@ The following areas remain application-specific:
 
 The `RefreshTokenStrategy` extracts refresh tokens from request body (`refreshToken`), `Authorization: Bearer` header, or a custom `x-refresh-token` header. The framework handles header shape normalization (string or string array) internally.
 
+Refresh token rotation is configurable:
+
+- **`rotation: true`** — refresh exchanges are one-time-use and return a newly issued refresh token in the same family. Replay detection is active in this mode.
+- **`rotation: false`** — refresh exchanges return a new access token but keep the same refresh token string until it expires or is revoked. This mode trades stronger replay protection for reusable refresh tokens and should be chosen deliberately.
+
 ## further reading
 
 - **`@konekti/jwt`**: `../../packages/jwt/README.md`

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -240,6 +240,15 @@ export class AuthModule {}
 
 See `@konekti/passport` documentation for full refresh token lifecycle details.
 
+### Refresh token rotation modes
+
+`RefreshTokenService.rotateRefreshToken()` supports two distinct modes controlled by `refreshToken.rotation`:
+
+- **`rotation: true`** — one-time-use refresh tokens. A successful refresh atomically consumes the current token, issues a new refresh token in the same family, and returns `{ accessToken, refreshToken: <new token> }`. Replay / reuse detection is active in this mode and requires `store.consume()`.
+- **`rotation: false`** — reusable refresh tokens. A successful refresh returns a new access token but reuses the same refresh token string until it expires or is revoked. No new family member is issued on refresh, and the store record is not consumed as part of the refresh operation.
+
+Choose `rotation: true` when you want one-time-use refresh tokens with replay detection. Choose `rotation: false` only when reusable refresh tokens are an acceptable application policy tradeoff.
+
 ## Related packages
 
 - `@konekti/passport` — the auth strategy/guard layer that calls this token core, including refresh token lifecycle

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -40,6 +40,8 @@ Scope note:
 - **Rotate**: Exchange refresh tokens for new access + refresh tokens with replay detection
 - **Revoke**: Invalidate specific tokens or all tokens for a subject (logout)
 
+When the underlying `@konekti/jwt` refresh-token configuration uses `rotation: false`, the refresh operation still returns a new access token but reuses the same refresh token string until expiry or revocation. Replay-detection semantics described in this section apply to rotation mode (`rotation: true`).
+
 ### Use the refresh token strategy
 
 ```typescript


### PR DESCRIPTION
## Summary

- The refresh-token docs previously focused on rotation + replay detection and left `rotation: false` behavior ambiguous.
- Documented that non-rotation mode returns a new access token while reusing the same refresh token string until expiry or revocation.
- Clarified that replay-detection language applies to rotation mode, and updated both package-level and cross-package auth docs for consistency.

## Verification

- Readback review of `packages/jwt/README.md`, `packages/passport/README.md`, and `docs/concepts/auth-and-jwt.md` for consistent wording

Closes #491