### PR TITLE
Resolve #1073: close GraphQL, OpenAPI, and HTTP request-surface drift

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -30,7 +30,7 @@ pnpm add @fluojs/graphql graphql graphql-yoga
 
 ## 빠른 시작
 
-`GraphqlModule`을 등록하고 표준 데코레이터를 사용하여 resolver를 정의합니다.
+`GraphqlModule.forRoot(...)`를 등록하고 표준 데코레이터를 사용하여 resolver를 정의합니다. 현재 `@fluojs/graphql`는 동기 모듈 엔트리포인트만 제공하며 `GraphqlModule.forRootAsync(...)` 계약은 없습니다.
 
 ```typescript
 import { Module } from '@fluojs/core';
@@ -121,7 +121,7 @@ GraphqlModule.forRoot({
 
 ## 공개 API 개요
 
-- `GraphqlModule`: GraphQL 통합을 위한 메인 엔트리 포인트.
+- `GraphqlModule.forRoot(options)`: GraphQL 통합을 위한 메인 엔트리 포인트.
 - `Resolver`, `Query`, `Mutation`, `Subscription`: 작업 데코레이터.
 - `Arg`: 인자 매핑 데코레이터.
 - `createDataLoader`, `createDataLoaderMap`: DataLoader 팩토리 헬퍼.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -30,7 +30,7 @@ pnpm add @fluojs/graphql graphql graphql-yoga
 
 ## Quick Start
 
-Register the `GraphqlModule` and define a resolver using standard decorators.
+Register `GraphqlModule.forRoot(...)` and define a resolver using standard decorators. `@fluojs/graphql` currently exposes a synchronous module entrypoint only; there is no `GraphqlModule.forRootAsync(...)` contract.
 
 ```typescript
 import { Module } from '@fluojs/core';
