### PR TITLE
Resolve #954: align CLI Inject output with variadic syntax

### DIFF
--- a/packages/cli/src/generators.test.ts
+++ b/packages/cli/src/generators.test.ts
@@ -138,9 +138,9 @@ describe('CLI generators', () => {
     const service = generateServiceFiles('User', { hasRepo: true })[0]?.content ?? '';
 
     expect(controller).toContain("import { UserService } from './user.service';");
-    expect(controller).toContain('@Inject([UserService])');
+    expect(controller).toContain('@Inject(UserService)');
     expect(service).toContain("import { UserRepo } from './user.repo';");
-    expect(service).toContain('@Inject([UserRepo])');
+    expect(service).toContain('@Inject(UserRepo)');
   });
 
   describe('registerInModule', () => {

--- a/packages/cli/src/generators/templates/controller.ts.ejs
+++ b/packages/cli/src/generators/templates/controller.ts.ejs
@@ -9,7 +9,7 @@ import { <%- service %> } from './<%- kebab %>.service';
 
 @Controller('/<%- kebab %>')
 <% if (hasService) { %>
-@Inject([<%- service %>])
+@Inject(<%- service %>)
 <% } %>
 class <%- pascal %> {
 <% if (hasService) { %>

--- a/packages/cli/src/generators/templates/service.ts.ejs
+++ b/packages/cli/src/generators/templates/service.ts.ejs
@@ -7,7 +7,7 @@ import { <%- repo %> } from './<%- kebab %>.repo';
 <% } %>
 
 <% if (hasRepo) { %>
-@Inject([<%- repo %>])
+@Inject(<%- repo %>)
 <% } %>
 export class <%- pascal %> {
 <% if (hasRepo) { %>

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -336,7 +336,7 @@ import type { HealthResponseDto } from './health.response.dto';
 
 import { HealthRepo } from './health.repo';
 
-@Inject([HealthRepo])
+@Inject(HealthRepo)
 export class HealthService {
   constructor(private readonly repo: HealthRepo) {}
 
@@ -375,7 +375,7 @@ import { Controller, Get } from '@konekti/http';
 import { HealthService } from './health.service';
 import { HealthResponseDto } from './health.response.dto';
 
-@Inject([HealthService])
+@Inject(HealthService)
 @Controller('/health-info')
 export class HealthController {
   constructor(private readonly service: HealthService) {}

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -978,7 +978,7 @@ function detectManualFollowUps(source: string, filePath: string): MigrationWarni
         if (!hasInjectParameterWarning && decoratorName === 'Inject') {
           hasInjectParameterWarning = true;
           warnings.push(
-            buildWarning(filePath, sourceFile, modifier, 'inject-token', 'Constructor @Inject(TOKEN) parameter decorators need manual migration to class-level @Inject([...]).'),
+            buildWarning(filePath, sourceFile, modifier, 'inject-token', 'Constructor @Inject(TOKEN) parameter decorators need manual migration to class-level @Inject(TOKEN, ...) syntax.'),
           );
         }
 


### PR DESCRIPTION
## Summary
- switch CLI generator templates and starter scaffold output from legacy `@Inject([Token])` syntax to canonical variadic `@Inject(Token)` calls
- update NestJS migrate follow-up guidance so manual `@Inject(TOKEN)` rewrites point to the new class-level variadic syntax
- keep the change scoped to the CLI lane without touching broader docs/example ownership lanes

## Changes
- updated `packages/cli/src/generators/templates/controller.ts.ejs` and `service.ts.ejs`
- updated `packages/cli/src/generators.test.ts` assertions for canonical variadic output
- updated `packages/cli/src/new/scaffold.ts` health starter output
- updated `packages/cli/src/transforms/nestjs-migrate.ts` inject-token follow-up wording

## Testing
- `pnpm --filter @konekti/runtime... build`
- `pnpm --filter @konekti/cli typecheck`
- `pnpm --filter @konekti/cli test`
- `pnpm --filter @konekti/cli build`
- `pnpm --filter @konekti/cli sandbox:create`
- `pnpm --filter @konekti/cli sandbox:verify`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- CLI-generated and CLI-guided canonical `@Inject(...)` syntax now follows the new variadic form.
- This preserves the existing explicit class-level DI contract and changes only the emitted/guided syntax shape.

Closes #954