### PR TITLE
Resolve #1124: align public package workspace dependency ranges

### DIFF
--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -41,6 +41,8 @@ fluo의 설계 철학과 그 이면의 "왜"와 "어떻게"를 이해합니다.
 - **[보안 미들웨어](./concepts/security-middleware.ko.md)**: API 보호를 위한 최선의 실천 방법.
 - **[프로덕션 배포](./operations/deployment.ko.md)**: `pnpm dev`에서 실제 운영 환경으로의 전환.
 
+[Release Governance](./operations/release-governance.ko.md)는 공개 패키지의 기준 intended publish surface, release-readiness gate, 그리고 내부 `workspace:^` dependency-range 정책을 확인할 때 기준 문서로 사용하세요.
+
 ## 📚 참조 자료
 
 심층적인 기술 명세 및 비교 자료입니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,8 @@ Practical, task-oriented documentation for day-to-day development.
 - **[Security Middleware](./concepts/security-middleware.md)**: Best practices for protecting your API.
 - **[Production Deployment](./operations/deployment.md)**: Moving from `pnpm dev` to a production environment.
 
+Use [Release Governance](./operations/release-governance.md) when you need the canonical intended publish surface, release-readiness gates, or the enforced internal `workspace:^` dependency-range policy for public packages.
+
 ## 📚 Reference
 
 Detailed technical specifications and comparisons.

--- a/docs/operations/release-governance.ko.md
+++ b/docs/operations/release-governance.ko.md
@@ -94,7 +94,7 @@ fluo는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅니
 거버넌스는 자동화된 게이트와 수동 체크리스트를 통해 강제됩니다.
 
 ### CI/CD 강제 사항
-- **`pnpm verify:release-readiness`**: 기본적으로 `CHANGELOG.md`나 release-readiness summary 파일을 변경하지 않고 패키징된 CLI 엔트리포인트와 스타터 스캐폴딩을 검증합니다.
+- **`pnpm verify:release-readiness`**: 기본적으로 `CHANGELOG.md`나 release-readiness summary 파일을 변경하지 않고 패키징된 CLI 엔트리포인트, 스타터 스캐폴딩, intended public package manifest dependency range를 검증합니다.
 - **`pnpm generate:release-readiness-drafts`**: 릴리스 노트를 준비할 때 release-readiness summary 산출물과 `CHANGELOG.md` 드래프트 블록을 명시적으로 갱신합니다.
 - **`pnpm verify:platform-consistency-governance`**: 영어와 한국어 문서 간의 구조적 일관성을 강제합니다.
 - **`pnpm verify:public-export-tsdoc`**: `packages/*/src` 아래 변경된 public export가 repo-wide TSDoc 최소 기준을 놓치면 실패합니다.

--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -94,7 +94,7 @@ During the `0.x` phase, the **Minor** version is used for breaking changes. Ever
 Governance is enforced through automated gates and manual checklists.
 
 ### CI/CD Enforcement
-- **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints and starter scaffolding without mutating `CHANGELOG.md` or release-readiness summary files by default.
+- **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints, starter scaffolding, and intended public package manifest dependency ranges without mutating `CHANGELOG.md` or release-readiness summary files by default.
 - **`pnpm generate:release-readiness-drafts`**: Explicitly refreshes the release-readiness summary artifacts and the draft `CHANGELOG.md` block when maintainers are preparing release notes.
 - **`pnpm verify:platform-consistency-governance`**: Enforces structural parity between English and Korean documentation.
 - **`pnpm verify:public-export-tsdoc`**: Fails when changed public exports in `packages/*/src` miss the repo-wide TSDoc minimum baseline.

--- a/packages/cache-manager/package.json
+++ b/packages/cache-manager/package.json
@@ -44,13 +44,13 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
-    "@fluojs/redis": "workspace:*",
+    "@fluojs/redis": "workspace:^",
     "ioredis": "^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",
