### PR TITLE
Resolve #653: clear blocking Biome lint debt

### DIFF
--- a/packages/cache-manager/src/cache-service.test.ts
+++ b/packages/cache-manager/src/cache-service.test.ts
@@ -33,7 +33,7 @@ class MockRedisClient {
   async set(key: string, value: string, ...args: Array<string | number>): Promise<'OK'> {
     this.storage.set(key, value);
 
-    const exIndex = args.findIndex((a) => a === 'EX');
+    const exIndex = args.indexOf('EX');
 
     if (exIndex >= 0) {
       const ttlSeconds = Number(args[exIndex + 1]);
@@ -66,7 +66,7 @@ class MockRedisClient {
       return ['0', []];
     }
 
-    const matchIndex = args.findIndex((value) => value === 'MATCH');
+    const matchIndex = args.indexOf('MATCH');
     const rawPattern = matchIndex >= 0 ? args[matchIndex + 1] : '*';
     const pattern = typeof rawPattern === 'string' ? rawPattern : '*';
     const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;

--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -353,12 +353,12 @@ describe('CacheInterceptor', () => {
 
       const { interceptor, cacheService } = createInterceptor({
         httpKeyStrategy: 'route',
-        principalScopeResolver: (context) => context.requestContext.metadata['tenantId'] as string | undefined,
+        principalScopeResolver: (context) => context.requestContext.metadata.tenantId as string | undefined,
       });
       const firstRequestContext = createRequestContext('GET', '/products', '/products');
       const secondRequestContext = createRequestContext('GET', '/products', '/products');
-      firstRequestContext.metadata['tenantId'] = 'tenant-a';
-      secondRequestContext.metadata['tenantId'] = 'tenant-b';
+      firstRequestContext.metadata.tenantId = 'tenant-a';
+      secondRequestContext.metadata.tenantId = 'tenant-b';
 
       const firstContext = createContext(ProductController, 'list', firstRequestContext);
       const secondContext = createContext(ProductController, 'list', secondRequestContext);
@@ -385,11 +385,11 @@ describe('CacheInterceptor', () => {
 
       const { interceptor, cacheService } = createInterceptor({
         httpKeyStrategy: 'route',
-        principalScopeResolver: (context) => context.requestContext.metadata['tenantId'] as string | undefined,
+        principalScopeResolver: (context) => context.requestContext.metadata.tenantId as string | undefined,
       });
       const anonymousRequestContext = createRequestContext('GET', '/products', '/products');
       const tenantScopedRequestContext = createRequestContext('GET', '/products', '/products');
-      tenantScopedRequestContext.metadata['tenantId'] = 'tenant-a';
+      tenantScopedRequestContext.metadata.tenantId = 'tenant-a';
 
       const anonymousContext = createContext(ProductController, 'list', anonymousRequestContext);
       const tenantScopedContext = createContext(ProductController, 'list', tenantScopedRequestContext);

--- a/packages/cache-manager/src/module.test.ts
+++ b/packages/cache-manager/src/module.test.ts
@@ -44,7 +44,7 @@ class MockRedisClient implements RedisCompatibleClient {
       return ['0', []];
     }
 
-    const matchIndex = args.findIndex((value) => value === 'MATCH');
+    const matchIndex = args.indexOf('MATCH');
     const pattern = String(args[matchIndex + 1] ?? '*');
     const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;
 

--- a/packages/cache-manager/src/redis-store.test.ts
+++ b/packages/cache-manager/src/redis-store.test.ts
@@ -35,7 +35,7 @@ class MockRedisClient implements RedisCompatibleClient {
   }
 
   async scan(cursor: string, ...args: Array<string | number>): Promise<[string, string[]]> {
-    const matchIndex = args.findIndex((value) => value === 'MATCH');
+    const matchIndex = args.indexOf('MATCH');
     const rawPattern = matchIndex >= 0 ? args[matchIndex + 1] : '*';
     const pattern = typeof rawPattern === 'string' ? rawPattern : '*';
     const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern;

--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -64,7 +64,7 @@ function findNamedImportSource(sourceFile: ts.SourceFile, className: string): st
     }
 
     const importClause = statement.importClause;
-    if (!importClause || !importClause.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
+    if (!importClause?.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
       continue;
     }
 
@@ -119,7 +119,7 @@ export function ensureModuleImport(source: string, className: string, importPath
     }
 
     const importClause = statement.importClause;
-    if (!importClause || !importClause.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
+    if (!importClause?.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
       continue;
     }
 
@@ -147,7 +147,7 @@ export function ensureModuleImport(source: string, className: string, importPath
 
   if (imports.length > 0) {
     const lastImport = imports[imports.length - 1];
-    return source.slice(0, lastImport.getEnd()) + `\n${newImportLine}` + source.slice(lastImport.getEnd());
+    return `${source.slice(0, lastImport.getEnd())}\n${newImportLine}${source.slice(lastImport.getEnd())}`;
   }
 
   return `${newImportLine}\n${source}`;

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -132,7 +132,7 @@ function buildWarning(filePath: string, sourceFile: ts.SourceFile, node: ts.Node
 
 function getImportBindings(importDeclaration: ts.ImportDeclaration): ImportBinding[] {
   const importClause = importDeclaration.importClause;
-  if (!importClause || !importClause.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
+  if (!importClause?.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
     return [];
   }
 
@@ -160,7 +160,7 @@ function toBindingKey(binding: ImportBinding): string {
 
 function updateNamedImports(importDeclaration: ts.ImportDeclaration, bindings: ImportBinding[]): ts.ImportDeclaration | undefined {
   const importClause = importDeclaration.importClause;
-  if (!importClause || !importClause.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
+  if (!importClause?.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
     return importDeclaration;
   }
 
@@ -304,7 +304,7 @@ function rewriteImports(source: string, filePath: string): { changed: boolean; s
     }
 
     const importClause = statement.importClause;
-    if (!importClause || !importClause.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
+    if (!importClause?.namedBindings || !ts.isNamedImports(importClause.namedBindings)) {
       warnings.push(buildWarning(filePath, sourceFile, statement, 'import-unsupported', 'Unsupported Nest import form detected. Review this import manually.'));
       statements.push(statement);
       continue;
@@ -378,7 +378,7 @@ function hasDecoratorNamed(modifiers: readonly ts.ModifierLike[] | undefined, na
 
 function hasConflictingScopeImport(sourceFile: ts.SourceFile): boolean {
   for (const statement of sourceFile.statements) {
-    if (!ts.isImportDeclaration(statement) || !statement.importClause || !statement.importClause.namedBindings || !ts.isNamedImports(statement.importClause.namedBindings)) {
+    if (!ts.isImportDeclaration(statement) || !statement.importClause?.namedBindings || !ts.isNamedImports(statement.importClause.namedBindings)) {
       continue;
     }
 

--- a/packages/testing/src/http.ts
+++ b/packages/testing/src/http.ts
@@ -185,11 +185,11 @@ export function createTestRequestContextMiddleware(): Middleware {
 function buildFrameworkRequest(req: TestRequestWithOptions): FrameworkTestRequest {
   const method = (req.method ?? 'GET').toUpperCase() as HttpMethod;
   const queryString = req.query
-    ? '?' + new URLSearchParams(
+    ? `?${new URLSearchParams(
         Object.entries(req.query).flatMap(([key, value]) =>
           Array.isArray(value) ? value.map((v) => [key, v]) : [[key, value]],
         ),
-      ).toString()
+      ).toString()}`
     : '';
 
   return {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -327,11 +327,12 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
   overrideProvider<T>(token: Token<T>): OverrideProviderBuilder<T>;
   overrideProvider<T>(token: Token<T>, provider: Provider<T>): this;
   overrideProvider<T>(token: Token<T>, value: T): this;
-  overrideProvider<T>(token: Token<T>, value?: Provider<T> | T): this | OverrideProviderBuilder<T> {
-    if (arguments.length < 2) {
+  overrideProvider<T>(token: Token<T>, ...rest: [Provider<T> | T] | []): this | OverrideProviderBuilder<T> {
+    if (rest.length < 1) {
       return new DefaultOverrideProviderBuilder(this, token);
     }
 
+    const [value] = rest;
     this.overrides.push(normalizeOverride(token, value));
     return this;
   }

--- a/packages/testing/src/platform-conformance.ts
+++ b/packages/testing/src/platform-conformance.ts
@@ -92,7 +92,9 @@ function collectForbiddenKeyPaths(
   violations: string[],
 ): void {
   if (Array.isArray(value)) {
-    value.forEach((entry, index) => collectForbiddenKeyPaths(entry, patterns, allowPatterns, `${currentPath}[${index}]`, violations));
+    value.forEach((entry, index) => {
+      collectForbiddenKeyPaths(entry, patterns, allowPatterns, `${currentPath}[${index}]`, violations);
+    });
     return;
   }
 

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -557,14 +557,14 @@ describe('DefaultValidator', () => {
 
   it('supports custom validators with each over Set and Map', async () => {
     class CustomEachDto {
-      @Validate((value: unknown) => (typeof value === 'string' && value.startsWith('ok') ? true : false), {
+      @Validate((value: unknown) => !!(typeof value === 'string' && value.startsWith('ok')), {
         code: 'CUSTOM_PREFIX',
         each: true,
         message: 'entry must start with ok',
       })
       entries = new Set<string>();
 
-      @Validate((value: unknown) => (typeof value === 'number' && value > 0 ? true : false), {
+      @Validate((value: unknown) => !!(typeof value === 'number' && value > 0), {
         code: 'CUSTOM_POSITIVE',
         each: true,
         message: 'count must be positive',


### PR DESCRIPTION
Closes #653

## Summary
- remove the current Biome lint debt that blocks the Verify workflow
- keep behavior unchanged while applying semantics-preserving rewrites
- restore a clean baseline for queued docs/example PRs

## Verification
- re-ran Biome on the blocking file set with no remaining diagnostics
- relied on CI for full installed-environment verification

## Contract Impact
- no intended runtime behavior change