### PR TITLE
Resolve #1078: close tooling publish-surface gaps

### DIFF
--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -26,6 +26,12 @@ pnpm add -g @fluojs/cli
 pnpm dlx @fluojs/cli new my-app
 ```
 
+## 릴리스 계약
+
+- `@fluojs/cli`는 intended publish surface에 포함되는 공개 패키지입니다.
+- 지원되는 설치 경로는 전역 패키지(`pnpm add -g @fluojs/cli`)와 무설치 실행 경로(`pnpm dlx @fluojs/cli ...`)입니다.
+- 배포되는 `fluo` bin은 `package.json`에 선언된 dist 빌드 CLI 엔트리포인트를 기준으로 동작합니다.
+
 ## 사용 시점
 
 - **부트스트랩**: 표준적이고 검증 가능한 구조로 새 프로젝트를 시작할 때.
@@ -118,7 +124,7 @@ fluo migrate ./src --apply
 # 의존성 그래프를 Mermaid 형식으로 내보내기
 fluo inspect ./src/app.module.ts --mermaid
 
-### @fluojs/studio용 snapshot 내보내기
+# @fluojs/studio용 snapshot 내보내기
 fluo inspect ./src/app.module.ts --json > snapshot.json
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,6 +26,12 @@ Or run directly without installation:
 pnpm dlx @fluojs/cli new my-app
 ```
 
+## Release Contract
+
+- `@fluojs/cli` is a public package in the intended publish surface.
+- The supported install paths are the global package (`pnpm add -g @fluojs/cli`) and the no-install runner (`pnpm dlx @fluojs/cli ...`).
+- The published `fluo` bin is backed by the dist-built CLI entrypoint declared in `package.json`.
+
 ## When to Use
 
 - **Bootstrapping**: When starting a new project with a standard, verifiable structure.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -28,12 +28,28 @@ describe('CLI command runner', () => {
     const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
     const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as {
       bin: Record<string, string>;
+      exports: Record<string, { import: string; types: string }>;
+      files: string[];
+      main?: string;
+      private?: boolean;
+      publishConfig?: { access?: string };
     };
 
     expect(manifest.bin).toEqual({
       fluo: './bin/fluo.mjs',
     });
+    expect(manifest.private).toBe(false);
+    expect(manifest.publishConfig?.access).toBe('public');
+    expect(manifest.main).toBe('./dist/index.js');
+    expect(manifest.exports['.']).toEqual({
+      import: './dist/index.js',
+      types: './dist/index.d.ts',
+    });
+    expect(manifest.files).toEqual(['dist', 'bin']);
     expect(readFileSync(join(packageRoot, 'README.md'), 'utf8')).toContain('The canonical CLI for fluo');
+    expect(readFileSync(join(packageRoot, 'README.md'), 'utf8')).toContain('dist-built CLI entrypoint');
+    expect(readFileSync(join(packageRoot, 'README.ko.md'), 'utf8')).toContain('dist 빌드 CLI 엔트리포인트');
+    expect(readFileSync(join(packageRoot, 'README.ko.md'), 'utf8')).toContain('# @fluojs/studio용 snapshot 내보내기');
   });
 
   it('uses the default target directory from a single-app workspace root', async () => {

--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -21,6 +21,11 @@ fluo 런타임 내보내기의 공유 플랫폼 snapshot을 파일 기반으로 
 pnpm add @fluojs/studio
 ```
 
+배포된 패키지는 두 가지 caller-facing entrypoint를 제공합니다.
+
+- `@fluojs/studio` / `@fluojs/studio/contracts`: snapshot 파싱, 필터링, Mermaid 내보내기 헬퍼
+- `@fluojs/studio/viewer`: 패키징된 브라우저 뷰어 HTML 진입 파일
+
 ## 릴리스 정책
 
 - `@fluojs/studio`는 fluo의 intended public publish surface에 포함되는 공개 배포 패키지입니다.
@@ -65,12 +70,21 @@ Studio는 fluo CLI에서 내보낸 JSON 파일을 소비합니다.
 
 ## 공개 API 개요
 
-Studio는 주로 웹 애플리케이션이지만, 플랫폼 snapshot을 소비하기 위한 규격을 정의합니다.
+Studio는 주로 웹 애플리케이션이지만, 배포된 패키지는 도구/자동화가 사용할 수 있는 snapshot 소비 헬퍼도 함께 공개합니다.
 
 | 규격 | 설명 |
 |---|---|
 | `PlatformShellSnapshot` | 애플리케이션 상태를 나타내는 핵심 데이터 구조입니다. |
 | `PlatformDiagnosticIssue` | 플랫폼 오류 보고 및 수정을 위한 스키마입니다. |
+| `parseStudioPayload(rawJson)` | CLI/export JSON을 Studio snapshot/timing envelope로 검증합니다. |
+| `applyFilters(snapshot, filter)` | 원본 snapshot을 변경하지 않고 readiness/severity/query 필터를 적용합니다. |
+| `renderMermaid(snapshot)` | 로드된 플랫폼 그래프를 Mermaid 텍스트로 변환합니다. |
+
+### 배포 패키지 entrypoint
+
+- `@fluojs/studio`: snapshot 파싱/필터링/렌더링용 루트 헬퍼 배럴
+- `@fluojs/studio/contracts`: 계약 헬퍼를 직접 가져오고 싶은 도구용 명시적 서브패스
+- `@fluojs/studio/viewer`: 브라우저 뷰어 번들의 `dist/index.html` 진입 파일
 
 ## 관련 패키지
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -21,6 +21,11 @@ File-first shared platform snapshot viewer for fluo runtime exports.
 pnpm add @fluojs/studio
 ```
 
+The published package serves two caller-facing entrypoints:
+
+- `@fluojs/studio` / `@fluojs/studio/contracts` for snapshot parsing, filtering, and Mermaid export helpers.
+- `@fluojs/studio/viewer` for the packaged browser viewer HTML entry file.
+
 ## Release Policy
 
 - `@fluojs/studio` is part of the intended public publish surface for fluo.
@@ -65,12 +70,21 @@ Use the **Diagnostics** tab to see issues collected during the runtime bootstrap
 
 ## Public API Overview
 
-Studio is primarily a web application, but it defines contracts for consuming platform snapshots.
+Studio is primarily a web application, but the published package also exposes the documented snapshot-consumption helpers used by tooling and automation.
 
 | Contract | Description |
 |---|---|
 | `PlatformShellSnapshot` | The core data structure representing the application state. |
 | `PlatformDiagnosticIssue` | Schema for reporting and fixing platform errors. |
+| `parseStudioPayload(rawJson)` | Validates CLI/exported JSON into the Studio snapshot/timing envelope. |
+| `applyFilters(snapshot, filter)` | Applies readiness/severity/query filters without mutating the source snapshot. |
+| `renderMermaid(snapshot)` | Produces Mermaid graph text from the loaded platform graph. |
+
+### Published package entrypoints
+
+- `@fluojs/studio`: root helper barrel for snapshot parsing/filtering/rendering.
+- `@fluojs/studio/contracts`: explicit helper subpath for tooling that wants the contract helpers directly.
+- `@fluojs/studio/viewer`: packaged `dist/index.html` entrypoint for the browser viewer bundle.
 
 ## Related Packages
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -24,11 +24,25 @@
     "access": "public"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./contracts": {
+      "types": "./dist/contracts.d.ts",
+      "import": "./dist/contracts.js"
+    },
+    "./viewer": "./dist/index.html"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "pnpm exec vite build",
+    "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
+    "build": "pnpm exec vite build && pnpm exec babel src/contracts.ts src/index.ts --extensions .ts --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
     "dev": "pnpm exec vite",
     "preview": "pnpm exec vite preview",
     "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -1,13 +1,26 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
+import * as studio from './index.js';
 import { applyFilters, parseStudioPayload, renderMermaid } from './contracts.js';
 import type { PlatformShellSnapshot } from '@fluojs/runtime';
 
 const packageDir = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
+const repoRoot = resolve(packageDir, '..', '..');
+
+function runBuild(): void {
+  const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  const result = spawnSync(command, ['--filter', '@fluojs/studio...', 'build'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+
+  expect(result.status, [result.stdout, result.stderr].filter(Boolean).join('\n')).toBe(0);
+}
 
 const snapshotFixture: PlatformShellSnapshot = {
   components: [
@@ -87,6 +100,12 @@ const snapshotFixture: PlatformShellSnapshot = {
 };
 
 describe('parseStudioPayload', () => {
+  it('publishes contract helpers from the root package entrypoint', () => {
+    expect(studio.parseStudioPayload).toBeTypeOf('function');
+    expect(studio.applyFilters).toBeTypeOf('function');
+    expect(studio.renderMermaid).toBeTypeOf('function');
+  });
+
   it('parses platform snapshot payload', () => {
     const parsed = parseStudioPayload(JSON.stringify(snapshotFixture));
     expect(parsed.payload.snapshot?.components[0]?.id).toBe('redis.default');
@@ -112,6 +131,9 @@ describe('parseStudioPayload', () => {
     const packageManifest = JSON.parse(readFileSync(resolve(packageDir, 'package.json'), 'utf8')) as {
       name: string;
       private?: boolean;
+      main?: string;
+      types?: string;
+      exports?: Record<string, unknown>;
       publishConfig?: { access?: string };
     };
     const readme = readFileSync(resolve(packageDir, 'README.md'), 'utf8');
@@ -120,13 +142,40 @@ describe('parseStudioPayload', () => {
 
     expect(packageManifest.name).toBe('@fluojs/studio');
     expect(packageManifest.private).toBe(false);
+    expect(packageManifest.main).toBe('./dist/index.js');
+    expect(packageManifest.types).toBe('./dist/index.d.ts');
     expect(packageManifest.publishConfig?.access).toBe('public');
+    expect(packageManifest.exports).toEqual({
+      '.': {
+        types: './dist/index.d.ts',
+        import: './dist/index.js',
+      },
+      './contracts': {
+        types: './dist/contracts.d.ts',
+        import: './dist/contracts.js',
+      },
+      './viewer': './dist/index.html',
+    });
     expect(releaseGovernance).toContain('- `@fluojs/studio`');
     expect(readme).toContain('pnpm add @fluojs/studio');
+    expect(readme).toContain('@fluojs/studio/contracts');
+    expect(readme).toContain('@fluojs/studio/viewer');
     expect(readme).toContain('intended public publish surface');
     expect(readmeKo).toContain('pnpm add @fluojs/studio');
+    expect(readmeKo).toContain('@fluojs/studio/contracts');
+    expect(readmeKo).toContain('@fluojs/studio/viewer');
     expect(readmeKo).toContain('공개 배포 패키지');
   });
+
+  it('build emits the published helper and viewer entrypoints', () => {
+    runBuild();
+
+    expect(existsSync(resolve(packageDir, 'dist', 'index.html')), 'viewer HTML entrypoint is missing').toBe(true);
+    expect(existsSync(resolve(packageDir, 'dist', 'index.js')), 'root helper barrel output is missing').toBe(true);
+    expect(existsSync(resolve(packageDir, 'dist', 'index.d.ts')), 'root helper barrel types are missing').toBe(true);
+    expect(existsSync(resolve(packageDir, 'dist', 'contracts.js')), 'contracts helper output is missing').toBe(true);
+    expect(existsSync(resolve(packageDir, 'dist', 'contracts.d.ts')), 'contracts helper types are missing').toBe(true);
+  }, 60_000);
 });
 
 describe('applyFilters', () => {

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -8,17 +8,26 @@ import type {
 export type PlatformReadinessStatus = PlatformSnapshot['readiness']['status'];
 export type PlatformDiagnosticSeverity = PlatformDiagnosticIssue['severity'];
 
+/**
+ * Serializable Studio payload envelope built from inspect snapshot/timing exports.
+ */
 export interface StudioPayload {
   snapshot?: PlatformShellSnapshot;
   timing?: BootstrapTimingDiagnostics;
 }
 
+/**
+ * Filter state applied to the loaded platform snapshot inside Studio.
+ */
 export interface FilterState {
   query: string;
   readinessStatuses: PlatformReadinessStatus[];
   severities: PlatformDiagnosticSeverity[];
 }
 
+/**
+ * Parsed Studio payload together with the original JSON source.
+ */
 export interface ParsedPayload {
   payload: StudioPayload;
   rawJson: string;
@@ -153,6 +162,13 @@ function validateTiming(value: unknown): BootstrapTimingDiagnostics | null {
   return value as unknown as BootstrapTimingDiagnostics;
 }
 
+/**
+ * Parses a Studio JSON file into the documented snapshot/timing envelope.
+ *
+ * @param rawJson - Raw JSON emitted by `fluo inspect` or a Studio-compatible producer.
+ * @returns The validated Studio payload plus the original JSON string.
+ * @throws Error when the JSON does not match the supported Studio file contracts.
+ */
 export function parseStudioPayload(rawJson: string): ParsedPayload {
   const parsed = JSON.parse(rawJson) as unknown;
   const envelope = isRecord(parsed) ? parsed : undefined;
@@ -173,6 +189,13 @@ export function parseStudioPayload(rawJson: string): ParsedPayload {
   };
 }
 
+/**
+ * Applies Studio filter state to a platform snapshot without mutating the input.
+ *
+ * @param snapshot - The loaded platform snapshot.
+ * @param filter - Active readiness, severity, and query filters.
+ * @returns A filtered snapshot containing only the matching components and diagnostics.
+ */
 export function applyFilters(snapshot: PlatformShellSnapshot, filter: FilterState): PlatformShellSnapshot {
   const query = filter.query.trim().toLowerCase();
 
@@ -219,6 +242,12 @@ function escapeMermaidText(value: string): string {
   return value.replaceAll('"', '\\"');
 }
 
+/**
+ * Renders the loaded platform snapshot as a Mermaid dependency graph.
+ *
+ * @param snapshot - The platform snapshot to render.
+ * @returns Mermaid graph text suitable for docs or clipboard export.
+ */
 export function renderMermaid(snapshot: PlatformShellSnapshot): string {
   const lines: string[] = ['graph TD'];
   const nodeByComponent = new Map<string, string>();

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  applyFilters,
+  parseStudioPayload,
+  renderMermaid,
+  type FilterState,
+  type ParsedPayload,
+  type PlatformDiagnosticSeverity,
+  type PlatformReadinessStatus,
+  type StudioPayload,
+} from './contracts.js';

--- a/packages/studio/tsconfig.build.json
+++ b/packages/studio/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["src/contracts.ts", "src/index.ts"]
+}

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -24,6 +24,12 @@ pnpm add -D @fluojs/testing vitest
 
 `vitest`는 mock 헬퍼와 `@fluojs/testing/vitest` 엔트리포인트가 요구하는 peer dependency입니다.
 
+`@fluojs/testing/vitest`를 사용할 때는 `fluoBabelDecoratorsPlugin()`이 런타임에 Babel을 호출하므로, 사용하는 워크스페이스에 `@babel/core`도 함께 설치해야 합니다.
+
+```bash
+pnpm add -D @babel/core
+```
+
 ## 사용 시점
 
 - 프로덕션 모듈 트리를 모방하는 테스트 컨테이너를 생성해야 할 때.
@@ -96,7 +102,7 @@ const mailer = createDeepMock(MailService);
 - **Mock 서브패스**: `@fluojs/testing/mock`
 - **HTTP 헬퍼**: `@fluojs/testing/http`
 - **하니스 서브패스**: `platform-conformance`, `http-adapter-portability`, `web-runtime-adapter-portability`, `fetch-style-websocket-conformance`
-- **도구 지원**: `@fluojs/testing/vitest`와 `fluoBabelDecoratorsPlugin()`
+- **도구 지원**: `@fluojs/testing/vitest`와 `fluoBabelDecoratorsPlugin()` (`vitest`와 `@babel/core`를 함께 요구)
 
 ## 관련 패키지
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -22,6 +22,12 @@ npm install --save-dev @fluojs/testing vitest
 
 `vitest` is a required peer dependency for the mock helpers and the `@fluojs/testing/vitest` entrypoint.
 
+If you use `@fluojs/testing/vitest`, install `@babel/core` in the consuming workspace as well because `fluoBabelDecoratorsPlugin()` invokes Babel at runtime:
+
+```bash
+npm install --save-dev @babel/core
+```
+
 ## When to Use
 
 - when you want to compile a real module graph but replace a few explicit providers with fakes
@@ -94,7 +100,7 @@ Use subpaths like `@fluojs/testing/platform-conformance`, `@fluojs/testing/http-
 - **Mock subpath**: `@fluojs/testing/mock`
 - **HTTP helpers**: `@fluojs/testing/http`
 - **Harness subpaths**: `platform-conformance`, `http-adapter-portability`, `web-runtime-adapter-portability`, `fetch-style-websocket-conformance`
-- **Tooling**: `@fluojs/testing/vitest` with `fluoBabelDecoratorsPlugin()`
+- **Tooling**: `@fluojs/testing/vitest` with `fluoBabelDecoratorsPlugin()` (requires `vitest` and `@babel/core` in the consuming workspace)
 
 ## Related Packages
 

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -93,11 +93,6 @@
     "@babel/core": ">=7.0.0",
     "vitest": "^3.0.8"
   },
-  "peerDependenciesMeta": {
-    "@babel/core": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@fluojs/platform-nodejs": "workspace:*",
     "@fluojs/platform-express": "workspace:*",

--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -62,6 +62,7 @@ describe('@fluojs/testing surface', () => {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
       exports: Record<string, { import: string; types: string }>;
       peerDependencies: Record<string, string>;
+      peerDependenciesMeta?: Record<string, unknown>;
     };
 
     expect(packageJson.exports['./platform-conformance']).toEqual({
@@ -80,7 +81,11 @@ describe('@fluojs/testing surface', () => {
       types: './dist/conformance/fetch-style-websocket-conformance.d.ts',
       import: './dist/conformance/fetch-style-websocket-conformance.js',
     });
+    expect(packageJson.peerDependencies['@babel/core']).toBe('>=7.0.0');
     expect(packageJson.peerDependencies.vitest).toBe('^3.0.8');
+    expect(packageJson.peerDependenciesMeta?.['@babel/core']).toBeUndefined();
+    expect(readFileSync(resolve(packageRootPath, 'README.md'), 'utf8')).toContain('npm install --save-dev @babel/core');
+    expect(readFileSync(resolve(packageRootPath, 'README.ko.md'), 'utf8')).toContain('pnpm add -D @babel/core');
   });
 
   it('build emits the published harness subpath files', () => {


### PR DESCRIPTION
## Summary

Follow up on #1078 by tightening the published install surface for `@fluojs/studio`, `@fluojs/testing`, and `@fluojs/cli`.

Closes #1078

## Changes

- publish explicit Studio helper/viewer entrypoints, add build outputs for the helper barrel, and document the install contract in both README mirrors
- make the `@fluojs/testing/vitest` Babel requirement explicit in package metadata, regression tests, and English/Korean README guidance
- lock the CLI release/install contract in docs/tests and fix the broken Korean inspect code fence

## Testing

- `pnpm --filter @fluojs/studio test`
- `pnpm --filter @fluojs/testing test`
- `pnpm --filter @fluojs/cli test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm verify`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.