### PR TITLE
Resolve #1095: add GraphQL websocket transport budgets

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -95,7 +95,14 @@ class UserResolver {
 ```typescript
 GraphqlModule.forRoot({
   subscriptions: {
-    websocket: { enabled: true }
+    websocket: {
+      enabled: true,
+      limits: {
+        maxConnections: 100,
+        maxPayloadBytes: 64 * 1024,
+        maxOperationsPerConnection: 25,
+      },
+    }
   }
 })
 ```
@@ -104,6 +111,8 @@ GraphqlModule.forRoot({
 
 - `graphiql`을 명시적으로 켜거나 `introspection: true`를 설정하지 않으면 스키마 introspection은 기본적으로 비활성화됩니다.
 - 문서 depth, field complexity, aggregate query cost에 대한 request validation budget이 기본적으로 보수적인 값으로 활성화됩니다.
+- WebSocket 구독 경로에는 별도의 전송 budget이 기본 적용됩니다: 동시 연결 `100`, 최대 payload 크기 `64 KiB`, 연결당 활성 operation `25`개입니다.
+- 레거시 무제한 WebSocket 동작이 정말 필요할 때만 `subscriptions.websocket.limits = false`를 사용하고, 그 경우에도 동일한 수준의 외부 제어 수단을 마련해야 합니다.
 - 레거시 무제한 동작이 꼭 필요할 때만 `limits: false`를 사용하고, 그 경우에는 외부 제어 수단을 함께 두어야 합니다.
 
 ```typescript
@@ -114,6 +123,16 @@ GraphqlModule.forRoot({
     maxDepth: 8,
     maxComplexity: 120,
     maxCost: 240,
+  },
+  subscriptions: {
+    websocket: {
+      enabled: true,
+      limits: {
+        maxConnections: 100,
+        maxPayloadBytes: 64 * 1024,
+        maxOperationsPerConnection: 25,
+      },
+    },
   },
   resolvers: [HelloResolver],
 })

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -95,7 +95,14 @@ class UserResolver {
 ```typescript
 GraphqlModule.forRoot({
   subscriptions: {
-    websocket: { enabled: true }
+    websocket: {
+      enabled: true,
+      limits: {
+        maxConnections: 100,
+        maxPayloadBytes: 64 * 1024,
+        maxOperationsPerConnection: 25,
+      },
+    }
   }
 })
 ```
@@ -104,6 +111,8 @@ GraphqlModule.forRoot({
 
 - Schema introspection is disabled by default unless you explicitly enable `graphiql` or set `introspection: true`.
 - Request validation budgets are enabled by default with conservative limits for document depth, field complexity, and aggregate query cost.
+- WebSocket subscriptions use separate transport budgets by default: `100` concurrent connections, `64 KiB` maximum payload size, and `25` active operations per connection.
+- Set `subscriptions.websocket.limits = false` only when you intentionally need legacy unbounded websocket behavior and can enforce equivalent controls elsewhere.
 - Pass `limits: false` only when you intentionally need legacy unbounded behavior and can compensate with external controls.
 
 ```typescript
@@ -114,6 +123,16 @@ GraphqlModule.forRoot({
     maxDepth: 8,
     maxComplexity: 120,
     maxCost: 240,
+  },
+  subscriptions: {
+    websocket: {
+      enabled: true,
+      limits: {
+        maxConnections: 100,
+        maxPayloadBytes: 64 * 1024,
+        maxOperationsPerConnection: 25,
+      },
+    },
   },
   resolvers: [HelloResolver],
 })

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -26,7 +26,7 @@ async function findAvailablePort(): Promise<number> {
         return;
       }
 
-      server.close((error) => {
+      server.close((error?: Error) => {
         if (error) {
           reject(error);
           return;
@@ -96,20 +96,56 @@ type GraphqlWebSocketMessage = {
   id?: string;
   payload?: {
     data?: Record<string, unknown>;
+    errors?: Array<{ message?: string }>;
   };
   type: string;
 };
 
-function onceWebSocketOpen(socket: WebSocket): Promise<void> {
-  return new Promise((resolve, reject) => {
-    socket.once('open', () => resolve());
-    socket.once('error', reject);
-  });
-}
+type UnexpectedUpgradeResponse = {
+  on(event: 'data', listener: (chunk: Uint8Array) => void): void;
+  once(event: 'end', listener: () => void): void;
+  once(event: 'error', listener: (error: Error) => void): void;
+  statusCode?: number;
+};
 
 function onceWebSocketClosed(socket: WebSocket): Promise<void> {
   return new Promise((resolve) => {
     socket.once('close', () => resolve());
+  });
+}
+
+function onceWebSocketCloseEvent(socket: WebSocket): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve) => {
+    socket.once('close', (code: number, reason: Uint8Array) => {
+      resolve({ code, reason: new TextDecoder().decode(reason) });
+    });
+  });
+}
+
+function openGraphqlWebSocket(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/graphql`, 'graphql-transport-ws');
+    socket.once('open', () => resolve(socket));
+    socket.once('error', reject);
+  });
+}
+
+function onceUnexpectedWebSocketUpgradeResponse(socket: WebSocket): Promise<{ body: string; statusCode: number }> {
+  return new Promise((resolve, reject) => {
+    socket.once('unexpected-response', (_request: unknown, response: UnexpectedUpgradeResponse) => {
+      const chunks: Uint8Array[] = [];
+      response.on('data', (chunk: Uint8Array) => {
+        chunks.push(chunk);
+      });
+      response.once('end', () => {
+        resolve({
+          body: chunks.map((chunk) => new TextDecoder().decode(chunk)).join(''),
+          statusCode: response.statusCode ?? 0,
+        });
+      });
+      response.once('error', reject);
+    });
+    socket.once('error', reject);
   });
 }
 
@@ -148,9 +184,7 @@ function onceGraphqlWebSocketMessage(socket: WebSocket): Promise<GraphqlWebSocke
 }
 
 async function connectGraphqlWebSocket(port: number): Promise<WebSocket> {
-  const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/graphql`, 'graphql-transport-ws');
-
-  await onceWebSocketOpen(socket);
+  const socket = await openGraphqlWebSocket(port);
   socket.send(JSON.stringify({ type: 'connection_init' }));
 
   await expect(onceGraphqlWebSocketMessage(socket)).resolves.toEqual({
@@ -1047,6 +1081,174 @@ describe('@fluojs/graphql', () => {
       },
     ]);
 
+    socket.close();
+    await onceWebSocketClosed(socket);
+    await app.close();
+  });
+
+  it('rejects websocket upgrades that exceed the configured connection budget', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [GraphqlResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+              limits: {
+                maxConnections: 1,
+              },
+            },
+          },
+        }),
+      ],
+      providers: [ResolverState, GraphqlResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const firstSocket = await connectGraphqlWebSocket(port);
+    const secondSocket = new WebSocket(`ws://127.0.0.1:${String(port)}/graphql`, 'graphql-transport-ws');
+
+    await expect(onceUnexpectedWebSocketUpgradeResponse(secondSocket)).resolves.toEqual({
+      body: 'GraphQL websocket connection count exceeds the configured limit.\n',
+      statusCode: 503,
+    });
+
+    firstSocket.close();
+    await onceWebSocketClosed(firstSocket);
+    await app.close();
+  });
+
+  it('closes websocket clients when subscribe payloads exceed the configured budget', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [GraphqlResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+              limits: {
+                maxPayloadBytes: 128,
+              },
+            },
+          },
+        }),
+      ],
+      providers: [ResolverState, GraphqlResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const socket = await connectGraphqlWebSocket(port);
+    const closeEvent = onceWebSocketCloseEvent(socket);
+    socket.send(JSON.stringify({
+      id: 'sub-oversized',
+      payload: {
+        query: 'subscription { pingStream }',
+        variables: {
+          blob: 'x'.repeat(512),
+        },
+      },
+      type: 'subscribe',
+    }));
+
+    await expect(closeEvent).resolves.toMatchObject({
+      code: 1009,
+    });
+
+    await app.close();
+  });
+
+  it('rejects websocket subscribe messages that exceed the configured active operation budget', async () => {
+    let releaseOperation: (() => void) | undefined;
+    const waitForRelease = new Promise<void>((resolve) => {
+      releaseOperation = resolve;
+    });
+
+    @Inject()
+    @Resolver('BudgetedSubscriptionResolver')
+    class BudgetedSubscriptionResolver {
+      @Subscription()
+      async *slowStream(): AsyncGenerator<string, void, void> {
+        yield 'tick';
+        await waitForRelease;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [BudgetedSubscriptionResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+              limits: {
+                maxOperationsPerConnection: 1,
+              },
+            },
+          },
+        }),
+      ],
+      providers: [BudgetedSubscriptionResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+    await app.listen();
+
+    const socket = await connectGraphqlWebSocket(port);
+    socket.send(JSON.stringify({
+      id: 'sub-1',
+      payload: {
+        query: 'subscription { slowStream }',
+      },
+      type: 'subscribe',
+    }));
+
+    await expect(onceGraphqlWebSocketMessage(socket)).resolves.toEqual({
+      id: 'sub-1',
+      payload: {
+        data: {
+          slowStream: 'tick',
+        },
+      },
+      type: 'next',
+    });
+
+    socket.send(JSON.stringify({
+      id: 'sub-2',
+      payload: {
+        query: 'subscription { slowStream }',
+      },
+      type: 'subscribe',
+    }));
+
+    await expect(onceGraphqlWebSocketMessage(socket)).resolves.toEqual({
+      id: 'sub-2',
+      payload: [
+        {
+          message: 'GraphQL websocket active operation count exceeds the configured limit of 1.',
+        },
+      ],
+      type: 'error',
+    });
+
+    releaseOperation?.();
     socket.close();
     await onceWebSocketClosed(socket);
     await app.close();

--- a/packages/graphql/src/service.test.ts
+++ b/packages/graphql/src/service.test.ts
@@ -48,6 +48,24 @@ function resolveIntrospectionEnabled(service: GraphqlLifecycleService): boolean 
   return Reflect.apply(resolver, service, []) as boolean;
 }
 
