### PR TITLE
Resolve #1053: align Studio public release contract

### DIFF
--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -7,6 +7,7 @@ fluo 런타임 내보내기의 공유 플랫폼 snapshot을 파일 기반으로 
 ## 목차
 
 - [설치](#설치)
+- [릴리스 정책](#릴리스-정책)
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
@@ -19,6 +20,12 @@ fluo 런타임 내보내기의 공유 플랫폼 snapshot을 파일 기반으로 
 ```bash
 pnpm add @fluojs/studio
 ```
+
+## 릴리스 정책
+
+- `@fluojs/studio`는 fluo의 intended public publish surface에 포함되는 공개 배포 패키지입니다.
+- Studio의 npm 설치 계약은 `pnpm add @fluojs/studio`이며, 저장소 내부 개발 경로는 계속 `pnpm --dir packages/studio dev`를 사용합니다.
+- 이번 릴리스에서 지원하는 공개 패키지 표면은 파일 기반 뷰어와 문서화된 snapshot 소비 계약까지입니다. 내부 workspace 연결 방식은 지원되는 설치 경로가 아닙니다.
 
 ## 사용 시점
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -7,6 +7,7 @@ File-first shared platform snapshot viewer for fluo runtime exports.
 ## Table of Contents
 
 - [Installation](#installation)
+- [Release Policy](#release-policy)
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
@@ -19,6 +20,12 @@ File-first shared platform snapshot viewer for fluo runtime exports.
 ```bash
 pnpm add @fluojs/studio
 ```
+
+## Release Policy
+
+- `@fluojs/studio` is part of the intended public publish surface for fluo.
+- The npm install contract for Studio is `pnpm add @fluojs/studio`; local repo development still uses `pnpm --dir packages/studio dev`.
+- Studio's public package surface in this release is the file-first viewer and its documented snapshot-consumption contracts. Internal workspace wiring is not a supported install path.
 
 ## When to Use
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -10,7 +10,7 @@
     "devtools"
   ],
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -1,7 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import { applyFilters, parseStudioPayload, renderMermaid } from './contracts.js';
 import type { PlatformShellSnapshot } from '@fluojs/runtime';
+
+const packageDir = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
 
 const snapshotFixture: PlatformShellSnapshot = {
   components: [
@@ -100,6 +106,26 @@ describe('parseStudioPayload', () => {
     );
     expect(parsed.payload.snapshot?.components).toHaveLength(2);
     expect(parsed.payload.timing?.phases).toHaveLength(1);
+  });
+
+  it('keeps the Studio release contract aligned across manifest and README docs', () => {
+    const packageManifest = JSON.parse(readFileSync(resolve(packageDir, 'package.json'), 'utf8')) as {
+      name: string;
+      private?: boolean;
+      publishConfig?: { access?: string };
+    };
+    const readme = readFileSync(resolve(packageDir, 'README.md'), 'utf8');
+    const readmeKo = readFileSync(resolve(packageDir, 'README.ko.md'), 'utf8');
+    const releaseGovernance = readFileSync(resolve(packageDir, '../../docs/operations/release-governance.md'), 'utf8');
+
+    expect(packageManifest.name).toBe('@fluojs/studio');
+    expect(packageManifest.private).toBe(false);
+    expect(packageManifest.publishConfig?.access).toBe('public');
+    expect(releaseGovernance).toContain('- `@fluojs/studio`');
+    expect(readme).toContain('pnpm add @fluojs/studio');
+    expect(readme).toContain('intended public publish surface');
+    expect(readmeKo).toContain('pnpm add @fluojs/studio');
+    expect(readmeKo).toContain('공개 배포 패키지');
   });
 });
 


### PR DESCRIPTION
## Summary
- remove the contradictory private manifest flag from `@fluojs/studio` so the package matches the documented public install path
- document the Studio release policy in both package READMEs so the public install contract and local dev path are explicit
- add a regression test that keeps the Studio manifest, README install guidance, and release-governance publish surface aligned

## Changes
- set `packages/studio/package.json` to `\"private\": false` while preserving `publishConfig.access: \"public\"`
- add a `Release Policy` section to `packages/studio/README.md` and `packages/studio/README.ko.md`
- extend `packages/studio/src/contracts.test.ts` with a release-contract regression case

## Testing
- `pnpm --dir packages/studio test`
- `pnpm verify:platform-consistency-governance`
- `pnpm --dir packages/studio exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir packages/studio build`
- `pnpm typecheck` currently fails on the existing workspace baseline outside Studio scope (`packages/http` and `packages/runtime` package-resolution errors on current main/worktree setup)

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1053