### PR TITLE
Resolve #592: improve generator UX with clearer wiring feedback and next steps

### DIFF
--- a/docs/getting-started/generator-workflow.ko.md
+++ b/docs/getting-started/generator-workflow.ko.md
@@ -13,24 +13,36 @@ konekti g <schematic> <name>
 
 ## 사용 가능한 스키매틱
 
-| 스키매틱 | 별칭 (Alias) |
-| --- | --- |
-| `controller` | `co` |
-| `guard` | `gu` |
-| `interceptor` | `in` |
-| `middleware` | `mi` |
-| `module` | `mo` |
-| `repository` | `repo` |
-| `request-dto` | `req` |
-| `response-dto` | `res` |
-| `service` | `s` |
+| 스키매틱 | 별칭 (Alias) | 와이어링 |
+| --- | --- | --- |
+| `controller` | `co` | auto |
+| `guard` | `gu` | auto |
+| `interceptor` | `in` | auto |
+| `middleware` | `mi` | auto |
+| `module` | `mo` | manual |
+| `repository` | `repo` | auto |
+| `request-dto` | `req` | manual |
+| `response-dto` | `res` | manual |
+| `service` | `s` | auto |
+
+### 와이어링 동작 (wiring behavior)
+
+생성기는 두 가지 와이어링 동작 중 하나를 따릅니다:
+
+- **auto** — 생성된 클래스가 도메인 모듈에 자동 등록됩니다. 모듈 파일이 아직 없으면 CLI가 새로 생성합니다. 모듈의 `controllers`, `providers`, 또는 `middleware` 배열이 자동으로 업데이트됩니다.
+- **manual** — 파일만 생성됩니다. 생성된 클래스는 어디에도 자동 등록되지 않습니다. 모듈이나 컨트롤러에 직접 연결해야 합니다. CLI는 생성 후 구체적인 다음 단계 힌트를 출력합니다.
+
+생성기를 실행하면 CLI 출력에 다음이 포함됩니다:
+1. 생성된 각 파일에 대한 `CREATE` 라인.
+2. 클래스가 자동 등록되었는지 수동 와이어링이 필요한지를 나타내는 **Wiring** 상태 라인.
+3. 권장 후속 작업(예: `pnpm typecheck` 실행, DTO import 등)이 포함된 **Next steps** 힌트.
 
 ## 생성 규칙
 
 - **언어**: 모든 파일은 TypeScript로 생성됩니다.
 - **명명**: 파일명은 kebab-case를, 클래스명은 PascalCase를 사용합니다.
 - **위치**: 스타터 애플리케이션에서 파일은 기본적으로 `src/` 디렉토리에 작성됩니다.
-- **모듈 업데이트**: 생성기는 새 컴포넌트를 적절한 모듈에 자동으로 등록합니다.
+- **모듈 업데이트**: `auto` 와이어링을 가진 생성기는 새 컴포넌트를 적절한 모듈에 자동 등록합니다. `manual` 와이어링을 가진 생성기는 파일만 생성하며, 직접 연결해야 합니다.
 
 ### 예시 출력
 

--- a/docs/getting-started/generator-workflow.md
+++ b/docs/getting-started/generator-workflow.md
@@ -13,24 +13,36 @@ konekti g <schematic> <name>
 
 ## available schematics
 
