### PR TITLE
Resolve #1090: keep shutdown termination under host ownership

### DIFF
--- a/packages/platform-bun/README.ko.md
+++ b/packages/platform-bun/README.ko.md
@@ -24,7 +24,7 @@ npm install @fluojs/platform-bun
 
 fluo 애플리케이션을 [Bun](https://bun.sh/) 런타임에서 실행할 때 이 패키지를 사용합니다. 이 어댑터는 Bun의 고성능 `Request`/`Response` 브리지와 네이티브 `fetch` 방식의 아키텍처를 활용하여 Bun 사용자에게 원활하고 빠른 경험을 제공합니다.
 
-애플리케이션 종료 중에는 새 유입을 중단하고, Bun이 서버를 강제로 내리기 전에 활성 HTTP 핸들러가 bounded drain window 안에서 마무리될 수 있도록 동작합니다.
+애플리케이션 종료 중에는 새 유입을 중단하고, Bun이 서버를 강제로 내리기 전에 활성 HTTP 핸들러가 bounded drain window 안에서 마무리될 수 있도록 동작합니다. 시그널 기반 종료가 `forceExitTimeoutMs`를 넘기거나 실패하면 fluo는 그 상태를 로그와 `process.exitCode`로 보고하고, 최종 프로세스 종료는 Bun 또는 주변 호스트에 맡깁니다.
 
 ## 빠른 시작
 

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -24,7 +24,7 @@ npm install @fluojs/platform-bun
 
 Use this package when running fluo applications on the [Bun](https://bun.sh/) runtime. This adapter leverages Bun's high-performance `Request`/`Response` bridge and native `fetch`-style architecture, providing a seamless and fast experience for Bun users.
 
-During application shutdown, the adapter stops new ingress and gives active HTTP handlers a bounded drain window before Bun forcefully tears the server down.
+During application shutdown, the adapter stops new ingress and gives active HTTP handlers a bounded drain window before Bun forcefully tears the server down. If signal-driven shutdown exceeds `forceExitTimeoutMs` or fails, fluo reports that condition through logging and `process.exitCode` while leaving final process termination to Bun or the surrounding host.
 
 ## Quick Start
 

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -278,6 +278,64 @@ describe('@fluojs/platform-bun', () => {
     expect(process.listeners(signal).length).toBe(listenersBefore);
   });
 
+  it('marks shutdown timeout via exitCode without forcing process termination', async () => {
+    vi.useFakeTimers();
+
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message: string, error: unknown, context?: string) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
+      },
+      log() {},
+      warn() {},
+    };
+    const mockBun = installMockBun();
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [HealthController] });
+
+    const originalExitCode = process.exitCode;
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => undefined as never) as typeof process.exit);
+    const app = await runBunApplication(AppModule, {
+      forceExitTimeoutMs: 25,
+      hostname: '127.0.0.1',
+      logger,
+      port: 4313,
+      shutdownSignals: ['SIGTERM'],
+    });
+
+    const originalClose = app.close.bind(app);
+    app.close = () => new Promise<void>(() => {});
+
+    try {
+      expect(mockBun.lastServer).toBeDefined();
+
+      process.emit('SIGTERM', 'SIGTERM');
+      await vi.advanceTimersByTimeAsync(26);
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(loggerEvents).toContain(
+        'error:FluoFactory:Shutdown timeout exceeded after 25ms; leaving process termination to the host.:none',
+      );
+    } finally {
+      app.close = originalClose;
+      await app.close();
+      exitSpy.mockRestore();
+      process.exitCode = originalExitCode;
+      vi.useRealTimers();
+    }
+  });
+
   it('drains in-flight requests before Bun close resolves', async () => {
     const mockBun = installMockBun();
     const adapter = createBunAdapter() as BunHttpApplicationAdapter;

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -71,7 +71,7 @@ const adapter = createExpressAdapter(
 
 - `createExpressAdapter(options)`: Express HTTP 어댑터를 위한 팩토리입니다.
 - `bootstrapExpressApplication(module, options)`: 수동 제어를 위한 고급 부트스트랩 헬퍼입니다.
-- `runExpressApplication(module, options)`: 시그널 연결을 포함한 빠른 시작을 위한 호환 헬퍼입니다.
+- `runExpressApplication(module, options)`: 시그널 연결을 포함한 빠른 시작을 위한 호환 헬퍼입니다. timeout/실패 시에는 해당 상태를 로그와 `process.exitCode`로 보고하고, 최종 프로세스 종료는 주변 호스트에 맡깁니다.
 - `ExpressHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 
 ## 관련 패키지

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -71,7 +71,7 @@ const adapter = createExpressAdapter(
 
 - `createExpressAdapter(options)`: Factory for the Express HTTP adapter.
 - `bootstrapExpressApplication(module, options)`: Advanced bootstrap helper for manual control.
-- `runExpressApplication(module, options)`: Compatibility helper for quick startup with signal wiring.
+- `runExpressApplication(module, options)`: Compatibility helper for quick startup with signal wiring. On timeout/failure it reports the condition through logging and `process.exitCode`, while leaving final process termination to the surrounding host.
 - `ExpressHttpApplicationAdapter`: The core adapter implementation class.
 
 ## Related Packages

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -717,7 +717,7 @@ describe('@fluojs/platform-express', () => {
     }
   });
 
-  it('forces process exit when signal-driven shutdown exceeds forceExitTimeoutMs', async () => {
+  it('marks shutdown timeout via exitCode without forcing process termination', async () => {
     vi.useFakeTimers();
 
     const loggerEvents: string[] = [];
@@ -763,8 +763,11 @@ describe('@fluojs/platform-express', () => {
       process.emit('SIGTERM', 'SIGTERM');
       await vi.advanceTimersByTimeAsync(26);
 
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(loggerEvents).toContain('error:FluoFactory:Forced exit after 25ms shutdown timeout.:none');
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(loggerEvents).toContain(
+        'error:FluoFactory:Shutdown timeout exceeded after 25ms; leaving process termination to the host.:none',
+      );
     } finally {
       app.close = originalClose;
       await app.close();

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -77,7 +77,6 @@ export interface ExpressAdapterOptions {
 export type ExpressApplicationSignal = 'SIGINT' | 'SIGTERM';
 export type CorsInput = false | string | string[] | CorsOptions;
 
-const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 
@@ -632,76 +631,6 @@ function resolvePort(value: number | undefined): number {
   }
 
   return port;
-}
-
-function defaultShutdownSignals(): false | readonly ExpressApplicationSignal[] {
-  return ['SIGINT', 'SIGTERM'];
-}
-
-function registerShutdownSignals(
-  app: Application,
-  logger: ApplicationLogger,
-  signals: false | readonly ExpressApplicationSignal[],
-  forceExitTimeoutMs: number = DEFAULT_FORCE_EXIT_TIMEOUT_MS,
-): () => void {
-  if (signals === false || signals.length === 0) {
-    return () => {};
-  }
-
-  const seen = new Set<ExpressApplicationSignal>();
-  const bindings: Array<{ signal: ExpressApplicationSignal; handler: () => void }> = [];
-
-  for (const signal of signals) {
-    if (seen.has(signal)) {
-      continue;
-    }
-
-    seen.add(signal);
-    const handler = () => {
-      void closeFromSignal(app, logger, signal, forceExitTimeoutMs);
-    };
-
-    bindings.push({ signal, handler });
-    process.once(signal, handler);
-  }
-
-  return () => {
-    for (const binding of bindings) {
-      process.off(binding.signal, binding.handler);
-    }
-  };
-}
-
-async function closeFromSignal(
-  app: Application,
-  logger: ApplicationLogger,
-  signal: ExpressApplicationSignal,
-  forceExitTimeoutMs: number,
-): Promise<void> {
-  if (app.state === 'closed') {
-    process.exitCode = 0;
-    return;
-  }
-
-  const forceExitTimer = setTimeout(() => {
-    logger.error(`Forced exit after ${String(forceExitTimeoutMs)}ms shutdown timeout.`, undefined, 'FluoFactory');
-    process.exit(1);
-  }, forceExitTimeoutMs);
-
-  if (forceExitTimer.unref) {
-    forceExitTimer.unref();
-  }
-
-  try {
-    await app.close(signal);
-    clearTimeout(forceExitTimer);
-    logger.log(`Application closed after receiving ${signal}.`, 'FluoFactory');
-    process.exitCode = 0;
-  } catch (error: unknown) {
-    clearTimeout(forceExitTimer);
-    logger.error('Failed to shut down the application cleanly.', error, 'FluoFactory');
-    process.exitCode = 1;
-  }
 }
 
 async function listenServer(server: ExpressServer, port: number, host: string | undefined): Promise<void> {

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -79,7 +79,7 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 
 - `createFastifyAdapter(options)`: Fastify 어댑터를 위한 권장 팩토리입니다.
 - `bootstrapFastifyApplication(module, options)`: 암시적 리스닝 없이 수행하는 고급 부트스트랩입니다.
-- `runFastifyApplication(module, options)`: 생명주기 관리를 포함한 빠른 시작 헬퍼입니다.
+- `runFastifyApplication(module, options)`: 생명주기 관리를 포함한 빠른 시작 헬퍼입니다. timeout/실패 시에는 해당 상태를 로그와 `process.exitCode`로 보고하고, 최종 프로세스 종료는 주변 호스트에 맡깁니다.
 - `FastifyHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 
 ## 관련 패키지

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -79,7 +79,7 @@ fluo's Fastify adapter significantly outperforms the raw Node.js adapter in high
 
 - `createFastifyAdapter(options)`: Recommended factory for the Fastify adapter.
 - `bootstrapFastifyApplication(module, options)`: advanced bootstrap without implicit listening.
-- `runFastifyApplication(module, options)`: Quick-start helper with lifecycle management.
+- `runFastifyApplication(module, options)`: Quick-start helper with lifecycle management. On timeout/failure it reports the condition through logging and `process.exitCode`, while leaving final process termination to the surrounding host.
 - `FastifyHttpApplicationAdapter`: The core adapter implementation.
 
 ## Related Packages

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -742,7 +742,7 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
-  it('forces process exit when signal-driven shutdown exceeds forceExitTimeoutMs', async () => {
+  it('marks shutdown timeout via exitCode without forcing process termination', async () => {
     vi.useFakeTimers();
 
     const loggerEvents: string[] = [];
@@ -788,8 +788,11 @@ describe('@fluojs/platform-fastify', () => {
       process.emit('SIGTERM', 'SIGTERM');
       await vi.advanceTimersByTimeAsync(26);
 
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      expect(loggerEvents).toContain('error:FluoFactory:Forced exit after 25ms shutdown timeout.:none');
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(loggerEvents).toContain(
+        'error:FluoFactory:Shutdown timeout exceeded after 25ms; leaving process termination to the host.:none',
+      );
     } finally {
       app.close = originalClose;
       await app.close();

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -68,7 +68,6 @@ export type FastifyApplicationSignal = 'SIGINT' | 'SIGTERM';
 /** CORS shorthand accepted by the Fastify runtime bootstrap helpers. */
 export type CorsInput = false | string | string[] | CorsOptions;
 
-const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 
@@ -764,76 +763,6 @@ function resolvePort(value: number | undefined): number {
   }
 
   return port;
-}
-
-function defaultShutdownSignals(): false | readonly FastifyApplicationSignal[] {
-  return ['SIGINT', 'SIGTERM'];
-}
-
-function registerShutdownSignals(
-  app: Application,
-  logger: ApplicationLogger,
-  signals: false | readonly FastifyApplicationSignal[],
-  forceExitTimeoutMs: number = DEFAULT_FORCE_EXIT_TIMEOUT_MS,
-): () => void {
-  if (signals === false || signals.length === 0) {
-    return () => {};
-  }
-
-  const seen = new Set<FastifyApplicationSignal>();
-  const bindings: Array<{ signal: FastifyApplicationSignal; handler: () => void }> = [];
-
-  for (const signal of signals) {
-    if (seen.has(signal)) {
-      continue;
-    }
-
-    seen.add(signal);
-    const handler = () => {
-      void closeFromSignal(app, logger, signal, forceExitTimeoutMs);
-    };
-
-    bindings.push({ signal, handler });
-    process.once(signal, handler);
-  }
-
-  return () => {
-    for (const binding of bindings) {
-      process.off(binding.signal, binding.handler);
-    }
-  };
-}
-
-async function closeFromSignal(
-  app: Application,
-  logger: ApplicationLogger,
-  signal: FastifyApplicationSignal,
-  forceExitTimeoutMs: number,
-): Promise<void> {
-  if (app.state === 'closed') {
-    process.exitCode = 0;
-    return;
-  }
-
-  const forceExitTimer = setTimeout(() => {
-    logger.error(`Forced exit after ${String(forceExitTimeoutMs)}ms shutdown timeout.`, undefined, 'FluoFactory');
-    process.exit(1);
-  }, forceExitTimeoutMs);
-
-  if (forceExitTimer.unref) {
-    forceExitTimer.unref();
-  }
-
-  try {
-    await app.close(signal);
-    clearTimeout(forceExitTimer);
-    logger.log(`Application closed after receiving ${signal}.`, 'FluoFactory');
-    process.exitCode = 0;
-  } catch (error: unknown) {
-    clearTimeout(forceExitTimer);
-    logger.error('Failed to shut down the application cleanly.', error, 'FluoFactory');
-    process.exitCode = 1;
-  }
 }
 
 function toHttpException(error: unknown): HttpException {

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -59,6 +59,8 @@ const adapter = createNodejsAdapter({
 ### 직접 애플리케이션 실행
 `runNodejsApplication`을 사용하여 graceful shutdown 및 로깅이 포함된 보일러플레이트 없는 시작이 가능합니다.
 
+시그널 기반 종료가 `forceExitTimeoutMs`를 넘기거나 실패하면 헬퍼는 해당 상태를 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료는 호스트 프로세스 소유자에게 맡깁니다.
+
 ```typescript
 import { runNodejsApplication } from '@fluojs/platform-nodejs';
 import { AppModule } from './app.module';

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -59,6 +59,8 @@ const adapter = createNodejsAdapter({
 ### Direct Application Execution
 You can use `runNodejsApplication` for a zero-boilerplate startup that includes graceful shutdown and logging.
 
+When signal-driven shutdown exceeds `forceExitTimeoutMs` or fails, the helper logs the condition and sets `process.exitCode`, but leaves final process termination to the host process owner.
+
 ```typescript
 import { runNodejsApplication } from '@fluojs/platform-nodejs';
 import { AppModule } from './app.module';

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -125,6 +125,7 @@ class UsersModule {}
 - 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다.
 - 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.
+- 시그널 기반 종료 헬퍼는 bounded drain semantics를 유지하면서 timeout/실패 상황을 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료 소유권은 주변 호스트 런타임에 남겨 둡니다.
 
 ## 공개 API 개요
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -125,6 +125,7 @@ class UsersModule {}
 - Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests.
 - Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.
+- Signal-driven shutdown helpers preserve bounded drain semantics, log timeout/failure conditions, and set `process.exitCode` when shutdown does not finish cleanly, but they leave final process termination ownership to the surrounding host runtime.
 
 ## Public API Overview
 

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Inject } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
@@ -1219,6 +1219,64 @@ describe('bootstrapApplication', () => {
     await app.close();
 
     expect(process.listeners(signal).length).toBe(listenersBefore);
+  });
+
+  it('marks signal-driven shutdown timeouts without terminating the host process directly', async () => {
+    vi.useFakeTimers();
+
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message, error, context) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
+      },
+      log() {},
+      warn() {},
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const originalExitCode = process.exitCode;
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => undefined as never) as typeof process.exit);
+    const port = await findAvailablePort();
+    const app = await runNodeApplication(AppModule, {
+      cors: false,
+      forceExitTimeoutMs: 25,
+      logger,
+      port,
+      shutdownSignals: ['SIGTERM'],
+    });
+
+    const originalClose = app.close.bind(app);
+    app.close = () => new Promise<void>(() => {});
+
+    try {
+      process.emit('SIGTERM', 'SIGTERM');
+      await vi.advanceTimersByTimeAsync(26);
+
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(loggerEvents).toContain(
+        'error:FluoFactory:Shutdown timeout exceeded after 25ms; leaving process termination to the host.:none',
+      );
+    } finally {
+      app.close = originalClose;
+      await app.close();
+      exitSpy.mockRestore();
+      process.exitCode = originalExitCode;
+      vi.useRealTimers();
+    }
   });
 
   it('supports https startup and reports the https listen URL', async () => {

--- a/packages/runtime/src/http-adapter-shared.ts
+++ b/packages/runtime/src/http-adapter-shared.ts
@@ -63,7 +63,7 @@ export interface BootstrapHttpAdapterApplicationOptions
  * Options for running an HTTP adapter application with shutdown management.
  */
 export interface RunHttpAdapterApplicationOptions extends BootstrapHttpAdapterApplicationOptions {
-  /** Timeout for forced exit during shutdown in milliseconds. */
+  /** Timeout for marking shutdown as failed during signal-driven teardown in milliseconds. */
   forceExitTimeoutMs?: number;
   /** Custom shutdown registration logic. */
   shutdownRegistration?: HttpAdapterShutdownRegistration;

--- a/packages/runtime/src/node/internal-node-shutdown.ts
+++ b/packages/runtime/src/node/internal-node-shutdown.ts
@@ -5,10 +5,24 @@ type NodeShutdownSignal = 'SIGINT' | 'SIGTERM';
 
 const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
 
+/**
+ * Returns the default POSIX shutdown signals used by Node-hosted runtime helpers.
+ *
+ * @returns The ordered list of signals that trigger graceful shutdown registration.
+ */
 export function defaultNodeShutdownSignals(): readonly NodeShutdownSignal[] {
   return ['SIGINT', 'SIGTERM'];
 }
 
+/**
+ * Creates shutdown registration logic for Node-hosted adapters.
+ *
+ * The returned registration preserves graceful shutdown semantics while leaving
+ * final process termination ownership to the surrounding host/runtime.
+ *
+ * @param signals Signals to register, or `false` to disable signal handling.
+ * @returns Registration callback consumed by HTTP adapter startup helpers.
+ */
 export function createNodeShutdownSignalRegistration(
   signals: false | readonly NodeShutdownSignal[] = defaultNodeShutdownSignals(),
 ): HttpAdapterShutdownRegistration {
@@ -20,6 +34,18 @@ export function createNodeShutdownSignalRegistration(
   );
 }
 
+/**
+ * Registers process signal handlers that attempt graceful shutdown.
+ *
+ * When the shutdown timeout elapses, the helper records failure via logging and
+ * `process.exitCode` but does not terminate the host process directly.
+ *
+ * @param app Application instance to close when a signal arrives.
+ * @param logger Logger used for shutdown diagnostics.
+ * @param signals Signals to bind, or `false` to skip registration.
+ * @param forceExitTimeoutMs Timeout window used to mark shutdown as failed.
+ * @returns Unregister callback that removes the installed signal handlers.
+ */
 export function registerShutdownSignals(
   app: Application,
   logger: ApplicationLogger,
@@ -54,9 +80,15 @@ async function closeFromSignal(app: Application, logger: ApplicationLogger, sign
     return;
   }
 
+  let timedOut = false;
   const forceExitTimer = setTimeout(() => {
-    logger.error(`Forced exit after ${String(forceExitTimeoutMs)}ms shutdown timeout.`, undefined, 'FluoFactory');
-    process.exit(1);
+    timedOut = true;
+    logger.error(
+      `Shutdown timeout exceeded after ${String(forceExitTimeoutMs)}ms; leaving process termination to the host.`,
+      undefined,
+      'FluoFactory',
+    );
+    process.exitCode = 1;
   }, forceExitTimeoutMs);
 
   if (forceExitTimer.unref) {
@@ -66,7 +98,10 @@ async function closeFromSignal(app: Application, logger: ApplicationLogger, sign
   try {
     await app.close(signal);
     clearTimeout(forceExitTimer);
-    process.exitCode = 0;
+
+    if (!timedOut) {
+      process.exitCode = 0;
+    }
   } catch (error: unknown) {
     clearTimeout(forceExitTimer);
     logger.error('Failed to shut down the application cleanly.', error, 'FluoFactory');


### PR DESCRIPTION
Closes #1090

## Summary
- remove direct `process.exit(1)` calls from the shared Node shutdown helper and leave final process termination to the host runtime
- delete legacy forced-exit shutdown code from the Express and Fastify adapters while keeping bounded drain behavior
- document the shutdown ownership contract across runtime/platform READMEs and add Bun/Node/adapter regression coverage

## Changes
- update `packages/runtime/src/node/internal-node-shutdown.ts` to log timeout/failure conditions and set `process.exitCode` instead of terminating the process directly
- align runtime shutdown option docs and add regression coverage in `packages/runtime/src/application.test.ts`
- remove dead shutdown signal implementations from `packages/platform-express/src/adapter.ts` and `packages/platform-fastify/src/adapter.ts`
- add/update shutdown ownership documentation in runtime, platform-nodejs, platform-bun, platform-express, and platform-fastify English/Korean READMEs

## Testing
- `pnpm vitest run packages/runtime/src/application.test.ts packages/platform-express/src/adapter.test.ts packages/platform-fastify/src/adapter.test.ts packages/platform-bun/src/adapter.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` *(repo-wide warnings only; public export TSDoc check passed, and no new warnings came from the touched files)*
- `lsp_diagnostics` on modified source/test files returned no errors after build output was available

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- shutdown/drain remains bounded and graceful
- timeout/failure now reports through logging plus `process.exitCode`, while final process termination remains host-owned