### PR TITLE
Resolve #980: make fluo new flags-first for the HTTP shape

### DIFF
--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -44,6 +44,12 @@ cd my-app
 pnpm dev
 ```
 
+기본 스타터는 여전히 Node.js + Fastify HTTP 애플리케이션 기준선을 유지합니다. 이제 flags-first v2 shape 옵션으로 같은 HTTP 경로를 명시적으로 선택해도 생성 결과는 바뀌지 않습니다.
+
+```bash
+fluo new my-app --shape application --transport http --runtime node --platform fastify
+```
+
 ### 2. 기능 추가
 컨트롤러와 서비스가 포함된 새 리소스를 추가하고, 모듈에 자동으로 연결합니다.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -44,6 +44,12 @@ cd my-app
 pnpm dev
 ```
 
+The default starter remains the Node.js + Fastify HTTP application baseline. You can now select that HTTP path explicitly with flags-first v2 shape options without changing the generated result:
+
+```bash
+fluo new my-app --shape application --transport http --runtime node --platform fastify
+```
+
 ### 2. Generate a feature
 Add a new resource with a controller and service, automatically wired into the module.
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -146,6 +146,45 @@ describe('CLI command runner', () => {
     expect(stdoutBuffer.join('')).toContain('yarn dev');
   });
 
+  it('accepts explicit HTTP shape flags while preserving the default starter result', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli([
+      'new',
+      '--shape',
+      'application',
+      '--transport',
+      'http',
+      '--runtime',
+      'node',
+      '--platform',
+      'fastify',
+      '--tooling',
+      'standard',
+      '--topology',
+      'single-package',
+      'starter-app',
+    ], {
+      cwd: workspaceDirectory,
+      skipInstall: true,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const projectDirectory = join(workspaceDirectory, 'starter-app');
+    const packageJson = readFileSync(join(projectDirectory, 'package.json'), 'utf8');
+    const mainFile = readFileSync(join(projectDirectory, 'src', 'main.ts'), 'utf8');
+
+    expect(exitCode).toBe(0);
+    expect(stdoutBuffer.join('')).toContain('Installing dependencies with pnpm');
+    expect(stdoutBuffer.join('')).toContain('cd ./starter-app');
+    expect(packageJson).toContain('@fluojs/platform-fastify');
+    expect(packageJson).toContain('@fluojs/runtime');
+    expect(mainFile).toContain("createFastifyAdapter({ port })");
+  });
+
   it('scaffolds a local .env file while ignoring it from git by default', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);
@@ -252,6 +291,12 @@ describe('CLI command runner', () => {
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Usage: fluo new|create [project-name] [options]');
     expect(stdoutBuffer.join('')).toMatch(/\| Option\s+\| Aliases \| Description\s+\|/);
+    expect(stdoutBuffer.join('')).toContain('--shape <application>');
+    expect(stdoutBuffer.join('')).toContain('--transport <http>');
+    expect(stdoutBuffer.join('')).toContain('--runtime <node>');
+    expect(stdoutBuffer.join('')).toContain('--platform <fastify>');
+    expect(stdoutBuffer.join('')).toContain('--tooling <standard>');
+    expect(stdoutBuffer.join('')).toContain('--topology <single-package>');
     expect(stdoutBuffer.join('')).toContain('--package-manager <pnpm|npm|yarn|bun>');
     expect(stdoutBuffer.join('')).not.toContain('Schematics');
     expect(stdoutBuffer.join('')).toContain('Next steps:');

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -37,6 +37,36 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
   },
   {
     aliases: [],
+    description: 'Select the scaffold shape explicitly (currently only application for the HTTP starter path).',
+    option: '--shape <application>',
+  },
+  {
+    aliases: [],
+    description: 'Select the transport path explicitly (currently only http).',
+    option: '--transport <http>',
+  },
+  {
+    aliases: [],
+    description: 'Select the runtime explicitly (currently only node for the HTTP starter path).',
+    option: '--runtime <node>',
+  },
+  {
+    aliases: [],
+    description: 'Select the platform adapter explicitly (currently only fastify for the HTTP starter path).',
+    option: '--platform <fastify>',
+  },
+  {
+    aliases: [],
+    description: 'Select the starter tooling preset explicitly (currently only standard).',
+    option: '--tooling <standard>',
+  },
+  {
+    aliases: [],
+    description: 'Select the starter topology mode explicitly (currently only single-package).',
+    option: '--topology <single-package>',
+  },
+  {
+    aliases: [],
     description: 'Choose which package manager installs the starter dependencies.',
     option: '--package-manager <pnpm|npm|yarn|bun>',
   },
@@ -58,8 +88,27 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
 ];
 
 const SUPPORTED_PACKAGE_MANAGERS = new Set<BootstrapAnswers['packageManager']>(['bun', 'npm', 'pnpm', 'yarn']);
+const SUPPORTED_SHAPES = new Set<BootstrapAnswers['shape']>(['application']);
+const SUPPORTED_TRANSPORTS = new Set<BootstrapAnswers['transport']>(['http']);
+const SUPPORTED_RUNTIMES = new Set<BootstrapAnswers['runtime']>(['node']);
+const SUPPORTED_PLATFORMS = new Set<BootstrapAnswers['platform']>(['fastify']);
+const SUPPORTED_TOOLING_PRESETS = new Set<BootstrapAnswers['tooling']>(['standard']);
+const SUPPORTED_TOPOLOGY_MODES = new Set<BootstrapAnswers['topology']['mode']>(['single-package']);
 
-function readOptionValue(argv: string[], index: number, option: '--name' | '--package-manager' | '--target-directory'): string {
+function readOptionValue(
+  argv: string[],
+  index: number,
+  option:
+    | '--name'
+    | '--package-manager'
+    | '--platform'
+    | '--runtime'
+    | '--shape'
+    | '--target-directory'
+    | '--tooling'
+    | '--topology'
+    | '--transport',
+): string {
   const value = argv[index + 1];
 
   if (!value || value.startsWith('-')) {
@@ -98,6 +147,79 @@ function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolea
         }
         index += 1;
         break;
+      case '--shape':
+        if (parsed.shape) {
+          throw new Error('Duplicate --shape option.');
+        }
+
+        parsed.shape = readOptionValue(argv, index, '--shape') as BootstrapAnswers['shape'];
+        if (!SUPPORTED_SHAPES.has(parsed.shape)) {
+          throw new Error(`Invalid --shape value "${parsed.shape}". Use: application.`);
+        }
+        index += 1;
+        break;
+      case '--transport':
+        if (parsed.transport) {
+          throw new Error('Duplicate --transport option.');
+        }
+
+        parsed.transport = readOptionValue(argv, index, '--transport') as BootstrapAnswers['transport'];
+        if (!SUPPORTED_TRANSPORTS.has(parsed.transport)) {
+          throw new Error(`Invalid --transport value "${parsed.transport}". Use: http.`);
+        }
+        index += 1;
+        break;
+      case '--runtime':
+        if (parsed.runtime) {
+          throw new Error('Duplicate --runtime option.');
+        }
+
+        parsed.runtime = readOptionValue(argv, index, '--runtime') as BootstrapAnswers['runtime'];
+        if (!SUPPORTED_RUNTIMES.has(parsed.runtime)) {
+          throw new Error(`Invalid --runtime value "${parsed.runtime}". Use: node.`);
+        }
+        index += 1;
+        break;
+      case '--platform':
+        if (parsed.platform) {
+          throw new Error('Duplicate --platform option.');
+        }
+
+        parsed.platform = readOptionValue(argv, index, '--platform') as BootstrapAnswers['platform'];
+        if (!SUPPORTED_PLATFORMS.has(parsed.platform)) {
+          throw new Error(`Invalid --platform value "${parsed.platform}". Use: fastify.`);
+        }
+        index += 1;
+        break;
+      case '--tooling':
+        if (parsed.tooling) {
+          throw new Error('Duplicate --tooling option.');
+        }
+
+        parsed.tooling = readOptionValue(argv, index, '--tooling') as BootstrapAnswers['tooling'];
+        if (!SUPPORTED_TOOLING_PRESETS.has(parsed.tooling)) {
+          throw new Error(`Invalid --tooling value "${parsed.tooling}". Use: standard.`);
+        }
+        index += 1;
+        break;
+      case '--topology': {
+        const topologyMode = readOptionValue(argv, index, '--topology') as BootstrapAnswers['topology']['mode'];
+
+        if (parsed.topology) {
+          throw new Error('Duplicate --topology option.');
+        }
+
+        if (!SUPPORTED_TOPOLOGY_MODES.has(topologyMode)) {
+          throw new Error(`Invalid --topology value "${topologyMode}". Use: single-package.`);
+        }
+
+        parsed.topology = {
+          deferred: true,
+          mode: topologyMode,
+        };
+        index += 1;
+        break;
+      }
       case '--target-directory':
         if (hasExplicitTargetDirectory) {
           throw new Error('Duplicate --target-directory option.');

--- a/packages/cli/src/new/resolver.test.ts
+++ b/packages/cli/src/new/resolver.test.ts
@@ -26,9 +26,30 @@ describe('resolveBootstrapPlan', () => {
           '@fluojs/testing',
         ],
       },
-      scaffoldPreset: 'standard-http-node-fastify',
+      emitter: {
+        platform: 'fastify',
+        preset: 'standard',
+        runtime: 'node',
+        transport: 'http',
+        type: 'http',
+      },
       schema: DEFAULT_BOOTSTRAP_SCHEMA,
     });
+  });
+
+  it('accepts explicit HTTP shape flags without changing the compatibility baseline', () => {
+    expect(resolveBootstrapPlan({
+      packageManager: 'pnpm' as const,
+      platform: 'fastify',
+      runtime: 'node',
+      shape: 'application',
+      tooling: 'standard',
+      topology: {
+        deferred: true,
+        mode: 'single-package',
+      },
+      transport: 'http',
+    })).toEqual(resolveBootstrapPlan({ packageManager: 'pnpm' as const }));
   });
 
   it('does not treat package-manager choice as runtime or platform selection', () => {

--- a/packages/cli/src/new/resolver.ts
+++ b/packages/cli/src/new/resolver.ts
@@ -18,6 +18,17 @@ const TRANSPORTS: readonly BootstrapTransport[] = ['http'];
 const TOOLING_PRESETS: readonly BootstrapToolingPreset[] = ['standard'];
 const TOPOLOGY_MODES: readonly BootstrapTopology['mode'][] = ['single-package'];
 
+type ResolvedHttpScaffoldEmitter = {
+  platform: 'fastify';
+  preset: 'standard';
+  runtime: 'node';
+  transport: 'http';
+  type: 'http';
+};
+
+/**
+ * Shape-first compatibility baseline for `fluo new` until additional starter variants ship.
+ */
 export const DEFAULT_BOOTSTRAP_SCHEMA: BootstrapSchema = {
   platform: 'fastify',
   runtime: 'node',
@@ -30,6 +41,9 @@ export const DEFAULT_BOOTSTRAP_SCHEMA: BootstrapSchema = {
   transport: 'http',
 };
 
+/**
+ * Dependency set required by the currently supported `fluo new` starter baseline.
+ */
 export interface ResolvedBootstrapDependencies {
   dependencies: readonly [
     '@fluojs/config',
@@ -46,9 +60,12 @@ export interface ResolvedBootstrapDependencies {
   ];
 }
 
+/**
+ * Scaffold planning result that routes a resolved schema into the correct emitter boundary.
+ */
 export interface ResolvedBootstrapPlan {
   dependencies: ResolvedBootstrapDependencies;
-  scaffoldPreset: 'standard-http-node-fastify';
+  emitter: ResolvedHttpScaffoldEmitter;
   schema: BootstrapSchema;
 }
 
@@ -87,6 +104,12 @@ function normalizeTopology(topology: Partial<BootstrapTopology> | undefined): Bo
   };
 }
 
+/**
+ * Resolves a partial starter schema onto the currently supported v2 compatibility baseline.
+ *
+ * @param partial Partial CLI/runtime schema selections.
+ * @returns A normalized bootstrap schema with defaults applied.
+ */
 export function resolveBootstrapSchema(partial: Partial<BootstrapSchema> = {}): BootstrapSchema {
   return {
     platform: assertOneOf('platform', partial.platform ?? DEFAULT_BOOTSTRAP_SCHEMA.platform, PLATFORMS),
@@ -98,6 +121,12 @@ export function resolveBootstrapSchema(partial: Partial<BootstrapSchema> = {}): 
   };
 }
 
+/**
+ * Resolves the dependency and emitter plan for the requested starter schema.
+ *
+ * @param options Partial or full bootstrap options collected from the CLI/runtime surface.
+ * @returns The normalized schema plus the emitter boundary that should render scaffold files.
+ */
 export function resolveBootstrapPlan(options: BootstrapResolutionInput | BootstrapOptions): ResolvedBootstrapPlan {
   const schema = resolveBootstrapSchema(options);
 
@@ -118,7 +147,13 @@ export function resolveBootstrapPlan(options: BootstrapResolutionInput | Bootstr
 
   return {
     dependencies: DEFAULT_DEPENDENCIES,
-    scaffoldPreset: 'standard-http-node-fastify',
+    emitter: {
+      platform: 'fastify',
+      preset: 'standard',
+      runtime: 'node',
+      transport: 'http',
+      type: 'http',
+    },
     schema,
   };
 }

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -14,6 +14,33 @@ afterEach(() => {
     rmSync(directory, { force: true, recursive: true });
   }
 });
+
+function readDirectorySnapshot(rootDirectory: string): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  const pending = [rootDirectory];
+
+  while (pending.length > 0) {
+    const currentDirectory = pending.pop();
+
+    if (!currentDirectory) {
+      continue;
+    }
+
+    for (const entry of readdirSync(currentDirectory)) {
+      const entryPath = join(currentDirectory, entry);
+      const entryStat = statSync(entryPath);
+
+      if (entryStat.isDirectory()) {
+        pending.push(entryPath);
+        continue;
+      }
+
+      snapshot[relative(rootDirectory, entryPath)] = readFileSync(entryPath, 'utf8');
+    }
+  }
+
+  return snapshot;
+}
 
 describe('scaffoldBootstrapApp', () => {
   it('generates TS6 starter configs without deprecated baseUrl aliases', async () => {
@@ -49,5 +76,37 @@ describe('scaffoldBootstrapApp', () => {
     expect(viteConfig).not.toContain('baseUrl');
     expect(vitestConfig).toContain("import { fluoBabelDecoratorsPlugin } from '@fluojs/testing/vitest';");
     expect(vitestConfig).not.toContain('baseUrl');
+  });
+
+  it('keeps the default Node + Fastify HTTP scaffold identical when explicit shape flags are provided', async () => {
+    const defaultTargetDirectory = mkdtempSync(join(tmpdir(), 'fluo-scaffold-default-'));
+    const explicitTargetDirectory = mkdtempSync(join(tmpdir(), 'fluo-scaffold-explicit-'));
+    temporaryDirectories.push(defaultTargetDirectory, explicitTargetDirectory);
+
+    await scaffoldBootstrapApp({
+      ...DEFAULT_BOOTSTRAP_SCHEMA,
+      packageManager: 'pnpm',
+      projectName: 'starter-app',
+      skipInstall: true,
+      targetDirectory: defaultTargetDirectory,
+    });
+
+    await scaffoldBootstrapApp({
+      packageManager: 'pnpm',
+      platform: 'fastify',
+      projectName: 'starter-app',
+      runtime: 'node',
+      shape: 'application',
+      skipInstall: true,
+      targetDirectory: explicitTargetDirectory,
+      tooling: 'standard',
+      topology: {
+        deferred: true,
+        mode: 'single-package',
+      },
+      transport: 'http',
+    });
+
+    expect(readDirectorySnapshot(explicitTargetDirectory)).toEqual(readDirectorySnapshot(defaultTargetDirectory));
   });
 });

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -576,7 +576,7 @@ type ScaffoldFile = {
   path: string;
 };
 
-function buildScaffoldFiles(
+function emitSharedScaffoldFiles(
   options: BootstrapOptions,
   bootstrapPlan: ResolvedBootstrapPlan,
   releaseVersion: string,
@@ -592,6 +592,11 @@ function buildScaffoldFiles(
     { content: createVitestConfig(), path: 'vitest.config.ts' },
     { content: createGitignore(), path: '.gitignore' },
     { content: createEnvFile(), path: '.env' },
+   ];
+ }
+
+ function emitStandardHttpNodeFastifyScaffoldFiles(options: BootstrapOptions): ScaffoldFile[] {
+   return [
     { content: createAppFile(), path: 'src/app.ts' },
     { content: createMainFile(), path: 'src/main.ts' },
     { content: createHealthResponseDtoFile(), path: 'src/health/health.response.dto.ts' },
@@ -604,6 +609,26 @@ function buildScaffoldFiles(
     { content: createHealthModuleFile(), path: 'src/health/health.module.ts' },
     { content: createAppTestFile(), path: 'src/app.test.ts' },
     { content: createAppE2eTestFile(), path: 'src/app.e2e.test.ts' },
+  ];
+}
+
+function emitScaffoldFilesForPlan(options: BootstrapOptions, bootstrapPlan: ResolvedBootstrapPlan): ScaffoldFile[] {
+  if (bootstrapPlan.emitter.type === 'http') {
+    return emitStandardHttpNodeFastifyScaffoldFiles(options);
+  }
+
+  return [];
+}
+
+function buildScaffoldFiles(
+  options: BootstrapOptions,
+  bootstrapPlan: ResolvedBootstrapPlan,
+  releaseVersion: string,
+  packageSpecs: Record<string, string>,
+): ScaffoldFile[] {
+  return [
+    ...emitSharedScaffoldFiles(options, bootstrapPlan, releaseVersion, packageSpecs),
+    ...emitScaffoldFilesForPlan(options, bootstrapPlan),
   ];
 }
 


### PR DESCRIPTION
Closes #980

## Summary

- add explicit shape-aware `fluo new` flags for the HTTP starter path while keeping the default Node + Fastify scaffold unchanged
- route HTTP starter generation through bootstrap-plan and emitter boundaries instead of one monolithic scaffold builder
- document the new flags-first HTTP path in the CLI README mirror pair

## Changes

- parse `--shape`, `--transport`, `--runtime`, `--platform`, `--tooling`, and `--topology` in `fluo new`
- keep the compatibility baseline pinned to `application/node/http/fastify/standard/single-package`
- split shared scaffold files from the HTTP emitter path and lock the compatibility baseline with regression coverage

## Testing

- pnpm build
- pnpm --filter @fluojs/cli typecheck
- pnpm --filter @fluojs/cli test
- lsp diagnostics clean on changed files (`packages/cli/src/commands/new.ts`, `packages/cli/src/new/resolver.ts`, `packages/cli/src/new/scaffold.ts`, tests, README mirror pair)

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.