### PR TITLE
Resolve #498: fix shutdown correctness and response semantics

### DIFF
--- a/packages/http/src/correlation.ts
+++ b/packages/http/src/correlation.ts
@@ -19,9 +19,9 @@ export function createCorrelationMiddleware(): Middleware {
         context.requestContext.requestId = resolveInboundRequestId(context.request.headers);
       }
 
-      await next();
-
       context.response.setHeader(REQUEST_ID_HEADER, context.requestContext.requestId);
+
+      await next();
     },
   };
 }

--- a/packages/http/src/dispatcher.test.ts
+++ b/packages/http/src/dispatcher.test.ts
@@ -14,6 +14,7 @@ import type {
 import {
   FromBody,
   FromQuery,
+  createCorrelationMiddleware,
   createDispatcher,
   createHandlerMapping,
   Controller,
@@ -764,6 +765,36 @@ describe('dispatcher runtime', () => {
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ ok: true });
     expect(events).toEqual(['start', 'match', 'handler', 'finish']);
+  });
+
+  it('sets the correlation response header before downstream code commits the response', async () => {
+    @Controller('/correlation')
+    class CorrelationController {
+      @Get('/')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(CorrelationController);
+    const dispatcher = createDispatcher({
+      appMiddleware: [createCorrelationMiddleware()],
+      handlerMapping: createHandlerMapping([{ controllerToken: CorrelationController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+    response.setHeader = function setHeader(name, value) {
+      if (this.committed) {
+        throw new Error(`setHeader after commit: ${name}`);
+      }
+
+      this.headers[name] = value;
+    };
+
+    await dispatcher.dispatch(createRequest('/correlation', 'GET'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['x-request-id']).toEqual(expect.any(String));
   });
 
   it('passes matched handler metadata to request error observers', async () => {

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -149,6 +149,33 @@ describe('handler mapping', () => {
     expect(unversionedMatch).toBeUndefined();
   });
 
+  it('fails fast when URI version aliases normalize to the same route', () => {
+    @Version('1')
+    @Controller('/users')
+    class UsersV1Controller {
+      @Get('/')
+      listUsers() {
+        return [{ id: '1' }];
+      }
+    }
+
+    @Version('v1')
+    @Controller('/users')
+    class UsersAliasController {
+      @Get('/')
+      listUsersAlias() {
+        return [{ id: '1' }];
+      }
+    }
+
+    expect(() =>
+      createHandlerMapping([
+        { controllerToken: UsersV1Controller },
+        { controllerToken: UsersAliasController },
+      ]),
+    ).toThrow(RouteConflictError);
+  });
+
   it('resolves versions from configured request headers', () => {
     @Controller('/users')
     class UsersController {

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -308,7 +308,8 @@ function buildDescriptorList(sources: HandlerSource[], versioning: ResolvedVersi
   const seen = new Set<string>();
 
   for (const descriptor of descriptors) {
-    const routeKey = `${descriptor.route.method}:${descriptor.route.path}:${descriptor.route.version ?? '<none>'}`;
+    const routeVersion = descriptor.route.version === undefined ? '<none>' : normalizeVersionValue(descriptor.route.version);
+    const routeKey = `${descriptor.route.method}:${descriptor.route.path}:${routeVersion}`;
 
     if (seen.has(routeKey)) {
       throw new RouteConflictError(`Duplicate route registration detected for ${routeKey}.`);

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -508,7 +508,7 @@ describe('@konekti/platform-fastify', () => {
     await app.close();
   });
 
-  it('clears dispatcher only after fastify close settles when timeout wins', async () => {
+  it('keeps dispatcher until fastify close settles even when close() times out', async () => {
     const adapter = new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
     const app = {
       close: () => Promise.resolve(),
@@ -529,7 +529,7 @@ describe('@konekti/platform-fastify', () => {
       return deferred.promise;
     };
 
-    await adapter.close();
+    await expect(adapter.close()).rejects.toThrow(/shutdown timeout/i);
 
     expect(closeCallCount).toBe(1);
     expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
@@ -538,5 +538,61 @@ describe('@konekti/platform-fastify', () => {
     await Promise.resolve();
 
     expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
+  });
+
+  it('fails close() when the fastify server does not stop within the shutdown timeout', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
+    const deferred = createDeferred<void>();
+    const app = {
+      close: () => deferred.promise,
+      server: {
+        listening: true,
+      },
+    };
+
+    Reflect.set(adapter, 'app', app);
+    Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
+
+    await expect(adapter.close()).rejects.toThrow(/shutdown timeout/i);
+
+    deferred.resolve();
+    await Promise.resolve();
+  });
+
+  it('keeps malformed cookie values instead of failing the request', async () => {
+    @Controller('/cookies')
+    class CookieController {
+      @Get('/')
+      readCookies(_input: undefined, context: RequestContext) {
+        return context.request.cookies;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [CookieController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/cookies`, {
+      headers: {
+        cookie: 'good=hello%20world; bad=%E0%A4%A',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      bad: '%E0%A4%A',
+      good: 'hello world',
+    });
+
+    await app.close();
   });
 });

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -299,7 +299,11 @@ export async function runFastifyApplication(
     logger.error('Failed to start application.', error, 'KonektiFactory');
 
     if (app.state !== 'closed') {
-      await app.close('bootstrap-failed');
+      try {
+        await app.close('bootstrap-failed');
+      } catch (closeError) {
+        logger.error('Failed to close application after startup failure.', closeError, 'KonektiFactory');
+      }
     }
 
     throw error;
@@ -538,7 +542,13 @@ function parseCookieHeader(cookieHeader: string | undefined): Record<string, str
           return [pair.trim(), ''] as [string, string];
         }
 
-        return [pair.slice(0, index).trim(), decodeURIComponent(pair.slice(index + 1).trim())] as [string, string];
+        const rawValue = pair.slice(index + 1).trim();
+
+        try {
+          return [pair.slice(0, index).trim(), decodeURIComponent(rawValue)] as [string, string];
+        } catch {
+          return [pair.slice(0, index).trim(), rawValue] as [string, string];
+        }
       }),
   );
 }
@@ -837,8 +847,10 @@ function delay(ms: number): Promise<void> {
 function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number): Promise<void> {
   return Promise.race([
     closePromise,
-    new Promise<void>((resolve) => {
-      setTimeout(resolve, timeoutMs);
+    new Promise<void>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Fastify adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
     }),
   ]);
 }

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -231,6 +231,59 @@ describe('bootstrapApplication', () => {
     expect(events).toEqual(['adapter:listen', 'adapter:close:SIGTERM', 'adapter:close:SIGTERM']);
   });
 
+  it('surfaces shutdown hook failures from close() instead of masking them as success', async () => {
+    class AppService {
+      onApplicationShutdown() {
+        throw new Error('shutdown hook failed');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      providers: [AppService],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    await expect(app.close('SIGTERM')).rejects.toThrow('shutdown hook failed');
+    expect(app.state).toBe('bootstrapped');
+  });
+
+  it('preserves the original startup failure when adapter close also fails during bootstrap cleanup', async () => {
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message, error, context) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : String(error)}`);
+      },
+      log() {},
+      warn() {},
+    };
+
+    const adapter: HttpApplicationAdapter = {
+      async close() {
+        throw new Error('adapter close failed');
+      },
+      async listen() {
+        throw new Error('listen failed');
+      },
+    };
+
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    const app = await bootstrapApplication({
+      adapter,
+      logger,
+      rootModule: AppModule,
+    });
+
+    await expect(app.listen()).rejects.toThrow('listen failed');
+    expect(loggerEvents).toContain('error:KonektiApplication:Failed to start the HTTP adapter.:listen failed');
+  });
+
   it('disposes container-managed instances when the application closes', async () => {
     class DisposableResource {
       destroyed = false;

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -561,6 +561,24 @@ describe('KonektiFactory.createApplicationContext', () => {
       'app:shutdown:SIGTERM',
     ]);
   });
+
+  it('surfaces shutdown hook failures from application context close()', async () => {
+    class AppService {
+      onApplicationShutdown() {
+        throw new Error('context shutdown failed');
+      }
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const context = await KonektiFactory.createApplicationContext(AppModule, {
+    });
+
+    await expect(context.close('SIGTERM')).rejects.toThrow('context shutdown failed');
+  });
 });
 
 describe('KonektiFactory.createMicroservice', () => {

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -86,6 +86,104 @@ async function disposeContainer(container: Container): Promise<void> {
   await container.dispose();
 }
 
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function createLifecycleCloseError(errors: unknown[]): Error {
+  if (errors.length === 1) {
+    return toError(errors[0]);
+  }
+
+  return new AggregateError(errors, 'Application close failed for one or more shutdown steps.');
+}
+
+async function runCleanupCallbacks(cleanups: readonly (() => void)[]): Promise<unknown[]> {
+  const errors: unknown[] = [];
+
+  for (const cleanup of cleanups) {
+    try {
+      cleanup();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  return errors;
+}
+
+async function closeRuntimeResources(options: {
+  adapter?: HttpApplicationAdapter;
+  container: Container;
+  lifecycleInstances: readonly unknown[];
+  runtimeCleanup: readonly (() => void)[];
+  signal?: string;
+}): Promise<void> {
+  const errors: unknown[] = [];
+
+  errors.push(...(await runCleanupCallbacks(options.runtimeCleanup)));
+
+  try {
+    await runShutdownHooks(options.lifecycleInstances, options.signal);
+  } catch (error) {
+    errors.push(error);
+  }
+
+  if (options.adapter) {
+    try {
+      await options.adapter.close(options.signal);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  try {
+    await disposeContainer(options.container);
+  } catch (error) {
+    errors.push(error);
+  }
+
+  if (errors.length > 0) {
+    throw createLifecycleCloseError(errors);
+  }
+}
+
+async function runBootstrapFailureCleanup(options: {
+  container?: Container;
+  lifecycleInstances: readonly unknown[];
+  logger: ApplicationLogger;
+  runtimeCleanup: readonly (() => void)[];
+  scope: 'application' | 'application context';
+}): Promise<void> {
+  const errors: unknown[] = [];
+
+  errors.push(...(await runCleanupCallbacks(options.runtimeCleanup)));
+
+  if (options.lifecycleInstances.length > 0) {
+    try {
+      await runShutdownHooks(options.lifecycleInstances, 'bootstrap-failed');
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (options.container) {
+    try {
+      await disposeContainer(options.container);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  for (const error of errors) {
+    options.logger.error(
+      `Failed to clean up after ${options.scope} bootstrap failure.`,
+      error,
+      'KonektiFactory',
+    );
+  }
+}
+
 function hasMethod<TName extends string>(
   value: unknown,
   methodName: TName,
@@ -357,17 +455,13 @@ class KonektiApplication implements Application {
     }
 
     this.closingPromise = (async () => {
-      for (const cleanup of this.runtimeCleanup) {
-        cleanup();
-      }
-
-      try {
-        await runShutdownHooks(this.lifecycleInstances, signal);
-      } catch (error) {
-        console.error('[konekti] shutdown hook threw an error:', error);
-      }
-      await this.adapter.close(signal);
-      await disposeContainer(this.container);
+      await closeRuntimeResources({
+        adapter: this.adapter,
+        container: this.container,
+        lifecycleInstances: this.lifecycleInstances,
+        runtimeCleanup: this.runtimeCleanup,
+        signal,
+      });
       this.closed = true;
       this.applicationState = 'closed';
     })();
@@ -408,16 +502,12 @@ class KonektiApplicationContext implements ApplicationContext {
     }
 
     this.closingPromise = (async () => {
-      for (const cleanup of this.runtimeCleanup) {
-        cleanup();
-      }
-
-      try {
-        await runShutdownHooks(this.lifecycleInstances, signal);
-      } catch (error) {
-        console.error('[konekti] shutdown hook threw an error:', error);
-      }
-      await disposeContainer(this.container);
+      await closeRuntimeResources({
+        container: this.container,
+        lifecycleInstances: this.lifecycleInstances,
+        runtimeCleanup: this.runtimeCleanup,
+        signal,
+      });
       this.closed = true;
     })();
 
@@ -563,7 +653,7 @@ async function runBootstrapHooks(instances: unknown[]): Promise<void> {
 /**
  * 종료 단계의 hook을 역순으로 실행해 이미 시작한 리소스를 정리한다.
  */
-async function runShutdownHooks(instances: unknown[], signal?: string): Promise<void> {
+async function runShutdownHooks(instances: readonly unknown[], signal?: string): Promise<void> {
   for (const instance of [...instances].reverse()) {
     if (isOnModuleDestroy(instance)) {
       await instance.onModuleDestroy();
@@ -791,17 +881,13 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
   } catch (error: unknown) {
     logger.error('Failed to bootstrap application.', error, 'KonektiFactory');
 
-    if (lifecycleInstances.length > 0) {
-      await runShutdownHooks(lifecycleInstances, 'bootstrap-failed');
-    }
-
-    if (bootstrappedContainer) {
-      await disposeContainer(bootstrappedContainer);
-    }
-
-    for (const cleanup of runtimeCleanup) {
-      cleanup();
-    }
+    await runBootstrapFailureCleanup({
+      container: bootstrappedContainer,
+      lifecycleInstances,
+      logger,
+      runtimeCleanup,
+      scope: 'application',
+    });
 
     throw error;
   }
@@ -850,17 +936,13 @@ export class KonektiFactory {
     } catch (error: unknown) {
       logger.error('Failed to bootstrap application context.', error, 'KonektiFactory');
 
-      if (lifecycleInstances.length > 0) {
-        await runShutdownHooks(lifecycleInstances, 'bootstrap-failed');
-      }
-
-      if (bootstrappedContainer) {
-        await disposeContainer(bootstrappedContainer);
-      }
-
-      for (const cleanup of runtimeCleanup) {
-        cleanup();
-      }
+      await runBootstrapFailureCleanup({
+        container: bootstrappedContainer,
+        lifecycleInstances,
+        logger,
+        runtimeCleanup,
+        scope: 'application context',
+      });
 
       throw error;
     }

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -264,7 +264,11 @@ export async function runNodeApplication(
     logger.error('Failed to start application.', error, 'KonektiFactory');
 
     if (app.state !== 'closed') {
-      await app.close('bootstrap-failed');
+      try {
+        await app.close('bootstrap-failed');
+      } catch (closeError) {
+        logger.error('Failed to close application after startup failure.', closeError, 'KonektiFactory');
+      }
     }
 
     throw error;

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -148,6 +148,8 @@ The compiled test container.
 | `.has(token)` | Check whether a provider token is available in the compiled graph. |
 | `.dispatch(request)` | Run a request through the compiled module dispatcher (`createDispatcher`) and return a `TestResponse`. |
 
+`get()` is intentionally a **synchronous** convenience for tests that only touch synchronously-constructable providers. It does not await async factories and should not be treated as the same resolution path as `resolve()`. Use `resolve()` when provider identity must match the runtime container path or when async factories may be involved.
+
 ### Module introspection utilities
 
 Use these to extract module metadata for test setup without manually accessing metadata symbols:


### PR DESCRIPTION
Closes #498

## Summary
- surface shutdown and cleanup failures from runtime/application close paths instead of masking them as success
- make fastify close timeout fail explicitly while preserving dispatcher state until close actually settles
- fix correlation header timing, URI version alias conflict detection, malformed cookie decode fallback, and clarify testing `get()` vs `resolve()` semantics

## Verification
- `pnpm build`
- `pnpm --filter @konekti/runtime typecheck && pnpm --filter @konekti/platform-fastify typecheck && pnpm --filter @konekti/http typecheck && pnpm --filter @konekti/testing typecheck`
- `pnpm exec vitest run packages/runtime/src/application.test.ts packages/runtime/src/bootstrap.test.ts packages/platform-fastify/src/adapter.test.ts packages/http/src/mapping.test.ts packages/http/src/dispatcher.test.ts`