### PR TITLE
Resolve #1120: dedupe interactive starter-shape choices

### DIFF
--- a/packages/cli/src/new/prompt.test.ts
+++ b/packages/cli/src/new/prompt.test.ts
@@ -68,6 +68,30 @@ describe('collectBootstrapAnswers', () => {
     };
   }
 
+  it('presents exactly three deduplicated starter-shape choices', async () => {
+    let starterShapeChoices: readonly { label: string; value: string }[] = [];
+
+    const prompt = createPrompt({
+      confirm: async (_message, defaultValue) => defaultValue,
+      select: async <T extends string>(message: string, choices: readonly { label: string; value: T }[], defaultValue?: T) => {
+        if (message === 'Starter shape') {
+          starterShapeChoices = choices;
+          return 'application' as T;
+        }
+
+        return (defaultValue ?? 'pnpm') as T;
+      },
+    });
+
+    await collectBootstrapAnswers({}, process.cwd(), undefined, { interactive: true, prompt });
+
+    expect(starterShapeChoices).toEqual([
+      { label: 'Application', value: 'application' },
+      { label: 'Microservice', value: 'microservice' },
+      { label: 'Mixed', value: 'mixed' },
+    ]);
+  });
+
   it('collects the application wizard path without terminal emulation', async () => {
     const prompt = createPrompt({
       confirm: async (_message, defaultValue) => defaultValue,

--- a/packages/cli/src/new/prompt.ts
+++ b/packages/cli/src/new/prompt.ts
@@ -7,7 +7,6 @@ import { resolveBootstrapSchema } from './resolver.js';
 import {
   DOCUMENTED_MICROSERVICE_TRANSPORTS,
   getApplicationStarterProfiles,
-  STARTER_PROFILE_REGISTRY,
 } from './starter-profiles.js';
 import type { BootstrapAnswers, PackageManager } from './types.js';
 
@@ -28,6 +27,12 @@ type PromptChoice<T extends string> = {
   label: string;
   value: T;
 };
+
+const STARTER_SHAPE_CHOICES = [
+  { label: 'Application', value: 'application' },
+  { label: 'Microservice', value: 'microservice' },
+  { label: 'Mixed', value: 'mixed' },
+] as const;
 
 /** Prompt contract used by the interactive `fluo new` wizard. */
 export interface BootstrapPrompter {
@@ -133,12 +138,7 @@ async function resolveInteractiveBootstrapAnswers(
   }
 
   if (!answers.shape) {
-    answers.shape = await prompt.select('Starter shape', [
-      ...STARTER_PROFILE_REGISTRY.map((profile) => ({
-        label: profile.promptLabel,
-        value: profile.schema.shape,
-      })),
-    ] as const, 'application');
+    answers.shape = await prompt.select('Starter shape', STARTER_SHAPE_CHOICES, 'application');
   }
 
   if (answers.shape === 'application' && !answers.runtime) {

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -171,7 +171,7 @@ describe('parseStudioPayload', () => {
     expect(existsSync(resolve(packageDir, 'dist', 'index.d.ts')), 'root helper barrel types are missing').toBe(true);
     expect(existsSync(resolve(packageDir, 'dist', 'contracts.js')), 'contracts helper output is missing').toBe(true);
     expect(existsSync(resolve(packageDir, 'dist', 'contracts.d.ts')), 'contracts helper types are missing').toBe(true);
-  }, 60_000);
+  }, 120_000);
 });
 
 describe('applyFilters', () => {

--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -97,5 +97,5 @@ describe('@fluojs/testing surface', () => {
       expect(existsSync(resolve(packageRootPath, entry.import)), `${subpath} import output is missing`).toBe(true);
       expect(existsSync(resolve(packageRootPath, entry.types)), `${subpath} types output is missing`).toBe(true);
     }
-  }, 60_000);
+  }, 120_000);
 });

