### PR TITLE
Resolve #568: add optional request-scoped DataLoader helper

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -111,6 +111,8 @@ interface GraphQLContext {
 
 - `createGraphqlProviders(options)`
 - `GRAPHQL_MODULE_OPTIONS`, `GRAPHQL_LIFECYCLE_SERVICE`
+- `getRequestScopedDataLoader(context, key, createLoader)`
+- `createRequestScopedDataLoaderFactory(key, createLoader)`
 
 ## 데코레이터
 
@@ -246,6 +248,41 @@ class UserResolver {
 ```
 
 resolver와 loader factory가 모두 request scope이므로 GraphQL operation마다 DataLoader 캐시가 분리됩니다.
+
+선택적으로 사용할 수 있는 얇은 helper(데코레이터 없음):
+
+```typescript
+import DataLoader from 'dataloader';
+import { Inject } from '@konekti/core';
+import { Arg, Query, Resolver, type GraphQLContext, getRequestScopedDataLoader } from '@konekti/graphql';
+
+const USER_BY_ID_LOADER = Symbol('user-by-id-loader');
+
+class UserByIdInput {
+  @Arg('id')
+  id = '';
+}
+
+@Inject([UserRepository])
+@Resolver('UserResolver')
+class UserResolver {
+  constructor(private readonly repo: UserRepository) {}
+
+  @Query()
+  async userName(input: UserByIdInput, context: GraphQLContext): Promise<string> {
+    const loader = getRequestScopedDataLoader(context, USER_BY_ID_LOADER, () =>
+      new DataLoader<string, User | null>(async (ids) => {
+        const users = await this.repo.findManyByIds(ids);
+        const map = new Map(users.map((user) => [user.id, user]));
+        return ids.map((item) => map.get(item) ?? null);
+      }),
+    );
+
+    const user = await loader.load(input.id);
+    return user?.name ?? 'unknown';
+  }
+}
+```
 
 ## 플러그인 기반 complexity/depth 제한
 

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -111,6 +111,8 @@ interface GraphQLContext {
 
 - `createGraphqlProviders(options)`
 - `GRAPHQL_MODULE_OPTIONS`, `GRAPHQL_LIFECYCLE_SERVICE`
+- `getRequestScopedDataLoader(context, key, createLoader)`
+- `createRequestScopedDataLoaderFactory(key, createLoader)`
 
 ## Decorators
 
@@ -246,6 +248,41 @@ class UserResolver {
 ```
 
 Because both resolver and loader factory are request-scoped, each GraphQL operation gets isolated DataLoader caches.
+
+Optional lightweight helper (no decorator required):
+
+```typescript
+import DataLoader from 'dataloader';
+import { Inject } from '@konekti/core';
+import { Arg, Query, Resolver, type GraphQLContext, getRequestScopedDataLoader } from '@konekti/graphql';
+
+const USER_BY_ID_LOADER = Symbol('user-by-id-loader');
+
+class UserByIdInput {
+  @Arg('id')
+  id = '';
+}
+
+@Inject([UserRepository])
+@Resolver('UserResolver')
+class UserResolver {
+  constructor(private readonly repo: UserRepository) {}
+
+  @Query()
+  async userName(input: UserByIdInput, context: GraphQLContext): Promise<string> {
+    const loader = getRequestScopedDataLoader(context, USER_BY_ID_LOADER, () =>
+      new DataLoader<string, User | null>(async (ids) => {
+        const users = await this.repo.findManyByIds(ids);
+        const map = new Map(users.map((user) => [user.id, user]));
+        return ids.map((item) => map.get(item) ?? null);
+      }),
+    );
+
+    const user = await loader.load(input.id);
+    return user?.name ?? 'unknown';
+  }
+}
+```
 
 ## Complexity / depth limiting with plugins
 

--- a/packages/graphql/src/dataloader.test.ts
+++ b/packages/graphql/src/dataloader.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { createRequestScopedDataLoaderFactory, getRequestScopedDataLoader } from './dataloader.js';
+import type { GraphQLContext } from './types.js';
+
+function createContext(): GraphQLContext {
+  return {
+    request: {
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/graphql',
+      query: {},
+      raw: {},
+      url: '/graphql',
+    },
+  };
+}
+
+describe('request-scoped DataLoader helpers', () => {
+  it('reuses loader instance for the same operation context and key', () => {
+    const context = createContext();
+
+    const first = getRequestScopedDataLoader(context, 'userById', () => ({ id: Symbol('loader') }));
+    const second = getRequestScopedDataLoader(context, 'userById', () => ({ id: Symbol('loader') }));
+
+    expect(first).toBe(second);
+  });
+
+  it('creates isolated loader instances across different operation contexts', () => {
+    const contextA = createContext();
+    const contextB = createContext();
+
+    const loaderA = getRequestScopedDataLoader(contextA, 'userById', () => ({ id: Symbol('loader') }));
+    const loaderB = getRequestScopedDataLoader(contextB, 'userById', () => ({ id: Symbol('loader') }));
+
+    expect(loaderA).not.toBe(loaderB);
+  });
+
+  it('supports pre-bound factory helper', () => {
+    const context = createContext();
+    const getUserLoader = createRequestScopedDataLoaderFactory('userById', () => ({ id: Symbol('loader') }));
+
+    const first = getUserLoader(context);
+    const second = getUserLoader(context);
+
+    expect(first).toBe(second);
+  });
+});

--- a/packages/graphql/src/dataloader.ts
+++ b/packages/graphql/src/dataloader.ts
@@ -1,0 +1,27 @@
+import { GRAPHQL_REQUEST_SCOPED_LOADER_CACHE, type GraphQLContext } from './types.js';
+
+export function getRequestScopedDataLoader<TLoader>(
+  context: GraphQLContext,
+  key: string | symbol,
+  createLoader: () => TLoader,
+): TLoader {
+  const cache = context[GRAPHQL_REQUEST_SCOPED_LOADER_CACHE] ?? new Map<string | symbol, unknown>();
+  context[GRAPHQL_REQUEST_SCOPED_LOADER_CACHE] = cache;
+
+  const existing = cache.get(key);
+  if (existing !== undefined) {
+    return existing as TLoader;
+  }
+
+  const created = createLoader();
+  cache.set(key, created);
+
+  return created;
+}
+
+export function createRequestScopedDataLoaderFactory<TLoader>(
+  key: string | symbol,
+  createLoader: () => TLoader,
+): (context: GraphQLContext) => TLoader {
+  return (context: GraphQLContext) => getRequestScopedDataLoader(context, key, createLoader);
+}

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,3 +1,4 @@
+export * from './dataloader.js';
 export * from './decorators.js';
 export * from './metadata.js';
 export * from './module.js';

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -4,6 +4,7 @@ import type { FrameworkRequest, Principal } from '@konekti/http';
 import type { GraphQLObjectType, GraphQLSchema, GraphQLUnionType } from 'graphql';
 
 export const GRAPHQL_OPERATION_CONTAINER = Symbol.for('konekti.graphql.operation.container');
+export const GRAPHQL_REQUEST_SCOPED_LOADER_CACHE = Symbol.for('konekti.graphql.request_scoped_loader_cache');
 
 export interface GraphqlRequestContext {
   request: FrameworkRequest;
@@ -17,6 +18,7 @@ export interface GraphQLContext {
   connectionParams?: Record<string, unknown>;
   principal?: Principal;
   [GRAPHQL_OPERATION_CONTAINER]?: Container;
+  [GRAPHQL_REQUEST_SCOPED_LOADER_CACHE]?: Map<string | symbol, unknown>;
   [key: string]: unknown;
   socket?: unknown;
 }


### PR DESCRIPTION
## Summary
- add lightweight `getRequestScopedDataLoader(...)` and `createRequestScopedDataLoaderFactory(...)` helpers to keep DataLoader instances operation-scoped
- store helper cache on GraphQL operation context via an internal symbol without introducing a decorator abstraction
- add focused helper tests and README updates (EN/KO) documenting the optional usage path

Closes #568