### PR TITLE
Resolve #593: make bootstrap and provider failures recovery-oriented

### DIFF
--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -117,6 +117,22 @@ factory → resolve inject deps, then call useFactory(...deps)
 class   → resolve inject deps, then call new useClass(...deps)
 ```
 
+### Recovery-oriented error output
+
+Every DI error includes structured context to help diagnose failures without reading source code. When a resolution, scope, or registration error occurs, the error message appends:
+
+- **Token** — the token that failed to resolve or was misconfigured
+- **Scope** — the scope context where the failure occurred (e.g. `singleton`, `request`)
+- **Hint** — a plain-language recovery action (e.g. "Register a provider for this token" or "Use container.createRequestScope()")
+
+Errors also carry a machine-readable `meta` object with the same fields, suitable for structured logging or monitoring. Example:
+
+```text
+ContainerResolutionError: No provider registered for token UserService.
+  Token: UserService
+  Hint: Register a provider for this token using container.register(), or check that the owning module exports it and is imported by the consuming module.
+```
+
 ## File reading order for contributors
 
 1. `packages/core/src/decorators.ts` — `@Inject()` and `@Scope()` decorator definitions

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { Inject, Scope as ScopeDecorator } from '@konekti/core';
 
 import { Container } from './container.js';
-import { CircularDependencyError, DuplicateProviderError, ScopeMismatchError } from './errors.js';
+import { CircularDependencyError, ContainerResolutionError, DuplicateProviderError, RequestScopeResolutionError, ScopeMismatchError } from './errors.js';
 import { Scope, forwardRef, optional } from './types.js';
 
 describe('Container', () => {
@@ -983,5 +983,133 @@ describe('Container', () => {
 
       expect(events.filter((e) => e === 'plugin-a')).toHaveLength(1);
     });
+  });
+});
+
+describe('Recovery-oriented error context', () => {
+  it('ContainerResolutionError for missing provider includes token name and hint', async () => {
+    const TOKEN = Symbol('MissingService');
+    const container = new Container();
+
+    const error = await container.resolve(TOKEN).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ContainerResolutionError);
+    const message = (error as ContainerResolutionError).message;
+    expect(message).toContain('MissingService');
+    expect(message).toContain('Hint:');
+    expect(message).toContain('provider');
+  });
+
+  it('ContainerResolutionError for disposed container includes hint', async () => {
+    const container = new Container();
+    await container.dispose();
+
+    const error = await container.resolve(Symbol('any')).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ContainerResolutionError);
+    expect((error as ContainerResolutionError).message).toContain('Hint:');
+  });
+
+  it('RequestScopeResolutionError includes token name and hint about createRequestScope', async () => {
+    class RequestService {}
+
+    const root = new Container().register({
+      provide: RequestService,
+      scope: 'request',
+      useClass: RequestService,
+    });
+
+    const error = await root.resolve(RequestService).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(RequestScopeResolutionError);
+    const message = (error as RequestScopeResolutionError).message;
+    expect(message).toContain('RequestService');
+    expect(message).toContain('Hint:');
+    expect(message).toContain('createRequestScope');
+  });
+
+  it('ScopeMismatchError includes token names and hint when singleton depends on request-scoped', async () => {
+    class RequestDep {}
+    class SingletonService {
+      constructor(readonly dep: RequestDep) {}
+    }
+
+    const container = new Container().register(
+      { provide: RequestDep, scope: 'request', useClass: RequestDep },
+      { provide: SingletonService, useClass: SingletonService, inject: [RequestDep] },
+    );
+
+    const error = await container.resolve(SingletonService).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ScopeMismatchError);
+    const message = (error as ScopeMismatchError).message;
+    expect(message).toContain('SingletonService');
+    expect(message).toContain('RequestDep');
+    expect(message).toContain('Hint:');
+  });
+
+  it('ScopeMismatchError includes hint when registering singleton on request scope', () => {
+    const token = Symbol('singleton-token');
+    const root = new Container();
+    const requestScope = root.createRequestScope();
+
+    try {
+      requestScope.register({ provide: token, useValue: 'value' });
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ScopeMismatchError);
+      expect((error as ScopeMismatchError).message).toContain('Hint:');
+      expect((error as ScopeMismatchError).message).toContain('root container');
+    }
+  });
+
+  it('DuplicateProviderError includes token name and hint', () => {
+    class MyService {}
+
+    try {
+      new Container().register(MyService, MyService);
+      expect.unreachable('should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(DuplicateProviderError);
+      const message = (error as DuplicateProviderError).message;
+      expect(message).toContain('MyService');
+      expect(message).toContain('Hint:');
+      expect(message).toContain('override');
+    }
+  });
+
+  it('CircularDependencyError includes dependency chain and hint', async () => {
+    class ServiceA {
+      constructor(public b: ServiceB) {}
+    }
+
+    class ServiceB {
+      constructor(public a: ServiceA) {}
+    }
+
+    const container = new Container().register(
+      { provide: ServiceA, useClass: ServiceA, inject: [ServiceB] },
+      { provide: ServiceB, useClass: ServiceB, inject: [ServiceA] },
+    );
+
+    const error = await container.resolve(ServiceA).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(CircularDependencyError);
+    const message = (error as CircularDependencyError).message;
+    expect(message).toContain('Dependency chain:');
+    expect(message).toContain('Hint:');
+    expect(message).toContain('forwardRef');
+  });
+
+  it('error meta includes machine-readable token for ContainerResolutionError', async () => {
+    const TOKEN = Symbol('MyToken');
+    const container = new Container();
+
+    const error = await container.resolve(TOKEN).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(ContainerResolutionError);
+    expect((error as ContainerResolutionError).meta).toBeDefined();
+    expect((error as ContainerResolutionError).meta!['token']).toContain('MyToken');
+    expect((error as ContainerResolutionError).meta!['hint']).toBeDefined();
   });
 });

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -1,4 +1,4 @@
-import { InvariantError, getClassDiMetadata, type Token } from '@konekti/core';
+import { InvariantError, formatTokenName, getClassDiMetadata, type Token } from '@konekti/core';
 
 import {
   CircularDependencyError,
@@ -137,7 +137,10 @@ export class Container {
 
   register(...providers: Provider[]): this {
     if (this.disposed) {
-      throw new ContainerResolutionError('Container has been disposed and can no longer register providers.');
+      throw new ContainerResolutionError(
+        'Container has been disposed and can no longer register providers.',
+        { hint: 'Ensure providers are registered before calling container.dispose().' },
+      );
     }
 
     for (const provider of providers) {
@@ -145,8 +148,12 @@ export class Container {
 
       if (this.requestScopeEnabled && normalized.scope === Scope.DEFAULT && normalized.multi !== true) {
         throw new ScopeMismatchError(
-          `Singleton provider ${String(normalized.provide)} cannot be registered on a request-scope container. ` +
-            'Register it on the root container or override it within the request scope instead.',
+          `Singleton provider ${String(normalized.provide)} cannot be registered on a request-scope container.`,
+          {
+            token: normalized.provide,
+            scope: 'singleton',
+            hint: 'Register it on the root container before creating the request scope, or use container.override() within the request scope instead.',
+          },
         );
       }
 
@@ -180,7 +187,10 @@ export class Container {
    */
   override(...providers: Provider[]): this {
     if (this.disposed) {
-      throw new ContainerResolutionError('Container has been disposed and can no longer override providers.');
+      throw new ContainerResolutionError(
+        'Container has been disposed and can no longer override providers.',
+        { hint: 'Ensure overrides are applied before calling container.dispose().' },
+      );
     }
 
     for (const provider of providers) {
@@ -210,7 +220,10 @@ export class Container {
 
   createRequestScope(): Container {
     if (this.disposed) {
-      throw new ContainerResolutionError('Container has been disposed and can no longer create request scopes.');
+      throw new ContainerResolutionError(
+        'Container has been disposed and can no longer create request scopes.',
+        { hint: 'Create request scopes before calling container.dispose().' },
+      );
     }
 
     const child = new Container(this, true, this.root().singletonCache);
@@ -220,7 +233,10 @@ export class Container {
 
   async resolve<T>(token: Token<T>): Promise<T> {
     if (this.disposed) {
-      throw new ContainerResolutionError('Container has been disposed and can no longer resolve providers.');
+      throw new ContainerResolutionError(
+        'Container has been disposed and can no longer resolve providers.',
+        { token, hint: 'Ensure all resolves complete before calling container.dispose().' },
+      );
     }
 
     return this.resolveWithChain(token, [], new Set<Token>());
@@ -373,7 +389,13 @@ export class Container {
     const provider = this.lookupProvider(token);
 
     if (!provider) {
-      throw new ContainerResolutionError(`No provider registered for token ${String(token)}.`);
+      throw new ContainerResolutionError(
+        `No provider registered for token ${formatTokenName(token)}.`,
+        {
+          token,
+          hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
+        },
+      );
     }
 
     return provider;
@@ -536,7 +558,12 @@ export class Container {
 
     if (!this.requestScopeEnabled) {
       throw new RequestScopeResolutionError(
-        `Request-scoped provider ${String(provider.provide)} cannot be resolved outside request scope.`,
+        `Request-scoped provider ${formatTokenName(provider.provide)} cannot be resolved outside request scope.`,
+        {
+          token: provider.provide,
+          scope: 'request',
+          hint: 'Wrap the resolve call inside a request-scoped child container created via container.createRequestScope().',
+        },
       );
     }
 
@@ -556,7 +583,12 @@ export class Container {
 
     if (!this.requestScopeEnabled) {
       throw new RequestScopeResolutionError(
-        `Request-scoped provider ${String(provider.provide)} cannot be resolved outside request scope.`,
+        `Request-scoped provider ${formatTokenName(provider.provide)} cannot be resolved outside request scope.`,
+        {
+          token: provider.provide,
+          scope: 'request',
+          hint: 'Wrap the resolve call inside a request-scoped child container created via container.createRequestScope().',
+        },
       );
     }
 
@@ -727,8 +759,12 @@ export class Container {
 
       if (effectiveProvider?.scope === 'request') {
         throw new ScopeMismatchError(
-          `Singleton provider ${String(provider.provide)} depends on request-scoped provider ${String(depToken)}. ` +
-            'Singleton providers cannot depend on request-scoped providers.',
+          `Singleton provider ${formatTokenName(provider.provide)} depends on request-scoped provider ${formatTokenName(depToken)}.`,
+          {
+            token: provider.provide,
+            scope: 'singleton',
+            hint: `Singleton providers cannot depend on request-scoped providers. Either change ${formatTokenName(depToken)} to singleton/transient scope, or change ${formatTokenName(provider.provide)} to request scope.`,
+          },
         );
       }
     }

--- a/packages/di/src/errors.ts
+++ b/packages/di/src/errors.ts
@@ -1,35 +1,93 @@
 import { KonektiCodeError, formatTokenName } from '@konekti/core';
 
+export interface DiErrorContext {
+  readonly token?: unknown;
+  readonly scope?: string;
+  readonly module?: string;
+  readonly dependencyChain?: readonly unknown[];
+  readonly hint?: string;
+}
+
+function formatDiContext(ctx?: DiErrorContext): string {
+  if (!ctx) return '';
+
+  const parts: string[] = [];
+
+  if (ctx.token !== undefined) {
+    parts.push(`Token: ${formatTokenName(ctx.token)}`);
+  }
+
+  if (ctx.scope) {
+    parts.push(`Scope: ${ctx.scope}`);
+  }
+
+  if (ctx.module) {
+    parts.push(`Module: ${ctx.module}`);
+  }
+
+  if (ctx.dependencyChain && ctx.dependencyChain.length > 0) {
+    parts.push(`Dependency chain: ${ctx.dependencyChain.map((t) => formatTokenName(t)).join(' -> ')}`);
+  }
+
+  if (ctx.hint) {
+    parts.push(`Hint: ${ctx.hint}`);
+  }
+
+  if (parts.length === 0) return '';
+
+  return '\n  ' + parts.join('\n  ');
+}
+
 export class InvalidProviderError extends KonektiCodeError {
-  constructor(message: string) {
-    super(message, 'INVALID_PROVIDER');
+  constructor(message: string, context?: DiErrorContext) {
+    super(
+      message + formatDiContext(context),
+      'INVALID_PROVIDER',
+      context ? { meta: buildMeta(context) } : undefined,
+    );
   }
 }
 
 export class ContainerResolutionError extends KonektiCodeError {
-  constructor(message: string) {
-    super(message, 'CONTAINER_RESOLUTION_ERROR');
+  constructor(message: string, context?: DiErrorContext) {
+    super(
+      message + formatDiContext(context),
+      'CONTAINER_RESOLUTION_ERROR',
+      context ? { meta: buildMeta(context) } : undefined,
+    );
   }
 }
 
 export class RequestScopeResolutionError extends KonektiCodeError {
-  constructor(message: string) {
-    super(message, 'REQUEST_SCOPE_RESOLUTION_ERROR');
+  constructor(message: string, context?: DiErrorContext) {
+    super(
+      message + formatDiContext(context),
+      'REQUEST_SCOPE_RESOLUTION_ERROR',
+      context ? { meta: buildMeta(context) } : undefined,
+    );
   }
 }
 
 export class ScopeMismatchError extends KonektiCodeError {
-  constructor(message: string) {
-    super(message, 'SCOPE_MISMATCH');
+  constructor(message: string, context?: DiErrorContext) {
+    super(
+      message + formatDiContext(context),
+      'SCOPE_MISMATCH',
+      context ? { meta: buildMeta(context) } : undefined,
+    );
   }
 }
 
 export class CircularDependencyError extends KonektiCodeError {
   constructor(chain: readonly unknown[], detail?: string) {
     const path = chain.map((token) => formatTokenName(token)).join(' -> ');
+    const hint = 'Break the cycle by extracting shared logic into a separate provider, or use forwardRef() to defer one side of the dependency.';
     super(
-      detail ? `Circular dependency detected: ${path}. ${detail}` : `Circular dependency detected: ${path}`,
+      (detail ? `Circular dependency detected: ${path}. ${detail}` : `Circular dependency detected: ${path}`) +
+        `\n  Dependency chain: ${path}` +
+        `\n  Hint: ${hint}`,
       'CIRCULAR_DEPENDENCY',
+      { meta: { chain: chain.map((t) => formatTokenName(t)), hint } },
     );
   }
 }
@@ -37,9 +95,25 @@ export class CircularDependencyError extends KonektiCodeError {
 export class DuplicateProviderError extends KonektiCodeError {
   constructor(token: unknown) {
     const name = formatTokenName(token);
+    const hint = 'Use container.override() for intentional overrides, or check for accidental double-registration in your module providers array.';
     super(
-      `Token "${name}" is already registered. Use container.override() for intentional overrides.`,
+      `Token "${name}" is already registered.` +
+        `\n  Token: ${name}` +
+        `\n  Hint: ${hint}`,
       'DUPLICATE_PROVIDER',
+      { meta: { token: name, hint } },
     );
   }
+}
+
+function buildMeta(context: DiErrorContext): Record<string, unknown> {
+  const meta: Record<string, unknown> = {};
+
+  if (context.token !== undefined) meta['token'] = formatTokenName(context.token);
+  if (context.scope) meta['scope'] = context.scope;
+  if (context.module) meta['module'] = context.module;
+  if (context.dependencyChain) meta['dependencyChain'] = context.dependencyChain.map((t) => formatTokenName(t));
+  if (context.hint) meta['hint'] = context.hint;
+
+  return meta;
 }

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -389,6 +389,25 @@ KonektiFactory.create(options)  [or bootstrapApplication]
 
 If any of these fail, bootstrap throws before any provider is instantiated. This is a deliberate design choice — broken apps fail loudly at startup, not silently at the first request.
 
+### Recovery-oriented error output
+
+Every bootstrap and module-graph error includes structured context fields so that failures explain what went wrong, where it happened, and what to do next. The error message appends:
+
+- **Module** — the module where the failure was detected
+- **Token** — the token involved (if applicable)
+- **Phase** — the bootstrap phase (e.g. `module graph compilation`, `provider visibility validation`, `export validation`, `provider registration`)
+- **Hint** — a plain-language recovery action
+
+Errors also carry a machine-readable `meta` object with the same fields, suitable for structured logging or monitoring. Example:
+
+```text
+ModuleVisibilityError: Provider BillingService in module BillingModule cannot access token UserRepository...
+  Module: BillingModule
+  Token: UserRepository
+  Phase: provider visibility validation
+  Hint: Add UserRepository to the exports array of the module that owns it, then import that module into BillingModule. Alternatively, mark the owning module with @Global().
+```
+
 ### Lifecycle hook ordering
 
 ```text

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { Global, Inject, Module, defineModuleMetadata } from '@konekti/core';
 
 import { bootstrapModule, KonektiFactory } from './bootstrap.js';
