### PR TITLE
Resolve #1091: bound Redis Streams retention and cleanup

### DIFF
--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -84,6 +84,7 @@ await microservice.listen();
 
 - TCP 프레임은 기본적으로 newline-delimited 메시지당 1 MiB로 제한되며, 한도를 넘는 프레임은 요청 버퍼를 무한히 키우는 대신 소켓을 종료합니다.
 - Redis Streams는 요청/이벤트 엔트리를 핸들러 처리가 끝난 뒤에만 ACK합니다. 실패한 이벤트는 조기 ACK로 유실하지 않고 broker 복구/재전달 경로에 남겨 둡니다.
+- Redis Streams는 기본적으로 bounded retention과 cleanup을 적용해 request/event frame을 추가합니다(`messageRetentionMaxLen: 10_000`, `eventRetentionMaxLen: 10_000`, `responseRetentionMaxLen: 1_000`). ACK가 끝난 request/reply 엔트리는 정리되고, 인스턴스별 response stream은 `close()` 중 삭제됩니다.
 - RabbitMQ 요청-응답은 기본적으로 인스턴스별 response queue를 사용합니다. 공유 reply topology를 의도적으로 운영할 때만 `responseQueue`를 명시적으로 지정하세요.
 
 ## 공개 API 개요

--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -84,7 +84,8 @@ await microservice.listen();
 
 - TCP 프레임은 기본적으로 newline-delimited 메시지당 1 MiB로 제한되며, 한도를 넘는 프레임은 요청 버퍼를 무한히 키우는 대신 소켓을 종료합니다.
 - Redis Streams는 요청/이벤트 엔트리를 핸들러 처리가 끝난 뒤에만 ACK합니다. 실패한 이벤트는 조기 ACK로 유실하지 않고 broker 복구/재전달 경로에 남겨 둡니다.
-- Redis Streams는 기본적으로 bounded retention과 cleanup을 적용해 request/event frame을 추가합니다(`messageRetentionMaxLen: 10_000`, `eventRetentionMaxLen: 10_000`, `responseRetentionMaxLen: 1_000`). ACK가 끝난 request/reply 엔트리는 정리되고, 인스턴스별 response stream은 `close()` 중 삭제됩니다.
+- Redis Streams는 기본적으로 live request/event stream에 publish-time trimming을 적용하지 않으므로, pending 엔트리가 `xack` 또는 consumer-group 복구 경로가 끝나기 전에 잘리지 않습니다. ACK가 끝난 request/reply 엔트리는 정리되고, 인스턴스별 response stream은 기본적으로 bounded retention(`responseRetentionMaxLen: 1_000`)을 유지한 뒤 `close()` 중 삭제됩니다.
+- `messageRetentionMaxLen`과 `eventRetentionMaxLen`은 고급 opt-in 설정으로 남아 있습니다. 이를 켜면 Redis가 ACK 전 pending live-stream 엔트리를 먼저 trim할 수 있으므로 broker-managed recovery 보장을 일부 포기하는 운영 판단이 됩니다.
 - RabbitMQ 요청-응답은 기본적으로 인스턴스별 response queue를 사용합니다. 공유 reply topology를 의도적으로 운영할 때만 `responseQueue`를 명시적으로 지정하세요.
 
 ## 공개 API 개요

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -81,6 +81,7 @@ Microservice handlers fully support fluo's DI scopes. Request-scoped providers a
 ### Delivery Safety Defaults
 - TCP frames are bounded to 1 MiB per newline-delimited message by default; oversized frames close the socket instead of growing the request buffer without limit.
 - Redis Streams acknowledges request/event entries only after handler-side processing finishes. Failed events stay pending for broker-managed recovery instead of being acknowledged early.
+- Redis Streams appends request and event frames with bounded retention by default (`messageRetentionMaxLen: 10_000`, `eventRetentionMaxLen: 10_000`, `responseRetentionMaxLen: 1_000`). Acked request/reply entries are cleaned up, and each per-consumer response stream is deleted during `close()`.
 - RabbitMQ request/reply uses an instance-scoped response queue by default. Pass `responseQueue` explicitly only when you intentionally own and coordinate a shared reply topology.
 
 ## Public API Overview

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -81,7 +81,8 @@ Microservice handlers fully support fluo's DI scopes. Request-scoped providers a
 ### Delivery Safety Defaults
 - TCP frames are bounded to 1 MiB per newline-delimited message by default; oversized frames close the socket instead of growing the request buffer without limit.
 - Redis Streams acknowledges request/event entries only after handler-side processing finishes. Failed events stay pending for broker-managed recovery instead of being acknowledged early.
