### PR TITLE
Resolve #538: guard cyclic nested DTO payloads

### DIFF
--- a/packages/dto-validator/README.ko.md
+++ b/packages/dto-validator/README.ko.md
@@ -270,6 +270,8 @@ class CreateOrderDto {
 
 중첩 DTO를 변환할 때는 plain object payload만 nested 인스턴스에 복사합니다. non-plain 입력은 invalid data로 취급되며 DTO 필드에 암묵적으로 merge되지 않습니다.
 
+순환(cyclic) 중첩 payload도 invalid data로 취급하므로, 재귀 검증은 무한 재귀 대신 validation error로 실패합니다.
+
 ### 중첩 객체 배열
 
 ```typescript

--- a/packages/dto-validator/README.md
+++ b/packages/dto-validator/README.md
@@ -269,6 +269,8 @@ Errors use dot-notation paths: `{ field: 'address.city', ... }`.
 
 When transforming nested DTOs, only plain-object payloads are copied into the nested instance; non-plain inputs are treated as invalid data and are not implicitly merged into DTO fields.
 
+Cyclic nested payloads are treated as invalid data as well, so recursive validation fails with a validation error instead of recursing indefinitely.
+
 ### Arrays of Nested Objects
 
 ```typescript

--- a/packages/dto-validator/src/validation.test.ts
+++ b/packages/dto-validator/src/validation.test.ts
@@ -301,6 +301,114 @@ describe('DefaultValidator', () => {
     });
   });
 
