### PR TITLE
Resolve #1115: make release governance verification clean-tree safe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,13 @@ Use the following repo-local references before inventing a new style:
 - `packages/di/src/container.ts`
 - [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md)
 
-`pnpm lint` now includes `pnpm verify:public-export-tsdoc`, which checks changed package source files for this minimum baseline.
+`pnpm lint` now includes `pnpm verify:public-export-tsdoc`, which keeps PR-time enforcement scoped to changed package source files.
+Use `pnpm verify:public-export-tsdoc:baseline` when you need to audit the full governed `packages/*/src` surface for backlog TSDoc gaps.
+
+Release-readiness verification is now read-only by default:
+
+- `pnpm verify:release-readiness` validates release gates without dirtying the working tree.
+- `pnpm generate:release-readiness-drafts` explicitly refreshes `CHANGELOG.md` draft content plus the release-readiness summary artifacts when maintainers want writable outputs.
 
 ## maintainer workflows
 

--- a/docs/operations/public-export-tsdoc-baseline.ko.md
+++ b/docs/operations/public-export-tsdoc-baseline.ko.md
@@ -4,7 +4,7 @@
   <a href="./public-export-tsdoc-baseline.md">English</a> | <strong>한국어</strong>
 </p>
 
-이 문서는 `@fluojs/*` 패키지에서 변경되는 public export에 적용할 소스 레벨 TSDoc 최소 기준을 정의합니다. 이후 패키지군별 확장 작업 전에 IDE hover 도움말, 코드 리뷰 기대치, 패키지 README 예제를 같은 기준으로 맞추기 위한 출발점입니다.
+이 문서는 `@fluojs/*` 패키지의 public export에 적용할 소스 레벨 TSDoc 최소 기준을 정의합니다. 기본 PR 게이트는 변경 파일에 집중하고, 별도의 전체 기준선 모드는 전체 governed 표면을 감사할 수 있게 합니다.
 
 ## 이 문서가 중요한 경우
 
@@ -16,7 +16,7 @@
 
 ## 최소 기준
 
-변경된 모든 public export는 반드시 다음을 포함해야 합니다.
+선택한 모드에서 검사되는 모든 governed public export는 반드시 다음을 포함해야 합니다.
 
 - 계약을 평이한 언어로 설명하는 한 줄 이상의 summary.
 - 이름이 있는 각 함수 파라미터에 대한 `@param`.
@@ -57,7 +57,8 @@
 ## 자동화
 
 - `pnpm lint`는 이제 `pnpm verify:public-export-tsdoc`를 함께 실행합니다.
-- 게이트는 `packages/*/src` 아래 변경 파일만 대상으로 하므로, repo-wide rollout을 패키지군 단위로 현실적으로 진행할 수 있습니다.
+- `pnpm verify:public-export-tsdoc`는 빠른 PR 게이트를 위해 `packages/*/src` 아래 변경 파일만 대상으로 유지하므로, repo-wide rollout을 패키지군 단위로 현실적으로 진행할 수 있습니다.
+- `pnpm verify:public-export-tsdoc:baseline`은 동일한 규칙을 전체 governed `packages/*/src` 표면에 적용해 아직 손대지 않은 누락 파일도 탐지합니다.
 - re-export barrel은 자동 검사에서 제외되며, 실제 심볼이 정의된 위치에 문서를 작성해야 합니다.
 
 ## 관련 문서

--- a/docs/operations/public-export-tsdoc-baseline.md
+++ b/docs/operations/public-export-tsdoc-baseline.md
@@ -4,7 +4,7 @@
   <strong>English</strong> | <a href="./public-export-tsdoc-baseline.ko.md">한국어</a>
 </p>
 
-This guide defines the minimum source-level TSDoc baseline for changed public exports in `@fluojs/*` packages. It keeps IDE hover help, code review expectations, and package README examples aligned before the package-group rollout begins.
+This guide defines the minimum source-level TSDoc baseline for public exports in `@fluojs/*` packages. The default PR gate stays focused on changed files, while a separate full-baseline mode lets maintainers audit the entire governed surface.
 
 ## When this document matters
 
@@ -16,7 +16,7 @@ This guide defines the minimum source-level TSDoc baseline for changed public ex
 
 ## Minimum baseline
 
-Every changed public export MUST include:
+Every governed public export checked by the selected mode MUST include:
 
 - A one-line-or-better summary that explains the contract in plain language.
 - `@param` for every named function parameter.
@@ -57,7 +57,8 @@ Use these repo-local references as the preferred writing style:
 ## Automation
 
 - `pnpm lint` now includes `pnpm verify:public-export-tsdoc`.
-- The gate scopes itself to changed files under `packages/*/src` so the repo-wide rollout can proceed package-group by package-group.
+- `pnpm verify:public-export-tsdoc` keeps the fast PR gate scoped to changed files under `packages/*/src` so the repo-wide rollout can proceed package-group by package-group.
+- `pnpm verify:public-export-tsdoc:baseline` runs the same rule set against the full governed `packages/*/src` surface to catch untouched backlog files.
 - Re-export barrels are ignored by the automated check; document the underlying declaration where the symbol is defined.
 
 ## Related Docs

--- a/docs/operations/release-governance.ko.md
+++ b/docs/operations/release-governance.ko.md
@@ -94,9 +94,11 @@ fluo는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅니
 거버넌스는 자동화된 게이트와 수동 체크리스트를 통해 강제됩니다.
 
 ### CI/CD 강제 사항
-- **`pnpm verify:release-readiness`**: 패키징된 CLI 엔트리포인트와 스타터 스캐폴딩을 검증합니다.
+- **`pnpm verify:release-readiness`**: 기본적으로 `CHANGELOG.md`나 release-readiness summary 파일을 변경하지 않고 패키징된 CLI 엔트리포인트와 스타터 스캐폴딩을 검증합니다.
+- **`pnpm generate:release-readiness-drafts`**: 릴리스 노트를 준비할 때 release-readiness summary 산출물과 `CHANGELOG.md` 드래프트 블록을 명시적으로 갱신합니다.
 - **`pnpm verify:platform-consistency-governance`**: 영어와 한국어 문서 간의 구조적 일관성을 강제합니다.
 - **`pnpm verify:public-export-tsdoc`**: `packages/*/src` 아래 변경된 public export가 repo-wide TSDoc 최소 기준을 놓치면 실패합니다.
