### PR TITLE
Resolve #1056: align launch-facing package docs with shipped APIs

### DIFF
--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -137,7 +137,7 @@ Behavioral contract 메모:
 
 - 하나의 notification dispatch는 정확히 하나의 Discord thread 경로로 매핑됩니다. `payload.threadId` 또는 `recipients`의 단일 항목을 사용해야 합니다.
 - `payload.threadId`가 없으면 `DiscordService.sendNotification(...)`는 첫 번째 `recipients` 항목을 사용하고, 그것도 없으면 `defaultThreadId`로 폴백합니다.
-- 여러 Discord thread로 fan-out이 필요하다면 하나의 multi-recipient dispatch 대신 `dispatchMany(...)`를 사용해야 합니다.
+- 여러 Discord thread로 fan-out이 필요하다면 하나의 multi-recipient dispatch 대신 `sendMany(...)`를 사용해야 합니다.
 
 ### 명시적 fetch 주입을 사용하는 webhook-first 전달
 

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -137,7 +137,7 @@ Behavioral contract notes:
 
 - One notification dispatch maps to exactly one Discord thread route. Use `payload.threadId` or a single entry in `recipients`.
 - If `payload.threadId` is omitted, `DiscordService.sendNotification(...)` uses the first `recipients` entry or falls back to `defaultThreadId`.
-- If a notification needs fan-out across multiple Discord threads, call `dispatchMany(...)` instead of one multi-recipient dispatch.
+- If a notification needs fan-out across multiple Discord threads, call `sendMany(...)` instead of one multi-recipient dispatch.
 
 ### Webhook-first delivery with explicit fetch injection
 

--- a/packages/discord/src/module.test.ts
+++ b/packages/discord/src/module.test.ts
@@ -267,7 +267,7 @@ describe('DiscordModule', () => {
       }),
     ).rejects.toThrowError(
       new DiscordMessageValidationError(
-        'Discord notifications accept exactly one target thread per dispatch. Use `dispatchMany(...)` for fan-out delivery.',
+        'Discord notifications accept exactly one target thread per dispatch. Use `sendMany(...)` for fan-out delivery.',
       ),
     );
   });

--- a/packages/discord/src/service.ts
+++ b/packages/discord/src/service.ts
@@ -275,7 +275,7 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
 
     if (recipients.length > 1) {
       throw new DiscordMessageValidationError(
-        'Discord notifications accept exactly one target thread per dispatch. Use `dispatchMany(...)` for fan-out delivery.',
+      'Discord notifications accept exactly one target thread per dispatch. Use `sendMany(...)` for fan-out delivery.',
       );
     }
 

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -95,12 +95,7 @@ import { UseInterceptors } from '@fluojs/http';
 import { MongooseTransactionInterceptor } from '@fluojs/mongoose';
 
 @UseInterceptors(MongooseTransactionInterceptor)
-class UserController {
-  @Post()
-  async create() {
-    // 리포지토리에서 this.conn.currentSession()을 통해 세션을 획득하여 사용합니다.
-  }
-}
+class UserController {}
 ```
 
 ## 공개 API 개요

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -55,14 +55,13 @@ class AppModule {}
 
 ## 공통 패턴
 
-### MongooseConnection과 current()
+### `MongooseConnection`을 통한 연결 접근
 
 `MongooseConnection` 래퍼는 기본 Mongoose 연결에 대한 접근을 제공합니다.
 
 ```typescript
 import { MongooseConnection } from '@fluojs/mongoose';
 