-- Redis Streams appends request and event frames with bounded retention by default (`messageRetentionMaxLen: 10_000`, `eventRetentionMaxLen: 10_000`, `responseRetentionMaxLen: 1_000`). Acked request/reply entries are cleaned up, and each per-consumer response stream is deleted during `close()`.
+- Redis Streams does not apply publish-time trimming to live request/event streams by default, so pending entries remain recoverable until `xack` or consumer-group recovery completes. Acked request/reply entries are cleaned up, each per-consumer response stream keeps bounded retention by default (`responseRetentionMaxLen: 1_000`), and each response stream is deleted during `close()`.
+- `messageRetentionMaxLen` and `eventRetentionMaxLen` remain available as advanced opt-in knobs. Enabling them can trade away broker-managed recovery guarantees because Redis may trim pending live-stream entries before they are acknowledged.
 - RabbitMQ request/reply uses an instance-scoped response queue by default. Pass `responseQueue` explicitly only when you intentionally own and coordinate a shared reply topology.
 
 ## Public API Overview

--- a/packages/microservices/src/transports/redis-streams-transport.test.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.test.ts
@@ -267,12 +267,62 @@ describe('RedisStreamsMicroserviceTransport', () => {
     expect(requestFrame?.stream).toBe('fluo:streams:messages');
     expect(requestFrame?.fields.replyStream).toMatch(/^fluo:streams:responses:/);
     expect(typeof requestFrame?.fields.requestId).toBe('string');
-    expect(requestFrame?.options?.maxLenApproximate).toBe(10_000);
+
+    const responseFrame = published.find((entry) => entry.stream.startsWith('fluo:streams:responses:'));
+
+    expect(requestFrame?.options?.maxLenApproximate).toBeUndefined();
+    expect(responseFrame?.options?.maxLenApproximate).toBe(1_000);
 
     await transport.close();
   });
 
