### PR TITLE
Resolve #745: guard against ghost workspace members

### DIFF
--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -147,6 +147,22 @@ function collectPackageDirs() {
     .map((entry) => entry.name);
 }
 
+function enforcePackageDirectoriesHaveManifests() {
+  const packagesRoot = join(repoRoot, 'packages');
+
+  for (const entry of readdirSync(packagesRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const manifestPath = join(packagesRoot, entry.name, 'package.json');
+    assert(
+      existsSync(manifestPath),
+      `packages/${entry.name} must contain package.json so packages/* does not admit ghost workspace members.`,
+    );
+  }
+}
+
 function collectMarkdownFiles(relativeRoot) {
   const absoluteRoot = join(repoRoot, relativeRoot);
   if (!existsSync(absoluteRoot)) {
@@ -337,6 +353,7 @@ function enforceRemovedRuntimeFactoryNamesNotUsedInDocs() {
 const changedFiles = changedFilesFromGit();
 
 enforceSsotMirrorStructure();
+enforcePackageDirectoriesHaveManifests();
 enforceReleaseGovernancePublishSurfaceSync();
 enforceRemovedRuntimeFactoryNamesNotUsedInDocs();
 enforceContractCompanionUpdates(changedFiles);


### PR DESCRIPTION
## Summary
- add a governance check that fails when any `packages/*` directory is missing a `package.json`
- verify the worktree contains no `@konekti/dto` or `@konekti/serializer` references and no tracked `packages/dto/` or `packages/serializer/` directories

## Changes
- extend `tooling/governance/verify-platform-consistency-governance.mjs` with a manifest check for every package directory
- keep the clean `origin/main` worktree state where `packages/dto/` and `packages/serializer/` are absent

## Testing
- `pnpm install`
- `pnpm verify:platform-consistency-governance`
- `lsp_diagnostics tooling/governance/verify-platform-consistency-governance.mjs`

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #745