### PR TITLE
Resolve #696: switch metrics DI to class-first MetricsService

### DIFF
--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -184,9 +184,9 @@ class AppModule {}
 공유 registry를 전달하면 `MetricsService`와 `METER_PROVIDER`가 같은 registry를 사용합니다.
 
 ```typescript
-import { METRICS_SERVICE, MetricsService } from '@konekti/metrics';
+import { MetricsService } from '@konekti/metrics';
 
-@Inject([METRICS_SERVICE])
+@Inject([MetricsService])
 class OrderService {
   constructor(private readonly metrics: MetricsService) {
     this.orderCounter = this.metrics.counter({
@@ -203,7 +203,7 @@ class OrderService {
 `MetricsService.getRegistry()`로 내부 `prom-client` `Registry`에 접근할 수 있습니다.
 
 ```typescript
-const metricsService = await app.container.resolve(METRICS_SERVICE);
+const metricsService = await app.container.resolve(MetricsService);
 const registry = metricsService.getRegistry();
 ```
 
@@ -238,7 +238,7 @@ const registry = new Registry();
 new Counter({ name: 'my_counter', help: 'help', registers: [registry] });
 
 // Throws: 'A metric with the name my_counter has already been registered.'
-MetricsModule.forRoot({ registry }).container.resolve(METRICS_SERVICE)
+MetricsModule.forRoot({ registry }).container.resolve(MetricsService)
   .counter({ name: 'my_counter', help: 'duplicate' });
 ```
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -187,9 +187,9 @@ class AppModule {}
 After providing a shared registry, `MetricsService` and `METER_PROVIDER` both use it:
 
 ```typescript
-import { METRICS_SERVICE, MetricsService } from '@konekti/metrics';
+import { MetricsService } from '@konekti/metrics';
 
-@Inject([METRICS_SERVICE])
+@Inject([MetricsService])
 class OrderService {
   constructor(private readonly metrics: MetricsService) {
     this.orderCounter = this.metrics.counter({
@@ -207,7 +207,7 @@ class OrderService {
 `MetricsService.getRegistry()` returns the underlying `prom-client` `Registry`:
 
 ```typescript
-const metricsService = await app.container.resolve(METRICS_SERVICE);
+const metricsService = await app.container.resolve(MetricsService);
 const registry = metricsService.getRegistry();
 // Use registry directly with prom-client APIs
 ```
@@ -243,7 +243,7 @@ const registry = new Registry();
 new Counter({ name: 'my_counter', help: 'help', registers: [registry] });
 
 // This throws: 'A metric with the name my_counter has already been registered.'
-MetricsModule.forRoot({ registry }).container.resolve(METRICS_SERVICE)
+MetricsModule.forRoot({ registry }).container.resolve(MetricsService)
   .counter({ name: 'my_counter', help: 'duplicate' });
 ```
 

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -6,7 +6,7 @@ import { Counter, Registry } from 'prom-client';
 
 import { MetricsModule } from './metrics-module.js';
 import { METER_PROVIDER } from './meter-provider.js';
-import { METRICS_SERVICE, type MetricsService } from './metrics-service.js';
+import { MetricsService } from './metrics-service.js';
 import { PrometheusMeterProvider } from './prometheus-meter-provider.js';
 
 type TestResponse = FrameworkResponse & { body?: unknown };
@@ -214,7 +214,7 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const metricsService = await app.container.resolve(METRICS_SERVICE) as MetricsService;
+    const metricsService = await app.container.resolve(MetricsService);
     const meterProvider = await app.container.resolve(METER_PROVIDER) as PrometheusMeterProvider;
 
     metricsService.counter({
@@ -256,7 +256,7 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const metricsService = await app.container.resolve(METRICS_SERVICE) as MetricsService;
+    const metricsService = await app.container.resolve(MetricsService);
     const resolvedRegistry = metricsService.getRegistry();
 
     expect(resolvedRegistry).toBe(sharedRegistry);
@@ -377,7 +377,7 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const metricsService = await app.container.resolve(METRICS_SERVICE) as MetricsService;
+    const metricsService = await app.container.resolve(MetricsService);
 
     expect(() => {
       metricsService.counter({
@@ -400,7 +400,7 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const metricsService = await app.container.resolve(METRICS_SERVICE) as MetricsService;
+    const metricsService = await app.container.resolve(MetricsService);
     const registry = metricsService.getRegistry();
 
     metricsService.counter({

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -10,7 +10,7 @@ import {
   type HttpMetricsPathLabelNormalizer,
 } from './http-metrics-middleware.js';
 import { METER_PROVIDER } from './meter-provider.js';
-import { METRICS_SERVICE, MetricsService } from './metrics-service.js';
+import { MetricsService } from './metrics-service.js';
 import { PrometheusMeterProvider } from './prometheus-meter-provider.js';
 
 export interface MetricsHttpOptions {
@@ -56,7 +56,7 @@ export class MetricsModule {
 
     const providers: Provider[] = [
       {
-        provide: METRICS_SERVICE,
+        provide: MetricsService,
         useValue: metricsService,
       },
       {

--- a/packages/metrics/src/metrics-service.ts
+++ b/packages/metrics/src/metrics-service.ts
@@ -7,8 +7,6 @@ import type {
 
 import { createPrometheusCounter, createPrometheusGauge, createPrometheusHistogram } from './prometheus-metrics-factory.js';
 
-export const METRICS_SERVICE = Symbol.for('konekti.metrics.service');
-
 export class MetricsService {
   constructor(private readonly registry: Registry) {}
 


### PR DESCRIPTION
Closes #696

## Summary
- Switch `MetricsModule` provider wiring to register and resolve `MetricsService` directly as the primary DI key.
- Remove `METRICS_SERVICE` from `@konekti/metrics` public surface while preserving `METER_PROVIDER` as the portable abstraction token.
- Update metrics README (EN/KO) and regression tests to use class-first injection/resolution.

## Changes
- `packages/metrics/src/metrics-module.ts`
  - Replace provider key `METRICS_SERVICE` with `MetricsService`.
- `packages/metrics/src/metrics-service.ts`
  - Remove exported `METRICS_SERVICE` token.
- `packages/metrics/src/metrics-module.test.ts`
  - Resolve `MetricsService` directly in duplicate-name and shared/isolated registry contract tests.
- `packages/metrics/README.md`
- `packages/metrics/README.ko.md`
  - Replace token-based injection/resolution examples with class-first `MetricsService`.

## Testing
- `pnpm exec vitest run packages/metrics/src/metrics-module.test.ts` ✅
- `pnpm build` ✅
- `pnpm typecheck` ✅
- LSP diagnostics on modified TS files (`metrics-module.ts`, `metrics-service.ts`, `metrics-module.test.ts`) ✅ no diagnostics

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact note
- Public DI surface for metrics is now class-first: consumers should inject/resolve `MetricsService` directly.
- `METER_PROVIDER` remains unchanged as the abstraction token.
- Registry-sharing semantics and duplicate metric-name behavior are preserved across `MetricsService` and `METER_PROVIDER` paths.