### PR TITLE
Resolve #504: stabilize cache consistency and throttler contracts

### DIFF
--- a/packages/cache-manager/src/cache-service.test.ts
+++ b/packages/cache-manager/src/cache-service.test.ts
@@ -178,6 +178,25 @@ describe('CacheService — general cache contract (outside HTTP interceptor)', (
       await expect(cache.get('key')).resolves.toBeUndefined();
     });
 
+    it('does not repopulate a key when del runs while remember is still loading', async () => {
+      let resolveLoader: ((value: { computed: boolean }) => void) | undefined;
+      const cache = createCacheService(createStore());
+      const loader = vi.fn(
+        () =>
+          new Promise<{ computed: boolean }>((resolve) => {
+            resolveLoader = resolve;
+          }),
+      );
+
+      const pending = cache.remember('key', loader);
+      await Promise.resolve();
+      await cache.del('key');
+      resolveLoader?.({ computed: true });
+
+      await expect(pending).resolves.toEqual({ computed: true });
+      await expect(cache.get('key')).resolves.toBeUndefined();
+    });
+
     it('set uses module default TTL when not specified', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-03-24T00:00:00.000Z'));
@@ -259,6 +278,34 @@ describe('CacheService — general cache contract (outside HTTP interceptor)', (
 
       await cache.set('complex', complexObject);
       await expect(cache.get('complex')).resolves.toEqual(complexObject);
+    });
+
+    it('does not leak cached object mutations back into subsequent reads', async () => {
+      const cache = createCacheService(createStore());
+      const complexObject = {
+        metadata: { total: 2 },
+        users: [{ id: 1, name: 'Alice' }],
+      };
+
+      await cache.set('complex', complexObject);
+      complexObject.metadata.total = 99;
+
+      const firstRead = await cache.get<typeof complexObject>('complex');
+      expect(firstRead).toEqual({
+        metadata: { total: 2 },
+        users: [{ id: 1, name: 'Alice' }],
+      });
+
+      if (!firstRead) {
+        throw new Error('Expected cached value to be defined.');
+      }
+
+      firstRead.users[0]!.name = 'Bob';
+
+      await expect(cache.get('complex')).resolves.toEqual({
+        metadata: { total: 2 },
+        users: [{ id: 1, name: 'Alice' }],
+      });
     });
 
     it('handles multiple independent key namespaces', async () => {

--- a/packages/cache-manager/src/clone.ts
+++ b/packages/cache-manager/src/clone.ts
@@ -1,0 +1,3 @@
+export function cloneCacheValue<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/packages/cache-manager/src/memory-store.test.ts
+++ b/packages/cache-manager/src/memory-store.test.ts
@@ -62,4 +62,23 @@ describe('MemoryStore', () => {
 
     await expect(store.get('users:list')).resolves.toEqual({ count: 1 });
   });
+
+  it('returns immutable snapshots instead of leaking internal object references', async () => {
+    const store = new MemoryStore();
+    const value = { nested: { count: 1 } };
+
+    await store.set('users:list', value, 60);
+    value.nested.count = 99;
+
+    const first = await store.get<typeof value>('users:list');
+    expect(first).toEqual({ nested: { count: 1 } });
+
+    if (!first) {
+      throw new Error('Expected cached value to be defined.');
+    }
+
+    first.nested.count = 42;
+
+    await expect(store.get('users:list')).resolves.toEqual({ nested: { count: 1 } });
+  });
 });

--- a/packages/cache-manager/src/memory-store.ts
+++ b/packages/cache-manager/src/memory-store.ts
@@ -1,4 +1,5 @@
 import type { CacheStore } from './types.js';
+import { cloneCacheValue } from './clone.js';
 
 interface MemoryCacheEntry<T = unknown> {
   expiresAt?: number;
@@ -47,7 +48,7 @@ export class MemoryStore implements CacheStore {
       return undefined;
     }
 
-    return entry.value as T;
+    return cloneCacheValue(entry.value as T);
   }
 
   async set<T = unknown>(key: string, value: T, ttlSeconds = 0): Promise<void> {
@@ -58,7 +59,7 @@ export class MemoryStore implements CacheStore {
     }
 
     const entry: MemoryCacheEntry<T> = {
-      value,
+      value: cloneCacheValue(value),
     };
 
     if (ttlSeconds > 0) {

--- a/packages/cache-manager/src/service.ts
+++ b/packages/cache-manager/src/service.ts
@@ -6,6 +6,8 @@ import type { CacheStore, NormalizedCacheModuleOptions } from './types.js';
 @Inject([CACHE_STORE, CACHE_OPTIONS])
 export class CacheService {
   private readonly inflight = new Map<string, Promise<unknown>>();
+  private readonly invalidationVersion = new Map<string, number>();
+  private resetVersion = 0;
 
   constructor(
     private readonly store: CacheStore,
@@ -31,6 +33,8 @@ export class CacheService {
     loader: () => Promise<T>,
     ttlSeconds?: number,
   ): Promise<T> {
+    const keyVersion = this.invalidationVersion.get(key) ?? 0;
+    const resetVersion = this.resetVersion;
     const cached = await this.get<T>(key);
 
     if (cached !== undefined) {
@@ -44,6 +48,12 @@ export class CacheService {
     }
 
     const promise = loader().then(async (value) => {
+      const currentKeyVersion = this.invalidationVersion.get(key) ?? 0;
+
+      if (currentKeyVersion !== keyVersion || this.resetVersion !== resetVersion) {
+        return value;
+      }
+
       await this.set(key, value, ttlSeconds);
       return value;
     }).finally(() => {
@@ -55,10 +65,13 @@ export class CacheService {
   }
 
   async del(key: string): Promise<void> {
+    this.invalidationVersion.set(key, (this.invalidationVersion.get(key) ?? 0) + 1);
     await this.store.del(key);
   }
 
   async reset(): Promise<void> {
+    this.resetVersion += 1;
+    this.invalidationVersion.clear();
     await this.store.reset();
   }
 }

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { IsArray, IsOptional, IsString, MinLength, ValidateNested } from '@konekti/dto-validator';
+import { IsArray, IsEnum, IsOptional, IsString, MinLength, ValidateNested } from '@konekti/dto-validator';
 import { Controller, FromBody, Post, RequestDto, createHandlerMapping } from '@konekti/http';
 
 import { buildOpenApiDocument } from './schema-builder.js';
@@ -98,5 +98,46 @@ describe('buildOpenApiDocument', () => {
         "required": true,
       }
     `);
+  });
+
+  it('omits enum type when allowed values mix primitive kinds', () => {
+    enum NumericStatus {
+      Draft,
+      Published,
+    }
+
+    class UpdatePostRequest {
+      @FromBody('status')
+      @IsEnum(NumericStatus)
+      status = NumericStatus.Draft;
+    }
+
+    @Controller('/posts')
+    class PostsController {
+      @RequestDto(UpdatePostRequest)
+      @Post('/status')
+      update() {
+        return { ok: true };
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: PostsController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Enum API',
+      version: '1.0.0',
+    });
+
+    expect(document.components?.schemas?.UpdatePostRequest).toEqual({
+      additionalProperties: false,
+      properties: {
+        status: {
+          enum: ['Draft', 'Published', 0, 1],
+        },
+      },
+      required: ['status'],
+      type: 'object',
+    });
   });
 });

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -221,9 +221,11 @@ function inferEnumValueType(value: unknown): 'boolean' | 'number' | 'string' {
 }
 
 function createEnumSchema(values: readonly unknown[]): OpenApiSchemaObject {
+  const typeSet = new Set(values.map((value) => inferEnumValueType(value)));
+
   return {
     enum: [...values],
-    type: inferEnumValueType(values[0]),
+    ...(typeSet.size === 1 && values.length > 0 ? { type: inferEnumValueType(values[0]) } : {}),
   };
 }
 

--- a/packages/throttler/src/decorators.ts
+++ b/packages/throttler/src/decorators.ts
@@ -1,4 +1,5 @@
 import type { ThrottlerHandlerOptions } from './types.js';
+import { validateThrottleOptions } from './validation.js';
 
 export const throttleRouteMetadataKey = Symbol.for('konekti.standard.route');
 const throttleKey = Symbol.for('konekti.throttler.throttle');
@@ -16,10 +17,10 @@ function getMetadataBag(metadata: unknown): StandardMetadataBag {
 }
 
 function cloneThrottleOptions(options: ThrottlerHandlerOptions): ThrottlerHandlerOptions {
-  return {
+  return validateThrottleOptions({
     limit: options.limit,
     ttl: options.ttl,
-  };
+  });
 }
 
 function getRouteRecord(metadata: unknown, name: string | symbol): StandardMetadataBag {

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -11,6 +11,7 @@ import {
 import { createMemoryThrottlerStore } from './store.js';
 import { THROTTLER_OPTIONS } from './tokens.js';
 import type { ThrottlerModuleOptions, ThrottlerStore } from './types.js';
+import { validateThrottleOptions, validateThrottlerModuleOptions } from './validation.js';
 
 type MetadataBag = Record<PropertyKey, unknown>;
 
@@ -58,6 +59,7 @@ export class ThrottlerGuard implements Guard {
   private readonly store: ThrottlerStore;
 
   constructor(private readonly options: ThrottlerModuleOptions) {
+    validateThrottlerModuleOptions(options);
     this.store = options.store ?? createMemoryThrottlerStore();
   }
 
@@ -77,8 +79,12 @@ export class ThrottlerGuard implements Guard {
     const methodThrottle = methodBag ? getThrottleMetadata(methodBag) : undefined;
     const classThrottle = classBag ? getClassThrottleMetadata(classBag) : undefined;
 
-    const ttlSeconds = methodThrottle?.ttl ?? classThrottle?.ttl ?? this.options.ttl;
-    const limit = methodThrottle?.limit ?? classThrottle?.limit ?? this.options.limit;
+    const resolvedThrottle = validateThrottleOptions({
+      limit: methodThrottle?.limit ?? classThrottle?.limit ?? this.options.limit,
+      ttl: methodThrottle?.ttl ?? classThrottle?.ttl ?? this.options.ttl,
+    });
+    const ttlSeconds = resolvedThrottle.ttl;
+    const limit = resolvedThrottle.limit;
 
     const middlewareCtx: MiddlewareContext = {
       request: requestContext.request,

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -5,6 +5,7 @@ import type { GuardContext, HandlerDescriptor, RequestContext } from '@konekti/h
 
 import { SkipThrottle, Throttle, getThrottleMetadata } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
+import { createThrottlerModule } from './module.js';
 import { createMemoryThrottlerStore } from './store.js';
 import type { ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
 
@@ -103,6 +104,26 @@ describe('@konekti/throttler decorators', () => {
     expect(bag[Symbol.for('konekti.throttler.class-throttle')]).toEqual({ limit: 100, ttl: 60 });
   });
 
+  it('rejects invalid @Throttle options eagerly', () => {
+    expect(() => {
+      class AuthController {
+        @Throttle({ limit: 0, ttl: 60 })
+        login() {}
+      }
+
+      return AuthController;
+    }).toThrow(/limit/i);
+
+    expect(() => {
+      class AuthController {
+        @Throttle({ limit: 1, ttl: Number.NaN })
+        login() {}
+      }
+
+      return AuthController;
+    }).toThrow(/ttl/i);
+  });
+
   it('captures @Throttle options by value to avoid shared mutable metadata', () => {
     const options = { limit: 5, ttl: 60 };
 
@@ -177,6 +198,12 @@ describe('ThrottlerGuard — in-memory store', () => {
       store: createMemoryThrottlerStore(),
       ttl: 60,
     };
+  });
+
+  it('rejects invalid module-level ttl and limit before request handling starts', () => {
+    expect(() => createThrottlerModule({ limit: 0, ttl: 60 })).toThrow(/limit/i);
+    expect(() => createThrottlerModule({ limit: 1, ttl: -1 })).toThrow(/ttl/i);
+    expect(() => createThrottlerModule({ limit: Number.POSITIVE_INFINITY, ttl: 60 })).toThrow(/limit/i);
   });
 
   it('allows requests up to the limit', async () => {
@@ -442,8 +469,6 @@ describe('ThrottlerGuard — Redis store mock', () => {
     expect(decodedHandler).toContain('path:%2Fv1%2Frate-limit');
     expect(decodedHandler).toContain('version:1');
     expect(decodedHandler).toContain('handler:hit');
-    expect(decodedHandler).toContain('module:RateModule');
-    expect(decodedHandler).toContain('controller:RateController');
     expect(decodedClient).toBe('2001:db8::1');
   });
 

--- a/packages/throttler/src/module.ts
+++ b/packages/throttler/src/module.ts
@@ -4,12 +4,15 @@ import { defineModule, type ModuleType } from '@konekti/runtime';
 import { ThrottlerGuard } from './guard.js';
 import { THROTTLER_GUARD, THROTTLER_OPTIONS } from './tokens.js';
 import type { ThrottlerModuleOptions } from './types.js';
+import { validateThrottlerModuleOptions } from './validation.js';
 
 export function createThrottlerProviders(options: ThrottlerModuleOptions): Provider[] {
+  const validatedOptions = validateThrottlerModuleOptions(options);
+
   return [
     {
       provide: THROTTLER_OPTIONS,
-      useValue: options,
+      useValue: validatedOptions,
     },
     {
       provide: THROTTLER_GUARD,

--- a/packages/throttler/src/validation.ts
+++ b/packages/throttler/src/validation.ts
@@ -1,0 +1,21 @@
+import type { ThrottlerHandlerOptions, ThrottlerModuleOptions } from './types.js';
+
+function assertPositiveFiniteInteger(value: number, field: 'limit' | 'ttl'): void {
+  if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid throttler ${field}: expected a positive finite integer.`);
+  }
+}
+
+export function validateThrottleOptions(options: ThrottlerHandlerOptions): ThrottlerHandlerOptions {
+  assertPositiveFiniteInteger(options.limit, 'limit');
+  assertPositiveFiniteInteger(options.ttl, 'ttl');
+  return {
+    limit: options.limit,
+    ttl: options.ttl,
+  };
+}
+
+export function validateThrottlerModuleOptions(options: ThrottlerModuleOptions): ThrottlerModuleOptions {
+  validateThrottleOptions(options);
+  return options;
+}


### PR DESCRIPTION
Closes #504

## Summary
- clone cached values at the memory-store boundary and block inflight `remember()` writes from resurrecting deleted keys
- validate throttler ttl/limit eagerly, and align the throttler store-key tests with the documented key contract
- omit OpenAPI enum `type` for mixed primitive enums so generated schemas stay accurate

## Verification
- `pnpm build`
- `pnpm --filter @konekti/cache-manager typecheck`
- `pnpm --filter @konekti/throttler typecheck`
- `pnpm --filter @konekti/openapi typecheck`
- `pnpm exec vitest run packages/cache-manager/src/memory-store.test.ts packages/cache-manager/src/cache-service.test.ts packages/throttler/src/module.test.ts packages/openapi/src/schema-builder.test.ts`