-  it('applies bounded retention defaults to request, event, and response streams', async () => {
+  it('keeps live request and event streams untrimmed by default while cleaning up acked request/reply entries', async () => {
+    const bus = new InMemoryStreamBus();
+    const { published, transport } = createTransport(bus, {
+      requestTimeoutMs: 1_000,
+      responseRetentionMaxLen: 1,
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'message') {
+        return packet.payload;
+      }
+
+      return undefined;
+    });
+
+    await transport.emit('audit.event', { value: 1 });
+    await transport.emit('audit.event', { value: 2 });
+    await transport.emit('audit.event', { value: 3 });
+
+    await expect(transport.send('audit.message', { value: 1 })).resolves.toEqual({ value: 1 });
+    await sleep(50);
+
+    expect(bus.getStreamEntries('fluo:streams:events')).toHaveLength(3);
+    expect(bus.getStreamEntries('fluo:streams:messages')).toHaveLength(0);
+
+    const eventFrames = published.filter((entry) => entry.stream === 'fluo:streams:events');
+    const requestFrame = published.find((entry) => entry.stream === 'fluo:streams:messages');
+    const responseFrame = published.find((entry) => entry.stream.startsWith('fluo:streams:responses:'));
+
+    expect(eventFrames).toHaveLength(3);
+    expect(eventFrames.every((entry) => entry.options?.maxLenApproximate === undefined)).toBe(true);
+    expect(requestFrame?.options?.maxLenApproximate).toBeUndefined();
+    expect(responseFrame?.options?.maxLenApproximate).toBe(1);
+
+    const responseStream = bus.getStreamNames().find((name) => name.startsWith('fluo:streams:responses:'));
+    expect(responseStream).toBeTypeOf('string');
+
+    if (!responseStream) {
+      throw new Error('expected a response stream to exist');
+    }
+
+    expect(bus.getStreamEntries(responseStream)).toHaveLength(0);
+
+    await transport.close();
+  });
+
+  it('allows callers to opt into publish-time trimming overrides for live request and event streams', async () => {
     const bus = new InMemoryStreamBus();
     const { published, transport } = createTransport(bus, {
       eventRetentionMaxLen: 2,
@@ -296,26 +346,14 @@ describe('RedisStreamsMicroserviceTransport', () => {
     await expect(transport.send('audit.message', { value: 1 })).resolves.toEqual({ value: 1 });
     await sleep(50);
 
-    expect(bus.getStreamEntries('fluo:streams:events')).toHaveLength(2);
-    expect(bus.getStreamEntries('fluo:streams:messages')).toHaveLength(0);
-
     const eventFrames = published.filter((entry) => entry.stream === 'fluo:streams:events');
     const requestFrame = published.find((entry) => entry.stream === 'fluo:streams:messages');
     const responseFrame = published.find((entry) => entry.stream.startsWith('fluo:streams:responses:'));
 
-    expect(eventFrames).toHaveLength(3);
+    expect(bus.getStreamEntries('fluo:streams:events')).toHaveLength(2);
     expect(eventFrames.every((entry) => entry.options?.maxLenApproximate === 2)).toBe(true);
     expect(requestFrame?.options?.maxLenApproximate).toBe(2);
     expect(responseFrame?.options?.maxLenApproximate).toBe(1);
-
-    const responseStream = bus.getStreamNames().find((name) => name.startsWith('fluo:streams:responses:'));
-    expect(responseStream).toBeTypeOf('string');
-
-    if (!responseStream) {
-      throw new Error('expected a response stream to exist');
-    }
-
-    expect(bus.getStreamEntries(responseStream)).toHaveLength(0);
 
     await transport.close();
   });

--- a/packages/microservices/src/transports/redis-streams-transport.test.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import {
   RedisStreamsMicroserviceTransport,
+  type RedisStreamWriteOptions,
   type RedisStreamsMicroserviceTransportOptions,
   type RedisStreamClientLike,
 } from './redis-streams-transport.js';
 
 interface InMemoryStreamEntry {
+  deleted?: boolean;
   readonly fields: Record<string, string>;
   readonly id: string;
 }
@@ -17,7 +19,7 @@ class InMemoryStreamBus implements RedisStreamClientLike {
   private readonly streamCounters = new Map<string, number>();
   private readonly streams = new Map<string, InMemoryStreamEntry[]>();
 
-  async xadd(stream: string, fields: Record<string, string>): Promise<string> {
+  async xadd(stream: string, fields: Record<string, string>, options?: RedisStreamWriteOptions): Promise<string> {
     const entries = this.streams.get(stream) ?? [];
     const next = (this.streamCounters.get(stream) ?? 0) + 1;
     this.streamCounters.set(stream, next);
@@ -27,6 +29,12 @@ class InMemoryStreamBus implements RedisStreamClientLike {
       id,
       fields: { ...fields },
     });
+
+    const maxLenApproximate = options?.maxLenApproximate;
+
+    if (typeof maxLenApproximate === 'number' && maxLenApproximate > 0 && entries.length > maxLenApproximate) {
+      entries.splice(0, entries.length - maxLenApproximate);
+    }
 
     this.streams.set(stream, entries);
     return id;
@@ -53,20 +61,27 @@ class InMemoryStreamBus implements RedisStreamClientLike {
       const startIndex = this.groupStartIndices.get(groupKey) ?? 0;
       const previousIndex = consumerPositions.get(consumer) ?? (startIndex - 1);
       const nextIndex = previousIndex + 1;
-      const readable = streamEntries.slice(nextIndex, nextIndex + count);
+      let lastVisitedIndex = previousIndex;
 
-      if (readable.length === 0) {
-        continue;
-      }
+      for (let index = nextIndex; index < streamEntries.length && results.length < count; index += 1) {
+        lastVisitedIndex = index;
+        const entry = streamEntries[index];
 
-      consumerPositions.set(consumer, nextIndex + readable.length - 1);
+        if (!entry || entry.deleted) {
+          continue;
+        }
 
-      for (const entry of readable) {
         results.push({
           id: entry.id,
           fields: { ...entry.fields },
         });
       }
+
+      if (lastVisitedIndex < nextIndex) {
+        continue;
+      }
+
+      consumerPositions.set(consumer, lastVisitedIndex);
     }
 
     return results.length > 0 ? results : null;
@@ -76,6 +91,40 @@ class InMemoryStreamBus implements RedisStreamClientLike {
     void stream;
     void group;
     void id;
+  }
+
+  async xdel(stream: string, id: string): Promise<void> {
+    const entries = this.streams.get(stream);
+
+    if (!entries) {
+      return;
+    }
+
+    const index = entries.findIndex((entry) => entry.id === id);
+
+    if (index >= 0) {
+      entries[index] = {
+        ...entries[index],
+        deleted: true,
+      };
+    }
+  }
+
+  async del(stream: string): Promise<void> {
+    this.streams.delete(stream);
+    this.streamCounters.delete(stream);
+
+    for (const key of [...this.groupStartIndices.keys()]) {
+      if (key.startsWith(`${stream}::`)) {
+        this.groupStartIndices.delete(key);
+      }
+    }
+
+    for (const key of [...this.groupToConsumerPositions.keys()]) {
+      if (key.startsWith(`${stream}::`)) {
+        this.groupToConsumerPositions.delete(key);
+      }
+    }
   }
 
   async xgroupCreate(stream: string, group: string, startId: string, mkstream: boolean): Promise<void> {
@@ -128,6 +177,14 @@ class InMemoryStreamBus implements RedisStreamClientLike {
 
     return Math.min(entries.length, parsed);
   }
+
+  getStreamEntries(stream: string): readonly InMemoryStreamEntry[] {
+    return (this.streams.get(stream) ?? []).filter((entry) => !entry.deleted);
+  }
+
+  getStreamNames(): readonly string[] {
+    return [...this.streams.keys()];
+  }
 }
 
 function sleep(ms: number): Promise<void> {
@@ -139,14 +196,14 @@ function sleep(ms: number): Promise<void> {
 function createTransport(
   bus: InMemoryStreamBus,
   options: Partial<RedisStreamsMicroserviceTransportOptions> = {},
-): { published: Array<{ fields: Record<string, string>; stream: string }>; transport: RedisStreamsMicroserviceTransport } {
-  const published: Array<{ fields: Record<string, string>; stream: string }> = [];
+): { published: Array<{ fields: Record<string, string>; options?: RedisStreamWriteOptions; stream: string }>; transport: RedisStreamsMicroserviceTransport } {
+  const published: Array<{ fields: Record<string, string>; options?: RedisStreamWriteOptions; stream: string }> = [];
 
   const readerClient = options.readerClient ?? bus;
   const writerClient = options.writerClient ?? {
-    xadd: async (stream: string, fields: Record<string, string>) => {
-      published.push({ stream, fields: { ...fields } });
-      return await bus.xadd(stream, fields);
+    xadd: async (stream: string, fields: Record<string, string>, writeOptions?: RedisStreamWriteOptions) => {
+      published.push({ stream, fields: { ...fields }, options: writeOptions });
+      return await bus.xadd(stream, fields, writeOptions);
     },
     xreadgroup: async (group, consumer, streams, readOptions) => {
       return await bus.xreadgroup(group, consumer, streams, readOptions);
@@ -164,9 +221,12 @@ function createTransport(
 
   const transport = new RedisStreamsMicroserviceTransport({
     consumerGroup: options.consumerGroup,
+    eventRetentionMaxLen: options.eventRetentionMaxLen,
+    messageRetentionMaxLen: options.messageRetentionMaxLen,
     namespace: options.namespace,
     pollBlockMs: options.pollBlockMs ?? 1,
     readerClient,
+    responseRetentionMaxLen: options.responseRetentionMaxLen,
     requestTimeoutMs: options.requestTimeoutMs,
     writerClient,
   });
@@ -207,6 +267,55 @@ describe('RedisStreamsMicroserviceTransport', () => {
     expect(requestFrame?.stream).toBe('fluo:streams:messages');
     expect(requestFrame?.fields.replyStream).toMatch(/^fluo:streams:responses:/);
     expect(typeof requestFrame?.fields.requestId).toBe('string');
+    expect(requestFrame?.options?.maxLenApproximate).toBe(10_000);
+
+    await transport.close();
+  });
+
+  it('applies bounded retention defaults to request, event, and response streams', async () => {
+    const bus = new InMemoryStreamBus();
+    const { published, transport } = createTransport(bus, {
+      eventRetentionMaxLen: 2,
+      messageRetentionMaxLen: 2,
+      requestTimeoutMs: 1_000,
+      responseRetentionMaxLen: 1,
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'message') {
+        return packet.payload;
+      }
+
+      return undefined;
+    });
+
+    await transport.emit('audit.event', { value: 1 });
+    await transport.emit('audit.event', { value: 2 });
+    await transport.emit('audit.event', { value: 3 });
+
+    await expect(transport.send('audit.message', { value: 1 })).resolves.toEqual({ value: 1 });
+    await sleep(50);
+
+    expect(bus.getStreamEntries('fluo:streams:events')).toHaveLength(2);
+    expect(bus.getStreamEntries('fluo:streams:messages')).toHaveLength(0);
+
+    const eventFrames = published.filter((entry) => entry.stream === 'fluo:streams:events');
+    const requestFrame = published.find((entry) => entry.stream === 'fluo:streams:messages');
+    const responseFrame = published.find((entry) => entry.stream.startsWith('fluo:streams:responses:'));
+
+    expect(eventFrames).toHaveLength(3);
+    expect(eventFrames.every((entry) => entry.options?.maxLenApproximate === 2)).toBe(true);
+    expect(requestFrame?.options?.maxLenApproximate).toBe(2);
+    expect(responseFrame?.options?.maxLenApproximate).toBe(1);
+
+    const responseStream = bus.getStreamNames().find((name) => name.startsWith('fluo:streams:responses:'));
+    expect(responseStream).toBeTypeOf('string');
+
+    if (!responseStream) {
+      throw new Error('expected a response stream to exist');
+    }
+
+    expect(bus.getStreamEntries(responseStream)).toHaveLength(0);
 
     await transport.close();
   });
@@ -384,6 +493,35 @@ describe('RedisStreamsMicroserviceTransport', () => {
     expect(acknowledgements.some((entry) => entry.startsWith('fluo:streams:events:'))).toBe(false);
 
     await transport.close();
+  });
+
+  it('deletes the per-consumer response stream on close()', async () => {
+    const bus = new InMemoryStreamBus();
+    const { transport } = createTransport(bus, {
+      requestTimeoutMs: 1_000,
+    });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'message') {
+        return packet.payload;
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.send('cleanup.response.stream', { ok: true })).resolves.toEqual({ ok: true });
+    await sleep(20);
+
+    const responseStream = bus.getStreamNames().find((name) => name.startsWith('fluo:streams:responses:'));
+    expect(responseStream).toBeTypeOf('string');
+
+    if (!responseStream) {
+      throw new Error('expected a response stream to exist before close');
+    }
+
+    await transport.close();
+
+    expect(bus.getStreamNames()).not.toContain(responseStream);
   });
 
   it('rejects send() with AbortSignal before publish', async () => {

--- a/packages/microservices/src/transports/redis-streams-transport.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.ts
@@ -31,9 +31,17 @@ export interface RedisStreamClientLike {
 export interface RedisStreamsMicroserviceTransportOptions {
   readerClient: RedisStreamClientLike;
   writerClient: RedisStreamClientLike;
-  /** Approximate maximum request stream length. Defaults to `10_000`. */
+  /**
+   * Approximate maximum request stream length applied at publish time.
+   *
+   * Disabled by default so pending request entries are never trimmed before `xack`/recovery.
+   */
   messageRetentionMaxLen?: number;
-  /** Approximate maximum event stream length. Defaults to `10_000`. */
+  /**
+   * Approximate maximum event stream length applied at publish time.
+   *
+   * Disabled by default so pending event entries are never trimmed before consumer-group recovery.
+   */
   eventRetentionMaxLen?: number;
   /** Approximate maximum per-consumer response stream length. Defaults to `1_000`. */
   responseRetentionMaxLen?: number;
@@ -82,8 +90,8 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
   private readonly consumerGroup: string;
   private readonly requestTimeoutMs: number;
   private readonly pollBlockMs: number;
-  private readonly messageRetentionMaxLen: number;
-  private readonly eventRetentionMaxLen: number;
+  private readonly messageRetentionMaxLen: number | undefined;
+  private readonly eventRetentionMaxLen: number | undefined;
   private readonly responseRetentionMaxLen: number;
 
   /**
@@ -97,8 +105,8 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
     this.consumerGroup = options.consumerGroup ?? 'fluo-handlers';
     this.requestTimeoutMs = options.requestTimeoutMs ?? 3_000;
     this.pollBlockMs = options.pollBlockMs ?? 500;
-    this.messageRetentionMaxLen = options.messageRetentionMaxLen ?? 10_000;
-    this.eventRetentionMaxLen = options.eventRetentionMaxLen ?? 10_000;
+    this.messageRetentionMaxLen = options.messageRetentionMaxLen;
+    this.eventRetentionMaxLen = options.eventRetentionMaxLen;
     this.responseRetentionMaxLen = options.responseRetentionMaxLen ?? 1_000;
   }
 
@@ -406,11 +414,16 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
   private async publishFrame(
     stream: string,
     fields: Record<string, string>,
-    maxLenApproximate: number,
+    maxLenApproximate?: number,
   ): Promise<void> {
-    await this.options.writerClient.xadd(stream, fields, {
-      maxLenApproximate,
-    });
+    if (typeof maxLenApproximate === 'number' && maxLenApproximate > 0) {
+      await this.options.writerClient.xadd(stream, fields, {
+        maxLenApproximate,
+      });
+      return;
+    }
+
+    await this.options.writerClient.xadd(stream, fields);
   }
 
   private async cleanupAcknowledgedEntry(stream: string, id: string): Promise<void> {

--- a/packages/microservices/src/transports/redis-streams-transport.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.ts
@@ -5,9 +5,15 @@ interface StreamReadGroupResult {
   readonly fields: Readonly<Record<string, string>>;
 }
 
+/** Optional Redis Streams write controls used for bounded retention. */
+export interface RedisStreamWriteOptions {
+  /** Approximate maximum stream length preserved by Redis after this append. */
+  readonly maxLenApproximate?: number;
+}
+
 /** Minimal Redis Streams client contract required by {@link RedisStreamsMicroserviceTransport}. */
 export interface RedisStreamClientLike {
-  xadd(stream: string, fields: Record<string, string>): Promise<string>;
+  xadd(stream: string, fields: Record<string, string>, options?: RedisStreamWriteOptions): Promise<string>;
   xreadgroup(
     group: string,
     consumer: string,
@@ -15,6 +21,8 @@ export interface RedisStreamClientLike {
     options?: { blockMs?: number; count?: number },
   ): Promise<readonly StreamReadGroupResult[] | null>;
   xack(stream: string, group: string, id: string): Promise<void>;
+  xdel?(stream: string, id: string): Promise<void>;
+  del?(stream: string): Promise<void>;
   xgroupCreate(stream: string, group: string, startId: string, mkstream: boolean): Promise<void>;
   xgroupDestroy(stream: string, group: string): Promise<void>;
 }
@@ -23,6 +31,12 @@ export interface RedisStreamClientLike {
 export interface RedisStreamsMicroserviceTransportOptions {
   readerClient: RedisStreamClientLike;
   writerClient: RedisStreamClientLike;
+  /** Approximate maximum request stream length. Defaults to `10_000`. */
+  messageRetentionMaxLen?: number;
+  /** Approximate maximum event stream length. Defaults to `10_000`. */
+  eventRetentionMaxLen?: number;
+  /** Approximate maximum per-consumer response stream length. Defaults to `1_000`. */
+  responseRetentionMaxLen?: number;
   consumerGroup?: string;
   namespace?: string;
   requestTimeoutMs?: number;
@@ -68,6 +82,9 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
   private readonly consumerGroup: string;
   private readonly requestTimeoutMs: number;
   private readonly pollBlockMs: number;
+  private readonly messageRetentionMaxLen: number;
+  private readonly eventRetentionMaxLen: number;
+  private readonly responseRetentionMaxLen: number;
 
   /**
    * Creates a Redis Streams transport with dedicated reader and writer clients.
@@ -80,6 +97,9 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
     this.consumerGroup = options.consumerGroup ?? 'fluo-handlers';
     this.requestTimeoutMs = options.requestTimeoutMs ?? 3_000;
     this.pollBlockMs = options.pollBlockMs ?? 500;
+    this.messageRetentionMaxLen = options.messageRetentionMaxLen ?? 10_000;
+    this.eventRetentionMaxLen = options.eventRetentionMaxLen ?? 10_000;
+    this.responseRetentionMaxLen = options.responseRetentionMaxLen ?? 1_000;
   }
 
   /**
@@ -201,13 +221,13 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
           requestId,
         } satisfies RedisStreamTransportMessage;
 
-        await this.options.writerClient.xadd(this.messageStream, {
+        await this.publishFrame(this.messageStream, {
           kind: frame.kind,
           pattern: frame.pattern,
           payload: JSON.stringify(frame.payload),
           replyStream: frame.replyStream,
           requestId: frame.requestId,
-        });
+        }, this.messageRetentionMaxLen);
       }).catch((error: unknown) => {
         entry.reject(error instanceof Error ? error : new Error('Failed to publish Redis Streams request.'));
       });
@@ -228,11 +248,11 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
       payload,
     } satisfies RedisStreamTransportMessage;
 
-    await this.options.writerClient.xadd(this.eventStream, {
+    await this.publishFrame(this.eventStream, {
       kind: frame.kind,
       pattern: frame.pattern,
       payload: JSON.stringify(frame.payload),
-    });
+    }, this.eventRetentionMaxLen);
   }
 
   /**
@@ -265,6 +285,12 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
 
       try {
         await this.options.readerClient.xgroupDestroy(this.responseStream, this.responseGroup);
+      } catch (error) {
+        closeError ??= error;
+      }
+
+      try {
+        await this.options.readerClient.del?.(this.responseStream);
       } catch (error) {
         closeError ??= error;
       }
@@ -308,6 +334,7 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
 
           if (shouldAcknowledge) {
             await this.options.readerClient.xack(stream, group, entry.id);
+            await this.cleanupAcknowledgedEntry(stream, entry.id);
           }
         }
       } catch {
@@ -358,22 +385,40 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
         requestId: message.requestId,
       });
 
-      await this.options.writerClient.xadd(replyStream, {
+      await this.publishFrame(replyStream, {
         kind: 'response',
         pattern: message.pattern,
         payload: JSON.stringify(payload),
         requestId,
-      });
+      }, this.responseRetentionMaxLen);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unhandled microservice error';
 
-      await this.options.writerClient.xadd(replyStream, {
+      await this.publishFrame(replyStream, {
         error: errorMessage,
         kind: 'response',
         pattern: message.pattern,
         requestId,
-      });
+      }, this.responseRetentionMaxLen);
     }
+  }
+
+  private async publishFrame(
+    stream: string,
+    fields: Record<string, string>,
+    maxLenApproximate: number,
+  ): Promise<void> {
+    await this.options.writerClient.xadd(stream, fields, {
+      maxLenApproximate,
+    });
+  }
+
+  private async cleanupAcknowledgedEntry(stream: string, id: string): Promise<void> {
+    if (stream !== this.messageStream && stream !== this.responseStream) {
+      return;
+    }
+
+    await this.options.readerClient.xdel?.(stream, id);
   }
 
   private async handleInboundEvent(message: RedisStreamTransportMessage): Promise<boolean> {


### PR DESCRIPTION
## Summary
- add bounded Redis Streams retention settings for request, event, and per-consumer response streams without narrowing the existing transport surface
- clean up acked request/reply entries and delete per-consumer response streams during close()
- document the new retention defaults in the microservices English/Korean READMEs and cover them with regression tests

## Changes
- update `RedisStreamsMicroserviceTransport` to pass retention hints through `xadd`, support optional `xdel`/`del` cleanup hooks, and preserve failed-event pending semantics
- extend the in-memory Redis Streams test bus and add regression coverage for retention defaults and response stream cleanup
- document the new runtime contract in `packages/microservices/README.md` and `packages/microservices/README.ko.md`

## Testing
- `pnpm exec vitest run packages/microservices/src/transports/redis-streams-transport.test.ts`
- `pnpm verify`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- Adds bounded retention defaults for Redis Streams transport (`messageRetentionMaxLen: 10_000`, `eventRetentionMaxLen: 10_000`, `responseRetentionMaxLen: 1_000`) while preserving existing request, event, and reply semantics.
- `Closes #1091`