-@Inject(MongooseConnection)
 export class UserRepository {
   constructor(private readonly conn: MongooseConnection) {}
 
@@ -106,25 +105,18 @@ class UserController {
 
 ## 공개 API 개요
 
-### `MongooseModule`
+- `MongooseModule.forRoot(options)` / `MongooseModule.forRootAsync(options)`
+- `MongooseConnection`
+- `MongooseTransactionInterceptor`
+- `MONGOOSE_CONNECTION`, `MONGOOSE_DISPOSE`, `MONGOOSE_OPTIONS`
+- `createMongooseProviders(options)`
+- `createMongoosePlatformStatusSnapshot(...)`
 
-- `static forRoot(options: MongooseModuleOptions): ModuleType`
-- `static forRootAsync(options: MongooseModuleAsyncOptions): ModuleType`
+### 관련 export 타입
 
-### `MongooseConnection`
-
-- `current(): Connection`
-  - 기본 Mongoose 연결을 반환합니다.
-- `currentSession(): ClientSession | undefined`
-  - 현재 ALS 컨텍스트에서 활성화된 세션을 반환합니다.
-- `transaction(fn, options?): Promise<T>`
-  - 관리되는 세션 및 트랜잭션 내에서 함수를 실행합니다.
-- `requestTransaction(fn, signal?, options?): Promise<T>`
-  - HTTP 요청 라이프사이클에 특화된 세션 경계를 실행합니다.
-
-### `MONGOOSE_CONNECTION` (Token)
-
-원시 Mongoose `Connection`을 위한 주입 토큰입니다.
+- `MongooseModuleOptions<TConnection>`
+- `MongooseConnectionLike`
+- `MongooseSessionLike`
 
 ## 관련 패키지
 
@@ -135,3 +127,5 @@ class UserController {
 ## 예제 소스
 
 - `packages/mongoose/src/vertical-slice.test.ts`: 표준 DTO → 서비스 → 리포지토리 → Mongoose 흐름 예제.
+- `packages/mongoose/src/module.test.ts`: 모듈 등록과 수명 주기 계약 예제.
+- `packages/mongoose/src/public-api.test.ts`: 공개 export 검증 예제.

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -94,6 +94,12 @@ class UserController {}
 - `createMongooseProviders(options)`
 - `createMongoosePlatformStatusSnapshot(...)`
 
+### Related exported types
+
+- `MongooseModuleOptions<TConnection>`
+- `MongooseConnectionLike`
+- `MongooseSessionLike`
+
 ## Related Packages
 
 - `@fluojs/runtime`: manages startup and shutdown hooks

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -116,5 +116,5 @@ async refresh(input: never, ctx: RequestContext) {
 ## 예제 소스
 
 - `packages/passport/src/guard.test.ts`: 가드 실행 및 권한 강제 패턴 예제.
-- `packages/passport/src/passport-js.ts`: Passport.js 브릿지 구현체.
+- `packages/passport/src/adapters/passport-js.ts`: Passport.js 브릿지 구현체.
 - `examples/auth-jwt-passport/src/auth/bearer.strategy.ts`: 표준 JWT 전략 구현 예제.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -55,7 +55,7 @@ export class AuthModule {}
 `@UseAuth()`와 `@RequireScopes()`를 사용하여 인증을 강제합니다.
 
 ```typescript
-import { Controller, Get } from '@fluojs/http';
+import { Controller, Get, type RequestContext } from '@fluojs/http';
 import { UseAuth, RequireScopes } from '@fluojs/passport';
 
 @Controller('/profile')
@@ -86,10 +86,16 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 패키지에서 제공하는 `RefreshTokenStrategy`와 `RefreshTokenService`를 사용하여 안전한 토큰 로테이션 및 폐기 기능을 구현할 수 있습니다.
 
 ```typescript
-@Post('/refresh')
-@UseAuth('refresh-token')
-async refresh(input: never, ctx: RequestContext) {
-  return ctx.principal; // 새 토큰 쌍이 포함된 principal 반환
+import { Controller, Post, type RequestContext } from '@fluojs/http';
+import { UseAuth } from '@fluojs/passport';
+
+@Controller('/auth')
+export class AuthController {
+  @Post('/refresh')
+  @UseAuth('refresh-token')
+  async refresh(input: never, ctx: RequestContext) {
+    return ctx.principal; // 새 토큰 쌍이 포함된 principal 반환
+  }
 }
 ```
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -116,5 +116,5 @@ async refresh(input: never, ctx: RequestContext) {
 ## Example Sources
 
 - `packages/passport/src/guard.test.ts`: Guard execution and scope enforcement patterns.
-- `packages/passport/src/passport-js.ts`: Implementation of the Passport.js bridge.
+- `packages/passport/src/adapters/passport-js.ts`: Implementation of the Passport.js bridge.
 - `examples/auth-jwt-passport/src/auth/bearer.strategy.ts`: Canonical JWT strategy implementation.

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -55,7 +55,7 @@ export class AuthModule {}
 Use `@UseAuth()` and `@RequireScopes()` to enforce authentication.
 
 ```typescript
-import { Controller, Get } from '@fluojs/http';
+import { Controller, Get, type RequestContext } from '@fluojs/http';
 import { UseAuth, RequireScopes } from '@fluojs/passport';
 
 @Controller('/profile')
@@ -86,10 +86,16 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 The package provides a built-in `RefreshTokenStrategy` and `RefreshTokenService` to handle secure token rotation and revocation.
 
 ```typescript
-@Post('/refresh')
-@UseAuth('refresh-token')
-async refresh(input: never, ctx: RequestContext) {
-  return ctx.principal; // Contains new token pair
+import { Controller, Post, type RequestContext } from '@fluojs/http';
+import { UseAuth } from '@fluojs/passport';
+
+@Controller('/auth')
+export class AuthController {
+  @Post('/refresh')
+  @UseAuth('refresh-token')
+  async refresh(input: never, ctx: RequestContext) {
+    return ctx.principal; // Contains new token pair
+  }
 }
 ```
 

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -57,6 +57,7 @@ class AppModule {}
 `PrismaService`는 Prisma와 상호작용하는 기본 방법입니다. `current()` 메서드는 트랜잭션 범위 내에 있으면 자동으로 트랜잭션용 클라이언트를, 그렇지 않으면 루트 클라이언트를 반환합니다.
 
 ```typescript
+import { Inject } from '@fluojs/core';
 import { PrismaService } from '@fluojs/prisma';
 import { PrismaClient } from '@prisma/client';
 
@@ -87,7 +88,7 @@ await this.prisma.transaction(async () => {
 컨트롤러나 메서드에 `PrismaTransactionInterceptor`를 적용하면 전체 요청을 자동으로 트랜잭션으로 감쌉니다.
 
 ```typescript
-import { UseInterceptors } from '@fluojs/http';
+import { Post, UseInterceptors } from '@fluojs/http';
 import { PrismaTransactionInterceptor } from '@fluojs/prisma';
 
 @UseInterceptors(PrismaTransactionInterceptor)
@@ -103,13 +104,13 @@ class UserController {
 
 ### `PrismaModule`
 
-- `static forRoot(options: PrismaModuleOptions): ModuleType`
-- `static forRootAsync(options: PrismaModuleAsyncOptions): ModuleType`
-  - `strictTransactions: true` 설정 시 트랜잭션 미지원 환경에서 즉시 예외를 발생시킵니다.
+- `PrismaModule.forRoot(options)` / `PrismaModule.forRootAsync(options)`
+- `forRootAsync(...)`는 `AsyncModuleOptions<PrismaModuleOptions<...>>`를 받습니다.
+- `strictTransactions: true` 설정 시 트랜잭션 미지원 환경에서 즉시 예외를 발생시킵니다.
 
 ### `PrismaService<TClient>`
 
-- `current(): TClient`
+- `current(): TClient | PrismaTransactionClient<TClient>`
   - 현재 컨텍스트에 맞는 트랜잭션 클라이언트 또는 루트 클라이언트를 반환합니다.
 - `transaction(fn, options?): Promise<T>`
   - 대화형 트랜잭션 내에서 함수를 실행합니다.
@@ -119,6 +120,13 @@ class UserController {
 ### `PRISMA_CLIENT` (Token)
 
 원시 `PrismaClient` 인스턴스를 위한 주입 토큰입니다.
+
+### 관련 export 타입
+
+- `PrismaModuleOptions`
+- `PrismaTransactionClient<TClient>`
+- `InferPrismaTransactionClient<TClient>`
+- `InferPrismaTransactionOptions<TClient>`
 
 ## 관련 패키지
 

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -57,6 +57,7 @@ class AppModule {}
 The `PrismaService` is the primary way to interact with Prisma. Its `current()` method automatically returns the active transaction client if inside a transaction scope, or the root client otherwise.
 
 ```typescript
+import { Inject } from '@fluojs/core';
 import { PrismaService } from '@fluojs/prisma';
 import { PrismaClient } from '@prisma/client';
 
@@ -87,7 +88,7 @@ await this.prisma.transaction(async () => {
 Apply the `PrismaTransactionInterceptor` to a controller or method to wrap the entire request in a transaction automatically.
 
 ```typescript
-import { UseInterceptors } from '@fluojs/http';
+import { Post, UseInterceptors } from '@fluojs/http';
 import { PrismaTransactionInterceptor } from '@fluojs/prisma';
 
 @UseInterceptors(PrismaTransactionInterceptor)
@@ -103,13 +104,13 @@ class UserController {
 
 ### `PrismaModule`
 
-- `static forRoot(options: PrismaModuleOptions): ModuleType`
-- `static forRootAsync(options: PrismaModuleAsyncOptions): ModuleType`
-  - Supports `strictTransactions: true` to throw if transaction support is missing.
+- `PrismaModule.forRoot(options)` / `PrismaModule.forRootAsync(options)`
+- `forRootAsync(...)` accepts `AsyncModuleOptions<PrismaModuleOptions<...>>`.
+- Supports `strictTransactions: true` to throw if transaction support is missing.
 
 ### `PrismaService<TClient>`
 
-- `current(): TClient`
+- `current(): TClient | PrismaTransactionClient<TClient>`
   - Returns the ambient transaction client or the root client.
 - `transaction(fn, options?): Promise<T>`
   - Runs a function within an interactive transaction.
@@ -119,6 +120,13 @@ class UserController {
 ### `PRISMA_CLIENT` (Token)
 
 Injectable token for the raw `PrismaClient` instance.
+
+### Related exported types
+
+- `PrismaModuleOptions`
+- `PrismaTransactionClient<TClient>`
+- `InferPrismaTransactionClient<TClient>`
+- `InferPrismaTransactionOptions<TClient>`
 
 ## Related Packages
 

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -138,7 +138,7 @@ Behavioral contract 메모:
 
 - 하나의 notification dispatch는 정확히 하나의 Slack 대상지로 매핑됩니다. `payload.channel` 또는 `recipients`의 단일 항목을 사용해야 합니다.
 - `payload.channel`이 없으면 `SlackService.sendNotification(...)`는 첫 번째 `recipients` 항목을 사용하고, 그것도 없으면 `defaultChannel`로 폴백합니다.
-- 여러 Slack 대상지로 fan-out이 필요하다면 하나의 multi-recipient dispatch 대신 `dispatchMany(...)`를 사용해야 합니다.
+- 여러 Slack 대상지로 fan-out이 필요하다면 하나의 multi-recipient dispatch 대신 `sendMany(...)`를 사용해야 합니다.
 
 ### 명시적 fetch 주입을 사용하는 webhook-first 전달
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -138,7 +138,7 @@ Behavioral contract notes:
 
 - One notification dispatch maps to exactly one Slack destination. Use `payload.channel` or a single entry in `recipients`.
 - If `payload.channel` is omitted, `SlackService.sendNotification(...)` uses the first `recipients` entry or falls back to `defaultChannel`.
-- If a notification needs fan-out across multiple Slack destinations, call `dispatchMany(...)` instead of one multi-recipient dispatch.
+- If a notification needs fan-out across multiple Slack destinations, call `sendMany(...)` instead of one multi-recipient dispatch.
 
 ### Webhook-first delivery with explicit fetch injection
 

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -263,7 +263,7 @@ describe('SlackModule', () => {
       }),
     ).rejects.toThrowError(
       new SlackMessageValidationError(
-        'Slack notifications accept exactly one target channel per dispatch. Use `dispatchMany(...)` for fan-out delivery.',
+        'Slack notifications accept exactly one target channel per dispatch. Use `sendMany(...)` for fan-out delivery.',
       ),
     );
   });

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -274,7 +274,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
 
     if (recipients.length > 1) {
       throw new SlackMessageValidationError(
-        'Slack notifications accept exactly one target channel per dispatch. Use `dispatchMany(...)` for fan-out delivery.',
+      'Slack notifications accept exactly one target channel per dispatch. Use `sendMany(...)` for fan-out delivery.',
       );
     }
 

--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -17,7 +17,7 @@ fluo 런타임용 Socket.IO v4 게이트웨이 어댑터입니다.
 ## 설치
 
 ```bash
-npm install @fluojs/socket.io @fluojs/websockets socket.io
+npm install @fluojs/core @fluojs/socket.io @fluojs/websockets socket.io
 ```
 
 ## 사용 시점

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -17,7 +17,7 @@ Socket.IO v4 gateway adapter for the fluo runtime.
 ## Installation
 
 ```bash
-npm install @fluojs/socket.io @fluojs/websockets socket.io
+npm install @fluojs/core @fluojs/socket.io @fluojs/websockets socket.io
 ```
 
 ## When to Use


### PR DESCRIPTION
## Summary

Align the launch-facing README/API surface for `@fluojs/slack`, `@fluojs/discord`, `@fluojs/socket.io`, `@fluojs/passport`, `@fluojs/prisma`, and `@fluojs/mongoose`.

## Changes

- update Slack and Discord README mirrors to reference the shipped `sendMany(...)` API
- update direct Slack/Discord validation strings and regression tests so user-facing guidance matches the public API
- fix install/example/source-path drift in the Socket.IO, Passport, Prisma, and Mongoose README mirrors without broadening scope beyond issue #1056

## Testing

- `pnpm --filter @fluojs/slack --filter @fluojs/discord --filter @fluojs/socket.io --filter @fluojs/passport --filter @fluojs/prisma --filter @fluojs/mongoose run test`
- `pnpm verify:platform-consistency-governance`
- attempted `pnpm --filter @fluojs/slack --filter @fluojs/discord --filter @fluojs/socket.io --filter @fluojs/passport --filter @fluojs/prisma --filter @fluojs/mongoose run typecheck`
- attempted `pnpm --filter @fluojs/slack --filter @fluojs/discord --filter @fluojs/socket.io --filter @fluojs/passport --filter @fluojs/prisma --filter @fluojs/mongoose run build`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed in this PR; updates are limited to README alignment and direct user-facing validation copy.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract impact: no runtime behavior was broadened. This PR aligns launch-facing documentation and the Slack/Discord validation guidance with the already shipped API surface.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Package README English/Korean mirrors were updated together for each affected package. No `docs/reference/*` or broader platform-governance files changed in this PR.

Closes #1056