### PR TITLE
Resolve #688: stabilize CLI starter-generation test under CI budgets

### DIFF
--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -142,6 +142,8 @@ pnpm --dir packages/cli run sandbox:test
 
 이 명령은 `@konekti/cli`를 다시 빌드하고, standalone temp 샌드박스 경로 자체에 `starter-app`을 스캐폴드한 뒤, 워크스페이스 로컬 tarball을 설치합니다. 이후 `typecheck`/`build`/`test`를 검증하고 `konekti g repo User` 실행 후 생성된 repo 템플릿까지 포함해 `typecheck`와 `test`를 다시 검증합니다.
 
+가장 무거운 end-to-end 검증(로컬 패키지 cold build/pack/install + 생성 프로젝트 명령 검증)은 이 샌드박스 경로에서 수행하세요.
+
 `KONEKTI_CLI_SANDBOX_ROOT=/path`는 고급 override로 계속 사용할 수 있지만, 반드시 모노레포 워크스페이스 바깥의 전용 디렉터리를 가리켜야 합니다. repo 내부 경로를 지정하면 harness가 경고를 출력하고 temp 샌드박스 루트로 자동 fallback해서 `pnpm install`이 워크스페이스 install로 흡수되지 않게 합니다.
 
 반복 작업 시에는 아래 명령을 사용하면 됩니다.
@@ -152,7 +154,7 @@ pnpm --dir packages/cli run sandbox:verify
 pnpm --dir packages/cli run sandbox:clean
 ```
 
-패키지 전용 Vitest 스위트는 `pnpm --dir packages/cli run test`로 실행할 수 있습니다.
+패키지 전용 Vitest 스위트는 `pnpm --dir packages/cli run test`로 실행할 수 있습니다. 이 스위트는 일반 CI 시간 예산에 맞춰 스타터 스캐폴드 계약 검증과 로컬 설치 스모크 검증을 빠르게 유지합니다.
 
 ## 핵심 API
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -142,6 +142,8 @@ pnpm --dir packages/cli run sandbox:test
 
 That command rebuilds `@konekti/cli`, scaffolds `starter-app` directly at a standalone temp sandbox path, installs local tarballs from the workspace, verifies `typecheck`/`build`/`test`, runs `konekti g repo User`, and then re-runs `typecheck` + `test` with generated repo templates.
 
+Use this sandbox path for the heaviest end-to-end verification (cold local package build/pack/install plus generated-project command checks).
+
 `KONEKTI_CLI_SANDBOX_ROOT=/path` remains available as an advanced override, but it must point to a dedicated directory outside the monorepo workspace. If it points inside the repo, the harness prints a warning and falls back to the temp sandbox root so `pnpm install` cannot be captured by the workspace.
 
 For iterative work:
@@ -152,7 +154,7 @@ pnpm --dir packages/cli run sandbox:verify
 pnpm --dir packages/cli run sandbox:clean
 ```
 
-Use `pnpm --dir packages/cli run test` for the package-local Vitest suite.
+Use `pnpm --dir packages/cli run test` for the package-local Vitest suite. That suite keeps starter scaffold contract assertions and local-install smoke checks fast for regular CI budgets.
 
 ## Key API
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -11,18 +11,6 @@ import { generatorManifest } from './generators/manifest.js';
 
 const createdDirectories: string[] = [];
 
