### PR TITLE
Resolve #964: align release metadata with fluo canonical naming

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,7 +33,7 @@ body:
     id: version
     attributes:
       label: fluo Version
-      description: e.g. v1.2.3, or @latest
+      description: e.g. fluo v1.2.3, `fluo --version`, or @fluojs/cli@latest
     validations:
       required: true
   - type: textarea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - `@konekti/terminus`: Terminus-style health indicators, structured `/health` aggregation, and runtime readiness integration layered on `createHealthModule()`.
 
 <!-- release-readiness-draft:start -->
-### Draft release readiness entry (2026-04-02)
+### Draft release readiness entry (2026-04-10)
 
 - Breaking changes:
   - _Describe public contract changes and include migration notes._
 - New features by package:
-  - _List package-level additions (for example `@konekti/http`, `@konekti/cli`)._
+  - _List package-level additions (for example `@fluojs/http`, `@fluojs/cli`)._
 - Bug fixes:
   - _List notable fixes by package._
 - Deprecations:

--- a/docs/operations/release-governance.ko.md
+++ b/docs/operations/release-governance.ko.md
@@ -4,7 +4,7 @@
   <strong>한국어</strong> | <a href="./release-governance.md">English</a>
 </p>
 
-이 문서는 Konekti 생태계의 릴리스 표준, 안정성 계약 및 버전 관리 정책을 정의합니다. 프레임워크 업데이트가 예측 가능하고, 파괴적 변경 사항이 명확하게 전달되며, 공개 패키지가 높은 품질을 유지할 수 있도록 보장합니다.
+이 문서는 fluo 생태계의 릴리스 표준, 안정성 계약 및 버전 관리 정책을 정의합니다. 프레임워크 업데이트가 예측 가능하고, 파괴적 변경 사항이 명확하게 전달되며, 공개 패키지가 높은 품질을 유지할 수 있도록 보장합니다.
 
 ## 이 문서가 필요한 경우
 
@@ -17,7 +17,7 @@
 
 ## 안정성 계약 (Stability Contract)
 
-Konekti는 패키지의 성숙도를 전달하기 위해 계층화된 안정성 모델을 사용합니다.
+fluo는 패키지의 성숙도를 전달하기 위해 계층화된 안정성 모델을 사용합니다.
 
 | 등급 | 안정성 | 설명 |
 | :--- | :--- | :--- |
@@ -36,7 +36,7 @@ Konekti는 패키지의 성숙도를 전달하기 위해 계층화된 안정성 
 
 ## 버전 관리 정책 (Versioning Policy)
 
-Konekti는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅니다.
+fluo는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅니다.
 
 - **Major (`X.0.0`)**: 중대한 파괴적 변경, 아키텍처의 전환 또는 지원 중단된 API의 삭제.
 - **Minor (`0.X.0`)**: 새로운 기능 추가, 하위 호환성을 유지하는 개선 또는 문서화된 동작을 보존하는 주요 내부 리팩토링.
@@ -47,45 +47,45 @@ Konekti는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅
 
 ## intended publish surface
 
-- `@konekti/cache-manager`
-- `@konekti/cli`
-- `@konekti/config`
-- `@konekti/core`
-- `@konekti/cqrs`
-- `@konekti/cron`
-- `@konekti/email`
-- `@konekti/discord`
-- `@konekti/di`
-- `@konekti/drizzle`
-- `@konekti/event-bus`
-- `@konekti/graphql`
-- `@konekti/http`
-- `@konekti/jwt`
-- `@konekti/metrics`
-- `@konekti/microservices`
-- `@konekti/mongoose`
-- `@konekti/notifications`
-- `@konekti/openapi`
-- `@konekti/passport`
-- `@konekti/platform-bun`
-- `@konekti/platform-cloudflare-workers`
-- `@konekti/platform-deno`
-- `@konekti/platform-express`
-- `@konekti/platform-fastify`
-- `@konekti/platform-nodejs`
-- `@konekti/prisma`
-- `@konekti/queue`
-- `@konekti/redis`
-- `@konekti/runtime`
-- `@konekti/serialization`
-- `@konekti/slack`
-- `@konekti/socket.io`
-- `@konekti/studio`
-- `@konekti/terminus`
-- `@konekti/testing`
-- `@konekti/throttler`
-- `@konekti/validation`
-- `@konekti/websockets`
+- `@fluojs/cache-manager`
+- `@fluojs/cli`
+- `@fluojs/config`
+- `@fluojs/core`
+- `@fluojs/cqrs`
+- `@fluojs/cron`
+- `@fluojs/email`
+- `@fluojs/discord`
+- `@fluojs/di`
+- `@fluojs/drizzle`
+- `@fluojs/event-bus`
+- `@fluojs/graphql`
+- `@fluojs/http`
+- `@fluojs/jwt`
+- `@fluojs/metrics`
+- `@fluojs/microservices`
+- `@fluojs/mongoose`
+- `@fluojs/notifications`
+- `@fluojs/openapi`
+- `@fluojs/passport`
+- `@fluojs/platform-bun`
+- `@fluojs/platform-cloudflare-workers`
+- `@fluojs/platform-deno`
+- `@fluojs/platform-express`
+- `@fluojs/platform-fastify`
+- `@fluojs/platform-nodejs`
+- `@fluojs/prisma`
+- `@fluojs/queue`
+- `@fluojs/redis`
+- `@fluojs/runtime`
+- `@fluojs/serialization`
+- `@fluojs/slack`
+- `@fluojs/socket.io`
+- `@fluojs/studio`
+- `@fluojs/terminus`
+- `@fluojs/testing`
+- `@fluojs/throttler`
+- `@fluojs/validation`
+- `@fluojs/websockets`
 
 ---
 
@@ -97,7 +97,7 @@ Konekti는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅
 - **`pnpm verify:release-readiness`**: 패키징된 CLI 엔트리포인트와 스타터 스캐폴딩을 검증합니다.
 - **`pnpm verify:platform-consistency-governance`**: 영어와 한국어 문서 간의 구조적 일관성을 강제합니다.
 - **`pnpm verify:public-export-tsdoc`**: `packages/*/src` 아래 변경된 public export가 repo-wide TSDoc 최소 기준을 놓치면 실패합니다.
