### PR TITLE
Resolve #1072: make cache-manager deferred eviction failure-safe

### DIFF
--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -136,7 +136,7 @@ CacheModule.forRoot({
 
 ### 지연 삭제 시점
 
-`@CacheEvict(...)`가 붙은 non-GET 핸들러는 응답이 성공적으로 commit된 뒤에 캐시를 삭제합니다. 어댑터 경로가 `response.send(...)`를 호출하지 않더라도, 인터셉터는 bounded fallback timer를 통해 성공한 쓰기 이후 stale 엔트리가 무기한 남지 않도록 보장합니다.
+`@CacheEvict(...)`가 붙은 non-GET 핸들러는 응답이 성공적으로 commit된 뒤에 캐시를 삭제합니다. 어댑터 경로가 `response.send(...)`를 호출하지 않더라도, 인터셉터는 bounded fallback timer를 통해 성공한 쓰기 이후 stale 엔트리가 무기한 남지 않도록 보장합니다. 또한 지연 eviction 실패는 인터셉터 내부에 containment되어 cache key factory나 cache store 삭제 오류가 응답 이후 unhandled promise rejection으로 노출되지 않습니다.
 
 ## 공개 API 개요
 

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -136,7 +136,7 @@ The built-in memory store is designed for single-process, bounded caching:
 
 ### Deferred eviction timing
 
-For non-GET handlers decorated with `@CacheEvict(...)`, eviction is deferred until the response successfully commits. If an adapter path never calls `response.send(...)`, the interceptor still runs a bounded fallback timer so successful writes do not leave stale entries behind indefinitely.
+For non-GET handlers decorated with `@CacheEvict(...)`, eviction is deferred until the response successfully commits. If an adapter path never calls `response.send(...)`, the interceptor still runs a bounded fallback timer so successful writes do not leave stale entries behind indefinitely. Deferred eviction failures stay contained inside the interceptor, so cache-key factories or cache-store deletes cannot surface as post-response unhandled promise rejections.
 
 ## Public API Overview
 

--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -273,6 +273,34 @@ describe('CacheInterceptor', () => {
     expect(value).toEqual({ refreshed: true });
   });
 
+  it('contains deferred eviction metadata failures after the response commits', async () => {
+    const unhandledRejection = vi.fn();
+    process.once('unhandledRejection', unhandledRejection);
+
+    class ProductController {
+      @CacheEvict(async () => {
+        throw new Error('evict metadata failed');
+      })
+      refresh() {}
+    }
+
+    const { interceptor } = createInterceptor();
+    const requestContext = createRequestContext('POST', '/products/refresh');
+    const context = createContext(ProductController, 'refresh', requestContext, 'POST');
+    const next: CallHandler = {
+      handle: vi.fn(async () => ({ refreshed: true })),
+    };
+
+    const value = await interceptor.intercept(context, next);
+    await expect(requestContext.response.send(value)).resolves.toBeUndefined();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(value).toEqual({ refreshed: true });
+    expect(unhandledRejection).not.toHaveBeenCalled();
+
+    process.removeListener('unhandledRejection', unhandledRejection);
+  });
+
   it('evicts immediately when the handler already committed the response before returning', async () => {
     class ProductController {
       @CacheEvict('/products')

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -152,7 +152,8 @@ function installDeferredEviction(
     }
 
     completed = true;
-    void evict();
+    void evict().catch(() => {
+    });
   };
 
   const restore = () => {


### PR DESCRIPTION
Closes #1072

## Summary
- contain deferred `@CacheEvict(...)` failures inside `CacheInterceptor` so post-response eviction work cannot escape as an unhandled promise rejection
- add targeted regression coverage for the async metadata failure path after the response commits
- document the containment guarantee in the cache-manager English/Korean README mirrors

## Changes
- wrap deferred eviction execution in an internal `.catch(...)` path inside `installDeferredEviction(...)`
- add a regression test that exercises an async `@CacheEvict(...)` metadata failure after `response.send(...)`
- clarify the documented deferred-eviction contract in `packages/cache-manager/README.md` and `packages/cache-manager/README.ko.md`

## Testing
- `pnpm --filter @fluojs/cache-manager test -- src/interceptor.test.ts`
- `pnpm --filter @fluojs/core --filter @fluojs/di --filter @fluojs/http --filter @fluojs/runtime --filter @fluojs/redis build` *(stops in `@fluojs/http` because fresh-worktree dependency build order still leaves `@fluojs/validation` unresolved before this issue diff is involved)*
- `pnpm --filter @fluojs/cache-manager typecheck` *(currently blocked by the same fresh-worktree workspace resolution issue)*
- `pnpm --filter @fluojs/cache-manager build` *(currently blocked by the same fresh-worktree workspace resolution issue)*

## Behavioral contract
- no documented contract was removed
- the existing deferred-eviction timing contract is now more explicit: deferred eviction failures are contained and do not surface as post-response unhandled promise rejections
- regression coverage was added for the new explicit failure-containment guarantee