### PR TITLE
Resolve #1046: close oversized Node request streams after 413

### DIFF
--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -23,6 +23,26 @@ type NodeFrameworkRequest = FrameworkRequest & {
   rawBody?: Uint8Array;
 };
 
+export class NodeRequestPayloadTooLargeException extends PayloadTooLargeException {
+  constructor(private readonly request: IncomingMessage) {
+    super('Request body exceeds the size limit.');
+  }
+
+  prepareResponse(response: ServerResponse): void {
+    response.setHeader('Connection', 'close');
+
+    const destroyRequest = () => {
+      if (!this.request.destroyed) {
+        this.request.destroy();
+      }
+    };
+
+    response.once('finish', destroyRequest);
+    response.once('close', destroyRequest);
+    this.request.pause();
+  }
+}
+
 /**
  * Creates a framework request from a raw Node incoming message.
  *
@@ -210,7 +230,7 @@ async function readRequestBody(
     totalSize += buf.byteLength;
 
     if (totalSize > maxBodySize) {
-      throw new PayloadTooLargeException('Request body exceeds the size limit.');
+      throw new NodeRequestPayloadTooLargeException(request);
     }
 
     chunks.push(buf);

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -1,4 +1,4 @@
-import { createServer as createHttpServer, type RequestListener } from 'node:http';
+import { createServer as createHttpServer, type RequestListener, type ServerResponse } from 'node:http';
 import { createServer as createHttpsServer, type ServerOptions as HttpsServerOptions } from 'node:https';
 import type { AddressInfo, Socket } from 'node:net';
 
@@ -21,6 +21,7 @@ import {
 } from './internal-node-compression.js';
 import {
   createFrameworkRequest,
+  NodeRequestPayloadTooLargeException,
   createRequestSignal,
   resolveRequestIdFromHeaders,
 } from './internal-node-request.js';
@@ -227,6 +228,10 @@ function createNodeRequestResponseFactory(
       return resolveRequestIdFromHeaders(request.headers);
     },
     async writeErrorResponse(error, response, requestId) {
+      if (error instanceof NodeRequestPayloadTooLargeException) {
+        error.prepareResponse((response as MutableFrameworkResponse & { raw: ServerResponse }).raw);
+      }
+
       await writeNodeAdapterErrorResponse(error, response, requestId);
     },
   };

--- a/packages/runtime/src/node/node-request.test.ts
+++ b/packages/runtime/src/node/node-request.test.ts
@@ -1,24 +1,35 @@
 import type { IncomingMessage } from 'node:http';
+import { EventEmitter } from 'node:events';
 
 import { describe, expect, it } from 'vitest';
 
 import { createFrameworkRequest } from './node-request.js';
+import { NodeRequestPayloadTooLargeException } from './internal-node-request.js';
 
 function createIncomingMessage(options: {
   body?: string | Uint8Array;
+  bodyChunks?: Array<string | Uint8Array>;
+  destroy?: () => void;
   headers: Record<string, string | string[] | undefined>;
   method?: string;
+  pause?: () => void;
   url?: string;
 }): IncomingMessage {
   const chunks: Uint8Array[] = [];
 
-  if (options.body !== undefined) {
+  if (options.bodyChunks) {
+    for (const chunk of options.bodyChunks) {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+    }
+  } else if (options.body !== undefined) {
     chunks.push(typeof options.body === 'string' ? Buffer.from(options.body, 'utf8') : options.body);
   }
 
   return {
+    destroy: options.destroy,
     headers: options.headers,
     method: options.method ?? 'GET',
+    pause: options.pause,
     async *[Symbol.asyncIterator]() {
       for (const chunk of chunks) {
         yield chunk;
@@ -74,5 +85,43 @@ describe('node request adapter', () => {
     const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
 
     expect(frameworkRequest.body).toEqual({ ok: true });
+  });
+
+  it('destroys the raw Node request stream when maxBodySize is exceeded', async () => {
+    let destroyed = false;
+    let paused = false;
+    const request = createIncomingMessage({
+      bodyChunks: ['12345', '67890'],
+      destroy: () => {
+        destroyed = true;
+      },
+      headers: {
+        'content-type': 'text/plain',
+      },
+      method: 'POST',
+      pause: () => {
+        paused = true;
+      },
+      url: '/body',
+    });
+
+    const response = new EventEmitter() as EventEmitter & {
+      headers: Record<string, string>;
+      setHeader: (name: string, value: string) => void;
+    };
+    response.headers = {};
+    response.setHeader = (name, value) => {
+      response.headers[name] = value;
+    };
+
+    const thrown = await createFrameworkRequest(request, new AbortController().signal, undefined, 8).catch((error: unknown) => error);
+
+    expect(thrown).toBeInstanceOf(NodeRequestPayloadTooLargeException);
+    (thrown as NodeRequestPayloadTooLargeException).prepareResponse(response as never);
+
+    expect(paused).toBe(true);
+    expect(response.headers.Connection).toBe('close');
+    response.emit('finish');
+    expect(destroyed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fix the raw Node request overflow path so the runtime still returns HTTP 413 while actively terminating oversized uploads instead of leaving the incoming stream running.

Closes #1046

## Changes

- add a Node-specific payload-too-large exception that pauses the request immediately and schedules stream destruction after the 413 response is flushed
- hook the Node adapter error path to mark the response `Connection: close` before final cleanup
- add a regression test covering the oversized Node request path cleanup behavior

## Testing

- `pnpm exec vitest run packages/runtime/src/node/node-request.test.ts packages/platform-nodejs/src/index.test.ts`
- `pnpm --filter @fluojs/runtime build`
- `pnpm --filter @fluojs/runtime typecheck`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract note: no public contract changed. This PR aligns the raw Node path with the existing `@fluojs/runtime` README guarantee that `maxBodySize` is enforced while bytes are still streaming.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.