### PR TITLE
Resolve #690: remove local-install smoke from root CLI starter test path

### DIFF
--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -154,7 +154,7 @@ pnpm --dir packages/cli run sandbox:verify
 pnpm --dir packages/cli run sandbox:clean
 ```
 
-패키지 전용 Vitest 스위트는 `pnpm --dir packages/cli run test`로 실행할 수 있습니다. 이 스위트는 일반 CI 시간 예산에 맞춰 스타터 스캐폴드 계약 검증과 로컬 설치 스모크 검증을 빠르게 유지합니다.
+패키지 전용 Vitest 스위트는 `pnpm --dir packages/cli run test`로 실행할 수 있습니다. 이 스위트는 일반 CI 시간 예산에 맞춰 스타터 스캐폴드 계약 검증을 인밴드로 유지하고, cold 로컬 build/pack/install 스모크는 `pnpm --dir packages/cli run sandbox:test` 경로로 분리합니다.
 
 ## 핵심 API
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -154,7 +154,7 @@ pnpm --dir packages/cli run sandbox:verify
 pnpm --dir packages/cli run sandbox:clean
 ```
 
-Use `pnpm --dir packages/cli run test` for the package-local Vitest suite. That suite keeps starter scaffold contract assertions and local-install smoke checks fast for regular CI budgets.
+Use `pnpm --dir packages/cli run test` for the package-local Vitest suite. That suite keeps starter scaffold contract assertions in-band for regular CI budgets, while cold local build/pack/install smoke belongs to `pnpm --dir packages/cli run sandbox:test`.
 
 ## Key API
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -599,8 +599,7 @@ describe('CLI command runner', () => {
     expect(moduleContent).toContain('order.controller');
   });
 
-  it('creates a new starter project scaffold through the CLI with local dependency install smoke', async () => {
-    const repoRoot = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+  it('creates a new starter project scaffold through the CLI while keeping scaffold contract assertions', async () => {
     const targetDirectory = mkdtempSync(join(tmpdir(), 'konekti-new-'));
     createdDirectories.push(targetDirectory);
     const stdoutBuffer: string[] = [];
@@ -609,8 +608,7 @@ describe('CLI command runner', () => {
 
     const exitCode = await runCli(['new', 'starter-app', '--package-manager', 'pnpm'], {
       cwd: targetDirectory,
-      dependencySource: 'local',
-      repoRoot,
+      skipInstall: true,
       stderr: { write: () => undefined },
       stdout: { write: (message) => stdoutBuffer.push(message) },
     });
@@ -633,7 +631,6 @@ describe('CLI command runner', () => {
     expect(readFileSync(join(projectDirectory, '.gitignore'), 'utf8')).toContain('.env');
     expect(readFileSync(join(projectDirectory, '.env'), 'utf8')).toContain('PORT=3000');
     expect(stdoutBuffer.join('')).toContain('Installing dependencies with pnpm');
-    expect(existsSync(join(projectDirectory, 'node_modules'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'health', 'health.repo.ts'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'health', 'health.repo.test.ts'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'health', 'health.service.ts'))).toBe(true);


### PR DESCRIPTION
Closes #690

## Summary
- remove the remaining local dependency install smoke from `packages/cli/src/cli.test.ts` by switching the root CI-facing starter scaffold test path to scaffold-contract assertions without in-band local install
- keep scaffold contract assertions for generated starter files/scripts/routes in the regular Vitest path
- tighten `packages/cli/README.md` and `packages/cli/README.ko.md` wording so cold local build/pack/install smoke is explicitly owned by `pnpm --dir packages/cli run sandbox:test`

## Verification
- `pnpm build`
- `pnpm typecheck`
- `pnpm --dir packages/cli run test`
- `pnpm --dir packages/cli run sandbox:test`

## Contract Impact
- no public starter behavior change
- test-strategy-only change: root CI-facing Vitest path now keeps scaffold contract checks, while heavy local install/build/generator verification remains on the documented sandbox integration path