### PR TITLE
Resolve #1020: bound cache-manager memory defaults

### DIFF
--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -43,6 +43,8 @@ npm install @fluojs/cache-manager @fluojs/redis ioredis
 
 `CacheModule`을 등록하고 컨트롤러에 `CacheInterceptor`를 사용합니다.
 
+내장 메모리 경로는 기본적으로 안전한 상한을 갖습니다. `ttl`을 생략하면 fluo는 기본 TTL 300초를 적용하고, 메모리 저장소의 live 엔트리가 1,000개를 넘으면 가장 오래된 키부터 제거합니다.
+
 ```typescript
 import { Module } from '@fluojs/core';
 import { Controller, Get, UseInterceptors } from '@fluojs/http';
@@ -121,6 +123,14 @@ CacheModule.forRoot({
   httpKeyStrategy: 'route+query',
 })
 ```
+
+### 메모리 저장소 운영 한계
+
+내장 메모리 저장소는 단일 프로세스의 bounded cache 용도로 설계되어 있습니다.
+
+- 기본 메모리 경로에서 `ttl`을 생략하면 `CacheModule.forRoot()`는 300초 TTL을 사용합니다.
+- `ttl: 0`은 만료 없는 엔트리로 계속 지원되지만, 메모리 저장소는 가장 최근의 live 키 1,000개만 유지합니다.
+- 키 종류가 매우 많거나 여러 인스턴스가 캐시를 공유해야 한다면 프로세스 로컬 메모리 대신 Redis 저장소를 사용하세요.
 
 ## 공개 API 개요
 

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -43,6 +43,8 @@ npm install @fluojs/cache-manager @fluojs/redis ioredis
 
 Register the `CacheModule` and use the `CacheInterceptor` on your controllers.
 
+The built-in memory path is intentionally bounded by default: when you omit `ttl`, fluo applies a 300-second default TTL and keeps at most 1,000 live memory-store entries before evicting the oldest keys.
+
 ```typescript
 import { Module } from '@fluojs/core';
 import { Controller, Get, UseInterceptors } from '@fluojs/http';
@@ -121,6 +123,14 @@ CacheModule.forRoot({
   httpKeyStrategy: 'route+query',
 })
 ```
+
+### Memory Store Operational Limits
+
+The built-in memory store is designed for single-process, bounded caching:
+
+- If you omit `ttl` on the default memory path, `CacheModule.forRoot()` uses a 300-second TTL.
+- `ttl: 0` is still supported for no-expiry entries, but the memory store keeps only the most recent 1,000 live keys.
+- High-cardinality or multi-instance deployments should use the Redis store instead of relying on process-local memory.
 
 ## Public API Overview
 

--- a/packages/cache-manager/src/cache-service.test.ts
+++ b/packages/cache-manager/src/cache-service.test.ts
@@ -197,6 +197,41 @@ describe('CacheService — general cache contract (outside HTTP interceptor)', (
       await expect(cache.get('key')).resolves.toBeUndefined();
     });
 
