### PR TITLE
Resolve #936: fix validation error identity and schema fallback handling

### DIFF
--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -88,6 +88,7 @@ class UpdateUserDto extends PartialType(UserDto) {}
 ### Standard Schema 지원 (Zod, Valibot)
 
 `@ValidateClass`를 통해 클래스 레벨에서 선호하는 스키마 라이브러리를 사용할 수 있습니다. Konekti는 [Standard Schema](https://github.com/standard-schema/spec) 규격을 구현하는 모든 라이브러리를 지원합니다.
+유효하지 않은 입력은 명시적인 `issues`로 보고되어야 하며, 이슈가 없는 검증 결과는 성공으로 처리합니다.
 
 ```typescript
 import { ValidateClass } from '@konekti/validation';
@@ -146,4 +147,3 @@ class UserDto {
 
 - `packages/validation/src/validation.test.ts`: 모든 데코레이터와 엔진에 대한 종합 테스트.
 - `examples/realworld-api`: 실제 프로덕션과 유사한 환경에서의 DTO 사용 예시.
-

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -80,6 +80,8 @@ class UpdateUserDto extends PartialType(UserDto) {}
 
 ### Standard Schema support
 
+Standard Schema adapters are expected to report invalid input through explicit issues. Validation results without issues are treated as successful.
+
 ```ts
 import { ValidateClass } from '@konekti/validation';
 import { z } from 'zod';

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -55,6 +55,7 @@
     "@types/validator": "^13.15.10",
     "arktype": "^2.2.0",
     "valibot": "^1.0.0",
+    "vitest": "^3.2.4",
     "zod": "^4.1.11"
   }
 }

--- a/packages/validation/src/errors.ts
+++ b/packages/validation/src/errors.ts
@@ -6,6 +6,7 @@ export class DtoValidationError extends Error {
     readonly issues: readonly ValidationIssue[],
   ) {
     super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = 'DtoValidationError';
   }
 }

--- a/packages/validation/src/standard-schema.ts
+++ b/packages/validation/src/standard-schema.ts
@@ -101,16 +101,26 @@ function toStandardValidationIssue(issue: StandardSchemaIssueLike): ValidationIs
   };
 }
 
+function isStandardSchemaFailureResult(
+  result: unknown,
+): result is { readonly issues?: readonly StandardSchemaIssueLike[] | unknown } {
+  return typeof result === 'object' && result !== null && 'issues' in result;
+}
+
 export function createClassValidatorFromStandardSchema(schema: StandardSchemaV1Like): CustomClassValidator {
-  return async (value) => {
+  return async (value: unknown) => {
     const result = await schema['~standard'].validate(value);
 
-    if (Array.isArray(result.issues)) {
-      return result.issues.length > 0
-        ? result.issues.map((issue) => toStandardValidationIssue(issue))
-        : [{ code: 'INVALID_FIELD', message: 'Invalid value.' }];
+    if (!isStandardSchemaFailureResult(result) || result.issues === undefined) {
+      return true;
     }
 
-    return true;
+    if (!Array.isArray(result.issues)) {
+      return [{ code: 'INVALID_SCHEMA_RESULT', message: 'Standard Schema validator returned malformed issues.' }];
+    }
+
+    return result.issues.length > 0
+      ? result.issues.map((issue) => toStandardValidationIssue(issue))
+      : true;
   };
 }

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -273,6 +273,14 @@ describe('DefaultValidator', () => {
     await expect(validator.materialize({ email: 'not-an-email' }, CreateUserDto)).rejects.toBeInstanceOf(DtoValidationError);
   });
 
+  it('preserves DtoValidationError prototype identity', () => {
+    const error = new DtoValidationError('Validation failed.', []);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(DtoValidationError);
+    expect(Object.getPrototypeOf(error)).toBe(DtoValidationError.prototype);
+  });
+
   it('resolves lazy circular nested references at validation time', async () => {
     class ParentDto {
       @MinLength(1)
@@ -675,6 +683,46 @@ describe('DefaultValidator', () => {
       validator.validate(Object.assign(new CreateUserDto(), { email: 'bad' }), CreateUserDto),
     ).rejects.toMatchObject({
       issues: expect.arrayContaining([expect.objectContaining({ field: 'email' })]),
+    });
+  });
+
+  it('treats empty Standard Schema issues as a successful validation result', async () => {
+    @ValidateClass({
+      '~standard': {
+        validate: async () => ({ issues: [] }),
+        vendor: 'test',
+        version: 1,
+      },
+    })
+    class CreateUserDto {
+      email = '';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(Object.assign(new CreateUserDto(), { email: 'hello@konekti.dev' }), CreateUserDto),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects malformed Standard Schema issues payloads explicitly', async () => {
+    @ValidateClass({
+      '~standard': {
+        validate: async () => ({ issues: 'bad-result' }) as never,
+        vendor: 'test',
+        version: 1,
+      },
+    })
+    class CreateUserDto {
+      email = '';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(Object.assign(new CreateUserDto(), { email: 'hello@konekti.dev' }), CreateUserDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_SCHEMA_RESULT', message: 'Standard Schema validator returned malformed issues.' }],
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,9 @@ importers:
       valibot:
         specifier: ^1.0.0
         version: 1.3.1(typescript@5.9.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
       zod:
         specifier: ^4.1.11
         version: 4.3.6


### PR DESCRIPTION
## Summary
- restore `DtoValidationError` prototype identity so runtime `instanceof` checks remain reliable
- treat Standard Schema results with empty `issues` as success and reject malformed `issues` payloads explicitly
- add targeted regression coverage and align validation README wording with the adapter semantics

## Changes
- update `packages/validation/src/errors.ts` to restore the subclass prototype chain
- tighten `packages/validation/src/standard-schema.ts` result handling for empty and malformed `issues`
- add regression tests in `packages/validation/src/validation.test.ts`
- document the Standard Schema success semantics in `packages/validation/README.md` and `packages/validation/README.ko.md`
- add local `vitest` package metadata for the validation workspace package

## Testing
- `pnpm --filter @konekti/core build`
- `pnpm --filter @konekti/validation test`
- `pnpm --filter @konekti/validation build`
- `pnpm --filter @konekti/validation typecheck`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #936