### PR TITLE
Resolve #522: use current TypeScript import attribute API

### DIFF
--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -136,7 +136,7 @@ export function ensureModuleImport(source: string, className: string, importPath
         ]),
       ),
       statement.moduleSpecifier,
-      statement.assertClause,
+      statement.attributes,
     );
 
     return replaceNodeText(source, sourceFile, statement, printer.printNode(ts.EmitHint.Unspecified, updatedImport, sourceFile));


### PR DESCRIPTION
## Summary
- replace the deprecated `assertClause` import-declaration field with the current `attributes` field in the CLI module generator
- preserve existing generator output and module rewrite behavior across the CLI test suite

## Changes
- update `packages/cli/src/generators/module.ts` to pass `statement.attributes` into `ts.factory.updateImportDeclaration(...)`
- keep the generator behavior otherwise unchanged

## Testing
- `pnpm --filter @konekti/cli build`
- `pnpm --filter @konekti/cli test`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- no public CLI behavior change; this only moves the generator implementation onto the current TypeScript AST API while preserving existing output semantics

Closes #522