### PR TITLE
Resolve #972: remove deprecated baseUrl from example tsconfig alias flow

### DIFF
--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,11 +1,9 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "..",
-    "ignoreDeprecations": "6.0",
     "noEmit": true,
     "paths": {
-      "@fluojs/*": ["packages/*/src/index.ts"]
+      "@fluojs/*": ["../packages/*/src/index.ts"]
     },
     "types": ["node"]
   },


### PR DESCRIPTION
Closes #972

## Summary
- remove the deprecated `baseUrl` + `ignoreDeprecations: \"6.0\"` bridge from `examples/tsconfig.json`
- keep example workspace alias resolution working by making the `@fluojs/*` path mapping explicit relative to the examples tsconfig location
- keep scope limited to the shared examples/foundation tsconfig surface

## Changes
- deleted `compilerOptions.baseUrl` from `examples/tsconfig.json`
- deleted the temporary `ignoreDeprecations` suppression added for the TS6 transition
- rewired `compilerOptions.paths` to `../packages/*/src/index.ts` so example typecheck/import resolution still targets workspace sources without relying on deprecated `baseUrl`

## Testing
- `pnpm install`
- `pnpm verify`
  - build: passed
  - typecheck: passed, including `tsc -p examples/tsconfig.json --noEmit`
  - lint: passed with existing repo warnings unrelated to this change
  - test: passed (`176` files, `1588` tests)
- `lsp_diagnostics examples/tsconfig.json`: clean

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.
- Contract impact note: no user-facing example runtime contract changed; this only removes a deprecated TypeScript configuration path while preserving existing example import/typecheck resolution.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.