### PR TITLE
Resolve #542: defer Socket.IO disconnect cleanup until handlers settle

### DIFF
--- a/packages/platform-socket.io/README.ko.md
+++ b/packages/platform-socket.io/README.ko.md
@@ -69,6 +69,7 @@ export class AppModule {}
 - 연결된 네임스페이스 소켓마다 `@OnConnect()`, `@OnMessage(event?)`, `@OnDisconnect()` 핸들러를 바인딩합니다
 - 런타임 DI 컨테이너에서 게이트웨이 인스턴스를 resolve하며, singleton이 아닌 게이트웨이는 경고 후 건너뜁니다
 - 공용 `SocketIoRoomService` 추상화를 통해 room 헬퍼를 노출합니다
+- 비동기 `@OnDisconnect()` 핸들러가 끝날 때까지 room helper를 사용할 수 있게 유지한 뒤, 소켓을 내부 레지스트리에서 제거합니다
 - 소켓 단위 `error` 이벤트를 로깅하고, 오류가 난 소켓을 내부 레지스트리에서 제거합니다
 - 타임아웃을 고려한 종료 처리로 Socket.IO 서버를 닫습니다
 

--- a/packages/platform-socket.io/README.md
+++ b/packages/platform-socket.io/README.md
@@ -69,6 +69,7 @@ export class AppModule {}
 - Binds `@OnConnect()`, `@OnMessage(event?)`, and `@OnDisconnect()` handlers for each connected namespace socket
 - Resolves gateway instances from the runtime DI container and skips non-singleton gateways with warnings
 - Exposes room helpers through the shared `SocketIoRoomService` abstraction
+- Keeps room helpers available until async `@OnDisconnect()` handlers settle, then removes the socket from the internal registry
 - Logs socket-level `error` events and removes errored sockets from the internal registry
 - Closes the Socket.IO server with timeout-aware shutdown handling
 

--- a/packages/platform-socket.io/src/adapter.ts
+++ b/packages/platform-socket.io/src/adapter.ts
@@ -400,8 +400,10 @@ export class SocketIoLifecycleService
         return;
       }
 
-      void this.handleDisconnect(resolved, socket, reason, description);
-      this.socketRegistry.delete(socket.id);
+      void this.handleDisconnect(resolved, socket, reason, description)
+        .finally(() => {
+          this.socketRegistry.delete(socket.id);
+        });
     });
   }
 

--- a/packages/platform-socket.io/src/module.test.ts
+++ b/packages/platform-socket.io/src/module.test.ts
@@ -385,6 +385,64 @@ describe('@konekti/platform-socket.io', () => {
     expect(loggerEvents).toContain('error:SocketIoLifecycleService:Socket.IO gateway socket emitted an error.:socket exploded');
   });
 
+  it('waits for disconnect handlers to settle before removing the socket from the registry', async () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getServer() {
+          return {};
+        },
+      } as never,
+      {
+        transports: ['websocket'],
+      },
+    );
+    const deferred = createDeferred<void>();
+    const listeners: {
+      disconnect?: (reason: string, description: unknown) => void;
+      onAny?: (event: string, ...args: unknown[]) => void;
+    } = {};
+    const socket = {
+      id: 'socket-1',
+      disconnect: () => undefined,
+      on(event: 'disconnect', listener: (reason: string, description: unknown) => void) {
+        listeners.disconnect = listener;
+        return this;
+      },
+      onAny(listener: (event: string, ...args: unknown[]) => void) {
+        listeners.onAny = listener;
+        return this;
+      },
+    } as unknown as Socket;
+    const state = Reflect.get(service, 'createConnectionHandlerState').call(service);
+    const socketRegistry = Reflect.get(service, 'socketRegistry') as Map<string, Socket>;
+    let disconnectHandled = false;
+
+    Reflect.set(service, 'handleDisconnect', async () => {
+      disconnectHandled = true;
+      await deferred.promise;
+    });
+
+    state.handlersReady = true;
+    socketRegistry.set(socket.id, socket);
+    Reflect.get(service, 'attachConnectionListeners').call(service, state, [], socket, {} as never);
+
+    listeners.disconnect?.('client namespace disconnect', undefined);
+    await Promise.resolve();
+
+    expect(disconnectHandled).toBe(true);
+    expect(socketRegistry.has(socket.id)).toBe(true);
+
+    deferred.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(socketRegistry.has(socket.id)).toBe(false);
+  });
+
   it('isolates same room names across namespaces', async () => {
     class GatewayState {
       adminMessages: unknown[] = [];


### PR DESCRIPTION
## Summary
- keep Socket.IO room helpers available until async `@OnDisconnect()` handlers settle
- add an ordering regression test and document the disconnect cleanup contract in both READMEs

## Changes
- move `socketRegistry.delete(socket.id)` into a `.finally()` chained to `handleDisconnect()`
- add a regression test proving the registry entry remains available while disconnect handlers are still pending and is removed only after settlement
- document the async disconnect cleanup guarantee in `packages/platform-socket.io/README.md` and `packages/platform-socket.io/README.ko.md`

## Testing
- `pnpm --filter @konekti/platform-socket.io... build`
- direct built-output behavior check for disconnect ordering (`socketio-disconnect-ordering-manual-check:ok`)
- `lsp_diagnostics` on changed files in the main workspace

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves the documented Socket.IO lifecycle contract by keeping room helpers and socket lookup available until async disconnect handlers finish, preventing cleanup races during valid disconnect-time work

Closes #542