### PR TITLE
Resolve #1125: align CLI workspace caret dependency policy

### DIFF
--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -30,28 +30,28 @@ const LOCAL_PACKAGE_DIRECTORY_BY_NAME = {
 
 const FIXTURE_WORKSPACE_DEPENDENCIES: Partial<Record<keyof typeof LOCAL_PACKAGE_DIRECTORY_BY_NAME, Record<string, string>>> = {
   '@fluojs/http': {
-    '@fluojs/core': 'workspace:*',
-    '@fluojs/di': 'workspace:*',
-    '@fluojs/validation': 'workspace:*',
+    '@fluojs/core': 'workspace:^',
+    '@fluojs/di': 'workspace:^',
+    '@fluojs/validation': 'workspace:^',
   },
   '@fluojs/platform-fastify': {
-    '@fluojs/http': 'workspace:*',
-    '@fluojs/runtime': 'workspace:*',
+    '@fluojs/http': 'workspace:^',
+    '@fluojs/runtime': 'workspace:^',
   },
   '@fluojs/platform-express': {
-    '@fluojs/http': 'workspace:*',
-    '@fluojs/runtime': 'workspace:*',
+    '@fluojs/http': 'workspace:^',
+    '@fluojs/runtime': 'workspace:^',
   },
   '@fluojs/platform-nodejs': {
-    '@fluojs/http': 'workspace:*',
-    '@fluojs/runtime': 'workspace:*',
+    '@fluojs/http': 'workspace:^',
+    '@fluojs/runtime': 'workspace:^',
   },
   '@fluojs/runtime': {
-    '@fluojs/config': 'workspace:*',
-    '@fluojs/core': 'workspace:*',
+    '@fluojs/config': 'workspace:^',
+    '@fluojs/core': 'workspace:^',
   },
   '@fluojs/testing': {
-    '@fluojs/runtime': 'workspace:*',
+    '@fluojs/runtime': 'workspace:^',
   },
 };
 
@@ -178,12 +178,16 @@ function readPackedPackageManifest(tarballPath: string): {
   };
 }
 
