### PR TITLE
test(packages): add package-local vitest ownership

### DIFF
--- a/packages/cache-manager/package.json
+++ b/packages/cache-manager/package.json
@@ -39,7 +39,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -58,5 +60,8 @@
     "ioredis": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/cache-manager/vitest.config.ts
+++ b/packages/cache-manager/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,6 +57,7 @@
     "typescript": "^5.8.2"
   },
   "devDependencies": {
-    "@types/ejs": "^3.1.5"
+    "@types/ejs": "^3.1.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,11 +37,16 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "dotenv": "^16.0.0",
     "dotenv-expand": "^11.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,5 +45,8 @@
     "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
     "test": "pnpm exec vitest run -c vitest.config.ts",
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/cqrs/package.json
+++ b/packages/cqrs/package.json
@@ -38,12 +38,17 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/di": "workspace:*",
     "@konekti/event-bus": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/cqrs/vitest.config.ts
+++ b/packages/cqrs/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -46,5 +48,8 @@
     "@konekti/redis": "workspace:*",
     "@konekti/runtime": "workspace:*",
     "croner": "^8.1.2"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/cron/vitest.config.ts
+++ b/packages/cron/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -44,5 +44,8 @@
   },
   "dependencies": {
     "@konekti/core": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -35,12 +35,17 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/di": "workspace:*",
     "@konekti/notifications": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/discord/vitest.config.ts
+++ b/packages/discord/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -53,5 +55,8 @@
     "drizzle-orm": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/drizzle/vitest.config.ts
+++ b/packages/drizzle/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -47,7 +47,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -58,6 +60,7 @@
     "nodemailer": "^6.10.1"
   },
   "devDependencies": {
-    "@types/nodemailer": "^8.0.0"
+    "@types/nodemailer": "^8.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/email/vitest.config.ts
+++ b/packages/email/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -41,7 +41,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -55,5 +57,8 @@
     "ioredis": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/event-bus/vitest.config.ts
+++ b/packages/event-bus/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -38,10 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
-  },
-  "devDependencies": {
-    "@types/ws": "^8.18.1"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -54,5 +53,9 @@
     "graphql-ws": "^5.16.2",
     "graphql-yoga": "^5.18.1",
     "ws": "^8.18.3"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.18.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/graphql/vitest.config.ts
+++ b/packages/graphql/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -43,11 +43,16 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/validation": "workspace:*",
     "@konekti/di": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/http/vitest.config.ts
+++ b/packages/http/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -38,11 +38,16 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/di": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/jwt/vitest.config.ts
+++ b/packages/jwt/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -37,7 +37,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/di": "workspace:*",
@@ -46,6 +48,7 @@
     "prom-client": "^15.1.3"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/metrics/vitest.config.ts
+++ b/packages/metrics/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/microservices/package.json
+++ b/packages/microservices/package.json
@@ -70,7 +70,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -96,5 +98,8 @@
     "mqtt": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/microservices/vitest.config.ts
+++ b/packages/microservices/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -53,5 +55,8 @@
     "mongoose": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/mongoose/vitest.config.ts
+++ b/packages/mongoose/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -38,11 +38,16 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/di": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/notifications/vitest.config.ts
+++ b/packages/notifications/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -38,12 +38,17 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/validation": "workspace:*",
     "@konekti/http": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/openapi/vitest.config.ts
+++ b/packages/openapi/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/passport/package.json
+++ b/packages/passport/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -46,5 +48,8 @@
     "@konekti/http": "workspace:*",
     "@konekti/jwt": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/passport/vitest.config.ts
+++ b/packages/passport/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/platform-bun/package.json
+++ b/packages/platform-bun/package.json
@@ -37,10 +37,15 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/http": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-bun/vitest.config.ts
+++ b/packages/platform-bun/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/platform-cloudflare-workers/package.json
+++ b/packages/platform-cloudflare-workers/package.json
@@ -38,10 +38,15 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/http": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-cloudflare-workers/vitest.config.ts
+++ b/packages/platform-cloudflare-workers/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/platform-deno/package.json
+++ b/packages/platform-deno/package.json
@@ -37,10 +37,15 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/http": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-deno/vitest.config.ts
+++ b/packages/platform-deno/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/platform-express/package.json
+++ b/packages/platform-express/package.json
@@ -37,7 +37,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/http": "workspace:*",
@@ -45,6 +47,7 @@
     "express": "^5.1.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.3"
+    "@types/express": "^5.0.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-express/vitest.config.ts
+++ b/packages/platform-express/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -37,7 +37,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@fastify/multipart": "^9.2.1",
@@ -45,5 +47,8 @@
     "@konekti/runtime": "workspace:*",
     "fastify": "^5.6.1",
     "fastify-raw-body": "^5.0.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-fastify/vitest.config.ts
+++ b/packages/platform-fastify/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/platform-nodejs/package.json
+++ b/packages/platform-nodejs/package.json
@@ -38,10 +38,15 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/http": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-nodejs/vitest.config.ts
+++ b/packages/platform-nodejs/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -54,5 +56,8 @@
     "@prisma/client": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/prisma/vitest.config.ts
+++ b/packages/prisma/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -39,7 +39,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -47,5 +49,8 @@
     "@konekti/redis": "workspace:*",
     "@konekti/runtime": "workspace:*",
     "bullmq": "^5.58.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/queue/vitest.config.ts
+++ b/packages/queue/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -38,12 +38,17 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/di": "workspace:*",
     "@konekti/runtime": "workspace:*",
     "ioredis": "^5.10.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/redis/vitest.config.ts
+++ b/packages/redis/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -80,6 +80,7 @@
     "@konekti/http": "workspace:*"
   },
   "devDependencies": {
-    "@konekti/serialization": "workspace:*"
+    "@konekti/serialization": "workspace:*",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/serialization/package.json
+++ b/packages/serialization/package.json
@@ -45,5 +45,8 @@
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/http": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -35,12 +35,17 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
     "@konekti/di": "workspace:*",
     "@konekti/notifications": "workspace:*",
     "@konekti/runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/slack/vitest.config.ts
+++ b/packages/slack/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/socket.io/package.json
+++ b/packages/socket.io/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@socket.io/bun-engine": "^0.1.0",
@@ -56,6 +58,7 @@
     "@konekti/platform-fastify": "workspace:*",
     "@konekti/platform-nodejs": "workspace:*",
     "socket.io": "^4.8.1",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/socket.io/vitest.config.ts
+++ b/packages/socket.io/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -31,12 +31,15 @@
     "build": "pnpm exec vite build",
     "dev": "pnpm exec vite",
     "preview": "pnpm exec vite preview",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/runtime": "workspace:*"
   },
   "devDependencies": {
-    "@konekti-internal/tooling-vite": "workspace:*"
+    "@konekti-internal/tooling-vite": "workspace:*",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/studio/vitest.config.ts
+++ b/packages/studio/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/terminus/package.json
+++ b/packages/terminus/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -61,5 +63,8 @@
     "@konekti/redis": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/terminus/vitest.config.ts
+++ b/packages/terminus/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -82,11 +82,6 @@
     "test": "pnpm exec vitest run -c vitest.config.ts",
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
-  "devDependencies": {
-    "@konekti/platform-nodejs": "workspace:*",
-    "@konekti/platform-express": "workspace:*",
-    "@konekti/platform-fastify": "workspace:*"
-  },
   "dependencies": {
     "@konekti/config": "workspace:*",
     "@konekti/core": "workspace:*",
@@ -102,5 +97,11 @@
     "@babel/core": {
       "optional": true
     }
+  },
+  "devDependencies": {
+    "@konekti/platform-nodejs": "workspace:*",
+    "@konekti/platform-express": "workspace:*",
+    "@konekti/platform-fastify": "workspace:*",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/throttler/package.json
+++ b/packages/throttler/package.json
@@ -38,7 +38,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -59,6 +61,7 @@
     }
   },
   "devDependencies": {
-    "ioredis": "^5.10.0"
+    "ioredis": "^5.10.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/throttler/vitest.config.ts
+++ b/packages/throttler/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/websockets/package.json
+++ b/packages/websockets/package.json
@@ -70,7 +70,9 @@
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
     "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
-    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit"
+    "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
+    "test": "pnpm exec vitest run -c vitest.config.ts",
+    "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
     "@konekti/core": "workspace:*",
@@ -83,6 +85,7 @@
     "@konekti/platform-bun": "workspace:*",
     "@konekti/platform-express": "workspace:*",
     "@konekti/platform-fastify": "workspace:*",
-    "@types/ws": "^8.18.1"
+    "@types/ws": "^8.18.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/websockets/vitest.config.ts
+++ b/packages/websockets/vitest.config.ts
@@ -1,0 +1,7 @@
+import { createKonektiVitestWorkspaceConfig } from '../../tooling/vitest/src';
+
+export default createKonektiVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,10 @@ importers:
       ioredis:
         specifier: ^5.0.0
         version: 5.10.0
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/cli:
     dependencies:
@@ -175,6 +179,9 @@ importers:
       '@types/ejs':
         specifier: ^3.1.5
         version: 3.1.5
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/config:
     dependencies:
@@ -187,8 +194,16 @@ importers:
       dotenv-expand:
         specifier: ^11.0.0
         version: 11.0.7
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
-  packages/core: {}
+  packages/core:
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/cqrs:
     dependencies:
@@ -204,6 +219,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/cron:
     dependencies:
@@ -222,12 +241,20 @@ importers:
       croner:
         specifier: ^8.1.2
         version: 8.1.2
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/di:
     dependencies:
       '@konekti/core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/discord:
     dependencies:
@@ -243,6 +270,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/drizzle:
     dependencies:
@@ -261,6 +292,10 @@ importers:
       drizzle-orm:
         specifier: '>=0.30.0'
         version: 0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@7.5.0(typescript@5.9.3))
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/email:
     dependencies:
@@ -286,6 +321,9 @@ importers:
       '@types/nodemailer':
         specifier: ^8.0.0
         version: 8.0.0
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/event-bus:
     dependencies:
@@ -301,6 +339,10 @@ importers:
       ioredis:
         specifier: ^5.0.0
         version: 5.10.0
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/graphql:
     dependencies:
@@ -338,6 +380,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/http:
     dependencies:
@@ -350,6 +395,10 @@ importers:
       '@konekti/validation':
         specifier: workspace:*
         version: link:../validation
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/jwt:
     dependencies:
@@ -362,6 +411,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/metrics:
     dependencies:
@@ -381,6 +434,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/microservices:
     dependencies:
@@ -405,6 +461,10 @@ importers:
       mqtt:
         specifier: ^5.0.0
         version: 5.15.1
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/mongoose:
     dependencies:
@@ -423,6 +483,10 @@ importers:
       mongoose:
         specifier: '>=7.0.0'
         version: 9.3.2(socks@2.8.7)
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/notifications:
     dependencies:
@@ -435,6 +499,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/openapi:
     dependencies:
@@ -450,6 +518,10 @@ importers:
       '@konekti/validation':
         specifier: workspace:*
         version: link:../validation
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/passport:
     dependencies:
@@ -468,6 +540,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/platform-bun:
     dependencies:
