### PR TITLE
Resolve #1077: fix platform and runtime launch blockers

### DIFF
--- a/packages/metrics/src/public-surface.test.ts
+++ b/packages/metrics/src/public-surface.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import * as metrics from './index.js';
+
+describe('@fluojs/metrics public surface', () => {
+  it('keeps the documented metrics barrel public while hiding package-only wiring details', () => {
+    expect(metrics).toHaveProperty('MetricsModule');
+    expect(metrics).toHaveProperty('MetricsService');
+    expect(metrics).toHaveProperty('METER_PROVIDER');
+    expect(metrics).toHaveProperty('PrometheusMeterProvider');
+    expect(metrics).toHaveProperty('Registry');
+    expect(metrics).not.toHaveProperty('createMetricsModule');
+  });
+
+  it('keeps the published package surface aligned with emitted dist artifacts', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    ) as {
+      exports: Record<string, { import: string; types: string }>;
+      files: string[];
+      main: string;
+      types: string;
+    };
+
+    expect(packageJson.exports).toMatchObject({
+      '.': {
+        import: './dist/index.js',
+        types: './dist/index.d.ts',
+      },
+    });
+    expect(packageJson.main).toBe('./dist/index.js');
+    expect(packageJson.types).toBe('./dist/index.d.ts');
+    expect(packageJson.files).toEqual(['dist']);
+  });
+});

--- a/packages/platform-cloudflare-workers/src/adapter.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.test.ts
@@ -335,6 +335,62 @@ describe('@fluojs/platform-cloudflare-workers', () => {
       await entrypoint.close();
     }
   });
