### PR TITLE
Resolve #828: restore root build and typecheck baseline

### DIFF
--- a/tooling/governance/verify-platform-consistency-governance.d.mts
+++ b/tooling/governance/verify-platform-consistency-governance.d.mts
@@ -1,0 +1,16 @@
+export interface DirectProcessEnvViolation {
+  excerpt: string;
+  line: number;
+  path: string;
+}
+
+export function isGovernedPackageSourcePath(relativePath: string): boolean;
+export function collectDirectProcessEnvViolations(
+  relativePaths: readonly string[],
+  readSource: (relativePath: string) => string,
+): DirectProcessEnvViolation[];
+export function enforceNoDirectProcessEnvInOrdinaryPackageSource(
+  relativePaths?: readonly string[],
+  readSource?: (relativePath: string) => string,
+): void;
+export function main(): void;

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -7,6 +7,7 @@
   "include": [
     "vite.config.ts",
     "vitest.config.ts",
-    "tooling/**/*.ts"
+    "tooling/**/*.ts",
+    "tooling/**/*.d.mts"
   ]
 }


### PR DESCRIPTION
Closes #828

## Summary

Restore the shared root Build and typecheck baseline on `main` by adding a typed declaration companion for the governance `.mjs` module and including tooling `.d.mts` files in the root tools tsconfig.

## Changes

- add `tooling/governance/verify-platform-consistency-governance.d.mts` for the exported governance helpers used by the Vitest suite
- update `tsconfig.tools.json` so root tooling typecheck includes `tooling/**/*.d.mts`
- keep the patch limited to the baseline typecheck blocker; no runtime/package behavior changes

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts`

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

Contract impact note: none. This PR only restores root tooling/typecheck baseline behavior and does not change package runtime behavior.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

PR scope note: no governance docs or package README alignment claims changed in this repair.