### PR TITLE
Resolve #1071: fix jwt/passport auth follow-up regressions

### DIFF
--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -69,6 +69,8 @@ const principal = await verifier.verifyAccessToken(token);
 // principal: { subject: 'user-123', roles: ['admin'], scopes: ['read:profile'], ... }
 ```
 
+`JwtService.sign(payload, { expiresIn })`를 사용할 때는 payload 안에 기존 `exp` 값이 있더라도 호출 시점의 `expiresIn` 재정의가 항상 우선합니다. 따라서 토큰 수명은 호출 위치에서 결정적으로 제어됩니다.
+
 ## 일반적인 패턴
 
 ### 비대칭 서명 (RS256/ES256)

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -69,6 +69,8 @@ const principal = await verifier.verifyAccessToken(token);
 // principal: { subject: 'user-123', roles: ['admin'], scopes: ['read:profile'], ... }
 ```
 
+When you use `JwtService.sign(payload, { expiresIn })`, the per-call `expiresIn` override always wins over any pre-existing `payload.exp` value so token lifetime stays deterministic at the call site.
+
 ## Common Patterns
 
 ### Asymmetric Signing (RS256/ES256)

--- a/packages/jwt/src/service.test.ts
+++ b/packages/jwt/src/service.test.ts
@@ -54,6 +54,36 @@ describe('JwtService', () => {
     });
   });
 
