### PR TITLE
Resolve #686: add affected-scope PR validation with safe full fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-pr-verification-scope:
+    name: Resolve PR verification scope
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.resolve.outputs.mode }}
+      reason: ${{ steps.resolve.outputs.reason }}
+      filter_args: ${{ steps.resolve.outputs.filter_args }}
+      package_names: ${{ steps.resolve.outputs.package_names }}
+      test_paths: ${{ steps.resolve.outputs.test_paths }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve PR verification scope
+        id: resolve
+        run: node tooling/ci/detect-pr-verification-scope.mjs
+
   build-and-typecheck:
     name: Build and typecheck
     runs-on: ubuntu-latest
+    needs:
+      - resolve-pr-verification-scope
 
     steps:
       - name: Checkout
@@ -31,10 +51,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
+      - name: Build (scoped PR)
+        if: github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped'
+        run: pnpm -r --if-present ${{ needs.resolve-pr-verification-scope.outputs.filter_args }} run build
+
+      - name: Build (full)
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
         run: pnpm build
 
-      - name: Typecheck
+      - name: Typecheck (scoped PR)
+        if: github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped'
+        run: pnpm -r --if-present ${{ needs.resolve-pr-verification-scope.outputs.filter_args }} run typecheck
+
+      - name: Typecheck (full)
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
         run: pnpm typecheck
 
   lint:
@@ -63,6 +93,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs:
+      - resolve-pr-verification-scope
 
     steps:
       - name: Checkout
@@ -80,7 +112,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Test
+      - name: Test (scoped PR)
+        if: github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped'
+        run: pnpm vitest run ${{ needs.resolve-pr-verification-scope.outputs.test_paths }}
+
+      - name: Test (full)
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
         run: pnpm test
 
   verify-platform-consistency-governance:
@@ -138,11 +175,16 @@ jobs:
       - lint
       - test
       - verify-platform-consistency-governance
+      - resolve-pr-verification-scope
     runs-on: ubuntu-latest
 
     steps:
       - name: PR verification gate passed
-        run: echo "PR verification jobs passed."
+        run: |
+          echo "PR verification jobs passed."
+          echo "verification mode: ${{ needs.resolve-pr-verification-scope.outputs.mode }}"
+          echo "scope reason: ${{ needs.resolve-pr-verification-scope.outputs.reason }}"
+          echo "scoped packages: ${{ needs.resolve-pr-verification-scope.outputs.package_names }}"
 
   release-verify:
     name: Release verify

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -30,7 +30,7 @@ Konekti를 처음 접하신다면 다음 경로를 따라 첫 애플리케이션
 - `getting-started/generator-workflow.ko.md` - CLI를 사용한 모듈 및 프로바이더 생성.
 - `operations/testing-guide.ko.md` - 단위 및 통합 테스트 패턴.
 - `operations/platform-conformance-authoring-checklist.ko.md` - 플랫폼-지향 패키지 conformance harness 게이트와 authoring checklist.
-- `operations/release-governance.ko.md` - 릴리스 검증 절차, CI 거버넌스 게이트(PR build/typecheck+governance 게이트 vs `main` release-readiness 게이트), 플랫폼 일관성 강제 명령어.
+- `operations/release-governance.ko.md` - 릴리스 검증 절차, CI 거버넌스 게이트(PR 영향 범위(affected-scope) build/typecheck/test + 안전한 full fallback + governance 게이트 vs `main` full verification + release-readiness 게이트), 플랫폼 일관성 강제 명령어.
 - `operations/deployment.ko.md` - 로컬 개발에서 운영 환경으로의 배포.
 - `concepts/auth-and-jwt.ko.md` - 인증 및 세션 관리 구현.
 - `concepts/openapi.ko.md` - API 명세 작성 및 노출.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Practical guides for day-to-day development once your application is running.
 - `getting-started/generator-workflow.md` - Using the CLI to generate modules and providers.
 - `operations/testing-guide.md` - Unit and integration testing patterns.
 - `operations/platform-conformance-authoring-checklist.md` - Platform-facing package conformance harness gate and authoring checklist.
-- `operations/release-governance.md` - Release checks, CI governance gates (PR build/typecheck + governance gate vs `main` release-readiness gate), and platform consistency enforcement commands.
+- `operations/release-governance.md` - Release checks, CI governance gates (PR affected-scope build/typecheck/test with safe full fallback and governance gate vs `main` full verification + release-readiness gate), and platform consistency enforcement commands.
 - `operations/deployment.md` - Moving from local development to production.
 - `concepts/auth-and-jwt.md` - Implementing authentication and session management.
 - `concepts/openapi.md` - Documenting and exposing your API surface.

--- a/docs/operations/release-governance.ko.md
+++ b/docs/operations/release-governance.ko.md
@@ -116,12 +116,15 @@
 
 ### PR CI 자동화
 
-`.github/workflows/ci.yml`은 `main` 대상 pull request와 `main` push에서 모두 동작하지만, 이벤트별 검증 범위를 분리합니다:
+`.github/workflows/ci.yml`은 `main` 대상 pull request와 `main` push에서 모두 동작하며, 이벤트별 검증 범위와 안전한 fallback 경로를 분리합니다.
 
-- pull request에서는 `pnpm build` + `pnpm typecheck`를 하나의 잡에서 실행해 타입체크가 필요한 빌드 산출물을 보도록 하고, `pnpm lint`, `pnpm test`, `pnpm verify:platform-consistency-governance`는 해당 잡과 병렬로 실행한 뒤 단일 PR 게이트 잡으로 통합합니다.
-- `main` push에서는 동일한 PR 검증 구조에 더해 `pnpm verify:release-readiness`를 추가로 실행하고, 릴리스 등급 aggregate 게이트를 통과해야 합니다.
+- pull request는 먼저 `tooling/ci/detect-pr-verification-scope.mjs`로 검증 범위를 계산합니다.
+  - 판별기가 패키지 단위 변경을 안전하게 증명할 수 있으면, PR `build` + `typecheck`는 변경 패키지와 reverse dependents에 대해 실행하고, PR `test`는 동일한 영향 워크스페이스 디렉터리로 Vitest를 실행합니다.
+  - 범위 안전성을 증명할 수 없으면(예: docs/governance/public-surface 변경, tooling/workflow 변경, 루트 설정 변경, merge-base/diff 불확실성) CI는 full-repo `build`, `typecheck`, `test`로 자동 fallback합니다.
+  - PR에 `ci:full-verify` 라벨을 붙이거나 `CI_FORCE_FULL_VERIFY=1`을 설정하면 명시적으로 full verification을 강제할 수 있습니다.
+- `main` push에서는 full-repo `build`, `typecheck`, `lint`, `test`를 유지하고, 추가로 `pnpm verify:release-readiness`를 실행한 뒤 릴리스 등급 aggregate 게이트를 통과해야 합니다.
 
-이 구조는 PR 피드백 속도를 높이면서도 `main`의 릴리스 지향 플로우에서 release-readiness 보장을 유지합니다.
+이 구조는 좁은 범위 PR의 피드백 속도를 높이면서도 `main` 릴리스 지향 플로우의 거버넌스 가드레일과 release-readiness 보장을 유지합니다.
 
 `pnpm verify:platform-consistency-governance`는 다음 거버넌스 가드레일을 강제합니다.
 

--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -117,12 +117,15 @@ The command also writes `tooling/release/release-readiness-summary.md`.
 
 ### PR CI automation
 
-`.github/workflows/ci.yml` runs on every pull request targeting `main` and on every push to `main`, but the verification scope now differs by event:
+`.github/workflows/ci.yml` runs on every pull request targeting `main` and on every push to `main`, with event-specific verification scope and safety fallbacks:
 
-- Pull requests run `pnpm build` + `pnpm typecheck` in one job (so typecheck sees required build outputs), while `pnpm lint`, `pnpm test`, and `pnpm verify:platform-consistency-governance` run in parallel with that job under a single PR gate job.
-- Pushes to `main` keep the same PR verification shape and additionally run `pnpm verify:release-readiness`, then require a release-grade aggregate gate.
+- Pull requests first run `tooling/ci/detect-pr-verification-scope.mjs` to resolve scope.
+  - If the detector can prove a package-only change safely, PR `build` + `typecheck` run on changed packages plus reverse dependents, and PR `test` runs Vitest on the same affected workspace directories.
+  - If scope safety cannot be proven (for example docs/governance/public-surface changes, tooling/workflow changes, root config changes, merge-base/diff uncertainty), CI falls back to full-repo `build`, `typecheck`, and `test`.
+  - PRs can explicitly force full verification with the `ci:full-verify` label or `CI_FORCE_FULL_VERIFY=1`.
+- Pushes to `main` keep full-repo `build`, `typecheck`, `lint`, and `test`, and additionally run `pnpm verify:release-readiness`, then require a release-grade aggregate gate.
 
-This keeps PR feedback fast while preserving release-readiness guarantees on `main` release-oriented flows.
+This keeps narrow PR feedback fast while preserving governance safeguards and release-readiness guarantees on `main` release-oriented flows.
 
 `pnpm verify:platform-consistency-governance` enforces the platform consistency governance guardrails:
 

--- a/packages/testing/src/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/platform-consistency-governance-docs.test.ts
@@ -76,6 +76,13 @@ describe('platform consistency governance docs', () => {
   it('keeps PR CI governance-gated while reserving release-readiness for main pushes', () => {
     const ciWorkflow = readFileSync(resolve(repoRoot, '.github/workflows/ci.yml'), 'utf8');
 
+    expect(ciWorkflow).toContain('resolve-pr-verification-scope:');
+    expect(ciWorkflow).toContain('run: node tooling/ci/detect-pr-verification-scope.mjs');
+    expect(ciWorkflow).toContain("if: github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped'");
+    expect(ciWorkflow).toContain(
+      'run: pnpm vitest run $' + '{{ needs.resolve-pr-verification-scope.outputs.test_paths }}',
+    );
+    expect(ciWorkflow).toContain("if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'");
     expect(ciWorkflow).toContain('build-and-typecheck:');
     expect(ciWorkflow).toContain("if: github.event_name == 'pull_request'");
     expect(ciWorkflow).toContain('verify-platform-consistency-governance');

--- a/tooling/ci/detect-pr-verification-scope.mjs
+++ b/tooling/ci/detect-pr-verification-scope.mjs
@@ -1,0 +1,396 @@
+#!/usr/bin/env node
+
+import { appendFileSync, existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDirectory, '..', '..');
+
+const alwaysFullVerifyPrefixes = [
+  '.github/',
+  'docs/',
+  'tooling/',
+  'examples/',
+  'apps/',
+];
+
+const alwaysFullVerifyPaths = new Set([
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'tsconfig.base.json',
+  'tsconfig.tools.json',
+  'vitest.config.ts',
+  'biome.json',
+]);
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    ...options,
+  });
+
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status ?? 1}.`);
+  }
+
+  return result;
+}
+
+function parseWorkspaceGlobs() {
+  const workspaceFile = join(repoRoot, 'pnpm-workspace.yaml');
+  if (!existsSync(workspaceFile)) {
+    return [];
+  }
+
+  const content = readFileSync(workspaceFile, 'utf8');
+  const matches = [...content.matchAll(/^\s+-\s+['"]?([^'"#\n]+?)['"]?\s*$/gm)];
+  return matches.map((match) => match[1].trim());
+}
+
+function collectWorkspaceManifests() {
+  const manifests = [];
+  const workspaceGlobs = parseWorkspaceGlobs();
+
+  for (const workspace of workspaceGlobs) {
+    const [segment] = workspace.split('/');
+    const parentDirectory = join(repoRoot, segment);
+
+    if (!existsSync(parentDirectory)) {
+      continue;
+    }
+
+    for (const entry of readdirSync(parentDirectory, { withFileTypes: true })) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      const workspaceDirectory = join(parentDirectory, entry.name);
+      const manifestPath = join(workspaceDirectory, 'package.json');
+      if (!existsSync(manifestPath)) {
+        continue;
+      }
+
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+      if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+        continue;
+      }
+
+      manifests.push({
+        directory: `${segment}/${entry.name}`,
+        name: manifest.name,
+        manifest,
+      });
+    }
+  }
+
+  return manifests;
+}
+
+function collectLocalDependencies(manifest, workspaceNames) {
+  const dependencySections = [
+    manifest.dependencies,
+    manifest.devDependencies,
+    manifest.peerDependencies,
+    manifest.optionalDependencies,
+  ];
+
+  const dependencies = new Set();
+  for (const section of dependencySections) {
+    if (!section || typeof section !== 'object') {
+      continue;
+    }
+
+    for (const [dependencyName, dependencyVersion] of Object.entries(section)) {
+      if (!workspaceNames.has(dependencyName)) {
+        continue;
+      }
+
+      if (typeof dependencyVersion === 'string' && (dependencyVersion.startsWith('workspace:') || dependencyVersion === 'catalog:')) {
+        dependencies.add(dependencyName);
+      }
+    }
+  }
+
+  return dependencies;
+}
+
+function readPrLabels() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !existsSync(eventPath)) {
+    return [];
+  }
+
+  const payload = JSON.parse(readFileSync(eventPath, 'utf8'));
+  const labels = payload?.pull_request?.labels;
+  if (!Array.isArray(labels)) {
+    return [];
+  }
+
+  return labels
+    .map((label) => label?.name)
+    .filter((name) => typeof name === 'string');
+}
+
+function changedFilesFromGit() {
+  const baseBranch = process.env.GITHUB_BASE_REF || 'main';
+  const preferredBase = `origin/${baseBranch}`;
+  const mergeBaseResult = run('git', ['merge-base', 'HEAD', preferredBase], { allowFailure: true });
+
+  if (mergeBaseResult.status !== 0 || mergeBaseResult.stdout.trim().length === 0) {
+    return {
+      ok: false,
+      reason: `unable to compute merge-base with ${preferredBase}`,
+      files: [],
+    };
+  }
+
+  const mergeBase = mergeBaseResult.stdout.trim();
+  const diffResult = run('git', ['diff', '--name-only', `${mergeBase}...HEAD`], { allowFailure: true });
+
+  if (diffResult.status !== 0) {
+    return {
+      ok: false,
+      reason: 'unable to compute changed files from git diff',
+      files: [],
+    };
+  }
+
+  const files = diffResult.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return {
+    ok: true,
+    reason: files.length === 0 ? 'no changed files detected; running full verification for safety' : 'changed files detected',
+    files,
+  };
+}
+
+export function shouldForceFullVerificationByPath(changedFiles) {
+  for (const path of changedFiles) {
+    if (alwaysFullVerifyPaths.has(path)) {
+      return `changed ${path}`;
+    }
+
+    if (alwaysFullVerifyPrefixes.some((prefix) => path.startsWith(prefix))) {
+      return `changed ${path}`;
+    }
+
+    if (path === 'README.md' || path === 'README.ko.md' || path.endsWith('/README.md') || path.endsWith('/README.ko.md')) {
+      return `changed public/docs surface file ${path}`;
+    }
+
+    if (!path.startsWith('packages/')) {
+      return `changed non-package file ${path}`;
+    }
+  }
+
+  return undefined;
+}
+
+export function resolveChangedPackageDirectories(changedFiles) {
+  const directories = new Set();
+  for (const path of changedFiles) {
+    if (!path.startsWith('packages/')) {
+      continue;
+    }
+
+    const [, packageDirectory] = path.split('/');
+    if (packageDirectory) {
+      directories.add(`packages/${packageDirectory}`);
+    }
+  }
+
+  return directories;
+}
+
+export function resolveVerificationScope(changedFiles) {
+  const fullVerifyReason = shouldForceFullVerificationByPath(changedFiles);
+  if (fullVerifyReason) {
+    return {
+      mode: 'full',
+      reason: `${fullVerifyReason}; cannot prove safe affected-only coverage`,
+      filters: [],
+      packageNames: [],
+      packageDirectories: [],
+    };
+  }
+
+  const workspaceManifests = collectWorkspaceManifests();
+  const workspaceNames = new Set(workspaceManifests.map((manifest) => manifest.name));
+  const manifestsByDirectory = new Map(workspaceManifests.map((entry) => [entry.directory, entry]));
+
+  const changedDirectories = resolveChangedPackageDirectories(changedFiles);
+  if (changedDirectories.size === 0) {
+    return {
+      mode: 'full',
+      reason: 'no changed package directory detected; running full verification for safety',
+      filters: [],
+      packageNames: [],
+      packageDirectories: [],
+    };
+  }
+
+  const changedPackageNames = [];
+  for (const directory of changedDirectories) {
+    const manifest = manifestsByDirectory.get(directory);
+    if (!manifest) {
+      return {
+        mode: 'full',
+        reason: `unable to resolve workspace manifest for ${directory}`,
+        filters: [],
+        packageNames: [],
+        packageDirectories: [],
+      };
+    }
+
+    changedPackageNames.push(manifest.name);
+  }
+
+  const reverseDependents = new Map();
+  for (const workspace of workspaceManifests) {
+    const dependencies = collectLocalDependencies(workspace.manifest, workspaceNames);
+
+    for (const dependencyName of dependencies) {
+      const dependents = reverseDependents.get(dependencyName) ?? new Set();
+      dependents.add(workspace.name);
+      reverseDependents.set(dependencyName, dependents);
+    }
+  }
+
+  const closure = new Set(changedPackageNames);
+  const queue = [...changedPackageNames];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+
+    const dependents = reverseDependents.get(current);
+    if (!dependents) {
+      continue;
+    }
+
+    for (const dependent of dependents) {
+      if (closure.has(dependent)) {
+        continue;
+      }
+
+      closure.add(dependent);
+      queue.push(dependent);
+    }
+  }
+
+  const packageNames = [...closure].sort((left, right) => left.localeCompare(right));
+  const directoryByPackageName = new Map(workspaceManifests.map((entry) => [entry.name, entry.directory]));
+  const packageDirectories = packageNames
+    .map((packageName) => directoryByPackageName.get(packageName))
+    .filter((directory) => typeof directory === 'string')
+    .sort((left, right) => left.localeCompare(right));
+
+  return {
+    mode: 'scoped',
+    reason: `scoped verification for ${packageNames.length} workspace package(s) from ${changedPackageNames.length} changed package(s)`,
+    filters: packageNames.map((name) => `--filter=${name}`),
+    packageNames,
+    packageDirectories,
+  };
+}
+
+export function collectResult() {
+  if (process.env.CI_FORCE_FULL_VERIFY === '1') {
+    return {
+      mode: 'full',
+      reason: 'CI_FORCE_FULL_VERIFY=1',
+      filters: [],
+      packageNames: [],
+      packageDirectories: [],
+    };
+  }
+
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  if (eventName !== 'pull_request') {
+    return {
+      mode: 'full',
+      reason: `event ${eventName ?? 'unknown'} requires full verification`,
+      filters: [],
+      packageNames: [],
+      packageDirectories: [],
+    };
+  }
+
+  const labels = readPrLabels();
+  if (labels.includes('ci:full-verify')) {
+    return {
+      mode: 'full',
+      reason: 'ci:full-verify label present',
+      filters: [],
+      packageNames: [],
+      packageDirectories: [],
+    };
+  }
+
+  const changedFilesResult = changedFilesFromGit();
+  if (!changedFilesResult.ok) {
+    return {
+      mode: 'full',
+      reason: changedFilesResult.reason,
+      filters: [],
+      packageNames: [],
+      packageDirectories: [],
+    };
+  }
+
+  if (changedFilesResult.files.length === 0) {
+    return {
+      mode: 'full',
+      reason: changedFilesResult.reason,
+      filters: [],
+      packageNames: [],
+      packageDirectories: [],
+    };
+  }
+
+  return resolveVerificationScope(changedFilesResult.files);
+}
+
+export function writeGithubOutput(result) {
+  const githubOutput = process.env.GITHUB_OUTPUT;
+  if (!githubOutput) {
+    return;
+  }
+
+  const lines = [
+    `mode=${result.mode}`,
+    `reason=${result.reason}`,
+    `filter_args=${result.filters.join(' ')}`,
+    `package_names=${result.packageNames.join(',')}`,
+    `test_paths=${result.packageDirectories.join(' ')}`,
+  ];
+  lines.push(`is_scoped=${result.mode === 'scoped' ? 'true' : 'false'}`);
+
+  const content = `${lines.join('\n')}\n`;
+  appendFileSync(githubOutput, content, 'utf8');
+}
+
+export function main() {
+  const result = collectResult();
+
+  console.log(`[ci][verification-scope] mode=${result.mode}`);
+  console.log(`[ci][verification-scope] reason=${result.reason}`);
+  if (result.packageNames.length > 0) {
+    console.log(`[ci][verification-scope] packages=${result.packageNames.join(', ')}`);
+  }
+
+  writeGithubOutput(result);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}


### PR DESCRIPTION
Closes #686

## Summary
- add `tooling/ci/detect-pr-verification-scope.mjs` to compute PR verification scope from changed packages plus reverse dependents and emit workflow outputs.
- update `.github/workflows/ci.yml` so PR `build`/`typecheck`/`test` run scoped verification when safe, while automatically falling back to full verification when scope safety cannot be proven.
- keep governance safeguards on PRs (`pnpm verify:platform-consistency-governance`) and keep full verification + `pnpm verify:release-readiness` on `main` push/release-oriented flows.
- update release/governance docs (EN/KO + docs index EN/KO) and extend governance regression test coverage for the new CI behavior.

## Verification
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅
- `pnpm verify:platform-consistency-governance` ✅
- `pnpm vitest run packages/testing/src/platform-consistency-governance-docs.test.ts` ✅
- `pnpm lint` ⚠️ repository baseline warnings in `packages/config/src/*.test.ts` unrelated to this change
- `pnpm exec biome lint .github/workflows/ci.yml docs/README.md docs/README.ko.md docs/operations/release-governance.md docs/operations/release-governance.ko.md packages/testing/src/platform-consistency-governance-docs.test.ts tooling/ci/detect-pr-verification-scope.mjs` ✅

## Contract Impact
- runtime/package behavioral contracts are unchanged.
- CI execution strategy changes for PRs only: affected-scope verification is used when safely provable, with explicit and automatic fallback paths to full verification to avoid reducing governance or cross-package/public-surface coverage.