### PR TITLE
Resolve #1010: add named Redis client support

### DIFF
--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -69,6 +69,10 @@ export class CacheRepository {
 
 ## 일반적인 패턴
 
+### 이름 있는 클라이언트
+
+하나의 애플리케이션에서 여러 Redis 연결이 필요하면 `RedisModule.forRootNamed(name, options)`를 사용하세요. `RedisModule.forRoot(options)`는 계속 기본 `REDIS_CLIENT`와 `RedisService` 별칭을 유지하고, 이름 있는 등록은 `getRedisClientToken(name)`과 `getRedisServiceToken(name)`으로 해석합니다.
+
 ### 원시 클라이언트 접근 (Raw Client Access)
 
 파이프라인, Lua 스크립트, Pub/Sub 등 복잡한 Redis 명령이 필요한 경우 원시 클라이언트를 직접 주입받아 사용합니다.
@@ -92,8 +96,11 @@ export class AdvancedService {
 
 ### 핵심 구성 요소
 - `RedisModule`: 전역 Redis 클라이언트 등록 및 수명 주기 훅을 관리합니다.
+- `RedisModule.forRootNamed(name, options)`: 기본 별칭을 유지한 채 추가 Redis 클라이언트를 등록합니다.
 - `RedisService`: JSON 코덱 지원 및 `get`/`set`/`del` 메서드를 제공하는 파사드입니다.
 - `REDIS_CLIENT`: 내부 `ioredis` 인스턴스에 접근하기 위한 DI 토큰입니다.
+- `getRedisClientToken(name)`: 이름 있는 raw client 토큰 헬퍼입니다.
+- `getRedisServiceToken(name)`: 이름 있는 `RedisService` 토큰 헬퍼입니다.
 
 ### 타입
 - `RedisModuleOptions`: `ioredis` 생성자에 전달되는 설정 옵션입니다.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -69,6 +69,10 @@ export class CacheRepository {
 
 ## Common Patterns
 
+### Named Clients
+
+Use `RedisModule.forRootNamed(name, options)` when one application needs more than one Redis connection. `RedisModule.forRoot(options)` still owns the default `REDIS_CLIENT` and `RedisService` aliases; named registrations are resolved with `getRedisClientToken(name)` and `getRedisServiceToken(name)`.
+
 ### Raw Client Access
 
 If you need advanced Redis commands (pipelines, lua scripts, pub/sub), inject the raw client directly.
@@ -92,8 +96,11 @@ export class AdvancedService {
 
 ### Core
 - `RedisModule`: Registers the global Redis client and lifecycle hooks.
+- `RedisModule.forRootNamed(name, options)`: Registers an additional named Redis client without replacing the default aliases.
 - `RedisService`: Facade with JSON codec support and `get`/`set`/`del` methods.
 - `REDIS_CLIENT`: DI token for the underlying `ioredis` instance.
+- `getRedisClientToken(name)`: DI token helper for a named raw client.
+- `getRedisServiceToken(name)`: DI token helper for a named `RedisService` facade.
 
 ### Types
 - `RedisModuleOptions`: Configuration options passed directly to the `ioredis` constructor.

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -1,5 +1,5 @@
 export * from './module.js';
-export { RedisService } from './redis-service.js';
+export * from './redis-service.js';
 export * from './status.js';
 export * from './tokens.js';
 export * from './types.js';

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -78,6 +78,8 @@ vi.mock('ioredis', () => ({
 }));
 
 import {
+  getRedisClientToken,
+  getRedisServiceToken,
   RedisModule,
   createRedisPlatformStatusSnapshot,
   REDIS_CLIENT,
@@ -137,6 +139,60 @@ describe('@fluojs/redis', () => {
     await app.close();
 
     expect(mockRedisState.events).toEqual(['connect', 'quit']);
+  });
+
+  it('registers named Redis clients without changing the default aliases', async () => {
+    const NAMED_REDIS_CLIENT = getRedisClientToken('cache');
+    const NAMED_REDIS_SERVICE = getRedisServiceToken('cache');
+
+    @Inject(REDIS_CLIENT)
+    class DefaultClientConsumer {
+      constructor(readonly redis: MockRedisInstance) {}
+    }
+
+    @Inject(NAMED_REDIS_CLIENT)
+    class NamedClientConsumer {
+      constructor(readonly redis: MockRedisInstance) {}
+    }
+
+    @Inject(RedisService, NAMED_REDIS_SERVICE)
+    class RedisFacadeConsumer {
+      constructor(
+        readonly defaultRedis: RedisService,
+        readonly namedRedis: RedisService,
+      ) {}
+    }
+
+    class FeatureModule {}
+    defineModule(FeatureModule, {
+      providers: [DefaultClientConsumer, NamedClientConsumer, RedisFacadeConsumer],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        RedisModule.forRoot({ db: 0, host: '127.0.0.1', port: 6379 }),
+        RedisModule.forRootNamed('cache', { db: 1, host: '127.0.0.1', port: 6379 }),
+        FeatureModule,
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const defaultConsumer = await app.container.resolve(DefaultClientConsumer);
+    const namedConsumer = await app.container.resolve(NamedClientConsumer);
+    const facadeConsumer = await app.container.resolve(RedisFacadeConsumer);
+
+    expect(mockRedisState.instances).toHaveLength(2);
+    expect(defaultConsumer.redis).toBe(mockRedisState.instances[0]);
+    expect(namedConsumer.redis).toBe(mockRedisState.instances[1]);
+    expect(facadeConsumer.defaultRedis.getRawClient()).toBe(defaultConsumer.redis);
+    expect(facadeConsumer.namedRedis.getRawClient()).toBe(namedConsumer.redis);
+    expect(await app.container.resolve(NAMED_REDIS_SERVICE)).toBe(facadeConsumer.namedRedis);
+    expect(mockRedisState.events).toEqual(['connect', 'connect']);
+
+    await app.close();
+
+    expect(mockRedisState.events).toEqual(['connect', 'connect', 'quit', 'quit']);
   });
 
   it('falls back to disconnect when quit fails during shutdown', async () => {
@@ -307,6 +363,7 @@ describe('@fluojs/redis', () => {
     expect(snapshot.readiness).toEqual({ critical: true, status: 'ready' });
     expect(snapshot.health).toEqual({ status: 'healthy' });
     expect(snapshot.details).toMatchObject({
+      componentId: undefined,
       connectionState: 'ready',
       lazyConnect: true,
     });

--- a/packages/redis/src/module.ts
+++ b/packages/redis/src/module.ts
@@ -2,29 +2,73 @@ import type { Provider } from '@fluojs/di';
 import { defineModule, type ModuleType } from '@fluojs/runtime';
 import Redis from 'ioredis';
 
-import { RedisService } from './redis-service.js';
+import { getRedisServiceToken, RedisService } from './redis-service.js';
 import { RedisLifecycleService } from './service.js';
-import { REDIS_CLIENT } from './tokens.js';
+import { getRedisClientToken, REDIS_CLIENT } from './tokens.js';
 import type { RedisModuleOptions } from './types.js';
+
+function getRedisLifecycleToken(name: string): symbol {
+  return Symbol.for(`fluo.redis.lifecycle:${name}`);
+}
 
 /**
  * Creates the providers that back Fluo's shared Redis integration.
  *
  * @param options Redis constructor options forwarded to `ioredis` with `lazyConnect` forced on.
+ * @param name Optional Redis client name for additional named registrations.
  * @returns Providers for the raw client token, the JSON-aware facade, and lifecycle hooks.
  */
-export function createRedisProviders(options: RedisModuleOptions): Provider[] {
+export function createRedisProviders(options: RedisModuleOptions, name?: string): Provider[] {
+  const clientToken = getRedisClientToken(name);
+
+  if (clientToken === REDIS_CLIENT) {
+    return [
+      {
+        scope: 'singleton',
+        provide: REDIS_CLIENT,
+        useFactory: () => new Redis({
+          ...options,
+          lazyConnect: true,
+        }),
+      },
+      RedisService,
+      RedisLifecycleService,
+    ];
+  }
+
+  if (name === undefined) {
+    throw new Error('Redis client name must be defined for named provider creation.');
+  }
+
+  const serviceToken = getRedisServiceToken(name);
+
   return [
     {
       scope: 'singleton',
-      provide: REDIS_CLIENT,
+      provide: clientToken,
       useFactory: () => new Redis({
         ...options,
         lazyConnect: true,
       }),
     },
-    RedisService,
-    RedisLifecycleService,
+    {
+      inject: [clientToken],
+      provide: serviceToken,
+      scope: 'singleton',
+      useFactory: (...deps: unknown[]) => {
+        const [client] = deps as [Redis];
+        return new RedisService(client);
+      },
+    },
+    {
+      inject: [clientToken],
+      provide: getRedisLifecycleToken(name),
+      scope: 'singleton',
+      useFactory: (...deps: unknown[]) => {
+        const [client] = deps as [Redis];
+        return new RedisLifecycleService(client, name);
+      },
+    },
   ];
 }
 
@@ -54,6 +98,18 @@ export class RedisModule {
       global: true,
       exports: [REDIS_CLIENT, RedisService],
       providers: createRedisProviders(options),
+    });
+  }
+
+  static forRootNamed(name: string, options: RedisModuleOptions): ModuleType {
+    const clientToken = getRedisClientToken(name);
+    const serviceToken = getRedisServiceToken(name);
+    class NamedRedisModuleDefinition {}
+
+    return defineModule(NamedRedisModuleDefinition, {
+      global: true,
+      exports: [clientToken, serviceToken],
+      providers: createRedisProviders(options, name),
     });
   }
 }

--- a/packages/redis/src/redis-service.ts
+++ b/packages/redis/src/redis-service.ts
@@ -1,7 +1,7 @@
-import { Inject } from '@fluojs/core';
+import { Inject, type Token } from '@fluojs/core';
 import type Redis from 'ioredis';
 
-import { REDIS_CLIENT } from './tokens.js';
+import { REDIS_CLIENT, getRedisClientToken } from './tokens.js';
 
 function decodeRedisValue(raw: string): unknown {
   try {
@@ -86,4 +86,18 @@ export class RedisService {
   getRawClient(): Redis {
     return this.client;
   }
+}
+
+/**
+ * Resolves the facade token for the default or a named `RedisService` binding.
+ *
+ * @param name Optional Redis client name registered through `RedisModule.forRootNamed(...)`.
+ * @returns `RedisService` for the default client path, otherwise a stable named service token.
+ */
+export function getRedisServiceToken(name?: string): Token<RedisService> {
+  if (getRedisClientToken(name) === REDIS_CLIENT) {
+    return RedisService;
+  }
+
+  return Symbol.for(`fluo.redis.service:${name?.trim()}`) as Token<RedisService>;
 }

--- a/packages/redis/src/service.ts
+++ b/packages/redis/src/service.ts
@@ -3,7 +3,7 @@ import type Redis from 'ioredis';
 import type { OnApplicationShutdown, OnModuleInit } from '@fluojs/runtime';
 
 import { createRedisPlatformStatusSnapshot } from './status.js';
-import { REDIS_CLIENT } from './tokens.js';
+import { getRedisComponentId, REDIS_CLIENT } from './tokens.js';
 
 const QUITTABLE_STATUSES = new Set(['connect', 'connecting', 'ready', 'reconnecting']);
 const DISCONNECTABLE_STATUSES = new Set(['close', 'connect', 'connecting', 'ready', 'reconnecting', 'wait']);
@@ -29,7 +29,10 @@ function isDisconnectable(status: string): boolean {
  */
 @Inject(REDIS_CLIENT)
 export class RedisLifecycleService implements OnModuleInit, OnApplicationShutdown {
-  constructor(private readonly client: Redis) {}
+  constructor(
+    private readonly client: Redis,
+    private readonly clientName?: string,
+  ) {}
 
   async onModuleInit(): Promise<void> {
     if (!this.shouldConnectOnInit()) {
@@ -57,6 +60,7 @@ export class RedisLifecycleService implements OnModuleInit, OnApplicationShutdow
 
   createPlatformStatusSnapshot() {
     return createRedisPlatformStatusSnapshot({
+      componentId: getRedisComponentId(this.clientName),
       status: this.client.status,
     });
   }

--- a/packages/redis/src/status.ts
+++ b/packages/redis/src/status.ts
@@ -1,6 +1,7 @@
 import type Redis from 'ioredis';
 import type { PlatformHealthReport, PlatformReadinessReport, PlatformSnapshot } from '@fluojs/runtime';
 
+/** Normalized Redis platform snapshot shape used by health/readiness integrations. */
 export interface PersistencePlatformStatusSnapshot {
   readiness: PlatformReadinessReport;
   health: PlatformHealthReport;
@@ -8,7 +9,9 @@ export interface PersistencePlatformStatusSnapshot {
   details: Record<string, unknown>;
 }
 
+/** Input consumed by the Redis status adapter when translating runtime state. */
 export interface RedisStatusAdapterInput {
+  componentId?: string;
   status: Redis['status'];
 }
 
@@ -66,9 +69,16 @@ function createHealth(input: RedisStatusAdapterInput): PlatformHealthReport {
   };
 }
 
+/**
+ * Adapts one Redis client status into Fluo's platform snapshot contract.
+ *
+ * @param input Redis client status and optional component identity.
+ * @returns A normalized snapshot describing readiness, health, ownership, and details.
+ */
 export function createRedisPlatformStatusSnapshot(input: RedisStatusAdapterInput): PersistencePlatformStatusSnapshot {
   return {
     details: {
+      componentId: input.componentId,
       connectionState: input.status,
       lazyConnect: true,
     },

--- a/packages/redis/src/tokens.ts
+++ b/packages/redis/src/tokens.ts
@@ -1,2 +1,45 @@
-/** Injection token for the shared `ioredis` client managed by {@link RedisModule}. */
+/** Injection token for the shared default `ioredis` client managed by {@link RedisModule}. */
 export const REDIS_CLIENT = Symbol.for('fluo.redis.client');
+
+/** Stable name used when callers request the default Redis client contract. */
+export const DEFAULT_REDIS_CLIENT_NAME = 'default';
+
+function normalizeRedisClientName(name?: string): string | undefined {
+  if (name === undefined) {
+    return undefined;
+  }
+
+  const normalized = name.trim();
+
+  if (normalized.length === 0) {
+    throw new Error('Redis client name must be a non-empty string.');
+  }
+
+  return normalized;
+}
+
+/**
+ * Resolves the DI token for the default or a named Redis client.
+ *
+ * @param name Optional Redis client name registered through `RedisModule.forRootNamed(...)`.
+ * @returns The default `REDIS_CLIENT` token when `name` is omitted, otherwise a stable named token.
+ */
+export function getRedisClientToken(name?: string): symbol {
+  const normalizedName = normalizeRedisClientName(name);
+
+  if (normalizedName === undefined) {
+    return REDIS_CLIENT;
+  }
+
+  return Symbol.for(`fluo.redis.client:${normalizedName}`);
+}
+
+/**
+ * Builds the stable component/dependency id used by platform status snapshots.
+ *
+ * @param name Optional Redis client name registered through `RedisModule.forRootNamed(...)`.
+ * @returns A stable component id such as `redis.default` or `redis.jobs`.
+ */
+export function getRedisComponentId(name?: string): string {
+  return `redis.${normalizeRedisClientName(name) ?? DEFAULT_REDIS_CLIENT_NAME}`;
+}


### PR DESCRIPTION
## Summary
- preserve the default `REDIS_CLIENT` / `RedisService` contract while adding first-class named Redis client helpers and `RedisModule.forRootNamed(...)`
- wire `@fluojs/cache-manager`, `@fluojs/queue`, `@fluojs/cron`, and `@fluojs/terminus` to resolve configured named Redis clients without colliding with the default alias
- update package READMEs, regression tests, and public-surface snapshots for the new named-client contract

## Changes
- added `getRedisClientToken(name?)`, `getRedisServiceToken(name?)`, stable Redis component ids, and named lifecycle-managed providers in `@fluojs/redis`
- updated downstream Redis consumers to accept `clientName`/named Redis resolution while preserving existing default behavior
- refreshed docs and test coverage for default and named registration/lifecycle behavior

## Testing
- `pnpm verify` (build, typecheck, lint all passed; initial full test run exposed queue dead-letter regressions)
- `pnpm exec vitest run packages/queue/src/module.test.ts`
- `node tooling/governance/verify-public-export-tsdoc.mjs`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1010