### PR TITLE
Resolve #1027: harden socket.io auth, cors, and payload bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Breaking changes
 
+- `@fluojs/socket.io`: Socket.IO now defaults to a deny-by-default CORS posture (`origin: false`) and applies bounded Engine.IO payload limits unless you override them explicitly. Migration note: pass `cors.origin` (or the full `cors` object) for approved origins, wire `auth.connection` / `auth.message` guards for namespace-event authorization, and raise `engine.maxHttpBufferSize` only when your deployment intentionally needs larger realtime payloads.
 - `@fluojs/http`, `@fluojs/throttler`: default request identity resolution for rate limiting is now proxy-aware and no longer falls back to a shared `unknown` bucket. Migration note: ensure proxied/serverless adapters forward `Forwarded`, `X-Forwarded-For`, or `X-Real-IP`, or configure an explicit `keyResolver`/`keyGenerator` when no socket identity is available.
 - `@fluojs/runtime`: Node-specific startup helpers are no longer exported from the root barrel. Migration note: import `createNodeHttpAdapter`, `bootstrapNodeApplication`, and `runNodeApplication` from `@fluojs/runtime/node`.
 - `@fluojs/cli`, `examples/*`, `docs/*`: the canonical starter/examples/migration story now uses adapter-first Fastify startup on the runtime facade. Migration note: align generated or copied `src/main.ts` files to `createFastifyAdapter(...)` (or another explicit transport adapter), and reserve `@fluojs/runtime/node` for Node compatibility helper flows.

--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -70,9 +70,38 @@ class MyService {
 }
 ```
 
+### auth guard, 안전한 CORS 기본값, bounded payload
+`SocketIoModule.forRoot(...)`로 namespace/message 인증을 명시하고, CORS를 deny-by-default로 유지하며, 인바운드 Engine.IO payload 크기를 제한할 수 있습니다.
+
+```ts
+SocketIoModule.forRoot({
+  auth: {
+    connection({ socket }) {
+      return socket.handshake.auth.token === 'demo-token'
+        ? true
+        : { message: 'Authentication required.' };
+    },
+    message({ payload }) {
+      return payload === 'allowed'
+        ? true
+        : { message: 'Forbidden event.' };
+    },
+  },
+  cors: {
+    origin: ['https://app.example.com'],
+  },
+  engine: {
+    maxHttpBufferSize: 65_536,
+  },
+});
+```
+
+이제 `cors`를 생략하면 `@fluojs/socket.io`는 `origin: false`를 기본값으로 사용하므로 cross-origin 노출은 명시적 opt-in이 필요합니다. `engine.maxHttpBufferSize`를 생략하면 어댑터가 1 MiB Engine.IO payload 상한을 적용합니다.
+
 ## 공개 API 개요
 
 - `SocketIoModule.forRoot(options)`
+- `SocketIoModule.forRoot({ auth, cors, engine, ... })`
 - `SOCKETIO_SERVER`
 - `SOCKETIO_ROOM_SERVICE`
 - `createSocketIoProviders(options)`

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -72,9 +72,38 @@ class MyService {
 }
 ```
 
+### Auth guards, safe CORS defaults, and bounded payloads
+Use `SocketIoModule.forRoot(...)` to require explicit namespace/message auth, keep CORS in a deny-by-default posture, and cap inbound Engine.IO payload size.
+
+```typescript
+SocketIoModule.forRoot({
+  auth: {
+    connection({ socket }) {
+      return socket.handshake.auth.token === 'demo-token'
+        ? true
+        : { message: 'Authentication required.' };
+    },
+    message({ payload }) {
+      return payload === 'allowed'
+        ? true
+        : { message: 'Forbidden event.' };
+    },
+  },
+  cors: {
+    origin: ['https://app.example.com'],
+  },
+  engine: {
+    maxHttpBufferSize: 65_536,
+  },
+});
+```
+
+When `cors` is omitted, `@fluojs/socket.io` now defaults to `origin: false` so cross-origin exposure stays opt-in. When `engine.maxHttpBufferSize` is omitted, the adapter applies a bounded 1 MiB Engine.IO payload limit.
+
 ## Public API Overview
 
 - `SocketIoModule.forRoot(options)`: Main module for Socket.IO integration.
