### PR TITLE
feat(openapi): compose descriptors and sources in module options

### DIFF
--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -1727,6 +1727,114 @@ describe('OpenApiModule', () => {
     expect(paths['/admin/internal']).toBeUndefined();
   });
 
+  it('forRoot composes descriptors and sources when both are provided', async () => {
+    @Controller('/from-sources')
+    class SourcesController {
+      @Get('/')
+      getSources() {
+        return { from: 'sources' };
+      }
+    }
+
+    @Controller('/from-descriptors')
+    class DescriptorsController {
+      @Get('/')
+      getDescriptors() {
+        return { from: 'descriptors' };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      descriptors: createHandlerMapping([{ controllerToken: DescriptorsController }]).descriptors,
+      sources: [{ controllerToken: SourcesController }],
+      title: 'Composed API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [SourcesController, DescriptorsController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        paths: expect.objectContaining({
+          '/from-sources': expect.objectContaining({
+            get: expect.any(Object),
+          }),
+          '/from-descriptors': expect.objectContaining({
+            get: expect.any(Object),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('forRootAsync composes descriptors and sources when both are provided', async () => {
+    @Controller('/async-sources')
+    class AsyncSourcesController {
+      @Get('/')
+      getSources() {
+        return { from: 'sources' };
+      }
+    }
+
+    @Controller('/async-descriptors')
+    class AsyncDescriptorsController {
+      @Get('/')
+      getDescriptors() {
+        return { from: 'descriptors' };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRootAsync({
+      useFactory: async () => ({
+        descriptors: createHandlerMapping([{ controllerToken: AsyncDescriptorsController }]).descriptors,
+        sources: [{ controllerToken: AsyncSourcesController }],
+        title: 'Async Composed API',
+        version: '1.0.0',
+      }),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [AsyncSourcesController, AsyncDescriptorsController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        info: {
+          title: 'Async Composed API',
+          version: '1.0.0',
+        },
+        paths: expect.objectContaining({
+          '/async-sources': expect.objectContaining({
+            get: expect.any(Object),
+          }),
+          '/async-descriptors': expect.objectContaining({
+            get: expect.any(Object),
+          }),
+        }),
+      }),
+    );
+  });
+
   it('forRoot options apply documentTransform after document generation', async () => {
     @Controller('/health')
     class HealthController {

--- a/packages/openapi/src/openapi-module.ts
+++ b/packages/openapi/src/openapi-module.ts
@@ -86,6 +86,21 @@ function isOpenApiModuleOptions(value: unknown): value is OpenApiModuleOptions {
   return typeof options.title === 'string' && typeof options.version === 'string';
 }
 
+function resolveOpenApiDescriptors(options: OpenApiModuleOptions): readonly HandlerDescriptor[] {
+  const sourceDescriptors = createHandlerMapping([...(options.sources ?? [])]).descriptors;
+  const explicitDescriptors = [...(options.descriptors ?? [])];
+
+  if (sourceDescriptors.length === 0) {
+    return explicitDescriptors;
+  }
+
+  if (explicitDescriptors.length === 0) {
+    return sourceDescriptors;
+  }
+
+  return [...sourceDescriptors, ...explicitDescriptors];
+}
+
 export class OpenApiModule {
   static forRoot(options: OpenApiModuleOptions): ModuleType {
     return this.createModule({
@@ -151,13 +166,9 @@ export class OpenApiModule {
               throw new Error('OpenApiModule options provider must resolve title and version.');
             }
 
-            if (options.descriptors && options.sources) {
-              throw new Error('OpenApiModule.forRoot() accepts either descriptors or sources, but not both.');
-            }
-
             const registry = new OpenApiHandlerRegistry();
 
-            registry.setDescriptors(options.descriptors ?? createHandlerMapping([...(options.sources ?? [])]).descriptors);
+            registry.setDescriptors(resolveOpenApiDescriptors(options));
 
             return buildOpenApiDocument({
               documentTransform: options.documentTransform,


### PR DESCRIPTION
## Summary
- allow `OpenApiModule` to compose handler descriptors from both `sources` and explicit `descriptors` instead of treating them as mutually exclusive
- keep descriptor resolution in a dedicated helper for deterministic emission behavior in slice 2
- add sync/async module tests that verify composed options emit both path sets in `/openapi.json`

## Validation
- pnpm exec vitest run packages/openapi/src/openapi-module.test.ts
- pnpm exec vitest run packages/openapi/src
- pnpm build
- pnpm typecheck

Part of #567