### PR TITLE
Resolve #746: fix testing package compilation against runtime platform contract

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,7 +8,21 @@ export * from './json-logger.js';
 export * from './logger.js';
 export * from './multipart.js';
 export * from './node.js';
-export * from './platform-contract.js';
+export type {
+  PlatformCheckResult,
+  PlatformComponent,
+  PlatformComponentInput,
+  PlatformComponentRegistration,
+  PlatformDiagnosticIssue,
+  PlatformHealthReport,
+  PlatformOptionsBase,
+  PlatformReadinessReport,
+  PlatformShell,
+  PlatformShellSnapshot,
+  PlatformSnapshot,
+  PlatformState,
+  PlatformValidationResult,
+} from './platform-contract.js';
 export * from './request-transaction.js';
 export { APPLICATION_LOGGER, PLATFORM_SHELL } from './tokens.js';
 export * from './types.js';

--- a/packages/runtime/src/platform-contract.test.ts
+++ b/packages/runtime/src/platform-contract.test.ts
@@ -5,7 +5,7 @@ import type {
   PlatformShellSnapshot,
   PlatformSnapshot,
   PlatformValidationResult,
-} from './platform-contract.js';
+} from './index.js';
 
 describe('platform contract spine', () => {
   it('freezes the shared platform snapshot shape for tooling consumers', () => {

--- a/packages/runtime/src/platform-shell.test.ts
+++ b/packages/runtime/src/platform-shell.test.ts
@@ -7,7 +7,7 @@ import type {
   PlatformSnapshot,
   PlatformState,
   PlatformValidationResult,
-} from './platform-contract.js';
+} from './index.js';
 import { RuntimePlatformShell } from './platform-shell.js';
 
 class StubPlatformComponent implements PlatformComponent {


### PR DESCRIPTION
## Summary

- make the runtime platform-contract type exports explicit in the root barrel so platform-facing consumers resolve the intended public contract from `@konekti/runtime`
- update runtime contract tests to import through the public barrel, locking the testing/cron/event-bus consumer path that issue #746 depends on

## Changes

- replaced the wildcard `platform-contract` barrel export with explicit type re-exports in `packages/runtime/src/index.ts`
- switched runtime platform contract tests to consume the public barrel instead of the internal file path
- verified `packages/testing/src/platform-conformance.ts`, `packages/cron/src/status.ts`, and `packages/event-bus/src/status.ts` already align with the exported contract and required no additional source changes

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run packages/runtime packages/testing packages/cron packages/event-bus`

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact

- No consumer-visible runtime behavior changes. This PR tightens the published type contract and adds regression coverage for the public runtime barrel.

Closes #746