### PR TITLE
Resolve #937: harden Redis throttler TTL-boundary persistence

### DIFF
--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -8,7 +8,12 @@ import { ThrottlerGuard } from './guard.js';
 import { ThrottlerModule, createThrottlerProviders } from './module.js';
 import { createMemoryThrottlerStore } from './store.js';
 import { THROTTLER_OPTIONS } from './tokens.js';
-import type { ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+import type {
+  ThrottlerConsumeInput,
+  ThrottlerModuleOptions,
+  ThrottlerStore,
+  ThrottlerStoreEntry,
+} from './types.js';
 
 function createRequestContext(remoteAddress = '127.0.0.1'): RequestContext {
   const headers: Record<string, string | string[]> = {};
@@ -433,7 +438,7 @@ describe('ThrottlerGuard — Redis store mock', () => {
   it('delegates atomic consume calls to the provided store', async () => {
     const entries = new Map<string, ThrottlerStoreEntry>();
     const store: ThrottlerStore = {
-      consume: vi.fn((key: string, input) => {
+      consume: vi.fn((key: string, input: ThrottlerConsumeInput) => {
         const now = input.now;
         const ttlMs = input.ttlSeconds * 1000;
         const entry = entries.get(key);
@@ -468,7 +473,7 @@ describe('ThrottlerGuard — Redis store mock', () => {
 
   it('builds store keys from route and token identity context', async () => {
     const store: ThrottlerStore = {
-      consume: vi.fn(async (_key: string, input) => ({
+      consume: vi.fn(async (_key: string, input: ThrottlerConsumeInput) => ({
         count: 1,
         resetAt: input.now + input.ttlSeconds * 1000,
       })),
@@ -515,7 +520,7 @@ describe('ThrottlerGuard — Redis store mock', () => {
 
   it('builds the same store key even when handler discovery order differs across module instances', async () => {
     const buildStore = (): ThrottlerStore => ({
-      consume: vi.fn(async (_key: string, input) => ({
+      consume: vi.fn(async (_key: string, input: ThrottlerConsumeInput) => ({
         count: 1,
         resetAt: input.now + input.ttlSeconds * 1000,
       })),

--- a/packages/throttler/src/redis-store.test.ts
+++ b/packages/throttler/src/redis-store.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type Redis from 'ioredis';
+
+import { RedisThrottlerStore } from './redis-store.js';
+
+function createRedisClientMock(result: unknown) {
+  return {
+    eval: vi.fn(async () => result),
+  } as unknown as Pick<Redis, 'eval'>;
+}
+
+describe('RedisThrottlerStore', () => {
+  it('persists the reset window at the TTL boundary with millisecond precision', async () => {
+    const now = 1_710_000_000_000;
+    const client = createRedisClientMock([1, now + 60_000]);
+    const store = new RedisThrottlerStore(client as Redis);
+
+    const entry = await store.consume('throttle:auth:127.0.0.1', {
+      now,
+      ttlSeconds: 60,
+    });
+
+    expect(entry).toEqual({ count: 1, resetAt: now + 60_000 });
+    expect(client.eval).toHaveBeenCalledWith(
+      expect.stringContaining("math.max(resetAt - now, 1)"),
+      1,
+      'throttle:auth:127.0.0.1',
+      String(now),
+      '60000',
+    );
+    expect(client.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('SET', key, cjson.encode({ count = count, resetAt = resetAt }), 'PX', ttlMsLeft)"),
+      1,
+      'throttle:auth:127.0.0.1',
+      String(now),
+      '60000',
+    );
+  });
+
+  it('rejects malformed consume-script responses', async () => {
+    const client = createRedisClientMock(['not-a-number', 'still-not-a-number']);
+    const store = new RedisThrottlerStore(client as Redis);
+
+    await expect(
+      store.consume('throttle:auth:127.0.0.1', {
+        now: 1_710_000_000_000,
+        ttlSeconds: 60,
+      }),
+    ).rejects.toThrow('Redis throttler consume script returned non-numeric counters.');
+  });
+});

--- a/packages/throttler/src/redis-store.ts
+++ b/packages/throttler/src/redis-store.ts
@@ -23,11 +23,8 @@ const CONSUME_LUA = [
   '    count = count + 1',
   '  end',
   'end',
-  'local ttlMsLeft = resetAt - now',
-  "if ttlMsLeft > 0 then",
-  '  local ttlSeconds = math.floor((ttlMsLeft + 999) / 1000)',
-  "  redis.call('SET', key, cjson.encode({ count = count, resetAt = resetAt }), 'EX', ttlSeconds)",
-  'end',
+  'local ttlMsLeft = math.max(resetAt - now, 1)',
+  "redis.call('SET', key, cjson.encode({ count = count, resetAt = resetAt }), 'PX', ttlMsLeft)",
   'return {count, resetAt}',
 ].join('\n');
 

--- a/packages/throttler/src/vitest-module.d.ts
+++ b/packages/throttler/src/vitest-module.d.ts
@@ -1,0 +1,6 @@
+declare module 'vitest' {
+  export const describe: typeof globalThis.describe;
+  export const expect: typeof globalThis.expect;
+  export const it: typeof globalThis.it;
+  export const vi: typeof globalThis.vi;
+}

--- a/packages/throttler/src/vitest-module.d.ts
+++ b/packages/throttler/src/vitest-module.d.ts
@@ -1,4 +1,5 @@
 declare module 'vitest' {
+  export const beforeEach: typeof globalThis.beforeEach;
   export const describe: typeof globalThis.describe;
   export const expect: typeof globalThis.expect;
   export const it: typeof globalThis.it;

--- a/packages/throttler/tsconfig.json
+++ b/packages/throttler/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "types": ["node"]
+    "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Closes #937

## Summary
- fix the Redis throttler consume script so TTL-boundary resets are always persisted with millisecond precision
- add direct regression coverage for the Redis consume path, including malformed script return handling
- keep the documented distributed Redis throttling contract unchanged

## Changes
- switch the Redis Lua consume script from second-rounded `EX` writes to unconditional millisecond `PX` writes with a 1ms floor
- add `packages/throttler/src/redis-store.test.ts` to cover TTL-boundary persistence and invalid script responses
- add package-local Vitest typing support for throttler test files via `packages/throttler/tsconfig.json` and `packages/throttler/src/vitest-module.d.ts`

## Testing
- `pnpm exec vitest run packages/throttler/src/redis-store.test.ts packages/throttler/src/module.test.ts packages/throttler/src/status.test.ts`
- `pnpm --filter @konekti/throttler... build`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
