### PR TITLE
Resolve #693: switch GraphQL lifecycle wiring to class-based provider checks

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -116,7 +116,7 @@ interface GraphQLContext {
 - `getRequestScopedDataLoader(context, key, createLoader)` — low-level 캐시 헬퍼
 - `createRequestScopedDataLoaderFactory(key, createLoader)` — low-level 팩토리 헬퍼
 
-`GRAPHQL_MODULE_OPTIONS`와 `GRAPHQL_LIFECYCLE_SERVICE`는 패키지 내부 lifecycle wiring에 사용하는 토큰이며, 공개 module/resolver API surface에 포함되지 않습니다.
+`GRAPHQL_MODULE_OPTIONS`는 계속 패키지 내부 lifecycle wiring 토큰이며, 공개 module/resolver API surface에 포함되지 않습니다. `GRAPHQL_LIFECYCLE_SERVICE`도 비공개이며 내부 class-alias wiring 용도로는 더 이상 사용하지 않습니다.
 
 #### 0.x 마이그레이션 노트
 

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -116,7 +116,7 @@ interface GraphQLContext {
 - `getRequestScopedDataLoader(context, key, createLoader)` — low-level cache helper
 - `createRequestScopedDataLoaderFactory(key, createLoader)` — low-level factory helper
 
-`GRAPHQL_MODULE_OPTIONS` and `GRAPHQL_LIFECYCLE_SERVICE` are internal lifecycle wiring tokens used by the package implementation and are not part of the public module/resolver API surface.
+`GRAPHQL_MODULE_OPTIONS` remains an internal lifecycle wiring token and is not part of the public module/resolver API surface. `GRAPHQL_LIFECYCLE_SERVICE` is also non-public and no longer used for internal class-alias wiring.
 
 #### 0.x migration note
 

--- a/packages/graphql/src/module.ts
+++ b/packages/graphql/src/module.ts
@@ -2,7 +2,7 @@ import type { Provider } from '@konekti/di';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { GraphqlEndpointController, GraphqlLifecycleService } from './service.js';
-import { GRAPHQL_LIFECYCLE_SERVICE, GRAPHQL_MODULE_OPTIONS } from './tokens.js';
+import { GRAPHQL_MODULE_OPTIONS } from './tokens.js';
 import type { GraphqlModuleOptions } from './types.js';
 
 export function createGraphqlProviders(options: GraphqlModuleOptions): Provider[] {
@@ -11,10 +11,7 @@ export function createGraphqlProviders(options: GraphqlModuleOptions): Provider[
       provide: GRAPHQL_MODULE_OPTIONS,
       useValue: options,
     },
-    {
-      provide: GRAPHQL_LIFECYCLE_SERVICE,
-      useClass: GraphqlLifecycleService,
-    },
+    GraphqlLifecycleService,
   ];
 }
 

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -37,7 +37,7 @@ import { WebSocketServer, type WebSocket } from 'ws';
 
 import { discoverResolverDescriptors } from './discovery.js';
 import { createCodeFirstSchema, resolveSchema } from './schema.js';
-import { GRAPHQL_LIFECYCLE_SERVICE, GRAPHQL_MODULE_OPTIONS } from './tokens.js';
+import { GRAPHQL_MODULE_OPTIONS } from './tokens.js';
 import { isGraphqlPath, toFetchRequest, writeFetchResponse } from './transport.js';
 import { GRAPHQL_OPERATION_CONTAINER } from './types.js';
 import type {
@@ -411,7 +411,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
 
   private registerMiddleware(): void {
     for (const compiledModule of this.compiledModules) {
-      if (!compiledModule.providerTokens.has(GRAPHQL_LIFECYCLE_SERVICE)) {
+      if (!compiledModule.providerTokens.has(GraphqlLifecycleService)) {
         continue;
       }
 
@@ -428,7 +428,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
 
   private unregisterMiddleware(): void {
     for (const compiledModule of this.compiledModules) {
-      if (!compiledModule.providerTokens.has(GRAPHQL_LIFECYCLE_SERVICE)) {
+      if (!compiledModule.providerTokens.has(GraphqlLifecycleService)) {
         continue;
       }
 

--- a/packages/graphql/src/tokens.ts
+++ b/packages/graphql/src/tokens.ts
@@ -1,7 +1,5 @@
 import type { Token } from '@konekti/core';
 
-import type { GraphqlLifecycleService } from './service.js';
 import type { GraphqlModuleOptions } from './types.js';
 
 export const GRAPHQL_MODULE_OPTIONS: Token<GraphqlModuleOptions> = Symbol.for('konekti.graphql.module-options');
-export const GRAPHQL_LIFECYCLE_SERVICE: Token<GraphqlLifecycleService> = Symbol.for('konekti.graphql.lifecycle-service');


### PR DESCRIPTION
## Summary
- Replace internal GraphQL lifecycle alias wiring with direct class-based provider wiring in `@konekti/graphql`.
- Keep `GRAPHQL_MODULE_OPTIONS` as the internal options token and remove the remaining `GRAPHQL_LIFECYCLE_SERVICE` token role from module/service internals.
- Update GraphQL README (EN/KO) wording to reflect that lifecycle alias wiring is no longer used while preserving the hidden public surface.

## Changes
- `packages/graphql/src/module.ts`: removed `GRAPHQL_LIFECYCLE_SERVICE` provider alias and registered `GraphqlLifecycleService` directly.
- `packages/graphql/src/service.ts`: switched middleware registration gates from token checks to `GraphqlLifecycleService` class checks.
- `packages/graphql/src/tokens.ts`: removed `GRAPHQL_LIFECYCLE_SERVICE` token definition; kept `GRAPHQL_MODULE_OPTIONS` internal.
- `packages/graphql/README.md`, `packages/graphql/README.ko.md`: adjusted internal-token wording only.

## Testing
- `pnpm exec vitest run packages/graphql/src/module.test.ts packages/graphql/src/service.test.ts packages/graphql/src/public-api.test.ts`
- `pnpm typecheck`
- `pnpm build`
- `lsp_diagnostics` on modified TS files (`module.ts`, `service.ts`, `tokens.ts`) reports no diagnostics.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact note
This PR is an internal DI cleanup only. Public GraphQL package surface remains unchanged (tokens stay non-public), and GraphQL runtime behavior/resolver discovery/middleware registration semantics are preserved.

Closes #693