### PR TITLE
Resolve #1114: route HTTP and microservice failure logs through framework logger

### DIFF
--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Container } from '@fluojs/di';
 
@@ -773,6 +773,65 @@ describe('dispatcher runtime', () => {
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ ok: true });
     expect(events).toEqual(['start', 'match', 'handler', 'finish']);
+  });
+
+  it('routes observer and request-scope disposal failures through the dispatcher logger', async () => {
+    const logger = {
+      error: vi.fn(),
+    };
+    const observer = {
+      onRequestStart() {
+        throw new Error('observer seam failed');
+      },
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(HealthController);
+    const createRequestScope = root.createRequestScope.bind(root);
+
+    vi.spyOn(root, 'createRequestScope').mockImplementation(() => {
+      const scope = createRequestScope();
+      const dispose = scope.dispose.bind(scope);
+
+      scope.dispose = async () => {
+        await dispose();
+        throw new Error('scope dispose failed');
+      };
+
+      return scope;
+    });
+
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: HealthController }]),
+      logger,
+      observers: [observer],
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/health', 'GET', { 'x-request-id': 'req-logger-seam' }), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(logger.error).toHaveBeenNthCalledWith(
+      1,
+      'Request observer threw an unhandled error.',
+      expect.objectContaining({ message: 'observer seam failed' }),
+      'HttpDispatcher',
+    );
+    expect(logger.error).toHaveBeenNthCalledWith(
+      2,
+      'Request-scoped container dispose threw an error.',
+      expect.objectContaining({ message: 'scope dispose failed' }),
+      'HttpDispatcher',
+    );
   });
 
   it('sets the correlation response header before downstream code commits the response', async () => {

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -14,6 +14,7 @@ import type {
   Binder,
   ContentNegotiationOptions,
   Dispatcher,
+  DispatcherLogger,
   FrameworkRequest,
   FrameworkResponse,
   GuardContext,
@@ -52,8 +53,22 @@ export interface CreateDispatcherOptions {
   observers?: RequestObserverLike[];
   /** Optional global error handler. */
   onError?: ErrorHandler;
+  logger?: DispatcherLogger;
   /** Root DI container for creating request scopes. */
   rootContainer: Container;
+}
+
+function logDispatchFailure(
+  logger: DispatcherLogger | undefined,
+  message: string,
+  error: unknown,
+): void {
+  if (logger) {
+    logger.error(message, error, 'HttpDispatcher');
+    return;
+  }
+
+  console.error(`[fluo][HttpDispatcher] ${message}`, error);
 }
 
 function createDispatchRequest(request: FrameworkRequest): FrameworkRequest {
@@ -127,12 +142,13 @@ async function notifyObserversSafely(
   observers: RequestObserverLike[],
   requestContext: RequestContext,
   callback: (observer: RequestObserver, context: RequestObservationContext) => Promise<void> | void,
+  logger: DispatcherLogger | undefined,
   handler?: HandlerDescriptor,
 ): Promise<void> {
   try {
     await notifyObservers(observers, requestContext, callback, handler);
   } catch (error) {
-    console.error('[fluo] request observer threw an unhandled error:', error);
+    logDispatchFailure(logger, 'Request observer threw an unhandled error.', error);
   }
 }
 
@@ -143,6 +159,7 @@ async function dispatchMatchedHandler(
   contentNegotiation: ResolvedContentNegotiation | undefined,
   binder: Binder | undefined,
   globalInterceptors: InterceptorLike[] | undefined,
+  logger: DispatcherLogger | undefined,
 ): Promise<void> {
   const guardContext: GuardContext = {
     handler,
@@ -177,6 +194,7 @@ async function dispatchMatchedHandler(
     async (observer, context) => {
       await observer.onRequestSuccess?.(context, result);
     },
+    logger,
     handler,
   );
 }
@@ -191,9 +209,14 @@ interface DispatchPhaseContext {
 }
 
 async function notifyRequestStart(context: DispatchPhaseContext): Promise<void> {
-  await notifyObserversSafely(context.observers, context.requestContext, async (observer, observationContext) => {
-    await observer.onRequestStart?.(observationContext);
-  });
+  await notifyObserversSafely(
+    context.observers,
+    context.requestContext,
+    async (observer, observationContext) => {
+      await observer.onRequestStart?.(observationContext);
+    },
+    context.options.logger,
+  );
 }
 
 async function notifyHandlerMatched(context: DispatchPhaseContext, descriptor: HandlerDescriptor): Promise<void> {
@@ -203,6 +226,7 @@ async function notifyHandlerMatched(context: DispatchPhaseContext, descriptor: H
     async (observer, observationContext) => {
       await observer.onHandlerMatched?.(observationContext);
     },
+    context.options.logger,
     descriptor,
   );
 }
@@ -214,6 +238,7 @@ async function notifyRequestError(context: DispatchPhaseContext, error: unknown)
     async (observer, observationContext) => {
       await observer.onRequestError?.(observationContext, error);
     },
+    context.options.logger,
     context.matchedHandler,
   );
 }
@@ -225,6 +250,7 @@ async function notifyRequestFinish(context: DispatchPhaseContext): Promise<void>
     async (observer, observationContext) => {
       await observer.onRequestFinish?.(observationContext);
     },
+    context.options.logger,
     context.matchedHandler,
   );
 }
@@ -262,6 +288,7 @@ async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void>
         context.contentNegotiation,
         context.options.binder,
         context.options.interceptors,
+        context.options.logger,
       );
     });
   });
@@ -318,8 +345,7 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
           try {
             await phaseContext.requestContext.container.dispose();
           } catch (error) {
-            // dispose errors are logged but must not mask the original request error
-            console.error('[fluo] request-scoped container dispose threw an error:', error);
+            logDispatchFailure(options.logger, 'Request-scoped container dispose threw an error.', error);
           }
         }
       });

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -211,6 +211,11 @@ export interface Dispatcher {
   dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void>;
 }
 
+/** Logger seam used by the dispatcher for non-fatal internal failure reporting. */
+export interface DispatcherLogger {
+  error(message: string, error?: unknown, context?: string): void;
+}
+
 /** Observation payload delivered to request observers throughout one dispatch. */
 export interface RequestObservationContext {
   handler?: HandlerDescriptor;

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { Inject, Scope } from '@fluojs/core';
 import { defineControllerMetadata, defineModuleMetadata } from '@fluojs/core/internal';
 import { bootstrapApplication, FluoFactory } from '@fluojs/runtime';
+import type { ApplicationLogger } from '@fluojs/runtime';
 
 import { BidiStreamPattern, ClientStreamPattern, EventPattern, MessagePattern, ServerStreamPattern } from './decorators.js';
 import { KafkaMicroserviceTransport } from './transports/kafka-transport.js';
@@ -13,6 +14,7 @@ import { RedisPubSubMicroserviceTransport } from './transports/redis-transport.j
 import { TcpMicroserviceTransport } from './transports/tcp-transport.js';
 import type {
   MicroserviceTransport,
+  MicroserviceTransportLogger,
   ServerStreamWriter,
   TransportBidiStreamHandler,
   TransportClientStreamHandler,
@@ -542,6 +544,67 @@ describe('@fluojs/microservices', () => {
     await Promise.all([microservice.listen(), microservice.listen()]);
 
     expect(listenCalls).toBe(1);
+
+    await microservice.close();
+  });
+
+  it('injects the framework logger into transports without changing non-fatal event semantics', async () => {
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message: string, error?: unknown, context?: string) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
+      },
+      log() {},
+      warn() {},
+    };
+
+    class LoggerAwareTransport implements MicroserviceTransport {
+      private handler: TransportHandler | undefined;
+      private logger: MicroserviceTransportLogger | undefined;
+
+      setLogger(loggerInstance: MicroserviceTransportLogger): void {
+        this.logger = loggerInstance;
+      }
+
+      async close(): Promise<void> {}
+
+      async emit(pattern: string, payload: unknown): Promise<void> {
+        void pattern;
+        void payload;
+        this.logger?.error('Event handler failed.', new Error('event boom'), 'LoggerAwareTransport');
+      }
+
+      async listen(handler: TransportHandler): Promise<void> {
+        this.handler = handler;
+      }
+
+      async send(): Promise<unknown> {
+        return undefined;
+      }
+    }
+
+    const transport = new LoggerAwareTransport();
+
+    class Handler {
+      @EventPattern('audit.fail')
+      onAudit() {
+        throw new Error('event boom');
+      }
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [MicroservicesModule.forRoot({ transport })],
+      providers: [Handler],
+    });
+
+    const microservice = await FluoFactory.createMicroservice(AppModule, { logger });
+    await microservice.listen();
+
+    await expect(microservice.emit('audit.fail', { ok: false })).resolves.toBeUndefined();
+
+    expect(loggerEvents).toContain('error:LoggerAwareTransport:Event handler failed.:event boom');
 
     await microservice.close();
   });

