### PR TITLE
Resolve #1025: harden microservices transport delivery and buffer safety

### DIFF
--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -84,6 +84,12 @@ await microservice.listen();
 
 마이크로서비스 핸들러도 fluo의 request/transient scope 모델을 그대로 따르므로, 메시지 또는 이벤트 단위로 격리된 상태를 안전하게 사용할 수 있습니다.
 
+### 전달 안전 기본값
+
+- TCP 프레임은 기본적으로 newline-delimited 메시지당 1 MiB로 제한되며, 한도를 넘는 프레임은 요청 버퍼를 무한히 키우는 대신 소켓을 종료합니다.
+- Redis Streams는 요청/이벤트 엔트리를 핸들러 처리가 끝난 뒤에만 ACK합니다. 실패한 이벤트는 조기 ACK로 유실하지 않고 broker 복구/재전달 경로에 남겨 둡니다.
+- RabbitMQ 요청-응답은 기본적으로 인스턴스별 response queue를 사용합니다. 공유 reply topology를 의도적으로 운영할 때만 `responseQueue`를 명시적으로 지정하세요.
+
 ## 공개 API 개요
 
 ### 루트 배럴 (`@fluojs/microservices`)

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -81,6 +81,11 @@ First-party support for all gRPC streaming modes: Server-side, Client-side, and 
 ### Request-Scoped DI
 Microservice handlers fully support fluo's DI scopes. Request-scoped providers are isolated per message or per event, ensuring safe state management in concurrent processing.
 
+### Delivery Safety Defaults
+- TCP frames are bounded to 1 MiB per newline-delimited message by default; oversized frames close the socket instead of growing the request buffer without limit.
+- Redis Streams acknowledges request/event entries only after handler-side processing finishes. Failed events stay pending for broker-managed recovery instead of being acknowledged early.
+- RabbitMQ request/reply uses an instance-scoped response queue by default. Pass `responseQueue` explicitly only when you intentionally own and coordinate a shared reply topology.
+
 ## Public API Overview
 
 ### Root barrel (`@fluojs/microservices`)

