### PR TITLE
Resolve #929: harden Bun and Deno shutdown draining

### DIFF
--- a/packages/platform-bun/README.ko.md
+++ b/packages/platform-bun/README.ko.md
@@ -24,6 +24,8 @@ npm install @konekti/platform-bun
 
 Konekti 애플리케이션을 [Bun](https://bun.sh/) 런타임에서 실행할 때 이 패키지를 사용합니다. 이 어댑터는 Bun의 고성능 `Request`/`Response` 브리지와 네이티브 `fetch` 방식의 아키텍처를 활용하여 Bun 사용자에게 원활하고 빠른 경험을 제공합니다.
 
+애플리케이션 종료 중에는 새 유입을 중단하고, Bun이 서버를 강제로 내리기 전에 활성 HTTP 핸들러가 bounded drain window 안에서 마무리될 수 있도록 동작합니다.
+
 ## 빠른 시작
 
 ```typescript
@@ -83,4 +85,3 @@ export class MyGateway {}
 
 - `packages/platform-bun/src/adapter.test.ts`
 - `packages/websockets/src/bun/bun.test.ts`
-

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -24,6 +24,8 @@ npm install @konekti/platform-bun
 
 Use this package when running Konekti applications on the [Bun](https://bun.sh/) runtime. This adapter leverages Bun's high-performance `Request`/`Response` bridge and native `fetch`-style architecture, providing a seamless and fast experience for Bun users.
 
+During application shutdown, the adapter stops new ingress and gives active HTTP handlers a bounded drain window before Bun forcefully tears the server down.
+
 ## Quick Start
 
 ```typescript
@@ -83,4 +85,3 @@ export class MyGateway {}
 
 - `packages/platform-bun/src/adapter.test.ts`
 - `packages/websockets/src/bun/bun.test.ts`
-

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -38,6 +38,17 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
 function installMockBun(): MockBun {
   const mockBun = {} as MockBun;
 
@@ -265,6 +276,77 @@ describe('@konekti/platform-bun', () => {
     }
 
     expect(process.listeners(signal).length).toBe(listenersBefore);
+  });
+
+  it('drains in-flight requests before Bun close resolves', async () => {
+    const mockBun = installMockBun();
+    const adapter = createBunAdapter() as BunHttpApplicationAdapter;
+    const deferred = createDeferred<void>();
+    let closeSettled = false;
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        await deferred.promise;
+        response.setStatus(200);
+        await response.send({ ok: true });
+      },
+    });
+
+    const responsePromise = mockBun.lastServer!.fetch(new Request('http://127.0.0.1:3000/drain'));
+    const closePromise = adapter.close().then(() => {
+      closeSettled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(closeSettled).toBe(false);
+    expect(mockBun.lastServer?.stop).toHaveBeenCalledTimes(1);
+
+    deferred.resolve();
+
+    await expect(responsePromise).resolves.toBeInstanceOf(Response);
+    await closePromise;
+
+    expect(closeSettled).toBe(true);
+    expect(adapter.getServer()).toBeUndefined();
+  });
+
+  it('keeps the Bun dispatcher until drain settles even when close() times out', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const mockBun = installMockBun();
+      const adapter = createBunAdapter() as BunHttpApplicationAdapter;
+      const deferred = createDeferred<void>();
+      const dispatcher = {
+        async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+          await deferred.promise;
+          response.setStatus(200);
+          await response.send({ ok: true });
+        },
+      };
+
+      await adapter.listen(dispatcher);
+
+      const responsePromise = mockBun.lastServer!.fetch(new Request('http://127.0.0.1:3000/timeout-check'));
+      const closeResultPromise = adapter.close().catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      await expect(closeResultPromise).resolves.toBeInstanceOf(Error);
+      expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
+
+      deferred.resolve();
+      await responsePromise;
+      vi.useRealTimers();
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('throws a clear error when Bun.serve() is unavailable', async () => {

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -164,10 +164,15 @@ export interface RunBunApplicationOptions extends BootstrapBunApplicationOptions
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_DISPATCHER_NOT_READY_MESSAGE = 'Bun adapter received a request before dispatcher binding completed.';
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 const BUN_WEBSOCKET_SUPPORT_REASON =
   'Bun exposes Bun.serve() + server.upgrade() request-upgrade hosting. Use @konekti/websockets/bun for the official raw websocket binding.';
 
 export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWebSocketBindingHost {
+  private closeInFlight?: Promise<void>;
+  private dispatcher?: Dispatcher;
+  private inFlightDrain?: Deferred<void>;
+  private inFlightRequestCount = 0;
   private server?: BunServerLike;
   private realtimeBinding?: BunWebSocketBinding<unknown>;
 
@@ -210,15 +215,14 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   }
 
   async listen(dispatcher: Dispatcher): Promise<void> {
+    this.dispatcher = dispatcher;
+
+    if (this.server) {
+      return;
+    }
+
     const bun = requireBunGlobal();
     const realtimeBinding = this.realtimeBinding;
-
-    const fetch = createBunFetchHandler({
-      dispatcher,
-      maxBodySize: this.options.maxBodySize,
-      multipart: this.options.multipart,
-      rawBody: this.options.rawBody,
-    });
 
     this.server = bun.serve({
       development: this.options.development,
@@ -235,9 +239,7 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
           }
         }
 
-        const response = await fetch(request);
-
-        return response;
+        return await this.dispatchHttpRequest(request);
       },
       hostname: this.options.hostname,
       idleTimeout: realtimeBinding?.idleTimeout ?? this.options.idleTimeout,
@@ -249,13 +251,85 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   }
 
   async close(): Promise<void> {
+    if (this.closeInFlight) {
+      await waitForCloseWithTimeout(this.closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+      return;
+    }
+
     if (!this.server) {
+      this.dispatcher = undefined;
       return;
     }
 
     const server = this.server;
-    this.server = undefined;
-    server.stop(this.options.stopActiveConnections);
+    const closePromise = closeBunServerWithDrain(
+      server,
+      this.options.stopActiveConnections,
+      () => this.waitForInFlightRequests(),
+    );
+    const closeInFlight = closePromise.finally(() => {
+      if (this.server === server) {
+        this.server = undefined;
+      }
+
+      this.closeInFlight = undefined;
+      this.dispatcher = undefined;
+    });
+
+    this.closeInFlight = closeInFlight;
+    void closeInFlight.catch(() => {});
+
+    await waitForCloseWithTimeout(closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+  }
+
+  private async dispatchHttpRequest(request: Request): Promise<Response> {
+    if (this.closeInFlight) {
+      return createShutdownResponse();
+    }
+
+    const release = this.trackInFlightRequest();
+
+    try {
+      return await dispatchWebRequest({
+        dispatcher: this.dispatcher,
+        dispatcherNotReadyMessage: DEFAULT_DISPATCHER_NOT_READY_MESSAGE,
+        maxBodySize: this.options.maxBodySize,
+        multipart: this.options.multipart,
+        rawBody: this.options.rawBody,
+        request,
+      });
+    } finally {
+      release();
+    }
+  }
+
+  private trackInFlightRequest(): () => void {
+    this.inFlightRequestCount += 1;
+
+    if (this.inFlightRequestCount === 1) {
+      this.inFlightDrain = createDeferred<void>();
+    }
+
+    return () => {
+      if (this.inFlightRequestCount === 0) {
+        return;
+      }
+
+      this.inFlightRequestCount -= 1;
+
+      if (this.inFlightRequestCount === 0) {
+        this.inFlightDrain?.resolve();
+        this.inFlightDrain = undefined;
+      }
+    };
+  }
+
+  private async waitForInFlightRequests(): Promise<void> {
+    if (this.inFlightRequestCount === 0) {
+      return;
+    }
+
+    await this.inFlightDrain?.promise;
   }
 }
 
@@ -341,6 +415,60 @@ function resolvePort(port: number | undefined): number {
   return typeof port === 'number' && Number.isFinite(port) ? port : DEFAULT_PORT;
 }
 
+function closeBunServerWithDrain(
+  server: BunServerLike,
+  stopActiveConnections: boolean | undefined,
+  waitForDrain: () => Promise<void>,
+): Promise<void> {
+  return (async () => {
+    server.stop(stopActiveConnections);
+    await waitForDrain();
+  })();
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createShutdownResponse(): Response {
+  return new Response(JSON.stringify({
+    error: {
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'Server is shutting down.',
+      status: 503,
+    },
+  }), {
+    headers: {
+      'content-type': 'application/json',
+    },
+    status: 503,
+  });
+}
+
+function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number): Promise<void> {
+  return Promise.race([
+    closePromise,
+    new Promise<void>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Bun adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+    }),
+  ]);
+}
+
 function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
 }

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -24,6 +24,8 @@ deno add npm:@konekti/platform-deno npm:@konekti/runtime npm:@konekti/http
 
 Konekti 애플리케이션을 [Deno](https://deno.com/) 런타임에서 실행할 때 이 패키지를 사용합니다. 이 어댑터는 Deno의 네이티브 `fetch` 표준 `Request` 및 `Response` 객체를 활용하여 TypeScript 백엔드 개발을 위한 안전하고 고성능인 환경을 제공합니다.
 
+애플리케이션 종료 중에는 새 유입을 중단하고, Deno 서버 수명주기가 종료되기 전에 활성 HTTP 핸들러가 bounded drain window 안에서 마무리될 수 있도록 동작합니다.
+
 ## 빠른 시작
 
 ```typescript
@@ -71,4 +73,3 @@ export class MyGateway {}
 
 - `packages/platform-deno/src/adapter.test.ts`
 - `packages/websockets/src/deno/deno.test.ts`
-

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -24,6 +24,8 @@ deno add npm:@konekti/platform-deno npm:@konekti/runtime npm:@konekti/http
 
 Use this package when running Konekti applications on the [Deno](https://deno.com/) runtime. This adapter leverages Deno's native `fetch`-standard `Request` and `Response` objects, providing a secure and high-performance environment for TypeScript backend development.
 
+During application shutdown, the adapter stops new ingress and gives active HTTP handlers a bounded drain window before the Deno server lifecycle completes.
+
 ## Quick Start
 
 ```typescript
@@ -71,4 +73,3 @@ export class MyGateway {}
 
 - `packages/platform-deno/src/adapter.test.ts`
 - `packages/websockets/src/deno/deno.test.ts`
-

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -5,6 +5,8 @@ import {
   Get,
   Post,
   SseResponse,
+  type FrameworkRequest,
+  type FrameworkResponse,
   type RequestContext,
 } from '@konekti/http';
 import { defineModule, type ApplicationLogger } from '@konekti/runtime';
@@ -255,6 +257,85 @@ describe('@konekti/platform-deno', () => {
     );
 
     await app.close();
+  });
+
+  it('drains in-flight requests before Deno close resolves', async () => {
+    const server = createServeStub();
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: server.serve,
+    });
+    const deferred = createDeferred<void>();
+    let closeSettled = false;
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        await deferred.promise;
+        response.setStatus(200);
+        await response.send({ ok: true });
+      },
+    });
+
+    const responsePromise = server.handler!(new Request('https://runtime.test/drain'));
+    const closePromise = adapter.close().then(() => {
+      closeSettled = true;
+    });
+
+    await Promise.resolve();
+
+    expect(closeSettled).toBe(false);
+    expect(server.shutdown).toHaveBeenCalledTimes(1);
+
+    deferred.resolve();
+
+    await expect(responsePromise).resolves.toBeInstanceOf(Response);
+    await closePromise;
+
+    expect(closeSettled).toBe(true);
+    expect(adapter.getServer()).toBeUndefined();
+  });
+
+  it('keeps the Deno dispatcher until drain settles even when close() times out', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const server = createServeStub();
+      const adapter = new DenoHttpApplicationAdapter({
+        hostname: '0.0.0.0',
+        port: 3000,
+        serve: server.serve,
+      });
+      const deferred = createDeferred<void>();
+      const dispatcher = {
+        async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+          await deferred.promise;
+          response.setStatus(200);
+          await response.send({ ok: true });
+        },
+      };
+
+      await adapter.listen(dispatcher);
+
+      const responsePromise = server.handler!(new Request('https://runtime.test/timeout-check'));
+      const closeResultPromise = adapter.close().catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      await expect(closeResultPromise).resolves.toBeInstanceOf(Error);
+      expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
+
+      deferred.resolve();
+      await responsePromise;
+      vi.useRealTimers();
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+
+      expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('exposes a not-ready error when requests arrive before listen()', async () => {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -83,6 +83,7 @@ export interface RunDenoApplicationOptions extends RunHttpAdapterApplicationOpti
 
 const DEFAULT_HOSTNAME = '0.0.0.0';
 const DEFAULT_PORT = 3000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 
 declare global {
   interface GlobalThis {
@@ -94,6 +95,8 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
   private abortController?: AbortController;
   private closeInFlight?: Promise<void>;
   private dispatcher?: Dispatcher;
+  private inFlightDrain?: Deferred<void>;
+  private inFlightRequestCount = 0;
   private server?: DenoServeController;
   private websocketBinding?: DenoWebSocketBinding<DenoServerWebSocket>;
 
@@ -125,22 +128,32 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
   }
 
   async handle(request: Request): Promise<Response> {
-    if (this.websocketBinding && isWebSocketUpgradeRequest(request)) {
-      const upgradeWebSocket = resolveUpgradeWebSocket(this.options.upgradeWebSocket);
-
-      return await this.websocketBinding.fetch(request, {
-        upgrade: (upgradeRequest) => upgradeWebSocket(upgradeRequest),
-      });
+    if (this.closeInFlight) {
+      return createShutdownResponse();
     }
 
-    return await dispatchWebRequest({
-      dispatcher: this.dispatcher,
-      dispatcherNotReadyMessage: 'Deno adapter received a request before dispatcher binding completed.',
-      maxBodySize: this.options.maxBodySize,
-      multipart: this.options.multipart,
-      rawBody: this.options.rawBody,
-      request,
-    });
+    const release = this.trackInFlightRequest();
+
+    try {
+      if (this.websocketBinding && isWebSocketUpgradeRequest(request)) {
+        const upgradeWebSocket = resolveUpgradeWebSocket(this.options.upgradeWebSocket);
+
+        return await this.websocketBinding.fetch(request, {
+          upgrade: (upgradeRequest) => upgradeWebSocket(upgradeRequest),
+        });
+      }
+
+      return await dispatchWebRequest({
+        dispatcher: this.dispatcher,
+        dispatcherNotReadyMessage: 'Deno adapter received a request before dispatcher binding completed.',
+        maxBodySize: this.options.maxBodySize,
+        multipart: this.options.multipart,
+        rawBody: this.options.rawBody,
+        request,
+      });
+    } finally {
+      release();
+    }
   }
 
   async listen(dispatcher: Dispatcher): Promise<void> {
@@ -166,31 +179,70 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
 
   async close(): Promise<void> {
     if (this.closeInFlight) {
-      await this.closeInFlight;
+      await waitForCloseWithTimeout(this.closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
       return;
     }
 
     const server = this.server;
     const abortController = this.abortController;
 
-    this.server = undefined;
-    this.abortController = undefined;
-
     if (!server) {
       this.dispatcher = undefined;
+      this.abortController = undefined;
       return;
     }
 
-    this.closeInFlight = (async () => {
-      abortController?.abort();
-      await server.shutdown();
-      await server.finished;
-      this.dispatcher = undefined;
-    })().finally(() => {
+    const closePromise = closeDenoServerWithDrain(
+      server,
+      abortController,
+      () => this.waitForInFlightRequests(),
+    );
+    const closeInFlight = closePromise.finally(() => {
+      if (this.server === server) {
+        this.server = undefined;
+      }
+
+      if (this.abortController === abortController) {
+        this.abortController = undefined;
+      }
+
       this.closeInFlight = undefined;
+      this.dispatcher = undefined;
     });
 
-    await this.closeInFlight;
+    this.closeInFlight = closeInFlight;
+    void closeInFlight.catch(() => {});
+
+    await waitForCloseWithTimeout(closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+  }
+
+  private trackInFlightRequest(): () => void {
+    this.inFlightRequestCount += 1;
+
+    if (this.inFlightRequestCount === 1) {
+      this.inFlightDrain = createDeferred<void>();
+    }
+
+    return () => {
+      if (this.inFlightRequestCount === 0) {
+        return;
+      }
+
+      this.inFlightRequestCount -= 1;
+
+      if (this.inFlightRequestCount === 0) {
+        this.inFlightDrain?.resolve();
+        this.inFlightDrain = undefined;
+      }
+    };
+  }
+
+  private async waitForInFlightRequests(): Promise<void> {
+    if (this.inFlightRequestCount === 0) {
+      return;
+    }
+
+    await this.inFlightDrain?.promise;
   }
 }
 
@@ -260,4 +312,60 @@ function resolveUpgradeWebSocket(
 
 function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
+}
+
+function closeDenoServerWithDrain(
+  server: DenoServeController,
+  abortController: AbortController | undefined,
+  waitForDrain: () => Promise<void>,
+): Promise<void> {
+  return (async () => {
+    abortController?.abort();
+    await server.shutdown();
+    await waitForDrain();
+    await server.finished;
+  })();
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
+function createShutdownResponse(): Response {
+  return new Response(JSON.stringify({
+    error: {
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'Server is shutting down.',
+      status: 503,
+    },
+  }), {
+    headers: {
+      'content-type': 'application/json',
+    },
+    status: 503,
+  });
+}
+
+function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number): Promise<void> {
+  return Promise.race([
+    closePromise,
+    new Promise<void>((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error(`Deno adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+    }),
+  ]);
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  reject: (reason?: unknown) => void;
+  resolve: (value: T | PromiseLike<T>) => void;
 }


### PR DESCRIPTION
## Summary
- add bounded shutdown drain tracking to `@konekti/platform-bun` and `@konekti/platform-deno` without changing their public API shape
- keep dispatcher cleanup aligned with the mature Node-backed adapters and return a shutdown guard response for late requests during close
- document the lifecycle guarantee in the affected package READMEs and add regression coverage for in-flight request draining/timeouts

## Changes
- Bun adapter: track in-flight requests, wait for drain during close, keep dispatcher bound until shutdown settles, and guard late requests with `503`
- Deno adapter: mirror the same bounded drain/dispatcher cleanup pattern around `AbortController` + `server.shutdown()`
- README/README.ko updates for both packages to document the shutdown drain guarantee
- regression tests for in-flight request drain and close-timeout behavior in both adapter suites

## Testing
- `pnpm exec vitest run packages/platform-bun/src/adapter.test.ts packages/platform-deno/src/adapter.test.ts`
- `pnpm --filter @konekti/platform-bun... --filter @konekti/platform-deno... run build`
- `lsp_diagnostics` clean on changed Bun/Deno adapter source and test files

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Contract impact: none beyond strengthening shutdown/drain guarantees for Bun and Deno adapters.

Closes #929