--- a/packages/microservices/src/service.ts
+++ b/packages/microservices/src/service.ts
@@ -93,6 +93,7 @@ export class MicroserviceLifecycleService implements Microservice, MicroserviceR
       this.descriptors.push(...this.discoverHandlerDescriptors());
 
       const transport = this.moduleOptions.transport;
+      transport.setLogger?.(this.logger);
 
       if (transport.listenServerStreaming) {
         transport.listenServerStreaming(

--- a/packages/microservices/src/transports/grpc-transport.test.ts
+++ b/packages/microservices/src/transports/grpc-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { GrpcMicroserviceTransport } from './grpc-transport.js';
 import type { ServerStreamWriter } from '../types.js';
@@ -701,6 +701,30 @@ describe('GrpcMicroserviceTransport', () => {
 
     expect(first).toBe(2);
     expect(second).toBe(4);
+
+    await transport.close();
+  });
+
+  it('routes event handler failures through the injected logger without rejecting emit()', async () => {
+    const { transport } = createGrpcTransport();
+    const logger = { error: vi.fn() };
+
+    transport.setLogger(logger);
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'event') {
+        throw new Error('grpc event failed');
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.emit('MathService.Notify', { value: 'bad' })).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event handler failed.',
+      expect.objectContaining({ message: 'grpc event failed' }),
+      'GrpcMicroserviceTransport',
+    );
 
     await transport.close();
   });

--- a/packages/microservices/src/transports/grpc-transport.ts
+++ b/packages/microservices/src/transports/grpc-transport.ts
@@ -1,4 +1,4 @@
-import type { MicroserviceTransport, ServerStreamWriter, TransportBidiStreamHandler, TransportClientStreamHandler, TransportHandler, TransportServerStreamHandler } from '../types.js';
+import type { MicroserviceTransport, MicroserviceTransportLogger, ServerStreamWriter, TransportBidiStreamHandler, TransportClientStreamHandler, TransportHandler, TransportServerStreamHandler } from '../types.js';
 
 type DynamicImport = (specifier: string) => Promise<unknown>;
 
@@ -135,6 +135,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
   private readonly clients = new Map<string, ServiceRuntime>();
   private grpc: GrpcJsLike | undefined;
   private handler: TransportHandler | undefined;
+  private logger: MicroserviceTransportLogger | undefined;
   private listening = false;
   private listenPromise: Promise<void> | undefined;
   private readonly pending = new Map<string, PendingRequest>();
