### PR TITLE
Resolve #663: remove redundant CQRS_EVENT_BUS alias from public contract

### DIFF
--- a/docs/concepts/cqrs.ko.md
+++ b/docs/concepts/cqrs.ko.md
@@ -14,7 +14,7 @@
 
 - command 실행용 `CommandBus` (`COMMAND_BUS`)
 - query 실행용 `QueryBus` (`QUERY_BUS`)
-- `@konekti/event-bus`를 통한 이벤트 발행용 `CqrsEventBus` (`EVENT_BUS`, 별칭: `CQRS_EVENT_BUS`)
+- `@konekti/event-bus`를 통한 이벤트 발행용 `CqrsEventBus` (`EVENT_BUS`)
 
 또한 이슈 기대치에 맞춘 기본 계약도 공개합니다.
 

--- a/docs/concepts/cqrs.md
+++ b/docs/concepts/cqrs.md
@@ -14,7 +14,7 @@ This guide describes the CQRS package model in Konekti.
 
 - `CommandBus` (`COMMAND_BUS`) for command execution
 - `QueryBus` (`QUERY_BUS`) for query execution
-- `CqrsEventBus` (`EVENT_BUS`, alias: `CQRS_EVENT_BUS`) for event publishing via `@konekti/event-bus`
+- `CqrsEventBus` (`EVENT_BUS`) for event publishing via `@konekti/event-bus`
 
 It also publishes issue-aligned base contracts:
 

--- a/packages/cqrs/README.ko.md
+++ b/packages/cqrs/README.ko.md
@@ -116,8 +116,7 @@ export class AppModule {}
 - `createCqrsProviders()` - 수동 조합을 위한 raw provider 목록을 반환합니다.
 - `COMMAND_BUS` - `CommandBus`용 DI 토큰입니다.
 - `QUERY_BUS` - `QueryBus`용 DI 토큰입니다.
-- `EVENT_BUS` - 이슈 기대치에 맞춘 `CqrsEventBus`용 CQRS 이벤트 버스 토큰입니다.
-- `CQRS_EVENT_BUS` - 동일 토큰에 대한 호환 별칭입니다.
+- `EVENT_BUS` - `CqrsEventBus`용 정식 CQRS 이벤트 버스 토큰입니다.
 - `ICommand`, `IQuery<TResult>`, `IEvent` - CQRS 메시지 마커 인터페이스입니다.
 - `ICommandHandler<TCommand, TResult>`, `IQueryHandler<TQuery, TResult>`, `IEventHandler<TEvent>`, `ISaga<TEvent>` - 핸들러 계약 인터페이스입니다.
 - `@CommandHandler(CommandClass)` - 클래스에 command handler 메타데이터를 기록합니다.
@@ -125,6 +124,11 @@ export class AppModule {}
 - `@EventHandler(EventClass)` - 클래스에 CQRS event handler 메타데이터를 기록합니다.
 - `@Saga(EventClass | EventClass[])` - 하나 이상의 이벤트 타입에 반응하는 클래스 기반 saga/process-manager 메타데이터를 기록합니다.
 - `createCqrsPlatformStatusSnapshot(input)` - CQRS event/saga lifecycle 의존성 및 drain 가시성을 공통 platform snapshot 필드로 매핑합니다.
+
+### 마이그레이션 노트 (0.x)
+
+- `CQRS_EVENT_BUS`는 공개 패키지 표면에서 제거되었습니다.
+- CQRS 이벤트 버스 DI 사용 코드는 `EVENT_BUS`로 마이그레이션하세요.
 
 ### 모듈 옵션 동작
 

--- a/packages/cqrs/README.md
+++ b/packages/cqrs/README.md
@@ -116,8 +116,7 @@ export class AppModule {}
 - `createCqrsProviders()` - returns raw providers for manual composition.
 - `COMMAND_BUS` - DI token for `CommandBus`.
 - `QUERY_BUS` - DI token for `QueryBus`.
-- `EVENT_BUS` - issue-compatible CQRS event-bus token for `CqrsEventBus`.
-- `CQRS_EVENT_BUS` - compatibility alias to the same CQRS event-bus token.
+- `EVENT_BUS` - canonical CQRS event-bus token for `CqrsEventBus`.
 - `ICommand`, `IQuery<TResult>`, `IEvent` - marker interfaces for CQRS message types.
 - `ICommandHandler<TCommand, TResult>`, `IQueryHandler<TQuery, TResult>`, `IEventHandler<TEvent>`, `ISaga<TEvent>` - handler contracts.
 - `@CommandHandler(CommandClass)` - marks a class as a command handler.
@@ -125,6 +124,11 @@ export class AppModule {}
 - `@EventHandler(EventClass)` - marks a class with CQRS event-handler metadata.
 - `@Saga(EventClass | EventClass[])` - marks a class-level saga/process-manager for one or more event types.
 - `createCqrsPlatformStatusSnapshot(input)` - maps CQRS event/saga lifecycle dependency and drain visibility into shared platform snapshot fields
+
+### migration notes (0.x)
+
+- `CQRS_EVENT_BUS` has been removed from the public package surface.
+- Migrate all CQRS event-bus DI usage to `EVENT_BUS`.
 
 ### module option semantics
 

--- a/packages/cqrs/src/index.ts
+++ b/packages/cqrs/src/index.ts
@@ -27,7 +27,7 @@ export {
 } from './metadata.js';
 export { createCqrsModule, createCqrsProviders, type CqrsModuleOptions } from './module.js';
 export * from './status.js';
