### PR TITLE
Resolve #1007: stage sandbox local packages before npm pack

### DIFF
--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -1,6 +1,8 @@
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, relative } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -8,6 +10,50 @@ import { scaffoldBootstrapApp } from './scaffold.js';
 import { DEFAULT_BOOTSTRAP_SCHEMA } from './resolver.js';
 
 const temporaryDirectories: string[] = [];
+const LOCAL_PACKAGE_DIRECTORY_BY_NAME = {
+  '@fluojs/platform-bun': 'platform-bun',
+  '@fluojs/cli': 'cli',
+  '@fluojs/config': 'config',
+  '@fluojs/core': 'core',
+  '@fluojs/di': 'di',
+  '@fluojs/http': 'http',
+  '@fluojs/platform-cloudflare-workers': 'platform-cloudflare-workers',
+  '@fluojs/platform-deno': 'platform-deno',
+  '@fluojs/microservices': 'microservices',
+  '@fluojs/platform-express': 'platform-express',
+  '@fluojs/platform-fastify': 'platform-fastify',
+  '@fluojs/platform-nodejs': 'platform-nodejs',
+  '@fluojs/runtime': 'runtime',
+  '@fluojs/testing': 'testing',
+  '@fluojs/validation': 'validation',
+} as const;
+
+const FIXTURE_WORKSPACE_DEPENDENCIES: Partial<Record<keyof typeof LOCAL_PACKAGE_DIRECTORY_BY_NAME, Record<string, string>>> = {
+  '@fluojs/http': {
+    '@fluojs/core': 'workspace:*',
+    '@fluojs/di': 'workspace:*',
+    '@fluojs/validation': 'workspace:*',
+  },
+  '@fluojs/platform-fastify': {
+    '@fluojs/http': 'workspace:*',
+    '@fluojs/runtime': 'workspace:*',
+  },
+  '@fluojs/platform-express': {
+    '@fluojs/http': 'workspace:*',
+    '@fluojs/runtime': 'workspace:*',
+  },
+  '@fluojs/platform-nodejs': {
+    '@fluojs/http': 'workspace:*',
+    '@fluojs/runtime': 'workspace:*',
+  },
+  '@fluojs/runtime': {
+    '@fluojs/config': 'workspace:*',
+    '@fluojs/core': 'workspace:*',
+  },
+  '@fluojs/testing': {
+    '@fluojs/runtime': 'workspace:*',
+  },
+};
 
 afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) {
@@ -40,6 +86,106 @@ function readDirectorySnapshot(rootDirectory: string): Record<string, string> {
   }
 
   return snapshot;
+}
+
+function createLocalPackageCacheDirectory(repoRoot: string): string {
+  return join(tmpdir(), 'fluo-cli-local-packages', createHash('sha1').update(resolve(repoRoot)).digest('hex').slice(0, 12));
+}
+
+function createFixtureLocalRepo(): string {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'fluo-local-repo-'));
+  temporaryDirectories.push(repoRoot);
+
+  for (const [packageName, packageDirectory] of Object.entries(LOCAL_PACKAGE_DIRECTORY_BY_NAME)) {
+    const packageRoot = join(repoRoot, 'packages', packageDirectory);
+    const distDirectory = join(packageRoot, 'dist');
+    mkdirSync(distDirectory, { recursive: true });
+    writeFileSync(
+      join(packageRoot, 'package.json'),
+      `${JSON.stringify(
+        {
+          name: packageName,
+          version: '1.0.0',
+          type: 'module',
+          files: ['dist'],
+          main: 'dist/index.js',
+          types: 'dist/index.d.ts',
+          dependencies: FIXTURE_WORKSPACE_DEPENDENCIES[packageName as keyof typeof LOCAL_PACKAGE_DIRECTORY_BY_NAME] ?? {},
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+    writeFileSync(join(distDirectory, 'index.js'), `export const packageName = '${packageName}';\n`, 'utf8');
+    writeFileSync(join(distDirectory, 'index.d.ts'), `export declare const packageName: '${packageName}';\n`, 'utf8');
+  }
+
+  execFileSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' });
+  execFileSync('git', ['add', '.'], { cwd: repoRoot, stdio: 'ignore' });
+  execFileSync(
+    'git',
+    ['-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.com', 'commit', '-m', 'fixture'],
+    { cwd: repoRoot, stdio: 'ignore' },
+  );
+
+  return repoRoot;
+}
+
+function createDefaultLocalScaffoldOptions(targetDirectory: string, repoRoot: string) {
+  return {
+    ...DEFAULT_BOOTSTRAP_SCHEMA,
+    dependencySource: 'local' as const,
+    packageManager: 'pnpm' as const,
+    projectName: 'starter-app',
+    repoRoot,
+    skipInstall: true,
+    targetDirectory,
+  };
+}
+
+function readLocalDependencyTarballPaths(targetDirectory: string): string[] {
+  const packageJson = JSON.parse(readFileSync(join(targetDirectory, 'package.json'), 'utf8')) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  const fileSpecs = new Set<string>();
+
+  for (const section of [packageJson.dependencies, packageJson.devDependencies]) {
+    for (const specifier of Object.values(section ?? {})) {
+      if (specifier.startsWith('file:')) {
+        fileSpecs.add(specifier.slice('file:'.length));
+      }
+    }
+  }
+
+  return Array.from(fileSpecs);
+}
+
+function readPackedPackageManifest(tarballPath: string): {
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+} {
+  return JSON.parse(
+    execFileSync('tar', ['-xOf', tarballPath, 'package/package.json'], {
+      encoding: 'utf8',
+    }),
+  ) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+  };
+}
+
+function expectNoWorkspaceProtocolDependencies(tarballPath: string): void {
+  const manifest = readPackedPackageManifest(tarballPath);
+
+  for (const section of [manifest.dependencies, manifest.optionalDependencies, manifest.peerDependencies]) {
+    for (const specifier of Object.values(section ?? {})) {
+      expect(specifier).not.toContain('workspace:');
+    }
+  }
 }
 
 describe('scaffoldBootstrapApp', () => {
@@ -77,6 +223,69 @@ describe('scaffoldBootstrapApp', () => {
     expect(vitestConfig).toContain("import { fluoBabelDecoratorsPlugin } from '@fluojs/testing/vitest';");
     expect(vitestConfig).not.toContain('baseUrl');
   });
+
+  it('packs local starter tarballs from staged package manifests without workspace protocol dependencies', async () => {
+    const repoRoot = createFixtureLocalRepo();
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-scaffold-local-pack-'));
+    temporaryDirectories.push(targetDirectory);
+
+    await scaffoldBootstrapApp(createDefaultLocalScaffoldOptions(targetDirectory, repoRoot));
+
+    const tarballPaths = readLocalDependencyTarballPaths(targetDirectory);
+
+    expect(tarballPaths.length).toBeGreaterThan(0);
+
+    for (const tarballPath of tarballPaths) {
+      expectNoWorkspaceProtocolDependencies(tarballPath);
+    }
+  }, 30_000);
+
+  it('invalidates stale local package cache tarballs from the old rewrite pipeline', async () => {
+    const repoRoot = createFixtureLocalRepo();
+    const localPackageCacheDirectory = createLocalPackageCacheDirectory(repoRoot);
+    const warmupTargetDirectory = mkdtempSync(join(tmpdir(), 'fluo-scaffold-local-cache-warmup-'));
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-scaffold-local-cache-refresh-'));
+    temporaryDirectories.push(warmupTargetDirectory, targetDirectory);
+
+    await scaffoldBootstrapApp(createDefaultLocalScaffoldOptions(warmupTargetDirectory, repoRoot));
+
+    const tarballPaths = readLocalDependencyTarballPaths(warmupTargetDirectory);
+    expect(tarballPaths.length).toBeGreaterThan(0);
+
+    const staleTarballPath = tarballPaths[0];
+    const staleTarballName = staleTarballPath.split('/').at(-1);
+    expect(staleTarballName).toBeTruthy();
+
+    const cacheStampPath = join(localPackageCacheDirectory, 'cache-stamp.json');
+    const cacheStamp = JSON.parse(readFileSync(cacheStampPath, 'utf8')) as {
+      cacheFormatVersion?: number;
+      dirtyFingerprint: string;
+      headCommit: string;
+      packageVersions: Record<string, string>;
+    };
+
+    writeFileSync(staleTarballPath, 'stale tarball from old rewrite pipeline', 'utf8');
+    writeFileSync(
+      cacheStampPath,
+      `${JSON.stringify(
+        {
+          dirtyFingerprint: cacheStamp.dirtyFingerprint,
+          headCommit: cacheStamp.headCommit,
+          packageVersions: cacheStamp.packageVersions,
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    await scaffoldBootstrapApp(createDefaultLocalScaffoldOptions(targetDirectory, repoRoot));
+
+    const refreshedTarballPath = readLocalDependencyTarballPaths(targetDirectory).find((tarballPath) => tarballPath.endsWith(`/${staleTarballName}`));
+    expect(refreshedTarballPath).toBeTruthy();
+    expect(readFileSync(refreshedTarballPath!, 'utf8')).not.toContain('stale tarball from old rewrite pipeline');
+    expectNoWorkspaceProtocolDependencies(refreshedTarballPath!);
+  }, 30_000);
 
   it('keeps the default Node + Fastify HTTP scaffold identical when explicit shape flags are provided', async () => {
     const defaultTargetDirectory = mkdtempSync(join(tmpdir(), 'fluo-scaffold-default-'));

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -126,8 +126,10 @@ function describeApplicationStarter(options: Pick<BootstrapOptions, 'platform' |
 
 const LOCAL_PACKAGE_CACHE_DIR = join(tmpdir(), 'fluo-cli-local-packages');
 const LOCAL_PACKAGE_CACHE_STAMP_FILE = 'cache-stamp.json';
+const LOCAL_PACKAGE_CACHE_FORMAT_VERSION = 2;
 
 type LocalPackageCacheStamp = {
+  cacheFormatVersion: number;
   dirtyFingerprint: string;
   headCommit: string;
   packageVersions: Partial<Record<LocalPackageName, string>>;
@@ -2134,10 +2136,10 @@ export async function scaffoldBootstrapApp(
   }
 }
 
-function runPackCommand(repoRoot: string, packageDirectory: string, outputDirectory: string): Promise<void> {
+function runPackCommand(packageDirectory: string, outputDirectory: string): Promise<void> {
   return new Promise<void>((resolvePromise, reject) => {
     const child = spawn('npm', ['pack', '--pack-destination', outputDirectory], {
-      cwd: join(repoRoot, 'packages', packageDirectory),
+      cwd: packageDirectory,
       stdio: 'inherit',
     });
 
@@ -2304,6 +2306,87 @@ function createPackagePathArguments(packageNames: readonly LocalPackageName[]): 
   return Array.from(packagePaths);
 }
 
+function copyIfExists(sourcePath: string, destinationPath: string): void {
+  if (!existsSync(sourcePath)) {
+    return;
+  }
+
+  cpSync(sourcePath, destinationPath, { recursive: true });
+}
+
+function collectPackageStagePaths(
+  packageRoot: string,
+  manifest: {
+    bin?: Record<string, string> | string;
+    files?: string[];
+    main?: string;
+    types?: string;
+  },
+): string[] {
+  const stagePaths = new Set<string>();
+
+  for (const fixedPath of ['README.md', 'README.ko.md', 'LICENSE', 'LICENSE.md', 'LICENSE.txt']) {
+    if (existsSync(join(packageRoot, fixedPath))) {
+      stagePaths.add(fixedPath);
+    }
+  }
+
+  for (const fileEntry of manifest.files ?? []) {
+    if (existsSync(join(packageRoot, fileEntry))) {
+      stagePaths.add(fileEntry);
+    }
+  }
+
+  if (typeof manifest.bin === 'string') {
+    stagePaths.add(manifest.bin);
+  } else if (manifest.bin) {
+    for (const binPath of Object.values(manifest.bin)) {
+      stagePaths.add(binPath);
+    }
+  }
+
+  if (manifest.main) {
+    stagePaths.add(manifest.main);
+  }
+
+  if (manifest.types) {
+    stagePaths.add(manifest.types);
+  }
+
+  return Array.from(stagePaths);
+}
+
+function stagePackageForPacking(
+  repoRoot: string,
+  packageName: LocalPackageName,
+  packageVersions: ReadonlyMap<string, string>,
+  outputDirectory: string,
+): string {
+  const packageDirectory = PACKAGE_DIRECTORY_BY_NAME[packageName];
+  const packageRoot = join(repoRoot, 'packages', packageDirectory);
+  const stageDirectory = join(outputDirectory, `.stage-${packageDirectory}`);
+  const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as {
+    bin?: Record<string, string> | string;
+    dependencies?: Record<string, string>;
+    files?: string[];
+    main?: string;
+    optionalDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    types?: string;
+  };
+
+  rmSync(stageDirectory, { force: true, recursive: true });
+  mkdirSync(stageDirectory, { recursive: true });
+
+  for (const relativePath of collectPackageStagePaths(packageRoot, manifest)) {
+    copyIfExists(join(packageRoot, relativePath), join(stageDirectory, relativePath));
+  }
+
+  rewriteWorkspaceProtocolDependencies(manifest, packageVersions);
+  writeFileSync(join(stageDirectory, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  return stageDirectory;
+}
+
 function computeLocalPackageCacheStamp(
   repoRoot: string,
   packageNames: readonly LocalPackageName[],
@@ -2323,6 +2406,7 @@ function computeLocalPackageCacheStamp(
   }
 
   return {
+    cacheFormatVersion: LOCAL_PACKAGE_CACHE_FORMAT_VERSION,
     dirtyFingerprint,
     headCommit,
     packageVersions: toPackageVersionRecord(packageVersions),
@@ -2343,6 +2427,10 @@ function readLocalPackageCacheStamp(stampPath: string): LocalPackageCacheStamp |
 
 function cacheStampMatches(expected: LocalPackageCacheStamp, actual: LocalPackageCacheStamp | undefined): boolean {
   if (!actual) {
+    return false;
+  }
+
+  if (actual.cacheFormatVersion !== LOCAL_PACKAGE_CACHE_FORMAT_VERSION) {
     return false;
   }
 
@@ -2371,6 +2459,22 @@ function cacheContainsTarballs(
     const tarball = expectedTarballName(packageName, packageVersion);
     return packedFiles.has(tarball);
   });
+}
+
+function clearLocalPackageCacheArtifacts(outputDirectory: string): void {
+  if (!existsSync(outputDirectory)) {
+    return;
+  }
+
+  for (const entry of readdirSync(outputDirectory, { withFileTypes: true })) {
+    if (entry.name === LOCAL_PACKAGE_CACHE_STAMP_FILE) {
+      continue;
+    }
+
+    if (entry.isDirectory() || entry.name.endsWith('.tgz')) {
+      rmSync(join(outputDirectory, entry.name), { force: true, recursive: true });
+    }
+  }
 }
 
 function createLocalPackageCachePath(repoRoot: string): string {
@@ -2444,8 +2548,17 @@ async function packLocalPackages(
     const packageVersion = getPackageVersionOrThrow(packageVersions, packageName);
     const tarballName = expectedTarballName(packageName, packageVersion);
 
-    await runPackCommand(repoRoot, PACKAGE_DIRECTORY_BY_NAME[packageName], outputDirectory);
-    await normalizePackedPackageManifest(outputDirectory, tarballName, packageVersions);
+    const stageDirectory = stagePackageForPacking(repoRoot, packageName, packageVersions, outputDirectory);
+
+    try {
+      await runPackCommand(stageDirectory, outputDirectory);
+    } finally {
+      rmSync(stageDirectory, { force: true, recursive: true });
+    }
+
+    if (!existsSync(join(outputDirectory, tarballName))) {
+      throw new Error(`Unable to locate packed tarball for ${packageName}.`);
+    }
   }
 }
 
@@ -2502,53 +2615,6 @@ function rewriteWorkspaceProtocolDependencies(
   }
 }
 
-function runTarCommand(args: string[], cwd: string): Promise<void> {
-  return new Promise<void>((resolvePromise, reject) => {
-    const child = spawn('tar', args, {
-      cwd,
-      stdio: 'inherit',
-    });
-
-    child.on('error', reject);
-    child.on('exit', (code) => {
-      if (code === 0) {
-        resolvePromise();
-        return;
-      }
-
-      reject(new Error(`tar ${args.join(' ')} failed with exit code ${code}.`));
-    });
-  });
-}
-
-async function normalizePackedPackageManifest(
-  outputDirectory: string,
-  tarballName: string,
-  packageVersions: ReadonlyMap<string, string>,
-): Promise<void> {
-  const tarballPath = join(outputDirectory, tarballName);
-  const temporaryDirectory = join(outputDirectory, `.tmp-${tarballName.replace(/\.tgz$/, '')}`);
-  const packageJsonPath = join(temporaryDirectory, 'package', 'package.json');
-
-  rmSync(temporaryDirectory, { force: true, recursive: true });
-  mkdirSync(temporaryDirectory, { recursive: true });
-
-  await runTarCommand(['-xzf', tarballPath, '-C', temporaryDirectory], outputDirectory);
-
-  const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
-    dependencies?: Record<string, string>;
-    optionalDependencies?: Record<string, string>;
-    peerDependencies?: Record<string, string>;
-  };
-
-  rewriteWorkspaceProtocolDependencies(manifest, packageVersions);
-  writeFileSync(packageJsonPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
-
-  rmSync(tarballPath, { force: true });
-  await runTarCommand(['-czf', tarballPath, '-C', temporaryDirectory, 'package'], outputDirectory);
-  rmSync(temporaryDirectory, { force: true, recursive: true });
-}
-
 async function resolvePackageSpecs(
   options: BootstrapOptions,
   bootstrapPlan: ResolvedBootstrapPlan,
@@ -2575,6 +2641,7 @@ async function resolvePackageSpecs(
 
   if (!canReuseCachedTarballs) {
     await ensureWorkspaceBuildOutput(repoRoot, packageNames);
+    clearLocalPackageCacheArtifacts(outputDirectory);
     await packLocalPackages(repoRoot, outputDirectory, packageNames, packageVersions);
 
     if (expectedCacheStamp) {


### PR DESCRIPTION
Closes #1007

## Summary
- replace tarball extract/repack normalization with staged local package directories plus `npm pack`
- add cache format/version hygiene so stale tarballs from the old rewrite pipeline are not reused
- add focused scaffold regression coverage while keeping `sandbox:test` as the smoke path

## Verification
- pnpm --filter @fluojs/cli exec vitest run -c vitest.config.ts src/new/scaffold.test.ts
- pnpm --filter @fluojs/cli build
- pnpm --dir packages/cli sandbox:test starter-review

## Contract impact
- sandbox/local dependency-source installs become deterministic without changing the user-facing sandbox command contract