-| Schematic | Alias |
-| --- | --- |
-| `controller` | `co` |
-| `guard` | `gu` |
-| `interceptor` | `in` |
-| `middleware` | `mi` |
-| `module` | `mo` |
-| `repository` | `repo` |
-| `request-dto` | `req` |
-| `response-dto` | `res` |
-| `service` | `s` |
+| Schematic | Alias | Wiring |
+| --- | --- | --- |
+| `controller` | `co` | auto |
+| `guard` | `gu` | auto |
+| `interceptor` | `in` | auto |
+| `middleware` | `mi` | auto |
+| `module` | `mo` | manual |
+| `repository` | `repo` | auto |
+| `request-dto` | `req` | manual |
+| `response-dto` | `res` | manual |
+| `service` | `s` | auto |
+
+### wiring behavior
+
+Generators have one of two wiring behaviors:
+
+- **auto** — the generated class is auto-registered in the domain module. If the module file does not exist yet, the CLI creates it. The module's `controllers`, `providers`, or `middleware` array is updated automatically.
+- **manual** — files only. The generated class is not registered anywhere automatically. You must wire it into a module or controller yourself. The CLI prints a next-step hint with specific instructions after generation.
+
+After running any generator, the CLI output shows:
+1. A `CREATE` line for each generated file.
+2. A **Wiring** status line indicating whether the class was auto-registered or requires manual wiring.
+3. A **Next steps** hint with the recommended follow-up action (e.g., run `pnpm typecheck`, import a DTO, etc.).
 
 ## generation conventions
 
 - **Language**: All files are generated in TypeScript.
 - **Naming**: Uses kebab-case for filenames and PascalCase for classes.
 - **Location**: Files are written to the `src/` directory by default in starter applications.
-- **Module Updates**: Generators automatically register new components in the appropriate module.
+- **Module Updates**: Generators with `auto` wiring automatically register new components in the appropriate module. Generators with `manual` wiring produce files only — you wire them yourself.
 
 ### example output
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -77,6 +77,11 @@ konekti generate response-dto user-profile
 
 각 generator는 kebab-case 파일명과 PascalCase 클래스명을 가진 하나 이상의 파일을 생성합니다.
 
+생성 후 CLI 출력에는 다음이 포함됩니다:
+- 작성된 각 파일에 대한 `CREATE` 라인.
+- **Wiring** 상태 라인: `auto-registered`(클래스가 도메인 모듈에 추가됨) 또는 `files only`(수동 등록 필요).
+- 해당 generator 종류에 맞는 권장 후속 작업이 포함된 **Next steps** 힌트.
+
 ### NestJS 마이그레이션 codemod 실행
 
 ```bash

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -77,6 +77,11 @@ Implemented generator kinds include `controller`, `guard`, `interceptor`, `middl
 
 Each generator produces one or more files with correctly kebab-cased names and PascalCase class names.
 