+  it('prefers per-call expiresIn over a pre-existing payload exp claim', async () => {
+    const service = createJwtService({
+      algorithms: ['HS256'],
+      issuer: 'jwt-service-tests',
+      secret: 'service-secret',
+    });
+    const now = Math.floor(Date.now() / 1000);
+    const token = await service.sign(
+      {
+        exp: now + 3600,
+        role: 'reader',
+        sub: 'service-overrides-user',
+      },
+      {
+        expiresIn: 60,
+      },
+    );
+
+    const decoded = service.decode(token);
+
+    expect(decoded).toMatchObject({
+      exp: expect.any(Number),
+      role: 'reader',
+      sub: 'service-overrides-user',
+    });
+
+    expect((decoded as { exp: number }).exp).toBeLessThanOrEqual(now + 60);
+    expect((decoded as { exp: number }).exp).toBeGreaterThanOrEqual(now + 59);
+  });
+
   it('decodes payload without signature verification', async () => {
     const service = createJwtService({
       algorithms: ['HS256'],

--- a/packages/jwt/src/service.ts
+++ b/packages/jwt/src/service.ts
@@ -179,7 +179,7 @@ export class JwtService {
       aud: options?.audience ?? (payload as JwtClaims).aud,
       exp:
         expiresInSeconds !== undefined
-          ? ((payload as JwtClaims).exp ?? now + expiresInSeconds)
+          ? now + expiresInSeconds
           : (payload as JwtClaims).exp,
       iss: options?.issuer ?? (payload as JwtClaims).iss,
       nbf: options?.notBefore ?? (payload as JwtClaims).nbf,

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -86,8 +86,17 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 패키지에서 제공하는 `RefreshTokenStrategy`와 `RefreshTokenService`를 사용하여 안전한 토큰 로테이션 및 폐기 기능을 구현할 수 있습니다.
 
 ```typescript
+import { Module } from '@fluojs/core';
 import { Controller, Post, type RequestContext } from '@fluojs/http';
-import { UseAuth } from '@fluojs/passport';
+import { UseAuth, createRefreshTokenProviders } from '@fluojs/passport';
+
+@Module({
+  providers: [
+    MyRefreshTokenService,
+    ...createRefreshTokenProviders(MyRefreshTokenService),
+  ],
+})
+export class AuthModule {}
 
 @Controller('/auth')
 export class AuthController {
@@ -98,6 +107,8 @@ export class AuthController {
   }
 }
 ```
+
+`createRefreshTokenProviders(...)`는 표준 DI alias provider를 반환하므로, `REFRESH_TOKEN_SERVICE`를 해석하면 등록한 구체 서비스 인스턴스와 동일한 객체를 받게 됩니다.
 
 ## 공개 API 개요
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -86,8 +86,17 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 The package provides a built-in `RefreshTokenStrategy` and `RefreshTokenService` to handle secure token rotation and revocation.
 
 ```typescript
+import { Module } from '@fluojs/core';
 import { Controller, Post, type RequestContext } from '@fluojs/http';
-import { UseAuth } from '@fluojs/passport';
+import { UseAuth, createRefreshTokenProviders } from '@fluojs/passport';
+
+@Module({
+  providers: [
+    MyRefreshTokenService,
+    ...createRefreshTokenProviders(MyRefreshTokenService),
+  ],
+})
+export class AuthModule {}
 
 @Controller('/auth')
 export class AuthController {
@@ -98,6 +107,8 @@ export class AuthController {
   }
 }
 ```
+
+`createRefreshTokenProviders(...)` returns standard DI alias providers, so resolving `REFRESH_TOKEN_SERVICE` yields the same concrete service instance you registered.
 
 ## Public API Overview
 

--- a/packages/passport/src/refresh/refresh-token.test.ts
+++ b/packages/passport/src/refresh/refresh-token.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { Container } from '@fluojs/di';
 import type { DefaultJwtVerifier } from '@fluojs/jwt';
 import { JwtExpiredTokenError, JwtInvalidTokenError } from '@fluojs/jwt';
 
 import { AuthenticationExpiredError, AuthenticationFailedError, AuthenticationRequiredError } from '../errors.js';
-import { RefreshTokenStrategy, type RefreshTokenService } from './refresh-token.js';
+import { REFRESH_TOKEN_SERVICE, RefreshTokenStrategy, createRefreshTokenProviders, type RefreshTokenService } from './refresh-token.js';
 import type { AuthStrategyResult } from '../types.js';
 import type { GuardContext, RequestContext } from '@fluojs/http';
 
@@ -286,5 +287,34 @@ describe('RefreshTokenService contract', () => {
     await service.revokeAllForSubject('user-1');
 
     expect(service.revokeAllForSubject).toHaveBeenCalledWith('user-1');
+  });
+
+  it('creates valid DI alias providers for shared refresh-token service access', async () => {
+    class RefreshTokenServiceImpl implements RefreshTokenService {
+      async issueRefreshToken(): Promise<string> {
+        return 'refresh-token';
+      }
+
+      async rotateRefreshToken(): Promise<{ accessToken: string; refreshToken: string }> {
+        return {
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        };
+      }
+
+      async revokeRefreshToken(): Promise<void> {}
+
+      async revokeAllForSubject(): Promise<void> {}
+    }
+
+    const container = new Container().register(
+      RefreshTokenServiceImpl,
+      ...createRefreshTokenProviders(RefreshTokenServiceImpl),
+    );
+
+    const byClass = await container.resolve(RefreshTokenServiceImpl);
+    const bySharedToken = await container.resolve(REFRESH_TOKEN_SERVICE);
+
+    expect(bySharedToken).toBe(byClass);
   });
 });

--- a/packages/passport/src/refresh/refresh-token.ts
+++ b/packages/passport/src/refresh/refresh-token.ts
@@ -1,5 +1,6 @@
 import type { GuardContext, RequestContext } from '@fluojs/http';
 import { Inject, InvariantError, type Token } from '@fluojs/core';
+import type { Provider } from '@fluojs/di';
 import { DefaultJwtVerifier, JwtExpiredTokenError, JwtInvalidTokenError } from '@fluojs/jwt';
 
 import {
@@ -140,11 +141,11 @@ export class RefreshTokenStrategy implements AuthStrategy {
  */
 export function createRefreshTokenProviders(
   service: Token<RefreshTokenService>,
-): Array<{ provide: Token<unknown>; useToken: Token<unknown> }> {
+): Provider[] {
   return [
     {
       provide: REFRESH_TOKEN_SERVICE,
-      useToken: service,
+      useExisting: service,
     },
   ];
 }


### PR DESCRIPTION
## Summary
- make `JwtService.sign(payload, { expiresIn })` deterministically override any existing `payload.exp`
- return a valid DI alias provider shape from `createRefreshTokenProviders(...)` and cover it with a container regression test
- document the corrected JWT lifetime and refresh-token DI contracts in the English/Korean package READMEs

## Changes
- fixed the JWT service facade so per-call lifetime overrides no longer defer to a pre-existing payload `exp`
- added regression coverage for the JWT override path and for refresh-token shared-token alias resolution
- updated `@fluojs/jwt` and `@fluojs/passport` README mirrors to describe the corrected public contract

## Testing
- `pnpm vitest run packages/jwt/src/service.test.ts packages/passport/src/refresh/refresh-token.test.ts`
- `pnpm --filter @fluojs/jwt typecheck`
- `pnpm --filter @fluojs/passport typecheck`
- `pnpm build`
- `pnpm typecheck` *(currently fails in this worktree because existing workspace alias resolution errors surface in unrelated packages such as `packages/http` and `packages/runtime`; no additional failures came from the jwt/passport changes)*
- `pnpm lint` *(shows existing repo-wide Biome warnings outside this issue scope; `pnpm verify:public-export-tsdoc` passed)*

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1071