-    "@fluojs/runtime": "workspace:*",
+    "@fluojs/runtime": "workspace:^",
     "ejs": "^3.1.10",
     "tsx": "^4.20.4",
     "typescript": "^6.0.2"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -42,7 +42,7 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
+    "@fluojs/core": "workspace:^",
     "dotenv": "^16.0.0",
     "dotenv-expand": "^11.0.0"
   },

--- a/packages/cqrs/package.json
+++ b/packages/cqrs/package.json
@@ -43,10 +43,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/event-bus": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/event-bus": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/cron/package.json
+++ b/packages/cron/package.json
@@ -43,10 +43,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/redis": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/redis": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
     "croner": "^8.1.2"
   },
   "devDependencies": {

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -43,7 +43,7 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*"
+    "@fluojs/core": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/discord/package.json
+++ b/packages/discord/package.json
@@ -43,10 +43,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/notifications": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/notifications": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -43,10 +43,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
     "drizzle-orm": ">=0.30.0"

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -59,13 +59,13 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/notifications": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/notifications": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
-    "@fluojs/queue": "workspace:*",
+    "@fluojs/queue": "workspace:^",
     "nodemailer": "^6.10.1"
   },
   "peerDependenciesMeta": {
@@ -77,7 +77,7 @@
     }
   },
   "devDependencies": {
-    "@fluojs/queue": "workspace:*",
+    "@fluojs/queue": "workspace:^",
     "@types/nodemailer": "^8.0.0",
     "vitest": "^3.2.4"
   }

