### PR TITLE
Resolve #1029: make http and throttler proxy-aware by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Breaking changes
 
+- `@fluojs/http`, `@fluojs/throttler`: default request identity resolution for rate limiting is now proxy-aware and no longer falls back to a shared `unknown` bucket. Migration note: ensure proxied/serverless adapters forward `Forwarded`, `X-Forwarded-For`, or `X-Real-IP`, or configure an explicit `keyResolver`/`keyGenerator` when no socket identity is available.
 - `@fluojs/runtime`: Node-specific startup helpers are no longer exported from the root barrel. Migration note: import `createNodeHttpAdapter`, `bootstrapNodeApplication`, and `runNodeApplication` from `@fluojs/runtime/node`.
 - `@fluojs/cli`, `examples/*`, `docs/*`: the canonical starter/examples/migration story now uses adapter-first Fastify startup on the runtime facade. Migration note: align generated or copied `src/main.ts` files to `createFastifyAdapter(...)` (or another explicit transport adapter), and reserve `@fluojs/runtime/node` for Node compatibility helper flows.
 - `@fluojs/cli`, `examples/*`, `docs/*`: public onboarding/governance guidance now treats Node.js, Bun, Deno, and Cloudflare Workers as the official runtime matrix. Migration note: keep the default Fastify starter path for Node.js, but point runtime-specific startup choices to the corresponding published `@fluojs/platform-*` package README and adapter entrypoint.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -84,6 +84,10 @@ function someDeepHelper() {
 }
 ```
 
+### 프록시 뒤의 속도 제한
+
+`createRateLimitMiddleware(...)`는 클라이언트 식별자를 `Forwarded`, `X-Forwarded-For`, `X-Real-IP`, 마지막으로 raw socket `remoteAddress` 순서로 해석합니다. 어댑터가 프록시 헤더도 raw socket 접근도 제공하지 않는다면 공유 fallback 버킷에 의존하지 말고 명시적인 `keyResolver`를 설정하세요.
+
 ### 서버 전송 이벤트
 
 ```ts
