### PR TITLE
Resolve #955: switch repo code to variadic Inject usage

### DIFF
--- a/examples/auth-jwt-passport/src/auth/auth.controller.ts
+++ b/examples/auth-jwt-passport/src/auth/auth.controller.ts
@@ -5,7 +5,7 @@ import { RequireScopes, UseAuth } from '@konekti/passport';
 import { LoginDto } from './login.dto';
 import { AuthService } from './auth.service';
 
-@Inject([AuthService])
+@Inject(AuthService)
 @Controller('/auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}

--- a/examples/auth-jwt-passport/src/auth/auth.service.ts
+++ b/examples/auth-jwt-passport/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@konekti/core';
 import { DefaultJwtSigner } from '@konekti/jwt';
 
-@Inject([DefaultJwtSigner])
+@Inject(DefaultJwtSigner)
 export class AuthService {
   constructor(private readonly signer: DefaultJwtSigner) {}
 

--- a/examples/auth-jwt-passport/src/auth/bearer.strategy.ts
+++ b/examples/auth-jwt-passport/src/auth/bearer.strategy.ts
@@ -21,7 +21,7 @@ function readAuthorizationHeader(context: GuardContext): string | undefined {
   return undefined;
 }
 
-@Inject([DefaultJwtVerifier])
+@Inject(DefaultJwtVerifier)
 export class BearerJwtStrategy implements AuthStrategy {
   constructor(private readonly verifier: DefaultJwtVerifier) {}
 

--- a/examples/minimal/src/hello.controller.ts
+++ b/examples/minimal/src/hello.controller.ts
@@ -3,7 +3,7 @@ import { Controller, Get } from '@konekti/http';
 
 import { HelloService } from './hello.service';
 
-@Inject([HelloService])
+@Inject(HelloService)
 @Controller('/hello')
 export class HelloController {
   constructor(private readonly helloService: HelloService) {}

--- a/examples/ops-metrics-terminus/src/ops/ops.controller.ts
+++ b/examples/ops-metrics-terminus/src/ops/ops.controller.ts
@@ -3,7 +3,7 @@ import { Controller, Get } from '@konekti/http';
 
 import { OpsMetricsService } from './ops-metrics.service';
 
-@Inject([OpsMetricsService])
+@Inject(OpsMetricsService)
 @Controller('/ops')
 export class OpsController {
   constructor(private readonly service: OpsMetricsService) {}

--- a/examples/realworld-api/src/users/users.controller.ts
+++ b/examples/realworld-api/src/users/users.controller.ts
@@ -5,7 +5,7 @@ import { CreateUserDto } from './create-user.dto';
 import type { UserResponseDto } from './user-response.dto';
 import { UsersService } from './users.service';
 
-@Inject([UsersService])
+@Inject(UsersService)
 @Controller('/users')
 export class UsersController {
   constructor(private readonly service: UsersService) {}

--- a/examples/realworld-api/src/users/users.service.ts
+++ b/examples/realworld-api/src/users/users.service.ts
@@ -3,7 +3,7 @@ import { Inject } from '@konekti/core';
 import { UsersRepo } from './users.repo';
 import type { UserResponseDto } from './user-response.dto';
 
-@Inject([UsersRepo])
+@Inject(UsersRepo)
 export class UsersService {
   constructor(private readonly repo: UsersRepo) {}
 

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -179,7 +179,10 @@ function installDeferredEviction(
   return restore;
 }
 
-@Inject([CacheService, CACHE_OPTIONS])
+/**
+ * Caches GET responses and evicts related entries after successful write operations.
+ */
+@Inject(CacheService, CACHE_OPTIONS)
 export class CacheInterceptor implements Interceptor {
   constructor(
     private readonly cache: CacheService,

--- a/packages/cache-manager/src/module.test.ts
+++ b/packages/cache-manager/src/module.test.ts
@@ -101,7 +101,7 @@ describe('CacheModule.forRoot', () => {
   });
 
   it('supports memory store without redis module/client installed', async () => {
-    @Inject([CacheService])
+    @Inject(CacheService)
     class Consumer {
       constructor(readonly cache: CacheService) {}
     }
@@ -134,7 +134,7 @@ describe('CacheModule.forRoot', () => {
   });
 
   it('supports redis store when a raw redis-style client is provided', async () => {
-    @Inject([CacheService])
+    @Inject(CacheService)
     class Consumer {
       constructor(readonly cache: CacheService) {}
     }

--- a/packages/cache-manager/src/service.ts
+++ b/packages/cache-manager/src/service.ts
@@ -6,7 +6,7 @@ import type { CacheStore, NormalizedCacheModuleOptions } from './types.js';
 /**
  * Application-level cache facade used for direct cache reads, writes, and read-through loading.
  */
-@Inject([CACHE_STORE, CACHE_OPTIONS])
+@Inject(CACHE_STORE, CACHE_OPTIONS)
 export class CacheService {
   private readonly inflight = new Map<string, Promise<unknown>>();
   private readonly invalidationVersion = new Map<string, number>();

--- a/packages/config/src/reload-module.ts
+++ b/packages/config/src/reload-module.ts
@@ -15,6 +15,9 @@ import type {
 
 const CONFIG_RELOAD_OPTIONS = Symbol('konekti.config.reload-options');
 
+/**
+ * Exposes the config reload manager contract for dependency injection.
+ */
 export const CONFIG_RELOADER = Symbol('konekti.config.reloader');
 
 function createSubscription<T>(listeners: Set<T>, listener: T): ConfigReloadSubscription {
@@ -27,7 +30,10 @@ function createSubscription<T>(listeners: Set<T>, listener: T): ConfigReloadSubs
   };
 }
 
-@Inject([ConfigService, CONFIG_RELOAD_OPTIONS])
+/**
+ * Lazily creates and coordinates the active config reloader instance.
+ */
+@Inject(ConfigService, CONFIG_RELOAD_OPTIONS)
 export class ConfigReloadManager implements ConfigReloader {
   private reloader: ConfigReloader | undefined;
   private reloadForwarder: ConfigReloadSubscription | undefined;
@@ -115,6 +121,9 @@ export class ConfigReloadManager implements ConfigReloader {
   }
 }
 
+/**
+ * Registers config reload services and exports the shared reloader token.
+ */
 export class ConfigReloadModule {
   static forRoot(options?: ConfigLoadOptions): new () => ConfigReloadModule {
     const loadOptions = options ?? {};

--- a/packages/core/src/decorators.test.ts
+++ b/packages/core/src/decorators.test.ts
@@ -78,7 +78,7 @@ describe('core decorators', () => {
     const LOGGER = Symbol('LOGGER');
     const CACHE = Symbol('CACHE');
 
-    @Inject([LOGGER, CACHE])
+    @Inject(LOGGER, CACHE)
     class LegacyArrayService {}
 
     expect(getClassDiMetadata(LegacyArrayService)).toEqual({

--- a/packages/core/src/decorators.test.ts
+++ b/packages/core/src/decorators.test.ts
@@ -78,7 +78,7 @@ describe('core decorators', () => {
     const LOGGER = Symbol('LOGGER');
     const CACHE = Symbol('CACHE');
 
-    @Inject(LOGGER, CACHE)
+    @Inject([LOGGER, CACHE])
     class LegacyArrayService {}
 
     expect(getClassDiMetadata(LegacyArrayService)).toEqual({

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -38,7 +38,7 @@ export function Global(): StandardClassDecoratorFn {
  *
  * Passing tokens variadically (`@Inject(A, B)`) is the canonical API. Calling `@Inject()` records an
  * explicit empty inject list so subclasses can intentionally clear inherited constructor tokens.
- * During the staged migration window, the legacy array form (`@Inject([A, B])`) is still normalized.
+ * During the staged migration window, the legacy array form (`@Inject(A, B)`) is still normalized.
  *
  * @param tokens Constructor-parameter token list used by `@konekti/di` during dependency resolution.
  * @returns A standard class decorator that stores explicit injection metadata on the target class.

--- a/packages/core/src/decorators.ts
+++ b/packages/core/src/decorators.ts
@@ -38,7 +38,7 @@ export function Global(): StandardClassDecoratorFn {
  *
  * Passing tokens variadically (`@Inject(A, B)`) is the canonical API. Calling `@Inject()` records an
  * explicit empty inject list so subclasses can intentionally clear inherited constructor tokens.
- * During the staged migration window, the legacy array form (`@Inject(A, B)`) is still normalized.
+ * During the staged migration window, the legacy array form (`@Inject([A, B])`) is still normalized.
  *
  * @param tokens Constructor-parameter token list used by `@konekti/di` during dependency resolution.
  * @returns A standard class decorator that stores explicit injection metadata on the target class.

--- a/packages/cqrs/src/buses/command-bus.ts
+++ b/packages/cqrs/src/buses/command-bus.ts
@@ -27,7 +27,7 @@ function isCommandHandler(value: unknown): value is ICommandHandler<ICommand, un
  * The command bus resolves singleton handlers only, warns on unsupported scopes,
  * and throws explicit contract errors when no handler or multiple handlers exist.
  */
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER])
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER)
 export class CommandBusLifecycleService extends CqrsBusBase implements CommandBus, OnApplicationBootstrap {
   private descriptors = new Map<CommandType, CommandHandlerDescriptor>();
   private discoveryPromise: Promise<void> | undefined;

--- a/packages/cqrs/src/buses/event-bus.ts
+++ b/packages/cqrs/src/buses/event-bus.ts
@@ -24,7 +24,7 @@ function isEventHandler(value: unknown): value is IEventHandler<IEvent> {
  * This service keeps CQRS event handlers singleton-only, fans events into saga orchestration,
  * and delegates the final publication step to `@konekti/event-bus`.
  */
-@Inject([KONEKTI_EVENT_BUS, CqrsSagaLifecycleService, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER])
+@Inject(KONEKTI_EVENT_BUS, CqrsSagaLifecycleService, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER)
 export class CqrsEventBusService extends CqrsBusBase implements CqrsEventBus, OnApplicationBootstrap, OnApplicationShutdown {
   private descriptors: EventHandlerDescriptor[] = [];
   private discoveryPromise: Promise<void> | undefined;

--- a/packages/cqrs/src/buses/query-bus.ts
+++ b/packages/cqrs/src/buses/query-bus.ts
@@ -29,7 +29,7 @@ function isQueryHandler(value: unknown): value is IQueryHandler<IQuery<unknown>,
  * The query bus resolves singleton handlers only, warns on unsupported scopes,
  * and preserves the one-query-to-one-handler contract used by the CQRS surface.
  */
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER])
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER)
 export class QueryBusLifecycleService extends CqrsBusBase implements QueryBus, OnApplicationBootstrap {
   private descriptors = new Map<QueryType, QueryHandlerDescriptor>();
   private discoveryPromise: Promise<void> | undefined;

--- a/packages/cqrs/src/buses/saga-bus.ts
+++ b/packages/cqrs/src/buses/saga-bus.ts
@@ -32,7 +32,7 @@ function toErrorMessage(error: unknown): string {
  * The service prevents re-entrant dispatch loops within the same async context and waits for
  * in-flight saga chains during shutdown so lifecycle guarantees remain predictable.
  */
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER])
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER)
 export class CqrsSagaLifecycleService extends CqrsBusBase implements OnApplicationBootstrap, OnApplicationShutdown {
   private descriptorsByEvent = new Map<CqrsEventType, SagaDescriptor[]>();
   private discoveryPromise: Promise<void> | undefined;

--- a/packages/cqrs/src/module.test.ts
+++ b/packages/cqrs/src/module.test.ts
@@ -133,7 +133,7 @@ describe('@konekti/cqrs', () => {
       users = new Map<string, string>();
     }
 
-    @Inject([Store])
+    @Inject(Store)
     @CommandHandler(CreateUserCommand)
     class CreateUserHandler implements ICommandHandler<CreateUserCommand, string> {
       constructor(private readonly store: Store) {}
@@ -144,7 +144,7 @@ describe('@konekti/cqrs', () => {
       }
     }
 
-    @Inject([Store])
+    @Inject(Store)
     @QueryHandler(GetUserQuery)
     class GetUserHandler implements IQueryHandler<GetUserQuery, { id: string; name: string | undefined }> {
       constructor(private readonly store: Store) {}
@@ -397,7 +397,7 @@ describe('@konekti/cqrs', () => {
       constructor(public readonly orderId: string) {}
     }
 
-    @Inject([EVENT_BUS, ProcessStore])
+    @Inject(EVENT_BUS, ProcessStore)
     @CommandHandler(StartPaymentCommand)
     class StartPaymentHandler implements ICommandHandler<StartPaymentCommand> {
       constructor(
@@ -411,7 +411,7 @@ describe('@konekti/cqrs', () => {
       }
     }
 
-    @Inject([EVENT_BUS, ProcessStore])
+    @Inject(EVENT_BUS, ProcessStore)
     @CommandHandler(ReserveInventoryCommand)
     class ReserveInventoryHandler implements ICommandHandler<ReserveInventoryCommand> {
       constructor(
@@ -425,7 +425,7 @@ describe('@konekti/cqrs', () => {
       }
     }
 
-    @Inject([ProcessStore])
+    @Inject(ProcessStore)
     @CommandHandler(CompleteOrderCommand)
     class CompleteOrderHandler implements ICommandHandler<CompleteOrderCommand> {
       constructor(private readonly store: ProcessStore) {}
@@ -435,7 +435,7 @@ describe('@konekti/cqrs', () => {
       }
     }
 
-    @Inject([COMMAND_BUS, ProcessStore])
+    @Inject(COMMAND_BUS, ProcessStore)
     @Saga([OrderSubmittedEvent, PaymentAuthorizedEvent, InventoryReservedEvent])
     class OrderFulfillmentSaga implements ISaga<IEvent> {
       constructor(
@@ -635,7 +635,7 @@ describe('@konekti/cqrs', () => {
       ) {}
     }
 
-    @Inject([SequenceStore])
+    @Inject(SequenceStore)
     @Saga(SequencedEvent)
     class SequencingSaga implements ISaga<SequencedEvent> {
       constructor(private readonly store: SequenceStore) {}
@@ -678,7 +678,7 @@ describe('@konekti/cqrs', () => {
       constructor(public readonly id: string) {}
     }
 
-    @Inject([ShutdownStore])
+    @Inject(ShutdownStore)
     @Saga(ShutdownEvent)
     class ShutdownSaga implements ISaga<ShutdownEvent> {
       constructor(private readonly store: ShutdownStore) {}
@@ -721,7 +721,7 @@ describe('@konekti/cqrs', () => {
       eventNames: string[] = [];
     }
 
-    @Inject([Store])
+    @Inject(Store)
     @CommandHandler(CreateUserCommand)
     class CreateUserHandler implements ICommandHandler<CreateUserCommand, string> {
       constructor(private readonly store: Store) {}
@@ -732,7 +732,7 @@ describe('@konekti/cqrs', () => {
       }
     }
 
-    @Inject([Store])
+    @Inject(Store)
     @QueryHandler(GetUserCountQuery)
     class GetUserHandler implements IQueryHandler<GetUserCountQuery, number> {
       constructor(private readonly store: Store) {}
@@ -742,7 +742,7 @@ describe('@konekti/cqrs', () => {
       }
     }
 
-    @Inject([Store])
+    @Inject(Store)
     @EventHandler(UserCreatedEvent)
     class UserCreatedEventRecorder implements IEventHandler<UserCreatedEvent> {
       constructor(private readonly store: Store) {}
@@ -752,7 +752,7 @@ describe('@konekti/cqrs', () => {
       }
     }
 
-    @Inject([Store])
+    @Inject(Store)
     class UserCreatedOnEventProjection {
       constructor(private readonly store: Store) {}
 

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -333,7 +333,7 @@ describe('@konekti/cron', () => {
       count = 0;
     }
 
-    @Inject([TickStore])
+    @Inject(TickStore)
     class FeatureCronService {
       constructor(private readonly store: TickStore) {}
 
@@ -374,7 +374,7 @@ describe('@konekti/cron', () => {
       count = 0;
     }
 
-    @Inject([TickStore])
+    @Inject(TickStore)
     class SuccessTask {
       constructor(private readonly store: TickStore) {}
 
@@ -577,7 +577,7 @@ describe('@konekti/cron', () => {
       count = 0;
     }
 
-    @Inject([SharedStore])
+    @Inject(SharedStore)
     class DistributedTaskService {
       constructor(private readonly store: SharedStore) {}
 
@@ -716,7 +716,7 @@ describe('@konekti/cron', () => {
       count = 0;
     }
 
-    @Inject([SharedStore])
+    @Inject(SharedStore)
     class DistributedTaskService {
       constructor(private readonly store: SharedStore) {}
 
@@ -798,7 +798,7 @@ describe('@konekti/cron', () => {
       count = 0;
     }
 
-    @Inject([TickStore])
+    @Inject(TickStore)
     class DefaultSchedulerTaskService {
       constructor(private readonly store: TickStore) {}
 
@@ -1366,7 +1366,7 @@ describe('@konekti/cron', () => {
       timeoutCount = 0;
     }
 
-    @Inject([TickStore])
+    @Inject(TickStore)
     class TaskService {
       constructor(private readonly store: TickStore) {}
 
@@ -1512,7 +1512,7 @@ describe('@konekti/cron', () => {
       timeoutCount = 0;
     }
 
-    @Inject([TickStore])
+    @Inject(TickStore)
     class TaskService {
       constructor(private readonly store: TickStore) {}
 

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -146,7 +146,7 @@ function assertValidCronExpression(expression: string): void {
  * optional distributed locks through Redis, and exposes runtime task management
  * through {@link SchedulingRegistry}.
  */
-@Inject([CRON_OPTIONS, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER])
+@Inject(CRON_OPTIONS, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER)
 export class CronLifecycleService
   implements SchedulingRegistry, OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy
 {

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -68,7 +68,7 @@ describe('Container', () => {
   it('supports @Inject and @Scope metadata for dependency tokens and scope', async () => {
     class Logger {}
 
-    @Inject([Logger])
+    @Inject(Logger)
     @ScopeDecorator('request')
     class RequestService {
       constructor(readonly logger: Logger) {}
@@ -89,7 +89,7 @@ describe('Container', () => {
   it('accepts Scope constants in both decorator and provider registrations', async () => {
     class Logger {}
 
-    @Inject([Logger])
+    @Inject(Logger)
     @ScopeDecorator(Scope.REQUEST)
     class RequestService {
       constructor(readonly logger: Logger) {}

--- a/packages/di/src/types.ts
+++ b/packages/di/src/types.ts
@@ -129,7 +129,7 @@ export interface NormalizedProvider<T = unknown> {
  *
  * @example
  * ```ts
- * @Inject([forwardRef(() => AuthService)])
+ * @Inject(forwardRef(() => AuthService))
  * class UsersService {
  *   constructor(private readonly auth: AuthService) {}
  * }

--- a/packages/discord/src/channel.ts
+++ b/packages/discord/src/channel.ts
@@ -13,7 +13,7 @@ import type { DiscordNotificationDispatchRequest, DiscordSendResult, NormalizedD
  * This class keeps the foundation package channel-agnostic while allowing `@konekti/discord`
  * to interpret Discord-specific payload fields, webhook delivery, and transport behavior.
  */
-@Inject([DiscordService, DISCORD_OPTIONS])
+@Inject(DiscordService, DISCORD_OPTIONS)
 export class DiscordChannel implements NotificationChannel<DiscordNotificationDispatchRequest, DiscordSendResult> {
   readonly channel: string;
 

--- a/packages/discord/src/service.ts
+++ b/packages/discord/src/service.ts
@@ -46,7 +46,7 @@ function assertMessageContent(message: NormalizedDiscordMessage): void {
  * explicitly injected {@link DiscordTransport} contracts, and translates
  * `@konekti/notifications` envelopes into concrete Discord messages.
  */
-@Inject([DISCORD_OPTIONS])
+@Inject(DISCORD_OPTIONS)
 export class DiscordService implements Discord, OnModuleInit, OnApplicationShutdown {
   private lifecycleState: 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'created';
   private resolvedTransport: DiscordTransport | undefined;

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -46,7 +46,7 @@ type DrizzleRuntimeOptions = {
  * @typeParam TTransactionDatabase Transaction-scoped database handle resolved inside `database.transaction(...)` callbacks.
  * @typeParam TTransactionOptions Options forwarded to the underlying Drizzle transaction runner.
  */
-@Inject([DRIZZLE_DATABASE, DRIZZLE_DISPOSE, DRIZZLE_OPTIONS])
+@Inject(DRIZZLE_DATABASE, DRIZZLE_DISPOSE, DRIZZLE_OPTIONS)
 export class DrizzleDatabase<
   TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
   TTransactionDatabase = TDatabase,

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -43,7 +43,7 @@ describe('@konekti/drizzle', () => {
       },
     };
 
-    @Inject([DrizzleDatabase])
+    @Inject(DrizzleDatabase)
     class UserService {
       constructor(private readonly db: DrizzleDatabase<typeof database, typeof transactionDatabase>) {}
 

--- a/packages/drizzle/src/transaction.ts
+++ b/packages/drizzle/src/transaction.ts
@@ -11,7 +11,7 @@ import type { DrizzleDatabaseLike } from './types.js';
  * Pair this with repository/service code that reads `DrizzleDatabase.current()` so downstream calls share the same
  * request-scoped transaction handle.
  */
-@Inject([DrizzleDatabase])
+@Inject(DrizzleDatabase)
 export class DrizzleTransactionInterceptor implements Interceptor {
   constructor(private readonly database: DrizzleDatabase<DrizzleDatabaseLike<unknown, unknown>, unknown, unknown>) {}
 

--- a/packages/drizzle/src/vertical-slice.test.ts
+++ b/packages/drizzle/src/vertical-slice.test.ts
@@ -146,7 +146,7 @@ describe('@konekti/drizzle vertical slice', () => {
       id = '';
     }
 
-    @Inject([DrizzleDatabase])
+    @Inject(DrizzleDatabase)
     class UserRepository {
       constructor(private readonly db: DrizzleDatabase<typeof database, typeof transactionDatabase>) {}
 
@@ -166,7 +166,7 @@ describe('@konekti/drizzle vertical slice', () => {
       }
     }
 
-    @Inject([UserRepository])
+    @Inject(UserRepository)
     class UserService {
       constructor(private readonly repo: UserRepository) {}
 
@@ -186,7 +186,7 @@ describe('@konekti/drizzle vertical slice', () => {
     }
 
     @Controller('/users')
-    @Inject([UserService])
+    @Inject(UserService)
     class UsersController {
       constructor(private readonly users: UserService) {}
 

--- a/packages/email/src/channel.ts
+++ b/packages/email/src/channel.ts
@@ -12,7 +12,7 @@ import type { EmailNotificationDispatchRequest, EmailSendResult, NormalizedEmail
  * This class keeps the foundation package channel-agnostic while allowing `@konekti/email`
  * to interpret email-specific payload fields, template rendering, and transport delivery.
  */
-@Inject([EmailService, EMAIL_OPTIONS])
+@Inject(EmailService, EMAIL_OPTIONS)
 export class EmailChannel implements NotificationChannel<EmailNotificationDispatchRequest, EmailSendResult> {
   readonly channel: string;
 

--- a/packages/email/src/queue.ts
+++ b/packages/email/src/queue.ts
@@ -49,7 +49,7 @@ export function createEmailNotificationsQueueAdapter(queue: QueueLifecycleServic
 
 /** Internal queue worker that converts queued notification jobs back into email delivery. */
 @QueueWorker(EmailNotificationQueueJob, DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS)
-@Inject([EmailService])
+@Inject(EmailService)
 export class EmailNotificationsQueueWorker {
   constructor(private readonly email: EmailService) {}
 

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -72,7 +72,7 @@ function assertMessageContent(message: NormalizedEmailMessage): void {
  * explicitly injected {@link EmailTransport} contracts, and translates
  * `@konekti/notifications` envelopes into concrete email messages.
  */
-@Inject([EMAIL_OPTIONS])
+@Inject(EMAIL_OPTIONS)
 export class EmailService implements Email, OnModuleInit, OnApplicationShutdown {
   private lifecycleState: 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'created';
   private resolvedTransport: EmailTransport | undefined;

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -103,7 +103,7 @@ describe('@konekti/event-bus', () => {
       received: UserCreatedEvent | undefined;
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class UserCreatedHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -156,7 +156,7 @@ describe('@konekti/event-bus', () => {
       successCalls = 0;
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class SuccessfulHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -213,7 +213,7 @@ describe('@konekti/event-bus', () => {
       secondSeen = '';
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class FirstHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -224,7 +224,7 @@ describe('@konekti/event-bus', () => {
       }
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class SecondHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -262,7 +262,7 @@ describe('@konekti/event-bus', () => {
       successCalls = 0;
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class SuccessHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -317,7 +317,7 @@ describe('@konekti/event-bus', () => {
       startedCalls = 0;
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class SlowHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -364,7 +364,7 @@ describe('@konekti/event-bus', () => {
       startedCalls = 0;
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class SlowHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -405,7 +405,7 @@ describe('@konekti/event-bus', () => {
       calls = 0;
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class Handler {
       constructor(private readonly store: EventStore) {}
 
@@ -451,7 +451,7 @@ describe('@konekti/event-bus', () => {
       controllerCalls = 0;
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class ImportedProviderHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -461,7 +461,7 @@ describe('@konekti/event-bus', () => {
       }
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class ImportedControllerHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -501,7 +501,7 @@ describe('@konekti/event-bus', () => {
       seenUserId = '';
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class BaseEventHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -553,7 +553,7 @@ describe('@konekti/event-bus', () => {
       count = 0;
     }
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class UserCreatedHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -563,7 +563,7 @@ describe('@konekti/event-bus', () => {
       }
     }
 
-    @Inject([EVENT_BUS])
+    @Inject(EVENT_BUS)
     class UserPublisher {
       constructor(private readonly eventBus: EventBus) {}
 
@@ -694,7 +694,7 @@ describe('@konekti/event-bus', () => {
 
     const ALIAS_TOKEN = Symbol('AliasToken');
 
-    @Inject([EventStore])
+    @Inject(EventStore)
     class MultiTokenHandler {
       constructor(private readonly store: EventStore) {}
 
@@ -732,7 +732,7 @@ describe('@konekti/event-bus', () => {
     }
 
     const FirstCollidingHandler = (() => {
-      @Inject([EventStore])
+      @Inject(EventStore)
       class CollidingHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -746,7 +746,7 @@ describe('@konekti/event-bus', () => {
     })();
 
     const SecondCollidingHandler = (() => {
-      @Inject([EventStore])
+      @Inject(EventStore)
       class CollidingHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -932,7 +932,7 @@ describe('@konekti/event-bus', () => {
         received: UserCreatedEvent | undefined;
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class TransportHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -971,7 +971,7 @@ describe('@konekti/event-bus', () => {
         successCalls = 0;
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class SuccessfulTransportHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -1019,7 +1019,7 @@ describe('@konekti/event-bus', () => {
         derivedCalls = 0;
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class BaseHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -1029,7 +1029,7 @@ describe('@konekti/event-bus', () => {
         }
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class DerivedHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -1082,7 +1082,7 @@ describe('@konekti/event-bus', () => {
         receivedSku = '';
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class InventoryHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -1139,7 +1139,7 @@ describe('@konekti/event-bus', () => {
         detailedEvent: DetailedInventoryEvent | undefined;
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class BaseHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -1149,7 +1149,7 @@ describe('@konekti/event-bus', () => {
         }
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class DetailedHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -1192,7 +1192,7 @@ describe('@konekti/event-bus', () => {
         secondSeen = '';
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class FirstHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -1203,7 +1203,7 @@ describe('@konekti/event-bus', () => {
         }
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class SecondHandler {
         constructor(private readonly store: EventStore) {}
 
@@ -1252,7 +1252,7 @@ describe('@konekti/event-bus', () => {
         calls = 0;
       }
 
-      @Inject([EventStore])
+      @Inject(EventStore)
       class LocalHandler {
         constructor(private readonly store: EventStore) {}
 

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -87,7 +87,7 @@ function isClassProvider(provider: Provider): provider is Extract<Provider, { pr
  * The service discovers `@OnEvent()` handlers, clones payloads before dispatch,
  * and can publish the same events to an external transport such as Redis Pub/Sub.
  */
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, EVENT_BUS_OPTIONS])
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, EVENT_BUS_OPTIONS)
 export class EventBusLifecycleService implements EventBus, OnApplicationBootstrap, OnApplicationShutdown {
   private descriptors: EventHandlerDescriptor[] = [];
   private discoveryPromise: Promise<void> | undefined;

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -160,6 +160,9 @@ const runtimeRequire = createRequire(import.meta.url);
 let graphqlInstanceOfPatched = false;
 const allowedCrossRealmGraphqlObjects = new WeakSet<object>();
 
+/**
+ * Declares the HTTP endpoints that receive GraphQL GET and POST requests.
+ */
 @Controller('/graphql')
 export class GraphqlEndpointController {
   @Get('/')
@@ -287,7 +290,10 @@ async function loadGraphqlDeps(): Promise<GraphqlDeps> {
   };
 }
 
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, GRAPHQL_INTERNAL_MODULE_OPTIONS_TOKEN])
+/**
+ * Boots the GraphQL runtime, middleware, and subscription transports for the active adapter.
+ */
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, GRAPHQL_INTERNAL_MODULE_OPTIONS_TOKEN)
 export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplicationShutdown {
   private middlewareRegistered = false;
   private readonly operationContainers = new WeakMap<Request, Container>();

--- a/packages/jwt/src/module.test.ts
+++ b/packages/jwt/src/module.test.ts
@@ -27,7 +27,7 @@ class NoopRefreshTokenStore implements RefreshTokenStore {
   }
 }
 
-@Inject([DefaultJwtSigner, DefaultJwtVerifier])
+@Inject(DefaultJwtSigner, DefaultJwtVerifier)
 class JwtRoundTripService {
   constructor(
     private readonly signer: DefaultJwtSigner,

--- a/packages/jwt/src/module.ts
+++ b/packages/jwt/src/module.ts
@@ -33,7 +33,7 @@ function resolveRefreshTokenOptions(value: unknown): NonNullable<JwtVerifierOpti
   return normalizeRefreshTokenOptions((value as JwtVerifierOptions).refreshToken);
 }
 
-@Inject([JWT_OPTIONS, DefaultJwtSigner, DefaultJwtVerifier, RUNTIME_CONTAINER])
+@Inject(JWT_OPTIONS, DefaultJwtSigner, DefaultJwtVerifier, RUNTIME_CONTAINER)
 class AsyncRefreshTokenServiceRegistrar {
   private registered = false;
 
@@ -93,6 +93,12 @@ function createJwtModuleProviders(
   return providers;
 }
 
+/**
+ * Creates the core JWT providers for direct module composition.
+ *
+ * @param options JWT verification and signing options used for provider registration.
+ * @returns Providers for the JWT verifier, signer, facade, and optional refresh token service.
+ */
 export function createJwtCoreProviders(options: JwtVerifierOptions): Provider[] {
   return createJwtModuleProviders({
     provide: JWT_OPTIONS,
@@ -101,6 +107,9 @@ export function createJwtCoreProviders(options: JwtVerifierOptions): Provider[] 
   }, Boolean(options.refreshToken), 'singleton');
 }
 
+/**
+ * Registers JWT services and optional refresh-token support for an application module.
+ */
 export class JwtModule {
   static forRoot(options: JwtVerifierOptions): ModuleType {
     return this.createModule({

--- a/packages/jwt/src/service.ts
+++ b/packages/jwt/src/service.ts
@@ -147,7 +147,7 @@ export interface VerifyOptions {
  * `decode` surface for applications migrating from similar auth service
  * patterns.
  */
-@Inject([JWT_OPTIONS, DefaultJwtSigner, DefaultJwtVerifier])
+@Inject(JWT_OPTIONS, DefaultJwtSigner, DefaultJwtVerifier)
 export class JwtService {
   constructor(
     private readonly options: JwtVerifierOptions,

--- a/packages/jwt/src/signing/signer.ts
+++ b/packages/jwt/src/signing/signer.ts
@@ -29,7 +29,10 @@ function resolveSigningKeyEntry(options: JwtVerifierOptions, algorithm: JwtAlgor
   return keys.find((entry) => entry.privateKey !== undefined);
 }
 
-@Inject([JWT_OPTIONS])
+/**
+ * Issues access and refresh tokens with the configured signing keys and algorithms.
+ */
+@Inject(JWT_OPTIONS)
 export class DefaultJwtSigner {
   private readonly refreshAlgorithms: JwtAlgorithm[];
 

--- a/packages/jwt/src/signing/verifier.ts
+++ b/packages/jwt/src/signing/verifier.ts
@@ -8,14 +8,23 @@ import { JwksClient } from './jwks.js';
 import { normalizeRefreshTokenOptions } from '../refresh/refresh-token.js';
 import type { JwtAlgorithm, JwtClaims, JwtKeyEntry, JwtPrincipal, JwtVerifierOptions } from '../types.js';
 
+/**
+ * Provides the resolved JWT verifier options through dependency injection.
+ */
 export const JWT_OPTIONS = Symbol.for('konekti.jwt.options');
 
+/**
+ * Maps supported HMAC JWT algorithms to their Node.js hash names.
+ */
 export const HMAC_HASH: Partial<Record<JwtAlgorithm, string>> = {
   HS256: 'sha256',
   HS384: 'sha384',
   HS512: 'sha512',
 };
 
+/**
+ * Maps supported asymmetric JWT algorithms to their Node.js hash names.
+ */
 export const ASYMMETRIC_HASH: Partial<Record<JwtAlgorithm, string>> = {
   RS256: 'sha256',
   RS384: 'sha384',
@@ -222,7 +231,10 @@ function normalizePrincipal(claims: JwtClaims): JwtPrincipal {
   };
 }
 
-@Inject([JWT_OPTIONS])
+/**
+ * Verifies JWT access and refresh tokens against the configured key sources.
+ */
+@Inject(JWT_OPTIONS)
 export class DefaultJwtVerifier {
   private readonly jwksClient: JwksClient | undefined;
   private readonly keyResolutionState: KeyResolutionState;

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -191,7 +191,7 @@ describe('@konekti/microservices', () => {
       createdEvents: string[] = [];
     }
 
-    @Inject([Store])
+    @Inject(Store)
     class UserHandlers {
       constructor(private readonly store: Store) {}
 
@@ -299,7 +299,7 @@ describe('@konekti/microservices', () => {
       events: string[] = [];
     }
 
-    @Inject([Store])
+    @Inject(Store)
     class Handler {
       constructor(private readonly store: Store) {}
 
@@ -345,7 +345,7 @@ describe('@konekti/microservices', () => {
       events: string[] = [];
     }
 
-    @Inject([Store])
+    @Inject(Store)
     class Handler {
       constructor(private readonly store: Store) {}
 
@@ -382,7 +382,7 @@ describe('@konekti/microservices', () => {
       message = '';
     }
 
-    @Inject([Store])
+    @Inject(Store)
     class ControllerLikeHandler {
       constructor(private readonly store: Store) {}
 
@@ -424,7 +424,7 @@ describe('@konekti/microservices', () => {
       secondSeen = '';
     }
 
-    @Inject([Store])
+    @Inject(Store)
     class FirstHandler {
       constructor(private readonly store: Store) {}
 
@@ -435,7 +435,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([Store])
+    @Inject(Store)
     class SecondHandler {
       constructor(private readonly store: Store) {}
 
@@ -473,7 +473,7 @@ describe('@konekti/microservices', () => {
       count = 0;
     }
 
-    @Inject([SharedState])
+    @Inject(SharedState)
     class HybridHandlers {
       constructor(private readonly state: SharedState) {}
 
@@ -585,7 +585,7 @@ describe('@konekti/microservices', () => {
       readonly id = ++created;
     }
 
-    @Inject([RequestState])
+    @Inject(RequestState)
     @Scope('request')
     class RequestScopedHandler {
       constructor(private readonly state: RequestState) {}
@@ -631,7 +631,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([RequestState])
+    @Inject(RequestState)
     @Scope('request')
     class RequestScopedHandler {
       constructor(private readonly state: RequestState) {}
@@ -670,7 +670,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([RequestState])
+    @Inject(RequestState)
     @Scope('request')
     class RequestScopedHandler {
       constructor(private readonly state: RequestState) {}
@@ -742,7 +742,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([EventContext])
+    @Inject(EventContext)
     @Scope('request')
     class RequestScopedEventHandler {
       constructor(private readonly ctx: EventContext) {}
@@ -782,7 +782,7 @@ describe('@konekti/microservices', () => {
       readonly id = ++SharedScope.counter;
     }
 
-    @Inject([SharedScope])
+    @Inject(SharedScope)
     @Scope('request')
     class FirstEventHandler {
       constructor(private readonly scope: SharedScope) {}
@@ -793,7 +793,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([SharedScope])
+    @Inject(SharedScope)
     @Scope('request')
     class SecondEventHandler {
       constructor(private readonly scope: SharedScope) {}
@@ -836,7 +836,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([DisposableContext])
+    @Inject(DisposableContext)
     @Scope('request')
     class DisposableHandler {
       constructor(private readonly ctx: DisposableContext) {}
@@ -880,7 +880,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([DisposableContext])
+    @Inject(DisposableContext)
     @Scope('request')
     class FailingHandler {
       constructor(private readonly ctx: DisposableContext) {}
@@ -957,7 +957,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([StreamContext])
+    @Inject(StreamContext)
     @Scope('request')
     class StreamHandler {
       constructor(private readonly ctx: StreamContext) {}
@@ -1006,7 +1006,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([StreamContext])
+    @Inject(StreamContext)
     @Scope('request')
     class FailingStreamHandler {
       constructor(private readonly ctx: StreamContext) {}
@@ -1052,7 +1052,7 @@ describe('@konekti/microservices', () => {
       readonly id = ++created;
     }
 
-    @Inject([StreamState])
+    @Inject(StreamState)
     @Scope('request')
     class ScopedStreamHandler {
       constructor(private readonly state: StreamState) {}
@@ -1111,7 +1111,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([ClientStreamContext])
+    @Inject(ClientStreamContext)
     @Scope('request')
     class ClientStreamHandler {
       constructor(private readonly ctx: ClientStreamContext) {}
@@ -1135,7 +1135,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([FailingClientStreamContext])
+    @Inject(FailingClientStreamContext)
     @Scope('request')
     class FailingClientStreamHandler {
       constructor(private readonly ctx: FailingClientStreamContext) {}
@@ -1190,7 +1190,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([BidiStreamContext])
+    @Inject(BidiStreamContext)
     @Scope('request')
     class BidiHandler {
       constructor(private readonly ctx: BidiStreamContext) {}
@@ -1212,7 +1212,7 @@ describe('@konekti/microservices', () => {
       }
     }
 
-    @Inject([FailingBidiContext])
+    @Inject(FailingBidiContext)
     @Scope('request')
     class FailingBidiHandler {
       constructor(private readonly ctx: FailingBidiContext) {}

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -55,7 +55,7 @@ function isClassProvider(provider: Provider): provider is Extract<Provider, { pr
  * The service resolves singleton or request-scoped handlers, exposes programmatic
  * send/emit/stream APIs, and delegates transport-specific I/O to the configured adapter.
  */
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, MICROSERVICE_OPTIONS])
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, MICROSERVICE_OPTIONS)
 export class MicroserviceLifecycleService implements Microservice, MicroserviceRuntime, OnApplicationShutdown {
   private readonly descriptors: HandlerDescriptor[] = [];
   private readonly handlerInstances = new Map<Token, Promise<unknown>>();

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -55,7 +55,7 @@ async function executeSessionTransaction<T>(session: MongooseSessionLike, fn: ()
  *
  * @typeParam TConnection Root Mongoose connection shape registered in the module.
  */
-@Inject([MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, MONGOOSE_OPTIONS])
+@Inject(MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, MONGOOSE_OPTIONS)
 export class MongooseConnection<TConnection extends MongooseConnectionLike = MongooseConnectionLike>
   implements MongooseHandleProvider<TConnection>, OnApplicationShutdown
 {

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -39,7 +39,7 @@ describe('@konekti/mongoose', () => {
       },
     };
 
-    @Inject([MongooseConnection])
+    @Inject(MongooseConnection)
     class UserService {
       constructor(private readonly conn: MongooseConnection<typeof connection>) {}
 

--- a/packages/mongoose/src/transaction.ts
+++ b/packages/mongoose/src/transaction.ts
@@ -11,7 +11,7 @@ import type { MongooseConnectionLike } from './types.js';
  * Pair this with repository/service code that reads `MongooseConnection.current()` and `currentSession()` so downstream
  * calls share the same request-scoped session.
  */
-@Inject([MongooseConnection])
+@Inject(MongooseConnection)
 export class MongooseTransactionInterceptor implements Interceptor {
   constructor(private readonly connection: MongooseConnection<MongooseConnectionLike>) {}
 

--- a/packages/mongoose/src/vertical-slice.test.ts
+++ b/packages/mongoose/src/vertical-slice.test.ts
@@ -124,7 +124,7 @@ describe('@konekti/mongoose vertical slice', () => {
       id = '';
     }
 
-    @Inject([MongooseConnection])
+    @Inject(MongooseConnection)
     class UserRepository {
       constructor(private readonly conn: MongooseConnection<typeof connection>) {}
 
@@ -152,7 +152,7 @@ describe('@konekti/mongoose vertical slice', () => {
       }
     }
 
-    @Inject([UserRepository])
+    @Inject(UserRepository)
     class UserService {
       constructor(private readonly repo: UserRepository) {}
 
@@ -172,7 +172,7 @@ describe('@konekti/mongoose vertical slice', () => {
     }
 
     @Controller('/users')
-    @Inject([UserService])
+    @Inject(UserService)
     class UsersController {
       constructor(private readonly users: UserService) {}
 

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -27,7 +27,7 @@ import type {
  * resolves channels by name, applies optional queue delegation, and emits optional
  * lifecycle events through the configured publisher seam.
  */
-@Inject([NOTIFICATIONS_OPTIONS, NOTIFICATION_CHANNELS])
+@Inject(NOTIFICATIONS_OPTIONS, NOTIFICATION_CHANNELS)
 export class NotificationsService implements Notifications {
   private readonly channelsByName = new Map<string, NotificationChannel>();
   private fallbackDeliveryIdSequence = 0;

--- a/packages/openapi/src/openapi-module.ts
+++ b/packages/openapi/src/openapi-module.ts
@@ -164,7 +164,7 @@ export class OpenApiModule {
     const openApiDocumentToken = Symbol('konekti.openapi.document');
 
     @Controller('')
-    @Inject([openApiDocumentToken, openApiModuleOptionsToken])
+    @Inject(openApiDocumentToken, openApiModuleOptionsToken)
     class OpenApiController {
       constructor(
         private readonly document: OpenApiDocument,

--- a/packages/passport/src/cookie/cookie-auth.ts
+++ b/packages/passport/src/cookie/cookie-auth.ts
@@ -5,20 +5,35 @@ import { DefaultJwtVerifier } from '@konekti/jwt';
 import { AuthenticationRequiredError } from '../errors.js';
 import type { AuthStrategy, AuthStrategyResult } from '../types.js';
 
+/**
+ * Provides cookie-auth strategy options through dependency injection.
+ */
 export const COOKIE_AUTH_OPTIONS = Symbol.for('konekti.passport.cookie-auth-options');
 
+/**
+ * Configures cookie names and fallback behavior for cookie-based authentication.
+ */
 export interface CookieAuthOptions {
   accessTokenCookieName?: string;
   refreshTokenCookieName?: string;
   requireAccessToken?: boolean;
 }
 
+/**
+ * Supplies the default cookie names and access-token requirement for cookie auth.
+ */
 export const DEFAULT_COOKIE_AUTH_OPTIONS: Required<CookieAuthOptions> = {
   accessTokenCookieName: 'access_token',
   refreshTokenCookieName: 'refresh_token',
   requireAccessToken: true,
 };
 
+/**
+ * Normalizes optional cookie-auth settings into a fully populated options object.
+ *
+ * @param options Partial cookie-auth configuration supplied by the caller.
+ * @returns Cookie-auth options with defaults applied.
+ */
 export function normalizeCookieAuthOptions(options?: CookieAuthOptions): Required<CookieAuthOptions> {
   return {
     accessTokenCookieName: options?.accessTokenCookieName ?? DEFAULT_COOKIE_AUTH_OPTIONS.accessTokenCookieName,
@@ -27,7 +42,10 @@ export function normalizeCookieAuthOptions(options?: CookieAuthOptions): Require
   };
 }
 
-@Inject([DefaultJwtVerifier, COOKIE_AUTH_OPTIONS])
+/**
+ * Authenticates requests by reading and verifying JWTs from HTTP cookies.
+ */
+@Inject(DefaultJwtVerifier, COOKIE_AUTH_OPTIONS)
 export class CookieAuthStrategy implements AuthStrategy {
   private readonly options: Required<CookieAuthOptions>;
 
@@ -85,4 +103,7 @@ export class CookieAuthStrategy implements AuthStrategy {
   }
 }
 
+/**
+ * Identifies the built-in cookie authentication strategy.
+ */
 export const COOKIE_AUTH_STRATEGY_NAME = 'cookie';

--- a/packages/passport/src/guard.ts
+++ b/packages/passport/src/guard.ts
@@ -62,7 +62,7 @@ function toErrorMessage(error: unknown): string {
  * mismatches become `403 Forbidden`, and strategies may short-circuit the
  * response by returning `{ handled: true }` after committing the response.
  */
-@Inject([AUTH_STRATEGY_REGISTRY, PASSPORT_OPTIONS])
+@Inject(AUTH_STRATEGY_REGISTRY, PASSPORT_OPTIONS)
 export class AuthGuard implements AuthGuardContract {
   constructor(
     private readonly strategies: AuthStrategyRegistry = {},

--- a/packages/passport/src/refresh/jwt-refresh-token-adapter.ts
+++ b/packages/passport/src/refresh/jwt-refresh-token-adapter.ts
@@ -9,8 +9,14 @@ import {
 
 import type { RefreshTokenService } from './refresh-token.js';
 
+/**
+ * Provides refresh-token module options through dependency injection.
+ */
 export const REFRESH_TOKEN_MODULE_OPTIONS = Symbol.for('konekti.passport.refresh-token-module-options');
 
+/**
+ * Configures refresh-token storage, rotation, and secret material.
+ */
 export interface RefreshTokenModuleOptions {
   expiresInSeconds?: number;
   rotation?: boolean;
@@ -91,7 +97,10 @@ function createInMemoryStore(): RefreshTokenStore {
   };
 }
 
-@Inject([DefaultJwtSigner, DefaultJwtVerifier, REFRESH_TOKEN_MODULE_OPTIONS])
+/**
+ * Bridges JWT refresh-token primitives into the passport refresh-token service contract.
+ */
+@Inject(DefaultJwtSigner, DefaultJwtVerifier, REFRESH_TOKEN_MODULE_OPTIONS)
 export class JwtRefreshTokenAdapter implements RefreshTokenService {
   private readonly service: JwtRefreshTokenService;
 

--- a/packages/passport/src/refresh/refresh-token.ts
+++ b/packages/passport/src/refresh/refresh-token.ts
@@ -9,6 +9,9 @@ import {
 } from '../errors.js';
 import type { AuthStrategy, AuthStrategyResult } from '../types.js';
 
+/**
+ * Defines the operations required to issue, rotate, and revoke refresh tokens.
+ */
 export interface RefreshTokenService {
   issueRefreshToken(subject: string): Promise<string>;
   rotateRefreshToken(currentToken: string): Promise<{ accessToken: string; refreshToken: string }>;
@@ -16,12 +19,21 @@ export interface RefreshTokenService {
   revokeAllForSubject(subject: string): Promise<void>;
 }
 
+/**
+ * Identifies the active refresh-token service implementation in dependency injection.
+ */
 export const REFRESH_TOKEN_SERVICE = Symbol.for('konekti.passport.refresh-token-service');
 
+/**
+ * Represents the refresh-token payload accepted by refresh endpoints.
+ */
 export interface RefreshTokenInput {
   refreshToken: string;
 }
 
+/**
+ * Captures the token pair returned after a successful refresh-token exchange.
+ */
 export interface RefreshTokenAuthResult {
   accessToken: string;
   refreshToken: string;
@@ -30,7 +42,10 @@ export interface RefreshTokenAuthResult {
 
 const MALFORMED_REFRESH_TOKEN = Symbol('MALFORMED_REFRESH_TOKEN');
 
-@Inject([REFRESH_TOKEN_SERVICE, DefaultJwtVerifier])
+/**
+ * Authenticates refresh-token requests and exchanges them for a fresh token pair.
+ */
+@Inject(REFRESH_TOKEN_SERVICE, DefaultJwtVerifier)
 export class RefreshTokenStrategy implements AuthStrategy {
   constructor(
     private readonly refreshTokenService: RefreshTokenService,
@@ -117,6 +132,12 @@ export class RefreshTokenStrategy implements AuthStrategy {
   }
 }
 
+/**
+ * Creates alias providers that expose a refresh-token service under the shared token.
+ *
+ * @param service DI token for the concrete refresh-token service implementation.
+ * @returns Providers that bind the shared refresh-token token to the supplied service.
+ */
 export function createRefreshTokenProviders(
   service: Token<RefreshTokenService>,
 ): Array<{ provide: Token<unknown>; useToken: Token<unknown> }> {

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -90,7 +90,7 @@ describe('@konekti/prisma', () => {
       },
     };
 
-    @Inject([PrismaService])
+    @Inject(PrismaService)
     class UserService {
       constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
 

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -44,7 +44,7 @@ type TransactionAbortSignalSupport = 'unknown' | 'supported' | 'unsupported';
  * @typeParam TTransactionClient Transaction-scoped client resolved inside `$transaction(...)` callbacks.
  * @typeParam TTransactionOptions Options forwarded to Prisma interactive transactions.
  */
-@Inject([PRISMA_CLIENT, PRISMA_OPTIONS])
+@Inject(PRISMA_CLIENT, PRISMA_OPTIONS)
 export class PrismaService<
   TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
   TTransactionClient = InferPrismaTransactionClient<TClient>,

--- a/packages/prisma/src/transaction.ts
+++ b/packages/prisma/src/transaction.ts
@@ -11,7 +11,7 @@ import type { PrismaClientLike } from './types.js';
  * Pair this with repository/service code that reads `PrismaService.current()` so downstream calls share the same
  * request-scoped transaction client.
  */
-@Inject([PrismaService])
+@Inject(PrismaService)
 export class PrismaTransactionInterceptor implements Interceptor {
   constructor(private readonly prisma: PrismaService<PrismaClientLike>) {}
 

--- a/packages/prisma/src/vertical-slice.test.ts
+++ b/packages/prisma/src/vertical-slice.test.ts
@@ -162,7 +162,7 @@ describe('@konekti/prisma vertical slice', () => {
       id = '';
     }
 
-    @Inject([PrismaService])
+    @Inject(PrismaService)
     class UserRepository {
       constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
 
@@ -186,7 +186,7 @@ describe('@konekti/prisma vertical slice', () => {
       }
     }
 
-    @Inject([UserRepository])
+    @Inject(UserRepository)
     class UserService {
       constructor(private readonly repo: UserRepository) {}
 
@@ -206,7 +206,7 @@ describe('@konekti/prisma vertical slice', () => {
     }
 
     @Controller('/users')
-    @Inject([UserService])
+    @Inject(UserService)
     class UsersController {
       constructor(private readonly users: UserService) {}
 

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -372,7 +372,7 @@ describe('@konekti/queue', () => {
       subject = '';
     }
 
-    @Inject([WorkerStore])
+    @Inject(WorkerStore)
     @QueueWorker(SendWelcomeEmailJob)
     class SendWelcomeEmailWorker {
       constructor(private readonly store: WorkerStore) {}
@@ -383,7 +383,7 @@ describe('@konekti/queue', () => {
       }
     }
 
-    @Inject([QUEUE])
+    @Inject(QUEUE)
     class UserService {
       constructor(private readonly queue: Queue) {}
 
@@ -588,7 +588,7 @@ describe('@konekti/queue', () => {
       received: string[] = [];
     }
 
-    @Inject([WorkerStore])
+    @Inject(WorkerStore)
     @QueueWorker(BootstrapJob)
     class BootstrapWorker {
       constructor(private readonly store: WorkerStore) {}
@@ -598,7 +598,7 @@ describe('@konekti/queue', () => {
       }
     }
 
-    @Inject([QUEUE])
+    @Inject(QUEUE)
     class BootstrapPublisher {
       constructor(private readonly queue: Queue) {}
 

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -135,7 +135,7 @@ async function closeConnection(connection: QueueOwnedConnection): Promise<void> 
  * The service discovers `@QueueWorker()` providers during bootstrap, creates the
  * BullMQ queues/workers they require, and shuts them down with the application.
  */
-@Inject([QUEUE_OPTIONS, REDIS_CLIENT, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER])
+@Inject(QUEUE_OPTIONS, REDIS_CLIENT, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER)
 export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy {
   private readonly descriptorsByJobType = new Map<QueueJobType, QueueWorkerDescriptor>();
   private readonly queuesByJobName = new Map<string, QueueInstance>();

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -107,7 +107,7 @@ describe('@konekti/redis', () => {
   });
 
   it('registers a global Redis client, connects on bootstrap, and quits on shutdown', async () => {
-    @Inject([REDIS_CLIENT])
+    @Inject(REDIS_CLIENT)
     class CacheService {
       constructor(readonly redis: MockRedisInstance) {}
     }
@@ -209,7 +209,7 @@ describe('@konekti/redis', () => {
   });
 
   it('provides a typed RedisService facade with class-first injection', async () => {
-    @Inject([RedisService])
+    @Inject(RedisService)
     class CacheFacade {
       constructor(readonly redisService: RedisService) {}
     }
@@ -241,7 +241,7 @@ describe('@konekti/redis', () => {
   });
 
   it('returns raw string when stored value is not JSON', async () => {
-    @Inject([RedisService])
+    @Inject(RedisService)
     class CacheFacade {
       constructor(readonly redisService: RedisService) {}
     }
@@ -268,7 +268,7 @@ describe('@konekti/redis', () => {
   });
 
   it('keeps RedisService as the facade injection identity', async () => {
-    @Inject([RedisService])
+    @Inject(RedisService)
     class CacheFacade {
       constructor(readonly redisService: RedisService) {}
     }

--- a/packages/redis/src/redis-service.ts
+++ b/packages/redis/src/redis-service.ts
@@ -23,7 +23,7 @@ function decodeRedisValue(raw: string): unknown {
  * import { RedisService } from '@konekti/redis';
  *
  * export class SessionStore {
- *   @Inject([RedisService])
+ *   @Inject(RedisService)
  *   private readonly redis: RedisService;
  *
  *   async save(sessionId: string, value: object) {
@@ -32,7 +32,7 @@ function decodeRedisValue(raw: string): unknown {
  * }
  * ```
  */
-@Inject([REDIS_CLIENT])
+@Inject(REDIS_CLIENT)
 export class RedisService {
   constructor(private readonly client: Redis) {}
 

--- a/packages/redis/src/service.ts
+++ b/packages/redis/src/service.ts
@@ -24,7 +24,10 @@ function isDisconnectable(status: string): boolean {
   return DISCONNECTABLE_STATUSES.has(status);
 }
 
-@Inject([REDIS_CLIENT])
+/**
+ * Manages Redis client startup and shutdown as part of the application lifecycle.
+ */
+@Inject(REDIS_CLIENT)
 export class RedisLifecycleService implements OnModuleInit, OnApplicationShutdown {
   constructor(private readonly client: Redis) {}
 

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -316,7 +316,7 @@ describe('bootstrapApplication', () => {
       async listen() {},
     };
 
-    @Inject([RUNTIME_CONTAINER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER])
+    @Inject(RUNTIME_CONTAINER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER)
     class RuntimeTokenProbe implements OnModuleInit, OnApplicationBootstrap {
       seenCompiledModules: readonly CompiledModule[] = [];
       seenContainer: Container | undefined;

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -19,7 +19,7 @@ describe('bootstrapModule', () => {
       providers: [Logger],
     });
 
-    @Inject([Logger])
+    @Inject(Logger)
     class AppService {
       constructor(readonly logger: Logger) {}
     }
@@ -46,7 +46,7 @@ describe('bootstrapModule', () => {
       providers: [InternalRepository],
     });
 
-    @Inject([InternalRepository])
+    @Inject(InternalRepository)
     class BillingService {}
 
     class BillingModule {}
@@ -144,7 +144,7 @@ describe('bootstrapModule', () => {
   it('allows subclasses to inherit @Inject metadata for dependency validation', () => {
     class Logger {}
 
-    @Inject([Logger])
+    @Inject(Logger)
     class BaseBillingService {
       constructor(readonly logger: Logger) {}
     }
@@ -163,7 +163,7 @@ describe('bootstrapModule', () => {
     class Logger {}
     class Metrics {}
 
-    @Inject([Logger])
+    @Inject(Logger)
     class BaseBillingService {
       constructor(readonly logger: Logger) {}
     }
@@ -196,7 +196,7 @@ describe('bootstrapModule', () => {
     })
     class SharedModule {}
 
-    @Inject([Logger])
+    @Inject(Logger)
     class BillingService {
       constructor(readonly logger: Logger) {}
     }
@@ -505,7 +505,7 @@ describe('bootstrapModule requiredConstructorParameters fix', () => {
   it('keeps supporting the legacy array syntax during the staged migration', () => {
     class Logger {}
 
-    @Inject([Logger])
+    @Inject(Logger)
     class LegacyAppService {
       constructor(readonly logger: Logger) {}
     }
@@ -888,7 +888,7 @@ describe('Recovery-oriented error context (runtime)', () => {
         providers: [InternalRepository],
       });
 
-      @Inject([InternalRepository])
+      @Inject(InternalRepository)
       class BillingService {}
 
       class BillingModule {}
@@ -919,7 +919,7 @@ describe('Recovery-oriented error context (runtime)', () => {
         providers: [InternalRepository],
       });
 
-      @Inject([InternalRepository])
+      @Inject(InternalRepository)
       class BillingController {}
 
       class BillingModule {}
@@ -949,7 +949,7 @@ describe('Recovery-oriented error context (runtime)', () => {
         providers: [InternalRepository],
       });
 
-      @Inject([InternalRepository])
+      @Inject(InternalRepository)
       class BillingService {}
 
       class BillingModule {}

--- a/packages/slack/src/channel.ts
+++ b/packages/slack/src/channel.ts
@@ -13,7 +13,7 @@ import type { NormalizedSlackModuleOptions, SlackNotificationDispatchRequest, Sl
  * This class keeps the foundation package channel-agnostic while allowing `@konekti/slack`
  * to interpret Slack-specific payload fields, webhook delivery, and transport behavior.
  */
-@Inject([SlackService, SLACK_OPTIONS])
+@Inject(SlackService, SLACK_OPTIONS)
 export class SlackChannel implements NotificationChannel<SlackNotificationDispatchRequest, SlackSendResult> {
   readonly channel: string;
 

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -46,7 +46,7 @@ function assertMessageContent(message: NormalizedSlackMessage): void {
  * explicitly injected {@link SlackTransport} contracts, and translates
  * `@konekti/notifications` envelopes into concrete Slack messages.
  */
-@Inject([SLACK_OPTIONS])
+@Inject(SLACK_OPTIONS)
 export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown {
   private lifecycleState: 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'created';
   private resolvedTransport: SlackTransport | undefined;

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -263,7 +263,7 @@ function extractPayload(args: unknown[]): unknown {
  * This service preserves the README-level gateway contracts for namespace discovery, buffered pre-ready events,
  * Bun engine hosting, and graceful shutdown behavior.
  */
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, SOCKETIO_OPTIONS_INTERNAL])
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, SOCKETIO_OPTIONS_INTERNAL)
 export class SocketIoLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, SocketIoRoomService
 {

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -327,7 +327,7 @@ describe('@konekti/socket.io', () => {
   });
 
   it('injects the Socket.IO server token into singleton providers', async () => {
-    @Inject([SOCKETIO_SERVER])
+    @Inject(SOCKETIO_SERVER)
     class ServerProbe {
       constructor(public readonly server: SocketIoServer) {}
     }
@@ -404,7 +404,7 @@ describe('@konekti/socket.io', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState, SOCKETIO_ROOM_SERVICE])
+    @Inject(GatewayState, SOCKETIO_ROOM_SERVICE)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(
@@ -480,7 +480,7 @@ describe('@konekti/socket.io', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState, SOCKETIO_ROOM_SERVICE])
+    @Inject(GatewayState, SOCKETIO_ROOM_SERVICE)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(
@@ -591,7 +591,7 @@ describe('@konekti/socket.io', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/async-connect' })
     class AsyncGateway {
       constructor(private readonly state: GatewayState) {}
@@ -811,7 +811,7 @@ describe('@konekti/socket.io', () => {
       chatMessages: unknown[] = [];
     }
 
-    @Inject([GatewayState, SOCKETIO_ROOM_SERVICE])
+    @Inject(GatewayState, SOCKETIO_ROOM_SERVICE)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(
@@ -831,7 +831,7 @@ describe('@konekti/socket.io', () => {
       }
     }
 
-    @Inject([GatewayState, SOCKETIO_ROOM_SERVICE])
+    @Inject(GatewayState, SOCKETIO_ROOM_SERVICE)
     @WebSocketGateway({ path: '/admin' })
     class AdminGateway {
       constructor(

--- a/packages/terminus/src/health-check.ts
+++ b/packages/terminus/src/health-check.ts
@@ -134,7 +134,7 @@ export function assertHealthCheck(report: HealthCheckReport, message = 'Health c
 }
 
 /** Service facade that resolves and runs the health indicators registered in Terminus. */
-@Inject([TERMINUS_HEALTH_INDICATORS])
+@Inject(TERMINUS_HEALTH_INDICATORS)
 export class TerminusHealthService {
   constructor(private readonly indicators: readonly HealthIndicator[]) {}
 

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -58,7 +58,7 @@ describe('@konekti/testing', () => {
       readonly name = 'logger';
     }
 
-    @Inject([Logger])
+    @Inject(Logger)
     class UserService {
       constructor(readonly logger: Logger) {}
     }
@@ -83,7 +83,7 @@ describe('@konekti/testing', () => {
       readonly name = 'logger';
     }
 
-    @Inject([Logger])
+    @Inject(Logger)
     class UserService {
       constructor(readonly logger: Logger) {}
     }
@@ -109,7 +109,7 @@ describe('@konekti/testing', () => {
       readonly name: string = 'logger';
     }
 
-    @Inject([Logger])
+    @Inject(Logger)
     class UserService {
       constructor(readonly logger: Logger) {}
     }
@@ -179,7 +179,7 @@ describe('@konekti/testing', () => {
       readonly name: string = 'fake-logger';
     }
 
-    @Inject([Logger])
+    @Inject(Logger)
     class UserService {
       constructor(readonly logger: Logger) {}
     }
@@ -518,7 +518,7 @@ describe('TestingModuleRef.dispatch', () => {
       }
     }
 
-    @Inject([CounterService])
+    @Inject(CounterService)
     @Controller('/counter')
     class CounterController {
       constructor(private readonly counter: CounterService) {}
@@ -629,7 +629,7 @@ describe('overrideModule', () => {
       }
     }
 
-    @Inject([RealService])
+    @Inject(RealService)
     class ConsumerService {
       constructor(readonly dep: RealService) {}
     }
@@ -761,7 +761,7 @@ describe('mockToken', () => {
       readonly name = 'logger';
     }
 
-    @Inject([Logger])
+    @Inject(Logger)
     class UserService {
       constructor(readonly logger: Logger) {}
     }

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -58,7 +58,7 @@ function buildHandlerKey(handler: GuardContext['handler']): string {
 /**
  * Guard that enforces module-, class-, and method-level throttling policies.
  */
-@Inject([THROTTLER_OPTIONS])
+@Inject(THROTTLER_OPTIONS)
 export class ThrottlerGuard implements Guard {
   private readonly store: ThrottlerStore;
 

--- a/packages/websockets/src/bun/bun-service.ts
+++ b/packages/websockets/src/bun/bun-service.ts
@@ -117,7 +117,10 @@ function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
 }
 
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS_INTERNAL])
+/**
+ * Boots Bun-backed websocket gateways and manages their room lifecycle state.
+ */
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS_INTERNAL)
 export class BunWebSocketGatewayLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
 {

--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -193,7 +193,7 @@ describe('@konekti/websockets/bun', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(private readonly state: GatewayState) {}

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
@@ -110,7 +110,10 @@ function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
 }
 
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS_INTERNAL])
+/**
+ * Boots Cloudflare Workers websocket gateways and manages their room lifecycle state.
+ */
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS_INTERNAL)
 export class CloudflareWorkersWebSocketGatewayLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
 {

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -251,7 +251,7 @@ describe('@konekti/websockets/cloudflare-workers', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(private readonly state: GatewayState) {}

--- a/packages/websockets/src/deno/deno-service.ts
+++ b/packages/websockets/src/deno/deno-service.ts
@@ -110,7 +110,10 @@ function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
 }
 
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS_INTERNAL])
+/**
+ * Boots Deno-backed websocket gateways and manages their room lifecycle state.
+ */
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS_INTERNAL)
 export class DenoWebSocketGatewayLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
 {

--- a/packages/websockets/src/deno/deno.test.ts
+++ b/packages/websockets/src/deno/deno.test.ts
@@ -254,7 +254,7 @@ describe('@konekti/websockets/deno', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(private readonly state: GatewayState) {}

--- a/packages/websockets/src/module.test.ts
+++ b/packages/websockets/src/module.test.ts
@@ -345,7 +345,7 @@ describe('@konekti/websockets', () => {
       connects = 0;
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/dedupe' })
     class DedupeGateway {
       constructor(private readonly state: GatewayState) {}
@@ -454,7 +454,7 @@ describe('@konekti/websockets', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(private readonly state: GatewayState) {}
@@ -517,7 +517,7 @@ describe('@konekti/websockets', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(private readonly state: GatewayState) {}
@@ -580,7 +580,7 @@ describe('@konekti/websockets', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(private readonly state: GatewayState) {}
@@ -652,7 +652,7 @@ describe('@konekti/websockets', () => {
         }
       }
 
-      @Inject([GatewayState])
+      @Inject(GatewayState)
       class ChatGateway {
         constructor(private readonly state: GatewayState) {}
 
@@ -729,7 +729,7 @@ describe('@konekti/websockets', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/async-connect' })
     class AsyncGateway {
       constructor(private readonly state: GatewayState) {}
@@ -788,7 +788,7 @@ describe('@konekti/websockets', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/buffer-cap' })
     class BufferedGateway {
       constructor(private readonly state: GatewayState) {}
@@ -850,7 +850,7 @@ describe('@konekti/websockets', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/async-connect-then-message' })
     class AsyncGateway2 {
       constructor(private readonly state: GatewayState) {}
@@ -910,7 +910,7 @@ describe('@konekti/websockets', () => {
       steps: string[] = [];
     }
 
-    @Inject([SharedState])
+    @Inject(SharedState)
     @WebSocketGateway({ path: '/ordered' })
     class FirstGateway {
       constructor(private readonly state: SharedState) {}
@@ -922,7 +922,7 @@ describe('@konekti/websockets', () => {
       }
     }
 
-    @Inject([SharedState])
+    @Inject(SharedState)
     @WebSocketGateway({ path: '/ordered' })
     class SecondGateway {
       constructor(private readonly state: SharedState) {}

--- a/packages/websockets/src/node/node-service.ts
+++ b/packages/websockets/src/node/node-service.ts
@@ -164,7 +164,7 @@ function rejectBadUpgradeRequest(socket: Duplex): void {
  * This service preserves the documented runtime behavior for shared-path discovery order, optional server-backed
  * listeners, buffered pre-ready events, heartbeat handling, and graceful shutdown.
  */
-@Inject([RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS_INTERNAL])
+@Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, WEBSOCKET_OPTIONS_INTERNAL)
 export class NodeWebSocketGatewayLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
 {

--- a/packages/websockets/src/node/node.test.ts
+++ b/packages/websockets/src/node/node.test.ts
@@ -103,7 +103,7 @@ describe('@konekti/websockets/node', () => {
       messages: unknown[] = [];
     }
 
-    @Inject([GatewayState])
+    @Inject(GatewayState)
     @WebSocketGateway({ path: '/chat' })
     class ChatGateway {
       constructor(private readonly state: GatewayState) {}


### PR DESCRIPTION
## Summary
- convert repo-code TypeScript surfaces under `packages/**` and `examples/**` from class-level `@Inject([A, B])` to canonical variadic `@Inject(A, B)`
- rewrite explicit empty array overrides to `@Inject()` while leaving `packages/cli/**` generator/codemod surfaces for #954 and markdown/docs/README surfaces for #956
- add the minimum source-level TSDoc required for touched public exports so repo verification still passes after the syntax migration

## Changes
- updated canonical package source, tests, and example apps that still used class-level array inject syntax
- preserved staged compatibility behavior by leaving runtime normalization intact in `packages/core/src/decorators.ts` and only changing internal usage sites
- kept CLI-owned generator expectations and codemod guidance unchanged

## Testing
- `pnpm verify`
- `lsp_diagnostics` error checks across every changed package/example directory returned 0 errors

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Closes #955