### PR TITLE
Resolve #694: remove websocket lifecycle alias token wiring

### DIFF
--- a/packages/websocket/src/module.test.ts
+++ b/packages/websocket/src/module.test.ts
@@ -14,7 +14,7 @@ import type { HttpApplicationAdapter } from '@konekti/http';
 import { OnConnect, OnDisconnect, OnMessage, WebSocketGateway } from './decorators.js';
 import * as publicApi from './index.js';
 import { getWebSocketGatewayMetadata, getWebSocketHandlerMetadataEntries } from './metadata.js';
-import { createWebSocketModule } from './module.js';
+import { createWebSocketModule, createWebSocketProviders } from './module.js';
 import { WebSocketGatewayLifecycleService } from './service.js';
 import type { WebSocketModuleOptions } from './types.js';
 
@@ -194,6 +194,20 @@ describe('@konekti/websocket', () => {
     expect(publicApi).not.toHaveProperty('WEBSOCKET_GATEWAY_SERVICE');
     expect(publicApi).not.toHaveProperty('WEBSOCKET_SERVICE');
     expect(publicApi).not.toHaveProperty('WEBSOCKET_OPTIONS');
+  });
+
+  it('wires lifecycle service with a direct class provider', () => {
+    const options: WebSocketModuleOptions = {
+      shutdown: { timeoutMs: 1234 },
+    };
+    const providers = createWebSocketProviders(options);
+    const optionsProvider = providers.find(
+      (provider) => typeof provider === 'object' && provider !== null && 'useValue' in provider,
+    );
+
+    expect(providers).toContain(WebSocketGatewayLifecycleService);
+    expect(optionsProvider).toBeDefined();
+    expect(optionsProvider).toHaveProperty('useValue', options);
   });
 
   it('writes gateway and handler metadata with standard decorators', () => {

--- a/packages/websocket/src/module.ts
+++ b/packages/websocket/src/module.ts
@@ -2,7 +2,7 @@ import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { WebSocketGatewayLifecycleService } from './service.js';
-import { WEBSOCKET_GATEWAY_SERVICE, WEBSOCKET_OPTIONS } from './tokens.js';
+import { WEBSOCKET_OPTIONS } from './tokens.js';
 import type { WebSocketModuleOptions } from './types.js';
 
 export function createWebSocketProviders(options: WebSocketModuleOptions = {}): Provider[] {
@@ -11,10 +11,7 @@ export function createWebSocketProviders(options: WebSocketModuleOptions = {}): 
       provide: WEBSOCKET_OPTIONS,
       useValue: options,
     },
-    {
-      provide: WEBSOCKET_GATEWAY_SERVICE,
-      useClass: WebSocketGatewayLifecycleService,
-    },
+    WebSocketGatewayLifecycleService,
   ];
 }
 

--- a/packages/websocket/src/tokens.ts
+++ b/packages/websocket/src/tokens.ts
@@ -1,7 +1,5 @@
 import type { Token } from '@konekti/core';
 
-import type { WebSocketGatewayLifecycleService } from './service.js';
 import type { WebSocketModuleOptions } from './types.js';
 
-export const WEBSOCKET_GATEWAY_SERVICE: Token<WebSocketGatewayLifecycleService> = Symbol.for('konekti.websocket.gateway-service');
 export const WEBSOCKET_OPTIONS: Token<WebSocketModuleOptions> = Symbol.for('konekti.websocket.options');


### PR DESCRIPTION
Closes #694

## Summary
- Replaced `createWebSocketProviders()` internal lifecycle wiring from `WEBSOCKET_GATEWAY_SERVICE` alias-token mapping to direct class-provider registration of `WebSocketGatewayLifecycleService`.
- Removed the now-unused `WEBSOCKET_GATEWAY_SERVICE` token from internal websocket token definitions while keeping `WEBSOCKET_OPTIONS` internal and unchanged in public exports.
- Added a regression test asserting providers include the lifecycle service as a direct class provider and still keep internal token names hidden from package public API.

## Verification
- `pnpm test packages/websocket/src/module.test.ts`
- `pnpm --filter @konekti/websocket... run build`
- `pnpm --filter @konekti/websocket run typecheck`
- `lsp_diagnostics` on changed files (`packages/websocket/src/module.ts`, `packages/websocket/src/tokens.ts`, `packages/websocket/src/module.test.ts`) reports no errors.

## Contract Impact
- No public API surface or documented runtime behavior changes.
- Gateway discovery, bootstrap/shutdown lifecycle wiring, and websocket runtime semantics are preserved; this PR is internal DI cleanup only.