### PR TITLE
Resolve #1012: adopt named Redis client selection in cache-manager and terminus

### DIFF
--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -98,6 +98,17 @@ CacheModule.forRoot({
 })
 ```
 
+여러 Redis 클라이언트를 등록했다면 `redis.clientName`으로 사용할 `@fluojs/redis` 연결을 지정할 수 있습니다.
+
+```typescript
+CacheModule.forRoot({
+  store: 'redis',
+  redis: { clientName: 'cache' },
+})
+```
+
+`redis.client`는 여전히 가장 높은 우선순위의 명시적 override입니다. DI 기반 선택을 완전히 우회해야 할 때만 사용하세요.
+
 ### 쿼리 매개변수 기반 캐싱
 
 기본적으로 캐시 키는 쿼리 매개변수를 무시합니다. 검색 조건 등에 따라 다른 응답을 캐싱하려면 `httpKeyStrategy: 'route+query'`를 활성화하세요.

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -98,6 +98,17 @@ CacheModule.forRoot({
 })
 ```
 
+If you registered multiple Redis clients, set `redis.clientName` to target a named `@fluojs/redis` connection.
+
+```typescript
+CacheModule.forRoot({
+  store: 'redis',
+  redis: { clientName: 'cache' },
+})
+```
+
+`redis.client` remains the highest-precedence override. Use it only when you need to bypass DI-based client selection entirely.
+
 ### Query-Sensitive Caching
 
 By default, the cache key ignores query parameters. Enable `httpKeyStrategy: 'route+query'` to cache different responses for different search parameters.

--- a/packages/cache-manager/src/module.test.ts
+++ b/packages/cache-manager/src/module.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { Inject } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Controller, Get, Post, UseInterceptors, type FrameworkRequest, type FrameworkResponse } from '@fluojs/http';
+import { getRedisClientToken, REDIS_CLIENT } from '@fluojs/redis';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 
 import { CacheEvict } from './decorators.js';
@@ -10,8 +11,6 @@ import { CacheInterceptor } from './interceptor.js';
 import { CacheService } from './service.js';
 import { CacheModule } from './module.js';
 import type { RedisCompatibleClient } from './types.js';
-
-const REDIS_CLIENT_TOKEN = Symbol.for('fluo.redis.client');
 
 class MockRedisClient implements RedisCompatibleClient {
   readonly storage = new Map<string, string>();
@@ -147,7 +146,7 @@ describe('CacheModule.forRoot', () => {
 
     const redisClient = new MockRedisClient();
     const app = await bootstrapApplication({
-      providers: [{ provide: REDIS_CLIENT_TOKEN, useValue: redisClient }],
+      providers: [{ provide: REDIS_CLIENT, useValue: redisClient }],
       rootModule: AppModule,
     });
     const consumer = await app.container.resolve(Consumer);
@@ -155,6 +154,75 @@ describe('CacheModule.forRoot', () => {
     await consumer.cache.set('/users', { count: 3 }, 30);
 
     await expect(consumer.cache.get('/users')).resolves.toEqual({ count: 3 });
+
+    await app.close();
+  });
+
+  it('uses a named redis client when redis.clientName is configured', async () => {
+    @Inject(CacheService)
+    class Consumer {
+      constructor(readonly cache: CacheService) {}
+    }
+
+    const namedRedisToken = getRedisClientToken('cache');
+    const redisClient = new MockRedisClient();
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CacheModule.forRoot({ store: 'redis', redis: { clientName: 'cache' } })],
+      providers: [Consumer],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: namedRedisToken, useValue: redisClient }],
+      rootModule: AppModule,
+    });
+    const consumer = await app.container.resolve(Consumer);
+
+    await consumer.cache.set('/named', { count: 7 }, 30);
+
+    await expect(consumer.cache.get('/named')).resolves.toEqual({ count: 7 });
+    expect(JSON.parse(redisClient.storage.get('fluo:cache:/named') ?? 'null')).toMatchObject({
+      value: { count: 7 },
+    });
+
+    await app.close();
+  });
+
+  it('prefers an explicit redis client over redis.clientName', async () => {
+    @Inject(CacheService)
+    class Consumer {
+      constructor(readonly cache: CacheService) {}
+    }
+
+    const namedRedisToken = getRedisClientToken('cache');
+    const explicitClient = new MockRedisClient();
+    const namedClient = new MockRedisClient();
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CacheModule.forRoot({
+        store: 'redis',
+        redis: {
+          client: explicitClient,
+          clientName: 'cache',
+        },
+      })],
+      providers: [Consumer],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: namedRedisToken, useValue: namedClient }],
+      rootModule: AppModule,
+    });
+    const consumer = await app.container.resolve(Consumer);
+
+    await consumer.cache.set('/override', { count: 11 }, 30);
+
+    expect(JSON.parse(explicitClient.storage.get('fluo:cache:/override') ?? 'null')).toMatchObject({
+      value: { count: 11 },
+    });
+    expect(namedClient.storage.has('fluo:cache:/override')).toBe(false);
 
     await app.close();
   });