+- `SocketIoModule.forRoot({ auth, cors, engine, ... })`: Configures namespace/message guards plus explicit CORS and Engine.IO payload bounds.
 - `SOCKETIO_SERVER`: Token to inject the raw Socket.IO `Server`.
 - `SOCKETIO_ROOM_SERVICE`: Token to inject the `SocketIoRoomService`.
 - `createSocketIoProviders(options)`: Helper for custom provider composition.

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -23,7 +23,11 @@ import {
 import { Server, type Namespace, type ServerOptions, type Socket } from 'socket.io';
 
 import { SOCKETIO_OPTIONS_INTERNAL } from './options-token.internal.js';
-import type { SocketIoModuleOptions, SocketIoRoomService } from './types.js';
+import type {
+  SocketIoGuardRejection,
+  SocketIoModuleOptions,
+  SocketIoRoomService,
+} from './types.js';
 
 interface DiscoveryCandidate {
   moduleName: string;
@@ -112,9 +116,35 @@ type SocketIoBootstrapRuntime =
 const DEFAULT_SOCKETIO_SHUTDOWN_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET = 128;
 const DEFAULT_SOCKETIO_ENGINE_PATH = '/socket.io/';
+const DEFAULT_SOCKETIO_MAX_HTTP_BUFFER_SIZE = 1_048_576;
 
 function isFinitePositiveInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && Number.isFinite(value) && value > 0;
+}
+
+function normalizeGuardRejection(
+  result: boolean | SocketIoGuardRejection | void,
+  defaultMessage: string,
+): SocketIoGuardRejection | undefined {
+  if (result === undefined || result === true) {
+    return undefined;
+  }
+
+  if (result === false) {
+    return { message: defaultMessage };
+  }
+
+  return result;
+}
+
+function createGuardError(rejection: SocketIoGuardRejection, defaultMessage: string): Error & { data?: unknown } {
+  const error = new Error(rejection.message ?? defaultMessage) as Error & { data?: unknown };
+
+  if (rejection.data !== undefined) {
+    error.data = rejection.data;
+  }
+
+  return error;
 }
 
 function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
@@ -422,9 +452,9 @@ export class SocketIoLifecycleService
   private createServerOptions(): Partial<ServerOptions> {
     const options: Partial<ServerOptions> = {};
 
-    if (this.moduleOptions.cors !== undefined) {
-      options.cors = this.moduleOptions.cors;
-    }
+    options.cors = this.resolveCorsOptions();
+
+    options.maxHttpBufferSize = this.resolveMaxHttpBufferSize();
 
     if (this.moduleOptions.transports !== undefined) {
       options.transports = this.moduleOptions.transports;
@@ -441,11 +471,23 @@ export class SocketIoLifecycleService
       path: DEFAULT_SOCKETIO_ENGINE_PATH,
     };
 
-    if (this.moduleOptions.cors !== undefined) {
-      options.cors = normalizeCorsForBunEngine(this.moduleOptions.cors);
-    }
+    options.cors = normalizeCorsForBunEngine(this.resolveCorsOptions());
 
     return options;
+  }
+
+  private resolveCorsOptions(): NonNullable<ServerOptions['cors']> {
+    return this.moduleOptions.cors ?? { credentials: false, origin: false };
+  }
+
+  private resolveMaxHttpBufferSize(): number {
+    const configured = this.moduleOptions.engine?.maxHttpBufferSize;
+
+    if (!isFinitePositiveInteger(configured)) {
+      return DEFAULT_SOCKETIO_MAX_HTTP_BUFFER_SIZE;
+    }
+
+    return configured;
   }
 
   private installBunSocketIoBinding(runtime: Extract<SocketIoBootstrapRuntime, { kind: 'bun' }>, io: Server): void {
@@ -578,9 +620,41 @@ export class SocketIoLifecycleService
   }
 
   private bindNamespaceHandlers(attachment: NamespaceAttachment): void {
+    if (this.moduleOptions.auth?.connection) {
+      attachment.namespace.use((socket: Socket, next: (error?: Error) => void) => {
+        void this.runConnectionGuard(attachment.path, socket)
+          .then(() => next())
+          .catch((error) => {
+            next(error instanceof Error ? error : new Error('Socket.IO connection rejected.'));
+          });
+      });
+    }
+
     attachment.namespace.on('connection', (socket: Socket) => {
       void this.bindConnectionHandlers(attachment.descriptors, socket);
     });
+  }
+
+  private async runConnectionGuard(path: string, socket: Socket): Promise<void> {
+    const guard = this.moduleOptions.auth?.connection;
+
+    if (!guard) {
+      return;
+    }
+
+    const rejection = normalizeGuardRejection(
+      await guard({
+        activeConnectionCount: this.socketRegistry.size,
+        namespacePath: path,
+        request: socket.request as IncomingMessage,
+        socket,
+      }),
+      'Socket.IO connection rejected.',
+    );
+
+    if (rejection) {
+      throw createGuardError(rejection, 'Socket.IO connection rejected.');
+    }
   }
 
   private async bindConnectionHandlers(descriptors: WebSocketGatewayDescriptor[], socket: Socket): Promise<void> {
@@ -737,12 +811,75 @@ export class SocketIoLifecycleService
     payload: unknown,
     acknowledgement?: (...callbackArgs: unknown[]) => void,
   ): Promise<void> {
+    const hasMatchingHandlers = resolved.some(({ descriptor }) => this.selectMessageHandlers(descriptor, event).length > 0);
+
+    if (!hasMatchingHandlers) {
+      return;
+    }
+
+    const rejection = await this.resolveMessageGuardRejection(socket, request, event, payload);
+
+    if (rejection) {
+      this.reportRejectedMessage(socket, event, acknowledgement, rejection);
+      return;
+    }
+
     for (const { descriptor, instance } of resolved) {
       const handlers = this.selectMessageHandlers(descriptor, event);
 
       for (const handler of handlers) {
         await this.invokeGatewayMethod(instance, descriptor, handler, [payload, socket, request, acknowledgement]);
       }
+    }
+  }
+
+  private async resolveMessageGuardRejection(
+    socket: Socket,
+    request: IncomingMessage,
+    event: string,
+    payload: unknown,
+  ): Promise<SocketIoGuardRejection | undefined> {
+    const guard = this.moduleOptions.auth?.message;
+
+    if (!guard) {
+      return undefined;
+    }
+
+    const rejection = normalizeGuardRejection(
+      await guard({
+        activeConnectionCount: this.socketRegistry.size,
+        event,
+        namespacePath: socket.nsp.name,
+        payload,
+        request,
+        socket,
+      }),
+      'Socket.IO message rejected.',
+    );
+
+    return rejection;
+  }
+
+  private reportRejectedMessage(
+    socket: Socket,
+    event: string,
+    acknowledgement: ((...callbackArgs: unknown[]) => void) | undefined,
+    rejection: SocketIoGuardRejection,
+  ): void {
+    this.logger.warn(
+      `Socket.IO message ${event} for socket ${socket.id} was rejected before handler dispatch.`,
+      'SocketIoLifecycleService',
+    );
+
+    if (acknowledgement) {
+      acknowledgement({
+        data: rejection.data,
+        error: rejection.message ?? 'Socket.IO message rejected.',
+      });
+    }
+
+    if (rejection.disconnect === true) {
+      socket.disconnect(true);
     }
   }
 

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -241,6 +241,12 @@ function onceConnected(socket: ClientSocket): Promise<void> {
   });
 }
 
