### PR TITLE
Resolve #1050: isolate terminus redis indicators behind a subpath

### DIFF
--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -57,7 +57,7 @@ class AppModule {}
 패키지에서 기본으로 제공하는 인디케이터들은 다음과 같습니다.
 
 - `PrismaHealthIndicator` / `DrizzleHealthIndicator`
-- `RedisHealthIndicator`
+- `RedisHealthIndicator` (`@fluojs/terminus/redis`에서 제공)
 - `HttpHealthIndicator`
 - `MemoryHealthIndicator`
 - `DiskHealthIndicator`
@@ -67,7 +67,8 @@ class AppModule {}
 Redis나 DB 클라이언트와 같이 DI 컨테이너의 의존성이 필요한 인디케이터를 사용할 때는, 모듈 로드 시점에 피어 의존성을 import하지 않도록 제공되는 provider 팩토리를 사용하세요.
 
 ```typescript
-import { createRedisHealthIndicatorProvider, TerminusModule } from '@fluojs/terminus';
+import { TerminusModule } from '@fluojs/terminus';
+import { createRedisHealthIndicatorProvider } from '@fluojs/terminus/redis';
 
 TerminusModule.forRoot({
   indicatorProviders: [
@@ -104,8 +105,15 @@ TerminusModule.forRoot({
 
 ### `TerminusHealthService`
 
-- `runHealthCheck(indicators: HealthIndicator[]): Promise<HealthCheckReport>`
-  - 수동으로 헬스 체크 집계를 실행합니다.
+- `check(): Promise<HealthCheckReport>`
+  - 현재 등록된 인디케이터를 실행해 집계된 보고서를 반환합니다.
+- `isHealthy(): Promise<boolean>`
+  - 현재 집계 결과가 완전히 healthy 상태인지 반환합니다.
+
+### `@fluojs/terminus/redis`
+
+- `RedisHealthIndicator`, `createRedisHealthIndicator()`, `createRedisHealthIndicatorProvider()`
+  - Redis 전용 인디케이터 헬퍼는 선택적 Redis 피어가 설치되지 않은 환경에서도 루트 패키지 import가 안전하도록 전용 subpath에서 export됩니다.
 
 ### `HealthCheckError`
 

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -57,7 +57,7 @@ class AppModule {}
 The package provides several indicators out of the box:
 
 - `PrismaHealthIndicator` / `DrizzleHealthIndicator`
-- `RedisHealthIndicator`
+- `RedisHealthIndicator` (from `@fluojs/terminus/redis`)
 - `HttpHealthIndicator`
 - `MemoryHealthIndicator`
 - `DiskHealthIndicator`
@@ -67,7 +67,8 @@ The package provides several indicators out of the box:
 To use indicators that require dependencies from the DI container (like Redis or Database clients) without importing peer dependencies at module load time, use the provider factories.
 
 ```typescript
