### PR TITLE
Resolve #953: add foundation Inject syntax migration

### DIFF
--- a/packages/core/README.ko.md
+++ b/packages/core/README.ko.md
@@ -46,7 +46,7 @@ class CoreModule {}
 })
 class AppModule {}
 
-@Inject([DatabaseService])
+@Inject(DatabaseService)
 @Scope('singleton')
 class UserService {
   constructor(private readonly db: DatabaseService) {}
@@ -61,16 +61,18 @@ Konekti는 TC39 표준 데코레이터를 사용하므로 `experimentalDecorator
 
 ### 명시적인 의존성 메타데이터
 
-`@Inject([...])`는 리플렉션 기반 추론 대신 코드 안에서 의존성 토큰을 직접 드러냅니다.
+`@Inject(...)`는 리플렉션 기반 추론 대신 코드 안에서 의존성 토큰을 직접 드러냅니다. 상속된 constructor 토큰을 명시적으로 비우려면 `@Inject()`를 사용하면 됩니다.
 
 ```ts
 const CONFIG_TOKEN = Symbol('CONFIG_TOKEN');
 
-@Inject([CONFIG_TOKEN])
+@Inject(CONFIG_TOKEN)
 class UsesConfigValue {
   constructor(private readonly config: Config) {}
 }
 ```
+
+레거시 배열 형식(`@Inject([A, B])`)은 단계적 마이그레이션 동안 계속 허용되지만, 이제 공개 API의 canonical form은 variadic 호출입니다.
 
 ### 형제 패키지를 위한 공용 메타데이터 헬퍼
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -48,7 +48,7 @@ class CoreModule {}
 })
 class AppModule {}
 
-@Inject([DatabaseService])
+@Inject(DatabaseService)
 @Scope('singleton')
 class UserService {
   constructor(private readonly db: DatabaseService) {}
@@ -63,16 +63,18 @@ Konekti uses TC39 standard decorators. You do not need `experimentalDecorators: 
 
 ### Explicit dependency metadata
 
-`@Inject([...])` keeps dependency wiring visible in code instead of relying on emitted reflection metadata.
+`@Inject(...)` keeps dependency wiring visible in code instead of relying on emitted reflection metadata. Call `@Inject()` when you want to record an explicit empty override for inherited constructor tokens.
 
 ```ts
 const CONFIG_TOKEN = Symbol('CONFIG_TOKEN');
 
-@Inject([CONFIG_TOKEN])
+@Inject(CONFIG_TOKEN)
 class UsesConfigValue {
   constructor(private readonly config: Config) {}
 }
 ```
+
+The legacy array form (`@Inject([A, B])`) is still accepted during the staged migration window, but variadic calls are now the canonical public API.
 
 ### Shared metadata helpers for sibling packages
 

--- a/packages/core/src/decorators.test.ts
+++ b/packages/core/src/decorators.test.ts
@@ -28,7 +28,7 @@ describe('core decorators', () => {
   it('writes inject and scope metadata through decorators', () => {
     const LOGGER = Symbol('LOGGER');
 
-    @Inject([LOGGER])
+    @Inject(LOGGER)
     @Scope('request')
     class AppService {}
 
@@ -41,7 +41,7 @@ describe('core decorators', () => {
   it('inherits DI metadata through decorators while keeping own reads separate', () => {
     const LOGGER = Symbol('LOGGER');
 
-    @Inject([LOGGER])
+    @Inject(LOGGER)
     @Scope('request')
     class BaseService {}
 
@@ -54,14 +54,14 @@ describe('core decorators', () => {
     });
   });
 
-  it('allows @Inject([]) to clear inherited inject tokens', () => {
+  it('treats @Inject() as an explicit empty inject override', () => {
     const LOGGER = Symbol('LOGGER');
 
-    @Inject([LOGGER])
+    @Inject(LOGGER)
     @Scope('request')
     class BaseService {}
 
-    @Inject([])
+    @Inject()
     class ChildService extends BaseService {}
 
     expect(getOwnClassDiMetadata(ChildService)).toEqual({
@@ -71,6 +71,29 @@ describe('core decorators', () => {
     expect(getClassDiMetadata(ChildService)).toEqual({
       inject: [],
       scope: 'request',
+    });
+  });
+
+  it('keeps the legacy array syntax working during the migration window', () => {
+    const LOGGER = Symbol('LOGGER');
+    const CACHE = Symbol('CACHE');
+
+    @Inject([LOGGER, CACHE])
+    class LegacyArrayService {}
+
+    expect(getClassDiMetadata(LegacyArrayService)).toEqual({
+      inject: [LOGGER, CACHE],
+      scope: undefined,
+    });
+  });
+
+  it('stores an explicit empty inject list for zero-dependency classes', () => {
+    @Inject()
+    class ZeroDependencyService {}
+
+    expect(getOwnClassDiMetadata(ZeroDependencyService)).toEqual({
+      inject: [],
+      scope: undefined,
     });
   });
 });

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -36,13 +36,41 @@ export function Global(): StandardClassDecoratorFn {
 /**
  * Defines explicit constructor injection tokens for the decorated class.
  *
+ * Passing tokens variadically (`@Inject(A, B)`) is the canonical API. Calling `@Inject()` records an
+ * explicit empty inject list so subclasses can intentionally clear inherited constructor tokens.
+ * During the staged migration window, the legacy array form (`@Inject([A, B])`) is still normalized.
+ *
+ * @param tokens Constructor-parameter token list used by `@konekti/di` during dependency resolution.
+ * @returns A standard class decorator that stores explicit injection metadata on the target class.
+ */
+export function Inject(): StandardClassDecoratorFn;
+/**
+ * Defines explicit constructor injection tokens for the decorated class.
+ *
  * @param tokens Constructor-parameter token list used by `@konekti/di` during dependency resolution.
  * @returns A standard class decorator that stores explicit injection metadata on the target class.
  */
 export function Inject<const TTokens extends readonly Token[]>(
-  tokens: TupleOnly<TTokens>,
+  ...tokens: TupleOnly<TTokens>
 ): StandardClassDecoratorFn;
-export function Inject(tokens: readonly Token[]): StandardClassDecoratorFn {
+/**
+ * Defines explicit constructor injection tokens for the decorated class.
+ *
+ * @param tokens Constructor-parameter token list used by `@konekti/di` during dependency resolution.
+ * @returns A standard class decorator that stores explicit injection metadata on the target class.
+ */
+export function Inject(tokens: readonly Token[]): StandardClassDecoratorFn;
+/**
+ * Defines explicit constructor injection tokens for the decorated class.
+ *
+ * @param tokensOrList Constructor-parameter token list used by `@konekti/di` during dependency resolution.
+ * @returns A standard class decorator that stores explicit injection metadata on the target class.
+ */
+export function Inject(...tokensOrList: readonly unknown[]): StandardClassDecoratorFn {
+  const tokens = tokensOrList.length === 1 && Array.isArray(tokensOrList[0])
+    ? [...tokensOrList[0] as readonly Token[]]
+    : [...tokensOrList as readonly Token[]];
+
   return (target) => {
     defineClassDiMetadata(target, { inject: [...tokens] });
   };

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -41,7 +41,7 @@ class Logger {
   }
 }
 
-@Inject([Logger])
+@Inject(Logger)
 @Scope('singleton')
 class UserService {
   constructor(private readonly logger: Logger) {}

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -40,7 +40,7 @@ class Logger {
   log(msg: string) { console.log(msg); }
 }
 
-@Inject([Logger])
+@Inject(Logger)
 @Scope('singleton')
 class UserService {
   constructor(private logger: Logger) {}
@@ -100,4 +100,3 @@ const scopedService = await requestContainer.resolve(RequestScopedService);
 - `packages/di/src/container.ts`
 - `packages/di/src/container.test.ts`
 - `examples/minimal/src/app.ts`
-

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -45,7 +45,7 @@ function isExistingProvider(value: Provider): value is ExistingProvider {
 
 function normalizeInjectToken(token: Token | ForwardRefFn | OptionalToken): Token | ForwardRefFn | OptionalToken {
   if (token == null) {
-    throw new InvalidProviderError('Inject token must not be null or undefined. Check that all tokens in @Inject([...]) are defined at the point of decoration (forward-reference cycles require forwardRef()).');
+    throw new InvalidProviderError('Inject token must not be null or undefined. Check that all tokens in @Inject(...) are defined at the point of decoration (forward-reference cycles require forwardRef()).');
   }
 
   return token;

--- a/packages/di/src/errors.ts
+++ b/packages/di/src/errors.ts
@@ -38,14 +38,14 @@ function formatDiContext(ctx?: DiErrorContext): string {
 
   if (parts.length === 0) return '';
 
-  return '\n  ' + parts.join('\n  ');
+  return `\n  ${parts.join('\n  ')}`;
 }
 
 /**
  * Raised when a provider declaration or inject token cannot be normalized into a valid DI registration.
  *
  * @remarks
- * This usually points to malformed provider objects, missing `@Inject([...])` tokens, or `null`/
+ * This usually points to malformed provider objects, missing `@Inject(...)` tokens, or `null`/
  * `undefined` references that were evaluated before a `forwardRef()` indirection could be applied.
  */
 export class InvalidProviderError extends KonektiCodeError {
@@ -144,11 +144,11 @@ export class DuplicateProviderError extends KonektiCodeError {
 function buildMeta(context: DiErrorContext): Record<string, unknown> {
   const meta: Record<string, unknown> = {};
 
-  if (context.token !== undefined) meta['token'] = formatTokenName(context.token);
-  if (context.scope) meta['scope'] = context.scope;
-  if (context.module) meta['module'] = context.module;
-  if (context.dependencyChain) meta['dependencyChain'] = context.dependencyChain.map((t) => formatTokenName(t));
-  if (context.hint) meta['hint'] = context.hint;
+  if (context.token !== undefined) meta.token = formatTokenName(context.token);
+  if (context.scope) meta.scope = context.scope;
+  if (context.module) meta.module = context.module;
+  if (context.dependencyChain) meta.dependencyChain = context.dependencyChain.map((t) => formatTokenName(t));
+  if (context.hint) meta.hint = context.hint;
 
   return meta;
 }

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -165,7 +165,7 @@ async function readGraphqlWebSocketMessages(socket: WebSocket, count: number): P
   });
 }
 
-@Inject([])
+@Inject()
 class ResolverState {
   mutableValue = 'init';
 }
@@ -232,7 +232,7 @@ const OperationResultUnionType = new GraphQLUnionType({
   types: [UnionSuccessPayloadType, UnionErrorPayloadType],
 });
 
-@Inject([ResolverState])
+@Inject(ResolverState)
 @Resolver('RootResolver')
 class GraphqlResolver {
   constructor(private readonly state: ResolverState) {}
@@ -264,7 +264,7 @@ class GraphqlResolver {
   }
 }
 
-@Inject([])
+@Inject()
 @Resolver('ObjectOutputResolver')
 class ObjectOutputResolver {
   @Query({ outputType: OperationPayloadType })
@@ -292,7 +292,7 @@ class ObjectOutputResolver {
   }
 }
 
-@Inject([])
+@Inject()
 @Resolver('ListOutputResolver')
 class ListOutputResolver {
   @Query({ input: ValuesInput, argTypes: { values: listOf('string') }, outputType: listOf('string') })
@@ -317,7 +317,7 @@ class ListOutputResolver {
   }
 }
 
-@Inject([])
+@Inject()
 @Resolver('UnionOutputResolver')
 class UnionOutputResolver {
   @Query({ outputType: OperationResultUnionType })
@@ -900,7 +900,7 @@ describe('@konekti/graphql', () => {
       },
     };
 
-    @Inject([])
+    @Inject()
     @Resolver('ReservedContextResolver')
     class ReservedContextResolver {
       @Query()
@@ -944,13 +944,13 @@ describe('@konekti/graphql — provider scopes', () => {
   it('isolates request-scoped resolver instances across concurrent operations', async () => {
     let issued = 0;
 
-    @Inject([])
+    @Inject()
     @Scope('request')
     class RequestIdentity {
       readonly id = `req-${String(++issued)}`;
     }
 
-    @Inject([RequestIdentity])
+    @Inject(RequestIdentity)
     @Scope('request')
     @Resolver('ConcurrentRequestResolver')
     class ConcurrentRequestResolver {
@@ -989,13 +989,13 @@ describe('@konekti/graphql — provider scopes', () => {
   });
 
   it('request-scoped resolver receives a fresh instance per operation', async () => {
-    @Inject([])
+    @Inject()
     @Scope('request')
     class RequestCounter {
       count = 0;
     }
 
-    @Inject([RequestCounter])
+    @Inject(RequestCounter)
     @Scope('request')
     @Resolver('ScopedResolver')
     class RequestScopedResolver {
@@ -1028,13 +1028,13 @@ describe('@konekti/graphql — provider scopes', () => {
   });
 
   it('reuses one request scope across all resolver fields in the same operation', async () => {
-    @Inject([])
+    @Inject()
     @Scope('request')
     class OperationCounter {
       count = 0;
     }
 
-    @Inject([OperationCounter])
+    @Inject(OperationCounter)
     @Scope('request')
     @Resolver('OperationScopedResolver')
     class OperationScopedResolver {
@@ -1075,13 +1075,13 @@ describe('@konekti/graphql — provider scopes', () => {
   it('isolates request-scoped subscription resolvers per websocket operation', async () => {
     let issued = 0;
 
-    @Inject([])
+    @Inject()
     @Scope('request')
     class SubscriptionRequestIdentity {
       readonly id = `subscription-${String(++issued)}`;
     }
 
-    @Inject([SubscriptionRequestIdentity])
+    @Inject(SubscriptionRequestIdentity)
     @Scope('request')
     @Resolver('ScopedSubscriptionResolver')
     class ScopedSubscriptionResolver {
@@ -1149,13 +1149,13 @@ describe('@konekti/graphql — provider scopes', () => {
   });
 
   it('transient resolver receives a fresh instance per operation', async () => {
-    @Inject([])
+    @Inject()
     @Scope('transient')
     class TransientCounter {
       count = 0;
     }
 
-    @Inject([TransientCounter])
+    @Inject(TransientCounter)
     @Scope('transient')
     @Resolver('TransientResolver')
     class TransientScopedResolver {
@@ -1188,12 +1188,12 @@ describe('@konekti/graphql — provider scopes', () => {
   });
 
   it('singleton resolver shares state across operations', async () => {
-    @Inject([])
+    @Inject()
     class SingletonCounter {
       count = 0;
     }
 
-    @Inject([SingletonCounter])
+    @Inject(SingletonCounter)
     @Resolver('SingletonResolver')
     class SingletonScopedResolver {
       constructor(private readonly counter: SingletonCounter) {}
@@ -1289,13 +1289,13 @@ describe('@konekti/graphql — provider scopes', () => {
   });
 
   it('inherits request scope from useFactory resolverClass metadata', async () => {
-    @Inject([])
+    @Inject()
     @Scope('request')
     class FactoryRequestCounter {
       count = 0;
     }
 
-    @Inject([FactoryRequestCounter])
+    @Inject(FactoryRequestCounter)
     @Scope('request')
     @Resolver('FactoryRequestScopedResolver')
     class FactoryRequestScopedResolver {

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -471,8 +471,8 @@ describe('bootstrapModule duplicate provider detection', () => {
 });
 
 describe('bootstrapModule requiredConstructorParameters fix', () => {
-  it('does not throw for a class decorated with @Inject([]) (explicit empty inject list)', () => {
-    @Inject([])
+  it('does not throw for a class decorated with @Inject() (explicit empty inject list)', () => {
+    @Inject()
     class ZeroDependencyService {}
 
     class AppModule {}
@@ -483,10 +483,10 @@ describe('bootstrapModule requiredConstructorParameters fix', () => {
     expect(() => bootstrapModule(AppModule)).not.toThrow();
   });
 
-  it('does not throw for a class decorated with @Inject([Token]) that also has a default parameter', () => {
+  it('does not throw for a class decorated with @Inject(Token) that also has a default parameter', () => {
     class Logger {}
 
-    @Inject([Logger])
+    @Inject(Logger)
     class AppService {
       constructor(
         readonly logger: Logger,
@@ -497,6 +497,22 @@ describe('bootstrapModule requiredConstructorParameters fix', () => {
     class AppModule {}
     defineModuleMetadata(AppModule, {
       providers: [Logger, AppService],
+    });
+
+    expect(() => bootstrapModule(AppModule)).not.toThrow();
+  });
+
+  it('keeps supporting the legacy array syntax during the staged migration', () => {
+    class Logger {}
+
+    @Inject([Logger])
+    class LegacyAppService {
+      constructor(readonly logger: Logger) {}
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [Logger, LegacyAppService],
     });
 
     expect(() => bootstrapModule(AppModule)).not.toThrow();
@@ -948,10 +964,10 @@ describe('Recovery-oriented error context (runtime)', () => {
       } catch (error) {
         const meta = (error as ModuleVisibilityError & { meta?: Record<string, unknown> }).meta;
         expect(meta).toBeDefined();
-        expect(meta!['module']).toBe('BillingModule');
-        expect(meta!['phase']).toBe('provider visibility validation');
-        expect(meta!['hint']).toBeDefined();
-        expect(meta!['token']).toBeDefined();
+        expect(meta!.module).toBe('BillingModule');
+        expect(meta!.phase).toBe('provider visibility validation');
+        expect(meta!.hint).toBeDefined();
+        expect(meta!.token).toBeDefined();
       }
     });
   });
@@ -997,8 +1013,8 @@ describe('Recovery-oriented error context (runtime)', () => {
       } catch (error) {
         const meta = (error as ModuleGraphError & { meta?: Record<string, unknown> }).meta;
         expect(meta).toBeDefined();
-        expect(meta!['phase']).toBe('module graph compilation');
-        expect(meta!['hint']).toBeDefined();
+        expect(meta!.phase).toBe('module graph compilation');
+        expect(meta!.hint).toBeDefined();
       }
     });
   });
@@ -1047,9 +1063,9 @@ describe('Recovery-oriented error context (runtime)', () => {
       } catch (error) {
         const meta = (error as ModuleInjectionMetadataError & { meta?: Record<string, unknown> }).meta;
         expect(meta).toBeDefined();
-        expect(meta!['module']).toContain('BillingModule');
-        expect(meta!['phase']).toBe('injection metadata validation');
-        expect(meta!['hint']).toBeDefined();
+        expect(meta!.module).toContain('BillingModule');
+        expect(meta!.phase).toBe('injection metadata validation');
+        expect(meta!.hint).toBeDefined();
       }
     });
   });
@@ -1115,10 +1131,10 @@ describe('Recovery-oriented error context (runtime)', () => {
       } catch (error) {
         const meta = (error as DuplicateProviderError & { meta?: Record<string, unknown> }).meta;
         expect(meta).toBeDefined();
-        expect(meta!['module']).toBeDefined();
-        expect(meta!['token']).toBeDefined();
-        expect(meta!['phase']).toBe('provider registration');
-        expect(meta!['hint']).toBeDefined();
+        expect(meta!.module).toBeDefined();
+        expect(meta!.token).toBeDefined();
+        expect(meta!.phase).toBe('provider registration');
+        expect(meta!.hint).toBeDefined();
       }
     });
   });

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -1,11 +1,17 @@
 import type { Provider } from '@konekti/di';
-import { type Token } from '@konekti/core';
+import type { Token } from '@konekti/core';
 import { getClassDiMetadata, getModuleMetadata, getOwnClassDiMetadata } from '@konekti/core/internal';
 import type { MiddlewareLike } from '@konekti/http';
 
 import { ModuleGraphError, ModuleInjectionMetadataError, ModuleVisibilityError } from './errors.js';
 import type { BootstrapModuleOptions, CompiledModule, ModuleDefinition, ModuleType } from './types.js';
 
+/**
+ * Returns the public token represented by a provider declaration.
+ *
+ * @param provider Provider declaration or class provider shortcut.
+ * @returns The token that should be registered and resolved for the provider.
+ */
 export function providerToken(provider: Provider): Token {
   if (typeof provider === 'function') {
     return provider;
@@ -69,6 +75,12 @@ function controllerDependencies(controller: ModuleType): InjectionToken[] {
   return [...(getEffectiveClassDiMetadata(controller)?.inject ?? [])];
 }
 
+/**
+ * Collects runtime provider tokens into a set for visibility and validation checks.
+ *
+ * @param providers Runtime providers supplied through bootstrap options.
+ * @returns A set containing each provider token exactly once.
+ */
 export function createRuntimeTokenSet(providers: Provider[] = []): Set<Token> {
   return new Set(providers.map((provider) => providerToken(provider)));
 }
@@ -111,20 +123,20 @@ function validateClassInjectionMetadata(
     {
       module: scope,
       phase: 'injection metadata validation',
-      hint: `Ensure ${subject} has a matching @Inject([...]) decorator or provider.inject array that covers all ${required} constructor parameters.`,
+      hint: `Ensure ${subject} has a matching @Inject(...) decorator or provider.inject array that covers all ${required} constructor parameters. Use @Inject() for an explicit empty override.`,
     },
   );
 }
 
 function validateProviderInjectionMetadata(provider: Provider, scope: string): void {
   if (typeof provider === 'function') {
-      validateClassInjectionMetadata(
-        `Provider ${provider.name || '<anonymous>'}`,
-        provider,
-        getEffectiveClassDiMetadata(provider)?.inject ?? [],
-        scope,
-        '@Inject([...]) metadata',
-      );
+       validateClassInjectionMetadata(
+         `Provider ${provider.name || '<anonymous>'}`,
+         provider,
+         getEffectiveClassDiMetadata(provider)?.inject ?? [],
+         scope,
+         '@Inject(...) metadata',
+       );
     return;
   }
 
@@ -140,7 +152,7 @@ function validateProviderInjectionMetadata(provider: Provider, scope: string): v
         provider.useClass,
         provider.inject ?? getEffectiveClassDiMetadata(provider.useClass)?.inject ?? [],
         scope,
-        provider.inject ? 'provider.inject entries' : '@Inject([...]) metadata or provider.inject entries',
+        provider.inject ? 'provider.inject entries' : '@Inject(...) metadata or provider.inject entries',
       );
   }
 }
@@ -151,7 +163,7 @@ function validateControllerInjectionMetadata(controller: ModuleType, scope: stri
     controller,
     getEffectiveClassDiMetadata(controller)?.inject ?? [],
     scope,
-    '@Inject([...]) metadata',
+    '@Inject(...) metadata',
   );
 }
 
@@ -384,6 +396,13 @@ function validateCompiledModules(
   }
 }
 
+/**
+ * Compiles and validates the reachable module graph for a bootstrap entry module.
+ *
+ * @param rootModule Root application module used as the graph entrypoint.
+ * @param options Bootstrap options that contribute runtime providers and validation tokens.
+ * @returns Compiled modules in dependency order after visibility and injection validation succeed.
+ */
 export function compileModuleGraph(rootModule: ModuleType, options: BootstrapModuleOptions = {}): CompiledModule[] {
   const ordered: CompiledModule[] = [];
   const runtimeProviders = options.providers ?? [];


### PR DESCRIPTION
## Summary
- switch the foundation `@Inject` surface to canonical variadic syntax while preserving explicit empty override semantics via `@Inject()`
- keep legacy array syntax normalized during the staged migration and align DI/runtime diagnostics with the new canonical form
- update focused core/runtime/graphql regression coverage and affected package README examples for the new public contract

## Changes
- add variadic and zero-argument `Inject` support in `packages/core/src/decorators.ts` and lock the contract in core tests
- update `packages/di` and `packages/runtime` diagnostics/help text to recommend `@Inject(...)` and mention `@Inject()` explicit empty overrides
- convert foundation-owned GraphQL regression coverage and package README examples to the canonical syntax while preserving legacy compatibility

## Testing
- `pnpm verify`
- `pnpm exec vitest run packages/core/src/decorators.test.ts packages/di/src/container.test.ts packages/runtime/src/bootstrap.test.ts packages/graphql/src/module.test.ts`
- `lsp_diagnostics` on `packages/core`, `packages/di`, `packages/runtime`, `packages/graphql` → 0 errors

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- breaking: canonical class-level inject syntax is now `@Inject(A, B)`
- preserved: `@Inject()` is stored as the explicit empty override form, matching previous `@Inject([])` inheritance semantics
- staged migration: legacy `@Inject([A, B])` continues to normalize during this lane so downstream issue lanes can migrate safely

Closes #953