--- a/tooling/scripts/run-workspace-build-closure.mjs
+++ b/tooling/scripts/run-workspace-build-closure.mjs
@@ -1,9 +1,42 @@
 #!/usr/bin/env node
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+
+const WORKSPACE_BUILD_LOCK_DIRECTORY = '.workspace-build-closure.lock';
+const WORKSPACE_BUILD_LOCK_TIMEOUT_MS = 120_000;
+const WORKSPACE_BUILD_LOCK_POLL_MS = 50;
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function acquireWorkspaceBuildLock(rootDirectory) {
+  const lockDirectory = join(rootDirectory, WORKSPACE_BUILD_LOCK_DIRECTORY);
+  const deadline = Date.now() + WORKSPACE_BUILD_LOCK_TIMEOUT_MS;
+
+  while (true) {
+    try {
+      mkdirSync(lockDirectory);
+
+      return () => {
+        rmSync(lockDirectory, { force: true, recursive: true });
+      };
+    } catch (error) {
+      if (!(error instanceof Error) || !('code' in error) || error.code !== 'EEXIST') {
+        throw error;
+      }
+
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for workspace build lock at ${lockDirectory}.`);
+      }
+
+      sleep(WORKSPACE_BUILD_LOCK_POLL_MS);
+    }
+  }
+}
 
 function detectPackageManager() {
   const userAgent = process.env.npm_config_user_agent ?? '';
@@ -157,72 +190,77 @@ export function runWorkspaceBuildClosure(targetPackageName, rootDirectory, optio
   const order = resolveWorkspaceBuildOrder(targetPackageName, rootDirectory);
   const workspaceManifests = collectWorkspaceManifests(rootDirectory);
   const manifestByName = new Map(workspaceManifests.map((entry) => [entry.name, entry]));
+  const releaseLock = acquireWorkspaceBuildLock(rootDirectory);
 
   let stdout = '';
   let stderr = '';
 
-  for (const packageName of order) {
-    const entry = manifestByName.get(packageName);
-    if (!entry || typeof entry.manifest.scripts?.build !== 'string') {
-      continue;
+  try {
+    for (const packageName of order) {
+      const entry = manifestByName.get(packageName);
+      if (!entry || typeof entry.manifest.scripts?.build !== 'string') {
+        continue;
+      }
+
+      const args = packageManager.startsWith('npm') ? ['run', 'build'] : ['run', 'build'];
+      const result = spawnSync(packageManager, args, {
+        cwd: entry.directory,
+        encoding: 'utf8',
+        stdio,
+      });
+
+      if (stdio === 'pipe') {
+        stdout += `\n[build:${packageName}]\n${result.stdout ?? ''}`;
+        stderr += `\n[build:${packageName}]\n${result.stderr ?? ''}`;
+      }
+
+      if (result.error) {
+        throw result.error;
+      }
+
+      if (result.signal) {
+        stderr = `${stderr}\nBuild for ${packageName} terminated by signal ${result.signal}.`.trim();
+        return {
+          order,
+          packageManager,
+          status: 1,
+          stderr,
+          stdout: stdout.trim(),
+        };
+      }
+
+      if (typeof result.status !== 'number') {
+        stderr = `${stderr}\nBuild for ${packageName} exited without a numeric status.`.trim();
+        return {
+          order,
+          packageManager,
+          status: 1,
+          stderr,
+          stdout: stdout.trim(),
+        };
+      }
+
+      if (result.status !== 0) {
+        return {
+          order,
+          packageManager,
+          status: result.status,
+          stderr: stderr.trim(),
+          stdout: stdout.trim(),
+        };
+      }
     }
 
-    const args = packageManager.startsWith('npm') ? ['run', 'build'] : ['run', 'build'];
-    const result = spawnSync(packageManager, args, {
-      cwd: entry.directory,
-      encoding: 'utf8',
-      stdio,
-    });
-
-    if (stdio === 'pipe') {
-      stdout += `\n[build:${packageName}]\n${result.stdout ?? ''}`;
-      stderr += `\n[build:${packageName}]\n${result.stderr ?? ''}`;
-    }
-
-    if (result.error) {
-      throw result.error;
-    }
-
-    if (result.signal) {
-      stderr = `${stderr}\nBuild for ${packageName} terminated by signal ${result.signal}.`.trim();
-      return {
-        order,
-        packageManager,
-        status: 1,
-        stderr,
-        stdout: stdout.trim(),
-      };
-    }
-
-    if (typeof result.status !== 'number') {
-      stderr = `${stderr}\nBuild for ${packageName} exited without a numeric status.`.trim();
-      return {
-        order,
-        packageManager,
-        status: 1,
-        stderr,
-        stdout: stdout.trim(),
-      };
-    }
-
-    if (result.status !== 0) {
-      return {
-        order,
-        packageManager,
-        status: result.status,
-        stderr: stderr.trim(),
-        stdout: stdout.trim(),
-      };
-    }
+    return {
+      order,
+      packageManager,
+      status: 0,
+      stderr: stderr.trim(),
+      stdout: stdout.trim(),
+    };
+  } finally {
+    releaseLock();
   }
-
-  return {
-    order,
-    packageManager,
-    status: 0,
-    stderr: stderr.trim(),
-    stdout: stdout.trim(),
-  };
 }
 
 function main() {

--- a/tooling/scripts/run-workspace-build-closure.test.ts
+++ b/tooling/scripts/run-workspace-build-closure.test.ts
@@ -1,4 +1,6 @@
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -61,5 +63,90 @@ describe('resolveWorkspaceBuildOrder', () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('terminated by signal SIGTERM');
+  });
+
+  it('serializes concurrent workspace build closures that share the same repo root', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'fluo-build-closure-lock-'));
+    const packageDirectory = join(root, 'packages', 'app');
+    const fakeManager = join(root, 'fake-pm.sh');
+    const buildLog = join(root, 'build.log');
+    const helperModuleUrl = new URL('./run-workspace-build-closure.mjs', import.meta.url).href;
+    const runnerSource = `
+      import { runWorkspaceBuildClosure } from ${JSON.stringify(helperModuleUrl)};
+      const result = runWorkspaceBuildClosure('@test/app', ${JSON.stringify(root)}, {
+        packageManager: ${JSON.stringify(fakeManager)},
+        stdio: 'pipe',
+      });
+      if (result.status !== 0) {
+        console.error(result.stderr || result.stdout);
+        process.exit(result.status);
+      }
+    `;
+
+    mkdirSync(packageDirectory, { recursive: true });
+
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ private: true, workspaces: ['packages/*'] }, null, 2),
+      'utf8',
+    );
+    writeFileSync(
+      join(packageDirectory, 'package.json'),
+      JSON.stringify({ name: '@test/app', version: '0.0.0', scripts: { build: 'noop' } }, null, 2),
+      'utf8',
+    );
+    writeFileSync(
+      fakeManager,
+      '#!/bin/sh\nprintf "start %s\\n" "$$" >> "$BUILD_LOG"\nsleep 0.2\nprintf "end %s\\n" "$$" >> "$BUILD_LOG"\n',
+      'utf8',
+    );
+    chmodSync(fakeManager, 0o755);
+
+    const runWorker = async () => {
+      await new Promise<void>((resolve, reject) => {
+        const child = spawn(process.execPath, ['--input-type=module', '--eval', runnerSource], {
+          cwd: root,
+          env: {
+            ...process.env,
+            BUILD_LOG: buildLog,
+          },
+          stdio: 'pipe',
+        });
+        const childEvents = child as unknown as NodeJS.EventEmitter;
+
+        let stderr = '';
+        child.stderr.on('data', (chunk) => {
+          stderr += String(chunk);
+        });
+
+        void once(childEvents, 'error').then(([error]) => {
+          reject(error);
+        });
+
+        void once(childEvents, 'exit').then(([code]) => {
+          if (code === 0) {
+            resolve();
+            return;
+          }
+
+          reject(new Error(stderr || `worker exited with code ${code ?? 'unknown'}`));
+        });
+      });
+    };
+
+    await Promise.all([runWorker(), runWorker()]);
+
+    const events = readFileSync(buildLog, 'utf8').trim().split('\n');
+    expect(events).toHaveLength(4);
+
+    const [firstStart, firstEnd, secondStart, secondEnd] = events.map((event) => event.split(' '));
+
+    expect(firstStart[0]).toBe('start');
+    expect(firstEnd[0]).toBe('end');
+    expect(firstStart[1]).toBe(firstEnd[1]);
+    expect(secondStart[0]).toBe('start');
+    expect(secondEnd[0]).toBe('end');
+    expect(secondStart[1]).toBe(secondEnd[1]);
+    expect(firstStart[1]).not.toBe(secondStart[1]);
   });
 });


### PR DESCRIPTION
## Summary

Fix the interactive `fluo new` starter-shape menu so it renders the documented top-level branches only, and stabilize the workspace build-contract test path that CI exercises on `main`.

## Changes

- replace the `Starter shape` prompt choices with the three coarse branches: `Application`, `Microservice`, and `Mixed`
- keep the existing runtime / HTTP platform / microservice transport drill-down prompts unchanged
- add a regression test that captures the starter-shape choices array and asserts the menu stays deduplicated
- serialize `runWorkspaceBuildClosure(...)` calls so build-contract tests do not race each other while cleaning and rebuilding shared workspace package dists
- add a regression test proving concurrent build-closure callers against the same repo root run sequentially instead of overlapping
- extend the `packages/studio` / `packages/testing` build-contract test timeouts so the serialized path still has enough CI budget to complete

## Testing

- `pnpm build`
- `pnpm --dir packages/cli test`
- `pnpm --dir packages/cli typecheck`
- `pnpm --dir packages/cli run sandbox:create`
- `pnpm exec vitest run packages/studio/src/contracts.test.ts packages/testing/src/surface.test.ts tooling/scripts/run-workspace-build-closure.test.ts`
- `pnpm test`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract impact:
- Restores the documented shape-first wizard contract by keeping the first prompt at the coarse branch level only.
- Runtime/platform/transport selection semantics remain unchanged after the shape step.
- Stabilizes the build-contract test harness so package build verification does not fail due to concurrent `prebuild`/`clean-dist` races or CI timeout budgets after serialization.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1120