-function expectNoWorkspaceProtocolDependencies(tarballPath: string): void {
+function expectPackedManifestUsesPublishedWorkspaceCaretPolicy(tarballPath: string): void {
   const manifest = readPackedPackageManifest(tarballPath);
 
   for (const section of [manifest.dependencies, manifest.optionalDependencies, manifest.peerDependencies]) {
-    for (const specifier of Object.values(section ?? {})) {
+    for (const [packageName, specifier] of Object.entries(section ?? {})) {
       expect(specifier).not.toContain('workspace:');
+
+      if (packageName.startsWith('@fluojs/')) {
+        expect(specifier).toBe('^1.0.0');
+      }
     }
   }
 }
@@ -212,9 +216,12 @@ describe('scaffoldBootstrapApp', () => {
 
     expect(packageJson.devDependencies?.typescript).toBe('^6.0.2');
     expect(packageJson.dependencies).toMatchObject({
-      '@fluojs/http': expect.any(String),
-      '@fluojs/platform-fastify': expect.any(String),
-      '@fluojs/runtime': expect.any(String),
+      '@fluojs/http': '^0.0.0',
+      '@fluojs/platform-fastify': '^0.0.0',
+      '@fluojs/runtime': '^0.0.0',
+    });
+    expect(packageJson.devDependencies).toMatchObject({
+      '@fluojs/testing': '^0.0.0',
     });
     expect(tsconfig).not.toContain('baseUrl');
     expect(tsconfigBuild).not.toContain('baseUrl');
@@ -224,7 +231,7 @@ describe('scaffoldBootstrapApp', () => {
     expect(vitestConfig).not.toContain('baseUrl');
   });
 
-  it('packs local starter tarballs from staged package manifests without workspace protocol dependencies', async () => {
+  it('packs local starter tarballs from staged package manifests with published workspace caret semantics', async () => {
     const repoRoot = createFixtureLocalRepo();
     const targetDirectory = mkdtempSync(join(tmpdir(), 'fluo-scaffold-local-pack-'));
     temporaryDirectories.push(targetDirectory);
@@ -236,7 +243,7 @@ describe('scaffoldBootstrapApp', () => {
     expect(tarballPaths.length).toBeGreaterThan(0);
 
     for (const tarballPath of tarballPaths) {
-      expectNoWorkspaceProtocolDependencies(tarballPath);
+      expectPackedManifestUsesPublishedWorkspaceCaretPolicy(tarballPath);
     }
   }, 30_000);
 
@@ -284,7 +291,7 @@ describe('scaffoldBootstrapApp', () => {
     const refreshedTarballPath = readLocalDependencyTarballPaths(targetDirectory).find((tarballPath) => tarballPath.endsWith(`/${staleTarballName}`));
     expect(refreshedTarballPath).toBeTruthy();
     expect(readFileSync(refreshedTarballPath!, 'utf8')).not.toContain('stale tarball from old rewrite pipeline');
-    expectNoWorkspaceProtocolDependencies(refreshedTarballPath!);
+    expectPackedManifestUsesPublishedWorkspaceCaretPolicy(refreshedTarballPath!);
   }, 30_000);
 
   it('keeps the default Node + Fastify HTTP scaffold identical when explicit shape flags are provided', async () => {

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -159,7 +159,29 @@ function createDependencySpec(
 ): string {
   return packageSpecs[packageName]
     ?? PUBLISHED_RUNTIME_DEPENDENCIES[packageName as keyof typeof PUBLISHED_RUNTIME_DEPENDENCIES]
-    ?? `^${releaseVersion}`;
+    ?? createPublishedInternalDependencySpec(releaseVersion);
+}
+
+function createPublishedInternalDependencySpec(version: string): string {
+  return `^${version}`;
+}
+
+function rewriteWorkspaceProtocolSpecifier(specifier: string, version: string): string {
+  const workspaceRange = specifier.slice('workspace:'.length);
+
+  if (workspaceRange === '^') {
+    return createPublishedInternalDependencySpec(version);
+  }
+
+  if (workspaceRange === '~') {
+    return `~${version}`;
+  }
+
+  if (workspaceRange === '*' || workspaceRange.length === 0) {
+    return version;
+  }
+
+  return workspaceRange;
 }
 
 function createRunCommand(packageManager: PackageManager, command: string): string {
@@ -2610,7 +2632,7 @@ function rewriteWorkspaceProtocolDependencies(
         continue;
       }
 
-      dependencies[packageName] = `^${version}`;
+      dependencies[packageName] = rewriteWorkspaceProtocolSpecifier(specifier, version);
     }
   }
 }


### PR DESCRIPTION
## Summary

Align the CLI scaffold's local-pack rewrite and generated starter dependency fallback with the repository's `workspace:^` internal dependency policy.

Closes #1125

## Changes

- make `packages/cli/src/new/scaffold.ts` preserve workspace protocol semantics when rewriting packed local manifests, including explicit `workspace:^` -> `^<version>` handling
- share the CLI's generated internal dependency fallback through the same caret-range policy path used by published starter specs
- tighten `packages/cli/src/new/scaffold.test.ts` to assert both packed tarball manifests and generated starter `package.json` files keep caret semantics for internal `@fluojs/*` dependencies

## Testing

- `pnpm --filter @fluojs/cli exec vitest run src/new/scaffold.test.ts -c vitest.config.ts`
- `pnpm --filter @fluojs/cli... build`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli build`
- `pnpm verify:release-readiness`
- `lsp_diagnostics` on `packages/cli/src/new/scaffold.ts` and `packages/cli/src/new/scaffold.test.ts` reported no diagnostics

## Public export documentation

No public exports changed in this PR.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract note: this PR does not broaden the CLI surface or change the documented starter matrix. It tightens the existing scaffold/local-pack contract so packed local manifests and generated starter dependency specs consistently follow the repository's public `workspace:^` policy through regression-tested behavior.

## Platform consistency governance (SSOT)

No governance docs changed in this PR.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.