-import { createRedisHealthIndicatorProvider, TerminusModule } from '@fluojs/terminus';
+import { TerminusModule } from '@fluojs/terminus';
+import { createRedisHealthIndicatorProvider } from '@fluojs/terminus/redis';
 
 TerminusModule.forRoot({
   indicatorProviders: [
@@ -104,8 +105,15 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 
 ### `TerminusHealthService`
 
-- `runHealthCheck(indicators: HealthIndicator[]): Promise<HealthCheckReport>`
-  - Manually trigger a health check aggregation.
+- `check(): Promise<HealthCheckReport>`
+  - Runs the currently registered indicators and returns the aggregated report.
+- `isHealthy(): Promise<boolean>`
+  - Returns whether the current aggregated report is fully healthy.
+
+### `@fluojs/terminus/redis`
+
+- `RedisHealthIndicator`, `createRedisHealthIndicator()`, `createRedisHealthIndicatorProvider()`
+  - Redis-specific indicator helpers are exported from the dedicated subpath so the root package stays import-safe without the optional Redis peer installed.
 
 ### `HealthCheckError`
 

--- a/packages/terminus/package.json
+++ b/packages/terminus/package.json
@@ -28,6 +28,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./redis": {
+      "types": "./dist/redis.d.ts",
+      "import": "./dist/redis.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/terminus/src/indicators/index.ts
+++ b/packages/terminus/src/indicators/index.ts
@@ -3,4 +3,3 @@ export * from './drizzle.js';
 export * from './http.js';
 export * from './memory.js';
 export * from './prisma.js';
-export * from './redis.js';

--- a/packages/terminus/src/public-subpaths.test.ts
+++ b/packages/terminus/src/public-subpaths.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+type ExportTarget = {
+  import: string;
+  types: string;
+};
+
+describe('@fluojs/terminus subpath exports', () => {
+  it('keeps the redis subpath aligned with emitted dist artifacts', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as {
+      exports: Record<string, ExportTarget>;
+    };
+
+    expect(packageJson.exports).toMatchObject({
+      './redis': {
+        import: './dist/redis.js',
+        types: './dist/redis.d.ts',
+      },
+    });
+  });
+});

--- a/packages/terminus/src/public-surface.test.ts
+++ b/packages/terminus/src/public-surface.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import * as terminus from './index.js';
+import * as terminusRedis from './redis.js';
 
 describe('terminus public surface', () => {
   it('keeps health-indicator seams public while internalizing options wiring', () => {
@@ -8,11 +9,18 @@ describe('terminus public surface', () => {
     expect(terminus).toHaveProperty('TERMINUS_INDICATOR_PROVIDER_TOKENS');
     expect(terminus).toHaveProperty('TerminusHealthService');
     expect(terminus).not.toHaveProperty('TERMINUS_OPTIONS');
+    expect(terminus).not.toHaveProperty('RedisHealthIndicator');
   });
 
   it('exposes Nest-style canonical module entrypoint', () => {
     expect(terminus).toHaveProperty('TerminusModule');
     expect((terminus as { TerminusModule: { forRoot: unknown } }).TerminusModule).toHaveProperty('forRoot');
     expect(terminus).not.toHaveProperty('createTerminusModule');
+  });
+
+  it('keeps redis-specific indicators on the dedicated subpath export', () => {
+    expect(terminusRedis).toHaveProperty('RedisHealthIndicator');
+    expect(terminusRedis).toHaveProperty('createRedisHealthIndicator');
+    expect(terminusRedis).toHaveProperty('createRedisHealthIndicatorProvider');
   });
 });

--- a/packages/terminus/src/redis.ts
+++ b/packages/terminus/src/redis.ts
@@ -1,0 +1,1 @@
+export * from './indicators/redis.js';


### PR DESCRIPTION
## Summary
- Move Redis-specific indicator exports off the `@fluojs/terminus` root barrel and into `@fluojs/terminus/redis` so the root package stays import-safe without the optional Redis peer installed.
- Add regression coverage for the new Redis subpath export map and for the root public surface no longer exposing Redis-specific helpers.
- Align the English and Korean `@fluojs/terminus` READMEs with the actual `TerminusHealthService` API and the new Redis import path.

## Changes
- Added the `./redis` export in `packages/terminus/package.json` and introduced `packages/terminus/src/redis.ts` as the dedicated Redis entrypoint.
- Removed the Redis indicator export from `packages/terminus/src/indicators/index.ts`.
- Added `packages/terminus/src/public-subpaths.test.ts` and updated `packages/terminus/src/public-surface.test.ts` to lock the new public contract.
- Updated `packages/terminus/README.md` and `packages/terminus/README.ko.md` to document the subpath import and correct `TerminusHealthService` usage.

## Testing
- `pnpm test` (in `packages/terminus`)
- `pnpm build` (workspace root, to materialize dependent package declarations)
- `pnpm typecheck` (in `packages/terminus`, after workspace build)
- `pnpm build` (in `packages/terminus`, after workspace build)
- `lsp_diagnostics` on modified TypeScript files: no errors

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- The root `@fluojs/terminus` barrel no longer eagerly exposes Redis-specific helpers.
- Redis indicator helpers remain supported from `@fluojs/terminus/redis`; this narrows the import surface specifically to preserve root import safety with the optional peer absent.

Closes #1050