### PR TITLE
Resolve #995: add starter profile registry for fluo new

### DIFF
--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -3,6 +3,14 @@ import { resolve } from 'node:path';
 import { renderAliasList, renderHelpTable } from '../help.js';
 import { collectBootstrapAnswers, type BootstrapPrompter } from '../new/prompt.js';
 import { scaffoldBootstrapApp } from '../new/scaffold.js';
+import {
+  SUPPORTED_BOOTSTRAP_PLATFORMS,
+  SUPPORTED_BOOTSTRAP_RUNTIMES,
+  SUPPORTED_BOOTSTRAP_SHAPES,
+  SUPPORTED_BOOTSTRAP_TOOLING_PRESETS,
+  SUPPORTED_BOOTSTRAP_TOPOLOGY_MODES,
+  SUPPORTED_BOOTSTRAP_TRANSPORTS,
+} from '../new/starter-profiles.js';
 import type { BootstrapAnswers, NewCommandOptions } from '../new/types.js';
 
 type CliStream = {
@@ -111,22 +119,12 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
 ];
 
 const SUPPORTED_PACKAGE_MANAGERS = new Set<BootstrapAnswers['packageManager']>(['bun', 'npm', 'pnpm', 'yarn']);
-const SUPPORTED_SHAPES = new Set<BootstrapAnswers['shape']>(['application', 'microservice', 'mixed']);
-const SUPPORTED_TRANSPORTS = new Set<BootstrapAnswers['transport']>([
-  'http',
-  'tcp',
-  'redis',
-  'redis-streams',
-  'nats',
-  'kafka',
-  'rabbitmq',
-  'mqtt',
-  'grpc',
-]);
-const SUPPORTED_RUNTIMES = new Set<BootstrapAnswers['runtime']>(['node']);
-const SUPPORTED_PLATFORMS = new Set<BootstrapAnswers['platform']>(['fastify', 'none']);
-const SUPPORTED_TOOLING_PRESETS = new Set<BootstrapAnswers['tooling']>(['standard']);
-const SUPPORTED_TOPOLOGY_MODES = new Set<BootstrapAnswers['topology']['mode']>(['single-package']);
+const SUPPORTED_SHAPES = new Set<BootstrapAnswers['shape']>(SUPPORTED_BOOTSTRAP_SHAPES);
+const SUPPORTED_TRANSPORTS = new Set<BootstrapAnswers['transport']>(SUPPORTED_BOOTSTRAP_TRANSPORTS);
+const SUPPORTED_RUNTIMES = new Set<BootstrapAnswers['runtime']>(SUPPORTED_BOOTSTRAP_RUNTIMES);
+const SUPPORTED_PLATFORMS = new Set<BootstrapAnswers['platform']>(SUPPORTED_BOOTSTRAP_PLATFORMS);
+const SUPPORTED_TOOLING_PRESETS = new Set<BootstrapAnswers['tooling']>(SUPPORTED_BOOTSTRAP_TOOLING_PRESETS);
+const SUPPORTED_TOPOLOGY_MODES = new Set<BootstrapAnswers['topology']['mode']>(SUPPORTED_BOOTSTRAP_TOPOLOGY_MODES);
 
 function readOptionValue(
   argv: string[],

--- a/packages/cli/src/new/prompt.ts
+++ b/packages/cli/src/new/prompt.ts
@@ -3,13 +3,13 @@ import { dirname, join, resolve } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 
 import { resolveBootstrapSchema } from './resolver.js';
+import { DOCUMENTED_MICROSERVICE_TRANSPORTS, STARTER_PROFILE_REGISTRY } from './starter-profiles.js';
 import type { BootstrapAnswers, PackageManager } from './types.js';
 
 /** Default package manager used when detection has no signal. */
 export const DEFAULT_PACKAGE_MANAGER: PackageManager = 'pnpm';
 const DEFAULT_INSTALL_DEPENDENCIES = true;
 const DEFAULT_INITIALIZE_GIT = false;
-const MICROSERVICE_TRANSPORTS = ['tcp', 'redis', 'redis-streams', 'nats', 'kafka', 'rabbitmq', 'mqtt', 'grpc'] as const;
 
 type WritableStream = {
   write(message: string): unknown;
@@ -144,9 +144,10 @@ async function resolveInteractiveBootstrapAnswers(
 
   if (!answers.shape) {
     answers.shape = await prompt.select('Starter shape', [
-      { label: 'Application (HTTP starter)', value: 'application' },
-      { label: 'Microservice (transport-first starter)', value: 'microservice' },
-      { label: 'Mixed (HTTP API + microservice starter)', value: 'mixed' },
+      ...STARTER_PROFILE_REGISTRY.map((profile) => ({
+        label: profile.promptLabel,
+        value: profile.schema.shape,
+      })),
     ] as const, 'application');
   }
 
@@ -159,7 +160,7 @@ async function resolveInteractiveBootstrapAnswers(
   if (answers.shape === 'microservice' && !answers.transport) {
     answers.transport = await prompt.select(
       'Microservice transport',
-      MICROSERVICE_TRANSPORTS.map((transport) => ({ label: transport, value: transport })),
+      DOCUMENTED_MICROSERVICE_TRANSPORTS.map((transport) => ({ label: transport, value: transport })),
       'tcp',
     ) as BootstrapAnswers['transport'];
   }

--- a/packages/cli/src/new/resolver.test.ts
+++ b/packages/cli/src/new/resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { DEFAULT_BOOTSTRAP_SCHEMA, resolveBootstrapPlan, resolveBootstrapSchema } from './resolver.js';
+import { STARTER_PROFILE_REGISTRY } from './starter-profiles.js';
 
 describe('resolveBootstrapSchema', () => {
   it('returns the shape-first compatibility baseline when no explicit schema is provided', () => {
@@ -37,6 +38,56 @@ describe('resolveBootstrapSchema', () => {
 });
 
 describe('resolveBootstrapPlan', () => {
+  it('locks the shipped starter registry to the current three supported matrix profiles', () => {
+    expect(STARTER_PROFILE_REGISTRY.map((profile) => ({
+      id: profile.id,
+      schema: profile.schema,
+    }))).toEqual([
+      {
+        id: 'application-node-fastify-http',
+        schema: {
+          platform: 'fastify',
+          runtime: 'node',
+          shape: 'application',
+          tooling: 'standard',
+          topology: {
+            deferred: true,
+            mode: 'single-package',
+          },
+          transport: 'http',
+        },
+      },
+      {
+        id: 'microservice-node-none-tcp',
+        schema: {
+          platform: 'none',
+          runtime: 'node',
+          shape: 'microservice',
+          tooling: 'standard',
+          topology: {
+            deferred: true,
+            mode: 'single-package',
+          },
+          transport: 'tcp',
+        },
+      },
+      {
+        id: 'mixed-node-fastify-tcp',
+        schema: {
+          platform: 'fastify',
+          runtime: 'node',
+          shape: 'mixed',
+          tooling: 'standard',
+          topology: {
+            deferred: true,
+            mode: 'single-package',
+          },
+          transport: 'tcp',
+        },
+      },
+    ]);
+  });
+
   it('keeps the current fluo new default path on the Node + Fastify HTTP starter', () => {
     expect(resolveBootstrapPlan({ packageManager: 'pnpm' as const })).toEqual({
       dependencies: {
@@ -61,6 +112,7 @@ describe('resolveBootstrapPlan', () => {
         transport: 'http',
         type: 'http',
       },
+      profile: STARTER_PROFILE_REGISTRY[0],
       schema: DEFAULT_BOOTSTRAP_SCHEMA,
     });
   });
@@ -114,6 +166,7 @@ describe('resolveBootstrapPlan', () => {
         transport: 'tcp',
         type: 'microservice',
       },
+      profile: STARTER_PROFILE_REGISTRY[1],
       schema: {
         platform: 'none',
         runtime: 'node',
@@ -156,6 +209,7 @@ describe('resolveBootstrapPlan', () => {
         transport: 'tcp',
         type: 'mixed',
       },
+      profile: STARTER_PROFILE_REGISTRY[2],
       schema: {
         platform: 'fastify',
         runtime: 'node',

--- a/packages/cli/src/new/resolver.ts
+++ b/packages/cli/src/new/resolver.ts
@@ -1,181 +1,44 @@
 import type {
   BootstrapOptions,
-  BootstrapPlatform,
-  BootstrapRuntime,
   BootstrapSchema,
   BootstrapShape,
-  BootstrapToolingPreset,
   BootstrapTopology,
-  BootstrapTransport,
 } from './types.js';
+import {
+  DOCUMENTED_MICROSERVICE_TRANSPORTS,
+  getDefaultBootstrapSchema,
+  getDefaultBootstrapSchemaForShape,
+  getStarterProfileForShape,
+  getStarterProfileFromSchema,
+  isDocumentedMicroserviceTransport,
+  SUPPORTED_BOOTSTRAP_PLATFORMS,
+  SUPPORTED_BOOTSTRAP_RUNTIMES,
+  SUPPORTED_BOOTSTRAP_SHAPES,
+  SUPPORTED_BOOTSTRAP_TOOLING_PRESETS,
+  SUPPORTED_BOOTSTRAP_TOPOLOGY_MODES,
+  SUPPORTED_BOOTSTRAP_TRANSPORTS,
+  type StarterProfile,
+} from './starter-profiles.js';
 
 type BootstrapResolutionInput = Partial<BootstrapSchema> & Pick<Partial<BootstrapOptions>, 'packageManager'>;
-
-const SHAPES: readonly BootstrapShape[] = ['application', 'microservice', 'mixed'];
-const RUNTIMES: readonly BootstrapRuntime[] = ['node'];
-const PLATFORMS: readonly BootstrapPlatform[] = ['fastify', 'none'];
-const TRANSPORTS: readonly BootstrapTransport[] = [
-  'http',
-  'tcp',
-  'redis',
-  'redis-streams',
-  'nats',
-  'kafka',
-  'rabbitmq',
-  'mqtt',
-  'grpc',
-];
-const TOOLING_PRESETS: readonly BootstrapToolingPreset[] = ['standard'];
-const TOPOLOGY_MODES: readonly BootstrapTopology['mode'][] = ['single-package'];
-const MICROSERVICE_TRANSPORTS: readonly BootstrapTransport[] = [
-  'tcp',
-  'redis',
-  'redis-streams',
-  'nats',
-  'kafka',
-  'rabbitmq',
-  'mqtt',
-  'grpc',
-];
-
-type ResolvedHttpScaffoldEmitter = {
-  platform: 'fastify';
-  preset: 'standard';
-  runtime: 'node';
-  transport: 'http';
-  type: 'http';
-};
-
-type ResolvedMicroserviceScaffoldEmitter = {
-  platform: 'none';
-  preset: 'standard';
-  runtime: 'node';
-  transport: 'tcp';
-  type: 'microservice';
-};
-
-type ResolvedMixedScaffoldEmitter = {
-  platform: 'fastify';
-  preset: 'standard';
-  runtime: 'node';
-  transport: 'tcp';
-  type: 'mixed';
- };
-
-type ResolvedBootstrapDependencies = {
-  dependencies: readonly string[];
-  devDependencies: readonly string[];
-};
-
-const DEFAULT_APPLICATION_BOOTSTRAP_SCHEMA: BootstrapSchema = {
-  platform: 'fastify',
-  runtime: 'node',
-  shape: 'application',
-  tooling: 'standard',
-  topology: {
-    deferred: true,
-    mode: 'single-package',
-  },
-  transport: 'http',
-};
-
-const DEFAULT_MICROSERVICE_BOOTSTRAP_SCHEMA: BootstrapSchema = {
-  platform: 'none',
-  runtime: 'node',
-  shape: 'microservice',
-  tooling: 'standard',
-  topology: {
-    deferred: true,
-    mode: 'single-package',
-  },
-  transport: 'tcp',
-};
-
-const DEFAULT_MIXED_BOOTSTRAP_SCHEMA: BootstrapSchema = {
-  platform: 'fastify',
-  runtime: 'node',
-  shape: 'mixed',
-  tooling: 'standard',
-  topology: {
-    deferred: true,
-    mode: 'single-package',
-  },
-  transport: 'tcp',
-};
 
 /**
  * Shape-first compatibility baseline for `fluo new` until additional starter variants ship.
  */
-export const DEFAULT_BOOTSTRAP_SCHEMA: BootstrapSchema = {
-  ...DEFAULT_APPLICATION_BOOTSTRAP_SCHEMA,
-};
+export const DEFAULT_BOOTSTRAP_SCHEMA: BootstrapSchema = getDefaultBootstrapSchema();
 
 /**
  * Dependency set required by the currently supported `fluo new` starter baseline.
  */
 export interface ResolvedBootstrapPlan {
-  dependencies: ResolvedBootstrapDependencies;
-  emitter: ResolvedHttpScaffoldEmitter | ResolvedMicroserviceScaffoldEmitter | ResolvedMixedScaffoldEmitter;
+  dependencies: StarterProfile['dependencies'];
+  emitter: StarterProfile['emitter'];
+  profile: StarterProfile;
   schema: BootstrapSchema;
 }
 
-const DEFAULT_HTTP_DEPENDENCIES: ResolvedBootstrapDependencies = {
-  dependencies: [
-    '@fluojs/config',
-    '@fluojs/core',
-    '@fluojs/validation',
-    '@fluojs/di',
-    '@fluojs/http',
-    '@fluojs/platform-fastify',
-    '@fluojs/runtime',
-  ],
-  devDependencies: [
-    '@fluojs/cli',
-    '@fluojs/testing',
-  ],
-};
-
-const DEFAULT_MICROSERVICE_DEPENDENCIES: ResolvedBootstrapDependencies = {
-  dependencies: [
-    '@fluojs/config',
-    '@fluojs/core',
-    '@fluojs/di',
-    '@fluojs/microservices',
-    '@fluojs/runtime',
-  ],
-  devDependencies: [
-    '@fluojs/cli',
-    '@fluojs/testing',
-  ],
-};
-
-const DEFAULT_MIXED_DEPENDENCIES: ResolvedBootstrapDependencies = {
-  dependencies: [
-    '@fluojs/config',
-    '@fluojs/core',
-    '@fluojs/validation',
-    '@fluojs/di',
-    '@fluojs/http',
-    '@fluojs/microservices',
-    '@fluojs/platform-fastify',
-    '@fluojs/runtime',
-  ],
-  devDependencies: [
-    '@fluojs/cli',
-    '@fluojs/testing',
-  ],
-};
-
 function defaultSchemaForShape(shape: BootstrapShape): BootstrapSchema {
-  if (shape === 'microservice') {
-    return DEFAULT_MICROSERVICE_BOOTSTRAP_SCHEMA;
-  }
-
-  if (shape === 'mixed') {
-    return DEFAULT_MIXED_BOOTSTRAP_SCHEMA;
-  }
-
-  return DEFAULT_APPLICATION_BOOTSTRAP_SCHEMA;
+  return getDefaultBootstrapSchemaForShape(shape);
 }
 
 function assertOneOf<T extends string>(
@@ -193,7 +56,7 @@ function assertOneOf<T extends string>(
 function normalizeTopology(topology: Partial<BootstrapTopology> | undefined): BootstrapTopology {
   return {
     deferred: topology?.deferred ?? true,
-    mode: assertOneOf('topology mode', topology?.mode ?? DEFAULT_BOOTSTRAP_SCHEMA.topology.mode, TOPOLOGY_MODES),
+    mode: assertOneOf('topology mode', topology?.mode ?? DEFAULT_BOOTSTRAP_SCHEMA.topology.mode, SUPPORTED_BOOTSTRAP_TOPOLOGY_MODES),
   };
 }
 
@@ -204,16 +67,16 @@ function normalizeTopology(topology: Partial<BootstrapTopology> | undefined): Bo
  * @returns A normalized bootstrap schema with defaults applied.
  */
 export function resolveBootstrapSchema(partial: Partial<BootstrapSchema> = {}): BootstrapSchema {
-  const shape = assertOneOf('shape', partial.shape ?? DEFAULT_BOOTSTRAP_SCHEMA.shape, SHAPES);
+  const shape = assertOneOf('shape', partial.shape ?? DEFAULT_BOOTSTRAP_SCHEMA.shape, SUPPORTED_BOOTSTRAP_SHAPES);
   const defaults = defaultSchemaForShape(shape);
 
   return {
-    platform: assertOneOf('platform', partial.platform ?? defaults.platform, PLATFORMS),
-    runtime: assertOneOf('runtime', partial.runtime ?? defaults.runtime, RUNTIMES),
+    platform: assertOneOf('platform', partial.platform ?? defaults.platform, SUPPORTED_BOOTSTRAP_PLATFORMS),
+    runtime: assertOneOf('runtime', partial.runtime ?? defaults.runtime, SUPPORTED_BOOTSTRAP_RUNTIMES),
     shape,
-    tooling: assertOneOf('tooling', partial.tooling ?? defaults.tooling, TOOLING_PRESETS),
+    tooling: assertOneOf('tooling', partial.tooling ?? defaults.tooling, SUPPORTED_BOOTSTRAP_TOOLING_PRESETS),
     topology: normalizeTopology(partial.topology),
-    transport: assertOneOf('transport', partial.transport ?? defaults.transport, TRANSPORTS),
+    transport: assertOneOf('transport', partial.transport ?? defaults.transport, SUPPORTED_BOOTSTRAP_TRANSPORTS),
   };
 }
 
@@ -225,72 +88,18 @@ export function resolveBootstrapSchema(partial: Partial<BootstrapSchema> = {}): 
  */
 export function resolveBootstrapPlan(options: BootstrapResolutionInput | BootstrapOptions): ResolvedBootstrapPlan {
   const schema = resolveBootstrapSchema(options);
+  const starterProfile = getStarterProfileFromSchema(schema);
 
-  if (
-    schema.shape === 'application'
-    && schema.runtime === 'node'
-    && schema.transport === 'http'
-    && schema.platform === 'fastify'
-    && schema.tooling === 'standard'
-    && schema.topology.deferred === true
-    && schema.topology.mode === 'single-package'
-  ) {
+  if (starterProfile) {
     return {
-      dependencies: DEFAULT_HTTP_DEPENDENCIES,
-      emitter: {
-        platform: 'fastify',
-        preset: 'standard',
-        runtime: 'node',
-        transport: 'http',
-        type: 'http',
-      },
+      dependencies: starterProfile.dependencies,
+      emitter: starterProfile.emitter,
+      profile: starterProfile,
       schema,
     };
   }
 
-  if (
-    schema.shape === 'microservice'
-    && schema.runtime === 'node'
-    && schema.transport === 'tcp'
-    && schema.platform === 'none'
-    && schema.tooling === 'standard'
-    && schema.topology.deferred === true
-    && schema.topology.mode === 'single-package'
-  ) {
-    return {
-      dependencies: DEFAULT_MICROSERVICE_DEPENDENCIES,
-      emitter: {
-        platform: 'none',
-        preset: 'standard',
-        runtime: 'node',
-        transport: 'tcp',
-        type: 'microservice',
-      },
-      schema,
-    };
-  }
-
-  if (
-    schema.shape === 'mixed'
-    && schema.runtime === 'node'
-    && schema.transport === 'tcp'
-    && schema.platform === 'fastify'
-    && schema.tooling === 'standard'
-    && schema.topology.deferred === true
-    && schema.topology.mode === 'single-package'
-  ) {
-    return {
-      dependencies: DEFAULT_MIXED_DEPENDENCIES,
-      emitter: {
-        platform: 'fastify',
-        preset: 'standard',
-        runtime: 'node',
-        transport: 'tcp',
-        type: 'mixed',
-      },
-      schema,
-    };
-  }
+  const defaultProfile = getStarterProfileForShape(schema.shape);
 
   if (schema.shape === 'microservice' && schema.transport === 'http') {
     throw new Error(
@@ -299,7 +108,7 @@ export function resolveBootstrapPlan(options: BootstrapResolutionInput | Bootstr
     );
   }
 
-  if (schema.shape === 'application' && MICROSERVICE_TRANSPORTS.includes(schema.transport)) {
+  if (schema.shape === 'application' && isDocumentedMicroserviceTransport(schema.transport)) {
     throw new Error(
       'Unsupported bootstrap schema "application/node/' + schema.transport + '/' + schema.platform + '/standard/single-package". '
       + 'Application starters currently require the HTTP transport.',
@@ -313,15 +122,15 @@ export function resolveBootstrapPlan(options: BootstrapResolutionInput | Bootstr
     );
   }
 
-  if (schema.shape === 'microservice' && MICROSERVICE_TRANSPORTS.includes(schema.transport) && schema.transport !== 'tcp') {
+  if (schema.shape === 'microservice' && isDocumentedMicroserviceTransport(schema.transport) && schema.transport !== defaultProfile.schema.transport) {
     throw new Error(
       'Unsupported bootstrap schema "microservice/node/' + schema.transport + '/' + schema.platform + '/standard/single-package". '
       + 'The first-class microservice starter currently emits the runnable TCP starter, while transport validation recognizes the documented families: '
-      + MICROSERVICE_TRANSPORTS.join(', ') + '.',
+      + DOCUMENTED_MICROSERVICE_TRANSPORTS.join(', ') + '.',
     );
   }
 
-  if (schema.shape === 'mixed' && MICROSERVICE_TRANSPORTS.includes(schema.transport) && schema.transport !== 'tcp') {
+  if (schema.shape === 'mixed' && isDocumentedMicroserviceTransport(schema.transport) && schema.transport !== defaultProfile.schema.transport) {
     throw new Error(
       'Unsupported bootstrap schema "mixed/node/' + schema.transport + '/' + schema.platform + '/standard/' + schema.topology.mode + '". '
       + 'The first mixed starter currently supports only the attached TCP microservice contract.',

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { initializeGitRepository, installDependencies } from './install.js';
 import { resolveBootstrapPlan, type ResolvedBootstrapPlan } from './resolver.js';
+import type { StarterScaffoldRecipeId } from './starter-profiles.js';
 import type { BootstrapOptions, PackageManager } from './types.js';
 
 const PACKAGE_DIRECTORY_BY_NAME = {
@@ -323,11 +324,11 @@ Use the unit template for handler logic and the integration template when you ne
 }
 
 function createProjectReadme(options: BootstrapOptions, bootstrapPlan: ResolvedBootstrapPlan): string {
-  if (bootstrapPlan.emitter.type === 'microservice') {
+  if (bootstrapPlan.profile.id === 'microservice-node-none-tcp') {
     return createMicroserviceProjectReadme(options);
   }
 
-  if (bootstrapPlan.emitter.type === 'mixed') {
+  if (bootstrapPlan.profile.id === 'mixed-node-fastify-tcp') {
     return createMixedProjectReadme(options);
   }
 
@@ -951,7 +952,7 @@ describe('AppModule e2e', () => {
 }
 
 function createEnvFile(bootstrapPlan: ResolvedBootstrapPlan): string {
-  if (bootstrapPlan.emitter.type === 'microservice' || bootstrapPlan.emitter.type === 'mixed') {
+  if (bootstrapPlan.profile.id === 'microservice-node-none-tcp' || bootstrapPlan.profile.id === 'mixed-node-fastify-tcp') {
     return `MICROSERVICE_HOST=127.0.0.1
 MICROSERVICE_PORT=4000
 PORT=3000
@@ -1003,12 +1004,12 @@ function emitSharedScaffoldFiles(
   ];
 }
 
-function emitScaffoldFilesForPlan(options: BootstrapOptions, bootstrapPlan: ResolvedBootstrapPlan): ScaffoldFile[] {
-  if (bootstrapPlan.emitter.type === 'http') {
+function emitScaffoldFilesForRecipe(options: BootstrapOptions, recipeId: StarterScaffoldRecipeId): ScaffoldFile[] {
+  if (recipeId === 'application-node-fastify-http') {
     return emitStandardHttpNodeFastifyScaffoldFiles(options);
   }
 
-  if (bootstrapPlan.emitter.type === 'microservice') {
+  if (recipeId === 'microservice-node-none-tcp') {
     return [
       { content: createMicroserviceAppFile(), path: 'src/app.ts' },
       { content: createMicroserviceMainFile(), path: 'src/main.ts' },
@@ -1018,7 +1019,7 @@ function emitScaffoldFilesForPlan(options: BootstrapOptions, bootstrapPlan: Reso
     ];
   }
 
-  if (bootstrapPlan.emitter.type === 'mixed') {
+  if (recipeId === 'mixed-node-fastify-tcp') {
     return [
       { content: createMixedAppFile(), path: 'src/app.ts' },
       { content: createMixedMainFile(), path: 'src/main.ts' },
@@ -1037,6 +1038,10 @@ function emitScaffoldFilesForPlan(options: BootstrapOptions, bootstrapPlan: Reso
   }
 
   return [];
+}
+
+function emitScaffoldFilesForPlan(options: BootstrapOptions, bootstrapPlan: ResolvedBootstrapPlan): ScaffoldFile[] {
+  return emitScaffoldFilesForRecipe(options, bootstrapPlan.profile.id);
 }
 
 function buildScaffoldFiles(

--- a/packages/cli/src/new/starter-profiles.ts
+++ b/packages/cli/src/new/starter-profiles.ts
@@ -1,0 +1,191 @@
+import type {
+  BootstrapPlatform,
+  BootstrapRuntime,
+  BootstrapSchema,
+  BootstrapShape,
+  BootstrapToolingPreset,
+  BootstrapTopology,
+  BootstrapTransport,
+} from './types.js';
+
+export type StarterEmitterType = 'http' | 'microservice' | 'mixed';
+export type StarterScaffoldRecipeId = 'application-node-fastify-http' | 'microservice-node-none-tcp' | 'mixed-node-fastify-tcp';
+
+type StarterDependencies = {
+  dependencies: readonly string[];
+  devDependencies: readonly string[];
+};
+
+export interface StarterProfile {
+  dependencies: StarterDependencies;
+  emitter: {
+    platform: BootstrapPlatform;
+    preset: BootstrapToolingPreset;
+    runtime: BootstrapRuntime;
+    transport: BootstrapTransport;
+    type: StarterEmitterType;
+  };
+  id: StarterScaffoldRecipeId;
+  promptLabel: string;
+  schema: BootstrapSchema;
+}
+
+const DEFAULT_TOPOLOGY: BootstrapTopology = {
+  deferred: true,
+  mode: 'single-package',
+};
+
+function createSchema(
+  shape: BootstrapShape,
+  runtime: BootstrapRuntime,
+  platform: BootstrapPlatform,
+  transport: BootstrapTransport,
+  tooling: BootstrapToolingPreset = 'standard',
+): BootstrapSchema {
+  return {
+    platform,
+    runtime,
+    shape,
+    tooling,
+    topology: { ...DEFAULT_TOPOLOGY },
+    transport,
+  };
+}
+
+function cloneBootstrapSchema(schema: BootstrapSchema): BootstrapSchema {
+  return {
+    ...schema,
+    topology: { ...schema.topology },
+  };
+}
+
+export const DOCUMENTED_MICROSERVICE_TRANSPORTS: readonly BootstrapTransport[] = [
+  'tcp',
+  'redis',
+  'redis-streams',
+  'nats',
+  'kafka',
+  'rabbitmq',
+  'mqtt',
+  'grpc',
+];
+
+export const STARTER_PROFILE_REGISTRY: readonly StarterProfile[] = [
+  {
+    dependencies: {
+      dependencies: [
+        '@fluojs/config',
+        '@fluojs/core',
+        '@fluojs/validation',
+        '@fluojs/di',
+        '@fluojs/http',
+        '@fluojs/platform-fastify',
+        '@fluojs/runtime',
+      ],
+      devDependencies: [
+        '@fluojs/cli',
+        '@fluojs/testing',
+      ],
+    },
+    emitter: {
+      platform: 'fastify',
+      preset: 'standard',
+      runtime: 'node',
+      transport: 'http',
+      type: 'http',
+    },
+    id: 'application-node-fastify-http',
+    promptLabel: 'Application (HTTP starter)',
+    schema: createSchema('application', 'node', 'fastify', 'http'),
+  },
+  {
+    dependencies: {
+      dependencies: [
+        '@fluojs/config',
+        '@fluojs/core',
+        '@fluojs/di',
+        '@fluojs/microservices',
+        '@fluojs/runtime',
+      ],
+      devDependencies: [
+        '@fluojs/cli',
+        '@fluojs/testing',
+      ],
+    },
+    emitter: {
+      platform: 'none',
+      preset: 'standard',
+      runtime: 'node',
+      transport: 'tcp',
+      type: 'microservice',
+    },
+    id: 'microservice-node-none-tcp',
+    promptLabel: 'Microservice (transport-first starter)',
+    schema: createSchema('microservice', 'node', 'none', 'tcp'),
+  },
+  {
+    dependencies: {
+      dependencies: [
+        '@fluojs/config',
+        '@fluojs/core',
+        '@fluojs/validation',
+        '@fluojs/di',
+        '@fluojs/http',
+        '@fluojs/microservices',
+        '@fluojs/platform-fastify',
+        '@fluojs/runtime',
+      ],
+      devDependencies: [
+        '@fluojs/cli',
+        '@fluojs/testing',
+      ],
+    },
+    emitter: {
+      platform: 'fastify',
+      preset: 'standard',
+      runtime: 'node',
+      transport: 'tcp',
+      type: 'mixed',
+    },
+    id: 'mixed-node-fastify-tcp',
+    promptLabel: 'Mixed (HTTP API + microservice starter)',
+    schema: createSchema('mixed', 'node', 'fastify', 'tcp'),
+  },
+] as const;
+
+export const SUPPORTED_BOOTSTRAP_SHAPES: readonly BootstrapShape[] = STARTER_PROFILE_REGISTRY.map((profile) => profile.schema.shape);
+export const SUPPORTED_BOOTSTRAP_RUNTIMES: readonly BootstrapRuntime[] = ['node'];
+export const SUPPORTED_BOOTSTRAP_PLATFORMS: readonly BootstrapPlatform[] = ['fastify', 'none'];
+export const SUPPORTED_BOOTSTRAP_TRANSPORTS: readonly BootstrapTransport[] = ['http', ...DOCUMENTED_MICROSERVICE_TRANSPORTS];
+export const SUPPORTED_BOOTSTRAP_TOOLING_PRESETS: readonly BootstrapToolingPreset[] = ['standard'];
+export const SUPPORTED_BOOTSTRAP_TOPOLOGY_MODES: readonly BootstrapTopology['mode'][] = ['single-package'];
+
+export const DEFAULT_BOOTSTRAP_PROFILE = STARTER_PROFILE_REGISTRY[0]!;
+
+export function getStarterProfileForShape(shape: BootstrapShape): StarterProfile {
+  return STARTER_PROFILE_REGISTRY.find((profile) => profile.schema.shape === shape) ?? DEFAULT_BOOTSTRAP_PROFILE;
+}
+
+export function getDefaultBootstrapSchemaForShape(shape: BootstrapShape): BootstrapSchema {
+  return cloneBootstrapSchema(getStarterProfileForShape(shape).schema);
+}
+
+export function getDefaultBootstrapSchema(): BootstrapSchema {
+  return cloneBootstrapSchema(DEFAULT_BOOTSTRAP_PROFILE.schema);
+}
+
+export function getStarterProfileFromSchema(schema: BootstrapSchema): StarterProfile | undefined {
+  return STARTER_PROFILE_REGISTRY.find((profile) => (
+    profile.schema.shape === schema.shape
+    && profile.schema.runtime === schema.runtime
+    && profile.schema.platform === schema.platform
+    && profile.schema.transport === schema.transport
+    && profile.schema.tooling === schema.tooling
+    && profile.schema.topology.deferred === schema.topology.deferred
+    && profile.schema.topology.mode === schema.topology.mode
+  ));
+}
+
+export function isDocumentedMicroserviceTransport(transport: BootstrapTransport): boolean {
+  return DOCUMENTED_MICROSERVICE_TRANSPORTS.includes(transport);
+}


### PR DESCRIPTION
## Summary
- introduce an internal starter profile registry for the currently shipped `fluo new` matrix
- refactor command parsing, prompt resolution, bootstrap planning, and scaffold recipe selection to consume the shared registry
- lock the shipped application, microservice, and mixed starter contracts with regression coverage under the new abstraction

## Changes
- add `packages/cli/src/new/starter-profiles.ts` as the single internal source of truth for starter schemas, dependencies, emitter metadata, and scaffold recipe ids
- route `commands/new.ts`, `prompt.ts`, `resolver.ts`, and `scaffold.ts` through the shared registry while preserving the current starter matrix exactly
- extend resolver tests to assert the registry shape and current shipped matrix without widening runtime/platform/transport support

## Testing
- pnpm build
- pnpm --filter @fluojs/cli typecheck
- pnpm --filter @fluojs/cli test
- lsp_diagnostics clean for `packages/cli/src/new`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- internal-only refactor for the existing starter matrix; shipped starter behavior remains unchanged

Closes #995