### PR TITLE
Resolve #737: add rich TSDoc tags to foundation/runtime public APIs

### DIFF
--- a/packages/config/src/service.ts
+++ b/packages/config/src/service.ts
@@ -19,6 +19,9 @@ export class ConfigService<T extends Record<string, unknown> = ConfigDictionary>
 
   /**
    * Returns a config value by key (including dot-path keys) or `undefined` when missing.
+   *
+   * @param key Configuration key or dot-path key to resolve from the current snapshot.
+   * @returns The resolved value clone for object-like entries, or `undefined` when the key does not exist.
    */
   get<K extends DotPaths<T>>(key: K): DotValue<T, K & string> | undefined {
     return this._resolve(key as string) as DotValue<T, K & string> | undefined;
@@ -26,6 +29,10 @@ export class ConfigService<T extends Record<string, unknown> = ConfigDictionary>
 
   /**
    * Returns a config value by key and throws when the key is missing.
+   *
+   * @param key Configuration key or dot-path key that must exist in the current snapshot.
+   * @returns The resolved value clone for object-like entries.
+   * @throws {KonektiError} When the key is absent (`code: 'CONFIG_KEY_MISSING'`).
    */
   getOrThrow<K extends DotPaths<T>>(key: K): DotValue<T, K & string> {
     const value = this._resolve(key as string);
@@ -39,6 +46,9 @@ export class ConfigService<T extends Record<string, unknown> = ConfigDictionary>
 
   /**
    * @deprecated Use `get()` instead. `get()` now returns `T | undefined` matching NestJS semantics.
+   *
+   * @param key Configuration key or dot-path key to resolve from the current snapshot.
+   * @returns The resolved value clone for object-like entries, or `undefined` when the key does not exist.
    */
   getOptional<K extends DotPaths<T>>(key: K): DotValue<T, K & string> | undefined {
     return this._resolve(key as string) as DotValue<T, K & string> | undefined;
@@ -46,6 +56,8 @@ export class ConfigService<T extends Record<string, unknown> = ConfigDictionary>
 
   /**
    * Returns a deep-cloned snapshot of the current normalized config dictionary.
+   *
+   * @returns A detached deep clone of the current configuration snapshot.
    */
   snapshot(): ConfigDictionary {
     return cloneConfigDictionary(this.values);
@@ -53,6 +65,9 @@ export class ConfigService<T extends Record<string, unknown> = ConfigDictionary>
 
   /**
    * Replaces the internal snapshot used by this service (runtime reload flow).
+   *
+   * @param values Next validated configuration dictionary to store as the internal snapshot.
+   * @returns `void`.
    */
   _replaceSnapshot(values: T): void {
     this.values = cloneConfigDictionary(values);

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -12,6 +12,9 @@ type TupleOnly<T extends readonly unknown[]> = number extends T['length'] ? neve
 
 /**
  * Declares module-level metadata (`imports`, `providers`, `controllers`, `exports`, `global`) on a class.
+ *
+ * @param definition Module composition metadata consumed by the runtime module-graph compiler.
+ * @returns A standard class decorator that records the module contract on the target class.
  */
 export function Module(definition: ModuleMetadata): StandardClassDecoratorFn {
   return (target) => {
@@ -21,6 +24,8 @@ export function Module(definition: ModuleMetadata): StandardClassDecoratorFn {
 
 /**
  * Marks the decorated module as global so its exported providers are visible without explicit imports.
+ *
+ * @returns A standard class decorator that marks the target module as globally visible.
  */
 export function Global(): StandardClassDecoratorFn {
   return (target) => {
@@ -30,6 +35,9 @@ export function Global(): StandardClassDecoratorFn {
 
 /**
  * Defines explicit constructor injection tokens for the decorated class.
+ *
+ * @param tokens Constructor-parameter token list used by `@konekti/di` during dependency resolution.
+ * @returns A standard class decorator that stores explicit injection metadata on the target class.
  */
 export function Inject<const TTokens extends readonly Token[]>(
   tokens: TupleOnly<TTokens>,
@@ -42,6 +50,9 @@ export function Inject(tokens: readonly Token[]): StandardClassDecoratorFn {
 
 /**
  * Sets the provider lifecycle scope used by the DI container.
+ *
+ * @param scope Provider lifetime strategy (`singleton`, `request`, or `transient`).
+ * @returns A standard class decorator that stores scope metadata on the target class.
  */
 export function Scope(scope: NonNullable<ClassDiMetadata['scope']>): StandardClassDecoratorFn {
   return (target) => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -140,6 +140,13 @@ export class Container {
 
   /**
    * Registers providers in the current container scope.
+   *
+   * @param providers Provider definitions to register in this container.
+   * @returns The same container instance for fluent registration chains.
+   * @throws {ContainerResolutionError} When called after the container was disposed.
+   * @throws {ScopeMismatchError} When registering singleton providers directly on a request scope.
+   * @throws {DuplicateProviderError} When registration conflicts with existing single/multi mappings.
+   * @throws {InvalidProviderError} When a provider definition is structurally invalid.
    */
   register(...providers: Provider[]): this {
     if (this.disposed) {
@@ -190,6 +197,11 @@ export class Container {
    * is added. There is intentionally no way to replace a single entry within a multi-provider
    * set — the whole set is replaced. If you need to preserve other entries, re-register them
    * together with the replacement in one `override()` call.
+   *
+   * @param providers Provider definitions that should replace existing registrations for each token.
+   * @returns The same container instance for fluent override chains.
+   * @throws {ContainerResolutionError} When called after the container was disposed.
+   * @throws {InvalidProviderError} When a provider definition is structurally invalid.
    */
   override(...providers: Provider[]): this {
     if (this.disposed) {
@@ -222,6 +234,9 @@ export class Container {
 
   /**
    * Returns whether a token is registered in this scope chain.
+   *
+   * @param token Token to check across this container and its ancestors.
+   * @returns `true` when a single or multi provider exists for the token.
    */
   has(token: Token): boolean {
     return this.lookupProvider(token) !== undefined || this.hasMulti(token);
@@ -229,6 +244,9 @@ export class Container {
 
   /**
    * Creates a child request-scope container that shares root singleton cache.
+   *
+   * @returns A request-scope child container bound to this container hierarchy.
+   * @throws {ContainerResolutionError} When called after the container was disposed.
    */
   createRequestScope(): Container {
     if (this.disposed) {
@@ -245,6 +263,13 @@ export class Container {
 
   /**
    * Resolves a token to an instance using scope-aware caching rules.
+   *
+   * @param token Token to resolve.
+   * @returns A promise that resolves to the token instance (or multi-provider instance array).
+   * @throws {ContainerResolutionError} When called after disposal or when no provider is registered.
+   * @throws {RequestScopeResolutionError} When request-scoped providers are resolved from root scope.
+   * @throws {ScopeMismatchError} When singleton providers depend on request-scoped providers.
+   * @throws {CircularDependencyError} When provider dependency resolution detects a cycle.
    */
   async resolve<T>(token: Token<T>): Promise<T> {
     if (this.disposed) {
@@ -259,6 +284,9 @@ export class Container {
 
   /**
    * Disposes cached instances and nested request scopes.
+   *
+   * @returns A promise that settles after all cached disposable instances are torn down.
+   * @throws {Error} Propagates one or more disposal errors (`AggregateError` when multiple failures occur).
    */
   async dispose(): Promise<void> {
     if (this.disposePromise) {

--- a/packages/runtime/src/abort.ts
+++ b/packages/runtime/src/abort.ts
@@ -2,6 +2,11 @@
  * Races a promise-returning function against an AbortSignal.
  * Rejects immediately if the signal is already aborted, or rejects as soon
  * as the signal fires while `fn` is still pending.
+ *
+ * @param fn Async operation to execute while observing the abort signal.
+ * @param signal Abort signal that can cancel the in-flight operation.
+ * @returns The resolved value from `fn` when no abort happens first.
+ * @throws {Error} An `AbortError` when the signal is already aborted or aborts before `fn` settles.
  */
 export async function raceWithAbort<T>(fn: () => Promise<T>, signal: AbortSignal): Promise<T> {
   if (signal.aborted) {
@@ -23,6 +28,9 @@ export async function raceWithAbort<T>(fn: () => Promise<T>, signal: AbortSignal
 
 /**
  * Normalises an abort reason into an `Error` with `name = 'AbortError'`.
+ *
+ * @param reason Abort reason attached to the triggering `AbortSignal`.
+ * @returns A normalized `Error` instance with `name` set to `AbortError`.
  */
 export function createAbortError(reason: unknown): Error {
   const message = reason instanceof Error ? reason.message : 'Request aborted before response commit.';

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -349,6 +349,10 @@ function registerModuleMiddleware(container: Container, modules: CompiledModule[
 
 /**
  * Associates module metadata with a module type.
+ *
+ * @param moduleType Module class that should receive runtime module metadata.
+ * @param definition Module definition contract (`imports`, `providers`, `controllers`, `exports`, etc.).
+ * @returns The same `moduleType` reference for fluent helper composition.
  */
 export function defineModule<T extends ModuleType>(moduleType: T, definition: ModuleDefinition): T {
   defineModuleMetadata(moduleType, definition);
@@ -358,6 +362,12 @@ export function defineModule<T extends ModuleType>(moduleType: T, definition: Mo
 
 /**
  * Bootstraps the module graph and returns the root container baseline.
+ *
+ * @param rootModule Root module type used as the module-graph entrypoint.
+ * @param options Bootstrap-module options such as runtime providers and duplicate-provider policy.
+ * @returns The compiled module graph and initialized DI container baseline.
+ * @throws {DuplicateProviderError} When duplicate module provider tokens are detected and policy is `throw`.
+ * @throws {Error} When module-graph compilation or provider registration fails.
  */
 export function bootstrapModule(rootModule: ModuleType, options: BootstrapModuleOptions = {}): BootstrapResult {
   const modules = compileModuleGraph(rootModule, options);
@@ -890,8 +900,12 @@ function createRuntimeDispatcher(
 }
 
 /**
- * bootstrap-level provider 등록, 모듈 부트스트랩, lifecycle hook 실행까지를 묶어
- * 런타임 애플리케이션 셸을 만든다.
+ * Creates the runtime application shell by composing bootstrap-level providers,
+ * module bootstrap, and lifecycle hook execution.
+ *
+ * @param options Runtime bootstrap contract including root module, adapter, and global runtime hooks.
+ * @returns A fully bootstrapped `Application` shell ready for `ready()`/`listen()`.
+ * @throws {Error} Propagates module-graph, lifecycle, or runtime initialization failures.
  */
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
   const logger = options.logger ?? createConsoleApplicationLogger();
@@ -1006,6 +1020,11 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
 export class KonektiFactory {
   /**
    * Creates a full HTTP-capable application from the root module.
+   *
+   * @param rootModule Root module type used as the application composition entrypoint.
+   * @param options Optional HTTP-runtime bootstrap options.
+   * @returns A bootstrapped HTTP-capable `Application`.
+   * @throws {Error} Propagates bootstrap failures from `bootstrapApplication(...)`.
    */
   static async create(rootModule: ModuleType, options: CreateApplicationOptions = {}): Promise<Application> {
     return bootstrapApplication({
@@ -1016,6 +1035,11 @@ export class KonektiFactory {
 
   /**
    * Creates an application context without attaching an HTTP runtime.
+   *
+   * @param rootModule Root module type used as the context composition entrypoint.
+   * @param options Optional context bootstrap options.
+   * @returns A bootstrapped `ApplicationContext` that exposes DI and lifecycle control.
+   * @throws {Error} Propagates module-graph, lifecycle, and context bootstrap failures.
    */
   static async createApplicationContext(
     rootModule: ModuleType,
@@ -1115,6 +1139,12 @@ export class KonektiFactory {
 
   /**
    * Creates a microservice application from the configured runtime token.
+   *
+   * @param rootModule Root module type used as the microservice composition entrypoint.
+   * @param options Optional microservice bootstrap options, including `microserviceToken` overrides.
+   * @returns A bootstrapped `MicroserviceApplication` wrapper around the resolved runtime transport.
+   * @throws {InvariantError} When the resolved runtime token does not implement `listen()`.
+   * @throws {Error} Propagates application-context bootstrap or runtime-resolution failures.
    */
   static async createMicroservice(
     rootModule: ModuleType,

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -120,23 +120,42 @@ function createValidatorJsDecorator(validator: ValidatorJsRuleName) {
   };
 }
 
-/** Validates that the decorated field is a string value. */
+/**
+ * Validates that the decorated field is a string value.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a string validation rule.
+ */
 export function IsString(options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidationDecorator(() => ({ kind: 'string', ...options }));
 }
 
-/** Validates that the decorated field is a number value. */
+/**
+ * Validates that the decorated field is a number value.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a number validation rule.
+ */
 export function IsNumber(options?: ValidationDecoratorOptions & { allowNaN?: boolean }): FieldDecoratorFn {
   return createValidationDecorator(() => ({ kind: 'number', ...options }));
 }
 
-/** Validates that the decorated field is a boolean value. */
+/**
+ * Validates that the decorated field is a boolean value.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a boolean validation rule.
+ */
 export function IsBoolean(options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidationDecorator(() => ({ kind: 'boolean', ...options }));
 }
 
 /**
  * Applies subsequent validators only when the condition returns `true`.
+ *
+ * @param validateIf Predicate that decides whether subsequent validators should run.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that adds conditional validation execution.
  */
 export const ValidateIf = (
   validateIf: (dto: unknown, value: unknown) => boolean | Promise<boolean>,
@@ -158,7 +177,13 @@ export const IsInt = createFlagValidationDecorator((options) => ({ kind: 'int', 
 export const IsPositive = createFlagValidationDecorator((options) => ({ kind: 'positive', ...options }));
 export const IsNegative = createFlagValidationDecorator((options) => ({ kind: 'negative', ...options }));
 
-/** Validates that the field value is included in the given enum-like set. */
+/**
+ * Validates that the field value is included in the given enum-like set.
+ *
+ * @param values Enum object or literal value list that defines the accepted set.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an enum-membership rule.
+ */
 export function IsEnum(values: Record<string, unknown> | readonly unknown[], options?: ValidationDecoratorOptions): FieldDecoratorFn {
   const normalized = Array.isArray(values) ? values : Object.values(values);
   return createValidationDecorator(() => ({ kind: 'enum', values: normalized, ...options }));
@@ -172,12 +197,25 @@ export const MaxDate = createValidationOptionsWithConfigDecorator<Date>((value, 
 export const Contains = createValidationOptionsWithConfigDecorator<string>((value, options) => ({ kind: 'contains', value, ...options }));
 export const NotContains = createValidationOptionsWithConfigDecorator<string>((value, options) => ({ kind: 'notContains', value, ...options }));
 
-/** Validates string length using optional min/max boundaries. */
+/**
+ * Validates string length using optional min/max boundaries.
+ *
+ * @param min Minimum inclusive length.
+ * @param max Optional maximum inclusive length.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a bounded-length rule.
+ */
 export function Length(min: number, max?: number, options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidationDecorator(() => ({ kind: 'length', max, min, ...options }));
 }
 
-/** Validates a nested DTO instance using the provided constructor. */
+/**
+ * Validates a nested DTO instance using the provided constructor.
+ *
+ * @param dto DTO constructor (or lazy constructor factory) used for nested validation/materialization.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers recursive nested DTO validation.
+ */
 export function ValidateNested(dto: Constructor | (() => Constructor), options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidationDecorator(() => ({
     dto,
@@ -189,7 +227,14 @@ export function ValidateNested(dto: Constructor | (() => Constructor), options?:
 export const MinLength = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'minLength', value, ...options }));
 export const MaxLength = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'maxLength', value, ...options }));
 
-/** Validates the field using a regular expression pattern. */
+/**
+ * Validates the field using a regular expression pattern.
+ *
+ * @param pattern Pattern source (`RegExp` or string) passed to validator.js `matches`.
+ * @param modifiersOrOptions Regex modifiers string (for string patterns) or validation options.
+ * @param options Validation options used when modifiers are provided separately.
+ * @returns A field decorator that registers a regex-matching rule.
+ */
 export function Matches(
   pattern: RegExp | string,
   modifiersOrOptions?: string | ValidationDecoratorOptions,
@@ -287,7 +332,13 @@ export const ArrayNotEmpty = createFlagValidationDecorator((options) => ({ kind:
 export const ArrayMinSize = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'arrayMinSize', value, ...options }));
 export const ArrayMaxSize = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'arrayMaxSize', value, ...options }));
 
-/** Ensures all values in the array are unique, optionally by selector. */
+/**
+ * Ensures all values in the array are unique, optionally by selector.
+ *
+ * @param selectorOrOptions Optional selector callback used to compute uniqueness keys, or validation options.
+ * @param options Validation options used when a selector callback is provided.
+ * @returns A field decorator that registers an array-uniqueness rule.
+ */
 export function ArrayUnique(
   selectorOrOptions?: ((value: unknown) => unknown) | ValidationDecoratorOptions,
   options?: ValidationDecoratorOptions,
@@ -298,7 +349,13 @@ export function ArrayUnique(
   return createValidationDecorator(() => ({ kind: 'arrayUnique', selector, ...resolvedOptions }));
 }
 
-/** Registers a custom field-level validation function. */
+/**
+ * Registers a custom field-level validation function.
+ *
+ * @param validate Custom validator callback invoked with `(dto, value)`.
+ * @param options Optional custom-validator metadata (`message`, `code`, `source`, `each`).
+ * @returns A field decorator that registers a custom validation rule.
+ */
 export function Validate(validate: CustomFieldValidator, options?: CustomValidationDecoratorOptions): FieldDecoratorFn {
   return createValidationDecorator(() => ({
     code: options?.code,
@@ -313,6 +370,10 @@ export function Validate(validate: CustomFieldValidator, options?: CustomValidat
 /**
  * Registers class-level validation logic.
  * Supports either a custom validator callback or a Standard Schema object.
+ *
+ * @param validate Class-level validator callback or a Standard Schema-compatible validator definition.
+ * @param options Optional validation behavior (`message`, `code`).
+ * @returns A class decorator that appends class-level validation rules.
  */
 export function ValidateClass(validate: ValidateClassInput, options?: ValidationDecoratorOptions): ClassDecoratorFn {
   const decorator = (_target: Function, context: ClassDecoratorContext) => {


### PR DESCRIPTION
## Summary
- Add SDK-style rich TSDoc tags (`@param`, `@returns`, `@throws`) to public APIs in `@konekti/core`, `@konekti/di`, `@konekti/config`, `@konekti/runtime`, and `@konekti/validation`.
- Keep scope limited to publicly importable symbols in the issue target files and preserve existing runtime behavior (docs-only change).
- Align runtime bootstrap entrypoint docs with canonical English wording while preserving existing public contracts.

## Changes
- Updated rich TSDoc for public decorators and container/runtime/config/validation entrypoints:
  - `packages/core/src/decorators.ts`
  - `packages/di/src/container.ts`
  - `packages/config/src/service.ts`
  - `packages/runtime/src/abort.ts`
  - `packages/runtime/src/bootstrap.ts`
  - `packages/validation/src/decorators.ts`

## Testing
- `pnpm install`
- `pnpm verify`
- `lsp_diagnostics` on each changed file (no diagnostics)

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact
- doc-only (no runtime behavior/API shape changes)

Closes #737