### PR TITLE
Resolve #527: apply principal scope to anonymous cache keys

### DIFF
--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -345,6 +345,70 @@ describe('CacheInterceptor', () => {
       expect(await cacheService.get('/products|principal:issuer-a:bob')).toEqual({ owner: 'bob' });
     });
 
+    it('applies principalScopeResolver to anonymous requests', async () => {
+      class ProductController {
+        @CacheTTL(120)
+        list() {}
+      }
+
+      const { interceptor, cacheService } = createInterceptor({
+        httpKeyStrategy: 'route',
+        principalScopeResolver: (context) => context.requestContext.metadata['tenantId'] as string | undefined,
+      });
+      const firstRequestContext = createRequestContext('GET', '/products', '/products');
+      const secondRequestContext = createRequestContext('GET', '/products', '/products');
+      firstRequestContext.metadata['tenantId'] = 'tenant-a';
+      secondRequestContext.metadata['tenantId'] = 'tenant-b';
+
+      const firstContext = createContext(ProductController, 'list', firstRequestContext);
+      const secondContext = createContext(ProductController, 'list', secondRequestContext);
+      const next: CallHandler = {
+        handle: vi
+          .fn<CallHandler['handle']>()
+          .mockResolvedValueOnce({ tenant: 'tenant-a' })
+          .mockResolvedValueOnce({ tenant: 'tenant-b' }),
+      };
+
+      await interceptor.intercept(firstContext, next);
+      await interceptor.intercept(secondContext, next);
+
+      expect(next.handle).toHaveBeenCalledTimes(2);
+      expect(await cacheService.get('/products|principal:tenant-a')).toEqual({ tenant: 'tenant-a' });
+      expect(await cacheService.get('/products|principal:tenant-b')).toEqual({ tenant: 'tenant-b' });
+    });
+
+    it('falls back to the base key when anonymous principalScopeResolver returns undefined', async () => {
+      class ProductController {
+        @CacheTTL(120)
+        list() {}
+      }
+
+      const { interceptor, cacheService } = createInterceptor({
+        httpKeyStrategy: 'route',
+        principalScopeResolver: (context) => context.requestContext.metadata['tenantId'] as string | undefined,
+      });
+      const anonymousRequestContext = createRequestContext('GET', '/products', '/products');
+      const tenantScopedRequestContext = createRequestContext('GET', '/products', '/products');
+      tenantScopedRequestContext.metadata['tenantId'] = 'tenant-a';
+
+      const anonymousContext = createContext(ProductController, 'list', anonymousRequestContext);
+      const tenantScopedContext = createContext(ProductController, 'list', tenantScopedRequestContext);
+      const next: CallHandler = {
+        handle: vi
+          .fn<CallHandler['handle']>()
+          .mockResolvedValueOnce({ scope: 'base' })
+          .mockResolvedValueOnce({ scope: 'tenant-a' }),
+      };
+
+      await interceptor.intercept(anonymousContext, next);
+      await interceptor.intercept(tenantScopedContext, next);
+      await interceptor.intercept(anonymousContext, next);
+
+      expect(next.handle).toHaveBeenCalledTimes(2);
+      expect(await cacheService.get('/products')).toEqual({ scope: 'base' });
+      expect(await cacheService.get('/products|principal:tenant-a')).toEqual({ scope: 'tenant-a' });
+    });
+
     it('strategy "route+query" includes sorted query in cache key', async () => {
       class ProductController {
         @CacheTTL(120)

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -54,15 +54,15 @@ function appendPrincipalScope(
   context: InterceptorContext,
   resolver: PrincipalScopeResolver | undefined,
 ): string {
+  if (resolver) {
+    const scope = resolver(context);
+    return scope !== undefined ? `${key}|principal:${scope}` : key;
+  }
+
   const principal = context.requestContext.principal;
 
   if (!principal) {
     return key;
-  }
-
-  if (resolver) {
-    const scope = resolver(context);
-    return scope !== undefined ? `${key}|principal:${scope}` : key;
   }
 
   const issuer = encodeURIComponent(principal.issuer ?? 'unknown');


### PR DESCRIPTION
## Summary
- apply `principalScopeResolver` to anonymous requests for built-in string cache key strategies
- add regression coverage for anonymous tenant scoping and base-key fallback when the resolver returns `undefined`

## Changes
- move resolver application ahead of the authenticated-principal fallback in `appendPrincipalScope()`
- preserve existing `issuer:subject` behavior when no resolver is configured
- add interceptor tests covering anonymous tenant-separated keys and anonymous fallback-to-base behavior

## Testing
- `pnpm --filter @konekti/cache-manager... build`
- `node --input-type=module - <<'EOF' ... manual-cache-scope-check ... EOF`
- `lsp_diagnostics` on changed files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- restores the documented `principalScopeResolver` contract for built-in string cache key strategies without changing custom `@CacheKey(...)` or function-based key ownership

Closes #527