### PR TITLE
Resolve #555: front-load Prisma, Drizzle, Redis, and Metrics strengths in docs

### DIFF
--- a/docs/concepts/caching.ko.md
+++ b/docs/concepts/caching.ko.md
@@ -40,6 +40,7 @@
 - raw ioredis 스타일 클라이언트 메서드(`get`, `set`, `del`, `scan`)를 사용합니다.
 - 만료 시각이 포함된 JSON 코덱 엔트리를 저장합니다.
 - 파괴적인 전역 flush 대신, prefix 범위의 `SCAN` + `DEL` 리셋 전략을 사용합니다.
+- `store: 'redis'` 모드에서 런타임 Redis client 라이프사이클은 cache-manager가 아니라 `@konekti/redis`가 소유합니다(lazy bootstrap connect + graceful shutdown 시맨틱).
 
 ## 모듈 연결
 
@@ -89,6 +90,8 @@ createCacheModule({ store: 'redis' });
 ```
 
 Redis 모드를 선택했는데 Redis 클라이언트를 찾지 못하면, 부트스트랩 초기에 명확한 설정 오류로 실패합니다.
+
+백킹 Redis 모듈이 존재하면 `wait` 상태에서 bootstrap 연결을 시도하고, 연결 오류를 fail-fast로 드러냅니다. 종료 시에는 `quit()` 우선 + `disconnect()` 폴백을 사용합니다.
 
 ## 설계 경계
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -40,6 +40,7 @@ This guide explains Konekti's HTTP response caching model powered by `@konekti/c
 - Uses raw ioredis-style client methods (`get`, `set`, `del`, `scan`).
 - Stores JSON-coded cache entries with expiration timestamps.
 - Uses scoped `SCAN` + `DEL` reset strategy (prefix-bound) rather than destructive global flush.
+- In `store: 'redis'` mode, runtime client lifecycle is owned by `@konekti/redis` (lazy bootstrap connect + graceful shutdown semantics) rather than by cache-manager itself.
 
 ## module wiring
 
@@ -89,6 +90,8 @@ createCacheModule({ store: 'redis' });
 ```
 
 When Redis mode is selected without a resolvable Redis client, bootstrap fails early with an explicit configuration error.
+
+When the backing Redis module is present, bootstrap connects in `wait` state and fails fast on connection errors; shutdown prefers `quit()` with `disconnect()` fallback.
 
 ## design boundaries
 

--- a/docs/concepts/observability.ko.md
+++ b/docs/concepts/observability.ko.md
@@ -47,7 +47,9 @@ interface ApplicationLogger {
 ## 메트릭 (Metrics)
 
 - **엔드포인트**: `@konekti/metrics`는 `GET /metrics` 엔드포인트를 제공합니다.
-- **수집**: `prom-client`를 사용하여 기본 메트릭을 격리된 레지스트리에 수집합니다.
+- **수집**: `prom-client`를 사용하며, 기본적으로 호출 단위 격리 registry에 기본 메트릭을 수집합니다.
+- **공유 registry 옵션**: `MetricsModule.forRoot({ registry })`로 외부 `Registry`를 전달하면 프레임워크 메트릭과 애플리케이션 메트릭을 하나의 스크레이프 타겟에서 노출할 수 있습니다.
+- **HTTP 메트릭 라벨**: `HttpMetricsMiddleware`는 low-cardinality path 정규화를 사용합니다(기본 `template`, opt-in `raw`). 기록 라벨은 `method`, `path`, `status`입니다.
 - **격리**: 메트릭 노출은 헬스 체크와 독립적이며 미들웨어로 보호할 수 있습니다.
 
 ## 책임 범위

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -47,7 +47,9 @@ Liveness and readiness are separate concerns. A failed readiness check affects `
 ## metrics
 
 - **Endpoint**: `@konekti/metrics` provides the `GET /metrics` endpoint.
-- **Collection**: Uses `prom-client` to collect default metrics into isolated registries.
+- **Collection**: Uses `prom-client` to collect default metrics into isolated registries by default.
+- **Shared registry option**: You can pass a `Registry` to `MetricsModule.forRoot({ registry })` so framework metrics and application metrics share one scrape target.
+- **HTTP metric labels**: `HttpMetricsMiddleware` uses low-cardinality path normalization (`template` by default, `raw` opt-in) and records `method`, `path`, `status`.
 - **Isolation**: Metrics exposure is independent of health checks and can be secured with middleware.
 
 ## responsibilities

--- a/docs/concepts/transactions.ko.md
+++ b/docs/concepts/transactions.ko.md
@@ -2,7 +2,7 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./transactions.ko.md"><kbd>한국어</kbd></a></p>
 
-이 가이드는 런타임 및 공식 ORM 통합에서 사용되는 트랜잭션 의미론을 설명합니다.
+이 가이드는 런타임 및 공식 ORM 통합(특히 `@konekti/prisma`, `@konekti/drizzle`)에서 사용되는 트랜잭션 의미론을 설명합니다.
 
 ### 관련 문서
 
@@ -40,12 +40,15 @@
 - 가드가 성공적으로 실행된 후 인터셉터 경계에서 시작됩니다.
 - 트랜잭션 핸들은 패키지별 방식으로 해결됩니다.
 - 인증 실패는 트랜잭션 시작을 방지하여 불필요한 롤백 로직을 피합니다.
