### PR TITLE
Resolve #780: add web-runtime adapter portability coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,36 @@ jobs:
         if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
         run: pnpm test
 
+  official-web-runtime-adapter-portability:
+    name: Official web runtime adapter portability (${{ matrix.adapter }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        adapter:
+          - bun
+          - deno
+          - cloudflare-workers
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run official web runtime adapter portability suite
+        run: pnpm vitest run packages/testing/src/web-runtime-adapter-portability.test.ts --testNamePattern "${{ matrix.adapter }} web runtime adapter portability"
+
   verify-platform-consistency-governance:
     name: Verify platform consistency governance
     runs-on: ubuntu-latest
@@ -174,6 +204,7 @@ jobs:
       - build-and-typecheck
       - lint
       - test
+      - official-web-runtime-adapter-portability
       - verify-platform-consistency-governance
       - resolve-pr-verification-scope
     runs-on: ubuntu-latest

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -244,7 +244,7 @@ await harness.assertAll();
 
 ### HTTP 어댑터 portability harness
 
-HTTP 어댑터가 내장 Node 런타임 어댑터와의 parity를 증명해야 할 때는 `createHttpAdapterPortabilityHarness(...)`를 사용하세요. 이 하니스는 요청 정규화, raw-body 처리, SSE 스트리밍, 시작 로그, HTTPS 시작, 종료 시그널 정리 동작을 함께 검증합니다.
+Node 스타일 HTTP 어댑터가 내장 Node 런타임 어댑터와의 parity를 증명해야 할 때는 `createHttpAdapterPortabilityHarness(...)`를 사용하세요. 이 하니스는 요청 정규화, raw-body 처리, SSE 스트리밍, 시작 로그, HTTPS 시작, 종료 시그널 정리 동작을 함께 검증합니다.
 
 ```ts
 import { createHttpAdapterPortabilityHarness } from '@konekti/testing';
@@ -269,6 +269,39 @@ await harness.assertSupportsSseStreaming();
 - 시작 로그가 명시적 host/HTTPS listen 대상을 반영해야 함
 - 시그널 기반 시작 헬퍼가 close 시 등록한 종료 리스너를 제거해야 함
 
+### Web-runtime HTTP 어댑터 portability harness
+
+fetch 스타일 런타임 어댑터가 Node 전용 socket/HTTPS 헬퍼를 가져오지 않고도 공유 Web request/response 계약 parity를 증명해야 할 때는 `createWebRuntimeHttpAdapterPortabilityHarness(...)`를 사용하세요.
+
+```ts
+import { createWebRuntimeHttpAdapterPortabilityHarness } from '@konekti/testing';
+import { bootstrapCloudflareWorkerApplication } from '@konekti/platform-cloudflare-workers';
+
+const harness = createWebRuntimeHttpAdapterPortabilityHarness({
+  async bootstrap(rootModule, options) {
+    const worker = await bootstrapCloudflareWorkerApplication(rootModule, options);
+
+    return {
+      close: () => worker.close(),
+      dispatch: (request) => worker.fetch(request, {}, { waitUntil() {} }),
+    };
+  },
+  name: 'cloudflare-workers',
+});
+
+await harness.assertPreservesMalformedCookieValues();
+await harness.assertPreservesRawBodyForJsonAndText();
+await harness.assertExcludesRawBodyForMultipart();
+await harness.assertSupportsSseStreaming();
+```
+
+Web-runtime portability harness는 다음 parity 기대값을 검증합니다.
+
+- 잘못된 쿠키 값이 요청 경로를 중단시키지 않고 그대로 관측 가능해야 함
+- `rawBody`는 JSON/text 요청에서만 opt-in으로 유지되고 multipart 파싱에서는 설정되지 않아야 함
+- SSE 응답이 `text/event-stream` 프레이밍을 유지해야 함
+- 어댑터가 Node listener ownership을 가정하지 않고도 직접 `Request` / `Response` dispatch로 검증 가능해야 함
+
 ## 핵심 API
 
 ### `createTestingModule(options)`
@@ -292,6 +325,10 @@ createTestingModule(options: TestingModuleOptions): TestingModuleBuilder
 ### `createHttpAdapterPortabilityHarness(options)`
 
 내장/외부 전송 어댑터를 위한 공유 HTTP adapter portability 하니스입니다.
+
+### `createWebRuntimeHttpAdapterPortabilityHarness(options)`
+
+공식 Web 런타임 어댑터를 위한 공유 fetch-style portability 하니스입니다.
 
 ### `TestingModuleBuilder`
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -230,7 +230,7 @@ The kit enforces these invariants:
 
 ### HTTP adapter portability harness
 
-Use `createHttpAdapterPortabilityHarness(...)` when an HTTP adapter must prove parity with the built-in Node runtime adapter for request normalization, raw-body handling, SSE streaming, startup logging, HTTPS startup, and shutdown signal cleanup.
+Use `createHttpAdapterPortabilityHarness(...)` when a Node-style HTTP adapter must prove parity with the built-in Node runtime adapter for request normalization, raw-body handling, SSE streaming, startup logging, HTTPS startup, and shutdown signal cleanup.
 
 ```ts
 import { createHttpAdapterPortabilityHarness } from '@konekti/testing';
@@ -254,6 +254,39 @@ The adapter portability harness covers these parity expectations:
 - SSE responses keep `text/event-stream` framing.
 - startup logs reflect explicit host and HTTPS listen targets.
 - signal-driven startup helpers remove registered shutdown listeners on close.
+
+### Web-runtime HTTP adapter portability harness
+
+Use `createWebRuntimeHttpAdapterPortabilityHarness(...)` when a fetch-style runtime adapter must prove parity for the shared Web request/response contract without importing Node-only socket or HTTPS helpers.
+
+```ts
+import { createWebRuntimeHttpAdapterPortabilityHarness } from '@konekti/testing';
+import { bootstrapCloudflareWorkerApplication } from '@konekti/platform-cloudflare-workers';
+
+const harness = createWebRuntimeHttpAdapterPortabilityHarness({
+  async bootstrap(rootModule, options) {
+    const worker = await bootstrapCloudflareWorkerApplication(rootModule, options);
+
+    return {
+      close: () => worker.close(),
+      dispatch: (request) => worker.fetch(request, {}, { waitUntil() {} }),
+    };
+  },
+  name: 'cloudflare-workers',
+});
+
+await harness.assertPreservesMalformedCookieValues();
+await harness.assertPreservesRawBodyForJsonAndText();
+await harness.assertExcludesRawBodyForMultipart();
+await harness.assertSupportsSseStreaming();
+```
+
+The Web-runtime portability harness covers these parity expectations:
+
+- malformed cookie values remain observable instead of aborting the request path.
+- `rawBody` stays opt-in for JSON/text requests and remains unset for multipart parsing.
+- SSE responses keep `text/event-stream` framing.
+- adapters stay verifiable through direct `Request` / `Response` dispatch without assuming Node listener ownership.
 
 ### Resolving tokens directly
 
@@ -308,6 +341,10 @@ Shared platform conformance test harness for official platform-facing packages.
 ### `createHttpAdapterPortabilityHarness(options)`
 
 Shared HTTP adapter portability harness for built-in and external transport adapters.
+
+### `createWebRuntimeHttpAdapterPortabilityHarness(options)`
+
+Shared fetch-style runtime adapter portability harness for official Web runtime adapters.
 
 ### `TestingModuleBuilder`
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,5 +1,6 @@
 export * from './http.js';
 export * from './http-adapter-portability.js';
+export * from './web-runtime-adapter-portability.js';
 export * from './app.js';
 export * from './mock.js';
 export * from './platform-conformance.js';

--- a/packages/testing/src/web-runtime-adapter-portability.test.ts
+++ b/packages/testing/src/web-runtime-adapter-portability.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, vi } from 'vitest';
+
+// @ts-ignore Vitest workspace alias resolution handles package test imports.
+import { bootstrapBunApplication, type BunServeOptions, type BunServerLike } from '@konekti/platform-bun';
+// @ts-ignore Vitest workspace alias resolution handles package test imports.
+import { bootstrapCloudflareWorkerApplication, type CloudflareWorkerExecutionContext } from '@konekti/platform-cloudflare-workers';
+// @ts-ignore Vitest workspace alias resolution handles package test imports.
+import { bootstrapDenoApplication, type DenoServeController, type DenoServeHandler, type DenoServeOptions } from '@konekti/platform-deno';
+
+import { createWebRuntimeHttpAdapterPortabilityHarness } from './web-runtime-adapter-portability.js';
+
+type MockBunServer = BunServerLike & {
+  fetch(request: Request): Promise<Response>;
+};
+
+type MockBun = {
+  lastServer?: MockBunServer;
+  serve: ReturnType<typeof vi.fn<(options: BunServeOptions) => MockBunServer>>;
+};
+
+function createExecutionContext(): CloudflareWorkerExecutionContext {
+  return {
+    waitUntil() {},
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createServeStub() {
+  const finished = createDeferred<void>();
+  const shutdown = vi.fn(async () => {
+    finished.resolve();
+  });
+  let capturedHandler: DenoServeHandler | undefined;
+
+  return {
+    get handler() {
+      return capturedHandler;
+    },
+    serve: vi.fn((options: DenoServeOptions, handler: DenoServeHandler): DenoServeController => {
+      capturedHandler = handler;
+
+      if (options.onListen) {
+        options.onListen({
+          hostname: options.hostname ?? '0.0.0.0',
+          port: options.port ?? 3000,
+        });
+      }
+
+      return {
+        finished: finished.promise,
+        shutdown,
+      };
+    }),
+  };
+}
+
+function installMockBun(): MockBun {
+  const mockBun = {} as MockBun;
+
+  mockBun.serve = vi.fn((options: BunServeOptions) => {
+    const protocol = options.tls ? 'https' : 'http';
+    const hostname = options.hostname ?? 'localhost';
+    const port = options.port ?? 3000;
+    let server!: MockBunServer;
+
+    server = {
+      fetch: async (request: Request): Promise<Response> => await options.fetch(request, server),
+      hostname,
+      port,
+      stop() {},
+      url: new URL(`${protocol}://${hostname}:${String(port)}`),
+    };
+
+    mockBun.lastServer = server;
+    return server;
+  });
+
+  (globalThis as typeof globalThis & { Bun?: MockBun }).Bun = mockBun;
+  return mockBun;
+}
+
+function registerWebRuntimePortabilitySuite(
+  name: string,
+  harness: {
+    assertExcludesRawBodyForMultipart(): Promise<void>;
+    assertPreservesMalformedCookieValues(): Promise<void>;
+    assertPreservesRawBodyForJsonAndText(): Promise<void>;
+    assertSupportsSseStreaming(): Promise<void>;
+  },
+): void {
+  describe(`${name} web runtime adapter portability`, () => {
+    it('preserves malformed cookie values', async () => {
+      await harness.assertPreservesMalformedCookieValues();
+    });
+
+    it('preserves raw body for JSON and text requests when enabled', async () => {
+      await harness.assertPreservesRawBodyForJsonAndText();
+    });
+
+    it('does not preserve rawBody for multipart requests', async () => {
+      await harness.assertExcludesRawBodyForMultipart();
+    });
+
+    it('supports SSE streaming', async () => {
+      await harness.assertSupportsSseStreaming();
+    });
+  });
+}
+
+registerWebRuntimePortabilitySuite(
+  'bun',
+  createWebRuntimeHttpAdapterPortabilityHarness({
+    async bootstrap(rootModule, options) {
+      const originalBun = (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
+      const mockBun = installMockBun();
+      const app = await bootstrapBunApplication(rootModule, options);
+
+      await app.listen();
+
+      return {
+        async close() {
+          await app.close();
+
+          if (originalBun === undefined) {
+            delete (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
+            return;
+          }
+
+          (globalThis as typeof globalThis & { Bun?: MockBun }).Bun = originalBun;
+        },
+        async dispatch(request: Request) {
+          return await mockBun.lastServer!.fetch(request);
+        },
+      };
+    },
+    name: 'bun',
+  }),
+);
+
+registerWebRuntimePortabilitySuite(
+  'deno',
+  createWebRuntimeHttpAdapterPortabilityHarness({
+    async bootstrap(rootModule, options) {
+      const server = createServeStub();
+      const app = await bootstrapDenoApplication(rootModule, {
+        ...options,
+        serve: server.serve,
+      });
+
+      await app.listen();
+
+      return {
+        close() {
+          return app.close();
+        },
+        async dispatch(request: Request) {
+          return await server.handler!(request);
+        },
+      };
+    },
+    name: 'deno',
+  }),
+);
+
+registerWebRuntimePortabilitySuite(
+  'cloudflare-workers',
+  createWebRuntimeHttpAdapterPortabilityHarness({
+    async bootstrap(rootModule, options) {
+      const worker = await bootstrapCloudflareWorkerApplication(rootModule, options);
+
+      return {
+        close() {
+          return worker.close();
+        },
+        async dispatch(request: Request) {
+          return await worker.fetch(request, {}, createExecutionContext());
+        },
+      };
+    },
+    name: 'cloudflare-workers',
+  }),
+);

--- a/packages/testing/src/web-runtime-adapter-portability.ts
+++ b/packages/testing/src/web-runtime-adapter-portability.ts
@@ -1,0 +1,241 @@
+// @ts-ignore Worktree-local LSP does not resolve workspace package aliases.
+import { Controller, Get, Post, SseResponse, type RequestContext } from '@konekti/http';
+// @ts-ignore Worktree-local LSP does not resolve workspace package aliases.
+import { defineModule, type ModuleType, type UploadedFile } from '@konekti/runtime';
+
+declare module '@konekti/http' {
+  interface FrameworkRequest {
+    files?: UploadedFile[];
+    rawBody?: Uint8Array;
+  }
+}
+
+type WebRuntimePortabilityAppLike = {
+  close(): Promise<void>;
+  dispatch(request: Request): Promise<Response>;
+};
+
+export interface WebRuntimeHttpAdapterPortabilityHarnessOptions<
+  TBootstrapOptions extends object,
+  TApp extends WebRuntimePortabilityAppLike = WebRuntimePortabilityAppLike,
+> {
+  bootstrap: (rootModule: ModuleType, options: TBootstrapOptions) => Promise<TApp>;
+  name: string;
+}
+
+function decodeUtf8(input: Uint8Array | undefined): string {
+  return new TextDecoder().decode(input ?? new Uint8Array());
+}
+
+async function closeSilently(app: WebRuntimePortabilityAppLike): Promise<void> {
+  try {
+    await app.close();
+  } catch {}
+}
+
+export class WebRuntimeHttpAdapterPortabilityHarness<
+  TBootstrapOptions extends object,
+  TApp extends WebRuntimePortabilityAppLike = WebRuntimePortabilityAppLike,
+> {
+  constructor(private readonly options: WebRuntimeHttpAdapterPortabilityHarnessOptions<TBootstrapOptions, TApp>) {}
+
+  async assertPreservesMalformedCookieValues(): Promise<void> {
+    @Controller('/cookies')
+    class CookieController {
+      @Get('/')
+      readCookies(_input: undefined, context: RequestContext) {
+        return context.request.cookies;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [CookieController],
+    });
+
+    const app = await this.options.bootstrap(AppModule, { cors: false } as TBootstrapOptions);
+
+    try {
+      const response = await app.dispatch(new Request('https://runtime.test/cookies', {
+        headers: {
+          cookie: 'good=hello%20world; bad=%E0%A4%A',
+        },
+      }));
+
+      if (response.status !== 200) {
+        throw new Error(`${this.options.name} adapter changed malformed-cookie handling: expected 200 but received ${String(response.status)}.`);
+      }
+
+      const body = await response.json();
+      if (
+        typeof body !== 'object' ||
+        body === null ||
+        !('bad' in body) ||
+        !('good' in body) ||
+        (body as Record<string, unknown>).bad !== '%E0%A4%A' ||
+        (body as Record<string, unknown>).good !== 'hello world' ||
+        Object.keys(body as Record<string, unknown>).length !== 2
+      ) {
+        throw new Error(`${this.options.name} adapter changed malformed-cookie normalization.`);
+      }
+    } finally {
+      await closeSilently(app);
+    }
+  }
+
+  async assertPreservesRawBodyForJsonAndText(): Promise<void> {
+    @Controller('/webhooks')
+    class WebhookController {
+      @Post('/json')
+      handleJson(_input: undefined, context: RequestContext) {
+        return {
+          parsed: context.request.body,
+          raw: decodeUtf8(context.request.rawBody),
+        };
+      }
+
+      @Post('/text')
+      handleText(_input: undefined, context: RequestContext) {
+        return {
+          parsed: context.request.body,
+          raw: decodeUtf8(context.request.rawBody),
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [WebhookController],
+    });
+
+    const app = await this.options.bootstrap(AppModule, { cors: false, rawBody: true } as TBootstrapOptions);
+
+    try {
+      const [jsonResponse, textResponse] = await Promise.all([
+        app.dispatch(new Request('https://runtime.test/webhooks/json', {
+          body: JSON.stringify({ provider: 'stripe' }),
+          headers: { 'content-type': 'application/json' },
+          method: 'POST',
+        })),
+        app.dispatch(new Request('https://runtime.test/webhooks/text', {
+          body: 'ping=1',
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+          method: 'POST',
+        })),
+      ]);
+
+      if (jsonResponse.status !== 201 || textResponse.status !== 201) {
+        throw new Error(`${this.options.name} adapter changed rawBody response status semantics.`);
+      }
+
+      const [jsonBody, textBody] = await Promise.all([jsonResponse.json(), textResponse.json()]);
+
+      if (JSON.stringify(jsonBody) !== JSON.stringify({ parsed: { provider: 'stripe' }, raw: '{"provider":"stripe"}' })) {
+        throw new Error(`${this.options.name} adapter changed JSON rawBody semantics.`);
+      }
+
+      if (JSON.stringify(textBody) !== JSON.stringify({ parsed: 'ping=1', raw: 'ping=1' })) {
+        throw new Error(`${this.options.name} adapter changed text rawBody semantics.`);
+      }
+    } finally {
+      await closeSilently(app);
+    }
+  }
+
+  async assertExcludesRawBodyForMultipart(): Promise<void> {
+    @Controller('/uploads')
+    class UploadController {
+      @Post('/')
+      upload(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+          fileCount: context.request.files?.length ?? 0,
+          hasRawBody: context.request.rawBody !== undefined,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UploadController],
+    });
+
+    const app = await this.options.bootstrap(AppModule, { cors: false, rawBody: true } as TBootstrapOptions);
+
+    try {
+      const form = new FormData();
+      form.set('name', 'Ada');
+      form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
+
+      const response = await app.dispatch(new Request('https://runtime.test/uploads', {
+        body: form,
+        method: 'POST',
+      }));
+
+      if (response.status !== 201) {
+        throw new Error(`${this.options.name} adapter changed multipart response status semantics.`);
+      }
+
+      const body = await response.json();
+      if (JSON.stringify(body) !== JSON.stringify({ body: { name: 'Ada' }, fileCount: 1, hasRawBody: false })) {
+        throw new Error(`${this.options.name} adapter changed multipart rawBody semantics.`);
+      }
+    } finally {
+      await closeSilently(app);
+    }
+  }
+
+  async assertSupportsSseStreaming(): Promise<void> {
+    @Controller('/events')
+    class EventsController {
+      @Get('/')
+      stream(_input: undefined, context: RequestContext) {
+        const stream = new SseResponse(context);
+
+        stream.comment('connected');
+        stream.send({ ready: true }, { event: 'ready', id: 'evt-1' });
+        stream.close();
+
+        return stream;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [EventsController],
+    });
+
+    const app = await this.options.bootstrap(AppModule, { cors: false } as TBootstrapOptions);
+
+    try {
+      const response = await app.dispatch(new Request('https://runtime.test/events', {
+        headers: { accept: 'text/event-stream' },
+      }));
+      const body = await response.text();
+
+      if (response.status !== 200) {
+        throw new Error(`${this.options.name} adapter changed SSE response status semantics.`);
+      }
+
+      const contentType = response.headers.get('content-type') ?? '';
+      if (!contentType.includes('text/event-stream')) {
+        throw new Error(`${this.options.name} adapter does not expose text/event-stream content-type.`);
+      }
+
+      if (!body.includes('event: ready') || !body.includes('data: {"ready":true}')) {
+        throw new Error(`${this.options.name} adapter changed SSE body framing.`);
+      }
+    } finally {
+      await closeSilently(app);
+    }
+  }
+}
+
+export function createWebRuntimeHttpAdapterPortabilityHarness<
+  TBootstrapOptions extends object,
+  TApp extends WebRuntimePortabilityAppLike = WebRuntimePortabilityAppLike,
+>(
+  options: WebRuntimeHttpAdapterPortabilityHarnessOptions<TBootstrapOptions, TApp>,
+): WebRuntimeHttpAdapterPortabilityHarness<TBootstrapOptions, TApp> {
+  return new WebRuntimeHttpAdapterPortabilityHarness(options);
+}

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -199,6 +199,11 @@ const officialFetchAdapterDocs = [
     path: 'packages/platform-deno/README.md',
     runtimeToken: 'Deno.serve',
   },
+  {
+    label: 'Cloudflare Workers adapter contract docs',
+    path: 'packages/platform-cloudflare-workers/README.md',
+    runtimeToken: 'Cloudflare Workers',
+  },
 ].flatMap((entry) => {
   if (!existsSync(join(repoRoot, entry.path))) {
     return [];


### PR DESCRIPTION
## Summary

- add a Web-runtime portability harness in `@konekti/testing` so official fetch-style adapters can be verified without Node-only socket/HTTPS assumptions
- add Bun, Deno, and Cloudflare Workers portability suites plus a dedicated CI matrix job for those official runtime targets
- extend release-readiness enforcement so Cloudflare Workers official support claims stay covered by adapter contract checks

## Changes

- add `createWebRuntimeHttpAdapterPortabilityHarness(...)` and shared parity assertions for malformed cookies, rawBody behavior, multipart exclusion, and SSE framing
- add Bun/Deno/Cloudflare Workers portability regression tests and export the new harness from `@konekti/testing`
- add an `official-web-runtime-adapter-portability` CI matrix job and include Cloudflare Workers in release-readiness adapter-doc enforcement
- document the new testing harness in `packages/testing/README.md` and `packages/testing/README.ko.md`

## Testing

- `pnpm build`
- `pnpm exec tsc -p packages/testing/tsconfig.build.json --noEmit`
- `pnpm exec vitest run packages/testing/src/http-adapter-portability.test.ts packages/testing/src/web-runtime-adapter-portability.test.ts`
- `pnpm verify:platform-consistency-governance`

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact

- Intended impact: none. This PR adds verification and CI enforcement for already-documented official runtime adapters.

Closes #780