### PR TITLE
Resolve #1052: fix testing harness subpath exports

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -46,20 +46,20 @@
       "import": "./dist/mock.js"
     },
     "./platform-conformance": {
-      "types": "./dist/platform-conformance.d.ts",
-      "import": "./dist/platform-conformance.js"
+      "types": "./dist/conformance/platform-conformance.d.ts",
+      "import": "./dist/conformance/platform-conformance.js"
     },
     "./http-adapter-portability": {
-      "types": "./dist/http-adapter-portability.d.ts",
-      "import": "./dist/http-adapter-portability.js"
+      "types": "./dist/portability/http-adapter-portability.d.ts",
+      "import": "./dist/portability/http-adapter-portability.js"
     },
     "./web-runtime-adapter-portability": {
-      "types": "./dist/web-runtime-adapter-portability.d.ts",
-      "import": "./dist/web-runtime-adapter-portability.js"
+      "types": "./dist/portability/web-runtime-adapter-portability.d.ts",
+      "import": "./dist/portability/web-runtime-adapter-portability.js"
     },
     "./fetch-style-websocket-conformance": {
-      "types": "./dist/fetch-style-websocket-conformance.d.ts",
-      "import": "./dist/fetch-style-websocket-conformance.js"
+      "types": "./dist/conformance/fetch-style-websocket-conformance.d.ts",
+      "import": "./dist/conformance/fetch-style-websocket-conformance.js"
     },
     "./types": {
       "types": "./dist/types.d.ts",

--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -1,4 +1,7 @@
-import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
@@ -9,6 +12,27 @@ import * as portability from './portability/http-adapter-portability.js';
 import * as webPortability from './portability/web-runtime-adapter-portability.js';
 import * as conformance from './conformance/platform-conformance.js';
 import * as fetchStyleWebsocket from './conformance/fetch-style-websocket-conformance.js';
+
+const packageRoot = new URL('..', import.meta.url);
+const packageRootPath = fileURLToPath(packageRoot);
+const repoRootPath = fileURLToPath(new URL('../../..', import.meta.url));
+const packageJsonPath = new URL('../package.json', import.meta.url);
+const emittedHarnessSubpaths = [
+  './platform-conformance',
+  './http-adapter-portability',
+  './web-runtime-adapter-portability',
+  './fetch-style-websocket-conformance',
+] as const;
+
+function runBuild(): void {
+  const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  const result = spawnSync(command, ['--filter', '@fluojs/testing...', 'build'], {
+    cwd: repoRootPath,
+    encoding: 'utf8',
+  });
+
+  expect(result.status, [result.stdout, result.stderr].filter(Boolean).join('\n')).toBe(0);
+}
 
 describe('@fluojs/testing surface', () => {
   it('keeps the root barrel focused on module/app helpers', () => {
@@ -35,27 +59,42 @@ describe('@fluojs/testing surface', () => {
   });
 
   it('keeps published subpath metadata aligned with the built surface', () => {
-    const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
       exports: Record<string, { import: string; types: string }>;
       peerDependencies: Record<string, string>;
     };
 
     expect(packageJson.exports['./platform-conformance']).toEqual({
-      types: './dist/platform-conformance.d.ts',
-      import: './dist/platform-conformance.js',
+      types: './dist/conformance/platform-conformance.d.ts',
+      import: './dist/conformance/platform-conformance.js',
     });
     expect(packageJson.exports['./http-adapter-portability']).toEqual({
-      types: './dist/http-adapter-portability.d.ts',
-      import: './dist/http-adapter-portability.js',
+      types: './dist/portability/http-adapter-portability.d.ts',
+      import: './dist/portability/http-adapter-portability.js',
     });
     expect(packageJson.exports['./web-runtime-adapter-portability']).toEqual({
-      types: './dist/web-runtime-adapter-portability.d.ts',
-      import: './dist/web-runtime-adapter-portability.js',
+      types: './dist/portability/web-runtime-adapter-portability.d.ts',
+      import: './dist/portability/web-runtime-adapter-portability.js',
     });
     expect(packageJson.exports['./fetch-style-websocket-conformance']).toEqual({
-      types: './dist/fetch-style-websocket-conformance.d.ts',
-      import: './dist/fetch-style-websocket-conformance.js',
+      types: './dist/conformance/fetch-style-websocket-conformance.d.ts',
+      import: './dist/conformance/fetch-style-websocket-conformance.js',
     });
     expect(packageJson.peerDependencies.vitest).toBe('^3.0.8');
   });
+
+  it('build emits the published harness subpath files', () => {
+    runBuild();
+
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      exports: Record<string, { import: string; types: string }>;
+    };
+
+    for (const subpath of emittedHarnessSubpaths) {
+      const entry = packageJson.exports[subpath];
+
+      expect(existsSync(resolve(packageRootPath, entry.import)), `${subpath} import output is missing`).toBe(true);
+      expect(existsSync(resolve(packageRootPath, entry.types)), `${subpath} types output is missing`).toBe(true);
+    }
+  }, 60_000);
 });


### PR DESCRIPTION
## Summary
- Align `@fluojs/testing` harness subpath exports with the actual emitted `dist/conformance/*` and `dist/portability/*` files.
- Add a regression test that builds the `@fluojs/testing` dependency closure and asserts the published harness subpath files are actually emitted.

## Changes
- Updated `packages/testing/package.json` so the published harness subpaths point at the real built file locations.
- Extended `packages/testing/src/surface.test.ts` to verify both the export metadata and the emitted build artifacts.

## Testing
- ✅ `pnpm --filter @fluojs/testing test`
- ⚠️ `pnpm --filter @fluojs/testing... typecheck` currently fails due to pre-existing workspace declaration/type issues in dependency packages such as `packages/config`, `packages/di`, and `packages/validation`.
- ✅ Build-surface regression is covered by `packages/testing/src/surface.test.ts`, which runs `pnpm --filter @fluojs/testing... build` and asserts the emitted files for the published harness subpaths.

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- No README contract changed. This PR preserves the documented `@fluojs/testing/*` subpath contract and fixes the published surface/build alignment behind it.

Closes #1052