### PR TITLE
Resolve #926: fix microservices transport subpath exports

### DIFF
--- a/packages/microservices/package.json
+++ b/packages/microservices/package.json
@@ -34,32 +34,32 @@
       "import": "./dist/index.js"
     },
     "./grpc": {
-      "types": "./dist/grpc-transport.d.ts",
-      "import": "./dist/grpc-transport.js"
+      "types": "./dist/transports/grpc-transport.d.ts",
+      "import": "./dist/transports/grpc-transport.js"
     },
     "./kafka": {
-      "types": "./dist/kafka-transport.d.ts",
-      "import": "./dist/kafka-transport.js"
+      "types": "./dist/transports/kafka-transport.d.ts",
+      "import": "./dist/transports/kafka-transport.js"
     },
     "./mqtt": {
-      "types": "./dist/mqtt-transport.d.ts",
-      "import": "./dist/mqtt-transport.js"
+      "types": "./dist/transports/mqtt-transport.d.ts",
+      "import": "./dist/transports/mqtt-transport.js"
     },
     "./nats": {
-      "types": "./dist/nats-transport.d.ts",
-      "import": "./dist/nats-transport.js"
+      "types": "./dist/transports/nats-transport.d.ts",
+      "import": "./dist/transports/nats-transport.js"
     },
     "./redis": {
-      "types": "./dist/redis-transport.d.ts",
-      "import": "./dist/redis-transport.js"
+      "types": "./dist/transports/redis-transport.d.ts",
+      "import": "./dist/transports/redis-transport.js"
     },
     "./rabbitmq": {
-      "types": "./dist/rabbitmq-transport.d.ts",
-      "import": "./dist/rabbitmq-transport.js"
+      "types": "./dist/transports/rabbitmq-transport.d.ts",
+      "import": "./dist/transports/rabbitmq-transport.js"
     },
     "./tcp": {
-      "types": "./dist/tcp-transport.d.ts",
-      "import": "./dist/tcp-transport.js"
+      "types": "./dist/transports/tcp-transport.d.ts",
+      "import": "./dist/transports/tcp-transport.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/microservices/src/public-subpaths.test.ts
+++ b/packages/microservices/src/public-subpaths.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+type ExportTarget = {
+  import: string;
+  types: string;
+};
+
+describe('@konekti/microservices transport subpath exports', () => {
+  it('keeps documented transport subpaths aligned with emitted dist artifacts', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as {
+      exports: Record<string, ExportTarget>;
+    };
+
+    expect(packageJson.exports).toMatchObject({
+      './grpc': {
+        import: './dist/transports/grpc-transport.js',
+        types: './dist/transports/grpc-transport.d.ts',
+      },
+      './kafka': {
+        import: './dist/transports/kafka-transport.js',
+        types: './dist/transports/kafka-transport.d.ts',
+      },
+      './mqtt': {
+        import: './dist/transports/mqtt-transport.js',
+        types: './dist/transports/mqtt-transport.d.ts',
+      },
+      './nats': {
+        import: './dist/transports/nats-transport.js',
+        types: './dist/transports/nats-transport.d.ts',
+      },
+      './redis': {
+        import: './dist/transports/redis-transport.js',
+        types: './dist/transports/redis-transport.d.ts',
+      },
+      './rabbitmq': {
+        import: './dist/transports/rabbitmq-transport.js',
+        types: './dist/transports/rabbitmq-transport.d.ts',
+      },
+      './tcp': {
+        import: './dist/transports/tcp-transport.js',
+        types: './dist/transports/tcp-transport.d.ts',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- point `@konekti/microservices` transport subpath exports at the emitted `dist/transports/*` artifacts
- add a regression test that locks the documented transport subpath map to the build layout

## Changes
- updated `packages/microservices/package.json` export entries for `./grpc`, `./kafka`, `./mqtt`, `./nats`, `./redis`, `./rabbitmq`, and `./tcp`
- added `packages/microservices/src/public-subpaths.test.ts` to guard the documented subpath contract

## Testing
- `pnpm --filter @konekti/microservices... build`
- `pnpm vitest run packages/microservices/src/public-subpaths.test.ts`
- `node --input-type=module -e 'const subpaths=["grpc","kafka","mqtt","nats","redis","rabbitmq","tcp"]; for (const subpath of subpaths) { const resolved = import.meta.resolve(`@konekti/microservices/${subpath}`); console.log(`${subpath} -> ${resolved}`); }'` (from `packages/microservices/`)

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- restores the documented `@konekti/microservices/{transport}` public entrypoints without changing the package README contract

Closes #926