@@ -152,6 +153,10 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
   constructor(private readonly options: GrpcMicroserviceTransportOptions) {
     this.requestTimeoutMs = options.requestTimeoutMs ?? 3_000;
     this.server = options.server;
+  }
+
+  setLogger(logger: MicroserviceTransportLogger): void {
+    this.logger = logger;
   }
 
   /**
@@ -1271,6 +1276,11 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
   }
 
   private logEventHandlerFailure(error: unknown): void {
+    if (this.logger) {
+      this.logger.error('Event handler failed.', error, 'GrpcMicroserviceTransport');
+      return;
+    }
+
     console.error('[fluo][GrpcMicroserviceTransport] event handler failed:', error);
   }
 }

--- a/packages/microservices/src/transports/mqtt-transport.test.ts
+++ b/packages/microservices/src/transports/mqtt-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { MqttMicroserviceTransport } from './mqtt-transport.js';
 
@@ -311,6 +311,32 @@ describe('MqttMicroserviceTransport', () => {
 
     await transport.listen(async () => 'second');
     await expect(transport.send('health.ping', {})).resolves.toBe('second');
+    await transport.close();
+  });
+
+  it('routes event handler failures through the injected logger without rejecting emit()', async () => {
+    const broker = new InMemoryMqttBroker();
+    const transport = new MqttMicroserviceTransport({ client: new InMemoryMqttClient(broker) });
+    const logger = { error: vi.fn() };
+
+    transport.setLogger(logger);
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'event') {
+        throw new Error('mqtt event failed');
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.emit('audit.event', { value: 'bad' })).resolves.toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event handler failed.',
+      expect.objectContaining({ message: 'mqtt event failed' }),
+      'MqttMicroserviceTransport',
+    );
+
     await transport.close();
   });
 

--- a/packages/microservices/src/transports/mqtt-transport.ts
+++ b/packages/microservices/src/transports/mqtt-transport.ts
@@ -1,4 +1,4 @@
-import type { MicroserviceTransport, TransportHandler } from '../types.js';
+import type { MicroserviceTransport, MicroserviceTransportLogger, TransportHandler } from '../types.js';
 
 type DynamicImport = (specifier: string) => Promise<unknown>;
 
@@ -93,6 +93,7 @@ export class MqttMicroserviceTransport implements MicroserviceTransport {
   private closing = false;
   private handler: TransportHandler | undefined;
   private readonly internallyOwnedClient: boolean;
+  private logger: MicroserviceTransportLogger | undefined;
   private listening = false;
   private listenPromise: Promise<void> | undefined;
   private readonly messageListener = (topic: string, payload: Buffer) => {
@@ -131,6 +132,10 @@ export class MqttMicroserviceTransport implements MicroserviceTransport {
     this.requestTimeoutMs = options.requestTimeoutMs ?? 3_000;
     this.client = options.client;
     this.internallyOwnedClient = !options.client;
+  }
+
+  setLogger(logger: MicroserviceTransportLogger): void {
+    this.logger = logger;
   }
 
   /**
@@ -571,6 +576,11 @@ export class MqttMicroserviceTransport implements MicroserviceTransport {
   }
 
   private logEventHandlerFailure(error: unknown): void {
+    if (this.logger) {
+      this.logger.error('Event handler failed.', error, 'MqttMicroserviceTransport');
+      return;
+    }
+
     console.error('[fluo][MqttMicroserviceTransport] event handler failed:', error);
   }
 }

--- a/packages/microservices/src/transports/nats-transport.test.ts
+++ b/packages/microservices/src/transports/nats-transport.test.ts
@@ -126,9 +126,10 @@ describe('NatsMicroserviceTransport', () => {
         return new TextEncoder().encode(value);
       },
     };
-    const logger = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = { error: vi.fn() };
 
     const transport = new NatsMicroserviceTransport({ client: nats, codec });
+    transport.setLogger(logger);
     await transport.listen(async (packet) => {
       if (packet.kind === 'event') {
         throw new Error('nats event failed');
@@ -140,7 +141,11 @@ describe('NatsMicroserviceTransport', () => {
     await expect(transport.emit('audit.value', { value: 9 })).resolves.toBeUndefined();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(logger).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event handler failed.',
+      expect.objectContaining({ message: 'nats event failed' }),
+      'NatsMicroserviceTransport',
+    );
 
     await transport.close();
   });
@@ -155,15 +160,20 @@ describe('NatsMicroserviceTransport', () => {
         return new TextEncoder().encode(value);
       },
     };
-    const logger = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = { error: vi.fn() };
 
     const transport = new NatsMicroserviceTransport({ client: nats, codec });
+    transport.setLogger(logger);
     await transport.listen(async () => undefined);
 
     nats.publish('fluo.microservices.events', new TextEncoder().encode('{not-json'));
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(logger).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event handler failed.',
+      expect.any(Error),
+      'NatsMicroserviceTransport',
+    );
 
     await transport.close();
   });

--- a/packages/microservices/src/transports/nats-transport.ts
+++ b/packages/microservices/src/transports/nats-transport.ts
@@ -1,4 +1,4 @@
-import type { MicroserviceTransport, TransportHandler } from '../types.js';
+import type { MicroserviceTransport, MicroserviceTransportLogger, TransportHandler } from '../types.js';
 
 interface NatsMessageLike {
   readonly data: Uint8Array;
@@ -55,6 +55,7 @@ interface PendingRequest {
 export class NatsMicroserviceTransport implements MicroserviceTransport {
   private closing = false;
   private handler: TransportHandler | undefined;
+  private logger: MicroserviceTransportLogger | undefined;
   private listening = false;
   private readonly eventSubject: string;
   private readonly messageSubject: string;
@@ -63,6 +64,11 @@ export class NatsMicroserviceTransport implements MicroserviceTransport {
   private subscriptions: NatsSubscriptionLike[] = [];
 
   private logEventHandlerFailure(error: unknown): void {
+    if (this.logger) {
+      this.logger.error('Event handler failed.', error, 'NatsMicroserviceTransport');
+      return;
+    }
+
     console.error('[fluo][NatsMicroserviceTransport] event handler failed:', error);
   }
 
@@ -81,6 +87,10 @@ export class NatsMicroserviceTransport implements MicroserviceTransport {
     this.eventSubject = options.eventSubject ?? 'fluo.microservices.events';
     this.messageSubject = options.messageSubject ?? 'fluo.microservices.messages';
     this.requestTimeoutMs = options.requestTimeoutMs ?? 3_000;
+  }
+
+  setLogger(logger: MicroserviceTransportLogger): void {
+    this.logger = logger;
   }
 
   /**

--- a/packages/microservices/src/transports/redis-streams-transport.test.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   RedisStreamsMicroserviceTransport,
@@ -516,6 +516,9 @@ describe('RedisStreamsMicroserviceTransport', () => {
         },
       },
     });
+    const logger = { error: vi.fn() };
+
+    transport.setLogger(logger);
 
     await transport.listen(async (packet) => {
       if (packet.kind === 'event') {
@@ -529,6 +532,11 @@ describe('RedisStreamsMicroserviceTransport', () => {
     await sleep(20);
 
     expect(acknowledgements.some((entry) => entry.startsWith('fluo:streams:events:'))).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event handler failed.',
+      expect.objectContaining({ message: 'event failed' }),
+      'RedisStreamsMicroserviceTransport',
+    );
 
     await transport.close();
   });
@@ -716,13 +724,21 @@ describe('RedisStreamsMicroserviceTransport', () => {
     const { transport } = createTransport(bus, {
       requestTimeoutMs: 1_000,
     });
+    const logger = { error: vi.fn() };
 
+    transport.setLogger(logger);
     await transport.listen(async () => {
       throw new Error('redis streams event handler failed');
     });
 
     await expect(transport.emit('audit.login', { message: 'ok' })).resolves.toBeUndefined();
     await sleep(30);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event handler failed.',
+      expect.objectContaining({ message: 'redis streams event handler failed' }),
+      'RedisStreamsMicroserviceTransport',
+    );
 
     await transport.close();
   });

--- a/packages/microservices/src/transports/redis-streams-transport.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.ts
@@ -1,4 +1,4 @@
-import type { MicroserviceTransport, TransportHandler } from '../types.js';
+import type { MicroserviceTransport, MicroserviceTransportLogger, TransportHandler } from '../types.js';
 
 interface StreamReadGroupResult {
   readonly id: string;
@@ -81,6 +81,7 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
   private closing = false;
   private readonly consumerId: string;
   private handler: TransportHandler | undefined;
+  private logger: MicroserviceTransportLogger | undefined;
   private listening = false;
   private listenPromise: Promise<void> | undefined;
   private readonly pending = new Map<string, PendingRequest>();
@@ -108,6 +109,10 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
     this.messageRetentionMaxLen = options.messageRetentionMaxLen;
     this.eventRetentionMaxLen = options.eventRetentionMaxLen;
     this.responseRetentionMaxLen = options.responseRetentionMaxLen ?? 1_000;
+  }
+
+  setLogger(logger: MicroserviceTransportLogger): void {
+    this.logger = logger;
   }
 
   /**
@@ -509,6 +514,11 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
   }
 
   private logEventHandlerFailure(error: unknown): void {
+    if (this.logger) {
+      this.logger.error('Event handler failed.', error, 'RedisStreamsMicroserviceTransport');
+      return;
+    }
+
     console.error('[fluo][RedisStreamsMicroserviceTransport] event handler failed:', error);
   }
 

--- a/packages/microservices/src/transports/redis-transport.test.ts
+++ b/packages/microservices/src/transports/redis-transport.test.ts
@@ -116,7 +116,8 @@ describe('RedisPubSubMicroserviceTransport', () => {
       publishClient,
       subscribeClient,
     });
-    const logger = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logger = { error: vi.fn() };
+    transport.setLogger(logger);
 
     await transport.listen(async (packet) => {
       if (packet.kind === 'event') {
@@ -129,7 +130,11 @@ describe('RedisPubSubMicroserviceTransport', () => {
     await expect(transport.emit('audit.value', { value: 9 })).resolves.toBeUndefined();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(logger).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Event handler failed.',
+      expect.objectContaining({ message: 'redis event failed' }),
+      'RedisPubSubMicroserviceTransport',
+    );
 
     await transport.close();
   });

--- a/packages/microservices/src/transports/redis-transport.ts
+++ b/packages/microservices/src/transports/redis-transport.ts
@@ -1,4 +1,4 @@
-import type { MicroserviceTransport, TransportHandler } from '../types.js';
+import type { MicroserviceTransport, MicroserviceTransportLogger, TransportHandler } from '../types.js';
 
 interface RedisPubSubMessage {
   kind: 'event';
@@ -30,6 +30,7 @@ export interface RedisPubSubMicroserviceTransportOptions {
  */
 export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
   private handler: TransportHandler | undefined;
