### PR TITLE
Resolve #850: maintainability(http): src 파일을 dispatch/middleware/adapters/context 폴더로 분리

### DIFF
--- a/packages/http/src/adapters/binding.test.ts
+++ b/packages/http/src/adapters/binding.test.ts
@@ -6,7 +6,7 @@ import {
   FromQuery,
   FromPath,
   Optional,
-} from './decorators.js';
+} from '../decorators.js';
 import {
   ArrayMinSize,
   IsEmail,
@@ -16,10 +16,10 @@ import {
   ValidateIf,
   ValidateNested,
 } from '@konekti/validation';
-import { BadRequestException } from './exceptions.js';
+import { BadRequestException } from '../exceptions.js';
 import { DefaultBinder } from './binding.js';
 import { HttpDtoValidationAdapter } from './dto-validation-adapter.js';
-import type { ArgumentResolverContext, FrameworkRequest, FrameworkResponse } from './types.js';
+import type { ArgumentResolverContext, FrameworkRequest, FrameworkResponse } from '../types.js';
 
 function createRequest(overrides: Partial<FrameworkRequest> = {}): FrameworkRequest {
   return {

--- a/packages/http/src/adapters/binding.ts
+++ b/packages/http/src/adapters/binding.ts
@@ -1,9 +1,9 @@
 import { InvariantError, type Constructor, type MetadataPropertyKey, type MetadataSource, type Token } from '@konekti/core';
 import { getDtoBindingSchema } from '@konekti/core/internal';
 
-import { BadRequestException, type HttpExceptionDetail } from './exceptions.js';
-import { toInputErrorDetail } from './input-error-detail.js';
-import type { ArgumentResolverContext, Binder, Converter, ConverterLike, ConverterTarget, FrameworkRequest } from './types.js';
+import { BadRequestException, type HttpExceptionDetail } from '../exceptions.js';
+import { toInputErrorDetail } from '../input-error-detail.js';
+import type { ArgumentResolverContext, Binder, Converter, ConverterLike, ConverterTarget, FrameworkRequest } from '../types.js';
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 

--- a/packages/http/src/adapters/dto-validation-adapter.ts
+++ b/packages/http/src/adapters/dto-validation-adapter.ts
@@ -2,9 +2,9 @@ import { type Constructor } from '@konekti/core';
 import { getDtoBindingSchema } from '@konekti/core/internal';
 import { DefaultValidator as BaseDefaultValidator, DtoValidationError } from '@konekti/validation';
 
-import { BadRequestException } from './exceptions.js';
-import { toInputErrorDetail } from './input-error-detail.js';
-import type { ValidationIssue, Validator } from './types.js';
+import { BadRequestException } from '../exceptions.js';
+import { toInputErrorDetail } from '../input-error-detail.js';
+import type { ValidationIssue, Validator } from '../types.js';
 
 export class HttpDtoValidationAdapter implements Validator {
   private readonly validator = new BaseDefaultValidator();

--- a/packages/http/src/context/request-context.test.ts
+++ b/packages/http/src/context/request-context.test.ts
@@ -11,7 +11,7 @@ import {
   runWithRequestContext,
   setContextValue,
 } from './request-context.js';
-import type { RequestContext } from './types.js';
+import type { RequestContext } from '../types.js';
 
 function createMockContext(): RequestContext {
   const root = new Container();

--- a/packages/http/src/context/request-context.ts
+++ b/packages/http/src/context/request-context.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 
 import { KonektiError } from '@konekti/core';
 
-import type { ContextKey, RequestContext } from './types.js';
+import type { ContextKey, RequestContext } from '../types.js';
 
 const requestContextStore = new AsyncLocalStorage<RequestContext>();
 

--- a/packages/http/src/context/sse.test.ts
+++ b/packages/http/src/context/sse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { FrameworkResponse, FrameworkResponseStream, RequestContext } from './types.js';
+import type { FrameworkResponse, FrameworkResponseStream, RequestContext } from '../types.js';
 import { SseResponse, encodeSseComment, encodeSseMessage } from './sse.js';
 
 interface MockSseStream extends FrameworkResponseStream {

--- a/packages/http/src/context/sse.ts
+++ b/packages/http/src/context/sse.ts
@@ -1,4 +1,4 @@
-import type { FrameworkResponse, FrameworkResponseStream, RequestContext } from './types.js';
+import type { FrameworkResponse, FrameworkResponseStream, RequestContext } from '../types.js';
 
 export interface SseSendOptions {
   event?: string;

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -1,10 +1,10 @@
-import { NotAcceptableException } from './exceptions.js';
+import { NotAcceptableException } from '../exceptions.js';
 import type {
   ContentNegotiationOptions,
   FrameworkRequest,
   HandlerDescriptor,
   ResponseFormatter,
-} from './types.js';
+} from '../types.js';
 
 interface AcceptToken {
   mediaRange: string;

--- a/packages/http/src/dispatch/dispatch-error-policy.ts
+++ b/packages/http/src/dispatch/dispatch-error-policy.ts
@@ -1,11 +1,11 @@
-import { HandlerNotFoundError } from './errors.js';
+import { HandlerNotFoundError } from '../errors.js';
 import {
   HttpException,
   InternalServerErrorException,
   NotFoundException,
   createErrorResponse,
-} from './exceptions.js';
-import type { FrameworkResponse } from './types.js';
+} from '../exceptions.js';
+import type { FrameworkResponse } from '../types.js';
 
 function toHttpException(error: unknown): HttpException {
   if (error instanceof HttpException) {

--- a/packages/http/src/dispatch/dispatch-handler-policy.ts
+++ b/packages/http/src/dispatch/dispatch-handler-policy.ts
@@ -1,8 +1,8 @@
 import { InvariantError, type Token } from '@konekti/core';
 
-import { DefaultBinder } from './binding.js';
-import { HttpDtoValidationAdapter } from './dto-validation-adapter.js';
-import type { ArgumentResolverContext, Binder, HandlerDescriptor, RequestContext } from './types.js';
+import { DefaultBinder } from '../adapters/binding.js';
+import { HttpDtoValidationAdapter } from '../adapters/dto-validation-adapter.js';
+import type { ArgumentResolverContext, Binder, HandlerDescriptor, RequestContext } from '../types.js';
 
 const defaultBinder = new DefaultBinder();
 const defaultValidator = new HttpDtoValidationAdapter();

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -8,7 +8,7 @@ import type {
   FrameworkRequest,
   FrameworkResponse,
   HandlerDescriptor,
-} from './types.js';
+} from '../types.js';
 
 function resolveDefaultSuccessStatus(handler: HandlerDescriptor, value: unknown): number {
   switch (handler.route.method) {

--- a/packages/http/src/dispatch/dispatch-routing-policy.test.ts
+++ b/packages/http/src/dispatch/dispatch-routing-policy.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { HandlerNotFoundError } from './errors.js';
+import { HandlerNotFoundError } from '../errors.js';
 import { matchHandlerOrThrow, updateRequestParams } from './dispatch-routing-policy.js';
-import type { FrameworkRequest, HandlerDescriptor, HandlerMapping, RequestContext } from './types.js';
+import type { FrameworkRequest, HandlerDescriptor, HandlerMapping, RequestContext } from '../types.js';
 
 function createRequest(path: string, method: FrameworkRequest['method']): FrameworkRequest {
   return {

--- a/packages/http/src/dispatch/dispatch-routing-policy.ts
+++ b/packages/http/src/dispatch/dispatch-routing-policy.ts
@@ -1,5 +1,5 @@
-import { HandlerNotFoundError } from './errors.js';
-import type { FrameworkRequest, HandlerMapping, HandlerMatch, RequestContext } from './types.js';
+import { HandlerNotFoundError } from '../errors.js';
+import type { FrameworkRequest, HandlerMapping, HandlerMatch, RequestContext } from '../types.js';
 
 export function matchHandlerOrThrow(handlerMapping: HandlerMapping, request: FrameworkRequest): HandlerMatch {
   const match = handlerMapping.match(request);

--- a/packages/http/src/dispatch/dispatcher-status.test.ts
+++ b/packages/http/src/dispatch/dispatcher-status.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Container } from '@konekti/di';
 
-import type { FrameworkRequest, FrameworkResponse, HandlerDescriptor, HandlerMapping, Interceptor, InterceptorContext } from './types.js';
+import type { FrameworkRequest, FrameworkResponse, HandlerDescriptor, HandlerMapping, Interceptor, InterceptorContext } from '../types.js';
 import { createDispatcher } from './dispatcher.js';
 
 function createResponse(): FrameworkResponse & { body?: unknown } {

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -35,7 +35,7 @@ import {
 import { IsNumber, IsString, MinLength, ValidateNested } from '@konekti/validation';
 
 import { IntersectionType, OmitType, PartialType, PickType } from '@konekti/validation';
-import { forRoutes, runMiddlewareChain } from './middleware.js';
+import { forRoutes, runMiddlewareChain } from '../middleware/middleware.js';
 
 function createResponse(): FrameworkResponse & { body?: unknown } {
   return {

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -4,12 +4,12 @@ import type { Container } from '@konekti/di';
 import { invokeControllerHandler } from './dispatch-handler-policy.js';
 import { resolveContentNegotiation, writeErrorResponse, writeSuccessResponse, type ResolvedContentNegotiation } from './dispatch-response-policy.js';
 import { matchHandlerOrThrow, updateRequestParams } from './dispatch-routing-policy.js';
-import { RequestAbortedError } from './errors.js';
-import { runGuardChain } from './guards.js';
-import { runInterceptorChain } from './interceptors.js';
-import { runMiddlewareChain } from './middleware.js';
-import { createRequestContext, runWithRequestContext } from './request-context.js';
-import { SseResponse } from './sse.js';
+import { RequestAbortedError } from '../errors.js';
+import { runGuardChain } from '../guards.js';
+import { runInterceptorChain } from '../interceptors.js';
+import { runMiddlewareChain } from '../middleware/middleware.js';
+import { createRequestContext, runWithRequestContext } from '../context/request-context.js';
+import { SseResponse } from '../context/sse.js';
 import type {
   Binder,
   ContentNegotiationOptions,
@@ -27,7 +27,7 @@ import type {
   RequestObservationContext,
   RequestObserver,
   RequestObserverLike,
-} from './types.js';
+} from '../types.js';
 
 export type ErrorHandler = (error: unknown, request: FrameworkRequest, response: FrameworkResponse, requestId?: string) => Promise<boolean | void> | boolean | void;
 

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,6 +1,6 @@
 export * from './adapter.js';
-export * from './correlation.js';
-export * from './cors.js';
+export * from './middleware/correlation.js';
+export * from './middleware/cors.js';
 export {
   All,
   Controller,
@@ -27,7 +27,7 @@ export {
   UseInterceptors,
   Version,
 } from './decorators.js';
-export * from './dispatcher.js';
+export * from './dispatch/dispatcher.js';
 export * from './errors.js';
 export * from './exceptions.js';
 export * from './mapping.js';
@@ -36,9 +36,9 @@ export {
   isMiddlewareRouteConfig,
   matchRoutePattern,
   normalizeRoutePattern,
-} from './middleware.js';
-export * from './rate-limit.js';
-export * from './request-context.js';
-export * from './security-headers.js';
-export * from './sse.js';
+} from './middleware/middleware.js';
+export * from './middleware/rate-limit.js';
+export * from './context/request-context.js';
+export * from './middleware/security-headers.js';
+export * from './context/sse.js';
 export * from './types.js';

--- a/packages/http/src/internal.ts
+++ b/packages/http/src/internal.ts
@@ -1,1 +1,1 @@
-export { DefaultBinder } from './binding.js';
+export { DefaultBinder } from './adapters/binding.js';

--- a/packages/http/src/middleware/correlation.ts
+++ b/packages/http/src/middleware/correlation.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import type { Middleware } from './types.js';
+import type { Middleware } from '../types.js';
 
 const REQUEST_ID_HEADER = 'x-request-id';
 const CORRELATION_ID_HEADER = 'x-correlation-id';

--- a/packages/http/src/middleware/cors.test.ts
+++ b/packages/http/src/middleware/cors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { FrameworkRequest, FrameworkResponse } from './types.js';
+import type { FrameworkRequest, FrameworkResponse } from '../types.js';
 import { createCorsMiddleware } from './cors.js';
 
 function createRequest(method: FrameworkRequest['method'], origin?: string): FrameworkRequest {

--- a/packages/http/src/middleware/cors.ts
+++ b/packages/http/src/middleware/cors.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from './types.js';
+import type { Middleware } from '../types.js';
 
 export interface CorsOptions {
   allowCredentials?: boolean;

--- a/packages/http/src/middleware/middleware.test.ts
+++ b/packages/http/src/middleware/middleware.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Container } from '@konekti/di';
 
-import type { FrameworkResponse, Middleware, MiddlewareContext, MiddlewareLike, Next } from './types.js';
+import type { FrameworkResponse, Middleware, MiddlewareContext, MiddlewareLike, Next } from '../types.js';
 import { forRoutes, isMiddlewareRouteConfig, runMiddlewareChain } from './middleware.js';
 
 function createResponse(): FrameworkResponse {

--- a/packages/http/src/middleware/middleware.ts
+++ b/packages/http/src/middleware/middleware.ts
@@ -1,6 +1,6 @@
 import type { Constructor, Token } from '@konekti/core';
 
-import type { Middleware, MiddlewareContext, MiddlewareLike, MiddlewareRouteConfig, Next, RequestContext } from './types.js';
+import type { Middleware, MiddlewareContext, MiddlewareLike, MiddlewareRouteConfig, Next, RequestContext } from '../types.js';
 
 function isMiddleware(value: MiddlewareLike): value is Middleware {
   return typeof value === 'object' && value !== null && 'handle' in value;

--- a/packages/http/src/middleware/rate-limit.test.ts
+++ b/packages/http/src/middleware/rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createMemoryRateLimitStore, createRateLimitMiddleware } from './rate-limit.js';
-import type { MiddlewareContext } from './types.js';
+import type { MiddlewareContext } from '../types.js';
 
 function createContext(remoteAddress = '127.0.0.1') {
   const response = {

--- a/packages/http/src/middleware/rate-limit.ts
+++ b/packages/http/src/middleware/rate-limit.ts
@@ -1,5 +1,5 @@
-import type { MiddlewareContext, Middleware } from './types.js';
-import { TooManyRequestsException, createErrorResponse } from './exceptions.js';
+import type { MiddlewareContext, Middleware } from '../types.js';
+import { TooManyRequestsException, createErrorResponse } from '../exceptions.js';
 
 export interface RateLimitStoreEntry {
   count: number;

--- a/packages/http/src/middleware/security-headers.test.ts
+++ b/packages/http/src/middleware/security-headers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createSecurityHeadersMiddleware } from './security-headers.js';
-import type { MiddlewareContext } from './types.js';
+import type { MiddlewareContext } from '../types.js';
 
 function createContext() {
   return {

--- a/packages/http/src/middleware/security-headers.ts
+++ b/packages/http/src/middleware/security-headers.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from './types.js';
+import type { Middleware } from '../types.js';
 
 export interface SecurityHeadersOptions {
   contentSecurityPolicy?: string | false;


### PR DESCRIPTION
Closes #850

## Summary

`packages/http/src/` 의 약 30개 파일을 책임 기반 하위 폴더로 재구조화합니다.

- **dispatch/**: 디스패처 및 파이프라인 정책 파일 (dispatcher, routing/error/handler/response/content-negotiation policy)
- **middleware/**: HTTP 미들웨어 (cors, correlation, rate-limit, security-headers, middleware)
- **adapters/**: DTO 바인딩 및 검증 어댑터 (binding, dto-validation-adapter)
- **context/**: 요청 컨텍스트 및 SSE (request-context, sse)

루트에 유지된 파일: `index.ts`, `adapter.ts`, `types.ts`, `errors.ts`, `exceptions.ts`, `decorators.ts`, `interceptors.ts`, `guards.ts`, `mapping.ts`, `internal.ts`, `input-error-detail.ts`

## What changed

- 파일 이동 + 테스트 파일 함께 이동
- 이동된 파일 내 상대 import 경로 업데이트
- `index.ts` re-export 경로를 새 위치에 맞게 업데이트
- `internal.ts` re-export 경로 업데이트

## What did NOT change

- 비즈니스 로직, 타입, 인터페이스 변경 없음
- `index.ts` 공개 API re-export 시그니처 변경 없음
- `package.json` exports 변경 없음

## Verification

```bash
npx vitest run --project packages packages/http/src/
# 14 test files, 119 tests passed
```

## Contract impact

없음. 파일 재구조화만 수행하며 런타임 동작 변경 없음.

## Reference

`docs/reference/package-folder-structure.md` 기준 준수