### PR TITLE
Resolve #646: add adapter runtime cross-links

### DIFF
--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -4,6 +4,15 @@
 
 Konekti 런타임 애플리케이션을 위한 Express 기반 HTTP 어댑터입니다.
 
+## 관련 문서
+
+- `../runtime/README.ko.md`
+- `../../docs/concepts/http-runtime.ko.md`
+- `../../docs/concepts/lifecycle-and-shutdown.ko.md`
+- `../../docs/concepts/observability.ko.md`
+- `../../docs/reference/package-chooser.ko.md`
+- `../../docs/reference/package-surface.ko.md`
+
 ## 설치
 
 ```bash

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -4,6 +4,15 @@
 
 Express-backed HTTP adapter for Konekti runtime applications.
 
+## See also
+
+- `../runtime/README.md`
+- `../../docs/concepts/http-runtime.md`
+- `../../docs/concepts/lifecycle-and-shutdown.md`
+- `../../docs/concepts/observability.md`
+- `../../docs/reference/package-chooser.md`
+- `../../docs/reference/package-surface.md`
+
 ## Installation
 
 ```bash

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -4,6 +4,15 @@
 
 Konekti 런타임 애플리케이션을 위한 Fastify 기반 HTTP 어댑터입니다.
 
+## 관련 문서
+
+- `../runtime/README.ko.md`
+- `../../docs/concepts/http-runtime.ko.md`
+- `../../docs/concepts/lifecycle-and-shutdown.ko.md`
+- `../../docs/concepts/observability.ko.md`
+- `../../docs/reference/package-chooser.ko.md`
+- `../../docs/reference/package-surface.ko.md`
+
 ## 설치
 
 ```bash

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -4,6 +4,15 @@
 
 Fastify-backed HTTP adapter for Konekti runtime applications.
 
+## See also
+
+- `../runtime/README.md`
+- `../../docs/concepts/http-runtime.md`
+- `../../docs/concepts/lifecycle-and-shutdown.md`
+- `../../docs/concepts/observability.md`
+- `../../docs/reference/package-chooser.md`
+- `../../docs/reference/package-surface.md`
+
 ## Installation
 
 ```bash

--- a/packages/websocket/README.ko.md
+++ b/packages/websocket/README.ko.md
@@ -5,6 +5,13 @@
 
 공유 Node HTTP/S 서버의 업그레이드 리스너를 사용하는 Konekti용 데코레이터 기반 WebSocket 게이트웨이 패키지입니다.
 
+## 관련 문서
+
+- `../runtime/README.ko.md`
+- `../../docs/operations/third-party-extension-contract.ko.md`
+- `../../docs/reference/package-chooser.ko.md`
+- `../../docs/reference/package-surface.ko.md`
+
 ## 설치
 
 ```bash

--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -5,6 +5,13 @@
 
 Decorator-based WebSocket gateway integration for Konekti applications using a shared Node HTTP/S server upgrade listener.
 
+## See also
+
+- `../runtime/README.md`
+- `../../docs/operations/third-party-extension-contract.md`
+- `../../docs/reference/package-chooser.md`
+- `../../docs/reference/package-surface.md`
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
Closes #646

## Summary
- add See also / 관련 문서 links to Express, Fastify, and WebSocket adapter READMEs
- point adapter readers toward runtime, lifecycle, observability, and package reference docs

## Verification
- docs-only README update
- reviewed changed file set in worktree

## Contract Impact
- no runtime behavior change; documentation only