-- **동작 계약 체크**: `process.env`가 승인된 패턴(`@konekti/config`) 외부에서 액세스될 경우 릴리스를 차단합니다.
+- **동작 계약 체크**: `process.env`가 승인된 패턴(`@fluojs/config`) 외부에서 액세스될 경우 릴리스를 차단합니다.
 
 ### 변경 이력 표준 (Changelog Standards)
 모든 공개 릴리스는 *Keep a Changelog* 형식을 따르는 루트 `CHANGELOG.md`에 일치하는 항목이 있어야 합니다. GitHub 릴리스는 배포 단계에서 이 내용을 바탕으로 자동으로 생성됩니다.

--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -4,7 +4,7 @@
   <strong>English</strong> | <a href="./release-governance.ko.md">한국어</a>
 </p>
 
-This document defines the release standards, stability contracts, and versioning policies for the Konekti ecosystem. It ensures that framework updates are predictable, breaking changes are communicated, and public-facing packages maintain high quality.
+This document defines the release standards, stability contracts, and versioning policies for the fluo ecosystem. It ensures that framework updates are predictable, breaking changes are communicated, and public-facing packages maintain high quality.
 
 ## When this document matters
 
@@ -17,7 +17,7 @@ This document defines the release standards, stability contracts, and versioning
 
 ## Stability Contract
 
-Konekti uses a tiered stability model to communicate the maturity of its packages.
+fluo uses a tiered stability model to communicate the maturity of its packages.
 
 | Tier | Stability | Description |
 | :--- | :--- | :--- |
@@ -36,7 +36,7 @@ A package graduates to `1.0` (Stable) only when:
 
 ## Versioning Policy
 
-Konekti follows strict **Semantic Versioning (Semver)**.
+fluo follows strict **Semantic Versioning (Semver)**.
 
 - **Major (`X.0.0`)**: Significant breaking changes, architectural shifts, or removal of deprecated APIs.
 - **Minor (`0.X.0`)**: New features, non-breaking enhancements, or significant internal refactorings that preserve documented behavior.
@@ -47,45 +47,45 @@ During the `0.x` phase, the **Minor** version is used for breaking changes. Ever
 
 ## intended publish surface
 
-- `@konekti/cache-manager`
-- `@konekti/cli`
-- `@konekti/config`
-- `@konekti/core`
-- `@konekti/cqrs`
-- `@konekti/cron`
-- `@konekti/email`
-- `@konekti/discord`
-- `@konekti/di`
-- `@konekti/drizzle`
-- `@konekti/event-bus`
-- `@konekti/graphql`
-- `@konekti/http`
-- `@konekti/jwt`
-- `@konekti/metrics`
-- `@konekti/microservices`
-- `@konekti/mongoose`
-- `@konekti/notifications`
-- `@konekti/openapi`
-- `@konekti/passport`
-- `@konekti/platform-bun`
-- `@konekti/platform-cloudflare-workers`
-- `@konekti/platform-deno`
-- `@konekti/platform-express`
-- `@konekti/platform-fastify`
-- `@konekti/platform-nodejs`
-- `@konekti/prisma`
-- `@konekti/queue`
-- `@konekti/redis`
-- `@konekti/runtime`
-- `@konekti/serialization`
-- `@konekti/slack`
-- `@konekti/socket.io`
-- `@konekti/studio`
-- `@konekti/terminus`
-- `@konekti/testing`
-- `@konekti/throttler`
-- `@konekti/validation`
-- `@konekti/websockets`
+- `@fluojs/cache-manager`
+- `@fluojs/cli`
+- `@fluojs/config`
+- `@fluojs/core`
+- `@fluojs/cqrs`
+- `@fluojs/cron`
+- `@fluojs/email`
+- `@fluojs/discord`
+- `@fluojs/di`
+- `@fluojs/drizzle`
+- `@fluojs/event-bus`
+- `@fluojs/graphql`
+- `@fluojs/http`
+- `@fluojs/jwt`
+- `@fluojs/metrics`
+- `@fluojs/microservices`
+- `@fluojs/mongoose`
+- `@fluojs/notifications`
+- `@fluojs/openapi`
+- `@fluojs/passport`
+- `@fluojs/platform-bun`
+- `@fluojs/platform-cloudflare-workers`
+- `@fluojs/platform-deno`
+- `@fluojs/platform-express`
+- `@fluojs/platform-fastify`
+- `@fluojs/platform-nodejs`
+- `@fluojs/prisma`
+- `@fluojs/queue`
+- `@fluojs/redis`
+- `@fluojs/runtime`
+- `@fluojs/serialization`
+- `@fluojs/slack`
+- `@fluojs/socket.io`
+- `@fluojs/studio`
+- `@fluojs/terminus`
+- `@fluojs/testing`
+- `@fluojs/throttler`
+- `@fluojs/validation`
+- `@fluojs/websockets`
 
 ---
 
@@ -97,7 +97,7 @@ Governance is enforced through automated gates and manual checklists.
 - **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints and starter scaffolding.
 - **`pnpm verify:platform-consistency-governance`**: Enforces structural parity between English and Korean documentation.
 - **`pnpm verify:public-export-tsdoc`**: Fails when changed public exports in `packages/*/src` miss the repo-wide TSDoc minimum baseline.
-- **Behavioral Contract Check**: Blocks releases if `process.env` is accessed outside of the sanctioned `@konekti/config` patterns.
+- **Behavioral Contract Check**: Blocks releases if `process.env` is accessed outside of the sanctioned `@fluojs/config` patterns.
 
 ### Changelog Standards
 Every public release must have a matching entry in the root `CHANGELOG.md` following the *Keep a Changelog* format. GitHub Releases are automatically populated from this content during the deployment phase.

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -2,61 +2,61 @@
 
 <p><strong><kbd>한국어</kbd></strong> <a href="./package-surface.md"><kbd>English</kbd></a></p>
 
