### PR TITLE
Resolve #1049: clear Bun shutdown timeout handles

### DIFF
--- a/packages/platform-bun/README.ko.md
+++ b/packages/platform-bun/README.ko.md
@@ -48,9 +48,8 @@ Bun 서버를 직접 관리하려는 경우 fetch 핸들러를 직접 사용할 
 ```typescript
 import { createBunFetchHandler } from '@fluojs/platform-bun';
 
-const handler = await createBunFetchHandler({ 
+const handler = await createBunFetchHandler({
   dispatcher: app.getHttpDispatcher(),
-  port: 3000 
 });
 
 Bun.serve({

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -48,9 +48,8 @@ If you prefer to manage the Bun server yourself, you can use the fetch handler d
 ```typescript
 import { createBunFetchHandler } from '@fluojs/platform-bun';
 
-const handler = await createBunFetchHandler({ 
+const handler = await createBunFetchHandler({
   dispatcher: app.getHttpDispatcher(),
-  port: 3000 
 });
 
 Bun.serve({

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -311,6 +311,37 @@ describe('@fluojs/platform-bun', () => {
     expect(adapter.getServer()).toBeUndefined();
   });
 
+  it('clears the shutdown timeout handle after close resolves', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const mockBun = installMockBun();
+      const adapter = createBunAdapter() as BunHttpApplicationAdapter;
+      const deferred = createDeferred<void>();
+
+      await adapter.listen({
+        async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+          await deferred.promise;
+          response.setStatus(200);
+        },
+      });
+
+      const responsePromise = mockBun.lastServer!.fetch(new Request('http://127.0.0.1:3000/timer-cleanup'));
+      const closePromise = adapter.close();
+
+      expect(vi.getTimerCount()).toBe(1);
+
+      deferred.resolve();
+      await Promise.resolve();
+      await responsePromise;
+      await closePromise;
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps the Bun dispatcher until drain settles even when close() times out', async () => {
     vi.useFakeTimers();
 

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -453,14 +453,22 @@ function createShutdownResponse(): Response {
 }
 
 function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number): Promise<void> {
-  return Promise.race([
-    closePromise,
-    new Promise<void>((_resolve, reject) => {
-      setTimeout(() => {
-        reject(new Error(`Bun adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`));
-      }, timeoutMs);
-    }),
-  ]);
+  return new Promise<void>((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => {
+      reject(new Error(`Bun adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`));
+    }, timeoutMs);
+
+    void closePromise.then(
+      () => {
+        clearTimeout(timeoutHandle);
+        resolve();
+      },
+      (error: unknown) => {
+        clearTimeout(timeoutHandle);
+        reject(error);
+      },
+    );
+  });
 }
 
 function isWebSocketUpgradeRequest(request: Request): boolean {


### PR DESCRIPTION
Closes #1049

## Summary
- clear the Bun shutdown timeout handle once `close()` settles so a successful drain does not keep the event loop alive for the full timeout window
- add a regression test covering timer cleanup after a successful Bun adapter shutdown
- fix the `@fluojs/platform-bun` README manual fetch example to remove the unsupported `port` option from `createBunFetchHandler(...)`

## Changes
- update `waitForCloseWithTimeout()` in `packages/platform-bun/src/adapter.ts` to clear the timeout handle on resolve/reject
- add a fake-timer regression test in `packages/platform-bun/src/adapter.test.ts`
- align `packages/platform-bun/README.md` and `packages/platform-bun/README.ko.md` with the actual fetch-handler options

## Testing
- `pnpm build`
- `pnpm --filter @fluojs/platform-bun build`
- `pnpm --filter @fluojs/platform-bun typecheck`
- `pnpm --filter @fluojs/platform-bun test`
- `lsp_diagnostics` on `packages/platform-bun/src/adapter.ts` and `packages/platform-bun/src/adapter.test.ts` (no diagnostics)

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract impact: no behavioral contract change. This preserves the documented bounded shutdown drain behavior while ensuring the fallback timeout handle is cleared after a successful close.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Scope note: changes are limited to `@fluojs/platform-bun` runtime code, its direct regression test, and the package README mirror. Broader platform adapter documentation alignment remains out of scope for #1055.