### PR TITLE
Resolve #1048: pin openapi Swagger UI assets

### DIFF
--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -80,6 +80,9 @@ fluo는 컨트롤러와 메서드를 조사하여 전체 OpenAPI 3.1.0 문서를
 ### 보안 문서화
 `@ApiBearerAuth()` 및 `@ApiSecurity()`를 사용하여 Bearer 토큰이나 API 키와 같은 보안 요구사항을 쉽게 문서화할 수 있습니다.
 
+### 결정적인 Swagger UI 자산
+`ui: true`를 활성화하면 생성되는 `/docs` 페이지는 정확한 `swagger-ui-dist` 버전의 자산을 참조하여 패키지 릴리스마다 동일한 동작을 유지합니다.
+
 ## 공개 API 개요
 
 - `OpenApiModule`: OpenAPI 통합을 위한 메인 엔트리 포인트.
@@ -96,5 +99,5 @@ fluo는 컨트롤러와 메서드를 조사하여 전체 OpenAPI 3.1.0 문서를
 
 ## 예제 소스
 
-- `packages/openapi/src/module.test.ts`: 통합 테스트 및 사용 예제.
+- `packages/openapi/src/openapi-module.test.ts`: 통합 테스트 및 사용 예제.
 - `examples/openapi-swagger`: 전체 OpenAPI 애플리케이션 예제.

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -80,6 +80,9 @@ Handles URI-based versioning from `@fluojs/http` automatically. Your OpenAPI pat
 ### Security Documentation
 Easily document authentication requirements like Bearer tokens or API keys using `@ApiBearerAuth()` and `@ApiSecurity()`.
 
+### Deterministic Swagger UI Assets
+When `ui: true` is enabled, the generated `/docs` page references an exact `swagger-ui-dist` asset version so release behavior stays deterministic across package updates.
+
 ## Public API Overview
 
 - `OpenApiModule`: Main entry point for OpenAPI integration.
@@ -96,5 +99,5 @@ Easily document authentication requirements like Bearer tokens or API keys using
 
 ## Example Sources
 
-- `packages/openapi/src/module.test.ts`: Integration tests and usage examples.
+- `packages/openapi/src/openapi-module.test.ts`: Integration tests and usage examples.
 - `examples/openapi-swagger`: Complete OpenAPI application example.

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -307,6 +307,9 @@ describe('OpenApiModule', () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toBe('text/html; charset=utf-8');
+    expect(response.body).toEqual(expect.stringContaining('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui.css'));
+    expect(response.body).toEqual(expect.stringContaining('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui-bundle.js'));
+    expect(response.body).not.toEqual(expect.stringContaining('https://unpkg.com/swagger-ui-dist@5/'));
     expect(response.body).toEqual(expect.stringContaining('const specUrl = window.location.pathname.replace('));
     expect(response.body).toEqual(expect.stringContaining("url: specUrl"));
     expect(response.body).toEqual(expect.stringContaining('SwaggerUIBundle'));
@@ -355,9 +358,13 @@ describe('OpenApiModule', () => {
     const docsTrailingHtml = await docsTrailingSlashResponse.text();
 
     expect(docsResponse.status).toBe(200);
+    expect(docsHtml).toContain('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui.css');
+    expect(docsHtml).toContain('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui-bundle.js');
     expect(docsHtml).toContain('const specUrl = window.location.pathname.replace(');
     expect(docsHtml).toContain('url: specUrl');
     expect(docsTrailingSlashResponse.status).toBe(200);
+    expect(docsTrailingHtml).toContain('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui.css');
+    expect(docsTrailingHtml).toContain('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui-bundle.js');
     expect(docsTrailingHtml).toContain('const specUrl = window.location.pathname.replace(');
     expect(docsTrailingHtml).toContain('url: specUrl');
     expect(specResponse.status).toBe(200);

--- a/packages/openapi/src/openapi-module.ts
+++ b/packages/openapi/src/openapi-module.ts
@@ -18,8 +18,10 @@ import {
   type OpenApiSecuritySchemeObject,
 } from './schema-builder.js';
 
-const SWAGGER_UI_CSS_URL = 'https://unpkg.com/swagger-ui-dist@5/swagger-ui.css';
-const SWAGGER_UI_BUNDLE_JS_URL = 'https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js';
+const SWAGGER_UI_DIST_VERSION = '5.32.2';
+const SWAGGER_UI_DIST_BASE_URL = `https://unpkg.com/swagger-ui-dist@${SWAGGER_UI_DIST_VERSION}`;
+const SWAGGER_UI_CSS_URL = `${SWAGGER_UI_DIST_BASE_URL}/swagger-ui.css`;
+const SWAGGER_UI_BUNDLE_JS_URL = `${SWAGGER_UI_DIST_BASE_URL}/swagger-ui-bundle.js`;
 
 /**
  * Public options for `OpenApiModule.forRoot(...)` and `OpenApiModule.forRootAsync(...)`.


### PR DESCRIPTION
## Summary
- pin the `@fluojs/openapi` Swagger UI HTML asset URLs to an exact `swagger-ui-dist` version so `/docs` stays deterministic across releases
- add regression coverage for exact asset URLs in both plain and global-prefix Swagger UI responses
- align the English/Korean package README contract notes and fix the stale example-source reference

## Changes
- update `packages/openapi/src/openapi-module.ts` to build Swagger UI asset URLs from a pinned exact version
- extend `packages/openapi/src/openapi-module.test.ts` to assert exact CSS/JS asset URLs instead of floating major-only URLs
- update `packages/openapi/README.md` and `packages/openapi/README.ko.md` to document deterministic Swagger UI assets and point example sources at `openapi-module.test.ts`

## Testing
- `pnpm --filter @fluojs/openapi test`
- `pnpm --filter @fluojs/openapi typecheck`
- `pnpm --filter @fluojs/openapi build`
- `lsp_diagnostics` on `packages/openapi/src/openapi-module.ts`
- `lsp_diagnostics` on `packages/openapi/src/openapi-module.test.ts`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
This keeps the documented `/docs` surface intact while making its upstream Swagger UI assets deterministic by pinning an exact version. Closes #1048.