### PR TITLE
Resolve #539: preserve injected Redis client ownership

### DIFF
--- a/packages/event-bus/README.ko.md
+++ b/packages/event-bus/README.ko.md
@@ -118,6 +118,8 @@ export class AppModule {}
 
 구독(subscribe) 모드의 클라이언트는 다른 명령을 실행할 수 없으므로 두 개의 별도 Redis 클라이언트가 필요합니다.
 
+`RedisEventBusTransport`는 주입받은 Redis client의 lifecycle을 소유하지 않습니다. `close()` 시 transport가 등록한 채널 구독과 message listener만 정리하며, 호출자가 제공한 client에 대해 `quit()`이나 `disconnect()`를 호출하지 않습니다.
+
 ## 런타임 동작
 
 - 핸들러 검색은 애플리케이션 부트스트랩 중에 `COMPILED_MODULES`를 통해 실행됩니다.

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -118,6 +118,8 @@ export class AppModule {}
 
 Two separate Redis clients are required because a client in subscribe mode cannot issue other commands.
 
+`RedisEventBusTransport` does not own the lifecycle of injected Redis clients. On `close()`, it unsubscribes the channels it registered and detaches its message listener, but it does not call `quit()` or `disconnect()` on caller-provided clients.
+
 ## Runtime behavior
 
 - Handler discovery runs during application bootstrap via `COMPILED_MODULES`.

--- a/packages/event-bus/src/redis-transport.test.ts
+++ b/packages/event-bus/src/redis-transport.test.ts
@@ -6,6 +6,7 @@ class MockRedisClient {
   readonly messageListeners: Array<(channel: string, message: string) => void> = [];
   readonly publishes: Array<{ channel: string; message: string }> = [];
   readonly subscribedChannels: string[] = [];
+  readonly unsubscribedChannels: string[][] = [];
   disconnectCalls = 0;
   offCalls = 0;
 
@@ -37,6 +38,10 @@ class MockRedisClient {
 
   async subscribe(channel: string): Promise<void> {
     this.subscribedChannels.push(channel);
+  }
+
+  async unsubscribe(...channels: string[]): Promise<void> {
+    this.unsubscribedChannels.push(channels);
   }
 
   emitMessage(channel: string, payload: string): void {
@@ -91,7 +96,7 @@ describe('RedisEventBusTransport', () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
-  it('serializes publish payloads and disconnects both clients on close', async () => {
+  it('serializes publish payloads and only cleans up transport-owned subscriptions on close', async () => {
     const publishClient = new MockRedisClient();
     const subscribeClient = new MockRedisClient();
     const transport = new RedisEventBusTransport({
@@ -106,8 +111,31 @@ describe('RedisEventBusTransport', () => {
 
     await transport.close();
 
-    expect(publishClient.disconnectCalls).toBe(1);
-    expect(subscribeClient.disconnectCalls).toBe(1);
+    expect(publishClient.disconnectCalls).toBe(0);
+    expect(subscribeClient.disconnectCalls).toBe(0);
+    expect(subscribeClient.unsubscribedChannels).toEqual([['AuditEvent']]);
+    expect(subscribeClient.offCalls).toBe(1);
+    expect(subscribeClient.messageListeners).toHaveLength(0);
+  });
+
+  it('still detaches listeners when unsubscribe fails during close', async () => {
+    const publishClient = new MockRedisClient();
+    const subscribeClient = new MockRedisClient();
+    const transport = new RedisEventBusTransport({
+      publishClient: publishClient as never,
+      subscribeClient: subscribeClient as never,
+    });
+
+    subscribeClient.unsubscribe = vi.fn(async () => {
+      throw new Error('unsubscribe failed');
+    });
+
+    await transport.subscribe('AuditEvent', async () => undefined);
+
+    await expect(transport.close()).rejects.toThrow('unsubscribe failed');
+
+    expect(publishClient.disconnectCalls).toBe(0);
+    expect(subscribeClient.disconnectCalls).toBe(0);
     expect(subscribeClient.offCalls).toBe(1);
     expect(subscribeClient.messageListeners).toHaveLength(0);
   });

--- a/packages/event-bus/src/redis-transport.ts
+++ b/packages/event-bus/src/redis-transport.ts
@@ -51,12 +51,25 @@ export class RedisEventBusTransport implements EventBusTransport {
   }
 
   async close(): Promise<void> {
-    this.handlersByChannel.clear();
-    if (this.messageListenerAttached) {
-      this.subscribeClient.off('message', this.onMessage);
-      this.messageListenerAttached = false;
+    let closeError: unknown;
+    const channels = [...this.handlersByChannel.keys()];
+
+    try {
+      if (channels.length > 0) {
+        await this.subscribeClient.unsubscribe(...channels);
+      }
+    } catch (error) {
+      closeError = error;
+    } finally {
+      this.handlersByChannel.clear();
+      if (this.messageListenerAttached) {
+        this.subscribeClient.off('message', this.onMessage);
+        this.messageListenerAttached = false;
+      }
     }
-    this.subscribeClient.disconnect();
-    this.publishClient.disconnect();
+
+    if (closeError) {
+      throw closeError;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- stop `RedisEventBusTransport` from disconnecting caller-provided Redis clients on shutdown
- add ownership regression coverage and document the injected-client lifecycle boundary in both READMEs

## Changes
- make `RedisEventBusTransport.close()` unsubscribe registered channels and detach its message listener without calling `disconnect()` on injected Redis clients
- preserve cleanup on unsubscribe failure by detaching listeners in `finally` and rethrowing the unsubscribe error
- update `redis-transport.test.ts` to assert no client disconnect happens and add a regression test for unsubscribe-failure cleanup
- document that the Redis Pub/Sub transport does not own injected client lifecycle in `README.md` and `README.ko.md`

## Testing
- `pnpm --filter @konekti/event-bus... build`
- `pnpm exec vitest run packages/event-bus/src/redis-transport.test.ts --config vitest.config.ts`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- restores the intended ownership boundary so the Redis Pub/Sub transport only cleans up its own subscriptions/listeners while caller-owned Redis clients remain available to the owner package or application

Closes #539