### PR TITLE
Resolve #611: promote canonical examples to first-class verification targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,21 @@ Inside `packages/cli/`:
 - `pnpm sandbox:test`: Runs integration tests against the sandbox app.
 - `pnpm sandbox:clean`: Removes the sandbox directory.
 
+### example verification
+
+Canonical examples in `examples/` are first-class workspace members and verification targets. They participate in the monorepo dependency graph, TypeScript type-checking, and Vitest test runs.
+
+- **Typecheck**: `pnpm typecheck` includes `tsc -p examples/tsconfig.json --noEmit`. Examples share path-mapped workspace packages, so editor resolution and CI catch type errors in example code.
+- **Tests**: `pnpm test` runs `vitest run`, which includes the `examples` project defined in `vitest.config.ts`. Each example has tests in `src/app.test.ts`.
+- **Dependencies**: Each example has a `package.json` with `workspace:*` dependencies on `@konekti/*` packages. Run `pnpm install` after adding or changing example dependencies.
+
+When modifying core packages, verify that examples still pass:
+
+```sh
+pnpm vitest run examples/
+pnpm typecheck
+```
+
 ### using worktrees
 
 We recommend using `git worktree` for multi-tasking or resolving issues in isolation.

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@konekti/example-minimal",
+  "description": "Minimal runnable Konekti application — canonical verification target.",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "typecheck": "tsc -p ../tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@konekti/core": "workspace:*",
+    "@konekti/http": "workspace:*",
+    "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "@konekti/testing": "workspace:*"
+  }
+}

--- a/examples/realworld-api/package.json
+++ b/examples/realworld-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@konekti/example-realworld-api",
+  "description": "Realistic Konekti application with CRUD, validation, and config — canonical verification target.",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "typecheck": "tsc -p ../tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@konekti/config": "workspace:*",
+    "@konekti/core": "workspace:*",
+    "@konekti/http": "workspace:*",
+    "@konekti/runtime": "workspace:*",
+    "@konekti/validation": "workspace:*"
+  },
+  "devDependencies": {
+    "@konekti/testing": "workspace:*"
+  }
+}

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -8,5 +8,6 @@
     },
     "types": ["node"]
   },
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts"],
+  "exclude": ["**/node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "pnpm -r --filter './packages/*' --if-present run build",
-    "typecheck": "tsc -p tsconfig.tools.json --noEmit && pnpm -r --filter './packages/*' --if-present run typecheck",
+    "typecheck": "tsc -p tsconfig.tools.json --noEmit && tsc -p examples/tsconfig.json --noEmit && pnpm -r --filter './packages/*' --if-present run typecheck",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "pnpm -r --if-present run lint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,44 @@ importers:
         specifier: ^3.0.8
         version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
+  examples/minimal:
+    dependencies:
+      '@konekti/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@konekti/http':
+        specifier: workspace:*
+        version: link:../../packages/http
+      '@konekti/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+    devDependencies:
+      '@konekti/testing':
+        specifier: workspace:*
+        version: link:../../packages/testing
+
+  examples/realworld-api:
+    dependencies:
+      '@konekti/config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@konekti/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@konekti/http':
+        specifier: workspace:*
+        version: link:../../packages/http
+      '@konekti/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+      '@konekti/validation':
+        specifier: workspace:*
+        version: link:../../packages/validation
+    devDependencies:
+      '@konekti/testing':
+        specifier: workspace:*
+        version: link:../../packages/testing
+
   packages/cache-manager:
     dependencies:
       '@konekti/core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - packages/*
   - tooling/*
+  - examples/*


### PR DESCRIPTION
## Summary

Canonical examples (`examples/minimal`, `examples/realworld-api`) are promoted from semi-external assets to first-class pnpm workspace members with explicit manifests, integrated TypeScript type-checking, and documented verification workflows.

Closes #611

## Changes

- **`pnpm-workspace.yaml`**: Added `examples/*` alongside `packages/*` and `tooling/*` so examples participate in the workspace dependency graph.
- **`examples/minimal/package.json`** (new): Private workspace manifest with `workspace:*` dependencies on `@konekti/core`, `@konekti/http`, `@konekti/runtime`, and `@konekti/testing`.
- **`examples/realworld-api/package.json`** (new): Same pattern, plus `@konekti/config` and `@konekti/validation`.
- **`examples/tsconfig.json`**: Added `node_modules` exclusion for cleaner editor behavior.
- **`package.json`**: Root `typecheck` script now includes `tsc -p examples/tsconfig.json --noEmit` so CI catches type errors in example code.
- **`CONTRIBUTING.md`**: Added "example verification" section documenting the typecheck, test, and dependency workflows.

## Testing

- `tsc -p examples/tsconfig.json --noEmit` — zero errors
- `vitest run examples/` — 11/11 tests pass (minimal 5, realworld-api 6)
- `vitest run` (full suite) — 103 files, 1198 tests, all passing
- `pnpm install` resolves workspace links correctly for both examples

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

### Contract notes

This change does not alter runtime behavior. It promotes examples from undeclared assets to workspace members, ensuring they cannot silently decay as the docs already reference them as part of the recommended DX path. The existing `vitest.config.ts` examples project is unchanged — it already treated examples as verification targets.