### PR TITLE
Resolve #590: add metadata foundations for package discoverability

### DIFF
--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -23,7 +23,6 @@
 - `@konekti/drizzle`
 - `@konekti/mongoose`
 - `@konekti/terminus`
-
 - `@konekti/openapi`
 - `@konekti/graphql`
 - `@konekti/serialization`
@@ -34,6 +33,7 @@
 - `@konekti/event-bus`
 - `@konekti/websocket`
 - `@konekti/queue`
+- `@konekti/throttler`
 - `@konekti/testing`
 - `@konekti/cli`
 - `@konekti/studio`
@@ -49,7 +49,7 @@
 - **`@konekti/platform-express`**: Express 기반 HTTP 어댑터.
 - **`@konekti/platform-socket.io`**: 공용 Konekti 런타임과 websocket 데코레이터 위에 구축된 Socket.IO v4 게이트웨이 어댑터.
 - **`@konekti/microservices`**: 트랜스포트 추상화, 패턴 데코레이터, 마이크로서비스 런타임. 서브패스 export는 `./tcp`, `./redis`, `./nats`, `./kafka`, `./rabbitmq`, `./grpc`, `./mqtt` 트랜스포트 엔트리포인트를 포함합니다.
-- **`@konekti/validation` 패키지**: 유효성 검사 데코레이터, 매핑된 DTO 헬퍼, 검증 엔진.
+- **`@konekti/validation`**: 유효성 검사 데코레이터, 매핑된 DTO 헬퍼, 검증 엔진.
 - **`@konekti/jwt`**: 핵심 JWT 로직.
 - **`@konekti/passport`**: 인증 전략 레지스트리 및 범용 가드 연결.
 - **`@konekti/openapi`**: 문서 생성 및 OpenAPI 데코레이터.
@@ -67,6 +67,7 @@
 - **`@konekti/drizzle`**: Drizzle handle을 ALS 트랜잭션 컨텍스트에 통합(비동기 모듈 팩토리, strict/fallback 트랜잭션 동작, optional `dispose` 셧다운 훅).
 - **`@konekti/mongoose`**: 런타임/DI 연결을 위한 Mongoose 통합 패키지.
 - **`@konekti/terminus`**: 헬스 인디케이터 조합과 런타임 헬스 응답 집계를 확장하는 운영 헬스 패키지.
+- **`@konekti/throttler`**: 인메모리/Redis 스토어 어댑터를 지원하는 데코레이터 기반 속도 제한.
 - **`@konekti/testing`**: 테스트 모듈 및 헬퍼 유틸리티.
 - **`@konekti/cli`**: 애플리케이션 부트스트랩/생성/마이그레이션 + 런타임 진단 inspect 명령어.
 - **`@konekti/studio`**: 런타임 그래프/타이밍 JSON 내보내기를 파일 기반으로 확인하는 diagnostics viewer.

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -33,6 +33,7 @@ This page provides an overview of the current public package family within the K
 - `@konekti/event-bus`
 - `@konekti/websocket`
 - `@konekti/queue`
+- `@konekti/throttler`
 - `@konekti/testing`
 - `@konekti/cli`
 - `@konekti/studio`
@@ -48,7 +49,7 @@ This page provides an overview of the current public package family within the K
 - **`@konekti/platform-express`**: Express-based HTTP adapter.
 - **`@konekti/platform-socket.io`**: Socket.IO v4 gateway adapter built on the shared Konekti runtime and websocket decorators.
 - **`@konekti/microservices`**: Transport abstraction, pattern decorators, and microservice runtime. Subpath exports include `./tcp`, `./redis`, `./nats`, `./kafka`, `./rabbitmq`, `./grpc`, and `./mqtt` transport entrypoints.
-- **`@konekti/validation` package**: Validation decorators, mapped DTO helpers, and validation engine.
+- **`@konekti/validation`**: Validation decorators, mapped DTO helpers, and validation engine.
 - **`@konekti/jwt`**: Core JWT logic.
 - **`@konekti/passport`**: Authentication strategy registry and generic guard wiring.
 - **`@konekti/openapi`**: Document generation and OpenAPI decorators.