-export { CQRS_EVENT_BUS, COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
+export { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 export type {
   CommandBus,
   CommandHandlerClass,

--- a/packages/cqrs/src/module.test.ts
+++ b/packages/cqrs/src/module.test.ts
@@ -17,7 +17,7 @@ import { CqrsEventBusService } from './event-bus.js';
 import { getCommandHandlerMetadata, getEventHandlerMetadata, getQueryHandlerMetadata, getSagaMetadata } from './metadata.js';
 import { createCqrsModule } from './module.js';
 import { CqrsSagaLifecycleService } from './saga-bus.js';
-import { CQRS_EVENT_BUS, COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
+import { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 import type {
   CommandBus,
   CqrsEventBus,
@@ -273,17 +273,16 @@ describe('@konekti/cqrs', () => {
     expect(publish).toHaveBeenNthCalledWith(3, events[1]);
   });
 
-  it('exposes EVENT_BUS as a CQRS-compatible alias token', async () => {
+  it('exposes EVENT_BUS as the canonical CQRS event-bus token', async () => {
     class AppModule {}
     defineModule(AppModule, {
       imports: [createCqrsModule()],
     });
 
     const app = await bootstrapApplication({ rootModule: AppModule });
-    const busByAlias = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
-    const busByLegacy = await app.container.resolve<CqrsEventBus>(CQRS_EVENT_BUS);
+    const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
 
-    expect(busByAlias).toBe(busByLegacy);
+    expect(eventBus).toBeInstanceOf(CqrsEventBusService);
 
     await app.close();
   });
@@ -744,7 +743,7 @@ describe('@konekti/cqrs', () => {
     const app = await bootstrapApplication({ rootModule: AppModule });
     const commandBus = await app.container.resolve<CommandBus>(COMMAND_BUS);
     const queryBus = await app.container.resolve<QueryBus>(QUERY_BUS);
-    const eventBus = await app.container.resolve<CqrsEventBus>(CQRS_EVENT_BUS);
+    const eventBus = await app.container.resolve<CqrsEventBus>(EVENT_BUS);
     const store = await app.container.resolve(Store);
 
     await commandBus.execute(new CreateUserCommand('alice'));

--- a/packages/cqrs/src/module.ts
+++ b/packages/cqrs/src/module.ts
@@ -6,7 +6,7 @@ import { CommandBusLifecycleService } from './command-bus.js';
 import { CqrsEventBusService } from './event-bus.js';
 import { QueryBusLifecycleService } from './query-bus.js';
 import { CqrsSagaLifecycleService } from './saga-bus.js';
-import { CQRS_EVENT_BUS, COMMAND_BUS, QUERY_BUS } from './tokens.js';
+import { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 import type { CommandHandlerClass, EventHandlerClass, QueryHandlerClass, SagaClass } from './types.js';
 
 export interface CqrsModuleOptions {
@@ -51,7 +51,7 @@ export function createCqrsProviders(options: CqrsModuleOptions = {}): Provider[]
     },
     CqrsSagaLifecycleService,
     {
-      provide: CQRS_EVENT_BUS,
+      provide: EVENT_BUS,
       useClass: CqrsEventBusService,
     },
     ...collectOptionHandlerProviders(options),
@@ -62,7 +62,7 @@ export function createCqrsModule(options: CqrsModuleOptions = {}): ModuleType {
   class CqrsModule {}
 
   return defineModule(CqrsModule, {
-    exports: [COMMAND_BUS, QUERY_BUS, CQRS_EVENT_BUS],
+    exports: [COMMAND_BUS, QUERY_BUS, EVENT_BUS],
     global: true,
     imports: [createEventBusModule(options.eventBus)],
     providers: createCqrsProviders(options),

--- a/packages/cqrs/src/tokens.ts
+++ b/packages/cqrs/src/tokens.ts
@@ -4,5 +4,4 @@ import type { CommandBus, CqrsEventBus, QueryBus } from './types.js';
 
 export const COMMAND_BUS: Token<CommandBus> = Symbol.for('konekti.cqrs.command-bus');
 export const QUERY_BUS: Token<QueryBus> = Symbol.for('konekti.cqrs.query-bus');
-export const CQRS_EVENT_BUS: Token<CqrsEventBus> = Symbol.for('konekti.cqrs.event-bus');
-export const EVENT_BUS: Token<CqrsEventBus> = CQRS_EVENT_BUS;
+export const EVENT_BUS: Token<CqrsEventBus> = Symbol.for('konekti.cqrs.event-bus');


### PR DESCRIPTION
## Summary
- Remove `CQRS_EVENT_BUS` from the public `@konekti/cqrs` token surface and keep `EVENT_BUS` as the single canonical CQRS event-bus contract.
- Preserve runtime CQRS behavior by continuing to bind `CqrsEventBusService` to the same `Symbol.for('konekti.cqrs.event-bus')` token, now exposed only as `EVENT_BUS`.
- Align CQRS docs/tests and add explicit 0.x migration notes for token-surface change.

## Changes
- Updated CQRS token/module exports (`packages/cqrs/src/tokens.ts`, `packages/cqrs/src/module.ts`, `packages/cqrs/src/index.ts`) to remove the redundant alias from public surface.
- Updated CQRS regression coverage (`packages/cqrs/src/module.test.ts`) to validate canonical `EVENT_BUS` resolution instead of alias compatibility.
- Updated contract docs (`packages/cqrs/README.md`, `packages/cqrs/README.ko.md`, `docs/concepts/cqrs.md`, `docs/concepts/cqrs.ko.md`) and added migration wording.

## Testing
- `pnpm exec vitest run packages/cqrs/src/module.test.ts packages/cqrs/src/status.test.ts`
- `pnpm typecheck`
- `pnpm build`

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact note
- Public CQRS event-bus token surface changed: `CQRS_EVENT_BUS` is no longer exported as a public token alias.
- Runtime event-bus behavior is unchanged; `EVENT_BUS` remains the stable CQRS event-bus DI contract.

Closes #663