+- Prisma 통합(`requestTransaction`)은 abort-aware 실행을 사용하며, 드라이버가 transaction `signal` 옵션을 거부하면 `signal` 없이 1회 재시도합니다.
+- Drizzle 통합(`requestTransaction`)은 abort-aware이며, wrapped handle에 `transaction` runner가 없으면(strict 모드가 아닐 때) abort-aware 직접 실행으로 폴백합니다.
 
 ## 커밋 및 롤백
 
 - **커밋**: 래핑된 요청 경로가 성공적으로 종료된 후 발생합니다.
 - **롤백**: 컨트롤러 또는 인터셉터 실패, 검증 에러, 또는 완료 전 요청 중단에 의해 트리거됩니다.
 - **정리**: 중단된 요청이 고립된 트랜잭션을 남겨두어서는 안 됩니다.
+- **셧다운 안전성**: Prisma/Drizzle 통합은 애플리케이션 종료 시 활성 request transaction을 abort하고 settle 완료를 기다린 뒤 disconnect/dispose 정리를 진행합니다.
 
 ## 스트리밍 및 장기 실행 요청
 

--- a/docs/concepts/transactions.md
+++ b/docs/concepts/transactions.md
@@ -2,7 +2,7 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./transactions.ko.md"><kbd>한국어</kbd></a></p>
 
-This guide outlines the transaction semantics used across the runtime and official ORM integrations.
+This guide outlines the transaction semantics used across the runtime and official ORM integrations, especially `@konekti/prisma` and `@konekti/drizzle`.
 
 ### related documentation
 
@@ -40,12 +40,15 @@ The following propagation types are currently not supported as standard defaults
 - Begins at the interceptor boundary, after successful guard execution.
 - Transaction handles are resolved in a package-specific manner.
 - Authentication failures prevent the transaction from starting, avoiding unnecessary rollback logic.
+- Prisma integration (`requestTransaction`) is abort-aware and retries once without transaction `signal` options when a driver rejects them.
+- Drizzle integration (`requestTransaction`) is abort-aware and falls back to direct abort-aware execution when the wrapped handle lacks a `transaction` runner (unless strict mode is enabled).
 
 ## commit and rollback
 
 - **Commit**: Occurs after the wrapped request path finishes successfully.
 - **Rollback**: Triggered by controller or interceptor failures, validation errors, or request abortions before completion.
 - **Clean-up**: Aborted requests must not leave orphaned transactions.
+- **Shutdown safety**: Prisma and Drizzle integrations abort active request transactions and wait for settlement during application shutdown before disconnect/dispose cleanup proceeds.
 
 ## streaming and long-lived requests
 

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -54,14 +54,17 @@
 - **`@konekti/openapi`**: 문서 생성 및 OpenAPI 데코레이터.
 - **`@konekti/graphql`**: GraphQL 모듈, 스키마 노출, 실행 파이프라인.
 - **`@konekti/serialization`**: 클래스 기반 응답 직렬화 및 인터셉터.
-- **`@konekti/cache-manager`**: 메모리/Redis 스토어를 지원하는 데코레이터 기반 HTTP 응답 캐시.
-- **`@konekti/metrics`**: Prometheus 메트릭 노출.
+- **`@konekti/cache-manager`**: 데코레이터 기반 HTTP 응답 캐시 + 독립형 cache service/store API, 메모리/Redis 백엔드 지원.
+- **`@konekti/metrics`**: 기본 격리 registry + 선택적 공유 registry 배선을 지원하는 Prometheus 메트릭 패키지이며, low-cardinality HTTP 메트릭 미들웨어를 제공합니다.
 - **`@konekti/cron`**: 분산 락을 지원하는 데코레이터 기반 작업 스케줄링.
 - **`@konekti/cqrs`**: 부트스트랩 시점 핸들러 탐색, saga/process-manager 지원, event-bus 위임을 제공하는 command/query 버스.
 - **`@konekti/event-bus`**: 프로세스 내 이벤트 발행 및 탐색.
 - **`@konekti/websocket`**: 데코레이터 기반 WebSocket 게이트웨이 탐색 및 Node 업그레이드 연결.
 - **`@konekti/queue`**: 워커 탐색과 DLQ(Dead Letter Queue)를 지원하는 Redis 기반 백그라운드 작업.
-- **데이터 통합**: `@konekti/redis`, `@konekti/prisma`, `@konekti/drizzle`, `@konekti/mongoose`.
+- **`@konekti/redis`**: 앱 범위 Redis lifecycle 소유(`lazyConnect` 부트스트랩 + graceful shutdown), raw 토큰 주입, `getRawClient()` escape hatch가 있는 `RedisService` facade 제공.
+- **`@konekti/prisma`**: Prisma lifecycle + ALS 기반 트랜잭션 컨텍스트 통합(비동기 모듈 팩토리, strict transaction 모드, abort-aware request transaction 처리 포함).
+- **`@konekti/drizzle`**: Drizzle handle을 ALS 트랜잭션 컨텍스트에 통합(비동기 모듈 팩토리, strict/fallback 트랜잭션 동작, optional `dispose` 셧다운 훅).
+- **`@konekti/mongoose`**: 런타임/DI 연결을 위한 Mongoose 통합 패키지.
 - **`@konekti/terminus`**: 헬스 인디케이터 조합과 런타임 헬스 응답 집계를 확장하는 운영 헬스 패키지.
 - **`@konekti/testing`**: 테스트 모듈 및 헬퍼 유틸리티.
 - **`@konekti/cli`**: 애플리케이션 부트스트랩/생성/마이그레이션 + 런타임 진단 inspect 명령어.

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -53,14 +53,17 @@ This page provides an overview of the current public package family within the K
 - **`@konekti/openapi`**: Document generation and OpenAPI decorators.
 - **`@konekti/graphql`**: GraphQL module, schema exposure, and execution pipeline.
 - **`@konekti/serialization`**: Class-based response serialization and interceptors.
