### PR TITLE
Resolve #520: wait for mongoose session cleanup before dispose

### DIFF
--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -121,8 +121,12 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
       );
     } finally {
       abortContext.cleanup();
-      this.untrackActiveRequestTransaction(active);
-      await acquiredSession?.endSession();
+
+      try {
+        await acquiredSession?.endSession();
+      } finally {
+        this.untrackActiveRequestTransaction(active);
+      }
     }
   }
 

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -146,6 +146,85 @@ describe('@konekti/mongoose', () => {
     ]);
   });
 
+  it('waits for async request session cleanup before dispose on shutdown', async () => {
+    const events: string[] = [];
+    let resolveEndSessionStarted!: () => void;
+    let resolveEndSession!: () => void;
+    const endSessionStarted = new Promise<void>((resolve) => {
+      resolveEndSessionStarted = resolve;
+    });
+    const endSessionDeferred = new Promise<void>((resolve) => {
+      resolveEndSession = resolve;
+    });
+
+    const session: MongooseSessionLike = {
+      abortTransaction() {
+        events.push('transaction:abort');
+      },
+      async commitTransaction() {
+        events.push('transaction:commit');
+      },
+      async endSession() {
+        events.push('session:end:start');
+        resolveEndSessionStarted();
+        await endSessionDeferred;
+        events.push('session:end:done');
+      },
+      async startTransaction() {
+        events.push('transaction:start');
+      },
+    };
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    const MongooseModule = createMongooseModule<typeof connection>({
+      connection,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MongooseModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
+
+    const openTransaction = mongoose.requestTransaction(async () => new Promise<never>(() => undefined));
+    const closePromise = app.close();
+
+    await endSessionStarted;
+
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'transaction:abort',
+      'session:end:start',
+    ]);
+
+    resolveEndSession();
+
+    await closePromise;
+    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'transaction:abort',
+      'session:end:start',
+      'session:end:done',
+      'dispose',
+    ]);
+  });
+
   it('enforces strictTransactions for sync and async module builders', async () => {
     const connection = {};
 


### PR DESCRIPTION
## Summary
- delay mongoose request-transaction settlement until async `endSession()` cleanup completes
- add a shutdown regression test proving `dispose` does not run before async session cleanup finishes

## Changes
- move `untrackActiveRequestTransaction(active)` until after `await acquiredSession?.endSession()` inside `requestTransaction()` cleanup
- preserve leak-safety by untracking in a nested `finally` even if `endSession()` rejects
- add a module-level regression test that pauses `endSession()` and verifies shutdown waits for `session:end:done` before `dispose`

## Testing
- `pnpm --filter @konekti/mongoose... build`
- `pnpm exec vitest run packages/mongoose/src/module.test.ts packages/mongoose/src/vertical-slice.test.ts --config vitest.config.ts`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves the documented mongoose shutdown lifecycle by ensuring open request transactions remain tracked until session cleanup actually finishes, so `dispose(connection)` cannot run early

Closes #520