-이 페이지는 Konekti 공개 패키지 패밀리와 런타임 매핑의 기준 문서(source of truth)입니다. 패키지 책임에 대한 권위 있는 조회에 활용하세요.
+이 페이지는 fluo 공개 패키지 패밀리와 런타임 매핑의 기준 문서(source of truth)입니다. 패키지 책임에 대한 권위 있는 조회에 활용하세요.
 
 ## 공개 패키지 패밀리
 
 | 패밀리 | 설명 | 패키지 |
 | --- | --- | --- |
-| **Core** | 공유 계약 및 DI. | `@konekti/core`, `@konekti/di`, `@konekti/config`, `@konekti/runtime` |
-| **HTTP** | 웹 API 실행 및 라우팅. | `@konekti/http`, `@konekti/graphql`, `@konekti/validation`, `@konekti/serialization`, `@konekti/openapi` |
-| **Auth** | 인증 및 인가. | `@konekti/jwt`, `@konekti/passport` |
-| **Platform** | 런타임 어댑터. | `@konekti/platform-fastify`, `@konekti/platform-nodejs`, `@konekti/platform-express`, `@konekti/platform-bun`, `@konekti/platform-deno`, `@konekti/platform-cloudflare-workers` |
-| **Realtime** | WebSocket 및 Socket.IO. | `@konekti/websockets`, `@konekti/socket.io` |
-| **Persistence** | 데이터베이스 및 캐시. | `@konekti/prisma`, `@konekti/drizzle`, `@konekti/mongoose`, `@konekti/redis`, `@konekti/cache-manager` |
-| **Patterns** | 메시징 및 아키텍처. | `@konekti/microservices`, `@konekti/cqrs`, `@konekti/event-bus`, `@konekti/cron`, `@konekti/queue`, `@konekti/notifications`, `@konekti/email`, `@konekti/slack`, `@konekti/discord` |
-| **Operations** | 헬스 및 모니터링. | `@konekti/metrics`, `@konekti/terminus`, `@konekti/throttler` |
-| **Tooling** | CLI 및 진단. | `@konekti/cli`, `@konekti/studio`, `@konekti/testing` |
+| **Core** | 공유 계약 및 DI. | `@fluojs/core`, `@fluojs/di`, `@fluojs/config`, `@fluojs/runtime` |
+| **HTTP** | 웹 API 실행 및 라우팅. | `@fluojs/http`, `@fluojs/graphql`, `@fluojs/validation`, `@fluojs/serialization`, `@fluojs/openapi` |
+| **Auth** | 인증 및 인가. | `@fluojs/jwt`, `@fluojs/passport` |
+| **Platform** | 런타임 어댑터. | `@fluojs/platform-fastify`, `@fluojs/platform-nodejs`, `@fluojs/platform-express`, `@fluojs/platform-bun`, `@fluojs/platform-deno`, `@fluojs/platform-cloudflare-workers` |
+| **Realtime** | WebSocket 및 Socket.IO. | `@fluojs/websockets`, `@fluojs/socket.io` |
+| **Persistence** | 데이터베이스 및 캐시. | `@fluojs/prisma`, `@fluojs/drizzle`, `@fluojs/mongoose`, `@fluojs/redis`, `@fluojs/cache-manager` |
+| **Patterns** | 메시징 및 아키텍처. | `@fluojs/microservices`, `@fluojs/cqrs`, `@fluojs/event-bus`, `@fluojs/cron`, `@fluojs/queue`, `@fluojs/notifications`, `@fluojs/email`, `@fluojs/slack`, `@fluojs/discord` |
+| **Operations** | 헬스 및 모니터링. | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
+| **Tooling** | CLI 및 진단. | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing` |
 
 ## canonical runtime package matrix
 
-Konekti는 전송 중립(transport-neutral) 런타임을 사용합니다. 어댑터가 이 런타임을 특정 호스팅 환경에 연결합니다.
+fluo는 전송 중립(transport-neutral) 런타임을 사용합니다. 어댑터가 이 런타임을 특정 호스팅 환경에 연결합니다.
 
 | 런타임 대상 | 어댑터 패키지 | 비고 |
 | --- | --- | --- |
-| **Node.js (기본)** | `@konekti/platform-fastify` | Node.js에서 고성능을 위한 권장 시작 경로. |
-| **Node.js (Bare)** | `@konekti/platform-nodejs` | Node HTTP 리스너를 직접 제어해야 할 때 사용. |
-| **Node.js (Express)** | `@konekti/platform-express` | 기존 Express 코드와의 미들웨어 호환성이 필요할 때 사용. |
-| **Bun** | `@konekti/platform-bun` | 공식 Bun 네이티브 fetch-style 시작 경로. |
-| **Deno** | `@konekti/platform-deno` | 공식 `Deno.serve()` 시작 경로. |
-| **Cloudflare Workers** | `@konekti/platform-cloudflare-workers` | fetch-style 어댑터 심(seam) 위에 구축된 stateless isolate 라이프사이클. |
+| **Node.js (기본)** | `@fluojs/platform-fastify` | Node.js에서 고성능을 위한 권장 시작 경로. |
+| **Node.js (Bare)** | `@fluojs/platform-nodejs` | Node HTTP 리스너를 직접 제어해야 할 때 사용. |
+| **Node.js (Express)** | `@fluojs/platform-express` | 기존 Express 코드와의 미들웨어 호환성이 필요할 때 사용. |
+| **Bun** | `@fluojs/platform-bun` | 공식 Bun 네이티브 fetch-style 시작 경로. |
+| **Deno** | `@fluojs/platform-deno` | 공식 `Deno.serve()` 시작 경로. |
+| **Cloudflare Workers** | `@fluojs/platform-cloudflare-workers` | fetch-style 어댑터 심(seam) 위에 구축된 stateless isolate 라이프사이클. |
 
 ## 패키지 책임
 
 ### core
-- **`@konekti/core`**: 메타데이터 헬퍼 및 TC39 표준 데코레이터 지원.
-- **`@konekti/di`**: 프로바이더 해결, 라이프사이클 스코프, 의존성 그래프 분석.
-- **`@konekti/config`**: 환경 인식 설정 로딩 및 타입 안전 접근.
-- **`@konekti/runtime`**: 애플리케이션 부트스트랩, 모듈 오케스트레이션, 플랫폼 셸 등록.
+- **`@fluojs/core`**: 메타데이터 헬퍼 및 TC39 표준 데코레이터 지원.
+- **`@fluojs/di`**: 프로바이더 해결, 라이프사이클 스코프, 의존성 그래프 분석.
+- **`@fluojs/config`**: 환경 인식 설정 로딩 및 타입 안전 접근.
+- **`@fluojs/runtime`**: 애플리케이션 부트스트랩, 모듈 오케스트레이션, 플랫폼 셸 등록.
 
 ### adapters
 - **`platform-*`**: `PlatformAdapter` 인터페이스를 구현합니다. 추상 HTTP 호출을 런타임별 리스너에 연결합니다.
-- **`@konekti/socket.io`**: 업스트림 Socket.IO 시맨틱을 미러링하는 전용 전송 브랜드 어댑터.
+- **`@fluojs/socket.io`**: 업스트림 Socket.IO 시맨틱을 미러링하는 전용 전송 브랜드 어댑터.
 
 ### features
-- **`@konekti/http`**: 라우팅, 가드, 인터셉터, 예외 처리.
-- **`@konekti/graphql`**: HTTP 추상화 위에서 동작하는 GraphQL 스키마 노출, 리졸버 실행, 구독 지원.
-- **`@konekti/jwt`**: HTTP 비종속 JWT 서명, 검증, principal 정규화.
-- **`@konekti/passport`**: 전략 비종속 인증 가드, scope 처리, Passport.js 브리지.
-- **`@konekti/microservices`**: TCP, Redis, NATS, Kafka, RabbitMQ, MQTT, gRPC를 위한 패턴 매칭 전송 추상화.
-- **`@konekti/notifications`**: provider별 알림 패키지가 공유하는 채널 계약과 오케스트레이션 계층.
-- **`@konekti/email`**: 전송 중립(transport-agnostic) 이메일 발송 코어. 알림 채널 및 큐 워커 통합을 제공합니다.
-- **`@konekti/email/node`**: Nodemailer/SMTP 전송을 제공하는 `@konekti/email`의 Node.js 전용 서브패스.
-- **`@konekti/slack`**: standalone으로도 동작하고 1st-party notifications 채널로도 등록할 수 있는 webhook-first Slack 전달 코어.
-- **`@konekti/discord`**: standalone으로도 동작하고 1st-party notifications 채널로도 등록할 수 있는 webhook-first Discord 전달 코어.
-- **`@konekti/websockets`**: 전송 중립 WebSocket 게이트웨이 작성.
-- **`@konekti/validation`**: class-validator 기반 입력 구체화(materialization) 및 안전성.
-- **`@konekti/prisma` / `@konekti/drizzle`**: ORM 라이프사이클 및 ALS 기반 트랜잭션 컨텍스트.
+- **`@fluojs/http`**: 라우팅, 가드, 인터셉터, 예외 처리.
+- **`@fluojs/graphql`**: HTTP 추상화 위에서 동작하는 GraphQL 스키마 노출, 리졸버 실행, 구독 지원.
+- **`@fluojs/jwt`**: HTTP 비종속 JWT 서명, 검증, principal 정규화.
+- **`@fluojs/passport`**: 전략 비종속 인증 가드, scope 처리, Passport.js 브리지.
+- **`@fluojs/microservices`**: TCP, Redis, NATS, Kafka, RabbitMQ, MQTT, gRPC를 위한 패턴 매칭 전송 추상화.
+- **`@fluojs/notifications`**: provider별 알림 패키지가 공유하는 채널 계약과 오케스트레이션 계층.
+- **`@fluojs/email`**: 전송 중립(transport-agnostic) 이메일 발송 코어. 알림 채널 및 큐 워커 통합을 제공합니다.
+- **`@fluojs/email/node`**: Nodemailer/SMTP 전송을 제공하는 `@fluojs/email`의 Node.js 전용 서브패스.
+- **`@fluojs/slack`**: standalone으로도 동작하고 1st-party notifications 채널로도 등록할 수 있는 webhook-first Slack 전달 코어.
+- **`@fluojs/discord`**: standalone으로도 동작하고 1st-party notifications 채널로도 등록할 수 있는 webhook-first Discord 전달 코어.
+- **`@fluojs/websockets`**: 전송 중립 WebSocket 게이트웨이 작성.
+- **`@fluojs/validation`**: class-validator 기반 입력 구체화(materialization) 및 안전성.
+- **`@fluojs/prisma` / `@fluojs/drizzle`**: ORM 라이프사이클 및 ALS 기반 트랜잭션 컨텍스트.
 
 ## 명명 규칙
 - **`platform-*`**: `PlatformAdapter`를 구현하는 런타임/프로토콜 어댑터 전용.

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -2,61 +2,61 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./package-surface.ko.md"><kbd>한국어</kbd></a></p>
 
-This page is the source of truth for the Konekti public package families and their mapping to runtimes. Use this for authoritative lookup of package responsibilities.
+This page is the source of truth for the fluo public package families and their mapping to runtimes. Use this for authoritative lookup of package responsibilities.
 
 ## public package families
 
 | family | description | packages |
 | --- | --- | --- |
-| **Core** | Shared contracts and DI. | `@konekti/core`, `@konekti/di`, `@konekti/config`, `@konekti/runtime` |
-| **HTTP** | Web API execution and routing. | `@konekti/http`, `@konekti/graphql`, `@konekti/validation`, `@konekti/serialization`, `@konekti/openapi` |
-| **Auth** | Authentication and authorization. | `@konekti/jwt`, `@konekti/passport` |
-| **Platform** | Runtime adapters. | `@konekti/platform-fastify`, `@konekti/platform-nodejs`, `@konekti/platform-express`, `@konekti/platform-bun`, `@konekti/platform-deno`, `@konekti/platform-cloudflare-workers` |
-| **Realtime** | WebSocket and Socket.IO. | `@konekti/websockets`, `@konekti/socket.io` |
-| **Persistence** | Database and cache. | `@konekti/prisma`, `@konekti/drizzle`, `@konekti/mongoose`, `@konekti/redis`, `@konekti/cache-manager` |
-| **Patterns** | Messaging and architecture. | `@konekti/microservices`, `@konekti/cqrs`, `@konekti/event-bus`, `@konekti/cron`, `@konekti/queue`, `@konekti/notifications`, `@konekti/email`, `@konekti/slack`, `@konekti/discord` |
-| **Operations** | Health and monitoring. | `@konekti/metrics`, `@konekti/terminus`, `@konekti/throttler` |
-| **Tooling** | CLI and diagnostics. | `@konekti/cli`, `@konekti/studio`, `@konekti/testing` |
+| **Core** | Shared contracts and DI. | `@fluojs/core`, `@fluojs/di`, `@fluojs/config`, `@fluojs/runtime` |
+| **HTTP** | Web API execution and routing. | `@fluojs/http`, `@fluojs/graphql`, `@fluojs/validation`, `@fluojs/serialization`, `@fluojs/openapi` |
+| **Auth** | Authentication and authorization. | `@fluojs/jwt`, `@fluojs/passport` |
+| **Platform** | Runtime adapters. | `@fluojs/platform-fastify`, `@fluojs/platform-nodejs`, `@fluojs/platform-express`, `@fluojs/platform-bun`, `@fluojs/platform-deno`, `@fluojs/platform-cloudflare-workers` |
+| **Realtime** | WebSocket and Socket.IO. | `@fluojs/websockets`, `@fluojs/socket.io` |
+| **Persistence** | Database and cache. | `@fluojs/prisma`, `@fluojs/drizzle`, `@fluojs/mongoose`, `@fluojs/redis`, `@fluojs/cache-manager` |
+| **Patterns** | Messaging and architecture. | `@fluojs/microservices`, `@fluojs/cqrs`, `@fluojs/event-bus`, `@fluojs/cron`, `@fluojs/queue`, `@fluojs/notifications`, `@fluojs/email`, `@fluojs/slack`, `@fluojs/discord` |
+| **Operations** | Health and monitoring. | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
+| **Tooling** | CLI and diagnostics. | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing` |
 
 ## canonical runtime package matrix
 
