### PR TITLE
Resolve #1030: harden messaging delivery semantics

### DIFF
--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -157,6 +157,11 @@ await discord.send({
 
 bot 기반 REST 전달처럼 더 풍부한 API 연동이 필요하다면 export된 `DiscordTransport` 계약을 구현해 `DiscordModule.forRoot(...)` 또는 `forRootAsync(...)`에 주입하면 됩니다.
 
+Behavioral contract 메모:
+
+- 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 실패를 호출자에게 에러를 노출하기 전에 bounded exponential backoff로 재시도합니다.
+- 호출자에게 보이는 `DiscordTransportError` 메시지는 기본적으로 raw upstream response body를 포함하지 않습니다.
+
 ### 의도적인 제한 사항
 
 Discord 패키지는 의도적으로 다음을 **포함하지 않습니다**:

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -157,6 +157,11 @@ await discord.send({
 
 For richer API integrations such as bot-backed REST delivery, implement the exported `DiscordTransport` contract and inject it through `DiscordModule.forRoot(...)` or `forRootAsync(...)`.
 
+Behavioral contract notes:
+
+- The built-in webhook transport retries transient `408`, `429`, and `5xx` failures with bounded exponential backoff before surfacing an error.
+- Caller-visible `DiscordTransportError` messages omit raw upstream response bodies by default.
+
 ### Intentional limitations
 
 The Discord package intentionally does **not**:

--- a/packages/discord/src/channel.ts
+++ b/packages/discord/src/channel.ts
@@ -38,9 +38,7 @@ export class DiscordChannel implements NotificationChannel<DiscordNotificationDi
     const receipt = await this.discord.sendNotification(notification, { signal: context.signal });
 
     if (receipt.ok === false) {
-      throw new DiscordTransportError(
-        `Discord transport reported an unsuccessful delivery${receipt.response ? `: ${receipt.response}` : '.'}`,
-      );
+      throw new DiscordTransportError('Discord transport reported an unsuccessful delivery.');
     }
 
     return {

--- a/packages/discord/src/module.test.ts
+++ b/packages/discord/src/module.test.ts
@@ -290,7 +290,82 @@ describe('DiscordModule', () => {
         },
         {},
       ),
-    ).rejects.toThrowError(new DiscordTransportError('Discord transport reported an unsuccessful delivery: denied'));
+    ).rejects.toThrowError(new DiscordTransportError('Discord transport reported an unsuccessful delivery.'));
+  });
+
+  it('retries transient webhook failures with exponential backoff before succeeding', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi
+        .fn<DiscordFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          async text() {
+            return 'rate limited';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 502,
+          statusText: 'Bad Gateway',
+          async text() {
+            return '{"message":"temporary outage"}';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ channel_id: 'chan-1', guild_id: 'guild-1', id: 'msg-1' });
+          },
+        });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send({ attachments: [], components: [], content: 'Retry path', embeds: [], threadId: 'thread-ops' }, {});
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toMatchObject({ messageId: 'msg-1', ok: true, statusCode: 200, threadId: 'thread-ops' });
+      expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sanitizes webhook failure errors after bounded retries', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi.fn<DiscordFetchLike>().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        async text() {
+          return '{"token":"secret","detail":"should not leak"}';
+        },
+      });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send({ attachments: [], components: [], content: 'Retry path', embeds: [], threadId: 'thread-ops' }, {});
+      const expectation = expect(pending).rejects.toThrowError(
+        new DiscordTransportError(
+          'Discord webhook delivery failed with status 500 Internal Server Error after 3 attempt(s). Upstream response body was omitted from the caller-visible error.',
+        ),
+      );
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('accepts custom provider-backed transports without bootstrap verification', async () => {

--- a/packages/discord/src/webhook.ts
+++ b/packages/discord/src/webhook.ts
@@ -8,6 +8,9 @@ import type {
   NormalizedDiscordMessage,
 } from './types.js';
 
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
@@ -71,6 +74,44 @@ async function readResponseBody(response: DiscordFetchResponse): Promise<string>
   }
 }
 
+function createStatusFailureMessage(response: DiscordFetchResponse, attempt: number): string {
+  return `Discord webhook delivery failed with status ${response.status}${response.statusText ? ` ${response.statusText}` : ''} after ${String(attempt)} attempt(s). Upstream response body was omitted from the caller-visible error.`;
+}
+
+function createTransportFailureMessage(attempt: number): string {
+  return `Discord webhook delivery failed after ${String(attempt)} attempt(s). Upstream response details were omitted from the caller-visible error.`;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function isTransientStatus(status: number): boolean {
+  return status === 408 || status === 429 || (status >= 500 && status <= 599);
+}
+
+async function waitForRetry(delayMs: number, signal: AbortSignal | undefined): Promise<void> {
+  if (delayMs <= 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+
+    function onAbort() {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+    }
+
+    if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
 function parseJsonRecord(body: string): Record<string, unknown> | undefined {
   if (!body) {
     return undefined;
@@ -114,41 +155,64 @@ export function createDiscordWebhookTransport(options: DiscordWebhookTransportOp
 
   return {
     async send(message: NormalizedDiscordMessage, context: DiscordTransportContext) {
-      const response = await fetchLike(resolveWebhookUrl(webhookUrl, message, wait), {
-        body: JSON.stringify(createWebhookPayload(message)),
-        headers: {
-          'content-type': 'application/json; charset=utf-8',
-        },
-        method: 'POST',
-        signal: context.signal,
-      });
+      for (let attempt = 1; attempt <= DEFAULT_RETRY_ATTEMPTS; attempt += 1) {
+        try {
+          const response = await fetchLike(resolveWebhookUrl(webhookUrl, message, wait), {
+            body: JSON.stringify(createWebhookPayload(message)),
+            headers: {
+              'content-type': 'application/json; charset=utf-8',
+            },
+            method: 'POST',
+            signal: context.signal,
+          });
 
-      const body = await readResponseBody(response);
+          const body = await readResponseBody(response);
 
-      if (!response.ok) {
-        const suffix = body ? `: ${body}` : '';
-        throw new DiscordTransportError(
-          `Discord webhook delivery failed with status ${response.status}${response.statusText ? ` ${response.statusText}` : ''}${suffix}.`,
-        );
+          if (!response.ok) {
+            if (attempt < DEFAULT_RETRY_ATTEMPTS && isTransientStatus(response.status)) {
+              await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
+              continue;
+            }
+
+            throw new DiscordTransportError(createStatusFailureMessage(response, attempt));
+          }
+
+          const parsed = parseJsonRecord(body);
+          const warnings: string[] = [];
+
+          if (body && !parsed) {
+            warnings.push('Discord webhook returned a non-JSON success body.');
+          }
+
+          return {
+            channelId: getStringField(parsed, 'channel_id'),
+            guildId: getStringField(parsed, 'guild_id'),
+            messageId: getStringField(parsed, 'id'),
+            ok: true,
+            response: body || undefined,
+            statusCode: response.status,
+            threadId: getStringField(parsed, 'thread_id') ?? message.threadId,
+            warnings,
+          };
+        } catch (error) {
+          if (isAbortError(error) || context.signal?.aborted) {
+            throw error;
+          }
+
+          if (attempt < DEFAULT_RETRY_ATTEMPTS) {
+            await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
+            continue;
+          }
+
+          if (error instanceof DiscordTransportError) {
+            throw error;
+          }
+
+          throw new DiscordTransportError(createTransportFailureMessage(attempt));
+        }
       }
 
-      const parsed = parseJsonRecord(body);
-      const warnings: string[] = [];
-
-      if (body && !parsed) {
-        warnings.push('Discord webhook returned a non-JSON success body.');
-      }
-
-      return {
-        channelId: getStringField(parsed, 'channel_id'),
-        guildId: getStringField(parsed, 'guild_id'),
-        messageId: getStringField(parsed, 'id'),
-        ok: true,
-        response: body || undefined,
-        statusCode: response.status,
-        threadId: getStringField(parsed, 'thread_id') ?? message.threadId,
-        warnings,
-      };
+      throw new DiscordTransportError(createTransportFailureMessage(DEFAULT_RETRY_ATTEMPTS));
     },
   };
 }

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -150,6 +150,7 @@ EmailModule.forRootAsync({
 Behavioral contract 메모:
 
 - `EmailService.send(...)`는 전달 전에 `defaultFrom`과 `defaultReplyTo`를 해석합니다.
+- `EmailService.send(...)`는 `accepted`, `pending`, `rejected` 수신자를 분리해 보존하므로 provider의 부분 실패가 호출자에게 그대로 보입니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.
 
@@ -188,6 +189,10 @@ export class AppModule {}
 - `to`, `cc`, `bcc`, `from`, `replyTo`
 - `text`, `html`, `attachments`, `headers`
 - 모듈에 renderer가 구성된 경우 `templateData`
+
+Behavioral contract 메모:
+
+- `EmailChannel`은 `pending` 또는 `rejected` 수신자가 하나라도 있으면 전달을 성공으로 보고하지 않고 notification dispatch를 실패로 처리합니다.
 
 ### 큐 기반 대량 전달
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -150,6 +150,7 @@ EmailModule.forRootAsync({
 Behavioral contract notes:
 
 - `EmailService.send(...)` resolves `defaultFrom` and `defaultReplyTo` before delivery.
+- `EmailService.send(...)` preserves `accepted`, `pending`, and `rejected` recipients separately so partial provider failures stay caller-visible.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.
 
@@ -188,6 +189,10 @@ Supported notification payload fields:
 - `to`, `cc`, `bcc`, `from`, `replyTo`
 - `text`, `html`, `attachments`, `headers`
 - `templateData` when a renderer is configured on the module
+
+Behavioral contract notes:
+
+- `EmailChannel` treats any `pending` or `rejected` recipients as a failed notification dispatch instead of reporting the delivery as successful.
 
 ### Queue-backed bulk delivery
 

--- a/packages/email/src/channel.ts
+++ b/packages/email/src/channel.ts
@@ -5,6 +5,14 @@ import { EmailService } from './service.js';
 import { EMAIL_OPTIONS } from './tokens.js';
 import type { EmailNotificationDispatchRequest, EmailSendResult, NormalizedEmailModuleOptions } from './types.js';
 
+function createIncompleteDeliveryError(receipt: EmailSendResult): Error {
+  const error = new Error(
+    `Email transport reported an incomplete delivery (accepted=${String(receipt.accepted.length)}, pending=${String(receipt.pending.length)}, rejected=${String(receipt.rejected.length)}).`,
+  );
+  error.name = 'EmailDeliveryError';
+  return error;
+}
+
 /**
  * Notification channel implementation that bridges `@fluojs/notifications` to {@link EmailService}.
  *
@@ -35,6 +43,10 @@ export class EmailChannel implements NotificationChannel<EmailNotificationDispat
     context: NotificationChannelContext,
   ): Promise<NotificationChannelDelivery<EmailSendResult>> {
     const receipt = await this.email.sendNotification(notification, { signal: context.signal });
+
+    if (receipt.accepted.length === 0 || receipt.pending.length > 0 || receipt.rejected.length > 0) {
+      throw createIncompleteDeliveryError(receipt);
+    }
 
     return {
       externalId: receipt.messageId,

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -150,6 +150,17 @@ import { EMAIL } from './tokens.js';
 import { EmailConfigurationError } from './errors.js';
 import type { Email, EmailTransport, EmailTransportFactory, NormalizedEmailMessage } from './types.js';
 
+class PartialDeliveryTransport implements EmailTransport {
+  async send(): Promise<{ accepted: string[]; messageId: string; pending: string[]; rejected: string[] }> {
+    return {
+      accepted: ['accepted@example.com'],
+      messageId: 'partial-1',
+      pending: ['pending@example.com'],
+      rejected: ['rejected@example.com'],
+    };
+  }
+}
+
 class RecordingTransport implements EmailTransport {
   constructor(private readonly messagePrefix: string) {}
 
@@ -384,6 +395,32 @@ describe('EmailModule', () => {
     await worker.handle(enqueued[1] as EmailNotificationQueueJob);
 
     expect(transportState.sent).toHaveLength(2);
+  });
+
+  it('fails notifications delivery when the transport reports pending or rejected recipients', async () => {
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: new PartialDeliveryTransport(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const channel = await container.resolve(EmailChannel);
+
+    await expect(
+      channel.send(
+        {
+          channel: 'email',
+          payload: { text: 'Hello' },
+          recipients: ['user@example.com'],
+          subject: 'Subject',
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({
+      message: 'Email transport reported an incomplete delivery (accepted=1, pending=1, rejected=1).',
+      name: 'EmailDeliveryError',
+    });
   });
 
   it('accepts custom provider-backed transports without bootstrap verification', async () => {

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -158,6 +158,11 @@ await slack.send({
 
 `chat.postMessage` 같은 더 풍부한 API 연동이 필요하다면 export된 `SlackTransport` 계약을 구현해 `SlackModule.forRoot(...)` 또는 `forRootAsync(...)`에 주입하면 됩니다.
 
+Behavioral contract 메모:
+
+- 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 실패를 호출자에게 에러를 노출하기 전에 bounded exponential backoff로 재시도합니다.
+- 호출자에게 보이는 `SlackTransportError` 메시지는 기본적으로 raw upstream response body를 포함하지 않습니다.
+
 ### 의도적인 제한 사항
 
 Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -158,6 +158,11 @@ await slack.send({
 
 For richer API integrations such as `chat.postMessage`, implement the exported `SlackTransport` contract and inject it through `SlackModule.forRoot(...)` or `forRootAsync(...)`.
 
+Behavioral contract notes:
+
+- The built-in webhook transport retries transient `408`, `429`, and `5xx` failures with bounded exponential backoff before surfacing an error.
+- Caller-visible `SlackTransportError` messages omit raw upstream response bodies by default.
+
 ### Intentional limitations
 
 The Slack package intentionally does **not**:

--- a/packages/slack/src/channel.ts
+++ b/packages/slack/src/channel.ts
@@ -38,9 +38,7 @@ export class SlackChannel implements NotificationChannel<SlackNotificationDispat
     const receipt = await this.slack.sendNotification(notification, { signal: context.signal });
 
     if (receipt.ok === false) {
-      throw new SlackTransportError(
-        `Slack transport reported an unsuccessful delivery${receipt.response ? `: ${receipt.response}` : '.'}`,
-      );
+      throw new SlackTransportError('Slack transport reported an unsuccessful delivery.');
     }
 
     return {

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -286,7 +286,82 @@ describe('SlackModule', () => {
         },
         {},
       ),
-    ).rejects.toThrowError(new SlackTransportError('Slack transport reported an unsuccessful delivery: denied'));
+    ).rejects.toThrowError(new SlackTransportError('Slack transport reported an unsuccessful delivery.'));
+  });
+
+  it('retries transient webhook failures with exponential backoff before succeeding', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi
+        .fn<SlackFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          async text() {
+            return 'rate_limited';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          async text() {
+            return 'temporary outage';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          async text() {
+            return 'ok';
+          },
+        });
+      const transport = createSlackWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+      });
+
+      const pending = transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Retry path' }, {});
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toMatchObject({ ok: true, response: 'ok', statusCode: 200 });
+      expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sanitizes webhook failure errors after bounded retries', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi.fn<SlackFetchLike>().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        async text() {
+          return '<html>secret upstream body</html>';
+        },
+      });
+      const transport = createSlackWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+      });
+
+      const pending = transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Retry path' }, {});
+      const expectation = expect(pending).rejects.toThrowError(
+        new SlackTransportError(
+          'Slack webhook delivery failed with status 500 Internal Server Error after 3 attempt(s). Upstream response body was omitted from the caller-visible error.',
+        ),
+      );
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('accepts custom provider-backed transports without bootstrap verification', async () => {

--- a/packages/slack/src/webhook.ts
+++ b/packages/slack/src/webhook.ts
@@ -8,6 +8,9 @@ import type {
   SlackWebhookTransportOptions,
 } from './types.js';
 
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 250;
+
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
@@ -52,6 +55,44 @@ async function readResponseBody(response: SlackFetchResponse): Promise<string> {
   }
 }
 
+function createStatusFailureMessage(response: SlackFetchResponse, attempt: number): string {
+  return `Slack webhook delivery failed with status ${response.status}${response.statusText ? ` ${response.statusText}` : ''} after ${String(attempt)} attempt(s). Upstream response body was omitted from the caller-visible error.`;
+}
+
+function createTransportFailureMessage(attempt: number): string {
+  return `Slack webhook delivery failed after ${String(attempt)} attempt(s). Upstream response details were omitted from the caller-visible error.`;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function isTransientStatus(status: number): boolean {
+  return status === 408 || status === 429 || (status >= 500 && status <= 599);
+}
+
+async function waitForRetry(delayMs: number, signal: AbortSignal | undefined): Promise<void> {
+  if (delayMs <= 0) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+
+    function onAbort() {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new DOMException('The operation was aborted.', 'AbortError'));
+    }
+
+    if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
 /**
  * Creates a webhook-first Slack transport backed by an explicit fetch-compatible boundary.
  *
@@ -79,31 +120,54 @@ export function createSlackWebhookTransport(options: SlackWebhookTransportOption
 
   return {
     async send(message: NormalizedSlackMessage, context: SlackTransportContext) {
-      const response = await fetchLike(webhookUrl, {
-        body: JSON.stringify(createWebhookPayload(message)),
-        headers: {
-          'content-type': 'application/json; charset=utf-8',
-        },
-        method: 'POST',
-        signal: context.signal,
-      });
+      for (let attempt = 1; attempt <= DEFAULT_RETRY_ATTEMPTS; attempt += 1) {
+        try {
+          const response = await fetchLike(webhookUrl, {
+            body: JSON.stringify(createWebhookPayload(message)),
+            headers: {
+              'content-type': 'application/json; charset=utf-8',
+            },
+            method: 'POST',
+            signal: context.signal,
+          });
 
-      const body = await readResponseBody(response);
+          const body = await readResponseBody(response);
 
-      if (!response.ok) {
-        const suffix = body ? `: ${body}` : '';
-        throw new SlackTransportError(
-          `Slack webhook delivery failed with status ${response.status}${response.statusText ? ` ${response.statusText}` : ''}${suffix}.`,
-        );
+          if (!response.ok) {
+            if (attempt < DEFAULT_RETRY_ATTEMPTS && isTransientStatus(response.status)) {
+              await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
+              continue;
+            }
+
+            throw new SlackTransportError(createStatusFailureMessage(response, attempt));
+          }
+
+          return {
+            channel: message.channel,
+            ok: true,
+            response: body,
+            statusCode: response.status,
+            warnings: body && body !== 'ok' ? ['Slack webhook returned a non-standard success body.'] : [],
+          };
+        } catch (error) {
+          if (isAbortError(error) || context.signal?.aborted) {
+            throw error;
+          }
+
+          if (attempt < DEFAULT_RETRY_ATTEMPTS) {
+            await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
+            continue;
+          }
+
+          if (error instanceof SlackTransportError) {
+            throw error;
+          }
+
+          throw new SlackTransportError(createTransportFailureMessage(attempt));
+        }
       }
 
-      return {
-        channel: message.channel,
-        ok: true,
-        response: body,
-        statusCode: response.status,
-        warnings: body && body !== 'ok' ? ['Slack webhook returned a non-standard success body.'] : [],
-      };
+      throw new SlackTransportError(createTransportFailureMessage(DEFAULT_RETRY_ATTEMPTS));
     },
   };
 }


### PR DESCRIPTION
Closes #1030

## Summary

- Harden delivery semantics across `@fluojs/email`, `@fluojs/slack`, and `@fluojs/discord` without broadening into CQRS or unrelated infra-messaging work.
- Make partial email delivery failures visible to `@fluojs/notifications` and add bounded retry/backoff plus sanitized caller-visible errors for Slack/Discord webhook transports.
- Update the affected English/Korean package READMEs so the documented behavioral contract matches the runtime change.

## Changes

- Fail `EmailChannel` notification dispatches when a transport receipt reports any `pending` or `rejected` recipients.
- Retry transient Slack/Discord webhook failures (`408`, `429`, `5xx`) with bounded exponential backoff before surfacing a transport error.
- Remove raw upstream response bodies from caller-visible Slack/Discord delivery errors, including the notifications-channel failure path.
- Add failure-path regression coverage for email partial delivery semantics and Slack/Discord retry + sanitized error behavior.
- Document the new default delivery semantics in `packages/{email,slack,discord}/README.md` and `README.ko.md`.

## Testing

- `pnpm --filter @fluojs/email test`
- `pnpm --filter @fluojs/slack test`
- `pnpm --filter @fluojs/discord test`
- `pnpm --filter @fluojs/email typecheck`
- `pnpm --filter @fluojs/slack typecheck`
- `pnpm --filter @fluojs/discord typecheck`
- `pnpm build`
- `pnpm verify:platform-consistency-governance`
- `pnpm typecheck` *(currently fails in pre-existing workspace module-resolution issues under `packages/http` and `packages/runtime`; the touched messaging packages pass their own package typechecks.)*

## Public export documentation

No public exports changed in this PR.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

No platform contract docs changed in this PR.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.