### PR TITLE
Resolve #1092: add generated-project smoke verification for fluo new

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ When modifying `@fluojs/cli` or core runtime packages, use the sandbox scripts t
 
 Inside `packages/cli/`:
 - `pnpm sandbox:create`: Generates a fresh starter app in a temporary directory.
+- `pnpm sandbox:matrix`: Runs the representative generated-project smoke suite for the default app, TCP microservice, and mixed starter baselines.
 - `pnpm sandbox:verify`: Runs `build`, `typecheck`, and `test` inside the sandbox app.
 - `pnpm sandbox:test`: Runs integration tests against the sandbox app.
 - `pnpm sandbox:clean`: Removes the sandbox directory.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "test": "pnpm exec vitest run -c vitest.config.ts",
     "test:watch": "pnpm exec vitest -c vitest.config.ts",
     "sandbox:create": "node ./scripts/local-test-env.mjs create",
+    "sandbox:matrix": "node ./scripts/local-test-env.mjs matrix",
     "sandbox:verify": "node ./scripts/local-test-env.mjs verify",
     "sandbox:test": "node ./scripts/local-test-env.mjs test",
     "sandbox:clean": "node ./scripts/local-test-env.mjs clean"

--- a/packages/cli/scripts/local-test-env.mjs
+++ b/packages/cli/scripts/local-test-env.mjs
@@ -323,13 +323,21 @@ function verifySandboxProject(projectName) {
   const projectDirectory = resolveProjectDirectory(projectName);
   verifySandboxExists(projectDirectory);
   const packageJson = JSON.parse(readFileSync(join(projectDirectory, 'package.json'), 'utf8'));
-  const isMicroserviceStarter = Boolean(packageJson.dependencies?.['@fluojs/microservices']);
+  const hasHttpStarter = Boolean(packageJson.dependencies?.['@fluojs/http']);
+  const hasMicroserviceStarter = Boolean(packageJson.dependencies?.['@fluojs/microservices']);
+  const starterContract = hasHttpStarter && hasMicroserviceStarter
+    ? 'mixed'
+    : hasMicroserviceStarter
+      ? 'microservice'
+      : 'application';
 
-  if (isMicroserviceStarter) {
+  if (starterContract === 'microservice' || starterContract === 'mixed') {
     if (!existsSync(join(projectDirectory, 'src', 'math', 'math.handler.test.ts'))) {
-      throw new Error('Expected the microservice starter scaffold to include src/math/math.handler.test.ts.');
+      throw new Error(`Expected the ${starterContract} starter scaffold to include src/math/math.handler.test.ts.`);
     }
-  } else if (!existsSync(join(projectDirectory, 'src', 'app.e2e.test.ts'))) {
+  }
+
+  if (starterContract === 'application' && !existsSync(join(projectDirectory, 'src', 'app.e2e.test.ts'))) {
     throw new Error('Expected the starter scaffold to include src/app.e2e.test.ts.');
   }
 
@@ -337,11 +345,20 @@ function verifySandboxProject(projectName) {
     throw new Error('Expected the starter scaffold to include vite.config.ts.');
   }
 
-  if (isMicroserviceStarter) {
+  if (starterContract === 'microservice' || starterContract === 'mixed') {
     const mainFile = readFileSync(join(projectDirectory, 'src', 'main.ts'), 'utf8');
-    if (!mainFile.includes('createMicroservice')) {
+
+    if (starterContract === 'microservice' && !mainFile.includes('createMicroservice')) {
       throw new Error('Expected the microservice starter main.ts to bootstrap FluoFactory.createMicroservice(...).');
     }
+
+    if (
+      starterContract === 'mixed'
+      && (!mainFile.includes('await app.connectMicroservice();') || !mainFile.includes('await app.startAllMicroservices();'))
+    ) {
+      throw new Error('Expected the mixed starter main.ts to attach and start the TCP microservice from the HTTP app bootstrap.');
+    }
+
   }
 
   for (const configPath of ['tsconfig.json', 'tsconfig.build.json', 'vite.config.ts', 'vitest.config.ts']) {

--- a/packages/cli/scripts/local-test-env.mjs
+++ b/packages/cli/scripts/local-test-env.mjs
@@ -9,6 +9,36 @@ const sandboxMetadataFileName = '.fluo-cli-sandbox.json';
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptDirectory, '..');
 const repoRoot = resolve(packageRoot, '..', '..');
+const representativeStarterSmokeScenarios = [
+  {
+    env: {},
+    label: 'default Node.js + Fastify application',
+    projectName: 'starter-app',
+  },
+  {
+    env: {
+      FLUO_CLI_SANDBOX_PLATFORM: 'none',
+      FLUO_CLI_SANDBOX_RUNTIME: 'node',
+      FLUO_CLI_SANDBOX_SHAPE: 'microservice',
+      FLUO_CLI_SANDBOX_TRANSPORT: 'tcp',
+    },
+    label: 'TCP microservice starter',
+    projectName: 'starter-microservice',
+  },
+  {
+    env: {
+      FLUO_CLI_SANDBOX_PLATFORM: 'fastify',
+      FLUO_CLI_SANDBOX_RUNTIME: 'node',
+      FLUO_CLI_SANDBOX_SHAPE: 'mixed',
+      FLUO_CLI_SANDBOX_TRANSPORT: 'tcp',
+    },
+    label: 'mixed Fastify + TCP starter',
+    projectName: 'starter-mixed',
+  },
+];
+
+let runCliPromise;
+
 function isPathInsideDirectory(parentDirectory, candidatePath) {
   const resolvedParentDirectory = resolve(parentDirectory);
   const resolvedCandidatePath = resolve(candidatePath);
@@ -190,17 +220,69 @@ function verifySandboxExists(projectDirectory) {
 }
 
 async function loadRunCli() {
-  log('Building @fluojs/cli dist for the local harness');
-  run('pnpm', ['build'], packageRoot);
+  if (!runCliPromise) {
+    runCliPromise = (async () => {
+      log('Building @fluojs/cli dist for the local harness');
+      run('pnpm', ['build'], packageRoot);
 
-  const cliModuleUrl = pathToFileURL(join(packageRoot, 'dist', 'cli.js')).href;
-  const cliModule = await import(cliModuleUrl);
+      const cliModuleUrl = pathToFileURL(join(packageRoot, 'dist', 'cli.js')).href;
+      const cliModule = await import(cliModuleUrl);
 
-  if (typeof cliModule.runCli !== 'function') {
-    throw new Error('Unable to load runCli from packages/cli/dist/cli.js.');
+      if (typeof cliModule.runCli !== 'function') {
+        throw new Error('Unable to load runCli from packages/cli/dist/cli.js.');
+      }
+
+      return cliModule.runCli;
+    })();
   }
 
-  return cliModule.runCli;
+  return runCliPromise;
+}
+
+async function withStarterEnv(envOverrides, action) {
+  const keys = [
+    'FLUO_CLI_SANDBOX_PLATFORM',
+    'FLUO_CLI_SANDBOX_RUNTIME',
+    'FLUO_CLI_SANDBOX_SHAPE',
+    'FLUO_CLI_SANDBOX_TRANSPORT',
+  ];
+  const previous = new Map(keys.map((key) => [key, process.env[key]]));
+
+  for (const key of keys) {
+    const next = envOverrides[key];
+
+    if (typeof next === 'string') {
+      process.env[key] = next;
+      continue;
+    }
+
+    delete process.env[key];
+  }
+
+  try {
+    return await action();
+  } finally {
+    for (const key of keys) {
+      const value = previous.get(key);
+
+      if (typeof value === 'string') {
+        process.env[key] = value;
+        continue;
+      }
+
+      delete process.env[key];
+    }
+  }
+}
+
+async function runRepresentativeStarterSmokeMatrix() {
+  for (const scenario of representativeStarterSmokeScenarios) {
+    await withStarterEnv(scenario.env, async () => {
+      log(`Running representative starter smoke: ${scenario.label}`);
+      await createSandboxProject(scenario.projectName);
+      verifySandboxProject(scenario.projectName);
+    });
+  }
 }
 
 async function createSandboxProject(projectName) {
@@ -301,6 +383,7 @@ function printUsage() {
   process.stdout.write(
     [
       'Usage: node ./scripts/local-test-env.mjs <create|verify|test|clean> [project-name]',
+      'Use `matrix` to run the representative generated-project smoke suite (default app, TCP microservice, mixed app).',
       'Defaults project-name to starter-app and uses the sandbox root itself as the generated app directory.',
       'Set FLUO_CLI_SANDBOX_ROOT to override the sandbox root outside the repo workspace.',
     ].join('\n') + '\n',
@@ -325,6 +408,10 @@ async function main() {
       logSandboxRoot();
       await createSandboxProject(projectName);
       verifySandboxProject(projectName);
+      break;
+    case 'matrix':
+      logSandboxRoot();
+      await runRepresentativeStarterSmokeMatrix();
       break;
     case 'clean':
       logSandboxRoot();

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -137,7 +137,7 @@ function writeSummary(checks) {
     '',
     ...checks.map((check) => `- [${check.pass ? 'x' : ' '}] ${check.label} — ${check.detail}`),
     '',
-    '- Commands executed: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`',
+    '- Commands executed: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm --dir packages/cli sandbox:matrix`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`',
     '- Side effects: `CHANGELOG.md` draft release-readiness section updated',
   ].join('\n');
   const summaryKo = [
@@ -147,7 +147,7 @@ function writeSummary(checks) {
     '',
     ...checks.map((check) => `- [${check.pass ? 'x' : ' '}] ${check.label} — ${check.detail}`),
     '',
-    '- 실행한 명령: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`',
+    '- 실행한 명령: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm --dir packages/cli sandbox:matrix`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`',
     '- 부수 효과: `CHANGELOG.md` 릴리즈 준비도 드래프트 섹션 갱신',
   ].join('\n');
 
@@ -201,6 +201,7 @@ upsertReleaseCandidateDraft();
 run('pnpm', ['build']);
 run('pnpm', ['typecheck']);
 run('pnpm', ['test']);
+run('pnpm', ['--dir', 'packages/cli', 'sandbox:matrix']);
 
 const quickStart = read('docs/getting-started/quick-start.md');
 const contributing = read('CONTRIBUTING.md');
@@ -215,6 +216,12 @@ const governancePackageList = sorted(parsePackageListFromSection(releaseGovernan
 const packageSurfaceList = parsePackageNamesFromFamilyTable(packageSurface, 'public package families');
 const workspacePackages = workspacePackageNames();
 
+assertCheck(
+  checks,
+  'Representative generated-project smoke suite',
+  true,
+  'Release readiness runs `pnpm --dir packages/cli sandbox:matrix` to verify install/build/test/generator flows for the default app, TCP microservice, and mixed starter baselines.',
+);
 assertCheck(
   checks,
   'Canonical bootstrap docs',


### PR DESCRIPTION
## Summary
- add a representative `pnpm sandbox:matrix` harness in `@fluojs/cli` for generated-project smoke coverage across the default app, TCP microservice, and mixed starter baselines
- wire `pnpm verify:release-readiness` to execute the generated-project smoke matrix so release-grade verification now covers scaffold -> install -> typecheck/build/test -> installed CLI generator flows
- document the repo-local matrix command in `CONTRIBUTING.md` without changing the supported starter matrix or public starter/runtime contract

## Changes
- add representative starter matrix orchestration and cached CLI dist loading in `packages/cli/scripts/local-test-env.mjs`
- expose the matrix entrypoint via `packages/cli/package.json`
- update release-readiness verification to run the CLI smoke matrix and record it in the summary output
- document the new maintainer verification path in `CONTRIBUTING.md`

## Testing
- `pnpm --dir packages/cli test`
- `pnpm --dir packages/cli sandbox:matrix`
- `pnpm verify:release-readiness`
- `pnpm lint`

## Behavioral contract
- No documented starter/runtime support was removed or narrowed.
- This PR strengthens verification depth only; it does not change the supported starter matrix.
- References #1092