### PR TITLE
Resolve #941: optimize core metadata and DI internals

### DIFF
--- a/packages/core/src/metadata.test.ts
+++ b/packages/core/src/metadata.test.ts
@@ -355,6 +355,25 @@ describe('metadata helpers', () => {
     });
   });
 
+  it('does not retain caller-owned inject arrays across partial class DI writes', () => {
+    class ExampleService {}
+
+    const inject = ['LOGGER'];
+
+    defineClassDiMetadata(ExampleService, {
+      inject,
+    });
+    inject.push('MUTATED');
+    defineClassDiMetadata(ExampleService, {
+      scope: 'request',
+    });
+
+    expect(getOwnClassDiMetadata(ExampleService)).toEqual({
+      inject: ['LOGGER'],
+      scope: 'request',
+    });
+  });
+
   it('falls back to inherited DI metadata while keeping own lookups explicit', () => {
     class BaseService {}
 
@@ -439,5 +458,28 @@ describe('metadata helpers', () => {
 
   it('ensures Symbol.metadata is available through the exported initializer', () => {
     expect(ensureMetadataSymbol()).toBe((Symbol as typeof Symbol & { metadata?: symbol }).metadata);
+  });
+
+  it('does not retain caller-owned module metadata arrays across partial writes', () => {
+    class ExampleModule {}
+
+    const imports = ['SharedModule'];
+
+    defineModuleMetadata(ExampleModule, {
+      imports,
+    });
+    imports.push('MutatedModule');
+    defineModuleMetadata(ExampleModule, {
+      providers: ['LoggerProvider'],
+    });
+
+    expect(getModuleMetadata(ExampleModule)).toEqual({
+      controllers: undefined,
+      exports: undefined,
+      global: undefined,
+      imports: ['SharedModule'],
+      middleware: undefined,
+      providers: ['LoggerProvider'],
+    });
   });
 });

--- a/packages/core/src/metadata/class-di.ts
+++ b/packages/core/src/metadata/class-di.ts
@@ -24,22 +24,35 @@ function getClassMetadataLineage(target: Function): Function[] {
   return lineage;
 }
 
+/**
+ * Defines class-level DI metadata while preserving previously written fields for split decorator passes.
+ *
+ * @param target Class receiving DI metadata.
+ * @param metadata Partial or complete DI metadata payload.
+ */
 export function defineClassDiMetadata(target: Function, metadata: ClassDiMetadata): void {
-  const existing = classDiMetadataStore.read(target);
-
-  classDiMetadataStore.write(
-    target,
-    {
-      inject: metadata.inject !== undefined ? metadata.inject : existing?.inject,
-      scope: metadata.scope ?? existing?.scope,
-    },
-  );
+  classDiMetadataStore.update(target, (existing) => ({
+    inject: metadata.inject !== undefined ? metadata.inject : existing?.inject,
+    scope: metadata.scope ?? existing?.scope,
+  }));
 }
 
+/**
+ * Reads only the DI metadata defined directly on a class.
+ *
+ * @param target Class being inspected.
+ * @returns A defensive clone of the class's own DI metadata, or `undefined` when absent.
+ */
 export function getOwnClassDiMetadata(target: Function): ClassDiMetadata | undefined {
   return classDiMetadataStore.read(target);
 }
 
+/**
+ * Resolves inherited DI metadata by walking the constructor lineage from base to leaf.
+ *
+ * @param target Class being inspected.
+ * @returns The effective inherited DI metadata, or `undefined` when no lineage metadata exists.
+ */
 export function getInheritedClassDiMetadata(target: Function): ClassDiMetadata | undefined {
   let effective: ClassDiMetadata | undefined;
 
@@ -59,6 +72,12 @@ export function getInheritedClassDiMetadata(target: Function): ClassDiMetadata |
   return effective ? cloneClassDiMetadata(effective) : undefined;
 }
 
+/**
+ * Reads the effective DI metadata visible to a class, including inherited fallback values.
+ *
+ * @param target Class being inspected.
+ * @returns The effective DI metadata for the class, or `undefined` when none exists.
+ */
 export function getClassDiMetadata(target: Function): ClassDiMetadata | undefined {
   return getInheritedClassDiMetadata(target);
 }

--- a/packages/core/src/metadata/module.ts
+++ b/packages/core/src/metadata/module.ts
@@ -34,22 +34,29 @@ function cloneModuleMetadata(metadata: ModuleMetadata): ModuleMetadata {
   };
 }
 
+/**
+ * Defines module metadata while preserving previously written fields for partial decorator passes.
+ *
+ * @param target Module class receiving metadata.
+ * @param metadata Partial or complete module metadata payload.
+ */
 export function defineModuleMetadata(target: Function, metadata: ModuleMetadata): void {
-  const existing = moduleMetadataStore.read(target);
-
-  moduleMetadataStore.write(
-    target,
-    {
-      controllers: metadata.controllers ?? existing?.controllers,
-      exports: metadata.exports ?? existing?.exports,
-      global: metadata.global ?? existing?.global,
-      imports: metadata.imports ?? existing?.imports,
-      middleware: metadata.middleware ?? existing?.middleware,
-      providers: metadata.providers ?? existing?.providers,
-    },
-  );
+  moduleMetadataStore.update(target, (existing) => ({
+    controllers: metadata.controllers ?? existing?.controllers,
+    exports: metadata.exports ?? existing?.exports,
+    global: metadata.global ?? existing?.global,
+    imports: metadata.imports ?? existing?.imports,
+    middleware: metadata.middleware ?? existing?.middleware,
+    providers: metadata.providers ?? existing?.providers,
+  }));
 }
 
+/**
+ * Reads cloned module metadata for the provided module class.
+ *
+ * @param target Module class being inspected.
+ * @returns A defensive clone of module metadata, or `undefined` when none was defined.
+ */
 export function getModuleMetadata(target: Function): ModuleMetadata | undefined {
   return moduleMetadataStore.read(target);
 }

--- a/packages/core/src/metadata/store.ts
+++ b/packages/core/src/metadata/store.ts
@@ -1,8 +1,18 @@
+/**
+ * Clone-on-read/write metadata store contract for function/object keyed metadata records.
+ */
 export interface ClonedWeakMapStore<TKey extends object, TValue> {
   read(target: TKey): TValue | undefined;
+  update(target: TKey, updateValue: (current: TValue | undefined) => TValue): void;
   write(target: TKey, value: TValue): void;
 }
 
+/**
+ * Creates a WeakMap-backed store that clones values when they enter or leave the cache.
+ *
+ * @param cloneValue Clone routine used to isolate stored metadata from caller mutations.
+ * @returns A cloned WeakMap store for metadata helpers.
+ */
 export function createClonedWeakMapStore<TKey extends object, TValue>(
   cloneValue: (value: TValue) => TValue,
 ): ClonedWeakMapStore<TKey, TValue> {
@@ -12,6 +22,9 @@ export function createClonedWeakMapStore<TKey extends object, TValue>(
     read(target: TKey): TValue | undefined {
       const value = store.get(target);
       return value !== undefined ? cloneValue(value) : undefined;
+    },
+    update(target: TKey, updateValue: (current: TValue | undefined) => TValue): void {
+      store.set(target, cloneValue(updateValue(store.get(target))));
     },
     write(target: TKey, value: TValue): void {
       store.set(target, cloneValue(value));

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -577,6 +577,35 @@ describe('Container', () => {
 
       await expect(container.resolve(MyService)).rejects.toThrow(ScopeMismatchError);
     });
+
+    it('checks each singleton alias dependency independently when aliases converge on one request-scoped provider', async () => {
+      const REQUEST_LOGGER = Symbol('RequestLogger');
+      const LOGGER_ALIAS_A = Symbol('LoggerAliasA');
+      const LOGGER_ALIAS_B = Symbol('LoggerAliasB');
+      const LOGGER_ALIAS_C = Symbol('LoggerAliasC');
+
+      class RequestLogger {}
+
+      class MyService {
+        constructor(
+          readonly loggerA: RequestLogger,
+          readonly loggerB: RequestLogger,
+        ) {}
+      }
+
+      const container = new Container().register(
+        { provide: REQUEST_LOGGER, useClass: RequestLogger, scope: Scope.REQUEST },
+        { provide: LOGGER_ALIAS_A, useExisting: REQUEST_LOGGER },
+        { provide: LOGGER_ALIAS_B, useExisting: LOGGER_ALIAS_A },
+        { provide: LOGGER_ALIAS_C, useExisting: REQUEST_LOGGER },
+        { provide: MyService, useClass: MyService, inject: [LOGGER_ALIAS_B, LOGGER_ALIAS_C] },
+      );
+
+      const error = await container.resolve(MyService).catch((value: unknown) => value);
+
+      expect(error).toBeInstanceOf(ScopeMismatchError);
+      expect(error).not.toBeInstanceOf(CircularDependencyError);
+    });
   });
 
   describe('multi-provider', () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -563,10 +563,15 @@ export class Container {
     activeTokens: Set<Token>,
     run: (chain: Token[], activeTokens: Set<Token>) => Promise<T>,
   ): Promise<T> {
-    const nextChain = [...chain, token];
-    const nextActiveTokens = new Set([...activeTokens, token]);
+    chain.push(token);
+    activeTokens.add(token);
 
-    return await run(nextChain, nextActiveTokens);
+    try {
+      return await run(chain, activeTokens);
+    } finally {
+      activeTokens.delete(token);
+      chain.pop();
+    }
   }
 
   private root(): Container {
@@ -822,23 +827,28 @@ export class Container {
     visited = new Set<Token>(),
     chain: Token[] = [],
   ): NormalizedProvider | undefined {
-    if (visited.has(token)) {
-      throw new CircularDependencyError([...chain, token]);
+    let currentToken = token;
+
+    while (true) {
+      if (visited.has(currentToken)) {
+        throw new CircularDependencyError([...chain, currentToken]);
+      }
+
+      visited.add(currentToken);
+
+      const provider = this.lookupProvider(currentToken);
+
+      if (!provider) {
+        return undefined;
+      }
+
+      if (provider.type !== 'existing' || provider.useExisting === undefined) {
+        return provider;
+      }
+
+      chain.push(currentToken);
+      currentToken = provider.useExisting;
     }
-
-    visited.add(token);
-
-    const provider = this.lookupProvider(token);
-
-    if (!provider) {
-      return undefined;
-    }
-
-    if (provider.type === 'existing' && provider.useExisting !== undefined) {
-      return this.resolveEffectiveProvider(provider.useExisting, visited, [...chain, token]);
-    }
-
-    return provider;
   }
 
   private resolveProviderDependencyToken(depEntry: Token | ForwardRefFn | OptionalToken): Token {
@@ -854,10 +864,10 @@ export class Container {
   }
 
   private async resolveProviderDeps(provider: NormalizedProvider, chain: Token[], activeTokens: Set<Token>): Promise<unknown[]> {
-    const deps: unknown[] = [];
+    const deps = new Array<unknown>(provider.inject.length);
 
-    for (const entry of provider.inject) {
-      deps.push(await this.resolveDepToken(entry, chain, activeTokens));
+    for (const [index, entry] of provider.inject.entries()) {
+      deps[index] = await this.resolveDepToken(entry, chain, activeTokens);
     }
 
     return deps;


### PR DESCRIPTION
## Summary
- reduce `@konekti/core` metadata partial-write clone churn by updating cloned stores in place while preserving defensive reads
- reduce `@konekti/di` dependency-chain allocation overhead during alias resolution and provider dependency collection
- add targeted regression coverage for metadata write isolation and converging alias scope checks

## Changes
- add a store-level update path for cloned metadata stores and use it in core module/class DI metadata writers
- reuse active dependency chain state during DI resolution and flatten alias traversal to avoid repeated array/set allocations
- add regression tests covering caller-owned metadata arrays and shared request-scoped alias targets

## Testing
- `pnpm --filter @konekti/core test`
- `pnpm --filter @konekti/di test`
- `pnpm --filter @konekti/core build && pnpm --filter @konekti/di build`
- `pnpm --filter @konekti/core typecheck`
- `pnpm --filter @konekti/di typecheck`
- `node tooling/governance/verify-public-export-tsdoc.mjs`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #941