### PR TITLE
Resolve #524: clean up errored Socket.IO sockets

### DIFF
--- a/packages/platform-socket.io/README.ko.md
+++ b/packages/platform-socket.io/README.ko.md
@@ -69,6 +69,7 @@ export class AppModule {}
 - 연결된 네임스페이스 소켓마다 `@OnConnect()`, `@OnMessage(event?)`, `@OnDisconnect()` 핸들러를 바인딩합니다
 - 런타임 DI 컨테이너에서 게이트웨이 인스턴스를 resolve하며, singleton이 아닌 게이트웨이는 경고 후 건너뜁니다
 - 공용 `SocketIoRoomService` 추상화를 통해 room 헬퍼를 노출합니다
+- 소켓 단위 `error` 이벤트를 로깅하고, 오류가 난 소켓을 내부 레지스트리에서 제거합니다
 - 타임아웃을 고려한 종료 처리로 Socket.IO 서버를 닫습니다
 
 ## `@konekti/websocket`과의 차이

--- a/packages/platform-socket.io/README.md
+++ b/packages/platform-socket.io/README.md
@@ -69,6 +69,7 @@ export class AppModule {}
 - Binds `@OnConnect()`, `@OnMessage(event?)`, and `@OnDisconnect()` handlers for each connected namespace socket
 - Resolves gateway instances from the runtime DI container and skips non-singleton gateways with warnings
 - Exposes room helpers through the shared `SocketIoRoomService` abstraction
+- Logs socket-level `error` events and removes errored sockets from the internal registry
 - Closes the Socket.IO server with timeout-aware shutdown handling
 
 ## Difference from `@konekti/websocket`

--- a/packages/platform-socket.io/src/adapter.ts
+++ b/packages/platform-socket.io/src/adapter.ts
@@ -389,6 +389,11 @@ export class SocketIoLifecycleService
       void this.handleMessage(resolved, socket, request, event, extractPayload(args), ack);
     });
 
+    socket.on('error', (error: Error) => {
+      this.socketRegistry.delete(socket.id);
+      this.logger.error('Socket.IO gateway socket emitted an error.', error, 'SocketIoLifecycleService');
+    });
+
     socket.on('disconnect', (reason: string, description: unknown) => {
       if (!state.handlersReady) {
         state.bufferedDisconnect = { description, reason };

--- a/packages/platform-socket.io/src/module.test.ts
+++ b/packages/platform-socket.io/src/module.test.ts
@@ -336,6 +336,55 @@ describe('@konekti/platform-socket.io', () => {
     expect(loggerEvents.some((event) => event.includes('dropped the oldest pending message'))).toBe(true);
   });
 
+  it('removes errored sockets from the registry and logs the error', () => {
+    const loggerEvents: string[] = [];
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger(loggerEvents),
+      {
+        async close() {},
+        getServer() {
+          return {};
+        },
+      } as never,
+      {
+        transports: ['websocket'],
+      },
+    );
+    const listeners: {
+      disconnect?: (reason: string, description: unknown) => void;
+      error?: (error: Error) => void;
+      onAny?: (event: string, ...args: unknown[]) => void;
+    } = {};
+    const socket = {
+      id: 'socket-1',
+      disconnect: () => undefined,
+      on(event: 'disconnect' | 'error', listener: ((reason: string, description: unknown) => void) | ((error: Error) => void)) {
+        if (event === 'disconnect') {
+          listeners.disconnect = listener as (reason: string, description: unknown) => void;
+        } else {
+          listeners.error = listener as (error: Error) => void;
+        }
+        return this;
+      },
+      onAny(listener: (event: string, ...args: unknown[]) => void) {
+        listeners.onAny = listener;
+        return this;
+      },
+    } as unknown as Socket;
+    const state = Reflect.get(service, 'createConnectionHandlerState').call(service);
+    const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, Socket>;
+
+    socketRegistry.set(socket.id, socket);
+    Reflect.get(service, 'attachConnectionListeners').call(service, state, [], socket, {} as never);
+
+    listeners.error?.(new Error('socket exploded'));
+
+    expect(socketRegistry.has(socket.id)).toBe(false);
+    expect(loggerEvents).toContain('error:SocketIoLifecycleService:Socket.IO gateway socket emitted an error.:socket exploded');
+  });
+
   it('isolates same room names across namespaces', async () => {
     class GatewayState {
       adminMessages: unknown[] = [];


### PR DESCRIPTION
## Summary
- add a Socket.IO socket `error` listener that removes errored sockets from the internal registry and logs the failure
- add a regression test for the error-path cleanup and document the runtime behavior in both READMEs

## Changes
- register `socket.on('error')` inside `attachConnectionListeners()`
- remove the errored socket from `socketRegistry` and log the error through `SocketIoLifecycleService`
- add a module-level regression test proving registry cleanup and logger output on socket errors
- document socket-level error cleanup in `packages/platform-socket.io/README.md` and `packages/platform-socket.io/README.ko.md`

## Testing
- `pnpm --filter @konekti/platform-socket.io... build`
- `pnpm exec vitest run packages/platform-socket.io/src/module.test.ts --config vitest.config.ts`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves lifecycle safety by making Socket.IO error-path cleanup explicit and documented, matching the existing websocket adapter cleanup model

Closes #524