### PR TITLE
Resolve #1096: add JWKS fetch timeout budget

### DIFF
--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -93,6 +93,20 @@ const verifier = new DefaultJwtVerifier({
 
 `@fluojs/jwt`는 `scope` (문자열)와 `scopes` (배열) 클레임을 자동으로 감지하여 `JwtPrincipal`의 단일 `scopes: string[]` 속성으로 통합합니다. 이를 통해 권한 가드에서 일관된 로직을 적용할 수 있습니다.
 
+### 원격 JWKS 검증
+
+검증 키를 원격 JWKS 엔드포인트에서 가져올 때는, 느리거나 멈춘 identity provider 때문에 인증 경로가 무한정 대기하지 않도록 fetch budget을 명시적으로 제한하세요.
+
+```typescript
+const verifier = new DefaultJwtVerifier({
+  algorithms: ['RS256'],
+  jwksRequestTimeoutMs: 5_000,
+  jwksUri: 'https://issuer.example.com/.well-known/jwks.json',
+});
+```
+
+`jwksRequestTimeoutMs`의 기본값은 `5_000`이며, 예산을 넘기면 진행 중인 JWKS fetch를 abort합니다.
+
 ## 공개 API 개요
 
 ### 주요 클래스

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -93,6 +93,20 @@ const verifier = new DefaultJwtVerifier({
 
 `@fluojs/jwt` automatically unifies `scope` (string) and `scopes` (array) claims into a single `scopes: string[]` property in the `JwtPrincipal`, ensuring consistent behavior for authorization guards.
 
+### Remote JWKS verification
+
+When verification keys come from a remote JWKS endpoint, keep the fetch path bounded so auth traffic cannot hang on a slow or stalled identity provider.
+
+```typescript
+const verifier = new DefaultJwtVerifier({
+  algorithms: ['RS256'],
+  jwksRequestTimeoutMs: 5_000,
+  jwksUri: 'https://issuer.example.com/.well-known/jwks.json',
+});
+```
+
+`jwksRequestTimeoutMs` defaults to `5_000` and aborts the outbound JWKS fetch once that budget is exceeded.
+
 ## Public API Overview
 
 ### Core Classes

--- a/packages/jwt/src/signing/jwks.test.ts
+++ b/packages/jwt/src/signing/jwks.test.ts
@@ -88,6 +88,24 @@ describe('JwksClient', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('fails fast when the jwks fetch exceeds the configured timeout budget', async () => {
+    globalThis.fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise((_, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => {
+            reject(Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' }));
+          },
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+
+    const client = new JwksClient('https://example.test/.well-known/jwks.json', 30_000, 5);
+
+    await expect(client.getSigningKey('key-1')).rejects.toThrow('JWKS fetch timed out after 5ms.');
+  });
 });
 
 describe('DefaultJwtVerifier with jwksUri', () => {
@@ -118,5 +136,30 @@ describe('DefaultJwtVerifier with jwksUri', () => {
     await expect(verifier.verifyAccessToken(token)).resolves.toMatchObject({
       subject: 'jwks-user',
     });
+  });
+
+  it('passes the jwks request timeout through verifier options', async () => {
+    globalThis.fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise((_, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => {
+            reject(Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' }));
+          },
+          { once: true },
+        );
+      });
+    }) as typeof fetch;
+
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['RS256'],
+      jwksRequestTimeoutMs: 5,
+      jwksUri: 'https://example.test/.well-known/jwks.json',
+    });
+
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const token = createRs256Token(privateKey, 'key-1');
+
+    await expect(verifier.verifyAccessToken(token)).rejects.toThrow('JWKS fetch timed out after 5ms.');
   });
 });

--- a/packages/jwt/src/signing/jwks.ts
+++ b/packages/jwt/src/signing/jwks.ts
@@ -17,7 +17,12 @@ export class JwksClient {
   constructor(
     private readonly uri: string,
     private readonly cacheTtl: number = 600_000,
+    private readonly requestTimeoutMs: number = 5_000,
   ) {}
+
+  private isAbortError(error: unknown): boolean {
+    return error instanceof Error && error.name === 'AbortError';
+  }
 
   async getSigningKey(kid: string): Promise<KeyObject> {
     const now = Date.now();
@@ -52,11 +57,21 @@ export class JwksClient {
 
   private async fetchKeys(): Promise<Jwk[]> {
     let response: Response;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, this.requestTimeoutMs);
 
     try {
-      response = await fetch(this.uri);
-    } catch {
+      response = await fetch(this.uri, { signal: controller.signal });
+    } catch (error) {
+      if (this.isAbortError(error)) {
+        throw new JwtConfigurationError(`JWKS fetch timed out after ${String(this.requestTimeoutMs)}ms.`);
+      }
+
       throw new JwtConfigurationError(`Failed to fetch JWKS from "${this.uri}".`);
+    } finally {
+      clearTimeout(timeout);
     }
 
     if (!response.ok) {

--- a/packages/jwt/src/signing/verifier.ts
+++ b/packages/jwt/src/signing/verifier.ts
@@ -242,7 +242,9 @@ export class DefaultJwtVerifier {
   private readonly refreshVerificationOptions: JwtVerifierOptions | undefined;
 
   constructor(private readonly options: JwtVerifierOptions) {
-    this.jwksClient = options.jwksUri ? new JwksClient(options.jwksUri, options.jwksCacheTtl) : undefined;
+    this.jwksClient = options.jwksUri
+      ? new JwksClient(options.jwksUri, options.jwksCacheTtl, options.jwksRequestTimeoutMs)
+      : undefined;
     this.keyResolutionState = createKeyResolutionState(options.keys);
     this.refreshVerificationOptions =
       options.refreshToken

--- a/packages/jwt/src/types.ts
+++ b/packages/jwt/src/types.ts
@@ -18,6 +18,7 @@ export interface JwtVerifierOptions {
   clockSkewSeconds?: number;
   issuer?: string;
   jwksCacheTtl?: number;
+  jwksRequestTimeoutMs?: number;
   jwksUri?: string;
   keys?: JwtKeyEntry[];
   maxAge?: number;


### PR DESCRIPTION
## Summary
- add a bounded timeout budget to remote JWKS fetches and abort stalled requests instead of waiting indefinitely
- cover the timeout behavior in jwks tests and document the new verifier option in the JWT README

## Verification
- pnpm --filter @fluojs/jwt test
- pnpm build
- pnpm --filter @fluojs/jwt typecheck
- pnpm --filter @fluojs/jwt build

## Contract impact
- preserves the existing JWKS verifier contract while adding a default 5-second timeout budget via `jwksRequestTimeoutMs`

Closes #1096