### PR TITLE
Resolve #665: narrow platform-socket.io public contracts to room/server APIs

### DIFF
--- a/packages/platform-socket.io/README.ko.md
+++ b/packages/platform-socket.io/README.ko.md
@@ -54,6 +54,13 @@ export class AppModule {}
 - `SOCKETIO_SERVER` - Socket.IO `Server` 인스턴스를 DI로 주입합니다
 - `SOCKETIO_ROOM_SERVICE` - Socket.IO 네이티브 room API 기반 헬퍼를 주입합니다
 
+루트 패키지 엔트리포인트의 공개 토큰 표면은 `SOCKETIO_SERVER`와 `SOCKETIO_ROOM_SERVICE`에 집중하도록 의도적으로 제한됩니다.
+
+### Migration note (0.x)
+
+`SOCKETIO_LIFECYCLE_SERVICE`는 더 이상 루트 공개 엔트리포인트와 `createSocketIoModule()`의 exports에 포함되지 않습니다.
+소비자는 room 헬퍼에는 `SOCKETIO_ROOM_SERVICE`를, raw Socket.IO 서버 접근에는 `SOCKETIO_SERVER`를 주입해야 합니다.
+
 ### Module options
 
 `createSocketIoModule(options)` 및 `createSocketIoProviders(options)`는 다음 옵션을 받습니다.

--- a/packages/platform-socket.io/README.md
+++ b/packages/platform-socket.io/README.md
@@ -54,6 +54,13 @@ export class AppModule {}
 - `SOCKETIO_SERVER` - inject the underlying Socket.IO `Server` instance
 - `SOCKETIO_ROOM_SERVICE` - inject room helpers built on native Socket.IO room APIs
 
+The root package entrypoint intentionally keeps the public token surface focused on `SOCKETIO_SERVER` and `SOCKETIO_ROOM_SERVICE`.
+
+### Migration note (0.x)
+
+`SOCKETIO_LIFECYCLE_SERVICE` is no longer part of the root public entrypoint and `createSocketIoModule()` exports.
+Consumers should inject `SOCKETIO_ROOM_SERVICE` for room helpers and `SOCKETIO_SERVER` for raw Socket.IO server access.
+
 ### Module options
 
 `createSocketIoModule(options)` and `createSocketIoProviders(options)` accept:

--- a/packages/platform-socket.io/src/index.ts
+++ b/packages/platform-socket.io/src/index.ts
@@ -1,4 +1,4 @@
 export * from './adapter.js';
 export * from './module.js';
-export * from './tokens.js';
+export { SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER } from './tokens.js';
 export * from './types.js';

--- a/packages/platform-socket.io/src/module.test.ts
+++ b/packages/platform-socket.io/src/module.test.ts
@@ -8,6 +8,7 @@ import { io as createClient, type Socket as ClientSocket } from 'socket.io-clien
 import type { Server as SocketIoServer, Socket } from 'socket.io';
 
 import { createSocketIoModule } from './module.js';
+import * as publicApi from './index.js';
 import { SocketIoLifecycleService } from './adapter.js';
 import { SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER } from './tokens.js';
 import type { SocketIoRoomService } from './types.js';
@@ -80,11 +81,18 @@ function onceEvent<T>(socket: ClientSocket, event: string): Promise<T> {
 
 function onceDisconnected(socket: ClientSocket): Promise<string> {
   return new Promise((resolve) => {
-    socket.once('disconnect', (reason) => resolve(reason));
+    socket.once('disconnect', (reason: string) => resolve(reason));
   });
 }
 
 describe('@konekti/platform-socket.io', () => {
+  it('keeps lifecycle and options tokens out of the root public entrypoint', () => {
+    expect(publicApi.SOCKETIO_ROOM_SERVICE).toBeDefined();
+    expect(publicApi.SOCKETIO_SERVER).toBeDefined();
+    expect('SOCKETIO_LIFECYCLE_SERVICE' in publicApi).toBe(false);
+    expect('SOCKETIO_OPTIONS' in publicApi).toBe(false);
+  });
+
   it('injects the Socket.IO server token into singleton providers', async () => {
     @Inject([SOCKETIO_SERVER])
     class ServerProbe {

--- a/packages/platform-socket.io/src/module.ts
+++ b/packages/platform-socket.io/src/module.ts
@@ -36,7 +36,7 @@ export function createSocketIoModule(options: SocketIoModuleOptions = {}): Modul
   class SocketIoModule {}
 
   return defineModule(SocketIoModule, {
-    exports: [SOCKETIO_LIFECYCLE_SERVICE, SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER],
+    exports: [SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER],
     global: true,
     providers: createSocketIoProviders(options),
   });


### PR DESCRIPTION
Closes #665

## Summary
- Narrowed `@konekti/platform-socket.io` root public token surface to consumer-facing `SOCKETIO_ROOM_SERVICE` and `SOCKETIO_SERVER`.
- Removed `SOCKETIO_LIFECYCLE_SERVICE` from `createSocketIoModule()` exports while preserving room helper behavior and raw `SOCKETIO_SERVER` access.
- Added a regression test that verifies lifecycle/options tokens are not exposed from the root entrypoint, and added README migration notes (EN/KO).

## Verification
- `pnpm vitest run packages/platform-socket.io/src/module.test.ts`
- `pnpm --filter @konekti/platform-socket.io typecheck`
- `pnpm typecheck`
- `pnpm build`

## Contract impact
- Pre-release (`0.x`) public contract change: `SOCKETIO_LIFECYCLE_SERVICE` is internalized from the root entrypoint/module exports.
- Stable consumer-facing contracts remain unchanged: room helpers through `SOCKETIO_ROOM_SERVICE` and raw server handle through `SOCKETIO_SERVER`.
- README/README.ko include explicit migration notes for consumers using the removed lifecycle token surface.