### PR TITLE
Resolve #1011: support named Redis client selection in queue and cron

### DIFF
--- a/packages/cron/README.ko.md
+++ b/packages/cron/README.ko.md
@@ -87,6 +87,8 @@ import { RedisModule } from '@fluojs/redis';
 class AppModule {}
 ```
 
+분산 락에 기본 Redis가 아닌 다른 연결을 쓰려면 `RedisModule.forRootNamed(...)`로 등록한 이름을 `distributed.clientName`에 지정하세요.
+
 ### 동적 스케줄링
 
 `SCHEDULING_REGISTRY`를 사용하여 런타임에 작업을 관리할 수 있습니다.

--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -87,6 +87,8 @@ import { RedisModule } from '@fluojs/redis';
 class AppModule {}
 ```
 
+To use a non-default Redis connection for distributed locks, set `distributed.clientName` to the name registered through `RedisModule.forRootNamed(...)`.
+
 ### Dynamic Scheduling
 
 You can manage tasks at runtime using the `SCHEDULING_REGISTRY`.

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Inject, Scope } from '@fluojs/core';
 import { defineControllerMetadata } from '@fluojs/core/internal';
-import { REDIS_CLIENT } from '@fluojs/redis';
+import { getRedisClientToken, REDIS_CLIENT } from '@fluojs/redis';
 import { bootstrapApplication, defineModule, type ApplicationLogger } from '@fluojs/runtime';
 
 import { Cron, Interval, Timeout } from './decorators.js';
@@ -644,7 +644,7 @@ describe('@fluojs/cron', () => {
     await appTwo.close();
   });
 
