### PR TITLE
Resolve #979: add shape-first bootstrap schema foundation

### DIFF
--- a/packages/cli/src/new/prompt.test.ts
+++ b/packages/cli/src/new/prompt.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { detectPackageManager, resolveBootstrapAnswers } from './prompt.js';
+import { DEFAULT_BOOTSTRAP_SCHEMA } from './resolver.js';
 
 const createdDirectories: string[] = [];
 
@@ -42,6 +43,7 @@ describe('resolveBootstrapAnswers', () => {
 
     expect(resolveBootstrapAnswers({ projectName: 'starter-app' }, workspaceDirectory)).toEqual({
       packageManager: 'bun',
+      ...DEFAULT_BOOTSTRAP_SCHEMA,
       projectName: 'starter-app',
       targetDirectory: './starter-app',
     });

--- a/packages/cli/src/new/prompt.ts
+++ b/packages/cli/src/new/prompt.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
+import { resolveBootstrapSchema } from './resolver.js';
 import type { BootstrapAnswers, PackageManager } from './types.js';
 
 export const DEFAULT_PACKAGE_MANAGER: PackageManager = 'pnpm';
@@ -114,9 +115,11 @@ export function resolveBootstrapAnswers(
   }
 
   const projectName = assertValidProjectName(partial.projectName);
+  const schema = resolveBootstrapSchema(partial);
 
   return {
     packageManager: partial.packageManager ?? detectPackageManager(cwd, userAgent),
+    ...schema,
     projectName,
     targetDirectory: partial.targetDirectory ?? `./${projectName}`,
   };

--- a/packages/cli/src/new/resolver.test.ts
+++ b/packages/cli/src/new/resolver.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_BOOTSTRAP_SCHEMA, resolveBootstrapPlan, resolveBootstrapSchema } from './resolver.js';
+
+describe('resolveBootstrapSchema', () => {
+  it('returns the shape-first compatibility baseline when no explicit schema is provided', () => {
+    expect(resolveBootstrapSchema()).toEqual(DEFAULT_BOOTSTRAP_SCHEMA);
+  });
+});
+
+describe('resolveBootstrapPlan', () => {
+  it('keeps the current fluo new default path on the Node + Fastify HTTP starter', () => {
+    expect(resolveBootstrapPlan({ packageManager: 'pnpm' as const })).toEqual({
+      dependencies: {
+        dependencies: [
+          '@fluojs/config',
+          '@fluojs/core',
+          '@fluojs/validation',
+          '@fluojs/di',
+          '@fluojs/http',
+          '@fluojs/platform-fastify',
+          '@fluojs/runtime',
+        ],
+        devDependencies: [
+          '@fluojs/cli',
+          '@fluojs/testing',
+        ],
+      },
+      scaffoldPreset: 'standard-http-node-fastify',
+      schema: DEFAULT_BOOTSTRAP_SCHEMA,
+    });
+  });
+
+  it('does not treat package-manager choice as runtime or platform selection', () => {
+    const npmPlan = resolveBootstrapPlan({ packageManager: 'npm' as const });
+    const bunPlan = resolveBootstrapPlan({ packageManager: 'bun' as const });
+
+    expect(npmPlan.schema).toEqual(DEFAULT_BOOTSTRAP_SCHEMA);
+    expect(bunPlan.schema).toEqual(DEFAULT_BOOTSTRAP_SCHEMA);
+    expect(npmPlan.dependencies).toEqual(bunPlan.dependencies);
+  });
+
+  it('rejects unsupported topology or runtime combinations until later issues extend the matrix', () => {
+    expect(() => resolveBootstrapPlan({
+      packageManager: 'pnpm' as const,
+      runtime: 'node',
+      shape: 'application',
+      tooling: 'standard',
+      topology: {
+        deferred: false,
+        mode: 'single-package',
+      },
+      transport: 'http',
+      platform: 'fastify',
+    })).toThrow(
+      'Unsupported bootstrap schema "application/node/http/fastify/standard/single-package". The current compatibility baseline only supports the standard single-package Node + Fastify HTTP starter.',
+    );
+  });
+});

--- a/packages/cli/src/new/resolver.ts
+++ b/packages/cli/src/new/resolver.ts
@@ -1,0 +1,124 @@
+import type {
+  BootstrapOptions,
+  BootstrapPlatform,
+  BootstrapRuntime,
+  BootstrapSchema,
+  BootstrapShape,
+  BootstrapToolingPreset,
+  BootstrapTopology,
+  BootstrapTransport,
+} from './types.js';
+
+type BootstrapResolutionInput = Partial<BootstrapSchema> & Pick<Partial<BootstrapOptions>, 'packageManager'>;
+
+const SHAPES: readonly BootstrapShape[] = ['application'];
+const RUNTIMES: readonly BootstrapRuntime[] = ['node'];
+const PLATFORMS: readonly BootstrapPlatform[] = ['fastify'];
+const TRANSPORTS: readonly BootstrapTransport[] = ['http'];
+const TOOLING_PRESETS: readonly BootstrapToolingPreset[] = ['standard'];
+const TOPOLOGY_MODES: readonly BootstrapTopology['mode'][] = ['single-package'];
+
+export const DEFAULT_BOOTSTRAP_SCHEMA: BootstrapSchema = {
+  platform: 'fastify',
+  runtime: 'node',
+  shape: 'application',
+  tooling: 'standard',
+  topology: {
+    deferred: true,
+    mode: 'single-package',
+  },
+  transport: 'http',
+};
+
+export interface ResolvedBootstrapDependencies {
+  dependencies: readonly [
+    '@fluojs/config',
+    '@fluojs/core',
+    '@fluojs/validation',
+    '@fluojs/di',
+    '@fluojs/http',
+    '@fluojs/platform-fastify',
+    '@fluojs/runtime',
+  ];
+  devDependencies: readonly [
+    '@fluojs/cli',
+    '@fluojs/testing',
+  ];
+}
+
+export interface ResolvedBootstrapPlan {
+  dependencies: ResolvedBootstrapDependencies;
+  scaffoldPreset: 'standard-http-node-fastify';
+  schema: BootstrapSchema;
+}
+
+const DEFAULT_DEPENDENCIES: ResolvedBootstrapDependencies = {
+  dependencies: [
+    '@fluojs/config',
+    '@fluojs/core',
+    '@fluojs/validation',
+    '@fluojs/di',
+    '@fluojs/http',
+    '@fluojs/platform-fastify',
+    '@fluojs/runtime',
+  ],
+  devDependencies: [
+    '@fluojs/cli',
+    '@fluojs/testing',
+  ],
+};
+
+function assertOneOf<T extends string>(
+  label: string,
+  value: T,
+  supported: readonly T[],
+): T {
+  if (!supported.includes(value)) {
+    throw new Error(`Unsupported ${label} "${value}". Supported values: ${supported.join(', ')}.`);
+  }
+
+  return value;
+}
+
+function normalizeTopology(topology: Partial<BootstrapTopology> | undefined): BootstrapTopology {
+  return {
+    deferred: topology?.deferred ?? true,
+    mode: assertOneOf('topology mode', topology?.mode ?? DEFAULT_BOOTSTRAP_SCHEMA.topology.mode, TOPOLOGY_MODES),
+  };
+}
+
+export function resolveBootstrapSchema(partial: Partial<BootstrapSchema> = {}): BootstrapSchema {
+  return {
+    platform: assertOneOf('platform', partial.platform ?? DEFAULT_BOOTSTRAP_SCHEMA.platform, PLATFORMS),
+    runtime: assertOneOf('runtime', partial.runtime ?? DEFAULT_BOOTSTRAP_SCHEMA.runtime, RUNTIMES),
+    shape: assertOneOf('shape', partial.shape ?? DEFAULT_BOOTSTRAP_SCHEMA.shape, SHAPES),
+    tooling: assertOneOf('tooling', partial.tooling ?? DEFAULT_BOOTSTRAP_SCHEMA.tooling, TOOLING_PRESETS),
+    topology: normalizeTopology(partial.topology),
+    transport: assertOneOf('transport', partial.transport ?? DEFAULT_BOOTSTRAP_SCHEMA.transport, TRANSPORTS),
+  };
+}
+
+export function resolveBootstrapPlan(options: BootstrapResolutionInput | BootstrapOptions): ResolvedBootstrapPlan {
+  const schema = resolveBootstrapSchema(options);
+
+  if (
+    schema.shape !== 'application'
+    || schema.runtime !== 'node'
+    || schema.transport !== 'http'
+    || schema.platform !== 'fastify'
+    || schema.tooling !== 'standard'
+    || schema.topology.deferred !== true
+    || schema.topology.mode !== 'single-package'
+  ) {
+    throw new Error(
+      `Unsupported bootstrap schema "${schema.shape}/${schema.runtime}/${schema.transport}/${schema.platform}/${schema.tooling}/${schema.topology.mode}". `
+      + 'The current compatibility baseline only supports the standard single-package Node + Fastify HTTP starter.',
+    );
+  }
+
+  return {
+    dependencies: DEFAULT_DEPENDENCIES,
+    scaffoldPreset: 'standard-http-node-fastify',
+    schema,
+  };
+}

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { scaffoldBootstrapApp } from './scaffold.js';
+import { DEFAULT_BOOTSTRAP_SCHEMA } from './resolver.js';
 
 const temporaryDirectories: string[] = [];
 
@@ -20,6 +21,7 @@ describe('scaffoldBootstrapApp', () => {
     temporaryDirectories.push(targetDirectory);
 
     await scaffoldBootstrapApp({
+      ...DEFAULT_BOOTSTRAP_SCHEMA,
       packageManager: 'pnpm',
       projectName: 'starter-app',
       skipInstall: true,
@@ -27,6 +29,7 @@ describe('scaffoldBootstrapApp', () => {
     });
 
     const packageJson = JSON.parse(readFileSync(join(targetDirectory, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
     };
     const tsconfig = readFileSync(join(targetDirectory, 'tsconfig.json'), 'utf8');
@@ -35,6 +38,11 @@ describe('scaffoldBootstrapApp', () => {
     const vitestConfig = readFileSync(join(targetDirectory, 'vitest.config.ts'), 'utf8');
 
     expect(packageJson.devDependencies?.typescript).toBe('^6.0.2');
+    expect(packageJson.dependencies).toMatchObject({
+      '@fluojs/http': expect.any(String),
+      '@fluojs/platform-fastify': expect.any(String),
+      '@fluojs/runtime': expect.any(String),
+    });
     expect(tsconfig).not.toContain('baseUrl');
     expect(tsconfigBuild).not.toContain('baseUrl');
     expect(viteConfig).toContain("import { defineConfig } from 'vite';");

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -6,6 +6,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { installDependencies } from './install.js';
+import { resolveBootstrapPlan, type ResolvedBootstrapPlan } from './resolver.js';
 import type { BootstrapOptions, PackageManager } from './types.js';
 
 const PACKAGE_DIRECTORY_BY_NAME = {
@@ -109,6 +110,7 @@ function createExecCommand(packageManager: PackageManager, command: string): str
 
 function createProjectPackageJson(
   options: BootstrapOptions,
+  bootstrapPlan: ResolvedBootstrapPlan,
   releaseVersion: string,
   packageSpecs: Record<string, string>,
 ): string {
@@ -125,6 +127,19 @@ function createProjectPackageJson(
         resolutions: packageSpecs,
       }
     : {};
+
+  const dependencyEntries = Object.fromEntries(
+    bootstrapPlan.dependencies.dependencies.map((packageName) => [
+      packageName,
+      createDependencySpec(packageName, releaseVersion, packageSpecs),
+    ]),
+  );
+  const devDependencyEntries = Object.fromEntries(
+    bootstrapPlan.dependencies.devDependencies.map((packageName) => [
+      packageName,
+      createDependencySpec(packageName, releaseVersion, packageSpecs),
+    ]),
+  );
 
   return JSON.stringify(
     {
@@ -144,18 +159,9 @@ function createProjectPackageJson(
         'test:watch': 'vitest',
         typecheck: 'tsc -p tsconfig.json --noEmit',
       },
-      dependencies: {
-        '@fluojs/config': createDependencySpec('@fluojs/config', releaseVersion, packageSpecs),
-        '@fluojs/core': createDependencySpec('@fluojs/core', releaseVersion, packageSpecs),
-        '@fluojs/validation': createDependencySpec('@fluojs/validation', releaseVersion, packageSpecs),
-        '@fluojs/di': createDependencySpec('@fluojs/di', releaseVersion, packageSpecs),
-        '@fluojs/http': createDependencySpec('@fluojs/http', releaseVersion, packageSpecs),
-        '@fluojs/platform-fastify': createDependencySpec('@fluojs/platform-fastify', releaseVersion, packageSpecs),
-        '@fluojs/runtime': createDependencySpec('@fluojs/runtime', releaseVersion, packageSpecs),
-      },
+      dependencies: dependencyEntries,
       devDependencies: {
-        '@fluojs/cli': createDependencySpec('@fluojs/cli', releaseVersion, packageSpecs),
-        '@fluojs/testing': createDependencySpec('@fluojs/testing', releaseVersion, packageSpecs),
+        ...devDependencyEntries,
         ...PUBLISHED_DEV_DEPENDENCIES,
       },
     },
@@ -572,11 +578,12 @@ type ScaffoldFile = {
 
 function buildScaffoldFiles(
   options: BootstrapOptions,
+  bootstrapPlan: ResolvedBootstrapPlan,
   releaseVersion: string,
   packageSpecs: Record<string, string>,
 ): ScaffoldFile[] {
   return [
-    { content: createProjectPackageJson(options, releaseVersion, packageSpecs), path: 'package.json' },
+    { content: createProjectPackageJson(options, bootstrapPlan, releaseVersion, packageSpecs), path: 'package.json' },
     { content: createProjectReadme(options), path: 'README.md' },
     { content: createProjectTsconfig(), path: 'tsconfig.json' },
     { content: createProjectTsconfigBuild(), path: 'tsconfig.build.json' },
@@ -613,7 +620,8 @@ export async function scaffoldBootstrapApp(
 ): Promise<void> {
   const targetDirectory = resolve(options.targetDirectory);
   const releaseVersion = readOwnPackageVersion(importMetaUrl);
-  const packageSpecs = await resolvePackageSpecs(options);
+  const bootstrapPlan = resolveBootstrapPlan(options);
+  const packageSpecs = await resolvePackageSpecs(options, bootstrapPlan);
 
   mkdirSync(targetDirectory, { recursive: true });
 
@@ -627,7 +635,7 @@ export async function scaffoldBootstrapApp(
     }
   }
 
-  for (const file of buildScaffoldFiles(options, releaseVersion, packageSpecs)) {
+  for (const file of buildScaffoldFiles(options, bootstrapPlan, releaseVersion, packageSpecs)) {
     writeTextFile(join(targetDirectory, file.path), file.content);
   }
 
@@ -995,7 +1003,24 @@ async function normalizePackedPackageManifest(
   rmSync(temporaryDirectory, { force: true, recursive: true });
 }
 
-async function resolvePackageSpecs(options: BootstrapOptions): Promise<Record<string, string>> {
+function collectLocalPackageNames(bootstrapPlan: ResolvedBootstrapPlan): readonly LocalPackageName[] {
+  const packageNames = new Set<LocalPackageName>();
+
+  for (const packageName of bootstrapPlan.dependencies.dependencies) {
+    packageNames.add(packageName);
+  }
+
+  for (const packageName of bootstrapPlan.dependencies.devDependencies) {
+    packageNames.add(packageName);
+  }
+
+  return Array.from(packageNames);
+}
+
+async function resolvePackageSpecs(
+  options: BootstrapOptions,
+  bootstrapPlan: ResolvedBootstrapPlan,
+): Promise<Record<string, string>> {
   if (options.dependencySource !== 'local' || !options.repoRoot) {
     return {};
   }
@@ -1005,7 +1030,7 @@ async function resolvePackageSpecs(options: BootstrapOptions): Promise<Record<st
   const cacheStampPath = join(outputDirectory, LOCAL_PACKAGE_CACHE_STAMP_FILE);
   mkdirSync(outputDirectory, { recursive: true });
 
-  const packageNames = LOCAL_PACKAGE_NAMES;
+  const packageNames = collectLocalPackageNames(bootstrapPlan);
   const packageVersions = collectLocalPackageVersions(repoRoot, packageNames);
   const expectedCacheStamp = computeLocalPackageCacheStamp(repoRoot, packageNames, packageVersions);
   const currentCacheStamp = readLocalPackageCacheStamp(cacheStampPath);

--- a/packages/cli/src/new/types.ts
+++ b/packages/cli/src/new/types.ts
@@ -1,7 +1,26 @@
 export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn';
 export type DependencySource = 'local' | 'published';
+export type BootstrapShape = 'application';
+export type BootstrapRuntime = 'node';
+export type BootstrapPlatform = 'fastify';
+export type BootstrapTransport = 'http';
+export type BootstrapToolingPreset = 'standard';
 
-export interface BootstrapOptions {
+export interface BootstrapTopology {
+  deferred: boolean;
+  mode: 'single-package';
+}
+
+export interface BootstrapSchema {
+  platform: BootstrapPlatform;
+  runtime: BootstrapRuntime;
+  shape: BootstrapShape;
+  tooling: BootstrapToolingPreset;
+  topology: BootstrapTopology;
+  transport: BootstrapTransport;
+}
+
+export interface BootstrapOptions extends BootstrapSchema {
   dependencySource?: DependencySource;
   force?: boolean;
   packageManager: PackageManager;
@@ -16,7 +35,7 @@ export interface BootstrapPrompt {
   label: string;
 }
 
-export interface BootstrapAnswers {
+export interface BootstrapAnswers extends BootstrapSchema {
   packageManager: PackageManager;
   projectName: string;
   targetDirectory: string;


### PR DESCRIPTION
## Summary

- introduce a shape-first bootstrap schema and pure resolution layer for `fluo new`
- keep `packageManager` independent from runtime/platform resolution and preserve the current `fluo new my-app` baseline
- route scaffold dependency selection through the new bootstrap plan and cover the resolver layer with focused tests

## Changes

- added internal bootstrap schema types for `shape`, `runtime`, `platform`, `transport`, `tooling`, and deferred topology metadata
- added `resolveBootstrapSchema(...)` and `resolveBootstrapPlan(...)` as the new compatibility-baseline resolver foundation
- updated prompt answer resolution and scaffold package generation to consume the bootstrap plan instead of hard-coded dependency lists
- added focused resolver tests and compatibility assertions for the scaffolded dependency set

## Testing

- `pnpm install`
- `pnpm build`
- `pnpm --filter @fluojs/cli test`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli build`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract impact note: this PR adds the internal v2 bootstrap schema/resolver foundation while preserving the documented default `fluo new my-app` path, so no README contract text changes were required for the existing starter flow.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #979