### PR TITLE
Resolve #551: add @konekti/platform-express adapter

### DIFF
--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -15,6 +15,7 @@
 | `@Inject(TOKEN)` | `@konekti/core`의 `@Inject([TOKEN])` | 생성자 의존성 토큰 목록을 명시적으로 선언합니다. |
 | `Scope.DEFAULT`, `Scope.REQUEST`, `Scope.TRANSIENT` | `@Scope('singleton' \| 'request' \| 'transient')` | 기본값은 singleton입니다. |
 | `NestFactory.create(AppModule)` | `KonektiFactory.create(AppModule, options)` | `listen()`을 암시적으로 호출하지 않고 `Application` 셸을 반환합니다. |
+| `NestFactory.create<NestExpressApplication>(AppModule)` | `KonektiFactory.create(AppModule, { adapter: createExpressAdapter(...) })` | 런타임 facade 기반 시작 경로를 유지하면서 Express 트랜스포트 어댑터를 명시적으로 선택합니다. |
 | `app.listen(3000)` | `await app.listen()` | 애플리케이션 생성 이후 실행은 명시적으로 유지됩니다. |
 | `HttpException`, `NotFoundException`, `BadRequestException` | `@konekti/http`의 예외 클래스들 | 핸들러/가드에서 typed HTTP 예외를 던지는 모델은 동일합니다. |
 | `@UseGuards()`, `@UseInterceptors()`, validation pipes | `@UseGuards()`, `@UseInterceptors()`, `@RequestDto(...)`, `@Convert(...)`, global `converters` 런타임 옵션 | Konekti는 별도의 `@UsePipes()` 데코레이터 대신 HTTP 바인딩 계층에서 요청 변환을 처리합니다. |
@@ -212,6 +213,20 @@ import { AppModule } from './app.module';
 
 const app = await KonektiFactory.create(AppModule, {
   port: 3000,
+});
+
+await app.listen();
+```
+
+### Konekti (`KonektiFactory.create` + Express adapter)
+
+```typescript
+import { createExpressAdapter } from '@konekti/platform-express';
+import { KonektiFactory } from '@konekti/runtime';
+import { AppModule } from './app.module';
+
+const app = await KonektiFactory.create(AppModule, {
+  adapter: createExpressAdapter({ port: 3000 }),
 });
 
 await app.listen();
@@ -527,7 +542,7 @@ const service = await moduleRef.resolve(UserService);
 - 필요한 클래스에 `@Inject([...])` 토큰 목록 명시
 - 가드/인터셉터를 `@UseGuards`/`@UseInterceptors`로 이전
 - Nest pipe 기반 검증을 `@RequestDto` + `@konekti/validation` 패키지로 이전
-- 부트스트랩을 `runNodeApplication(...)` 또는 `bootstrapApplication(...)`로 전환
+- 부트스트랩을 `KonektiFactory.create(..., { adapter? })` 중심으로 전환하고, `runNodeApplication(...)` / `bootstrapApplication(...)`은 호환·저수준 경로로 유지
 - 테스트를 `createTestingModule(...)` + provider override 패턴으로 전환
 
 ## 관련 문서

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -15,6 +15,7 @@ This guide is for teams that already ship NestJS services and want a practical m
 | `@Inject(TOKEN)` | `@Inject([TOKEN])` from `@konekti/core` | Konekti takes an explicit token list for constructor dependencies. |
 | `Scope.DEFAULT`, `Scope.REQUEST`, `Scope.TRANSIENT` | `@Scope('singleton' \| 'request' \| 'transient')` | Default remains singleton. |
 | `NestFactory.create(AppModule)` | `KonektiFactory.create(AppModule, options)` | Returns the Konekti `Application` shell without implicitly calling `listen()`. |
+| `NestFactory.create<NestExpressApplication>(AppModule)` | `KonektiFactory.create(AppModule, { adapter: createExpressAdapter(...) })` | Keep startup on the runtime facade while selecting an Express transport adapter explicitly. |
 | `app.listen(3000)` | `await app.listen()` | Startup remains explicit after application creation. |
 | `HttpException`, `NotFoundException`, `BadRequestException` | `NotFoundException`, `BadRequestException`, and peers from `@konekti/http` | Same mental model: throw typed HTTP exceptions in handlers/guards. |
 | `@UseGuards()`, `@UseInterceptors()`, validation pipes | `@UseGuards()`, `@UseInterceptors()`, `@RequestDto(...)`, `@Convert(...)`, and global `converters` runtime options | Konekti keeps request conversion in the HTTP binding layer instead of a separate `@UsePipes()` decorator. |
@@ -212,6 +213,20 @@ import { AppModule } from './app.module';
 
 const app = await KonektiFactory.create(AppModule, {
   port: 3000,
+});
+
+await app.listen();
+```
+
+### Konekti (`KonektiFactory.create` + Express adapter)
+
+```typescript
+import { createExpressAdapter } from '@konekti/platform-express';
+import { KonektiFactory } from '@konekti/runtime';
+import { AppModule } from './app.module';
+
+const app = await KonektiFactory.create(AppModule, {
+  adapter: createExpressAdapter({ port: 3000 }),
 });
 
 await app.listen();
@@ -527,7 +542,7 @@ const service = await moduleRef.resolve(UserService);
 - convert DI metadata to explicit `@Inject([...])` token lists where needed
 - migrate guards/interceptors with `@UseGuards` and `@UseInterceptors`
 - move validation from Nest pipes to `@RequestDto` + the `@konekti/validation` package
-- switch bootstrap to `runNodeApplication(...)` or `bootstrapApplication(...)`
+- switch bootstrap to `KonektiFactory.create(..., { adapter? })` and keep `runNodeApplication(...)` / `bootstrapApplication(...)` as compatibility or low-level paths
 - migrate tests to `createTestingModule(...)` and provider overrides
 
 ## related docs

--- a/docs/operations/nestjs-parity-gaps.ko.md
+++ b/docs/operations/nestjs-parity-gaps.ko.md
@@ -74,7 +74,7 @@
 |---|---|
 | A1. standalone application context | `KonektiFactory.createApplicationContext(rootModule, options?)`가 `@konekti/runtime`에 출하되었습니다. HTTP 어댑터 없이 모듈 그래프를 부트스트랩하고, 라이프사이클 훅을 실행하며, 타입이 지정된 `get<T>()` + `close()` 컨텍스트를 반환합니다. |
 | A2. microservice / transport layer | `@konekti/microservices`에 TCP, Redis Pub/Sub, Kafka(요청/응답 + 이벤트), NATS, RabbitMQ(이벤트 전용) 트랜스포트, `@MessagePattern` / `@EventPattern` 데코레이터, `KonektiFactory.createMicroservice()`, 공유 컨테이너 기반 하이브리드 구성 및 런타임 통합 테스트가 출하되었습니다. |
-| A3. platform adapter breadth | `@konekti/platform-fastify`에 전체 패리티 테스트 스위트를 갖춘 `HttpApplicationAdapter` 구현 Fastify 어댑터가 출하되었습니다. |
+| A3. platform adapter breadth | `@konekti/platform-fastify`와 `@konekti/platform-express`가 패리티 중심 런타임 테스트를 갖춘 `HttpApplicationAdapter` 구현을 제공합니다. |
 | A4. HTTP versioning strategies beyond URI | URI, Header, Media type, Custom 4가지 전략 모두 `@konekti/http`와 `@konekti/runtime`에 출하되었습니다. |
 | A5. schema-based validation (Standard Schema) | Standard Schema 호환 검증기는 `@ValidateClass(schema)`를 통해 DTO 레벨에 직접 붙일 수 있으므로, Zod·Valibot·ArkType 스키마를 별도 schema 서브패키지 없이 표준 `ValidationIssue` 형태로 매핑할 수 있습니다. |
 | A6. request / transient provider scopes for GraphQL resolvers | `@konekti/graphql`이 오퍼레이션 컨텍스트마다 `createRequestScope()`를 연결합니다. `@Scope('request')`, `@Scope('transient')`, `@Scope('singleton')` 리졸버가 완전히 테스트되고 문서화되었습니다. |

--- a/docs/operations/nestjs-parity-gaps.md
+++ b/docs/operations/nestjs-parity-gaps.md
@@ -74,7 +74,7 @@ The following items were previously listed as open gaps and have since been ship
 |---|---|
 | A1. standalone application context | `KonektiFactory.createApplicationContext(rootModule, options?)` is shipped in `@konekti/runtime`. Boots the module graph without an HTTP adapter, runs lifecycle hooks, and returns a typed `get<T>()` + `close()` context. |
 | A2. microservice / transport layer | `@konekti/microservices` ships TCP, Redis Pub/Sub, Kafka (request/reply + event), NATS, and RabbitMQ (event-only) transports, `@MessagePattern` / `@EventPattern` decorators, `KonektiFactory.createMicroservice()`, and shared-container hybrid composition with runtime integration tests. |
-| A3. platform adapter breadth | `@konekti/platform-fastify` ships a Fastify adapter implementing `HttpApplicationAdapter` with full parity test suite. |
+| A3. platform adapter breadth | `@konekti/platform-fastify` and `@konekti/platform-express` ship `HttpApplicationAdapter` implementations with parity-focused runtime tests. |
 | A4. HTTP versioning strategies beyond URI | All four strategies (URI, Header, Media type, Custom) are shipped in `@konekti/http` and `@konekti/runtime`. |
 | A5. schema-based validation (Standard Schema) | Standard Schema-compatible validators can be attached directly at the DTO level through `@ValidateClass(schema)`, so Zod, Valibot, and ArkType schemas all map into the standard `ValidationIssue` shape without a separate schema subpackage. |
 | A6. request / transient provider scopes for GraphQL resolvers | `@konekti/graphql` wires `createRequestScope()` per operation context. `@Scope('request')`, `@Scope('transient')`, and `@Scope('singleton')` resolvers are fully tested and documented. |

--- a/docs/operations/release-governance.ko.md
+++ b/docs/operations/release-governance.ko.md
@@ -29,6 +29,7 @@
 - `@konekti/di`
 - `@konekti/runtime`
 - `@konekti/platform-fastify`
+- `@konekti/platform-express`
 - `@konekti/platform-socket.io`
 - `@konekti/microservices`
 - `@konekti/jwt`

--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -30,6 +30,7 @@ These packages are the current intended public release surface for the 0.x line:
 - `@konekti/di`
 - `@konekti/runtime`
 - `@konekti/platform-fastify`
+- `@konekti/platform-express`
 - `@konekti/platform-socket.io`
 - `@konekti/microservices`
 - `@konekti/jwt`

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -13,6 +13,7 @@
 - `@konekti/di`
 - `@konekti/runtime`
 - `@konekti/platform-fastify`
+- `@konekti/platform-express`
 - `@konekti/platform-socket.io`
 - `@konekti/microservices`
 - `@konekti/jwt`
