### PR TITLE
Resolve #683: remove REDIS_SERVICE compatibility alias from @konekti/redis

### DIFF
--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -118,7 +118,7 @@ await app.close();
 
 - Prisma: `PRISMA_CLIENT`
 - Drizzle: `DRIZZLE_DATABASE`(종료 경로 검증 시 `DRIZZLE_DISPOSE` 포함)
-- Redis: `REDIS_CLIENT` 또는 `RedisService` 오버라이드 (`REDIS_SERVICE`는 호환성 alias)
+- Redis: `REDIS_CLIENT` 또는 `RedisService` 오버라이드
 
 ### 6) OpenAPI 문서 검증
 

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -121,7 +121,7 @@ For persistence/cache-backed tests, keep module wiring real and override only ex
 
 - Prisma: override `PRISMA_CLIENT`
 - Drizzle: override `DRIZZLE_DATABASE` (and `DRIZZLE_DISPOSE` when shutdown behavior matters)
-- Redis: override `REDIS_CLIENT` or `RedisService` (`REDIS_SERVICE` remains a compatibility alias)
+- Redis: override `REDIS_CLIENT` or `RedisService`
 
 This keeps transaction/lifecycle behavior in the graph while removing external network/database coupling.
 

--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -14,7 +14,7 @@ Konekti를 위한 공유 Redis 연결 레이어입니다. 한 번 등록하고, 
 
 `@konekti/redis`는 Konekti에서 앱 범위 Redis client lifecycle을 담당합니다. singleton `ioredis` client를 만들고, `REDIS_CLIENT` DI 토큰으로 노출하며, 모듈 초기화 시 연결하고, 애플리케이션 종료 시 정리합니다.
 
-또한 `RedisService`를 facade의 기본 주입 식별자로 제공해 JSON 친화적인 `get`/`set`/`del` 사용을 지원하면서, 필요하면 raw `ioredis` 접근도 그대로 유지합니다. `REDIS_SERVICE`는 호환성 alias로 계속 제공합니다.
+또한 `RedisService`를 facade의 기본 주입 식별자로 제공해 JSON 친화적인 `get`/`set`/`del` 사용을 지원하면서, 필요하면 raw `ioredis` 접근도 그대로 유지합니다.
 
 ## 설치
 
