### PR TITLE
Resolve #526: reject non-plain nested DTO inputs

### DIFF
--- a/packages/dto-validator/README.ko.md
+++ b/packages/dto-validator/README.ko.md
@@ -268,6 +268,8 @@ class CreateOrderDto {
 
 에러는 점 표기법 경로를 사용합니다: `{ field: 'address.city', ... }`.
 
+중첩 DTO를 변환할 때는 plain object payload만 nested 인스턴스에 복사합니다. non-plain 입력은 invalid data로 취급되며 DTO 필드에 암묵적으로 merge되지 않습니다.
+
 ### 중첩 객체 배열
 
 ```typescript

--- a/packages/dto-validator/src/validation.test.ts
+++ b/packages/dto-validator/src/validation.test.ts
@@ -150,7 +150,7 @@ describe('DefaultValidator', () => {
     expect(Array.from(result.previousAddressSet)[0]).toBeInstanceOf(AddressDto);
   });
 
-  it('does not copy non-plain nested input into DTO instances during transform', async () => {
+  it('rejects non-plain nested input during transform', async () => {
     class ChildDto {}
 
     class ParentDto {
@@ -159,15 +159,80 @@ describe('DefaultValidator', () => {
     }
 
     const validator = new DefaultValidator();
-    const result = await validator.transform<ParentDto>(
-      {
-        child: 'unsafe-string-input',
-      },
-      ParentDto,
-    );
+    await expect(
+      validator.transform<ParentDto>(
+        {
+          child: 'unsafe-string-input',
+        },
+        ParentDto,
+      ),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_NESTED', field: 'child', message: 'child contains invalid nested data.' }],
+    });
+  });
 
-    expect(result.child).toBeInstanceOf(ChildDto);
-    expect(Object.keys(result.child as object)).toEqual([]);
+  it('rejects non-plain object instances for nested validation', async () => {
+    class ChildDto {}
+
+    class ParentDto {
+      @ValidateNested(() => ChildDto)
+      child = new ChildDto();
+    }
+
+    class UnsafeChildInput {
+      city = 'Seoul';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(
+        Object.assign(new ParentDto(), {
+          child: new UnsafeChildInput(),
+        }),
+        ParentDto,
+      ),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_NESTED', field: 'child', message: 'child contains invalid nested data.' }],
+    });
+  });
+
+  it('rejects non-plain nested entries across array, set, and map collections', async () => {
+    class ChildDto {}
+
+    class ParentDto {
+      @ValidateNested(() => ChildDto, { each: true })
+      childArray: ChildDto[] = [];
+
+      @ValidateNested(() => ChildDto, { each: true })
+      childSet = new Set<ChildDto>();
+
+      @ValidateNested(() => ChildDto, { each: true })
+      childMap = new Map<string, ChildDto>();
+    }
+
+    class UnsafeChildInput {
+      city = 'Seoul';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.transform<ParentDto>(
+        {
+          childArray: [new UnsafeChildInput()],
+          childMap: new Map([['home', new UnsafeChildInput()]]),
+          childSet: new Set([new UnsafeChildInput()]),
+        },
+        ParentDto,
+      ),
+    ).rejects.toMatchObject({
+      issues: [
+        { code: 'INVALID_NESTED', field: 'childArray[0]', message: 'childArray[0] contains invalid nested data.' },
+        { code: 'INVALID_NESTED', field: 'childSet[0]', message: 'childSet[0] contains invalid nested data.' },
+        { code: 'INVALID_NESTED', field: 'childMap[0]', message: 'childMap[0] contains invalid nested data.' },
+      ],
+    });
   });
 
   it('ignores dangerous keys when materializing nested DTO instances', async () => {

--- a/packages/dto-validator/src/validation.ts
+++ b/packages/dto-validator/src/validation.ts
@@ -423,6 +423,18 @@ function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown): 
   return instance as T;
 }
 
+function materializeNestedDtoValue<T>(target: Constructor<T>, rawValue: unknown): unknown {
+  if (rawValue instanceof target) {
+    return rawValue;
+  }
+
+  if (!isPlainObject(rawValue)) {
+    return rawValue;
+  }
+
+  return createNestedDtoInstance(target, rawValue);
+}
+
 function getDtoBindingMap(target: Constructor): Map<MetadataPropertyKey, DtoFieldBindingMetadata> {
   return new Map(
     getDtoBindingSchema(target).map((entry: { propertyKey: MetadataPropertyKey; metadata: DtoFieldBindingMetadata }) => [entry.propertyKey, entry.metadata]),
@@ -443,7 +455,7 @@ function applyBindingValues(
 }
 
 function transformNestedValue(value: unknown, target: Constructor): unknown {
-  return value === undefined || value === null ? value : createNestedDtoInstance(target, value);
+  return value === undefined || value === null ? value : materializeNestedDtoValue(target, value);
 }
 
 function transformNestedEachValue(value: unknown, target: Constructor): unknown {
@@ -597,6 +609,12 @@ async function validateNestedRule(
   for (const [index, entry] of values.entries()) {
     if (entry === undefined || entry === null) continue;
     const nestedPath = rule.each ? `${fieldPath}[${String(index)}]` : fieldPath;
+
+    if (!(entry instanceof resolvedDto) && !isPlainObject(entry)) {
+      issues.push(buildIssue(describeValidator(rule, nestedPath), nestedPath, inheritedSource));
+      continue;
+    }
+
     const nestedDto = createNestedDtoInstance(resolvedDto, entry);
     issues.push(...(await collectValidationIssuesInternal(resolvedDto, nestedDto, { fieldPrefix: nestedPath, inheritedSource })));
   }


### PR DESCRIPTION
## Summary
- reject non-plain nested DTO inputs with `INVALID_NESTED` instead of silently coercing them into empty DTO instances
- add regression coverage for scalar and collection-based nested inputs and align the Korean README with the existing English contract

## Changes
- preserve non-plain nested values during nested transform materialization so `ValidateNested` can classify them as invalid data
- make nested validation emit `INVALID_NESTED` for non-plain singular values and `each: true` collection entries
- update dto-validator tests for string inputs, foreign object instances, and array/set/map collection cases
- add the missing non-plain nested contract sentence to `packages/dto-validator/README.ko.md`

## Testing
- `pnpm --filter @konekti/dto-validator... build`
- `pnpm exec vitest run packages/dto-validator/src/validation.test.ts --config vitest.config.ts`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves the documented nested DTO transform contract by rejecting non-plain nested payloads instead of silently dropping them into empty DTO instances

Closes #526