### PR TITLE
Resolve #525: preserve refresh rotation mode in passport adapter

### DIFF
--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -40,6 +40,8 @@ Konekti의 strategy-agnostic auth 실행 레이어 — 어떤 `AuthStrategy`든 
 - **Rotate**: 재생 감지를 포함하여 refresh token을 새 access + refresh token으로 교환
 - **Revoke**: 특정 token 또는 subject의 모든 token 무효화(로그아웃)
 
+기반 `@konekti/jwt` refresh-token 설정이 `rotation: false`이면 refresh 작업은 새 access token만 반환하고 refresh token 문자열은 만료 또는 취소 시점까지 그대로 재사용합니다. 이 섹션의 replay-detection 의미는 rotation 모드(`rotation: true`)에 적용됩니다.
+
 ### Refresh token strategy 사용
 
 ```typescript

--- a/packages/passport/src/jwt-refresh-token-adapter.test.ts
+++ b/packages/passport/src/jwt-refresh-token-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { JwtConfigurationError, type DefaultJwtSigner, type DefaultJwtVerifier } from '@konekti/jwt';
+import { DefaultJwtSigner, DefaultJwtVerifier, JwtConfigurationError, type RefreshTokenStore } from '@konekti/jwt';
 
 import { JwtRefreshTokenAdapter } from './jwt-refresh-token-adapter.js';
 
@@ -35,5 +35,48 @@ describe('JwtRefreshTokenAdapter', () => {
         store: 'memory',
       }),
     ).not.toThrow();
+  });
+
+  it('preserves rotation:false and reuses the same refresh token string', async () => {
+    const verifierStore: RefreshTokenStore = {
+      async find() {
+        return undefined;
+      },
+      async revoke() {},
+      async revokeBySubject() {},
+      async save() {},
+    };
+
+    const signer = new DefaultJwtSigner({
+      algorithms: ['HS256'],
+      refreshToken: {
+        expiresInSeconds: 3600,
+        rotation: false,
+        secret: 'refresh-secret',
+        store: verifierStore,
+      },
+      secret: 'access-secret',
+    });
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      refreshToken: {
+        expiresInSeconds: 3600,
+        rotation: false,
+        secret: 'refresh-secret',
+        store: verifierStore,
+      },
+      secret: 'access-secret',
+    });
+    const adapter = new JwtRefreshTokenAdapter(signer, verifier, {
+      rotation: false,
+      secret: 'refresh-secret',
+      store: 'memory',
+    });
+
+    const issued = await adapter.issueRefreshToken('user-1');
+    const rotated = await adapter.rotateRefreshToken(issued);
+
+    expect(rotated.accessToken).toContain('.');
+    expect(rotated.refreshToken).toBe(issued);
   });
 });

--- a/packages/passport/src/jwt-refresh-token-adapter.ts
+++ b/packages/passport/src/jwt-refresh-token-adapter.ts
@@ -12,8 +12,9 @@ import type { RefreshTokenService } from './refresh-token.js';
 export const REFRESH_TOKEN_MODULE_OPTIONS = Symbol.for('konekti.passport.refresh-token-module-options');
 
 export interface RefreshTokenModuleOptions {
-  secret: string;
   expiresInSeconds?: number;
+  rotation?: boolean;
+  secret: string;
   store: RefreshTokenStore | 'memory';
 }
 
@@ -111,7 +112,7 @@ export class JwtRefreshTokenAdapter implements RefreshTokenService {
     this.service = new JwtRefreshTokenService(
       {
         expiresInSeconds: options.expiresInSeconds ?? 604800,
-        rotation: true,
+        rotation: options.rotation ?? true,
         secret: resolveSecret(options),
         store,
       },


### PR DESCRIPTION
## Summary
- forward the caller-selected refresh token rotation policy through `JwtRefreshTokenAdapter`
- add an adapter-level regression test for `rotation:false` and align the Korean README with the existing contract

## Changes
- add `rotation?: boolean` to `RefreshTokenModuleOptions`
- pass `rotation: options.rotation ?? true` into `JwtRefreshTokenService`
- add a regression test proving `rotation:false` keeps the same refresh token string on refresh
- document the reusable refresh-token mode in `packages/passport/README.ko.md`

## Testing
- `pnpm --filter @konekti/passport... build`
- `pnpm exec vitest run packages/passport/src/jwt-refresh-token-adapter.test.ts --config vitest.config.ts`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- restores the documented `rotation:false` refresh-token policy in the official passport adapter path without changing the default rotation-on behavior

Closes #525