+- **`pnpm verify:public-export-tsdoc:baseline`**: 동일한 TSDoc 기준을 전체 governed `packages/*/src` 표면에 적용해 아직 수정되지 않은 누락 파일도 탐지합니다.
 - **동작 계약 체크**: `process.env`가 승인된 패턴(`@fluojs/config`) 외부에서 액세스될 경우 릴리스를 차단합니다.
 
 ### 변경 이력 표준 (Changelog Standards)

--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -94,9 +94,11 @@ During the `0.x` phase, the **Minor** version is used for breaking changes. Ever
 Governance is enforced through automated gates and manual checklists.
 
 ### CI/CD Enforcement
-- **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints and starter scaffolding.
+- **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints and starter scaffolding without mutating `CHANGELOG.md` or release-readiness summary files by default.
+- **`pnpm generate:release-readiness-drafts`**: Explicitly refreshes the release-readiness summary artifacts and the draft `CHANGELOG.md` block when maintainers are preparing release notes.
 - **`pnpm verify:platform-consistency-governance`**: Enforces structural parity between English and Korean documentation.
 - **`pnpm verify:public-export-tsdoc`**: Fails when changed public exports in `packages/*/src` miss the repo-wide TSDoc minimum baseline.
+- **`pnpm verify:public-export-tsdoc:baseline`**: Runs the same TSDoc baseline against the full governed `packages/*/src` surface to catch untouched backlog files.
 - **Behavioral Contract Check**: Blocks releases if `process.env` is accessed outside of the sanctioned `@fluojs/config` patterns.
 
 ### Changelog Standards

--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -103,7 +103,9 @@ await app.close();
 | :--- | :--- |
 | `pnpm test` | 워크스페이스 전체에서 Vitest 스위트를 실행합니다. |
 | `pnpm verify` | Build → Typecheck → Lint → Test 순서로 실행합니다. |
-| `pnpm verify:release-readiness` | 패키징된 CLI 검증을 포함한 공개 릴리스를 위한 최종 관문입니다. |
+| `pnpm verify:release-readiness` | 패키징된 CLI 검증을 포함한 공개 릴리스를 위한 읽기 전용 최종 관문입니다. |
+| `pnpm generate:release-readiness-drafts` | 릴리스 준비를 위해 release-readiness summary 산출물과 changelog 드래프트 블록을 명시적으로 씁니다. |
+| `pnpm verify:public-export-tsdoc:baseline` | public-export TSDoc 기준을 전체 governed 패키지 소스 표면에 적용합니다. |
 
 ### 생성된 템플릿
 CLI(`fluo g repo <Name>`) 사용 시 기본적으로 제공되는 템플릿은 다음과 같습니다.

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -103,7 +103,9 @@ Keep the module wiring real but override the low-level client tokens to avoid ne
 | :--- | :--- |
 | `pnpm test` | Runs the full Vitest suite across the workspace. |
 | `pnpm verify` | Sequential execution: Build → Typecheck → Lint → Test. |
-| `pnpm verify:release-readiness` | Comprehensive gate for public releases, including packed CLI verification. |
+| `pnpm verify:release-readiness` | Comprehensive read-only gate for public releases, including packed CLI verification. |
+| `pnpm generate:release-readiness-drafts` | Explicitly writes release-readiness summary artifacts and the draft changelog block for release prep. |
+| `pnpm verify:public-export-tsdoc:baseline` | Runs the public-export TSDoc baseline against the full governed package source surface. |
 
 ### Generated Templates
 When using the CLI (`fluo g repo <Name>`), the following templates are provided as the baseline:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "lint": "biome lint && pnpm verify:public-export-tsdoc",
     "verify": "pnpm build && pnpm typecheck && pnpm lint && pnpm test",
     "verify:release-readiness": "node tooling/release/verify-release-readiness.mjs",
+    "generate:release-readiness-drafts": "node tooling/release/verify-release-readiness.mjs --write-drafts",
     "verify:public-export-tsdoc": "node tooling/governance/verify-public-export-tsdoc.mjs",
