### PR TITLE
Resolve #1047: propagate gRPC server-stream handler errors

### DIFF
--- a/packages/microservices/src/transports/grpc-transport.test.ts
+++ b/packages/microservices/src/transports/grpc-transport.test.ts
@@ -26,7 +26,7 @@ type UnaryImplementation = (
 ) => void;
 
 type ServerStreamImplementation = (
-  call: { metadata?: FakeGrpcMetadata; request: unknown; write(data: unknown): boolean; end(): void },
+  call: { metadata?: FakeGrpcMetadata; request: unknown; write(data: unknown): boolean; end(): void; destroy(err?: Error): void },
 ) => void;
 
 type ClientStreamImplementation = (
@@ -474,6 +474,14 @@ class FakeGrpcRuntime {
       end(): void {
         stream.emit('end');
       },
+      destroy(err?: Error): void {
+        if (err) {
+          stream.emit('error', err);
+          return;
+        }
+
+        stream.emit('end');
+      },
     };
 
     (implementation as ServerStreamImplementation)(call);
@@ -876,6 +884,61 @@ describe('GrpcMicroserviceTransport', () => {
     }
 
     expect(results).toEqual([{ value: 'first' }, { value: 'second' }]);
+
+    await transport.close();
+  });
+
+  it('server-stream handler throw surfaces as an error on the client iterator, not a clean EOF', async () => {
+    const { transport } = createGrpcTransport();
+
+    transport.listenServerStreaming(async () => {
+      throw new Error('server-stream explosion');
+    });
+
+    await transport.listen(async () => undefined);
+
+    const collected: unknown[] = [];
+    let caughtError: Error | undefined;
+
+    try {
+      for await (const item of transport.serverStream('MathService.StreamData', { count: 1 })) {
+        collected.push(item);
+      }
+    } catch (err) {
+      caughtError = err as Error;
+    }
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError!.message).toContain('server-stream explosion');
+    expect(collected).toEqual([]);
+
+    await transport.close();
+  });
+
+  it('server-stream writer.error() surfaces as an error on the client iterator', async () => {
+    const { transport } = createGrpcTransport();
+
+    transport.listenServerStreaming(async (_pattern, _payload, writer) => {
+      writer.write({ value: 'first' });
+      writer.error(new Error('server-stream writer failure'));
+    });
+
+    await transport.listen(async () => undefined);
+
+    const collected: unknown[] = [];
+    let caughtError: Error | undefined;
+
+    try {
+      for await (const item of transport.serverStream('MathService.StreamData', {})) {
+        collected.push(item);
+      }
+    } catch (err) {
+      caughtError = err as Error;
+    }
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError!.message).toContain('server-stream writer failure');
+    expect(collected).toEqual([{ value: 'first' }]);
 
     await transport.close();
   });

--- a/packages/microservices/src/transports/grpc-transport.ts
+++ b/packages/microservices/src/transports/grpc-transport.ts
@@ -20,6 +20,7 @@ interface GrpcServerLike {
 }
 
 interface GrpcWritableStreamLike {
+  destroy?(err?: Error): void;
   end(): void;
   write(data: unknown): boolean;
 }
@@ -443,13 +444,18 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
 
       if (methodDefinition.responseStream) {
         implementation[methodName] = (
-          call: { metadata?: GrpcMetadataLike; request: unknown; write(data: unknown): boolean; end(): void },
+          call: GrpcWritableStreamLike & { metadata?: GrpcMetadataLike; request: unknown },
         ) => {
           void this.handleInboundServerStream(serviceName, methodName, call).catch((error) => {
             try {
               const grpcError = this.mapGrpcHandlerError(error);
-              call.end();
-              void grpcError;
+              const mapped = Object.assign(new Error(grpcError.message), { code: grpcError.code });
+
+              if (call.destroy) {
+                call.destroy(mapped);
+              } else {
+                call.end();
+              }
             } catch {
               call.end();
             }
@@ -514,7 +520,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
   private async handleInboundServerStream(
     serviceName: string,
     methodName: string,
-    call: { metadata?: GrpcMetadataLike; request: unknown; write(data: unknown): boolean; end(): void },
+    call: GrpcWritableStreamLike & { metadata?: GrpcMetadataLike; request: unknown },
   ): Promise<void> {
     const handler = this.serverStreamHandler;
 
@@ -526,6 +532,11 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
     }
 
     const pattern = `${serviceName}.${methodName}`;
+    const mapHandlerError = (error: unknown): Error => {
+      const grpcError = this.mapGrpcHandlerError(error);
+      return Object.assign(new Error(grpcError.message), { code: grpcError.code });
+    };
+
     const writer: ServerStreamWriter = {
       write(data: unknown): void {
         call.write(data);
@@ -534,8 +545,13 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
         call.end();
       },
       error(err: Error): void {
-        void err;
-        call.end();
+        const mapped = mapHandlerError(err);
+
+        if (call.destroy) {
+          call.destroy(mapped);
+        } else {
+          call.end();
+        }
       },
     };
 


### PR DESCRIPTION
Closes #1047

## Summary
- propagate mapped errors through the gRPC server-stream error path instead of ending the stream cleanly
- align `ServerStreamWriter.error()` with bidi-stream semantics so client readers observe handler failures as stream errors
- add regression coverage for thrown server-stream handlers and `writer.error()` propagation

## Changes
- updated `GrpcMicroserviceTransport` server-stream inbound handling to prefer `destroy(mappedError)` when available
- updated the fake gRPC test runtime to support server-stream destroy/error delivery
- added server-stream regression tests mirroring bidi-stream error expectations

## Testing
- `pnpm exec vitest run packages/microservices/src/transports/grpc-transport.test.ts`
- `pnpm build`
- `pnpm --filter @fluojs/microservices typecheck`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
This change restores the documented gRPC streaming contract instead of changing it, so no README or migration note update was required.