### PR TITLE
Resolve #928: seal runtime universal barrel from Node-only exports

### DIFF
--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -136,6 +136,17 @@ class UsersModule {}
 - `defineModule(cls, metadata)`: 프로그래밍 방식의 모듈 정의 헬퍼입니다.
 - `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다.
 
+### Node 전용 서브경로 (`@konekti/runtime/node`)
+
+로거 팩토리 및 기타 Node 전용 헬퍼는 범용 루트 진입점에 포함되지 않습니다. `./node` 서브경로에서 가져오세요:
+
+```typescript
+import { createConsoleApplicationLogger, createJsonApplicationLogger } from '@konekti/runtime/node';
+```
+
+- `createConsoleApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 컬러 콘솔 로거.
+- `createJsonApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 구조화된 JSON 로거.
+
 ## 관련 패키지
 
 - [@konekti/core](../core): 핵심 데코레이터 및 메타데이터 시스템.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -136,6 +136,17 @@ The static facade for application lifecycle management.
 - `defineModule(cls, metadata)`: Programmatic module definition helper.
 - `bootstrapApplication(options)`: Lower-level async bootstrap function.
 
+### Node-Specific Subpath (`@konekti/runtime/node`)
+
+Logger factories and other Node-only helpers are **not** on the universal root entrypoint. Import them from the `./node` subpath:
+
+```typescript
+import { createConsoleApplicationLogger, createJsonApplicationLogger } from '@konekti/runtime/node';
+```
+
+- `createConsoleApplicationLogger()`: Colorized console logger using `process.stdout`/`process.stderr`.
+- `createJsonApplicationLogger()`: Structured JSON logger using `process.stdout`/`process.stderr`.
+
 ## Related Packages
 
 - [@konekti/core](../core): Core decorators and metadata system.

--- a/packages/runtime/src/exports.test.ts
+++ b/packages/runtime/src/exports.test.ts
@@ -6,7 +6,7 @@ import * as runtime from './index.js';
 import * as runtimeInternal from './internal.js';
 import * as runtimeInternalHttpAdapter from './adapters/internal-http-adapter.js';
 import * as runtimeInternalRequestResponseFactory from './adapters/internal-request-response-factory.js';
-import * as runtimeNode from './node/node.js';
+import * as runtimeNode from './node.js';
 import * as runtimeWeb from './web.js';
 
 describe('runtime export boundaries', () => {
@@ -20,8 +20,8 @@ describe('runtime export boundaries', () => {
 
   it('keeps only bootstrap-scoped operational helpers on the runtime root barrel', () => {
     expect(runtime.createHealthModule).toBeTypeOf('function');
-    expect(runtime.createConsoleApplicationLogger).toBeTypeOf('function');
-    expect(runtime.createJsonApplicationLogger).toBeTypeOf('function');
+    expect(runtime).not.toHaveProperty('createConsoleApplicationLogger');
+    expect(runtime).not.toHaveProperty('createJsonApplicationLogger');
     expect(runtime).toHaveProperty('APPLICATION_LOGGER');
     expect(runtime).toHaveProperty('PLATFORM_SHELL');
     expect(runtime).not.toHaveProperty('MetricsModule');
@@ -45,6 +45,11 @@ describe('runtime export boundaries', () => {
     expect(runtimeInternalHttpAdapter.bootstrapHttpAdapterApplication).toBeTypeOf('function');
     expect(runtimeInternalHttpAdapter.runHttpAdapterApplication).toBeTypeOf('function');
     expect(runtimeInternalRequestResponseFactory.dispatchWithRequestResponseFactory).toBeTypeOf('function');
+  });
+
+  it('exposes Node-only logger factories only on the ./node subpath', () => {
+    expect(runtimeNode.createConsoleApplicationLogger).toBeTypeOf('function');
+    expect(runtimeNode.createJsonApplicationLogger).toBeTypeOf('function');
   });
 
   it('declares the narrowed package export map', () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3,8 +3,6 @@ export * from './bootstrap.js';
 export * from './health/diagnostics.js';
 export * from './errors.js';
 export * from './health/health.js';
-export * from './logging/json-logger.js';
-export * from './logging/logger.js';
 export type {
   MultipartOptions,
   MultipartRequestLike,

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -1,1 +1,3 @@
+export * from './logging/json-logger.js';
+export * from './logging/logger.js';
 export * from './node/internal-node.js';


### PR DESCRIPTION
## Summary

Closes #928

- **Removed** `createConsoleApplicationLogger` and `createJsonApplicationLogger` from the universal `@konekti/runtime` root barrel (`index.ts`). Both use `process.stdout`, `process.stderr`, and `process.pid` — Node-only APIs that break cross-runtime portability.
- **Added** the same exports to the `./node` subpath entrypoint (`node.ts`), preserving full access for Node consumers via `@konekti/runtime/node`.
- **Updated** export boundary tests to assert loggers are absent from root and present on `./node`, plus a new dedicated test case for the Node-only logger subpath.
- **Updated** both README (EN/KO) to document the Node-specific subpath for logger factories.

## Verification

- `pnpm build` — full monorepo build passes
- `pnpm --filter @konekti/runtime typecheck` — clean
- `pnpm --filter @konekti/runtime test` — 138 tests passed, 0 failures
- Export boundary test (`exports.test.ts`) now asserts:
  - `runtime` root does NOT have `createConsoleApplicationLogger` or `createJsonApplicationLogger`
  - `runtimeNode` (./node) DOES have both

## Contract Impact

This is a **breaking change** to the root barrel's public export surface:

| Symbol | Before | After |
|--------|--------|-------|
| `createConsoleApplicationLogger` | `@konekti/runtime` | `@konekti/runtime/node` |
| `createJsonApplicationLogger` | `@konekti/runtime` | `@konekti/runtime/node` |

Consumers importing these from the root entrypoint must update to the `./node` subpath. This is permitted under 0.x breaking change policy (with migration note).

Internal modules (`bootstrap.ts`, `http-adapter-shared.ts`) use direct relative imports to the logger files, so they are unaffected.

## Remaining Risks

- Downstream packages or user code importing `createConsoleApplicationLogger`/`createJsonApplicationLogger` from `@konekti/runtime` will get a build error. Migration path is straightforward: change import to `@konekti/runtime/node`.
- `bootstrap.ts` and `http-adapter-shared.ts` still use `createConsoleApplicationLogger` as the default logger internally. This is intentional — those modules run in Node context. A future follow-up could make the default logger runtime-adaptive.