@@ -121,7 +121,7 @@ GraphqlModule.forRoot({
 
 ## Public API Overview
 
-- `GraphqlModule`: Main entry point for GraphQL integration.
+- `GraphqlModule.forRoot(options)`: Main entry point for GraphQL integration.
 - `Resolver`, `Query`, `Mutation`, `Subscription`: Operation decorators.
 - `Arg`: Argument mapping decorator.
 - `createDataLoader`, `createDataLoaderMap`: DataLoader factory helpers.

--- a/packages/graphql/src/public-api.test.ts
+++ b/packages/graphql/src/public-api.test.ts
@@ -20,6 +20,11 @@ describe('@fluojs/graphql public API surface', () => {
     expect(graphqlPublicApi).toHaveProperty('isGraphqlListTypeRef');
   });
 
+  it('keeps GraphqlModule limited to the documented synchronous entrypoint', () => {
+    expect(graphqlPublicApi.GraphqlModule).toHaveProperty('forRoot');
+    expect(graphqlPublicApi.GraphqlModule).not.toHaveProperty('forRootAsync');
+  });
+
   it('does not expose internal metadata, lifecycle, or descriptor internals', () => {
     expect(graphqlPublicApi).not.toHaveProperty('createGraphqlModule');
     expect(graphqlPublicApi).not.toHaveProperty('GRAPHQL_MODULE_OPTIONS');

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -123,11 +123,9 @@ stream(_input: undefined, ctx: RequestContext) {
 
 ## 내부 서브경로 (`@fluojs/http/internal`)
 
-`./internal` 서브경로는 플랫폼 어댑터와 핵심 런타임에서 사용하는 저수준 유틸리티를 내보냅니다. 이들은 변경될 수 있으며 일반적인 애플리케이션 코드에서 사용해서는 안 됩니다.
+`./internal` 서브경로는 플랫폼 어댑터와 핵심 런타임에서 사용하는 저수준 유틸리티만 내보냅니다. 이들은 변경될 수 있으며 일반적인 애플리케이션 코드에서 사용해서는 안 됩니다.
 
-- `createErrorResponse(error, requestId)`: 표준화된 JSON 에러 응답 팩토리.
-- `HttpException`: 모든 프레임워크 수준 HTTP 에러의 기본 클래스.
-- `PLATFORM_SHELL`: 활성 플랫폼 어댑터를 위한 DI 토큰.
+- `DefaultBinder`: 런타임 부트스트랩 경로에서 사용하는 기본 DTO/요청 바인더.
 - `resolveClientIdentity(request)`: 속도 제한과 런타임 통합에서 사용하는 프록시 인지 클라이언트 식별 해석기.
 
 ## 관련 패키지

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -125,11 +125,9 @@ stream(_input: undefined, ctx: RequestContext) {
 
 ## Internal Subpath (`@fluojs/http/internal`)
 
-The `./internal` subpath exports low-level utilities used by platform adapters and the core runtime. These are subject to change and should not be used in typical application code.
+The `./internal` subpath exports only the low-level utilities used by platform adapters and the core runtime. These are subject to change and should not be used in typical application code.
 
-- `createErrorResponse(error, requestId)`: Standardized JSON error response factory.
-- `HttpException`: Base class for all framework-level HTTP errors.
-- `PLATFORM_SHELL`: DI token for the active platform adapter.
+- `DefaultBinder`: Default DTO/request binder used by the runtime bootstrap path.
 - `resolveClientIdentity(request)`: Proxy-aware client identity resolver used by rate limiting and other runtime integrations.
 
 ## Related Packages

--- a/packages/http/src/public-api.test.ts
+++ b/packages/http/src/public-api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import * as httpPublicApi from './index.js';
+import * as httpInternalApi from './internal.js';
 
 describe('@fluojs/http public API surface', () => {
   it('keeps documented supported root-barrel exports', () => {
@@ -42,5 +43,11 @@ describe('@fluojs/http public API surface', () => {
     expect(httpPublicApi).not.toHaveProperty('DefaultConverter');
     expect(httpPublicApi).not.toHaveProperty('DefaultBinder');
     expect(httpPublicApi).not.toHaveProperty('getRouteProducesMetadata');
+  });
+
+  it('keeps the internal subpath limited to the documented exported helpers', () => {
+    expect(httpInternalApi).toHaveProperty('DefaultBinder');
+    expect(httpInternalApi).toHaveProperty('resolveClientIdentity');
+    expect(Object.keys(httpInternalApi).sort()).toEqual(['DefaultBinder', 'resolveClientIdentity']);
   });
 });

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -29,7 +29,7 @@ pnpm add @fluojs/openapi
 
 ## 빠른 시작
 
-`OpenApiModule`을 등록하고 컨트롤러에 어노테이션을 달아 문서를 생성합니다.
+`OpenApiModule`을 등록하고 `sources`(또는 미리 만든 `descriptors`)를 전달해 문서에 포함할 HTTP 핸들러를 명시합니다.
 
 ```typescript
 import { Controller, Get } from '@fluojs/http';
@@ -51,6 +51,7 @@ class UsersController {
 @Module({
   imports: [
     OpenApiModule.forRoot({
+      sources: [{ controllerToken: UsersController }],
       title: 'My API',
       version: '1.0.0',
       ui: true, // /docs에서 Swagger UI 활성화
@@ -65,6 +66,8 @@ await app.listen(3000);
 // OpenAPI JSON: http://localhost:3000/openapi.json
 // Swagger UI: http://localhost:3000/docs
 ```
+
+컨트롤러 탐색을 직접 건너뛰고 싶다면 `descriptors: createHandlerMapping([...]).descriptors`를 대신 전달할 수 있습니다. `OpenApiModule`은 `@Module({ controllers: [...] })`만으로 핸들러를 자동 추론하지 않습니다.
 
 ## 핵심 기능
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -29,7 +29,7 @@ pnpm add @fluojs/openapi
 
 ## Quick Start
 
-Register the `OpenApiModule` and annotate your controllers to generate the documentation.
+Register the `OpenApiModule` and pass `sources` (or prebuilt `descriptors`) so the document builder knows which HTTP handlers to include.
 
 ```typescript
 import { Controller, Get } from '@fluojs/http';
@@ -51,6 +51,7 @@ class UsersController {
 @Module({
   imports: [
     OpenApiModule.forRoot({
+      sources: [{ controllerToken: UsersController }],
       title: 'My API',
       version: '1.0.0',
       ui: true, // Enable Swagger UI at /docs
@@ -65,6 +66,8 @@ await app.listen(3000);
 // OpenAPI JSON: http://localhost:3000/openapi.json
 // Swagger UI: http://localhost:3000/docs
 ```
+
+If you need to bypass controller discovery, pass `descriptors: createHandlerMapping([...]).descriptors` instead. `OpenApiModule` does not infer handlers from `@Module({ controllers: [...] })` on its own.
 
 ## Core Capabilities
 

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -1786,6 +1786,53 @@ describe('OpenApiModule', () => {
     );
   });
 
+  it('README quick start stays executable when sources are provided explicitly', async () => {
+    @ApiTag('Users')
+    @Controller('/users')
+    class UsersController {
+      @ApiOperation({ summary: 'List all users' })
+      @ApiResponse(200, { description: 'Success' })
+      @Get('/')
+      list() {
+        return [];
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: UsersController }],
+      title: 'My API',
+      version: '1.0.0',
+      ui: true,
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [UsersController],
+      imports: [openApiModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        info: {
+          title: 'My API',
+          version: '1.0.0',
+        },
+        paths: expect.objectContaining({
+          '/users': expect.objectContaining({
+            get: expect.any(Object),
+          }),
+        }),
+      }),
+    );
+  });
+
   it('forRootAsync composes descriptors and sources when both are provided', async () => {
     @Controller('/async-sources')
     class AsyncSourcesController {


### PR DESCRIPTION
## Summary
- remove GraphQL documentation ambiguity by documenting and testing that `GraphqlModule` exposes only the synchronous `forRoot(...)` entrypoint
- fix the OpenAPI quick start so it is executable as written by requiring explicit `sources`/`descriptors`, and lock that path with a regression test
- align `@fluojs/http/internal` README claims and tests with the actual shipped internal export surface

## Changes
- updated English/Korean package READMEs for `@fluojs/graphql`, `@fluojs/openapi`, and `@fluojs/http`
- added regression coverage for the GraphQL module surface, the OpenAPI quick start flow, and the HTTP internal subpath export list
- kept the change scoped away from cache-manager follow-up work already landed in #1072

## Testing
- `pnpm test -- public-api.test.ts` in `packages/graphql`
- `pnpm test -- openapi-module.test.ts` in `packages/openapi`
- `pnpm test -- public-api.test.ts` in `packages/http`
- `pnpm build`
- `pnpm typecheck`
- `lsp_diagnostics` on modified test files: clean

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No changed public exports under `packages/*/src`; TSDoc baseline is unaffected in this PR.
- [x] No exported function signatures changed; matching `@param` / `@returns` updates were not required.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New or clarified behavioral contracts are documented in the affected package READMEs.
- [x] Intentional limitations are explicitly stated (for example, GraphQL remains `forRoot(...)`-only and OpenAPI requires explicit handler sources/descriptors).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] No governance docs changed, so English/Korean governance SSOT structure is unaffected.
- [x] No platform contract docs changed beyond package README alignment, so discoverability/tooling/CI governance updates were not required.
- [x] No README conformance claims were added that require `createPlatformConformanceHarness(...)` coverage.

Closes #1073