### PR TITLE
Resolve #963: align fluo wording across CLI and runtime surfaces

### DIFF
--- a/examples/README.ko.md
+++ b/examples/README.ko.md
@@ -2,9 +2,9 @@
 
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
-이 디렉토리는 Konekti의 공식 runnable example 애플리케이션을 모아 둔 곳입니다. 각 예제는 개별 README를 가지며, docs hub와 함께 읽는 것을 전제로 합니다.
+이 디렉토리는 fluo의 공식 runnable example 애플리케이션을 모아 둔 곳입니다. 각 예제는 개별 README를 가지며, docs hub와 함께 읽는 것을 전제로 합니다.
 
-이 예제들은 생성 스캐폴드와 runnable 예제가 계속 일치하도록 의도적으로 기본 Node.js + Fastify 경로를 유지합니다. 공식 Bun, Deno, Cloudflare Workers 런타임 가이드는 대응하는 `@konekti/platform-*` 패키지 README에서 다룹니다.
+이 예제들은 생성 스캐폴드와 runnable 예제가 계속 일치하도록 의도적으로 기본 Node.js + Fastify 경로를 유지합니다. 공식 Bun, Deno, Cloudflare Workers 런타임 가이드는 대응하는 `@fluojs/platform-*` 패키지 README에서 다룹니다.
 
 ## 현재 공식 예제
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,13 +2,13 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
-This directory contains the official runnable example applications for Konekti. Each example has its own README and is meant to be read alongside the docs hub rather than in isolation.
+This directory contains the official runnable example applications for fluo. Each example has its own README and is meant to be read alongside the docs hub rather than in isolation.
 
-These examples intentionally stay on the default Node.js + Fastify starter path so the generated scaffold and the runnable examples keep matching. Official Bun, Deno, and Cloudflare Workers runtime guidance lives in the corresponding `@konekti/platform-*` package READMEs.
+These examples intentionally stay on the default Node.js + Fastify starter path so the generated scaffold and the runnable examples keep matching. Official Bun, Deno, and Cloudflare Workers runtime guidance lives in the corresponding `@fluojs/platform-*` package READMEs.
 
 ## current official examples
 
-- `./minimal/` — the smallest runnable Konekti app, matching the canonical starter path
+- `./minimal/` — the smallest runnable fluo app, matching the canonical starter path
 - `./realworld-api/` — a more realistic multi-module HTTP API with config, DTO validation, explicit DI, and CRUD
 - `./auth-jwt-passport/` — bearer-token auth example with JWT issuance and protected routes via passport core
 - `./ops-metrics-terminus/` — operations example centered on `/metrics`, `/health`, and `/ready`

--- a/examples/auth-jwt-passport/README.ko.md
+++ b/examples/auth-jwt-passport/README.ko.md
@@ -2,7 +2,7 @@
 
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
-`@konekti/jwt`와 `@konekti/passport`를 가장 단순한 공식 bearer-token 흐름으로 묶어 보여주는 runnable Konekti 인증 예제입니다.
+`@fluojs/jwt`와 `@fluojs/passport`를 가장 단순한 공식 bearer-token 흐름으로 묶어 보여주는 runnable fluo 인증 예제입니다.
 
 ## 이 예제가 보여주는 것
 
@@ -11,7 +11,7 @@
 - custom `AuthStrategy`를 통한 bearer token 검증
 - reflection 기반 주입 대신 명시적 DI token metadata
 - auth 라우트와 함께 동작하는 runtime-owned `/health`, `/ready`
-- `@konekti/testing`을 사용한 unit / integration / e2e 스타일 테스트
+- `@fluojs/testing`을 사용한 unit / integration / e2e 스타일 테스트
 
 ## 라우트
 

--- a/examples/auth-jwt-passport/README.md
+++ b/examples/auth-jwt-passport/README.md
@@ -2,7 +2,7 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
-Runnable Konekti authentication example that combines `@konekti/jwt` and `@konekti/passport` around the simplest official bearer-token flow.
+Runnable fluo authentication example that combines `@fluojs/jwt` and `@fluojs/passport` around the simplest official bearer-token flow.
 
 ## what this example demonstrates
 