+  it('rejects cyclic nested payloads during validation instead of recursing indefinitely', async () => {
+    class NodeDto {
+      @MinLength(1)
+      name = '';
+
+      @ValidateNested(() => NodeDto)
+      child?: NodeDto;
+    }
+
+    const validator = new DefaultValidator();
+    const payload: { child?: unknown; name: string } = { name: 'root' };
+    payload.child = payload;
+
+    await expect(
+      validator.validate(Object.assign(new NodeDto(), payload), NodeDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_NESTED', field: 'child.child', message: 'child.child contains invalid nested data.' }],
+    });
+  });
+
+  it('rejects cyclic nested payloads during transform instead of recursing indefinitely', async () => {
+    class NodeDto {
+      @MinLength(1)
+      name = '';
+
+      @ValidateNested(() => NodeDto)
+      child?: NodeDto;
+    }
+
+    const validator = new DefaultValidator();
+    const payload: { child?: unknown; name: string } = { name: 'root' };
+    payload.child = payload;
+
+    await expect(
+      validator.transform<NodeDto>(payload, NodeDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_NESTED', field: 'child.child', message: 'child.child contains invalid nested data.' }],
+    });
+  });
+
+  it('rejects cyclic DTO instances during validation instead of recursing indefinitely', async () => {
+    class NodeDto {
+      @MinLength(1)
+      name = '';
+
+      @ValidateNested(() => NodeDto)
+      child?: NodeDto;
+    }
+
+    const validator = new DefaultValidator();
+    const root = Object.assign(new NodeDto(), { name: 'root' });
+    root.child = root;
+
+    await expect(
+      validator.validate(root, NodeDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_NESTED', field: 'child', message: 'child contains invalid nested data.' }],
+    });
+  });
+
+  it('rejects cyclic nested collection entries during validation instead of recursing indefinitely', async () => {
+    class NodeDto {
+      @MinLength(1)
+      name = '';
+
+      @ValidateNested(() => NodeDto, { each: true })
+      children: NodeDto[] = [];
+    }
+
+    const validator = new DefaultValidator();
+    const root = Object.assign(new NodeDto(), { name: 'root' });
+    root.children = [root];
+
+    await expect(
+      validator.validate(root, NodeDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_NESTED', field: 'children[0]', message: 'children[0] contains invalid nested data.' }],
+    });
+  });
+
+  it('allows shared nested payload objects across sibling fields', async () => {
+    class ChildDto {
+      @MinLength(1)
+      name = '';
+    }
+
+    class ParentDto {
+      @ValidateNested(() => ChildDto)
+      left = new ChildDto();
+
+      @ValidateNested(() => ChildDto)
+      right = new ChildDto();
+    }
+
+    const shared = { name: 'ok' };
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(
+        Object.assign(new ParentDto(), {
+          left: shared,
+          right: shared,
+        }),
+        ParentDto,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it('reports stable field paths for deeply nested DTO validation failures', async () => {
     class Level3Dto {
       @MinLength(2, { message: 'leaf must have length at least 2' })

--- a/packages/dto-validator/src/validation.ts
+++ b/packages/dto-validator/src/validation.ts
@@ -130,6 +130,31 @@ interface CachedDtoMetadata {
   }[];
 }
 
+interface NestedTraversalContext {
+  readonly active: WeakSet<object>;
+}
+
+function enterTraversal(value: unknown, context?: NestedTraversalContext): boolean {
+  if (!context || typeof value !== 'object' || value === null) {
+    return true;
+  }
+
+  if (context.active.has(value)) {
+    return false;
+  }
+
+  context.active.add(value);
+  return true;
+}
+
+function exitTraversal(value: unknown, context?: NestedTraversalContext): void {
+  if (!context || typeof value !== 'object' || value === null) {
+    return;
+  }
+
+  context.active.delete(value);
+}
+
 const dtoMetadataCache = new WeakMap<Constructor, CachedDtoMetadata>();
 
 function collectNestedDtoTransforms(dtoValidationSchema: DtoValidationSchema): CachedDtoMetadata['nestedDtoTransforms'] {
@@ -393,7 +418,7 @@ const RULE_HANDLERS: { [K in RuleKind]: RuleHandler<K> } = {
   },
 };
 
-function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown): T {
+function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown, context?: NestedTraversalContext): T {
   if (rawValue instanceof target) {
     return rawValue as T;
   }
@@ -404,26 +429,34 @@ function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown): 
     return instance as T;
   }
 
-  assignSafeOwnEnumerableProperties(instance, rawValue);
-
-  const metadata = getCachedDtoMetadata(target);
-  applyBindingValues(instance, rawValue, metadata.mergedPropertyKeys, metadata.bindingMap);
-
-  for (const nestedEntry of metadata.nestedDtoTransforms) {
-    const currentValue = instance[nestedEntry.propertyKey];
-    if (currentValue === undefined || currentValue === null) {
-      continue;
-    }
-
-    instance[nestedEntry.propertyKey] = nestedEntry.each
-      ? transformNestedEachValue(currentValue, nestedEntry.target)
-      : transformNestedValue(currentValue, nestedEntry.target);
+  if (!enterTraversal(rawValue, context)) {
+    return rawValue as T;
   }
 
-  return instance as T;
+  try {
+    assignSafeOwnEnumerableProperties(instance, rawValue);
+
+    const metadata = getCachedDtoMetadata(target);
+    applyBindingValues(instance, rawValue, metadata.mergedPropertyKeys, metadata.bindingMap);
+
+    for (const nestedEntry of metadata.nestedDtoTransforms) {
+      const currentValue = instance[nestedEntry.propertyKey];
+      if (currentValue === undefined || currentValue === null) {
+        continue;
+      }
+
+      instance[nestedEntry.propertyKey] = nestedEntry.each
+        ? transformNestedEachValue(currentValue, nestedEntry.target, context)
+        : transformNestedValue(currentValue, nestedEntry.target, context);
+    }
+
+    return instance as T;
+  } finally {
+    exitTraversal(rawValue, context);
+  }
 }
 
-function materializeNestedDtoValue<T>(target: Constructor<T>, rawValue: unknown): unknown {
+function materializeNestedDtoValue<T>(target: Constructor<T>, rawValue: unknown, context?: NestedTraversalContext): unknown {
   if (rawValue instanceof target) {
     return rawValue;
   }
@@ -432,7 +465,11 @@ function materializeNestedDtoValue<T>(target: Constructor<T>, rawValue: unknown)
     return rawValue;
   }
 
-  return createNestedDtoInstance(target, rawValue);
+  if (context?.active.has(rawValue)) {
+    return rawValue;
+  }
+
+  return createNestedDtoInstance(target, rawValue, context);
 }
 
 function getDtoBindingMap(target: Constructor): Map<MetadataPropertyKey, DtoFieldBindingMetadata> {
@@ -454,24 +491,24 @@ function applyBindingValues(
   }
 }
 
-function transformNestedValue(value: unknown, target: Constructor): unknown {
-  return value === undefined || value === null ? value : materializeNestedDtoValue(target, value);
+function transformNestedValue(value: unknown, target: Constructor, context?: NestedTraversalContext): unknown {
+  return value === undefined || value === null ? value : materializeNestedDtoValue(target, value, context);
 }
 
-function transformNestedEachValue(value: unknown, target: Constructor): unknown {
+function transformNestedEachValue(value: unknown, target: Constructor, context?: NestedTraversalContext): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => transformNestedValue(item, target));
+    return value.map((item) => transformNestedValue(item, target, context));
   }
 
   if (value instanceof Set) {
-    return new Set(Array.from(value.values(), (item) => transformNestedValue(item, target)));
+    return new Set(Array.from(value.values(), (item) => transformNestedValue(item, target, context)));
   }
 
   if (value instanceof Map) {
-    return new Map(Array.from(value.entries(), ([key, item]) => [key, transformNestedValue(item, target)]));
+    return new Map(Array.from(value.entries(), ([key, item]) => [key, transformNestedValue(item, target, context)]));
   }
 
-  return transformNestedValue(value, target);
+  return transformNestedValue(value, target, context);
 }
 
 function describeValidator(rule: DtoFieldValidationRule, field: string): { code: string; message: string } {
@@ -601,6 +638,7 @@ async function validateNestedRule(
   value: unknown,
   fieldPath: string,
   inheritedSource: ValidationIssue['source'],
+  context: NestedTraversalContext,
 ): Promise<ValidationIssue[]> {
   const values = rule.each ? getIterableValues(value) ?? [value] : [value];
   const issues: ValidationIssue[] = [];
@@ -609,14 +647,30 @@ async function validateNestedRule(
   for (const [index, entry] of values.entries()) {
     if (entry === undefined || entry === null) continue;
     const nestedPath = rule.each ? `${fieldPath}[${String(index)}]` : fieldPath;
+    const trackedEntry = typeof entry === 'object' && entry !== null ? entry : undefined;
 
     if (!(entry instanceof resolvedDto) && !isPlainObject(entry)) {
       issues.push(buildIssue(describeValidator(rule, nestedPath), nestedPath, inheritedSource));
       continue;
     }
 
-    const nestedDto = createNestedDtoInstance(resolvedDto, entry);
-    issues.push(...(await collectValidationIssuesInternal(resolvedDto, nestedDto, { fieldPrefix: nestedPath, inheritedSource })));
+    if (trackedEntry && context.active.has(trackedEntry)) {
+      issues.push(buildIssue(describeValidator(rule, nestedPath), nestedPath, inheritedSource));
+      continue;
+    }
+
+    const nestedDto = createNestedDtoInstance(resolvedDto, entry, context);
+    const shouldTrackEntry = trackedEntry && !(entry instanceof resolvedDto)
+      ? enterTraversal(trackedEntry, context)
+      : false;
+
+    try {
+      issues.push(...(await collectValidationIssuesInternal(resolvedDto, nestedDto, { fieldPrefix: nestedPath, inheritedSource }, context)));
+    } finally {
+      if (trackedEntry && shouldTrackEntry) {
+        exitTraversal(trackedEntry, context);
+      }
+    }
   }
 
   return issues;
@@ -629,6 +683,7 @@ async function evaluateRule(
   propertyKey: MetadataPropertyKey,
   fieldPath: string,
   source: ValidationIssue['source'],
+  context: NestedTraversalContext,
 ): Promise<ValidationIssue[]> {
   const fallback = describeValidator(rule, fieldPath);
 
@@ -637,7 +692,7 @@ async function evaluateRule(
   }
 
   if (rule.kind === 'nested') {
-    return validateNestedRule(rule, value, fieldPath, source);
+    return validateNestedRule(rule, value, fieldPath, source, context);
   }
 
   if (rule.each) {
@@ -666,6 +721,7 @@ async function applyPropertyRules(
   propertyKey: MetadataPropertyKey,
   fieldPath: string,
   source: ValidationIssue['source'],
+  context: NestedTraversalContext,
 ): Promise<ValidationIssue[]> {
   const conditionallySkip = await (async () => {
     for (const rule of rules) {
@@ -687,7 +743,7 @@ async function applyPropertyRules(
     if (rule.kind === 'validateIf' || rule.kind === 'optional') continue;
     if (conditionallySkip) continue;
     if (shouldSkipRuleForMissingValue(rule, value)) continue;
-    issues.push(...(await evaluateRule(rule, value, dto, propertyKey, fieldPath, source)));
+    issues.push(...(await evaluateRule(rule, value, dto, propertyKey, fieldPath, source, context)));
   }
 
   return issues;
@@ -701,30 +757,39 @@ async function validateClassRule(rule: ClassValidationRule, dto: unknown): Promi
 }
 
 async function collectValidationIssues<T>(target: Constructor<T>, value: T): Promise<readonly ValidationIssue[]> {
-  return collectValidationIssuesInternal(target, value, {});
+  return collectValidationIssuesInternal(target, value, {}, { active: new WeakSet<object>() });
 }
 
 async function collectValidationIssuesInternal<T>(
   target: Constructor<T>,
   value: T,
   context: { fieldPrefix?: string; inheritedSource?: ValidationIssue['source'] },
+  traversal: NestedTraversalContext,
 ): Promise<readonly ValidationIssue[]> {
-  const metadata = getCachedDtoMetadata(target);
-  const issues: ValidationIssue[] = [];
-
-  for (const entry of metadata.dtoValidationSchema) {
-    const fieldValue = (value as Record<PropertyKey, unknown>)[entry.propertyKey];
-    const source = metadata.bindingMap.get(entry.propertyKey)?.source ?? context.inheritedSource;
-    const fieldPath = context.fieldPrefix ? joinFieldPath(context.fieldPrefix, toFieldName(entry.propertyKey)) : toFieldName(entry.propertyKey);
-    issues.push(...(await applyPropertyRules(entry.rules, fieldValue, value, entry.propertyKey, fieldPath, source)));
+  if (!enterTraversal(value, traversal)) {
+    return [];
   }
 
-  for (const rule of metadata.classValidationRules) {
-    const classIssues = await validateClassRule(rule, value);
-    issues.push(...(context.fieldPrefix ? prefixIssues(classIssues, context.fieldPrefix, context.inheritedSource) : classIssues));
-  }
+  try {
+    const metadata = getCachedDtoMetadata(target);
+    const issues: ValidationIssue[] = [];
 
-  return issues;
+    for (const entry of metadata.dtoValidationSchema) {
+      const fieldValue = (value as Record<PropertyKey, unknown>)[entry.propertyKey];
+      const source = metadata.bindingMap.get(entry.propertyKey)?.source ?? context.inheritedSource;
+      const fieldPath = context.fieldPrefix ? joinFieldPath(context.fieldPrefix, toFieldName(entry.propertyKey)) : toFieldName(entry.propertyKey);
+      issues.push(...(await applyPropertyRules(entry.rules, fieldValue, value, entry.propertyKey, fieldPath, source, traversal)));
+    }
+
+    for (const rule of metadata.classValidationRules) {
+      const classIssues = await validateClassRule(rule, value);
+      issues.push(...(context.fieldPrefix ? prefixIssues(classIssues, context.fieldPrefix, context.inheritedSource) : classIssues));
+    }
+
+    return issues;
+  } finally {
+    exitTraversal(value, traversal);
+  }
 }
 
 export class DefaultValidator implements Validator {
@@ -735,7 +800,7 @@ export class DefaultValidator implements Validator {
   }
 
   async transform<T>(value: unknown, target: Constructor<T>): Promise<T> {
-    const instance = createNestedDtoInstance(target, value);
+    const instance = createNestedDtoInstance(target, value, { active: new WeakSet<object>() });
     const issues = await collectValidationIssues(target, instance);
 
     if (issues.length > 0) {


### PR DESCRIPTION
## Summary
- guard nested DTO transform/validation against cyclic object graphs without breaking normal sibling reuse
- add regression coverage for plain payload cycles, DTO-instance cycles, collection cycles, and shared nested aliases

## Changes
- add an active-path `WeakSet` traversal guard to dto-validator nested transform and validation paths
- surface cyclic nested payloads as `INVALID_NESTED` instead of recursing indefinitely
- preserve normal nested DTO behavior by allowing shared sibling references that are not part of the current recursion path
- add regression tests for plain-object cycles, DTO-instance cycles, `each: true` collection cycles, and shared nested payload reuse
- document cyclic nested payload rejection in `packages/dto-validator/README.md` and `packages/dto-validator/README.ko.md`

## Testing
- `pnpm --filter @konekti/dto-validator... build`
- `pnpm exec vitest run packages/dto-validator/src/validation.test.ts --config vitest.config.ts`
- `lsp_diagnostics` on changed TypeScript files in the main workspace

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves existing nested DTO validation semantics for normal payloads while failing fast on cyclic object graphs that previously could recurse indefinitely

Closes #538