### PR TITLE
Resolve #497: harden DI circular resolution and override semantics

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -317,6 +317,24 @@ describe('Container', () => {
       expect(a.b.value).toBe('b');
     });
 
+    it('fails fast for a true circular dependency even when both sides use forwardRef', async () => {
+      class ServiceA {
+        constructor(public b: ServiceB) {}
+      }
+
+      class ServiceB {
+        constructor(public a: ServiceA) {}
+      }
+
+      const container = new Container().register(
+        { provide: ServiceA, useClass: ServiceA, inject: [forwardRef(() => ServiceB)] },
+        { provide: ServiceB, useClass: ServiceB, inject: [forwardRef(() => ServiceA)] },
+      );
+
+      await expect(container.resolve(ServiceA)).rejects.toThrow(CircularDependencyError);
+      await expect(container.resolve(ServiceA)).rejects.toThrow(/forwardRef only defers token lookup/i);
+    });
+
     it('throws CircularDependencyError for a deep cycle (A -> B -> C -> A)', async () => {
       class ServiceA {
         constructor(public b: ServiceB) {}
@@ -435,6 +453,14 @@ describe('Container', () => {
       expect(requestResolved).toBe(requestOverride);
       expect(requestResolved).not.toBe(rootAfterOverride);
       expect(secondRequestResolved).toBe(rootAfterOverride);
+    });
+
+    it('throws ScopeMismatchError when registering a singleton on a request scope container', () => {
+      const token = Symbol('singleton-token');
+      const root = new Container();
+      const requestScope = root.createRequestScope();
+
+      expect(() => requestScope.register({ provide: token, useValue: 'request-only' })).toThrow(ScopeMismatchError);
     });
   });
 
@@ -594,6 +620,18 @@ describe('Container', () => {
 
       await expect(root.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b']);
       await expect(child.resolve<string[]>(PLUGINS)).resolves.toEqual(['child-only']);
+    });
+
+    it('child single override() stops parent multi-provider collection for that token', async () => {
+      const PLUGINS = Symbol('Plugins');
+      const root = new Container().register(
+        { provide: PLUGINS, useValue: 'root-a', multi: true },
+        { provide: PLUGINS, useValue: 'root-b', multi: true },
+      );
+      const child = root.createRequestScope().override({ provide: PLUGINS, useValue: 'child-only' });
+
+      await expect(root.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b']);
+      await expect(child.resolve<string>(PLUGINS)).resolves.toBe('child-only');
     });
 
     it('keeps request-scoped multi providers isolated per request scope', async () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -141,6 +141,13 @@ export class Container {
     for (const provider of providers) {
       const normalized = normalizeProvider(provider);
 
+      if (this.requestScopeEnabled && normalized.scope === Scope.DEFAULT && normalized.multi !== true) {
+        throw new ScopeMismatchError(
+          `Singleton provider ${String(normalized.provide)} cannot be registered on a request-scope container. ` +
+            'Register it on the root container or override it within the request scope instead.',
+        );
+      }
+
       this.assertNoRegistrationConflict(normalized.provide, normalized.multi === true);
 
       if (normalized.multi) {
@@ -188,6 +195,7 @@ export class Container {
         continue;
       }
 
+      this.multiOverriddenTokens.add(normalized.provide);
       this.registrations.set(normalized.provide, normalized);
     }
 
@@ -329,14 +337,18 @@ export class Container {
   }
 
   private async resolveFromRegisteredProviders<T>(token: Token<T>, chain: Token[], activeTokens: Set<Token>): Promise<T> {
-    const multiProviders = this.collectMultiProviders(token);
+    const localSingleProvider = this.registrations.get(token);
 
-    if (multiProviders.length > 0) {
-      const instances = await this.withTokenInChain(token, chain, activeTokens, async (c, at) =>
-        this.resolveMultiProviderInstances(multiProviders, c, at),
-      );
+    if (!localSingleProvider) {
+      const multiProviders = this.collectMultiProviders(token);
 
-      return instances as T;
+      if (multiProviders.length > 0) {
+        const instances = await this.withTokenInChain(token, chain, activeTokens, async (c, at) =>
+          this.resolveMultiProviderInstances(multiProviders, c, at),
+        );
+
+        return instances as T;
+      }
     }
 
     const provider = this.requireProvider(token);
@@ -382,13 +394,10 @@ export class Container {
     }
 
     if (allowForwardRef) {
-      // A forwardRef dep is in the chain — return the partially-initialized
-      // instance from the singleton cache if it is already being constructed.
-      const cache = this.singletonCacheFor(token);
-
-      if (cache?.has(token)) {
-        return cache.get(token);
-      }
+      throw new CircularDependencyError(
+        [...chain, token],
+        'forwardRef only defers token lookup and does not resolve true circular construction.',
+      );
     }
 
     throw new CircularDependencyError([...chain, token]);
@@ -451,18 +460,6 @@ export class Container {
     }
 
     return cache.get(provider.provide);
-  }
-
-  private singletonCacheFor(token: Token): Map<Token, Promise<unknown>> | undefined {
-    const provider = this.lookupProvider(token);
-
-    if (!provider || provider.scope !== Scope.DEFAULT) return undefined;
-
-    if (this.requestScopeEnabled && this.registrations.has(token)) {
-      return this.requestCache;
-    }
-
-    return this.root().singletonCache;
   }
 
   private async resolveDepToken(

--- a/packages/di/src/errors.ts
+++ b/packages/di/src/errors.ts
@@ -25,9 +25,12 @@ export class ScopeMismatchError extends KonektiCodeError {
 }
 
 export class CircularDependencyError extends KonektiCodeError {
-  constructor(chain: readonly unknown[]) {
+  constructor(chain: readonly unknown[], detail?: string) {
     const path = chain.map((token) => formatTokenName(token)).join(' -> ');
-    super(`Circular dependency detected: ${path}`, 'CIRCULAR_DEPENDENCY');
+    super(
+      detail ? `Circular dependency detected: ${path}. ${detail}` : `Circular dependency detected: ${path}`,
+      'CIRCULAR_DEPENDENCY',
+    );
   }
 }
 


### PR DESCRIPTION
Closes #497

## Summary
- fail fast when a true circular dependency re-enters through `forwardRef`, with a clearer DI error message
- block accidental singleton registration inside request-scope containers while preserving request-scope overrides
- ensure child single-provider overrides stop inheriting parent multi-provider collections

## Verification
- `pnpm exec vitest run packages/di/src/container.test.ts`
- `pnpm --filter @konekti/di typecheck`
- `pnpm --filter @konekti/di build`