-- **`@konekti/cache-manager`**: Decorator-driven HTTP response caching with memory and Redis stores.
-- **`@konekti/metrics`**: Prometheus metrics exposure.
+- **`@konekti/cache-manager`**: Decorator-driven HTTP response caching plus standalone cache service/store APIs, with memory and Redis backends.
+- **`@konekti/metrics`**: Prometheus metrics exposure with isolated registries by default, optional shared registry wiring, and low-cardinality HTTP metric middleware.
 - **`@konekti/cron`**: Decorator-based (`@Cron`, `@Interval`, `@Timeout`) and runtime-registry task scheduling with distributed lock support.
 - **`@konekti/cqrs`**: Command/query buses with bootstrap-time handler discovery, saga/process-manager support, and event-bus delegation.
 - **`@konekti/event-bus`**: In-process event publishing and discovery.
 - **`@konekti/websocket`**: Decorator-based WebSocket gateway discovery and Node upgrade wiring.
 - **`@konekti/queue`**: Redis-backed background jobs with worker discovery and DLQ support.
-- **Data Integrations**: `@konekti/redis`, `@konekti/prisma`, `@konekti/drizzle`, `@konekti/mongoose`.
+- **`@konekti/redis`**: App-scoped Redis lifecycle ownership (`lazyConnect` bootstrap + graceful shutdown), raw token injection, and `RedisService` facade with `getRawClient()` escape hatch.
+- **`@konekti/prisma`**: Prisma lifecycle and ALS-backed transaction context, including async module factory, strict transaction mode, and abort-aware request transaction handling.
+- **`@konekti/drizzle`**: Drizzle handle integration with ALS transaction context, async module factory, strict/fallback transaction behavior, and optional `dispose` shutdown hook.
+- **`@konekti/mongoose`**: Mongoose integration package for runtime/DI wiring.
 - **`@konekti/terminus`**: Health indicator composition and enriched runtime health aggregation.
 - **`@konekti/testing`**: Testing module and helper utilities.
 - **`@konekti/cli`**: Application bootstrap, generation, migration, and runtime diagnostics inspection commands.

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -50,6 +50,23 @@ const db = drizzle(pool);
 export class AppModule {}
 ```
 
+### 비동기 모듈 등록
+
+```typescript
+import { createDrizzleModuleAsync } from '@konekti/drizzle';
+
+const DrizzleModule = createDrizzleModuleAsync({
+  inject: [ConfigService],
+  useFactory: async (config: ConfigService) => ({
+    database: createDrizzleHandle(config.get('DATABASE_URL')),
+    strictTransactions: true,
+    dispose: async (database) => {
+      await closeDrizzleHandle(database);
+    },
+  }),
+});
+```
+
 ### Repository에서 database 사용
 
 ```typescript
@@ -106,12 +123,13 @@ class UsersController {}
 |---|---|---|
 | `DrizzleDatabase` | `src/database.ts` | `current()`, `transaction()`, `requestTransaction()`, `onApplicationShutdown()`을 가진 wrapper |
 | `createDrizzleModule(options)` | `src/module.ts` | 모든 provider를 포함한 importable Konekti 모듈 생성 |
+| `createDrizzleModuleAsync(options)` | `src/module.ts` | async 옵션을 1회 해석해 동일한 provider surface를 등록하는 비동기 변형 |
 | `createDrizzleProviders(options)` | `src/module.ts` | 수동 등록을 위한 raw provider 배열 반환 |
 | `DrizzleTransactionInterceptor` | `src/transaction.ts` | 자동 per-request transaction을 위한 opt-in interceptor |
 | `DRIZZLE_DATABASE` | `src/tokens.ts` | raw Drizzle database handle을 위한 DI 토큰 |
 | `DRIZZLE_DISPOSE` | `src/tokens.ts` | optional cleanup hook을 위한 DI 토큰 |
 | `DRIZZLE_OPTIONS` | `src/tokens.ts` | 정규화된 Drizzle module option을 위한 DI 토큰 |
-| `DrizzleDatabaseLike` | `src/types.ts` | seam 타입 — `transaction` callback이 있는 임의의 객체 |
+| `DrizzleDatabaseLike` | `src/types.ts` | seam 타입 — optional `transaction` callback을 가진 객체 |
 | `DrizzleModuleOptions` | `src/types.ts` | `{ database, dispose?, strictTransactions? }` |
 | `DrizzleHandleProvider` | `src/types.ts` | public transaction-aware handle 계약 |
 