@@ -11,7 +11,7 @@ Runnable Konekti authentication example that combines `@konekti/jwt` and `@konek
 - verifying bearer tokens through a custom `AuthStrategy`
 - explicit DI token metadata instead of reflection-based injection
 - runtime-owned `/health` and `/ready` endpoints alongside auth routes
-- unit, integration, and e2e-style testing with `@konekti/testing`
+- unit, integration, and e2e-style testing with `@fluojs/testing`
 
 ## routes
 

--- a/examples/auth-jwt-passport/src/auth/auth.module.ts
+++ b/examples/auth-jwt-passport/src/auth/auth.module.ts
@@ -14,9 +14,9 @@ import { BearerJwtStrategy } from './bearer.strategy';
     ...createJwtCoreProviders({
       accessTokenTtlSeconds: 3600,
       algorithms: ['HS256'],
-      audience: 'konekti-auth-example-clients',
-      issuer: 'konekti-auth-example',
-      secret: 'konekti-auth-example-secret',
+      audience: 'fluo-auth-example-clients',
+      issuer: 'fluo-auth-example',
+      secret: 'fluo-auth-example-secret',
     }),
     ...createPassportProviders(
       { defaultStrategy: 'jwt' },

--- a/examples/minimal/README.ko.md
+++ b/examples/minimal/README.ko.md
@@ -2,7 +2,7 @@
 
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
-가장 작은 실행 가능한 Konekti 애플리케이션입니다. 이 예제는 `konekti new`가 생성하는 것과 동일한 시작 경로를 따르되, 필수 요소만 남겼습니다.
+가장 작은 실행 가능한 fluo 애플리케이션입니다. 이 예제는 `konekti new`가 생성하는 것과 동일한 시작 경로를 따르되, 필수 요소만 남겼습니다.
 
 ## 이 예제가 보여주는 것
 
@@ -10,11 +10,11 @@
 - `@Module`, `@Inject`, `@Controller`, `@Get`을 사용한 표준 데코레이터 DI
 - `createHealthModule()`의 내장 `/health` 및 `/ready` 엔드포인트
 - `/hello` 경로의 단일 스타터 컨트롤러
-- `@konekti/testing`을 사용한 단위 및 e2e 스타일 테스트
+- `@fluojs/testing`을 사용한 단위 및 e2e 스타일 테스트
 
 ## 실행 방법
 
-이 예제는 Konekti 모노레포 내부에 있으며 워크스페이스 링크 패키지를 사용합니다. 저장소 루트에서:
+이 예제는 fluo 모노레포 내부에 있으며 워크스페이스 링크 패키지를 사용합니다. 저장소 루트에서:
 
 ```sh
 pnpm install
@@ -44,7 +44,7 @@ examples/minimal/
 이 예제는 `konekti new` 출력의 의도적인 부분 집합입니다. config, health 모듈, 생성된 테스트, 빌드 도구가 포함된 전체 스타터 경험을 원한다면:
 
 ```sh
-pnpm add -g @konekti/cli
+pnpm add -g @fluojs/cli
 konekti new my-app
 ```
 

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -2,7 +2,7 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
-The smallest runnable Konekti application. This example follows the exact same startup path that `konekti new` generates, stripped down to the essentials.
+The smallest runnable fluo application. This example follows the exact same startup path that `konekti new` generates, stripped down to the essentials.
 
 ## what this example demonstrates
 
@@ -10,11 +10,11 @@ The smallest runnable Konekti application. This example follows the exact same s
 - Standard decorator DI with `@Module`, `@Inject`, `@Controller`, `@Get`
 - Built-in `/health` and `/ready` endpoints from `createHealthModule()`
 - A single starter controller at `/hello`
-- Unit and e2e-style testing with `@konekti/testing`
+- Unit and e2e-style testing with `@fluojs/testing`
 
 ## how to run
 
-This example lives inside the Konekti monorepo and uses workspace-linked packages. From the repository root:
+This example lives inside the fluo monorepo and uses workspace-linked packages. From the repository root:
 
 ```sh
 pnpm install
@@ -44,7 +44,7 @@ examples/minimal/
 This example is intentionally a subset of the `konekti new` output. If you want the full starter experience with config, health module, generated tests, and build tooling, run:
 
 ```sh