@@ -44,6 +45,7 @@
 - **`@konekti/http`**: HTTP 실행, 바인딩, 예외, 라우트 메타데이터.
 - **`@konekti/runtime`**: 애플리케이션 부트스트랩 및 런타임 오케스트레이션.
 - **`@konekti/platform-fastify`**: Fastify 기반 HTTP 어댑터.
+- **`@konekti/platform-express`**: Express 기반 HTTP 어댑터.
 - **`@konekti/platform-socket.io`**: 공용 Konekti 런타임과 websocket 데코레이터 위에 구축된 Socket.IO v4 게이트웨이 어댑터.
 - **`@konekti/microservices`**: 트랜스포트 추상화, 패턴 데코레이터, 마이크로서비스 런타임.
 - **`@konekti/validation` 패키지**: 유효성 검사 데코레이터, 매핑된 DTO 헬퍼, 검증 엔진.

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -13,6 +13,7 @@ This page provides an overview of the current public package family within the K
 - `@konekti/di`
 - `@konekti/runtime`
 - `@konekti/platform-fastify`
+- `@konekti/platform-express`
 - `@konekti/platform-socket.io`
 - `@konekti/microservices`
 - `@konekti/jwt`
@@ -43,6 +44,7 @@ This page provides an overview of the current public package family within the K
 - **`@konekti/http`**: HTTP execution, binding, exceptions, and route metadata.
 - **`@konekti/runtime`**: Application bootstrap and runtime orchestration.
 - **`@konekti/platform-fastify`**: Fastify-based HTTP adapter.
+- **`@konekti/platform-express`**: Express-based HTTP adapter.
 - **`@konekti/platform-socket.io`**: Socket.IO v4 gateway adapter built on the shared Konekti runtime and websocket decorators.
 - **`@konekti/microservices`**: Transport abstraction, pattern decorators, and microservice runtime.
 - **`@konekti/validation` package**: Validation decorators, mapped DTO helpers, and validation engine.

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -1,0 +1,76 @@
+# @konekti/platform-express
+
+<p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
+
+Konekti 런타임 애플리케이션을 위한 Express 기반 HTTP 어댑터입니다.
+
+## 설치
+
+```bash
+npm install @konekti/platform-express express
+```
+
+## 빠른 시작
+
+```typescript
+import { createExpressAdapter } from '@konekti/platform-express';
+import { KonektiFactory } from '@konekti/runtime';
+
+const app = await KonektiFactory.create(AppModule, {
+  adapter: createExpressAdapter({ port: 3000 }),
+});
+
+await app.listen();
+```
+
+## API
+
+- `createExpressAdapter(options)` - Express `HttpApplicationAdapter`를 생성합니다.
+- `bootstrapExpressApplication(rootModule, options)` - 고급 부트스트랩 헬퍼(암시적 종료 시그널 연결 없음)입니다.
+- `runExpressApplication(rootModule, options)` - 부트스트랩 + 수신(listen) + 시작 로그 + 종료 시그널 연결을 위한 호환 헬퍼입니다.
+
+### 지원 옵션
+
+새 애플리케이션 시작 예시는 `KonektiFactory.create(..., { adapter: createExpressAdapter(...) })`를 우선 사용해야 합니다. `runExpressApplication()` 및 `bootstrapExpressApplication()`은 호환 또는 고급 경로로 유지됩니다.
+
+`runExpressApplication()` 및 `bootstrapExpressApplication()`은 `runNodeApplication()`과 동일한 형태의 런타임 옵션을 지원합니다.
+
+- `rawBody`
+- `multipart`
+- `https`
+- `host`
+- `cors` (`false | string | string[] | CorsOptions`)
+- `shutdownTimeoutMs`
+
+`runExpressApplication()`은 다음 옵션도 지원합니다.
+
+- `shutdownSignals`
+- `forceExitTimeoutMs`
+
+## supported operations
+
+- Express 요청/응답을 `FrameworkRequest` / `FrameworkResponse`로 브리지합니다.
+- 모든 인바운드 요청을 Konekti HTTP 디스패처로 전달합니다.
+- 멀티파트가 아닌 요청에서 `rawBody` 선택(opt-in) 보존을 지원합니다.
+- multipart form-data 파싱과 `UploadedFile[]` 노출을 지원합니다.
+- 시작 재시도(`EADDRINUSE`)와 HTTPS 리스너 옵션을 지원합니다.
+
+## runtime invariants
+
+- multipart 요청에서는 `rawBody`를 채우지 않습니다.
+- 디스패처가 응답을 커밋하지 않으면 어댑터가 빈 페이로드를 전송해 응답을 종료합니다.
+- 시작 로그는 런타임 컨벤션(`Listening on ...`)을 따르며 와일드카드 호스트 바인딩 상세를 포함합니다.
+- 문자열/JSON/바이너리 페이로드 직렬화 동작은 runtime/fastify 어댑터 기대치와 일치합니다.
+
+## lifecycle guarantees
+
+- `close(signal?)`는 graceful shutdown을 수행하고 `shutdownTimeoutMs`를 강제합니다.
+- `runExpressApplication()`에서 기본 `SIGINT` / `SIGTERM` 기반 종료를 지원합니다.
+- `forceExitTimeoutMs`를 설정하면 종료 미완료 시 프로세스를 강제 종료할 수 있습니다.
+
+## intentional limitations
+
+- 이 어댑터는 `@konekti/runtime`를 대체하지 않으며, 부트스트랩/생명주기/DI/종료 소유권은 런타임 패키지에 유지됩니다.
+- Express plugin/middleware passthrough 계층은 제공하지 않으며, 미들웨어/가드/인터셉터는 Konekti 디스패처 계약을 통해 동작합니다.
+- standalone Express 모드는 제공하지 않습니다. 이 어댑터는 런타임 소유 시작 경로를 전제로 합니다.
+- 이 패키지에는 WebSocket upgrade 처리가 포함되지 않습니다.

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -1,0 +1,76 @@
+# @konekti/platform-express
+
+<p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
+
+Express-backed HTTP adapter for Konekti runtime applications.
+
+## Installation
+
+```bash
+npm install @konekti/platform-express express
+```
+
+## Quick Start
+
+```typescript
+import { createExpressAdapter } from '@konekti/platform-express';
+import { KonektiFactory } from '@konekti/runtime';
+
+const app = await KonektiFactory.create(AppModule, {
+  adapter: createExpressAdapter({ port: 3000 }),
+});
+
+await app.listen();
+```
+
+## API
+
+- `createExpressAdapter(options)` - create an Express `HttpApplicationAdapter`
+- `bootstrapExpressApplication(rootModule, options)` - advanced bootstrap helper without implicit shutdown signal wiring
+- `runExpressApplication(rootModule, options)` - compatibility helper for bootstrap + listen + startup logging + shutdown signal wiring
+
+### Supported options
+
+`createExpressAdapter()`, `runExpressApplication()`, and `bootstrapExpressApplication()` all remain supported. New application startup examples should prefer `KonektiFactory.create(..., { adapter: createExpressAdapter(...) })` so the public startup story stays centered on the runtime facade.
+
+`runExpressApplication()` and `bootstrapExpressApplication()` support the same runtime option shapes as `runNodeApplication()` for:
+
+- `rawBody`
+- `multipart`
+- `https`
+- `host`
+- `cors` (`false | string | string[] | CorsOptions`)
+- `shutdownTimeoutMs`
+
+`runExpressApplication()` also supports:
+
+- `shutdownSignals`
+- `forceExitTimeoutMs`
+
+## supported operations
+
+- Bridges Express requests and responses into `FrameworkRequest` / `FrameworkResponse`.
+- Dispatches every incoming request through the Konekti HTTP dispatcher.
+- Supports `rawBody` opt-in for non-multipart requests.
+- Supports multipart form-data parsing and exposes uploaded files as `UploadedFile[]`.
+- Supports startup retry (`EADDRINUSE`) and HTTPS listener options.
+
+## runtime invariants
+
+- `rawBody` is never populated for multipart requests.
+- If the dispatcher does not commit a response, the adapter sends an empty payload to finalize the response.
+- Startup logs follow runtime conventions (`Listening on ...`) and include bind-target detail for wildcard hosts.
+- Response serialization behavior mirrors runtime/fastify adapter expectations for string, JSON, and binary payloads.
+
+## lifecycle guarantees
+
+- `close(signal?)` performs graceful shutdown and enforces `shutdownTimeoutMs`.
+- Signal-driven shutdown (`SIGINT` / `SIGTERM` by default) is supported through `runExpressApplication()`.
+- `forceExitTimeoutMs` can terminate the process when shutdown does not complete in time.
+
+## intentional limitations
+
+- This adapter does not replace `@konekti/runtime`; runtime bootstrap, lifecycle, DI, and shutdown ownership stay in the runtime package.
+- No Express plugin/middleware passthrough layer is provided; middleware/guards/interceptors run through Konekti dispatcher contracts.
+- No standalone Express mode; this adapter is designed for runtime-managed startup.
+- No WebSocket upgrade handling in this package.