@@ -477,6 +553,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/platform-cloudflare-workers:
     dependencies:
@@ -486,6 +566,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/platform-deno:
     dependencies:
@@ -495,6 +579,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/platform-express:
     dependencies:
@@ -511,6 +599,9 @@ importers:
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.6
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/platform-fastify:
     dependencies:
@@ -529,6 +620,10 @@ importers:
       fastify-raw-body:
         specifier: ^5.0.0
         version: 5.0.0
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/platform-nodejs:
     dependencies:
@@ -538,6 +633,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/prisma:
     dependencies:
@@ -559,6 +658,10 @@ importers:
       '@prisma/client':
         specifier: '>=5.0.0'
         version: 7.5.0(typescript@5.9.3)
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/queue:
     dependencies:
@@ -577,6 +680,10 @@ importers:
       bullmq:
         specifier: ^5.58.0
         version: 5.71.0
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/redis:
     dependencies:
@@ -592,6 +699,10 @@ importers:
       ioredis:
         specifier: ^5.10.0
         version: 5.10.0
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/runtime:
     dependencies:
@@ -611,6 +722,9 @@ importers:
       '@konekti/serialization':
         specifier: workspace:*
         version: link:../serialization
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/serialization:
     dependencies:
@@ -620,6 +734,10 @@ importers:
       '@konekti/http':
         specifier: workspace:*
         version: link:../http
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/slack:
     dependencies:
@@ -635,6 +753,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/socket.io:
     dependencies:
@@ -672,6 +794,9 @@ importers:
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/studio:
     dependencies:
@@ -682,6 +807,9 @@ importers:
       '@konekti-internal/tooling-vite':
         specifier: workspace:*
         version: link:../../tooling/vite
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/terminus:
     dependencies:
@@ -706,6 +834,10 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
+    devDependencies:
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/testing:
     dependencies:
@@ -727,9 +859,6 @@ importers:
       '@konekti/runtime':
         specifier: workspace:*
         version: link:../runtime
-      vitest:
-        specifier: ^3.0.8
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
     devDependencies:
       '@konekti/platform-express':
         specifier: workspace:*
@@ -740,6 +869,9 @@ importers:
       '@konekti/platform-nodejs':
         specifier: workspace:*
         version: link:../platform-nodejs
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/throttler:
     dependencies:
@@ -762,6 +894,9 @@ importers:
       ioredis:
         specifier: ^5.10.0
         version: 5.10.0
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   packages/validation:
     dependencies:
@@ -821,6 +956,9 @@ importers:
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
 
   tooling/babel: {}
 


### PR DESCRIPTION
## Summary
- add local `vitest` ownership plus `test` and `test:watch` scripts for packages that already own tests
- add per-package `vitest.config.ts` wrappers, including `studio`, on top of the shared workspace Vitest config
- refresh `pnpm-lock.yaml` and confirm both package-local and root test execution paths work again

## Verification
- `pnpm --dir packages/core test`
- `pnpm --dir packages/config test`
- `pnpm --dir packages/microservices test`
- `pnpm --dir packages/studio test`
- `pnpm -r --filter './packages/*' --if-present test`
- `pnpm test`