### PR TITLE
Resolve #661: make cache-manager public DI class-first with token seam compatibility

### DIFF
--- a/docs/concepts/caching.ko.md
+++ b/docs/concepts/caching.ko.md
@@ -14,10 +14,11 @@
 
 `@konekti/cache-manager`는 다음을 제공합니다.
 
-- 캐시 서비스(`CACHE_MANAGER`)와 모듈 옵션 토큰(`CACHE_OPTIONS`)
+- 캐시 퍼사드/인터셉터 사용을 위한 클래스 우선 DI 진입점(`CacheService`, `CacheInterceptor`)
 - 메모리/Redis 캐시 스토어
 - 라우트 데코레이터(`@CacheKey`, `@CacheTTL`, `@CacheEvict`)
-- read-through 및 eviction 동작을 수행하는 캐시 인터셉터(`CACHE_INTERCEPTOR`)
+- 기존 token-first 연결을 위한 호환 별칭 토큰(`CACHE_MANAGER`, `CACHE_INTERCEPTOR`)
+- 모듈/스토어 연결 seam을 위한 토큰(`CACHE_OPTIONS`, `CACHE_STORE`)
 
 ## 요청 동작 규약
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -14,10 +14,11 @@ This guide explains Konekti's HTTP response caching model powered by `@konekti/c
 
 `@konekti/cache-manager` provides:
 
-- a cache service (`CACHE_MANAGER`) and module options token (`CACHE_OPTIONS`)
+- class-first DI entry points (`CacheService`, `CacheInterceptor`) for cache facade/interceptor usage
 - memory and Redis cache stores
 - route decorators (`@CacheKey`, `@CacheTTL`, `@CacheEvict`)
-- a cache interceptor (`CACHE_INTERCEPTOR`) for read-through and eviction behavior
+- compatibility alias tokens (`CACHE_MANAGER`, `CACHE_INTERCEPTOR`) for legacy token-first wiring
+- token seams (`CACHE_OPTIONS`, `CACHE_STORE`) for module/store wiring
 
 ## request behavior
 

--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -54,7 +54,7 @@ class AppModule {}
 ```ts
 import { Inject } from '@konekti/core';
 import { Module } from '@konekti/runtime';
-import { CACHE_MANAGER, createCacheModule, type CacheService } from '@konekti/cache-manager';
+import { CacheService, createCacheModule } from '@konekti/cache-manager';
 
 interface UserProfile {
   id: string;
@@ -62,7 +62,7 @@ interface UserProfile {
   email: string;
 }
 
-@Inject([CACHE_MANAGER])
+@Inject([CacheService])
 class UserService {
   constructor(private readonly cache: CacheService) {}
 
@@ -118,8 +118,10 @@ class AppModule {}
 - `createCacheProviders(options)` — 수동 조합용 프로바이더 목록을 반환합니다.
 - `createCacheManagerPlatformStatusSnapshot(input)` — 캐시 스토어 종류/소유권/준비 상태를 공유 platform snapshot 형식에 맞게 매핑합니다.
 - `createCacheManagerPlatformDiagnosticIssues(input)` — 캐시 스토어 준비 실패에 대한 공유 `PlatformDiagnosticIssue` 항목을 출력합니다.
-- `CACHE_MANAGER` — `CacheService` DI 토큰.
-- `CACHE_OPTIONS` — 정규화된 모듈 옵션 DI 토큰.
+- `CacheService` — 애플리케이션 레벨 캐싱의 기본 DI 클래스입니다.
+- `CacheInterceptor` — HTTP read-through/eviction 동작의 기본 DI 클래스입니다.
+- `CACHE_MANAGER` / `CACHE_INTERCEPTOR` — 기존 token-first 연결을 위한 호환 별칭 토큰입니다.
+- `CACHE_OPTIONS` / `CACHE_STORE` — 내부 연결 및 커스텀 스토어 조합에 사용하는 토큰 기반 module/store seam입니다.
 
 `CacheModuleOptions`의 주요 필드는 `store`, `ttl`, `isGlobal`, `httpKeyStrategy`, `principalScopeResolver`입니다.
 

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -54,7 +54,7 @@ Use `CacheService` directly for non-HTTP caching needs such as external API resp
 ```ts
 import { Inject } from '@konekti/core';
 import { Module } from '@konekti/runtime';
-import { CACHE_MANAGER, createCacheModule, type CacheService } from '@konekti/cache-manager';
+import { CacheService, createCacheModule } from '@konekti/cache-manager';
 
 const EXTERNAL_API = Symbol.for('EXTERNAL_API');
 
@@ -64,7 +64,7 @@ interface UserProfile {
   email: string;
 }
 
-@Inject([CACHE_MANAGER])
+@Inject([CacheService])
 class UserService {
   constructor(private readonly cache: CacheService) {}
 
@@ -120,8 +120,10 @@ class AppModule {}
 - `createCacheProviders(options)` — returns providers for manual composition.
 - `createCacheManagerPlatformStatusSnapshot(input)` — maps cache store kind/ownership/readiness into shared platform snapshot shape.
 - `createCacheManagerPlatformDiagnosticIssues(input)` — emits shared `PlatformDiagnosticIssue` entries for cache store readiness failures.
-- `CACHE_MANAGER` — DI token for `CacheService`.
-- `CACHE_OPTIONS` — DI token for normalized module options.
+- `CacheService` — primary DI class for application-level caching.
+- `CacheInterceptor` — primary DI class for HTTP read-through/eviction behavior.
+- `CACHE_MANAGER` / `CACHE_INTERCEPTOR` — compatibility alias tokens for legacy token-first wiring.
+- `CACHE_OPTIONS` / `CACHE_STORE` — token-based module/store seams used for internal wiring and custom store composition.
 
 `CacheModuleOptions` primary fields are `store`, `ttl`, `isGlobal`, `httpKeyStrategy`, and `principalScopeResolver`.
 

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -2,8 +2,8 @@ import { Inject, metadataSymbol } from '@konekti/core';
 import { SseResponse, type CallHandler, type Interceptor, type InterceptorContext } from '@konekti/http';
 
 import { cacheRouteMetadataKey, getCacheEvictMetadata, getCacheKeyMetadata, getCacheTtlMetadata } from './decorators.js';
-import { CACHE_MANAGER, CACHE_OPTIONS } from './tokens.js';
-import type { CacheService } from './service.js';
+import { CacheService } from './service.js';
+import { CACHE_OPTIONS } from './tokens.js';
 import type { CacheEvictDecoratorValue, CacheKeyDecoratorValue, CacheKeyStrategy, NormalizedCacheModuleOptions, PrincipalScopeResolver } from './types.js';
 
 type MetadataBag = Record<PropertyKey, unknown>;
@@ -178,7 +178,7 @@ function installDeferredEviction(
   return restore;
 }
 
-@Inject([CACHE_MANAGER, CACHE_OPTIONS])
+@Inject([CacheService, CACHE_OPTIONS])
 export class CacheInterceptor implements Interceptor {
   constructor(
     private readonly cache: CacheService,

--- a/packages/cache-manager/src/module.test.ts
+++ b/packages/cache-manager/src/module.test.ts
@@ -6,10 +6,10 @@ import { bootstrapApplication, defineModule } from '@konekti/runtime';
 
 import { CacheEvict } from './decorators.js';
 import { CacheInterceptor } from './interceptor.js';
-import { CACHE_MANAGER } from './tokens.js';
+import { CacheService } from './service.js';
+import { CACHE_INTERCEPTOR, CACHE_MANAGER } from './tokens.js';
 import { createCacheModule } from './module.js';
 import type { RedisCompatibleClient } from './types.js';
-import type { CacheService } from './service.js';
 
 const REDIS_CLIENT_TOKEN = Symbol.for('konekti.redis.client');
 
@@ -101,7 +101,7 @@ describe('createCacheModule', () => {
   });
 
   it('supports memory store without redis module/client installed', async () => {
-    @Inject([CACHE_MANAGER])
+    @Inject([CacheService])
     class Consumer {
       constructor(readonly cache: CacheService) {}
     }
@@ -134,7 +134,7 @@ describe('createCacheModule', () => {
   });
 
   it('supports redis store when a raw redis-style client is provided', async () => {
-    @Inject([CACHE_MANAGER])
+    @Inject([CacheService])
     class Consumer {
       constructor(readonly cache: CacheService) {}
     }
@@ -155,6 +155,36 @@ describe('createCacheModule', () => {
     await consumer.cache.set('/users', { count: 3 }, 30);
 
     await expect(consumer.cache.get('/users')).resolves.toEqual({ count: 3 });
+
+    await app.close();
+  });
+
+  it('keeps CACHE_MANAGER as a compatibility alias for CacheService', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCacheModule({ store: 'memory' })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const byClass = await app.container.resolve(CacheService);
+    const byToken = await app.container.resolve<CacheService>(CACHE_MANAGER);
+
+    expect(byToken).toBe(byClass);
+
+    await app.close();
+  });
+
+  it('keeps CACHE_INTERCEPTOR as a compatibility alias for CacheInterceptor', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [createCacheModule({ store: 'memory' })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const byClass = await app.container.resolve(CacheInterceptor);
+    const byToken = await app.container.resolve<CacheInterceptor>(CACHE_INTERCEPTOR);
+
+    expect(byToken).toBe(byClass);
 
     await app.close();
   });

--- a/packages/cache-manager/src/module.ts
+++ b/packages/cache-manager/src/module.ts
@@ -111,16 +111,20 @@ export function createCacheProviders(options: CacheModuleOptions = {}): Provider
       },
     },
     {
-      provide: CACHE_MANAGER,
+      provide: CacheService,
       useClass: CacheService,
     },
     {
-      provide: CACHE_INTERCEPTOR,
-      useClass: CacheInterceptor,
+      provide: CACHE_MANAGER,
+      useExisting: CacheService,
     },
     {
       provide: CacheInterceptor,
-      useExisting: CACHE_INTERCEPTOR,
+      useClass: CacheInterceptor,
+    },
+    {
+      provide: CACHE_INTERCEPTOR,
+      useExisting: CacheInterceptor,
     },
   ];
 }
@@ -130,7 +134,7 @@ export function createCacheModule(options: CacheModuleOptions = {}): ModuleType 
   const normalized = normalizeCacheModuleOptions(options);
 
   return defineModule(CacheModule, {
-    exports: [CACHE_MANAGER, CACHE_INTERCEPTOR],
+    exports: [CacheService, CacheInterceptor, CACHE_MANAGER, CACHE_INTERCEPTOR],
     global: normalized.isGlobal,
     providers: createCacheProviders(options),
   });


### PR DESCRIPTION
## Summary
- Promote `CacheService` and `CacheInterceptor` as the public DI-first classes in `createCacheProviders()`/`createCacheModule()` exports.
- Preserve internal token seams (`CACHE_OPTIONS`, `CACHE_STORE`) and keep `CACHE_MANAGER` / `CACHE_INTERCEPTOR` as compatibility aliases via `useExisting`.
- Align cache-manager and request-pipeline docs (`packages/cache-manager/README*.md`, `docs/concepts/caching*.md`) with the class-first DI guidance.

## Testing
- `pnpm vitest run packages/cache-manager/src/module.test.ts packages/cache-manager/src/interceptor.test.ts`
- `pnpm --filter @konekti/cache-manager typecheck`
- `pnpm --filter @konekti/cache-manager build`
- `pnpm typecheck`
- `pnpm build`

## Contract impact
- Behavioral cache semantics are unchanged (GET-only read-through defaults, TTL semantics, eviction timing, and Redis bootstrap failure behavior remain intact).
- Public DI surface is now class-first (`CacheService`, `CacheInterceptor`), while legacy token-first usage remains supported through compatibility aliases (`CACHE_MANAGER`, `CACHE_INTERCEPTOR`).
- Internal non-class seams remain token-based (`CACHE_OPTIONS`, `CACHE_STORE`) as documented.

Closes #661