### PR TITLE
Resolve #997: sync expanded fluo new starter docs

### DIFF
--- a/docs/getting-started/quick-start.ko.md
+++ b/docs/getting-started/quick-start.ko.md
@@ -31,6 +31,12 @@ fluo new my-fluo-app --shape application --transport http --runtime node --platf
 같은 명령 계열로 다른 공개 v2 스타터 경로도 선택할 수 있습니다.
 
 ```sh
+# Express 애플리케이션 스타터
+fluo new my-fluo-express --shape application --transport http --runtime node --platform express
+
+# Raw Node.js HTTP 애플리케이션 스타터
+fluo new my-fluo-node --shape application --transport http --runtime node --platform nodejs
+
 # Bun 애플리케이션 스타터
 fluo new my-fluo-bun --shape application --transport http --runtime bun --platform bun
 
@@ -46,6 +52,15 @@ fluo new my-fluo-microservice --shape microservice --transport tcp --runtime nod
 # 실행 가능한 Redis Streams microservice 스타터
 fluo new my-fluo-redis-streams --shape microservice --transport redis-streams --runtime node --platform none
 
+# 실행 가능한 NATS microservice 스타터
+fluo new my-fluo-nats --shape microservice --transport nats --runtime node --platform none
+
+# 실행 가능한 Kafka microservice 스타터
+fluo new my-fluo-kafka --shape microservice --transport kafka --runtime node --platform none
+
+# 실행 가능한 RabbitMQ microservice 스타터
+fluo new my-fluo-rabbitmq --shape microservice --transport rabbitmq --runtime node --platform none
+
 # 실행 가능한 MQTT microservice 스타터
 fluo new my-fluo-mqtt --shape microservice --transport mqtt --runtime node --platform none
 
@@ -56,7 +71,7 @@ fluo new my-fluo-grpc --shape microservice --transport grpc --runtime node --pla
 fluo new my-fluo-mixed --shape mixed --transport tcp --runtime node --platform fastify
 ```
 
-이 공개 스타터 경로와 남아 있는 더 넓은 어댑터 생태계를 문서 수준에서 구분해 보려면 [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md)를 확인하세요.
+현재 제공되는 스타터 매트릭스와 남아 있는 더 넓은 어댑터 생태계를 문서 수준에서 구분해 보려면 [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md)를 확인하세요.
 
 `fluo new`가 interactive terminal에서 실행되면, wizard도 이와 동일한 shape-first 모델로 수렴합니다. wizard는 프로젝트 이름, starter shape, 유지보수되는 tooling preset, package manager, dependency 설치 여부, git 초기화 여부를 묻습니다.
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -31,6 +31,12 @@ fluo new my-fluo-app --shape application --transport http --runtime node --platf
 The same command family also exposes the other published v2 starter paths:
 
 ```sh
+# Express application starter
+fluo new my-fluo-express --shape application --transport http --runtime node --platform express
+
+# Raw Node.js HTTP application starter
+fluo new my-fluo-node --shape application --transport http --runtime node --platform nodejs
+
 # Bun application starter
 fluo new my-fluo-bun --shape application --transport http --runtime bun --platform bun
 
@@ -46,6 +52,15 @@ fluo new my-fluo-microservice --shape microservice --transport tcp --runtime nod
 # Runnable Redis Streams microservice starter
 fluo new my-fluo-redis-streams --shape microservice --transport redis-streams --runtime node --platform none
 
+# Runnable NATS microservice starter
+fluo new my-fluo-nats --shape microservice --transport nats --runtime node --platform none
+
+# Runnable Kafka microservice starter
+fluo new my-fluo-kafka --shape microservice --transport kafka --runtime node --platform none
+
+# Runnable RabbitMQ microservice starter
+fluo new my-fluo-rabbitmq --shape microservice --transport rabbitmq --runtime node --platform none
+
 # Runnable MQTT microservice starter
 fluo new my-fluo-mqtt --shape microservice --transport mqtt --runtime node --platform none
 
@@ -56,7 +71,7 @@ fluo new my-fluo-grpc --shape microservice --transport grpc --runtime node --pla
 fluo new my-fluo-mixed --shape mixed --transport tcp --runtime node --platform fastify
 ```
 
