### PR TITLE
Resolve #940: align messaging docs and shared clone usage

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1,2 +1,2 @@
 export * from './metadata.js';
-export { fallbackClone } from './utils.js';
+export { cloneWithFallback, fallbackClone } from './utils.js';

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -22,6 +22,7 @@ describe('@konekti/core public API surface', () => {
     expect(corePublicApi).not.toHaveProperty('getClassDiMetadata');
     expect(corePublicApi).not.toHaveProperty('metadataSymbol');
     expect(corePublicApi).not.toHaveProperty('ensureSymbolMetadataPolyfill');
+    expect(corePublicApi).not.toHaveProperty('cloneWithFallback');
     expect(corePublicApi).not.toHaveProperty('fallbackClone');
   });
 
@@ -33,6 +34,7 @@ describe('@konekti/core public API surface', () => {
     expect(coreInternalApi).toHaveProperty('getClassDiMetadata');
     expect(coreInternalApi).toHaveProperty('metadataSymbol');
     expect(coreInternalApi).toHaveProperty('ensureSymbolMetadataPolyfill');
+    expect(coreInternalApi).toHaveProperty('cloneWithFallback');
     expect(coreInternalApi).toHaveProperty('fallbackClone');
   });
 });

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { cloneMutableValue } from './metadata/shared.js'
 import { fallbackClone } from './utils.js'

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -98,6 +98,20 @@ function cloneFallbackValue<T>(value: T, seen: WeakMap<object, unknown>): T {
 }
 
 /**
+ * Clones a value through `structuredClone()` and falls back to the hardened internal clone path when needed.
+ *
+ * @param value Value to clone.
+ * @returns A cloned value produced by `structuredClone()` when available, or `fallbackClone()` when the runtime clone fails.
+ */
+export function cloneWithFallback<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return fallbackClone(value);
+  }
+}
+
+/**
  * Creates a best-effort deep clone for runtimes where `structuredClone()` is not available or throws.
  *
  * Supported fallback shapes include arrays, dates, regular expressions, maps, sets, typed arrays,

--- a/packages/cqrs/src/event-clone.ts
+++ b/packages/cqrs/src/event-clone.ts
@@ -1,13 +1,5 @@
-import { fallbackClone } from '@konekti/core/internal';
+import { cloneWithFallback } from '@konekti/core/internal';
 import type { CqrsEventType, IEvent } from './types.js';
-
-function cloneValue<T>(value: T): T {
-  try {
-    return structuredClone(value);
-  } catch {
-    return fallbackClone(value) as T;
-  }
-}
 
 /**
  * Creates an isolated event instance by cloning the source payload before rehydrating the event prototype.
@@ -17,7 +9,7 @@ function cloneValue<T>(value: T): T {
  * @returns A detached event instance with the requested event prototype.
  */
 export function createIsolatedEvent<TEvent extends IEvent>(eventType: CqrsEventType<TEvent>, source: unknown): TEvent {
-  const clonedPayload = cloneValue(source);
+  const clonedPayload = cloneWithFallback(source);
 
   if (typeof clonedPayload !== 'object' || clonedPayload === null) {
     return clonedPayload as TEvent;

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -1,5 +1,5 @@
 import { Inject, type MetadataPropertyKey, type Token } from '@konekti/core';
-import { fallbackClone, getClassDiMetadata } from '@konekti/core/internal';
+import { cloneWithFallback, getClassDiMetadata } from '@konekti/core/internal';
 import type { Container, Provider } from '@konekti/di';
 import {
   type ApplicationLogger,
@@ -39,16 +39,8 @@ interface InvocationBound {
   promise: Promise<never>;
 }
 
-function cloneValue<T>(value: T): T {
-  try {
-    return structuredClone(value);
-  } catch {
-    return fallbackClone(value) as T;
-  }
-}
-
 function createIsolatedEvent<TEvent extends object>(eventType: EventType<TEvent>, source: unknown): TEvent {
-  const clonedPayload = cloneValue(source);
+  const clonedPayload = cloneWithFallback(source);
 
   if (typeof clonedPayload !== 'object' || clonedPayload === null) {
     return clonedPayload as TEvent;

--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -81,13 +81,25 @@ await microservice.listen();
 
 ## 공개 API 개요
 
-- `MicroservicesModule`
-- `MessagePattern`, `EventPattern`
-- `ServerStreamPattern`, `ClientStreamPattern`, `BidiStreamPattern`
-- `TcpMicroserviceTransport`, `NatsMicroserviceTransport`, `KafkaMicroserviceTransport` 등 트랜스포트 어댑터
-- `MicroserviceLifecycleService`
-- `MICROSERVICE`
-- `createMicroservicePlatformStatusSnapshot(...)`
+### 루트 배럴 (`@konekti/microservices`)
+
+- `MicroservicesModule`, `createMicroservicesProviders`: 모듈 등록 진입점입니다.
+- `MessagePattern`, `EventPattern`, `ServerStreamPattern`, `ClientStreamPattern`, `BidiStreamPattern`: 라우팅/스트리밍 데코레이터입니다.
+- `TcpMicroserviceTransport`, `RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `KafkaMicroserviceTransport`, `RabbitMqMicroserviceTransport`, `GrpcMicroserviceTransport`, `MqttMicroserviceTransport`: 루트 배럴에서 제공하는 트랜스포트 어댑터입니다.
+- `MicroserviceLifecycleService`, `MICROSERVICE`: 런타임 접근용 서비스와 호환 토큰입니다.
+- `createMicroservicePlatformStatusSnapshot`, `ServerStreamWriter`: 상태 스냅샷/TypeScript 계약 헬퍼입니다.
+
+### 지원되는 트랜스포트 서브패스
+
+- `@konekti/microservices/tcp`
+- `@konekti/microservices/redis` (Redis Pub/Sub 트랜스포트)
+- `@konekti/microservices/nats`
+- `@konekti/microservices/kafka`
+- `@konekti/microservices/rabbitmq`
+- `@konekti/microservices/grpc`
+- `@konekti/microservices/mqtt`
+
+`RedisStreamsMicroserviceTransport`는 현재 루트 배럴에서만 지원하며, `@konekti/microservices/redis-streams` 전용 export는 없습니다.
 
 ## 관련 패키지
 
@@ -98,4 +110,6 @@ await microservice.listen();
 ## 예제 소스
 
 - `packages/microservices/src/module.test.ts`
+- `packages/microservices/src/public-api.test.ts`
+- `packages/microservices/src/public-subpaths.test.ts`
 - `packages/microservices/src/public-surface.test.ts`

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -78,11 +78,25 @@ Microservice handlers fully support Konekti's DI scopes. Request-scoped provider
 
 ## Public API Overview
 
-- `MicroservicesModule`: Main entry point for microservice integration.
-- `MessagePattern`, `EventPattern`: Routing decorators.
-- `TcpMicroserviceTransport`, `NatsMicroserviceTransport`, `KafkaMicroserviceTransport`, etc.: Transport adapters.
-- `MicroserviceLifecycleService`: Concrete runtime service for programmatic control.
-- `ServerStreamWriter`: Interface for server-side streaming responses.
+### Root barrel (`@konekti/microservices`)
+
+- `MicroservicesModule`, `createMicroservicesProviders`: module registration helpers.
+- `MessagePattern`, `EventPattern`, `ServerStreamPattern`, `ClientStreamPattern`, `BidiStreamPattern`: routing and streaming decorators.
+- `TcpMicroserviceTransport`, `RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `KafkaMicroserviceTransport`, `RabbitMqMicroserviceTransport`, `GrpcMicroserviceTransport`, `MqttMicroserviceTransport`: transport adapters exported from the root barrel.
+- `MicroserviceLifecycleService`, `MICROSERVICE`: programmatic runtime access and compatibility token.
+- `createMicroservicePlatformStatusSnapshot`, `ServerStreamWriter`: status and TypeScript contract helpers.
+
+### Supported transport subpaths
+
+- `@konekti/microservices/tcp`
+- `@konekti/microservices/redis` (Redis Pub/Sub transport)
+- `@konekti/microservices/nats`
+- `@konekti/microservices/kafka`
+- `@konekti/microservices/rabbitmq`
+- `@konekti/microservices/grpc`
+- `@konekti/microservices/mqtt`
+
+`RedisStreamsMicroserviceTransport` is currently supported from the root barrel only; there is no dedicated `@konekti/microservices/redis-streams` export.
 
 ## Related Packages
 
@@ -93,5 +107,7 @@ Microservice handlers fully support Konekti's DI scopes. Request-scoped provider
 ## Example Sources
 
 - `packages/microservices/src/module.test.ts`: Integration tests for all transports.
+- `packages/microservices/src/public-api.test.ts`: Root-barrel contract coverage.
+- `packages/microservices/src/public-subpaths.test.ts`: Export-map coverage for documented transport subpaths.
 - `examples/microservices-tcp`: Basic TCP microservice example.
 - `examples/microservices-kafka`: Distributed Kafka-based architecture example.

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -1,5 +1,5 @@
 import { Inject, type MetadataPropertyKey, type Token } from '@konekti/core';
-import { fallbackClone, getClassDiMetadata } from '@konekti/core/internal';
+import { cloneWithFallback, getClassDiMetadata } from '@konekti/core/internal';
 import type { Container, Provider } from '@konekti/di';
 import {
   type ApplicationLogger,
@@ -27,14 +27,6 @@ interface DiscoveryCandidate {
   scope: 'request' | 'singleton' | 'transient';
   targetType: Function;
   token: Token;
-}
-
-function clonePayload<T>(payload: T): T {
-  try {
-    return structuredClone(payload);
-  } catch {
-    return fallbackClone(payload) as T;
-  }
 }
 
 function methodKeyToName(methodKey: MetadataPropertyKey): string {
@@ -105,7 +97,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
       if (transport.listenServerStreaming) {
         transport.listenServerStreaming(
           async (pattern: string, payload: unknown, writer: ServerStreamWriter) => {
-            await this.dispatchServerStream(pattern, clonePayload(payload), writer);
+    await this.dispatchServerStream(pattern, cloneWithFallback(payload), writer);
           },
         );
       }
@@ -204,7 +196,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
    * @returns The transport response payload.
    */
   async send(pattern: string, payload: unknown, signal?: AbortSignal): Promise<unknown> {
-    return this.moduleOptions.transport.send(pattern, clonePayload(payload), signal);
+    return this.moduleOptions.transport.send(pattern, cloneWithFallback(payload), signal);
   }
 
   /**
@@ -215,7 +207,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
    * @returns A promise that resolves once the transport accepts the event.
    */
   async emit(pattern: string, payload: unknown): Promise<void> {
-    await this.moduleOptions.transport.emit(pattern, clonePayload(payload));
+    await this.moduleOptions.transport.emit(pattern, cloneWithFallback(payload));
   }
 
   /**
@@ -235,7 +227,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
       throw new Error('The configured transport does not support server streaming. Use a transport that implements serverStream().');
     }
 
-    return transport.serverStream(pattern, clonePayload(payload), signal);
+    return transport.serverStream(pattern, cloneWithFallback(payload), signal);
   }
 
   /**
@@ -295,10 +287,10 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
         throw new Error(`No message handler registered for pattern "${packet.pattern}".`);
       }
 
-      return await this.invokeHandler(first, clonePayload(packet.payload));
+    return await this.invokeHandler(first, cloneWithFallback(packet.payload));
     }
 
-    return await this.dispatchEventHandlers(matches, clonePayload(packet.payload));
+    return await this.dispatchEventHandlers(matches, cloneWithFallback(packet.payload));
   }
 
   private async dispatchServerStream(pattern: string, payload: unknown, writer: ServerStreamWriter): Promise<void> {
@@ -561,7 +553,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
     const scopedDescriptors = descriptors.filter((descriptor) => descriptor.scope !== 'singleton');
 
     const singletonResults = await Promise.allSettled(
-      singletonDescriptors.map((descriptor) => this.invokeHandler(descriptor, clonePayload(payload))),
+      singletonDescriptors.map((descriptor) => this.invokeHandler(descriptor, cloneWithFallback(payload))),
     );
 
     for (const result of singletonResults) {
@@ -584,7 +576,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
     try {
       const scopedResults = await Promise.allSettled(
         scopedDescriptors.map((descriptor) =>
-          this.invokeResolvedHandlerInScope(perEventScope, descriptor, clonePayload(payload)),
+    this.invokeResolvedHandlerInScope(perEventScope, descriptor, cloneWithFallback(payload)),
         ),
       );
 

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -1,5 +1,5 @@
 import { Inject } from '@konekti/core';
-import { fallbackClone } from '@konekti/core/internal';
+import { cloneWithFallback } from '@konekti/core/internal';
 import type { Container } from '@konekti/di';
 import { REDIS_CLIENT } from '@konekti/redis';
 import {
@@ -94,16 +94,8 @@ function serializeJobPayload(job: object): QueuePayload {
   return serialized;
 }
 
-function cloneQueuePayload(payload: QueuePayload): QueuePayload {
-  try {
-    return structuredClone(payload);
-  } catch {
-    return fallbackClone(payload) as QueuePayload;
-  }
-}
-
 function rehydrateJobPayload<TJob extends object>(jobType: QueueJobType<TJob>, payload: QueuePayload): TJob {
-  return Object.assign(Object.create(jobType.prototype), cloneQueuePayload(payload)) as TJob;
+  return Object.assign(Object.create(jobType.prototype), cloneWithFallback(payload)) as TJob;
 }
 
 function toBullBackoff(backoff: QueueBackoffOptions | undefined): JobsOptions['backoff'] {
@@ -564,7 +556,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
         failedAt: new Date(job.finishedOn ?? Date.now()).toISOString(),
         jobId: job.id ?? '',
         jobName: descriptor.jobName,
-        payload: isQueuePayload(job.data) ? cloneQueuePayload(job.data) : job.data,
+        payload: isQueuePayload(job.data) ? cloneWithFallback(job.data) : job.data,
       };
 
       await this.getRedisClient().rpush(deadLetterKey(descriptor.jobName), JSON.stringify(deadLetter));


### PR DESCRIPTION
## Summary
- align `@konekti/microservices` English/Korean READMEs with the documented root-barrel exports and supported transport subpaths
- add a shared `cloneWithFallback()` helper under `@konekti/core/internal` and reuse it across CQRS, event-bus, microservices, and queue payload cloning paths
- keep the change contract-neutral while preserving regression coverage around fallback cloning and documented export surfaces

## Changes
- updated `packages/microservices/README.md` and `packages/microservices/README.ko.md` together to document the current root API and subpath surface
- added `cloneWithFallback()` in `packages/core/src/utils.ts` and exported it from `@konekti/core/internal`
- replaced duplicated `structuredClone()` + fallback wrappers in messaging packages with the shared helper

## Testing
- `pnpm build`
- `pnpm --filter @konekti/core --filter @konekti/cqrs --filter @konekti/event-bus --filter @konekti/microservices --filter @konekti/queue typecheck`
- `pnpm vitest run packages/core/src/utils.test.ts packages/core/src/public-api.test.ts packages/cqrs/src/event-clone.test.ts packages/event-bus/src/module.test.ts packages/microservices/src/public-api.test.ts packages/microservices/src/public-subpaths.test.ts packages/queue/src/module.test.ts`
- `lsp_diagnostics` clean on all changed files

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- Contract impact: none. This PR aligns existing messaging documentation and consolidates clone helper usage without widening supported behavior.

Closes #940