### PR TITLE
Resolve #1098: add queue dead-letter retention policy

### DIFF
--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -101,6 +101,8 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 모든 재시도에 실패한 작업은 Redis의 데드 레터 리스트(`fluo:queue:dead-letter:<jobName>`)로 자동 이동되어, 나중에 수동으로 확인하거나 복구할 수 있습니다.
 
+`QueueModule.forRoot()`는 기본적으로 작업별 최근 데드 레터 엔트리 `1_000`개만 유지합니다. 무제한 보관이 꼭 필요하면 `defaultDeadLetterMaxEntries: false`로 opt-out 하고, 더 엄격한 운영 예산이 필요하면 더 작은 양의 정수를 지정하세요.
+
 ## 공개 API 개요
 
 ### 핵심 구성 요소

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -101,6 +101,8 @@ Workers can be configured with a maximum number of attempts and backoff strategi
 
 Jobs that fail all retry attempts are automatically moved to a dead-letter list in Redis (`fluo:queue:dead-letter:<jobName>`) for manual inspection or recovery.
 
+`QueueModule.forRoot()` keeps the most recent `1_000` dead-letter entries per job by default. Set `defaultDeadLetterMaxEntries: false` to opt out, or provide a smaller positive number when operators need a tighter retention budget.
+
 ## Public API Overview
 
 ### Core

--- a/packages/queue/src/helpers.ts
+++ b/packages/queue/src/helpers.ts
@@ -82,6 +82,27 @@ export function normalizePositiveInteger(value: number | undefined, fallback: nu
   return normalized;
 }
 
+export function normalizePositiveIntegerOrFalse(
+  value: number | false | undefined,
+  fallback: number | false,
+): number | false {
+  if (value === false) {
+    return false;
+  }
+
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const normalized = Math.trunc(value);
+
+  if (normalized < 1) {
+    return fallback;
+  }
+
+  return normalized;
+}
+
 export function normalizeRateLimiter(rateLimiter: QueueRateLimiterOptions | undefined): QueueRateLimiterOptions | undefined {
   if (!rateLimiter) {
     return undefined;

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -269,6 +269,34 @@ class MockRedisClient {
     this.deadLetters.set(key, entries);
     return entries.length;
   }
+
+  async ltrim(key: string, start: number, stop: number): Promise<'OK'> {
+    const entries = this.deadLetters.get(key) ?? [];
+
+    const resolveIndex = (index: number): number => {
+      if (index < 0) {
+        return Math.max(entries.length + index, 0);
+      }
+
+      return Math.min(index, entries.length - 1);
+    };
+
+    if (entries.length === 0) {
+      this.deadLetters.set(key, []);
+      return 'OK';
+    }
+
+    const startIndex = resolveIndex(start);
+    const stopIndex = resolveIndex(stop);
+
+    if (startIndex > stopIndex) {
+      this.deadLetters.set(key, []);
+      return 'OK';
+    }
+
+    this.deadLetters.set(key, entries.slice(startIndex, stopIndex + 1));
+    return 'OK';
+  }
 }
 
 function createLogger(events: string[]): ApplicationLogger {
@@ -625,6 +653,79 @@ describe('@fluojs/queue', () => {
         },
       },
     });
+
+    await app.close();
+  });
+
+  it('trims dead-letter lists to the configured module retention budget', async () => {
+    class TrimmedDeadLetterJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(TrimmedDeadLetterJob, { attempts: 1, jobName: 'trimmed-dead-letter-job' })
+    class TrimmedDeadLetterWorker {
+      async handle(_job: TrimmedDeadLetterJob): Promise<void> {
+        throw new Error('trim me');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot({ defaultDeadLetterMaxEntries: 2 })],
+      providers: [TrimmedDeadLetterWorker],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const queue = await app.container.resolve<Queue>(QUEUE);
+
+    await queue.enqueue(new TrimmedDeadLetterJob('job-1'));
+    await queue.enqueue(new TrimmedDeadLetterJob('job-2'));
+    await queue.enqueue(new TrimmedDeadLetterJob('job-3'));
+
+    const deadLetters = redis.deadLetters.get('fluo:queue:dead-letter:trimmed-dead-letter-job') ?? [];
+
+    expect(deadLetters).toHaveLength(2);
+    expect(deadLetters.map((entry) => JSON.parse(entry).payload.id)).toEqual(['job-2', 'job-3']);
+
+    await app.close();
+  });
+
+  it('allows opting out of dead-letter trimming with defaultDeadLetterMaxEntries: false', async () => {
+    class UnboundedDeadLetterJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(UnboundedDeadLetterJob, { attempts: 1, jobName: 'unbounded-dead-letter-job' })
+    class UnboundedDeadLetterWorker {
+      async handle(_job: UnboundedDeadLetterJob): Promise<void> {
+        throw new Error('keep all dead letters');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot({ defaultDeadLetterMaxEntries: false })],
+      providers: [UnboundedDeadLetterWorker],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const queue = await app.container.resolve<Queue>(QUEUE);
+
+    await queue.enqueue(new UnboundedDeadLetterJob('job-1'));
+    await queue.enqueue(new UnboundedDeadLetterJob('job-2'));
+    await queue.enqueue(new UnboundedDeadLetterJob('job-3'));
+
+    const deadLetters = redis.deadLetters.get('fluo:queue:dead-letter:unbounded-dead-letter-job') ?? [];
+
+    expect(deadLetters).toHaveLength(3);
 
     await app.close();
   });

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -1,7 +1,7 @@
 import type { Provider } from '@fluojs/di';
 import { defineModule, type ModuleType } from '@fluojs/runtime';
 
-import { normalizePositiveInteger, normalizeRateLimiter } from './helpers.js';
+import { normalizePositiveInteger, normalizePositiveIntegerOrFalse, normalizeRateLimiter } from './helpers.js';
 import { QueueLifecycleService } from './service.js';
 import { QUEUE, QUEUE_OPTIONS } from './tokens.js';
 import type { NormalizedQueueModuleOptions, QueueModuleOptions } from './types.js';
@@ -19,6 +19,7 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
         }
       : undefined,
     defaultConcurrency: normalizePositiveInteger(options.defaultConcurrency, 1),
+    defaultDeadLetterMaxEntries: normalizePositiveIntegerOrFalse(options.defaultDeadLetterMaxEntries, 1_000),
     defaultRateLimiter,
   };
 }

