### PR TITLE
Resolve #679: remove cache-manager compatibility alias tokens

### DIFF
--- a/docs/concepts/caching.ko.md
+++ b/docs/concepts/caching.ko.md
@@ -17,8 +17,18 @@
 - 캐시 퍼사드/인터셉터 사용을 위한 클래스 우선 DI 진입점(`CacheService`, `CacheInterceptor`)
 - 메모리/Redis 캐시 스토어
 - 라우트 데코레이터(`@CacheKey`, `@CacheTTL`, `@CacheEvict`)
-- 기존 token-first 연결을 위한 호환 별칭 토큰(`CACHE_MANAGER`, `CACHE_INTERCEPTOR`)
 - 모듈/스토어 연결 seam을 위한 토큰(`CACHE_OPTIONS`, `CACHE_STORE`)
+
+### 0.x 마이그레이션 노트
+
+현재 `0.x` 라인에서 호환 별칭 `CACHE_MANAGER`, `CACHE_INTERCEPTOR`는 공개 패키지 표면에서 제거되었습니다.
+
+- DI 주입은 클래스 우선 진입점으로 마이그레이션하세요.
+  - `CACHE_MANAGER` -> `CacheService`
+  - `CACHE_INTERCEPTOR` -> `CacheInterceptor`
+- 내부 토큰 seam은 토큰 기반으로 그대로 유지됩니다.
+  - `CACHE_OPTIONS`
+  - `CACHE_STORE`
 
 ## 요청 동작 규약
 

--- a/docs/concepts/caching.md
+++ b/docs/concepts/caching.md
@@ -17,8 +17,18 @@ This guide explains Konekti's HTTP response caching model powered by `@konekti/c
 - class-first DI entry points (`CacheService`, `CacheInterceptor`) for cache facade/interceptor usage
 - memory and Redis cache stores
 - route decorators (`@CacheKey`, `@CacheTTL`, `@CacheEvict`)
-- compatibility alias tokens (`CACHE_MANAGER`, `CACHE_INTERCEPTOR`) for legacy token-first wiring
 - token seams (`CACHE_OPTIONS`, `CACHE_STORE`) for module/store wiring
+
+### 0.x migration note
+
+In the current `0.x` line, compatibility aliases `CACHE_MANAGER` and `CACHE_INTERCEPTOR` are removed from the public package surface.
+
+- Migrate DI to class-first entry points:
+  - `CACHE_MANAGER` -> `CacheService`
+  - `CACHE_INTERCEPTOR` -> `CacheInterceptor`
+- Internal token seams remain token-based and unchanged:
+  - `CACHE_OPTIONS`
+  - `CACHE_STORE`
 
 ## request behavior
 

--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -120,10 +120,20 @@ class AppModule {}
 - `createCacheManagerPlatformDiagnosticIssues(input)` — 캐시 스토어 준비 실패에 대한 공유 `PlatformDiagnosticIssue` 항목을 출력합니다.
 - `CacheService` — 애플리케이션 레벨 캐싱의 기본 DI 클래스입니다.
 - `CacheInterceptor` — HTTP read-through/eviction 동작의 기본 DI 클래스입니다.
-- `CACHE_MANAGER` / `CACHE_INTERCEPTOR` — 기존 token-first 연결을 위한 호환 별칭 토큰입니다.
 - `CACHE_OPTIONS` / `CACHE_STORE` — 내부 연결 및 커스텀 스토어 조합에 사용하는 토큰 기반 module/store seam입니다.
 
 `CacheModuleOptions`의 주요 필드는 `store`, `ttl`, `isGlobal`, `httpKeyStrategy`, `principalScopeResolver`입니다.
+
+### 0.x 마이그레이션 노트 (호환 별칭 제거)
+
+현재 `0.x` 라인부터 `CACHE_MANAGER`, `CACHE_INTERCEPTOR`는 공개 패키지 표면에서 제거되었습니다.
+
+- 생성자 주입은 클래스 우선 DI로 마이그레이션하세요.
+  - `CACHE_MANAGER` -> `CacheService`
+  - `CACHE_INTERCEPTOR` -> `CacheInterceptor`
+- 내부 토큰 seam은 토큰 기반으로 그대로 유지됩니다.
+  - `CACHE_OPTIONS`
+  - `CACHE_STORE`
 
 ## 동작 규약
 

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -122,10 +122,20 @@ class AppModule {}
 - `createCacheManagerPlatformDiagnosticIssues(input)` — emits shared `PlatformDiagnosticIssue` entries for cache store readiness failures.
 - `CacheService` — primary DI class for application-level caching.
 - `CacheInterceptor` — primary DI class for HTTP read-through/eviction behavior.
-- `CACHE_MANAGER` / `CACHE_INTERCEPTOR` — compatibility alias tokens for legacy token-first wiring.
 - `CACHE_OPTIONS` / `CACHE_STORE` — token-based module/store seams used for internal wiring and custom store composition.
 
 `CacheModuleOptions` primary fields are `store`, `ttl`, `isGlobal`, `httpKeyStrategy`, and `principalScopeResolver`.
+
+### 0.x Migration Note (Compatibility Alias Removal)
+
+As of the current `0.x` line, `CACHE_MANAGER` and `CACHE_INTERCEPTOR` are removed from the public package surface.
+
+- Migrate constructor injection to class-first DI:
+  - `CACHE_MANAGER` -> `CacheService`
+  - `CACHE_INTERCEPTOR` -> `CacheInterceptor`
+- Internal token seams remain token-based and unchanged:
+  - `CACHE_OPTIONS`
+  - `CACHE_STORE`
 
 ## Behavior
 