@@ -104,7 +108,7 @@ stream(_input: undefined, ctx: RequestContext) {
 - **실행 데코레이터**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`
 - **핵심 런타임 타입**: `RequestContext`, `FrameworkRequest`, `FrameworkResponse`, `SseResponse`
 - **예외**: `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `InternalServerErrorException`, `PayloadTooLargeException`
-- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `createCorsMiddleware`, `getCurrentRequestContext`
+- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `createCorsMiddleware`, `createRateLimitMiddleware`, `getCurrentRequestContext`
 
 ## 내부 서브경로 (`@fluojs/http/internal`)
 
@@ -113,6 +117,7 @@ stream(_input: undefined, ctx: RequestContext) {
 - `createErrorResponse(error, requestId)`: 표준화된 JSON 에러 응답 팩토리.
 - `HttpException`: 모든 프레임워크 수준 HTTP 에러의 기본 클래스.
 - `PLATFORM_SHELL`: 활성 플랫폼 어댑터를 위한 DI 토큰.
+- `resolveClientIdentity(request)`: 속도 제한과 런타임 통합에서 사용하는 프록시 인지 클라이언트 식별 해석기.
 
 ## 관련 패키지
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -86,6 +86,10 @@ function someDeepHelper() {
 }
 ```
 
+### Rate limiting behind proxies
+
+`createRateLimitMiddleware(...)` resolves client identity from `Forwarded`, `X-Forwarded-For`, `X-Real-IP`, and finally the raw socket `remoteAddress`. If your adapter runs without proxy headers or raw socket access, provide an explicit `keyResolver` instead of relying on a shared fallback bucket.
+
 ### Server-sent events
 
 ```ts
@@ -106,7 +110,7 @@ stream(_input: undefined, ctx: RequestContext) {
 - **Execution decorators**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`
 - **Core runtime types**: `RequestContext`, `FrameworkRequest`, `FrameworkResponse`, `SseResponse`
 - **Exceptions**: `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `InternalServerErrorException`, `PayloadTooLargeException`
-- **Helpers**: `createHandlerMapping`, `createDispatcher`, `createCorsMiddleware`, `getCurrentRequestContext`
+- **Helpers**: `createHandlerMapping`, `createDispatcher`, `createCorsMiddleware`, `createRateLimitMiddleware`, `getCurrentRequestContext`
 
 ## Internal Subpath (`@fluojs/http/internal`)
 
@@ -115,6 +119,7 @@ The `./internal` subpath exports low-level utilities used by platform adapters a
 - `createErrorResponse(error, requestId)`: Standardized JSON error response factory.
 - `HttpException`: Base class for all framework-level HTTP errors.
 - `PLATFORM_SHELL`: DI token for the active platform adapter.
+- `resolveClientIdentity(request)`: Proxy-aware client identity resolver used by rate limiting and other runtime integrations.
 
 ## Related Packages
 

--- a/packages/http/src/client-identity.ts
+++ b/packages/http/src/client-identity.ts
@@ -43,8 +43,20 @@ function normalizeClientIdentity(value: string | undefined): string | undefined 
     normalized = normalized.slice(1, -1).trim();
   }
 
+  const bracketedHostPort = normalized.match(/^\[(.+)]:(\d+)$/);
+
+  if (bracketedHostPort) {
+    return bracketedHostPort[1]?.trim() || undefined;
+  }
+
   if (normalized.startsWith('[') && normalized.endsWith(']')) {
     normalized = normalized.slice(1, -1).trim();
+  }
+
+  const ipv4HostPort = normalized.match(/^((?:\d{1,3}\.){3}\d{1,3}):(\d+)$/);
+
+  if (ipv4HostPort) {
+    return ipv4HostPort[1]?.trim() || undefined;
   }
 
   return normalized || undefined;

--- a/packages/http/src/client-identity.ts
+++ b/packages/http/src/client-identity.ts
@@ -1,0 +1,145 @@
+import type { FrameworkRequest } from './types.js';
+
+const FORWARDED_HEADER = 'forwarded';
+const X_FORWARDED_FOR_HEADER = 'x-forwarded-for';
+const X_REAL_IP_HEADER = 'x-real-ip';
+
+function readHeader(
+  headers: Readonly<Record<string, string | string[] | undefined>>,
+  name: string,
+): string | undefined {
+  const direct = headers[name];
+
+  if (typeof direct === 'string') {
+    return direct;
+  }
+
+  if (Array.isArray(direct)) {
+    return direct.find((value) => value.trim().length > 0);
+  }
+
+  const match = Object.entries(headers).find(([key]) => key.toLowerCase() === name);
+  const value = match?.[1];
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return value?.find((entry) => entry.trim().length > 0);
+}
+
+function normalizeClientIdentity(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  let normalized = value.trim();
+
+  if (!normalized || normalized.toLowerCase() === 'unknown') {
+    return undefined;
+  }
+
+  if (normalized.startsWith('"') && normalized.endsWith('"')) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+
+  return normalized || undefined;
+}
+
+function resolveForwardedClientIdentity(
+  headers: Readonly<Record<string, string | string[] | undefined>>,
+): string | undefined {
+  const forwarded = readHeader(headers, FORWARDED_HEADER);
+
+  if (!forwarded) {
+    return undefined;
+  }
+
+  for (const field of forwarded.split(',')) {
+    for (const part of field.split(';')) {
+      const separator = part.indexOf('=');
+
+      if (separator === -1) {
+        continue;
+      }
+
+      const key = part.slice(0, separator).trim().toLowerCase();
+
+      if (key !== 'for') {
+        continue;
+      }
+
+      const normalized = normalizeClientIdentity(part.slice(separator + 1));
+
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function resolveCommaSeparatedClientIdentity(
+  headers: Readonly<Record<string, string | string[] | undefined>>,
+  headerName: string,
+): string | undefined {
+  const headerValue = readHeader(headers, headerName);
+
+  if (!headerValue) {
+    return undefined;
+  }
+
+  for (const value of headerValue.split(',')) {
+    const normalized = normalizeClientIdentity(value);
+
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveSocketClientIdentity(raw: unknown): string | undefined {
+  if (!raw || typeof raw !== 'object') {
+    return undefined;
+  }
+
+  const socket = (raw as { socket?: { remoteAddress?: unknown } }).socket;
+  return typeof socket?.remoteAddress === 'string'
+    ? normalizeClientIdentity(socket.remoteAddress)
+    : undefined;
+}
+
+/**
+ * Resolve one stable client identity from the normalized request contract.
+ *
+ * Resolution order is `Forwarded`, `X-Forwarded-For`, `X-Real-IP`, then the
+ * raw socket's `remoteAddress`. If none are available, callers must provide an
+ * explicit resolver because falling back to a shared `unknown` bucket is not
+ * safe in proxied or serverless environments.
+ *
+ * @param request Adapter-normalized request whose headers/raw transport state should be inspected.
+ * @returns A proxy-aware client identity string suitable for rate limiting.
+ * @throws Error When the request exposes no trustworthy proxy header or socket identity.
+ */
+export function resolveClientIdentity(request: FrameworkRequest): string {
+  const clientIdentity =
+    resolveForwardedClientIdentity(request.headers) ??
+    resolveCommaSeparatedClientIdentity(request.headers, X_FORWARDED_FOR_HEADER) ??
+    normalizeClientIdentity(readHeader(request.headers, X_REAL_IP_HEADER)) ??
+    resolveSocketClientIdentity(request.raw);
+
+  if (clientIdentity) {
+    return clientIdentity;
+  }
+
+  throw new Error(
+    'Unable to resolve client identity from Forwarded, X-Forwarded-For, X-Real-IP, or raw socket remoteAddress. Provide an explicit keyResolver/keyGenerator for this environment.',
+  );
+}

--- a/packages/http/src/internal.ts
+++ b/packages/http/src/internal.ts
@@ -1,1 +1,2 @@
 export { DefaultBinder } from './adapters/binding.js';
+export { resolveClientIdentity } from './client-identity.js';

--- a/packages/http/src/middleware/rate-limit.test.ts
+++ b/packages/http/src/middleware/rate-limit.test.ts
@@ -147,6 +147,63 @@ describe('createRateLimitMiddleware', () => {
     expect(secondContext.response.statusCode).toBe(200);
   });
 
+  it('normalizes ipv4 forwarded identities that include client ports', async () => {
+    const middleware = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
+    const next = vi.fn(async () => {});
+    const firstContext = createContext({
+      headers: { forwarded: 'for=198.51.100.10:1234;proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+    const secondContext = createContext({
+      headers: { forwarded: 'for=198.51.100.10:5678;proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+
+    await middleware.handle(firstContext, next);
+    await middleware.handle(secondContext, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(secondContext.response.statusCode).toBe(429);
+  });
+
+  it('normalizes bracketed ipv6 forwarded identities that include client ports', async () => {
+    const middleware = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
+    const next = vi.fn(async () => {});
+    const firstContext = createContext({
+      headers: { forwarded: 'for="[2001:db8::1]:1234";proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+    const secondContext = createContext({
+      headers: { forwarded: 'for="[2001:db8::1]:5678";proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+
+    await middleware.handle(firstContext, next);
+    await middleware.handle(secondContext, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(secondContext.response.statusCode).toBe(429);
+  });
+
+  it('normalizes comma-separated proxy identities when the first hop includes a port', async () => {
+    const middleware = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
+    const next = vi.fn(async () => {});
+    const firstContext = createContext({
+      headers: { 'x-forwarded-for': '198.51.100.10:1234, 10.0.0.10' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+    const secondContext = createContext({
+      headers: { 'x-forwarded-for': '198.51.100.10:5678, 10.0.0.10' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+
+    await middleware.handle(firstContext, next);
+    await middleware.handle(secondContext, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(secondContext.response.statusCode).toBe(429);
+  });
+
   it('accepts proxied requests when the raw socket address is unavailable', async () => {
     const middleware = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
     const next = vi.fn(async () => {});

--- a/packages/http/src/middleware/rate-limit.test.ts
+++ b/packages/http/src/middleware/rate-limit.test.ts
@@ -3,7 +3,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMemoryRateLimitStore, createRateLimitMiddleware } from './rate-limit.js';
 import type { MiddlewareContext } from '../types.js';
 
-function createContext(remoteAddress = '127.0.0.1') {
+function createContext(
+  options:
+    | string
+    | {
+        headers?: Record<string, string | string[]>;
+        raw?: unknown;
+      } = '127.0.0.1',
+) {
+  const headers = typeof options === 'string' ? {} : (options.headers ?? {});
+  const raw =
+    typeof options === 'string'
+      ? {
+          socket: {
+            remoteAddress: options,
+          },
+        }
+      : (options.raw ?? {
+          socket: {
+            remoteAddress: '127.0.0.1',
+          },
+        });
   const response = {
     committed: false,
     headers: {} as Record<string, string | string[]>,
@@ -22,11 +42,8 @@ function createContext(remoteAddress = '127.0.0.1') {
 
   return {
     request: {
-      raw: {
-        socket: {
-          remoteAddress,
-        },
-      },
+      headers,
+      raw,
     },
     requestContext: {},
     response,
@@ -108,6 +125,49 @@ describe('createRateLimitMiddleware', () => {
     await middleware.handle(contextB, next);
 
     expect(next).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses forwarded headers before the proxy socket address', async () => {
+    const middleware = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
+    const next = vi.fn(async () => {});
+    const firstContext = createContext({
+      headers: { 'x-forwarded-for': '198.51.100.10, 10.0.0.10' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+    const secondContext = createContext({
+      headers: { 'x-forwarded-for': '198.51.100.11, 10.0.0.10' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+
+    await middleware.handle(firstContext, next);
+    await middleware.handle(secondContext, next);
+
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(firstContext.response.statusCode).toBe(200);
+    expect(secondContext.response.statusCode).toBe(200);
+  });
+
+  it('accepts proxied requests when the raw socket address is unavailable', async () => {
+    const middleware = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
+    const next = vi.fn(async () => {});
+    const context = createContext({
+      headers: { forwarded: 'for="[2001:db8:cafe::17]";proto=https' },
+      raw: {},
+    });
+
+    await middleware.handle(context, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(context.response.statusCode).toBe(200);
+  });
+
+  it('throws when no proxy or socket client identity is available', async () => {
+    const middleware = createRateLimitMiddleware({ limit: 1, windowMs: 1_000 });
+    const next = vi.fn(async () => {});
+    const context = createContext({ headers: {}, raw: {} });
+
+    await expect(middleware.handle(context, next)).rejects.toThrow(/resolve client identity/i);
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('accepts a custom store implementation', async () => {

--- a/packages/http/src/middleware/rate-limit.ts
+++ b/packages/http/src/middleware/rate-limit.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareContext, Middleware } from '../types.js';
 import { TooManyRequestsException, createErrorResponse } from '../exceptions.js';
+import { resolveClientIdentity } from '../client-identity.js';
 
 export interface RateLimitStoreEntry {
   count: number;
@@ -21,8 +22,7 @@ export interface RateLimitOptions {
 }
 
 function defaultKeyResolver(ctx: MiddlewareContext): string {
-  const raw = ctx.request.raw as { socket?: { remoteAddress?: string } } | undefined;
-  return raw?.socket?.remoteAddress ?? 'unknown';
+  return resolveClientIdentity(ctx.request);
 }
 
 export function createMemoryRateLimitStore(): RateLimitStore {

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -86,7 +86,7 @@ ThrottlerModule.forRoot({
 
 ### 커스텀 키 생성
 
-기본적으로 클라이언트의 IP 주소를 기준으로 제한합니다. API 키나 사용자 ID 등 다른 식별자를 사용하도록 커스터마이징할 수 있습니다.
+기본적으로 `Forwarded`, `X-Forwarded-For`, `X-Real-IP`, 마지막으로 raw socket `remoteAddress` 순서로 클라이언트 식별자를 해석합니다. 어느 것도 없으면 서로 다른 호출자를 같은 버킷으로 합치지 않도록 예외를 던집니다. API 키나 사용자 ID 등 다른 식별자를 사용하도록 커스터마이징할 수도 있습니다.
 
 ```typescript
 ThrottlerModule.forRoot({

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -86,7 +86,7 @@ ThrottlerModule.forRoot({
 
 ### Custom Key Generation
 
-By default, the throttler uses the client's IP address. You can customize this to use API keys, user IDs, or other identifiers.
+By default, the throttler resolves client identity from `Forwarded`, `X-Forwarded-For`, `X-Real-IP`, and finally the raw socket `remoteAddress`. If none are available, it throws instead of collapsing unrelated callers into a shared bucket. You can customize this to use API keys, user IDs, or other identifiers.
 
 ```typescript
 ThrottlerModule.forRoot({

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -1,6 +1,7 @@
 import { Inject } from '@fluojs/core';
 import { metadataSymbol } from '@fluojs/core/internal';
 import { TooManyRequestsException, type Guard, type GuardContext, type MiddlewareContext } from '@fluojs/http';
+import { resolveClientIdentity } from '@fluojs/http/internal';
 
 import {
   getClassSkipThrottleMetadata,
@@ -33,8 +34,7 @@ function getMethodMetadataBag(controllerToken: Function, methodName: string): Me
 }
 
 function defaultKeyGenerator(ctx: MiddlewareContext): string {
-  const raw = ctx.request.raw as { socket?: { remoteAddress?: string } } | undefined;
-  return raw?.socket?.remoteAddress ?? 'unknown';
+  return resolveClientIdentity(ctx.request);
 }
 
 function buildStoreKey(handlerKey: string, clientKey: string): string {

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -15,8 +15,19 @@ import type {
   ThrottlerStoreEntry,
 } from './types.js';
 
-function createRequestContext(remoteAddress = '127.0.0.1'): RequestContext {
-  const headers: Record<string, string | string[]> = {};
+function createRequestContext(
+  options:
+    | string
+    | {
+        headers?: Record<string, string | string[]>;
+        raw?: unknown;
+      } = '127.0.0.1',
+): RequestContext {
+  const headers: Record<string, string | string[]> = typeof options === 'string' ? {} : (options.headers ?? {});
+  const raw =
+    typeof options === 'string'
+      ? { socket: { remoteAddress: options } }
+      : (options.raw ?? { socket: { remoteAddress: '127.0.0.1' } });
   const response = {
     committed: false,
     headers,
@@ -37,12 +48,12 @@ function createRequestContext(remoteAddress = '127.0.0.1'): RequestContext {
     request: {
       body: undefined,
       cookies: {},
-      headers: {},
+      headers,
       method: 'GET',
       params: {},
       path: '/test',
       query: {},
-      raw: { socket: { remoteAddress } },
+      raw,
       url: '/test',
     },
     response: response as unknown as RequestContext['response'],
@@ -395,6 +406,38 @@ describe('ThrottlerGuard — in-memory store', () => {
     await guard.canActivate(createGuardContext(TestController, 'other', ctx1));
 
     expect(true).toBe(true);
+  });
+
+  it('uses forwarded client identity before the proxy socket address', async () => {
+    class TestController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1 });
+    const firstContext = createRequestContext({
+      headers: { forwarded: 'for=198.51.100.10;proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+    const secondContext = createRequestContext({
+      headers: { forwarded: 'for=198.51.100.11;proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', firstContext))).resolves.toBe(true);
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', secondContext))).resolves.toBe(true);
+  });
+
+  it('rejects when no proxy or socket client identity is available', async () => {
+    class TestController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard(options);
+    const ctx = createRequestContext({ headers: {}, raw: {} });
+
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', ctx))).rejects.toThrow(
+      /resolve client identity/i,
+    );
   });
 
   it('separates throttling state for handlers with identical class and method names', async () => {

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -427,6 +427,27 @@ describe('ThrottlerGuard — in-memory store', () => {
     await expect(guard.canActivate(createGuardContext(TestController, 'action', secondContext))).resolves.toBe(true);
   });
 
+  it('normalizes forwarded client identity ports before building throttler keys', async () => {
+    class TestController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1 });
+    const firstContext = createRequestContext({
+      headers: { forwarded: 'for=198.51.100.10:1234;proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+    const secondContext = createRequestContext({
+      headers: { forwarded: 'for=198.51.100.10:5678;proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', firstContext))).resolves.toBe(true);
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', secondContext))).rejects.toThrow(
+      'Too Many Requests',
+    );
+  });
+
   it('rejects when no proxy or socket client identity is available', async () => {
     class TestController {
       action() {}

--- a/packages/throttler/src/types.ts
+++ b/packages/throttler/src/types.ts
@@ -42,7 +42,7 @@ export interface ThrottlerModuleOptions {
   /** Maximum number of requests allowed within the window (module-wide default). */
   limit: number;
   /**
-   * Key generator function. Defaults to remote IP.
+   * Key generator function. Defaults to proxy-aware client identity resolution.
    * Receives the raw middleware context so custom headers (e.g. x-api-key) can be used.
    */
   keyGenerator?: (ctx: MiddlewareContext) => string;


### PR DESCRIPTION
Closes #1029

## Summary

- make the default client identity path shared and proxy-aware across `@fluojs/http` and `@fluojs/throttler`
- prefer `Forwarded`, `X-Forwarded-For`, and `X-Real-IP` before raw socket addresses, and fail loudly when no client identity is available
- keep the diff narrow to request identity defaults and regression coverage, leaving broader request-id/correlation hardening for `#1028`

## Changes

- add `resolveClientIdentity(request)` under `@fluojs/http/internal` and switch HTTP rate limiting to use it by default
- switch `@fluojs/throttler` default key generation to the same resolver and cover proxied plus raw-socket-absent cases in regression tests
- document the new default behavior in the HTTP/throttler English and Korean READMEs and add a migration note to `CHANGELOG.md`

## Testing

- `cd packages/http && pnpm test` ✅
- `cd packages/http && pnpm typecheck` ✅
- `cd packages/throttler && pnpm test` ✅
- `cd packages/throttler && pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm verify:public-export-tsdoc` ✅
- `pnpm typecheck` ⚠️ fails in the current worktree due pre-existing workspace import-resolution errors outside this diff (for example `@fluojs/core` / `@fluojs/http` resolution in root package typecheck)
- `pnpm lint` ⚠️ reports existing repository-wide warnings outside this diff

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] No platform contract docs changed in this PR, so no companion governance/doc-index tooling update was required.
- [x] No new package README platform-conformance claims were introduced beyond behavior covered by the added regression tests.