-function run(command: string, args: string[], cwd: string): void {
-  const result = spawnSync(command, args, {
-    cwd,
-    encoding: 'utf8',
-    stdio: 'pipe',
-  });
-
-  if (result.status !== 0) {
-    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status ?? 1}\n${result.stdout ?? ''}\n${result.stderr ?? ''}`);
-  }
-}
-
 const inspectFixtureModulePath = join(
   dirname(fileURLToPath(import.meta.url)),
   'fixtures',
@@ -611,7 +599,7 @@ describe('CLI command runner', () => {
     expect(moduleContent).toContain('order.controller');
   });
 
-  it('creates a new starter project through the CLI', async () => {
+  it('creates a new starter project scaffold through the CLI with local dependency install smoke', async () => {
     const repoRoot = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
     const targetDirectory = mkdtempSync(join(tmpdir(), 'konekti-new-'));
     createdDirectories.push(targetDirectory);
@@ -627,6 +615,9 @@ describe('CLI command runner', () => {
       stdout: { write: (message) => stdoutBuffer.push(message) },
     });
 
+    const packageJson = JSON.parse(readFileSync(join(projectDirectory, 'package.json'), 'utf8')) as {
+      scripts?: Record<string, string>;
+    };
     const readmeContent = readFileSync(join(projectDirectory, 'README.md'), 'utf8');
     const mainContent = readFileSync(join(projectDirectory, 'src', 'main.ts'), 'utf8');
     const appTestContent = readFileSync(join(projectDirectory, 'src', 'app.test.ts'), 'utf8');
@@ -636,6 +627,9 @@ describe('CLI command runner', () => {
     expect(readFileSync(join(projectDirectory, 'package.json'), 'utf8')).toContain('@konekti/runtime');
     expect(readFileSync(join(projectDirectory, 'package.json'), 'utf8')).not.toContain('@konekti/prisma');
     expect(readFileSync(join(projectDirectory, 'package.json'), 'utf8')).not.toContain('@konekti/drizzle');
+    expect(packageJson.scripts?.typecheck).toBeDefined();
+    expect(packageJson.scripts?.build).toBeDefined();
+    expect(packageJson.scripts?.test).toBeDefined();
     expect(readFileSync(join(projectDirectory, '.gitignore'), 'utf8')).toContain('.env');
     expect(readFileSync(join(projectDirectory, '.env'), 'utf8')).toContain('PORT=3000');
     expect(stdoutBuffer.join('')).toContain('Installing dependencies with pnpm');
@@ -660,14 +654,6 @@ describe('CLI command runner', () => {
     expect(appE2eTestContent).toContain("path: '/ready'");
     expect(appE2eTestContent).toContain("path: '/health-info/'");
 
-    run('pnpm', ['typecheck'], projectDirectory);
-    run('pnpm', ['build'], projectDirectory);
-    run('pnpm', ['test'], projectDirectory);
-    run('pnpm', ['exec', 'konekti', 'g', 'repo', 'User'], projectDirectory);
-    expect(existsSync(join(projectDirectory, 'src', 'users', 'user.repo.ts'))).toBe(true);
-    expect(existsSync(join(projectDirectory, 'src', 'users', 'user.repo.slice.test.ts'))).toBe(true);
-    run('pnpm', ['typecheck'], projectDirectory);
-    run('pnpm', ['test'], projectDirectory);
   }, 90000);
 
   it('keeps the local sandbox outside the repo workspace', () => {


### PR DESCRIPTION
Closes #688

## Summary
- Split the CI-facing `packages/cli/src/cli.test.ts` starter-generation coverage so the test keeps scaffold contract + local-install smoke assertions, while removing the heaviest post-scaffold typecheck/build/test/generator reruns from the regular Vitest path.
- Preserved starter-generation contract assertions (starter file shape, runtime/package expectations, test template presence, bootstrap/readme invariants) and added explicit script-presence assertions (`typecheck`/`build`/`test`) to keep command-surface coverage.
- Updated `packages/cli/README.md` and `packages/cli/README.ko.md` to document testing strategy boundaries: heavy cold local package build/pack/install + generated-project command verification belongs to `pnpm --dir packages/cli run sandbox:test`, while package Vitest remains CI-budget-friendly.

## Verification
- `pnpm run build`
- `pnpm --dir packages/cli run test`
- `pnpm run typecheck`
- `lsp_diagnostics` on `packages/cli/src/cli.test.ts` (no diagnostics)

## Contract Impact
- No public CLI starter behavior changed.
- Change is limited to test strategy and docs clarifying where heavy integration verification runs.