+    "verify:public-export-tsdoc:baseline": "node tooling/governance/verify-public-export-tsdoc.mjs --mode=full",
     "verify:platform-consistency-governance": "node tooling/governance/verify-platform-consistency-governance.mjs"
   },
   "pnpm": {

--- a/tooling/governance/verify-public-export-tsdoc.d.mts
+++ b/tooling/governance/verify-public-export-tsdoc.d.mts
@@ -1,12 +1,24 @@
-export interface PublicExportTSDocViolation {
+export type PublicExportTSDocViolation = {
   kind: string;
   line: number;
   name: string;
   path: string;
   reason: string;
-}
+};
 
 export function isGovernedPublicExportSourcePath(relativePath: string): boolean;
+
+export function changedPublicExportSourcePathsFromGit(
+  relativePaths?: string[],
+  readSource?: (relativePath: string) => string,
+  gitRef?: string | null,
+  readSourceAtRef?: (gitRef: string | null, relativePath: string) => string | null,
+  hasChangedPublicExportDeclarations?: (...args: unknown[]) => boolean,
+): string[];
+
+export function governedPublicExportSourcePathsFromWorkspace(relativePaths?: string[]): string[];
+
+export function publicExportTSDocTargetPaths(mode?: 'changed' | 'full', changedPaths?: string[], workspacePaths?: string[]): string[];
 
 export function collectPublicExportTSDocViolations(
   relativePaths: string[],
@@ -16,6 +28,12 @@ export function collectPublicExportTSDocViolations(
 export function enforcePublicExportTSDocBaseline(
   relativePaths?: string[],
   readSource?: (relativePath: string) => string,
+  mode?: 'changed' | 'full',
 ): void;
 
-export function main(): void;
+export function enforcePublicExportTSDocBaselineForMode(
+  mode?: 'changed' | 'full',
+  readSource?: (relativePath: string) => string,
+  changedPaths?: string[],
+  workspacePaths?: string[],
+): void;

--- a/tooling/governance/verify-public-export-tsdoc.mjs
+++ b/tooling/governance/verify-public-export-tsdoc.mjs
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { dirname, extname, resolve } from 'node:path';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import ts from 'typescript';
@@ -55,6 +55,26 @@ function changedFilesFromGit() {
   addDiffFiles(['diff', '--name-only', '--cached']);
 
   return [...changedFiles].sort((left, right) => left.localeCompare(right));
+}
+
+function workspaceFilesFromPackagesDirectory(directory = join(repoRoot, 'packages')) {
+  const files = [];
+
+  function visit(currentDirectory) {
+    for (const entry of readdirSync(currentDirectory, { withFileTypes: true })) {
+      const nextPath = join(currentDirectory, entry.name);
+
+      if (entry.isDirectory()) {
+        visit(nextPath);
+        continue;
+      }
+
+      files.push(relative(repoRoot, nextPath).replaceAll('\\', '/'));
+    }
+  }
+
+  visit(directory);
+  return files.sort((left, right) => left.localeCompare(right));
 }
 
 function preferredBaseRefFromGit() {
@@ -343,6 +363,26 @@ export function changedPublicExportSourcePathsFromGit(
   });
 }
 
+export function governedPublicExportSourcePathsFromWorkspace(relativePaths = workspaceFilesFromPackagesDirectory()) {
+  return relativePaths.filter((relativePath) => isGovernedPublicExportSourcePath(relativePath));
+}
+
+export function publicExportTSDocTargetPaths(
+  mode = 'changed',
+  changedPaths = changedPublicExportSourcePathsFromGit(),
+  workspacePaths = governedPublicExportSourcePathsFromWorkspace(),
+) {
+  if (mode === 'changed') {
+    return changedPaths;
+  }
+
+  if (mode === 'full') {
+    return workspacePaths;
+  }
+
+  throw new Error(`Unsupported public export TSDoc mode: ${mode}`);
+}
+
 function scriptKindForPath(relativePath) {
   const extension = extname(relativePath);
 
@@ -385,13 +425,15 @@ export function collectPublicExportTSDocViolations(relativePaths, readSource = r
 export function enforcePublicExportTSDocBaseline(
   relativePaths = changedPublicExportSourcePathsFromGit(),
   readSource = read,
+  mode = 'changed',
 ) {
   const violations = collectPublicExportTSDocViolations(relativePaths, readSource);
+  const scopeDescription = mode === 'full' ? 'governed public exports' : 'changed public exports';
 
   assert(
     violations.length === 0,
     [
-      'changed public exports must include a TSDoc summary and matching @param/@returns tags when applicable.',
+      `${scopeDescription} must include a TSDoc summary and matching @param/@returns tags when applicable.`,
       'Use docs/operations/public-export-tsdoc-baseline.md for the authoring checklist and golden examples.',
       ...violations.map(
         (violation) => `${violation.path}:${violation.line} ${violation.kind} ${violation.name} is missing ${violation.reason}`,
@@ -400,9 +442,40 @@ export function enforcePublicExportTSDocBaseline(
   );
 }
 
-export function main() {
-  enforcePublicExportTSDocBaseline();
-  console.log('Public export TSDoc checks passed.');
+export function enforcePublicExportTSDocBaselineForMode(
+  mode = 'changed',
+  readSource = read,
+  changedPaths = changedPublicExportSourcePathsFromGit(),
+  workspacePaths = governedPublicExportSourcePathsFromWorkspace(),
+) {
+  const relativePaths = publicExportTSDocTargetPaths(mode, changedPaths, workspacePaths);
+  enforcePublicExportTSDocBaseline(relativePaths, readSource, mode);
+}
+
+function parseCliOptions(argv = process.argv.slice(2)) {
+  let mode = 'changed';
+
+  for (const argument of argv) {
+    if (argument === '--all' || argument === '--mode=full') {
+      mode = 'full';
+      continue;
+    }
+
+    if (argument === '--mode=changed') {
+      mode = 'changed';
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${argument}`);
+  }
+
+  return { mode };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const { mode } = parseCliOptions(argv);
+  enforcePublicExportTSDocBaselineForMode(mode);
+  console.log(`Public export TSDoc checks passed (${mode} mode).`);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/tooling/governance/verify-public-export-tsdoc.test.ts
+++ b/tooling/governance/verify-public-export-tsdoc.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  changedPublicExportSourcePathsFromGit,
   collectPublicExportTSDocViolations,
+  enforcePublicExportTSDocBaselineForMode,
   enforcePublicExportTSDocBaseline,
+  governedPublicExportSourcePathsFromWorkspace,
   isGovernedPublicExportSourcePath,
+  publicExportTSDocTargetPaths,
 } from './verify-public-export-tsdoc.mjs';
 
 describe('isGovernedPublicExportSourcePath', () => {
@@ -127,37 +131,23 @@ describe('enforcePublicExportTSDocBaseline', () => {
 });
 
 describe('publicExportTSDocTargetPaths', () => {
-  it('keeps diff-scoped mode unchanged by default', async () => {
-    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
-
+  it('keeps diff-scoped mode unchanged by default', () => {
     expect(
-      governanceModule.publicExportTSDocTargetPaths(
-        'changed',
-        ['packages/http/src/handler.ts'],
-        ['packages/http/src/handler.ts', 'packages/core/src/app.ts'],
-      ),
+      publicExportTSDocTargetPaths('changed', ['packages/http/src/handler.ts'], ['packages/http/src/handler.ts', 'packages/core/src/app.ts']),
     ).toEqual(['packages/http/src/handler.ts']);
   });
 
-  it('returns the full governed workspace set in full mode', async () => {
-    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
-
+  it('returns the full governed workspace set in full mode', () => {
     expect(
-      governanceModule.publicExportTSDocTargetPaths(
-        'full',
-        ['packages/http/src/handler.ts'],
-        ['packages/http/src/handler.ts', 'packages/core/src/app.ts'],
-      ),
+      publicExportTSDocTargetPaths('full', ['packages/http/src/handler.ts'], ['packages/http/src/handler.ts', 'packages/core/src/app.ts']),
     ).toEqual(['packages/http/src/handler.ts', 'packages/core/src/app.ts']);
   });
 });
 
 describe('governedPublicExportSourcePathsFromWorkspace', () => {
-  it('collects governed package source files across the workspace', async () => {
-    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
-
+  it('collects governed package source files across the workspace', () => {
     expect(
-      governanceModule.governedPublicExportSourcePathsFromWorkspace([
+      governedPublicExportSourcePathsFromWorkspace([
         'packages/core/src/app.ts',
         'packages/core/src/app.test.ts',
         'packages/core/src/index.ts',
@@ -169,36 +159,21 @@ describe('governedPublicExportSourcePathsFromWorkspace', () => {
 });
 
 describe('enforcePublicExportTSDocBaselineForMode', () => {
-  it('lets diff mode ignore untouched governed files', async () => {
-    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
-
+  it('lets diff mode ignore untouched governed files', () => {
     expect(() =>
-      governanceModule.enforcePublicExportTSDocBaselineForMode(
-        'changed',
-        () => 'export const HTTP_STATUS = 200;\n',
-        [],
-        ['packages/http/src/handler.ts'],
-      ),
+      enforcePublicExportTSDocBaselineForMode('changed', () => 'export const HTTP_STATUS = 200;\n', [], ['packages/http/src/handler.ts']),
     ).not.toThrow();
   });
 
-  it('makes full mode fail for untouched governed files that miss the baseline', async () => {
-    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
-
+  it('makes full mode fail for untouched governed files that miss the baseline', () => {
     expect(() =>
-      governanceModule.enforcePublicExportTSDocBaselineForMode(
-        'full',
-        () => 'export const HTTP_STATUS = 200;\n',
-        [],
-        ['packages/http/src/handler.ts'],
-      ),
+      enforcePublicExportTSDocBaselineForMode('full', () => 'export const HTTP_STATUS = 200;\n', [], ['packages/http/src/handler.ts']),
     ).toThrowError(/governed public exports must include a TSDoc summary/);
   });
 });
 
 describe('changedPublicExportSourcePathsFromGit', () => {
-  it('ignores import-only namespace churn when exported declarations are unchanged', async () => {
-    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
+  it('ignores import-only namespace churn when exported declarations are unchanged', () => {
     const currentSource = [
       "import { Module } from '@fluojs/core';",
       '',
@@ -220,18 +195,16 @@ describe('changedPublicExportSourcePathsFromGit', () => {
     ].join('\n');
 
     expect(
-      governanceModule.changedPublicExportSourcePathsFromGit(
+      changedPublicExportSourcePathsFromGit(
         ['packages/core/src/example.ts'],
         () => currentSource,
         'test-base',
         () => previousSource,
-        () => false,
       ),
     ).toEqual([]);
   });
 
-  it('keeps files selected when an exported class signature changes inside the body', async () => {
-    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
+  it('keeps files selected when an exported class signature changes inside the body', () => {
     const currentSource = [
       '/**',
       ' * Example service.',
@@ -263,18 +236,16 @@ describe('changedPublicExportSourcePathsFromGit', () => {
     ].join('\n');
 
     expect(
-      governanceModule.changedPublicExportSourcePathsFromGit(
+      changedPublicExportSourcePathsFromGit(
         ['packages/core/src/example.ts'],
         () => currentSource,
         'test-base',
         () => previousSource,
-        () => true,
       ),
     ).toEqual(['packages/core/src/example.ts']);
   });
 
-  it('keeps files selected when an exported interface or type literal shape changes', async () => {
-    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
+  it('keeps files selected when an exported interface or type literal shape changes', () => {
     const currentSource = [
       '/**',
       ' * Example options.',
@@ -320,7 +291,7 @@ describe('changedPublicExportSourcePathsFromGit', () => {
     ].join('\n');
 
     expect(
-      governanceModule.changedPublicExportSourcePathsFromGit(
+      changedPublicExportSourcePathsFromGit(
         ['packages/core/src/example.ts'],
         () => currentSource,
         'test-base',

--- a/tooling/governance/verify-public-export-tsdoc.test.ts
+++ b/tooling/governance/verify-public-export-tsdoc.test.ts
@@ -126,6 +126,76 @@ describe('enforcePublicExportTSDocBaseline', () => {
   });
 });
 
+describe('publicExportTSDocTargetPaths', () => {
+  it('keeps diff-scoped mode unchanged by default', async () => {
+    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
+
+    expect(
+      governanceModule.publicExportTSDocTargetPaths(
+        'changed',
+        ['packages/http/src/handler.ts'],
+        ['packages/http/src/handler.ts', 'packages/core/src/app.ts'],
+      ),
+    ).toEqual(['packages/http/src/handler.ts']);
+  });
+
+  it('returns the full governed workspace set in full mode', async () => {
+    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
+
+    expect(
+      governanceModule.publicExportTSDocTargetPaths(
+        'full',
+        ['packages/http/src/handler.ts'],
+        ['packages/http/src/handler.ts', 'packages/core/src/app.ts'],
+      ),
+    ).toEqual(['packages/http/src/handler.ts', 'packages/core/src/app.ts']);
+  });
+});
+
+describe('governedPublicExportSourcePathsFromWorkspace', () => {
+  it('collects governed package source files across the workspace', async () => {
+    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
+
+    expect(
+      governanceModule.governedPublicExportSourcePathsFromWorkspace([
+        'packages/core/src/app.ts',
+        'packages/core/src/app.test.ts',
+        'packages/core/src/index.ts',
+        'packages/core/dist/index.js',
+        'tooling/governance/verify-public-export-tsdoc.mjs',
+      ]),
+    ).toEqual(['packages/core/src/app.ts', 'packages/core/src/index.ts']);
+  });
+});
+
+describe('enforcePublicExportTSDocBaselineForMode', () => {
+  it('lets diff mode ignore untouched governed files', async () => {
+    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
+
+    expect(() =>
+      governanceModule.enforcePublicExportTSDocBaselineForMode(
+        'changed',
+        () => 'export const HTTP_STATUS = 200;\n',
+        [],
+        ['packages/http/src/handler.ts'],
+      ),
+    ).not.toThrow();
+  });
+
+  it('makes full mode fail for untouched governed files that miss the baseline', async () => {
+    const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;
+
+    expect(() =>
+      governanceModule.enforcePublicExportTSDocBaselineForMode(
+        'full',
+        () => 'export const HTTP_STATUS = 200;\n',
+        [],
+        ['packages/http/src/handler.ts'],
+      ),
+    ).toThrowError(/governed public exports must include a TSDoc summary/);
+  });
+});
+
 describe('changedPublicExportSourcePathsFromGit', () => {
   it('ignores import-only namespace churn when exported declarations are unchanged', async () => {
     const governanceModule = (await import('./verify-public-export-tsdoc.mjs')) as any;

--- a/tooling/release/verify-release-readiness.d.mts
+++ b/tooling/release/verify-release-readiness.d.mts
@@ -1,0 +1,25 @@
+export type ReleaseReadinessCheck = {
+  detail: string;
+  label: string;
+  pass: boolean;
+};
+
+export type ReleaseReadinessDependencies = {
+  run?: (command: string, args: string[]) => void;
+  read?: (relativePath: string) => string;
+  existsSync?: (targetPath: string) => boolean;
+  workspacePackageNames?: () => string[];
+  mkdirSync?: (targetPath: string, options: { recursive: boolean }) => void;
+  readFileSync?: (targetPath: string, encoding: string) => string;
+  writeFileSync?: (targetPath: string, content: string, encoding: string) => void;
+};
+
+export type ReleaseReadinessResult = {
+  checks: ReleaseReadinessCheck[];
+  writeDrafts: boolean;
+};
+
+export function runReleaseReadinessVerification(
+  options?: { writeDrafts?: boolean },
+  dependencies?: ReleaseReadinessDependencies,
+): ReleaseReadinessResult;

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -9,6 +9,18 @@ const summaryPath = join(scriptDirectory, 'release-readiness-summary.md');
 const summaryKoPath = join(scriptDirectory, 'release-readiness-summary.ko.md');
 const changelogPath = join(repoRoot, 'CHANGELOG.md');
 
+function parseCliOptions(argv = process.argv.slice(2)) {
+  const writeDrafts = argv.includes('--write-drafts');
+
+  for (const argument of argv) {
+    if (argument !== '--write-drafts') {
+      throw new Error(`Unknown option: ${argument}`);
+    }
+  }
+
+  return { writeDrafts };
+}
+
 function languageToggle(current) {
   const english = current === 'en' ? '<strong><kbd>English</kbd></strong>' : '<a href="./release-readiness-summary.md"><kbd>English</kbd></a>';
   const korean = current === 'ko' ? '<strong><kbd>한국어</kbd></strong>' : '<a href="./release-readiness-summary.ko.md"><kbd>한국어</kbd></a>';
@@ -128,8 +140,13 @@ function workspacePackageNames() {
   return sorted(names);
 }
 
-function writeSummary(checks) {
-  mkdirSync(scriptDirectory, { recursive: true });
+export function buildSummary(checks, writeDrafts) {
+  const sideEffects = writeDrafts
+    ? '- Side effects: `CHANGELOG.md`, `tooling/release/release-readiness-summary.md`, and `tooling/release/release-readiness-summary.ko.md` updated'
+    : '- Side effects: none by default; use `pnpm generate:release-readiness-drafts` to refresh draft artifacts explicitly.';
+  const sideEffectsKo = writeDrafts
+    ? '- 부수 효과: `CHANGELOG.md`, `tooling/release/release-readiness-summary.md`, `tooling/release/release-readiness-summary.ko.md` 갱신'
+    : '- 부수 효과: 기본값은 없음; 초안 산출물을 갱신하려면 `pnpm generate:release-readiness-drafts`를 명시적으로 실행하세요.';
   const summary = [
     '# release readiness summary',
     '',
@@ -138,7 +155,7 @@ function writeSummary(checks) {
     ...checks.map((check) => `- [${check.pass ? 'x' : ' '}] ${check.label} — ${check.detail}`),
     '',
     '- Commands executed: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm --dir packages/cli sandbox:matrix`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`',
-    '- Side effects: `CHANGELOG.md` draft release-readiness section updated',
+    sideEffects,
   ].join('\n');
   const summaryKo = [
     '# 릴리즈 준비도 검증 요약',
@@ -148,20 +165,21 @@ function writeSummary(checks) {
     ...checks.map((check) => `- [${check.pass ? 'x' : ' '}] ${check.label} — ${check.detail}`),
     '',
     '- 실행한 명령: `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm --dir packages/cli sandbox:matrix`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`',
-    '- 부수 효과: `CHANGELOG.md` 릴리즈 준비도 드래프트 섹션 갱신',
+    sideEffectsKo,
   ].join('\n');
 
-  writeFileSync(summaryPath, `${summary}\n`, 'utf8');
-  writeFileSync(summaryKoPath, `${summaryKo}\n`, 'utf8');
+  return { summary, summaryKo };
 }
 
-function upsertReleaseCandidateDraft() {
-  if (!existsSync(changelogPath)) {
-    throw new Error('Release readiness check failed: CHANGELOG.md is missing at the repository root.');
-  }
+function writeSummary(checks, writeDrafts, dependencies = {}) {
+  const { mkdirSync: createDirectory = mkdirSync, writeFileSync: writeFile = writeFileSync } = dependencies;
+  createDirectory(scriptDirectory, { recursive: true });
+  const { summary, summaryKo } = buildSummary(checks, writeDrafts);
+  writeFile(summaryPath, `${summary}\n`, 'utf8');
+  writeFile(summaryKoPath, `${summaryKo}\n`, 'utf8');
+}
 
-  const changelog = readFileSync(changelogPath, 'utf8');
-  const draftDate = new Date().toISOString().slice(0, 10);
+export function withReleaseCandidateDraft(changelog, draftDate = new Date().toISOString().slice(0, 10)) {
   const startMarker = '<!-- release-readiness-draft:start -->';
   const endMarker = '<!-- release-readiness-draft:end -->';
   const draftBlock = [
@@ -192,131 +210,178 @@ function upsertReleaseCandidateDraft() {
     next = changelog.replace('## [Unreleased]', `## [Unreleased]\n\n${draftBlock}`);
   }
 
-  writeFileSync(changelogPath, next.endsWith('\n') ? next : `${next}\n`, 'utf8');
+  return next.endsWith('\n') ? next : `${next}\n`;
 }
 
-const checks = [];
+function upsertReleaseCandidateDraft(dependencies = {}) {
+  const {
+    existsSync: pathExists = existsSync,
+    readFileSync: readFile = readFileSync,
+    writeFileSync: writeFile = writeFileSync,
+  } = dependencies;
 
-upsertReleaseCandidateDraft();
-run('pnpm', ['build']);
-run('pnpm', ['typecheck']);
-run('pnpm', ['test']);
-run('pnpm', ['--dir', 'packages/cli', 'sandbox:matrix']);
+  if (!pathExists(changelogPath)) {
+    throw new Error('Release readiness check failed: CHANGELOG.md is missing at the repository root.');
+  }
 
-const quickStart = read('docs/getting-started/quick-start.md');
-const contributing = read('CONTRIBUTING.md');
-const releaseGovernance = read('docs/operations/release-governance.md');
-const packageSurface = read('docs/reference/package-surface.md');
-const toolchainContract = read('docs/reference/toolchain-contract-matrix.md');
-const cliReadme = read('packages/cli/README.md');
-const scaffoldSource = read('packages/cli/src/new/scaffold.ts');
-const cliPackage = JSON.parse(read('packages/cli/package.json'));
-const changelog = read('CHANGELOG.md');
-const governancePackageList = sorted(parsePackageListFromSection(releaseGovernance, 'intended publish surface'));
-const packageSurfaceList = parsePackageNamesFromFamilyTable(packageSurface, 'public package families');
-const workspacePackages = workspacePackageNames();
+  const changelog = readFile(changelogPath, 'utf8');
+  const next = withReleaseCandidateDraft(changelog);
 
-assertCheck(
-  checks,
-  'Representative generated-project smoke suite',
-  true,
-  'Release readiness runs `pnpm --dir packages/cli sandbox:matrix` to verify install/build/test/generator flows for the default app, TCP microservice, and mixed starter baselines.',
-);
-assertCheck(
-  checks,
-  'Canonical bootstrap docs',
-  quickStart.includes('pnpm add -g @fluojs/cli') &&
-    quickStart.includes('fluo new my-fluo-app') &&
-    quickStart.includes('The fluo CLI is your central tool for project scaffolding and component generation.'),
-  'The quick start guide documents the public `pnpm add -g @fluojs/cli` + `fluo new` path.',
-);
-assertCheck(
-  checks,
-  'Repo-local smoke path docs',
-  contributing.includes('pnpm sandbox:create') &&
-    contributing.includes('pnpm sandbox:verify') &&
-    contributing.includes('pnpm sandbox:test'),
-  'The repo-local sandbox path is documented in CONTRIBUTING.md as monorepo verification support.',
-);
-assertCheck(
-  checks,
-  'Starter shape and runtime ownership',
-  scaffoldSource.includes('const RuntimeHealthModule = createHealthModule();') &&
-    scaffoldSource.includes('@Controller(\'/health-info\')') &&
-    scaffoldSource.includes('const app = await FluoFactory.create(AppModule, {') &&
-    scaffoldSource.includes('adapter: createFastifyAdapter({ port })') &&
-    scaffoldSource.includes('await app.listen();') &&
-    scaffoldSource.includes('createHealthModule') &&
-    scaffoldSource.includes('createFastifyAdapter') &&
-    !scaffoldSource.includes('MetricsModule.forRoot') &&
-    !scaffoldSource.includes('OpenApiModule.forRoot') &&
-    !scaffoldSource.includes('src/node-http-adapter.ts'),
-  'The generated starter uses runtime-owned bootstrap helpers plus a starter-owned health module, without default metrics or OpenAPI surfaces.',
-);
-assertCheck(
-  checks,
-  'Generic-first bootstrap contract',
-  !quickStart.includes('ORM') &&
-    !quickStart.includes('Database') &&
-    !scaffoldSource.includes('@fluojs/prisma') &&
-    !scaffoldSource.includes('@fluojs/drizzle') &&
-    !scaffoldSource.includes('@fluojs/mongoose') &&
-    !scaffoldSource.includes('createTierNote'),
-  'Bootstrap docs and scaffold source no longer encode ORM/DB prompts, support tiers, or starter-time ORM adapter injection.',
-);
-assertCheck(
-  checks,
-  'Toolchain contract lock',
-  toolchainContract.includes('## generated app baseline') &&
-    toolchainContract.includes('## CLI & scaffolding contracts') &&
-    toolchainContract.includes('## naming conventions (CLI output)') &&
-    toolchainContract.includes('fluo new') &&
-    toolchainContract.includes('fluo inspect'),
-  'The toolchain contract matrix documents the generated app baseline plus the canonical fluo command surfaces.',
-);
-assertCheck(
-  checks,
-  'Manifest benchmark evidence',
-  releaseGovernance.includes('## intended publish surface') &&
-    releaseGovernance.includes('pnpm verify:release-readiness') &&
-    releaseGovernance.includes('pnpm verify:platform-consistency-governance'),
-  'Release governance documents the canonical publish surface and the automated release gates.',
-);
-assertCheck(
-  checks,
-  'Dist-based package entrypoints',
-  cliPackage.bin.fluo === './bin/fluo.mjs' &&
+  writeFile(changelogPath, next, 'utf8');
+}
+
+export function runReleaseReadinessVerification(options = {}, dependencies = {}) {
+  const { writeDrafts = false } = options;
+  const {
+    run: runCommand = run,
+    read: readText = read,
+    existsSync: pathExists = existsSync,
+    workspacePackageNames: listWorkspacePackageNames = workspacePackageNames,
+    mkdirSync: createDirectory = mkdirSync,
+    readFileSync: readFile = readFileSync,
+    writeFileSync: writeFile = writeFileSync,
+  } = dependencies;
+  const checks = [];
+
+  runCommand('pnpm', ['build']);
+  runCommand('pnpm', ['typecheck']);
+  runCommand('pnpm', ['test']);
+  runCommand('pnpm', ['--dir', 'packages/cli', 'sandbox:matrix']);
+
+  const quickStart = readText('docs/getting-started/quick-start.md');
+  const contributing = readText('CONTRIBUTING.md');
+  const releaseGovernance = readText('docs/operations/release-governance.md');
+  const packageSurface = readText('docs/reference/package-surface.md');
+  const toolchainContract = readText('docs/reference/toolchain-contract-matrix.md');
+  const cliReadme = readText('packages/cli/README.md');
+  const scaffoldSource = readText('packages/cli/src/new/scaffold.ts');
+  const cliPackage = JSON.parse(readText('packages/cli/package.json'));
+  const changelog = readText('CHANGELOG.md');
+  const governancePackageList = sorted(parsePackageListFromSection(releaseGovernance, 'intended publish surface'));
+  const packageSurfaceList = parsePackageNamesFromFamilyTable(packageSurface, 'public package families');
+  const workspacePackages = listWorkspacePackageNames();
+
+  assertCheck(
+    checks,
+    'Representative generated-project smoke suite',
+    true,
+    'Release readiness runs `pnpm --dir packages/cli sandbox:matrix` to verify install/build/test/generator flows for the default app, TCP microservice, and mixed starter baselines.',
+  );
+  assertCheck(
+    checks,
+    'Canonical bootstrap docs',
+    quickStart.includes('pnpm add -g @fluojs/cli') &&
+      quickStart.includes('fluo new my-fluo-app') &&
+      quickStart.includes('The fluo CLI is your central tool for project scaffolding and component generation.'),
+    'The quick start guide documents the public `pnpm add -g @fluojs/cli` + `fluo new` path.',
+  );
+  assertCheck(
+    checks,
+    'Repo-local smoke path docs',
+    contributing.includes('pnpm sandbox:create') &&
+      contributing.includes('pnpm sandbox:verify') &&
+      contributing.includes('pnpm sandbox:test'),
+    'The repo-local sandbox path is documented in CONTRIBUTING.md as monorepo verification support.',
+  );
+  assertCheck(
+    checks,
+    'Starter shape and runtime ownership',
+    scaffoldSource.includes('const RuntimeHealthModule = createHealthModule();') &&
+      scaffoldSource.includes('@Controller(\'/health-info\')') &&
+      scaffoldSource.includes('const app = await FluoFactory.create(AppModule, {') &&
+      scaffoldSource.includes('adapter: createFastifyAdapter({ port })') &&
+      scaffoldSource.includes('await app.listen();') &&
+      scaffoldSource.includes('createHealthModule') &&
+      scaffoldSource.includes('createFastifyAdapter') &&
+      !scaffoldSource.includes('MetricsModule.forRoot') &&
+      !scaffoldSource.includes('OpenApiModule.forRoot') &&
+      !scaffoldSource.includes('src/node-http-adapter.ts'),
+    'The generated starter uses runtime-owned bootstrap helpers plus a starter-owned health module, without default metrics or OpenAPI surfaces.',
+  );
+  assertCheck(
+    checks,
+    'Generic-first bootstrap contract',
+    !quickStart.includes('ORM') &&
+      !quickStart.includes('Database') &&
+      !scaffoldSource.includes('@fluojs/prisma') &&
+      !scaffoldSource.includes('@fluojs/drizzle') &&
+      !scaffoldSource.includes('@fluojs/mongoose') &&
+      !scaffoldSource.includes('createTierNote'),
+    'Bootstrap docs and scaffold source no longer encode ORM/DB prompts, support tiers, or starter-time ORM adapter injection.',
+  );
+  assertCheck(
+    checks,
+    'Toolchain contract lock',
+    toolchainContract.includes('## generated app baseline') &&
+      toolchainContract.includes('## CLI & scaffolding contracts') &&
+      toolchainContract.includes('## naming conventions (CLI output)') &&
+      toolchainContract.includes('fluo new') &&
+      toolchainContract.includes('fluo inspect'),
+    'The toolchain contract matrix documents the generated app baseline plus the canonical fluo command surfaces.',
+  );
+  assertCheck(
+    checks,
+    'Manifest benchmark evidence',
+    releaseGovernance.includes('## intended publish surface') &&
+      releaseGovernance.includes('pnpm verify:release-readiness') &&
+      releaseGovernance.includes('pnpm verify:platform-consistency-governance'),
+    'Release governance documents the canonical publish surface and the automated release gates.',
+  );
+  assertCheck(
+    checks,
+    'Dist-based package entrypoints',
     cliPackage.bin.fluo === './bin/fluo.mjs' &&
-    cliPackage.main === './dist/index.js' &&
-    cliReadme.includes('canonical CLI'),
-  'CLI manifest and bin prove a dist-backed public `fluo` entrypoint with a subordinate compatibility alias.',
-);
-assertCheck(
-  checks,
-  'Root OSS license file',
-  existsSync(join(repoRoot, 'LICENSE')) || existsSync(join(repoRoot, 'LICENSE.md')),
-  'A repository-level OSS license file exists at the root.',
-);
-assertCheck(
-  checks,
-  'Public changelog baseline',
-  changelog.includes('# Changelog') && changelog.includes('## [Unreleased]') && changelog.includes('## [0.0.0]'),
-  'CHANGELOG.md exists with Keep a Changelog baseline sections for Unreleased and current 0.x history.',
-);
-assertCheck(
-  checks,
-  'Public package surface docs are synchronized',
-  governancePackageList.length > 0 &&
-    packageSurfaceList.length > 0 &&
-    areSameStringArrays(governancePackageList, packageSurfaceList),
-  'release-governance and package-surface docs declare the same @fluojs public package list.',
-);
-assertCheck(
-  checks,
-  'Documented public packages exist in workspace',
-  governancePackageList.every((packageName) => workspacePackages.includes(packageName)),
-  'Every documented public package maps to an existing workspace package manifest.',
-);
+      cliPackage.bin.fluo === './bin/fluo.mjs' &&
+      cliPackage.main === './dist/index.js' &&
+      cliReadme.includes('canonical CLI'),
+    'CLI manifest and bin prove a dist-backed public `fluo` entrypoint with a subordinate compatibility alias.',
+  );
+  assertCheck(
+    checks,
+    'Root OSS license file',
+    pathExists(join(repoRoot, 'LICENSE')) || pathExists(join(repoRoot, 'LICENSE.md')),
+    'A repository-level OSS license file exists at the root.',
+  );
+  assertCheck(
+    checks,
+    'Public changelog baseline',
+    changelog.includes('# Changelog') && changelog.includes('## [Unreleased]') && changelog.includes('## [0.0.0]'),
+    'CHANGELOG.md exists with Keep a Changelog baseline sections for Unreleased and current 0.x history.',
+  );
+  assertCheck(
+    checks,
+    'Public package surface docs are synchronized',
+    governancePackageList.length > 0 &&
+      packageSurfaceList.length > 0 &&
+      areSameStringArrays(governancePackageList, packageSurfaceList),
+    'release-governance and package-surface docs declare the same @fluojs public package list.',
+  );
+  assertCheck(
+    checks,
+    'Documented public packages exist in workspace',
+    governancePackageList.every((packageName) => workspacePackages.includes(packageName)),
+    'Every documented public package maps to an existing workspace package manifest.',
+  );
 
-writeSummary(checks);
-console.log(`Release readiness summary written to ${summaryPath}`);
+  if (writeDrafts) {
+    upsertReleaseCandidateDraft({ existsSync: pathExists, readFileSync: readFile, writeFileSync: writeFile });
+    writeSummary(checks, true, { mkdirSync: createDirectory, writeFileSync: writeFile });
+  }
+
+  return { checks, writeDrafts };
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = parseCliOptions(argv);
+  const result = runReleaseReadinessVerification(options);
+
+  if (result.writeDrafts) {
+    console.log(`Release readiness drafts written to ${summaryPath}, ${summaryKoPath}, and ${changelogPath}`);
+  } else {
+    console.log('Release readiness checks passed without writing draft artifacts.');
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+function createDependencies() {
+  const docs = new Map([
+    ['docs/getting-started/quick-start.md', 'pnpm add -g @fluojs/cli\nfluo new my-fluo-app\nThe fluo CLI is your central tool for project scaffolding and component generation.'],
+    ['CONTRIBUTING.md', 'pnpm sandbox:create\npnpm sandbox:verify\npnpm sandbox:test'],
+    [
+      'docs/operations/release-governance.md',
+      '## intended publish surface\n- `@fluojs/cli`\n- `@fluojs/core`\n\npnpm verify:release-readiness\npnpm verify:platform-consistency-governance',
+    ],
+    ['docs/reference/package-surface.md', '## public package families\n| Core | `@fluojs/cli` `@fluojs/core` |'],
+    ['docs/reference/toolchain-contract-matrix.md', '## generated app baseline\n## CLI & scaffolding contracts\n## naming conventions (CLI output)\nfluo new\nfluo inspect'],
+    ['packages/cli/README.md', 'canonical CLI'],
+    [
+      'packages/cli/src/new/scaffold.ts',
+      "const RuntimeHealthModule = createHealthModule();\n@Controller('/health-info')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateHealthModule\ncreateFastifyAdapter",
+    ],
+    ['packages/cli/package.json', JSON.stringify({ bin: { fluo: './bin/fluo.mjs' }, main: './dist/index.js' })],
+    ['CHANGELOG.md', '# Changelog\n\n## [Unreleased]\n\n## [0.0.0]\n'],
+  ]);
+
+  return {
+    run: vi.fn(),
+    read: vi.fn((relativePath) => {
+      const value = docs.get(relativePath);
+      if (typeof value !== 'string') {
+        throw new Error(`Unexpected read: ${relativePath}`);
+      }
+
+      return value;
+    }),
+    existsSync: vi.fn((targetPath) => targetPath.endsWith('/LICENSE') || targetPath.endsWith('/CHANGELOG.md')),
+    workspacePackageNames: vi.fn(() => ['@fluojs/cli', '@fluojs/core']),
+    mkdirSync: vi.fn(),
+    readFileSync: vi.fn(() => '# Changelog\n\n## [Unreleased]\n'),
+    writeFileSync: vi.fn(),
+  };
+}
+
+describe('runReleaseReadinessVerification', () => {
+  it('keeps default verification read-only', async () => {
+    // @ts-ignore tooling script is exercised via runtime import.
+    const releaseModule = (await import('./verify-release-readiness.mjs')) as any;
+    const dependencies = createDependencies();
+
+    const result = releaseModule.runReleaseReadinessVerification({}, dependencies);
+
+    expect(result.writeDrafts).toBe(false);
+    expect(dependencies.run).toHaveBeenCalledTimes(4);
+    expect(dependencies.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('writes draft artifacts only when explicitly requested', async () => {
+    // @ts-ignore tooling script is exercised via runtime import.
+    const releaseModule = (await import('./verify-release-readiness.mjs')) as any;
+    const dependencies = createDependencies();
+
+    const result = releaseModule.runReleaseReadinessVerification({ writeDrafts: true }, dependencies);
+
+    expect(result.writeDrafts).toBe(true);
+    expect(dependencies.writeFileSync).toHaveBeenCalledTimes(3);
+    expect(dependencies.writeFileSync.mock.calls.some(([targetPath]) => String(targetPath).endsWith('/CHANGELOG.md'))).toBe(true);
+    expect(
+      dependencies.writeFileSync.mock.calls.some(([, content]) =>
+        String(content).includes('use `pnpm generate:release-readiness-drafts`') ||
+        String(content).includes('`CHANGELOG.md`, `tooling/release/release-readiness-summary.md`'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { runReleaseReadinessVerification } from './verify-release-readiness.mjs';
 
 function createDependencies() {
   const docs = new Map([
@@ -38,24 +39,20 @@ function createDependencies() {
 }
 
 describe('runReleaseReadinessVerification', () => {
-  it('keeps default verification read-only', async () => {
-    // @ts-ignore tooling script is exercised via runtime import.
-    const releaseModule = (await import('./verify-release-readiness.mjs')) as any;
+  it('keeps default verification read-only', () => {
     const dependencies = createDependencies();
 
-    const result = releaseModule.runReleaseReadinessVerification({}, dependencies);
+    const result = runReleaseReadinessVerification({}, dependencies);
 
     expect(result.writeDrafts).toBe(false);
     expect(dependencies.run).toHaveBeenCalledTimes(4);
     expect(dependencies.writeFileSync).not.toHaveBeenCalled();
   });
 
-  it('writes draft artifacts only when explicitly requested', async () => {
-    // @ts-ignore tooling script is exercised via runtime import.
-    const releaseModule = (await import('./verify-release-readiness.mjs')) as any;
+  it('writes draft artifacts only when explicitly requested', () => {
     const dependencies = createDependencies();
 
-    const result = releaseModule.runReleaseReadinessVerification({ writeDrafts: true }, dependencies);
+    const result = runReleaseReadinessVerification({ writeDrafts: true }, dependencies);
 
     expect(result.writeDrafts).toBe(true);
     expect(dependencies.writeFileSync).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
## Summary
- keep `pnpm verify:release-readiness` read-only by default and move draft-writing behind `pnpm generate:release-readiness-drafts`
- add a full-baseline `pnpm verify:public-export-tsdoc:baseline` path while preserving the existing diff-scoped PR gate
- update the release/testing governance docs and add regression coverage for clean-tree-safe verification and full-baseline TSDoc selection

## Changes
- refactor `tooling/release/verify-release-readiness.mjs` so default verification no longer writes `CHANGELOG.md` or summary artifacts, and add targeted tests for the explicit write path
- extend `tooling/governance/verify-public-export-tsdoc.mjs` with `changed` vs `full` mode selection plus coverage proving untouched governed files are only enforced in full mode
- wire the new package scripts and update `CONTRIBUTING.md`, release governance, testing guide, and TSDoc baseline docs in English/Korean

## Testing
- `pnpm exec vitest run tooling/governance/verify-public-export-tsdoc.test.ts tooling/release/verify-release-readiness.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm verify:public-export-tsdoc`
- `pnpm verify:release-readiness`
- `GIT_MASTER=1 git status --short` (confirmed no `CHANGELOG.md` or summary artifact writes after default release-readiness verification)

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- doc-only / governance-only change
- preserves the existing diff-scoped PR path while adding an explicit full-baseline entrypoint for maintainers

Closes #1115