### PR TITLE
Resolve #853: move 4 bus implementation files into buses/ subfolder

### DIFF
--- a/packages/cqrs/src/buses/command-bus.ts
+++ b/packages/cqrs/src/buses/command-bus.ts
@@ -2,16 +2,16 @@ import { Inject, InvariantError } from '@konekti/core';
 import type { OnApplicationBootstrap } from '@konekti/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@konekti/runtime/internal';
 
-import { CommandHandlerNotFoundException, DuplicateCommandHandlerError } from './errors.js';
-import { getCommandHandlerMetadata } from './metadata.js';
-import { CqrsBusBase, createDuplicateHandlerMessage } from './discovery.js';
+import { CommandHandlerNotFoundException, DuplicateCommandHandlerError } from '../errors.js';
+import { getCommandHandlerMetadata } from '../metadata.js';
+import { CqrsBusBase, createDuplicateHandlerMessage } from '../discovery.js';
 import type {
   CommandBus,
   CommandHandlerDescriptor,
   CommandType,
   ICommand,
   ICommandHandler,
-} from './types.js';
+} from '../types.js';
 
 function isCommandHandler(value: unknown): value is ICommandHandler<ICommand, unknown> {
   if (typeof value !== 'object' || value === null) {

--- a/packages/cqrs/src/buses/event-bus.ts
+++ b/packages/cqrs/src/buses/event-bus.ts
@@ -3,12 +3,12 @@ import { EVENT_BUS as KONEKTI_EVENT_BUS, type EventBus } from '@konekti/event-bu
 import type { OnApplicationShutdown, OnApplicationBootstrap } from '@konekti/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@konekti/runtime/internal';
 
-import { CqrsBusBase } from './discovery.js';
-import { createIsolatedEvent } from './event-clone.js';
-import { getEventHandlerMetadata } from './metadata.js';
+import { CqrsBusBase } from '../discovery.js';
+import { createIsolatedEvent } from '../event-clone.js';
+import { getEventHandlerMetadata } from '../metadata.js';
 import { CqrsSagaLifecycleService } from './saga-bus.js';
-import { createCqrsPlatformStatusSnapshot } from './status.js';
-import type { CqrsEventBus, CqrsEventType, EventHandlerDescriptor, IEvent, IEventHandler } from './types.js';
+import { createCqrsPlatformStatusSnapshot } from '../status.js';
+import type { CqrsEventBus, CqrsEventType, EventHandlerDescriptor, IEvent, IEventHandler } from '../types.js';
 
 function isEventHandler(value: unknown): value is IEventHandler<IEvent> {
   if (typeof value !== 'object' || value === null) {

--- a/packages/cqrs/src/buses/query-bus.ts
+++ b/packages/cqrs/src/buses/query-bus.ts
@@ -4,16 +4,16 @@ import {
 } from '@konekti/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@konekti/runtime/internal';
 
-import { DuplicateQueryHandlerError, QueryHandlerNotFoundException } from './errors.js';
-import { getQueryHandlerMetadata } from './metadata.js';
-import { CqrsBusBase, createDuplicateHandlerMessage } from './discovery.js';
+import { DuplicateQueryHandlerError, QueryHandlerNotFoundException } from '../errors.js';
+import { getQueryHandlerMetadata } from '../metadata.js';
+import { CqrsBusBase, createDuplicateHandlerMessage } from '../discovery.js';
 import type {
   IQuery,
   IQueryHandler,
   QueryBus,
   QueryHandlerDescriptor,
   QueryType,
-} from './types.js';
+} from '../types.js';
 
 function isQueryHandler(value: unknown): value is IQueryHandler<IQuery<unknown>, unknown> {
   if (typeof value !== 'object' || value === null) {

--- a/packages/cqrs/src/buses/saga-bus.ts
+++ b/packages/cqrs/src/buses/saga-bus.ts
@@ -4,11 +4,11 @@ import { Inject, InvariantError, KonektiError, type Token } from '@konekti/core'
 import type { OnApplicationBootstrap, OnApplicationShutdown } from '@konekti/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@konekti/runtime/internal';
 
-import { CqrsBusBase } from './discovery.js';
-import { SagaExecutionError } from './errors.js';
-import { createIsolatedEvent } from './event-clone.js';
-import { getSagaMetadata } from './metadata.js';
-import type { CqrsEventType, IEvent, ISaga, SagaDescriptor } from './types.js';
+import { CqrsBusBase } from '../discovery.js';
+import { SagaExecutionError } from '../errors.js';
+import { createIsolatedEvent } from '../event-clone.js';
+import { getSagaMetadata } from '../metadata.js';
+import type { CqrsEventType, IEvent, ISaga, SagaDescriptor } from '../types.js';
 
 function isSaga(value: unknown): value is ISaga<IEvent> {
   if (typeof value !== 'object' || value === null) {

--- a/packages/cqrs/src/index.ts
+++ b/packages/cqrs/src/index.ts
@@ -25,9 +25,9 @@ export {
 } from './metadata.js';
 export { CqrsModule, createCqrsProviders, type CqrsModuleOptions } from './module.js';
 export * from './status.js';
-export { CommandBusLifecycleService } from './command-bus.js';
-export { CqrsEventBusService } from './event-bus.js';
-export { QueryBusLifecycleService } from './query-bus.js';
+export { CommandBusLifecycleService } from './buses/command-bus.js';
+export { CqrsEventBusService } from './buses/event-bus.js';
+export { QueryBusLifecycleService } from './buses/query-bus.js';
 export { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 export type {
   CommandBus,

--- a/packages/cqrs/src/module.test.ts
+++ b/packages/cqrs/src/module.test.ts
@@ -6,7 +6,7 @@ import { OnEvent, type EventBusTransport } from '@konekti/event-bus';
 import { bootstrapApplication, defineModule, type ApplicationLogger } from '@konekti/runtime';
 
 import { CommandHandler, EventHandler, QueryHandler, Saga } from './decorators.js';
-import { CommandBusLifecycleService } from './command-bus.js';
+import { CommandBusLifecycleService } from './buses/command-bus.js';
 import {
   CommandHandlerNotFoundException,
   DuplicateCommandHandlerError,
@@ -14,11 +14,11 @@ import {
   QueryHandlerNotFoundException,
   SagaExecutionError,
 } from './errors.js';
-import { CqrsEventBusService } from './event-bus.js';
+import { CqrsEventBusService } from './buses/event-bus.js';
 import { getCommandHandlerMetadata, getEventHandlerMetadata, getQueryHandlerMetadata, getSagaMetadata } from './metadata.js';
 import { CqrsModule } from './module.js';
-import { QueryBusLifecycleService } from './query-bus.js';
-import { CqrsSagaLifecycleService } from './saga-bus.js';
+import { QueryBusLifecycleService } from './buses/query-bus.js';
+import { CqrsSagaLifecycleService } from './buses/saga-bus.js';
 import { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 import type {
   CommandBus,

--- a/packages/cqrs/src/module.ts
+++ b/packages/cqrs/src/module.ts
@@ -2,10 +2,10 @@ import type { Provider } from '@konekti/di';
 import { EventBusModule, type EventBusModuleOptions } from '@konekti/event-bus';
 import { defineModule, type ModuleType } from '@konekti/runtime';
 
-import { CommandBusLifecycleService } from './command-bus.js';
-import { CqrsEventBusService } from './event-bus.js';
-import { QueryBusLifecycleService } from './query-bus.js';
-import { CqrsSagaLifecycleService } from './saga-bus.js';
+import { CommandBusLifecycleService } from './buses/command-bus.js';
+import { CqrsEventBusService } from './buses/event-bus.js';
+import { QueryBusLifecycleService } from './buses/query-bus.js';
+import { CqrsSagaLifecycleService } from './buses/saga-bus.js';
 import { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 import type {
   CommandHandlerClass,


### PR DESCRIPTION
## Summary

Closes #853

- **파일 이동**: `command-bus.ts`, `event-bus.ts`, `query-bus.ts`, `saga-bus.ts`를 `packages/cqrs/src/buses/`로 이동
- **Import 경로 업데이트**: 이동된 파일 내부 import 경로 및 `module.ts`, `index.ts`, `module.test.ts`의 참조 경로 수정
- **공개 API 변경 없음**: `index.ts`의 re-export 시그니처는 동일하게 유지

## Verification

- `pnpm test` — 154 test files, 1466 tests passed
- `docs/reference/package-folder-structure.md` 구조 기준 준수

## Contract Impact

- 비즈니스 로직, 타입, 인터페이스 변경 없음
- `packages/cqrs/` 외부 파일 수정 없음