### PR TITLE
Resolve #1075: fix cron timing and messaging public-contract drift

### DIFF
--- a/packages/cron/README.ko.md
+++ b/packages/cron/README.ko.md
@@ -90,6 +90,8 @@ class AppModule {}
 
 `distributed.clientName`을 생략하면 위의 기본 Redis 등록을 계속 사용합니다. 분산 락에 기본 Redis가 아닌 다른 연결을 쓰려면 `RedisModule.forRootNamed(...)`로 등록한 이름을 `distributed.clientName`에 지정하세요.
 
+`distributed.lockTtlMs`는 `1_000ms` 이상이어야 합니다. fluo는 최소 지원 경계인 `1_000ms`를 포함해 TTL이 만료되기 전에 Redis 락을 갱신합니다.
+
 ```typescript
 @Module({
   imports: [

--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -90,6 +90,8 @@ class AppModule {}
 
 Leave `distributed.clientName` unset to keep using the default Redis registration above. To use a non-default Redis connection for distributed locks, set `distributed.clientName` to the name registered through `RedisModule.forRootNamed(...)`.
 
+`distributed.lockTtlMs` must stay at or above `1_000ms`. fluo renews the Redis lock before that TTL expires, including the minimum supported `1_000ms` boundary.
+
 ```typescript
 @Module({
   imports: [

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -28,6 +28,7 @@ interface ScheduledRecord {
 
 class InMemoryLockRedisClient {
   private readonly locks = new Map<string, string>();
+  renewalCalls = 0;
 
   async set(key: string, value: string, _mode: 'PX', _ttl: number, _existence: 'NX'): Promise<'OK' | null> {
     if (this.locks.has(key)) {
@@ -44,6 +45,7 @@ class InMemoryLockRedisClient {
     }
 
     if (script.includes('PEXPIRE')) {
+      this.renewalCalls += 1;
       return 1;
     }
 
@@ -1401,6 +1403,70 @@ describe('@fluojs/cron', () => {
       'error:Distributed cron lock ownership lost for lock-due-renewal-task.',
       'after',
     ]);
+
+    await app.close();
+  });
+
+  it('renews distributed locks before the minimum supported ttl expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-20T00:00:00.000Z'));
+
+    const scheduled = createManualScheduler();
+    const redis = new InMemoryLockRedisClient();
+    const started = createDeferred<void>();
+    const release = createDeferred<void>();
+    const events: string[] = [];
+
+    class DistributedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        afterRun: () => {
+          events.push('after');
+        },
+        distributed: true,
+        lockTtlMs: 1_000,
+        name: 'lock-min-ttl-task',
+        onError: (error) => {
+          events.push(`error:${error instanceof Error ? error.message : 'unknown'}`);
+        },
+        onSuccess: () => {
+          events.push('success');
+        },
+      })
+      async run() {
+        events.push('run');
+        started.resolve();
+        await release.promise;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        CronModule.forRoot({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-lock-min-ttl',
+            lockTtlMs: 1_000,
+          },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    const tickPromise = scheduled.records[0]!.tick();
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(500);
+    release.resolve();
+    await tickPromise;
+
+    expect(redis.renewalCalls).toBeGreaterThanOrEqual(1);
+    expect(events).toEqual(['run', 'success', 'after']);
 
     await app.close();
   });

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -812,7 +812,7 @@ export class CronLifecycleService
   }
 
   private createLockRenewalState(lockTtlMs: number): LockRenewalState {
-    const renewalIntervalMs = Math.max(1_000, Math.floor(lockTtlMs / 2));
+    const renewalIntervalMs = Math.max(250, Math.floor(lockTtlMs / 2));
 
     return {
       lockPostRunError: undefined,

--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -22,12 +22,8 @@ pnpm add @fluojs/microservices
 
 선택적 트랜스포트 의존성:
 
-- **gRPC**: `@grpc/grpc-js`, `@grpc/proto-loader`
-- **NATS**: `nats`
-- **Kafka**: `kafkajs`
-- **RabbitMQ**: `amqplib`
-- **Redis**: `ioredis`
-- **MQTT**: `mqtt`
+- `@fluojs/microservices`가 직접 로드하는 선택적 peer: `@grpc/grpc-js`, `@grpc/proto-loader`, `ioredis`, `mqtt`
+- 애플리케이션이 transport에 명시적으로 넘겨야 하는 caller-owned broker client: `nats`, `kafkajs`, `amqplib`
 
 ## 사용 시점
 
@@ -64,7 +60,7 @@ const microservice = await fluoFactory.createMicroservice(AppModule);
 await microservice.listen();
 ```
 
-`fluo new`는 NATS, Kafka, RabbitMQ를 숨겨진 내장 구현이 아니라 caller-owned bootstrap contract로 취급합니다. 생성된 스타터는 `src/app.ts`에서 `nats` + `JSONCodec()`, `kafkajs` producer/consumer collaborator, `amqplib` publisher/consumer collaborator를 직접 연결하고, 외부 broker 의존성은 `.env`와 생성된 README에 그대로 드러냅니다.
+`fluo new`는 NATS, Kafka, RabbitMQ를 숨겨진 내장 구현이 아니라 caller-owned bootstrap contract로 취급합니다. 생성된 스타터는 `src/app.ts`에서 `nats` + `JSONCodec()`, `kafkajs` producer/consumer collaborator, `amqplib` publisher/consumer collaborator를 직접 연결하고, 외부 broker 의존성은 `.env`와 생성된 README에 그대로 드러냅니다. 이 패키지 자체가 해당 런타임을 직접 로드하지 않으므로 `@fluojs/microservices`의 peer dependency로도 선언하지 않습니다.
 
 ## 주요 기능
 

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -21,12 +21,9 @@ pnpm add @fluojs/microservices
 ```
 
 Optional transport-specific dependencies:
-- **gRPC**: `@grpc/grpc-js`, `@grpc/proto-loader`
-- **NATS**: `nats`
-- **Kafka**: `kafkajs`
-- **RabbitMQ**: `amqplib`
-- **Redis**: `ioredis`
-- **MQTT**: `mqtt`
+
+- Package-managed optional peers loaded by `@fluojs/microservices`: `@grpc/grpc-js`, `@grpc/proto-loader`, `ioredis`, `mqtt`
+- Caller-owned broker clients passed explicitly to transports: `nats`, `kafkajs`, `amqplib`
 
 ## When to Use
 
@@ -65,7 +62,7 @@ const microservice = await fluoFactory.createMicroservice(AppModule);
 await microservice.listen();
 ```
 
-`fluo new` treats NATS, Kafka, and RabbitMQ as explicit caller-owned bootstrap contracts rather than hidden built-ins. The generated starters wire `nats` + `JSONCodec()`, `kafkajs` producer/consumer collaborators, and `amqplib` publisher/consumer collaborators in `src/app.ts`, while still making the external broker dependency visible through `.env` and the generated README.
+`fluo new` treats NATS, Kafka, and RabbitMQ as explicit caller-owned bootstrap contracts rather than hidden built-ins. The generated starters wire `nats` + `JSONCodec()`, `kafkajs` producer/consumer collaborators, and `amqplib` publisher/consumer collaborators in `src/app.ts`, while still making the external broker dependency visible through `.env` and the generated README. Those packages are not loaded from `@fluojs/microservices` itself and therefore are not declared as package peers here.
 
 ## Core Capabilities
 

--- a/packages/microservices/src/public-surface.test.ts
+++ b/packages/microservices/src/public-surface.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import * as microservices from './index.js';
@@ -20,5 +23,26 @@ describe('@fluojs/microservices root barrel public surface', () => {
     expect(microservices).not.toHaveProperty('getHandlerMetadataEntries');
     expect(microservices).not.toHaveProperty('microserviceMetadataSymbol');
     expect(Object.keys(microservices).sort()).toMatchSnapshot();
+  });
+
+  it('keeps broker dependency documentation aligned with the published manifest', () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf8'),
+    ) as {
+      peerDependencies?: Record<string, string>;
+    };
+    const readme = readFileSync(resolve(import.meta.dirname, '../README.md'), 'utf8');
+
+    expect(packageJson.peerDependencies).toMatchObject({
+      '@grpc/grpc-js': '^1.0.0',
+      '@grpc/proto-loader': '^0.8.0',
+      ioredis: '^5.0.0',
+      mqtt: '^5.0.0',
+    });
+    expect(packageJson.peerDependencies).not.toHaveProperty('nats');
+    expect(packageJson.peerDependencies).not.toHaveProperty('kafkajs');
+    expect(packageJson.peerDependencies).not.toHaveProperty('amqplib');
+    expect(readme).toContain('Package-managed optional peers loaded by `@fluojs/microservices`: `@grpc/grpc-js`, `@grpc/proto-loader`, `ioredis`, `mqtt`');
+    expect(readme).toContain('Caller-owned broker clients passed explicitly to transports: `nats`, `kafkajs`, `amqplib`');
   });
 });

--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -110,7 +110,7 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 ### 타입
 - `QueueModuleOptions`: 전역 큐 설정(clientName, 기본 시도 횟수, 동시성, 전송률 제한 등)을 위한 타입입니다.
-- `QueueWorkerOptions`: 개별 작업 설정(시도 횟수, 백오프, 동시성, 우선순위 등)을 위한 타입입니다.
+- `QueueWorkerOptions`: 개별 작업 설정(시도 횟수, 백오프, 동시성, jobName, 전송률 제한 등)을 위한 타입입니다.
 - `QueueBackoffOptions`: 재시도 백오프 설정(`type`, `delayMs`)을 위한 타입입니다.
 
 ## 관련 패키지

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -110,7 +110,7 @@ Jobs that fail all retry attempts are automatically moved to a dead-letter list 
 
 ### Types
 - `QueueModuleOptions`: Global queue settings (clientName, default attempts, concurrency, rate limiting).
-- `QueueWorkerOptions`: Per-job settings (attempts, backoff, concurrency, priority).
+- `QueueWorkerOptions`: Per-job settings (attempts, backoff, concurrency, jobName, rate limiting).
 - `QueueBackoffOptions`: Retry backoff settings (`type`, `delayMs`).
 
 ## Related Packages

--- a/packages/queue/src/public-surface.test.ts
+++ b/packages/queue/src/public-surface.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import * as queue from './index.js';
@@ -13,5 +16,12 @@ describe('@fluojs/queue root barrel public surface', () => {
     expect(queue).toHaveProperty('createQueuePlatformStatusSnapshot');
     expect(queue).not.toHaveProperty('QUEUE_OPTIONS');
     expect(Object.keys(queue).sort()).toMatchSnapshot();
+  });
+
+  it('keeps the README worker options aligned with the supported public contract', () => {
+    const readme = readFileSync(resolve(import.meta.dirname, '../README.md'), 'utf8');
+
+    expect(readme).toContain('QueueWorkerOptions`: Per-job settings (attempts, backoff, concurrency, jobName, rate limiting).');
+    expect(readme).not.toContain('QueueWorkerOptions`: Per-job settings (attempts, backoff, concurrency, priority).');
   });
 });