--- a/packages/queue/src/public-surface.test.ts
+++ b/packages/queue/src/public-surface.test.ts
@@ -22,6 +22,7 @@ describe('@fluojs/queue root barrel public surface', () => {
     const readme = readFileSync(resolve(import.meta.dirname, '../README.md'), 'utf8');
 
     expect(readme).toContain('QueueWorkerOptions`: Per-job settings (attempts, backoff, concurrency, jobName, rate limiting).');
+    expect(readme).toContain('defaultDeadLetterMaxEntries');
     expect(readme).not.toContain('QueueWorkerOptions`: Per-job settings (attempts, backoff, concurrency, priority).');
   });
 });

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -46,6 +46,7 @@ type QueueOwnedConnection = ConnectionOptions & {
 
 interface QueueRedisClient {
   duplicate(): QueueOwnedConnection;
+  ltrim(key: string, start: number, stop: number): Promise<unknown>;
   rpush(key: string, value: string): Promise<unknown>;
 }
 
@@ -75,9 +76,9 @@ function hasQueueRedisClient(value: unknown): value is QueueRedisClient {
     return false;
   }
 
-  const client = value as { duplicate?: unknown; rpush?: unknown };
+  const client = value as { duplicate?: unknown; ltrim?: unknown; rpush?: unknown };
 
-  return typeof client.duplicate === 'function' && typeof client.rpush === 'function';
+  return typeof client.duplicate === 'function' && typeof client.rpush === 'function' && typeof client.ltrim === 'function';
 }
 
 function isQueuePayload(value: unknown): value is QueuePayload {
@@ -256,13 +257,13 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     const redisToken = getRedisClientToken(this.options.clientName);
 
     if (!this.runtimeContainer.has(redisToken)) {
-      throw new Error('@fluojs/queue requires a registered Redis client with duplicate() and rpush() methods.');
+      throw new Error('@fluojs/queue requires a registered Redis client with duplicate(), rpush(), and ltrim() methods.');
     }
 
     const redisClient = await this.runtimeContainer.resolve(redisToken);
 
     if (!hasQueueRedisClient(redisClient)) {
-      throw new Error('@fluojs/queue requires a Redis client with duplicate() and rpush() methods.');
+      throw new Error('@fluojs/queue requires a Redis client with duplicate(), rpush(), and ltrim() methods.');
     }
 
     return redisClient;
@@ -569,6 +570,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     }
 
     try {
+      const key = deadLetterKey(descriptor.jobName);
       const deadLetter = {
         attemptsMade: job.attemptsMade,
         errorMessage: error.message,
@@ -578,7 +580,12 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
         payload: isQueuePayload(job.data) ? cloneWithFallback(job.data) : job.data,
       };
 
-      await this.getRedisClient().rpush(deadLetterKey(descriptor.jobName), JSON.stringify(deadLetter));
+      const redis = this.getRedisClient();
+      await redis.rpush(key, JSON.stringify(deadLetter));
+
+      if (this.options.defaultDeadLetterMaxEntries !== false) {
+        await redis.ltrim(key, -this.options.defaultDeadLetterMaxEntries, -1);
+      }
     } catch (deadLetterError) {
       this.logger.error(
         `Failed to append dead-letter record for queue job ${descriptor.jobName}.`,

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -40,6 +40,7 @@ export interface QueueModuleOptions {
   defaultAttempts?: number;
   defaultBackoff?: QueueBackoffOptions;
   defaultConcurrency?: number;
+  defaultDeadLetterMaxEntries?: number | false;
   defaultRateLimiter?: QueueRateLimiterOptions;
 }
 
@@ -49,6 +50,7 @@ export interface NormalizedQueueModuleOptions {
   defaultAttempts: number;
   defaultBackoff?: QueueBackoffOptions;
   defaultConcurrency: number;
+  defaultDeadLetterMaxEntries: number | false;
   defaultRateLimiter?: QueueRateLimiterOptions;
 }
 


### PR DESCRIPTION
## Summary
- add a module-level dead-letter retention policy so queue dead-letter lists stay bounded by default and can opt out explicitly
- trim Redis dead-letter lists after terminal failures, cover the retention behavior in queue tests, and document the default policy in the queue README

## Verification
- pnpm --filter @fluojs/queue test
- pnpm build
- pnpm --filter @fluojs/queue typecheck
- pnpm --filter @fluojs/queue build

## Contract impact
- introduces a default dead-letter retention budget of 1,000 entries per job via `defaultDeadLetterMaxEntries`, with `false` preserving unbounded retention when operators explicitly opt out

Closes #1098