--- a/packages/cache-manager/src/module.test.ts
+++ b/packages/cache-manager/src/module.test.ts
@@ -7,7 +7,6 @@ import { bootstrapApplication, defineModule } from '@konekti/runtime';
 import { CacheEvict } from './decorators.js';
 import { CacheInterceptor } from './interceptor.js';
 import { CacheService } from './service.js';
-import { CACHE_INTERCEPTOR, CACHE_MANAGER } from './tokens.js';
 import { createCacheModule } from './module.js';
 import type { RedisCompatibleClient } from './types.js';
 
@@ -159,7 +158,7 @@ describe('createCacheModule', () => {
     await app.close();
   });
 
-  it('keeps CACHE_MANAGER as a compatibility alias for CacheService', async () => {
+  it('resolves CacheService via class-first public surface', async () => {
     class AppModule {}
     defineModule(AppModule, {
       imports: [createCacheModule({ store: 'memory' })],
@@ -167,14 +166,13 @@ describe('createCacheModule', () => {
 
     const app = await bootstrapApplication({ rootModule: AppModule });
     const byClass = await app.container.resolve(CacheService);
-    const byToken = await app.container.resolve<CacheService>(CACHE_MANAGER);
 
-    expect(byToken).toBe(byClass);
+    expect(byClass).toBeInstanceOf(CacheService);
 
     await app.close();
   });
 
-  it('keeps CACHE_INTERCEPTOR as a compatibility alias for CacheInterceptor', async () => {
+  it('resolves CacheInterceptor via class-first public surface', async () => {
     class AppModule {}
     defineModule(AppModule, {
       imports: [createCacheModule({ store: 'memory' })],
@@ -182,9 +180,8 @@ describe('createCacheModule', () => {
 
     const app = await bootstrapApplication({ rootModule: AppModule });
     const byClass = await app.container.resolve(CacheInterceptor);
-    const byToken = await app.container.resolve<CacheInterceptor>(CACHE_INTERCEPTOR);
 
-    expect(byToken).toBe(byClass);
+    expect(byClass).toBeInstanceOf(CacheInterceptor);
 
     await app.close();
   });

--- a/packages/cache-manager/src/module.ts
+++ b/packages/cache-manager/src/module.ts
@@ -5,7 +5,7 @@ import { CacheInterceptor } from './interceptor.js';
 import { MemoryStore } from './memory-store.js';
 import { RedisStore } from './redis-store.js';
 import { CacheService } from './service.js';
-import { CACHE_INTERCEPTOR, CACHE_MANAGER, CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
+import { CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
 import type { CacheModuleOptions, NormalizedCacheModuleOptions, RedisCompatibleClient } from './types.js';
 
 const REDIS_CLIENT_TOKEN = Symbol.for('konekti.redis.client');
@@ -115,16 +115,8 @@ export function createCacheProviders(options: CacheModuleOptions = {}): Provider
       useClass: CacheService,
     },
     {
-      provide: CACHE_MANAGER,
-      useExisting: CacheService,
-    },
-    {
       provide: CacheInterceptor,
       useClass: CacheInterceptor,
-    },
-    {
-      provide: CACHE_INTERCEPTOR,
-      useExisting: CacheInterceptor,
     },
   ];
 }
@@ -134,7 +126,7 @@ export function createCacheModule(options: CacheModuleOptions = {}): ModuleType 
   const normalized = normalizeCacheModuleOptions(options);
 
   return defineModule(CacheModule, {
-    exports: [CacheService, CacheInterceptor, CACHE_MANAGER, CACHE_INTERCEPTOR],
+    exports: [CacheService, CacheInterceptor],
     global: normalized.isGlobal,
     providers: createCacheProviders(options),
   });

--- a/packages/cache-manager/src/tokens.ts
+++ b/packages/cache-manager/src/tokens.ts
@@ -1,4 +1,2 @@
 export const CACHE_OPTIONS = Symbol.for('konekti.cache.options');
 export const CACHE_STORE = Symbol.for('konekti.cache.store');
-export const CACHE_MANAGER = Symbol.for('konekti.cache.manager');
-export const CACHE_INTERCEPTOR = Symbol.for('konekti.cache.interceptor');


### PR DESCRIPTION
Closes #679

## Summary
- Remove compatibility alias tokens CACHE_MANAGER and CACHE_INTERCEPTOR from @konekti/cache-manager public surface by deleting alias symbols and provider/export wiring.
- Keep class-first public DI surface (CacheService, CacheInterceptor) and preserve internal token seams (CACHE_OPTIONS, CACHE_STORE).
- Replace alias-focused module tests with class-first resolution tests and update cache docs (EN/KO) with explicit 0.x migration notes.

## Verification
- pnpm test -- packages/cache-manager/src/module.test.ts (workspace Vitest run completed successfully: 120 files / 1308 tests passed)
- pnpm --filter @konekti/cache-manager run typecheck
- pnpm --filter @konekti/cache-manager run build
- lsp_diagnostics on modified TS files (module.ts, module.test.ts, tokens.ts): no diagnostics

## Contract impact
- Breaking surface change in 0.x: CACHE_MANAGER / CACHE_INTERCEPTOR are removed from public package exports and DI alias wiring.
- Runtime caching behavior is unchanged.
- CACHE_OPTIONS / CACHE_STORE remain token-based internal seams.