--- a/packages/cache-manager/src/module.ts
+++ b/packages/cache-manager/src/module.ts
@@ -1,4 +1,5 @@
 import type { Provider, Container } from '@fluojs/di';
+import { getRedisClientToken } from '@fluojs/redis';
 import { defineModule, type ModuleType } from '@fluojs/runtime';
 import { RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 
@@ -8,8 +9,6 @@ import { RedisStore } from './stores/redis-store.js';
 import { CacheService } from './service.js';
 import { CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
 import type { CacheModuleOptions, NormalizedCacheModuleOptions, RedisCompatibleClient } from './types.js';
-
-const REDIS_CLIENT_TOKEN = Symbol.for('fluo.redis.client');
 
 function normalizeCacheModuleOptions(options: CacheModuleOptions = {}): NormalizedCacheModuleOptions {
   return {
@@ -54,15 +53,19 @@ async function resolveRedisClient(
 ): Promise<RedisCompatibleClient> {
   let resolvedClient = options.redis?.client;
 
-  if (!resolvedClient && container.has(REDIS_CLIENT_TOKEN)) {
-    resolvedClient = await container.resolve<RedisCompatibleClient>(REDIS_CLIENT_TOKEN);
+  if (!resolvedClient) {
+    const redisToken = getRedisClientToken(options.redis?.clientName);
+
+    if (container.has(redisToken)) {
+      resolvedClient = await container.resolve<RedisCompatibleClient>(redisToken);
+    }
   }
 
   if (!resolvedClient) {
     throw new Error(
       [
         '@fluojs/cache-manager redis store requires a Redis client at bootstrap.',
-        'Install and import @fluojs/redis (createRedisModule) or provide options.redis.client directly.',
+        'Install and import @fluojs/redis, configure options.redis.clientName, or provide options.redis.client directly.',
       ].join(' '),
     );
   }

--- a/packages/cache-manager/src/types.ts
+++ b/packages/cache-manager/src/types.ts
@@ -27,6 +27,7 @@ export interface RedisCompatibleClient {
  */
 export interface RedisCacheOptions {
   client?: RedisCompatibleClient;
+  clientName?: string;
   scanCount?: number;
 }
 

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -76,6 +76,17 @@ TerminusModule.forRoot({
 });
 ```
 
+이름 있는 Redis 연결을 점검하려면 `clientName`을 전달해 기본 클라이언트 대신 해당 named token을 해석하게 하세요.
+
+```typescript
+TerminusModule.forRoot({
+  indicatorProviders: [
+    createRedisHealthIndicatorProvider({ key: 'redis' }),
+    createRedisHealthIndicatorProvider({ clientName: 'cache', key: 'cache-redis' }),
+  ],
+});
+```
+
 ### 실패 시맨틱
 
 인디케이터가 실패하면 `HealthCheckError`를 던집니다. `TerminusHealthService`는 이 실패들을 모아 보고서를 작성합니다.

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -76,6 +76,17 @@ TerminusModule.forRoot({
 });
 ```
 
+If the indicator should use a named Redis connection, pass `clientName` so the provider resolves that named client token instead of the default one.
+
+```typescript
+TerminusModule.forRoot({
+  indicatorProviders: [
+    createRedisHealthIndicatorProvider({ key: 'redis' }),
+    createRedisHealthIndicatorProvider({ clientName: 'cache', key: 'cache-redis' }),
+  ],
+});
+```
+
 ### Failure Semantics
 
 When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthService` aggregates these failures into a report:

--- a/packages/terminus/src/indicators/redis.test.ts
+++ b/packages/terminus/src/indicators/redis.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getRedisClientToken } from '@fluojs/redis';
+
 import type { HealthCheckError } from '../errors.js';
-import { createRedisHealthIndicator, RedisHealthIndicator } from './redis.js';
+import { createRedisHealthIndicator, createRedisHealthIndicatorProvider, RedisHealthIndicator } from './redis.js';
 
 describe('RedisHealthIndicator', () => {
   it('uses redis ping methods when present', async () => {
@@ -48,5 +50,16 @@ describe('RedisHealthIndicator', () => {
       message: 'Redis health check failed.',
       name: 'HealthCheckError',
     } satisfies Partial<HealthCheckError>);
+  });
+
+  it('uses helper tokens for default and named redis indicator providers', () => {
+    const defaultProvider = createRedisHealthIndicatorProvider({ key: 'redis' });
+    const namedProvider = createRedisHealthIndicatorProvider({ clientName: 'cache', key: 'cache-redis' });
+
+    expect(defaultProvider).toMatchObject({ inject: [getRedisClientToken()] });
+    expect(namedProvider).toMatchObject({ inject: [getRedisClientToken('cache')] });
+    expect('provide' in defaultProvider && 'provide' in namedProvider && defaultProvider.provide).not.toBe(
+      'provide' in namedProvider ? namedProvider.provide : undefined,
+    );
   });
 });

--- a/packages/terminus/src/indicators/redis.ts
+++ b/packages/terminus/src/indicators/redis.ts
@@ -1,9 +1,8 @@
 import type { Provider } from '@fluojs/di';
+import { getRedisClientToken } from '@fluojs/redis';
 
 import { createDownResult, createUpResult, resolveIndicatorKey, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
-
-const REDIS_CLIENT = Symbol.for('fluo.redis.client');
 
 interface RedisClientLike {
   ping?: () => Promise<unknown>;
@@ -12,6 +11,7 @@ interface RedisClientLike {
 /** Options for probing Redis connectivity. */
 export interface RedisHealthIndicatorOptions {
   client?: RedisClientLike;
+  clientName?: string;
   key?: string;
   ping?: () => Promise<unknown> | unknown;
   timeoutMs?: number;
@@ -51,9 +51,11 @@ export function createRedisHealthIndicator(options: RedisHealthIndicatorOptions 
  * @returns A factory provider that exposes `RedisHealthIndicator` from the DI container.
  */
 export function createRedisHealthIndicatorProvider(options: Omit<RedisHealthIndicatorOptions, 'client'> = {}): Provider {
+  const indicatorProviderToken = Symbol('fluo.terminus.redis-health-indicator');
+
   return {
-    inject: [REDIS_CLIENT],
-    provide: RedisHealthIndicator,
+    inject: [getRedisClientToken(options.clientName)],
+    provide: indicatorProviderToken,
     useFactory: (client: unknown) => new RedisHealthIndicator({ ...options, client: client as RedisClientLike }),
   };
 }

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
-import { REDIS_CLIENT } from '@fluojs/redis';
+import { getRedisClientToken, REDIS_CLIENT } from '@fluojs/redis';
 import { bootstrapApplication, defineModule, type PlatformComponent } from '@fluojs/runtime';
 
 import { MemoryHealthIndicator } from './indicators/memory.js';
@@ -284,6 +284,76 @@ describe('TerminusModule.forRoot', () => {
     await app.dispatch(createRequest('/ready'), readyResponse);
     expect(readyResponse.statusCode).toBe(503);
     expect(readyResponse.body).toEqual({ status: 'unavailable' });
+
+    await app.close();
+  });
+
+  it('supports default and named redis indicator providers without token collisions', async () => {
+    const namedRedisToken = getRedisClientToken('cache');
+
+    class RedisIndicatorModule {}
+    defineModule(RedisIndicatorModule, {
+      exports: [REDIS_CLIENT, namedRedisToken],
+      global: true,
+      providers: [
+        {
+          provide: REDIS_CLIENT,
+          useValue: {
+            ping: async () => 'PONG',
+          },
+        },
+        {
+          provide: namedRedisToken,
+          useValue: {
+            ping: async () => 'PONG',
+          },
+        },
+      ],
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [
+        RedisIndicatorModule,
+        TerminusModule.forRoot({
+          indicatorProviders: [
+            createRedisHealthIndicatorProvider({ key: 'redis' }),
+            createRedisHealthIndicatorProvider({ clientName: 'cache', key: 'cache-redis' }),
+          ],
+        }),
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    const healthResponse = createResponse();
+    await app.dispatch(createRequest('/health'), healthResponse);
+    expect(healthResponse.statusCode).toBe(200);
+    expect(healthResponse.body).toMatchObject({
+      details: {
+        'cache-redis': {
+          status: 'up',
+        },
+        redis: {
+          status: 'up',
+        },
+      },
+      status: 'ok',
+    });
+    expect(healthResponse.body).toMatchObject({
+      contributors: {
+        down: [],
+      },
+    });
+    expect((healthResponse.body as { contributors: { up: string[] } }).contributors.up).toEqual(
+      expect.arrayContaining(['redis', 'cache-redis']),
+    );
+
+    const readyResponse = createResponse();
+    await app.dispatch(createRequest('/ready'), readyResponse);
+    expect(readyResponse.statusCode).toBe(200);
+    expect(readyResponse.body).toEqual({ status: 'ready' });
 
     await app.close();
   });


### PR DESCRIPTION
Closes #1012

## Summary
- adopt `@fluojs/redis` named client token helpers in `@fluojs/cache-manager` and `@fluojs/terminus`
- preserve the default Redis path while allowing named-client selection, with explicit cache-manager client injection still taking precedence
- document the new contract in the English/Korean package READMEs and cover the default, named, and coexistence paths with regression tests

## Changes
- add `redis.clientName` support to cache-manager Redis options and resolve clients through `getRedisClientToken(...)`
- update Terminus Redis indicator providers to resolve named clients and avoid provider-token collisions when multiple Redis indicators are registered
- remove local `Symbol.for('fluo.redis.client')` duplication in changed areas in favor of shared `@fluojs/redis` helpers

## Testing
- pnpm exec vitest run packages/cache-manager/src/module.test.ts packages/terminus/src/indicators/redis.test.ts packages/terminus/src/module.test.ts
- pnpm build && pnpm typecheck
- pnpm lint

## Behavioral contract
- default Redis behavior remains unchanged when no client selector is configured
- cache-manager still prefers `options.redis.client` over DI-based named/default resolution
- cache-manager and terminus READMEs now document named client selection in English and Korean, and regression tests cover the documented runtime invariants