### PR TITLE
Resolve #1118: Polish fluo new interactive terminal UX with @clack/prompts

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "sandbox:clean": "node ./scripts/local-test-env.mjs clean"
   },
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "@fluojs/runtime": "workspace:*",
     "ejs": "^3.1.10",
     "tsx": "^4.20.4",

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -1,5 +1,7 @@
 import { resolve } from 'node:path';
 
+import { spinner as clackSpinner, log as clackLog } from '@clack/prompts';
+
 import { renderAliasList, renderHelpTable } from '../help.js';
 import { collectBootstrapAnswers, type BootstrapPrompter } from '../new/prompt.js';
 import { scaffoldBootstrapApp } from '../new/scaffold.js';
@@ -416,7 +418,21 @@ export async function runNewCommand(argv: string[], runtime: NewCommandRuntimeOp
       stdout.write('Skipping dependency installation.\n');
     }
 
+    const isInteractiveShell = runtime.prompt === undefined && !runtime.interactive;
+    let s: ReturnType<typeof clackSpinner> | undefined;
+
+    if (isInteractiveShell && !answers.installDependencies) {
+      s = clackSpinner();
+      s.start('Scaffolding project files');
+    }
+
     await scaffoldBootstrapApp(options);
+
+    if (s) {
+      s.stop('Project files written');
+    } else if (isInteractiveShell && answers.installDependencies) {
+      clackLog.step('Scaffolding complete. Installing dependencies...');
+    }
 
     stdout.write('Done.\n');
     stdout.write(

--- a/packages/cli/src/new/install.ts
+++ b/packages/cli/src/new/install.ts
@@ -18,6 +18,10 @@ export interface InitializeGitRepositoryOptions {
   command?: string;
 }
 
+type WritableStream = {
+  write(message: string): unknown;
+};
+
 const COREPACK_DOCS_URL = 'https://nodejs.org/api/corepack.html';
 
 function checkCommandAvailability(command: string): boolean {
@@ -72,16 +76,16 @@ export function resolveInstallCommand(
  *
  * @param targetDirectory Generated project directory.
  * @param packageManager Package manager selected for the generated starter.
+ * @param stderr Optional stream for diagnostic messages.
  * @returns A promise that resolves when installation succeeds.
  */
-export async function installDependencies(targetDirectory: string, packageManager: PackageManager): Promise<void> {
+export async function installDependencies(targetDirectory: string, packageManager: PackageManager, stderr?: WritableStream): Promise<void> {
   const hasCorepack = packageManager === 'yarn' ? checkCommandAvailability('corepack') : undefined;
   const { args, command } = resolveInstallCommand(packageManager, { isCorepackAvailable: hasCorepack });
 
   if (packageManager === 'yarn' && hasCorepack === false) {
-    console.warn(
-      `[fluo] corepack was not found in PATH, falling back to "yarn install". See ${COREPACK_DOCS_URL}`,
-    );
+    const message = `[fluo] corepack was not found in PATH, falling back to "yarn install". See ${COREPACK_DOCS_URL}\n`;
+    (stderr ?? process.stderr).write(message);
   }
 
   await new Promise<void>((resolve, reject) => {

--- a/packages/cli/src/new/prompt.ts
+++ b/packages/cli/src/new/prompt.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { createInterface } from 'node:readline/promises';
+
+import * as clack from '@clack/prompts';
 
 import { resolveBootstrapSchema } from './resolver.js';
 import {
@@ -51,68 +52,51 @@ function hasOwnValue<Key extends keyof BootstrapAnswers>(
   return partial[key] !== undefined;
 }
 
-function createBootstrapPrompter(
-  stdin: NodeJS.ReadStream = process.stdin,
-  stdout: NodeJS.WriteStream = process.stdout,
-): BootstrapPrompter {
-  const readline = createInterface({ input: stdin, output: stdout });
-  const ask = async (message: string): Promise<string> => readline.question(message);
-
+function createBootstrapPrompter(): BootstrapPrompter {
   return {
-    close(): void {
-      readline.close();
-    },
     async confirm(message: string, defaultValue: boolean): Promise<boolean> {
-      const suffix = defaultValue ? 'Y/n' : 'y/N';
+      const result = await clack.confirm({
+        message,
+        initialValue: defaultValue,
+      });
 
-      while (true) {
-        const answer = (await ask(`${message} (${suffix}): `)).trim().toLowerCase();
-
-        if (answer.length === 0) {
-          return defaultValue;
-        }
-
-        if (['y', 'yes'].includes(answer)) {
-          return true;
-        }
-
-        if (['n', 'no'].includes(answer)) {
-          return false;
-        }
-
-        stdout.write('Please answer yes or no.\n');
+      if (clack.isCancel(result)) {
+        clack.cancel('Operation cancelled.');
+        process.exit(0);
       }
+
+      return result;
     },
     async select<T extends string>(message: string, choices: readonly PromptChoice<T>[], defaultValue?: T): Promise<T> {
-      const lines = [message];
+      const result = await clack.select({
+        message,
+        options: choices.map((choice) => ({ label: choice.label, value: choice.value })) as clack.Option<T>[],
+        initialValue: defaultValue,
+      }) as T | symbol;
 
-      for (const [index, choice] of choices.entries()) {
-        const marker = choice.value === defaultValue ? ' (default)' : '';
-        lines.push(`  ${index + 1}. ${choice.label}${marker}`);
+      if (clack.isCancel(result)) {
+        clack.cancel('Operation cancelled.');
+        process.exit(0);
       }
 
-      while (true) {
-        const answer = (await ask(`${lines.join('\n')}\n> `)).trim();
-
-        if (answer.length === 0 && defaultValue) {
-          return defaultValue;
-        }
-
-        const asIndex = Number(answer);
-        if (Number.isInteger(asIndex) && asIndex >= 1 && asIndex <= choices.length) {
-          return choices[asIndex - 1]!.value;
-        }
-
-        const exactMatch = choices.find((choice) => choice.value === answer);
-        if (exactMatch) {
-          return exactMatch.value;
-        }
-
-        stdout.write('Select one of the listed options.\n');
-      }
+      return result;
     },
     async text(message: string): Promise<string> {
-      return ask(`${message}: `);
+      const result = await clack.text({
+        message,
+        validate(value) {
+          if (!value || value.trim().length === 0) {
+            return 'Value is required.';
+          }
+        },
+      });
+
+      if (clack.isCancel(result)) {
+        clack.cancel('Operation cancelled.');
+        process.exit(0);
+      }
+
+      return result;
     },
   };
 }
@@ -369,13 +353,21 @@ export async function collectBootstrapAnswers(
     return resolveBootstrapAnswers(partial, cwd, userAgent);
   }
 
-  const prompt = options.prompt ?? createBootstrapPrompter(
-    options.stdin as NodeJS.ReadStream | undefined,
-    options.stdout as NodeJS.WriteStream | undefined,
-  );
+  const prompt = options.prompt ?? createBootstrapPrompter();
+  const isInteractiveShell = options.prompt === undefined;
 
   try {
-    return await resolveInteractiveBootstrapAnswers(partial, cwd, userAgent, prompt);
+    if (isInteractiveShell) {
+      clack.intro('fluo new');
+    }
+
+    const answers = await resolveInteractiveBootstrapAnswers(partial, cwd, userAgent, prompt);
+
+    if (isInteractiveShell) {
+      clack.outro(`Project created! Run: cd ${answers.targetDirectory}`);
+    }
+
+    return answers;
   } finally {
     prompt.close?.();
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@fluojs/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -1180,6 +1183,12 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@clack/core@1.2.0':
+    resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
+
+  '@clack/prompts@1.2.0':
+    resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
 
   '@envelop/core@5.5.1':
     resolution: {integrity: sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==}
@@ -2417,12 +2426,21 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
+  fast-string-truncated-width@1.2.1:
+    resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
+
+  fast-string-width@1.1.0:
+    resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
+
   fast-unique-numbers@9.0.27:
     resolution: {integrity: sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==}
     engines: {node: '>=18.2.0'}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.1.6:
+    resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
@@ -3041,6 +3059,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@2.0.0:
     resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
     engines: {node: '>=6'}
@@ -3622,6 +3643,18 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.10':
     optional: true
+
+  '@clack/core@1.2.0':
+    dependencies:
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.2.0':
+    dependencies:
+      '@clack/core': 1.2.0
+      fast-string-width: 1.1.0
+      fast-wrap-ansi: 0.1.6
+      sisteransi: 1.0.5
 
   '@envelop/core@5.5.1':
     dependencies:
@@ -4692,12 +4725,22 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
+  fast-string-truncated-width@1.2.1: {}
+
+  fast-string-width@1.1.0:
+    dependencies:
+      fast-string-truncated-width: 1.2.1
+
   fast-unique-numbers@9.0.27:
     dependencies:
       '@babel/runtime': 7.29.2
       tslib: 2.8.1
 
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.1.6:
+    dependencies:
+      fast-string-width: 1.1.0
 
   fastify-plugin@5.1.0: {}
 
@@ -5385,6 +5428,8 @@ snapshots:
   sift@17.1.3: {}
 
   siginfo@2.0.0: {}
+
+  sisteransi@1.0.5: {}
 
   slash@2.0.0: {}
 


### PR DESCRIPTION
## Summary

- Replaces the `readline`-based `createBootstrapPrompter` with `@clack/prompts` for arrow-key selection, enter-to-confirm visual toggles, and cancel handling
- Adds `intro`/`outro` chrome around the interactive wizard session
- Adds spinner feedback during scaffolding (when install is skipped) and a step log message when installation follows
- Fixes `console.warn` in `installDependencies` to route through the injected `stderr` stream instead of the global console

## Contract Impact

- `BootstrapPrompter` interface is **unchanged** — all existing test seams preserved
- Non-interactive / flag-first path is **unaffected** — `clack` prompts are never reached when `interactive: false` or when all flags are supplied
- `installDependencies` gains an optional `stderr` parameter (backward-compatible, defaults to `process.stderr`)

## Verification

- `pnpm exec vitest run` on `prompt.test.ts`, `install.test.ts`, `scaffold.test.ts`: **30 tests passed**
- `tsc --noEmit` on modified files: **no errors**
- `BootstrapPrompter`-injected test paths exercise no clack code paths (inject contract unchanged)

Closes #1118