+  private logger: MicroserviceTransportLogger | undefined;
   private listening = false;
   private listenPromise: Promise<void> | undefined;
   private readonly messageListener = (channel: string, message: string) => {
@@ -38,6 +39,11 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
   private readonly namespace: string;
 
   private logEventHandlerFailure(error: unknown): void {
+    if (this.logger) {
+      this.logger.error('Event handler failed.', error, 'RedisPubSubMicroserviceTransport');
+      return;
+    }
+
     console.error('[fluo][RedisPubSubMicroserviceTransport] event handler failed:', error);
   }
 
@@ -48,6 +54,10 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
    */
   constructor(private readonly options: RedisPubSubMicroserviceTransportOptions) {
     this.namespace = options.namespace ?? 'fluo:microservices';
+  }
+
+  setLogger(logger: MicroserviceTransportLogger): void {
+    this.logger = logger;
   }
 
   /**

--- a/packages/microservices/src/types.ts
+++ b/packages/microservices/src/types.ts
@@ -1,5 +1,6 @@
 import type { MetadataPropertyKey, Token } from '@fluojs/core';
 import type { Scope } from '@fluojs/di';
+import type { ApplicationLogger } from '@fluojs/runtime';
 
 /** Pattern matcher used to route messages and events to handler methods. */
 export type Pattern = RegExp | string;
@@ -34,6 +35,9 @@ export interface TransportPacket {
 
 /** Async entrypoint used by transports to hand packets to the runtime. */
 export type TransportHandler = (packet: TransportPacket) => Promise<unknown>;
+
+/** Narrow logger seam transports use for non-fatal handler failure reporting. */
+export interface MicroserviceTransportLogger extends Pick<ApplicationLogger, 'error'> {}
 
 /** Writer contract used for server-side and bidirectional streaming responses. */
 export interface ServerStreamWriter {
@@ -89,6 +93,7 @@ export interface MicroserviceTransport {
   listenBidiStreaming?(handler: TransportBidiStreamHandler): void;
   listenClientStreaming?(handler: TransportClientStreamHandler): void;
   listenServerStreaming?(handler: TransportServerStreamHandler): void;
+  setLogger?(logger: MicroserviceTransportLogger): void;
   send(pattern: string, payload: unknown, signal?: AbortSignal): Promise<unknown>;
   serverStream?(pattern: string, payload: unknown, signal?: AbortSignal): AsyncIterable<unknown>;
 }

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -2054,6 +2054,93 @@ describe('bootstrapApplication', () => {
     expect(loggerEvents).toContain('error:FluoApplication:Failed to start the HTTP adapter.:port already in use');
   });
 
+  it('threads the runtime logger into dispatcher observer and disposal failure paths', async () => {
+    const loggerEvents: string[] = [];
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message, error, context) {
+        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
+      },
+      log() {},
+      warn() {},
+    };
+    const observer = {
+      onRequestStart() {
+        throw new Error('observer seam failed');
+      },
+    };
+
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [HealthController],
+    });
+
+    const app = await bootstrapApplication({
+      logger,
+      observers: [observer],
+      rootModule: AppModule,
+    });
+    const createRequestScope = app.container.createRequestScope.bind(app.container);
+
+    vi.spyOn(app.container, 'createRequestScope').mockImplementation(() => {
+      const scope = createRequestScope();
+      const dispose = scope.dispose.bind(scope);
+
+      scope.dispose = async () => {
+        await dispose();
+        throw new Error('scope dispose failed');
+      };
+
+      return scope;
+    });
+    const request: FrameworkRequest = {
+      body: undefined,
+      cookies: {},
+      headers: { 'x-request-id': 'req-app-logger' },
+      method: 'GET',
+      params: {},
+      path: '/health',
+      query: {},
+      raw: {},
+      url: '/health',
+    };
+    const response: FrameworkResponse & { body?: unknown } = {
+      committed: false,
+      headers: {},
+      redirect(status, location) {
+        this.setStatus(status);
+        this.setHeader('Location', location);
+        this.committed = true;
+      },
+      send(body) {
+        this.body = body;
+        this.committed = true;
+      },
+      setHeader(name, value) {
+        this.headers[name] = value;
+      },
+      setStatus(code) {
+        this.statusCode = code;
+      },
+      statusCode: undefined,
+    };
+
+    await app.dispatch(request, response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(loggerEvents).toContain('error:HttpDispatcher:Request observer threw an unhandled error.:observer seam failed');
+    expect(loggerEvents).toContain('error:HttpDispatcher:Request-scoped container dispose threw an error.:scope dispose failed');
+  });
+
   it('parses Cookie header and exposes individual cookies via FromCookie', async () => {
     class TokenInput {
       @FromCookie()

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -868,12 +868,14 @@ function createRuntimeDispatcherOptions(
   options: BootstrapApplicationOptions,
   handlerMapping: ReturnType<typeof createHandlerMapping>,
   errorHandler: ErrorHandler | undefined,
+  logger: ApplicationLogger,
 ): ErrorAwareDispatcherOptions {
   const dispatcherOptions: ErrorAwareDispatcherOptions = {
     appMiddleware: options.middleware ?? [],
     binder: new DefaultBinder(options.converters ?? []),
     handlerMapping,
     interceptors: options.interceptors ?? [],
+    logger,
     observers: options.observers ?? [],
     rootContainer: bootstrapped.container,
   };
@@ -901,6 +903,7 @@ function createRuntimeDispatcher(
     options,
     handlerMapping,
     errorHandler,
+    logger,
   );
 
   return createDispatcher(dispatcherOptions);


### PR DESCRIPTION
## Summary

- route the HTTP dispatcher observer/disposal failure paths through the dispatcher logger seam and thread the runtime `ApplicationLogger` into that seam during bootstrap
- add a microservice transport logger contract, inject it from `MicroserviceLifecycleService`, and update the Redis Pub/Sub, NATS, MQTT, Redis Streams, and gRPC transports to use it for non-fatal event failure logging
- add focused regressions that prove the failure paths still stay non-fatal while reporting through the framework logger

## Changes

- added `DispatcherLogger` to `@fluojs/http` and used it for observer/disposal logging in `packages/http/src/dispatch/dispatcher.ts`
- passed the runtime logger from `packages/runtime/src/bootstrap.ts` and added integration coverage in `packages/runtime/src/application.test.ts`
- added `MicroserviceTransportLogger` / `setLogger(...)` in `packages/microservices/src/types.ts`, injected it from `packages/microservices/src/service.ts`, and updated the affected transports plus tests

## Testing

- `pnpm exec vitest run packages/http/src/dispatch/dispatcher.test.ts packages/runtime/src/application.test.ts packages/microservices/src/module.test.ts packages/microservices/src/transports/redis-transport.test.ts packages/microservices/src/transports/nats-transport.test.ts packages/microservices/src/transports/mqtt-transport.test.ts packages/microservices/src/transports/redis-streams-transport.test.ts packages/microservices/src/transports/grpc-transport.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `lsp_diagnostics` on changed runtime/source files returned no errors; changed test files only reported existing unused-value hints

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract impact note: none. This keeps the existing non-fatal failure semantics and only routes the identified logs through the framework logger contract.

Closes #1114