@@ -131,8 +149,13 @@ DrizzleDatabase.transaction(fn)
   → AsyncLocalStorage에 tx handle 저장
   → callback 안에서 current()가 tx handle 반환
 
+DrizzleDatabase.requestTransaction(fn)
+  → 같은 경계 시맨틱 + AbortSignal 지원
+  → transaction runner가 없고 strict 모드가 꺼져 있으면 abort-aware 직접 실행으로 폴백
+
 app.close()
   → onApplicationShutdown()
+  → 활성 request transaction abort + settle 대기
   → dispose가 있으면 dispose(database) 호출
 ```
 
@@ -146,6 +169,13 @@ cleanup hook을 database value에서 분리하면:
 ### Transaction 시맨틱
 
 `DrizzleDatabase`는 활성 transaction context를 추적하기 위해 `AsyncLocalStorage`를 사용한다. service와 repository 코드는 transaction 안인지 아닌지를 알 필요 없이 `current()`를 호출하면 되고, ALS store가 전환을 투명하게 처리한다.
+
+`strictTransactions`는 wrapped handle이 `transaction`을 제공하지 않을 때의 동작을 제어한다.
+
+- `false`(기본값): `transaction()`은 `fn()` 직접 실행, `requestTransaction()`은 abort-aware 직접 실행으로 폴백
+- `true`: `transaction()`과 `requestTransaction()` 모두 `Transaction not supported...` 예외 발생
+
+이미 활성 transaction context 안에서는 중첩 transaction 옵션 오버라이드를 허용하지 않는다.
 
 ## 파일 읽기 순서 (기여자용)
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -50,6 +50,23 @@ const db = drizzle(pool);
 export class AppModule {}
 ```
 
+### Async module registration
+
+```typescript
+import { createDrizzleModuleAsync } from '@konekti/drizzle';
+
+const DrizzleModule = createDrizzleModuleAsync({
+  inject: [ConfigService],
+  useFactory: async (config: ConfigService) => ({
+    database: createDrizzleHandle(config.get('DATABASE_URL')),
+    strictTransactions: true,
+    dispose: async (database) => {
+      await closeDrizzleHandle(database);
+    },
+  }),
+});
+```
+
 ### Using the database in a repository
 
 ```typescript
@@ -106,12 +123,13 @@ class UsersController {}
 |---|---|---|
 | `DrizzleDatabase` | `src/database.ts` | Wrapper with `current()`, `transaction()`, `requestTransaction()`, `onApplicationShutdown()` |
 | `createDrizzleModule(options)` | `src/module.ts` | Creates an importable Konekti module with all providers |
+| `createDrizzleModuleAsync(options)` | `src/module.ts` | Async variant that resolves module options once and registers the same provider surface |
 | `createDrizzleProviders(options)` | `src/module.ts` | Returns the raw provider array for manual registration |
 | `DrizzleTransactionInterceptor` | `src/transaction.ts` | Opt-in interceptor for automatic per-request transactions |
 | `DRIZZLE_DATABASE` | `src/tokens.ts` | DI token for the raw Drizzle database handle |
 | `DRIZZLE_DISPOSE` | `src/tokens.ts` | DI token for the optional cleanup hook |
 | `DRIZZLE_OPTIONS` | `src/tokens.ts` | DI token for normalized Drizzle module options |
-| `DrizzleDatabaseLike` | `src/types.ts` | Seam type — any object with a `transaction` callback |
+| `DrizzleDatabaseLike` | `src/types.ts` | Seam type — object with optional `transaction` callback |
 | `DrizzleModuleOptions` | `src/types.ts` | `{ database, dispose?, strictTransactions? }` |
 | `DrizzleHandleProvider` | `src/types.ts` | Public transaction-aware handle contract |
 
@@ -131,8 +149,13 @@ DrizzleDatabase.transaction(fn)
   → AsyncLocalStorage stores tx handle
   → current() returns tx handle within the callback
 
+DrizzleDatabase.requestTransaction(fn)
+  → same boundary behavior with AbortSignal support
+  → if transaction runner is missing and strict mode is off, falls back to abort-aware direct execution
+
 app.close()
   → onApplicationShutdown()
+  → aborts active request transactions and waits for settlement
   → calls dispose(database) if provided
 ```
 
@@ -146,6 +169,13 @@ Separating the cleanup hook from the database value means:
 ### Transaction semantics
 
 `DrizzleDatabase` uses `AsyncLocalStorage` to track the active transaction context. Service and repository code calls `current()` without knowing whether they are inside a transaction or not — the ALS store handles the switch transparently.
+
+`strictTransactions` controls fallback behavior when the wrapped handle does not implement `transaction`:
+
+- `false` (default): `transaction()` runs `fn()` directly; `requestTransaction()` runs abort-aware direct execution.
+- `true`: `transaction()` and `requestTransaction()` throw `Transaction not supported...`.
+
+Nested transaction option overrides are rejected while already inside an active transaction context.
 
 ## File reading order for contributors
 

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -48,6 +48,7 @@ interface MetricsModuleOptions {
       method: string;
       path: string;
       params: Readonly<Record<string, string>>;
+      request: FrameworkRequest;
     }) => string;
     unknownPathLabel?: string;
   };
