### PR TITLE
Resolve #521: cover inbound Redis event-bus failure logging

### DIFF
--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -946,6 +946,54 @@ describe('@konekti/event-bus', () => {
       await app.close();
     });
 
+    it('isolates and logs handler failures for incoming transport messages', async () => {
+      const transport = createMockTransport();
+      const loggerEvents: string[] = [];
+
+      class EventStore {
+        successCalls = 0;
+      }
+
+      @Inject([EventStore])
+      class SuccessfulTransportHandler {
+        constructor(private readonly store: EventStore) {}
+
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {
+          this.store.successCalls += 1;
+        }
+      }
+
+      class FailingTransportHandler {
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {
+          throw new Error('transport handler failed');
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [createEventBusModule({ transport })],
+        providers: [EventStore, SuccessfulTransportHandler, FailingTransportHandler],
+      });
+
+      const app = await bootstrapApplication({
+        logger: createLogger(loggerEvents),
+        rootModule: AppModule,
+      });
+      const store = await app.container.resolve(EventStore);
+
+      const incomingSubscription = transport.subscribed.find((entry) => entry.channel === 'UserCreatedEvent');
+      expect(incomingSubscription).toBeDefined();
+
+      await expect(incomingSubscription!.handler({ userId: 'transport-user-logged' })).resolves.toBeUndefined();
+
+      expect(store.successCalls).toBe(1);
+      expect(loggerEvents.some((event) => event.includes('Event handler FailingTransportHandler.onUserCreated failed.'))).toBe(true);
+
+      await app.close();
+    });
+
     it('keeps inherited handler matching consistent for transport messages', async () => {
       const transport = createMockTransport();
 


### PR DESCRIPTION
## Summary
- add a transport-level regression test proving incoming Redis-style messages still isolate handler failures and log them through the event-bus logger path
- lock the documented runtime contract without changing the already-correct production code path

## Changes
- add a `module.test.ts` transport case where one incoming handler throws and another still succeeds
- assert that the incoming transport subscription promise resolves and the failure is logged as `Event handler ... failed.`

## Testing
- `pnpm --filter @konekti/event-bus... build`
- `pnpm exec vitest run packages/event-bus/src/module.test.ts --config vitest.config.ts`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves the documented event-bus guarantee that handler failures are isolated and logged even when the event arrives through the transport subscription path

Closes #521