@@ -66,7 +66,6 @@ export class CacheService {
 | `createRedisModule(options)` | `src/module.ts` | global singleton Redis client 모듈 등록 |
 | `createRedisProviders(options)` | `src/module.ts` | 수동 조합을 위한 raw provider 목록 반환 |
 | `REDIS_CLIENT` | `src/tokens.ts` | 공유 raw `ioredis` client용 DI 토큰 |
-| `REDIS_SERVICE` | `src/redis-service.ts` | `RedisService`로 resolve되는 호환성 DI 토큰 alias |
 | `RedisService` | `src/redis-service.ts` | JSON codec 기반 `get`/`set`/`del` facade + `getRawClient()` escape hatch |
 | `createRedisPlatformStatusSnapshot(input)` | `src/status.ts` | Redis 연결 상태를 공통 ownership/readiness/health/details 스냅샷 형태로 매핑 |
 | `RedisModuleOptions` | `src/types.ts` | `lazyConnect`를 제외한 `ioredis` 옵션 |
@@ -86,6 +85,12 @@ export class CacheService {
 - `onApplicationShutdown()`은 이미 `end`면 종료 작업을 건너뛰고, `quit` 불가능 상태에서는 `disconnect()`를 직접 호출하며, 그 외에는 `quit()` 우선 + 실패 시 `disconnect()` 폴백을 사용합니다.
 - `quit()`가 실패했고 client가 여전히 닫히지 않았다면, 원래 `quit` 오류를 다시 던집니다.
 
+## 0.x 마이그레이션 노트
+
+- `@konekti/redis`의 `REDIS_SERVICE` 호환성 alias는 `0.x` 라인에서 제거되었습니다.
+- DI 사용 코드를 `@Inject([REDIS_SERVICE])`에서 `@Inject([RedisService])`로 마이그레이션하세요.
+- raw client DI 토큰은 기존처럼 `REDIS_CLIENT`를 사용합니다.
+
 ## 플랫폼 상태 스냅샷 시맨틱
 
 `createRedisPlatformStatusSnapshot({ status })`를 사용하면, 런타임에서 안전하게 쓸 수 있는 ownership/readiness/health/details를 공통 플랫폼 계약 형태로 내보낼 수 있습니다.
@@ -104,7 +109,6 @@ createRedisModule(options)
 
 service/repository 코드
   -> @Inject([REDIS_CLIENT]) 또는 @Inject([RedisService])
-  -> REDIS_SERVICE는 RedisService 호환성 alias로 유지
   -> raw client 또는 facade codec helper
 
 app bootstrap

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -14,7 +14,7 @@ Shared Redis connection layer for Konekti. Register it once, inject either the r
 
 `@konekti/redis` owns the app-scoped Redis client lifecycle for Konekti. It creates a singleton `ioredis` client, exposes it through the `REDIS_CLIENT` DI token, connects it during module initialization, and closes it during application shutdown.
 
-The package exposes `RedisService` as the primary facade injection identity for JSON-friendly `get`/`set`/`del` usage while still allowing direct raw `ioredis` access. `REDIS_SERVICE` remains available as a compatibility alias.
+The package exposes `RedisService` as the primary facade injection identity for JSON-friendly `get`/`set`/`del` usage while still allowing direct raw `ioredis` access.
 
 ## Installation
 
@@ -66,7 +66,6 @@ export class CacheService {
 | `createRedisModule(options)` | `src/module.ts` | Registers a global singleton Redis client module |
 | `createRedisProviders(options)` | `src/module.ts` | Returns the raw provider list for manual composition |
 | `REDIS_CLIENT` | `src/tokens.ts` | DI token for the shared raw `ioredis` client |
-| `REDIS_SERVICE` | `src/redis-service.ts` | Compatibility DI token alias that resolves to `RedisService` |
 | `RedisService` | `src/redis-service.ts` | Facade with JSON codec `get`/`set`/`del` helpers + `getRawClient()` escape hatch |
 | `createRedisPlatformStatusSnapshot(input)` | `src/status.ts` | Maps Redis connection state to shared ownership/readiness/health/details snapshot shape |
 | `RedisModuleOptions` | `src/types.ts` | `ioredis` options without `lazyConnect` |
@@ -86,6 +85,12 @@ export class CacheService {
 - `onApplicationShutdown()` skips work when already `end`, disconnects directly for non-quittable states, and otherwise prefers `quit()` with `disconnect()` fallback.
 - If `quit()` fails and the client still does not close, the original quit error is rethrown.
 
+## 0.x migration note
+
+- `REDIS_SERVICE` compatibility alias was removed from `@konekti/redis` in the `0.x` line.
+- Migrate DI usage from `@Inject([REDIS_SERVICE])` to `@Inject([RedisService])`.
+- `REDIS_CLIENT` remains the supported raw-client DI token.
+
 ## Platform status snapshot semantics
 
 Use `createRedisPlatformStatusSnapshot({ status })` to emit runtime-safe ownership/readiness/health details in the shared platform contract shape.
@@ -104,7 +109,6 @@ createRedisModule(options)
 
 service/repository code
   -> @Inject([REDIS_CLIENT]) or @Inject([RedisService])
-  -> REDIS_SERVICE remains a compatibility alias for RedisService
   -> raw client or facade codec helpers
 
 app bootstrap

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -1,5 +1,5 @@
 export * from './module.js';
-export { RedisService, REDIS_SERVICE } from './redis-service.js';
+export { RedisService } from './redis-service.js';
 export * from './status.js';
 export * from './tokens.js';
 export * from './types.js';

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -81,7 +81,6 @@ import {
   createRedisModule,
   createRedisPlatformStatusSnapshot,
   REDIS_CLIENT,
-  REDIS_SERVICE,
   RedisService,
 } from './index.js';
 
@@ -268,8 +267,8 @@ describe('@konekti/redis', () => {
     await app.close();
   });
 
-  it('keeps REDIS_SERVICE as an alias for RedisService', async () => {
-    @Inject([REDIS_SERVICE])
+  it('keeps RedisService as the facade injection identity', async () => {
+    @Inject([RedisService])
     class CacheFacade {
       constructor(readonly redisService: RedisService) {}
     }
@@ -286,8 +285,10 @@ describe('@konekti/redis', () => {
 
     const app = await bootstrapApplication({ rootModule: AppModule });
     const cacheFacade = await app.container.resolve(CacheFacade);
+    const resolvedByClass = await app.container.resolve(RedisService);
 
     expect(cacheFacade.redisService).toBeInstanceOf(RedisService);
+    expect(cacheFacade.redisService).toBe(resolvedByClass);
     const rawClient = cacheFacade.redisService.getRawClient();
 
     await rawClient.set('malformed:key', '{"id": "u1"');

--- a/packages/redis/src/module.ts
+++ b/packages/redis/src/module.ts
@@ -2,7 +2,7 @@ import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 import Redis from 'ioredis';
 
-import { REDIS_SERVICE, RedisService } from './redis-service.js';
+import { RedisService } from './redis-service.js';
 import { RedisLifecycleService } from './service.js';
 import { REDIS_CLIENT } from './tokens.js';
 import type { RedisModuleOptions } from './types.js';
@@ -18,10 +18,6 @@ export function createRedisProviders(options: RedisModuleOptions): Provider[] {
       }),
     },
     RedisService,
-    {
-      provide: REDIS_SERVICE,
-      useExisting: RedisService,
-    },
     RedisLifecycleService,
   ];
 }
@@ -31,7 +27,7 @@ export function createRedisModule(options: RedisModuleOptions): ModuleType {
 
   return defineModule(RedisModule, {
     global: true,
-    exports: [REDIS_CLIENT, RedisService, REDIS_SERVICE],
+    exports: [REDIS_CLIENT, RedisService],
     providers: createRedisProviders(options),
   });
 }

--- a/packages/redis/src/redis-service.ts
+++ b/packages/redis/src/redis-service.ts
@@ -3,8 +3,6 @@ import type Redis from 'ioredis';
 
 import { REDIS_CLIENT } from './tokens.js';
 
-export const REDIS_SERVICE = Symbol.for('konekti.redis.service');
-
 function decodeRedisValue(raw: string): unknown {
   try {
     return JSON.parse(raw);

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -167,7 +167,7 @@ await app.close();
 
 - Prisma: `PRISMA_CLIENT` 오버라이드
 - Drizzle: `DRIZZLE_DATABASE`(필요 시 `DRIZZLE_DISPOSE`) 오버라이드
-- Redis: `REDIS_CLIENT` 또는 `RedisService` 오버라이드 (`REDIS_SERVICE`는 호환성 alias)
+- Redis: `REDIS_CLIENT` 또는 `RedisService` 오버라이드
 
 ### OpenAPI 문서 검증 패턴
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -151,7 +151,7 @@ For persistence-backed modules, keep integration boundaries but replace external
 
 - Prisma: override `PRISMA_CLIENT` with a fake client.
 - Drizzle: override `DRIZZLE_DATABASE` (and optionally `DRIZZLE_DISPOSE`) with test doubles.
-- Redis: override `REDIS_CLIENT` or `RedisService` with in-memory doubles (`REDIS_SERVICE` remains a compatibility alias).
+- Redis: override `REDIS_CLIENT` or `RedisService` with in-memory doubles.
 
 The module graph remains real; only explicit external tokens are replaced.
 


### PR DESCRIPTION
Closes #683

## Summary
- Remove the `REDIS_SERVICE` compatibility alias from `@konekti/redis` provider wiring and package-root exports while keeping `RedisService` as the class-first facade identity and `REDIS_CLIENT` as the raw-client token.
- Replace alias-focused coverage with class-first `RedisService` identity assertions in `packages/redis/src/module.test.ts`.
- Update Redis/testing shared docs (`packages/redis/README*.md`, `packages/testing/README*.md`, `docs/operations/testing-guide*.md`) and add explicit `0.x` migration notes for `REDIS_SERVICE` removal.

## Testing
- `pnpm test -- packages/redis/src/module.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `lsp_diagnostics` on modified TypeScript files:
  - `packages/redis/src/module.ts`
  - `packages/redis/src/index.ts`
  - `packages/redis/src/redis-service.ts`
  - `packages/redis/src/module.test.ts`

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact note
This is an intentional `0.x` public-surface breaking change that removes the compatibility token `REDIS_SERVICE`. Runtime Redis behavior is unchanged; users should migrate to `@Inject([RedisService])`. The raw-client token `REDIS_CLIENT` remains public and supported.