### PR DESCRIPTION
## Summary
- renew distributed cron locks before the minimum supported `lockTtlMs` boundary expires and cover the regression in `packages/cron`
- align `@fluojs/queue` README worker options with the actual public contract and pin the docs contract with a regression test
- align `@fluojs/microservices` install/docs language with the published manifest so caller-owned broker clients stay distinct from package-managed optional peers

Closes #1075

## Changes
- updated cron lock renewal scheduling and added a minimum-TTL regression test
- documented the supported cron distributed lock TTL boundary in English/Korean READMEs
- removed the unsupported queue `priority` claim from English/Korean READMEs and added a README contract test
- clarified microservices broker dependency expectations in English/Korean READMEs and added a manifest/README alignment test

## Testing
- `pnpm exec vitest run packages/cron/src/module.test.ts packages/cron/src/public-surface.test.ts packages/queue/src/public-surface.test.ts packages/microservices/src/public-surface.test.ts packages/microservices/src/public-subpaths.test.ts packages/microservices/src/public-api.test.ts`
- `pnpm build`
- `pnpm typecheck`

## Public export documentation
- N/A — this PR does not add or change public source exports under `packages/*/src`; it tightens runtime behavior and README/package-manifest contract text.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- N/A — no governance docs or platform contract matrix documents changed in this PR.

## Contract impact
- `@fluojs/cron` now explicitly documents that distributed locks support `lockTtlMs >= 1000` and renew before expiry at that lower bound.
- `@fluojs/queue` documentation no longer promises an unsupported `priority` worker option.
- `@fluojs/microservices` documentation now matches the manifest: `@grpc/grpc-js`, `@grpc/proto-loader`, `ioredis`, and `mqtt` remain optional peers, while `nats`, `kafkajs`, and `amqplib` stay caller-owned collaborators.