### PR TITLE
Resolve #992: clarify fluo new starter support matrix

### DIFF
--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -46,6 +46,7 @@ fluo의 설계 철학과 그 이면의 "왜"와 "어떻게"를 이해합니다.
 심층적인 기술 명세 및 비교 자료입니다.
 
 - **[패키지 선택 가이드](./reference/package-chooser.ko.md)**: 특정 작업에 적합한 도구 찾기.
+- **[fluo new 지원 매트릭스](./reference/fluo-new-support-matrix.ko.md)**: 현재 스타터 계약과 더 넓게 문서화된 런타임/어댑터 생태계의 구분.
 - **[API 요약](./reference/package-surface.ko.md)**: 공개 패키지 패밀리, 런타임 범위, 패키지 책임을 정리한 기준 인벤토리.
 - **[호환성 매트릭스](./reference/toolchain-contract-matrix.ko.md)**: 버전, 런타임, 플랫폼 지원 현황.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Practical, task-oriented documentation for day-to-day development.
 Detailed technical specifications and comparisons.
 
 - **[Package Chooser](./reference/package-chooser.md)**: Find the right tools for your specific task.
+- **[fluo new Support Matrix](./reference/fluo-new-support-matrix.md)**: The current starter contract versus the broader documented runtime/adapter ecosystem.
 - **[API Surface Overview](./reference/package-surface.md)**: The canonical inventory of public package families, runtime coverage, and package responsibilities.
 - **[Compatibility Matrix](./reference/toolchain-contract-matrix.md)**: Versions, runtimes, and platform support.
 

--- a/docs/getting-started/bootstrap-paths.ko.md
+++ b/docs/getting-started/bootstrap-paths.ko.md
@@ -4,6 +4,8 @@
 
 fluo는 **런타임에 구애받지 않는 코어(Runtime-agnostic core)**를 기반으로 설계되었습니다. 즉, 비즈니스 로직을 한 번만 작성하면 전용 플랫폼 어댑터를 통해 TypeScript가 실행 가능한 거의 모든 환경에 배포할 수 있습니다.
 
+> 이 페이지는 부트스트랩 이후의 더 넓은 어댑터 생태계를 설명합니다. 현재 `fluo new`가 정확히 어떤 스타터를 스캐폴딩하는지는 [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md)를 확인하세요.
+
 ### 대상 독자
 로컬 Fastify 스타터를 넘어 Bun, Deno, 또는 Edge 함수와 같은 특정 환경을 타겟팅해야 하는 개발자.
 
@@ -36,6 +38,8 @@ Node.js 이외의 환경을 타겟팅하시나요? 어댑터만 교체하고 코
 - **Cloudflare Workers (`@fluojs/platform-cloudflare-workers`)**: Workers 환경 및 KV/Durable Objects와 통합됩니다.
 
 ### 런타임 선택 가이드
+아래 표는 어댑터 생태계 가이드이며, 현재 `fluo new` 스타터 프리셋 목록이 아닙니다.
+
 | 어댑터 | 패키지 | 최적의 용도 |
 | :--- | :--- | :--- |
 | **Fastify** | `@fluojs/platform-fastify` | 프로덕션급 Node.js 앱 (기본 선택). |
@@ -46,4 +50,5 @@ Node.js 이외의 환경을 타겟팅하시나요? 어댑터만 교체하고 코
 
 ### 다음 단계
 - **CLI 마스터하기**: [제너레이터 워크플로우](./generator-workflow.ko.md)가 모든 런타임에서 어떻게 동작하는지 확인해 보세요.
+- **현재 스타터 현실 먼저 확인하기**: 어떤 어댑터가 이미 스타터 프리셋인지 추정하기 전에 [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md)를 검토하세요.
 - **심화 탐구**: 사용 가능한 어댑터와 그 기능을 한눈에 보려면 [패키지 목록](../reference/package-surface.ko.md)을 참조하세요.

--- a/docs/getting-started/bootstrap-paths.md
+++ b/docs/getting-started/bootstrap-paths.md
@@ -4,6 +4,8 @@
 
 fluo is built on a **runtime-agnostic core**. This means you can write your business logic once and deploy it to virtually any TypeScript-capable environment using dedicated platform adapters.
 
+> This page describes the broader adapter ecosystem after bootstrapping. For the exact starter choices that `fluo new` scaffolds today, see the [fluo new support matrix](../reference/fluo-new-support-matrix.md).
+
 ### who this is for
 Developers moving beyond the local Fastify starter who need to target specific environments like Bun, Deno, or Edge functions.
 
@@ -36,6 +38,8 @@ For "zero-cold-start" environments, fluo provides specialized adapters that hand
 - **Cloudflare Workers (`@fluojs/platform-cloudflare-workers`)**: Integrated with the Workers environment and KV/Durable Objects.
 
 ### choosing your runtime
+The table below is an adapter ecosystem guide, not a list of current `fluo new` starter presets.
+
 | adapter | package | best for |
 | :--- | :--- | :--- |
 | **Fastify** | `@fluojs/platform-fastify` | Production-grade Node.js apps, default choice. |
@@ -46,4 +50,5 @@ For "zero-cold-start" environments, fluo provides specialized adapters that hand
 
 ### next steps
 - **Master the CLI**: See how the [Generator Workflow](./generator-workflow.md) works across all runtimes.
+- **Check starter reality first**: Review the [fluo new support matrix](../reference/fluo-new-support-matrix.md) before assuming an adapter already has a starter preset.
 - **Deep Dive**: Read the [Package Surface](../reference/package-surface.md) for a full matrix of available adapters and their capabilities.

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -50,6 +50,8 @@ export class UsersService {
 ### 4. 어댑터 우선 팩토리
 부트스트랩 과정은 비슷해 보이지만, fluo는 팩토리 호출 시 플랫폼 선택(Fastify, Express 등)을 명시적인 과정으로 만듭니다.
 
+다만 이런 더 넓은 어댑터 선택 가능성이 문서에 있는 모든 플랫폼이 이미 `fluo new`에 연결되어 있다는 뜻은 아닙니다. 현재 스타터 계약은 [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md)를 기준으로 보세요.
+
 **NestJS:**
 ```ts
 const app = await NestFactory.create(AppModule);
@@ -70,4 +72,5 @@ const app = await fluoFactory.create(AppModule, createFastifyAdapter());
 
 ### 다음 단계
 - **새롭게 시작하기**: [퀵 스타트](./quick-start.ko.md)를 통해 깨끗한 fluo 프로젝트를 확인해 보세요.
+- **현재 스타터 범위 확인하기**: 어떤 어댑터가 이미 스타터 프리셋인지 가정하기 전에 [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md)를 확인하세요.
 - **그래프 이해하기**: 명시적 주입에 대해 더 자세히 알고 싶다면 [DI와 모듈](../concepts/di-and-modules.ko.md)을 읽어보세요.

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -50,6 +50,8 @@ export class UsersService {
 ### 4. adapter-first factory
 Bootstrap feels similar, but fluo makes the platform choice (Fastify, Express, etc.) an explicit part of the factory call.
 
+That broader adapter choice does **not** mean every documented platform is already wired into `fluo new`. For the current starter contract, see the [fluo new support matrix](../reference/fluo-new-support-matrix.md).
+
 **NestJS:**
 ```ts
 const app = await NestFactory.create(AppModule);
@@ -70,4 +72,5 @@ const app = await fluoFactory.create(AppModule, createFastifyAdapter());
 
 ### next steps
 - **Start Fresh**: Use the [Quick Start](./quick-start.md) to see a clean fluo project.
+- **Check starter coverage**: Review the [fluo new support matrix](../reference/fluo-new-support-matrix.md) before assuming an adapter already has a starter preset.
 - **Learn the Graph**: Read [DI and Modules](../concepts/di-and-modules.md) for a deep dive into explicit injection.

--- a/docs/getting-started/quick-start.ko.md
+++ b/docs/getting-started/quick-start.ko.md
@@ -38,6 +38,8 @@ fluo new my-fluo-microservice --shape microservice --transport tcp --runtime nod
 fluo new my-fluo-mixed --shape mixed --transport tcp --runtime node --platform fastify
 ```
 
+이 공개 스타터 경로와 더 넓은 Express/Bun/Deno/Cloudflare 생태계를 문서 수준에서 구분해 보려면 [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md)를 확인하세요.
+
 `fluo new`가 interactive terminal에서 실행되면, wizard도 이와 동일한 shape-first 모델로 수렴합니다. wizard는 프로젝트 이름, starter shape, 유지보수되는 tooling preset, package manager, dependency 설치 여부, git 초기화 여부를 묻습니다.
 
 ### 3. 개발 시작

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -38,6 +38,8 @@ fluo new my-fluo-microservice --shape microservice --transport tcp --runtime nod
 fluo new my-fluo-mixed --shape mixed --transport tcp --runtime node --platform fastify
 ```
 
+For a docs-level split between these published starter paths and the broader Express/Bun/Deno/Cloudflare ecosystem, see the [fluo new support matrix](../reference/fluo-new-support-matrix.md).
+
 When `fluo new` runs in an interactive terminal, the wizard resolves onto this same shape-first model. It asks for the project name, starter shape, the maintained tooling preset, package manager, whether to install dependencies, and whether to initialize git.
 
 ### 3. start development

--- a/docs/reference/fluo-new-support-matrix.ko.md
+++ b/docs/reference/fluo-new-support-matrix.ko.md
@@ -1,0 +1,26 @@
+# fluo new 지원 매트릭스
+
+<p><a href="./fluo-new-support-matrix.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
+
+이 페이지는 현재 `fluo new`가 실제로 스캐폴딩하는 범위와, fluo가 다른 문서에서 설명하는 더 넓은 런타임/어댑터 생태계를 구분하기 위한 기준 문서입니다.
+
+## 현재 스타터 범위 vs 더 넓은 생태계 지원
+
+| 표면 | 현재 상태 | `fluo new`에 실제로 연결된 항목 | 다음 단계 |
+| --- | --- | --- | --- |
+| **애플리케이션 스타터** | **지금 스캐폴딩됨** | `fluo new my-app` 또는 `--shape application --transport http --runtime node --platform fastify`로 생성되는 Node.js + Fastify + HTTP | 이것이 현재 기본 스타터 기준선입니다. |
+| **마이크로서비스 스타터** | **지금 스캐폴딩됨** | `--shape microservice --transport tcp --runtime node --platform none`으로 생성되는 Node.js + 비HTTP 플랫폼 + TCP | 추가 transport 계열은 별도 문서에 있지만, `new`가 실제로 생성하는 runnable starter는 현재 TCP입니다. |
+| **mixed 스타터** | **지금 스캐폴딩됨** | `--shape mixed --transport tcp --runtime node --platform fastify`로 생성되는 Node.js + Fastify HTTP 앱 + 연결된 TCP microservice | 이것이 현재 공개된 유일한 mixed starter 변형입니다. |
+| **더 넓은 어댑터/런타임 생태계** | **문서화됨, 아직 `fluo new`에는 연결되지 않음** | `@fluojs/platform-express`, `@fluojs/platform-nodejs`, `@fluojs/platform-bun`, `@fluojs/platform-deno`, `@fluojs/platform-cloudflare-workers`는 실제 패키지/런타임 경로이지만 현재 `fluo new` 스타터 선택지는 아닙니다. | 스캐폴딩 이후나 수동 구성에서 이 경로를 채택하려면 아래 런타임/패키지 문서를 사용하세요. |
+
+## 다른 문서를 읽는 방법
+
+- `fluo new` 문서는 스타터 계약으로 읽고, 문서화된 모든 어댑터가 이미 스타터 프리셋을 가진다고 해석하지 마세요.
+- 런타임/패키지 참조 문서는 현재 스타터 매트릭스 밖에서 채택 가능한 어댑터, 플랫폼, 배포 대상을 설명하는 더 넓은 생태계 지도입니다.
+- 어떤 페이지가 Express, Bun, Deno, Cloudflare Workers를 언급하더라도, 위의 세 스타터 행으로 명시적으로 되돌아오지 않는 한 이는 생태계 지원을 뜻합니다.
+
+## 기준 출처
+
+- `packages/cli/src/new/resolver.ts`는 현재 스캐폴딩되는 `fluo new` 매트릭스의 기준 소스입니다.
+- [Package Surface](./package-surface.ko.md#canonical-runtime-package-matrix)는 더 넓은 런타임/패키지 생태계의 기준 소스입니다.
+- [Bootstrap Paths](../getting-started/bootstrap-paths.ko.md), [Package Chooser](./package-chooser.ko.md), [NestJS에서 마이그레이션하기](../getting-started/migrate-from-nestjs.ko.md)는 아직 스타터 프리셋이 아닌 어댑터를 다룰 때 이 문서로 연결되어야 합니다.

--- a/docs/reference/fluo-new-support-matrix.md
+++ b/docs/reference/fluo-new-support-matrix.md
@@ -1,0 +1,26 @@
+# fluo new support matrix
+
+<p><strong><kbd>English</kbd></strong> <a href="./fluo-new-support-matrix.ko.md"><kbd>한국어</kbd></a></p>
+
+Use this page to distinguish what `fluo new` scaffolds today from the broader runtime and adapter ecosystem that fluo documents elsewhere.
+
+## current starter coverage vs broader ecosystem support
+
+| surface | status today | what is wired into `fluo new` | where to go next |
+| --- | --- | --- | --- |
+| **Application starter** | **Scaffolded now** | Node.js + Fastify + HTTP via `fluo new my-app` or `--shape application --transport http --runtime node --platform fastify` | This is the default starter baseline today. |
+| **Microservice starter** | **Scaffolded now** | Node.js + no HTTP platform + TCP via `--shape microservice --transport tcp --runtime node --platform none` | Additional transport families are documented separately, but the runnable starter emitted by `new` is TCP today. |
+| **Mixed starter** | **Scaffolded now** | Node.js + Fastify HTTP app + attached TCP microservice via `--shape mixed --transport tcp --runtime node --platform fastify` | This is the only published mixed starter variant today. |
+| **Broader adapter/runtime ecosystem** | **Documented, not wired into `fluo new` yet** | `@fluojs/platform-express`, `@fluojs/platform-nodejs`, `@fluojs/platform-bun`, `@fluojs/platform-deno`, and `@fluojs/platform-cloudflare-workers` are real package/runtime paths, but they are not current `fluo new` starter choices. | Use the runtime/package docs below to adopt these adapters after scaffolding or in hand-authored setups. |
+
+## how to read other docs
+
+- Treat `fluo new` docs as a starter contract, not as a promise that every documented adapter already has a starter preset.
+- Treat runtime and package reference docs as the broader ecosystem map for adapters, platforms, and deployment targets you can adopt outside the current starter matrix.
+- When a page mentions Express, Bun, Deno, or Cloudflare Workers, read that as ecosystem support unless it explicitly points back to one of the three starter rows above.
+
+## authoritative sources
+
+- `packages/cli/src/new/resolver.ts` is the source of truth for the currently scaffolded `fluo new` matrix.
+- [Package Surface](./package-surface.md#canonical-runtime-package-matrix) is the source of truth for the broader runtime/package ecosystem.
+- [Bootstrap Paths](../getting-started/bootstrap-paths.md), [Package Chooser](./package-chooser.md), and [Migrate from NestJS](../getting-started/migrate-from-nestjs.md) should link here whenever they discuss adapters that are not starter presets yet.

--- a/docs/reference/package-chooser.ko.md
+++ b/docs/reference/package-chooser.ko.md
@@ -4,6 +4,8 @@
 
 이 가이드를 사용하여 특정 작업에 맞는 fluo 패키지를 선택하세요. 애플리케이션 스택을 효율적으로 구축할 수 있도록 목표별로 정리되어 있습니다.
 
+> 현재 `fluo new`가 실제로 무엇을 스캐폴딩하는지 찾고 있다면 [fluo new 지원 매트릭스](./fluo-new-support-matrix.ko.md)를 확인하세요. 이 chooser는 현재 스타터 프리셋만이 아니라 더 넓은 패키지 생태계를 다룹니다.
+
 ## 새 웹 API 만들기 (Node.js)
 
 > _"Node.js에서 표준 REST 또는 GraphQL API를 만들고 싶습니다."_
@@ -14,7 +16,7 @@
 | **HTTP 라우팅** | `@fluojs/http` |
 | **GraphQL API** | `@fluojs/graphql` |
 | **Fastify (권장)** | `@fluojs/platform-fastify` |
-| **Express 호환** | `@fluojs/platform-express` |
+| **Express 호환** | `@fluojs/platform-express` *(문서화된 생태계 지원이며, 현재 `fluo new` 스타터 프리셋은 아님)* |
 | **입력 유효성 검사** | `@fluojs/validation` |
 | **설정** | `@fluojs/config` |
 
@@ -27,6 +29,8 @@
 | **Bun** | `@fluojs/platform-bun` |
 | **Deno** | `@fluojs/platform-deno` |
 | **Cloudflare Workers** | `@fluojs/platform-cloudflare-workers` |
+
+이 어댑터 행들은 스캐폴딩 이후 또는 수동 구성에서 사용할 수 있는 지원 패키지 경로를 설명합니다. Bun, Deno, Cloudflare가 현재 `fluo new` 내부 chooser 분기라는 뜻은 아닙니다.
 
 ## 영속성 및 데이터 접근 추가
 

--- a/docs/reference/package-chooser.md
+++ b/docs/reference/package-chooser.md
@@ -4,6 +4,8 @@
 
 Use this guide to select the correct fluo packages for your specific task. This page is organized by goal to help you build your application stack efficiently.
 
+> Looking for what `fluo new` actually scaffolds today? See the [fluo new support matrix](./fluo-new-support-matrix.md). This chooser covers the broader package ecosystem, not just current starter presets.
+
 ## build a new web API (Node.js)
 
 > _"I want to build a standard REST or GraphQL API on Node.js."_
@@ -14,7 +16,7 @@ Use this guide to select the correct fluo packages for your specific task. This 
 | **HTTP Routing** | `@fluojs/http` |
 | **GraphQL API** | `@fluojs/graphql` |
 | **Fastify (Recommended)** | `@fluojs/platform-fastify` |
-| **Express Compatibility** | `@fluojs/platform-express` |
+| **Express Compatibility** | `@fluojs/platform-express` *(documented ecosystem support; not a current `fluo new` starter preset)* |
 | **Input Validation** | `@fluojs/validation` |
 | **Configuration** | `@fluojs/config` |
 
@@ -27,6 +29,8 @@ Use this guide to select the correct fluo packages for your specific task. This 
 | **Bun** | `@fluojs/platform-bun` |
 | **Deno** | `@fluojs/platform-deno` |
 | **Cloudflare Workers** | `@fluojs/platform-cloudflare-workers` |
+
+These adapter rows describe supported package paths after scaffolding or in hand-authored setups. They do **not** mean that Bun, Deno, or Cloudflare are currently chooser branches inside `fluo new`.
 
 ## add persistence & data access
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -64,6 +64,8 @@ fluo new my-mixed-app --shape mixed --transport tcp --runtime node --platform fa
 
 `fluo new`가 interactive TTY에서 실행되면, 이제 v2 wizard가 기존 flags/config 모델 위에 그대로 얹혀 동작합니다. wizard는 프로젝트 이름, shape-first 분기(`application` -> runtime, `microservice` -> transport), 유지보수 가능한 tooling preset, package manager, 즉시 dependency를 설치할지 여부, git 저장소를 초기화할지 여부를 묻습니다. 반면 non-interactive 플래그 경로와 프로그래밍 방식의 `runNewCommand(...)` 호출은 동일한 resolved defaults를 유지하는 first-class path로 계속 동작합니다.
 
+이 스타터 경로와 더 넓은 Express/Bun/Deno/Cloudflare 어댑터 생태계를 문서 수준에서 구분한 표는 [fluo new 지원 매트릭스](../../docs/reference/fluo-new-support-matrix.ko.md)를 확인하세요.
+
 ### 2. 기능 추가
 컨트롤러와 서비스가 포함된 새 리소스를 추가하고, 모듈에 자동으로 연결합니다.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,6 +64,8 @@ fluo new my-mixed-app --shape mixed --transport tcp --runtime node --platform fa
 
 When `fluo new` runs in an interactive TTY, the v2 wizard now layers on top of the same flags/config model instead of replacing it. The wizard asks for the project name, shape-first branch (`application` -> runtime, `microservice` -> transport), the maintained tooling preset, package-manager choice, whether to install dependencies immediately, and whether to initialize a git repository. Non-interactive flags and programmatic `runNewCommand(...)` calls still stay first-class paths with the same resolved defaults.
 
+For a docs-level table that separates these starter paths from the broader Express/Bun/Deno/Cloudflare adapter ecosystem, see the [fluo new support matrix](../../docs/reference/fluo-new-support-matrix.md).
+
 ### 2. Generate a feature
 Add a new resource with a controller and service, automatically wired into the module.
 

--- a/packages/cli/src/runtime-matrix-docs-contract.test.ts
+++ b/packages/cli/src/runtime-matrix-docs-contract.test.ts
@@ -36,6 +36,41 @@ describe('runtime matrix docs contract', () => {
     expect(read('packages/cli/README.ko.md')).toContain('../../docs/reference/package-surface.ko.md');
   });
 
+  it('publishes a clear fluo new support matrix and keeps linked docs aligned to it', () => {
+    expectAll(read('docs/reference/fluo-new-support-matrix.md'), [
+      'Application starter',
+      'Microservice starter',
+      'Mixed starter',
+      'Documented, not wired into `fluo new` yet',
+      '@fluojs/platform-express',
+      '@fluojs/platform-bun',
+      '@fluojs/platform-deno',
+      '@fluojs/platform-cloudflare-workers',
+    ]);
+    expectAll(read('docs/reference/fluo-new-support-matrix.ko.md'), [
+      '애플리케이션 스타터',
+      '마이크로서비스 스타터',
+      'mixed 스타터',
+      '문서화됨, 아직 `fluo new`에는 연결되지 않음',
+      '@fluojs/platform-express',
+      '@fluojs/platform-bun',
+      '@fluojs/platform-deno',
+      '@fluojs/platform-cloudflare-workers',
+    ]);
+    expect(read('docs/README.md')).toContain('./reference/fluo-new-support-matrix.md');
+    expect(read('docs/README.ko.md')).toContain('./reference/fluo-new-support-matrix.ko.md');
+    expect(read('docs/reference/package-chooser.md')).toContain('./fluo-new-support-matrix.md');
+    expect(read('docs/reference/package-chooser.ko.md')).toContain('./fluo-new-support-matrix.ko.md');
+    expect(read('docs/getting-started/quick-start.md')).toContain('../reference/fluo-new-support-matrix.md');
+    expect(read('docs/getting-started/quick-start.ko.md')).toContain('../reference/fluo-new-support-matrix.ko.md');
+    expect(read('docs/getting-started/bootstrap-paths.md')).toContain('../reference/fluo-new-support-matrix.md');
+    expect(read('docs/getting-started/bootstrap-paths.ko.md')).toContain('../reference/fluo-new-support-matrix.ko.md');
+    expect(read('docs/getting-started/migrate-from-nestjs.md')).toContain('../reference/fluo-new-support-matrix.md');
+    expect(read('docs/getting-started/migrate-from-nestjs.ko.md')).toContain('../reference/fluo-new-support-matrix.ko.md');
+    expect(read('packages/cli/README.md')).toContain('../../docs/reference/fluo-new-support-matrix.md');
+    expect(read('packages/cli/README.ko.md')).toContain('../../docs/reference/fluo-new-support-matrix.ko.md');
+  });
+
   it('keeps toolchain docs delegating runtime matrix ownership', () => {
     expect(read('docs/reference/toolchain-contract-matrix.md')).toContain('./package-surface.md');
     expect(read('docs/reference/toolchain-contract-matrix.ko.md')).toContain('./package-surface.ko.md');


### PR DESCRIPTION
## Summary
- add a dedicated docs-level `fluo new` support matrix that separates current starter coverage from the broader runtime/adapter ecosystem
- update chooser/getting-started/CLI docs in English and Korean so Express/Bun/Deno/Cloudflare do not read like current starter presets
- extend docs-contract coverage to enforce the new matrix page and its required links

## Testing
- pnpm exec vitest run -c vitest.config.ts src/runtime-matrix-docs-contract.test.ts
- lsp diagnostics clean for `packages/cli/src/runtime-matrix-docs-contract.test.ts`

## Behavioral contract
- doc-only clarification of the current `fluo new` starter contract
- no documented runtime/package support removed; broader ecosystem support remains documented separately from starter coverage

Closes #992