### PR TITLE
Resolve #740: sync README/API wording with rich TSDoc terminology

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -109,7 +109,7 @@ interface GraphQLContext {
 
 ### 기타 export
 
-- `createGraphqlProviders(options)`
+- `createGraphqlProviders(options)` — GraphQL 모듈 옵션 + lifecycle provider만 등록하며, `GraphqlEndpointController`를 등록하거나 단독으로 `/graphql` 엔드포인트를 노출하지는 않습니다
 - `createDataLoader(batchFn, options?)` — 퍼스트 파티 request-scoped DataLoader 팩토리
 - `createDataLoaderMap(definitions)` — 이름이 지정된 DataLoader 세트 팩토리
 - `DataLoader` — `dataloader` 패키지에서 re-export

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -109,7 +109,7 @@ interface GraphQLContext {
 
 ### Other exports
 
-- `createGraphqlProviders(options)`
+- `createGraphqlProviders(options)` — registers GraphQL module options + lifecycle providers only; does not register `GraphqlEndpointController` or expose `/graphql` by itself
 - `createDataLoader(batchFn, options?)` — first-party request-scoped DataLoader factory
 - `createDataLoaderMap(definitions)` — named DataLoader set factory
 - `DataLoader` — re-exported from the `dataloader` package

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -113,8 +113,8 @@ class UserController {}
 | 메서드 | 시그니처 | 설명 |
 |---|---|---|
 | `current()` | `() => TClient \| TTransactionClient` | 활성 트랜잭션 클라이언트(ALS에서)를 반환하거나, 트랜잭션이 없으면 루트 클라이언트를 반환 |
-| `transaction()` | `(fn: () => Promise<T>) => Promise<T>` | Prisma 인터랙티브 트랜잭션 안에서 `fn`을 실행하고, tx 클라이언트를 ALS에 저장 |
-| `requestTransaction()` | `(fn: () => Promise<T>, signal?: AbortSignal) => Promise<T>` | 요청 경계용 `transaction()`. abort-aware 실행을 사용하고, Prisma 드라이버가 signal 옵션을 거부하면 `signal` 없이 1회 재시도 |
+| `transaction()` | `(fn: () => Promise<T>, options?: TTransactionOptions) => Promise<T>` | Prisma 인터랙티브 트랜잭션 안에서 `fn`을 실행합니다(상황에 따라 활성 컨텍스트 재사용/직접 실행 폴백 포함). tx 클라이언트를 ALS에 저장하며, 이미 활성 트랜잭션 컨텍스트에서는 중첩 옵션 오버라이드를 거부합니다 |
+| `requestTransaction()` | `(fn: () => Promise<T>, signal?: AbortSignal, options?: TTransactionOptions) => Promise<T>` | 요청 경계용 `transaction()` 변형입니다. abort-aware 실행을 사용하고, Prisma 드라이버가 abort-signal 트랜잭션 옵션을 거부하면 `signal` 없이 1회 재시도합니다 |
 
 ### `PRISMA_CLIENT`
 

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -113,8 +113,8 @@ class UserController {}
 | Method | Signature | Description |
 |---|---|---|
 | `current()` | `() => TClient \| TTransactionClient` | Returns the active transaction client (from ALS), or the root client if no transaction is open |
-| `transaction()` | `(fn: () => Promise<T>) => Promise<T>` | Runs `fn` inside a Prisma interactive transaction; stores the tx client in ALS |
-| `requestTransaction()` | `(fn: () => Promise<T>, signal?: AbortSignal) => Promise<T>` | Like `transaction()`, intended for request boundaries. Uses abort-aware execution and retries once without `signal` when a Prisma driver rejects signal options |
+| `transaction()` | `(fn: () => Promise<T>, options?: TTransactionOptions) => Promise<T>` | Runs `fn` inside a Prisma interactive transaction (or reuses active context/direct fallback as needed), stores the tx client in ALS, and rejects nested option overrides in an already-active transaction context |
+| `requestTransaction()` | `(fn: () => Promise<T>, signal?: AbortSignal, options?: TTransactionOptions) => Promise<T>` | Request-boundary variant of `transaction()` with abort-aware execution; retries once without `signal` when a Prisma driver rejects abort-signal transaction options |
 
 ### `PRISMA_CLIENT`
 

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -377,7 +377,7 @@ await app.listen();
 | `renderRuntimeDiagnosticsMermaid(graph)` | `src/diagnostics.ts` | 진단 페이로드에서 모듈 레벨 Mermaid 그래프 텍스트 생성 |
 | `KonektiFactory.createApplicationContext(rootModule, options)` | `src/bootstrap.ts` | HTTP 런타임 없이 DI/생명주기 컨텍스트 부트스트랩 |
 | `KonektiFactory.createMicroservice(rootModule, options)` | `src/bootstrap.ts` | DI/생명주기 컨텍스트를 부트스트랩하고 트랜스포트 기반 마이크로서비스 런타임 연결 |
-| `bootstrapModule(module)` | `src/bootstrap.ts` | 하위 레벨: 모듈 그래프 컴파일 + 컨테이너 빌드 |
+| `bootstrapModule(rootModule, options)` | `src/bootstrap.ts` | 하위 레벨 부트스트랩 기준선: 모듈 그래프를 컴파일하고 런타임/모듈 프로바이더를 포함한 루트 컨테이너를 초기화 |
 | `defineModule(cls, metadata)` | `src/bootstrap.ts` | 데코레이터 없이 모듈 메타데이터를 연결하는 하위 레벨 헬퍼 |
 | `Application` | `src/types.ts` | 인터페이스: `container`, `modules`, `rootModule`, `state`, `dispatcher`, `dispatch()`, `ready()`, `listen()`, `close()` |
 | `@Module(metadata)` | `@konekti/core` | 모듈 프로바이더, 컨트롤러, 임포트, 익스포트 선언 |

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -377,7 +377,7 @@ Runtime validates component identity/dependency edges, starts components in depe
 | `renderRuntimeDiagnosticsMermaid(graph)` | `src/diagnostics.ts` | Emit module-level Mermaid graph text from diagnostics payload |
 | `KonektiFactory.createApplicationContext(rootModule, options)` | `src/bootstrap.ts` | Bootstrap DI/lifecycle context without HTTP runtime |
 | `KonektiFactory.createMicroservice(rootModule, options)` | `src/bootstrap.ts` | Bootstrap DI/lifecycle context and attach a transport-backed microservice runtime |
-| `bootstrapModule(module)` | `src/bootstrap.ts` | Lower-level: compile module graph + build container |
+| `bootstrapModule(rootModule, options)` | `src/bootstrap.ts` | Lower-level bootstrap baseline: compile the module graph and initialize the root container with runtime/module providers |
 | `defineModule(cls, metadata)` | `src/bootstrap.ts` | Low-level helper to attach module metadata without decorator |
 | `Application` | `src/types.ts` | Interface: `container`, `modules`, `rootModule`, `state`, `dispatcher`, `dispatch()`, `ready()`, `listen()`, `close()` |
 | `@Module(metadata)` | `@konekti/core` | Declares module providers, controllers, imports, exports |


### PR DESCRIPTION
## Summary
- Align runtime/graphql/prisma README API wording with the rich TSDoc terminology merged in #737-#739.
- Keep scope doc-only: updated API signatures/descriptions and helper wording in package READMEs (EN/KO) without runtime code changes.
- Preserve public behavior semantics; this lane only normalizes wording/terminology/style drift.

## Verification
- `pnpm verify:platform-consistency-governance`
- `lsp_diagnostics` clean for:
  - `packages/runtime/README.md`
  - `packages/runtime/README.ko.md`
  - `packages/graphql/README.md`
  - `packages/graphql/README.ko.md`
  - `packages/prisma/README.md`
  - `packages/prisma/README.ko.md`

## Contract Impact
- Doc-only wording/style alignment.
- No runtime behavior, API semantics, or implementation changes.

Closes #740