### PR TITLE
Resolve #567 (slice 1): add explicit OpenAPI request decorators

### DIFF
--- a/packages/openapi/src/decorators.test.ts
+++ b/packages/openapi/src/decorators.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import {
   ApiBearerAuth,
+  ApiBody,
+  ApiCookie,
   ApiExcludeEndpoint,
+  ApiHeader,
   ApiOperation,
+  ApiParam,
+  ApiQuery,
   ApiResponse,
   ApiSecurity,
   ApiTag,
@@ -23,6 +28,11 @@ describe('OpenAPI decorator metadata readers', () => {
     @ApiTag('users')
     class UsersController {
       @ApiOperation({ deprecated: true, summary: 'List users' })
+      @ApiParam('id', { description: 'User identifier', schema: { type: 'integer' } })
+      @ApiQuery('expand', { schema: { enum: ['profile'], type: 'string' } })
+      @ApiHeader('x-request-id', { required: true, schema: { type: 'string' } })
+      @ApiCookie('session', { schema: { type: 'string' } })
+      @ApiBody({ description: 'Explicit body', required: true, schema: { properties: { name: { type: 'string' } }, type: 'object' } })
       @ApiBearerAuth()
       @ApiSecurity('oauth2Auth', ['read:users'])
       @ApiExcludeEndpoint()
@@ -76,26 +86,90 @@ describe('OpenAPI decorator metadata readers', () => {
       firstMeta.securityRequirements.push({ apiKeyAuth: [] });
     }
 
+    if (firstMeta.parameters) {
+      firstMeta.parameters[0] = {
+        ...firstMeta.parameters[0],
+        name: 'mutated',
+      };
+    }
+
+    firstMeta.requestBody = {
+      content: {
+        'application/json': {
+          schema: {
+            type: 'string',
+          },
+        },
+      },
+    };
+
     const secondMeta = getMethodApiMetadata(UsersController, 'list');
 
-    expect(secondMeta).toEqual({
-      excludeEndpoint: true,
-      operation: { deprecated: true, description: undefined, summary: 'List users' },
-      responses: [
-        {
-          description: 'OK',
+    expect(secondMeta).toEqual(
+      expect.objectContaining({
+        excludeEndpoint: true,
+        operation: { deprecated: true, description: undefined, summary: 'List users' },
+        responses: [
+          {
+            description: 'OK',
+            schema: {
+              properties: {
+                id: { type: 'string' },
+              },
+              type: 'object',
+            },
+            status: 200,
+            type: undefined,
+          },
+        ],
+        security: ['oauth2Auth', 'bearerAuth'],
+        securityRequirements: [{ oauth2Auth: ['read:users'] }, { bearerAuth: [] }],
+        requestBody: {
+          description: 'Explicit body',
+          required: true,
           schema: {
             properties: {
-              id: { type: 'string' },
+              name: {
+                type: 'string',
+              },
             },
             type: 'object',
           },
-          status: 200,
-          type: undefined,
         },
-      ],
-      security: ['oauth2Auth', 'bearerAuth'],
-      securityRequirements: [{ oauth2Auth: ['read:users'] }, { bearerAuth: [] }],
-    });
+      }),
+    );
+
+    expect(secondMeta?.parameters).toEqual(
+      expect.arrayContaining([
+        {
+          description: 'User identifier',
+          in: 'path',
+          name: 'id',
+          required: true,
+          schema: { type: 'integer' },
+        },
+        {
+          description: undefined,
+          in: 'query',
+          name: 'expand',
+          required: undefined,
+          schema: { enum: ['profile'], type: 'string' },
+        },
+        {
+          description: undefined,
+          in: 'header',
+          name: 'x-request-id',
+          required: true,
+          schema: { type: 'string' },
+        },
+        {
+          description: undefined,
+          in: 'cookie',
+          name: 'session',
+          required: undefined,
+          schema: { type: 'string' },
+        },
+      ]),
+    );
   });
 });

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -13,6 +13,19 @@ export interface ApiResponseOptions {
   type?: Constructor;
 }
 
+export interface ApiParameterOptions {
+  description?: string;
+  required?: boolean;
+  schema?: Record<string, unknown>;
+}
+
+export interface ApiBodyOptions {
+  description?: string;
+  required?: boolean;
+  schema?: Record<string, unknown>;
+  content?: Record<string, { schema: Record<string, unknown> }>;
+}
+
 export interface ApiOperationMetadata {
   summary?: string;
   description?: string;
@@ -30,9 +43,26 @@ export interface ApiResponseMetadata {
   type?: Constructor;
 }
 
+export interface ApiParameterMetadata {
+  name: string;
+  in: 'cookie' | 'header' | 'path' | 'query';
+  description?: string;
+  required?: boolean;
+  schema?: Record<string, unknown>;
+}
+
+export interface ApiBodyMetadata {
+  description?: string;
+  required?: boolean;
+  schema?: Record<string, unknown>;
+  content?: Record<string, { schema: Record<string, unknown> }>;
+}
+
 export interface MethodApiMetadata {
   operation?: ApiOperationMetadata;
   responses: ApiResponseMetadata[];
+  parameters?: ApiParameterMetadata[];
+  requestBody?: ApiBodyMetadata;
   security?: string[];
   securityRequirements?: ApiSecurityRequirementMetadata[];
   excludeEndpoint?: boolean;
@@ -41,6 +71,8 @@ export interface MethodApiMetadata {
 const openApiControllerTagsKey = Symbol.for('konekti.openapi.controller-tags');
 const openApiMethodOperationKey = Symbol.for('konekti.openapi.method-operation');
 const openApiMethodResponsesKey = Symbol.for('konekti.openapi.method-responses');
+const openApiMethodParametersKey = Symbol.for('konekti.openapi.method-parameters');
+const openApiMethodRequestBodyKey = Symbol.for('konekti.openapi.method-request-body');
 const openApiMethodSecurityKey = Symbol.for('konekti.openapi.method-security');
 const openApiMethodSecurityRequirementsKey = Symbol.for('konekti.openapi.method-security-requirements');
 const openApiMethodExcludeEndpointKey = Symbol.for('konekti.openapi.method-exclude-endpoint');
@@ -107,6 +139,25 @@ function cloneApiResponseMetadata(response: ApiResponseMetadata): ApiResponseMet
   };
 }
 
+function cloneApiParameterMetadata(parameter: ApiParameterMetadata): ApiParameterMetadata {
+  return {
+    description: parameter.description,
+    in: parameter.in,
+    name: parameter.name,
+    required: parameter.required,
+    schema: cloneUnknown(parameter.schema),
+  };
+}
+
+function cloneApiBodyMetadata(requestBody: ApiBodyMetadata): ApiBodyMetadata {
+  return {
+    ...(requestBody.content !== undefined ? { content: cloneUnknown(requestBody.content) } : {}),
+    ...(requestBody.description !== undefined ? { description: requestBody.description } : {}),
+    ...(requestBody.required !== undefined ? { required: requestBody.required } : {}),
+    ...(requestBody.schema !== undefined ? { schema: cloneUnknown(requestBody.schema) } : {}),
+  };
+}
+
 /** Read tags registered via `@ApiTag` on a controller class. */
 export function getControllerTags(target: Function): string[] | undefined {
   const bag = getMetadataBag(target);
@@ -120,6 +171,8 @@ export function getMethodApiMetadata(target: Function, propertyKey: MetadataProp
 
   const operationMap = bag?.[openApiMethodOperationKey] as Map<MetadataPropertyKey, ApiOperationMetadata> | undefined;
   const responsesMap = bag?.[openApiMethodResponsesKey] as Map<MetadataPropertyKey, ApiResponseMetadata[]> | undefined;
+  const parametersMap = bag?.[openApiMethodParametersKey] as Map<MetadataPropertyKey, ApiParameterMetadata[]> | undefined;
+  const requestBodyMap = bag?.[openApiMethodRequestBodyKey] as Map<MetadataPropertyKey, ApiBodyMetadata> | undefined;
   const securityMap = bag?.[openApiMethodSecurityKey] as Map<MetadataPropertyKey, string[]> | undefined;
   const securityRequirementsMap = bag?.[openApiMethodSecurityRequirementsKey] as
     | Map<MetadataPropertyKey, ApiSecurityRequirementMetadata[]>
@@ -128,17 +181,21 @@ export function getMethodApiMetadata(target: Function, propertyKey: MetadataProp
 
   const operation = operationMap?.get(propertyKey);
   const responses = responsesMap?.get(propertyKey);
+  const parameters = parametersMap?.get(propertyKey);
+  const requestBody = requestBodyMap?.get(propertyKey);
   const security = securityMap?.get(propertyKey);
   const securityRequirements = securityRequirementsMap?.get(propertyKey);
   const excludeEndpoint = excludeEndpointMap?.get(propertyKey);
 
-  if (!operation && !responses && !security && !securityRequirements && !excludeEndpoint) {
+  if (!operation && !responses && !parameters && !requestBody && !security && !securityRequirements && !excludeEndpoint) {
     return undefined;
   }
 
   return {
     operation: cloneApiOperationMetadata(operation),
     responses: (responses ?? []).map((response) => cloneApiResponseMetadata(response)),
+    parameters: parameters?.map((parameter) => cloneApiParameterMetadata(parameter)),
+    requestBody: requestBody ? cloneApiBodyMetadata(requestBody) : undefined,
     security: security ? [...security] : undefined,
     securityRequirements: securityRequirements?.map((requirement) => cloneApiSecurityRequirementMetadata(requirement)),
     excludeEndpoint,
@@ -218,6 +275,76 @@ export function ApiSecurity(name: string, scopes: string[] = []): MethodDecorato
     const existingRequirements = requirementsMap.get(context.name) ?? [];
 
     requirementsMap.set(context.name, [...existingRequirements, { [name]: [...scopes] }]);
+  };
+}
+
+function registerMethodParameter(parameter: ApiParameterMetadata): MethodDecoratorFn {
+  return (_value, context) => {
+    const bag = context.metadata as MetadataBag;
+    let map = bag[openApiMethodParametersKey] as Map<MetadataPropertyKey, ApiParameterMetadata[]> | undefined;
+
+    if (!map) {
+      map = new Map();
+      bag[openApiMethodParametersKey] = map;
+    }
+
+    const existing = map.get(context.name) ?? [];
+
+    map.set(context.name, [...existing, cloneApiParameterMetadata(parameter)]);
+  };
+}
+
+export function ApiParam(name: string, options: ApiParameterOptions = {}): MethodDecoratorFn {
+  return registerMethodParameter({
+    description: options.description,
+    in: 'path',
+    name,
+    required: options.required ?? true,
+    schema: options.schema,
+  });
+}
+
+export function ApiQuery(name: string, options: ApiParameterOptions = {}): MethodDecoratorFn {
+  return registerMethodParameter({
+    description: options.description,
+    in: 'query',
+    name,
+    required: options.required,
+    schema: options.schema,
+  });
+}
+
+export function ApiHeader(name: string, options: ApiParameterOptions = {}): MethodDecoratorFn {
+  return registerMethodParameter({
+    description: options.description,
+    in: 'header',
+    name,
+    required: options.required,
+    schema: options.schema,
+  });
+}
+
+export function ApiCookie(name: string, options: ApiParameterOptions = {}): MethodDecoratorFn {
+  return registerMethodParameter({
+    description: options.description,
+    in: 'cookie',
+    name,
+    required: options.required,
+    schema: options.schema,
+  });
+}
+
+export function ApiBody(options: ApiBodyOptions): MethodDecoratorFn {
+  return (_value, context) => {
+    const bag = context.metadata as MetadataBag;
+    let map = bag[openApiMethodRequestBodyKey] as Map<MetadataPropertyKey, ApiBodyMetadata> | undefined;
+
+    if (!map) {
+      map = new Map();
+      bag[openApiMethodRequestBodyKey] = map;
+    }
+
+    map.set(context.name, cloneApiBodyMetadata(options));
   };
 }
 

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -8,7 +8,19 @@ import { Controller, Get, Post, Version, createHandlerMapping, type FrameworkReq
 import { FromBody, FromCookie, FromHeader, FromPath, FromQuery, RequestDto } from '@konekti/http';
 import { bootstrapApplication, bootstrapNodeApplication, defineModule } from '@konekti/runtime';
 
-import { ApiBearerAuth, ApiExcludeEndpoint, ApiOperation, ApiResponse, ApiSecurity, ApiTag } from './decorators.js';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiCookie,
+  ApiExcludeEndpoint,
+  ApiHeader,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiSecurity,
+  ApiTag,
+} from './decorators.js';
 import { OpenApiModule } from './openapi-module.js';
 
 type TestFrameworkResponse = FrameworkResponse & { body?: unknown };
@@ -1108,6 +1120,112 @@ describe('OpenApiModule', () => {
         },
       ]),
     );
+  });
+
+  it('allows explicit request decorators to override inferred request docs', async () => {
+    class UpdateUserRequest {
+      @FromPath('id')
+      @IsString()
+      id = '';
+
+      @FromBody('name')
+      @IsString()
+      name = '';
+    }
+
+    @Controller('/users')
+    class UsersController {
+      @Post('/:id')
+      @RequestDto(UpdateUserRequest)
+      @ApiParam('id', { description: 'Numeric user id', schema: { type: 'integer' } })
+      @ApiQuery('expand', { schema: { enum: ['profile'], type: 'string' } })
+      @ApiHeader('x-request-id', { required: true, schema: { type: 'string' } })
+      @ApiCookie('session', { schema: { type: 'string' } })
+      @ApiBody({
+        description: 'Explicitly documented body',
+        required: true,
+        schema: {
+          properties: {
+            displayName: { type: 'string' },
+          },
+          required: ['displayName'],
+          type: 'object',
+        },
+      })
+      updateUser() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: UsersController }],
+      title: 'Explicit request docs API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [UsersController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+
+    const document = response.body as {
+      paths: Record<string, { post?: { parameters?: unknown[]; requestBody?: unknown } }>;
+    };
+    const operation = document.paths['/users/{id}']?.post;
+
+    expect(operation?.parameters).toEqual(
+      expect.arrayContaining([
+        {
+          description: 'Numeric user id',
+          in: 'path',
+          name: 'id',
+          required: true,
+          schema: { type: 'integer' },
+        },
+        {
+          in: 'query',
+          name: 'expand',
+          schema: { enum: ['profile'], type: 'string' },
+        },
+        {
+          in: 'header',
+          name: 'x-request-id',
+          required: true,
+          schema: { type: 'string' },
+        },
+        {
+          in: 'cookie',
+          name: 'session',
+          schema: { type: 'string' },
+        },
+      ]),
+    );
+    expect(operation?.requestBody).toEqual({
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              displayName: { type: 'string' },
+            },
+            required: ['displayName'],
+            type: 'object',
+          },
+        },
+      },
+      description: 'Explicitly documented body',
+      required: true,
+    });
   });
 
   it('adds default error responses when @ApiResponse is absent', async () => {

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -1,6 +1,7 @@
 import { getDtoBindingSchema, getDtoValidationSchema, type Constructor, type DtoFieldValidationRule, type MetadataPropertyKey } from '@konekti/core';
 import type { HandlerDescriptor, HttpMethod } from '@konekti/http';
 import {
+  type ApiParameterMetadata,
   getControllerTags,
   getMethodApiMetadata,
   type ApiResponseMetadata,
@@ -52,6 +53,7 @@ export interface OpenApiMediaTypeObject {
 }
 
 export interface OpenApiRequestBodyObject {
+  description?: string;
   content: Record<string, OpenApiMediaTypeObject>;
   required?: boolean;
 }
@@ -814,6 +816,34 @@ function createRequestBody(
   };
 }
 
+function createExplicitRequestBody(methodMeta: MethodApiMetadata | undefined): OpenApiRequestBodyObject | undefined {
+  const requestBodyMeta = methodMeta?.requestBody;
+
+  if (!requestBodyMeta) {
+    return undefined;
+  }
+
+  const content = requestBodyMeta.content
+    ? requestBodyMeta.content
+    : requestBodyMeta.schema
+      ? {
+          'application/json': {
+            schema: requestBodyMeta.schema,
+          },
+        }
+      : undefined;
+
+  if (!content) {
+    return undefined;
+  }
+
+  return {
+    content,
+    ...(requestBodyMeta.description !== undefined ? { description: requestBodyMeta.description } : {}),
+    ...(requestBodyMeta.required !== undefined ? { required: requestBodyMeta.required } : {}),
+  };
+}
+
 function scalarizeArraySchemaItems(items: OpenApiSchemaObject | undefined): OpenApiSchemaObject {
   if (!items || items.$ref !== undefined || items.type === undefined || items.type === 'array' || items.type === 'object') {
     return { type: 'string' };
@@ -854,6 +884,62 @@ function alignParameterSchemaWithRuntimeBindingContract(
   }
 
   return aligned;
+}
+
+function createExplicitParameter(parameter: ApiParameterMetadata): OpenApiParameterObject {
+  const source = parameter.in;
+  const schema = alignParameterSchemaWithRuntimeBindingContract(parameter.schema ?? { type: 'string' }, source);
+  const isRequired = source === 'path' ? true : parameter.required;
+
+  return {
+    in: source,
+    name: parameter.name,
+    ...(parameter.description !== undefined ? { description: parameter.description } : {}),
+    ...(isRequired !== undefined ? { required: isRequired } : {}),
+    schema,
+  };
+}
+
+function mergeOperationParameters(
+  inferred: OpenApiParameterObject[],
+  explicit: ApiParameterMetadata[] | undefined,
+): OpenApiParameterObject[] {
+  if (!explicit || explicit.length === 0) {
+    return inferred;
+  }
+
+  const merged = new Map<string, OpenApiParameterObject>();
+
+  for (const parameter of inferred) {
+    merged.set(`${parameter.in}:${parameter.name}`, parameter);
+  }
+
+  for (const parameter of explicit) {
+    const explicitParameter = createExplicitParameter(parameter);
+    merged.set(`${explicitParameter.in}:${explicitParameter.name}`, explicitParameter);
+  }
+
+  return Array.from(merged.values());
+}
+
+function mergeOperationRequestBody(
+  inferred: OpenApiRequestBodyObject | undefined,
+  methodMeta: MethodApiMetadata | undefined,
+): OpenApiRequestBodyObject | undefined {
+  const explicit = createExplicitRequestBody(methodMeta);
+
+  if (!explicit) {
+    return inferred;
+  }
+
+  if (!inferred) {
+    return explicit;
+  }
+
+  return {
+    ...inferred,
+    ...explicit,
+  };
 }
 
 function createResponseObject(
@@ -931,8 +1017,11 @@ function createOperationObject(
   security: OpenApiSecurityRequirementObject[] | undefined,
   context: BuildSchemaContext,
 ): OpenApiOperationObject {
-  const parameters = createParameters(descriptor.route.request, context);
-  const requestBody = createRequestBody(descriptor.route.request, componentSchemas, context);
+  const parameters = mergeOperationParameters(createParameters(descriptor.route.request, context), methodMeta?.parameters);
+  const requestBody = mergeOperationRequestBody(
+    createRequestBody(descriptor.route.request, componentSchemas, context),
+    methodMeta,
+  );
 
   return {
     operationId: normalizeOperationId(descriptor),


### PR DESCRIPTION
## Summary
- Add explicit OpenAPI request-shape decorators in `@konekti/openapi`: `ApiParam`, `ApiQuery`, `ApiHeader`, `ApiCookie`, and `ApiBody`.
- Extend method metadata handling and schema-builder merge logic so explicit parameter/body docs can override inferred request DTO docs safely.
- Add coverage in `decorators.test.ts` and a new integration test in `openapi-module.test.ts` to validate explicit-over-inferred behavior.

## Verification
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run packages/openapi/src/decorators.test.ts packages/openapi/src/openapi-module.test.ts`

Refs #567