@@ -66,6 +67,7 @@ This page provides an overview of the current public package family within the K
 - **`@konekti/drizzle`**: Drizzle handle integration with ALS transaction context, async module factory, strict/fallback transaction behavior, and optional `dispose` shutdown hook.
 - **`@konekti/mongoose`**: Mongoose integration package for runtime/DI wiring.
 - **`@konekti/terminus`**: Health indicator composition and enriched runtime health aggregation.
+- **`@konekti/throttler`**: Decorator-based rate limiting with in-memory and Redis store adapters.
 - **`@konekti/testing`**: Testing module and helper utilities.
 - **`@konekti/cli`**: Application bootstrap, generation, migration, and runtime diagnostics inspection commands.
 - **`@konekti/studio`**: File-first diagnostics viewer for runtime graph/timing JSON exports.

--- a/packages/cache-manager/package.json
+++ b/packages/cache-manager/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@konekti/cache-manager",
-  "description": "HTTP response caching primitives for Konekti with memory and Redis stores.",
+  "description": "Decorator-driven HTTP response caching and standalone cache service for Konekti, with memory and Redis backends.",
+  "keywords": [
+    "konekti",
+    "cache",
+    "caching",
+    "http-cache",
+    "redis",
+    "memory-store",
+    "decorator"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/cli",
+  "description": "The Konekti CLI — bootstrap, generate, migrate, and inspect commands for application development.",
+  "keywords": [
+    "konekti",
+    "cli",
+    "scaffold",
+    "generator",
+    "migration",
+    "diagnostics"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@konekti/config",
+  "description": "Configuration loading, merging, validation, and typed runtime access for Konekti applications.",
+  "keywords": [
+    "konekti",
+    "config",
+    "configuration",
+    "environment",
+    "typed-config"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/core",
+  "description": "Shared contracts, decorators, and metadata helpers that form the foundation of every Konekti package.",
+  "keywords": [
+    "konekti",
+    "core",
+    "decorators",
+    "metadata",
+    "types",
+    "foundation"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/cqrs/package.json
+++ b/packages/cqrs/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@konekti/cqrs",
-  "description": "CQRS command/query buses and event bus delegation for Konekti.",
+  "description": "Command/query buses with bootstrap-time handler discovery, saga support, and event-bus delegation for Konekti.",
+  "keywords": [
+    "konekti",
+    "cqrs",
+    "command-bus",
+    "query-bus",
+    "saga",
+    "event-sourcing"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/cron",
+  "description": "Decorator-based task scheduling for Konekti with cron, interval, and timeout triggers and optional distributed locking.",
+  "keywords": [
+    "konekti",
+    "cron",
+    "scheduler",
+    "interval",
+    "timeout",
+    "distributed-lock"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/di",
+  "description": "Minimal token-based dependency injection container powering every Konekti application.",
+  "keywords": [
+    "konekti",
+    "di",
+    "dependency-injection",
+    "ioc",
+    "container",
+    "provider"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/drizzle",
+  "description": "Drizzle ORM integration for Konekti with ALS transaction context, async module factory, and optional dispose hook.",
+  "keywords": [
+    "konekti",
+    "drizzle",
+    "orm",
+    "database",
+    "transaction",
+    "als"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -1,6 +1,13 @@
 {
   "name": "@konekti/event-bus",
-  "description": "In-process only event publishing for Konekti applications.",
+  "description": "In-process event publishing and handler discovery for Konekti applications.",
+  "keywords": [
+    "konekti",
+    "event-bus",
+    "events",
+    "pubsub",
+    "in-process"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/graphql",
+  "description": "Decorator-based GraphQL module, schema exposure, and execution pipeline for Konekti.",
+  "keywords": [
+    "konekti",
+    "graphql",
+    "resolver",
+    "schema",
+    "yoga",
+    "api"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,5 +1,15 @@
 {
   "name": "@konekti/http",
+  "description": "HTTP execution layer — routing, guards, interceptors, DTO binding, and exception handling for Konekti.",
+  "keywords": [
+    "konekti",
+    "http",
+    "routing",
+    "guards",
+    "interceptors",
+    "controller",
+    "rest"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/jwt",
+  "description": "HTTP-agnostic JWT signing and verification core for Konekti authentication.",
+  "keywords": [
+    "konekti",
+    "jwt",
+    "authentication",
+    "token",
+    "signing",
+    "verification"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -3,7 +3,7 @@
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
 
-Prometheus metrics endpoint for konekti applications. Mount `MetricsModule` to expose a `/metrics` scrape target with Node.js default metrics collected out of the box.
+Prometheus metrics endpoint for Konekti applications. Mount `MetricsModule` to expose a `/metrics` scrape target with Node.js default metrics collected out of the box.
 
 ## See also
 

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@konekti/metrics",
+  "description": "Prometheus metrics exposure with isolated registries and low-cardinality HTTP metric middleware for Konekti.",
+  "keywords": [
+    "konekti",
+    "metrics",
+    "prometheus",
+    "monitoring",
+    "observability"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/microservices/package.json
+++ b/packages/microservices/package.json
@@ -1,5 +1,18 @@
 {
   "name": "@konekti/microservices",
+  "description": "Transport-driven microservice runtime with pattern decorators and multi-transport support for Konekti.",
+  "keywords": [
+    "konekti",
+    "microservices",
+    "transport",
+    "tcp",
+    "redis",
+    "nats",
+    "kafka",
+    "rabbitmq",
+    "grpc",
+    "mqtt"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/mongoose",
+  "description": "Mongoose integration for Konekti with session-aware transaction context and lifecycle management.",
+  "keywords": [
+    "konekti",
+    "mongoose",
+    "mongodb",
+    "database",
+    "transaction",
+    "odm"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -3,7 +3,7 @@
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
 
-Decorator-based OpenAPI 3.1.0 document generation for konekti applications. Annotate controllers and handlers, then mount `OpenApiModule` to automatically serve a spec at `/openapi.json` and an optional Swagger UI at `/docs`.
+Decorator-based OpenAPI 3.1.0 document generation for Konekti applications. Annotate controllers and handlers, then mount `OpenApiModule` to automatically serve a spec at `/openapi.json` and an optional Swagger UI at `/docs`.
 
 ## See also
 

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/openapi",
+  "description": "Decorator-based OpenAPI 3.1 document generation and Swagger UI for Konekti applications.",
+  "keywords": [
+    "konekti",
+    "openapi",
+    "swagger",
+    "api-docs",
+    "documentation",
+    "rest"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/passport/package.json
+++ b/packages/passport/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/passport",
+  "description": "Strategy-agnostic authentication guard wiring and strategy registry for Konekti.",
+  "keywords": [
+    "konekti",
+    "passport",
+    "authentication",
+    "auth",
+    "guard",
+    "strategy"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/platform-express/package.json
+++ b/packages/platform-express/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@konekti/platform-express",
+  "description": "Express-based HTTP adapter for the Konekti runtime.",
+  "keywords": [
+    "konekti",
+    "express",
+    "http-adapter",
+    "platform",
+    "server"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@konekti/platform-fastify",
+  "description": "Fastify-based HTTP adapter for the Konekti runtime.",
+  "keywords": [
+    "konekti",
+    "fastify",
+    "http-adapter",
+    "platform",
+    "server"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/platform-socket.io/package.json
+++ b/packages/platform-socket.io/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/platform-socket.io",
+  "description": "Socket.IO v4 gateway adapter for Konekti applications, built on the shared runtime and websocket decorators.",
+  "keywords": [
+    "konekti",
+    "socket.io",
+    "websocket",
+    "gateway",
+    "realtime",
+    "platform"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/prisma",
+  "description": "Prisma lifecycle and ALS-backed transaction context for Konekti, with async module factory and strict transaction mode.",
+  "keywords": [
+    "konekti",
+    "prisma",
+    "orm",
+    "database",
+    "transaction",
+    "als"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,5 +1,15 @@
 {
   "name": "@konekti/queue",
+  "description": "Redis-backed background job processing with worker discovery and DLQ support for Konekti.",
+  "keywords": [
+    "konekti",
+    "queue",
+    "jobs",
+    "background",
+    "worker",
+    "redis",
+    "dlq"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/redis",
+  "description": "App-scoped Redis lifecycle management, raw client injection, and RedisService facade for Konekti.",
+  "keywords": [
+    "konekti",
+    "redis",
+    "ioredis",
+    "cache",
+    "connection",
+    "lifecycle"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/runtime",
+  "description": "Application bootstrap and runtime orchestration — module graph compilation, DI wiring, and diagnostics export for Konekti.",
+  "keywords": [
+    "konekti",
+    "runtime",
+    "bootstrap",
+    "application",
+    "module-graph",
+    "orchestration"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/serialization/package.json
+++ b/packages/serialization/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/serialization",
+  "description": "Class-based response serialization and output shaping interceptors for Konekti.",
+  "keywords": [
+    "konekti",
+    "serialization",
+    "response",
+    "interceptor",
+    "output",
+    "transform"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/studio",
+  "description": "File-first diagnostics viewer for Konekti runtime graph and timing JSON exports.",
+  "keywords": [
+    "konekti",
+    "studio",
+    "diagnostics",
+    "viewer",
+    "module-graph",
+    "devtools"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -1,0 +1,103 @@
+# @konekti/terminus
+
+<p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
+
+Konekti 애플리케이션을 위한 헬스 인디케이터 조합 및 런타임 헬스 응답 집계 툴킷. `@konekti/terminus`는 런타임 health/readiness 엔드포인트 위에 의존성 인식 검사를 추가합니다.
+
+## 이 패키지가 하는 일
+
+- `createHealthModule()`을 통해 런타임 소유 `/health` + `/ready` 배선을 보존
+- 조합 가능한 헬스 인디케이터 계약(`HealthIndicator`, `HealthIndicatorResult`) 추가
+- 인디케이터 결과를 구조화된 보고서(`status`, `info`, `error`, `details`)로 집계
+- 인디케이터 실패 시 `/health`를 HTTP `503`으로 설정
+- 인디케이터 기반 readiness 검사를 등록하여 의존성 실패 시 `/ready`가 `503` 반환
+
+## 설치
+
+```bash
+npm install @konekti/terminus
+```
+
+선택적 피어 통합(`@konekti/prisma`, `@konekti/drizzle`, `@konekti/redis`)은 모듈 로드 시점에 import되지 않습니다. 해당 피어가 설치되지 않아도 안전하게 사용할 수 있습니다.
+
+## 빠른 시작
+
+```typescript
+import { Module } from '@konekti/core';
+import {
+  HttpHealthIndicator,
+  MemoryHealthIndicator,
+  createTerminusModule,
+} from '@konekti/terminus';
+
+@Module({
+  imports: [
+     createTerminusModule({
+       indicators: [
+         new HttpHealthIndicator({ key: 'upstream-api', url: 'https://example.com/health' }),
+         new MemoryHealthIndicator({ key: 'memory', heapUsedThresholdRatio: 0.9 }),
+      ],
+    }),
+  ],
+})
+class AppModule {}
+```
+
+## 내장 인디케이터
+
+- `PrismaHealthIndicator`
+- `DrizzleHealthIndicator`
+- `RedisHealthIndicator`
+- `HttpHealthIndicator`
+- `MemoryHealthIndicator`
+- `DiskHealthIndicator`
+
+편의 팩토리(`createPrismaHealthIndicator()` 등)도 내보내며, 클래스 인스턴스를 반환합니다.
+피어 기반 통합은 `createPrismaHealthIndicatorProvider()`, `createDrizzleHealthIndicatorProvider()`, `createRedisHealthIndicatorProvider()` 같은 DI 등록 헬퍼도 노출하여, 선택적 피어를 모듈 로드 시점에 import하지 않고도 해당 Konekti 클라이언트 토큰에서 인디케이터 인스턴스를 생성할 수 있습니다.
+
+DI 기반 인디케이터를 `/health`와 `/ready`에 참여시키려면 `indicatorProviders`로 전달하세요:
+
+```typescript
+import { REDIS_CLIENT } from '@konekti/redis';
+import { createRedisHealthIndicatorProvider, createTerminusModule } from '@konekti/terminus';
+
+createTerminusModule({
+  indicatorProviders: [createRedisHealthIndicatorProvider({ key: 'redis' })],
+});
+```
+
+Drizzle의 경우, 기본 경로는 `select 1`을 사용하는 **execute 가능한 handle**(`database.execute(...)`)을 사용합니다. Drizzle 설정이 범용 execute seam을 노출하지 않는 경우, 명시적 `ping` 콜백을 전달하세요.
+
+## 주요 API
+
+- `createTerminusModule(options)`
+- `createTerminusProviders(options)`
+- `runHealthCheck(indicators)`
+- `assertHealthCheck(report)`
+- `TerminusHealthService`
+- `HealthCheckError`
+
+## 실패 시맨틱
+
+- `indicator.check(key)`는 성공 시 `{ [key]: { status: 'up', ...details } }`를 반환합니다.
+- `indicator.check(key)`는 실패 시 `{ [key]: { status: 'down', ...details } }` 형태의 `causes`를 가진 `HealthCheckError`를 throw합니다.
+- `runHealthCheck(indicators)`는 해당 실패를 catch하고 구조화된 causes를 보존하여 `/health` 보고서에 집계합니다.
+
+## 헬스 보고서 형식
+
+```json
+{
+  "status": "error",
+  "checkedAt": "2026-03-24T00:00:00.000Z",
+  "info": {
+    "memory": { "status": "up", "rss": 123456 }
+  },
+  "error": {
+    "redis": { "status": "down", "message": "ECONNREFUSED" }
+  },
+  "details": {
+    "memory": { "status": "up", "rss": 123456 },
+    "redis": { "status": "down", "message": "ECONNREFUSED" }
+  }
+}
+```

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -1,6 +1,6 @@
 # @konekti/terminus
 
-<p><strong><kbd>English</kbd></strong></p>
+<p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
 Health indicator toolkit for Konekti applications. `@konekti/terminus` layers on top of runtime health/readiness endpoints and adds dependency-aware checks for `/health`.
 

--- a/packages/terminus/package.json
+++ b/packages/terminus/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/terminus",
+  "description": "Health indicator composition and enriched runtime health aggregation for Konekti applications.",
+  "keywords": [
+    "konekti",
+    "terminus",
+    "health",
+    "readiness",
+    "liveness",
+    "health-check"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/testing",
+  "description": "Testing module construction and provider override utilities for Konekti applications.",
+  "keywords": [
+    "konekti",
+    "testing",
+    "test",
+    "mock",
+    "override",
+    "module-builder"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/throttler/package.json
+++ b/packages/throttler/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@konekti/throttler",
   "description": "Decorator-based rate limiting for Konekti applications with in-memory and Redis store adapters.",
+  "keywords": [
+    "konekti",
+    "throttler",
+    "rate-limit",
+    "rate-limiting",
+    "redis",
+    "decorator"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/validation",
+  "description": "Input-side validation decorators, mapped DTO helpers, and validation engine for Konekti.",
+  "keywords": [
+    "konekti",
+    "validation",
+    "dto",
+    "input",
+    "decorators",
+    "schema"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@konekti/websocket",
+  "description": "Decorator-based WebSocket gateway discovery and Node HTTP upgrade wiring for Konekti.",
+  "keywords": [
+    "konekti",
+    "websocket",
+    "ws",
+    "gateway",
+    "realtime",
+    "upgrade"
+  ],
   "version": "0.0.0",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

Add and standardize package metadata so Konekti packages are easier to understand from npm, IDEs, and package READMEs. This establishes the stable taxonomy language that downstream issues (#591, #594) will build on.

Closes #590

## Changes

- **`package.json` descriptions** — populated all 31 public packages with meaningful `description` fields aligned to `package-surface.md` responsibilities; refined existing descriptions (cache-manager, cqrs, event-bus, throttler)
- **`package.json` keywords** — added `keywords` arrays to every public package for npm/IDE discoverability
- **`package-surface.md` (EN + KO)** — registered `@konekti/throttler` in public package family and responsibilities; fixed `@konekti/validation` label (removed stray "package" suffix); removed stray blank line in Korean variant
- **README capitalization** — fixed lowercase `konekti` → `Konekti` in `@konekti/metrics` and `@konekti/openapi` README openings
- **`@konekti/terminus` bilingual** — added language switch to English README and created `README.ko.md` (the only package that was missing a Korean counterpart)

## Testing

- All 31 `package.json` files validated as parseable JSON with `name → description → keywords` key ordering
- No runtime, API, or packaging behavior changes — metadata and docs only
- Typecheck not applicable (no `.ts` changes)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

> This PR contains zero runtime/behavior changes. All modifications are to `package.json` metadata fields, `package-surface.md` reference docs, and README prose.