### PR TITLE
Resolve #537: fail fast when refresh verification lacks HMAC algorithms

### DIFF
--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -184,6 +184,8 @@ verifyAccessToken(token)
 
 "이 알고리즘이 허용 목록에 있는가?"와 "이 구현이 이를 지원하는가?"라는 두 가지 별도의 확인 과정이 존재합니다. HMAC 알고리즘(HS*)은 공유 비밀키와 함께 `createHmac`을 사용하고, 비대칭 알고리즘(RS*, ES*)은 키 쌍과 함께 `createVerify`/`createSign`을 사용합니다. 이러한 분리는 지원되지 않는 경로가 실수로 열리는 일 없이 안전하게 허용 목록을 확장할 수 있게 해줍니다.
 
+refresh token 검증은 HMAC 전용 경로입니다. `refreshToken`이 구성된 경우 verifier는 허용 알고리즘 목록에 `HS256` / `HS384` / `HS512` 중 최소 하나가 있어야 하며, 그렇지 않으면 생성 시점에 즉시 실패합니다.
+
 ## 기여자를 위한 파일 읽기 순서
 
 1. `src/types.ts` — `JwtVerifierOptions`, `JwtClaims`, `JwtPrincipal`, `JwtVerifier`, `JwtSigner`

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -186,6 +186,8 @@ If `iss`, `aud`, `iat`, or `exp` are absent from the claims passed to `signAcces
 
 Two separate checks exist: "is this algorithm in the allowlist?" and "does this implementation support it?". HMAC algorithms (HS*) use `createHmac` with a shared secret; asymmetric algorithms (RS*, ES*) use `createVerify`/`createSign` with a key pair. The separation makes it safe to extend the allowlist without accidentally opening unsupported paths.
 
+Refresh token verification is HMAC-only. If `refreshToken` is configured, the verifier requires at least one of `HS256` / `HS384` / `HS512` in the allowed algorithm list and fails fast during construction otherwise.
+
 ## File reading order for contributors
 
 1. `src/types.ts` — `JwtVerifierOptions`, `JwtClaims`, `JwtPrincipal`, `JwtVerifier`, `JwtSigner`

--- a/packages/jwt/src/module.test.ts
+++ b/packages/jwt/src/module.test.ts
@@ -217,6 +217,30 @@ describe('JwtModule', () => {
     await expect(container.resolve(RefreshTokenService)).resolves.toBeInstanceOf(RefreshTokenService);
   });
 
+  it('fails singleton provider resolution when refreshToken is configured without any HMAC algorithms', async () => {
+    const container = new Container();
+    const moduleType = JwtModule.forRootAsync({
+      useFactory: async () => ({
+        algorithms: ['RS256'],
+        publicKey: '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApseudo\n-----END PUBLIC KEY-----',
+        refreshToken: {
+          expiresInSeconds: 60,
+          rotation: false,
+          secret: 'refresh-secret',
+          store: new NoopRefreshTokenStore(),
+        },
+      }),
+    });
+
+    const providers = moduleProviders(moduleType);
+
+    container.register(...providers);
+
+    await expect(resolveSingletonProviders(container, providers)).rejects.toThrow(
+      'JWT refresh token verifier requires at least one HMAC algorithm (HS256/HS384/HS512) in the allowed algorithms list.',
+    );
+  });
+
   it('registers refresh token service when refresh options are provided', async () => {
     const container = new Container();
     const moduleType = JwtModule.forRoot({

--- a/packages/jwt/src/refresh-token.test.ts
+++ b/packages/jwt/src/refresh-token.test.ts
@@ -374,4 +374,24 @@ describe('RefreshTokenService', () => {
         }),
     ).toThrow(JwtConfigurationError);
   });
+
+  it('fails fast when refresh token verification has no available HMAC algorithms', () => {
+    const store = new InMemoryRefreshTokenStore();
+
+    expect(
+      () =>
+        new DefaultJwtVerifier({
+          algorithms: ['RS256'],
+          publicKey: '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApseudo\n-----END PUBLIC KEY-----',
+          refreshToken: {
+            expiresInSeconds: 3600,
+            rotation: false,
+            secret: 'refresh-secret',
+            store,
+          },
+        }),
+    ).toThrowError(
+      'JWT refresh token verifier requires at least one HMAC algorithm (HS256/HS384/HS512) in the allowed algorithms list.',
+    );
+  });
 });

--- a/packages/jwt/src/verifier.ts
+++ b/packages/jwt/src/verifier.ts
@@ -256,6 +256,12 @@ export class DefaultJwtVerifier {
   ): JwtVerifierOptions {
     const algorithms = this.options.algorithms.filter((algorithm): algorithm is JwtAlgorithm => algorithm in HMAC_HASH);
 
+    if (algorithms.length === 0) {
+      throw new JwtConfigurationError(
+        'JWT refresh token verifier requires at least one HMAC algorithm (HS256/HS384/HS512) in the allowed algorithms list.',
+      );
+    }
+
     return {
       algorithms,
       audience: this.options.audience,


### PR DESCRIPTION
## Summary
- fail fast when refresh-token verification is configured without any available HMAC algorithms
- add direct verifier and DI-path regressions, and document the HMAC-only refresh verification contract in both READMEs

## Changes
- make `DefaultJwtVerifier` throw `JwtConfigurationError` during construction when `refreshToken` is configured but the allowed algorithms list contains no `HS256`/`HS384`/`HS512`
- add a direct refresh-token verifier regression in `refresh-token.test.ts`
- add an async `JwtModule.forRootAsync` DI regression in `module.test.ts`
- document that refresh-token verification is HMAC-only in `packages/jwt/README.md` and `packages/jwt/README.ko.md`

## Testing
- `pnpm --filter @konekti/jwt... build`
- `pnpm exec vitest run packages/jwt/src/verifier.test.ts packages/jwt/src/refresh-token.test.ts --config vitest.config.ts`
- direct built-output DI fail-fast verification (`jwt-refresh-hmac-failfast-manual-check:ok`)
- `lsp_diagnostics` on changed TypeScript files in the main workspace

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- preserves the documented refresh-token behavior while surfacing asymmetric-only verifier configurations as construction-time configuration errors instead of late runtime invalid-token failures

Closes #537