--- a/packages/microservices/src/transports/rabbitmq-transport.test.ts
+++ b/packages/microservices/src/transports/rabbitmq-transport.test.ts
@@ -4,17 +4,21 @@ import { RabbitMqMicroserviceTransport } from './rabbitmq-transport.js';
 
 class InMemoryQueueBus {
   private readonly listeners = new Map<string, Set<(message: string) => Promise<void> | void>>();
+  private readonly deliveryIndex = new Map<string, number>();
 
   async publish(queue: string, message: string): Promise<void> {
     const handlers = this.listeners.get(queue);
 
-    if (!handlers) {
+    if (!handlers || handlers.size === 0) {
       return;
     }
 
-    for (const handler of handlers) {
-      await handler(message);
-    }
+    const orderedHandlers = [...handlers];
+    const nextIndex = this.deliveryIndex.get(queue) ?? 0;
+    const handler = orderedHandlers[nextIndex % orderedHandlers.length];
+
+    this.deliveryIndex.set(queue, (nextIndex + 1) % orderedHandlers.length);
+    await handler(message);
   }
 
   async subscribe(queue: string, handler: (message: string) => Promise<void> | void): Promise<void> {
@@ -25,6 +29,7 @@ class InMemoryQueueBus {
 
   async unsubscribe(queue: string): Promise<void> {
     this.listeners.delete(queue);
+    this.deliveryIndex.delete(queue);
   }
 }
 
@@ -63,6 +68,57 @@ describe('RabbitMqMicroserviceTransport', () => {
     expect(events).toEqual(['ok']);
 
     await transport.close();
+  });
+
+  it('uses instance-scoped default response queues so concurrent instances do not steal replies', async () => {
+    const bus = new InMemoryQueueBus();
+    const createTransport = () => new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+      requestTimeoutMs: 200,
+    });
+
+    const firstTransport = createTransport();
+    const secondTransport = createTransport();
+
+    await firstTransport.listen(async (packet) => {
+      if (packet.kind !== 'message') {
+        return undefined;
+      }
+
+      const input = packet.payload as { delayMs: number; value: string };
+      await new Promise((resolve) => setTimeout(resolve, input.delayMs));
+      return input.value;
+    });
+
+    await secondTransport.listen(async (packet) => {
+      if (packet.kind !== 'message') {
+        return undefined;
+      }
+
+      const input = packet.payload as { delayMs: number; value: string };
+      await new Promise((resolve) => setTimeout(resolve, input.delayMs));
+      return input.value;
+    });
+
+    await expect(Promise.all([
+      firstTransport.send('reply.safe', { delayMs: 40, value: 'first' }),
+      secondTransport.send('reply.safe', { delayMs: 5, value: 'second' }),
+    ])).resolves.toEqual(['first', 'second']);
+
+    await firstTransport.close();
+    await secondTransport.close();
   });
 
   it('round-trips handler failures to send() caller', async () => {

--- a/packages/microservices/src/transports/rabbitmq-transport.ts
+++ b/packages/microservices/src/transports/rabbitmq-transport.ts
@@ -57,7 +57,7 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
   constructor(private readonly options: RabbitMqMicroserviceTransportOptions) {
     this.eventQueue = options.eventQueue ?? 'fluo.microservices.events';
     this.messageQueue = options.messageQueue ?? 'fluo.microservices.messages';
-    this.responseQueue = options.responseQueue ?? 'fluo.microservices.responses';
+    this.responseQueue = options.responseQueue ?? `fluo.microservices.responses.${crypto.randomUUID()}`;
     this.requestTimeoutMs = options.requestTimeoutMs ?? 3_000;
   }
 

--- a/packages/microservices/src/transports/redis-streams-transport.test.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.test.ts
@@ -256,6 +256,136 @@ describe('RedisStreamsMicroserviceTransport', () => {
     await transport.close();
   });
 
+  it('acks request entries only after the handler finishes', async () => {
+    const bus = new InMemoryStreamBus();
+    const acknowledgements: Array<{ group: string; id: string; stream: string }> = [];
+    let releaseHandler: (() => void) | undefined;
+    const handlerFinished = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+
+    const transport = new RedisStreamsMicroserviceTransport({
+      pollBlockMs: 1,
+      readerClient: {
+        xadd: async (stream, fields) => {
+          return await bus.xadd(stream, fields);
+        },
+        xreadgroup: async (group, consumer, streams, options) => {
+          return await bus.xreadgroup(group, consumer, streams, options);
+        },
+        xack: async (stream, group, id) => {
+          acknowledgements.push({ group, id, stream });
+          await bus.xack(stream, group, id);
+        },
+        xgroupCreate: async (stream, group, startId, mkstream) => {
+          await bus.xgroupCreate(stream, group, startId, mkstream);
+        },
+        xgroupDestroy: async (stream, group) => {
+          await bus.xgroupDestroy(stream, group);
+        },
+      },
+      requestTimeoutMs: 1_000,
+      writerClient: {
+        xadd: async (stream, fields) => {
+          return await bus.xadd(stream, fields);
+        },
+        xreadgroup: async (group, consumer, streams, options) => {
+          return await bus.xreadgroup(group, consumer, streams, options);
+        },
+        xack: async (stream, group, id) => {
+          await bus.xack(stream, group, id);
+        },
+        xgroupCreate: async (stream, group, startId, mkstream) => {
+          await bus.xgroupCreate(stream, group, startId, mkstream);
+        },
+        xgroupDestroy: async (stream, group) => {
+          await bus.xgroupDestroy(stream, group);
+        },
+      },
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'message') {
+        await handlerFinished;
+        return 'ok';
+      }
+
+      return undefined;
+    });
+
+    const pending = transport.send('delayed.ack', { value: 1 });
+    await sleep(20);
+    expect(acknowledgements).toEqual([]);
+
+    releaseHandler?.();
+
+    await expect(pending).resolves.toBe('ok');
+    await sleep(20);
+
+    expect(acknowledgements.some((entry) => entry.stream === 'fluo:streams:messages')).toBe(true);
+
+    await transport.close();
+  });
+
+  it('keeps failed events pending by skipping ack when the handler rejects', async () => {
+    const bus = new InMemoryStreamBus();
+    const acknowledgements: string[] = [];
+    const transport = new RedisStreamsMicroserviceTransport({
+      pollBlockMs: 1,
+      readerClient: {
+        xadd: async (stream, fields) => {
+          return await bus.xadd(stream, fields);
+        },
+        xreadgroup: async (group, consumer, streams, options) => {
+          return await bus.xreadgroup(group, consumer, streams, options);
+        },
+        xack: async (stream, group, id) => {
+          acknowledgements.push(`${stream}:${group}:${id}`);
+          await bus.xack(stream, group, id);
+        },
+        xgroupCreate: async (stream, group, startId, mkstream) => {
+          await bus.xgroupCreate(stream, group, startId, mkstream);
+        },
+        xgroupDestroy: async (stream, group) => {
+          await bus.xgroupDestroy(stream, group);
+        },
+      },
+      requestTimeoutMs: 1_000,
+      writerClient: {
+        xadd: async (stream, fields) => {
+          return await bus.xadd(stream, fields);
+        },
+        xreadgroup: async (group, consumer, streams, options) => {
+          return await bus.xreadgroup(group, consumer, streams, options);
+        },
+        xack: async (stream, group, id) => {
+          await bus.xack(stream, group, id);
+        },
+        xgroupCreate: async (stream, group, startId, mkstream) => {
+          await bus.xgroupCreate(stream, group, startId, mkstream);
+        },
+        xgroupDestroy: async (stream, group) => {
+          await bus.xgroupDestroy(stream, group);
+        },
+      },
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'event') {
+        throw new Error('event failed');
+      }
+
+      return undefined;
+    });
+
+    await transport.emit('audit.failed', { value: 1 });
+    await sleep(20);
+
+    expect(acknowledgements.some((entry) => entry.startsWith('fluo:streams:events:'))).toBe(false);
+
+    await transport.close();
+  });
+
   it('rejects send() with AbortSignal before publish', async () => {
     const bus = new InMemoryStreamBus();
     const { transport } = createTransport(bus, {

--- a/packages/microservices/src/transports/redis-streams-transport.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.ts
@@ -299,17 +299,16 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
         for (const entry of entries) {
           const parsed = this.parseFields(entry.fields);
 
-          if (parsed) {
-            if (stream === this.messageStream) {
-              this.handleInboundRequest(parsed);
-            } else if (stream === this.eventStream) {
-              this.handleInboundEvent(parsed);
-            } else if (stream === this.responseStream) {
-              this.handleInboundResponse(parsed);
-            }
+          if (!parsed) {
+            await this.options.readerClient.xack(stream, group, entry.id);
+            continue;
           }
 
-          await this.options.readerClient.xack(stream, group, entry.id);
+          const shouldAcknowledge = await this.handleStreamEntry(stream, parsed);
+
+          if (shouldAcknowledge) {
+            await this.options.readerClient.xack(stream, group, entry.id);
+          }
         }
       } catch {
         if (!this.closing) {
@@ -319,7 +318,21 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
     }
   }
 
-  private handleInboundRequest(message: RedisStreamTransportMessage): void {
+  private async handleStreamEntry(stream: string, message: RedisStreamTransportMessage): Promise<boolean> {
+    if (stream === this.messageStream) {
+      await this.handleInboundRequest(message);
+      return true;
+    }
+
+    if (stream === this.eventStream) {
+      return await this.handleInboundEvent(message);
+    }
+
+    this.handleInboundResponse(message);
+    return true;
+  }
+
+  private async handleInboundRequest(message: RedisStreamTransportMessage): Promise<void> {
     if (!this.handler) {
       return;
     }
@@ -333,54 +346,57 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
       ? message.replyStream
       : this.responseStream;
 
-    void Promise.resolve().then(async () => {
-      if (!this.handler) {
-        return;
-      }
-
-      try {
-        const payload = await this.handler({
-          kind: 'message',
-          pattern: message.pattern,
-          payload: message.payload,
-          requestId: message.requestId,
-        });
-
-        await this.options.writerClient.xadd(replyStream, {
-          kind: 'response',
-          pattern: message.pattern,
-          payload: JSON.stringify(payload),
-          requestId,
-        });
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : 'Unhandled microservice error';
-
-        await this.options.writerClient.xadd(replyStream, {
-          error: errorMessage,
-          kind: 'response',
-          pattern: message.pattern,
-          requestId,
-        });
-      }
-    }).catch(() => undefined);
-  }
-
-  private handleInboundEvent(message: RedisStreamTransportMessage): void {
     if (!this.handler) {
       return;
     }
 
-    if (message.kind !== 'event') {
-      return;
+    try {
+      const payload = await this.handler({
+        kind: 'message',
+        pattern: message.pattern,
+        payload: message.payload,
+        requestId: message.requestId,
+      });
+
+      await this.options.writerClient.xadd(replyStream, {
+        kind: 'response',
+        pattern: message.pattern,
+        payload: JSON.stringify(payload),
+        requestId,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unhandled microservice error';
+
+      await this.options.writerClient.xadd(replyStream, {
+        error: errorMessage,
+        kind: 'response',
+        pattern: message.pattern,
+        requestId,
+      });
+    }
+  }
+
+  private async handleInboundEvent(message: RedisStreamTransportMessage): Promise<boolean> {
+    if (!this.handler) {
+      return true;
     }
 
-    void this.handler({
-      kind: 'event',
-      pattern: message.pattern,
-      payload: message.payload,
-    }).catch((error) => {
+    if (message.kind !== 'event') {
+      return true;
+    }
+
+    try {
+      await this.handler({
+        kind: 'event',
+        pattern: message.pattern,
+        payload: message.payload,
+      });
+
+      return true;
+    } catch (error) {
       this.logEventHandlerFailure(error);
-    });
+      return false;
+    }
   }
 
   private handleInboundResponse(message: RedisStreamTransportMessage): void {

--- a/packages/microservices/src/transports/tcp-transport.test.ts
+++ b/packages/microservices/src/transports/tcp-transport.test.ts
@@ -1,8 +1,34 @@
+import { Socket } from 'node:net';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { TcpMicroserviceTransport } from './tcp-transport.js';
 
 describe('TcpMicroserviceTransport', () => {
+  it('closes sockets that exceed the inbound frame buffer cap', async () => {
+    const port = 40_000 + Math.floor(Math.random() * 10_000);
+    const handler = vi.fn(async () => undefined);
+    const transport = new TcpMicroserviceTransport({ port, requestTimeoutMs: 1_000 });
+
+    await transport.listen(handler);
+
+    await new Promise<void>((resolve, reject) => {
+      const socket = new Socket();
+
+      socket.once('close', () => resolve());
+      socket.once('error', () => resolve());
+      socket.connect(port, '127.0.0.1', () => {
+        socket.write('x'.repeat(1_048_577));
+      });
+
+      setTimeout(() => reject(new Error('Timed out waiting for oversized TCP frame to close.')), 1_000);
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+
+    await transport.close();
+  });
+
   it('removes abort listener after a request completes normally', async () => {
     const port = 40_000 + Math.floor(Math.random() * 10_000);
     const transport = new TcpMicroserviceTransport({ port, requestTimeoutMs: 1_000 });

--- a/packages/microservices/src/transports/tcp-transport.ts
+++ b/packages/microservices/src/transports/tcp-transport.ts
@@ -10,9 +10,12 @@ interface WireResponse {
 
 interface TcpMicroserviceTransportOptions {
   host?: string;
+  maxFrameBytes?: number;
   port: number;
   requestTimeoutMs?: number;
 }
+
+const DEFAULT_MAX_FRAME_BYTES = 1_048_576;
 
 /**
  * Lightweight TCP transport for request-response messages and fire-and-forget events.
@@ -25,6 +28,7 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
   private listenPromise: Promise<void> | undefined;
   private readonly sockets = new Set<Socket>();
   private readonly host: string;
+  private readonly maxFrameBytes: number;
   private readonly requestTimeoutMs: number;
   private readonly server = createServer((socket) => {
     this.sockets.add(socket);
@@ -39,6 +43,7 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
    */
   constructor(private readonly options: TcpMicroserviceTransportOptions) {
     this.host = options.host ?? '127.0.0.1';
+    this.maxFrameBytes = options.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
     this.requestTimeoutMs = options.requestTimeoutMs ?? 3_000;
   }
 
@@ -149,14 +154,21 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
 
     try {
       const payload = await this.handler(packet);
-      this.writeLine(socket, JSON.stringify({ payload, requestId } satisfies WireResponse));
+      this.writeLine(socket, this.serializeFrame({ payload, requestId } satisfies WireResponse));
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unhandled microservice error';
-      this.writeLine(socket, JSON.stringify({ error: message, requestId } satisfies WireResponse));
+
+      try {
+        this.writeLine(socket, this.serializeFrame({ error: message, requestId } satisfies WireResponse));
+      } catch {
+        socket.destroy();
+      }
     }
   }
 
   private async sendWirePacket(packet: TransportPacket, signal?: AbortSignal): Promise<unknown> {
+    const serializedPacket = this.serializeFrame(packet);
+
     return await new Promise<unknown>((resolve, reject) => {
       const socket = new Socket();
       let settled = false;
@@ -210,11 +222,15 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
 
       if (packet.kind === 'event') {
         socket.once('connect', () => {
-          this.writeLine(socket, JSON.stringify(packet));
-          settle(() => {
-            socket.end();
-            resolve(undefined);
-          });
+          try {
+            this.writeLine(socket, serializedPacket);
+            settle(() => {
+              socket.end();
+              resolve(undefined);
+            });
+          } catch (error) {
+            fail(error);
+          }
         });
       } else {
         this.bindSocketParser<WireResponse>(socket, (value) => {
@@ -236,7 +252,11 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
         });
 
         socket.once('connect', () => {
-          this.writeLine(socket, JSON.stringify(packet));
+          try {
+            this.writeLine(socket, serializedPacket);
+          } catch (error) {
+            fail(error);
+          }
         });
       }
 
@@ -247,19 +267,36 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
 
   private bindSocketParser<TPacket>(socket: Socket, onPacket: (packet: TPacket) => void): void {
     let buffer = '';
+    let bufferBytes = 0;
 
     socket.on('data', (chunk: Buffer | string) => {
-      buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      const chunkString = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      buffer += chunkString;
+      bufferBytes += Buffer.byteLength(chunkString, 'utf8');
+
+      if (bufferBytes > this.maxFrameBytes) {
+        socket.destroy();
+        return;
+      }
+
       let newLineIndex = buffer.indexOf('\n');
 
       while (newLineIndex >= 0) {
-        const line = buffer.slice(0, newLineIndex).trim();
+        const rawLine = buffer.slice(0, newLineIndex);
+        const line = rawLine.trim();
         buffer = buffer.slice(newLineIndex + 1);
+        bufferBytes = Buffer.byteLength(buffer, 'utf8');
+
+        if (Buffer.byteLength(rawLine, 'utf8') > this.maxFrameBytes) {
+          socket.destroy();
+          return;
+        }
 
         if (line.length > 0) {
           try {
             void Promise.resolve(onPacket(JSON.parse(line) as TPacket)).catch(() => undefined);
           } catch {
+            socket.destroy();
             return;
           }
         }
@@ -272,8 +309,18 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
   private writeLine(socket: Socket, line: string): void {
     socket.write(`${line}\n`);
   }
+
+  private serializeFrame(value: unknown): string {
+    const line = JSON.stringify(value);
+
+    if (Buffer.byteLength(line, 'utf8') > this.maxFrameBytes) {
+      throw new Error(`Microservice TCP frame exceeded ${String(this.maxFrameBytes)} bytes.`);
+    }
+
+    return line;
+  }
 }
 
 function randomRequestId(): string {
-  return Math.random().toString(36).slice(2, 14);
+  return crypto.randomUUID();
 }


### PR DESCRIPTION
Closes #1025

## Summary

Harden `@fluojs/microservices` transport defaults so request/reply and at-least-once delivery paths stay bounded and instance-safe without widening the transport surface.

## Changes

- Bound TCP newline-delimited frames to 1 MiB by default, reject oversize writes before dispatch, and switch request IDs to `crypto.randomUUID()`.
- Delay Redis Streams ACK until handler-side processing completes, keep failed events pending for broker-managed recovery, and add focused ACK timing regression coverage.
- Use instance-scoped default RabbitMQ response queues so concurrent transport instances do not steal replies, and document the new safety defaults in `README.md` / `README.ko.md`.

## Testing

- `pnpm --filter @fluojs/microservices test -- src/transports/tcp-transport.test.ts src/transports/redis-streams-transport.test.ts src/transports/rabbitmq-transport.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm verify:platform-consistency-governance`

## Public export documentation

No public exports changed in this PR.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (README mirrors updated together; governance docs unchanged.)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (Not applicable: platform contract docs unchanged.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (Not applicable: no platform conformance claim changed.)