+
+  it('does not reopen a lazy Worker entrypoint while close is draining the current application', async () => {
+    let bootstrapCount = 0;
+    const deferred = createDeferred<void>();
+
+    class StartupProbe {
+      onApplicationBootstrap() {
+        bootstrapCount += 1;
+      }
+    }
+
+    @Controller('/slow')
+    class SlowController {
+      @Get('/')
+      async getSlow() {
+        await deferred.promise;
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [SlowController],
+      providers: [StartupProbe],
+    });
+
+    const entrypoint = createCloudflareWorkerEntrypoint(AppModule, {
+      cors: false,
+    });
+
+    try {
+      await entrypoint.ready();
+
+      const firstFetch = entrypoint.fetch(new Request('https://worker.test/slow'), {}, createExecutionContext());
+
+      await Promise.resolve();
+
+      const closePromise = entrypoint.close();
+      const secondFetch = await entrypoint.fetch(new Request('https://worker.test/slow'), {}, createExecutionContext());
+
+      expect(secondFetch.status).toBe(503);
+      expect(bootstrapCount).toBe(1);
+
+      deferred.resolve();
+
+      const firstResponse = await firstFetch;
+      await closePromise;
+
+      expect(firstResponse.status).toBe(200);
+      await expect(firstResponse.json()).resolves.toEqual({ ok: true });
+      expect(bootstrapCount).toBe(1);
+    } finally {
+      deferred.resolve();
+      await entrypoint.close();
+    }
+  });
 });
 
 function createDeferred<T>() {

--- a/packages/platform-cloudflare-workers/src/adapter.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.ts
@@ -282,6 +282,7 @@ export function createCloudflareWorkerEntrypoint<Env = unknown>(
   rootModule: ModuleType,
   options: BootstrapCloudflareWorkerApplicationOptions = {},
 ): CloudflareWorkerEntrypoint<Env> {
+  let closeInFlight: Promise<void> | undefined;
   let runningApplication: Promise<CloudflareWorkerApplication<Env>> | undefined;
 
   const ready = async (): Promise<CloudflareWorkerApplication<Env>> => {
@@ -294,16 +295,37 @@ export function createCloudflareWorkerEntrypoint<Env = unknown>(
 
   return {
     async close(signal?: string) {
+      if (closeInFlight) {
+        await closeInFlight;
+        return;
+      }
+
       const application = runningApplication;
-      runningApplication = undefined;
 
       if (!application) {
         return;
       }
 
-      await (await application).close(signal);
+      const closing = (async () => {
+        try {
+          await (await application).close(signal);
+        } finally {
+          if (runningApplication === application) {
+            runningApplication = undefined;
+          }
+
+          closeInFlight = undefined;
+        }
+      })();
+
+      closeInFlight = closing;
+      await closing;
     },
     async fetch(request: Request, env: Env, executionContext: CloudflareWorkerExecutionContext) {
+      if (closeInFlight) {
+        return createShutdownResponse();
+      }
+
       return await (await ready()).fetch(request, env, executionContext);
     },
     ready,

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -42,10 +42,16 @@ await runDenoApplication(AppModule, {
 ## 주요 패턴
 
 ### 수동 요청 디스패칭
-테스트나 커스텀 `Deno.serve` 구현을 위해 어댑터의 `handle` 메서드를 사용하여 네이티브 웹 요청을 수동으로 디스패치할 수 있습니다.
+테스트나 커스텀 `Deno.serve` 구현을 위해 어댑터의 `handle` 메서드를 사용하여 네이티브 웹 요청을 수동으로 디스패치할 수 있습니다. 다만 `handle(...)`은 런타임 dispatcher가 바인딩된 뒤에만 동작하므로, 먼저 `app.listen()`(또는 `runDenoApplication(...)`)으로 부트스트랩을 완료해야 합니다.
 
 ```typescript
+import { fluoFactory } from '@fluojs/runtime';
+
 const adapter = createDenoAdapter({ port: 3000 });
+const app = await fluoFactory.create(AppModule, { adapter });
+
+await app.listen();
+
 const response = await adapter.handle(new Request('http://localhost:3000/health'));
 ```
 

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -42,10 +42,16 @@ await runDenoApplication(AppModule, {
 ## Common Patterns
 
 ### Manual Request Dispatching
-For testing or custom `Deno.serve` implementations, you can use the adapter's `handle` method to dispatch native web requests manually.
+For testing or custom `Deno.serve` implementations, you can use the adapter's `handle` method to dispatch native web requests manually. Bind the dispatcher first via `app.listen()` (or `runDenoApplication(...)`), because `handle(...)` only works after the runtime has been bootstrapped.
 
 ```typescript
+import { fluoFactory } from '@fluojs/runtime';
+
 const adapter = createDenoAdapter({ port: 3000 });
+const app = await fluoFactory.create(AppModule, { adapter });
+
+await app.listen();
+
 const response = await adapter.handle(new Request('http://localhost:3000/health'));
 ```
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -324,6 +324,102 @@ describe('@fluojs/platform-fastify', () => {
     await app.close();
   });
 
+  it('rejects multipart payloads once the cumulative body size exceeds multipart.maxTotalSize', async () => {
+    @Controller('/uploads')
+    class UploadController {
+      @Post('/')
+      upload(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+          fileCount: context.request.files?.length ?? 0,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UploadController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      multipart: {
+        maxFileSize: 1024,
+        maxTotalSize: 10,
+      },
+      port,
+    });
+
+    await app.listen();
+
+    const form = new FormData();
+    form.set('name', 'Ada');
+    form.set('payload', new Blob(['1234567890'], { type: 'text/plain' }), 'payload.txt');
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+      body: form,
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'PAYLOAD_TOO_LARGE',
+      },
+    });
+
+    await app.close();
+  });
+
+  it('defaults multipart.maxTotalSize to maxBodySize when no explicit multipart total is provided', async () => {
+    @Controller('/uploads')
+    class UploadController {
+      @Post('/')
+      upload(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+          fileCount: context.request.files?.length ?? 0,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UploadController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      maxBodySize: 8,
+      multipart: {
+        maxFileSize: 1024,
+      },
+      port,
+    });
+
+    await app.listen();
+
+    const form = new FormData();
+    form.set('name', 'Ada');
+    form.set('payload', new Blob(['12345678'], { type: 'text/plain' }), 'payload.txt');
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+      body: form,
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'PAYLOAD_TOO_LARGE',
+      },
+    });
+
+    await app.close();
+  });
+
   it('accepts a cors string and merges framework defaults', async () => {
     @Controller('/ping')
     class PingController {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -148,6 +148,7 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
     this.app = createFastifyApp(this.httpsOptions, this.maxBodySize);
     this.requestResponseFactory = createFastifyRequestResponseFactory(
       this.multipartOptions,
+      this.maxBodySize,
       this.preserveRawBody,
     );
   }
@@ -249,11 +250,12 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
 
 function createFastifyRequestResponseFactory(
   multipartOptions?: MultipartOptions,
+  maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
 ): RequestResponseFactory<FastifyRequest, FastifyReply, FastifyFrameworkResponse> {
   return {
     async createRequest(request: FastifyRequest, signal: AbortSignal) {
-      return createFrameworkRequest(request, signal, multipartOptions, preserveRawBody);
+      return createFrameworkRequest(request, signal, multipartOptions, maxBodySize, preserveRawBody);
     },
     createRequestSignal(reply: FastifyReply) {
       return createRequestSignal(reply.raw);
@@ -456,6 +458,7 @@ async function createFrameworkRequest(
   request: FastifyRequest,
   signal: AbortSignal,
   multipartOptions?: MultipartOptions,
+  maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
   const rawUrl = request.raw.url ?? '/';
@@ -468,7 +471,10 @@ async function createFrameworkRequest(
   let files: UploadedFile[] | undefined;
 
   if (isMultipart) {
-    const parsed = await parseMultipartRequest(request, multipartOptions);
+    const parsed = await parseMultipartRequest(request, {
+      ...multipartOptions,
+      maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
+    });
     body = parsed.fields;
     files = parsed.files;
   }
@@ -509,6 +515,13 @@ async function parseMultipartRequest(
   const files: UploadedFile[] = [];
   const maxFileSize = options.maxFileSize ?? 10 * 1024 * 1024;
   const maxFiles = options.maxFiles ?? 10;
+  const maxTotalSize = options.maxTotalSize ?? 10 * 1024 * 1024;
+  const contentLength = Number(request.headers['content-length']);
+  let totalSize = 0;
+
+  if (Number.isFinite(contentLength) && contentLength > maxTotalSize) {
+    throw new PayloadTooLargeException('Request body exceeds the configured multipart limits.');
+  }
 
   try {
     for await (const part of request.parts({
@@ -518,7 +531,17 @@ async function parseMultipartRequest(
       },
     })) {
       if (part.type === 'file') {
+        if (files.length >= maxFiles) {
+          throw new PayloadTooLargeException(`Exceeded maximum file count of ${String(maxFiles)}.`);
+        }
+
         const buffer = await part.toBuffer();
+        totalSize += buffer.byteLength;
+
+        if (totalSize > maxTotalSize) {
+          throw new PayloadTooLargeException('Request body exceeds the configured multipart limits.');
+        }
+
         files.push({
           buffer,
           fieldname: part.fieldname,
@@ -527,14 +550,17 @@ async function parseMultipartRequest(
           size: buffer.byteLength,
         });
 
-        if (files.length > maxFiles) {
-          throw new PayloadTooLargeException(`Exceeded maximum file count of ${String(maxFiles)}.`);
-        }
-
         continue;
       }
 
-      setMultiValue(fields, part.fieldname, String(part.value ?? ''));
+      const value = String(part.value ?? '');
+      totalSize += Buffer.byteLength(value, 'utf8');
+
+      if (totalSize > maxTotalSize) {
+        throw new PayloadTooLargeException('Request body exceeds the configured multipart limits.');
+      }
+
+      setMultiValue(fields, part.fieldname, value);
     }
   } catch (error: unknown) {
     if (isFastifyMultipartTooLargeError(error)) {

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -142,6 +142,7 @@ class UsersModule {}
 | `@fluojs/runtime/node` | Node.js 전용 로거 팩토리 (`createConsoleApplicationLogger`, `createJsonApplicationLogger`) 및 종료 시그널 등록. |
 | `@fluojs/runtime/web` | Bun, Deno, Cloudflare Workers를 위한 공유 웹 표준 요청/응답 유틸리티. |
 | `@fluojs/runtime/internal` | 저수준 오케스트레이션 헬퍼 및 HTTP 어댑터 기본 로직. |
+| `@fluojs/runtime/internal-node` | 어댑터/패키지 호환 계층이 사용하는 Node 전용 내부 seam이며, 애플리케이션 코드에서는 `@fluojs/runtime/node`를 우선 사용하세요. |
 
 ### Node 전용 서브경로 (`@fluojs/runtime/node`)
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -142,6 +142,7 @@ class UsersModule {}
 | `@fluojs/runtime/node` | Node.js-specific logger factories (`createConsoleApplicationLogger`, `createJsonApplicationLogger`) and shutdown signal registration. |
 | `@fluojs/runtime/web` | Shared Web-standard request/response utilities for Bun, Deno, and Cloudflare Workers. |
 | `@fluojs/runtime/internal` | Low-level orchestration helpers and HTTP adapter base logic. |
+| `@fluojs/runtime/internal-node` | Node-only internal seam used by adapter/package compatibility layers; prefer `@fluojs/runtime/node` in application code. |
 
 ### Node-Specific Subpath (`@fluojs/runtime/node`)
 

--- a/packages/runtime/src/exports.test.ts
+++ b/packages/runtime/src/exports.test.ts
@@ -55,11 +55,19 @@ describe('runtime export boundaries', () => {
   it('declares the narrowed package export map', () => {
     const packageJson = JSON.parse(
       readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
-    ) as { exports: Record<string, unknown> };
+    ) as {
+      exports: Record<string, unknown>;
+      typesVersions?: Record<string, Record<string, string[]>>;
+    };
 
+    expect(packageJson.exports).toHaveProperty('./node');
     expect(packageJson.exports).toHaveProperty('./web');
     expect(packageJson.exports).toHaveProperty('./internal');
     expect(packageJson.exports).toHaveProperty('./internal/http-adapter');
     expect(packageJson.exports).toHaveProperty('./internal/request-response-factory');
+    expect(packageJson.exports).toHaveProperty('./internal-node');
+    expect(packageJson.typesVersions?.['*']).toMatchObject({
+      'internal-node': ['./dist/internal-node.d.ts'],
+    });
   });
 });

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -94,7 +94,8 @@ TerminusModule.forRoot({
 
 - 하나 이상의 인디케이터가 실패하면 `/health`는 HTTP `503`을 반환합니다.
 - 준비 상태(readiness)와 관련된 인디케이터가 실패하면 `/ready`는 HTTP `503`을 반환합니다.
-- 응답 본문은 `status`, `info`, `error`, `details`를 포함한 구조화된 JSON 객체입니다.
+- 응답 본문은 `status`, `contributors`, `info`, `error`, `details`를 포함한 구조화된 JSON 객체입니다.
+- 하나의 인디케이터가 여러 keyed entry를 반환할 수도 있으며, 이 경우 `/health`는 모든 entry를 `details`와 `contributors.up` / `contributors.down` 요약에 그대로 반영합니다.
 
 ## 공개 API 개요
 

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -94,7 +94,8 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 
 - `/health` returns HTTP `503` if any indicator fails.
 - `/ready` returns HTTP `503` if any indicator associated with readiness fails.
-- The response body contains a structured JSON object with `status`, `info`, `error`, and `details`.
+- The response body contains a structured JSON object with `status`, `contributors`, `info`, `error`, and `details`.
+- Indicators may emit multiple keyed entries in a single check result; `/health` preserves every keyed entry in `details` and in the `contributors.up` / `contributors.down` summaries.
 
 ## Public API Overview
 

--- a/packages/terminus/src/health-check.test.ts
+++ b/packages/terminus/src/health-check.test.ts
@@ -99,6 +99,36 @@ describe('runHealthCheck', () => {
       status: 'down',
     });
   });
+
+  it('preserves every keyed entry returned by a multi-result indicator', async () => {
+    const indicators: HealthIndicator[] = [
+      {
+        key: 'dependencies',
+        check: async () => ({
+          database: { latencyMs: 4, status: 'up' },
+          redis: { message: 'timeout', status: 'down' },
+        }),
+      },
+    ];
+
+    const report = await runHealthCheck(indicators);
+
+    expect(report.status).toBe('error');
+    expect(report.contributors).toEqual({
+      down: ['redis'],
+      up: ['database'],
+    });
+    expect(report.info).toEqual({
+      database: { latencyMs: 4, status: 'up' },
+    });
+    expect(report.error).toEqual({
+      redis: { message: 'timeout', status: 'down' },
+    });
+    expect(report.details).toEqual({
+      database: { latencyMs: 4, status: 'up' },
+      redis: { message: 'timeout', status: 'down' },
+    });
+  });
 });
 
 describe('assertHealthCheck', () => {

--- a/packages/terminus/src/health-check.ts
+++ b/packages/terminus/src/health-check.ts
@@ -24,18 +24,10 @@ function hasIndicatorStatus(value: unknown): value is HealthIndicatorState {
 }
 
 function normalizeIndicatorResult(key: string, result: HealthIndicatorResult): HealthIndicatorResult {
-  const candidate = result[key];
+  const normalizedEntries = Object.entries(result).filter(([, entryValue]) => hasIndicatorStatus(entryValue));
 
-  if (hasIndicatorStatus(candidate)) {
-    return result;
-  }
-
-  for (const [entryKey, entryValue] of Object.entries(result)) {
-    if (hasIndicatorStatus(entryValue)) {
-      return {
-        [entryKey]: entryValue,
-      };
-    }
+  if (normalizedEntries.length > 0) {
+    return Object.fromEntries(normalizedEntries);
   }
 
   return {
@@ -72,33 +64,22 @@ function inferIndicatorKey(indicator: HealthIndicator, index: number): string {
  * @returns A structured report containing `info`, `error`, and full `details` maps.
  */
 export async function runHealthCheck(indicators: readonly HealthIndicator[]): Promise<HealthCheckReport> {
-  const checks = await Promise.all(
+  const checks = (await Promise.all(
     indicators.map(async (indicator, index) => {
       const key = inferIndicatorKey(indicator, index);
 
       try {
         const result = await indicator.check(key);
-        const normalized = normalizeIndicatorResult(key, result);
-        const [normalizedKey, normalizedState] = Object.entries(normalized)[0] ?? [key, {
-          message: 'Indicator did not return a valid result.',
-          status: 'down',
-        }];
-        return [normalizedKey, normalizedState] as const;
+        return Object.entries(normalizeIndicatorResult(key, result));
       } catch (error: unknown) {
         if (error instanceof HealthCheckError) {
-          const causes = normalizeIndicatorResult(key, error.causes);
-          const [causeKey, causeState] = Object.entries(causes)[0] ?? [key, {
-            message: error.message,
-            status: 'down',
-          }];
-
-          return [causeKey, causeState] as const;
+          return Object.entries(normalizeIndicatorResult(key, error.causes));
         }
 
-        return [key, toFailureResult(key, error)[key]] as const;
+        return Object.entries(toFailureResult(key, error));
       }
     }),
-  );
+  )).flat();
 
   const details = Object.fromEntries(checks);
   const infoEntries = checks.filter(([, result]) => result.status === 'up');


### PR DESCRIPTION
Closes #1077

## Summary
- enforce Fastify multipart launch limits, including `multipart.maxTotalSize` and the runtime `maxBodySize` fallback
- prevent Cloudflare Worker lazy entrypoints from reopening while shutdown is draining, and preserve Terminus multi-entry health aggregation
- align runtime/Deno/metrics/terminus launch-facing docs and public-surface coverage with shipped behavior

## Changes
- tightened `packages/platform-fastify` multipart parsing to reject cumulative multipart bodies once configured limits are exceeded, with adapter regressions for explicit and fallback totals
- guarded `packages/platform-cloudflare-workers` lazy entrypoints so `fetch()` returns shutdown-safe `503` responses during teardown instead of reopening a new app
- updated `packages/terminus` aggregation to preserve every keyed indicator entry and documented the resulting `/health` response shape
- expanded `packages/runtime` export-map coverage for `./node` and `./internal-node`, added a `packages/metrics` published-surface regression, and corrected Deno manual `handle()` docs

## Testing
- `npm exec vitest -- run packages/platform-fastify/src/adapter.test.ts packages/platform-cloudflare-workers/src/adapter.test.ts packages/platform-deno/src/adapter.test.ts packages/runtime/src/exports.test.ts packages/metrics/src/public-surface.test.ts packages/terminus/src/health-check.test.ts packages/terminus/src/module.test.ts packages/terminus/src/public-surface.test.ts packages/terminus/src/public-subpaths.test.ts`
- `pnpm --filter @fluojs/platform-fastify --filter @fluojs/platform-cloudflare-workers --filter @fluojs/platform-deno --filter @fluojs/runtime --filter @fluojs/metrics --filter @fluojs/terminus run typecheck`
- `npm run build`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- Fastify multipart requests now honor the documented cumulative limit and inherit `maxBodySize` when `multipart.maxTotalSize` is omitted.
- Cloudflare Worker entrypoints no longer reopen during teardown and instead surface the documented shutdown-safe `503` response.
- Terminus now preserves all keyed entries returned by an indicator in `/health` aggregation and contributor summaries.