@@ -55,6 +56,7 @@ interface MetricsModuleOptions {
   provider?: 'prometheus';    // 현재 지원되는 provider
   defaultMetrics?: boolean;   // Node.js 기본 메트릭 수집 (기본값: true)
   middleware?: MiddlewareLike[];
+  registry?: Registry;        // 커스텀 메트릭과 공유할 외부 Prometheus registry
 }
 
 class MetricsModule {
@@ -121,6 +123,8 @@ MetricsModule.forRoot({
 
 높은 cardinality를 의도적으로 감수하는 경우에만 `pathLabelMode: 'raw'`를 사용하세요.
 
+`unknownPathLabel`의 기본값은 `UNKNOWN`입니다. 커스텀 normalizer가 빈 문자열을 반환하면 이 라벨로 폴백합니다.
+
 ### Provider 계약
 
 `MetricsModule`은 현재 Prometheus meter provider만 지원합니다. `prometheus`가 아닌 provider 값을 넘기면 런타임에서 예외를 던집니다.
@@ -135,12 +139,72 @@ MetricsModule.forRoot({
 
 ## 커스텀 메트릭
 
-`MetricsModule`은 `forRoot()` 호출마다 전용 `prom-client` `Registry` 인스턴스를 생성합니다. 현재 public API는 그 내부 레지스트리를 노출하지 않으므로, 커스텀 메트릭과 내장 엔드포인트가 같은 레지스트리를 공유하는 방식은 아직 공식 지원되지 않습니다.
+`MetricsModule`은 기본적으로 `forRoot()` 호출마다 전용 `prom-client` `Registry` 인스턴스를 생성합니다. 필요하면 외부 `Registry`를 전달해 프레임워크 메트릭과 애플리케이션 메트릭을 하나의 스크레이프 엔드포인트로 합칠 수 있습니다.
+
+### 공유 Registry (권장)
+
+외부 `Registry`를 `forRoot()`에 전달하면, 커스텀 메트릭과 프레임워크 메트릭이 동일 엔드포인트를 공유합니다.
+
+```typescript
+import { Counter, Registry } from 'prom-client';
+import { MetricsModule } from '@konekti/metrics';
+
+const sharedRegistry = new Registry();
+
+const httpRequests = new Counter({
+  name: 'http_requests_total',
+  help: '총 HTTP 요청 수',
+  labelNames: ['method', 'status'],
+  registers: [sharedRegistry],
+});
+
+httpRequests.inc({ method: 'GET', status: '200' });
+
+@Module({
+  imports: [
+    MetricsModule.forRoot({ registry: sharedRegistry }),
+  ],
+})
+class AppModule {}
+// GET /metrics → framework metrics + http_requests_total
+```
+
+### 공유 Registry에서 MetricsService 사용
+
+공유 registry를 전달하면 `MetricsService`와 `METER_PROVIDER`가 같은 registry를 사용합니다.
+
+```typescript
+import { METRICS_SERVICE, MetricsService } from '@konekti/metrics';
+
+@Inject([METRICS_SERVICE])
+class OrderService {
+  constructor(private readonly metrics: MetricsService) {
+    this.orderCounter = this.metrics.counter({
+      name: 'orders_created_total',
+      help: '총 주문 생성 수',
+      labelNames: ['status'],
+    });
+  }
+}
+```
+
+### Registry 직접 접근
+
+`MetricsService.getRegistry()`로 내부 `prom-client` `Registry`에 접근할 수 있습니다.
+
+```typescript
+const metricsService = await app.container.resolve(METRICS_SERVICE);
+const registry = metricsService.getRegistry();
+```
+
+### 격리 Registry (기본값)
+
+`registry` 옵션을 생략하면 각 `forRoot()` 호출은 별도 registry를 생성합니다.
 
 ```typescript
 import { Counter } from 'prom-client';
 
-// 전역 레지스트리 사용 (MetricsModule의 내부 레지스트리와 별개)
+// 전역 registry 사용 (MetricsModule 내부 registry와 별개)
 const httpRequests = new Counter({
   name: 'http_requests_total',
   help: '총 HTTP 요청 수',
@@ -150,7 +214,25 @@ const httpRequests = new Counter({
 httpRequests.inc({ method: 'GET', status: '200' });
 ```
 
-> **참고:** `MetricsModule`은 자체 격리된 `Registry`를 사용합니다. 하나의 엔드포인트에서 공유 레지스트리를 쓰고 싶다면, 직접 레지스트리 배선을 추가하도록 이 모듈을 확장하거나 래핑해야 합니다.
+> **참고:** 격리 registry 모드에서는 모듈 외부에서 등록한 메트릭이 내장 `/metrics` 엔드포인트에 나타나지 않습니다. 통합 스크레이프가 필요하면 공유 registry를 사용하세요.
+
+### 중복 Metric 이름
+
+Prometheus는 metric 이름의 전역 유일성을 요구합니다. 공유 registry에서 같은 이름을 두 번 등록하면 예외가 발생합니다.
+
+```typescript
+import { Counter } from 'prom-client';
+
+const registry = new Registry();
+
+new Counter({ name: 'my_counter', help: 'help', registers: [registry] });
+
+// Throws: 'A metric with the name my_counter has already been registered.'
+MetricsModule.forRoot({ registry }).container.resolve(METRICS_SERVICE)
+  .counter({ name: 'my_counter', help: 'duplicate' });
+```
+
+이 동작은 `prom-client`와 동일하며, 조용한 metric 충돌을 방지합니다.
 
 ---
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -48,6 +48,7 @@ interface MetricsModuleOptions {
       method: string;
       path: string;
       params: Readonly<Record<string, string>>;
+      request: FrameworkRequest;
     }) => string;
     unknownPathLabel?: string;
   };
@@ -83,6 +84,8 @@ MetricsModule.forRoot({ path: '/internal/metrics' })
 ### Disable default metrics
 
 By default, `prom-client`'s `collectDefaultMetrics()` is called, which registers standard Node.js process and GC metrics. In `prom-client` v15 these values are collected on scrape rather than by a background interval. Disable default metrics if you want the built-in endpoint to expose only metrics registered by the module itself:
+
+Default metrics are guarded per registry, so repeated `forRoot()` calls with the same registry do not double-register default collectors.
 
 ```typescript
 MetricsModule.forRoot({ defaultMetrics: false })
@@ -121,6 +124,8 @@ MetricsModule.forRoot({
 ```
 
 Use `pathLabelMode: 'raw'` only when you intentionally accept higher cardinality labels.
+
+`unknownPathLabel` defaults to `UNKNOWN`. If a custom normalizer returns a blank string, the middleware falls back to that label.
 
 ### Provider contract
 

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -38,6 +38,22 @@ const prisma = new PrismaClient();
 const AppModule = createPrismaModule({ client: prisma });
 ```
 
+### 1-a. 의존성이 필요하면 비동기 모듈 등록 사용
+
+```typescript
+import { createPrismaModuleAsync } from '@konekti/prisma';
+
+const AppModule = createPrismaModuleAsync({
+  inject: [ConfigService],
+  useFactory: async (config: ConfigService) => ({
+    client: new PrismaClient({
+      datasourceUrl: config.get('DATABASE_URL'),
+    }),
+    strictTransactions: true,
+  }),
+});
+```
+
 ### 2. 리포지토리에서 `PrismaService` 사용
 
 ```typescript
@@ -98,7 +114,7 @@ class UserController {}
 |---|---|---|
 | `current()` | `() => TClient \| TTransactionClient` | 활성 트랜잭션 클라이언트(ALS에서)를 반환하거나, 트랜잭션이 없으면 루트 클라이언트를 반환 |
 | `transaction()` | `(fn: () => Promise<T>) => Promise<T>` | Prisma 인터랙티브 트랜잭션 안에서 `fn`을 실행하고, tx 클라이언트를 ALS에 저장 |
-| `requestTransaction()` | `(fn: () => Promise<T>, signal?: AbortSignal) => Promise<T>` | `transaction()`과 동일하나, 인터셉터가 요청 경계에서 사용하도록 설계됨 |
+| `requestTransaction()` | `(fn: () => Promise<T>, signal?: AbortSignal) => Promise<T>` | 요청 경계용 `transaction()`. abort-aware 실행을 사용하고, Prisma 드라이버가 signal 옵션을 거부하면 `signal` 없이 1회 재시도 |
 
 ### `PRISMA_CLIENT`
 
@@ -124,11 +140,20 @@ import { createPrismaProviders } from '@konekti/prisma';
 const providers = createPrismaProviders({ client: prisma });
 ```
 
-### `createPrismaModule(options)`
+### `createPrismaModule(options)` / `createPrismaModuleAsync(options)`
 
-`createPrismaProviders`를 호출하고 결과를 Konekti 모듈 정의로 감싸는 편의 함수입니다.
+sync는 `createPrismaProviders`를 직접 감싸고, async는 비동기 factory로 같은 옵션을 해석한 뒤 Konekti 모듈 정의로 감싸는 편의 함수입니다.
 
-`PrismaModuleOptions`는 `strictTransactions?: boolean`도 지원하며, public package는 `PRISMA_OPTIONS`, `PrismaTransactionClient`, `PrismaModuleOptions`, `PrismaHandleProvider`도 export합니다.
+`createPrismaModuleAsync(...)`는 모듈 인스턴스 기준으로 async factory 결과를 1회 memoize합니다.
+
+`PrismaModuleOptions`는 `strictTransactions?: boolean`을 지원합니다.
+
+- `false`(기본값): `$transaction`이 없으면 `transaction()` / `requestTransaction()`이 직접 실행으로 폴백
+- `true`: `$transaction`이 없으면 즉시 예외 발생
+
+이미 활성 트랜잭션 컨텍스트 안에서는 중첩 트랜잭션 옵션 오버라이드를 허용하지 않습니다.
+
+public package는 `PRISMA_OPTIONS`, `PrismaTransactionClient`, `PrismaModuleOptions`, `PrismaHandleProvider`도 export합니다.
 
 ### `PrismaTransactionInterceptor`
 
@@ -136,13 +161,13 @@ HTTP 인터셉터(`src/transaction.ts`). 각 요청을 `prismaService.requestTra
 
 ### `PrismaClientLike`
 
-`PrismaService`가 제네릭으로 받는 seam 인터페이스입니다. `$connect`, `$disconnect`, `$transaction`만 요구하므로, 전체 `PrismaClient` 대신 최소한의 테스트 스텁으로 대체할 수 있습니다.
+`PrismaService`가 제네릭으로 받는 seam 인터페이스입니다. `$connect`, `$disconnect`, `$transaction`은 optional이며, 라이프사이클/트랜잭션 기능이 없는 최소 스텁이나 폴백 시나리오도 표현할 수 있습니다.
 
 ```typescript
 interface PrismaClientLike {
-  $connect(): Promise<void>;
-  $disconnect(): Promise<void>;
-  $transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T>;
+  $connect?(): Promise<void>;
+  $disconnect?(): Promise<void>;
+  $transaction?<T>(fn: (tx: unknown) => Promise<T>): Promise<T>;
 }
 ```
 
@@ -168,8 +193,8 @@ Prisma Client
 ```
 
 **라이프사이클 훅:**
-- `OnModuleInit` → `$connect()` — Konekti 모듈이 초기화될 때 호출
-- `OnApplicationShutdown` → `$disconnect()` — 그레이스풀 셧다운 시 호출
+- `OnModuleInit` → `$connect()` (구현된 경우)
+- `OnApplicationShutdown` → 진행 중 요청 트랜잭션 abort + settle 대기 후 `$disconnect()` 호출 (구현된 경우)
 
 ## 파일 읽기 순서 (기여자용)
 

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -38,6 +38,22 @@ const prisma = new PrismaClient();
 const AppModule = createPrismaModule({ client: prisma });
 ```
 
+### 1-a. Register asynchronously when dependencies are needed
+
+```typescript
+import { createPrismaModuleAsync } from '@konekti/prisma';
+
+const AppModule = createPrismaModuleAsync({
+  inject: [ConfigService],
+  useFactory: async (config: ConfigService) => ({
+    client: new PrismaClient({
+      datasourceUrl: config.get('DATABASE_URL'),
+    }),
+    strictTransactions: true,
+  }),
+});
+```
+
 ### 2. Use `PrismaService` in a repository
 
 ```typescript
@@ -98,7 +114,7 @@ class UserController {}
 |---|---|---|
 | `current()` | `() => TClient \| TTransactionClient` | Returns the active transaction client (from ALS), or the root client if no transaction is open |
 | `transaction()` | `(fn: () => Promise<T>) => Promise<T>` | Runs `fn` inside a Prisma interactive transaction; stores the tx client in ALS |
-| `requestTransaction()` | `(fn: () => Promise<T>, signal?: AbortSignal) => Promise<T>` | Like `transaction()`, intended for use by interceptors at the request boundary |
+| `requestTransaction()` | `(fn: () => Promise<T>, signal?: AbortSignal) => Promise<T>` | Like `transaction()`, intended for request boundaries. Uses abort-aware execution and retries once without `signal` when a Prisma driver rejects signal options |
 
 ### `PRISMA_CLIENT`
 
@@ -124,11 +140,20 @@ import { createPrismaProviders } from '@konekti/prisma';
 const providers = createPrismaProviders({ client: prisma });
 ```
 
-### `createPrismaModule(options)`
+### `createPrismaModule(options)` / `createPrismaModuleAsync(options)`
 
-Convenience wrapper that calls `createPrismaProviders` and wraps the result in a Konekti module definition.
+Convenience wrappers that call `createPrismaProviders` (sync) or resolve the same options through an async factory (async) and wrap the result in a Konekti module definition.
 
-`PrismaModuleOptions` also supports `strictTransactions?: boolean`, and the public package exports `PRISMA_OPTIONS`, `PrismaTransactionClient`, `PrismaModuleOptions`, and `PrismaHandleProvider`.
+`createPrismaModuleAsync(...)` memoizes the async factory result once per module instance.
+
+`PrismaModuleOptions` supports `strictTransactions?: boolean`:
+
+- `false` (default): if `$transaction` is missing, `transaction()` / `requestTransaction()` fall back to direct execution.
+- `true`: missing `$transaction` throws immediately.
+
+Nested transaction option overrides are rejected while already inside an active transaction context.
+
+The public package also exports `PRISMA_OPTIONS`, `PrismaTransactionClient`, `PrismaModuleOptions`, and `PrismaHandleProvider`.
 
 ### `PrismaTransactionInterceptor`
 
@@ -136,13 +161,13 @@ HTTP interceptor (`src/transaction.ts`) that wraps each request in `prismaServic
 
 ### `PrismaClientLike`
 
-Seam interface that `PrismaService` is generic over. Requires only `$connect`, `$disconnect`, and `$transaction` — allows testing with a minimal stub instead of a full `PrismaClient`.
+Seam interface that `PrismaService` is generic over. `$connect`, `$disconnect`, and `$transaction` are optional — allowing lightweight test seams and fallback behavior when lifecycle/transaction capabilities are absent.
 
 ```typescript
 interface PrismaClientLike {
-  $connect(): Promise<void>;
-  $disconnect(): Promise<void>;
-  $transaction<T>(fn: (tx: unknown) => Promise<T>): Promise<T>;
+  $connect?(): Promise<void>;
+  $disconnect?(): Promise<void>;
+  $transaction?<T>(fn: (tx: unknown) => Promise<T>): Promise<T>;
 }
 ```
 
@@ -168,8 +193,8 @@ Prisma Client
 ```
 
 **Lifecycle hooks:**
-- `OnModuleInit` → `$connect()` — called when the Konekti module initializes
-- `OnApplicationShutdown` → `$disconnect()` — called on graceful shutdown
+- `OnModuleInit` → `$connect()` (if implemented)
+- `OnApplicationShutdown` → aborts in-flight request transactions, waits for settlement, then calls `$disconnect()` (if implemented)
 
 ## File Reading Order (for contributors)
 

--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -67,7 +67,7 @@ export class CacheService {
 | `createRedisProviders(options)` | `src/module.ts` | 수동 조합을 위한 raw provider 목록 반환 |
 | `REDIS_CLIENT` | `src/tokens.ts` | 공유 raw `ioredis` client용 DI 토큰 |
 | `REDIS_SERVICE` | `src/redis-service.ts` | Redis facade 서비스용 DI 토큰 |
-| `RedisService` | `src/redis-service.ts` | JSON codec 기반 `get`/`set`/`del` facade |
+| `RedisService` | `src/redis-service.ts` | JSON codec 기반 `get`/`set`/`del` facade + `getRawClient()` escape hatch |
 | `RedisModuleOptions` | `src/types.ts` | `lazyConnect`를 제외한 `ioredis` 옵션 |
 
 ## RedisService codec 동작
@@ -76,12 +76,14 @@ export class CacheService {
 - `get(key)`는 유효한 JSON payload를 파싱해서 반환합니다.
 - `get(key)`는 non-JSON 또는 malformed JSON payload라면 저장된 raw 문자열을 그대로 반환합니다.
 - `set(key, value)`는 항상 `JSON.stringify(value)`로 저장하고, `ttlSeconds > 0`이면 Redis `EX`를 사용합니다.
+- `getRawClient()`는 facade 표면 밖의 명령이 필요할 때 공유 raw `ioredis` client를 반환합니다.
 
 ## 라이프사이클 동작
 
 - `createRedisModule()`은 항상 `lazyConnect: true`로 client를 생성합니다.
 - `onModuleInit()`은 `wait` 상태에서만 `connect()`를 호출하므로, Redis가 필수인 경우 connect 실패를 bootstrap 단계에서 바로 드러냅니다.
 - `onApplicationShutdown()`은 이미 `end`면 종료 작업을 건너뛰고, `quit` 불가능 상태에서는 `disconnect()`를 직접 호출하며, 그 외에는 `quit()` 우선 + 실패 시 `disconnect()` 폴백을 사용합니다.
+- `quit()`가 실패했고 client가 여전히 닫히지 않았다면, 원래 `quit` 오류를 다시 던집니다.
 
 ## 구조
 

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -67,7 +67,7 @@ export class CacheService {
 | `createRedisProviders(options)` | `src/module.ts` | Returns the raw provider list for manual composition |
 | `REDIS_CLIENT` | `src/tokens.ts` | DI token for the shared raw `ioredis` client |
 | `REDIS_SERVICE` | `src/redis-service.ts` | DI token for the Redis facade service |
-| `RedisService` | `src/redis-service.ts` | Facade with JSON codec `get`/`set`/`del` helpers |
+| `RedisService` | `src/redis-service.ts` | Facade with JSON codec `get`/`set`/`del` helpers + `getRawClient()` escape hatch |
 | `RedisModuleOptions` | `src/types.ts` | `ioredis` options without `lazyConnect` |
 
 ## RedisService codec behavior
@@ -76,12 +76,14 @@ export class CacheService {
 - `get(key)` returns parsed JSON for valid JSON payloads.
 - `get(key)` returns the raw stored string for non-JSON or malformed JSON payloads.
 - `set(key, value)` always stores `JSON.stringify(value)` and uses Redis `EX` when `ttlSeconds > 0`.
+- `getRawClient()` returns the shared raw `ioredis` client for commands outside the facade surface.
 
 ## Lifecycle behavior
 
 - `createRedisModule()` always creates the client with `lazyConnect: true`.
 - `onModuleInit()` calls `connect()` only in `wait` state, so bootstrap fails early if Redis is required and connect fails.
 - `onApplicationShutdown()` skips work when already `end`, disconnects directly for non-quittable states, and otherwise prefers `quit()` with `disconnect()` fallback.
+- If `quit()` fails and the client still does not close, the original quit error is rethrown.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Surface shipped Prisma and Drizzle strengths in EN/KO package READMEs, including async module factories, strict transaction behavior, abort-aware request transaction handling, and lifecycle/shutdown details.
- Expand Redis and Metrics EN/KO READMEs to clarify lifecycle ownership, RedisService raw-client escape hatch, shared registry support, HTTP label normalization strategy, and duplicate-name-safe registration behavior.
- Update cross-package concepts/reference docs (`transactions`, `caching`, `observability`, `package-surface` in EN/KO) to reflect these capabilities consistently.

## Verification
- `lsp_diagnostics` on modified Markdown files: 0 diagnostics.
- `pnpm build`: pass.
- `pnpm typecheck`: fails on this branch and on `main` with pre-existing workspace issues unrelated to this docs-only change.

Closes #555