### PR TITLE
Resolve #680: remove THROTTLER_GUARD compatibility alias from throttler

### DIFF
--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -73,18 +73,15 @@ import { ThrottlerGuard } from '@konekti/throttler';
 class ApiController {}
 ```
 
-### `THROTTLER_GUARD`
+### `THROTTLER_OPTIONS`
 
-`ThrottlerGuard`를 가리키는 호환성 DI 토큰 별칭입니다.
+`ThrottlerGuard` 생성 및 모듈 와이어링에서 사용하는 모듈 옵션 DI 토큰입니다.
 
-```typescript
-import { UseGuards } from '@konekti/http';
-import { THROTTLER_GUARD } from '@konekti/throttler';
+## 0.x 마이그레이션 노트
 
-@UseGuards(THROTTLER_GUARD)
-@Controller('/api')
-class ApiController {}
-```
+- `THROTTLER_GUARD` 호환성 별칭이 공개 API에서 제거되었습니다.
+- `@UseGuards(...)` 및 DI 등록에서는 `ThrottlerGuard`를 직접 사용하세요.
+- 런타임 throttling 동작과 모듈 옵션 의미는 변경되지 않았습니다.
 
 ### `createThrottlerPlatformStatusSnapshot(input)` / `createThrottlerPlatformDiagnosticIssues(input)`
 

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -73,18 +73,15 @@ import { ThrottlerGuard } from '@konekti/throttler';
 class ApiController {}
 ```
 
-### `THROTTLER_GUARD`
+### `THROTTLER_OPTIONS`
 
-Compatibility DI token alias that resolves to `ThrottlerGuard`.
+Module-options DI token used by `ThrottlerGuard` construction and module wiring.
 
-```typescript
-import { UseGuards } from '@konekti/http';
-import { THROTTLER_GUARD } from '@konekti/throttler';
+## 0.x migration notes
 
-@UseGuards(THROTTLER_GUARD)
-@Controller('/api')
-class ApiController {}
-```
+- `THROTTLER_GUARD` compatibility alias was removed from the public API.
+- Use `ThrottlerGuard` directly in `@UseGuards(...)` and DI registrations.
+- Runtime throttling behavior and module options semantics are unchanged.
 
 ### `createThrottlerPlatformStatusSnapshot(input)` / `createThrottlerPlatformDiagnosticIssues(input)`
 

--- a/packages/throttler/src/index.ts
+++ b/packages/throttler/src/index.ts
@@ -4,5 +4,5 @@ export { RedisThrottlerStore } from './redis-store.js';
 export * from './module.js';
 export * from './status.js';
 export { createMemoryThrottlerStore } from './store.js';
-export { THROTTLER_GUARD, THROTTLER_OPTIONS } from './tokens.js';
+export { THROTTLER_OPTIONS } from './tokens.js';
 export type { ThrottlerHandlerOptions, ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -7,7 +7,7 @@ import { SkipThrottle, Throttle, getThrottleMetadata } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
 import { createThrottlerModule, createThrottlerProviders } from './module.js';
 import { createMemoryThrottlerStore } from './store.js';
-import { THROTTLER_GUARD, THROTTLER_OPTIONS } from './tokens.js';
+import { THROTTLER_OPTIONS } from './tokens.js';
 import type { ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
 
 function createRequestContext(remoteAddress = '127.0.0.1'): RequestContext {
@@ -92,7 +92,7 @@ function isObjectProvider(provider: unknown): provider is ObjectProvider {
 }
 
 describe('createThrottlerProviders', () => {
-  it('registers class-first ThrottlerGuard identity and keeps token alias compatibility', () => {
+  it('registers class-first ThrottlerGuard identity and keeps THROTTLER_OPTIONS token-based', () => {
     const providers = createThrottlerProviders({
       limit: 10,
       ttl: 60,
@@ -102,9 +102,6 @@ describe('createThrottlerProviders', () => {
     );
     const classProvider = providers.find(
       (provider) => isObjectProvider(provider) && provider.provide === ThrottlerGuard,
-    );
-    const aliasProvider = providers.find(
-      (provider) => isObjectProvider(provider) && provider.provide === THROTTLER_GUARD,
     );
 
     expect(optionsProvider).toMatchObject({
@@ -118,10 +115,8 @@ describe('createThrottlerProviders', () => {
       provide: ThrottlerGuard,
       useClass: ThrottlerGuard,
     });
-    expect(aliasProvider).toMatchObject({
-      provide: THROTTLER_GUARD,
-      useExisting: ThrottlerGuard,
-    });
+
+    expect(providers).toHaveLength(2);
   });
 });
 

--- a/packages/throttler/src/module.ts
+++ b/packages/throttler/src/module.ts
@@ -2,7 +2,7 @@ import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { ThrottlerGuard } from './guard.js';
-import { THROTTLER_GUARD, THROTTLER_OPTIONS } from './tokens.js';
+import { THROTTLER_OPTIONS } from './tokens.js';
 import type { ThrottlerModuleOptions } from './types.js';
 import { validateThrottlerModuleOptions } from './validation.js';
 
@@ -18,10 +18,6 @@ export function createThrottlerProviders(options: ThrottlerModuleOptions): Provi
       provide: ThrottlerGuard,
       useClass: ThrottlerGuard,
     },
-    {
-      provide: THROTTLER_GUARD,
-      useExisting: ThrottlerGuard,
-    },
   ];
 }
 
@@ -29,7 +25,7 @@ export function createThrottlerModule(options: ThrottlerModuleOptions): ModuleTy
   class ThrottlerModule {}
 
   return defineModule(ThrottlerModule, {
-    exports: [ThrottlerGuard, THROTTLER_GUARD],
+    exports: [ThrottlerGuard],
     global: true,
     providers: createThrottlerProviders(options),
   });

--- a/packages/throttler/src/tokens.ts
+++ b/packages/throttler/src/tokens.ts
@@ -1,2 +1,1 @@
 export const THROTTLER_OPTIONS = Symbol.for('konekti.throttler.options');
-export const THROTTLER_GUARD = Symbol.for('konekti.throttler.guard');


### PR DESCRIPTION
Closes #680

## Summary
- remove `THROTTLER_GUARD` from `@konekti/throttler` public exports and module provider/export wiring
- keep class-first guard identity via `ThrottlerGuard` and preserve token-based `THROTTLER_OPTIONS`
- replace alias-focused provider expectations with class-first provider-surface assertions and update README/README.ko with explicit `0.x` migration notes

## Verification
- `pnpm exec vitest run packages/throttler/src/module.test.ts`
- `pnpm --filter @konekti/throttler run typecheck`
- `pnpm typecheck`
- `pnpm build`

## Contract impact
This PR intentionally changes the pre-1.0 public package surface by removing the documented compatibility alias token `THROTTLER_GUARD`. Runtime throttling behavior and `THROTTLER_OPTIONS` semantics remain unchanged. English/Korean package READMEs now include explicit `0.x` migration notes for consumers.