### PR TITLE
Resolve #540: preserve mongoose transaction failures during cleanup

### DIFF
--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -35,8 +35,13 @@ async function executeSessionTransaction<T>(session: MongooseSessionLike, fn: ()
     const result = await fn();
     await session.commitTransaction();
     return result;
-  } catch (error) {
-    await session.abortTransaction();
+  } catch (error: unknown) {
+    try {
+      await session.abortTransaction();
+    } catch (abortError) {
+      void abortError;
+    }
+
     throw error;
   }
 }

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -324,6 +324,97 @@ describe('@konekti/mongoose', () => {
     ]);
   });
 
+  it('preserves the commit failure when abort cleanup also fails', async () => {
+    const events: string[] = [];
+    const commitError = new Error('commit failed');
+    const abortError = new Error('abort failed');
+    const session: MongooseSessionLike = {
+      abortTransaction() {
+        events.push('transaction:abort');
+        throw abortError;
+      },
+      commitTransaction() {
+        events.push('transaction:commit');
+        throw commitError;
+      },
+      endSession() {
+        events.push('session:end');
+      },
+      startTransaction() {
+        events.push('transaction:start');
+      },
+    };
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    const mongoose = new MongooseConnection<typeof connection>(connection);
+
+    await expect(
+      mongoose.transaction(async () => {
+        events.push('tx:work');
+        return 'ok';
+      }),
+    ).rejects.toBe(commitError);
+
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'tx:work',
+      'transaction:commit',
+      'transaction:abort',
+      'session:end',
+    ]);
+  });
+
+  it('ends the session even when abort cleanup throws after a transaction error', async () => {
+    const events: string[] = [];
+    const abortError = new Error('abort failed');
+    const session: MongooseSessionLike = {
+      abortTransaction() {
+        events.push('transaction:abort');
+        throw abortError;
+      },
+      commitTransaction() {
+        events.push('transaction:commit');
+      },
+      endSession() {
+        events.push('session:end');
+      },
+      startTransaction() {
+        events.push('transaction:start');
+      },
+    };
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    const mongoose = new MongooseConnection<typeof connection>(connection);
+
+    await expect(
+      mongoose.transaction(async () => {
+        events.push('tx:work');
+        throw new Error('transaction failed');
+      }),
+    ).rejects.toThrow('transaction failed');
+
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'tx:work',
+      'transaction:abort',
+      'session:end',
+    ]);
+  });
+
   it('handles connection without startSession gracefully', async () => {
     const events: string[] = [];
 


### PR DESCRIPTION
## Summary
- preserve the primary transaction/commit failure even when Mongoose abort cleanup also throws
- add regression coverage for commit-failure plus abort-failure and transaction-failure plus abort-failure paths

## Changes
- make `executeSessionTransaction()` treat `abortTransaction()` as best-effort cleanup so it cannot mask the original failure
- keep `endSession()` in the outer `finally` path so session cleanup still runs after abort cleanup errors
- add unit regressions covering both `commitTransaction()` failure + `abortTransaction()` failure and callback failure + `abortTransaction()` failure

## Testing
- `pnpm --filter @konekti/mongoose... build`
- direct built-output validation of both failure-ordering scenarios via `node --input-type=module`
- `lsp_diagnostics` on changed TypeScript files

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves the documented mongoose transaction cleanup contract while ensuring secondary abort cleanup failures do not replace the original commit/transaction error seen by callers

Closes #540