### PR TITLE
Resolve #1055: align adapter docs and Deno IPv6 listen targets

### DIFF
--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -298,6 +298,30 @@ describe('@fluojs/platform-deno', () => {
     await app.close();
   });
 
+  it('formats explicit IPv6 listen targets with brackets', () => {
+    const adapter = createDenoAdapter({
+      hostname: '::1',
+      port: 3000,
+    });
+
+    expect(adapter.getListenTarget()).toEqual({
+      bindTarget: '[::1]:3000',
+      url: 'http://[::1]:3000',
+    });
+  });
+
+  it('formats IPv6 wildcard listen targets with a bracketed bind target and localhost URL', () => {
+    const adapter = createDenoAdapter({
+      hostname: '::',
+      port: 3000,
+    });
+
+    expect(adapter.getListenTarget()).toEqual({
+      bindTarget: '[::]:3000',
+      url: 'http://localhost:3000',
+    });
+  });
+
   it('registers and removes Deno shutdown signal listeners through the run helper', async () => {
     const signals = installDenoSignalMock();
 

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -359,13 +359,17 @@ function createDenoShutdownSignalRegistration(
 
 function createListenTarget(hostname: string, port: number): HttpAdapterListenTarget {
   const isWildcard = hostname === '0.0.0.0' || hostname === '::';
-  const bindTarget = `${hostname}:${String(port)}`;
-  const publicHostname = isWildcard ? 'localhost' : hostname;
+  const bindTarget = `${formatHostForAuthority(hostname)}:${String(port)}`;
+  const publicHostname = isWildcard ? 'localhost' : formatHostForAuthority(hostname);
 
   return {
     bindTarget,
     url: `http://${publicHostname}:${String(port)}`,
   };
+}
+
+function formatHostForAuthority(hostname: string): string {
+  return hostname.includes(':') && !hostname.startsWith('[') ? `[${hostname}]` : hostname;
 }
 
 function resolveServe(serve: DenoServeFunction | undefined): DenoServeFunction {

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -53,14 +53,18 @@ async streamEvents(@Res() res: FrameworkResponse) {
 ```
 
 ### 바디 파싱 및 멀티파트
-어댑터 옵션에서 설정하면 `rawBody` 및 멀티파트 form-data 파싱을 즉시 사용할 수 있습니다.
+`rawBody` 및 멀티파트 form-data 파싱을 즉시 사용할 수 있습니다. 어댑터를 직접 생성할 때는 멀티파트 제한을 두 번째 인자로 전달하고, `bootstrapExpressApplication(...)` 및 `runExpressApplication(...)`에서는 같은 설정을 `options.multipart` 아래에 전달하면 됩니다.
 
 ```typescript
-const adapter = createExpressAdapter({
-  port: 3000,
-  rawBody: true,
-  multipart: true,
-});
+const adapter = createExpressAdapter(
+  {
+    port: 3000,
+    rawBody: true,
+  },
+  {
+    maxTotalSize: 10 * 1024 * 1024,
+  },
+);
 ```
 
 ## 공개 API 개요
@@ -80,4 +84,3 @@ const adapter = createExpressAdapter({
 
 - `packages/platform-express/src/adapter.test.ts`
 - `examples/minimal/src/main.ts` (Fastify 기반이지만 공유 `fluoFactory` 패턴을 보여줌)
-

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -53,14 +53,18 @@ async streamEvents(@Res() res: FrameworkResponse) {
 ```
 
 ### Body Parsing and Multipart
-The adapter handles `rawBody` and multipart form-data parsing out of the box when configured in the adapter options.
+The adapter handles `rawBody` and multipart form-data parsing out of the box. When you construct the adapter directly, pass multipart limits as the second argument. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` accept the same multipart settings under `options.multipart`.
 
 ```typescript
-const adapter = createExpressAdapter({
-  port: 3000,
-  rawBody: true,
-  multipart: true,
-});
+const adapter = createExpressAdapter(
+  {
+    port: 3000,
+    rawBody: true,
+  },
+  {
+    maxTotalSize: 10 * 1024 * 1024,
+  },
+);
 ```
 
 ## Public API Overview
@@ -80,4 +84,3 @@ const adapter = createExpressAdapter({
 
 - `packages/platform-express/src/adapter.test.ts`
 - `examples/minimal/src/main.ts` (Fastify-based, but demonstrates the shared `fluoFactory` pattern)
-

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -42,14 +42,18 @@ await app.listen();
 ## 주요 패턴
 
 ### 멀티파트 및 Raw Body
-Fastify 어댑터는 내부 Fastify 플러그인을 통해 멀티파트 form-data 및 raw body 파싱을 기본적으로 지원하며, 이는 표준 fluo 요청 인터페이스를 통해 노출됩니다.
+Fastify 어댑터는 내부 Fastify 플러그인을 통해 멀티파트 form-data 및 raw body 파싱을 기본적으로 지원하며, 이는 표준 fluo 요청 인터페이스를 통해 노출됩니다. 어댑터를 직접 생성할 때는 멀티파트 제한을 두 번째 인자로 전달하고, `bootstrapFastifyApplication(...)` 및 `runFastifyApplication(...)`에서는 같은 설정을 `options.multipart` 아래에 전달하면 됩니다.
 
 ```typescript
-const adapter = createFastifyAdapter({
-  port: 3000,
-  multipart: true,
-  rawBody: true,
-});
+const adapter = createFastifyAdapter(
+  {
+    port: 3000,
+    rawBody: true,
+  },
+  {
+    maxTotalSize: 10 * 1024 * 1024,
+  },
+);
 ```
 
 ### 서버 기반 실시간 통신 (Real-Time)
@@ -89,4 +93,3 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 - `packages/platform-fastify/src/adapter.test.ts`
 - `examples/minimal/src/main.ts`
 - `examples/realworld-api/src/main.ts`
-

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -42,14 +42,18 @@ await app.listen();
 ## Common Patterns
 
 ### Multipart and Raw Body
-The Fastify adapter includes built-in support for multipart form-data and raw body parsing via internal Fastify plugins, exposed through the standard fluo request interface.
+The Fastify adapter includes built-in support for multipart form-data and raw body parsing via internal Fastify plugins, exposed through the standard fluo request interface. When you construct the adapter directly, pass multipart limits as the second argument. `bootstrapFastifyApplication(...)` and `runFastifyApplication(...)` accept the same multipart settings under `options.multipart`.
 
 ```typescript
-const adapter = createFastifyAdapter({
-  port: 3000,
-  multipart: true,
-  rawBody: true,
-});
+const adapter = createFastifyAdapter(
+  {
+    port: 3000,
+    rawBody: true,
+  },
+  {
+    maxTotalSize: 10 * 1024 * 1024,
+  },
+);
 ```
 
 ### Server-Backed Real-Time
@@ -89,4 +93,3 @@ fluo's Fastify adapter significantly outperforms the raw Node.js adapter in high
 - `packages/platform-fastify/src/adapter.test.ts`
 - `examples/minimal/src/main.ts`
 - `examples/realworld-api/src/main.ts`
-

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -74,7 +74,7 @@ await runNodejsApplication(AppModule, {
 - `createNodejsAdapter(options)`: raw Node.js HTTP 어댑터를 위한 기본 팩토리입니다.
 - `bootstrapNodejsApplication(module, options)`: 리스너를 시작하지 않고 애플리케이션 인스턴스를 생성합니다.
 - `runNodejsApplication(module, options)`: 생명주기 관리를 포함하여 애플리케이션을 부트스트랩하고 시작합니다.
-- `NodejsHttpApplicationAdapter`: `HttpApplicationAdapter`를 구현하는 기본 어댑터 클래스입니다.
+- `NodejsHttpApplicationAdapter`: `createNodejsAdapter(...)`가 반환하는 어댑터 인스턴스를 설명하는 타입 전용 별칭입니다.
 
 ## 관련 패키지
 

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -74,7 +74,7 @@ await runNodejsApplication(AppModule, {
 - `createNodejsAdapter(options)`: Primary factory for the raw Node.js HTTP adapter.
 - `bootstrapNodejsApplication(module, options)`: Creates an application instance without starting the listener.
 - `runNodejsApplication(module, options)`: Bootstraps and starts the application with lifecycle management.
-- `NodejsHttpApplicationAdapter`: The underlying adapter class implementing `HttpApplicationAdapter`.
+- `NodejsHttpApplicationAdapter`: Type-only alias describing the adapter instances returned by `createNodejsAdapter(...)`.
 
 ## Related Packages
 


### PR DESCRIPTION
Closes #1055

## Summary
- align the Express and Fastify README multipart examples with the shipped adapter signatures in both English and Korean mirrors
- clarify that `NodejsHttpApplicationAdapter` is a type-only export in the Node.js package README mirrors
- bracket IPv6 Deno listen targets and add regression coverage for `::1` and `::`

## Changes
- updated `packages/platform-express/README.md` and `packages/platform-express/README.ko.md`
- updated `packages/platform-fastify/README.md` and `packages/platform-fastify/README.ko.md`
- updated `packages/platform-nodejs/README.md` and `packages/platform-nodejs/README.ko.md`
- updated `packages/platform-deno/src/adapter.ts` and `packages/platform-deno/src/adapter.test.ts`

## Testing
- `pnpm verify:platform-consistency-governance`
- `pnpm --filter @fluojs/platform-deno test`
- `pnpm build`
- `pnpm typecheck`
- `lsp_diagnostics` on `packages/platform-deno/src/adapter.ts`
- `lsp_diagnostics` on `packages/platform-deno/src/adapter.test.ts`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.
- No public export source signatures changed in this PR.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.
- Contract impact: no public adapter contract changed; this PR aligns launch-facing docs with the shipped APIs and fixes Deno IPv6 listen-target formatting.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed package READMEs.
- [x] Companion updates include regression-test evidence for the Deno runtime invariant change.
- [x] No platform-bun scope or issue #1049 files were touched.