+function onceConnectError(socket: ClientSocket): Promise<Error & { data?: unknown }> {
+  return new Promise((resolve) => {
+    socket.once('connect_error', (error: Error & { data?: unknown }) => resolve(error));
+  });
+}
+
 function onceEvent<T>(socket: ClientSocket, event: string): Promise<T> {
   return new Promise((resolve) => {
     socket.once(event, (payload: T) => resolve(payload));
@@ -470,6 +476,247 @@ describe('@fluojs/socket.io', () => {
     await app.close();
   });
 
+  it('uses safe deny-by-default CORS and bounded engine defaults when options are omitted', () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getRealtimeCapability() {
+          return createServerBackedHttpAdapterRealtimeCapability({});
+        },
+      } as never,
+      {},
+    );
+
+    const serverOptions = Reflect.get(service, 'createServerOptions').call(service) as {
+      cors?: unknown;
+      maxHttpBufferSize?: number;
+    };
+    const bunOptions = Reflect.get(service, 'createBunEngineOptions').call(service) as {
+      cors?: unknown;
+    };
+
+    expect(serverOptions.cors).toEqual({ credentials: false, origin: false });
+    expect(serverOptions.maxHttpBufferSize).toBe(1_048_576);
+    expect(bunOptions.cors).toEqual({ credentials: false, origin: false });
+  });
+
+  it('forwards configured engine payload bounds into Socket.IO server options', () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getRealtimeCapability() {
+          return createServerBackedHttpAdapterRealtimeCapability({});
+        },
+      } as never,
+      {
+        engine: {
+          maxHttpBufferSize: 64,
+        },
+      },
+    );
+
+    const serverOptions = Reflect.get(service, 'createServerOptions').call(service) as {
+      maxHttpBufferSize?: number;
+    };
+
+    expect(serverOptions.maxHttpBufferSize).toBe(64);
+  });
+
+  it('rejects anonymous namespace connections before gateway handlers execute', async () => {
+    class GatewayState {
+      connectCount = 0;
+      messages: unknown[] = [];
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/guarded' })
+    class GuardedGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        this.state.connectCount += 1;
+      }
+
+      @OnMessage('ping')
+      onPing(payload: unknown) {
+        this.state.messages.push(payload);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({
+        auth: {
+          connection({ socket }) {
+            return socket.handshake.auth.token === 'demo-token'
+              ? true
+              : { data: { code: 'AUTH_REQUIRED' }, message: 'Authentication required.' };
+          },
+        },
+        transports: ['websocket'],
+      })],
+      providers: [GatewayState, GuardedGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+
+    await app.listen();
+
+    const rejectedSocket = createClient(`http://127.0.0.1:${String(port)}/guarded`, {
+      reconnection: false,
+      transports: ['websocket'],
+    });
+    const rejectedError = await onceConnectError(rejectedSocket);
+
+    expect(rejectedError.message).toBe('Authentication required.');
+    expect(rejectedError.data).toEqual({ code: 'AUTH_REQUIRED' });
+    expect(state.connectCount).toBe(0);
+
+    rejectedSocket.close();
+
+    const allowedSocket = createClient(`http://127.0.0.1:${String(port)}/guarded`, {
+      auth: { token: 'demo-token' },
+      reconnection: false,
+      transports: ['websocket'],
+    });
+    await onceConnected(allowedSocket);
+
+    allowedSocket.emit('ping', 'allowed');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(state.connectCount).toBe(1);
+    expect(state.messages).toEqual(['allowed']);
+
+    allowedSocket.close();
+    await app.close();
+  });
+
+  it('rejects guarded message events without invoking gateway handlers', async () => {
+    class GatewayState {
+      messages: unknown[] = [];
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/message-guard' })
+    class GuardedGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnMessage('ping')
+      onPing(payload: unknown) {
+        this.state.messages.push(payload);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({
+        auth: {
+          message({ payload }) {
+            return payload === 'allowed'
+              ? true
+              : { data: { code: 'AUTH_REQUIRED' }, message: 'Forbidden event.' };
+          },
+        },
+        transports: ['websocket'],
+      })],
+      providers: [GatewayState, GuardedGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+
+    await app.listen();
+
+    const socket = createClient(`http://127.0.0.1:${String(port)}/message-guard`, {
+      reconnection: false,
+      transports: ['websocket'],
+    });
+    await onceConnected(socket);
+
+    const rejectedAck = await new Promise<unknown>((resolve) => {
+      socket.emit('ping', 'blocked', (response: unknown) => resolve(response));
+    });
+
+    expect(rejectedAck).toEqual({ data: { code: 'AUTH_REQUIRED' }, error: 'Forbidden event.' });
+    expect(state.messages).toEqual([]);
+
+    socket.emit('ping', 'allowed');
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(state.messages).toEqual(['allowed']);
+
+    socket.close();
+    await app.close();
+  });
+
+  it('disconnects sockets when inbound payloads exceed the configured engine limit', async () => {
+    class GatewayState {
+      messages: unknown[] = [];
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/payload-limit' })
+    class PayloadGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnMessage('ping')
+      onPing(payload: unknown) {
+        this.state.messages.push(payload);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({
+        engine: {
+          maxHttpBufferSize: 32,
+        },
+        transports: ['websocket'],
+      })],
+      providers: [GatewayState, PayloadGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+
+    await app.listen();
+
+    const socket = createClient(`http://127.0.0.1:${String(port)}/payload-limit`, {
+      reconnection: false,
+      transports: ['websocket'],
+    });
+    await onceConnected(socket);
+
+    const disconnected = onceDisconnected(socket);
+    socket.emit('ping', 'x'.repeat(256));
+
+    expect(['transport close', 'transport error']).toContain(await disconnected);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(state.messages).toEqual([]);
+
+    await app.close();
+  });
+
   for (const scenario of supportedSocketIoAdapterScenarios) {
     it(`boots a real ${scenario.name} app and handles connect, message, room broadcast, and disconnect`, async () => {
     class GatewayState {
@@ -674,7 +921,7 @@ describe('@fluojs/socket.io', () => {
     const socket = {
       id: 'socket-1',
       disconnect: () => undefined,
-      on(event: 'disconnect', listener: (reason: string, description: unknown) => void) {
+      on(_event: 'disconnect', listener: (reason: string, description: unknown) => void) {
         listeners.disconnect = listener;
         return this;
       },
@@ -769,7 +1016,7 @@ describe('@fluojs/socket.io', () => {
     const socket = {
       id: 'socket-1',
       disconnect: () => undefined,
-      on(event: 'disconnect', listener: (reason: string, description: unknown) => void) {
+      on(_event: 'disconnect', listener: (reason: string, description: unknown) => void) {
         listeners.disconnect = listener;
         return this;
       },

--- a/packages/socket.io/src/types.ts
+++ b/packages/socket.io/src/types.ts
@@ -1,4 +1,6 @@
-import type { ServerOptions } from 'socket.io';
+import type { IncomingMessage } from 'node:http';
+
+import type { ServerOptions, Socket } from 'socket.io';
 
 import type { WebSocketRoomService } from '@fluojs/websockets';
 
@@ -38,9 +40,96 @@ export interface SocketIoRoomService extends WebSocketRoomService {
 }
 
 /**
+ * Rejection details returned by Socket.IO auth guards when a connection or message should be blocked.
+ */
+export interface SocketIoGuardRejection {
+  /** Optional structured payload forwarded to `connect_error` or acknowledgement callbacks. */
+  data?: unknown;
+
+  /** When `true`, rejected message events disconnect the current socket after the rejection is reported. */
+  disconnect?: boolean;
+
+  /** Caller-visible reason reported for the rejected operation. */
+  message?: string;
+}
+
+/**
+ * Runtime context passed to Socket.IO connection guards before gateway connect handlers execute.
+ */
+export interface SocketIoConnectionGuardContext {
+  /** Count of active Socket.IO connections already accepted by this lifecycle service. */
+  activeConnectionCount: number;
+
+  /** Namespace path currently being connected, normalized to the Socket.IO gateway path contract. */
+  namespacePath: string;
+
+  /** Raw HTTP handshake request exposed by the selected Socket.IO runtime. */
+  request: IncomingMessage;
+
+  /** Socket.IO socket instance under evaluation. */
+  socket: Socket;
+}
+
+/**
+ * Guard function that can reject one Socket.IO namespace connection before gateway lifecycle hooks run.
+ */
+export type SocketIoConnectionGuard = (
+  context: SocketIoConnectionGuardContext,
+) =>
+  | Promise<boolean | SocketIoGuardRejection | void>
+  | boolean
+  | SocketIoGuardRejection
+  | void;
+
+/**
+ * Runtime context passed to Socket.IO message guards before matched gateway message handlers execute.
+ */
+export interface SocketIoMessageGuardContext {
+  /** Number of active Socket.IO connections already accepted by this lifecycle service. */
+  activeConnectionCount: number;
+
+  /** Socket.IO event name currently being dispatched. */
+  event: string;
+
+  /** Namespace path that received the event. */
+  namespacePath: string;
+
+  /** Event payload extracted from the Socket.IO argument list. */
+  payload: unknown;
+
+  /** Raw HTTP handshake request associated with the current socket. */
+  request: IncomingMessage;
+
+  /** Socket.IO socket instance emitting the event. */
+  socket: Socket;
+}
+
+/**
+ * Guard function that can reject one inbound Socket.IO event before gateway message handlers execute.
+ */
+export type SocketIoMessageGuard = (
+  context: SocketIoMessageGuardContext,
+) =>
+  | Promise<boolean | SocketIoGuardRejection | void>
+  | boolean
+  | SocketIoGuardRejection
+  | void;
+
+/**
  * Options accepted by {@link SocketIoModule.forRoot} and {@link createSocketIoProviders}.
  */
 export interface SocketIoModuleOptions {
+  /**
+   * Optional auth guards evaluated before namespace connections and inbound message handlers proceed.
+   */
+  auth?: {
+    /** Rejects namespace connections before `@OnConnect()` handlers execute. */
+    connection?: SocketIoConnectionGuard;
+
+    /** Rejects inbound events before matching `@OnMessage(...)` handlers execute. */
+    message?: SocketIoMessageGuard;
+  };
+
   /**
    * In-memory outbound buffering controls applied before the server flushes messages to sockets.
    */
@@ -54,6 +143,14 @@ export interface SocketIoModuleOptions {
 
   /** Cross-origin configuration forwarded to the underlying Socket.IO server. */
   cors?: ServerOptions['cors'];
+
+  /**
+   * Engine-level bounds forwarded to Socket.IO's underlying Engine.IO server.
+   */
+  engine?: {
+    /** Maximum accepted inbound payload size in bytes before Engine.IO rejects the request or frame. */
+    maxHttpBufferSize?: number;
+  };
 
   /** Graceful shutdown controls for draining Socket.IO resources during application close. */
   shutdown?: {


### PR DESCRIPTION
Closes #1027

## Summary

- Harden `@fluojs/socket.io` around explicit auth, safe cross-origin defaults, and bounded Engine.IO payload handling.
- Keep the diff scoped to `packages/socket.io` plus the required migration note for the behavioral contract change.

## Changes

- Add `auth.connection` and `auth.message` guard hooks to `SocketIoModule.forRoot(...)` and enforce them inside `SocketIoLifecycleService` before namespace connect/message handler dispatch.
- Default Socket.IO CORS to `origin: false` when omitted and expose `engine.maxHttpBufferSize` with a bounded 1 MiB default.
- Add regression coverage for namespace/message guard behavior, deny-by-default CORS + engine option wiring, and oversized payload disconnect handling.
- Document the new contract in `packages/socket.io/README.md`, `packages/socket.io/README.ko.md`, and add a migration note to `CHANGELOG.md`.

## Testing

- `pnpm --filter @fluojs/socket.io test`
- `pnpm verify:public-export-tsdoc`
- `pnpm verify:platform-consistency-governance`
- `pnpm build`
- `pnpm typecheck`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.