### PR TITLE
Resolve #1121: polish fluo new install progress output

### DIFF
--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { spinner as clackSpinner, log as clackLog } from '@clack/prompts';
 
 import { renderAliasList, renderHelpTable } from '../help.js';
+import { installDependencies } from '../new/install.js';
 import { collectBootstrapAnswers, type BootstrapPrompter } from '../new/prompt.js';
 import { scaffoldBootstrapApp } from '../new/scaffold.js';
 import {
@@ -18,6 +19,23 @@ import type { BootstrapAnswers, NewCommandOptions } from '../new/types.js';
 type CliStream = {
   write(message: string): unknown;
 };
+
+function shouldUseInteractiveShell(runtime: NewCommandRuntimeOptions): boolean {
+  return runtime.prompt === undefined
+    && runtime.stdout === undefined
+    && runtime.stderr === undefined
+    && (runtime.interactive ?? true)
+    && Boolean(runtime.stdin?.isTTY ?? process.stdin.isTTY);
+}
+
+function extractDependencyInstallationOutput(error: unknown): string | undefined {
+  if (!(error instanceof Error) || !('output' in error)) {
+    return undefined;
+  }
+
+  const output = error.output;
+  return typeof output === 'string' && output.trim().length > 0 ? output : undefined;
+}
 
 function isHelpFlag(value: string | undefined): boolean {
   return value === '--help' || value === '-h';
@@ -401,37 +419,63 @@ export async function runNewCommand(argv: string[], runtime: NewCommandRuntimeOp
       stdin: runtime.stdin,
       stdout,
     });
+    const targetDirectory = resolve(runtime.cwd ?? process.cwd(), answers.targetDirectory);
     const options = {
       ...answers,
       dependencySource: runtime.dependencySource,
       force: parsed.force ?? runtime.force,
       initializeGit: answers.initializeGit,
-      installDependencies: answers.installDependencies,
+      installDependencies: false,
       repoRoot: runtime.repoRoot,
-      skipInstall: runtime.skipInstall,
-      targetDirectory: resolve(runtime.cwd ?? process.cwd(), answers.targetDirectory),
+      skipInstall: true,
+      targetDirectory,
     };
 
-    if (answers.installDependencies) {
-      stdout.write(`Installing dependencies with ${answers.packageManager}...\n`);
-    } else {
+    const isInteractiveShell = shouldUseInteractiveShell(runtime);
+    let scaffoldSpinner: ReturnType<typeof clackSpinner> | undefined;
+
+    if (!answers.installDependencies && !isInteractiveShell) {
       stdout.write('Skipping dependency installation.\n');
     }
 
-    const isInteractiveShell = runtime.prompt === undefined && !runtime.interactive;
-    let s: ReturnType<typeof clackSpinner> | undefined;
-
-    if (isInteractiveShell && !answers.installDependencies) {
-      s = clackSpinner();
-      s.start('Scaffolding project files');
+    if (isInteractiveShell) {
+      scaffoldSpinner = clackSpinner();
+      scaffoldSpinner.start('Scaffolding project files');
     }
 
     await scaffoldBootstrapApp(options);
 
-    if (s) {
-      s.stop('Project files written');
-    } else if (isInteractiveShell && answers.installDependencies) {
-      clackLog.step('Scaffolding complete. Installing dependencies...');
+    if (scaffoldSpinner) {
+      scaffoldSpinner.stop('Project files written');
+    }
+
+    if (answers.installDependencies) {
+      if (!isInteractiveShell) {
+        stdout.write(`Installing dependencies with ${answers.packageManager}...\n`);
+        await installDependencies(targetDirectory, answers.packageManager, { stderr });
+      } else {
+        const installSpinner = clackSpinner();
+        installSpinner.start(`Installing dependencies with ${answers.packageManager}`);
+
+        try {
+          await installDependencies(targetDirectory, answers.packageManager, {
+            stderr,
+            stdio: 'capture',
+          });
+          installSpinner.stop('Dependencies installed');
+        } catch (error: unknown) {
+          installSpinner.error('Dependency installation failed');
+
+          const output = extractDependencyInstallationOutput(error);
+          if (output) {
+            stderr.write(`\n[fluo] Full installation log:\n${output}${output.endsWith('\n') ? '' : '\n'}`);
+          }
+
+          throw error;
+        }
+      }
+    } else if (isInteractiveShell) {
+      clackLog.step('Dependency installation skipped');
     }
 
     stdout.write('Done.\n');

--- a/packages/cli/src/new/install.test.ts
+++ b/packages/cli/src/new/install.test.ts
@@ -1,6 +1,35 @@
-import { describe, expect, it } from 'vitest';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
 
-import { resolveInstallCommand } from './install.js';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { installDependencies, resolveInstallCommand } from './install.js';
+
+const createdDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of createdDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function createExecutableFixture(commandName: string, script: string): { directory: string; env: NodeJS.ProcessEnv } {
+  const directory = mkdtempSync(join(tmpdir(), `fluo-cli-install-${commandName}-`));
+  createdDirectories.push(directory);
+
+  const executablePath = join(directory, commandName);
+  writeFileSync(executablePath, script, 'utf8');
+  chmodSync(executablePath, 0o755);
+
+  return {
+    directory,
+    env: {
+      ...process.env,
+      PATH: `${directory}${delimiter}${process.env.PATH ?? ''}`,
+    },
+  };
+}
 
 describe('resolveInstallCommand', () => {
   it('uses direct install commands for bun, pnpm, and npm', () => {
@@ -30,5 +59,50 @@ describe('resolveInstallCommand', () => {
       args: ['install'],
       command: 'yarn',
     });
+  });
+
+  it('captures full subprocess output when install fails in capture mode', async () => {
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-install-target-'));
+    createdDirectories.push(targetDirectory);
+    const { env } = createExecutableFixture(
+      'npm',
+      '#!/bin/sh\nprintf "npm notice tarball contents\\n"\nprintf "npm error install failed\\n" 1>&2\nexit 2\n',
+    );
+
+    let thrownError: unknown;
+
+    try {
+      await installDependencies(targetDirectory, 'npm', {
+        env,
+        stdio: 'capture',
+      });
+    } catch (error: unknown) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect((thrownError as Error).message).toBe('Dependency installation failed with exit code 2.');
+    expect(thrownError).toMatchObject({
+      output: 'npm notice tarball contents\nnpm error install failed\n',
+    });
+  });
+
+  it('surfaces the yarn corepack fallback warning through the provided stderr stream', async () => {
+    const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-install-target-'));
+    createdDirectories.push(targetDirectory);
+    const { env } = createExecutableFixture('yarn', '#!/bin/sh\nexit 0\n');
+    const stderrBuffer: string[] = [];
+
+    await installDependencies(targetDirectory, 'yarn', {
+      env,
+      isCorepackAvailable: false,
+      stderr: {
+        write(message: string) {
+          stderrBuffer.push(message);
+        },
+      },
+    });
+
+    expect(stderrBuffer.join('')).toContain('corepack was not found in PATH');
   });
 });

--- a/packages/cli/src/new/install.ts
+++ b/packages/cli/src/new/install.ts
@@ -1,4 +1,5 @@
 import { spawn, spawnSync } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 
 import type { PackageManager } from './types.js';
 
@@ -22,7 +23,56 @@ type WritableStream = {
   write(message: string): unknown;
 };
 
+type InstallStdioMode = 'capture' | 'inherit';
+
+type InstallDependenciesOptions = {
+  env?: NodeJS.ProcessEnv;
+  isCorepackAvailable?: boolean;
+  stderr?: WritableStream;
+  stdio?: InstallStdioMode;
+};
+
 const COREPACK_DOCS_URL = 'https://nodejs.org/api/corepack.html';
+
+class DependencyInstallationError extends Error {
+  readonly output: string;
+
+  constructor(exitCode: number | null, output: string) {
+    super(
+      exitCode === null
+        ? 'Dependency installation failed without an exit code.'
+        : `Dependency installation failed with exit code ${exitCode}.`,
+    );
+    this.name = 'DependencyInstallationError';
+    this.output = output;
+  }
+}
+
+function appendStreamOutput(
+  stream: NodeJS.ReadableStream | null | undefined,
+  output: string[],
+): void {
+  stream?.on('data', (chunk) => {
+    output.push(typeof chunk === 'string' ? chunk : chunk.toString());
+  });
+}
+
+function waitForChildProcess(
+  child: ChildProcess,
+  capturedOutput?: string[],
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new DependencyInstallationError(code, capturedOutput?.join('') ?? ''));
+    });
+  });
+}
 
 function checkCommandAvailability(command: string): boolean {
   const checker = process.platform === 'win32' ? 'where' : 'which';
@@ -76,34 +126,48 @@ export function resolveInstallCommand(
  *
  * @param targetDirectory Generated project directory.
  * @param packageManager Package manager selected for the generated starter.
- * @param stderr Optional stream for diagnostic messages.
+ * @param options Runtime overrides for install execution and diagnostics.
  * @returns A promise that resolves when installation succeeds.
  */
-export async function installDependencies(targetDirectory: string, packageManager: PackageManager, stderr?: WritableStream): Promise<void> {
-  const hasCorepack = packageManager === 'yarn' ? checkCommandAvailability('corepack') : undefined;
+export async function installDependencies(
+  targetDirectory: string,
+  packageManager: PackageManager,
+  options: InstallDependenciesOptions = {},
+): Promise<void> {
+  const hasCorepack = packageManager === 'yarn'
+    ? (options.isCorepackAvailable ?? checkCommandAvailability('corepack'))
+    : undefined;
   const { args, command } = resolveInstallCommand(packageManager, { isCorepackAvailable: hasCorepack });
 
   if (packageManager === 'yarn' && hasCorepack === false) {
     const message = `[fluo] corepack was not found in PATH, falling back to "yarn install". See ${COREPACK_DOCS_URL}\n`;
-    (stderr ?? process.stderr).write(message);
+    (options.stderr ?? process.stderr).write(message);
   }
 
-  await new Promise<void>((resolve, reject) => {
+  const stdio = options.stdio ?? 'inherit';
+
+  if (stdio === 'capture') {
+    const capturedOutput: string[] = [];
     const child = spawn(command, args, {
       cwd: targetDirectory,
-      stdio: 'inherit',
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
 
-    child.on('error', reject);
-    child.on('exit', (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
+    appendStreamOutput(child.stdout, capturedOutput);
+    appendStreamOutput(child.stderr, capturedOutput);
 
-      reject(new Error(`Dependency installation failed with exit code ${code}.`));
-    });
+    await waitForChildProcess(child, capturedOutput);
+    return;
+  }
+
+  const child = spawn(command, args, {
+    cwd: targetDirectory,
+    env: options.env,
+    stdio: 'inherit',
   });
+
+  await waitForChildProcess(child);
 }
 
 /**


### PR DESCRIPTION
## Summary

Polish the `fluo new` dependency-install path so interactive TTY runs show concise progress and success/failure states by default instead of dumping raw package-manager notice output.

## Changes

- add a captured install-execution mode in `packages/cli/src/new/install.ts` that preserves full subprocess output for failure diagnostics
- keep inherited stdio as the default install behavior for non-interactive and automation-safe paths
- move the actual install step under `runNewCommand(...)` so interactive shells can wrap installation with a dedicated clack spinner
- replay the full captured install log to `stderr` only when installation fails in the interactive path
- add regression coverage for captured install failures and yarn/corepack fallback warnings

## Testing

- `pnpm build`
- `pnpm --dir packages/cli typecheck`
- `pnpm --dir packages/cli exec vitest run src/new/install.test.ts src/cli.test.ts`
- `pnpm --dir packages/cli run sandbox:create`
- manual pseudo-interactive smoke with a fake `npm` binary:
  - success path shows spinner + `Dependencies installed` without raw `npm notice` dump
  - failure path shows spinner error, then replays the full raw install log to `stderr`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract impact:
- `fluo new` still supports the same global install / `pnpm dlx` entrypoints and the same starter flags.
- The change only affects how dependency installation progress is rendered in interactive TTY runs.
- Non-interactive and automation-oriented paths keep the inherited package-manager output behavior for debuggability.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1121