### PR TITLE
Resolve #747: tighten @konekti/graphql barrel exports

### DIFF
--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,6 +1,23 @@
 export * from './dataloader.js';
 export * from './decorators.js';
-export * from './metadata.js';
 export * from './module.js';
-export * from './service.js';
-export * from './types.js';
+export {
+  isGraphqlListTypeRef,
+  listOf,
+} from './types.js';
+export type {
+  ArgFieldMetadata,
+  GraphQLContext,
+  GraphqlArgType,
+  GraphqlListTypeRef,
+  GraphqlModuleOptions,
+  GraphqlRequestContext,
+  GraphqlRootOutputNamedType,
+  GraphqlRootOutputType,
+  GraphqlScalarTypeName,
+  GraphqlSubscriptionsOptions,
+  GraphqlWebSocketSubscriptionsOptions,
+  ResolverHandlerMetadata,
+  ResolverHandlerType,
+  ResolverMetadata,
+} from './types.js';

--- a/packages/graphql/src/public-api.test.ts
+++ b/packages/graphql/src/public-api.test.ts
@@ -16,11 +16,30 @@ describe('@konekti/graphql public API surface', () => {
     expect(graphqlPublicApi).toHaveProperty('DataLoader');
     expect(graphqlPublicApi).toHaveProperty('getRequestScopedDataLoader');
     expect(graphqlPublicApi).toHaveProperty('createRequestScopedDataLoaderFactory');
+    expect(graphqlPublicApi).toHaveProperty('listOf');
+    expect(graphqlPublicApi).toHaveProperty('isGraphqlListTypeRef');
   });
 
-  it('does not expose internal lifecycle/module-option tokens', () => {
+  it('does not expose internal metadata, lifecycle, or descriptor internals', () => {
     expect(graphqlPublicApi).not.toHaveProperty('createGraphqlModule');
     expect(graphqlPublicApi).not.toHaveProperty('GRAPHQL_MODULE_OPTIONS');
     expect(graphqlPublicApi).not.toHaveProperty('GRAPHQL_LIFECYCLE_SERVICE');
+    expect(graphqlPublicApi).not.toHaveProperty('defineResolverMetadata');
+    expect(graphqlPublicApi).not.toHaveProperty('getResolverMetadata');
+    expect(graphqlPublicApi).not.toHaveProperty('defineResolverHandlerMetadata');
+    expect(graphqlPublicApi).not.toHaveProperty('getResolverHandlerMetadata');
+    expect(graphqlPublicApi).not.toHaveProperty('getResolverHandlerMetadataEntries');
+    expect(graphqlPublicApi).not.toHaveProperty('defineArgFieldMetadata');
+    expect(graphqlPublicApi).not.toHaveProperty('getArgFieldMetadata');
+    expect(graphqlPublicApi).not.toHaveProperty('getArgFieldMetadataEntries');
+    expect(graphqlPublicApi).not.toHaveProperty('resolverMetadataSymbol');
+    expect(graphqlPublicApi).not.toHaveProperty('handlerMetadataSymbol');
+    expect(graphqlPublicApi).not.toHaveProperty('argMetadataSymbol');
+    expect(graphqlPublicApi).not.toHaveProperty('GraphqlEndpointController');
+    expect(graphqlPublicApi).not.toHaveProperty('GraphqlLifecycleService');
+    expect(graphqlPublicApi).not.toHaveProperty('GRAPHQL_OPERATION_CONTAINER');
+    expect(graphqlPublicApi).not.toHaveProperty('GRAPHQL_REQUEST_SCOPED_LOADER_CACHE');
+    expect(graphqlPublicApi).not.toHaveProperty('ResolverDescriptor');
+    expect(graphqlPublicApi).not.toHaveProperty('ResolverHandlerDescriptor');
   });
 });


### PR DESCRIPTION
## Summary
- replace wildcard re-exports in `packages/graphql/src/index.ts` with the documented public decorators, module APIs, and type helpers only
- keep metadata helpers, lifecycle services, internal tokens, and descriptor types off the root barrel surface
- extend `packages/graphql/src/public-api.test.ts` to assert the tightened public API contract

## Verification
- pnpm build
- pnpm typecheck

## Contract impact
- Narrows the `@konekti/graphql` root barrel to the documented public surface only; no runtime behavior changed

Closes #747