### PR TITLE
Resolve #614: fix bootstrap-failure runtime test blocking CI activation

### DIFF
--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -1925,7 +1925,9 @@ describe('bootstrapApplication', () => {
       'module:destroy',
       'app:shutdown:bootstrap-failed',
     ]);
-    expect(loggerEvents).toContain('error:KonektiFactory:Failed to bootstrap application.:boom');
+    expect(loggerEvents).toContain(
+      'error:KonektiFactory:Failed to bootstrap application. Check the error below for what failed and how to fix it.:boom',
+    );
   });
 
   it('logs startup milestones, route mappings, and adapter start failures', async () => {


### PR DESCRIPTION
## Summary

Closes #614

The runtime test `bootstrapApplication > unwinds initialized providers when bootstrap hooks fail` in `packages/runtime/src/application.test.ts` was failing on `main` because the test assertion expected the old short logger message (`Failed to bootstrap application.`) while the runtime now emits an improved recovery-oriented message (`Failed to bootstrap application. Check the error below for what failed and how to fix it.`).

This is a one-line assertion fix — the runtime behavior is correct and intentionally documented in the `@konekti/runtime` README under "Recovery-oriented error output". The test expectation was stale.

## What changed

- **File**: `packages/runtime/src/application.test.ts` (line 1928)
- **Change**: Updated `toContain()` assertion string to match the actual logger message emitted by `bootstrap.ts:962-963`
- **Scope**: Test-only. No runtime behavior change.

## Verification

1. **Targeted test** — `pnpm exec vitest run packages/runtime/src/application.test.ts -t "unwinds initialized providers when bootstrap hooks fail"` → ✅ passed
2. **Full test suite** — `pnpm test` → ✅ 103 test files, 1198 tests passed
3. **Build** — `pnpm build` → ✅ all 31 packages built
4. **Typecheck** — `pnpm typecheck` → ✅ all packages pass

## Contract impact

None. The bootstrap-failure recovery contract (unwind initialized providers, log error, re-throw) is preserved exactly as documented. Only the test assertion string was stale.

## Why this unblocks CI

PR #613 (issue #607) enables the CI workflow with `pnpm install --frozen-lockfile && pnpm build && pnpm typecheck && pnpm test`. This test failure was the sole reason `pnpm test` fails on `main`, which would cause CI to start red. With this fix, the full verification chain passes cleanly.