### PR TITLE
Resolve #541: reject in-flight NATS requests on close

### DIFF
--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -129,6 +129,7 @@ class PaymentsHandler {
 
 - `NatsMicroserviceTransport`는 별도의 요청/응답 subject와 이벤트 subject를 사용해 `send()`와 `emit()`을 모두 지원합니다.
 - `send()`는 `requestTimeoutMs`를 적용하며, 트랜스포트가 에러 메시지로 직렬화해 되돌릴 수 있는 핸들러 실패만 호출자에게 전파합니다.
+- `close()`는 완료 전에 진행 중인 pending request를 결정적으로 reject합니다.
 - 재연결, 버퍼링, responder 가용성은 여전히 클라이언트/서버 책임입니다. 운영상 요청/응답 보장이 중요하다면 선택한 NATS 클라이언트/runtime 조합에서 별도로 검증해야 합니다.
 
 ### Redis

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -170,6 +170,7 @@ In this example, `AuditHandler` and `NotificationHandler` receive the same `Even
 
 - `NatsMicroserviceTransport` supports both `send()` and `emit()` by using separate request/reply and event subjects.
 - `send()` applies `requestTimeoutMs` and only propagates handler failures that the transport can serialize back as an error message.
+- `close()` rejects in-flight pending requests deterministically before returning control to the caller.
 - Reconnect behavior, buffering, and responder availability remain client/server concerns; if request/reply guarantees matter operationally, validate them against your chosen NATS client/runtime setup.
 
 ### Redis

--- a/packages/microservices/src/nats-transport.test.ts
+++ b/packages/microservices/src/nats-transport.test.ts
@@ -6,6 +6,7 @@ import { NatsMicroserviceTransport } from './nats-transport.js';
 
 class InMemoryNatsClient {
   private readonly subscriptions = new Map<string, Set<(message: { data: Uint8Array; respond(data: Uint8Array): void }) => void>>();
+  closeError: Error | undefined;
 
   subscribe(subject: string, handler: (message: { data: Uint8Array; respond(data: Uint8Array): void }) => void) {
     const handlers = this.subscriptions.get(subject) ?? new Set<typeof handler>();
@@ -73,6 +74,10 @@ class InMemoryNatsClient {
 
   close(): void {
     this.subscriptions.clear();
+
+    if (this.closeError) {
+      throw this.closeError;
+    }
   }
 }
 
@@ -161,5 +166,84 @@ describe('NatsMicroserviceTransport', () => {
     expect(logger).toHaveBeenCalled();
 
     await transport.close();
+  });
+
+  it('rejects pending requests when close() runs before a reply', async () => {
+    const nats = new InMemoryNatsClient();
+    let resolveRequestRelease!: () => void;
+    let resolveRequestStarted!: () => void;
+    const codec = {
+      decode(data: Uint8Array) {
+        return new TextDecoder().decode(data);
+      },
+      encode(value: string) {
+        return new TextEncoder().encode(value);
+      },
+    };
+    const requestRelease = new Promise<void>((resolve) => {
+      resolveRequestRelease = resolve;
+    });
+    const requestStarted = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve;
+    });
+
+    nats.request = vi.fn(async () => {
+      resolveRequestStarted();
+      await requestRelease;
+      return { data: codec.encode(JSON.stringify({ payload: { value: 1 } })) };
+    });
+
+    const transport = new NatsMicroserviceTransport({ client: nats, codec, requestTimeoutMs: 5_000 });
+    await transport.listen(async () => undefined);
+
+    const pending = transport.send('long.running', { value: 1 });
+    await requestStarted;
+    await transport.close();
+
+    await expect(pending).rejects.toThrow('NATS microservice transport closed before response.');
+
+    resolveRequestRelease();
+    await Promise.resolve();
+  });
+
+  it('still rejects pending requests when client.close fails during close', async () => {
+    const nats = new InMemoryNatsClient();
+    const closeError = new Error('close failed');
+    let resolveRequestRelease!: () => void;
+    let resolveRequestStarted!: () => void;
+    const codec = {
+      decode(data: Uint8Array) {
+        return new TextDecoder().decode(data);
+      },
+      encode(value: string) {
+        return new TextEncoder().encode(value);
+      },
+    };
+    const requestRelease = new Promise<void>((resolve) => {
+      resolveRequestRelease = resolve;
+    });
+    const requestStarted = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve;
+    });
+
+    nats.request = vi.fn(async () => {
+      resolveRequestStarted();
+      await requestRelease;
+      return { data: codec.encode(JSON.stringify({ payload: { value: 1 } })) };
+    });
+
+    nats.closeError = closeError;
+
+    const transport = new NatsMicroserviceTransport({ client: nats, codec, requestTimeoutMs: 5_000 });
+    await transport.listen(async () => undefined);
+
+    const pending = transport.send('long.running', { value: 1 });
+    await requestStarted;
+
+    await expect(transport.close()).rejects.toBe(closeError);
+    await expect(pending).rejects.toThrow('NATS microservice transport closed before response.');
+
+    resolveRequestRelease();
+    await Promise.resolve();
   });
 });

--- a/packages/microservices/src/nats-transport.ts
+++ b/packages/microservices/src/nats-transport.ts
@@ -40,11 +40,18 @@ interface NatsTransportResponse {
   readonly payload?: unknown;
 }
 
+interface PendingRequest {
+  reject(error: unknown): void;
+  resolve(value: unknown): void;
+}
+
 export class NatsMicroserviceTransport implements MicroserviceTransport {
+  private closing = false;
   private handler: TransportHandler | undefined;
   private listening = false;
   private readonly eventSubject: string;
   private readonly messageSubject: string;
+  private readonly pending = new Map<string, PendingRequest>();
   private readonly requestTimeoutMs: number;
   private subscriptions: NatsSubscriptionLike[] = [];
 
@@ -65,6 +72,7 @@ export class NatsMicroserviceTransport implements MicroserviceTransport {
   }
 
   async listen(handler: TransportHandler): Promise<void> {
+    this.closing = false;
     this.handler = handler;
 
     if (this.listening) {
@@ -83,24 +91,70 @@ export class NatsMicroserviceTransport implements MicroserviceTransport {
   }
 
   async send(pattern: string, payload: unknown): Promise<unknown> {
+    if (this.closing) {
+      throw new Error('NATS microservice transport is closing. Wait for close() to complete before send().');
+    }
+
+    if (!this.listening) {
+      throw new Error('NatsMicroserviceTransport is not listening. Call listen() before send().');
+    }
+
     const request: NatsTransportMessage = {
       kind: 'message',
       pattern,
       payload,
     };
 
-    const responseMessage = await this.options.client.request(
-      this.messageSubject,
-      this.encode(request),
-      { timeout: this.requestTimeoutMs },
-    );
-    const response = this.decode<NatsTransportResponse>(responseMessage.data);
+    const requestId = crypto.randomUUID();
 
-    if (response.error) {
-      throw new Error(response.error);
-    }
+    return await new Promise<unknown>((resolve, reject) => {
+      let settled = false;
 
-    return response.payload;
+      const cleanup = () => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        this.pending.delete(requestId);
+      };
+
+      const entry: PendingRequest = {
+        reject: (error: unknown) => {
+          cleanup();
+          reject(error);
+        },
+        resolve: (value: unknown) => {
+          cleanup();
+          resolve(value);
+        },
+      };
+
+      this.pending.set(requestId, entry);
+
+      void Promise.resolve().then(async () => {
+        if (this.closing) {
+          entry.reject(new Error('NATS microservice transport closed before request dispatch.'));
+          return;
+        }
+
+        const responseMessage = await this.options.client.request(
+          this.messageSubject,
+          this.encode(request),
+          { timeout: this.requestTimeoutMs },
+        );
+        const response = this.decode<NatsTransportResponse>(responseMessage.data);
+
+        if (response.error) {
+          entry.reject(new Error(response.error));
+          return;
+        }
+
+        entry.resolve(response.payload);
+      }).catch((error: unknown) => {
+        entry.reject(error instanceof Error ? error : new Error('Failed to send NATS request.'));
+      });
+    });
   }
 
   async emit(pattern: string, payload: unknown): Promise<void> {
@@ -114,14 +168,30 @@ export class NatsMicroserviceTransport implements MicroserviceTransport {
   }
 
   async close(): Promise<void> {
-    for (const subscription of this.subscriptions) {
-      subscription.unsubscribe();
+    this.closing = true;
+    let closeError: unknown;
+
+    try {
+      for (const subscription of this.subscriptions) {
+        subscription.unsubscribe();
+      }
+
+      this.options.client.close?.();
+    } catch (error) {
+      closeError = error;
+    } finally {
+      this.subscriptions = [];
+      this.listening = false;
+      this.handler = undefined;
+
+      for (const pending of [...this.pending.values()]) {
+        pending.reject(new Error('NATS microservice transport closed before response.'));
+      }
     }
 
-    this.subscriptions = [];
-    this.listening = false;
-    this.handler = undefined;
-    this.options.client.close?.();
+    if (closeError) {
+      throw closeError;
+    }
   }
 
   private async handleEventMessage(message: NatsMessageLike): Promise<void> {


### PR DESCRIPTION
## Summary
- reject in-flight NATS request/reply calls deterministically when the transport closes
- add close regression coverage and document the NATS shutdown contract in both READMEs

## Changes
- add a `closing` flag and pending request registry to `NatsMicroserviceTransport`
- reject in-flight requests during `close()` and prevent new `send()` calls once shutdown begins
- preserve pending-request rejection even when `client.close()` throws
- add targeted tests for reply-before-close race and close-error cleanup
- document deterministic pending-request rejection in the NATS transport section of `README.md` and `README.ko.md`

## Testing
- `pnpm --filter @konekti/microservices... build`
- `pnpm exec vitest run packages/microservices/src/nats-transport.test.ts --config vitest.config.ts`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- strengthens the documented NATS request/reply shutdown behavior so in-flight calls are rejected deterministically when the transport closes, matching existing Kafka/RabbitMQ/Redis Streams cleanup semantics

Closes #541