### PR TITLE
Resolve #1076: harden Socket.IO auth rejection handling before launch

### DIFF
--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -147,6 +147,26 @@ function createGuardError(rejection: SocketIoGuardRejection, defaultMessage: str
   return error;
 }
 
+function normalizeRejectedGuardError(error: unknown, defaultMessage: string): SocketIoGuardRejection {
+  if (error instanceof Error) {
+    return {
+      data: (error as Error & { data?: unknown }).data,
+      message: error.message || defaultMessage,
+    };
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    const candidate = error as SocketIoGuardRejection;
+    return {
+      data: candidate.data,
+      disconnect: candidate.disconnect,
+      message: candidate.message ?? defaultMessage,
+    };
+  }
+
+  return { message: defaultMessage };
+}
+
 function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
   if (typeof provider === 'function') {
     return getClassDiMetadata(provider)?.scope ?? 'singleton';
@@ -817,7 +837,18 @@ export class SocketIoLifecycleService
       return;
     }
 
-    const rejection = await this.resolveMessageGuardRejection(socket, request, event, payload);
+    let rejection: SocketIoGuardRejection | undefined;
+
+    try {
+      rejection = await this.resolveMessageGuardRejection(socket, request, event, payload);
+    } catch (error) {
+      this.logger.error(
+        `Socket.IO message guard for event ${event} on socket ${socket.id} rejected unexpectedly.`,
+        error,
+        'SocketIoLifecycleService',
+      );
+      rejection = normalizeRejectedGuardError(error, 'Socket.IO message rejected.');
+    }
 
     if (rejection) {
       this.reportRejectedMessage(socket, event, acknowledgement, rejection);

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -665,6 +665,89 @@ describe('@fluojs/socket.io', () => {
     await app.close();
   });
 
+  it('contains async message-guard rejections inside adapter reporting flow', async () => {
+    const loggerEvents: string[] = [];
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+
+    class GatewayState {
+      messages: unknown[] = [];
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/async-message-guard' })
+    class GuardedGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnMessage('ping')
+      onPing(payload: unknown) {
+        this.state.messages.push(payload);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({
+        auth: {
+          async message({ payload }) {
+            if (payload === 'allowed') {
+              return true;
+            }
+
+            const error = new Error('Forbidden event.') as Error & { data?: unknown };
+            error.data = { code: 'AUTH_REQUIRED' };
+            return await Promise.reject(error);
+          },
+        },
+        transports: ['websocket'],
+      })],
+      providers: [GatewayState, GuardedGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      logger: createLogger(loggerEvents),
+      port,
+    });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+
+    await app.listen();
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    const socket = createClient(`http://127.0.0.1:${String(port)}/async-message-guard`, {
+      reconnection: false,
+      transports: ['websocket'],
+    });
+
+    try {
+      await onceConnected(socket);
+
+      const rejectedAck = await new Promise<unknown>((resolve) => {
+        socket.emit('ping', 'blocked', (response: unknown) => resolve(response));
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+
+      expect(rejectedAck).toEqual({ data: { code: 'AUTH_REQUIRED' }, error: 'Forbidden event.' });
+      expect(state.messages).toEqual([]);
+      expect(unhandledRejections).toEqual([]);
+      expect(
+        loggerEvents.some((event) =>
+          event.includes(
+            'error:SocketIoLifecycleService:Socket.IO message guard for event ping on socket',
+          ) && event.endsWith(':Forbidden event.'),
+        ),
+      ).toBe(true);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+      socket.close();
+      await app.close();
+    }
+  });
+
   it('disconnects sockets when inbound payloads exceed the configured engine limit', async () => {
     class GatewayState {
       messages: unknown[] = [];


### PR DESCRIPTION
## Summary

Hardens the Socket.IO message-auth path so async guard rejections stay inside the adapter reporting flow instead of surfacing as unhandled promise rejections.

## Changes

- catch async `auth.message` guard rejections inside `SocketIoLifecycleService.handleMessage(...)`
- normalize rejected guard errors back into the existing Socket.IO rejection reporting path
- add regression coverage proving rejected async guards log/report cleanly without invoking gateway handlers or leaking unhandled rejections

## Testing

- `pnpm --filter @fluojs/socket.io test`
- `pnpm build`
- `pnpm --filter @fluojs/socket.io typecheck`
- `pnpm typecheck`
- `pnpm lint`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract impact: no public contract expansion; this restores the documented auth rejection/reporting behavior for async guard failures and adds regression coverage for that invariant.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1076