### PR TITLE
Resolve #664: reduce @konekti/websocket public token surface

### DIFF
--- a/packages/websocket/README.ko.md
+++ b/packages/websocket/README.ko.md
@@ -55,6 +55,10 @@ export class AppModule {}
 - `@OnConnect()`
 - `@OnDisconnect()`
 
+### 내부 모듈 배선 토큰
+
+`@konekti/websocket`는 lifecycle DI 토큰을 공개 API로 노출하지 않습니다. 게이트웨이 탐색/배선 토큰은 내부 구현 세부사항이며, 게이트웨이 작성 계약은 데코레이터 + 클래스 프로바이더 중심으로 유지됩니다.
+
 ### 모듈 옵션
 
 `createWebSocketModule(options)`와 `createWebSocketProviders(options)`는 아래 옵션을 받습니다.

--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -55,6 +55,10 @@ export class AppModule {}
 - `@OnConnect()` - handles accepted socket connections
 - `@OnDisconnect()` - handles socket close events
 
+### Internal module wiring tokens
+
+`@konekti/websocket` does not expose lifecycle DI tokens as part of its public API. Gateway discovery/wiring tokens are internal implementation details, while gateway authoring remains decorator- and class-provider-driven.
+
 ### Module options
 
 `createWebSocketModule(options)` and `createWebSocketProviders(options)` accept:

--- a/packages/websocket/src/index.ts
+++ b/packages/websocket/src/index.ts
@@ -2,5 +2,4 @@ export * from './decorators.js';
 export * from './metadata.js';
 export * from './module.js';
 export * from './service.js';
-export * from './tokens.js';
 export * from './types.js';

--- a/packages/websocket/src/module.test.ts
+++ b/packages/websocket/src/module.test.ts
@@ -12,6 +12,7 @@ import { bootstrapApplication, bootstrapNodeApplication, defineModule, type Appl
 import type { HttpApplicationAdapter } from '@konekti/http';
 
 import { OnConnect, OnDisconnect, OnMessage, WebSocketGateway } from './decorators.js';
+import * as publicApi from './index.js';
 import { getWebSocketGatewayMetadata, getWebSocketHandlerMetadataEntries } from './metadata.js';
 import { createWebSocketModule } from './module.js';
 import { WebSocketGatewayLifecycleService } from './service.js';
@@ -189,6 +190,12 @@ function createMockSocket(): {
 }
 
 describe('@konekti/websocket', () => {
+  it('keeps lifecycle DI tokens internal to module wiring', () => {
+    expect(publicApi).not.toHaveProperty('WEBSOCKET_GATEWAY_SERVICE');
+    expect(publicApi).not.toHaveProperty('WEBSOCKET_SERVICE');
+    expect(publicApi).not.toHaveProperty('WEBSOCKET_OPTIONS');
+  });
+
   it('writes gateway and handler metadata with standard decorators', () => {
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {

--- a/packages/websocket/src/tokens.ts
+++ b/packages/websocket/src/tokens.ts
@@ -5,4 +5,3 @@ import type { WebSocketModuleOptions } from './types.js';
 
 export const WEBSOCKET_GATEWAY_SERVICE: Token<WebSocketGatewayLifecycleService> = Symbol.for('konekti.websocket.gateway-service');
 export const WEBSOCKET_OPTIONS: Token<WebSocketModuleOptions> = Symbol.for('konekti.websocket.options');
-export const WEBSOCKET_SERVICE = WEBSOCKET_GATEWAY_SERVICE;


### PR DESCRIPTION
Closes #664

## Summary
- Removed lifecycle token re-exports from `@konekti/websocket` public entrypoint so gateway/runtime token wiring stays internal.
- Removed the redundant `WEBSOCKET_SERVICE` alias and kept internal module token wiring intact for existing gateway bootstrap behavior.
- Added regression coverage that asserts lifecycle DI tokens are not part of the package public API, and documented the class-provider/decorator-first contract in both README variants.

## Verification
- `pnpm vitest run packages/websocket/src/module.test.ts`
- `pnpm build`
- `pnpm typecheck`

## Contract Impact
- Preserved documented gateway discovery/runtime behavior (decorator + class-provider discovery, lifecycle bootstrap/shutdown semantics unchanged).
- Public surface is intentionally narrowed: lifecycle DI tokens are no longer exported from the package entrypoint; module wiring remains token-based internally.