+function resolveWebSocketLimits(service: GraphqlLifecycleService): {
+  maxConnections: number;
+  maxOperationsPerConnection: number;
+  maxPayloadBytes: number;
+} | undefined {
+  const resolver = Reflect.get(service, 'resolveWebSocketLimits');
+
+  if (typeof resolver !== 'function') {
+    throw new Error('Expected resolveWebSocketLimits method to exist.');
+  }
+
+  return Reflect.apply(resolver, service, []) as {
+    maxConnections: number;
+    maxOperationsPerConnection: number;
+    maxPayloadBytes: number;
+  } | undefined;
+}
+
 describe('GraphqlLifecycleService graphiql defaults', () => {
   it('defaults to false when graphiql option is not set', () => {
     const service = createService({});
@@ -98,5 +116,55 @@ describe('GraphqlLifecycleService graphiql defaults', () => {
 
     expect(resolveIntrospectionEnabled(disabled)).toBe(false);
     expect(resolveIntrospectionEnabled(enabled)).toBe(true);
+  });
+
+  it('uses conservative defaults for websocket limits when websocket transport is enabled', () => {
+    const service = createService({
+      subscriptions: {
+        websocket: {
+          enabled: true,
+        },
+      },
+    });
+
+    expect(resolveWebSocketLimits(service)).toEqual({
+      maxConnections: 100,
+      maxOperationsPerConnection: 25,
+      maxPayloadBytes: 64 * 1024,
+    });
+  });
+
+  it('respects explicit websocket limit overrides', () => {
+    const service = createService({
+      subscriptions: {
+        websocket: {
+          enabled: true,
+          limits: {
+            maxConnections: 5,
+            maxOperationsPerConnection: 2,
+            maxPayloadBytes: 4096,
+          },
+        },
+      },
+    });
+
+    expect(resolveWebSocketLimits(service)).toEqual({
+      maxConnections: 5,
+      maxOperationsPerConnection: 2,
+      maxPayloadBytes: 4096,
+    });
+  });
+
+  it('allows opting out of websocket hardening budgets', () => {
+    const service = createService({
+      subscriptions: {
+        websocket: {
+          enabled: true,
+          limits: false,
+        },
+      },
+    });
+
+    expect(resolveWebSocketLimits(service)).toBeUndefined();
   });
 });

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -76,6 +76,18 @@ interface GraphqlSubscribePayload {
   variables?: Record<string, unknown> | null;
 }
 
+interface GraphqlWebSocketLimits {
+  maxConnections: number;
+  maxOperationsPerConnection: number;
+  maxPayloadBytes: number;
+}
+
+const DEFAULT_GRAPHQL_WEBSOCKET_LIMITS: GraphqlWebSocketLimits = {
+  maxConnections: 100,
+  maxOperationsPerConnection: 25,
+  maxPayloadBytes: 64 * 1024,
+};
+
 function hasNodeUpgradeServer(value: unknown): value is NodeUpgradeServer {
   if (typeof value !== 'object' || value === null) {
     return false;
@@ -296,6 +308,7 @@ async function loadGraphqlDeps(): Promise<GraphqlDeps> {
  */
 @Inject(RUNTIME_CONTAINER, COMPILED_MODULES, APPLICATION_LOGGER, HTTP_APPLICATION_ADAPTER, GRAPHQL_INTERNAL_MODULE_OPTIONS_TOKEN)
 export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private graphQLErrorConstructor: typeof GraphQLErrorType | undefined;
   private middlewareRegistered = false;
   private readonly operationContainers = new WeakMap<Request, Container>();
   private readonly websocketOperationContainers = new Map<object, Map<string, Container>>();
@@ -369,6 +382,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     const deps = await loadGraphqlDeps();
     const schema = this.resolveSchema(deps);
     this.executeGraphqlOperation = deps.execute;
+    this.graphQLErrorConstructor = deps.GraphQLError;
     this.subscribeGraphqlOperation = deps.subscribe;
     const requestLimits = resolveGraphqlRequestLimits(this.options.limits);
     const validationPlugin = createGraphqlValidationPlugin({
@@ -403,6 +417,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     this.unregisterMiddleware();
     this.middlewareRegistered = false;
     this.executeGraphqlOperation = undefined;
+    this.graphQLErrorConstructor = undefined;
     this.subscribeGraphqlOperation = undefined;
     this.yoga = undefined;
   }
@@ -413,6 +428,21 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
 
   private resolveIntrospectionEnabled(): boolean {
     return this.options.introspection ?? this.resolveGraphiqlEnabled();
+  }
+
+  private resolveWebSocketLimits(): GraphqlWebSocketLimits | undefined {
+    const limits = this.options.subscriptions?.websocket?.limits;
+
+    if (limits === false) {
+      return undefined;
+    }
+
+    return {
+      maxConnections: limits?.maxConnections ?? DEFAULT_GRAPHQL_WEBSOCKET_LIMITS.maxConnections,
+      maxOperationsPerConnection:
+        limits?.maxOperationsPerConnection ?? DEFAULT_GRAPHQL_WEBSOCKET_LIMITS.maxOperationsPerConnection,
+      maxPayloadBytes: limits?.maxPayloadBytes ?? DEFAULT_GRAPHQL_WEBSOCKET_LIMITS.maxPayloadBytes,
+    };
   }
 
   private resolveSchema(deps: GraphqlDeps): GraphQLSchemaType {
@@ -496,14 +526,25 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     }
 
     const upgradeServer = this.resolveUpgradeServer();
+    const websocketLimits = this.resolveWebSocketLimits();
     const websocketServer = new WebSocketServer({
-      handleProtocols: (protocols) => handleProtocols(protocols),
+      handleProtocols: (protocols: Set<string>) => handleProtocols(protocols),
+      maxPayload: websocketLimits?.maxPayloadBytes ?? 0,
       noServer: true,
     });
     const upgradeListener: NodeUpgradeListener = (request, socket, head) => {
       const targetPath = new URL(request.url ?? '/', 'http://localhost').pathname;
 
       if (!isGraphqlPath(targetPath)) {
+        return;
+      }
+
+      if (websocketLimits && websocketServer.clients.size >= websocketLimits.maxConnections) {
+        this.rejectWebSocketUpgrade(
+          socket,
+          503,
+          'GraphQL websocket connection count exceeds the configured limit.',
+        );
         return;
       }
 
@@ -622,6 +663,12 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
       throw new Error('GraphQL server not initialized.');
     }
 
+    const websocketLimitError = this.createWebSocketOperationLimitError(context.extra.socket, operationId);
+
+    if (websocketLimitError) {
+      return [websocketLimitError];
+    }
+
     const frameworkRequest = buildFrameworkRequestFromIncomingMessage(context.extra.request);
     const fetchRequest = toFetchRequest(frameworkRequest);
     const operationContainer = this.getOrCreateWebSocketOperationContainer(context.extra.socket, operationId);
@@ -659,6 +706,50 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
       await this.disposeWebSocketOperationContainer(context.extra.socket, operationId);
       throw error;
     }
+  }
+
+  private createWebSocketOperationLimitError(socketKey: object, operationId: string): GraphQLErrorType | undefined {
+    const limits = this.resolveWebSocketLimits();
+
+    if (!limits) {
+      return undefined;
+    }
+
+    const socketContainers = this.websocketOperationContainers.get(socketKey);
+
+    if (socketContainers?.has(operationId) || (socketContainers?.size ?? 0) < limits.maxOperationsPerConnection) {
+      return undefined;
+    }
+
+    const GraphQLError = this.graphQLErrorConstructor;
+
+    if (!GraphQLError) {
+      throw new Error('GraphQL error constructor not initialized.');
+    }
+
+    return new GraphQLError(
+      `GraphQL websocket active operation count exceeds the configured limit of ${String(limits.maxOperationsPerConnection)}.`,
+    );
+  }
+
+  private rejectWebSocketUpgrade(socket: Duplex, statusCode: number, message: string): void {
+    if (!socket.writable) {
+      socket.destroy();
+      return;
+    }
+
+    const body = `${message}\n`;
+    socket.write(
+      [
+        `HTTP/1.1 ${String(statusCode)} ${statusCode === 503 ? 'Service Unavailable' : 'Bad Request'}`,
+        'Connection: close',
+        'Content-Type: text/plain; charset=utf-8',
+        `Content-Length: ${String(Buffer.byteLength(body))}`,
+        '',
+        body,
+      ].join('\r\n'),
+    );
+    socket.destroy();
   }
 
   private getOrCreateWebSocketOperationContainer(socketKey: object, operationId: string): Container {

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -48,12 +48,41 @@ export interface GraphQLContext {
 }
 
 /**
+ * Budget settings applied to the optional GraphQL websocket transport.
+ */
+export interface GraphqlWebSocketLimitsOptions {
+  /**
+   * Maximum number of concurrently connected websocket clients.
+   *
+   * Set to `false` through `subscriptions.websocket.limits = false` to opt out of
+   * the built-in connection budget entirely.
+   */
+  maxConnections?: number;
+  /**
+   * Maximum websocket frame payload size accepted from one client, in bytes.
+   */
+  maxPayloadBytes?: number;
+  /**
+   * Maximum number of active GraphQL operations allowed on one websocket connection.
+   */
+  maxOperationsPerConnection?: number;
+}
+
+/**
  * WebSocket-specific subscription settings for `GraphqlModule`.
  */
 export interface GraphqlWebSocketSubscriptionsOptions {
   connectionInitWaitTimeoutMs?: number;
   enabled?: boolean;
   keepAliveMs?: number;
+  /**
+   * Configures built-in websocket hardening budgets for connection count,
+   * payload size, and concurrent operations.
+   *
+   * Pass `false` to disable these websocket-specific guardrails and preserve
+   * legacy unbounded transport behavior.
+   */
+  limits?: GraphqlWebSocketLimitsOptions | false;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add websocket guardrails for connection count, payload size, and active operations per connection in the GraphQL lifecycle service
- cover the new websocket limits in module/service tests and document the default budgets plus opt-out behavior in the README

## Verification
- pnpm --filter @fluojs/graphql test
- pnpm build
- pnpm --filter @fluojs/graphql typecheck
- pnpm --filter @fluojs/graphql build

## Contract impact
- preserves the existing GraphQL websocket transport while adding documented default transport guardrails; callers can still opt out with `subscriptions.websocket.limits = false`

Closes #1095