-  it('fails bootstrap before scheduling jobs when distributed mode is enabled without REDIS_CLIENT', async () => {
+  it('fails bootstrap before scheduling jobs when the configured Redis client is missing', async () => {
     const scheduler = createManualScheduler();
 
     class DistributedTaskService {
@@ -668,12 +668,12 @@ describe('@fluojs/cron', () => {
     });
 
     await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
-      'Cron distributed mode requires REDIS_CLIENT to be registered.',
+      'Cron distributed mode requires the configured Redis client to be registered.',
     );
     expect(scheduler.records).toHaveLength(0);
   });
 
-  it('fails bootstrap before scheduling jobs when REDIS_CLIENT cannot perform lock operations', async () => {
+  it('fails bootstrap before scheduling jobs when the configured Redis client cannot perform lock operations', async () => {
     const scheduler = createManualScheduler();
 
     class DistributedTaskService {
@@ -701,8 +701,55 @@ describe('@fluojs/cron', () => {
         providers: [{ provide: REDIS_CLIENT, useValue: {} }],
         rootModule: AppModule,
       }),
-    ).rejects.toThrow('Cron distributed mode requires REDIS_CLIENT to implement set/eval lock operations.');
+    ).rejects.toThrow('Cron distributed mode requires the configured Redis client to implement set/eval lock operations.');
     expect(scheduler.records).toHaveLength(0);
+  });
+
+  it('uses a named Redis client for distributed locking when clientName is configured', async () => {
+    const NAMED_REDIS_CLIENT = getRedisClientToken('locks');
+    const scheduler = createManualScheduler();
+    const redis = new InMemoryLockRedisClient();
+
+    class Store {
+      runs = 0;
+    }
+
+    @Inject(Store)
+    class DistributedTaskService {
+      constructor(private readonly store: Store) {}
+
+      @Cron(CronExpression.EVERY_SECOND, { name: 'named-distributed-task' })
+      async run() {
+        this.store.runs += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        CronModule.forRoot({
+          distributed: {
+            clientName: 'locks',
+            enabled: true,
+            keyPrefix: 'named-locks',
+            lockTtlMs: 60_000,
+          },
+          scheduler: scheduler.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService, Store],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: NAMED_REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    await scheduler.records[0]!.tick();
+
+    expect((await app.container.resolve(Store)).runs).toBe(1);
+
+    await app.close();
   });
 
   it('releases owned distributed locks during shutdown so another node can continue', async () => {

--- a/packages/cron/src/module.ts
+++ b/packages/cron/src/module.ts
@@ -4,15 +4,16 @@ import { defineModule, type ModuleType } from '@fluojs/runtime';
 import { CronLifecycleService } from './service.js';
 import { defaultCronScheduler } from './scheduler.js';
 import { CRON_OPTIONS, SCHEDULING_REGISTRY } from './tokens.js';
-import type { CronDistributedOptions, CronModuleOptions, NormalizedCronModuleOptions } from './types.js';
+import type { CronModuleOptions, NormalizedCronModuleOptions } from './types.js';
 
 function randomId(): string {
   return `${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-function normalizeDistributedOptions(distributed: CronModuleOptions['distributed']): Required<CronDistributedOptions> & { enabled: boolean } {
+function normalizeDistributedOptions(distributed: CronModuleOptions['distributed']): NormalizedCronModuleOptions['distributed'] {
   if (distributed === undefined || distributed === false) {
     return {
+      clientName: undefined,
       enabled: false,
       keyPrefix: 'fluo:cron:lock',
       lockTtlMs: 30_000,
@@ -22,6 +23,7 @@ function normalizeDistributedOptions(distributed: CronModuleOptions['distributed
 
   if (distributed === true) {
     return {
+      clientName: undefined,
       enabled: true,
       keyPrefix: 'fluo:cron:lock',
       lockTtlMs: 30_000,
@@ -30,6 +32,7 @@ function normalizeDistributedOptions(distributed: CronModuleOptions['distributed
   }
 
   return {
+    clientName: distributed.clientName,
     enabled: distributed.enabled ?? true,
     keyPrefix: distributed.keyPrefix ?? 'fluo:cron:lock',
     lockTtlMs: distributed.lockTtlMs ?? 30_000,

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -1,7 +1,7 @@
 import { Inject, type MetadataPropertyKey, type Token } from '@fluojs/core';
 import { getClassDiMetadata } from '@fluojs/core/internal';
 import type { Container, Provider } from '@fluojs/di';
-import { REDIS_CLIENT } from '@fluojs/redis';
+import { getRedisClientToken, getRedisComponentId } from '@fluojs/redis';
 import { Cron as CronValidator } from 'croner';
 import {
   type ApplicationLogger,
@@ -415,6 +415,7 @@ export class CronLifecycleService
 
     return createCronPlatformStatusSnapshot({
       activeTicks: this.activeTasks.size,
+      dependencyId: this.options.distributed.enabled ? getRedisComponentId(this.options.distributed.clientName) : undefined,
       distributedEnabled: this.options.distributed.enabled,
       enabledTasks,
       lifecycleState: this.lifecycleState,
@@ -493,14 +494,16 @@ export class CronLifecycleService
       return;
     }
 
-    if (!this.runtimeContainer.has(REDIS_CLIENT)) {
-      throw new Error('Cron distributed mode requires REDIS_CLIENT to be registered.');
+    const redisToken = getRedisClientToken(this.options.distributed.clientName);
+
+    if (!this.runtimeContainer.has(redisToken)) {
+      throw new Error('Cron distributed mode requires the configured Redis client to be registered.');
     }
 
-    const redisClient = await this.runtimeContainer.resolve(REDIS_CLIENT);
+    const redisClient = await this.runtimeContainer.resolve(redisToken);
 
     if (!hasRedisLockClient(redisClient)) {
-      throw new Error('Cron distributed mode requires REDIS_CLIENT to implement set/eval lock operations.');
+      throw new Error('Cron distributed mode requires the configured Redis client to implement set/eval lock operations.');
     }
 
     this.redisClient = redisClient;

--- a/packages/cron/src/status.test.ts
+++ b/packages/cron/src/status.test.ts
@@ -6,6 +6,7 @@ describe('createCronPlatformStatusSnapshot', () => {
   it('reports distributed dependency edge and ready/healthy state', () => {
     const snapshot = createCronPlatformStatusSnapshot({
       activeTicks: 0,
+      dependencyId: 'redis.locks',
       distributedEnabled: true,
       enabledTasks: 2,
       lifecycleState: 'ready',
@@ -20,7 +21,7 @@ describe('createCronPlatformStatusSnapshot', () => {
     expect(snapshot.readiness).toEqual({ critical: true, status: 'ready' });
     expect(snapshot.health).toEqual({ status: 'healthy' });
     expect(snapshot.details).toMatchObject({
-      dependencies: ['redis.default'],
+      dependencies: ['redis.locks'],
       distributedEnabled: true,
       totalTasks: 3,
     });
@@ -29,6 +30,7 @@ describe('createCronPlatformStatusSnapshot', () => {
   it('marks lock renewal failures as degraded health', () => {
     const snapshot = createCronPlatformStatusSnapshot({
       activeTicks: 0,
+      dependencyId: 'redis.default',
       distributedEnabled: true,
       enabledTasks: 1,
       lifecycleState: 'ready',

--- a/packages/cron/src/status.ts
+++ b/packages/cron/src/status.ts
@@ -1,9 +1,12 @@
 import type { PlatformHealthReport, PlatformReadinessReport, PlatformSnapshot } from '@fluojs/runtime';
 
+/** Lifecycle phases reported by the cron platform status adapter. */
 export type CronLifecycleState = 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
 
+/** Input payload used to derive cron readiness, health, and dependency details. */
 export interface CronStatusAdapterInput {
   activeTicks: number;
+  dependencyId?: string;
   distributedEnabled: boolean;
   enabledTasks: number;
   lifecycleState: CronLifecycleState;
@@ -15,6 +18,7 @@ export interface CronStatusAdapterInput {
   totalTasks: number;
 }
 
+/** Cron-specific platform snapshot returned to health and readiness integrations. */
 export interface CronPlatformStatusSnapshot {
   readiness: PlatformReadinessReport;
   health: PlatformHealthReport;
@@ -104,11 +108,17 @@ function createHealth(input: CronStatusAdapterInput): PlatformHealthReport {
   };
 }
 
+/**
+ * Creates the cron platform snapshot consumed by status reporters.
+ *
+ * @param input Normalized cron runtime metrics and dependency information.
+ * @returns Readiness, health, ownership, and cron detail fields.
+ */
 export function createCronPlatformStatusSnapshot(input: CronStatusAdapterInput): CronPlatformStatusSnapshot {
   return {
     details: {
       activeTicks: input.activeTicks,
-      dependencies: input.distributedEnabled ? ['redis.default'] : [],
+      dependencies: input.distributedEnabled ? [input.dependencyId ?? 'redis.default'] : [],
       distributedEnabled: input.distributedEnabled,
       enabledTasks: input.enabledTasks,
       lifecycleState: input.lifecycleState,

--- a/packages/cron/src/types.ts
+++ b/packages/cron/src/types.ts
@@ -55,6 +55,7 @@ export type SchedulingTaskMetadata = CronTaskMetadata | IntervalTaskMetadata | T
 
 /** Distributed lock configuration for multi-instance scheduling. */
 export interface CronDistributedOptions {
+  clientName?: string;
   enabled?: boolean;
   keyPrefix?: string;
   lockTtlMs?: number;
@@ -88,7 +89,13 @@ export interface CronModuleOptions {
 
 /** Normalized scheduler configuration used internally by {@link CronLifecycleService}. */
 export interface NormalizedCronModuleOptions {
-  distributed: Required<CronDistributedOptions> & { enabled: boolean };
+  distributed: {
+    clientName?: string;
+    enabled: boolean;
+    keyPrefix: string;
+    lockTtlMs: number;
+    ownerId: string;
+  };
   scheduler: CronScheduler;
 }
 

--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -78,6 +78,14 @@ export class OrderService {
 
 ## 일반적인 패턴
 
+### 이름 있는 Redis 클라이언트
+
+큐가 기본 Redis 대신 다른 연결을 사용해야 한다면 `RedisModule.forRootNamed(...)`로 등록한 이름을 `clientName`에 지정하세요.
+
+```typescript
+QueueModule.forRoot({ clientName: 'jobs' })
+```
+
 ### 분산 재시도 (Distributed Retries)
 
 워커 설정에서 최대 시도 횟수와 백오프 전략을 지정하여 일시적인 실패를 자동으로 처리할 수 있습니다.
@@ -101,7 +109,7 @@ export class OrderService {
 - `@QueueWorker(JobClass, options?)`: 특정 작업을 처리할 핸들러를 지정하는 데코레이터입니다.
 
 ### 타입
-- `QueueOptions`: 전역 큐 설정(동시성, 전송률 제한 등)을 위한 타입입니다.
+- `QueueOptions`: 전역 큐 설정(clientName, 동시성, 전송률 제한 등)을 위한 타입입니다.
 - `WorkerOptions`: 개별 작업 설정(시도 횟수, 백오프, 우선순위 등)을 위한 타입입니다.
 
 ## 관련 패키지

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -78,6 +78,14 @@ export class OrderService {
 
 ## Common Patterns
 
+### Named Redis Client
+
+If your queues should use a non-default Redis connection, set `clientName` to the name registered with `RedisModule.forRootNamed(...)`.
+
+```typescript
+QueueModule.forRoot({ clientName: 'jobs' })
+```
+
 ### Distributed Retries
 
 Workers can be configured with a maximum number of attempts and backoff strategies to handle transient failures automatically.
@@ -101,7 +109,7 @@ Jobs that fail all retry attempts are automatically moved to a dead-letter list 
 - `@QueueWorker(JobClass, options?)`: Decorator to mark a class as a job handler.
 
 ### Types
-- `QueueOptions`: Global queue settings (concurrency, rate limiting).
+- `QueueOptions`: Global queue settings (clientName, concurrency, rate limiting).
 - `WorkerOptions`: Per-job settings (attempts, backoff, priority).
 
 ## Related Packages

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Inject, Scope } from '@fluojs/core';
 import { defineControllerMetadata } from '@fluojs/core/internal';
-import { REDIS_CLIENT } from '@fluojs/redis';
+import { getRedisClientToken, REDIS_CLIENT } from '@fluojs/redis';
 import { bootstrapApplication, defineModule, type ApplicationLogger } from '@fluojs/runtime';
 
 interface MockQueueConnection {
@@ -416,6 +416,56 @@ describe('@fluojs/queue', () => {
     expect(jobId).toBe('1');
     expect(workerStore.isPrototypeRehydrated).toBe(true);
     expect(workerStore.subject).toBe('welcome:user-1');
+
+    await app.close();
+  });
+
+  it('resolves a named Redis client when clientName is configured', async () => {
+    const NAMED_REDIS_CLIENT = getRedisClientToken('jobs');
+
+    class NamedJob {
+      constructor(public readonly userId: string) {}
+    }
+
+    class WorkerStore {
+      handled: string[] = [];
+    }
+
+    @Inject(WorkerStore)
+    @QueueWorker(NamedJob)
+    class NamedWorker {
+      constructor(private readonly store: WorkerStore) {}
+
+      async handle(job: NamedJob): Promise<void> {
+        this.store.handled.push(job.userId);
+      }
+    }
+
+    @Inject(QUEUE)
+    class UserService {
+      constructor(private readonly queue: Queue) {}
+
+      async enqueue(userId: string): Promise<string> {
+        return this.queue.enqueue(new NamedJob(userId));
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot({ clientName: 'jobs' })],
+      providers: [NamedWorker, UserService, WorkerStore],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: NAMED_REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const userService = await app.container.resolve(UserService);
+    const workerStore = await app.container.resolve(WorkerStore);
+
+    await expect(userService.enqueue('user-9')).resolves.toBe('1');
+    expect(workerStore.handled).toEqual(['user-9']);
 
     await app.close();
   });

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -10,6 +10,7 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
   const defaultRateLimiter = normalizeRateLimiter(options.defaultRateLimiter);
 
   return {
+    clientName: options.clientName,
     defaultAttempts: normalizePositiveInteger(options.defaultAttempts, 1),
     defaultBackoff: options.defaultBackoff
       ? {

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@fluojs/core';
 import { cloneWithFallback } from '@fluojs/core/internal';
 import type { Container } from '@fluojs/di';
-import { REDIS_CLIENT } from '@fluojs/redis';
+import { getRedisClientToken, getRedisComponentId } from '@fluojs/redis';
 import {
   type ApplicationLogger,
   type CompiledModule,
@@ -135,7 +135,7 @@ async function closeConnection(connection: QueueOwnedConnection): Promise<void> 
  * The service discovers `@QueueWorker()` providers during bootstrap, creates the
  * BullMQ queues/workers they require, and shuts them down with the application.
  */
-@Inject(QUEUE_OPTIONS, REDIS_CLIENT, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER)
+@Inject(QUEUE_OPTIONS, RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER)
 export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy {
   private readonly descriptorsByJobType = new Map<QueueJobType, QueueWorkerDescriptor>();
   private readonly queuesByJobName = new Map<string, QueueInstance>();
@@ -143,12 +143,12 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   private readonly ownedConnections: QueueOwnedConnection[] = [];
   private readonly pendingDeadLetterWrites = new Set<Promise<void>>();
   private lifecycleState: QueueLifecycleState = 'idle';
+  private redisClient: QueueRedisClient | undefined;
   private startPromise: Promise<void> | undefined;
   private shutdownPromise: Promise<void> | undefined;
 
   constructor(
     private readonly options: NormalizedQueueModuleOptions,
-    private readonly redisClient: unknown,
     private readonly runtimeContainer: Container,
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
@@ -204,6 +204,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
    */
   createPlatformStatusSnapshot() {
     return createQueuePlatformStatusSnapshot({
+      dependencyId: getRedisComponentId(this.options.clientName),
       lifecycleState: this.lifecycleState,
       pendingDeadLetterWrites: this.pendingDeadLetterWrites.size,
       queuesReady: this.queuesByJobName.size,
@@ -237,7 +238,8 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   }
 
   private async startLifecycle(): Promise<void> {
-    const redis = this.getRedisClient();
+    const redis = await this.resolveRedisClient();
+    this.redisClient = redis;
     this.discoverWorkers();
     await this.initializeWorkers(redis);
     this.lifecycleState = 'started';
@@ -246,12 +248,29 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   private async handleStartupFailure(): Promise<void> {
     await this.closeInitializedResources();
     this.lifecycleState = 'idle';
+    this.redisClient = undefined;
     this.startPromise = undefined;
   }
 
+  private async resolveRedisClient(): Promise<QueueRedisClient> {
+    const redisToken = getRedisClientToken(this.options.clientName);
+
+    if (!this.runtimeContainer.has(redisToken)) {
+      throw new Error('@fluojs/queue requires a registered Redis client with duplicate() and rpush() methods.');
+    }
+
+    const redisClient = await this.runtimeContainer.resolve(redisToken);
+
+    if (!hasQueueRedisClient(redisClient)) {
+      throw new Error('@fluojs/queue requires a Redis client with duplicate() and rpush() methods.');
+    }
+
+    return redisClient;
+  }
+
   private getRedisClient(): QueueRedisClient {
-    if (!hasQueueRedisClient(this.redisClient)) {
-      throw new Error('@fluojs/queue requires REDIS_CLIENT with duplicate() and rpush() methods.');
+    if (!this.redisClient) {
+      throw new Error('@fluojs/queue Redis client is not initialized.');
     }
 
     return this.redisClient;

--- a/packages/queue/src/status.test.ts
+++ b/packages/queue/src/status.test.ts
@@ -5,6 +5,7 @@ import { createQueuePlatformStatusSnapshot } from './status.js';
 describe('createQueuePlatformStatusSnapshot', () => {
   it('reports ready/healthy semantics with dependency visibility', () => {
     const snapshot = createQueuePlatformStatusSnapshot({
+      dependencyId: 'redis.jobs',
       lifecycleState: 'started',
       pendingDeadLetterWrites: 0,
       queuesReady: 2,
@@ -15,7 +16,7 @@ describe('createQueuePlatformStatusSnapshot', () => {
     expect(snapshot.readiness).toEqual({ critical: true, status: 'ready' });
     expect(snapshot.health).toEqual({ status: 'healthy' });
     expect(snapshot.details).toMatchObject({
-      dependencies: ['redis.default'],
+      dependencies: ['redis.jobs'],
       workersDiscovered: 2,
       workersReady: 2,
     });
@@ -23,6 +24,7 @@ describe('createQueuePlatformStatusSnapshot', () => {
 
   it('marks shutdown drain as degraded health and not-ready readiness', () => {
     const snapshot = createQueuePlatformStatusSnapshot({
+      dependencyId: 'redis.default',
       lifecycleState: 'stopping',
       pendingDeadLetterWrites: 1,
       queuesReady: 1,

--- a/packages/queue/src/status.ts
+++ b/packages/queue/src/status.ts
@@ -1,8 +1,11 @@
 import type { PlatformHealthReport, PlatformReadinessReport, PlatformSnapshot } from '@fluojs/runtime';
 
+/** Lifecycle phases reported by the queue platform status adapter. */
 export type QueueLifecycleState = 'idle' | 'starting' | 'started' | 'stopping' | 'stopped';
 
+/** Input payload used to derive queue readiness, health, and dependency details. */
 export interface QueueStatusAdapterInput {
+  dependencyId?: string;
   lifecycleState: QueueLifecycleState;
   pendingDeadLetterWrites: number;
   queuesReady: number;
@@ -10,6 +13,7 @@ export interface QueueStatusAdapterInput {
   workersReady: number;
 }
 
+/** Queue-specific platform snapshot returned to health and readiness integrations. */
 export interface QueuePlatformStatusSnapshot {
   readiness: PlatformReadinessReport;
   health: PlatformHealthReport;
@@ -97,11 +101,17 @@ function createHealth(input: QueueStatusAdapterInput): PlatformHealthReport {
   };
 }
 
+/**
+ * Creates the queue platform snapshot consumed by status reporters.
+ *
+ * @param input Normalized queue runtime metrics and dependency information.
+ * @returns Readiness, health, ownership, and queue detail fields.
+ */
 export function createQueuePlatformStatusSnapshot(input: QueueStatusAdapterInput): QueuePlatformStatusSnapshot {
   return {
     details: {
       deadLetterDrainTimeoutMs: 5_000,
-      dependencies: ['redis.default'],
+      dependencies: [input.dependencyId ?? 'redis.default'],
       lifecycleState: input.lifecycleState,
       pendingDeadLetterWrites: input.pendingDeadLetterWrites,
       queuesReady: input.queuesReady,

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -36,6 +36,7 @@ export interface QueueWorkerOptions {
 
 /** Module-wide defaults used when individual workers omit execution settings. */
 export interface QueueModuleOptions {
+  clientName?: string;
   defaultAttempts?: number;
   defaultBackoff?: QueueBackoffOptions;
   defaultConcurrency?: number;
@@ -44,6 +45,7 @@ export interface QueueModuleOptions {
 
 /** Normalized queue options resolved once during module registration. */
 export interface NormalizedQueueModuleOptions {
+  clientName?: string;
   defaultAttempts: number;
   defaultBackoff?: QueueBackoffOptions;
   defaultConcurrency: number;


### PR DESCRIPTION
## Summary
- add `clientName` support to `@fluojs/queue` so queue workers and status snapshots resolve the configured Redis client instead of assuming `redis.default`
- add `distributed.clientName` support to `@fluojs/cron` so distributed lock resolution and dependency reporting can target named Redis clients while preserving the default path
- update queue/cron tests and English/Korean READMEs to document and verify the new named-client contract

## Testing
- `pnpm verify` *(build, typecheck, lint/TSDoc passed; full test phase initially exposed queue dead-letter timing regressions, which were fixed before the final run)*
- `pnpm vitest run packages/queue/src/module.test.ts packages/queue/src/status.test.ts packages/cron/src/module.test.ts packages/cron/src/status.test.ts`
- `pnpm test`

## Behavioral contract
- default behavior remains unchanged when no Redis client name is provided
- queue status snapshots now report the selected Redis dependency id (`redis.default`, `redis.jobs`, etc.)
- distributed cron status snapshots now report the configured Redis lock dependency id and READMEs document the new option in both English and Korean

Closes #1011