-import { DuplicateProviderError, ModuleInjectionMetadataError } from './errors.js';
+import { DuplicateProviderError, ModuleGraphError, ModuleInjectionMetadataError, ModuleVisibilityError } from './errors.js';
 import { HTTP_APPLICATION_ADAPTER } from './tokens.js';
 import type { MicroserviceRuntime } from './types.js';
 
@@ -719,5 +719,295 @@ describe('KonektiFactory.createMicroservice', () => {
     expect(events).toEqual(['micro:listen']);
 
     await app.close();
+  });
+});
+
+describe('Recovery-oriented error context (runtime)', () => {
+  describe('ModuleVisibilityError includes structured context', () => {
+    it('includes module name, token, and actionable hint for provider visibility failures', () => {
+      class InternalRepository {}
+
+      class DataModule {}
+      defineModuleMetadata(DataModule, {
+        providers: [InternalRepository],
+      });
+
+      @Inject([InternalRepository])
+      class BillingService {}
+
+      class BillingModule {}
+      defineModuleMetadata(BillingModule, {
+        imports: [DataModule],
+        providers: [BillingService],
+      });
+
+      try {
+        bootstrapModule(BillingModule);
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ModuleVisibilityError);
+        const message = (error as Error).message;
+        expect(message).toContain('Module: BillingModule');
+        expect(message).toContain('Token:');
+        expect(message).toContain('Phase: provider visibility validation');
+        expect(message).toContain('Hint:');
+        expect(message).toContain('exports');
+      }
+    });
+
+    it('includes module name, token, and hint for controller visibility failures', () => {
+      class InternalRepository {}
+
+      class DataModule {}
+      defineModuleMetadata(DataModule, {
+        providers: [InternalRepository],
+      });
+
+      @Inject([InternalRepository])
+      class BillingController {}
+
+      class BillingModule {}
+      defineModuleMetadata(BillingModule, {
+        imports: [DataModule],
+        controllers: [BillingController],
+      });
+
+      try {
+        bootstrapModule(BillingModule);
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ModuleVisibilityError);
+        const message = (error as Error).message;
+        expect(message).toContain('Module: BillingModule');
+        expect(message).toContain('Token:');
+        expect(message).toContain('Phase: controller visibility validation');
+        expect(message).toContain('Hint:');
+      }
+    });
+
+    it('provides machine-readable meta on ModuleVisibilityError', () => {
+      class InternalRepository {}
+
+      class DataModule {}
+      defineModuleMetadata(DataModule, {
+        providers: [InternalRepository],
+      });
+
+      @Inject([InternalRepository])
+      class BillingService {}
+
+      class BillingModule {}
+      defineModuleMetadata(BillingModule, {
+        imports: [DataModule],
+        providers: [BillingService],
+      });
+
+      try {
+        bootstrapModule(BillingModule);
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        const meta = (error as ModuleVisibilityError & { meta?: Record<string, unknown> }).meta;
+        expect(meta).toBeDefined();
+        expect(meta!['module']).toBe('BillingModule');
+        expect(meta!['phase']).toBe('provider visibility validation');
+        expect(meta!['hint']).toBeDefined();
+        expect(meta!['token']).toBeDefined();
+      }
+    });
+  });
+
+  describe('ModuleGraphError includes structured context', () => {
+    it('includes module name and hint for circular module imports', () => {
+      class ModuleA {}
+      class ModuleB {}
+      defineModuleMetadata(ModuleA, {
+        imports: [ModuleB],
+      });
+      defineModuleMetadata(ModuleB, {
+        imports: [ModuleA],
+      });
+
+      try {
+        bootstrapModule(ModuleA);
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ModuleGraphError);
+        const message = (error as Error).message;
+        expect(message).toContain('Circular module import');
+        expect(message).toContain('Module:');
+        expect(message).toContain('Phase: module graph compilation');
+        expect(message).toContain('Hint:');
+        expect(message).toContain('extract');
+      }
+    });
+
+    it('provides machine-readable meta on ModuleGraphError', () => {
+      class ModuleA {}
+      class ModuleB {}
+      defineModuleMetadata(ModuleA, {
+        imports: [ModuleB],
+      });
+      defineModuleMetadata(ModuleB, {
+        imports: [ModuleA],
+      });
+
+      try {
+        bootstrapModule(ModuleA);
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        const meta = (error as ModuleGraphError & { meta?: Record<string, unknown> }).meta;
+        expect(meta).toBeDefined();
+        expect(meta!['phase']).toBe('module graph compilation');
+        expect(meta!['hint']).toBeDefined();
+      }
+    });
+  });
+
+  describe('ModuleInjectionMetadataError includes structured context', () => {
+    it('includes module scope and hint about @Inject for missing injection metadata', () => {
+      class Logger {}
+
+      class BillingService {
+        constructor(readonly logger: Logger) {}
+      }
+
+      class BillingModule {}
+      defineModuleMetadata(BillingModule, {
+        providers: [Logger, BillingService],
+      });
+
+      try {
+        bootstrapModule(BillingModule);
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ModuleInjectionMetadataError);
+        const message = (error as Error).message;
+        expect(message).toContain('module BillingModule');
+        expect(message).toContain('Phase: injection metadata validation');
+        expect(message).toContain('Hint:');
+        expect(message).toContain('@Inject');
+      }
+    });
+
+    it('provides machine-readable meta on ModuleInjectionMetadataError', () => {
+      class Logger {}
+
+      class BillingService {
+        constructor(readonly logger: Logger) {}
+      }
+
+      class BillingModule {}
+      defineModuleMetadata(BillingModule, {
+        providers: [Logger, BillingService],
+      });
+
+      try {
+        bootstrapModule(BillingModule);
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        const meta = (error as ModuleInjectionMetadataError & { meta?: Record<string, unknown> }).meta;
+        expect(meta).toBeDefined();
+        expect(meta!['module']).toContain('BillingModule');
+        expect(meta!['phase']).toBe('injection metadata validation');
+        expect(meta!['hint']).toBeDefined();
+      }
+    });
+  });
+
+  describe('DuplicateProviderError includes structured context', () => {
+    it('includes module, token, and hint when policy is "throw"', () => {
+      class SharedService {}
+
+      class ModuleA {}
+      defineModuleMetadata(ModuleA, {
+        providers: [SharedService],
+        exports: [SharedService],
+      });
+
+      class ModuleB {}
+      defineModuleMetadata(ModuleB, {
+        providers: [SharedService],
+        exports: [SharedService],
+      });
+
+      class RootModule {}
+      defineModuleMetadata(RootModule, {
+        imports: [ModuleA, ModuleB],
+      });
+
+      try {
+        bootstrapModule(RootModule, { duplicateProviderPolicy: 'throw' });
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(DuplicateProviderError);
+        const message = (error as Error).message;
+        expect(message).toContain('SharedService');
+        expect(message).toContain('Module:');
+        expect(message).toContain('Token:');
+        expect(message).toContain('Phase: provider registration');
+        expect(message).toContain('Hint:');
+      }
+    });
+
+    it('provides machine-readable meta on DuplicateProviderError', () => {
+      class SharedService {}
+
+      class ModuleA {}
+      defineModuleMetadata(ModuleA, {
+        providers: [SharedService],
+        exports: [SharedService],
+      });
+
+      class ModuleB {}
+      defineModuleMetadata(ModuleB, {
+        providers: [SharedService],
+        exports: [SharedService],
+      });
+
+      class RootModule {}
+      defineModuleMetadata(RootModule, {
+        imports: [ModuleA, ModuleB],
+      });
+
+      try {
+        bootstrapModule(RootModule, { duplicateProviderPolicy: 'throw' });
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        const meta = (error as DuplicateProviderError & { meta?: Record<string, unknown> }).meta;
+        expect(meta).toBeDefined();
+        expect(meta!['module']).toBeDefined();
+        expect(meta!['token']).toBeDefined();
+        expect(meta!['phase']).toBe('provider registration');
+        expect(meta!['hint']).toBeDefined();
+      }
+    });
+  });
+
+  describe('ModuleVisibilityError for export validation includes context', () => {
+    it('includes module name, token, and hint when exporting a non-local token', () => {
+      class NonExistentService {}
+
+      class BadModule {}
+      defineModuleMetadata(BadModule, {
+        exports: [NonExistentService],
+      });
+
+      class AppModule {}
+      defineModuleMetadata(AppModule, {
+        imports: [BadModule],
+      });
+
+      try {
+        bootstrapModule(AppModule);
+        expect.unreachable('should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ModuleVisibilityError);
+        const message = (error as Error).message;
+        expect(message).toContain('BadModule');
+        expect(message).toContain('Phase: export validation');
+        expect(message).toContain('Hint:');
+        expect(message).toContain('providers');
+      }
+    });
   });
 });

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -285,7 +285,12 @@ function collectProvidersForContainer(
         const message = createDuplicateProviderMessage(token, compiledModule.type.name, existing.moduleName);
 
         if (policy === 'throw') {
-          throw new DuplicateProviderError(message);
+          throw new DuplicateProviderError(message, {
+            module: compiledModule.type.name,
+            token,
+            phase: 'provider registration',
+            hint: `Remove the duplicate registration from one of the modules, use container.override() for intentional replacements, or set duplicateProviderPolicy to 'warn' or 'ignore'.`,
+          });
         }
 
         if (policy === 'warn') {
@@ -954,7 +959,11 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
       runtimeCleanup,
     );
   } catch (error: unknown) {
-    logger.error('Failed to bootstrap application.', error, 'KonektiFactory');
+    logger.error(
+      'Failed to bootstrap application. Check the error below for what failed and how to fix it.',
+      error,
+      'KonektiFactory',
+    );
 
     await runBootstrapFailureCleanup({
       container: bootstrappedContainer,
@@ -1048,7 +1057,11 @@ export class KonektiFactory {
         runtimeCleanup,
       );
     } catch (error: unknown) {
-      logger.error('Failed to bootstrap application context.', error, 'KonektiFactory');
+      logger.error(
+        'Failed to bootstrap application context. Check the error below for what failed and how to fix it.',
+        error,
+        'KonektiFactory',
+      );
 
       await runBootstrapFailureCleanup({
         container: bootstrappedContainer,
@@ -1080,7 +1093,11 @@ export class KonektiFactory {
       return new KonektiMicroserviceApplication(context, logger, runtime);
     } catch (error) {
       await context.close('bootstrap-failed');
-      logger.error('Failed to bootstrap microservice context.', error, 'KonektiFactory');
+      logger.error(
+        'Failed to bootstrap microservice context. Check the error below for what failed and how to fix it.',
+        error,
+        'KonektiFactory',
+      );
       throw error;
     }
   }

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -1,25 +1,93 @@
-import { KonektiError } from '@konekti/core';
+import { KonektiError, formatTokenName } from '@konekti/core';
+
+export interface RuntimeErrorContext {
+  readonly module?: string;
+  readonly token?: unknown;
+  readonly phase?: string;
+  readonly hint?: string;
+}
+
+function formatRuntimeContext(ctx?: RuntimeErrorContext): string {
+  if (!ctx) return '';
+
+  const parts: string[] = [];
+
+  if (ctx.module) {
+    parts.push(`Module: ${ctx.module}`);
+  }
+
+  if (ctx.token !== undefined) {
+    parts.push(`Token: ${formatTokenName(ctx.token)}`);
+  }
+
+  if (ctx.phase) {
+    parts.push(`Phase: ${ctx.phase}`);
+  }
+
+  if (ctx.hint) {
+    parts.push(`Hint: ${ctx.hint}`);
+  }
+
+  if (parts.length === 0) return '';
+
+  return '\n  ' + parts.join('\n  ');
+}
+
+function buildRuntimeMeta(context: RuntimeErrorContext): Record<string, unknown> {
+  const meta: Record<string, unknown> = {};
+
+  if (context.module) meta['module'] = context.module;
+  if (context.token !== undefined) meta['token'] = formatTokenName(context.token);
+  if (context.phase) meta['phase'] = context.phase;
+  if (context.hint) meta['hint'] = context.hint;
+
+  return meta;
+}
 
 export class ModuleGraphError extends KonektiError {
-  constructor(message: string) {
-    super(message, { code: 'MODULE_GRAPH_ERROR' });
+  constructor(message: string, context?: RuntimeErrorContext) {
+    super(
+      message + formatRuntimeContext(context),
+      {
+        code: 'MODULE_GRAPH_ERROR',
+        ...(context ? { meta: buildRuntimeMeta(context) } : undefined),
+      },
+    );
   }
 }
 
 export class ModuleVisibilityError extends KonektiError {
-  constructor(message: string) {
-    super(message, { code: 'MODULE_VISIBILITY_ERROR' });
+  constructor(message: string, context?: RuntimeErrorContext) {
+    super(
+      message + formatRuntimeContext(context),
+      {
+        code: 'MODULE_VISIBILITY_ERROR',
+        ...(context ? { meta: buildRuntimeMeta(context) } : undefined),
+      },
+    );
   }
 }
 
 export class ModuleInjectionMetadataError extends KonektiError {
-  constructor(message: string) {
-    super(message, { code: 'MODULE_INJECTION_METADATA_ERROR' });
+  constructor(message: string, context?: RuntimeErrorContext) {
+    super(
+      message + formatRuntimeContext(context),
+      {
+        code: 'MODULE_INJECTION_METADATA_ERROR',
+        ...(context ? { meta: buildRuntimeMeta(context) } : undefined),
+      },
+    );
   }
 }
 
 export class DuplicateProviderError extends KonektiError {
-  constructor(message: string) {
-    super(message, { code: 'DUPLICATE_PROVIDER_ERROR' });
+  constructor(message: string, context?: RuntimeErrorContext) {
+    super(
+      message + formatRuntimeContext(context),
+      {
+        code: 'DUPLICATE_PROVIDER_ERROR',
+        ...(context ? { meta: buildRuntimeMeta(context) } : undefined),
+      },
+    );
   }
 }

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -107,6 +107,11 @@ function validateClassInjectionMetadata(
 
   throw new ModuleInjectionMetadataError(
     `${subject} in ${scope} declares ${required} constructor ${parameterWord} but only ${configured} injection ${tokenWord} configured. Add ${remedy} for constructor parameter #${missingIndex}.`,
+    {
+      module: scope,
+      phase: 'injection metadata validation',
+      hint: `Ensure ${subject} has a matching @Inject([...]) decorator or provider.inject array that covers all ${required} constructor parameters.`,
+    },
   );
 }
 
@@ -180,7 +185,14 @@ function compileModule(
   }
 
   if (visiting.has(moduleType)) {
-    throw new ModuleGraphError(`Circular module import detected for ${moduleType.name}.`);
+    throw new ModuleGraphError(
+      `Circular module import detected for ${moduleType.name}.`,
+      {
+        module: moduleType.name,
+        phase: 'module graph compilation',
+        hint: 'Break the import cycle by extracting shared providers into a separate module that both sides can import independently.',
+      },
+    );
   }
 
   visiting.add(moduleType);
@@ -215,7 +227,14 @@ function resolveImportedModules(
     const importedModule = compiledByType.get(imported);
 
     if (!importedModule) {
-      throw new ModuleGraphError(`Imported module ${imported.name} was not compiled.`);
+      throw new ModuleGraphError(
+        `Imported module ${imported.name} was not compiled.`,
+        {
+          module: imported.name,
+          phase: 'module graph validation',
+          hint: `Ensure ${imported.name} is decorated with @Module() and included in the imports array of a compiled module.`,
+        },
+      );
     }
 
     return importedModule;
@@ -258,6 +277,12 @@ function validateProviderVisibility(
           `Provider ${String(providerToken(provider))} in module ${compiledModule.type.name} cannot access token ${String(
             token,
           )} because it is not local, not exported by an imported module, and not visible through a global module.`,
+          {
+            module: compiledModule.type.name,
+            token,
+            phase: 'provider visibility validation',
+            hint: `Add ${String(token)} to the exports array of the module that owns it, then import that module into ${compiledModule.type.name}. Alternatively, mark the owning module with @Global() to make its exports universally visible.`,
+          },
         );
       }
     }
@@ -280,6 +305,12 @@ function validateControllerVisibility(
           `Controller ${controller.name} in module ${compiledModule.type.name} cannot access token ${String(
             token,
           )} because it is not local, not exported by an imported module, and not visible through a global module.`,
+          {
+            module: compiledModule.type.name,
+            token,
+            phase: 'controller visibility validation',
+            hint: `Add ${String(token)} to the exports array of the module that owns it, then import that module into ${compiledModule.type.name}. Alternatively, mark the owning module with @Global().`,
+          },
         );
       }
     }
@@ -298,6 +329,12 @@ function createExportedTokenSet(
         `Module ${compiledModule.type.name} cannot export token ${String(
           token,
         )} because it is neither local nor re-exported from an imported module.`,
+        {
+          module: compiledModule.type.name,
+          token,
+          phase: 'export validation',
+          hint: `Either add a provider for ${String(token)} to ${compiledModule.type.name}'s providers array, or import a module that exports ${String(token)} so it can be re-exported.`,
+        },
       );
     }
 


### PR DESCRIPTION
## Summary

Closes #593

DI 및 런타임 에러에 구조화된 컨텍스트(토큰, 스코프, 모듈, 단계)와 실행 가능한 복구 힌트를 추가하여, 일반적인 부트스트랩 및 프로바이더 해결 실패 시 **무엇이 실패했는지**, **어디서 실패했는지**, **다음에 무엇을 해야 하는지** 알려줍니다.

### 변경 내역

**`packages/di/src/errors.ts`**
- `DiErrorContext` 인터페이스 추가 (token, scope, module, dependencyChain, hint 필드)
- `formatDiContext()` / `buildMeta()` 헬퍼 추가
- 모든 DI 에러 클래스에 선택적 컨텍스트 매개변수 추가
- `CircularDependencyError`에 의존성 체인 표시 및 `forwardRef()` 힌트 추가
- `DuplicateProviderError`에 토큰명 및 `override()` 힌트 추가

**`packages/di/src/container.ts`**
- `register()`, `override()`, `resolve()`, `createRequestScope()` 등 모든 에러 발생 지점에 구조화된 컨텍스트 전달
- 스코프 불일치, 삭제된 컨테이너, 누락된 프로바이더 등 각 실패 유형별 맞춤 힌트 추가

**`packages/runtime/src/errors.ts`**
- `RuntimeErrorContext` 인터페이스 추가 (module, token, phase, hint 필드)
- `formatRuntimeContext()` / `buildRuntimeMeta()` 헬퍼 추가
- 모든 런타임 에러 클래스에 선택적 컨텍스트 매개변수 추가

**`packages/runtime/src/module-graph.ts`**
- 순환 모듈 임포트, 프로바이더/컨트롤러 가시성, 내보내기 검증, 주입 메타데이터 검증 등 모든 에러 발생 지점에 구조화된 컨텍스트 전달

**`packages/runtime/src/bootstrap.ts`**
- `DuplicateProviderError`에 모듈, 토큰, 단계, 힌트 컨텍스트 추가
- 캐치 블록 로그 메시지 개선

**테스트**
- `packages/di/src/container.test.ts`: 8개 DI 에러 컨텍스트 회귀 테스트 추가
- `packages/runtime/src/bootstrap.test.ts`: 11개 런타임 에러 컨텍스트 회귀 테스트 추가

**문서**
- `packages/di/README.md`: "Recovery-oriented error output" 섹션 추가
- `packages/runtime/README.md`: "Recovery-oriented error output" 섹션 추가

### 검증

- `@konekti/di`, `@konekti/runtime` 타입체크 통과
- 전체 테스트 스위트 실행: 1166/1167 통과 (1개 실패는 기존 `application.test.ts`의 비관련 테스트)
- 전체 빌드 성공

### 에러 출력 예시

```
ContainerResolutionError: No provider registered for token UserService.
  Token: UserService
  Hint: Register a provider for this token using container.register(), or check that the owning module exports it and is imported by the consuming module.
```

```
ModuleVisibilityError: Provider BillingService in module BillingModule cannot access token UserRepository...
  Module: BillingModule
  Token: UserRepository
  Phase: provider visibility validation
  Hint: Add UserRepository to the exports array of the module that owns it, then import that module into BillingModule.
```