### PR TITLE
Resolve #1051: serialize runtime telemetry scrapes

### DIFF
--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -143,6 +143,16 @@ MetricsModule.forRoot({
 })
 ```
 
+### 기본 프로세스/Node 메트릭 비활성화
+
+`defaultMetrics`의 기본값은 `true`입니다. 따라서 별도 설정이 없으면 Registry마다 Prometheus 기본 프로세스/Node.js collector를 한 번 등록합니다. 최소 Registry만 노출하고 싶다면 비활성화하세요.
+
+```typescript
+MetricsModule.forRoot({
+  defaultMetrics: false,
+})
+```
+
 ## 공개 API 개요
 
 ### `MetricsModule`
@@ -153,6 +163,7 @@ MetricsModule.forRoot({
 ### 운영 기본값
 
 - `path` 기본값은 `'/metrics'`이며, `path: false`를 주면 스크레이프 엔드포인트를 완전히 비활성화합니다.
+- `defaultMetrics` 기본값은 `true`이며, `defaultMetrics: false`를 주면 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 비활성화합니다.
 - `endpointMiddleware`는 스크레이프 엔드포인트에만 route-scoped middleware를 바인딩합니다.
 - HTTP 메트릭은 기본적으로 템플릿 기반 path label 정규화를 사용합니다.
 - raw path label은 `allowUnsafeRawPathLabelMode: true`가 필요하며, 반드시 경계가 있는 내부 경로에만 제한해야 합니다.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -103,6 +103,16 @@ class AppModule {}
 
 Prometheus metric names must stay unique inside a registry. Shared-registry mode keeps that behavior intact instead of silently shadowing metrics.
 
+### Disable default process and Node metrics
+
+`defaultMetrics` defaults to `true`, so `MetricsModule.forRoot()` registers Prometheus default process and Node.js collectors once per registry unless you opt out.
+
+```ts
+MetricsModule.forRoot({
+  defaultMetrics: false,
+});
+```
+
 ## Public API Overview
 
 - `MetricsModule.forRoot(options)`
@@ -113,6 +123,7 @@ Prometheus metric names must stay unique inside a registry. Shared-registry mode
 ### Operational defaults
 
 - `path` defaults to `'/metrics'`, and `path: false` disables the scrape endpoint entirely.
+- `defaultMetrics` defaults to `true`, and `defaultMetrics: false` disables Prometheus default process and Node.js collectors for that registry.
 - `endpointMiddleware` binds route-scoped middleware only to the scrape endpoint.
 - HTTP metrics default to template-normalized path labels.
 - Raw path labels require `allowUnsafeRawPathLabelMode: true` and should stay limited to bounded internal routes.

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -428,6 +428,116 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
+  it('serializes overlapping scrapes and removes stale platform status series', async () => {
+    let currentReadiness: 'ready' | 'degraded' = 'ready';
+    let currentHealth: 'healthy' | 'degraded' = 'healthy';
+    let firstProbe = true;
+    let startFirstProbe: (() => void) | undefined;
+    let releaseFirstProbe: (() => void) | undefined;
+
+    const firstProbeStarted = new Promise<void>((resolve) => {
+      startFirstProbe = resolve;
+    });
+    const firstProbeReleased = new Promise<void>((resolve) => {
+      releaseFirstProbe = resolve;
+    });
+
+    async function waitForFirstProbeRelease(): Promise<void> {
+      if (!firstProbe) {
+        return;
+      }
+
+      firstProbe = false;
+      startFirstProbe?.();
+      await firstProbeReleased;
+    }
+
+    const component: PlatformComponent = {
+      async health() {
+        const status = currentHealth;
+        await waitForFirstProbeRelease();
+        return { status };
+      },
+      id: 'cache.default',
+      kind: 'cache',
+      async ready() {
+        const status = currentReadiness;
+        await waitForFirstProbeRelease();
+        return { critical: false, status };
+      },
+      snapshot() {
+        return {
+          dependencies: [],
+          details: { mode: 'memory' },
+          health: { status: currentHealth },
+          id: 'cache.default',
+          kind: 'cache',
+          ownership: { externallyManaged: false, ownsResources: true },
+          readiness: { critical: false, status: currentReadiness },
+          state: 'ready',
+          telemetry: { namespace: 'cache', tags: {} },
+        };
+      },
+      async start() {},
+      state() {
+        return 'ready';
+      },
+      async stop() {},
+      async validate() {
+        return { issues: [], ok: true };
+      },
+    };
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
+    });
+
+    const app = await bootstrapApplication({
+      platform: { components: [component] },
+      rootModule: AppModule,
+    });
+
+    const firstResponse = createResponse();
+    const secondResponse = createResponse();
+
+    const firstDispatch = app.dispatch(createRequest('/metrics'), firstResponse);
+    await firstProbeStarted;
+
+    currentReadiness = 'degraded';
+    currentHealth = 'degraded';
+
+    const secondDispatch = app.dispatch(createRequest('/metrics'), secondResponse);
+    releaseFirstProbe?.();
+
+    await Promise.all([firstDispatch, secondDispatch]);
+
+    const firstMetrics = String(firstResponse.body);
+    const secondMetrics = String(secondResponse.body);
+
+    expect(firstResponse.statusCode).toBe(200);
+    expect(firstMetrics).toContain(
+      'fluo_component_ready{component_id="cache.default",component_kind="cache",operation="readiness",result="ready",env="unknown",instance="local"} 1',
+    );
+    expect(firstMetrics).toContain(
+      'fluo_component_health{component_id="cache.default",component_kind="cache",operation="health",result="healthy",env="unknown",instance="local"} 1',
+    );
+    expect(firstMetrics).not.toContain('result="degraded"');
+
+    expect(secondResponse.statusCode).toBe(200);
+    expect(secondMetrics).toContain(
+      'fluo_component_ready{component_id="cache.default",component_kind="cache",operation="readiness",result="degraded",env="unknown",instance="local"} 0',
+    );
+    expect(secondMetrics).toContain(
+      'fluo_component_health{component_id="cache.default",component_kind="cache",operation="health",result="degraded",env="unknown",instance="local"} 0',
+    );
+    expect(secondMetrics).not.toContain('result="ready"');
+    expect(secondMetrics).not.toContain('result="healthy"');
+
+    await app.close();
+  });
+
   it('emits both framework and custom metrics from shared registry', async () => {
     const sharedRegistry = new Registry();
 

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -108,9 +108,8 @@ export class MetricsModule {
       class MetricsController {
         @Get(metricsRoutePath)
         async getMetrics(_input: undefined, ctx: RequestContext): Promise<string> {
-          await platformTelemetry.refresh(ctx);
           ctx.response.setHeader('content-type', registry.contentType);
-          return registry.metrics();
+          return platformTelemetry.collectMetrics(ctx, registry);
         }
       }
 
@@ -130,9 +129,19 @@ export class MetricsModule {
 }
 
 type RegistryMode = 'isolated' | 'shared';
+type PlatformHealthStatus = PlatformShellSnapshot['health']['status'];
+type PlatformReadinessStatus = PlatformShellSnapshot['readiness']['status'];
+type RuntimeTelemetryComponent = {
+  id: string;
+  kind: string;
+  health: PlatformHealthStatus;
+  readiness: PlatformReadinessStatus;
+};
 
 const PLATFORM_COMPONENT_LABELS = ['component_id', 'component_kind', 'operation', 'result', 'env', 'instance'] as const;
 const REGISTRY_MODE_LABELS = ['mode'] as const;
+const HEALTH_STATUSES = ['healthy', 'unhealthy', 'degraded'] as const satisfies readonly PlatformHealthStatus[];
+const READINESS_STATUSES = ['ready', 'not-ready', 'degraded'] as const satisfies readonly PlatformReadinessStatus[];
 
 function toReadinessValue(status: PlatformShellSnapshot['readiness']['status']): number {
   return status === 'ready' ? 1 : 0;
@@ -168,6 +177,9 @@ class RuntimePlatformTelemetry {
   private readonly readinessGauge: Gauge<string>;
   private readonly healthGauge: Gauge<string>;
   private readonly registryModeGauge: Gauge<string>;
+  private readonly lastHealthStatuses = new Map<string, PlatformHealthStatus>();
+  private readonly lastReadinessStatuses = new Map<string, PlatformReadinessStatus>();
+  private scrapeChain: Promise<unknown> = Promise.resolve();
 
   constructor(
     registry: Registry,
@@ -189,11 +201,25 @@ class RuntimePlatformTelemetry {
       labelNames: REGISTRY_MODE_LABELS,
       name: 'fluo_metrics_registry_mode',
     });
+
+    this.registryModeGauge.labels(this.registryMode).set(1);
+  }
+
+  async collectMetrics(ctx: RequestContext, registry: Registry): Promise<string> {
+    const collect = this.scrapeChain.then(async () => {
+      await this.refresh(ctx);
+      return registry.metrics();
+    });
+
+    this.scrapeChain = collect.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return collect;
   }
 
   async refresh(ctx: RequestContext): Promise<void> {
-    this.registryModeGauge.reset();
-    this.registryModeGauge.labels(this.registryMode).set(1);
 
     const platformShell = await this.resolvePlatformShell(ctx);
     if (!platformShell) {
@@ -204,25 +230,96 @@ class RuntimePlatformTelemetry {
     const env = this.labels?.env ?? 'unknown';
     const instance = this.labels?.instance ?? 'local';
 
-    this.readinessGauge.reset();
-    this.healthGauge.reset();
+    const components: RuntimeTelemetryComponent[] = [
+      {
+        health: snapshot.health.status,
+        id: 'runtime.shell',
+        kind: 'runtime',
+        readiness: snapshot.readiness.status,
+      },
+      ...snapshot.components.map((component: PlatformShellSnapshot['components'][number]) => ({
+        health: component.health.status,
+        id: component.id,
+        kind: component.kind,
+        readiness: component.readiness.status,
+      })),
+    ];
 
-    this.readinessGauge.labels('runtime.shell', 'runtime', 'readiness', snapshot.readiness.status, env, instance).set(
-      toReadinessValue(snapshot.readiness.status),
-    );
-    this.healthGauge.labels('runtime.shell', 'runtime', 'health', snapshot.health.status, env, instance).set(
-      toHealthValue(snapshot.health.status),
-    );
+    this.syncGaugeStatuses({
+      currentStatuses: new Map(components.map((component) => [this.toComponentKey(component.id, component.kind), component.health])),
+      env,
+      gauge: this.healthGauge,
+      instance,
+      lastStatuses: this.lastHealthStatuses,
+      operation: 'health',
+      statuses: HEALTH_STATUSES,
+      toMetricValue: toHealthValue,
+    });
+    this.syncGaugeStatuses({
+      currentStatuses: new Map(components.map((component) => [this.toComponentKey(component.id, component.kind), component.readiness])),
+      env,
+      gauge: this.readinessGauge,
+      instance,
+      lastStatuses: this.lastReadinessStatuses,
+      operation: 'readiness',
+      statuses: READINESS_STATUSES,
+      toMetricValue: toReadinessValue,
+    });
+  }
 
-    for (const component of snapshot.components) {
-      this.readinessGauge
-        .labels(component.id, component.kind, 'readiness', component.readiness.status, env, instance)
-        .set(toReadinessValue(component.readiness.status));
+  private syncGaugeStatuses<TStatus extends string>({
+    currentStatuses,
+    env,
+    gauge,
+    instance,
+    lastStatuses,
+    operation,
+    statuses,
+    toMetricValue,
+  }: {
+    currentStatuses: Map<string, TStatus>;
+    env: string;
+    gauge: Gauge<string>;
+    instance: string;
+    lastStatuses: Map<string, TStatus>;
+    operation: 'health' | 'readiness';
+    statuses: readonly TStatus[];
+    toMetricValue(status: TStatus): number;
+  }): void {
+    for (const [componentKey, previousStatus] of lastStatuses) {
+      const nextStatus = currentStatuses.get(componentKey);
+      if (nextStatus === previousStatus) {
+        continue;
+      }
 
-      this.healthGauge
-        .labels(component.id, component.kind, 'health', component.health.status, env, instance)
-        .set(toHealthValue(component.health.status));
+      const [componentId, componentKind] = this.fromComponentKey(componentKey);
+      for (const status of statuses) {
+        if (status !== previousStatus) {
+          continue;
+        }
+
+        gauge.remove(componentId, componentKind, operation, status, env, instance);
+      }
     }
+
+    for (const [componentKey, currentStatus] of currentStatuses) {
+      const [componentId, componentKind] = this.fromComponentKey(componentKey);
+      gauge.labels(componentId, componentKind, operation, currentStatus, env, instance).set(toMetricValue(currentStatus));
+    }
+
+    lastStatuses.clear();
+    for (const [componentKey, currentStatus] of currentStatuses) {
+      lastStatuses.set(componentKey, currentStatus);
+    }
+  }
+
+  private fromComponentKey(componentKey: string): [string, string] {
+    const separatorIndex = componentKey.indexOf('::');
+    return [componentKey.slice(0, separatorIndex), componentKey.slice(separatorIndex + 2)];
+  }
+
+  private toComponentKey(componentId: string, componentKind: string): string {
+    return `${componentId}::${componentKind}`;
   }
 
   private async resolvePlatformShell(ctx: RequestContext): Promise<{ snapshot(): Promise<PlatformShellSnapshot> } | undefined> {


### PR DESCRIPTION
## Summary
- stop resetting shared runtime telemetry gauges on every `/metrics` scrape and serialize runtime telemetry collection so overlapping scrapes observe a coherent snapshot
- remove stale readiness/health series when component result labels change without clearing the shared registry
- document that `defaultMetrics` is enabled by default in both English and Korean package READMEs

## Changes
- update `packages/metrics/src/metrics-module.ts` to set registry mode once, queue scrape-time telemetry collection, and replace per-request `reset()` calls with targeted stale-series removal
- add a regression test for overlapping scrapes in `packages/metrics/src/metrics-module.test.ts`
- document `defaultMetrics` defaults in `packages/metrics/README.md` and `packages/metrics/README.ko.md`

## Testing
- `pnpm exec vitest run packages/metrics/src/metrics-module.test.ts examples/ops-metrics-terminus/src/app.test.ts`
- `pnpm build`
- `pnpm typecheck`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Closes #1051