--- a/packages/email/src/public-surface.test.ts
+++ b/packages/email/src/public-surface.test.ts
@@ -50,7 +50,7 @@ describe('@fluojs/email public API surface', () => {
     expect(packageJson.dependencies).not.toHaveProperty('@fluojs/queue');
     expect(packageJson.dependencies).not.toHaveProperty('nodemailer');
     expect(packageJson.peerDependencies).toMatchObject({
-      '@fluojs/queue': 'workspace:*',
+      '@fluojs/queue': 'workspace:^',
       nodemailer: '^6.10.1',
     });
     expect(packageJson.peerDependenciesMeta).toMatchObject({

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -46,9 +46,9 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
     "ioredis": "^5.0.0"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -43,11 +43,11 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
-    "@fluojs/validation": "workspace:*",
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
+    "@fluojs/validation": "workspace:^",
     "dataloader": "^2.2.3",
     "graphql": "^16.13.1",
     "graphql-ws": "^5.16.2",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -48,9 +48,9 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/validation": "workspace:*",
-    "@fluojs/di": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/validation": "workspace:^",
+    "@fluojs/di": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -43,9 +43,9 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -42,9 +42,9 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
     "prom-client": "^15.1.3"
   },
   "devDependencies": {

--- a/packages/microservices/package.json
+++ b/packages/microservices/package.json
@@ -75,9 +75,9 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
     "@grpc/grpc-js": "^1.0.0",

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -43,10 +43,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
     "mongoose": ">=7.0.0"

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -43,9 +43,9 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -43,10 +43,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/validation": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/validation": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/passport/package.json
+++ b/packages/passport/package.json
@@ -43,11 +43,11 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/jwt": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/jwt": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/platform-bun/package.json
+++ b/packages/platform-bun/package.json
@@ -39,8 +39,8 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/platform-cloudflare-workers/package.json
+++ b/packages/platform-cloudflare-workers/package.json
@@ -40,8 +40,8 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/platform-deno/package.json
+++ b/packages/platform-deno/package.json
@@ -39,8 +39,8 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/platform-express/package.json
+++ b/packages/platform-express/package.json
@@ -42,8 +42,8 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
     "express": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@fastify/multipart": "^9.2.1",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
     "fastify": "^5.6.1",
     "fastify-raw-body": "^5.0.0"
   },

--- a/packages/platform-nodejs/package.json
+++ b/packages/platform-nodejs/package.json
@@ -43,8 +43,8 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -43,11 +43,11 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/validation": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/validation": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
     "@prisma/client": ">=5.0.0"

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -44,10 +44,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/redis": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/redis": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
     "bullmq": "^5.58.0"
   },
   "devDependencies": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -43,9 +43,9 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
     "ioredis": "^5.10.0"
   },
   "devDependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -74,13 +74,13 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/config": "workspace:*",
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*"
+    "@fluojs/config": "workspace:^",
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^"
   },
   "devDependencies": {
-    "@fluojs/serialization": "workspace:*",
+    "@fluojs/serialization": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/serialization/package.json
+++ b/packages/serialization/package.json
@@ -43,8 +43,8 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/http": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/http": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -43,10 +43,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/notifications": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/notifications": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/socket.io/package.json
+++ b/packages/socket.io/package.json
@@ -44,19 +44,19 @@
   },
   "dependencies": {
     "@socket.io/bun-engine": "^0.1.0",
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
-    "@fluojs/websockets": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
+    "@fluojs/websockets": "workspace:^"
   },
   "peerDependencies": {
     "socket.io": "^4.0.0"
   },
   "devDependencies": {
-    "@fluojs/platform-express": "workspace:*",
-    "@fluojs/platform-fastify": "workspace:*",
-    "@fluojs/platform-nodejs": "workspace:*",
+    "@fluojs/platform-express": "workspace:^",
+    "@fluojs/platform-fastify": "workspace:^",
+    "@fluojs/platform-nodejs": "workspace:^",
     "socket.io": "^4.8.1",
     "socket.io-client": "^4.8.1",
     "vitest": "^3.2.4"

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -50,10 +50,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
-    "@fluojs-internal/tooling-vite": "workspace:*",
+    "@fluojs-internal/tooling-vite": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/terminus/package.json
+++ b/packages/terminus/package.json
@@ -47,15 +47,15 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
-    "@fluojs/drizzle": "workspace:*",
-    "@fluojs/prisma": "workspace:*",
-    "@fluojs/redis": "workspace:*"
+    "@fluojs/drizzle": "workspace:^",
+    "@fluojs/prisma": "workspace:^",
+    "@fluojs/redis": "workspace:^"
   },
   "peerDependenciesMeta": {
     "@fluojs/drizzle": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -83,20 +83,20 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/config": "workspace:*",
-    "@fluojs/core": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/config": "workspace:^",
+    "@fluojs/core": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
     "@babel/core": ">=7.0.0",
     "vitest": "^3.0.8"
   },
   "devDependencies": {
-    "@fluojs/platform-nodejs": "workspace:*",
-    "@fluojs/platform-express": "workspace:*",
-    "@fluojs/platform-fastify": "workspace:*",
+    "@fluojs/platform-nodejs": "workspace:^",
+    "@fluojs/platform-express": "workspace:^",
+    "@fluojs/platform-fastify": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/throttler/package.json
+++ b/packages/throttler/package.json
@@ -43,13 +43,13 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
   },
   "peerDependencies": {
-    "@fluojs/redis": "workspace:*",
+    "@fluojs/redis": "workspace:^",
     "ioredis": "^5.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -47,7 +47,7 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
+    "@fluojs/core": "workspace:^",
     "@standard-schema/spec": "^1.1.0",
     "validator": "^13.15.26"
   },

