### PR TITLE
Resolve #944: clean request-pipeline follow-up internals

### DIFF
--- a/packages/serialization/src/serialize.test.ts
+++ b/packages/serialization/src/serialize.test.ts
@@ -170,6 +170,36 @@ describe('serialize', () => {
     expect(serialized.second).toBe(serialized.first);
   });
 
+  it('preserves shared decorated class-instance references across sibling fields', () => {
+    class ProfileView {
+      @Expose()
+      id: string;
+
+      @Exclude()
+      secret: string;
+
+      constructor(id: string, secret: string) {
+        this.id = id;
+        this.secret = secret;
+      }
+    }
+
+    const shared = new ProfileView('shared-profile', 'hidden');
+    const input = {
+      first: shared,
+      second: shared,
+    };
+
+    const serialized = serialize(input) as {
+      first?: { id: string };
+      second?: { id: string };
+    };
+
+    expect(serialized.first).toEqual({ id: 'shared-profile' });
+    expect(serialized.second).toEqual({ id: 'shared-profile' });
+    expect(serialized.second).toBe(serialized.first);
+  });
+
   it('serializes enumerable symbol-keyed properties in plain objects', () => {
     const token = Symbol('token');
     const input: Record<string | symbol, unknown> = {

--- a/packages/serialization/src/serialize.ts
+++ b/packages/serialization/src/serialize.ts
@@ -105,16 +105,33 @@ function markSerializationComplete(value: object, context: SerializationContext)
   cached.active = false;
 }
 
+function serializeWithTrackedReference<TSerialized>(
+  value: object,
+  context: SerializationContext,
+  create: () => TSerialized,
+  fill: (serialized: TSerialized) => void,
+): TSerialized {
+  const cachedValue = getCircularOrSharedValue(value, context);
+
+  if (context.references.has(value)) {
+    return cachedValue as TSerialized;
+  }
+
+  const serialized = create();
+  markSerializationStart(value, serialized, context);
+
+  try {
+    fill(serialized);
+    return serialized;
+  } finally {
+    markSerializationComplete(value, context);
+  }
+}
+
 function serializeClassInstance(
   value: Record<string | symbol, unknown>,
   context: SerializationContext,
 ): Record<string | symbol, unknown> {
-  const cachedValue = getCircularOrSharedValue(value, context);
-
-  if (context.references.has(value)) {
-    return cachedValue as Record<string | symbol, unknown>;
-  }
-
   const constructor = value.constructor as Function;
   const { classOptions, fieldMetadata } = getCachedMetadata(constructor, context);
   const hasMetadata = fieldMetadata.size > 0 || classOptions.excludeExtraneous === true;
@@ -123,56 +140,41 @@ function serializeClassInstance(
     return serializeRecord(value, context);
   }
 
-  const serialized: Record<string | symbol, unknown> = {};
-  markSerializationStart(value, serialized, context);
-  const candidateKeys = resolveCandidateKeys(value, fieldMetadata, classOptions.excludeExtraneous === true);
+  return serializeWithTrackedReference<Record<string | symbol, unknown>>(value, context, () => ({}), (serialized) => {
+    const candidateKeys = resolveCandidateKeys(value, fieldMetadata, classOptions.excludeExtraneous === true);
 
-  for (const propertyKey of candidateKeys) {
-    const metadata = fieldMetadata.get(propertyKey);
+    for (const propertyKey of candidateKeys) {
+      const metadata = fieldMetadata.get(propertyKey);
 
-    if (metadata?.excluded) {
-      continue;
+      if (metadata?.excluded) {
+        continue;
+      }
+
+      const raw = value[propertyKey as keyof typeof value];
+
+      if (raw === undefined && classOptions.excludeExtraneous === true && metadata?.exposed !== true) {
+        continue;
+      }
+
+      const transformed = metadata ? applyTransforms(raw, metadata) : raw;
+      serialized[propertyKey] = serializeInternal(transformed, context);
     }
-
-    const raw = value[propertyKey as keyof typeof value];
-
-    if (raw === undefined && classOptions.excludeExtraneous === true && metadata?.exposed !== true) {
-      continue;
-    }
-
-    const transformed = metadata ? applyTransforms(raw, metadata) : raw;
-    serialized[propertyKey] = serializeInternal(transformed, context);
-  }
-
-  markSerializationComplete(value, context);
-
-  return serialized;
+  });
 }
 
 function serializeRecord(
   value: Record<string | symbol, unknown>,
   context: SerializationContext,
 ): Record<string | symbol, unknown> {
-  const cachedValue = getCircularOrSharedValue(value, context);
-
-  if (context.references.has(value)) {
-    return cachedValue as Record<string | symbol, unknown>;
-  }
-
-  const serialized: Record<string | symbol, unknown> = {};
-  markSerializationStart(value, serialized, context);
-
   const symbolKeys = Object.getOwnPropertySymbols(value).filter((key) => Object.prototype.propertyIsEnumerable.call(value, key));
   const keys: Array<string | symbol> = [...Object.keys(value), ...symbolKeys];
 
-  for (const propertyKey of keys) {
-    const propertyValue = value[propertyKey];
-    serialized[propertyKey] = serializeInternal(propertyValue, context);
-  }
-
-  markSerializationComplete(value, context);
-
-  return serialized;
+  return serializeWithTrackedReference<Record<string | symbol, unknown>>(value, context, () => ({}), (serialized) => {
+    for (const propertyKey of keys) {
+      const propertyValue = value[propertyKey];
+      serialized[propertyKey] = serializeInternal(propertyValue, context);
+    }
+  });
 }
 
 function serializeInternal<T = unknown>(value: T, context: SerializationContext): unknown {
@@ -181,22 +183,11 @@ function serializeInternal<T = unknown>(value: T, context: SerializationContext)
   }
 
   if (Array.isArray(value)) {
-    const cachedValue = getCircularOrSharedValue(value, context);
-
-    if (context.references.has(value)) {
-      return cachedValue;
-    }
-
-    const serialized: unknown[] = [];
-    markSerializationStart(value, serialized, context);
-
-    for (const item of value) {
-      serialized.push(serializeInternal(item, context));
-    }
-
-    markSerializationComplete(value, context);
-
-    return serialized;
+    return serializeWithTrackedReference<unknown[]>(value, context, () => [], (serialized) => {
+      for (const item of value) {
+        serialized.push(serializeInternal(item, context));
+      }
+    });
   }
 
   if (value instanceof Date) {

--- a/packages/serialization/src/vitest-module.d.ts
+++ b/packages/serialization/src/vitest-module.d.ts
@@ -1,0 +1,5 @@
+declare module 'vitest' {
+  export const describe: typeof globalThis.describe;
+  export const expect: typeof globalThis.expect;
+  export const it: typeof globalThis.it;
+}

--- a/packages/serialization/tsconfig.json
+++ b/packages/serialization/tsconfig.json
@@ -4,5 +4,5 @@
     "rootDir": "src",
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -12,7 +12,7 @@ import {
 import { createMemoryThrottlerStore } from './store.js';
 import { THROTTLER_OPTIONS } from './tokens.js';
 import type { ThrottlerModuleOptions, ThrottlerStore } from './types.js';
-import { validateThrottleOptions, validateThrottlerModuleOptions } from './validation.js';
+import { validateThrottleOptions, validateThrottlerModuleOptions, validateThrottlerStoreEntry } from './validation.js';
 
 type MetadataBag = Record<PropertyKey, unknown>;
 
@@ -110,10 +110,10 @@ export class ThrottlerGuard implements Guard {
     const handlerKey = buildHandlerKey(handler);
     const storeKey = buildStoreKey(handlerKey, clientKey);
     const now = Date.now();
-    const entry = await this.store.consume(storeKey, {
+    const entry = validateThrottlerStoreEntry(await this.store.consume(storeKey, {
       now,
       ttlSeconds,
-    });
+    }));
 
     if (entry.count > limit) {
       const retryAfter = Math.ceil((entry.resetAt - now) / 1000);

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -471,6 +471,26 @@ describe('ThrottlerGuard — Redis store mock', () => {
     expect(store.consume).toHaveBeenCalledTimes(2);
   });
 
+  it('rejects invalid custom-store entries before enforcing limits', async () => {
+    const store: ThrottlerStore = {
+      consume: vi.fn(async () => ({
+        count: 0,
+        resetAt: Number.NaN,
+      })),
+    };
+
+    class TestController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ limit: 2, store, ttl: 60 });
+    const ctx = createRequestContext();
+
+    await expect(
+      guard.canActivate(createGuardContext(TestController, 'action', ctx)),
+    ).rejects.toThrow(/store count/i);
+  });
+
   it('builds store keys from route and token identity context', async () => {
     const store: ThrottlerStore = {
       consume: vi.fn(async (_key: string, input: ThrottlerConsumeInput) => ({

--- a/packages/throttler/src/redis-store.ts
+++ b/packages/throttler/src/redis-store.ts
@@ -1,6 +1,7 @@
 import type Redis from 'ioredis';
 
 import type { ThrottlerConsumeInput, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+import { validateThrottlerStoreEntry } from './validation.js';
 
 const CONSUME_LUA = [
   "local key = KEYS[1]",
@@ -40,7 +41,7 @@ function parseConsumeResult(result: unknown): ThrottlerStoreEntry {
     throw new Error('Redis throttler consume script returned non-numeric counters.');
   }
 
-  return { count, resetAt };
+  return validateThrottlerStoreEntry({ count, resetAt });
 }
 
 /**

--- a/packages/throttler/src/validation.ts
+++ b/packages/throttler/src/validation.ts
@@ -1,8 +1,14 @@
-import type { ThrottlerHandlerOptions, ThrottlerModuleOptions } from './types.js';
+import type { ThrottlerHandlerOptions, ThrottlerModuleOptions, ThrottlerStoreEntry } from './types.js';
 
-function assertPositiveFiniteInteger(value: number, field: 'limit' | 'ttl'): void {
+function assertPositiveFiniteInteger(value: number, field: string): void {
   if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
     throw new Error(`Invalid throttler ${field}: expected a positive finite integer.`);
+  }
+}
+
+function assertFiniteInteger(value: number, field: string): void {
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new Error(`Invalid throttler ${field}: expected a finite integer.`);
   }
 }
 
@@ -18,4 +24,14 @@ export function validateThrottleOptions(options: ThrottlerHandlerOptions): Throt
 export function validateThrottlerModuleOptions(options: ThrottlerModuleOptions): ThrottlerModuleOptions {
   validateThrottleOptions(options);
   return options;
+}
+
+export function validateThrottlerStoreEntry(entry: ThrottlerStoreEntry): ThrottlerStoreEntry {
+  assertPositiveFiniteInteger(entry.count, 'store count');
+  assertFiniteInteger(entry.resetAt, 'store resetAt');
+
+  return {
+    count: entry.count,
+    resetAt: entry.resetAt,
+  };
 }

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -420,6 +420,30 @@ describe('DefaultValidator', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('allows shared nested payload objects across collection entries', async () => {
+    class ChildDto {
+      @MinLength(1)
+      name = '';
+    }
+
+    class ParentDto {
+      @ValidateNested(() => ChildDto, { each: true })
+      children: ChildDto[] = [];
+    }
+
+    const shared = { name: 'ok' };
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(
+        Object.assign(new ParentDto(), {
+          children: [shared, shared],
+        }),
+        ParentDto,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
   it('reports stable field paths for deeply nested DTO validation failures', async () => {
     class Level3Dto {
       @MinLength(2, { message: 'leaf must have length at least 2' })

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -472,10 +472,6 @@ function materializeNestedDtoValue<T>(target: Constructor<T>, rawValue: unknown,
     return rawValue;
   }
 
-  if (context?.active.has(rawValue)) {
-    return rawValue;
-  }
-
   return createNestedDtoInstance(target, rawValue, context);
 }
 


### PR DESCRIPTION
## Summary
- streamline validation nested materialization traversal checks while keeping shared nested payload handling stable
- reuse serialization reference-tracking writes and add shared decorated-reference regression coverage
- centralize throttler store-entry validation so in-memory, Redis, and custom stores share one internal contract guard

## Changes
- remove a redundant nested traversal active-check in `@konekti/validation` and cover shared collection-entry reuse
- extract a shared tracked-reference writer in `@konekti/serialization` and cover shared decorated class-instance serialization
- validate `ThrottlerStoreEntry` centrally in `@konekti/throttler` for Redis parsing and guard-level store consumption, with custom-store regression coverage

## Testing
- `pnpm exec vitest run packages/validation/src/validation.test.ts packages/serialization/src/serialize.test.ts packages/throttler/src/module.test.ts packages/throttler/src/redis-store.test.ts`
- `pnpm build`
- `pnpm typecheck` **fails in this fresh worktree with existing workspace module-resolution errors outside this slice (for example `packages/http/src/adapter.ts` -> `Cannot find module '@konekti/core'`)**

## Public export documentation
- [x] No public exports changed in this PR.
- [x] Source `@example` blocks and README scenario examples remain unchanged.

## Behavioral contract
- [x] No documented behavioral contracts were removed.
- [x] No new public behavioral contracts were introduced, so affected READMEs remain accurate.
- [x] Intentional limitations remain unchanged.
- [x] Runtime invariants touched here are covered by targeted regression tests.

## Platform consistency governance (SSOT)
- [x] No governance or platform-contract docs changed in this PR.

Closes #944