### PR TITLE
Resolve #662: expose throttler guard as class-first identity

### DIFF
--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -60,9 +60,22 @@ class AuthController {
 
 특정 컨트롤러 클래스나 핸들러 메서드에 대해 속도 제한을 완전히 무시합니다.
 
+### `ThrottlerGuard`
+
+`@konekti/throttler`가 내보내는 class-first 기본 가드 식별자입니다.
+
+```typescript
+import { Controller, UseGuards } from '@konekti/http';
+import { ThrottlerGuard } from '@konekti/throttler';
+
+@UseGuards(ThrottlerGuard)
+@Controller('/api')
+class ApiController {}
+```
+
 ### `THROTTLER_GUARD`
 
-등록된 `ThrottlerGuard`를 위한 DI 토큰입니다. 명시적인 가드로 사용하려면 이를 주입하세요.
+`ThrottlerGuard`를 가리키는 호환성 DI 토큰 별칭입니다.
 
 ```typescript
 import { UseGuards } from '@konekti/http';

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -60,9 +60,22 @@ Overrides module-level defaults for a specific controller class or handler metho
 
 Bypasses throttling entirely for a specific controller class or handler method.
 
+### `ThrottlerGuard`
+
+Primary class-first guard identity exported by `@konekti/throttler`.
+
+```typescript
+import { Controller, UseGuards } from '@konekti/http';
+import { ThrottlerGuard } from '@konekti/throttler';
+
+@UseGuards(ThrottlerGuard)
+@Controller('/api')
+class ApiController {}
+```
+
 ### `THROTTLER_GUARD`
 
-DI token for the registered `ThrottlerGuard`. Inject it to use it as an explicit guard:
+Compatibility DI token alias that resolves to `ThrottlerGuard`.
 
 ```typescript
 import { UseGuards } from '@konekti/http';

--- a/packages/throttler/src/index.ts
+++ b/packages/throttler/src/index.ts
@@ -1,4 +1,5 @@
 export * from './decorators.js';
+export { ThrottlerGuard } from './guard.js';
 export { RedisThrottlerStore } from './redis-store.js';
 export * from './module.js';
 export * from './status.js';

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -5,8 +5,9 @@ import type { GuardContext, HandlerDescriptor, RequestContext } from '@konekti/h
 
 import { SkipThrottle, Throttle, getThrottleMetadata } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
-import { createThrottlerModule } from './module.js';
+import { createThrottlerModule, createThrottlerProviders } from './module.js';
 import { createMemoryThrottlerStore } from './store.js';
+import { THROTTLER_GUARD, THROTTLER_OPTIONS } from './tokens.js';
 import type { ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
 
 function createRequestContext(remoteAddress = '127.0.0.1'): RequestContext {
@@ -78,6 +79,51 @@ function createGuardContext(
     requestContext,
   };
 }
+
+type ObjectProvider = {
+  provide: unknown;
+  useClass?: unknown;
+  useExisting?: unknown;
+  useValue?: unknown;
+};
+
+function isObjectProvider(provider: unknown): provider is ObjectProvider {
+  return typeof provider === 'object' && provider !== null && 'provide' in provider;
+}
+
+describe('createThrottlerProviders', () => {
+  it('registers class-first ThrottlerGuard identity and keeps token alias compatibility', () => {
+    const providers = createThrottlerProviders({
+      limit: 10,
+      ttl: 60,
+    });
+    const optionsProvider = providers.find(
+      (provider) => isObjectProvider(provider) && provider.provide === THROTTLER_OPTIONS,
+    );
+    const classProvider = providers.find(
+      (provider) => isObjectProvider(provider) && provider.provide === ThrottlerGuard,
+    );
+    const aliasProvider = providers.find(
+      (provider) => isObjectProvider(provider) && provider.provide === THROTTLER_GUARD,
+    );
+
+    expect(optionsProvider).toMatchObject({
+      provide: THROTTLER_OPTIONS,
+      useValue: {
+        limit: 10,
+        ttl: 60,
+      },
+    });
+    expect(classProvider).toMatchObject({
+      provide: ThrottlerGuard,
+      useClass: ThrottlerGuard,
+    });
+    expect(aliasProvider).toMatchObject({
+      provide: THROTTLER_GUARD,
+      useExisting: ThrottlerGuard,
+    });
+  });
+});
 
 describe('@konekti/throttler decorators', () => {
   it('writes @Throttle method-level metadata into the route map', () => {

--- a/packages/throttler/src/module.ts
+++ b/packages/throttler/src/module.ts
@@ -15,8 +15,12 @@ export function createThrottlerProviders(options: ThrottlerModuleOptions): Provi
       useValue: validatedOptions,
     },
     {
-      provide: THROTTLER_GUARD,
+      provide: ThrottlerGuard,
       useClass: ThrottlerGuard,
+    },
+    {
+      provide: THROTTLER_GUARD,
+      useExisting: ThrottlerGuard,
     },
   ];
 }
@@ -25,7 +29,7 @@ export function createThrottlerModule(options: ThrottlerModuleOptions): ModuleTy
   class ThrottlerModule {}
 
   return defineModule(ThrottlerModule, {
-    exports: [THROTTLER_GUARD],
+    exports: [ThrottlerGuard, THROTTLER_GUARD],
     global: true,
     providers: createThrottlerProviders(options),
   });


### PR DESCRIPTION
Closes #662

## Summary
- register and export `ThrottlerGuard` as the primary class-first guard identity in `createThrottlerModule(...)`
- keep `THROTTLER_OPTIONS` token-based wiring unchanged and keep `THROTTLER_GUARD` as a compatibility alias via `useExisting: ThrottlerGuard`
- update `@konekti/throttler` README/README.ko API guidance plus provider wiring tests to reflect class-first public usage

## Verification
- `pnpm vitest run packages/throttler/src/module.test.ts`
- `pnpm build`
- `pnpm --filter @konekti/throttler typecheck`
- `pnpm --filter @konekti/throttler build`

## Contract Impact
- Runtime throttling behavior is unchanged (limit/ttl resolution, key generation, Retry-After handling, and store semantics preserved).
- Public guard identity preference changes to class-first (`ThrottlerGuard`), while token compatibility is preserved (`THROTTLER_GUARD` alias retained).
- `THROTTLER_OPTIONS` remains token-based for internal options wiring.
- Direct request-pipeline docs outside the package README were reviewed; no additional `THROTTLER_GUARD` usage references required updates.