-pnpm add -g @konekti/cli
+pnpm add -g @fluojs/cli
 konekti new my-app
 ```
 

--- a/examples/minimal/src/app.test.ts
+++ b/examples/minimal/src/app.test.ts
@@ -11,7 +11,7 @@ import { HelloController } from './hello.controller';
 describe('HelloService', () => {
   it('returns a greeting message', () => {
     const service = new HelloService();
-    expect(service.greet('Konekti')).toEqual({ message: 'Hello, Konekti!' });
+    expect(service.greet('fluo')).toEqual({ message: 'Hello, fluo!' });
   });
 });
 

--- a/examples/ops-metrics-terminus/README.ko.md
+++ b/examples/ops-metrics-terminus/README.ko.md
@@ -2,7 +2,7 @@
 
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
-`@konekti/metrics`와 `@konekti/terminus`에 초점을 둔 runnable Konekti 운영 예제입니다. 작은 앱에서 runtime health/readiness, Prometheus scrape, custom metric이 어떻게 함께 맞물리는지를 보여줍니다.
+`@fluojs/metrics`와 `@fluojs/terminus`에 초점을 둔 runnable fluo 운영 예제입니다. 작은 앱에서 runtime health/readiness, Prometheus scrape, custom metric이 어떻게 함께 맞물리는지를 보여줍니다.
 
 ## 이 예제가 보여주는 것
 
@@ -10,7 +10,7 @@
 - `TerminusModule.forRoot(...)`를 통한 `/health`, `/ready`
 - `MetricsModule`이 scrape하는 shared Registry에 등록한 custom Prometheus counter 하나
 - terminus와 metrics에 함께 노출되는 runtime-aligned health/readiness semantics
-- `@konekti/testing`을 사용한 unit / integration / e2e 스타일 검증
+- `@fluojs/testing`을 사용한 unit / integration / e2e 스타일 검증
 
 ## 라우트
 

--- a/examples/ops-metrics-terminus/README.md
+++ b/examples/ops-metrics-terminus/README.md
@@ -2,7 +2,7 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
-Runnable Konekti operations example focused on `@konekti/metrics` and `@konekti/terminus`. It shows how runtime health/readiness, Prometheus scraping, and one custom metric fit together in a small app.
+Runnable fluo operations example focused on `@fluojs/metrics` and `@fluojs/terminus`. It shows how runtime health/readiness, Prometheus scraping, and one custom metric fit together in a small app.
 
 ## what this example demonstrates
 
@@ -10,7 +10,7 @@ Runnable Konekti operations example focused on `@konekti/metrics` and `@konekti/
 - `/health` and `/ready` via `TerminusModule.forRoot(...)`
 - one custom Prometheus counter registered on a shared Registry that is scraped through `MetricsModule`
 - runtime-aligned health/readiness semantics exposed through terminus and metrics
-- unit, integration, and e2e-style verification with `@konekti/testing`
+- unit, integration, and e2e-style verification with `@fluojs/testing`
 
 ## routes
 

--- a/examples/realworld-api/README.ko.md
+++ b/examples/realworld-api/README.ko.md
@@ -2,20 +2,20 @@
 
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
-최소 스타터를 넘어 표준 앱 경로를 보여주는 보다 현실적인 Konekti 애플리케이션입니다. 동일한 스타터 정렬 adapter-first 부트스트랩 위에 모듈 조합, DTO 검증, config 로딩, 도메인 CRUD 슬라이스를 추가합니다.
+최소 스타터를 넘어 표준 앱 경로를 보여주는 보다 현실적인 fluo 애플리케이션입니다. 동일한 스타터 정렬 adapter-first 부트스트랩 위에 모듈 조합, DTO 검증, config 로딩, 도메인 CRUD 슬라이스를 추가합니다.
 
 ## 이 예제가 보여주는 것
 
 - `imports` / `exports`를 사용한 다중 모듈 조합
 - `ConfigModule.forRoot`을 통한 타입 안전 설정
-- `@konekti/validation` 데코레이터를 사용한 Request DTO 검증
+- `@fluojs/validation` 데코레이터를 사용한 Request DTO 검증
 - 명시적 DI 토큰을 사용한 Repository 패턴
 - 런타임 소유 `/health`, `/ready` + 도메인 `/users` CRUD 표면
-- `@konekti/testing`의 단위 및 e2e 스타일 테스트 패턴
+- `@fluojs/testing`의 단위 및 e2e 스타일 테스트 패턴
 
 ## 실행 방법
 
