### PR TITLE
docs: align runtime export surfaces and adapter naming

### DIFF
--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -106,6 +106,14 @@ stream(_input: undefined, ctx: RequestContext) {
 - **예외**: `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `InternalServerErrorException`, `PayloadTooLargeException`
 - **헬퍼**: `createHandlerMapping`, `createDispatcher`, `createCorsMiddleware`, `getCurrentRequestContext`
 
+## 내부 서브경로 (`@konekti/http/internal`)
+
+`./internal` 서브경로는 플랫폼 어댑터와 핵심 런타임에서 사용하는 저수준 유틸리티를 내보냅니다. 이들은 변경될 수 있으며 일반적인 애플리케이션 코드에서 사용해서는 안 됩니다.
+
+- `createErrorResponse(error, requestId)`: 표준화된 JSON 에러 응답 팩토리.
+- `HttpException`: 모든 프레임워크 수준 HTTP 에러의 기본 클래스.
+- `PLATFORM_SHELL`: 활성 플랫폼 어댑터를 위한 DI 토큰.
+
 ## 관련 패키지
 
 - `@konekti/core`: 컨트롤러, 라우트, DTO 메타데이터를 저장합니다.

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -108,6 +108,14 @@ stream(_input: undefined, ctx: RequestContext) {
 - **Exceptions**: `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `InternalServerErrorException`, `PayloadTooLargeException`
 - **Helpers**: `createHandlerMapping`, `createDispatcher`, `createCorsMiddleware`, `getCurrentRequestContext`
 
+## Internal Subpath (`@konekti/http/internal`)
+
+The `./internal` subpath exports low-level utilities used by platform adapters and the core runtime. These are subject to change and should not be used in typical application code.
+
+- `createErrorResponse(error, requestId)`: Standardized JSON error response factory.
+- `HttpException`: Base class for all framework-level HTTP errors.
+- `PLATFORM_SHELL`: DI token for the active platform adapter.
+
 ## Related Packages
 
 - `@konekti/core`: stores controller, route, and DTO metadata

--- a/packages/platform-cloudflare-workers/README.ko.md
+++ b/packages/platform-cloudflare-workers/README.ko.md
@@ -82,8 +82,8 @@ const adapter = createCloudflareWorkerAdapter({
 
 - `createCloudflareWorkerAdapter(options)`: Worker HTTP 어댑터를 위한 팩토리입니다.
 - `createCloudflareWorkerEntrypoint(module, options)`: 지연 부트스트랩 방식의 Worker 엔트리포인트를 생성합니다.
-- `bootstrapCloudflareWorkerApplication(module, options)`: 동기 방식의 부트스트랩 헬퍼입니다.
-- `CloudflareWorkerHttpAdapter`: 핵심 어댑터 구현 클래스입니다.
+- `bootstrapCloudflareWorkerApplication(module, options)`: Worker를 위한 비동기 부트스트랩 헬퍼입니다.
+- `CloudflareWorkerHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 
 ## 관련 패키지
 

--- a/packages/platform-cloudflare-workers/README.md
+++ b/packages/platform-cloudflare-workers/README.md
@@ -82,8 +82,8 @@ const adapter = createCloudflareWorkerAdapter({
 
 - `createCloudflareWorkerAdapter(options)`: Factory for the Worker HTTP adapter.
 - `createCloudflareWorkerEntrypoint(module, options)`: Creates a lazy-bootstrapping Worker entrypoint.
-- `bootstrapCloudflareWorkerApplication(module, options)`: Synchronous bootstrap helper.
-- `CloudflareWorkerHttpAdapter`: The core adapter implementation.
+- `bootstrapCloudflareWorkerApplication(module, options)`: Async bootstrap helper for Workers.
+- `CloudflareWorkerHttpApplicationAdapter`: The core adapter implementation.
 
 ## Related Packages
 

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -68,7 +68,7 @@ const adapter = createExpressAdapter({
 - `createExpressAdapter(options)`: Express HTTP 어댑터를 위한 팩토리입니다.
 - `bootstrapExpressApplication(module, options)`: 수동 제어를 위한 고급 부트스트랩 헬퍼입니다.
 - `runExpressApplication(module, options)`: 시그널 연결을 포함한 빠른 시작을 위한 호환 헬퍼입니다.
-- `ExpressHttpAdapter`: 핵심 어댑터 구현 클래스입니다.
+- `ExpressHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 
 ## 관련 패키지
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -68,7 +68,7 @@ const adapter = createExpressAdapter({
 - `createExpressAdapter(options)`: Factory for the Express HTTP adapter.
 - `bootstrapExpressApplication(module, options)`: Advanced bootstrap helper for manual control.
 - `runExpressApplication(module, options)`: Compatibility helper for quick startup with signal wiring.
-- `ExpressHttpAdapter`: The core adapter implementation class.
+- `ExpressHttpApplicationAdapter`: The core adapter implementation class.
 
 ## Related Packages
 

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -76,7 +76,7 @@ Konekti의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 
 - `createFastifyAdapter(options)`: Fastify 어댑터를 위한 권장 팩토리입니다.
 - `bootstrapFastifyApplication(module, options)`: 암시적 리스닝 없이 수행하는 고급 부트스트랩입니다.
 - `runFastifyApplication(module, options)`: 생명주기 관리를 포함한 빠른 시작 헬퍼입니다.
-- `FastifyHttpAdapter`: 핵심 어댑터 구현 클래스입니다.
+- `FastifyHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 
 ## 관련 패키지
 

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -76,7 +76,7 @@ Konekti's Fastify adapter significantly outperforms the raw Node.js adapter in h
 - `createFastifyAdapter(options)`: Recommended factory for the Fastify adapter.
 - `bootstrapFastifyApplication(module, options)`: advanced bootstrap without implicit listening.
 - `runFastifyApplication(module, options)`: Quick-start helper with lifecycle management.
-- `FastifyHttpAdapter`: The core adapter implementation.
+- `FastifyHttpApplicationAdapter`: The core adapter implementation.
 
 ## Related Packages
 

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -72,7 +72,7 @@ await runNodejsApplication(AppModule, {
 - `createNodejsAdapter(options)`: raw Node.js HTTP 어댑터를 위한 기본 팩토리입니다.
 - `bootstrapNodejsApplication(module, options)`: 리스너를 시작하지 않고 애플리케이션 인스턴스를 생성합니다.
 - `runNodejsApplication(module, options)`: 생명주기 관리를 포함하여 애플리케이션을 부트스트랩하고 시작합니다.
-- `NodejsHttpAdapter`: `HttpApplicationAdapter`를 구현하는 기본 어댑터 클래스입니다.
+- `NodejsHttpApplicationAdapter`: `HttpApplicationAdapter`를 구현하는 기본 어댑터 클래스입니다.
 
 ## 관련 패키지
 

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -72,7 +72,7 @@ await runNodejsApplication(AppModule, {
 - `createNodejsAdapter(options)`: Primary factory for the raw Node.js HTTP adapter.
 - `bootstrapNodejsApplication(module, options)`: Creates an application instance without starting the listener.
 - `runNodejsApplication(module, options)`: Bootstraps and starts the application with lifecycle management.
-- `NodejsHttpAdapter`: The underlying adapter class implementing `HttpApplicationAdapter`.
+- `NodejsHttpApplicationAdapter`: The underlying adapter class implementing `HttpApplicationAdapter`.
 
 ## Related Packages
 

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -121,20 +121,20 @@ class UsersModule {}
 
 ## 공개 API 개요
 
-### `KonektiFactory`
-애플리케이션 라이프사이클 관리를 위한 정적 파사드입니다.
-- `create(rootModule, options)`: `Application`(HTTP 셸)을 반환합니다.
-- `createApplicationContext(rootModule, options)`: `ApplicationContext`(DI 셸)를 반환합니다.
-- `createMicroservice(rootModule, options)`: `MicroserviceApplication`을 반환합니다.
-
-### 인터페이스
+- `KonektiFactory`: 애플리케이션 라이프사이클 관리를 위한 정적 파사드입니다.
 - `Application`: `ApplicationContext`를 확장하며 `listen()`, `dispatch()`, `state`를 포함합니다.
 - `ApplicationContext`: `get<T>(token)`, `close()` 기능을 제공하며 `container`와 `modules`에 접근할 수 있습니다.
 - `LifecycleHooks`: `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `OnApplicationShutdown`.
-
-### 유틸리티
 - `defineModule(cls, metadata)`: 프로그래밍 방식의 모듈 정의 헬퍼입니다.
 - `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다.
+
+## 플랫폼 전용 서브경로
+
+| 서브경로 | 용도 |
+| :--- | :--- |
+| `@konekti/runtime/node` | Node.js 전용 로거 팩토리 (`createConsoleApplicationLogger`, `createJsonApplicationLogger`) 및 종료 시그널 등록. |
+| `@konekti/runtime/web` | Bun, Deno, Cloudflare Workers를 위한 공유 웹 표준 요청/응답 유틸리티. |
+| `@konekti/runtime/internal` | 저수준 오케스트레이션 헬퍼 및 HTTP 어댑터 기본 로직. |
 
 ### Node 전용 서브경로 (`@konekti/runtime/node`)
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -121,20 +121,20 @@ class UsersModule {}
 
 ## Public API Overview
 
-### `KonektiFactory`
-The static facade for application lifecycle management.
-- `create(rootModule, options)`: Returns `Application` (HTTP shell).
-- `createApplicationContext(rootModule, options)`: Returns `ApplicationContext` (DI shell).
-- `createMicroservice(rootModule, options)`: Returns `MicroserviceApplication`.
-
-### Interfaces
+- `KonektiFactory`: Static facade for application lifecycle management.
 - `Application`: Extends `ApplicationContext` with `listen()`, `dispatch()`, and `state`.
 - `ApplicationContext`: Provides `get<T>(token)`, `close()`, and access to `container` and `modules`.
 - `LifecycleHooks`: `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `OnApplicationShutdown`.
-
-### Utilities
 - `defineModule(cls, metadata)`: Programmatic module definition helper.
 - `bootstrapApplication(options)`: Lower-level async bootstrap function.
+
+## Platform-Specific Subpaths
+
+| Subpath | Purpose |
+| :--- | :--- |
+| `@konekti/runtime/node` | Node.js-specific logger factories (`createConsoleApplicationLogger`, `createJsonApplicationLogger`) and shutdown signal registration. |
+| `@konekti/runtime/web` | Shared Web-standard request/response utilities for Bun, Deno, and Cloudflare Workers. |
+| `@konekti/runtime/internal` | Low-level orchestration helpers and HTTP adapter base logic. |
 
 ### Node-Specific Subpath (`@konekti/runtime/node`)
 


### PR DESCRIPTION
## Summary
This PR aligns the README documentation with the actual package entrypoints and class names for the runtime and platform adapter packages, resolving inconsistencies identified in #942.

### Changes
- **@konekti/runtime**: Added documentation for missing subpaths (`./web`, `./internal`) and updated the API overview.
- **@konekti/http**: Documented the `./internal` subpath.
- **Platform Adapters**: Corrected adapter class names to use the `...HttpApplicationAdapter` format (e.g., `NodejsHttpApplicationAdapter`, `ExpressHttpApplicationAdapter`) in README files.
- **@konekti/platform-cloudflare-workers**: Corrected the `bootstrapCloudflareWorkerApplication` description to reflect its asynchronous nature.
- **Multilingual Support**: Updated both English and Korean README pairs for all affected packages.

## Verification
- Verified documentation accuracy against `package.json` exports and source code.
- Successfully ran `pnpm verify` (build, typecheck, lint, test) in a clean worktree.

Resolves #942