### PR TITLE
Resolve #1094: align email root transport contract with node subpath docs

### DIFF
--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -23,13 +23,19 @@ fluo를 위한 transport-agnostic 이메일 코어 패키지입니다. Nest-like
 ## 설치
 
 ```bash
-npm install @fluojs/email nodemailer
+npm install @fluojs/email
 ```
 
 내장 notifications 채널과 queue worker 연동이 필요할 때만 `@fluojs/notifications`, `@fluojs/queue`를 함께 설치하면 됩니다.
 
 ```bash
 npm install @fluojs/notifications @fluojs/queue
+```
+
+명시적인 `@fluojs/email/node` 서브패스로 Node 전용 SMTP 전달을 사용할 때만 `nodemailer`를 설치하면 됩니다.
+
+```bash
+npm install @fluojs/email nodemailer
 ```
 
 Node 전용 SMTP 전달은 이제 명시적인 `@fluojs/email/node` 서브패스에 위치합니다. queue 기반 notifications 통합도 `@fluojs/email/queue` 서브패스로 분리되었고, 이 서브패스용 `@fluojs/queue`는 루트 설치 필수가 아닌 optional peer로 선언됩니다. 루트 `@fluojs/email` 엔트리포인트는 계속 transport-agnostic 상태를 유지하므로 Bun, Deno, Cloudflare, 커스텀 HTTP transport가 Node 전용 또는 queue 전용 동작을 함께 끌어오지 않습니다.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -23,13 +23,19 @@ Transport-agnostic email delivery core for fluo. It provides a Nest-like module 
 ## Installation
 
 ```bash
-npm install @fluojs/email nodemailer
+npm install @fluojs/email
 ```
 
 Install `@fluojs/notifications` and `@fluojs/queue` only when you want the built-in notifications channel and queue worker integration.
 
 ```bash
 npm install @fluojs/notifications @fluojs/queue
+```
+
+Install `nodemailer` only when you use the explicit `@fluojs/email/node` subpath for Node-only SMTP delivery.
+
+```bash
+npm install @fluojs/email nodemailer
 ```
 
 Node-specific SMTP delivery now lives behind the explicit `@fluojs/email/node` subpath. Queue-backed notifications integration likewise lives behind `@fluojs/email/queue`, and `@fluojs/queue` is declared as an optional peer for that subpath instead of a root install requirement. The root `@fluojs/email` entrypoint remains transport-agnostic so Bun, Deno, Cloudflare, and custom HTTP transports do not inherit Node-only or queue-specific behavior.

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -62,14 +62,17 @@
     "@fluojs/core": "workspace:*",
     "@fluojs/di": "workspace:*",
     "@fluojs/notifications": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
-    "nodemailer": "^6.10.1"
+    "@fluojs/runtime": "workspace:*"
   },
   "peerDependencies": {
-    "@fluojs/queue": "workspace:*"
+    "@fluojs/queue": "workspace:*",
+    "nodemailer": "^6.10.1"
   },
   "peerDependenciesMeta": {
     "@fluojs/queue": {
+      "optional": true
+    },
+    "nodemailer": {
       "optional": true
     }
   },

--- a/packages/email/src/public-surface.test.ts
+++ b/packages/email/src/public-surface.test.ts
@@ -48,11 +48,16 @@ describe('@fluojs/email public API surface', () => {
     };
 
     expect(packageJson.dependencies).not.toHaveProperty('@fluojs/queue');
+    expect(packageJson.dependencies).not.toHaveProperty('nodemailer');
     expect(packageJson.peerDependencies).toMatchObject({
       '@fluojs/queue': 'workspace:*',
+      nodemailer: '^6.10.1',
     });
     expect(packageJson.peerDependenciesMeta).toMatchObject({
       '@fluojs/queue': {
+        optional: true,
+      },
+      nodemailer: {
         optional: true,
       },
     });


### PR DESCRIPTION
## Summary
- move `nodemailer` out of the `@fluojs/email` root dependency list and keep it as an optional peer for the documented `@fluojs/email/node` seam
- add a public-surface regression check that the root package stays transport-agnostic while queue and node-only installs remain explicit
- align the English and Korean README installation guidance with the preserved root contract

## Changes
- updated `packages/email/package.json` so the root package no longer declares `nodemailer` as a runtime dependency
- extended `packages/email/src/public-surface.test.ts` to assert the optional peer-dependency contract for `nodemailer`
- updated `packages/email/README.md` and `packages/email/README.ko.md` to separate base install guidance from Node-only SMTP setup

## Testing
- `pnpm --filter @fluojs/email test`
- `pnpm --filter @fluojs/email typecheck`
- `pnpm build`
- `pnpm verify`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- contract-preserving fix: the root `@fluojs/email` entrypoint remains transport-agnostic, and Node/Nodemailer concerns stay behind `@fluojs/email/node`

Closes #1094