### PR TITLE
Resolve #523: restore Fastify shutdown watchdog parity

### DIFF
--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -35,12 +35,20 @@ await runFastifyApplication(AppModule, {
 - `https`
 - `host`
 - `cors` (`false | string | string[] | CorsOptions`)
+- `shutdownTimeoutMs`
+
+`runFastifyApplication()`은 다음 옵션도 지원합니다.
+
+- `shutdownSignals`
+- `forceExitTimeoutMs`
 
 ## 패리티(Parity) 참고 사항
 
 - `rawBody`는 선택 사항(opt-in)이며 멀티파트가 아닌 요청에 대해서만 채워집니다.
 - 멀티파트 요청은 `request.body` 필드와 `request.files` (`UploadedFile[]`)를 노출합니다.
 - 시작 로그는 런타임 컨벤션을 따르며 와일드카드 호스트에 대한 바인딩 대상 상세 정보를 포함합니다.
+- 시그널 기반 종료는 `runNodeApplication()`과 같은 런타임 소유 graceful-close 경로를 따르며, `forceExitTimeoutMs`로 강제 종료 watchdog을 둘 수 있습니다.
+- `forceExitTimeoutMs`가 `shutdownTimeoutMs`보다 짧으면 전체 drain window가 끝나기 전에 watchdog이 의도적으로 프로세스를 종료할 수 있습니다.
 
 ## 벤치마크
 

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -35,12 +35,20 @@ await runFastifyApplication(AppModule, {
 - `https`
 - `host`
 - `cors` (`false | string | string[] | CorsOptions`)
+- `shutdownTimeoutMs`
+
+`runFastifyApplication()` also supports:
+
+- `shutdownSignals`
+- `forceExitTimeoutMs`
 
 ## Parity notes
 
 - `rawBody` is opt-in and only populated for non-multipart requests.
 - Multipart requests expose `request.body` fields and `request.files` (`UploadedFile[]`).
 - Startup logs mirror runtime conventions and include bind-target details for wildcard hosts.
+- Signal-driven shutdown follows the same runtime-owned graceful-close path as `runNodeApplication()`, including an optional force-exit watchdog via `forceExitTimeoutMs`.
+- If `forceExitTimeoutMs` is shorter than `shutdownTimeoutMs`, the watchdog can intentionally terminate the process before the full drain window completes.
 
 ## Benchmark
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Controller, Get, Post, type FrameworkRequest, type RequestContext } from '@konekti/http';
 import { createHealthModule, defineModule, type ApplicationLogger } from '@konekti/runtime';
@@ -303,10 +303,10 @@ describe('@konekti/platform-fastify', () => {
     const loggerEvents: string[] = [];
     const logger: ApplicationLogger = {
       debug() {},
-      error(message, error, context) {
+      error(message: string, error: unknown, context?: string) {
         loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
       },
-      log(message, context) {
+      log(message: string, context?: string) {
         loggerEvents.push(`log:${context}:${message}`);
       },
       warn() {},
@@ -466,10 +466,10 @@ describe('@konekti/platform-fastify', () => {
     const loggerEvents: string[] = [];
     const logger: ApplicationLogger = {
       debug() {},
-      error(message, error, context) {
+      error(message: string, error: unknown, context?: string) {
         loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
       },
-      log(message, context) {
+      log(message: string, context?: string) {
         loggerEvents.push(`log:${context}:${message}`);
       },
       warn() {},
@@ -558,6 +558,63 @@ describe('@konekti/platform-fastify', () => {
 
     deferred.resolve();
     await Promise.resolve();
+  });
+
+  it('forces process exit when signal-driven shutdown exceeds forceExitTimeoutMs', async () => {
+    vi.useFakeTimers();
+
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message: string, error: unknown, context?: string) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
+      },
+      log(message: string, context?: string) {
+        loggerEvents.push(`log:${context}:${message}`);
+      },
+      warn() {},
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const originalExitCode = process.exitCode;
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => undefined as never) as typeof process.exit);
+    const port = await findAvailablePort();
+    const app = await runFastifyApplication(AppModule, {
+      cors: false,
+      forceExitTimeoutMs: 25,
+      logger,
+      port,
+      shutdownSignals: ['SIGTERM'],
+    });
+
+    const originalClose = app.close.bind(app);
+    app.close = () => new Promise<void>(() => {});
+
+    try {
+      process.emit('SIGTERM', 'SIGTERM');
+      await vi.advanceTimersByTimeAsync(26);
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(loggerEvents).toContain('error:KonektiFactory:Forced exit after 25ms shutdown timeout.:none');
+    } finally {
+      app.close = originalClose;
+      await app.close();
+      exitSpy.mockRestore();
+      process.exitCode = originalExitCode;
+      vi.useRealTimers();
+    }
   });
 
   it('keeps malformed cookie values instead of failing the request', async () => {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -58,6 +58,7 @@ export interface FastifyAdapterOptions {
 export type FastifyApplicationSignal = 'SIGINT' | 'SIGTERM';
 export type CorsInput = false | string | string[] | CorsOptions;
 
+const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 
@@ -80,6 +81,7 @@ export interface BootstrapFastifyApplicationOptions extends Omit<CreateApplicati
 }
 
 export interface RunFastifyApplicationOptions extends BootstrapFastifyApplicationOptions {
+  forceExitTimeoutMs?: number;
   shutdownSignals?: false | readonly FastifyApplicationSignal[];
 }
 
@@ -314,7 +316,12 @@ export async function runFastifyApplication(
     throw error;
   }
 
-  const unregisterShutdownSignals = registerShutdownSignals(app, logger, options.shutdownSignals ?? defaultShutdownSignals());
+  const unregisterShutdownSignals = registerShutdownSignals(
+    app,
+    logger,
+    options.shutdownSignals ?? defaultShutdownSignals(),
+    options.forceExitTimeoutMs,
+  );
   const close = app.close.bind(app);
   let shutdownSignalsUnregistered = false;
 
@@ -800,6 +807,7 @@ function registerShutdownSignals(
   app: Application,
   logger: ApplicationLogger,
   signals: false | readonly FastifyApplicationSignal[],
+  forceExitTimeoutMs: number = DEFAULT_FORCE_EXIT_TIMEOUT_MS,
 ): () => void {
   if (signals === false || signals.length === 0) {
     return () => {};
@@ -815,13 +823,7 @@ function registerShutdownSignals(
 
     seen.add(signal);
     const handler = () => {
-      void app.close(signal)
-        .then(() => {
-          logger.log(`Application closed after receiving ${signal}.`, 'KonektiFactory');
-        })
-        .catch((error: unknown) => {
-          logger.error(`Failed to close application after receiving ${signal}.`, error, 'KonektiFactory');
-        });
+      void closeFromSignal(app, logger, signal, forceExitTimeoutMs);
     };
 
     bindings.push({ signal, handler });
@@ -833,6 +835,38 @@ function registerShutdownSignals(
       process.off(binding.signal, binding.handler);
     }
   };
+}
+
+async function closeFromSignal(
+  app: Application,
+  logger: ApplicationLogger,
+  signal: FastifyApplicationSignal,
+  forceExitTimeoutMs: number,
+): Promise<void> {
+  if (app.state === 'closed') {
+    process.exitCode = 0;
+    return;
+  }
+
+  const forceExitTimer = setTimeout(() => {
+    logger.error(`Forced exit after ${String(forceExitTimeoutMs)}ms shutdown timeout.`, undefined, 'KonektiFactory');
+    process.exit(1);
+  }, forceExitTimeoutMs);
+
+  if (forceExitTimer.unref) {
+    forceExitTimer.unref();
+  }
+
+  try {
+    await app.close(signal);
+    clearTimeout(forceExitTimer);
+    logger.log(`Application closed after receiving ${signal}.`, 'KonektiFactory');
+    process.exitCode = 0;
+  } catch (error: unknown) {
+    clearTimeout(forceExitTimer);
+    logger.error('Failed to shut down the application cleanly.', error, 'KonektiFactory');
+    process.exitCode = 1;
+  }
 }
 
 function toHttpException(error: unknown): HttpException {


### PR DESCRIPTION
## Summary
- add `forceExitTimeoutMs` parity to `runFastifyApplication()` signal-driven shutdown
- add a regression test for watchdog-triggered forced exit and document the shutdown options in both READMEs

## Changes
- pass `forceExitTimeoutMs` into Fastify shutdown signal registration and use a watchdog around `app.close(signal)`
- keep listener cleanup on manual `app.close()` while aligning logging/exit-code behavior with the runtime shutdown model
- update `packages/platform-fastify/README.md` and `packages/platform-fastify/README.ko.md` with shutdown option and parity notes

## Testing
- `pnpm --filter @konekti/platform-fastify... build`
- `pnpm exec vitest run packages/platform-fastify/src/adapter.test.ts --config vitest.config.ts`

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves the existing runtime-owned graceful shutdown contract for Fastify while restoring the missing force-exit watchdog parity from the Node runtime path

Closes #523