-이 예제는 Konekti 모노레포 내부에 있으며 워크스페이스 링크 패키지를 사용합니다. 저장소 루트에서:
+이 예제는 fluo 모노레포 내부에 있으며 워크스페이스 링크 패키지를 사용합니다. 저장소 루트에서:
 
 ```sh
 pnpm install

--- a/examples/realworld-api/README.md
+++ b/examples/realworld-api/README.md
@@ -2,20 +2,20 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
-A more realistic Konekti application demonstrating the standard app path beyond the minimal starter. This example builds on the same starter-aligned adapter-first bootstrap while adding module composition, DTO validation, config loading, and a domain CRUD slice.
+A more realistic fluo application demonstrating the standard app path beyond the minimal starter. This example builds on the same starter-aligned adapter-first bootstrap while adding module composition, DTO validation, config loading, and a domain CRUD slice.
 
 ## what this example demonstrates
 
 - Multi-module composition with `imports` / `exports`
 - Typed configuration via `ConfigModule.forRoot`
-- Request DTO validation with `@konekti/validation` decorators
+- Request DTO validation with `@fluojs/validation` decorators
 - Repository pattern with explicit DI tokens
 - Runtime-owned `/health` and `/ready` plus a domain `/users` CRUD surface
-- Unit and e2e-style testing patterns from `@konekti/testing`
+- Unit and e2e-style testing patterns from `@fluojs/testing`
 
 ## how to run
 
-This example lives inside the Konekti monorepo and uses workspace-linked packages. From the repository root:
+This example lives inside the fluo monorepo and uses workspace-linked packages. From the repository root:
 
 ```sh
 pnpm install

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -703,7 +703,7 @@ describe('CLI command runner', () => {
     const output = stdoutBuffer.join('');
 
     expect(exitCode).toBe(0);
-    expect(output).toContain('Scaffold a new Konekti application');
+    expect(output).toContain('Scaffold a new fluo application');
     expect(output).toContain('Generate a schematic');
     expect(output).toContain('Inspect runtime platform snapshot/diagnostics');
     expect(output).toContain('dry-run by default');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -86,10 +86,10 @@ const GENERATE_OPTION_HELP: GenerateOptionHelpEntry[] = [
 ];
 
 const TOP_LEVEL_COMMAND_HELP: TopLevelCommandHelpEntry[] = [
-  { aliases: ['create'], command: 'new', description: 'Scaffold a new Konekti application and install dependencies.' },
-  { aliases: ['g'], command: 'generate', description: 'Generate a schematic inside an existing Konekti application.' },
+  { aliases: ['create'], command: 'new', description: 'Scaffold a new fluo application and install dependencies.' },
+  { aliases: ['g'], command: 'generate', description: 'Generate a schematic inside an existing fluo application.' },
   { aliases: [], command: 'inspect', description: 'Inspect runtime platform snapshot/diagnostics and emit timing optionally.' },
-  { aliases: [], command: 'migrate', description: 'Run NestJS-to-Konekti codemods (dry-run by default).' },
+  { aliases: [], command: 'migrate', description: 'Run NestJS-to-fluo codemods (dry-run by default).' },
   { aliases: [], command: 'help', description: 'Show top-level or command-specific help.' },
 ];
 

--- a/packages/cli/src/new/install.ts
+++ b/packages/cli/src/new/install.ts
@@ -59,7 +59,7 @@ export async function installDependencies(targetDirectory: string, packageManage
 
   if (packageManager === 'yarn' && hasCorepack === false) {
     console.warn(
-      `[konekti] corepack was not found in PATH, falling back to "yarn install". See ${COREPACK_DOCS_URL}`,
+      `[fluo] corepack was not found in PATH, falling back to "yarn install". See ${COREPACK_DOCS_URL}`,
     );
   }
 

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -1942,7 +1942,7 @@ describe('bootstrapApplication', () => {
       'app:shutdown:bootstrap-failed',
     ]);
     expect(loggerEvents).toContain(
-      'error:KonektiFactory:Failed to bootstrap application. Check the error below for what failed and how to fix it.:boom',
+      'error:KonektiFactory:Failed to bootstrap the fluo application. Check the error below for what failed and how to fix it.:boom',
     );
   });
 
@@ -1986,7 +1986,7 @@ describe('bootstrapApplication', () => {
     });
 
     expect(loggerEvents).toEqual([
-      'log:KonektiFactory:Starting Konekti application...',
+      'log:KonektiFactory:Starting fluo application...',
       'log:InstanceLoader:AppModule dependencies initialized',
       'log:RoutesResolver:HealthController {/health}',
       'log:RouterExplorer:Mapped {/health, GET} route',

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -487,7 +487,7 @@ class KonektiApplication implements Application {
     }
 
     this.applicationState = 'ready';
-    this.logger.log('Konekti application successfully started.', 'KonektiApplication');
+      this.logger.log('fluo application successfully started.', 'KonektiApplication');
   }
 
   dispatch = async (...args: Parameters<Dispatcher['dispatch']>): Promise<void> => {
@@ -616,7 +616,7 @@ class KonektiMicroserviceApplication implements MicroserviceApplication {
 
     await this.runtime.listen();
     this.microserviceState = 'ready';
-    this.logger.log('Konekti microservice successfully started.', 'KonektiFactory');
+      this.logger.log('fluo microservice successfully started.', 'KonektiFactory');
   }
 
   async send(pattern: string, payload: unknown, signal?: AbortSignal): Promise<unknown> {
@@ -930,7 +930,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
   const timingPhases: BootstrapTimingPhase[] = [];
 
   try {
-    logger.log('Starting Konekti application...', 'KonektiFactory');
+    logger.log('Starting fluo application...', 'KonektiFactory');
     const runtimeProviders = createRuntimeProviders(options, logger);
 
     const moduleBootstrapStart = timingEnabled ? runtimePerformance.now() : 0;
@@ -1009,7 +1009,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     );
   } catch (error: unknown) {
     logger.error(
-      'Failed to bootstrap application. Check the error below for what failed and how to fix it.',
+      'Failed to bootstrap the fluo application. Check the error below for what failed and how to fix it.',
       error,
       'KonektiFactory',
     );
@@ -1067,7 +1067,7 @@ export class KonektiFactory {
     const timingPhases: BootstrapTimingPhase[] = [];
 
     try {
-      logger.log('Starting Konekti application context...', 'KonektiFactory');
+      logger.log('Starting fluo application context...', 'KonektiFactory');
       const runtimeProviders = createRuntimeProviders(options, logger);
 
   const moduleBootstrapStart = timingEnabled ? runtimePerformance.now() : 0;

--- a/packages/runtime/src/logging/logger.ts
+++ b/packages/runtime/src/logging/logger.ts
@@ -11,7 +11,7 @@ function colorize(value: string, color: string, enabled: boolean): string {
 }
 
 function formatLog(level: 'DEBUG' | 'ERROR' | 'LOG' | 'WARN', context: string, message: string, color: boolean): string {
-  const prefix = colorize('[Konekti]', BRIGHT_GREEN, color);
+  const prefix = colorize('[fluo]', BRIGHT_GREEN, color);
   const pid = colorize(String(process.pid), BRIGHT_YELLOW, color);
   const timestamp = colorize(new Date().toLocaleString('en-US'), DIM, color);
   const levelColor = level === 'ERROR' || level === 'WARN' ? BRIGHT_RED : BRIGHT_GREEN;
@@ -23,20 +23,20 @@ function formatLog(level: 'DEBUG' | 'ERROR' | 'LOG' | 'WARN', context: string, m
 
 export function createConsoleApplicationLogger(): ApplicationLogger {
   return {
-    debug(message, context = 'Konekti') {
+    debug(message, context = 'fluo') {
       console.debug(formatLog('DEBUG', context, message, Boolean(process.stdout.isTTY)));
     },
-    error(message, error, context = 'Konekti') {
+    error(message, error, context = 'fluo') {
       console.error(formatLog('ERROR', context, message, Boolean(process.stderr.isTTY)));
 
       if (error) {
         console.error(error);
       }
     },
-    log(message, context = 'Konekti') {
+    log(message, context = 'fluo') {
       console.log(formatLog('LOG', context, message, Boolean(process.stdout.isTTY)));
     },
-    warn(message, context = 'Konekti') {
+    warn(message, context = 'fluo') {
       console.warn(formatLog('WARN', context, message, Boolean(process.stderr.isTTY)));
     },
   };


### PR DESCRIPTION
## Summary

- Align CLI help text and install fallback messaging to user-facing `fluo` branding while keeping the `konekti` command name unchanged.
- Rename runtime logger prefixes and bootstrap success/error strings to `fluo`, and update the matching runtime assertions.
- Refresh example READMEs, example-facing sample strings, and sandbox-generated output expectations so emitted/example surfaces prefer `@fluojs/*` and `fluo` wording.

Closes #963

## Changes

- Updated `packages/cli` help/error-facing wording for the owned lane surfaces.
- Updated `packages/runtime` logger/bootstrap wording without renaming stable exported symbols like `KonektiFactory`.
- Updated owned example READMEs and example source/test fixtures in `examples/`.

## Testing

- `pnpm exec vitest run packages/cli/src/cli.test.ts packages/cli/src/commands/migrate.test.ts`
- `pnpm exec vitest run packages/runtime/src/application.test.ts`
- `pnpm exec vitest run examples/minimal examples/realworld-api examples/auth-jwt-passport examples/ops-metrics-terminus`
- `pnpm build`
- `pnpm sandbox:create && pnpm sandbox:verify && pnpm sandbox:test && pnpm sandbox:clean` (in `packages/cli`)
- Attempted `pnpm typecheck`, which still fails on existing workspace-wide `@fluojs/*` module-resolution errors outside this lane (for example `packages/http` / `packages/runtime` package typecheck paths).

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