+    it('clears invalidation bookkeeping after churn across many deleted in-flight keys', async () => {
+      const cache = createCacheService(createStore());
+      const resolvers = new Map<string, (value: { computed: string }) => void>();
+
+      const pendingLoads = Array.from({ length: 50 }, (_, index) => {
+        const key = `key:${index}`;
+
+        const pending = cache.remember(
+          key,
+          () =>
+            new Promise<{ computed: string }>((resolve) => {
+              resolvers.set(key, resolve);
+            }),
+        );
+
+        return { key, pending };
+      });
+
+      await Promise.resolve();
+
+      await Promise.all(pendingLoads.map(async ({ key }) => {
+        await cache.del(key);
+      }));
+
+      for (const { key } of pendingLoads) {
+        resolvers.get(key)?.({ computed: key });
+      }
+
+      await Promise.all(pendingLoads.map(({ pending }) => pending));
+
+      const invalidatedInflight = Reflect.get(cache as object, 'invalidatedInflight');
+      expect(invalidatedInflight).toBeInstanceOf(Set);
+      expect((invalidatedInflight as Set<string>).size).toBe(0);
+    });
+
     it('set uses module default TTL when not specified', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-03-24T00:00:00.000Z'));

--- a/packages/cache-manager/src/module.test.ts
+++ b/packages/cache-manager/src/module.test.ts
@@ -9,7 +9,8 @@ import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { CacheEvict } from './decorators.js';
 import { CacheInterceptor } from './interceptor.js';
 import { CacheService } from './service.js';
-import { CacheModule } from './module.js';
+import { CacheModule, createCacheProviders } from './module.js';
+import { CACHE_OPTIONS } from './tokens.js';
 import type { RedisCompatibleClient } from './types.js';
 
 class MockRedisClient implements RedisCompatibleClient {
@@ -97,6 +98,23 @@ describe('CacheModule.forRoot', () => {
 
     expect(getModuleMetadata(localModule)?.global).toBe(false);
     expect(getModuleMetadata(globalModule)?.global).toBe(true);
+  });
+
+  it('uses a bounded TTL by default on the built-in memory store path', () => {
+    const optionsProvider = createCacheProviders().find(
+      (provider): provider is { provide: typeof CACHE_OPTIONS; useValue: { store: string; ttl: number } } =>
+        typeof provider === 'object' &&
+        provider !== null &&
+        'provide' in provider &&
+        provider.provide === CACHE_OPTIONS,
+    );
+
+    expect(optionsProvider).toMatchObject({
+      useValue: expect.objectContaining({
+        store: 'memory',
+        ttl: 300,
+      }),
+    });
   });
 
   it('supports memory store without redis module/client installed', async () => {

--- a/packages/cache-manager/src/module.ts
+++ b/packages/cache-manager/src/module.ts
@@ -10,13 +10,17 @@ import { CacheService } from './service.js';
 import { CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
 import type { CacheModuleOptions, NormalizedCacheModuleOptions, RedisCompatibleClient } from './types.js';
 
+const DEFAULT_MEMORY_STORE_TTL_SECONDS = 300;
+
 function normalizeCacheModuleOptions(options: CacheModuleOptions = {}): NormalizedCacheModuleOptions {
+  const store = options.store ?? 'memory';
+
   return {
     isGlobal: options.isGlobal ?? false,
     keyPrefix: options.keyPrefix ?? 'fluo:cache:',
     redis: options.redis,
-    store: options.store ?? 'memory',
-    ttl: options.ttl ?? 0,
+    store,
+    ttl: options.ttl ?? (store === 'memory' ? DEFAULT_MEMORY_STORE_TTL_SECONDS : 0),
     httpKeyStrategy: options.httpKeyStrategy ?? 'route',
     principalScopeResolver: options.principalScopeResolver,
   };

--- a/packages/cache-manager/src/service.ts
+++ b/packages/cache-manager/src/service.ts
@@ -9,8 +9,24 @@ import type { CacheStore, NormalizedCacheModuleOptions } from './types.js';
 @Inject(CACHE_STORE, CACHE_OPTIONS)
 export class CacheService {
   private readonly inflight = new Map<string, Promise<unknown>>();
-  private readonly invalidationVersion = new Map<string, number>();
+  private readonly pendingLoads = new Map<string, number>();
+  private readonly invalidatedInflight = new Set<string>();
   private resetVersion = 0;
+
+  private beginPendingLoad(key: string): void {
+    this.pendingLoads.set(key, (this.pendingLoads.get(key) ?? 0) + 1);
+  }
+
+  private endPendingLoad(key: string): void {
+    const remaining = (this.pendingLoads.get(key) ?? 0) - 1;
+
+    if (remaining > 0) {
+      this.pendingLoads.set(key, remaining);
+      return;
+    }
+
+    this.pendingLoads.delete(key);
+  }
 
   constructor(
     private readonly store: CacheStore,
@@ -58,35 +74,44 @@ export class CacheService {
     loader: () => Promise<T>,
     ttlSeconds?: number,
   ): Promise<T> {
-    const keyVersion = this.invalidationVersion.get(key) ?? 0;
-    const resetVersion = this.resetVersion;
-    const cached = await this.get<T>(key);
+    this.beginPendingLoad(key);
 
-    if (cached !== undefined) {
-      return cached;
-    }
+    try {
+      const resetVersion = this.resetVersion;
+      const cached = await this.get<T>(key);
 
-    const existing = this.inflight.get(key) as Promise<T> | undefined;
-
-    if (existing) {
-      return existing;
-    }
-
-    const promise = loader().then(async (value) => {
-      const currentKeyVersion = this.invalidationVersion.get(key) ?? 0;
-
-      if (currentKeyVersion !== keyVersion || this.resetVersion !== resetVersion) {
-        return value;
+      if (cached !== undefined) {
+        return cached;
       }
 
-      await this.set(key, value, ttlSeconds);
-      return value;
-    }).finally(() => {
-      this.inflight.delete(key);
-    });
+      const existing = this.inflight.get(key) as Promise<T> | undefined;
 
-    this.inflight.set(key, promise);
-    return promise;
+      if (existing) {
+        return existing;
+      }
+
+      const promise = loader().then(async (value) => {
+        if (this.invalidatedInflight.has(key) || this.resetVersion !== resetVersion) {
+          return value;
+        }
+
+        await this.set(key, value, ttlSeconds);
+
+        if (this.invalidatedInflight.has(key) || this.resetVersion !== resetVersion) {
+          await this.store.del(key);
+        }
+
+        return value;
+      }).finally(() => {
+        this.inflight.delete(key);
+        this.invalidatedInflight.delete(key);
+      });
+
+      this.inflight.set(key, promise);
+      return promise;
+    } finally {
+      this.endPendingLoad(key);
+    }
   }
 
   /**
@@ -96,7 +121,10 @@ export class CacheService {
    * @returns A promise that resolves after the entry is removed.
    */
   async del(key: string): Promise<void> {
-    this.invalidationVersion.set(key, (this.invalidationVersion.get(key) ?? 0) + 1);
+    if (this.pendingLoads.has(key) || this.inflight.has(key)) {
+      this.invalidatedInflight.add(key);
+    }
+
     await this.store.del(key);
   }
 
@@ -107,7 +135,7 @@ export class CacheService {
    */
   async reset(): Promise<void> {
     this.resetVersion += 1;
-    this.invalidationVersion.clear();
+    this.invalidatedInflight.clear();
     await this.store.reset();
   }
 }

--- a/packages/cache-manager/src/stores/memory-store.test.ts
+++ b/packages/cache-manager/src/stores/memory-store.test.ts
@@ -63,6 +63,18 @@ describe('MemoryStore', () => {
     await expect(store.get('users:list')).resolves.toEqual({ count: 1 });
   });
 
+  it('evicts the oldest live entries when key churn exceeds the in-memory safety cap', async () => {
+    const store = new MemoryStore();
+
+    for (let index = 0; index < 1_001; index += 1) {
+      await store.set(`users:${index}`, { index }, 0);
+    }
+
+    await expect(store.get('users:0')).resolves.toBeUndefined();
+    await expect(store.get('users:1')).resolves.toEqual({ index: 1 });
+    await expect(store.get('users:1000')).resolves.toEqual({ index: 1000 });
+  });
+
   it('returns immutable snapshots instead of leaking internal object references', async () => {
     const store = new MemoryStore();
     const value = { nested: { count: 1 } };

--- a/packages/cache-manager/src/stores/memory-store.ts
+++ b/packages/cache-manager/src/stores/memory-store.ts
@@ -6,6 +6,8 @@ interface MemoryCacheEntry<T = unknown> {
   value: T;
 }
 
+const DEFAULT_MAX_MEMORY_CACHE_ENTRIES = 1_000;
+
 function sweepExpiredEntries(entries: Map<string, MemoryCacheEntry>, now: number): number {
   let nextSweepAt = Number.POSITIVE_INFINITY;
 
@@ -23,6 +25,18 @@ function sweepExpiredEntries(entries: Map<string, MemoryCacheEntry>, now: number
   }
 
   return Number.isFinite(nextSweepAt) ? nextSweepAt : 0;
+}
+
+function enforceEntryLimit(entries: Map<string, MemoryCacheEntry>): void {
+  while (entries.size > DEFAULT_MAX_MEMORY_CACHE_ENTRIES) {
+    const oldestKey = entries.keys().next().value;
+
+    if (oldestKey === undefined) {
+      return;
+    }
+
+    entries.delete(oldestKey);
+  }
 }
 
 export class MemoryStore implements CacheStore {
@@ -67,7 +81,9 @@ export class MemoryStore implements CacheStore {
       entry.expiresAt = now + ttlMilliseconds;
     }
 
+    this.entries.delete(key);
     this.entries.set(key, entry);
+    enforceEntryLimit(this.entries);
 
     if (entry.expiresAt !== undefined) {
       this.nextSweepAt = this.nextSweepAt === 0 ? entry.expiresAt : Math.min(this.nextSweepAt, entry.expiresAt);


### PR DESCRIPTION
## Summary

Closes #1020

- make the default built-in memory cache path safe by applying a bounded default TTL
- cap memory-store live entries and prune in-flight invalidation bookkeeping so key churn cannot grow memory forever
- add regression coverage and document the bounded memory-store contract in both package READMEs

## Changes

- default `CacheModule.forRoot()` to a 300-second TTL when using the built-in memory store path
- evict oldest live entries after 1,000 in-memory keys and keep `ttl: 0` explicitly opt-in
- replace unbounded invalidation-version growth with bounded in-flight bookkeeping
- add regression tests for key churn, default memory behavior, and delete-during-load invalidation
- document the operational limits for the built-in memory store in English and Korean READMEs

## Testing

- `pnpm --filter @fluojs/cache-manager test`
- `pnpm --filter @fluojs/cache-manager typecheck`
- `pnpm build`
- `lsp_diagnostics packages/cache-manager/src` (0 errors)

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Contract impact note

The default memory-store path now expires entries after 300 seconds unless callers explicitly set `ttl`, and the built-in memory store keeps only the most recent 1,000 live keys. This is an intentional safety change for the documented in-process cache path; Redis behavior is unchanged.