### PR TITLE
Resolve #943: harden core clone fallbacks

### DIFF
--- a/packages/core/src/metadata.test.ts
+++ b/packages/core/src/metadata.test.ts
@@ -153,6 +153,31 @@ describe('metadata helpers', () => {
     });
   });
 
+  it('preserves custom middleware instances while still cloning the module middleware array', () => {
+    class ExampleMiddleware {
+      calls = 0;
+
+      handle() {
+        this.calls += 1;
+      }
+    }
+
+    const middleware = new ExampleMiddleware();
+
+    class ExampleModule {}
+
+    defineModuleMetadata(ExampleModule, {
+      middleware: [middleware],
+    });
+
+    const metadata = getModuleMetadata(ExampleModule);
+    const returnedMiddleware = metadata?.middleware?.[0] as typeof middleware | undefined;
+
+    expect(returnedMiddleware).toBe(middleware);
+    expect(metadata?.middleware).not.toBeUndefined();
+    expect(metadata?.middleware).not.toBe((getModuleMetadata(ExampleModule)?.middleware as unknown[] | undefined));
+  });
+
   it('builds DTO binding schema from field metadata', () => {
     class GetUserRequest {
       id!: string;

--- a/packages/core/src/metadata/shared.ts
+++ b/packages/core/src/metadata/shared.ts
@@ -33,6 +33,16 @@ export function ensureMetadataSymbol(): symbol {
 
 void ensureMetadataSymbol();
 
+function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
+}
+
 /**
  * Clones mutable metadata payloads before storing or returning them from shared metadata helpers.
  *
@@ -40,7 +50,11 @@ void ensureMetadataSymbol();
  * @returns A detached clone for supported mutable shapes, or the original value for immutable references.
  */
 export function cloneMutableValue<T>(value: T): T {
-  return fallbackClone(value);
+  if (Array.isArray(value) || value instanceof Date || value instanceof Map || value instanceof Set || isPlainObject(value)) {
+    return fallbackClone(value);
+  }
+
+  return value;
 }
 
 /**

--- a/packages/core/src/metadata/shared.ts
+++ b/packages/core/src/metadata/shared.ts
@@ -1,10 +1,22 @@
 import type { MetadataPropertyKey } from '../types.js';
+import { fallbackClone } from '../utils.js';
 
+/**
+ * Generic metadata bag shape used by the TC39 `Symbol.metadata` integration points.
+ */
 export type StandardMetadataBag = Record<PropertyKey, unknown>;
 
 const symbolWithMetadata = Symbol as typeof Symbol & { metadata?: symbol };
+/**
+ * Active symbol key used to read and write standard metadata bags.
+ */
 export let metadataSymbol = symbolWithMetadata.metadata ?? Symbol.for('konekti.symbol.metadata');
 
+/**
+ * Ensures `Symbol.metadata` exists and returns the symbol used by Konekti metadata helpers.
+ *
+ * @returns The resolved metadata symbol.
+ */
 export function ensureMetadataSymbol(): symbol {
   if (symbolWithMetadata.metadata) {
     metadataSymbol = symbolWithMetadata.metadata;
@@ -21,48 +33,19 @@ export function ensureMetadataSymbol(): symbol {
 
 void ensureMetadataSymbol();
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-
-  return prototype === Object.prototype || prototype === null;
-}
-
+/**
+ * Clones mutable metadata payloads before storing or returning them from shared metadata helpers.
+ *
+ * @param value Metadata value to clone defensively.
+ * @returns A detached clone for supported mutable shapes, or the original value for immutable references.
+ */
 export function cloneMutableValue<T>(value: T): T {
-  if (Array.isArray(value)) {
-    return value.map((item) => cloneMutableValue(item)) as T;
-  }
-
-  if (value instanceof Date) {
-    return new Date(value.getTime()) as T;
-  }
-
-  if (value instanceof Map) {
-    return new Map(
-      Array.from(value.entries(), ([key, entryValue]) => [key, cloneMutableValue(entryValue)]),
-    ) as T;
-  }
-
-  if (value instanceof Set) {
-    return new Set(Array.from(value.values(), (entryValue) => cloneMutableValue(entryValue))) as T;
-  }
-
-  if (isPlainObject(value)) {
-    const cloned: Record<string, unknown> = {};
-
-    for (const [key, entryValue] of Object.entries(value)) {
-      cloned[key] = cloneMutableValue(entryValue);
-    }
-
-    return cloned as T;
-  }
-
-  return value;
+  return fallbackClone(value);
 }
 
+/**
+ * Canonical symbol keys for metadata emitted through the standard decorator metadata bag.
+ */
 export const standardMetadataKeys = {
   classValidation: Symbol.for('konekti.standard.class-validation'),
   controller: Symbol.for('konekti.standard.controller'),
@@ -72,6 +55,9 @@ export const standardMetadataKeys = {
   route: Symbol.for('konekti.standard.route'),
 } as const;
 
+/**
+ * Canonical symbol keys for Konekti-owned metadata stores.
+ */
 export const metadataKeys = {
   module: Symbol.for('konekti.metadata.module'),
   controller: Symbol.for('konekti.metadata.controller'),
@@ -83,10 +69,23 @@ export const metadataKeys = {
   classValidation: Symbol.for('konekti.metadata.class-validation'),
 } as const;
 
+/**
+ * Clones a readonly collection into a mutable array for defensive metadata reads and writes.
+ *
+ * @param collection Collection to clone.
+ * @returns A cloned mutable array, or `undefined` when the collection is absent.
+ */
 export function cloneCollection<T>(collection: readonly T[] | undefined): T[] | undefined {
   return collection ? collection.map((value) => cloneMutableValue(value)) : undefined;
 }
 
+/**
+ * Looks up or creates a property-keyed metadata map for a target object.
+ *
+ * @param store WeakMap-backed metadata store.
+ * @param target Target object that owns the metadata map.
+ * @returns The existing or newly created metadata map for the target.
+ */
 export function getOrCreatePropertyMap<T>(
   store: WeakMap<object, Map<MetadataPropertyKey, T>>,
   target: object,
@@ -106,6 +105,10 @@ export function getOrCreatePropertyMap<T>(
  * Deduplication uses reference equality (===), so two objects with identical shapes
  * are treated as distinct entries unless they are the exact same reference.
  * Returns `undefined` when both inputs are empty or absent.
+ *
+ * @param existing Existing values in insertion order.
+ * @param values Additional values to merge.
+ * @returns A deduplicated merged array, or `undefined` when both inputs are empty.
  */
 export function mergeUnique<T>(existing: readonly T[] | undefined, values: readonly T[] | undefined): T[] | undefined {
   if (!existing?.length && !values?.length) {
@@ -125,6 +128,12 @@ export function mergeUnique<T>(existing: readonly T[] | undefined, values: reado
   return merged;
 }
 
+/**
+ * Reads the standard metadata bag stored directly on a target.
+ *
+ * @param target Target object that may own standard metadata.
+ * @returns The metadata bag when present, otherwise `undefined`.
+ */
 export function getStandardMetadataBag(target: object): StandardMetadataBag | undefined {
   const metadata = Reflect.get(target, metadataSymbol);
 
@@ -135,20 +144,47 @@ export function getStandardMetadataBag(target: object): StandardMetadataBag | un
   return metadata as StandardMetadataBag;
 }
 
+/**
+ * Reads the standard metadata bag stored on a target's constructor.
+ *
+ * @param target Instance or prototype whose constructor metadata should be inspected.
+ * @returns The constructor metadata bag when present, otherwise `undefined`.
+ */
 export function getStandardConstructorMetadataBag(target: object): StandardMetadataBag | undefined {
   const constructor = (target as { constructor?: Function }).constructor;
 
   return constructor ? getStandardMetadataBag(constructor) : undefined;
 }
 
+/**
+ * Reads a constructor-level metadata record from the standard metadata bag.
+ *
+ * @param target Instance or prototype whose constructor metadata should be inspected.
+ * @param key Symbol key of the stored metadata record.
+ * @returns The stored record when present, otherwise `undefined`.
+ */
 export function getStandardConstructorMetadataRecord<T>(target: object, key: symbol): T | undefined {
   return getStandardConstructorMetadataBag(target)?.[key] as T | undefined;
 }
 
+/**
+ * Reads a constructor-level property map from the standard metadata bag.
+ *
+ * @param target Instance or prototype whose constructor metadata should be inspected.
+ * @param key Symbol key of the stored metadata map.
+ * @returns The stored property map when present, otherwise `undefined`.
+ */
 export function getStandardConstructorMetadataMap<T>(target: object, key: symbol): Map<MetadataPropertyKey, T> | undefined {
   return getStandardConstructorMetadataRecord<Map<MetadataPropertyKey, T>>(target, key);
 }
 
+/**
+ * Merges stored and standard metadata property keys while preserving first-seen order.
+ *
+ * @param stored Property keys from the explicit Konekti store.
+ * @param standard Property keys from the standard metadata bag.
+ * @returns A deduplicated ordered list of metadata property keys.
+ */
 export function mergeMetadataPropertyKeys<TStored, TStandard>(
   stored: ReadonlyMap<MetadataPropertyKey, TStored> | undefined,
   standard: ReadonlyMap<MetadataPropertyKey, TStandard> | undefined,
@@ -172,6 +208,14 @@ export function mergeMetadataPropertyKeys<TStored, TStandard>(
   return keys;
 }
 
+/**
+ * Appends a value into a property-keyed array store, creating the array on first write.
+ *
+ * @param store WeakMap-backed property store.
+ * @param target Target object that owns the property map.
+ * @param propertyKey Property key associated with the array entry.
+ * @param value Value to append.
+ */
 export function appendPropertyMapValue<T>(
   store: WeakMap<object, Map<MetadataPropertyKey, T[]>>,
   target: object,
@@ -189,6 +233,13 @@ export function appendPropertyMapValue<T>(
   map.set(propertyKey, [value]);
 }
 
+/**
+ * Appends a value into a WeakMap-backed array store, creating the array on first write.
+ *
+ * @param store WeakMap-backed array store.
+ * @param target Target function used as the WeakMap key.
+ * @param value Value to append.
+ */
 export function appendWeakMapValue<T>(store: WeakMap<Function, T[]>, target: Function, value: T): void {
   const existing = store.get(target);
 

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { cloneMutableValue } from './metadata/shared.js'
+import { fallbackClone } from './utils.js'
+
+describe('fallbackClone', () => {
+  it('preserves circular references, symbol keys, and custom prototypes', () => {
+    const marker = Symbol('marker')
+
+    class RichValue {
+      name: string
+      self?: unknown
+
+      constructor(name: string) {
+        this.name = name
+      }
+
+      getLabel() {
+        return `value:${this.name}`
+      }
+    }
+
+    const source = new RichValue('root') as RichValue & { child?: unknown; [marker]?: unknown }
+    source.child = { nested: true }
+    source.self = source
+    source[marker] = { enabled: true }
+
+    const cloned = fallbackClone(source)
+
+    expect(cloned).toBeInstanceOf(RichValue)
+    expect(cloned).not.toBe(source)
+    expect(cloned.getLabel()).toBe('value:root')
+    expect(cloned.self).toBe(cloned)
+    expect(cloned.child).toEqual({ nested: true })
+    expect(cloned.child).not.toBe(source.child)
+    expect(cloned[marker]).toEqual({ enabled: true })
+    expect(cloned[marker]).not.toBe(source[marker])
+  })
+})
+
+describe('cloneMutableValue', () => {
+  it('reuses the hardened fallback clone path for richer metadata payloads', () => {
+    const marker = Symbol('marker')
+    const source = {
+      nested: { ok: true },
+      self: undefined as unknown,
+      [marker]: new Map([[{ key: 'entry' }, new Set([{ deep: true }])]]),
+    }
+
+    source.self = source
+
+    const cloned = cloneMutableValue(source)
+
+    expect(cloned).not.toBe(source)
+    expect(cloned.self).toBe(cloned)
+    expect(cloned.nested).toEqual({ ok: true })
+    expect(cloned.nested).not.toBe(source.nested)
+    expect(cloned[marker]).toBeInstanceOf(Map)
+
+    const [clonedKey, clonedValue] = Array.from(cloned[marker].entries())[0] ?? []
+    const [originalKey] = Array.from(source[marker].keys())
+    const [firstSetValue] = Array.from((clonedValue as Set<{ deep: boolean }>).values())
+
+    expect(clonedKey).toEqual({ key: 'entry' })
+    expect(clonedKey).not.toBe(originalKey)
+    expect(clonedValue).toBeInstanceOf(Set)
+    expect(firstSetValue).toEqual({ deep: true })
+  })
+})

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,32 +1,112 @@
-export function fallbackClone<T>(value: T): T {
+function cloneIntoDescriptorValue(
+  descriptor: PropertyDescriptor,
+  seen: WeakMap<object, unknown>,
+): PropertyDescriptor {
+  if (!('value' in descriptor)) {
+    return descriptor;
+  }
+
+  return {
+    ...descriptor,
+    value: cloneFallbackValue(descriptor.value, seen),
+  };
+}
+
+function cloneFallbackValue<T>(value: T, seen: WeakMap<object, unknown>): T {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  const existing = seen.get(value);
+
+  if (existing) {
+    return existing as T;
+  }
+
   if (Array.isArray(value)) {
-    return value.map((item) => fallbackClone(item)) as T;
+    const cloned: unknown[] = [];
+    seen.set(value, cloned);
+    cloned.push(...value.map((item) => cloneFallbackValue(item, seen)));
+    return cloned as T;
   }
 
   if (value instanceof Date) {
-    return new Date(value.getTime()) as T;
+    const cloned = new Date(value.getTime());
+    seen.set(value, cloned);
+    return cloned as T;
+  }
+
+  if (value instanceof RegExp) {
+    const cloned = new RegExp(value.source, value.flags);
+    cloned.lastIndex = value.lastIndex;
+    seen.set(value, cloned);
+    return cloned as T;
   }
 
   if (value instanceof Map) {
-    return new Map(
-      Array.from((value as Map<unknown, unknown>).entries(), ([k, v]) => [k, fallbackClone(v)]),
-    ) as T;
-  }
+    const cloned = new Map();
+    seen.set(value, cloned);
 
-  if (value instanceof Set) {
-    return new Set(Array.from((value as Set<unknown>).values(), (v) => fallbackClone(v))) as T;
-  }
-
-  if (typeof value === 'object' && value !== null) {
-    const source = value as Record<string, unknown>;
-    const cloned: Record<string, unknown> = {};
-
-    for (const [key, item] of Object.entries(source)) {
-      cloned[key] = fallbackClone(item);
+    for (const [key, entryValue] of value.entries()) {
+      cloned.set(cloneFallbackValue(key, seen), cloneFallbackValue(entryValue, seen));
     }
 
     return cloned as T;
   }
 
-  return value;
+  if (value instanceof Set) {
+    const cloned = new Set();
+    seen.set(value, cloned);
+
+    for (const entryValue of value.values()) {
+      cloned.add(cloneFallbackValue(entryValue, seen));
+    }
+
+    return cloned as T;
+  }
+
+  if (value instanceof DataView) {
+    const cloned = new DataView(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
+    seen.set(value, cloned);
+    return cloned as T;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    const cloned = new (value.constructor as new (source: typeof value) => typeof value)(value);
+    seen.set(value, cloned);
+    return cloned as T;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    const cloned = value.slice(0);
+    seen.set(value, cloned);
+    return cloned as T;
+  }
+
+  const cloned = Object.create(Object.getPrototypeOf(value)) as Record<PropertyKey, unknown>;
+  seen.set(value, cloned);
+
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+
+    if (descriptor) {
+      Object.defineProperty(cloned, key, cloneIntoDescriptorValue(descriptor, seen));
+    }
+  }
+
+  return cloned as T;
+}
+
+/**
+ * Creates a best-effort deep clone for runtimes where `structuredClone()` is not available or throws.
+ *
+ * Supported fallback shapes include arrays, dates, regular expressions, maps, sets, typed arrays,
+ * array buffers, plain objects, and custom prototype-based instances with symbol-keyed properties
+ * and circular references preserved.
+ *
+ * @param value Value to clone through the fallback path.
+ * @returns A deep clone for supported runtime shapes, or the original value for primitives/functions.
+ */
+export function fallbackClone<T>(value: T): T {
+  return cloneFallbackValue(value, new WeakMap<object, unknown>());
 }

--- a/packages/cqrs/src/event-clone.test.ts
+++ b/packages/cqrs/src/event-clone.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createIsolatedEvent } from './event-clone.js'
+
+const originalStructuredClone = globalThis.structuredClone
+
+afterEach(() => {
+  globalThis.structuredClone = originalStructuredClone
+})
+
+describe('createIsolatedEvent', () => {
+  it('uses the shared core fallback clone for symbol-keyed payload state', () => {
+    const marker = Symbol('marker')
+
+    class DomainEvent {
+      value?: { ok: boolean }
+      [marker]?: { nested: boolean }
+    }
+
+    const payload = {
+      value: { ok: true },
+      [marker]: { nested: true },
+    }
+
+    globalThis.structuredClone = vi.fn(() => {
+      throw new Error('fallback please')
+    })
+
+    const isolated = createIsolatedEvent(DomainEvent, payload)
+
+    expect(isolated).toBeInstanceOf(DomainEvent)
+    expect(isolated).not.toBe(payload)
+    expect(isolated.value).toEqual({ ok: true })
+    expect(isolated.value).not.toBe(payload.value)
+    expect(isolated[marker]).toEqual({ nested: true })
+    expect(isolated[marker]).not.toBe(payload[marker])
+  })
+})

--- a/packages/cqrs/src/event-clone.ts
+++ b/packages/cqrs/src/event-clone.ts
@@ -1,23 +1,5 @@
+import { fallbackClone } from '@konekti/core/internal';
 import type { CqrsEventType, IEvent } from './types.js';
-
-function fallbackClone(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map((item) => fallbackClone(item));
-  }
-
-  if (typeof value === 'object' && value !== null) {
-    const source = value as Record<string, unknown>;
-    const cloned: Record<string, unknown> = {};
-
-    for (const [key, item] of Object.entries(source)) {
-      cloned[key] = fallbackClone(item);
-    }
-
-    return cloned;
-  }
-
-  return value;
-}
 
 function cloneValue<T>(value: T): T {
   try {
@@ -27,6 +9,13 @@ function cloneValue<T>(value: T): T {
   }
 }
 
+/**
+ * Creates an isolated event instance by cloning the source payload before rehydrating the event prototype.
+ *
+ * @param eventType Event class whose prototype should back the isolated event.
+ * @param source Source payload to clone and assign onto the event instance.
+ * @returns A detached event instance with the requested event prototype.
+ */
 export function createIsolatedEvent<TEvent extends IEvent>(eventType: CqrsEventType<TEvent>, source: unknown): TEvent {
   const clonedPayload = cloneValue(source);
 


### PR DESCRIPTION
## Summary
- harden `@konekti/core` fallback cloning so unsupported `structuredClone()` paths preserve circular references, symbol keys, richer object shapes, and metadata payload copies through one shared implementation
- remove the local CQRS fallback clone duplication by reusing the shared core fallback path and add focused regression tests for both packages
- keep the PR scoped to core + CQRS so downstream duplicate cleanup can land separately without widening contract risk

## Changes
- expand `packages/core/src/utils.ts` fallback cloning to support circular structures, symbol-keyed properties, prototype-backed instances, `RegExp`, `ArrayBuffer`, `DataView`, and typed-array views
- route `packages/core/src/metadata/shared.ts` through the hardened fallback clone and add regression coverage in `packages/core/src/utils.test.ts`
- replace the ad hoc CQRS fallback in `packages/cqrs/src/event-clone.ts` and add `packages/cqrs/src/event-clone.test.ts`

## Testing
- `pnpm exec vitest run packages/core/src/utils.test.ts packages/cqrs/src/event-clone.test.ts packages/core/src/metadata.test.ts`
- `pnpm verify` *(build, typecheck, lint/TSDoc passed; full test run is currently blocked by unrelated existing failures in `packages/metrics/src/metrics-module.test.ts` on this fresh branch)*

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #943