### PR TITLE
Resolve #974: narrow studio TS6 typing to local CSS declarations

### DIFF
--- a/packages/studio/src/styles.d.ts
+++ b/packages/studio/src/styles.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "rootDir": "src",
-    "types": ["node", "vite/client"]
+    "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
Closes #974

## Summary
- replace the broad `vite/client` ambient typing shim in `packages/studio/tsconfig.json` with a package-local CSS declaration
- keep the TS6 baseline green while limiting Studio to the single stylesheet import contract it actually needs
- confirm the root verification matrix stays green on `main` baseline `1c6e7fc0aea0ce76b779f4323d2a904377d4eeb1`

## Changes
- narrowed `packages/studio/tsconfig.json` from `types: [\"node\", \"vite/client\"]` to `types: [\"node\"]`
- added `packages/studio/src/styles.d.ts` and included local `.d.ts` files in the Studio tsconfig
- re-ran Studio type/build checks plus full root verification

## Testing
- `pnpm --dir packages/studio exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir packages/studio exec vite build`
- `pnpm verify`
  - build: pass
  - typecheck: pass
  - lint: pass (repo-wide existing warnings only; no blocking diagnostics)
  - test: 177 files / 1589 tests passed

## Public export documentation
- [x] No changed public exports.
- [x] No changed exported functions requiring new `@param` / `@returns` tags.
- [x] Source `@example` blocks and README examples unchanged.

## Behavioral contract
- [x] No documented behavioral contracts were removed.
- [x] No new runtime contract was introduced; this is a type-surface narrowing for Studio tooling only.
- [x] Intentional limitation is explicit: Studio now declares only the local CSS import it needs instead of importing the full Vite ambient surface.
- [x] Regression coverage is provided by Studio type/build validation and full root verification.

## Contract impact note
- No runtime behavior change.
- No README or migration-note update required.