### PR TITLE
Resolve #576: fix root-run Vitest workspace package resolution

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,47 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { configDefaults, defineConfig } from 'vitest/config';
 
 import { konektiBabelDecoratorsPlugin } from './tooling/vite/src';
 
+const REPO_ROOT = dirname(fileURLToPath(import.meta.url));
+const PACKAGES_ROOT = join(REPO_ROOT, 'packages');
+
+function collectWorkspaceAliases(): Record<string, string> {
+  const aliases: Record<string, string> = {};
+
+  for (const packageName of readdirSync(PACKAGES_ROOT)) {
+    const packageRoot = join(PACKAGES_ROOT, packageName);
+    const sourceRoot = join(packageRoot, 'src');
+    const scopeName = `@konekti/${packageName}`;
+
+    const indexPath = join(sourceRoot, 'index.ts');
+    if (existsSync(indexPath)) {
+      aliases[scopeName] = indexPath;
+    }
+
+    if (!existsSync(sourceRoot)) {
+      continue;
+    }
+
+    for (const sourceEntry of readdirSync(sourceRoot)) {
+      if (extname(sourceEntry) !== '.ts' || sourceEntry.endsWith('.test.ts') || sourceEntry === 'index.ts') {
+        continue;
+      }
+
+      const subpath = sourceEntry.slice(0, -3);
+      aliases[`${scopeName}/${subpath}`] = join(sourceRoot, sourceEntry);
+    }
+  }
+
+  return aliases;
+}
+
 export default defineConfig({
+  resolve: {
+    alias: collectWorkspaceAliases(),
+  },
   plugins: [konektiBabelDecoratorsPlugin()],
   test: {
     projects: [


### PR DESCRIPTION
## Summary
- Fix root-run Vitest workspace package import resolution by mapping `@konekti/*` bare imports to each package `src` entry/subpath in `vitest.config.ts`.
- Remove dependency on prebuilt `dist` artifacts for package tests executed from repository root.
- Verify the originally failing OpenAPI suites and additional suites that import `@konekti/validation` (graphql/http/prisma).

## Additional affected suites observed
- `packages/graphql/src/module.test.ts`
- `packages/graphql/src/input-pipeline.test.ts`
- `packages/http/src/binding.test.ts`
- `packages/http/src/dispatcher.test.ts`
- `packages/http/src/decorators.test.ts`
- `packages/prisma/src/vertical-slice.test.ts`

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm test packages/openapi/src/schema-builder.test.ts packages/openapi/src/openapi-module.test.ts`
- `pnpm test packages/graphql/src/module.test.ts packages/graphql/src/input-pipeline.test.ts packages/http/src/binding.test.ts packages/http/src/dispatcher.test.ts packages/http/src/decorators.test.ts packages/prisma/src/vertical-slice.test.ts`
- `pnpm build`
- `pnpm typecheck`

Closes #576