-For a docs-level split between these published starter paths and the remaining broader adapter ecosystem, see the [fluo new support matrix](../reference/fluo-new-support-matrix.md).
+For a docs-level split between this shipped starter matrix and the remaining broader adapter ecosystem, see the [fluo new support matrix](../reference/fluo-new-support-matrix.md).
 
 When `fluo new` runs in an interactive terminal, the wizard resolves onto this same shape-first model. It asks for the project name, starter shape, the maintained tooling preset, package manager, whether to install dependencies, and whether to initialize git.
 

--- a/docs/reference/fluo-new-support-matrix.ko.md
+++ b/docs/reference/fluo-new-support-matrix.ko.md
@@ -17,10 +17,10 @@
 
 - `fluo new` 문서는 스타터 계약으로 읽고, 문서화된 모든 어댑터가 이미 스타터 프리셋을 가진다고 해석하지 마세요.
 - 런타임/패키지 참조 문서는 현재 스타터 매트릭스 밖에서 채택 가능한 어댑터, 플랫폼, 배포 대상을 설명하는 더 넓은 생태계 지도입니다.
-- 어떤 페이지가 Bun, Deno, Cloudflare Workers를 언급할 때 명시적인 `fluo new --shape application --transport http --runtime ... --platform ...` 명령이 함께 있다면 그것이 runnable starter 계약입니다. 그 밖의 어댑터 언급은 여전히 더 넓은 패키지 생태계를 설명합니다.
+- 어떤 페이지가 Node.js HTTP 플랫폼(Fastify, Express, raw Node.js), Bun, Deno, Cloudflare Workers를 언급할 때 명시적인 `fluo new --shape application --transport http --runtime ... --platform ...` 명령이 함께 있다면 그것이 runnable starter 계약입니다. 마이크로서비스의 경우 문서화된 `tcp`, `redis-streams`, `nats`, `kafka`, `rabbitmq`, `mqtt`, `grpc` 명령 변형을 runnable starter 계약으로 읽으세요. 그 밖의 어댑터/패키지 언급은 여전히 더 넓은 패키지 생태계를 설명합니다.
 
 ## 기준 출처
 
 - `packages/cli/src/new/resolver.ts`는 현재 스캐폴딩되는 `fluo new` 매트릭스의 기준 소스입니다.
 - [Package Surface](./package-surface.ko.md#canonical-runtime-package-matrix)는 더 넓은 런타임/패키지 생태계의 기준 소스입니다.
-- [Bootstrap Paths](../getting-started/bootstrap-paths.ko.md), [Package Chooser](./package-chooser.ko.md), [NestJS에서 마이그레이션하기](../getting-started/migrate-from-nestjs.ko.md)는 아직 스타터 프리셋이 아닌 어댑터를 다룰 때 이 문서로 연결되어야 합니다.
+- [Bootstrap Paths](../getting-started/bootstrap-paths.ko.md), [Package Chooser](./package-chooser.ko.md), [NestJS에서 마이그레이션하기](../getting-started/migrate-from-nestjs.ko.md)는 제공 중인 스타터 매트릭스와 더 넓은 패키지 생태계를 구분해야 할 때 이 문서로 연결되어야 합니다.

--- a/docs/reference/fluo-new-support-matrix.md
+++ b/docs/reference/fluo-new-support-matrix.md
@@ -17,10 +17,10 @@ Use this page to distinguish what `fluo new` scaffolds today from the broader ru
 
 - Treat `fluo new` docs as a starter contract, not as a promise that every documented adapter already has a starter preset.
 - Treat runtime and package reference docs as the broader ecosystem map for adapters, platforms, and deployment targets you can adopt outside the current starter matrix.
-- When a page mentions Bun, Deno, or Cloudflare Workers, treat the explicit `fluo new --shape application --transport http --runtime ... --platform ...` commands as the runnable starter contract. Other adapter mentions outside those starter rows still describe the broader package ecosystem.
+- When a page mentions Node.js HTTP platforms (Fastify, Express, raw Node.js), Bun, Deno, or Cloudflare Workers, treat the explicit `fluo new --shape application --transport http --runtime ... --platform ...` commands as the runnable starter contract. For microservices, treat the documented `tcp`, `redis-streams`, `nats`, `kafka`, `rabbitmq`, `mqtt`, and `grpc` command variants as the runnable starter contract. Other adapter/package mentions outside those starter rows still describe the broader package ecosystem.
 
 ## authoritative sources
 
 - `packages/cli/src/new/resolver.ts` is the source of truth for the currently scaffolded `fluo new` matrix.
 - [Package Surface](./package-surface.md#canonical-runtime-package-matrix) is the source of truth for the broader runtime/package ecosystem.
-- [Bootstrap Paths](../getting-started/bootstrap-paths.md), [Package Chooser](./package-chooser.md), and [Migrate from NestJS](../getting-started/migrate-from-nestjs.md) should link here whenever they discuss adapters that are not starter presets yet.
+- [Bootstrap Paths](../getting-started/bootstrap-paths.md), [Package Chooser](./package-chooser.md), and [Migrate from NestJS](../getting-started/migrate-from-nestjs.md) should link here whenever they need to distinguish the shipped starter matrix from the broader package ecosystem.

--- a/docs/reference/package-chooser.ko.md
+++ b/docs/reference/package-chooser.ko.md
@@ -17,6 +17,7 @@
 | **GraphQL API** | `@fluojs/graphql` |
 | **Fastify (권장)** | `@fluojs/platform-fastify` |
 | **Express 호환** | `@fluojs/platform-express` *(이제 Node.js에서 first-class `fluo new` 애플리케이션 스타터로도 제공됨)* |
+| **Raw Node.js HTTP** | `@fluojs/platform-nodejs` *(이제 Node.js에서 first-class `fluo new` 애플리케이션 스타터로도 제공됨)* |
 | **입력 유효성 검사** | `@fluojs/validation` |
 | **설정** | `@fluojs/config` |
 
@@ -31,6 +32,22 @@
 | **Cloudflare Workers** | `@fluojs/platform-cloudflare-workers` |
 
 이 어댑터 행들은 지원 패키지 경로를 설명하며, 이제 일치하는 runtime/platform 플래그를 사용하면 first-class `fluo new` 애플리케이션 스타터와도 직접 연결됩니다.
+
+## 마이크로서비스 스타터 만들기
+
+> _"HTTP 앱 대신 실행 가능한 `fluo new` microservice starter가 필요합니다."_
+
+| transport | 스타터 계약 |
+| --- | --- |
+| **TCP (기본값)** | `fluo new my-service --shape microservice --transport tcp --runtime node --platform none` |
+| **Redis Streams** | `fluo new my-service --shape microservice --transport redis-streams --runtime node --platform none` |
+| **NATS** | `fluo new my-service --shape microservice --transport nats --runtime node --platform none` |
+| **Kafka** | `fluo new my-service --shape microservice --transport kafka --runtime node --platform none` |
+| **RabbitMQ** | `fluo new my-service --shape microservice --transport rabbitmq --runtime node --platform none` |
+| **MQTT** | `fluo new my-service --shape microservice --transport mqtt --runtime node --platform none` |
+| **gRPC** | `fluo new my-service --shape microservice --transport grpc --runtime node --platform none` |
+
+이 표는 현재 실제로 제공되는 runnable starter 매트릭스를 설명합니다. 스타터 프리셋 밖의 더 넓은 문서화된 마이크로서비스 생태계에는 여전히 validation-only `redis` 참조가 포함됩니다.
 
 ## 영속성 및 데이터 접근 추가
 

--- a/docs/reference/package-chooser.md
+++ b/docs/reference/package-chooser.md
@@ -17,6 +17,7 @@ Use this guide to select the correct fluo packages for your specific task. This 
 | **GraphQL API** | `@fluojs/graphql` |
 | **Fastify (Recommended)** | `@fluojs/platform-fastify` |
 | **Express Compatibility** | `@fluojs/platform-express` *(also available as a first-class `fluo new` application starter on Node.js)* |
+| **Raw Node.js HTTP** | `@fluojs/platform-nodejs` *(also available as a first-class `fluo new` application starter on Node.js)* |
 | **Input Validation** | `@fluojs/validation` |
 | **Configuration** | `@fluojs/config` |
 
@@ -31,6 +32,22 @@ Use this guide to select the correct fluo packages for your specific task. This 
 | **Cloudflare Workers** | `@fluojs/platform-cloudflare-workers` |
 
 These adapter rows describe supported package paths and now map directly to first-class `fluo new` application starters when you use the matching runtime/platform flags.
+
+## build a microservice starter
+
+> _"I want a runnable `fluo new` microservice starter instead of an HTTP app."_
+
+| transport | starter contract |
+| --- | --- |
+| **TCP (default)** | `fluo new my-service --shape microservice --transport tcp --runtime node --platform none` |
+| **Redis Streams** | `fluo new my-service --shape microservice --transport redis-streams --runtime node --platform none` |
+| **NATS** | `fluo new my-service --shape microservice --transport nats --runtime node --platform none` |
+| **Kafka** | `fluo new my-service --shape microservice --transport kafka --runtime node --platform none` |
+| **RabbitMQ** | `fluo new my-service --shape microservice --transport rabbitmq --runtime node --platform none` |
+| **MQTT** | `fluo new my-service --shape microservice --transport mqtt --runtime node --platform none` |
+| **gRPC** | `fluo new my-service --shape microservice --transport grpc --runtime node --platform none` |
+
+These rows describe the currently shipped runnable starter matrix. The broader documented microservice ecosystem still includes validation-only `redis` references outside the starter presets.
 
 ## add persistence & data access
 

--- a/examples/README.ko.md
+++ b/examples/README.ko.md
@@ -4,7 +4,7 @@
 
 이 디렉토리는 fluo의 공식 runnable example 애플리케이션을 모아 둔 곳입니다. 각 예제는 개별 README를 가지며, docs hub와 함께 읽는 것을 전제로 합니다.
 
-이 예제들은 생성 스캐폴드와 runnable 예제가 계속 일치하도록 의도적으로 공개된 `fluo new` v2 매트릭스의 HTTP 쪽 경로를 유지합니다. 다른 first-class 스타터 계약은 실행 가능한 microservice starter 경로들(TCP 기본값, 그리고 Redis Streams, MQTT, gRPC)과 mixed single-package 경로(Fastify HTTP 앱 + attached TCP microservice)입니다. 공식 Bun, Deno, Cloudflare Workers 런타임 가이드는 대응하는 `@fluojs/platform-*` 패키지 README에서 다룹니다.
+이 예제들은 생성 스캐폴드와 runnable 예제가 계속 일치하도록 의도적으로 공개된 `fluo new` v2 매트릭스의 HTTP 쪽 경로를 유지합니다. 다른 first-class 스타터 계약은 Express, raw Node.js HTTP, Bun, Deno, Cloudflare Workers용 runnable 애플리케이션 스타터 변형, 실행 가능한 microservice starter 경로들(TCP 기본값, 그리고 Redis Streams, NATS, Kafka, RabbitMQ, MQTT, gRPC), 그리고 mixed single-package 경로(Fastify HTTP 앱 + attached TCP microservice)입니다.
 
 ## 현재 공식 예제
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 This directory contains the official runnable example applications for fluo. Each example has its own README and is meant to be read alongside the docs hub rather than in isolation.
 
-These examples intentionally stay on the HTTP side of the published `fluo new` v2 matrix so the generated scaffold and the runnable examples keep matching. The other first-class starter contracts are the runnable microservice starter paths (TCP by default, plus Redis Streams, MQTT, and gRPC) and the mixed single-package path (Fastify HTTP app + attached TCP microservice). Official Bun, Deno, and Cloudflare Workers runtime guidance lives in the corresponding `@fluojs/platform-*` package READMEs.
+These examples intentionally stay on the HTTP side of the published `fluo new` v2 matrix so the generated scaffold and the runnable examples keep matching. The other first-class starter contracts are the runnable application starter variants for Express, raw Node.js HTTP, Bun, Deno, and Cloudflare Workers; the runnable microservice starter paths (TCP by default, plus Redis Streams, NATS, Kafka, RabbitMQ, MQTT, and gRPC); and the mixed single-package path (Fastify HTTP app + attached TCP microservice).
 
 ## current official examples
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -82,7 +82,7 @@ fluo new my-mixed-app --shape mixed --transport tcp --runtime node --platform fa
 
 `fluo new`가 interactive TTY에서 실행되면, 이제 v2 wizard가 기존 flags/config 모델 위에 그대로 얹혀 동작합니다. wizard는 프로젝트 이름, shape-first 분기(`application` -> runtime + HTTP platform, `microservice` -> transport), 유지보수 가능한 tooling preset, package manager, 즉시 dependency를 설치할지 여부, git 저장소를 초기화할지 여부를 묻습니다. 반면 non-interactive 플래그 경로와 프로그래밍 방식의 `runNewCommand(...)` 호출은 동일한 resolved defaults를 유지하는 first-class path로 계속 동작합니다.
 
-이제 제공되는 애플리케이션/microservice 스타터 매트릭스와 남아 있는 더 넓은 어댑터 생태계를 문서 수준에서 구분한 표는 [fluo new 지원 매트릭스](../../docs/reference/fluo-new-support-matrix.ko.md)를 확인하세요.
+현재 제공되는 스타터 매트릭스(Node.js Fastify/Express/raw Node.js HTTP, Bun, Deno, Cloudflare Workers, TCP/Redis Streams/NATS/Kafka/RabbitMQ/MQTT/gRPC microservice, 그리고 mixed)와 남아 있는 더 넓은 어댑터 생태계를 문서 수준에서 구분한 표는 [fluo new 지원 매트릭스](../../docs/reference/fluo-new-support-matrix.ko.md)를 확인하세요.
 
 ### 2. 기능 추가
 컨트롤러와 서비스가 포함된 새 리소스를 추가하고, 모듈에 자동으로 연결합니다.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -82,7 +82,7 @@ fluo new my-mixed-app --shape mixed --transport tcp --runtime node --platform fa
 
 When `fluo new` runs in an interactive TTY, the v2 wizard now layers on top of the same flags/config model instead of replacing it. The wizard asks for the project name, shape-first branch (`application` -> runtime + HTTP platform, `microservice` -> transport), the maintained tooling preset, package-manager choice, whether to install dependencies immediately, and whether to initialize a git repository. Non-interactive flags and programmatic `runNewCommand(...)` calls still stay first-class paths with the same resolved defaults.
 
-For a docs-level table that separates the shipped application/microservice starter matrix from the remaining broader adapter ecosystem, see the [fluo new support matrix](../../docs/reference/fluo-new-support-matrix.md).
+For a docs-level table that separates the shipped starter matrix (Node.js Fastify/Express/raw Node.js HTTP, Bun, Deno, Cloudflare Workers, TCP/Redis Streams/NATS/Kafka/RabbitMQ/MQTT/gRPC microservices, plus mixed) from the remaining broader adapter ecosystem, see the [fluo new support matrix](../../docs/reference/fluo-new-support-matrix.md).
 
 ### 2. Generate a feature
 Add a new resource with a controller and service, automatically wired into the module.

--- a/packages/cli/src/runtime-matrix-docs-contract.test.ts
+++ b/packages/cli/src/runtime-matrix-docs-contract.test.ts
@@ -25,9 +25,19 @@ describe('runtime matrix docs contract', () => {
 
   it('keeps task and hub docs pointed at the canonical matrix', () => {
     expect(read('docs/reference/package-chooser.md')).toContain('./package-surface.md#canonical-runtime-package-matrix');
+    expectAll(read('docs/reference/package-chooser.md'), [
+      '--shape microservice --transport nats --runtime node --platform none',
+      '--shape microservice --transport kafka --runtime node --platform none',
+      '--shape microservice --transport rabbitmq --runtime node --platform none',
+    ]);
     expect(read('docs/reference/package-chooser.ko.md')).toContain(
       './package-surface.ko.md#canonical-runtime-package-matrix',
     );
+    expectAll(read('docs/reference/package-chooser.ko.md'), [
+      '--shape microservice --transport nats --runtime node --platform none',
+      '--shape microservice --transport kafka --runtime node --platform none',
+      '--shape microservice --transport rabbitmq --runtime node --platform none',
+    ]);
     expect(read('docs/README.md')).toContain('reference/package-surface.md');
     expect(read('docs/README.ko.md')).toContain('reference/package-surface.ko.md');
     expect(read('README.md')).toContain('docs/reference/package-surface.md');
@@ -43,6 +53,9 @@ describe('runtime matrix docs contract', () => {
       'Mixed starter',
       'Partially scaffolded, partially docs-only',
       '--transport redis-streams',
+      '--transport nats',
+      '--transport kafka',
+      '--transport rabbitmq',
       '--transport mqtt',
       '--transport grpc',
       '@fluojs/platform-express',
@@ -57,6 +70,9 @@ describe('runtime matrix docs contract', () => {
       'mixed 스타터',
       '일부는 스캐폴딩됨, 일부는 문서 전용',
       '--transport redis-streams',
+      '--transport nats',
+      '--transport kafka',
+      '--transport rabbitmq',
       '--transport mqtt',
       '--transport grpc',
       '@fluojs/platform-express',
@@ -94,6 +110,9 @@ describe('runtime matrix docs contract', () => {
       '--shape application --transport http --runtime cloudflare-workers --platform cloudflare-workers',
       '--shape microservice --transport tcp --runtime node --platform none',
       '--shape microservice --transport redis-streams --runtime node --platform none',
+      '--shape microservice --transport nats --runtime node --platform none',
+      '--shape microservice --transport kafka --runtime node --platform none',
+      '--shape microservice --transport rabbitmq --runtime node --platform none',
       '--shape microservice --transport mqtt --runtime node --platform none',
       '--shape microservice --transport grpc --runtime node --platform none',
       '--shape mixed --transport tcp --runtime node --platform fastify',
@@ -108,6 +127,9 @@ describe('runtime matrix docs contract', () => {
       '--shape application --transport http --runtime cloudflare-workers --platform cloudflare-workers',
       '--shape microservice --transport tcp --runtime node --platform none',
       '--shape microservice --transport redis-streams --runtime node --platform none',
+      '--shape microservice --transport nats --runtime node --platform none',
+      '--shape microservice --transport kafka --runtime node --platform none',
+      '--shape microservice --transport rabbitmq --runtime node --platform none',
       '--shape microservice --transport mqtt --runtime node --platform none',
       '--shape microservice --transport grpc --runtime node --platform none',
       '--shape mixed --transport tcp --runtime node --platform fastify',
@@ -115,11 +137,16 @@ describe('runtime matrix docs contract', () => {
     ]);
     expectAll(read('docs/getting-started/quick-start.md'), [
       '--shape application --transport http --runtime node --platform fastify',
+      '--shape application --transport http --runtime node --platform express',
+      '--shape application --transport http --runtime node --platform nodejs',
       '--shape application --transport http --runtime bun --platform bun',
       '--shape application --transport http --runtime deno --platform deno',
       '--shape application --transport http --runtime cloudflare-workers --platform cloudflare-workers',
       '--shape microservice --transport tcp --runtime node --platform none',
       '--shape microservice --transport redis-streams --runtime node --platform none',
+      '--shape microservice --transport nats --runtime node --platform none',
+      '--shape microservice --transport kafka --runtime node --platform none',
+      '--shape microservice --transport rabbitmq --runtime node --platform none',
       '--shape microservice --transport mqtt --runtime node --platform none',
       '--shape microservice --transport grpc --runtime node --platform none',
       '--shape mixed --transport tcp --runtime node --platform fastify',
@@ -127,11 +154,16 @@ describe('runtime matrix docs contract', () => {
     ]);
     expectAll(read('docs/getting-started/quick-start.ko.md'), [
       '--shape application --transport http --runtime node --platform fastify',
+      '--shape application --transport http --runtime node --platform express',
+      '--shape application --transport http --runtime node --platform nodejs',
       '--shape application --transport http --runtime bun --platform bun',
       '--shape application --transport http --runtime deno --platform deno',
       '--shape application --transport http --runtime cloudflare-workers --platform cloudflare-workers',
       '--shape microservice --transport tcp --runtime node --platform none',
       '--shape microservice --transport redis-streams --runtime node --platform none',
+      '--shape microservice --transport nats --runtime node --platform none',
+      '--shape microservice --transport kafka --runtime node --platform none',
+      '--shape microservice --transport rabbitmq --runtime node --platform none',
       '--shape microservice --transport mqtt --runtime node --platform none',
       '--shape microservice --transport grpc --runtime node --platform none',
       '--shape mixed --transport tcp --runtime node --platform fastify',
@@ -154,12 +186,14 @@ describe('runtime matrix docs contract', () => {
     ]);
     expectAll(read('examples/README.md'), [
       'HTTP side of the published `fluo new` v2 matrix',
-      'plus Redis Streams, MQTT, and gRPC',
+      'Express, raw Node.js HTTP, Bun, Deno, and Cloudflare Workers',
+      'plus Redis Streams, NATS, Kafka, RabbitMQ, MQTT, and gRPC',
       'mixed single-package path',
     ]);
     expectAll(read('examples/README.ko.md'), [
       '공개된 `fluo new` v2 매트릭스의 HTTP 쪽 경로',
-      'Redis Streams, MQTT, gRPC',
+      'Express, raw Node.js HTTP, Bun, Deno, Cloudflare Workers',
+      'Redis Streams, NATS, Kafka, RabbitMQ, MQTT, gRPC',
       'mixed single-package 경로',
     ]);
     expectAll(read('examples/minimal/README.md'), [


### PR DESCRIPTION
## Summary

- sync the published `fluo new` support matrix and linked docs with the fully shipped runtime/platform and transport starter coverage
- refresh the package chooser, quick-start, CLI README mirrors, and examples wording so they describe the current starter contract instead of the pre-expansion subset
- expand the CLI docs-contract test so the broader starter matrix stays enforced in English/Korean docs surfaces

## Changes

- updated `docs/reference/fluo-new-support-matrix(.ko).md` to describe the shipped starter matrix versus the broader package ecosystem using the fully expanded runtime/platform and transport set
- added the shipped microservice starter command matrix to `docs/reference/package-chooser(.ko).md` and expanded `docs/getting-started/quick-start(.ko).md` with the missing Express/raw Node.js/NATS/Kafka/RabbitMQ starter commands
- aligned `packages/cli/README(.ko).md`, `examples/README(.ko).md`, and `packages/cli/src/runtime-matrix-docs-contract.test.ts` with the final published contract

## Testing

- `pnpm exec vitest run packages/cli/src/runtime-matrix-docs-contract.test.ts`
- `pnpm build`
- `lsp_diagnostics` on `packages/cli/src/runtime-matrix-docs-contract.test.ts`

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Closes #997