### PR TITLE
Resolve #660: make @konekti/redis facade class-first while keeping REDIS_CLIENT

### DIFF
--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -118,7 +118,7 @@ await app.close();
 
 - Prisma: `PRISMA_CLIENT`
 - Drizzle: `DRIZZLE_DATABASE`(종료 경로 검증 시 `DRIZZLE_DISPOSE` 포함)
-- Redis: `REDIS_CLIENT` 또는 `REDIS_SERVICE`
+- Redis: `REDIS_CLIENT` 또는 `RedisService` 오버라이드 (`REDIS_SERVICE`는 호환성 alias)
 
 ### 6) OpenAPI 문서 검증
 

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -121,7 +121,7 @@ For persistence/cache-backed tests, keep module wiring real and override only ex
 
 - Prisma: override `PRISMA_CLIENT`
 - Drizzle: override `DRIZZLE_DATABASE` (and `DRIZZLE_DISPOSE` when shutdown behavior matters)
-- Redis: override `REDIS_CLIENT` or `REDIS_SERVICE`
+- Redis: override `REDIS_CLIENT` or `RedisService` (`REDIS_SERVICE` remains a compatibility alias)
 
 This keeps transaction/lifecycle behavior in the graph while removing external network/database coupling.
 

--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -14,7 +14,7 @@ Konekti를 위한 공유 Redis 연결 레이어입니다. 한 번 등록하고, 
 
 `@konekti/redis`는 Konekti에서 앱 범위 Redis client lifecycle을 담당합니다. singleton `ioredis` client를 만들고, `REDIS_CLIENT` DI 토큰으로 노출하며, 모듈 초기화 시 연결하고, 애플리케이션 종료 시 정리합니다.
 
-또한 `REDIS_SERVICE`로 노출되는 `RedisService`를 제공해 JSON 친화적인 `get`/`set`/`del` 사용을 지원하면서, 필요하면 raw `ioredis` 접근도 그대로 유지합니다.
+또한 `RedisService`를 facade의 기본 주입 식별자로 제공해 JSON 친화적인 `get`/`set`/`del` 사용을 지원하면서, 필요하면 raw `ioredis` 접근도 그대로 유지합니다. `REDIS_SERVICE`는 호환성 alias로 계속 제공합니다.
 
 ## 설치
 
