### PR TITLE
Resolve #982: add the interactive fluo new wizard

### DIFF
--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -56,6 +56,8 @@ fluo new my-app --shape application --transport http --runtime node --platform f
 fluo new my-microservice --shape microservice --transport tcp --runtime node --platform none
 ```
 
+`fluo new`가 interactive TTY에서 실행되면, 이제 v2 wizard가 기존 flags/config 모델 위에 그대로 얹혀 동작합니다. wizard는 프로젝트 이름, shape-first 분기(`application` -> runtime, `microservice` -> transport), 유지보수 가능한 tooling preset, package manager, 즉시 dependency를 설치할지 여부, git 저장소를 초기화할지 여부를 묻습니다. 반면 non-interactive 플래그 경로와 프로그래밍 방식의 `runNewCommand(...)` 호출은 동일한 resolved defaults를 유지하는 first-class path로 계속 동작합니다.
+
 ### 2. 기능 추가
 컨트롤러와 서비스가 포함된 새 리소스를 추가하고, 모듈에 자동으로 연결합니다.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,6 +56,8 @@ fluo new my-app --shape application --transport http --runtime node --platform f
 fluo new my-microservice --shape microservice --transport tcp --runtime node --platform none
 ```
 
+When `fluo new` runs in an interactive TTY, the v2 wizard now layers on top of the same flags/config model instead of replacing it. The wizard asks for the project name, shape-first branch (`application` -> runtime, `microservice` -> transport), the maintained tooling preset, package-manager choice, whether to install dependencies immediately, and whether to initialize a git repository. Non-interactive flags and programmatic `runNewCommand(...)` calls still stay first-class paths with the same resolved defaults.
+
 ### 2. Generate a feature
 Add a new resource with a controller and service, automatically wired into the module.
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -108,7 +108,7 @@ describe('CLI command runner', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(stdoutBuffer.join('')).toContain('Installing dependencies with npm');
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(stdoutBuffer.join('')).toContain('npm run dev');
   });
 
@@ -125,8 +125,78 @@ describe('CLI command runner', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(stdoutBuffer.join('')).toContain('Installing dependencies with pnpm');
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(stdoutBuffer.join('')).toContain('pnpm dev');
+  });
+
+  it('runs the interactive new wizard through injected answers without terminal emulation', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['new'], {
+      cwd: workspaceDirectory,
+      interactive: true,
+      prompt: {
+        confirm: async (message) => message === 'Initialize a git repository',
+        select: async <T extends string>(message: string, _choices: readonly { label: string; value: T }[], _defaultValue?: T) => {
+          switch (message) {
+            case 'Starter shape':
+              return 'microservice' as T;
+            case 'Microservice transport':
+              return 'tcp' as T;
+            case 'Tooling preset':
+              return 'standard' as T;
+            case 'Package manager':
+              return 'pnpm' as T;
+            default:
+              throw new Error(`Unexpected prompt: ${message}`);
+          }
+        },
+        text: async () => 'wizard-app',
+      },
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'wizard-app', '.git'))).toBe(true);
+    expect(readFileSync(join(workspaceDirectory, 'wizard-app', 'README.md'), 'utf8')).toContain('Shape: `microservice`');
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
+  });
+
+  it('keeps non-interactive programmatic new flows as a first-class path', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', 'starter-app'], {
+      cwd: workspaceDirectory,
+      interactive: false,
+      skipInstall: true,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'starter-app', '.git'))).toBe(false);
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
+  });
+
+  it('honors explicit install and git flags without changing the scaffold model', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', 'starter-app', '--no-install', '--git'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'starter-app', '.git'))).toBe(true);
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
   });
 
   it('honors explicit yarn selection without changing the stable scaffold shape', async () => {
@@ -142,7 +212,7 @@ describe('CLI command runner', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(stdoutBuffer.join('')).toContain('Installing dependencies with yarn');
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(stdoutBuffer.join('')).toContain('yarn dev');
   });
 
@@ -178,7 +248,7 @@ describe('CLI command runner', () => {
     const mainFile = readFileSync(join(projectDirectory, 'src', 'main.ts'), 'utf8');
 
     expect(exitCode).toBe(0);
-    expect(stdoutBuffer.join('')).toContain('Installing dependencies with pnpm');
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(stdoutBuffer.join('')).toContain('cd ./starter-app');
     expect(packageJson).toContain('@fluojs/platform-fastify');
     expect(packageJson).toContain('@fluojs/runtime');
@@ -217,7 +287,7 @@ describe('CLI command runner', () => {
     const mainFile = readFileSync(join(projectDirectory, 'src', 'main.ts'), 'utf8');
 
     expect(exitCode).toBe(0);
-    expect(stdoutBuffer.join('')).toContain('Installing dependencies with pnpm');
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(stdoutBuffer.join('')).toContain('cd ./starter-microservice');
     expect(packageJson).toContain('@fluojs/microservices');
     expect(packageJson).not.toContain('@fluojs/platform-fastify');
@@ -353,6 +423,10 @@ describe('CLI command runner', () => {
     expect(stdoutBuffer.join('')).toContain('--tooling <standard>');
     expect(stdoutBuffer.join('')).toContain('--topology <single-package>');
     expect(stdoutBuffer.join('')).toContain('--package-manager <pnpm|npm|yarn|bun>');
+    expect(stdoutBuffer.join('')).toContain('--install');
+    expect(stdoutBuffer.join('')).toContain('--no-install');
+    expect(stdoutBuffer.join('')).toContain('--git');
+    expect(stdoutBuffer.join('')).toContain('--no-git');
     expect(stdoutBuffer.join('')).not.toContain('Schematics');
     expect(stdoutBuffer.join('')).toContain('Next steps:');
     expect(stdoutBuffer.join('')).toContain('cd <app-name>');
@@ -737,7 +811,7 @@ describe('CLI command runner', () => {
     expect(packageJson.scripts?.test).toBeDefined();
     expect(readFileSync(join(projectDirectory, '.gitignore'), 'utf8')).toContain('.env');
     expect(readFileSync(join(projectDirectory, '.env'), 'utf8')).toContain('PORT=3000');
-    expect(stdoutBuffer.join('')).toContain('Installing dependencies with pnpm');
+    expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(existsSync(join(projectDirectory, 'src', 'health', 'health.repo.ts'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'health', 'health.repo.test.ts'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'health', 'health.service.ts'))).toBe(true);

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'node:path';
 
 import { renderAliasList, renderHelpTable } from '../help.js';
-import { resolveBootstrapAnswers } from '../new/prompt.js';
+import { collectBootstrapAnswers, type BootstrapPrompter } from '../new/prompt.js';
 import { scaffoldBootstrapApp } from '../new/scaffold.js';
 import type { BootstrapAnswers, NewCommandOptions } from '../new/types.js';
 
@@ -18,7 +18,10 @@ function isHelpFlag(value: string | undefined): boolean {
  */
 export interface NewCommandRuntimeOptions extends NewCommandOptions {
   cwd?: string;
+  interactive?: boolean;
+  prompt?: BootstrapPrompter;
   stderr?: CliStream;
+  stdin?: { isTTY?: boolean };
   stdout?: CliStream;
   userAgent?: string;
 }
@@ -81,6 +84,26 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
     option: '--force',
   },
   {
+    aliases: [],
+    description: 'Install starter dependencies after writing files.',
+    option: '--install',
+  },
+  {
+    aliases: [],
+    description: 'Skip starter dependency installation.',
+    option: '--no-install',
+  },
+  {
+    aliases: [],
+    description: 'Initialize a git repository in the generated starter.',
+    option: '--git',
+  },
+  {
+    aliases: [],
+    description: 'Skip git repository initialization in the generated starter.',
+    option: '--no-git',
+  },
+  {
     aliases: ['-h'],
     description: 'Show help for the new command.',
     option: '--help',
@@ -128,6 +151,19 @@ function readOptionValue(
   return value;
 }
 
+function setBooleanSelection(
+  currentValue: boolean | undefined,
+  nextValue: boolean,
+  positiveFlag: string,
+  negativeFlag: string,
+): boolean {
+  if (currentValue !== undefined) {
+    throw new Error(`Duplicate ${nextValue ? positiveFlag : negativeFlag} option.`);
+  }
+
+  return nextValue;
+}
+
 function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolean } {
   const parsed: Partial<BootstrapAnswers> & { force?: boolean } = {};
   let hasExplicitTargetDirectory = false;
@@ -164,7 +200,7 @@ function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolea
 
         parsed.shape = readOptionValue(argv, index, '--shape') as BootstrapAnswers['shape'];
         if (!SUPPORTED_SHAPES.has(parsed.shape)) {
-          throw new Error('Invalid --shape value "' + parsed.shape + '". Use one of: application, microservice.');
+          throw new Error(`Invalid --shape value "${parsed.shape}". Use one of: application, microservice.`);
         }
         index += 1;
         break;
@@ -244,6 +280,28 @@ function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolea
         break;
       case '--force':
         parsed.force = true;
+        break;
+      case '--install':
+        parsed.installDependencies = setBooleanSelection(
+          parsed.installDependencies,
+          true,
+          '--install',
+          '--no-install',
+        );
+        break;
+      case '--no-install':
+        parsed.installDependencies = setBooleanSelection(
+          parsed.installDependencies,
+          false,
+          '--install',
+          '--no-install',
+        );
+        break;
+      case '--git':
+        parsed.initializeGit = setBooleanSelection(parsed.initializeGit, true, '--git', '--no-git');
+        break;
+      case '--no-git':
+        parsed.initializeGit = setBooleanSelection(parsed.initializeGit, false, '--git', '--no-git');
         break;
       default:
         if (arg.startsWith('-')) {
@@ -327,21 +385,38 @@ export async function runNewCommand(argv: string[], runtime: NewCommandRuntimeOp
 
     const parsed = parseArgs(argv);
 
-    if (!parsed.projectName) {
+    const partialAnswers = {
+      ...parsed,
+      initializeGit: parsed.initializeGit ?? runtime.initializeGit,
+      installDependencies: parsed.installDependencies ?? runtime.installDependencies ?? (runtime.skipInstall === true ? false : undefined),
+    };
+
+    if (!partialAnswers.projectName && !(runtime.interactive ?? runtime.prompt ?? runtime.stdin?.isTTY ?? process.stdin.isTTY)) {
       throw new Error(newUsage());
     }
 
-    const answers = resolveBootstrapAnswers(parsed, runtime.cwd ?? process.cwd(), runtime.userAgent);
+    const answers = await collectBootstrapAnswers(partialAnswers, runtime.cwd ?? process.cwd(), runtime.userAgent, {
+      interactive: runtime.interactive,
+      prompt: runtime.prompt,
+      stdin: runtime.stdin,
+      stdout,
+    });
     const options = {
       ...answers,
       dependencySource: runtime.dependencySource,
       force: parsed.force ?? runtime.force,
+      initializeGit: answers.initializeGit,
+      installDependencies: answers.installDependencies,
       repoRoot: runtime.repoRoot,
       skipInstall: runtime.skipInstall,
       targetDirectory: resolve(runtime.cwd ?? process.cwd(), answers.targetDirectory),
     };
 
-    stdout.write(`Installing dependencies with ${answers.packageManager}...\n`);
+    if (answers.installDependencies) {
+      stdout.write(`Installing dependencies with ${answers.packageManager}...\n`);
+    } else {
+      stdout.write('Skipping dependency installation.\n');
+    }
 
     await scaffoldBootstrapApp(options);
 

--- a/packages/cli/src/new/install.ts
+++ b/packages/cli/src/new/install.ts
@@ -2,13 +2,20 @@ import { spawn, spawnSync } from 'node:child_process';
 
 import type { PackageManager } from './types.js';
 
+/** Concrete command invocation used for dependency installation. */
 export interface InstallCommand {
   args: string[];
   command: string;
 }
 
+/** Runtime overrides for resolving install commands in tests. */
 export interface ResolveInstallCommandOptions {
   isCorepackAvailable?: boolean;
+}
+
+/** Runtime overrides for git initialization in tests. */
+export interface InitializeGitRepositoryOptions {
+  command?: string;
 }
 
 const COREPACK_DOCS_URL = 'https://nodejs.org/api/corepack.html';
@@ -20,6 +27,13 @@ function checkCommandAvailability(command: string): boolean {
   return result.status === 0;
 }
 
+/**
+ * Resolves the concrete install command for a chosen package manager.
+ *
+ * @param packageManager Package manager selected for the generated starter.
+ * @param options Runtime overrides for command detection in tests.
+ * @returns The command and argument list to execute.
+ */
 export function resolveInstallCommand(
   packageManager: PackageManager,
   options: ResolveInstallCommandOptions = {},
@@ -53,6 +67,13 @@ export function resolveInstallCommand(
   };
 }
 
+/**
+ * Installs starter dependencies in the generated project directory.
+ *
+ * @param targetDirectory Generated project directory.
+ * @param packageManager Package manager selected for the generated starter.
+ * @returns A promise that resolves when installation succeeds.
+ */
 export async function installDependencies(targetDirectory: string, packageManager: PackageManager): Promise<void> {
   const hasCorepack = packageManager === 'yarn' ? checkCommandAvailability('corepack') : undefined;
   const { args, command } = resolveInstallCommand(packageManager, { isCorepackAvailable: hasCorepack });
@@ -77,6 +98,37 @@ export async function installDependencies(targetDirectory: string, packageManage
       }
 
       reject(new Error(`Dependency installation failed with exit code ${code}.`));
+    });
+  });
+}
+
+/**
+ * Initializes a git repository in the generated project directory.
+ *
+ * @param targetDirectory Generated project directory.
+ * @param options Runtime overrides for invoking git in tests.
+ * @returns A promise that resolves when repository initialization succeeds.
+ */
+export async function initializeGitRepository(
+  targetDirectory: string,
+  options: InitializeGitRepositoryOptions = {},
+): Promise<void> {
+  const command = options.command ?? 'git';
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, ['init'], {
+      cwd: targetDirectory,
+      stdio: 'inherit',
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`Git initialization failed with exit code ${code}.`));
     });
   });
 }

--- a/packages/cli/src/new/prompt.test.ts
+++ b/packages/cli/src/new/prompt.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { detectPackageManager, resolveBootstrapAnswers } from './prompt.js';
+import { collectBootstrapAnswers, detectPackageManager, resolveBootstrapAnswers, type BootstrapPrompter } from './prompt.js';
 import { DEFAULT_BOOTSTRAP_SCHEMA } from './resolver.js';
 
 const createdDirectories: string[] = [];
@@ -42,8 +42,83 @@ describe('resolveBootstrapAnswers', () => {
     );
 
     expect(resolveBootstrapAnswers({ projectName: 'starter-app' }, workspaceDirectory)).toEqual({
+      initializeGit: false,
+      installDependencies: true,
       packageManager: 'bun',
       ...DEFAULT_BOOTSTRAP_SCHEMA,
+      projectName: 'starter-app',
+      targetDirectory: './starter-app',
+    });
+  });
+});
+
+describe('collectBootstrapAnswers', () => {
+  function createPrompt(overrides: Partial<BootstrapPrompter>): BootstrapPrompter {
+    return {
+      confirm: async () => false,
+      select: async <T extends string>(_message: string, _choices: readonly { label: string; value: T }[], defaultValue?: T) => {
+        if (!defaultValue) {
+          throw new Error('Expected default value.');
+        }
+
+        return defaultValue;
+      },
+      text: async () => 'starter-app',
+      ...overrides,
+    };
+  }
+
+  it('collects the application wizard path without terminal emulation', async () => {
+    const prompt = createPrompt({
+      confirm: async (_message, defaultValue) => defaultValue,
+      select: async <T extends string>(message: string, _choices: readonly { label: string; value: T }[], defaultValue?: T) => {
+        if (message === 'Starter shape') {
+          return 'application' as T;
+        }
+
+        return (defaultValue ?? 'pnpm') as T;
+      },
+    });
+
+    await expect(collectBootstrapAnswers({}, process.cwd(), undefined, { interactive: true, prompt })).resolves.toEqual({
+      initializeGit: false,
+      installDependencies: true,
+      packageManager: 'pnpm',
+      ...DEFAULT_BOOTSTRAP_SCHEMA,
+      projectName: 'starter-app',
+      targetDirectory: './starter-app',
+    });
+  });
+
+  it('branches through the microservice transport wizard path', async () => {
+    const prompt = createPrompt({
+      confirm: async (_message, defaultValue) => defaultValue,
+      select: async <T extends string>(message: string, _choices: readonly { label: string; value: T }[], defaultValue?: T) => {
+        if (message === 'Starter shape') {
+          return 'microservice' as T;
+        }
+
+        if (message === 'Microservice transport') {
+          return 'kafka' as T;
+        }
+
+        return (defaultValue ?? 'pnpm') as T;
+      },
+    });
+
+    await expect(collectBootstrapAnswers({}, process.cwd(), undefined, { interactive: true, prompt })).resolves.toEqual({
+      initializeGit: false,
+      installDependencies: true,
+      packageManager: 'pnpm',
+      platform: 'none',
+      runtime: 'node',
+      shape: 'microservice',
+      tooling: 'standard',
+      topology: {
+        deferred: true,
+        mode: 'single-package',
+      },
+      transport: 'kafka',
       projectName: 'starter-app',
       targetDirectory: './starter-app',
     });

--- a/packages/cli/src/new/prompt.ts
+++ b/packages/cli/src/new/prompt.ts
@@ -1,10 +1,193 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import { createInterface } from 'node:readline/promises';
 
 import { resolveBootstrapSchema } from './resolver.js';
 import type { BootstrapAnswers, PackageManager } from './types.js';
 
+/** Default package manager used when detection has no signal. */
 export const DEFAULT_PACKAGE_MANAGER: PackageManager = 'pnpm';
+const DEFAULT_INSTALL_DEPENDENCIES = true;
+const DEFAULT_INITIALIZE_GIT = false;
+const MICROSERVICE_TRANSPORTS = ['tcp', 'redis', 'redis-streams', 'nats', 'kafka', 'rabbitmq', 'mqtt', 'grpc'] as const;
+
+type WritableStream = {
+  write(message: string): unknown;
+};
+
+type ReadableStream = {
+  isTTY?: boolean;
+};
+
+type PromptChoice<T extends string> = {
+  label: string;
+  value: T;
+};
+
+/** Prompt contract used by the interactive `fluo new` wizard. */
+export interface BootstrapPrompter {
+  close?(): void;
+  confirm(message: string, defaultValue: boolean): Promise<boolean>;
+  select<T extends string>(message: string, choices: readonly PromptChoice<T>[], defaultValue?: T): Promise<T>;
+  text(message: string): Promise<string>;
+}
+
+/** Runtime overrides for resolving bootstrap answers in tests and editors. */
+export interface ResolveBootstrapAnswersOptions {
+  interactive?: boolean;
+  prompt?: BootstrapPrompter;
+  stdin?: ReadableStream;
+  stdout?: WritableStream;
+}
+
+function hasOwnValue<Key extends keyof BootstrapAnswers>(
+  partial: Partial<BootstrapAnswers>,
+  key: Key,
+): partial is Partial<BootstrapAnswers> & Required<Pick<BootstrapAnswers, Key>> {
+  return partial[key] !== undefined;
+}
+
+function createBootstrapPrompter(
+  stdin: NodeJS.ReadStream = process.stdin,
+  stdout: NodeJS.WriteStream = process.stdout,
+): BootstrapPrompter {
+  const readline = createInterface({ input: stdin, output: stdout });
+  const ask = async (message: string): Promise<string> => readline.question(message);
+
+  return {
+    close(): void {
+      readline.close();
+    },
+    async confirm(message: string, defaultValue: boolean): Promise<boolean> {
+      const suffix = defaultValue ? 'Y/n' : 'y/N';
+
+      while (true) {
+        const answer = (await ask(`${message} (${suffix}): `)).trim().toLowerCase();
+
+        if (answer.length === 0) {
+          return defaultValue;
+        }
+
+        if (['y', 'yes'].includes(answer)) {
+          return true;
+        }
+
+        if (['n', 'no'].includes(answer)) {
+          return false;
+        }
+
+        stdout.write('Please answer yes or no.\n');
+      }
+    },
+    async select<T extends string>(message: string, choices: readonly PromptChoice<T>[], defaultValue?: T): Promise<T> {
+      const lines = [message];
+
+      for (const [index, choice] of choices.entries()) {
+        const marker = choice.value === defaultValue ? ' (default)' : '';
+        lines.push(`  ${index + 1}. ${choice.label}${marker}`);
+      }
+
+      while (true) {
+        const answer = (await ask(`${lines.join('\n')}\n> `)).trim();
+
+        if (answer.length === 0 && defaultValue) {
+          return defaultValue;
+        }
+
+        const asIndex = Number(answer);
+        if (Number.isInteger(asIndex) && asIndex >= 1 && asIndex <= choices.length) {
+          return choices[asIndex - 1]!.value;
+        }
+
+        const exactMatch = choices.find((choice) => choice.value === answer);
+        if (exactMatch) {
+          return exactMatch.value;
+        }
+
+        stdout.write('Select one of the listed options.\n');
+      }
+    },
+    async text(message: string): Promise<string> {
+      return ask(`${message}: `);
+    },
+  };
+}
+
+function shouldPromptForAnswers(
+  partial: Partial<BootstrapAnswers>,
+  interactive: boolean,
+): boolean {
+  return interactive && (
+    !hasOwnValue(partial, 'projectName')
+    || !hasOwnValue(partial, 'shape')
+    || !hasOwnValue(partial, 'tooling')
+    || !hasOwnValue(partial, 'packageManager')
+    || !hasOwnValue(partial, 'installDependencies')
+    || !hasOwnValue(partial, 'initializeGit')
+    || (partial.shape === 'application' && !hasOwnValue(partial, 'runtime'))
+    || (partial.shape === 'microservice' && !hasOwnValue(partial, 'transport'))
+  );
+}
+
+async function resolveInteractiveBootstrapAnswers(
+  partial: Partial<BootstrapAnswers>,
+  cwd: string,
+  userAgent: string | undefined,
+  prompt: BootstrapPrompter,
+): Promise<BootstrapAnswers> {
+  const answers: Partial<BootstrapAnswers> = { ...partial };
+  const detectedPackageManager = detectPackageManager(cwd, userAgent);
+
+  if (!answers.projectName) {
+    answers.projectName = assertValidProjectName(await prompt.text('Project name'));
+  }
+
+  if (!answers.shape) {
+    answers.shape = await prompt.select('Starter shape', [
+      { label: 'Application (HTTP starter)', value: 'application' },
+      { label: 'Microservice (transport-first starter)', value: 'microservice' },
+    ] as const, 'application');
+  }
+
+  if (answers.shape === 'application' && !answers.runtime) {
+    answers.runtime = await prompt.select('Runtime', [
+      { label: 'Node.js', value: 'node' },
+    ] as const, 'node');
+  }
+
+  if (answers.shape === 'microservice' && !answers.transport) {
+    answers.transport = await prompt.select(
+      'Microservice transport',
+      MICROSERVICE_TRANSPORTS.map((transport) => ({ label: transport, value: transport })),
+      'tcp',
+    ) as BootstrapAnswers['transport'];
+  }
+
+  if (!answers.tooling) {
+    answers.tooling = await prompt.select('Tooling preset', [
+      { label: 'standard', value: 'standard' },
+    ] as const, 'standard');
+  }
+
+  if (!answers.packageManager) {
+    answers.packageManager = await prompt.select('Package manager', [
+      { label: 'pnpm', value: 'pnpm' },
+      { label: 'npm', value: 'npm' },
+      { label: 'yarn', value: 'yarn' },
+      { label: 'bun', value: 'bun' },
+    ] as const, detectedPackageManager);
+  }
+
+  if (!hasOwnValue(answers, 'installDependencies')) {
+    answers.installDependencies = await prompt.confirm('Install dependencies now', DEFAULT_INSTALL_DEPENDENCIES);
+  }
+
+  if (!hasOwnValue(answers, 'initializeGit')) {
+    answers.initializeGit = await prompt.confirm('Initialize a git repository', DEFAULT_INITIALIZE_GIT);
+  }
+
+  return resolveBootstrapAnswers(answers, cwd, userAgent);
+}
 
 function assertValidProjectName(projectName: string): string {
   const trimmed = projectName.trim();
@@ -87,7 +270,6 @@ function detectFromDirectory(startDirectory: string): PackageManager | undefined
     }
 
     const parentDirectory = dirname(currentDirectory);
-
     if (parentDirectory === currentDirectory) {
       return undefined;
     }
@@ -96,6 +278,13 @@ function detectFromDirectory(startDirectory: string): PackageManager | undefined
   }
 }
 
+/**
+ * Detects the package manager that should back the generated starter.
+ *
+ * @param startDirectory Directory used for lockfile and manifest discovery.
+ * @param userAgent Optional package-manager user agent from the caller.
+ * @returns The detected package manager, or the repo default when no signal exists.
+ */
 export function detectPackageManager(
   startDirectory: string,
   userAgent?: string,
@@ -105,6 +294,14 @@ export function detectPackageManager(
     ?? DEFAULT_PACKAGE_MANAGER;
 }
 
+/**
+ * Resolves partial bootstrap selections onto the shared answer model.
+ *
+ * @param partial Partial bootstrap selections collected from flags or runtime callers.
+ * @param cwd Working directory used for package-manager detection.
+ * @param userAgent Optional package-manager user agent from the caller.
+ * @returns Fully resolved bootstrap answers with defaults applied.
+ */
 export function resolveBootstrapAnswers(
   partial: Partial<BootstrapAnswers>,
   cwd: string,
@@ -118,9 +315,45 @@ export function resolveBootstrapAnswers(
   const schema = resolveBootstrapSchema(partial);
 
   return {
+    initializeGit: partial.initializeGit ?? DEFAULT_INITIALIZE_GIT,
+    installDependencies: partial.installDependencies ?? DEFAULT_INSTALL_DEPENDENCIES,
     packageManager: partial.packageManager ?? detectPackageManager(cwd, userAgent),
     ...schema,
     projectName,
     targetDirectory: partial.targetDirectory ?? `./${projectName}`,
   };
+}
+
+/**
+ * Collects bootstrap answers through the interactive wizard when needed.
+ *
+ * @param partial Partial bootstrap selections collected from flags or runtime callers.
+ * @param cwd Working directory used for package-manager detection.
+ * @param userAgent Optional package-manager user agent from the caller.
+ * @param options Runtime overrides for interactive prompting.
+ * @returns Fully resolved bootstrap answers for scaffolding.
+ */
+export async function collectBootstrapAnswers(
+  partial: Partial<BootstrapAnswers>,
+  cwd: string,
+  userAgent?: string,
+  options: ResolveBootstrapAnswersOptions = {},
+): Promise<BootstrapAnswers> {
+  const interactive = options.interactive
+    ?? (options.prompt !== undefined || Boolean(options.stdin?.isTTY ?? process.stdin.isTTY));
+
+  if (!shouldPromptForAnswers(partial, interactive)) {
+    return resolveBootstrapAnswers(partial, cwd, userAgent);
+  }
+
+  const prompt = options.prompt ?? createBootstrapPrompter(
+    options.stdin as NodeJS.ReadStream | undefined,
+    options.stdout as NodeJS.WriteStream | undefined,
+  );
+
+  try {
+    return await resolveInteractiveBootstrapAnswers(partial, cwd, userAgent, prompt);
+  } finally {
+    prompt.close?.();
+  }
 }

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -152,4 +152,21 @@ describe('scaffoldBootstrapApp', () => {
     expect(mainFile).toContain('FluoFactory.createMicroservice(AppModule)');
     expect(appTestFile).toContain('InMemoryLoopbackTransport');
   });
+
+  it('can initialize git while skipping dependency installation', async () => {
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-scaffold-git-'));
+    temporaryDirectories.push(targetDirectory);
+
+    await scaffoldBootstrapApp({
+      ...DEFAULT_BOOTSTRAP_SCHEMA,
+      initializeGit: true,
+      installDependencies: false,
+      packageManager: 'pnpm',
+      projectName: 'starter-app',
+      targetDirectory,
+    });
+
+    expect(statSync(join(targetDirectory, '.git')).isDirectory()).toBe(true);
+    expect(readFileSync(join(targetDirectory, 'package.json'), 'utf8')).toContain('"name": "starter-app"');
+  });
 });

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { installDependencies } from './install.js';
+import { initializeGitRepository, installDependencies } from './install.js';
 import { resolveBootstrapPlan, type ResolvedBootstrapPlan } from './resolver.js';
 import type { BootstrapOptions, PackageManager } from './types.js';
 
@@ -853,7 +853,11 @@ export async function scaffoldBootstrapApp(
     writeTextFile(join(targetDirectory, file.path), file.content);
   }
 
-  if (!options.skipInstall) {
+  if (options.initializeGit) {
+    await initializeGitRepository(targetDirectory);
+  }
+
+  if (options.installDependencies ?? !options.skipInstall) {
     await installDependencies(targetDirectory, options.packageManager);
   }
 }

--- a/packages/cli/src/new/types.ts
+++ b/packages/cli/src/new/types.ts
@@ -1,16 +1,25 @@
+/** Supported package managers for generated starters. */
 export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn';
+/** Source for resolving starter package dependencies. */
 export type DependencySource = 'local' | 'published';
+/** Supported starter shapes for `fluo new`. */
 export type BootstrapShape = 'application' | 'microservice';
+/** Supported runtime families for the current starter matrix. */
 export type BootstrapRuntime = 'node';
+/** Supported platform adapters for the current starter matrix. */
 export type BootstrapPlatform = 'fastify' | 'none';
+/** Supported transport families for the current starter matrix. */
 export type BootstrapTransport = 'grpc' | 'http' | 'kafka' | 'mqtt' | 'nats' | 'rabbitmq' | 'redis' | 'redis-streams' | 'tcp';
+/** Supported tooling presets for the current starter matrix. */
 export type BootstrapToolingPreset = 'standard';
 
+/** Topology settings for the generated starter layout. */
 export interface BootstrapTopology {
   deferred: boolean;
   mode: 'single-package';
 }
 
+/** Shape-first scaffold schema resolved before file generation. */
 export interface BootstrapSchema {
   platform: BootstrapPlatform;
   runtime: BootstrapRuntime;
@@ -20,9 +29,12 @@ export interface BootstrapSchema {
   transport: BootstrapTransport;
 }
 
+/** Full scaffold options used by the file emitter and post-write steps. */
 export interface BootstrapOptions extends BootstrapSchema {
   dependencySource?: DependencySource;
   force?: boolean;
+  initializeGit?: boolean;
+  installDependencies?: boolean;
   packageManager: PackageManager;
   projectName: string;
   repoRoot?: string;
@@ -30,20 +42,27 @@ export interface BootstrapOptions extends BootstrapSchema {
   targetDirectory: string;
 }
 
+/** Prompt descriptor for bootstrap answer collection. */
 export interface BootstrapPrompt {
   key: keyof BootstrapAnswers;
   label: string;
 }
 
+/** Resolved answers shared by flag-driven, interactive, and programmatic flows. */
 export interface BootstrapAnswers extends BootstrapSchema {
+  initializeGit: boolean;
+  installDependencies: boolean;
   packageManager: PackageManager;
   projectName: string;
   targetDirectory: string;
 }
 
+/** Programmatic overrides for `runNewCommand(...)`. */
 export interface NewCommandOptions {
   dependencySource?: DependencySource;
   force?: boolean;
+  initializeGit?: boolean;
+  installDependencies?: boolean;
   repoRoot?: string;
   skipInstall?: boolean;
 }


### PR DESCRIPTION
## Summary
- add an interactive v2 `fluo new` wizard that layers on top of the existing flags/config answer model instead of replacing it
- carry install/git choices through the shared bootstrap pipeline so non-interactive and programmatic callers keep the same first-class resolution path
- cover the wizard with injected-answer tests and document the new behavioral contract in the CLI README mirrors

## Changes
- added interactive answer collection with shape-first branching for application/runtime vs microservice/transport flows
- added shared install and git initialization choices to bootstrap answers, scaffold execution, and CLI flags/runtime overrides
- expanded CLI/package tests to verify wizard branching, git initialization, skipped installs, and non-interactive behavior

## Testing
- pnpm build
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm exec vitest run src/new/prompt.test.ts src/new/scaffold.test.ts src/cli.test.ts -c vitest.config.ts
- pnpm verify:public-export-tsdoc

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Closes #982