--- a/packages/websockets/package.json
+++ b/packages/websockets/package.json
@@ -75,16 +75,16 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:*",
-    "@fluojs/di": "workspace:*",
-    "@fluojs/http": "workspace:*",
-    "@fluojs/runtime": "workspace:*",
+    "@fluojs/core": "workspace:^",
+    "@fluojs/di": "workspace:^",
+    "@fluojs/http": "workspace:^",
+    "@fluojs/runtime": "workspace:^",
     "ws": "^8.18.3"
   },
   "devDependencies": {
-    "@fluojs/platform-bun": "workspace:*",
-    "@fluojs/platform-express": "workspace:*",
-    "@fluojs/platform-fastify": "workspace:*",
+    "@fluojs/platform-bun": "workspace:^",
+    "@fluojs/platform-express": "workspace:^",
+    "@fluojs/platform-fastify": "workspace:^",
     "@types/ws": "^8.18.1",
     "vitest": "^3.2.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,19 +139,19 @@ importers:
   packages/cache-manager:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/redis':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../redis
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       ioredis:
         specifier: ^5.0.0
@@ -167,7 +167,7 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       ejs:
         specifier: ^3.1.10
@@ -189,7 +189,7 @@ importers:
   packages/config:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       dotenv:
         specifier: ^16.0.0
@@ -211,16 +211,16 @@ importers:
   packages/cqrs:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/event-bus':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../event-bus
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -230,16 +230,16 @@ importers:
   packages/cron:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/redis':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../redis
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       croner:
         specifier: ^8.1.2
@@ -252,7 +252,7 @@ importers:
   packages/di:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       vitest:
@@ -262,16 +262,16 @@ importers:
   packages/discord:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/notifications':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../notifications
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -281,16 +281,16 @@ importers:
   packages/drizzle:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       drizzle-orm:
         specifier: '>=0.30.0'
@@ -303,23 +303,23 @@ importers:
   packages/email:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/notifications':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../notifications
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       nodemailer:
         specifier: ^6.10.1
         version: 6.10.1
     devDependencies:
       '@fluojs/queue':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../queue
       '@types/nodemailer':
         specifier: ^8.0.0
@@ -331,13 +331,13 @@ importers:
   packages/event-bus:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       ioredis:
         specifier: ^5.0.0
@@ -350,19 +350,19 @@ importers:
   packages/graphql:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       '@fluojs/validation':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../validation
       dataloader:
         specifier: ^2.2.3
@@ -390,13 +390,13 @@ importers:
   packages/http:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/validation':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../validation
     devDependencies:
       vitest:
@@ -406,13 +406,13 @@ importers:
   packages/jwt:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -422,13 +422,13 @@ importers:
   packages/metrics:
     dependencies:
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       prom-client:
         specifier: ^15.1.3
@@ -444,13 +444,13 @@ importers:
   packages/microservices:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       '@grpc/grpc-js':
         specifier: ^1.0.0
@@ -472,16 +472,16 @@ importers:
   packages/mongoose:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       mongoose:
         specifier: '>=7.0.0'
@@ -494,13 +494,13 @@ importers:
   packages/notifications:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -510,16 +510,16 @@ importers:
   packages/openapi:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       '@fluojs/validation':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../validation
     devDependencies:
       vitest:
@@ -529,19 +529,19 @@ importers:
   packages/passport:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/jwt':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../jwt
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -551,10 +551,10 @@ importers:
   packages/platform-bun:
     dependencies:
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -564,10 +564,10 @@ importers:
   packages/platform-cloudflare-workers:
     dependencies:
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -577,10 +577,10 @@ importers:
   packages/platform-deno:
     dependencies:
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -590,10 +590,10 @@ importers:
   packages/platform-express:
     dependencies:
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       express:
         specifier: ^5.1.0
@@ -612,10 +612,10 @@ importers:
         specifier: ^9.2.1
         version: 9.4.0
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       fastify:
         specifier: ^5.6.1
@@ -631,10 +631,10 @@ importers:
   packages/platform-nodejs:
     dependencies:
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -644,19 +644,19 @@ importers:
   packages/prisma:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       '@fluojs/validation':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../validation
       '@prisma/client':
         specifier: '>=5.0.0'
@@ -669,16 +669,16 @@ importers:
   packages/queue:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/redis':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../redis
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       bullmq:
         specifier: ^5.58.0
@@ -691,13 +691,13 @@ importers:
   packages/redis:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       ioredis:
         specifier: ^5.10.0
@@ -710,20 +710,20 @@ importers:
   packages/runtime:
     dependencies:
       '@fluojs/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../config
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
     devDependencies:
       '@fluojs/serialization':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../serialization
       vitest:
         specifier: ^3.2.4
@@ -732,10 +732,10 @@ importers:
   packages/serialization:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
     devDependencies:
       vitest:
@@ -745,16 +745,16 @@ importers:
   packages/slack:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/notifications':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../notifications
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -764,32 +764,32 @@ importers:
   packages/socket.io:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       '@fluojs/websockets':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../websockets
       '@socket.io/bun-engine':
         specifier: ^0.1.0
         version: 0.1.0(typescript@6.0.2)
     devDependencies:
       '@fluojs/platform-express':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-express
       '@fluojs/platform-fastify':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-fastify
       '@fluojs/platform-nodejs':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-nodejs
       socket.io:
         specifier: ^4.8.1
@@ -804,11 +804,11 @@ importers:
   packages/studio:
     dependencies:
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       '@fluojs-internal/tooling-vite':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../../tooling/vite
       vitest:
         specifier: ^3.2.4
@@ -817,25 +817,25 @@ importers:
   packages/terminus:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/drizzle':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../drizzle
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/prisma':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../prisma
       '@fluojs/redis':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../redis
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       vitest:
@@ -848,29 +848,29 @@ importers:
         specifier: '>=7.0.0'
         version: 7.29.0
       '@fluojs/config':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../config
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       '@fluojs/platform-express':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-express
       '@fluojs/platform-fastify':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-fastify
       '@fluojs/platform-nodejs':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-nodejs
       vitest:
         specifier: ^3.2.4
@@ -879,19 +879,19 @@ importers:
   packages/throttler:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/redis':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../redis
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
     devDependencies:
       ioredis:
@@ -904,7 +904,7 @@ importers:
   packages/validation:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@standard-schema/spec':
         specifier: ^1.1.0
@@ -932,29 +932,29 @@ importers:
   packages/websockets:
     dependencies:
       '@fluojs/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@fluojs/di':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../di
       '@fluojs/http':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http
       '@fluojs/runtime':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../runtime
       ws:
         specifier: ^8.18.3
         version: 8.19.0
     devDependencies:
       '@fluojs/platform-bun':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-bun
       '@fluojs/platform-express':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-express
       '@fluojs/platform-fastify':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../platform-fastify
       '@types/ws':
         specifier: ^8.18.1

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -140,6 +140,66 @@ function workspacePackageNames() {
   return sorted(names);
 }
 
+function workspacePackageManifests() {
+  const packagesDirectory = join(repoRoot, 'packages');
+  const manifests = [];
+
+  for (const entry of readdirSync(packagesDirectory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const packageJsonPath = join(packagesDirectory, entry.name, 'package.json');
+
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+    if (typeof manifest.name === 'string') {
+      manifests.push({
+        manifest,
+        packageJsonPath,
+      });
+    }
+  }
+
+  return manifests.sort((left, right) => left.manifest.name.localeCompare(right.manifest.name));
+}
+
+function collectWorkspaceProtocolViolations(packageManifests, publicPackageNames) {
+  const dependencyFields = ['dependencies', 'optionalDependencies', 'peerDependencies', 'devDependencies'];
+  const publicPackageSet = new Set(publicPackageNames);
+  const violations = [];
+
+  for (const { manifest, packageJsonPath } of packageManifests) {
+    if (!publicPackageSet.has(manifest.name)) {
+      continue;
+    }
+
+    for (const field of dependencyFields) {
+      const dependencies = manifest[field];
+
+      if (!dependencies || typeof dependencies !== 'object') {
+        continue;
+      }
+
+      for (const [dependencyName, dependencyRange] of Object.entries(dependencies)) {
+        if (
+          dependencyName !== manifest.name &&
+          publicPackageSet.has(dependencyName) &&
+          dependencyRange === 'workspace:*'
+        ) {
+          violations.push(`${manifest.name} → ${dependencyName} in ${field} (${packageJsonPath})`);
+        }
+      }
+    }
+  }
+
+  return sorted(violations);
+}
+
 export function buildSummary(checks, writeDrafts) {
   const sideEffects = writeDrafts
     ? '- Side effects: `CHANGELOG.md`, `tooling/release/release-readiness-summary.md`, and `tooling/release/release-readiness-summary.ko.md` updated'
@@ -237,6 +297,7 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
     read: readText = read,
     existsSync: pathExists = existsSync,
     workspacePackageNames: listWorkspacePackageNames = workspacePackageNames,
+    workspacePackageManifests: listWorkspacePackageManifests = workspacePackageManifests,
     mkdirSync: createDirectory = mkdirSync,
     readFileSync: readFile = readFileSync,
     writeFileSync: writeFile = writeFileSync,
@@ -260,6 +321,10 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
   const governancePackageList = sorted(parsePackageListFromSection(releaseGovernance, 'intended publish surface'));
   const packageSurfaceList = parsePackageNamesFromFamilyTable(packageSurface, 'public package families');
   const workspacePackages = listWorkspacePackageNames();
+  const publicWorkspaceProtocolViolations = collectWorkspaceProtocolViolations(
+    listWorkspacePackageManifests(),
+    governancePackageList,
+  );
 
   assertCheck(
     checks,
@@ -361,6 +426,14 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
     'Documented public packages exist in workspace',
     governancePackageList.every((packageName) => workspacePackages.includes(packageName)),
     'Every documented public package maps to an existing workspace package manifest.',
+  );
+  assertCheck(
+    checks,
+    'Public internal dependency ranges use workspace:^',
+    publicWorkspaceProtocolViolations.length === 0,
+    publicWorkspaceProtocolViolations.length === 0
+      ? 'Intended public package manifests use `workspace:^` for internal `@fluojs/*` dependencies across dependency, optional, peer, and dev dependency fields.'
+      : `Replace \`workspace:*\` with \`workspace:^\` for: ${publicWorkspaceProtocolViolations.join('; ')}`,
   );
 
   if (writeDrafts) {

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -172,6 +172,7 @@ function collectWorkspaceProtocolViolations(packageManifests, publicPackageNames
   const dependencyFields = ['dependencies', 'optionalDependencies', 'peerDependencies', 'devDependencies'];
   const publicPackageSet = new Set(publicPackageNames);
   const violations = [];
+  const requiredRange = 'workspace:^';
 
   for (const { manifest, packageJsonPath } of packageManifests) {
     if (!publicPackageSet.has(manifest.name)) {
@@ -189,9 +190,9 @@ function collectWorkspaceProtocolViolations(packageManifests, publicPackageNames
         if (
           dependencyName !== manifest.name &&
           publicPackageSet.has(dependencyName) &&
-          dependencyRange === 'workspace:*'
+          dependencyRange !== requiredRange
         ) {
-          violations.push(`${manifest.name} → ${dependencyName} in ${field} (${packageJsonPath})`);
+          violations.push(`${manifest.name} → ${dependencyName} in ${field}: ${String(dependencyRange)} (${packageJsonPath})`);
         }
       }
     }
@@ -433,7 +434,7 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
     publicWorkspaceProtocolViolations.length === 0,
     publicWorkspaceProtocolViolations.length === 0
       ? 'Intended public package manifests use `workspace:^` for internal `@fluojs/*` dependencies across dependency, optional, peer, and dev dependency fields.'
-      : `Replace \`workspace:*\` with \`workspace:^\` for: ${publicWorkspaceProtocolViolations.join('; ')}`,
+      : `Use exact \`workspace:^\` ranges for internal public package dependencies in: ${publicWorkspaceProtocolViolations.join('; ')}`,
   );
 
   if (writeDrafts) {

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -32,6 +32,23 @@ function createDependencies() {
     }),
     existsSync: vi.fn((targetPath) => targetPath.endsWith('/LICENSE') || targetPath.endsWith('/CHANGELOG.md')),
     workspacePackageNames: vi.fn(() => ['@fluojs/cli', '@fluojs/core']),
+    workspacePackageManifests: vi.fn(() => [
+      {
+        manifest: {
+          name: '@fluojs/cli',
+          dependencies: {
+            '@fluojs/core': 'workspace:^',
+          },
+        },
+        packageJsonPath: '/repo/packages/cli/package.json',
+      },
+      {
+        manifest: {
+          name: '@fluojs/core',
+        },
+        packageJsonPath: '/repo/packages/core/package.json',
+      },
+    ]),
     mkdirSync: vi.fn(),
     readFileSync: vi.fn(() => '# Changelog\n\n## [Unreleased]\n'),
     writeFileSync: vi.fn(),
@@ -63,5 +80,30 @@ describe('runReleaseReadinessVerification', () => {
         String(content).includes('`CHANGELOG.md`, `tooling/release/release-readiness-summary.md`'),
       ),
     ).toBe(true);
+  });
+
+  it('fails when a documented public package keeps workspace:* for an internal dependency', () => {
+    const dependencies = createDependencies();
+    dependencies.workspacePackageManifests = vi.fn(() => [
+      {
+        manifest: {
+          name: '@fluojs/cli',
+          dependencies: {
+            '@fluojs/core': 'workspace:*',
+          },
+        },
+        packageJsonPath: '/repo/packages/cli/package.json',
+      },
+      {
+        manifest: {
+          name: '@fluojs/core',
+        },
+        packageJsonPath: '/repo/packages/core/package.json',
+      },
+    ]);
+
+    expect(() => runReleaseReadinessVerification({}, dependencies)).toThrowError(
+      'Release readiness check failed: Public internal dependency ranges use workspace:^.',
+    );
   });
 });

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -82,14 +82,14 @@ describe('runReleaseReadinessVerification', () => {
     ).toBe(true);
   });
 
-  it('fails when a documented public package keeps workspace:* for an internal dependency', () => {
+  it.each(['workspace:*', 'workspace:~', 'workspace:^1.2.3'])('fails when a documented public package uses %s instead of workspace:^', (invalidRange) => {
     const dependencies = createDependencies();
     dependencies.workspacePackageManifests = vi.fn(() => [
       {
         manifest: {
           name: '@fluojs/cli',
           dependencies: {
-            '@fluojs/core': 'workspace:*',
+            '@fluojs/core': invalidRange,
           },
         },
         packageJsonPath: '/repo/packages/cli/package.json',


### PR DESCRIPTION
## Summary
- switch intended public package manifests under `packages/*` from `workspace:*` to `workspace:^` for internal `@fluojs/*` dependencies while keeping documented package/subpath boundaries intact
- refresh `pnpm-lock.yaml` and add a `verify:release-readiness` regression guard plus focused test coverage so publish-surface manifests cannot drift back to `workspace:*`
- document the manifest range enforcement in the mirrored release governance docs

## Changes
- updated public package manifests (including relevant peer/dev dependency entries) to publish internal workspace dependencies with caret ranges
- updated `pnpm-lock.yaml` to match the manifest range policy
- extended `tooling/release/verify-release-readiness.mjs` and `tooling/release/verify-release-readiness.test.ts` to fail on documented public package manifests that keep `workspace:*`
- updated `docs/operations/release-governance.md` and `docs/operations/release-governance.ko.md` to note the additional release-readiness enforcement

## Testing
- `pnpm install --lockfile-only`
- `pnpm exec vitest run tooling/release/verify-release-readiness.test.ts`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:release-readiness`
- `pnpm lint` *(passes with existing repo-wide warnings unrelated to this change)*

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1124