-Konekti uses a transport-neutral runtime. Adapters bridge this runtime to specific hosting environments.
+fluo uses a transport-neutral runtime. Adapters bridge this runtime to specific hosting environments.
 
 | runtime target | adapter package | notes |
 | --- | --- | --- |
-| **Node.js (Default)** | `@konekti/platform-fastify` | Recommended starter path for high performance on Node.js. |
-| **Node.js (Bare)** | `@konekti/platform-nodejs` | Use when you need direct control over the Node HTTP listener. |
-| **Node.js (Express)** | `@konekti/platform-express` | Use for middleware compatibility with existing Express code. |
-| **Bun** | `@konekti/platform-bun` | Official Bun-native fetch-style startup path. |
-| **Deno** | `@konekti/platform-deno` | Official `Deno.serve()` startup path. |
-| **Cloudflare Workers** | `@konekti/platform-cloudflare-workers` | Stateless isolate lifecycle built on the fetch-style adapter seam. |
+| **Node.js (Default)** | `@fluojs/platform-fastify` | Recommended starter path for high performance on Node.js. |
+| **Node.js (Bare)** | `@fluojs/platform-nodejs` | Use when you need direct control over the Node HTTP listener. |
+| **Node.js (Express)** | `@fluojs/platform-express` | Use for middleware compatibility with existing Express code. |
+| **Bun** | `@fluojs/platform-bun` | Official Bun-native fetch-style startup path. |
+| **Deno** | `@fluojs/platform-deno` | Official `Deno.serve()` startup path. |
+| **Cloudflare Workers** | `@fluojs/platform-cloudflare-workers` | Stateless isolate lifecycle built on the fetch-style adapter seam. |
 
 ## package responsibilities
 
 ### core
-- **`@konekti/core`**: Metadata helpers and TC39-standard decorator support.
-- **`@konekti/di`**: Provider resolution, lifecycle scopes, and dependency graph analysis.
-- **`@konekti/config`**: Environment-aware configuration loading and typed access.
-- **`@konekti/runtime`**: Application bootstrap, module orchestration, and platform shell registration.
+- **`@fluojs/core`**: Metadata helpers and TC39-standard decorator support.
+- **`@fluojs/di`**: Provider resolution, lifecycle scopes, and dependency graph analysis.
+- **`@fluojs/config`**: Environment-aware configuration loading and typed access.
+- **`@fluojs/runtime`**: Application bootstrap, module orchestration, and platform shell registration.
 
 ### adapters
 - **`platform-*`**: Implement the `PlatformAdapter` interface. They bridge abstract HTTP calls to runtime-specific listeners.
-- **`@konekti/socket.io`**: A dedicated transport-brand adapter that mirrors upstream Socket.IO semantics.
+- **`@fluojs/socket.io`**: A dedicated transport-brand adapter that mirrors upstream Socket.IO semantics.
 
 ### features
-- **`@konekti/http`**: Routing, guards, interceptors, and exception handling.
-- **`@konekti/graphql`**: GraphQL schema exposure, resolver execution, and subscriptions on top of the HTTP abstraction.
-- **`@konekti/jwt`**: HTTP-agnostic JWT signing, verification, and principal normalization.
-- **`@konekti/passport`**: Strategy-agnostic authentication guards, scopes, and Passport.js bridges.
-- **`@konekti/microservices`**: Pattern-matching transport abstraction for TCP, Redis, NATS, Kafka, RabbitMQ, MQTT, and gRPC.
-- **`@konekti/notifications`**: Shared channel contract and orchestration layer for provider-specific notification packages.
-- **`@konekti/email`**: Transport-agnostic email delivery core. It provides a first-party notifications channel and queue worker integration.
-- **`@konekti/email/node`**: Node.js specific subpath for `@konekti/email` that provides first-party Nodemailer/SMTP transport.
-- **`@konekti/slack`**: Webhook-first Slack delivery core that can run standalone or register a first-party notifications channel.
-- **`@konekti/discord`**: Webhook-first Discord delivery core that can run standalone or register a first-party notifications channel.
-- **`@konekti/websockets`**: Transport-neutral WebSocket gateway authoring.
-- **`@konekti/validation`**: Class-validator based input materialization and safety.
-- **`@konekti/prisma` / `@konekti/drizzle`**: ORM lifecycle and ALS-backed transaction context.
+- **`@fluojs/http`**: Routing, guards, interceptors, and exception handling.
+- **`@fluojs/graphql`**: GraphQL schema exposure, resolver execution, and subscriptions on top of the HTTP abstraction.
+- **`@fluojs/jwt`**: HTTP-agnostic JWT signing, verification, and principal normalization.
+- **`@fluojs/passport`**: Strategy-agnostic authentication guards, scopes, and Passport.js bridges.
+- **`@fluojs/microservices`**: Pattern-matching transport abstraction for TCP, Redis, NATS, Kafka, RabbitMQ, MQTT, and gRPC.
+- **`@fluojs/notifications`**: Shared channel contract and orchestration layer for provider-specific notification packages.
+- **`@fluojs/email`**: Transport-agnostic email delivery core. It provides a first-party notifications channel and queue worker integration.
+- **`@fluojs/email/node`**: Node.js specific subpath for `@fluojs/email` that provides first-party Nodemailer/SMTP transport.
+- **`@fluojs/slack`**: Webhook-first Slack delivery core that can run standalone or register a first-party notifications channel.
+- **`@fluojs/discord`**: Webhook-first Discord delivery core that can run standalone or register a first-party notifications channel.
+- **`@fluojs/websockets`**: Transport-neutral WebSocket gateway authoring.
+- **`@fluojs/validation`**: Class-validator based input materialization and safety.
+- **`@fluojs/prisma` / `@fluojs/drizzle`**: ORM lifecycle and ALS-backed transaction context.
 
 ## naming conventions
 - **`platform-*`**: Reserved for runtime/protocol adapters implementing `PlatformAdapter`.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -34,7 +34,7 @@ describe('CLI command runner', () => {
       fluo: './bin/fluo.mjs',
       konekti: './bin/konekti.mjs',
     });
-    expect(readFileSync(join(packageRoot, 'README.md'), 'utf8')).toContain('canonical executable is `fluo`');
+    expect(readFileSync(join(packageRoot, 'README.md'), 'utf8')).toContain('The canonical CLI for fluo');
   });
 
   it('uses the default target directory from a single-app workspace root', async () => {

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -46,7 +46,7 @@ function parsePackageListFromSection(markdown: string, sectionTitle: string): st
       break;
     }
 
-    const match = line.match(/^- `(@konekti\/[^`]+)`$/);
+    const match = line.match(/^- `(@fluojs\/[^`]+)`$/);
     if (match?.[1]) {
       packages.push(match[1]);
     }
@@ -72,7 +72,7 @@ function parsePackageNamesFromFamilyTable(markdown: string, sectionTitle: string
       break;
     }
 
-    for (const match of line.matchAll(/`(@konekti\/[^`]+)`/g)) {
+    for (const match of line.matchAll(/`(@fluojs\/[^`]+)`/g)) {
       if (match[1]) {
         packages.add(match[1]);
       }

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -138,7 +138,7 @@ function parsePackageListFromSection(markdown, sectionTitle) {
       break;
     }
 
-    const match = line.match(/^- `(@konekti\/[^`]+)`$/);
+    const match = line.match(/^- `(@fluojs\/[^`]+)`$/);
     if (match) {
       packages.push(match[1]);
     }
@@ -516,8 +516,8 @@ function enforceCanonicalPackageSurfaceSync() {
   const koreanPackageSurface = parsePackageNamesFromFamilyTable(packageSurfaceKo, '공개 패키지 패밀리');
 
   assert(intendedPublishSurface.length > 0, 'release-governance.md must define an intended publish surface list.');
-  assert(englishPackageSurface.length > 0, 'package-surface.md must enumerate public @konekti packages in its family table.');
-  assert(koreanPackageSurface.length > 0, 'package-surface.ko.md must enumerate public @konekti packages in its family table.');
+  assert(englishPackageSurface.length > 0, 'package-surface.md must enumerate public @fluojs packages in its family table.');
+  assert(koreanPackageSurface.length > 0, 'package-surface.ko.md must enumerate public @fluojs packages in its family table.');
   assert(
     areSameStringArrays(intendedPublishSurface, englishPackageSurface),
     'docs/reference/package-surface.md must stay synchronized with docs/operations/release-governance.md intended publish surface.',

--- a/tooling/release/release-readiness-summary.ko.md
+++ b/tooling/release/release-readiness-summary.ko.md
@@ -3,11 +3,16 @@
 <p><a href="./release-readiness-summary.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
 - [x] Canonical bootstrap docs — The quick start guide documents the public `pnpm add -g @fluojs/cli` + `fluo new` path.
-- [x] Repo-local smoke path docs — The repo-local sandbox path is documented in the CLI README as monorepo-only verification support.
+- [x] Repo-local smoke path docs — The repo-local sandbox path is documented in CONTRIBUTING.md as monorepo verification support.
 - [x] Starter shape and runtime ownership — The generated starter uses runtime-owned bootstrap helpers plus a starter-owned health module, without default metrics or OpenAPI surfaces.
 - [x] Generic-first bootstrap contract — Bootstrap docs and scaffold source no longer encode ORM/DB prompts, support tiers, or starter-time ORM adapter injection.
 - [x] Toolchain contract lock — The toolchain contract matrix documents the generated app baseline plus the canonical fluo command surfaces.
+- [x] Manifest benchmark evidence — Release governance documents the canonical publish surface and the automated release gates.
 - [x] Dist-based package entrypoints — CLI manifest and bin prove a dist-backed public `fluo` entrypoint with a subordinate compatibility alias.
+- [x] Root OSS license file — A repository-level OSS license file exists at the root.
+- [x] Public changelog baseline — CHANGELOG.md exists with Keep a Changelog baseline sections for Unreleased and current 0.x history.
+- [x] Public package surface docs are synchronized — release-governance and package-surface docs declare the same @fluojs public package list.
+- [x] Documented public packages exist in workspace — Every documented public package maps to an existing workspace package manifest.
 
-- 실행한 명령: `pnpm --dir packages/cli build`, `pnpm --dir packages/cli typecheck`, `pnpm --dir packages/cli test`, `pnpm --dir packages/studio build`, `pnpm --dir packages/studio typecheck`, `pnpm --dir packages/studio test`, `pnpm --dir packages/cli run sandbox:create`, `pnpm --dir packages/cli run sandbox:verify`, `pnpm --dir packages/cli run sandbox:test`
+- 실행한 명령: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`
 - 부수 효과: `CHANGELOG.md` 릴리즈 준비도 드래프트 섹션 갱신

--- a/tooling/release/release-readiness-summary.md
+++ b/tooling/release/release-readiness-summary.md
@@ -3,11 +3,16 @@
 <p><strong><kbd>English</kbd></strong> <a href="./release-readiness-summary.ko.md"><kbd>한국어</kbd></a></p>
 
 - [x] Canonical bootstrap docs — The quick start guide documents the public `pnpm add -g @fluojs/cli` + `fluo new` path.
-- [x] Repo-local smoke path docs — The repo-local sandbox path is documented in the CLI README as monorepo-only verification support.
+- [x] Repo-local smoke path docs — The repo-local sandbox path is documented in CONTRIBUTING.md as monorepo verification support.
 - [x] Starter shape and runtime ownership — The generated starter uses runtime-owned bootstrap helpers plus a starter-owned health module, without default metrics or OpenAPI surfaces.
 - [x] Generic-first bootstrap contract — Bootstrap docs and scaffold source no longer encode ORM/DB prompts, support tiers, or starter-time ORM adapter injection.
 - [x] Toolchain contract lock — The toolchain contract matrix documents the generated app baseline plus the canonical fluo command surfaces.
+- [x] Manifest benchmark evidence — Release governance documents the canonical publish surface and the automated release gates.
 - [x] Dist-based package entrypoints — CLI manifest and bin prove a dist-backed public `fluo` entrypoint with a subordinate compatibility alias.
+- [x] Root OSS license file — A repository-level OSS license file exists at the root.
+- [x] Public changelog baseline — CHANGELOG.md exists with Keep a Changelog baseline sections for Unreleased and current 0.x history.
+- [x] Public package surface docs are synchronized — release-governance and package-surface docs declare the same @fluojs public package list.
+- [x] Documented public packages exist in workspace — Every documented public package maps to an existing workspace package manifest.
 
-- Commands executed: `pnpm --dir packages/cli build`, `pnpm --dir packages/cli typecheck`, `pnpm --dir packages/cli test`, `pnpm --dir packages/studio build`, `pnpm --dir packages/studio typecheck`, `pnpm --dir packages/studio test`, `pnpm --dir packages/cli run sandbox:create`, `pnpm --dir packages/cli run sandbox:verify`, `pnpm --dir packages/cli run sandbox:test`
+- Commands executed: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`
 - Side effects: `CHANGELOG.md` draft release-readiness section updated

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -56,7 +56,7 @@ function parsePackageListFromSection(markdown, sectionTitle) {
       break;
     }
 
-    const match = line.match(/^- `(@konekti\/[^`]+)`$/);
+    const match = line.match(/^- `(@fluojs\/[^`]+)`$/);
 
     if (match) {
       packages.push(match[1]);
@@ -83,7 +83,7 @@ function parsePackageNamesFromFamilyTable(markdown, sectionTitle) {
       break;
     }
 
-    for (const match of line.matchAll(/`(@konekti\/[^`]+)`/g)) {
+    for (const match of line.matchAll(/`(@fluojs\/[^`]+)`/g)) {
       packages.add(match[1]);
     }
   }
@@ -137,7 +137,7 @@ function writeSummary(checks) {
     '',
     ...checks.map((check) => `- [${check.pass ? 'x' : ' '}] ${check.label} — ${check.detail}`),
     '',
-    '- Commands executed: `pnpm typecheck`, `pnpm build`, `pnpm test`',
+    '- Commands executed: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`',
     '- Side effects: `CHANGELOG.md` draft release-readiness section updated',
   ].join('\n');
   const summaryKo = [
@@ -147,7 +147,7 @@ function writeSummary(checks) {
     '',
     ...checks.map((check) => `- [${check.pass ? 'x' : ' '}] ${check.label} — ${check.detail}`),
     '',
-    '- 실행한 명령: `pnpm typecheck`, `pnpm build`, `pnpm test`',
+    '- 실행한 명령: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`',
     '- 부수 효과: `CHANGELOG.md` 릴리즈 준비도 드래프트 섹션 갱신',
   ].join('\n');
 
@@ -203,6 +203,7 @@ run('pnpm', ['typecheck']);
 run('pnpm', ['test']);
 
 const quickStart = read('docs/getting-started/quick-start.md');
+const contributing = read('CONTRIBUTING.md');
 const releaseGovernance = read('docs/operations/release-governance.md');
 const packageSurface = read('docs/reference/package-surface.md');
 const toolchainContract = read('docs/reference/toolchain-contract-matrix.md');
@@ -213,53 +214,33 @@ const changelog = read('CHANGELOG.md');
 const governancePackageList = sorted(parsePackageListFromSection(releaseGovernance, 'intended publish surface'));
 const packageSurfaceList = parsePackageNamesFromFamilyTable(packageSurface, 'public package families');
 const workspacePackages = workspacePackageNames();
-const officialFetchAdapterDocs = [
-  {
-    label: 'Bun adapter contract docs',
-    path: 'packages/platform-bun/README.md',
-    runtimeToken: 'Bun.serve',
-  },
-  {
-    label: 'Deno adapter contract docs',
-    path: 'packages/platform-deno/README.md',
-    runtimeToken: 'Deno.serve',
-  },
-  {
-    label: 'Cloudflare Workers adapter contract docs',
-    path: 'packages/platform-cloudflare-workers/README.md',
-    runtimeToken: 'Cloudflare Workers',
-  },
-].flatMap((entry) => {
-  if (!existsSync(join(repoRoot, entry.path))) {
-    return [];
-  }
-
-  return [{
-    ...entry,
-    readme: read(entry.path),
-  }];
-});
 
 assertCheck(
   checks,
   'Canonical bootstrap docs',
-  quickStart.includes('pnpm dlx @fluojs/cli new starter-app') && quickStart.includes('canonical public bootstrap flow'),
-  'The quick start guide documents the public `pnpm add -g @fluojs/cli` + `konekti new` path.',
+  quickStart.includes('pnpm add -g @fluojs/cli') &&
+    quickStart.includes('fluo new my-fluo-app') &&
+    quickStart.includes('The fluo CLI is your central tool for project scaffolding and component generation.'),
+  'The quick start guide documents the public `pnpm add -g @fluojs/cli` + `fluo new` path.',
 );
 assertCheck(
   checks,
   'Repo-local smoke path docs',
-  cliReadme.includes('pnpm --dir packages/cli run sandbox:test') && cliReadme.includes('instead of publishing prereleases'),
-  'The repo-local sandbox path is documented in the CLI README as monorepo-only verification support.',
+  contributing.includes('pnpm sandbox:create') &&
+    contributing.includes('pnpm sandbox:verify') &&
+    contributing.includes('pnpm sandbox:test'),
+  'The repo-local sandbox path is documented in CONTRIBUTING.md as monorepo verification support.',
 );
 assertCheck(
   checks,
   'Starter shape and runtime ownership',
-  scaffoldSource.includes("const app = await KonektiFactory.create(AppModule, {});") &&
+  scaffoldSource.includes('const RuntimeHealthModule = createHealthModule();') &&
+    scaffoldSource.includes('@Controller(\'/health-info\')') &&
+    scaffoldSource.includes('const app = await KonektiFactory.create(AppModule, {') &&
+    scaffoldSource.includes('adapter: createFastifyAdapter({ port })') &&
     scaffoldSource.includes('await app.listen();') &&
-    scaffoldSource.includes('KonektiFactory.create(..., { cors })') &&
     scaffoldSource.includes('createHealthModule') &&
-    scaffoldSource.includes("@Controller('/health-info')") &&
+    scaffoldSource.includes('createFastifyAdapter') &&
     !scaffoldSource.includes('MetricsModule.forRoot') &&
     !scaffoldSource.includes('OpenApiModule.forRoot') &&
     !scaffoldSource.includes('src/node-http-adapter.ts'),
@@ -279,37 +260,29 @@ assertCheck(
 assertCheck(
   checks,
   'Toolchain contract lock',
-  !toolchainContract.includes('to be locked') &&
-    toolchainContract.includes('public contract') &&
-    toolchainContract.includes('generated (stable)') &&
-    toolchainContract.includes('internal-only'),
-  'The toolchain contract matrix is locked with public/generated/internal statuses.',
+  toolchainContract.includes('## generated app baseline') &&
+    toolchainContract.includes('## CLI & scaffolding contracts') &&
+    toolchainContract.includes('## naming conventions (CLI output)') &&
+    toolchainContract.includes('fluo new') &&
+    toolchainContract.includes('fluo inspect'),
+  'The toolchain contract matrix documents the generated app baseline plus the canonical fluo command surfaces.',
 );
 assertCheck(
   checks,
   'Manifest benchmark evidence',
-  releaseGovernance.includes('manifest decision note') && existsSync(join(repoRoot, 'tooling/benchmarks/manifest-decision.latest.json')),
-  'Release docs still point at the benchmark-backed manifest decision snapshot.',
+  releaseGovernance.includes('## intended publish surface') &&
+    releaseGovernance.includes('pnpm verify:release-readiness') &&
+    releaseGovernance.includes('pnpm verify:platform-consistency-governance'),
+  'Release governance documents the canonical publish surface and the automated release gates.',
 );
-for (const adapterDoc of officialFetchAdapterDocs) {
-  assertCheck(
-    checks,
-    adapterDoc.label,
-    adapterDoc.readme.includes(adapterDoc.runtimeToken) &&
-      adapterDoc.readme.includes('## supported operations') &&
-      adapterDoc.readme.includes('## runtime invariants') &&
-      adapterDoc.readme.includes('## lifecycle guarantees') &&
-      adapterDoc.readme.includes('## intentional limitations'),
-    `The official adapter README at ${adapterDoc.path} documents its runtime path and behavioral contract sections.`,
-  );
-}
 assertCheck(
   checks,
   'Dist-based package entrypoints',
-  cliPackage.bin.konekti === './bin/konekti.mjs' &&
+  cliPackage.bin.fluo === './bin/fluo.mjs' &&
+    cliPackage.bin.konekti === './bin/konekti.mjs' &&
     cliPackage.main === './dist/index.js' &&
     cliReadme.includes('canonical CLI'),
-  'CLI manifest and bin prove a dist-backed public entrypoint.',
+  'CLI manifest and bin prove a dist-backed public `fluo` entrypoint with a subordinate compatibility alias.',
 );
 assertCheck(
   checks,
@@ -329,7 +302,7 @@ assertCheck(
   governancePackageList.length > 0 &&
     packageSurfaceList.length > 0 &&
     areSameStringArrays(governancePackageList, packageSurfaceList),
-  'release-governance and package-surface docs declare the same @konekti public package list.',
+  'release-governance and package-surface docs declare the same @fluojs public package list.',
 );
 assertCheck(
   checks,


### PR DESCRIPTION
## Summary
- align release-governance and package-surface SSOT docs with the canonical `@fluojs/*` package scope and `fluo` prose
- update governance/release verification logic and its regression tests so release checks enforce `@fluojs/*` and canonical `fluo` CLI wording
- refresh release-readiness summary artifacts, changelog draft metadata, and bug report version wording for the fluo rename

## Testing
- pnpm vitest run packages/testing/src/conformance/platform-consistency-governance-docs.test.ts packages/cli/src/cli.test.ts
- pnpm verify:platform-consistency-governance
- pnpm verify:release-readiness
- pnpm verify

## Contract impact
- canonical package scope is `@fluojs/*`
- canonical public prose and CLI command are `fluo`
- compatibility alias `konekti` remains subordinate and is not treated as canonical in release/governance checks

Closes #964