@@ -66,7 +66,7 @@ export class CacheService {
 | `createRedisModule(options)` | `src/module.ts` | global singleton Redis client 모듈 등록 |
 | `createRedisProviders(options)` | `src/module.ts` | 수동 조합을 위한 raw provider 목록 반환 |
 | `REDIS_CLIENT` | `src/tokens.ts` | 공유 raw `ioredis` client용 DI 토큰 |
-| `REDIS_SERVICE` | `src/redis-service.ts` | Redis facade 서비스용 DI 토큰 |
+| `REDIS_SERVICE` | `src/redis-service.ts` | `RedisService`로 resolve되는 호환성 DI 토큰 alias |
 | `RedisService` | `src/redis-service.ts` | JSON codec 기반 `get`/`set`/`del` facade + `getRawClient()` escape hatch |
 | `createRedisPlatformStatusSnapshot(input)` | `src/status.ts` | Redis 연결 상태를 공통 ownership/readiness/health/details 스냅샷 형태로 매핑 |
 | `RedisModuleOptions` | `src/types.ts` | `lazyConnect`를 제외한 `ioredis` 옵션 |
@@ -103,7 +103,8 @@ createRedisModule(options)
   -> connect/quit를 관리하는 lifecycle provider 등록
 
 service/repository 코드
-  -> @Inject([REDIS_CLIENT]) 또는 @Inject([REDIS_SERVICE])
+  -> @Inject([REDIS_CLIENT]) 또는 @Inject([RedisService])
+  -> REDIS_SERVICE는 RedisService 호환성 alias로 유지
   -> raw client 또는 facade codec helper
 
 app bootstrap

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -14,7 +14,7 @@ Shared Redis connection layer for Konekti. Register it once, inject either the r
 
 `@konekti/redis` owns the app-scoped Redis client lifecycle for Konekti. It creates a singleton `ioredis` client, exposes it through the `REDIS_CLIENT` DI token, connects it during module initialization, and closes it during application shutdown.
 
-The package also exposes `RedisService` via `REDIS_SERVICE` for JSON-friendly `get`/`set`/`del` usage while still allowing direct raw `ioredis` access.
+The package exposes `RedisService` as the primary facade injection identity for JSON-friendly `get`/`set`/`del` usage while still allowing direct raw `ioredis` access. `REDIS_SERVICE` remains available as a compatibility alias.
 
 ## Installation
 
@@ -66,7 +66,7 @@ export class CacheService {
 | `createRedisModule(options)` | `src/module.ts` | Registers a global singleton Redis client module |
 | `createRedisProviders(options)` | `src/module.ts` | Returns the raw provider list for manual composition |
 | `REDIS_CLIENT` | `src/tokens.ts` | DI token for the shared raw `ioredis` client |
-| `REDIS_SERVICE` | `src/redis-service.ts` | DI token for the Redis facade service |
+| `REDIS_SERVICE` | `src/redis-service.ts` | Compatibility DI token alias that resolves to `RedisService` |
 | `RedisService` | `src/redis-service.ts` | Facade with JSON codec `get`/`set`/`del` helpers + `getRawClient()` escape hatch |
 | `createRedisPlatformStatusSnapshot(input)` | `src/status.ts` | Maps Redis connection state to shared ownership/readiness/health/details snapshot shape |
 | `RedisModuleOptions` | `src/types.ts` | `ioredis` options without `lazyConnect` |
@@ -103,7 +103,8 @@ createRedisModule(options)
   -> registers lifecycle provider that manages connect/quit
 
 service/repository code
-  -> @Inject([REDIS_CLIENT]) or @Inject([REDIS_SERVICE])
+  -> @Inject([REDIS_CLIENT]) or @Inject([RedisService])
+  -> REDIS_SERVICE remains a compatibility alias for RedisService
   -> raw client or facade codec helpers
 
 app bootstrap

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -209,8 +209,8 @@ describe('@konekti/redis', () => {
     expect(mockRedisState.events).toEqual(['connect']);
   });
 
-  it('provides a typed RedisService facade with get/set/del operations', async () => {
-    @Inject([REDIS_SERVICE])
+  it('provides a typed RedisService facade with class-first injection', async () => {
+    @Inject([RedisService])
     class CacheFacade {
       constructor(readonly redisService: RedisService) {}
     }
@@ -242,7 +242,7 @@ describe('@konekti/redis', () => {
   });
 
   it('returns raw string when stored value is not JSON', async () => {
-    @Inject([REDIS_SERVICE])
+    @Inject([RedisService])
     class CacheFacade {
       constructor(readonly redisService: RedisService) {}
     }
@@ -268,7 +268,7 @@ describe('@konekti/redis', () => {
     await app.close();
   });
 
-  it('returns malformed JSON payload as raw string', async () => {
+  it('keeps REDIS_SERVICE as an alias for RedisService', async () => {
     @Inject([REDIS_SERVICE])
     class CacheFacade {
       constructor(readonly redisService: RedisService) {}
@@ -286,6 +286,8 @@ describe('@konekti/redis', () => {
 
     const app = await bootstrapApplication({ rootModule: AppModule });
     const cacheFacade = await app.container.resolve(CacheFacade);
+
+    expect(cacheFacade.redisService).toBeInstanceOf(RedisService);
     const rawClient = cacheFacade.redisService.getRawClient();
 
     await rawClient.set('malformed:key', '{"id": "u1"');

--- a/packages/redis/src/module.ts
+++ b/packages/redis/src/module.ts
@@ -17,9 +17,10 @@ export function createRedisProviders(options: RedisModuleOptions): Provider[] {
         lazyConnect: true,
       }),
     },
+    RedisService,
     {
       provide: REDIS_SERVICE,
-      useClass: RedisService,
+      useExisting: RedisService,
     },
     RedisLifecycleService,
   ];
@@ -30,7 +31,7 @@ export function createRedisModule(options: RedisModuleOptions): ModuleType {
 
   return defineModule(RedisModule, {
     global: true,
-    exports: [REDIS_CLIENT, REDIS_SERVICE],
+    exports: [REDIS_CLIENT, RedisService, REDIS_SERVICE],
     providers: createRedisProviders(options),
   });
 }

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -167,7 +167,7 @@ await app.close();
 
 - Prisma: `PRISMA_CLIENT` 오버라이드
 - Drizzle: `DRIZZLE_DATABASE`(필요 시 `DRIZZLE_DISPOSE`) 오버라이드
-- Redis: `REDIS_CLIENT` 또는 `REDIS_SERVICE` 오버라이드
+- Redis: `REDIS_CLIENT` 또는 `RedisService` 오버라이드 (`REDIS_SERVICE`는 호환성 alias)
 
 ### OpenAPI 문서 검증 패턴
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -151,7 +151,7 @@ For persistence-backed modules, keep integration boundaries but replace external
 
 - Prisma: override `PRISMA_CLIENT` with a fake client.
 - Drizzle: override `DRIZZLE_DATABASE` (and optionally `DRIZZLE_DISPOSE`) with test doubles.
-- Redis: override `REDIS_CLIENT` or `REDIS_SERVICE` with in-memory doubles.
+- Redis: override `REDIS_CLIENT` or `RedisService` with in-memory doubles (`REDIS_SERVICE` remains a compatibility alias).
 
 The module graph remains real; only explicit external tokens are replaced.
 


### PR DESCRIPTION
Closes #660

## Summary
- Promote `RedisService` to the primary facade injection identity in `createRedisModule()` while keeping `REDIS_CLIENT` unchanged as the raw handle token.
- Preserve `REDIS_SERVICE` as a compatibility alias by wiring it via `useExisting: RedisService` so existing token-based consumers keep working.
- Update redis/testing docs (EN/KO) and redis module tests to reflect class-first facade usage plus explicit alias compatibility.

## Verification
- `pnpm vitest run packages/redis/src/module.test.ts`
- `pnpm build`
- `pnpm typecheck`

## Contract impact
- `REDIS_CLIENT` remains public and token-based as the raw `ioredis` seam.
- Facade injection identity is now class-first (`RedisService`) with `REDIS_SERVICE` retained as a public compatibility alias to preserve behavior.
- Package and downstream testing guidance docs were updated in the same PR to keep the contract coherent.