### PR TITLE
Resolve #1093: make cache-manager root imports safe without Redis peers

### DIFF
--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -24,6 +24,8 @@
 npm install @fluojs/cache-manager
 ```
 
+root `@fluojs/cache-manager` import는 memory-only 설치에서도 안전합니다. Redis peer는 Redis 저장소 경로를 명시적으로 선택할 때만 필요합니다.
+
 Redis 기반 캐싱을 사용하는 경우:
 
 ```bash
@@ -92,6 +94,8 @@ class UserService {
 ### Redis 저장소 사용
 
 Redis를 사용하려면 `@fluojs/redis`가 설정되어 있어야 하며, `store` 옵션을 `'redis'`로 설정합니다.
+
+memory-only 소비자는 `@fluojs/redis`나 `ioredis`를 설치하지 않아도 `@fluojs/cache-manager`를 계속 import할 수 있습니다. 이 optional peer들은 Redis 저장소 경로를 선택할 때만 해석됩니다.
 
 ```typescript
 CacheModule.forRoot({

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -24,6 +24,8 @@ General-purpose cache manager for fluo with pluggable memory and Redis stores. P
 npm install @fluojs/cache-manager
 ```
 
+The root `@fluojs/cache-manager` import stays safe for memory-only installs. You only need Redis peers when you explicitly select the Redis-backed store path.
+
 For Redis-backed caching:
 
 ```bash
@@ -92,6 +94,8 @@ class UserService {
 ### Redis Storage
 
 To use Redis, ensure `@fluojs/redis` is configured and set the store to `'redis'`.
+
+Memory-only consumers can keep importing from `@fluojs/cache-manager` without installing `@fluojs/redis` or `ioredis`; those optional peers are resolved only when the Redis store path is selected.
 
 ```typescript
 CacheModule.forRoot({

--- a/packages/cache-manager/src/module.ts
+++ b/packages/cache-manager/src/module.ts
@@ -1,5 +1,5 @@
+import type { Token } from '@fluojs/core';
 import type { Provider, Container } from '@fluojs/di';
-import { getRedisClientToken } from '@fluojs/redis';
 import { defineModule, type ModuleType } from '@fluojs/runtime';
 import { RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 
@@ -11,6 +11,42 @@ import { CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
 import type { CacheModuleOptions, NormalizedCacheModuleOptions, RedisCompatibleClient } from './types.js';
 
 const DEFAULT_MEMORY_STORE_TTL_SECONDS = 300;
+
+interface RedisPeerModule {
+  getRedisClientToken(clientName?: string): Token<RedisCompatibleClient>;
+}
+
+function isMissingRedisPeer(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const code = 'code' in error ? (error as { code?: unknown }).code : undefined;
+
+  return code === 'ERR_MODULE_NOT_FOUND' && error.message.includes('@fluojs/redis');
+}
+
+function createRedisBootstrapError(): Error {
+  return new Error(
+    [
+      '@fluojs/cache-manager redis store requires a Redis client at bootstrap.',
+      'Install and import @fluojs/redis, configure options.redis.clientName, or provide options.redis.client directly.',
+    ].join(' '),
+  );
+}
+
+async function resolveRedisPeerModule(): Promise<RedisPeerModule> {
+  try {
+    // @ts-ignore -- optional peer is resolved only when the Redis path is selected at runtime.
+    return await import('@fluojs/redis');
+  } catch (error) {
+    if (isMissingRedisPeer(error)) {
+      throw createRedisBootstrapError();
+    }
+
+    throw error;
+  }
+}
 
 function normalizeCacheModuleOptions(options: CacheModuleOptions = {}): NormalizedCacheModuleOptions {
   const store = options.store ?? 'memory';
@@ -58,7 +94,18 @@ async function resolveRedisClient(
   let resolvedClient = options.redis?.client;
 
   if (!resolvedClient) {
-    const redisToken = getRedisClientToken(options.redis?.clientName);
+    let redisToken: Token<RedisCompatibleClient>;
+
+    try {
+      const { getRedisClientToken } = await resolveRedisPeerModule();
+      redisToken = getRedisClientToken(options.redis?.clientName);
+    } catch (error) {
+      if (isMissingRedisPeer(error)) {
+        throw createRedisBootstrapError();
+      }
+
+      throw error;
+    }
 
     if (container.has(redisToken)) {
       resolvedClient = await container.resolve<RedisCompatibleClient>(redisToken);
@@ -66,12 +113,7 @@ async function resolveRedisClient(
   }
 
   if (!resolvedClient) {
-    throw new Error(
-      [
-        '@fluojs/cache-manager redis store requires a Redis client at bootstrap.',
-        'Install and import @fluojs/redis, configure options.redis.clientName, or provide options.redis.client directly.',
-      ].join(' '),
-    );
+    throw createRedisBootstrapError();
   }
 
   return resolvedClient;

--- a/packages/cache-manager/src/module.ts
+++ b/packages/cache-manager/src/module.ts
@@ -11,10 +11,15 @@ import { CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
 import type { CacheModuleOptions, NormalizedCacheModuleOptions, RedisCompatibleClient } from './types.js';
 
 const DEFAULT_MEMORY_STORE_TTL_SECONDS = 300;
+const REDIS_PEER_MODULE_SPECIFIER = '@fluojs/redis';
 
 interface RedisPeerModule {
   getRedisClientToken(clientName?: string): Token<RedisCompatibleClient>;
 }
+
+type OptionalModuleLoader = (specifier: string) => Promise<unknown>;
+
+const loadOptionalModule: OptionalModuleLoader = async (specifier) => import(specifier);
 
 function isMissingRedisPeer(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -23,7 +28,15 @@ function isMissingRedisPeer(error: unknown): boolean {
 
   const code = 'code' in error ? (error as { code?: unknown }).code : undefined;
 
-  return code === 'ERR_MODULE_NOT_FOUND' && error.message.includes('@fluojs/redis');
+  return code === 'ERR_MODULE_NOT_FOUND' && error.message.includes(REDIS_PEER_MODULE_SPECIFIER);
+}
+
+function isRedisPeerModule(value: unknown): value is RedisPeerModule {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return 'getRedisClientToken' in value && typeof value.getRedisClientToken === 'function';
 }
 
 function createRedisBootstrapError(): Error {
@@ -37,8 +50,13 @@ function createRedisBootstrapError(): Error {
 
 async function resolveRedisPeerModule(): Promise<RedisPeerModule> {
   try {
-    // @ts-ignore -- optional peer is resolved only when the Redis path is selected at runtime.
-    return await import('@fluojs/redis');
+    const moduleNamespace = await loadOptionalModule(REDIS_PEER_MODULE_SPECIFIER);
+
+    if (!isRedisPeerModule(moduleNamespace)) {
+      throw new Error('@fluojs/cache-manager expected @fluojs/redis to export getRedisClientToken().');
+    }
+
+    return moduleNamespace;
   } catch (error) {
     if (isMissingRedisPeer(error)) {
       throw createRedisBootstrapError();

--- a/packages/cache-manager/src/optional-peer.test.ts
+++ b/packages/cache-manager/src/optional-peer.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CACHE_OPTIONS, CACHE_STORE } from './tokens.js';
+import { MemoryStore } from './stores/memory-store.js';
+import type { NormalizedCacheModuleOptions } from './types.js';
+
+function isNormalizedOptionsProvider(
+  provider: unknown,
+): provider is { provide: typeof CACHE_OPTIONS; useValue: NormalizedCacheModuleOptions } {
+  return typeof provider === 'object' && provider !== null && 'provide' in provider && provider.provide === CACHE_OPTIONS;
+}
+
+function isStoreFactoryProvider(
+  provider: unknown,
+): provider is { provide: typeof CACHE_STORE; useFactory: (...deps: unknown[]) => unknown } {
+  return typeof provider === 'object' && provider !== null && 'provide' in provider && provider.provide === CACHE_STORE;
+}
+
+function createContainerStub() {
+  return {
+    has: vi.fn(() => false),
+    resolve: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  vi.doUnmock('@fluojs/redis');
+  vi.resetModules();
+});
+
+describe('optional Redis peer contract', () => {
+  it('keeps the root barrel importable for memory-only consumers when Redis peers are absent', async () => {
+    vi.doMock('@fluojs/redis', () => {
+      throw Object.assign(new Error("Cannot find package '@fluojs/redis'"), {
+        code: 'ERR_MODULE_NOT_FOUND',
+      });
+    });
+
+    const cacheManagerPublicApi = await import('./index.js');
+
+    expect(cacheManagerPublicApi).toHaveProperty('CacheModule');
+    expect(cacheManagerPublicApi).toHaveProperty('createCacheProviders');
+    expect(cacheManagerPublicApi).toHaveProperty('MemoryStore');
+    expect(cacheManagerPublicApi).toHaveProperty('RedisStore');
+  });
+
+  it('fails with installation guidance only when the redis store path is selected', async () => {
+    vi.doMock('@fluojs/redis', () => {
+      return {
+        getRedisClientToken: () => {
+          throw Object.assign(new Error("Cannot find package '@fluojs/redis'"), {
+            code: 'ERR_MODULE_NOT_FOUND',
+          });
+        },
+      };
+    });
+
+    const { createCacheProviders } = await import('./module.js');
+    const providers = createCacheProviders({ store: 'redis' });
+    const optionsProvider = providers.find(isNormalizedOptionsProvider);
+    const storeProvider = providers.find(isStoreFactoryProvider);
+
+    expect(optionsProvider).toBeDefined();
+    expect(storeProvider).toBeDefined();
+
+    await expect(storeProvider!.useFactory(optionsProvider!.useValue, createContainerStub())).rejects.toThrow(
+      '@fluojs/cache-manager redis store requires a Redis client at bootstrap.',
+    );
+    await expect(storeProvider!.useFactory(optionsProvider!.useValue, createContainerStub())).rejects.toThrow(
+      'Install and import @fluojs/redis',
+    );
+  });
+
+  it('does not touch the optional Redis peer when creating a memory store provider', async () => {
+    vi.doMock('@fluojs/redis', () => {
+      throw Object.assign(new Error("Cannot find package '@fluojs/redis'"), {
+        code: 'ERR_MODULE_NOT_FOUND',
+      });
+    });
+
+    const { createCacheProviders } = await import('./module.js');
+    const providers = createCacheProviders({ store: 'memory' });
+    const optionsProvider = providers.find(isNormalizedOptionsProvider);
+    const storeProvider = providers.find(isStoreFactoryProvider);
+
+    expect(optionsProvider).toBeDefined();
+    expect(storeProvider).toBeDefined();
+
+    await expect(storeProvider!.useFactory(optionsProvider!.useValue, createContainerStub())).resolves.toMatchObject({
+      constructor: expect.objectContaining({ name: MemoryStore.name }),
+    });
+  });
+});

--- a/packages/cache-manager/src/optional-peer.test.ts
+++ b/packages/cache-manager/src/optional-peer.test.ts
@@ -71,6 +71,24 @@ describe('optional Redis peer contract', () => {
     );
   });
 
+  it('fails fast when the optional Redis peer is installed without the expected token helper export', async () => {
+    vi.doMock('@fluojs/redis', () => {
+      return {};
+    });
+
+    const { createCacheProviders } = await import('./module.js');
+    const providers = createCacheProviders({ store: 'redis' });
+    const optionsProvider = providers.find(isNormalizedOptionsProvider);
+    const storeProvider = providers.find(isStoreFactoryProvider);
+
+    expect(optionsProvider).toBeDefined();
+    expect(storeProvider).toBeDefined();
+
+    await expect(storeProvider!.useFactory(optionsProvider!.useValue, createContainerStub())).rejects.toThrow(
+      '@fluojs/cache-manager expected @fluojs/redis to export getRedisClientToken().',
+    );
+  });
+
   it('does not touch the optional Redis peer when creating a memory store provider', async () => {
     vi.doMock('@fluojs/redis', () => {
       throw Object.assign(new Error("Cannot find package '@fluojs/redis'"), {


### PR DESCRIPTION
## Summary
- lazy-load `@fluojs/redis` token resolution so the root `@fluojs/cache-manager` barrel stays importable for memory-only consumers
- add optional-peer regression coverage for root imports, memory-store creation, and Redis-path installation guidance
- document in both package READMEs that Redis peers are only required when `store: 'redis'` is selected

## Changes
- update `packages/cache-manager/src/module.ts` to resolve Redis peers only on the Redis store path and keep the bootstrap error contract intact
- add `packages/cache-manager/src/optional-peer.test.ts` to lock the public-surface behavior
- align `packages/cache-manager/README.md` and `packages/cache-manager/README.ko.md` with the preserved memory-only contract

## Testing
- `pnpm --filter @fluojs/cache-manager test`
- `pnpm --filter @fluojs/cache-manager typecheck`
- `pnpm --filter @fluojs/cache-manager build`
- `pnpm -r --filter @fluojs/cache-manager... run build`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Closes #1093