### PR TITLE
Resolve #499: harden websocket and socket.io adapter boundaries

### DIFF
--- a/packages/platform-socket.io/src/adapter.ts
+++ b/packages/platform-socket.io/src/adapter.ts
@@ -66,6 +66,11 @@ interface NodeHttpServerLike {
 }
 
 const DEFAULT_SOCKETIO_SHUTDOWN_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET = 128;
+
+function isFinitePositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && Number.isFinite(value) && value > 0;
+}
 
 function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
   if (typeof provider === 'function') {
@@ -187,7 +192,7 @@ export class SocketIoLifecycleService
     await this.shutdown();
   }
 
-  joinRoom(socketId: string, room: string): void {
+  joinRoom(socketId: string, room: string, namespacePath?: string): void {
     const socket = this.resolveSocket(socketId);
 
     if (socket) {
@@ -195,11 +200,10 @@ export class SocketIoLifecycleService
       return;
     }
 
-    const namespace = this.resolveContextNamespace();
-    namespace?.in(socketId).socketsJoin(room);
+    this.resolveRequiredNamespace(namespacePath).in(socketId).socketsJoin(room);
   }
 
-  leaveRoom(socketId: string, room: string): void {
+  leaveRoom(socketId: string, room: string, namespacePath?: string): void {
     const socket = this.resolveSocket(socketId);
 
     if (socket) {
@@ -207,19 +211,11 @@ export class SocketIoLifecycleService
       return;
     }
 
-    const namespace = this.resolveContextNamespace();
-    namespace?.in(socketId).socketsLeave(room);
+    this.resolveRequiredNamespace(namespacePath).in(socketId).socketsLeave(room);
   }
 
-  broadcastToRoom(room: string, event: string, data: unknown): void {
-    const namespace = this.resolveContextNamespace();
-
-    if (namespace) {
-      namespace.to(room).emit(event, data);
-      return;
-    }
-
-    this.io?.to(room).emit(event, data);
+  broadcastToRoom(room: string, event: string, data: unknown, namespacePath?: string): void {
+    this.resolveRequiredNamespace(namespacePath).to(room).emit(event, data);
   }
 
   getRooms(socketId: string): ReadonlySet<string> {
@@ -281,6 +277,16 @@ export class SocketIoLifecycleService
     return this.resolveNamespace(namespaceName);
   }
 
+  private resolveRequiredNamespace(namespacePath?: string): Namespace {
+    const namespace = namespacePath ? this.resolveNamespace(normalizeGatewayPath(namespacePath)) : this.resolveContextNamespace();
+
+    if (!namespace) {
+      throw new Error('Socket.IO room helpers require an explicit namespace outside gateway handler context.');
+    }
+
+    return namespace;
+  }
+
   private resolveSocket(socketId: string): Socket | undefined {
     const registered = this.socketRegistry.get(socketId);
 
@@ -326,6 +332,12 @@ export class SocketIoLifecycleService
     };
   }
 
+  private maxPendingMessagesPerSocket(): number {
+    return isFinitePositiveInteger(this.moduleOptions.buffer?.maxPendingMessagesPerSocket)
+      ? this.moduleOptions.buffer.maxPendingMessagesPerSocket
+      : DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET;
+  }
+
   private attachConnectionListeners(
     state: ConnectionHandlerState,
     resolved: Array<{ descriptor: WebSocketGatewayDescriptor; instance: unknown }>,
@@ -336,6 +348,36 @@ export class SocketIoLifecycleService
       const ack = typeof args.at(-1) === 'function' ? (args.at(-1) as (...callbackArgs: unknown[]) => void) : undefined;
 
       if (!state.handlersReady) {
+        const limit = this.maxPendingMessagesPerSocket();
+        const policy = this.moduleOptions.buffer?.overflowPolicy ?? 'drop-oldest';
+
+        if (state.bufferedMessages.length >= limit) {
+          if (policy === 'close') {
+            socket.disconnect(true);
+            state.bufferedMessages = [];
+            this.socketRegistry.delete(socket.id);
+            this.logger.warn(
+              `Socket.IO connection ${socket.id} exceeded pending message buffer limit (${String(limit)}). Connection terminated.`,
+              'SocketIoLifecycleService',
+            );
+            return;
+          }
+
+          if (policy === 'drop-newest') {
+            this.logger.warn(
+              `Socket.IO connection ${socket.id} dropped an incoming message due to pending buffer limit (${String(limit)}).`,
+              'SocketIoLifecycleService',
+            );
+            return;
+          }
+
+          state.bufferedMessages.shift();
+          this.logger.warn(
+            `Socket.IO connection ${socket.id} dropped the oldest pending message because buffer limit (${String(limit)}) was reached.`,
+            'SocketIoLifecycleService',
+          );
+        }
+
         state.bufferedMessages.push({
           acknowledgement: ack,
           event,

--- a/packages/platform-socket.io/src/module.test.ts
+++ b/packages/platform-socket.io/src/module.test.ts
@@ -8,6 +8,7 @@ import { io as createClient, type Socket as ClientSocket } from 'socket.io-clien
 import type { Server as SocketIoServer, Socket } from 'socket.io';
 
 import { createSocketIoModule } from './module.js';
+import { SocketIoLifecycleService } from './adapter.js';
 import { SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER } from './tokens.js';
 import type { SocketIoRoomService } from './types.js';
 
@@ -285,6 +286,56 @@ describe('@konekti/platform-socket.io', () => {
     await app.close();
   });
 
+  it('drops oldest pre-connect socket.io messages once the pending buffer limit is reached', () => {
+    const loggerEvents: string[] = [];
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger(loggerEvents),
+      {
+        async close() {},
+        getServer() {
+          return {};
+        },
+      } as never,
+      {
+        buffer: {
+          maxPendingMessagesPerSocket: 2,
+          overflowPolicy: 'drop-oldest',
+        },
+        transports: ['websocket'],
+      },
+    );
+    const listeners: {
+      disconnect?: (reason: string, description: unknown) => void;
+      onAny?: (event: string, ...args: unknown[]) => void;
+    } = {};
+    const socket = {
+      id: 'socket-1',
+      disconnect: () => undefined,
+      on(event: 'disconnect', listener: (reason: string, description: unknown) => void) {
+        listeners.disconnect = listener;
+        return this;
+      },
+      onAny(listener: (event: string, ...args: unknown[]) => void) {
+        listeners.onAny = listener;
+        return this;
+      },
+    } as unknown as Socket;
+    const state = Reflect.get(service, 'createConnectionHandlerState').call(service) as {
+      bufferedMessages: Array<{ event: string; payload: unknown }>;
+    };
+
+    Reflect.get(service, 'attachConnectionListeners').call(service, state, [], socket, {} as never);
+
+    listeners.onAny?.('ping', 'one');
+    listeners.onAny?.('ping', 'two');
+    listeners.onAny?.('ping', 'three');
+
+    expect(state.bufferedMessages.map((message) => message.payload)).toEqual(['two', 'three']);
+    expect(loggerEvents.some((event) => event.includes('dropped the oldest pending message'))).toBe(true);
+  });
+
   it('isolates same room names across namespaces', async () => {
     class GatewayState {
       adminMessages: unknown[] = [];
@@ -377,6 +428,35 @@ describe('@konekti/platform-socket.io', () => {
     chatSocket.disconnect();
     adminSocket.disconnect();
     await Promise.all([chatDisconnected, adminDisconnected]);
+
+    await app.close();
+  });
+
+  it('requires an explicit namespace when room helpers are used outside gateway handler context', async () => {
+    @WebSocketGateway({ path: '/' })
+    class DefaultGateway {
+      @OnConnect()
+      onConnect() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createSocketIoModule({ transports: ['websocket'] })],
+      providers: [DefaultGateway],
+    });
+
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port: await findAvailablePort(),
+    });
+    const rooms = await app.container.resolve<SocketIoRoomService>(SOCKETIO_ROOM_SERVICE);
+
+    await app.listen();
+
+    expect(() => rooms.broadcastToRoom('shared-room', 'chat:broadcast', 'payload')).toThrow(/namespace/i);
+    expect(() => rooms.joinRoom('missing-socket', 'shared-room')).toThrow(/namespace/i);
+    expect(() => rooms.leaveRoom('missing-socket', 'shared-room')).toThrow(/namespace/i);
+    expect(() => rooms.broadcastToRoom('shared-room', 'chat:broadcast', 'payload', '/')).not.toThrow();
 
     await app.close();
   });

--- a/packages/platform-socket.io/src/types.ts
+++ b/packages/platform-socket.io/src/types.ts
@@ -3,9 +3,16 @@ import type { ServerOptions } from 'socket.io';
 import type { WebSocketRoomService } from '@konekti/websocket';
 
 export interface SocketIoRoomService extends WebSocketRoomService {
+  broadcastToRoom(room: string, event: string, data: unknown, namespacePath?: string): void;
+  joinRoom(socketId: string, room: string, namespacePath?: string): void;
+  leaveRoom(socketId: string, room: string, namespacePath?: string): void;
 }
 
 export interface SocketIoModuleOptions {
+  buffer?: {
+    maxPendingMessagesPerSocket?: number;
+    overflowPolicy?: 'close' | 'drop-newest' | 'drop-oldest';
+  };
   cors?: ServerOptions['cors'];
   shutdown?: {
     timeoutMs?: number;

--- a/packages/websocket/src/module.test.ts
+++ b/packages/websocket/src/module.test.ts
@@ -1,5 +1,6 @@
 import { createConnection, createServer } from 'node:net';
 import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
 
 import { describe, expect, it, vi } from 'vitest';
 import { WebSocket } from 'ws';
@@ -130,12 +131,14 @@ function createTestLifecycleService(
 
 type MockSocketListeners = {
   close?: (code: number, reason: Buffer) => void;
+  error?: (error: Error) => void;
   message?: (data: unknown) => void;
   pong?: () => void;
 };
 
 function createMockSocket(): {
   emitClose: (code?: number, reason?: Buffer) => void;
+  emitError: (error: Error) => void;
   emitPong: () => void;
   ping: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
@@ -148,9 +151,11 @@ function createMockSocket(): {
   const terminate = vi.fn();
 
   const socketObject = {
-    on(event: 'close' | 'message' | 'pong', listener: (...args: unknown[]) => void) {
+    on(event: 'close' | 'error' | 'message' | 'pong', listener: (...args: unknown[]) => void) {
       if (event === 'close') {
         listeners.close = listener as (code: number, reason: Buffer) => void;
+      } else if (event === 'error') {
+        listeners.error = listener as (error: Error) => void;
       } else if (event === 'message') {
         listeners.message = listener as (data: unknown) => void;
       } else {
@@ -169,6 +174,9 @@ function createMockSocket(): {
   return {
     emitClose(code = 1000, reason = Buffer.alloc(0)) {
       listeners.close?.(code, reason);
+    },
+    emitError(error: Error) {
+      listeners.error?.(error);
     },
     emitPong() {
       listeners.pong?.();
@@ -964,7 +972,7 @@ describe('@konekti/websocket', () => {
     }
   });
 
-  it('rejects websocket upgrade requests for unmatched gateway paths', async () => {
+  it('delegates unmatched websocket upgrade requests to later listeners', async () => {
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       @OnMessage('ping')
@@ -984,6 +992,20 @@ describe('@konekti/websocket', () => {
     });
 
     await app.listen();
+
+    const adapter = await app.container.resolve<HttpApplicationAdapter>(HTTP_APPLICATION_ADAPTER);
+    const server = adapter.getServer?.() as {
+      on(event: 'upgrade', listener: (request: IncomingMessage, socket: Duplex) => void): void;
+    };
+    const delegated = createDeferred<void>();
+
+    server.on('upgrade', (request, socket) => {
+      if (request.url === '/missing') {
+        delegated.resolve();
+        socket.write('HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n');
+        socket.end();
+      }
+    });
 
     const response = await new Promise<string>((resolve, reject) => {
       const socket = createConnection({ host: '127.0.0.1', port }, () => {
@@ -1008,7 +1030,62 @@ describe('@konekti/websocket', () => {
       socket.on('error', reject);
     });
 
-    expect(response).toContain('HTTP/1.1 404 Not Found');
+    await delegated.promise;
+    expect(response).toContain('HTTP/1.1 426 Upgrade Required');
+
+    await app.close();
+  });
+
+
+  it('rejects malformed websocket upgrade URLs without crashing the server', async () => {
+    @WebSocketGateway({ path: '/chat' })
+    class ChatGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createWebSocketModule()],
+      providers: [ChatGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const malformedResponse = await new Promise<string>((resolve, reject) => {
+      const socket = createConnection({ host: '127.0.0.1', port }, () => {
+        socket.write(
+          'GET http://%zz HTTP/1.1\r\n'
+            + 'Host: 127.0.0.1\r\n'
+            + 'Connection: Upgrade\r\n'
+            + 'Upgrade: websocket\r\n'
+            + 'Sec-WebSocket-Version: 13\r\n'
+            + 'Sec-WebSocket-Key: dGVzdC1rZXktMDAwMDAw\r\n'
+            + '\r\n',
+        );
+      });
+      const chunks: Buffer[] = [];
+
+      socket.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      socket.on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf8'));
+      });
+      socket.on('error', reject);
+    });
+
+    expect(malformedResponse).toContain('HTTP/1.1 400 Bad Request');
+
+    const followup = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
+    await onceOpen(followup);
+    followup.close();
 
     await app.close();
   });
@@ -1048,5 +1125,20 @@ describe('@konekti/websocket', () => {
     await closed;
 
     expect(socket.readyState).toBe(WebSocket.CLOSED);
+  });
+
+  it('attaches a socket error listener so websocket error events do not escape', () => {
+    const loggerEvents: string[] = [];
+    const service = createTestLifecycleService({}, loggerEvents);
+    const { emitError, socket } = createMockSocket();
+    const state = Reflect.get(service, 'createConnectionHandlerState').call(service) as { socketId: string };
+
+    Reflect.get(service, 'socketRegistry').set(state.socketId, socket);
+    Reflect.get(service, 'attachConnectionListeners').call(service, state, socket, {} as IncomingMessage);
+
+    expect(() => emitError(new Error('socket exploded'))).not.toThrow();
+    expect(
+      loggerEvents.some((event) => event.includes('error:WebSocketGatewayLifecycleService:WebSocket gateway socket emitted an error.:socket exploded')),
+    ).toBe(true);
   });
 });

--- a/packages/websocket/src/service.ts
+++ b/packages/websocket/src/service.ts
@@ -170,6 +170,15 @@ function rejectUpgradeRequest(socket: Duplex): void {
   socket.destroy();
 }
 
+function rejectBadUpgradeRequest(socket: Duplex): void {
+  if (socket.destroyed) {
+    return;
+  }
+
+  socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n');
+  socket.destroy();
+}
+
 @Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS])
 export class WebSocketGatewayLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
@@ -270,12 +279,18 @@ export class WebSocketGatewayLifecycleService
 
   private createUpgradeListener(attachmentsByPath: Map<string, GatewayAttachment>): NodeUpgradeListener {
     return (request, socket, head) => {
-      const url = new URL(request.url ?? '/', 'http://localhost');
-      const targetPath = normalizeGatewayPath(url.pathname);
-      const attachment = attachmentsByPath.get(targetPath);
+      let attachment: GatewayAttachment | undefined;
+
+      try {
+        const url = new URL(request.url ?? '/', 'http://localhost');
+        const targetPath = normalizeGatewayPath(url.pathname);
+        attachment = attachmentsByPath.get(targetPath);
+      } catch {
+        rejectBadUpgradeRequest(socket);
+        return;
+      }
 
       if (!attachment) {
-        rejectUpgradeRequest(socket);
         return;
       }
 
@@ -514,6 +529,11 @@ export class WebSocketGatewayLifecycleService
     socket.on('pong', () => {
       this.pingPending.delete(state.socketId);
       this.pingSentAt.delete(state.socketId);
+    });
+
+    socket.on('error', (error: Error) => {
+      this.unregisterSocket(state.socketId);
+      this.logger.error('WebSocket gateway socket emitted an error.', error, 'WebSocketGatewayLifecycleService');
     });
 
     socket.on('close', (code: number, reason: Buffer) => {


### PR DESCRIPTION
Closes #499

## Summary
- delegate unmatched websocket upgrades, reject malformed upgrade URLs safely, and absorb websocket socket `error` events instead of letting them escape
- add bounded pre-connect Socket.IO buffering with overflow policies to prevent unbounded message accumulation before `@OnConnect()` completes
- require an explicit namespace when Socket.IO room helpers are used outside gateway handler context, while still allowing gateway-context calls to use ALS

## Verification
- `pnpm install`
- `pnpm build`
- `pnpm --filter @konekti/websocket typecheck && pnpm --filter @konekti/platform-socket.io typecheck`
- `pnpm exec vitest run packages/websocket/src/module.test.ts packages/platform-socket.io/src/module.test.ts`