+After generation, the CLI output includes:
+- A `CREATE` line for each written file.
+- A **Wiring** status line: `auto-registered` (the class was added to the domain module) or `files only` (manual registration required).
+- A **Next steps** hint with the recommended follow-up action for that specific generator kind.
+
 ### Run NestJS migration codemods
 
 ```bash

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -290,7 +290,7 @@ describe('CLI command runner', () => {
 
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Usage: konekti generate|g <kind> <name> [options]');
-    expect(stdoutBuffer.join('')).toMatch(/\| Schematic\s+\| Aliases\s+\| Description\s+\|/);
+    expect(stdoutBuffer.join('')).toMatch(/\| Schematic\s+\| Aliases\s+\| Wiring\s+\| Description\s+\|/);
 
     for (const entry of generatorManifest) {
       expect(stdoutBuffer.join('')).toContain(entry.schematic);
@@ -1073,6 +1073,77 @@ describe('CLI command runner', () => {
     expect(exitCode).toBe(1);
     expect(stderrBuffer.join('')).toContain('Usage: konekti generate|g <kind> <name> [options]');
     expect(stderrBuffer.join('')).toMatch(/\|\s*request-dto\s*\|\s*req\s*\|/);
+  });
+
+  it('generate output includes CREATE prefix, wiring status, and next-step hint for auto-registered kinds', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'package.json'),
+      JSON.stringify({ name: 'test-app', private: true }, null, 2),
+    );
+
+    const stdoutBuffer: string[] = [];
+    const exitCode = await runCli(['g', 'service', 'Post'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('CREATE');
+    expect(output).toContain('Wiring: auto-registered in');
+    expect(output).toContain('Next steps:');
+    expect(output).toContain('pnpm typecheck');
+  });
+
+  it('generate output shows files-only wiring and manual hint for non-registered kinds', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'package.json'),
+      JSON.stringify({ name: 'test-app', private: true }, null, 2),
+    );
+
+    const stdoutBuffer: string[] = [];
+    const exitCode = await runCli(['g', 'request-dto', 'CreateUser'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('CREATE');
+    expect(output).toContain('Wiring: files only');
+    expect(output).toContain('manual registration required');
+    expect(output).toContain('Next steps:');
+  });
+
+  it('generate help includes Wiring column with auto and manual labels', async () => {
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['generate', '--help'], {
+      cwd: process.cwd(),
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('| Wiring');
+    expect(output).toContain('auto');
+    expect(output).toContain('manual');
+    expect(output).toContain('auto   = class is auto-registered in the domain module');
+    expect(output).toContain('manual = files only');
   });
 
   it('prints migrate usage for `help migrate`', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -51,6 +51,7 @@ type GenerateKindHelpEntry = {
   description: string;
   kind: GeneratorKind;
   schematic: string;
+  wiring: string;
 };
 
 type GenerateOptionHelpEntry = {
@@ -71,6 +72,7 @@ const GENERATE_KIND_HELP: GenerateKindHelpEntry[] = [
     description: entry.description,
     kind: entry.kind,
     schematic: entry.schematic,
+    wiring: entry.wiringBehavior === 'auto-registered' ? 'auto' : 'manual',
   })),
 ];
 
@@ -104,8 +106,12 @@ function generateUsage(): string {
     renderHelpTable(GENERATE_KIND_HELP, [
       { header: 'Schematic', render: (entry) => entry.schematic },
       { header: 'Aliases', render: (entry) => renderAliasList(entry.aliases) },
+      { header: 'Wiring', render: (entry) => entry.wiring },
       { header: 'Description', render: (entry) => entry.description },
     ]),
+    '',
+    '  auto   = class is auto-registered in the domain module (created if absent)',
+    '  manual = files only; you must wire the generated class into a module yourself',
     '',
     'Options',
     renderHelpTable(GENERATE_OPTION_HELP, [
@@ -116,6 +122,7 @@ function generateUsage(): string {
     '',
     'Next steps:',
     '  Run \'pnpm typecheck\' to verify the generated module wiring.',
+    '  Run \'pnpm test\' to execute the generated test templates.',
     '',
     'Docs: https://github.com/konektijs/konekti/tree/main/docs/getting-started/generator-workflow.md',
   ].join('\n');
@@ -330,12 +337,22 @@ export async function runCli(
 
     const targetDirectory = resolve(cwd, parsedCommand.parsed.targetDirectory ?? resolveDefaultTargetDirectory(cwd));
 
-    const files = runGenerateCommand(parsedCommand.parsed.kind, parsedCommand.parsed.name, targetDirectory, parsedCommand.parsed.options);
+    const result = runGenerateCommand(parsedCommand.parsed.kind, parsedCommand.parsed.name, targetDirectory, parsedCommand.parsed.options);
 
-    stdout.write(`Generated ${files.length} file(s):\n`);
-    for (const file of files) {
-      stdout.write(`- ${file}\n`);
+    stdout.write(`Generated ${result.generatedFiles.length} file(s):\n`);
+    for (const file of result.generatedFiles) {
+      stdout.write(`  CREATE ${file}\n`);
     }
+
+    stdout.write('\n');
+
+    if (result.wiringBehavior === 'auto-registered' && result.moduleRegistered) {
+      stdout.write(`Wiring: auto-registered in ${result.modulePath ?? 'module'}\n`);
+    } else if (result.wiringBehavior === 'files-only') {
+      stdout.write('Wiring: files only — manual registration required (see next steps)\n');
+    }
+
+    stdout.write(`\nNext steps:\n  ${result.nextStepHint}\n`);
 
     return 0;
   } catch (error: unknown) {

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -141,10 +141,53 @@ export { PostModule };
     utimesSync(modulePath, oldTimestamp, oldTimestamp);
     utimesSync(servicePath, oldTimestamp, oldTimestamp);
 
-    const writtenPaths = runGenerateCommand('service', 'Post', sourceDirectory, { force: true });
+    const result = runGenerateCommand('service', 'Post', sourceDirectory, { force: true });
 
-    expect(writtenPaths).toEqual([]);
+    expect(result.generatedFiles).toEqual([]);
+    expect(result.wiringBehavior).toBe('auto-registered');
+    expect(result.moduleRegistered).toBe(true);
     expect(statSync(modulePath).mtimeMs).toBe(oldTimestamp.getTime());
     expect(statSync(servicePath).mtimeMs).toBe(oldTimestamp.getTime());
+  });
+
+  it('returns GenerateResult with structured wiring metadata for auto-registered kinds', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const result = runGenerateCommand('controller', 'Order', sourceDirectory);
+
+    expect(result.generatedFiles.length).toBeGreaterThan(0);
+    expect(result.wiringBehavior).toBe('auto-registered');
+    expect(result.moduleRegistered).toBe(true);
+    expect(result.modulePath).toContain('order.module.ts');
+    expect(result.nextStepHint).toContain('pnpm typecheck');
+  });
+
+  it('returns GenerateResult with files-only wiring metadata for non-registered kinds', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const result = runGenerateCommand('request-dto', 'CreateUser', sourceDirectory);
+
+    expect(result.generatedFiles.length).toBeGreaterThan(0);
+    expect(result.wiringBehavior).toBe('files-only');
+    expect(result.moduleRegistered).toBe(false);
+    expect(result.modulePath).toBeUndefined();
+    expect(result.nextStepHint).toContain('@FromBody');
+  });
+
+  it('returns GenerateResult with module wiring hint for standalone module kind', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'konekti-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const result = runGenerateCommand('module', 'Auth', sourceDirectory);
+
+    expect(result.generatedFiles.length).toBeGreaterThan(0);
+    expect(result.wiringBehavior).toBe('files-only');
+    expect(result.moduleRegistered).toBe(false);
+    expect(result.nextStepHint).toContain('parent module');
   });
 });

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, normalize, resolve } from 'node:path';
 
 import type { GenerateOptions, GeneratorKind } from '../types.js';
-import type { ModuleArrayKey } from '../generators/manifest.js';
+import type { GeneratorManifestEntry, ModuleArrayKey } from '../generators/manifest.js';
 import { findGeneratorDefinition } from '../generators/manifest.js';
 
 import { ensureModuleImport, generateModuleFiles, registerInModule } from '../generators/module.js';
@@ -97,7 +97,15 @@ function prepareModuleUpdate(
   };
 }
 
-export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirectory: string, options: GenerateOptions = {}): string[] {
+export type GenerateResult = {
+  generatedFiles: string[];
+  moduleRegistered: boolean;
+  modulePath: string | undefined;
+  nextStepHint: string;
+  wiringBehavior: GeneratorManifestEntry['wiringBehavior'];
+};
+
+export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirectory: string, options: GenerateOptions = {}): GenerateResult {
   const normalizedName = name.trim();
   const kebab = assertValidResourceName(normalizedName);
   const generator = findGeneratorDefinition(kind);
@@ -124,12 +132,26 @@ export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirect
     return writeFileIfChanged(filePath, file.content) ? filePath : null;
   }).filter((filePath): filePath is string => filePath !== null);
 
+  let moduleRegistered = false;
+  let resolvedModulePath: string | undefined;
+
   if (moduleUpdate && writeFileIfChanged(moduleUpdate.modulePath, moduleUpdate.source)) {
+    moduleRegistered = true;
+    resolvedModulePath = moduleUpdate.modulePath;
 
     if (!writtenPaths.includes(moduleUpdate.modulePath)) {
       writtenPaths.push(moduleUpdate.modulePath);
     }
+  } else if (moduleUpdate) {
+    moduleRegistered = true;
+    resolvedModulePath = moduleUpdate.modulePath;
   }
 
-  return writtenPaths;
+  return {
+    generatedFiles: writtenPaths,
+    moduleRegistered: moduleRegistered,
+    modulePath: resolvedModulePath,
+    nextStepHint: generator.nextStepHint,
+    wiringBehavior: generator.wiringBehavior,
+  };
 }

--- a/packages/cli/src/generators/manifest.ts
+++ b/packages/cli/src/generators/manifest.ts
@@ -23,80 +23,100 @@ export type GeneratorManifestEntry = {
   factory: GeneratorFactory;
   kind: string;
   moduleRegistration?: ModuleRegistrationDescriptor;
+  nextStepHint: string;
   registryAliases?: readonly string[];
   schematic: string;
+  wiringBehavior: 'auto-registered' | 'files-only';
 };
 
 export const generatorManifest = [
   {
     aliases: ['co'],
-    description: 'Generate a controller and register it in the module controllers array.',
+    description: 'Generate a controller (auto-registered in the module controllers array).',
     factory: (name, options) => generateControllerFiles(name, options),
     kind: 'controller',
     moduleRegistration: { arrayKey: 'controllers', classSuffix: 'Controller' },
+    nextStepHint: "Run 'pnpm typecheck' to verify module wiring, then add route handlers.",
     schematic: 'controller',
+    wiringBehavior: 'auto-registered',
   },
   {
     aliases: ['gu'],
-    description: 'Generate a guard and register it as a provider in the module.',
+    description: 'Generate a guard (auto-registered as a provider in the module).',
     factory: (name) => generateGuardFiles(name),
     kind: 'guard',
     moduleRegistration: { arrayKey: 'providers', classSuffix: 'Guard' },
+    nextStepHint: "Run 'pnpm typecheck' to verify module wiring, then apply the guard to routes.",
     schematic: 'guard',
+    wiringBehavior: 'auto-registered',
   },
   {
     aliases: ['in'],
-    description: 'Generate an interceptor and register it as a provider in the module.',
+    description: 'Generate an interceptor (auto-registered as a provider in the module).',
     factory: (name) => generateInterceptorFiles(name),
     kind: 'interceptor',
     moduleRegistration: { arrayKey: 'providers', classSuffix: 'Interceptor' },
+    nextStepHint: "Run 'pnpm typecheck' to verify module wiring, then bind the interceptor to routes.",
     schematic: 'interceptor',
+    wiringBehavior: 'auto-registered',
   },
   {
     aliases: ['mi'],
-    description: 'Generate a middleware and register it in the module middleware array.',
+    description: 'Generate a middleware (auto-registered in the module middleware array).',
     factory: (name) => generateMiddlewareFiles(name),
     kind: 'middleware',
     moduleRegistration: { arrayKey: 'middleware', classSuffix: 'Middleware' },
+    nextStepHint: "Run 'pnpm typecheck' to verify module wiring, then configure route matching in forRoutes.",
     schematic: 'middleware',
+    wiringBehavior: 'auto-registered',
   },
   {
     aliases: ['mo'],
-    description: 'Generate a module.',
+    description: 'Generate a standalone module (import it in a parent module to activate).',
     factory: (name) => generateModuleFiles(name),
     kind: 'module',
+    nextStepHint: "Import the new module in a parent module's imports array, then run 'pnpm typecheck'.",
     schematic: 'module',
+    wiringBehavior: 'files-only',
   },
   {
     aliases: ['repo'],
-    description: 'Generate a persistence-agnostic repository and register it as a provider.',
+    description: 'Generate a persistence-agnostic repository (auto-registered as a provider).',
     factory: (name, options) => generateRepoFiles(name, options),
     kind: 'repo',
     moduleRegistration: { arrayKey: 'providers', classSuffix: 'Repo' },
+    nextStepHint: "Run 'pnpm typecheck' to verify module wiring, then add data-access methods to the repo stub.",
     registryAliases: ['repository'],
     schematic: 'repository',
+    wiringBehavior: 'auto-registered',
   },
   {
     aliases: ['req'],
-    description: 'Generate a request DTO for route-level data binding and validation.',
+    description: 'Generate a request DTO for route-level data binding and validation (files only — wire it into a controller manually).',
     factory: (name) => generateRequestDtoFiles(name),
     kind: 'request-dto',
+    nextStepHint: 'Import the DTO in a controller and add it as a parameter with @FromBody or @FromQuery.',
     schematic: 'request-dto',
+    wiringBehavior: 'files-only',
   },
   {
     aliases: ['res'],
-    description: 'Generate a response DTO for typed response payloads.',
+    description: 'Generate a response DTO for typed response payloads (files only — use it as a controller return type).',
     factory: (name) => generateResponseDtoFiles(name),
     kind: 'response-dto',
+    nextStepHint: 'Import the DTO in a controller and use it as the return type for route handlers.',
     schematic: 'response-dto',
+    wiringBehavior: 'files-only',
   },
   {
     aliases: ['s'],
-    description: 'Generate a service and register it as a provider in the module.',
+    description: 'Generate a service (auto-registered as a provider in the module).',
     factory: (name, options) => generateServiceFiles(name, options),
     kind: 'service',
     moduleRegistration: { arrayKey: 'providers', classSuffix: 'Service' },
+    nextStepHint: "Run 'pnpm typecheck' to verify module wiring, then implement business logic.",
     schematic: 'service',
+    wiringBehavior: 'auto-registered',
   },
 ] as const satisfies readonly GeneratorManifestEntry[];
 


### PR DESCRIPTION
## Summary

Closes #592

Improves the CLI generator output so that every `konekti generate` invocation clearly communicates:
- **What was created** — each file is listed with a `CREATE` prefix.
- **How it was wired** — a `Wiring` status line tells the user whether the class was auto-registered in a domain module or whether manual registration is required.
- **What to do next** — a per-generator `Next steps` hint provides the specific follow-up action (e.g., run `pnpm typecheck`, import a DTO into a controller, etc.).

## Changes

### `packages/cli/src/generators/manifest.ts`
- Added `wiringBehavior: 'auto-registered' | 'files-only'` field to `GeneratorManifestEntry`.
- Added `nextStepHint: string` field to each manifest entry with generator-specific guidance.
- Updated all 9 manifest descriptions to explicitly indicate wiring behavior.

### `packages/cli/src/commands/generate.ts`
- Changed return type from `string[]` to new `GenerateResult` struct with fields: `generatedFiles`, `moduleRegistered`, `modulePath`, `nextStepHint`, `wiringBehavior`.

### `packages/cli/src/cli.ts`
- Added `Wiring` column to `generateUsage()` help table with auto/manual labels and a legend.
- Updated generate command output to show `CREATE` file prefix, wiring status, and next-step hint.

### Tests
- Updated existing test assertions to match new help table header (includes Wiring column).
- Added 3 new regression tests in `cli.test.ts`: auto-registered output, files-only output, help Wiring column.
- Added 3 new regression tests in `generate.test.ts`: `GenerateResult` metadata for auto-registered, files-only, and module kinds.

### Docs
- `docs/getting-started/generator-workflow.md` / `.ko.md` — Added Wiring column to schematics table, new "wiring behavior" section.
- `packages/cli/README.md` / `.ko.md` — Added post-generation output description.

## Verification

- `pnpm typecheck`: ✅ 0 errors
- `pnpm test`: ✅ 115 tests passed (6 files, 0 failures)

## Contract impact

- `GenerateResult` is a new export from `commands/generate.ts` — additive, no breaking change.
- `GeneratorManifestEntry` has two new required fields (`wiringBehavior`, `nextStepHint`) — internal type, not part of the public package API.
- CLI output format changed: `CREATE` prefix + wiring/next-step lines. This is a UX improvement, not a programmatic API.