### PR TITLE
Resolve #695: remove internal Socket.IO lifecycle alias token wiring

### DIFF
--- a/packages/platform-socket.io/src/module.test.ts
+++ b/packages/platform-socket.io/src/module.test.ts
@@ -7,7 +7,7 @@ import { OnConnect, OnDisconnect, OnMessage, WebSocketGateway } from '@konekti/w
 import { io as createClient, type Socket as ClientSocket } from 'socket.io-client';
 import type { Server as SocketIoServer, Socket } from 'socket.io';
 
-import { createSocketIoModule } from './module.js';
+import { createSocketIoModule, createSocketIoProviders } from './module.js';
 import * as publicApi from './index.js';
 import { SocketIoLifecycleService } from './adapter.js';
 import { SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER } from './tokens.js';
@@ -91,6 +91,24 @@ describe('@konekti/platform-socket.io', () => {
     expect(publicApi.SOCKETIO_SERVER).toBeDefined();
     expect('SOCKETIO_LIFECYCLE_SERVICE' in publicApi).toBe(false);
     expect('SOCKETIO_OPTIONS' in publicApi).toBe(false);
+  });
+
+  it('wires lifecycle dependencies through the lifecycle service class internally', () => {
+    const providers = createSocketIoProviders();
+    const serverProvider = providers.find(
+      (provider) =>
+        typeof provider === 'object' && provider !== null && 'provide' in provider && provider.provide === SOCKETIO_SERVER,
+    ) as { inject?: unknown[] } | undefined;
+    const roomProvider = providers.find(
+      (provider) =>
+        typeof provider === 'object' &&
+        provider !== null &&
+        'provide' in provider &&
+        provider.provide === SOCKETIO_ROOM_SERVICE,
+    ) as { useExisting?: unknown } | undefined;
+
+    expect(serverProvider?.inject).toEqual([SocketIoLifecycleService]);
+    expect(roomProvider?.useExisting).toBe(SocketIoLifecycleService);
   });
 
   it('injects the Socket.IO server token into singleton providers', async () => {

--- a/packages/platform-socket.io/src/module.ts
+++ b/packages/platform-socket.io/src/module.ts
@@ -3,7 +3,6 @@ import { defineModule, type ModuleType } from '@konekti/runtime';
 
 import { SocketIoLifecycleService } from './adapter.js';
 import {
-  SOCKETIO_LIFECYCLE_SERVICE,
   SOCKETIO_OPTIONS,
   SOCKETIO_ROOM_SERVICE,
   SOCKETIO_SERVER,
@@ -17,17 +16,17 @@ export function createSocketIoProviders(options: SocketIoModuleOptions = {}): Pr
       useValue: options,
     },
     {
-      provide: SOCKETIO_LIFECYCLE_SERVICE,
+      provide: SocketIoLifecycleService,
       useClass: SocketIoLifecycleService,
     },
     {
       provide: SOCKETIO_SERVER,
       useFactory: (service: unknown) => (service as SocketIoLifecycleService).getServer(),
-      inject: [SOCKETIO_LIFECYCLE_SERVICE],
+      inject: [SocketIoLifecycleService],
     },
     {
       provide: SOCKETIO_ROOM_SERVICE,
-      useExisting: SOCKETIO_LIFECYCLE_SERVICE,
+      useExisting: SocketIoLifecycleService,
     },
   ];
 }

--- a/packages/platform-socket.io/src/tokens.ts
+++ b/packages/platform-socket.io/src/tokens.ts
@@ -1,10 +1,8 @@
 import type { Token } from '@konekti/core';
 import type { Server } from 'socket.io';
 
-import type { SocketIoLifecycleService } from './adapter.js';
 import type { SocketIoModuleOptions, SocketIoRoomService } from './types.js';
 
-export const SOCKETIO_LIFECYCLE_SERVICE: Token<SocketIoLifecycleService> = Symbol.for('konekti.socketio.lifecycle-service');
 export const SOCKETIO_OPTIONS: Token<SocketIoModuleOptions> = Symbol.for('konekti.socketio.options');
 export const SOCKETIO_SERVER: Token<Server> = Symbol.for('konekti.socketio.server');
 export const SOCKETIO_ROOM_SERVICE: Token<SocketIoRoomService> = Symbol.for('konekti.socketio.room-service');


### PR DESCRIPTION
Closes #695

## Summary
- Replace internal provider wiring that aliased `SOCKETIO_LIFECYCLE_SERVICE` with direct class-based wiring via `SocketIoLifecycleService`.
- Keep public contracts unchanged: `SOCKETIO_ROOM_SERVICE` remains the room-helper contract and `SOCKETIO_SERVER` remains raw server access.
- Remove the now-unused internal `SOCKETIO_LIFECYCLE_SERVICE` token constant from `tokens.ts`.
- Add a regression assertion in `module.test.ts` to verify room/server providers resolve through `SocketIoLifecycleService` internally.

## Testing
- `pnpm vitest run packages/platform-socket.io/src/module.test.ts`
- `pnpm --filter @konekti/platform-socket.io run typecheck`
- `pnpm --filter @konekti/platform-socket.io run build`
- `pnpm build`
- `pnpm typecheck`

## Contract impact
- No public behavioral contract changes.
- Preserved documented room-helper behavior and raw Socket.IO server token access.
- `SOCKETIO_OPTIONS` remains internal.