--- a/packages/platform-express/package.json
+++ b/packages/platform-express/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@konekti/platform-express",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/konektijs/konekti.git",
+    "directory": "packages/platform-express"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
+    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@konekti/http": "workspace:*",
+    "@konekti/runtime": "workspace:*",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.3"
+  }
+}

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -1,0 +1,831 @@
+import {
+  createServer as createHttpServer,
+  request as httpRequest,
+} from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { createServer as createNetServer } from 'node:net';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  Controller,
+  Get,
+  Post,
+  SseResponse,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  type RequestContext,
+} from '@konekti/http';
+import {
+  createHealthModule,
+  defineModule,
+  type ApplicationLogger,
+} from '@konekti/runtime';
+
+import {
+  bootstrapExpressApplication,
+  createExpressAdapter,
+  ExpressHttpApplicationAdapter,
+  isExpressMultipartTooLargeError,
+  runExpressApplication,
+} from './adapter.js';
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
+async function findAvailablePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createNetServer();
+
+    server.once('error', reject);
+    server.listen(0, () => {
+      const address = server.address();
+
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to resolve an available port.'));
+        return;
+      }
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(address.port);
+      });
+    });
+  });
+}
+
+async function requestHttps(url: string): Promise<{ body: string; statusCode: number }> {
+  return await new Promise((resolve, reject) => {
+    const request = httpsRequest(url, { rejectUnauthorized: false }, (response) => {
+      const chunks: Buffer[] = [];
+
+      response.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      response.on('end', () => {
+        resolve({
+          body: Buffer.concat(chunks).toString('utf8'),
+          statusCode: response.statusCode ?? 0,
+        });
+      });
+      response.on('error', reject);
+    });
+
+    request.on('error', reject);
+    request.end();
+  });
+}
+
+const TEST_TLS_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDBbj6DdMPNvDMr
+yNUM0dreceSBINfH+VDV750R3X57mdoqebUgjKOXjbjR7JRkloJ4PEgAic+840rq
+tyTN/MvmaAQg5OtNwsY7wp3Owaomr0sqw+wHM7NkPYMB0apxcWEBC7IWph1sKGcC
+iRxNDBBMEUmhxscatvhfkB/aqlQxLYjDylFcIX0A3NzIW0Rfaydk7/3R0hqkiF5x
+k/98U2cEPZn1E890q4IsfQ6mGMNi/fh1jMWiR5RFL9MlIhLEJPCyuW/sQMYSglan
+T2sKcABWjIShAc4gn87ncbmSv/6IDgfXtVRD6mehvFz9iHVSbV5sGM/bE4y3pgj2
+kQXpbdUnAgMBAAECggEAT8yIc7kPMmgrACw5YLGOxuhbqb3/51r+s1PIC9/B14IQ
+VCejxsrejp6EGe6tBZZmOu47kiVIk5d9h7mIsIZTJDnTQjLOtGTfXTYb3nldFdqJ
+exoa3JnCr18FFhIGbAinSUQm81sSllVQseYYy9xnOMqFAv27lFTZwKr3yUEtvJ9h
+oYqq5/yRNwwR1AT6lfWgSJa5S9cvs9YHK4k2XCnhKTqWkQ3Bh9awKy83142r1FWy
+rXk3IUwNaNAgRHSEw/9MGbcM6it+l55XjwzEBP/lI+DdDzhRhKgp3QsM/v26eHRl
+CwP0NA4d4i1m2kcT8dvtSTxrnwbylSxhVRDYXrsOMQKBgQDn+f9I9LlQJdGPWRda
+0YiyZtQZTGYfG/ZJvHPvhLA37rAfV7MGDqKgn22FJPJHT9vE+wVkUT531VErKKlO
+dOv6GIz/C3AolVTOTDKxTZnFkicxy4J7pZYHPRo8mIVGFlsKsPQVPz63UZMUkbR6
+0HkgcihnxKKlYFb+az7hNvPZbwKBgQDVdlglrw9jGreXtGplZLapsTmAc+GuL17R
+fqY4/aXNul0k6MNlSrm2/cUm/KI8AsHvRn2tvdFJnM1drmzEpTvcFx5a9N2F5HOU
+N1smlv31RT5B0XqoHTB7df2+zVeAGGcpDY8n27KI9/zigVdVQR/aR+fR7CFfNhCv
+sI8PQUkzyQKBgQDWKHckjEF0m6VuuGoWPvD6+nF+9Ygl2jOyeRdzHUVuLZ5NITK2
+OdargOOkEqrVaQVUQgYFSffou3eW54/+TXT5S6cHYjDmVo6XccMu6pw2yKoEj4Pj
+0MfD4QYSwR/wx3y/TwPXha7JoLavO6Cp7UKV0K46tk8Na/aEJNBFLO1MYwKBgElV
+jfTsTnn6rMYmikLpNcPYieuyY/8GcSnBu/NqWLLz6poKiU5cPK88QaYiNs4tGFlO
+u1CcHLGQeBFOIjnwlj8HhjszUoN0N6zc06jPSNIhhsDv6Zal6IkRwSnyu7PbLl2x
+NdQ4qv5ZS/y4+LrmU74W4/J/j/t4xITHQG66PB7ZAoGANNL4daB3T46IElDHnCbl
+j4hWQezWEMRCf4Ruqy24peC4Y8CXMaGA0oN6auePuTdLmGYa9nDn0J77rMqLIG7+
+v8OLobYRGfklwPOBs5puVFTEgihMq7Ejh2r9HhoRiCAZS5hIirS08BgrAskgVw9P
+dM+3fSZauOH3r+7JXAvrtMo=
+-----END PRIVATE KEY-----`;
+
+const TEST_TLS_CERTIFICATE = `-----BEGIN CERTIFICATE-----
+MIICpDCCAYwCCQCAEWnETUdMHDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAkx
+MjcuMC4wLjEwHhcNMjYwMzE4MDEzNTQ2WhcNMjYwMzE5MDEzNTQ2WjAUMRIwEAYD
+VQQDDAkxMjcuMC4wLjEwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDB
+bj6DdMPNvDMryNUM0dreceSBINfH+VDV750R3X57mdoqebUgjKOXjbjR7JRkloJ4
+PEgAic+840rqtyTN/MvmaAQg5OtNwsY7wp3Owaomr0sqw+wHM7NkPYMB0apxcWEB
+C7IWph1sKGcCiRxNDBBMEUmhxscatvhfkB/aqlQxLYjDylFcIX0A3NzIW0Rfaydk
+7/3R0hqkiF5xk/98U2cEPZn1E890q4IsfQ6mGMNi/fh1jMWiR5RFL9MlIhLEJPCy
+uW/sQMYSglanT2sKcABWjIShAc4gn87ncbmSv/6IDgfXtVRD6mehvFz9iHVSbV5s
+GM/bE4y3pgj2kQXpbdUnAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJhOoDgzUsiV
+XE0p5DznahRbv85K05BS6iXfMRnjgHziJyED0h6dD3vpFTnQLW9I7SQeMA21sZPx
+MNm+gL8/Jq2G2CGwx0naD9bsTFYboWhBk+SuQVj8f7g8xM7ya2nB8AJg07/n3VD5
+NJFlJnyXlpchaxikKeaLWWGJCzPosbqUDdS5Y9S3VkqxM3na4Z+04qLaLQSEEpSi
+WZWkDdOMceoMbJC0CpyVtWCW7mKKFOwL/yEtmJ0Uw0aaHwFOEj9+FQUPYjThCcbz
+fHFvqyh6pXZV7XKcPxCTNuIw2rpw2WqY5/H+lTmUFmSXieFZAAMRueGH8Y5trCHU
+JNCDpGwh8us=
+-----END CERTIFICATE-----`;
+
+describe('@konekti/platform-express', () => {
+  it('uses the runtime default port instead of process.env.PORT', async () => {
+    const previousPort = process.env.PORT;
+    process.env.PORT = '4321';
+
+    try {
+      const adapter = createExpressAdapter() as ExpressHttpApplicationAdapter;
+
+      expect(adapter.getListenTarget().url).toBe('http://localhost:3000');
+      await adapter.close();
+    } finally {
+      if (previousPort === undefined) {
+        delete process.env.PORT;
+      } else {
+        process.env.PORT = previousPort;
+      }
+    }
+  });
+
+  it('does not fail when process.env.PORT is invalid', async () => {
+    const previousPort = process.env.PORT;
+    process.env.PORT = 'not-a-number';
+
+    try {
+      const adapter = createExpressAdapter() as ExpressHttpApplicationAdapter;
+
+      expect(adapter.getListenTarget().url).toBe('http://localhost:3000');
+      await adapter.close();
+    } finally {
+      if (previousPort === undefined) {
+        delete process.env.PORT;
+      } else {
+        process.env.PORT = previousPort;
+      }
+    }
+  });
+
+  it('preserves raw body for JSON and text requests when enabled', async () => {
+    @Controller('/webhooks')
+    class WebhookController {
+      @Post('/json')
+      handleJson(_input: undefined, context: RequestContext) {
+        return {
+          parsed: context.request.body,
+          raw: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('utf8'),
+        };
+      }
+
+      @Post('/text')
+      handleText(_input: undefined, context: RequestContext) {
+        return {
+          parsed: context.request.body,
+          raw: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('utf8'),
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [WebhookController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      port,
+      rawBody: true,
+    });
+
+    await app.listen();
+
+    const [jsonResponse, textResponse] = await Promise.all([
+      fetch(`http://127.0.0.1:${String(port)}/webhooks/json`, {
+        body: JSON.stringify({ provider: 'stripe' }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      }),
+      fetch(`http://127.0.0.1:${String(port)}/webhooks/text`, {
+        body: 'ping=1',
+        headers: { 'content-type': 'text/plain; charset=utf-8' },
+        method: 'POST',
+      }),
+    ]);
+
+    expect(jsonResponse.status).toBe(201);
+    await expect(jsonResponse.json()).resolves.toEqual({
+      parsed: { provider: 'stripe' },
+      raw: '{"provider":"stripe"}',
+    });
+
+    expect(textResponse.status).toBe(201);
+    await expect(textResponse.json()).resolves.toEqual({
+      parsed: 'ping=1',
+      raw: 'ping=1',
+    });
+
+    await app.close();
+  });
+
+  it('does not preserve rawBody for multipart requests', async () => {
+    @Controller('/uploads')
+    class UploadController {
+      @Post('/')
+      upload(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+          fileCount: context.request.files?.length ?? 0,
+          hasRawBody: context.request.rawBody !== undefined,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UploadController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      port,
+      rawBody: true,
+    });
+
+    await app.listen();
+
+    const form = new FormData();
+    form.set('name', 'Ada');
+    form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+      body: form,
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      body: { name: 'Ada' },
+      fileCount: 1,
+      hasRawBody: false,
+    });
+
+    await app.close();
+  });
+
+  it('accepts a cors string and merges framework defaults', async () => {
+    @Controller('/ping')
+    class PingController {
+      @Get('/')
+      ping() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [PingController] });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: 'https://my-frontend.com',
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/ping`, {
+      headers: { origin: 'https://my-frontend.com' },
+    });
+
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://my-frontend.com');
+    expect(response.headers.get('access-control-allow-headers')).toContain('Authorization');
+    expect(response.headers.get('access-control-expose-headers')).toContain('X-Request-Id');
+
+    await app.close();
+  });
+
+  it('reports the configured host in startup logs', async () => {
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message: string, error: unknown, context?: string) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
+      },
+      log(message: string, context?: string) {
+        loggerEvents.push(`log:${context}:${message}`);
+      },
+      warn() {},
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await runExpressApplication(AppModule, {
+      cors: false,
+      host: '127.0.0.1',
+      logger,
+      port,
+    });
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/health`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(loggerEvents).toContain(`log:KonektiFactory:Listening on http://127.0.0.1:${String(port)}`);
+
+    await app.close();
+  });
+
+  it('removes registered shutdown signal listeners after close', async () => {
+    const logger: ApplicationLogger = {
+      debug() {},
+      error() {},
+      log() {},
+      warn() {},
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const signal = 'SIGTERM' as const;
+    const listenersBefore = process.listeners(signal).length;
+    const port = await findAvailablePort();
+    const app = await runExpressApplication(AppModule, {
+      cors: false,
+      logger,
+      port,
+      shutdownSignals: [signal],
+    });
+
+    expect(process.listeners(signal).length).toBe(listenersBefore + 1);
+
+    await app.close();
+
+    expect(process.listeners(signal).length).toBe(listenersBefore);
+  });
+
+  it('does not leak global-prefix path rewrites to request observers', async () => {
+    const observedPaths: string[] = [];
+
+    class PathObserver {
+      onRequestFinish(context: { requestContext: { request: FrameworkRequest } }) {
+        observedPaths.push(context.requestContext.request.path);
+      }
+    }
+
+    @Controller('/app')
+    class AppController {
+      @Get('/info')
+      getInfo() {
+        return { ok: true, route: 'app-info' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [AppController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      globalPrefix: '/api',
+      observers: [new PathObserver()],
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/api/app/info`);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, route: 'app-info' });
+    expect(observedPaths).toEqual(['/api/app/info']);
+
+    await app.close();
+  });
+
+  it('applies a global prefix to runtime-owned paths by default', async () => {
+    const HealthModule = createHealthModule();
+
+    @Controller('/app')
+    class AppController {
+      @Get('/info')
+      getInfo() {
+        return { ok: true, route: 'app-info' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [AppController],
+      imports: [HealthModule],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      globalPrefix: '/api',
+      port,
+    });
+
+    await app.listen();
+
+    const [prefixedApp, prefixedHealth, health] = await Promise.all([
+      fetch(`http://127.0.0.1:${String(port)}/api/app/info`),
+      fetch(`http://127.0.0.1:${String(port)}/api/health`),
+      fetch(`http://127.0.0.1:${String(port)}/health`),
+    ]);
+
+    expect(prefixedApp.status).toBe(200);
+    await expect(prefixedApp.json()).resolves.toEqual({ ok: true, route: 'app-info' });
+    expect(prefixedHealth.status).toBe(200);
+    await expect(prefixedHealth.json()).resolves.toEqual({ status: 'ok' });
+    expect(health.status).toBe(404);
+
+    await app.close();
+  });
+
+  it('supports SSE streaming', async () => {
+    @Controller('/events')
+    class EventsController {
+      @Get('/')
+      stream(_input: undefined, context: RequestContext) {
+        const stream = new SseResponse(context);
+
+        stream.comment('connected');
+        stream.send({ ready: true }, { event: 'ready', id: 'evt-1' });
+        setTimeout(() => {
+          stream.close();
+        }, 10);
+
+        return stream;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [EventsController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/events`, {
+      headers: { accept: 'text/event-stream' },
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/event-stream');
+    expect(body).toContain('event: ready');
+    expect(body).toContain('data: {"ready":true}');
+
+    await app.close();
+  });
+
+  it('supports https startup and reports the https listen URL', async () => {
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message: string, error: unknown, context?: string) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
+      },
+      log(message: string, context?: string) {
+        loggerEvents.push(`log:${context}:${message}`);
+      },
+      warn() {},
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await runExpressApplication(AppModule, {
+      cors: false,
+      host: '127.0.0.1',
+      https: {
+        cert: TEST_TLS_CERTIFICATE,
+        key: TEST_TLS_PRIVATE_KEY,
+      },
+      logger,
+      port,
+    });
+
+    const response = await requestHttps(`https://127.0.0.1:${String(port)}/health`);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({ ok: true });
+    expect(loggerEvents).toContain(`log:KonektiFactory:Listening on https://127.0.0.1:${String(port)}`);
+
+    await app.close();
+  });
+
+  it('keeps dispatcher until express close settles even when close() times out', async () => {
+    const adapter = new ExpressHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
+    const dispatcher = {
+      async dispatch() {},
+    };
+    const deferred = createDeferred<void>();
+    let closeCallCount = 0;
+    const server = {
+      close(callback: (error?: Error | null) => void) {
+        closeCallCount += 1;
+        void deferred.promise.then(() => {
+          callback(undefined);
+        });
+        return this;
+      },
+      listening: true,
+    } as unknown as ReturnType<typeof createHttpServer>;
+
+    Reflect.set(adapter, 'server', server);
+    Reflect.set(adapter, 'dispatcher', dispatcher);
+
+    await expect(adapter.close()).rejects.toThrow(/shutdown timeout/i);
+
+    expect(closeCallCount).toBe(1);
+    expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
+
+    deferred.resolve();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
+  });
+
+  it('fails close() when the express server does not stop within the shutdown timeout', async () => {
+    const adapter = new ExpressHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
+    const server = {
+      close(_callback: (error?: Error | null) => void) {
+        return this;
+      },
+      listening: true,
+    } as unknown as ReturnType<typeof createHttpServer>;
+
+    Reflect.set(adapter, 'server', server);
+    Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
+
+    await expect(adapter.close()).rejects.toThrow(/shutdown timeout/i);
+  });
+
+  it('retries startup after EADDRINUSE until the port becomes available', async () => {
+    const blocker = createHttpServer((_request, response) => {
+      response.statusCode = 200;
+      response.end('blocked');
+    });
+    const port = await findAvailablePort();
+
+    await new Promise<void>((resolve, reject) => {
+      blocker.once('error', reject);
+      blocker.listen({ host: '127.0.0.1', port }, () => {
+        resolve();
+      });
+    });
+
+    const closeBlocker = async (): Promise<void> => {
+      if (!blocker.listening) {
+        return;
+      }
+
+      await new Promise<void>((resolve) => {
+        blocker.close(() => {
+          resolve();
+        });
+      });
+    };
+
+    const adapter = new ExpressHttpApplicationAdapter(3000, '127.0.0.1', 20, 20, undefined, undefined, 1024, false, 1_000);
+    const dispatcher = {
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        response.setStatus(200);
+        await response.send({ ok: true });
+      },
+    };
+
+    try {
+      const listenPromise = adapter.listen(dispatcher);
+
+      setTimeout(() => {
+        void closeBlocker();
+      }, 80);
+
+      await listenPromise;
+
+      const response = await fetch('http://127.0.0.1:3000/retry-check');
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true });
+
+      await adapter.close();
+    } finally {
+      await closeBlocker();
+    }
+  });
+
+  it('forces process exit when signal-driven shutdown exceeds forceExitTimeoutMs', async () => {
+    vi.useFakeTimers();
+
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message: string, error: unknown, context?: string) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
+      },
+      log(message: string, context?: string) {
+        loggerEvents.push(`log:${context}:${message}`);
+      },
+      warn() {},
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const originalExitCode = process.exitCode;
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => undefined as never) as typeof process.exit);
+    const port = await findAvailablePort();
+    const app = await runExpressApplication(AppModule, {
+      cors: false,
+      forceExitTimeoutMs: 25,
+      logger,
+      port,
+      shutdownSignals: ['SIGTERM'],
+    });
+
+    const originalClose = app.close.bind(app);
+    app.close = () => new Promise<void>(() => {});
+
+    try {
+      process.emit('SIGTERM', 'SIGTERM');
+      await vi.advanceTimersByTimeAsync(26);
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(loggerEvents).toContain('error:KonektiFactory:Forced exit after 25ms shutdown timeout.:none');
+    } finally {
+      app.close = originalClose;
+      await app.close();
+      exitSpy.mockRestore();
+      process.exitCode = originalExitCode;
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps malformed cookie values instead of failing the request', async () => {
+    @Controller('/cookies')
+    class CookieController {
+      @Get('/')
+      readCookies(_input: undefined, context: RequestContext) {
+        return context.request.cookies;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [CookieController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/cookies`, {
+      headers: {
+        cookie: 'good=hello%20world; bad=%E0%A4%A',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      bad: '%E0%A4%A',
+      good: 'hello world',
+    });
+
+    await app.close();
+  });
+
+  it('classifies only explicit multipart limit errors as payload-too-large', () => {
+    expect(isExpressMultipartTooLargeError(Object.assign(new Error('File too large'), { statusCode: 413 }))).toBe(true);
+    expect(isExpressMultipartTooLargeError(Object.assign(new Error('Multipart boundary is invalid'), {
+      code: 'MULTIPART_PARSE_FAILED',
+      statusCode: 400,
+    }))).toBe(false);
+  });
+
+  it('propagates abort signal when the client disconnects', async () => {
+    const aborted = createDeferred<void>();
+
+    @Controller('/abort')
+    class AbortController {
+      @Get('/')
+      async wait(_input: undefined, context: RequestContext) {
+        await new Promise<void>((resolve) => {
+          context.request.signal?.addEventListener('abort', () => {
+            aborted.resolve();
+            resolve();
+          }, { once: true });
+        });
+
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [AbortController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const request = httpRequest({
+      host: '127.0.0.1',
+      method: 'GET',
+      path: '/abort',
+      port,
+    });
+    request.on('error', () => {});
+    request.end();
+
+    setTimeout(() => {
+      request.destroy();
+    }, 20);
+
+    await expect(Promise.race([
+      aborted.promise,
+      new Promise<void>((_resolve, reject) => {
+        setTimeout(() => {
+          reject(new Error('Abort signal was not propagated.'));
+        }, 2_000);
+      }),
+    ])).resolves.toBeUndefined();
+
+    await app.close();
+  });
+});

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -1,0 +1,1108 @@
+import type {
+  IncomingHttpHeaders,
+  IncomingMessage,
+  ServerResponse,
+} from 'node:http';
+import { createServer as createHttpServer } from 'node:http';
+import {
+  createServer as createHttpsServer,
+  type ServerOptions as HttpsServerOptions,
+} from 'node:https';
+import type { AddressInfo, Socket } from 'node:net';
+import { URL } from 'node:url';
+
+import express, {
+  type Express,
+  type Request as ExpressRequest,
+  type Response as ExpressResponse,
+} from 'express';
+
+import {
+  BadRequestException,
+  createCorsMiddleware,
+  createErrorResponse,
+  createSecurityHeadersMiddleware,
+  HttpException,
+  InternalServerErrorException,
+  matchRoutePattern,
+  normalizeRoutePattern,
+  NotFoundException,
+  PayloadTooLargeException,
+  type CorsOptions,
+  type Dispatcher,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  type HttpApplicationAdapter,
+  type MiddlewareContext,
+  type MiddlewareLike,
+  type Next,
+  type SecurityHeadersOptions,
+} from '@konekti/http';
+import {
+  bootstrapApplication,
+  createConsoleApplicationLogger,
+  parseMultipart,
+  type Application,
+  type ApplicationLogger,
+  type CreateApplicationOptions,
+  type ModuleType,
+  type MultipartOptions,
+  type UploadedFile,
+} from '@konekti/runtime';
+
+declare module '@konekti/http' {
+  interface FrameworkRequest {
+    files?: UploadedFile[];
+    rawBody?: Uint8Array;
+  }
+}
+
+export interface ExpressAdapterOptions {
+  host?: string;
+  https?: HttpsServerOptions;
+  maxBodySize?: number;
+  port?: number;
+  rawBody?: boolean;
+  retryDelayMs?: number;
+  retryLimit?: number;
+  shutdownTimeoutMs?: number;
+}
+
+export type ExpressApplicationSignal = 'SIGINT' | 'SIGTERM';
+export type CorsInput = false | string | string[] | CorsOptions;
+
+const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+
+export interface BootstrapExpressApplicationOptions extends Omit<CreateApplicationOptions, 'adapter' | 'logger' | 'middleware'> {
+  cors?: CorsInput;
+  globalPrefix?: string;
+  globalPrefixExclude?: readonly string[];
+  host?: string;
+  https?: HttpsServerOptions;
+  logger?: ApplicationLogger;
+  maxBodySize?: number;
+  middleware?: MiddlewareLike[];
+  multipart?: MultipartOptions;
+  port?: number;
+  rawBody?: boolean;
+  retryDelayMs?: number;
+  retryLimit?: number;
+  securityHeaders?: false | SecurityHeadersOptions;
+  shutdownTimeoutMs?: number;
+}
+
+export interface RunExpressApplicationOptions extends BootstrapExpressApplicationOptions {
+  forceExitTimeoutMs?: number;
+  shutdownSignals?: false | readonly ExpressApplicationSignal[];
+}
+
+interface ExpressListenTarget {
+  bindTarget: string;
+  url: string;
+}
+
+type ExpressServer = ReturnType<typeof createHttpServer> | ReturnType<typeof createHttpsServer>;
+
+type ExpressFrameworkResponse = FrameworkResponse & {
+  raw: ExpressResponse;
+  statusSet?: boolean;
+};
+
+type ExpressMultipartLikeError = Error & {
+  code?: unknown;
+  status?: unknown;
+  statusCode?: unknown;
+  type?: unknown;
+};
+
+export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
+  private closeInFlight?: Promise<void>;
+  private dispatcher?: Dispatcher;
+  private readonly app: Express;
+  private readonly server: ExpressServer;
+  private readonly sockets = new Set<Socket>();
+
+  constructor(
+    private readonly port: number,
+    private readonly host: string | undefined,
+    private readonly retryDelayMs = 150,
+    private readonly retryLimit = 20,
+    private readonly httpsOptions: HttpsServerOptions | undefined,
+    private readonly multipartOptions?: MultipartOptions,
+    private readonly maxBodySize = DEFAULT_MAX_BODY_SIZE,
+    private readonly preserveRawBody = false,
+    private readonly shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
+  ) {
+    this.app = express();
+    this.server = createExpressServer(this.httpsOptions, this.app);
+    this.app.use((request: ExpressRequest, response: ExpressResponse) => {
+      void this.handleRequest(request, response);
+    });
+    this.server.on('connection', (socket) => {
+      this.sockets.add(socket);
+      socket.once('close', () => {
+        this.sockets.delete(socket);
+      });
+    });
+  }
+
+  getServer(): unknown {
+    return this.server;
+  }
+
+  getListenTarget(): ExpressListenTarget {
+    return resolveListenTarget(this.server.address() ?? null, this.port, this.host, this.httpsOptions !== undefined);
+  }
+
+  async listen(dispatcher: Dispatcher): Promise<void> {
+    this.dispatcher = dispatcher;
+    await this.listenWithRetry();
+  }
+
+  async close(): Promise<void> {
+    if (!this.server.listening) {
+      this.dispatcher = undefined;
+      return;
+    }
+
+    if (!this.closeInFlight) {
+      const closePromise = closeServerWithDrain(this.server, this.sockets, this.shutdownTimeoutMs);
+      const closeInFlight = closePromise.finally(() => {
+        this.closeInFlight = undefined;
+        this.dispatcher = undefined;
+      });
+      this.closeInFlight = closeInFlight;
+      void closeInFlight.catch(() => {});
+    }
+
+    const closeInFlight = this.closeInFlight;
+
+    if (!closeInFlight) {
+      return;
+    }
+
+    await waitForCloseWithTimeout(closeInFlight, this.shutdownTimeoutMs);
+  }
+
+  private async listenWithRetry(): Promise<void> {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await listenServer(this.server, this.port, this.host);
+        return;
+      } catch (error: unknown) {
+        if (!isAddressInUseError(error) || attempt >= this.retryLimit) {
+          throw error;
+        }
+
+        await closeServerSilently(this.server);
+        await delay(this.retryDelayMs);
+      }
+    }
+  }
+
+  private async handleRequest(request: ExpressRequest, response: ExpressResponse): Promise<void> {
+    const frameworkResponse = createFrameworkResponse(response);
+    const signal = createRequestSignal(response);
+
+    try {
+      await this.dispatchRequest(request, signal, frameworkResponse);
+    } catch (error: unknown) {
+      await this.handleRequestError(error, request, signal, frameworkResponse);
+    }
+  }
+
+  private async dispatchRequest(
+    request: ExpressRequest,
+    signal: AbortSignal,
+    frameworkResponse: ExpressFrameworkResponse,
+  ): Promise<void> {
+    const frameworkRequest = await createFrameworkRequest(
+      request,
+      signal,
+      this.multipartOptions,
+      this.maxBodySize,
+      this.preserveRawBody,
+    );
+
+    const dispatcher = this.dispatcher;
+
+    if (!dispatcher) {
+      throw new Error('Express adapter received a request before dispatcher binding completed.');
+    }
+
+    await dispatcher.dispatch(frameworkRequest, frameworkResponse);
+
+    if (!frameworkResponse.committed) {
+      await frameworkResponse.send(undefined);
+    }
+  }
+
+  private async handleRequestError(
+    error: unknown,
+    request: ExpressRequest,
+    signal: AbortSignal,
+    frameworkResponse: ExpressFrameworkResponse,
+  ): Promise<void> {
+    if (signal.aborted || frameworkResponse.committed) {
+      return;
+    }
+
+    const requestId = resolveRequestIdFromHeaders(request.headers);
+    const httpError = toHttpException(error);
+    frameworkResponse.setStatus(httpError.status);
+    await frameworkResponse.send(createErrorResponse(httpError, requestId));
+  }
+}
+
+export function createExpressAdapter(
+  options: ExpressAdapterOptions = {},
+  multipartOptions?: MultipartOptions,
+): HttpApplicationAdapter {
+  return new ExpressHttpApplicationAdapter(
+    resolvePort(options.port),
+    options.host,
+    options.retryDelayMs,
+    options.retryLimit,
+    options.https,
+    multipartOptions,
+    options.maxBodySize,
+    options.rawBody,
+    options.shutdownTimeoutMs,
+  );
+}
+
+export async function bootstrapExpressApplication(
+  rootModule: ModuleType,
+  options: BootstrapExpressApplicationOptions,
+): Promise<Application> {
+  const logger = options.logger ?? createConsoleApplicationLogger();
+
+  return bootstrapApplication({
+    ...options,
+    adapter: createExpressAdapter(options, options.multipart),
+    logger,
+    middleware: createExpressMiddleware(options),
+    rootModule,
+  });
+}
+
+export async function runExpressApplication(
+  rootModule: ModuleType,
+  options: RunExpressApplicationOptions,
+): Promise<Application> {
+  const logger = options.logger ?? createConsoleApplicationLogger();
+  const adapter = createExpressAdapter(options, options.multipart) as ExpressHttpApplicationAdapter;
+  const app = await bootstrapApplication({
+    ...options,
+    adapter,
+    logger,
+    middleware: createExpressMiddleware(options),
+    rootModule,
+  });
+
+  try {
+    await app.listen();
+    logger.log(formatListenMessage(adapter.getListenTarget()), 'KonektiFactory');
+  } catch (error: unknown) {
+    logger.error('Failed to start application.', error, 'KonektiFactory');
+
+    if (app.state !== 'closed') {
+      try {
+        await app.close('bootstrap-failed');
+      } catch (closeError) {
+        logger.error('Failed to close application after startup failure.', closeError, 'KonektiFactory');
+      }
+    }
+
+    throw error;
+  }
+
+  const unregisterShutdownSignals = registerShutdownSignals(
+    app,
+    logger,
+    options.shutdownSignals ?? defaultShutdownSignals(),
+    options.forceExitTimeoutMs,
+  );
+  const close = app.close.bind(app);
+  let shutdownSignalsUnregistered = false;
+
+  app.close = async (signal?: string) => {
+    if (!shutdownSignalsUnregistered) {
+      unregisterShutdownSignals();
+      shutdownSignalsUnregistered = true;
+    }
+
+    await close(signal);
+  };
+
+  return app;
+}
+
+function createFrameworkResponse(response: ExpressResponse): ExpressFrameworkResponse {
+  return {
+    committed: response.headersSent || response.writableEnded,
+    headers: {},
+    raw: response,
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+      response.redirect(status, location);
+    },
+    async send(body: unknown) {
+      if (response.writableEnded) {
+        this.committed = true;
+        return;
+      }
+
+      const existingContentType = response.getHeader('content-type');
+      const serialized = serializeResponseBody(body, typeof existingContentType === 'string' ? existingContentType : undefined);
+
+      if (!response.hasHeader('content-type') && serialized.defaultContentType) {
+        response.setHeader('content-type', serialized.defaultContentType);
+      }
+
+      this.committed = true;
+      response.send(serialized.payload);
+    },
+    setHeader(name: string, value: string | string[]) {
+      const lowerName = name.toLowerCase();
+
+      if (lowerName === 'set-cookie') {
+        const merged = mergeSetCookieHeader(response.getHeader(name), value);
+        response.setHeader(name, merged);
+        this.headers[name] = merged;
+        return;
+      }
+
+      response.setHeader(name, value);
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      response.status(code);
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+async function createFrameworkRequest(
+  request: ExpressRequest,
+  signal: AbortSignal,
+  multipartOptions?: MultipartOptions,
+  maxBodySize = DEFAULT_MAX_BODY_SIZE,
+  preserveRawBody = false,
+): Promise<FrameworkRequest> {
+  const rawUrl = request.originalUrl || request.url || '/';
+  const url = new URL(rawUrl, 'http://localhost');
+  const headers = normalizeHeaders(request.headers);
+  const contentType = readPrimaryHeaderValue(headers['content-type']);
+  const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
+
+  let body: unknown;
+  let files: UploadedFile[] | undefined;
+  let rawBody: Uint8Array | undefined;
+
+  if (isMultipart) {
+    const parsed = await parseMultipartRequest(request, multipartOptions);
+    body = parsed.fields;
+    files = parsed.files;
+  } else {
+    const bodyResult = await readRequestBody(request, headers['content-type'], maxBodySize, preserveRawBody);
+    body = bodyResult.body;
+    rawBody = bodyResult.rawBody;
+  }
+
+  const frameworkRequest: FrameworkRequest & { files?: UploadedFile[]; rawBody?: Uint8Array } = {
+    body,
+    cookies: parseCookieHeader(Array.isArray(headers.cookie) ? headers.cookie[0] : headers.cookie),
+    headers,
+    method: request.method,
+    params: {},
+    path: url.pathname,
+    query: parseQueryParams(url.searchParams),
+    raw: request,
+    signal,
+    url: url.pathname + url.search,
+  };
+
+  if (files) {
+    frameworkRequest.files = files;
+  }
+
+  if (rawBody) {
+    frameworkRequest.rawBody = rawBody;
+  }
+
+  return frameworkRequest;
+}
+
+async function parseMultipartRequest(
+  request: IncomingMessage,
+  options: MultipartOptions = {},
+): Promise<{ fields: Record<string, string | string[]>; files: UploadedFile[] }> {
+  try {
+    return await parseMultipart(request, options);
+  } catch (error: unknown) {
+    if (isExpressMultipartTooLargeError(error)) {
+      if (error instanceof PayloadTooLargeException) {
+        throw error;
+      }
+
+      throw new PayloadTooLargeException('Request body exceeds the configured multipart limits.');
+    }
+
+    throw error;
+  }
+}
+
+export function isExpressMultipartTooLargeError(error: unknown): boolean {
+  if (error instanceof PayloadTooLargeException) {
+    return true;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const candidate = error as ExpressMultipartLikeError;
+
+  if (candidate.statusCode === 413 || candidate.status === 413) {
+    return true;
+  }
+
+  if (typeof candidate.code === 'string' && /LIMIT|TOO_LARGE|ENTITY_TOO_LARGE|FILE_TOO_LARGE/i.test(candidate.code)) {
+    return true;
+  }
+
+  if (typeof candidate.type === 'string' && candidate.type.toLowerCase() === 'entity.too.large') {
+    return true;
+  }
+
+  return error.message.toLowerCase().includes('too large');
+}
+
+function normalizeHeaders(headers: IncomingHttpHeaders): Record<string, string | string[] | undefined> {
+  const normalized: Record<string, string | string[] | undefined> = {};
+
+  for (const [name, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      normalized[name] = value;
+      continue;
+    }
+
+    if (typeof value === 'number') {
+      normalized[name] = String(value);
+      continue;
+    }
+
+    if (typeof value === 'string' || value === undefined) {
+      normalized[name] = value;
+      continue;
+    }
+
+    normalized[name] = String(value);
+  }
+
+  return normalized;
+}
+
+function parseQueryParams(searchParams: URLSearchParams): Record<string, string | string[]> {
+  const query: Record<string, string | string[]> = {};
+
+  for (const [key, value] of searchParams.entries()) {
+    const current = query[key];
+
+    if (current === undefined) {
+      query[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(current)) {
+      current.push(value);
+      continue;
+    }
+
+    query[key] = [current, value];
+  }
+
+  return query;
+}
+
+function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    cookieHeader
+      .split(';')
+      .map((pair) => pair.trim())
+      .filter(Boolean)
+      .map((pair) => {
+        const index = pair.indexOf('=');
+
+        if (index === -1) {
+          return [pair.trim(), ''] as [string, string];
+        }
+
+        const rawValue = pair.slice(index + 1).trim();
+
+        try {
+          return [pair.slice(0, index).trim(), decodeURIComponent(rawValue)] as [string, string];
+        } catch {
+          return [pair.slice(0, index).trim(), rawValue] as [string, string];
+        }
+      }),
+  );
+}
+
+function createRequestSignal(response: ServerResponse): AbortSignal {
+  const controller = new AbortController();
+  const abort = (reason: string) => {
+    if (!controller.signal.aborted) {
+      controller.abort(new Error(reason));
+    }
+  };
+
+  response.once('close', () => {
+    if (!response.writableEnded) {
+      abort('Response closed before response commit.');
+    }
+  });
+
+  return controller.signal;
+}
+
+function resolveRequestIdFromHeaders(headers: IncomingHttpHeaders): string | undefined {
+  const requestId = headers['x-request-id'] ?? headers['x-correlation-id'];
+  return Array.isArray(requestId) ? requestId[0] : requestId;
+}
+
+function createExpressMiddleware(options: BootstrapExpressApplicationOptions): MiddlewareLike[] {
+  const middleware = [...(options.middleware ?? [])];
+
+  if (options.securityHeaders !== false) {
+    middleware.unshift(createSecurityHeadersMiddleware(
+      typeof options.securityHeaders === 'object' ? options.securityHeaders : undefined,
+    ));
+  }
+
+  if (options.globalPrefix) {
+    middleware.unshift(createGlobalPrefixMiddleware(options.globalPrefix, options.globalPrefixExclude));
+  }
+
+  if (options.cors !== undefined && options.cors !== false) {
+    const defaultCorsOptions: CorsOptions = {
+      allowHeaders: ['Authorization', 'Content-Type'],
+      exposeHeaders: ['X-Request-Id'],
+    };
+    middleware.unshift(createCorsMiddleware(resolveCorsOptions(options.cors, defaultCorsOptions)));
+  }
+
+  return middleware;
+}
+
+function createGlobalPrefixMiddleware(prefix: string, exclude: readonly string[] | undefined): MiddlewareLike {
+  const normalizedPrefix = normalizeRoutePattern(prefix);
+
+  if (normalizedPrefix === '/') {
+    return {
+      async handle(_context: MiddlewareContext, next: Next) {
+        await next();
+      },
+    };
+  }
+
+  const exclusions = [...(exclude ?? [])].map((path) => normalizeRoutePattern(path));
+
+  return {
+    async handle(context: MiddlewareContext, next: Next) {
+      const requestPath = normalizeRoutePattern(context.request.path);
+
+      if (matchesExcludedPath(requestPath, exclusions)) {
+        await next();
+        return;
+      }
+
+      if (shouldRejectGlobalPrefixRequest(requestPath, normalizedPrefix, exclusions)) {
+        await writeGlobalPrefixNotFound(context.requestContext.requestId, context.response);
+        return;
+      }
+
+      const strippedPath = stripGlobalPrefix(requestPath, normalizedPrefix);
+      context.request = rewriteGlobalPrefixRequest(context.request, requestPath, strippedPath);
+      await next();
+    },
+  };
+}
+
+function shouldRejectGlobalPrefixRequest(
+  requestPath: string,
+  normalizedPrefix: string,
+  exclusions: readonly string[],
+): boolean {
+  if (!matchesPrefix(requestPath, normalizedPrefix)) {
+    return true;
+  }
+
+  return matchesExcludedPath(stripGlobalPrefix(requestPath, normalizedPrefix), exclusions);
+}
+
+function rewriteGlobalPrefixRequest(
+  request: MiddlewareContext['request'],
+  requestPath: string,
+  strippedPath: string,
+): MiddlewareContext['request'] {
+  return {
+    ...request,
+    path: strippedPath,
+    url: rewritePrefixedUrl(request.url, requestPath, strippedPath),
+  };
+}
+
+function resolveCorsOptions(cors: Exclude<CorsInput, false> | undefined, defaults: CorsOptions): CorsOptions {
+  if (cors === undefined) {
+    return defaults;
+  }
+
+  if (typeof cors === 'string' || Array.isArray(cors)) {
+    return { ...defaults, allowOrigin: cors };
+  }
+
+  return { ...defaults, ...cors };
+}
+
+function writeGlobalPrefixNotFound(requestId: string | undefined, response: FrameworkResponse): Promise<void> {
+  const error = new NotFoundException('Resource not found.');
+  response.setStatus(error.status);
+  return Promise.resolve(response.send(createErrorResponse(error, requestId)));
+}
+
+function matchesPrefix(path: string, prefix: string): boolean {
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+
+function stripGlobalPrefix(path: string, prefix: string): string {
+  if (path === prefix) {
+    return '/';
+  }
+
+  return normalizeRoutePattern(path.slice(prefix.length));
+}
+
+function matchesExcludedPath(path: string, exclusions: readonly string[]): boolean {
+  return exclusions.some((pattern) => matchRoutePattern(pattern, path));
+}
+
+function rewritePrefixedUrl(url: string, originalPath: string, rewrittenPath: string): string {
+  if (!url.startsWith(originalPath)) {
+    return rewrittenPath;
+  }
+
+  return rewrittenPath + url.slice(originalPath.length);
+}
+
+function formatListenMessage(target: ExpressListenTarget): string {
+  return target.url.endsWith(target.bindTarget)
+    ? `Listening on ${target.url}`
+    : `Listening on ${target.url} (bound to ${target.bindTarget})`;
+}
+
+function createExpressServer(httpsOptions: HttpsServerOptions | undefined, app: Express): ExpressServer {
+  return httpsOptions ? createHttpsServer(httpsOptions, app) : createHttpServer(app);
+}
+
+function resolveListenTarget(
+  address: AddressInfo | string | null,
+  port: number,
+  host: string | undefined,
+  useHttps: boolean,
+): ExpressListenTarget {
+  const protocol = useHttps ? 'https' : 'http';
+  const resolvedPort = typeof address === 'object' && address !== null ? address.port : port;
+  const bindHost = typeof address === 'object' && address !== null ? address.address : host ?? '0.0.0.0';
+  const publicHost = resolvePublicHost(host ?? bindHost);
+  const bindTarget = `${formatHostForAuthority(bindHost)}:${String(resolvedPort)}`;
+  const url = `${protocol}://${formatHostForAuthority(publicHost)}:${String(resolvedPort)}`;
+
+  return { bindTarget, url };
+}
+
+function resolvePublicHost(host: string): string {
+  return isWildcardHost(host) ? 'localhost' : host;
+}
+
+function isWildcardHost(host: string): boolean {
+  return host === '0.0.0.0' || host === '::' || host === '[::]';
+}
+
+function formatHostForAuthority(host: string): string {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
+function resolvePort(value: number | undefined): number {
+  const port = value ?? 3000;
+
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid PORT value: ${String(value ?? 3000)}.`);
+  }
+
+  return port;
+}
+
+function defaultShutdownSignals(): false | readonly ExpressApplicationSignal[] {
+  return ['SIGINT', 'SIGTERM'];
+}
+
+function registerShutdownSignals(
+  app: Application,
+  logger: ApplicationLogger,
+  signals: false | readonly ExpressApplicationSignal[],
+  forceExitTimeoutMs: number = DEFAULT_FORCE_EXIT_TIMEOUT_MS,
+): () => void {
+  if (signals === false || signals.length === 0) {
+    return () => {};
+  }
+
+  const seen = new Set<ExpressApplicationSignal>();
+  const bindings: Array<{ signal: ExpressApplicationSignal; handler: () => void }> = [];
+
+  for (const signal of signals) {
+    if (seen.has(signal)) {
+      continue;
+    }
+
+    seen.add(signal);
+    const handler = () => {
+      void closeFromSignal(app, logger, signal, forceExitTimeoutMs);
+    };
+
+    bindings.push({ signal, handler });
+    process.once(signal, handler);
+  }
+
+  return () => {
+    for (const binding of bindings) {
+      process.off(binding.signal, binding.handler);
+    }
+  };
+}
+
+async function closeFromSignal(
+  app: Application,
+  logger: ApplicationLogger,
+  signal: ExpressApplicationSignal,
+  forceExitTimeoutMs: number,
+): Promise<void> {
+  if (app.state === 'closed') {
+    process.exitCode = 0;
+    return;
+  }
+
+  const forceExitTimer = setTimeout(() => {
+    logger.error(`Forced exit after ${String(forceExitTimeoutMs)}ms shutdown timeout.`, undefined, 'KonektiFactory');
+    process.exit(1);
+  }, forceExitTimeoutMs);
+
+  if (forceExitTimer.unref) {
+    forceExitTimer.unref();
+  }
+
+  try {
+    await app.close(signal);
+    clearTimeout(forceExitTimer);
+    logger.log(`Application closed after receiving ${signal}.`, 'KonektiFactory');
+    process.exitCode = 0;
+  } catch (error: unknown) {
+    clearTimeout(forceExitTimer);
+    logger.error('Failed to shut down the application cleanly.', error, 'KonektiFactory');
+    process.exitCode = 1;
+  }
+}
+
+async function listenServer(server: ExpressServer, port: number, host: string | undefined): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onListening = () => {
+      cleanup();
+      resolve();
+    };
+
+    const cleanup = () => {
+      server.off('error', onError);
+      server.off('listening', onListening);
+    };
+
+    server.once('error', onError);
+    server.once('listening', onListening);
+
+    try {
+      server.listen({ host, port });
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+}
+
+function closeServerSilently(server: ExpressServer): Promise<void> {
+  if (!server.listening) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    server.close(() => {
+      resolve();
+    });
+  });
+}
+
+function closeServerWithDrain(
+  server: ExpressServer,
+  sockets: ReadonlySet<Socket>,
+  shutdownTimeoutMs: number,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      forceCloseConnections(server, sockets);
+    }, shutdownTimeoutMs);
+
+    const finish = (error?: Error | null) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    };
+
+    server.close((error) => {
+      finish(error);
+    });
+
+    closeIdleConnections(server);
+  });
+}
+
+function closeIdleConnections(server: ExpressServer): void {
+  server.closeIdleConnections?.();
+}
+
+function forceCloseConnections(server: ExpressServer, sockets: ReadonlySet<Socket>): void {
+  if (typeof server.closeAllConnections === 'function') {
+    server.closeAllConnections();
+    return;
+  }
+
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+}
+
+function toHttpException(error: unknown): HttpException {
+  if (error instanceof HttpException) {
+    return error;
+  }
+
+  return new InternalServerErrorException('Internal server error.', {
+    cause: error,
+  });
+}
+
+function isAddressInUseError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (error as NodeJS.ErrnoException).code === 'EADDRINUSE';
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number): Promise<void> {
+  return Promise.race([
+    closePromise,
+    new Promise<void>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Express adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+    }),
+  ]);
+}
+
+function mergeSetCookieHeader(
+  current: string | string[] | number | undefined,
+  incoming: string | string[],
+): string | string[] {
+  const nextValues = Array.isArray(incoming) ? incoming : [incoming];
+
+  if (current === undefined || typeof current === 'number') {
+    return nextValues.length === 1 ? nextValues[0] : [...nextValues];
+  }
+
+  const currentValues = Array.isArray(current) ? current : [current];
+  const merged = [...currentValues, ...nextValues];
+
+  return merged.length === 1 ? merged[0] : merged;
+}
+
+async function readRequestBody(
+  request: IncomingMessage,
+  contentType: string | string[] | undefined,
+  maxBodySize = DEFAULT_MAX_BODY_SIZE,
+  preserveRawBody = false,
+): Promise<{ body: unknown; rawBody?: Uint8Array }> {
+  const chunks: Uint8Array[] = [];
+  let totalSize = 0;
+
+  for await (const chunk of request) {
+    const bufferChunk: Uint8Array = typeof chunk === 'string' ? Buffer.from(chunk) : chunk;
+    totalSize += bufferChunk.byteLength;
+
+    if (totalSize > maxBodySize) {
+      throw new PayloadTooLargeException('Request body exceeds the size limit.');
+    }
+
+    chunks.push(bufferChunk);
+  }
+
+  if (chunks.length === 0) {
+    return { body: undefined };
+  }
+
+  const rawBody = Buffer.concat(chunks);
+  const bodyText = rawBody.toString('utf8');
+
+  if (bodyText.length === 0) {
+    return { body: undefined, rawBody: preserveRawBody ? rawBody : undefined };
+  }
+
+  const primaryContentType = readPrimaryHeaderValue(contentType);
+
+  if (typeof primaryContentType === 'string' && primaryContentType.includes('application/json')) {
+    try {
+      return {
+        body: JSON.parse(bodyText) as unknown,
+        rawBody: preserveRawBody ? rawBody : undefined,
+      };
+    } catch {
+      throw new BadRequestException('Request body contains invalid JSON.');
+    }
+  }
+
+  if (typeof primaryContentType === 'string' && primaryContentType.includes('application/x-www-form-urlencoded')) {
+    return {
+      body: parseUrlEncodedBody(bodyText),
+      rawBody: preserveRawBody ? rawBody : undefined,
+    };
+  }
+
+  return {
+    body: bodyText,
+    rawBody: preserveRawBody ? rawBody : undefined,
+  };
+}
+
+function parseUrlEncodedBody(bodyText: string): Record<string, string | string[]> {
+  const fields: Record<string, string | string[]> = {};
+  const searchParams = new URLSearchParams(bodyText);
+
+  for (const [key, value] of searchParams.entries()) {
+    setMultiValue(fields, key, value);
+  }
+
+  return fields;
+}
+
+function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {
+  if (Array.isArray(headerValue)) {
+    return headerValue[0];
+  }
+
+  return headerValue;
+}
+
+function setMultiValue(target: Record<string, string | string[]>, key: string, value: string): void {
+  const existing = target[key];
+
+  if (existing === undefined) {
+    target[key] = value;
+    return;
+  }
+
+  if (Array.isArray(existing)) {
+    existing.push(value);
+    return;
+  }
+
+  target[key] = [existing, value];
+}
+
+function serializeResponseBody(
+  body: unknown,
+  contentType?: string,
+): { defaultContentType?: string; payload: Buffer | string } {
+  if (body === undefined) {
+    return { payload: '' };
+  }
+
+  if (Buffer.isBuffer(body)) {
+    return {
+      defaultContentType: 'application/octet-stream',
+      payload: body,
+    };
+  }
+
+  if (body instanceof Uint8Array) {
+    return {
+      defaultContentType: 'application/octet-stream',
+      payload: Buffer.from(body),
+    };
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return {
+      defaultContentType: 'application/octet-stream',
+      payload: Buffer.from(body),
+    };
+  }
+
+  if (typeof body === 'string') {
+    const isJson = isJsonContentType(contentType);
+
+    return {
+      defaultContentType: isJson ? undefined : 'text/plain; charset=utf-8',
+      payload: isJson ? JSON.stringify(body) : body,
+    };
+  }
+
+  return {
+    defaultContentType: 'application/json; charset=utf-8',
+    payload: JSON.stringify(body),
+  };
+}
+
+function isJsonContentType(contentType: string | undefined): boolean {
+  return typeof contentType === 'string' && contentType.toLowerCase().includes('application/json');
+}

--- a/packages/platform-express/src/index.ts
+++ b/packages/platform-express/src/index.ts
@@ -1,0 +1,1 @@
+export * from './adapter.js';

--- a/packages/platform-express/tsconfig.build.json
+++ b/packages/platform-express/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/platform-express/tsconfig.json
+++ b/packages/platform-express/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -21,7 +21,7 @@
 4. `@konekti/http`에서 `createHandlerMapping()`과 `createDispatcher()`를 호출합니다.
 5. `dispatch()`, `listen()`, `ready()`, `close()`를 포함하는 `KonektiApplication` 셸을 반환합니다.
 
-`KonektiFactory`는 canonical public startup facade입니다. Node.js HTTP 앱의 기본 흐름은 `const app = await KonektiFactory.create(AppModule); await app.listen();` 입니다.
+`KonektiFactory`는 canonical public startup facade입니다. HTTP 앱의 기본 흐름은 `const app = await KonektiFactory.create(AppModule, { ...options }); await app.listen();`이며, `@konekti/platform-fastify`나 `@konekti/platform-express` 같은 트랜스포트 패키지를 선택할 때는 `options.adapter`를 전달합니다.
 
 ## 설치
 
@@ -53,6 +53,21 @@ class AppModule {}
 const app = await KonektiFactory.create(AppModule);
 await app.listen();
 ```
+
+### Adapter-first 시작 경로 (Express 예시)
+
+```typescript
+import { createExpressAdapter } from '@konekti/platform-express';
+import { KonektiFactory } from '@konekti/runtime';
+
+const app = await KonektiFactory.create(AppModule, {
+  adapter: createExpressAdapter({ port: 3000 }),
+});
+
+await app.listen();
+```
+
+`@konekti/platform-fastify`, `@konekti/platform-express`처럼 트랜스포트 패키지를 사용할 때는 위 adapter-first 형태를 사용하세요. canonical startup path는 계속 `KonektiFactory.create(...)`이며, 트랜스포트별 `run*Application()` 헬퍼는 호환/고급 경로로 유지됩니다.
 
 ### global request converters
 
@@ -177,7 +192,7 @@ const app = await KonektiFactory.create(AppModule, {
 await app.listen();
 ```
 
-`rawBody`는 선택 사항(opt-in)이며 파싱된 `request.body`와 함께 원래의 요청 바이트를 보존합니다. Node 어댑터는 현재 이를 JSON 및 텍스트와 같은 멀티파트가 아닌 바디에 적용하며, 옵션이 비활성화되어 있거나 요청이 멀티파트 파싱을 사용하는 경우에는 `request.rawBody`를 설정하지 않은 상태로 둡니다.
+`rawBody`는 선택 사항(opt-in)이며 파싱된 `request.body`와 함께 원래의 요청 바이트를 보존합니다. 내장 Node 어댑터와 Fastify/Express 플랫폼 어댑터는 이를 JSON/텍스트 같은 멀티파트가 아닌 바디에 적용하며, 옵션이 비활성화되어 있거나 요청이 멀티파트 파싱을 사용하는 경우에는 `request.rawBody`를 설정하지 않습니다.
 
 ### 호스트 바인딩 및 HTTPS
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -21,7 +21,7 @@ The assembly layer that compiles a module graph and wires DI and HTTP into a run
 4. Calls `createHandlerMapping()` and `createDispatcher()` from `@konekti/http`.
 5. Returns a `KonektiApplication` shell with `dispatch()`, `listen()`, `ready()`, and `close()`.
 
-`KonektiFactory` is the canonical public startup facade. For Node.js HTTP apps, the default flow is `const app = await KonektiFactory.create(AppModule); await app.listen();`.
+`KonektiFactory` is the canonical public startup facade. For HTTP apps, the default flow is `const app = await KonektiFactory.create(AppModule, { ...options }); await app.listen();`, with optional `options.adapter` when selecting a transport package such as `@konekti/platform-fastify` or `@konekti/platform-express`.
 
 ## Installation
 
@@ -53,6 +53,21 @@ class AppModule {}
 const app = await KonektiFactory.create(AppModule);
 await app.listen();
 ```
+
+### Adapter-first startup (Express example)
+
+```typescript
+import { createExpressAdapter } from '@konekti/platform-express';
+import { KonektiFactory } from '@konekti/runtime';
+
+const app = await KonektiFactory.create(AppModule, {
+  adapter: createExpressAdapter({ port: 3000 }),
+});
+
+await app.listen();
+```
+
+Use this adapter-first form when you need a transport package (`@konekti/platform-fastify`, `@konekti/platform-express`, etc.). Keep `KonektiFactory.create(...)` as the canonical startup path; transport-specific `run*Application()` helpers remain compatibility/advanced wrappers.
 
 ### Global request converters
 
@@ -177,7 +192,7 @@ const app = await KonektiFactory.create(AppModule, {
 await app.listen();
 ```
 
-`rawBody` is opt-in and preserves the original request bytes alongside the parsed `request.body`. The Node adapter currently applies this to non-multipart bodies such as JSON and text, and leaves `request.rawBody` unset when the option is disabled or the request uses multipart parsing.
+`rawBody` is opt-in and preserves the original request bytes alongside the parsed `request.body`. The built-in Node adapter and the Fastify/Express platform adapters apply this to non-multipart bodies such as JSON and text, and leave `request.rawBody` unset when the option is disabled or the request uses multipart parsing.
 
 ### Host binding and HTTPS
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,31 +144,6 @@ importers:
         specifier: '>=0.30.0'
         version: 0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@7.5.0(typescript@5.9.3))
 
-  packages/validation:
-    dependencies:
-      '@konekti/core':
-        specifier: workspace:*
-        version: link:../core
-      '@standard-schema/spec':
-        specifier: ^1.1.0
-        version: 1.1.0
-      validator:
-        specifier: ^13.15.26
-        version: 13.15.26
-    devDependencies:
-      '@types/validator':
-        specifier: ^13.15.10
-        version: 13.15.10
-      arktype:
-        specifier: ^2.2.0
-        version: 2.2.0
-      valibot:
-        specifier: ^1.0.0
-        version: 1.3.1(typescript@5.9.3)
-      zod:
-        specifier: ^4.1.11
-        version: 4.3.6
-
   packages/event-bus:
     dependencies:
       '@konekti/core':
@@ -192,15 +167,15 @@ importers:
       '@konekti/di':
         specifier: workspace:*
         version: link:../di
-      '@konekti/validation':
-        specifier: workspace:*
-        version: link:../dto
       '@konekti/http':
         specifier: workspace:*
         version: link:../http
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+      '@konekti/validation':
+        specifier: workspace:*
+        version: link:../validation
       graphql:
         specifier: ^16.13.1
         version: 16.13.1
@@ -228,7 +203,7 @@ importers:
         version: link:../di
       '@konekti/validation':
         specifier: workspace:*
-        version: link:../dto
+        version: link:../validation
 
   packages/jwt:
     dependencies:
@@ -296,15 +271,15 @@ importers:
       '@konekti/core':
         specifier: workspace:*
         version: link:../core
-      '@konekti/validation':
-        specifier: workspace:*
-        version: link:../dto
       '@konekti/http':
         specifier: workspace:*
         version: link:../http
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+      '@konekti/validation':
+        specifier: workspace:*
+        version: link:../validation
 
   packages/passport:
     dependencies:
@@ -320,6 +295,22 @@ importers:
       '@konekti/jwt':
         specifier: workspace:*
         version: link:../jwt
+
+  packages/platform-express:
+    dependencies:
+      '@konekti/http':
+        specifier: workspace:*
+        version: link:../http
+      '@konekti/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.3
+        version: 5.0.6
 
   packages/platform-fastify:
     dependencies:
@@ -372,15 +363,15 @@ importers:
       '@konekti/di':
         specifier: workspace:*
         version: link:../di
-      '@konekti/validation':
-        specifier: workspace:*
-        version: link:../dto
       '@konekti/http':
         specifier: workspace:*
         version: link:../http
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+      '@konekti/validation':
+        specifier: workspace:*
+        version: link:../validation
       '@prisma/client':
         specifier: '>=5.0.0'
         version: 7.5.0(typescript@5.9.3)
@@ -438,7 +429,7 @@ importers:
     devDependencies:
       '@konekti/serialization':
         specifier: workspace:*
-        version: link:../serializer
+        version: link:../serialization
       '@types/busboy':
         specifier: ^1.5.4
         version: 1.5.4
@@ -518,6 +509,31 @@ importers:
       ioredis:
         specifier: ^5.10.0
         version: 5.10.0
+
+  packages/validation:
+    dependencies:
+      '@konekti/core':
+        specifier: workspace:*
+        version: link:../core
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
+      validator:
+        specifier: ^13.15.26
+        version: 13.15.26
+    devDependencies:
+      '@types/validator':
+        specifier: ^13.15.10
+        version: 13.15.10
+      arktype:
+        specifier: ^2.2.0
+        version: 2.2.0
+      valibot:
+        specifier: ^1.0.0
+        version: 1.3.1(typescript@5.9.3)
+      zod:
+        specifier: ^4.1.11
+        version: 4.3.6
 
   packages/websocket:
     dependencies:
@@ -1332,11 +1348,17 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/busboy@1.5.4':
     resolution: {integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
@@ -1350,8 +1372,29 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -1425,6 +1468,10 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -1479,6 +1526,10 @@ packages:
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1513,6 +1564,14 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001777:
     resolution: {integrity: sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==}
 
@@ -1539,8 +1598,20 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -1695,6 +1766,13 @@ packages:
       sqlite3:
         optional: true
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -1702,6 +1780,10 @@ packages:
 
   electron-to-chromium@1.5.307:
     resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   engine.io-client@6.6.4:
     resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
@@ -1714,8 +1796,20 @@ packages:
     resolution: {integrity: sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==}
     engines: {node: '>=10.2.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1731,12 +1825,23 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -1782,9 +1887,21 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-readdir-recursive@1.1.0:
     resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
@@ -1797,9 +1914,20 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
@@ -1811,6 +1939,10 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graphql-ws@5.16.2:
     resolution: {integrity: sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==}
@@ -1827,6 +1959,14 @@ packages:
   graphql@16.13.1:
     resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1851,6 +1991,10 @@ packages:
     resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
     engines: {node: '>=12.22.0'}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
@@ -1870,6 +2014,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -1931,16 +2078,36 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -2011,6 +2178,10 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abort-controller@3.1.1:
     resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
 
@@ -2029,16 +2200,31 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+
+  path-to-regexp@8.4.1:
+    resolution: {integrity: sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2086,12 +2272,24 @@ packages:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -2136,6 +2334,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-regex2@5.1.0:
     resolution: {integrity: sha512-pNHAuBW7TrcleFHsxBr5QMi/Iyp0ENjUKz7GCcX1UO7cMh+NmVK6HxQckNL1tJp1XAJVjG6B8OKIPqodqj9rtw==}
     hasBin: true
@@ -2166,11 +2368,35 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   sift@17.1.3:
     resolution: {integrity: sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==}
@@ -2283,6 +2509,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3099,6 +3329,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.19.15
+
   '@types/busboy@1.5.4':
     dependencies:
       '@types/node': 22.19.15
@@ -3107,6 +3342,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/cors@2.8.19':
     dependencies:
@@ -3118,9 +3357,37 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.19.15
 
   '@types/validator@13.15.10': {}
 
@@ -3216,6 +3483,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -3265,6 +3537,20 @@ snapshots:
 
   bintrees@1.0.2: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3309,6 +3595,16 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001777: {}
 
   chai@5.3.3:
@@ -3340,7 +3636,13 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  content-disposition@1.0.1: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
 
@@ -3387,11 +3689,21 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@prisma/client': 7.5.0(typescript@5.9.3)
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
 
   electron-to-chromium@1.5.307: {}
+
+  encodeurl@2.0.0: {}
 
   engine.io-client@6.6.4:
     dependencies:
@@ -3424,7 +3736,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -3486,11 +3806,48 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
   expect-type@1.3.0: {}
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -3554,11 +3911,26 @@ snapshots:
       to-regex-range: 5.0.1
     optional: true
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
       safe-regex2: 5.1.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-readdir-recursive@1.1.0: {}
 
@@ -3567,7 +3939,27 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -3586,6 +3978,8 @@ snapshots:
       minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  gopd@1.2.0: {}
 
   graphql-ws@5.16.2(graphql@16.13.1):
     dependencies:
@@ -3608,6 +4002,12 @@ snapshots:
       tslib: 2.8.1
 
   graphql@16.13.1: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
 
   http-errors@2.0.1:
     dependencies:
@@ -3656,6 +4056,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ipaddr.js@1.9.1: {}
+
   ipaddr.js@2.3.0: {}
 
   is-binary-path@2.1.0:
@@ -3673,6 +4075,8 @@ snapshots:
 
   is-number@7.0.0:
     optional: true
+
+  is-promise@4.0.0: {}
 
   jake@10.9.4:
     dependencies:
@@ -3725,13 +4129,25 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
   memory-pager@1.5.0: {}
 
+  merge-descriptors@2.0.0: {}
+
   mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   minimatch@3.1.5:
     dependencies:
@@ -3795,6 +4211,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@1.0.0: {}
+
   node-abort-controller@3.1.1: {}
 
   node-gyp-build-optional-packages@5.2.2:
@@ -3809,13 +4227,23 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
 
+  parseurl@1.3.3: {}
+
   path-is-absolute@1.0.1: {}
+
+  path-to-regexp@8.4.1: {}
 
   pathe@2.0.3: {}
 
@@ -3865,9 +4293,20 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       tdigest: 0.1.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   punycode@2.3.1: {}
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
 
   raw-body@3.0.2:
     dependencies:
@@ -3930,6 +4369,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   safe-regex2@5.1.0:
     dependencies:
       ret: 0.5.0
@@ -3948,9 +4397,62 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   sift@17.1.3: {}
 
@@ -4069,6 +4571,12 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@5.9.3: {}
 


### PR DESCRIPTION
## Summary
- add new `@konekti/platform-express` package implementing the `HttpApplicationAdapter` contract
- provide bootstrap/run helpers with startup parity and graceful shutdown behavior, including multipart/raw body handling and abort propagation
- update runtime/docs package surface and migration/release docs (EN/KO) to include express adapter

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run packages/platform-express/src/adapter.test.ts`
- `pnpm test`

## Behavioral contract
- [x] No documented behavior was removed or narrowed
- [x] New adapter behavior is additive and documented in package/runtime/docs

Closes #551