### PR TITLE
Resolve #1126: add single-package release readiness preflight

### DIFF
--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -43,6 +43,8 @@ fluo의 설계 철학과 그 이면의 "왜"와 "어떻게"를 이해합니다.
 
 [Release Governance](./operations/release-governance.ko.md)는 공개 패키지의 기준 intended publish surface, release-readiness gate, 그리고 내부 `workspace:^` dependency-range 정책을 확인할 때 기준 문서로 사용하세요.
 
+CI 전용 단건 publish preflight 검증 경로(`pnpm verify:release-readiness --target-package --target-version --dist-tag`)를 확인할 때는 [테스트 전략](./operations/testing-guide.ko.md)을 Release Governance와 함께 기준 문서로 사용하세요.
+
 ## 📚 참조 자료
 
 심층적인 기술 명세 및 비교 자료입니다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,8 @@ Practical, task-oriented documentation for day-to-day development.
 
 Use [Release Governance](./operations/release-governance.md) when you need the canonical intended publish surface, release-readiness gates, or the enforced internal `workspace:^` dependency-range policy for public packages.
 
+Use [Testing Strategies](./operations/testing-guide.md) alongside Release Governance when you need the canonical verification path for CI-only single-package publish preflight checks via `pnpm verify:release-readiness --target-package --target-version --dist-tag`.
+
 ## 📚 Reference
 
 Detailed technical specifications and comparisons.

--- a/docs/operations/release-governance.ko.md
+++ b/docs/operations/release-governance.ko.md
@@ -94,7 +94,7 @@ fluo는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅니
 거버넌스는 자동화된 게이트와 수동 체크리스트를 통해 강제됩니다.
 
 ### CI/CD 강제 사항
-- **`pnpm verify:release-readiness`**: 기본적으로 `CHANGELOG.md`나 release-readiness summary 파일을 변경하지 않고 패키징된 CLI 엔트리포인트, 스타터 스캐폴딩, intended public package manifest dependency range를 검증합니다.
+- **`pnpm verify:release-readiness`**: 기본적으로 `CHANGELOG.md`나 release-readiness summary 파일을 변경하지 않고 패키징된 CLI 엔트리포인트, 스타터 스캐폴딩, intended public package manifest dependency range를 검증합니다. CI 전용 단건 publish 모드에서는 `--target-package`, `--target-version`, `--dist-tag`를 함께 넘겨 요청한 패키지의 intended publish surface 소속 여부, semver/dist-tag의 프리릴리즈 정합성, 그리고 publish 가능한 내부 `@fluojs/*` dependency shape를 같은 canonical gate에서 강제합니다.
 - **`pnpm generate:release-readiness-drafts`**: 릴리스 노트를 준비할 때 release-readiness summary 산출물과 `CHANGELOG.md` 드래프트 블록을 명시적으로 갱신합니다.
 - **`pnpm verify:platform-consistency-governance`**: 영어와 한국어 문서 간의 구조적 일관성을 강제합니다.
 - **`pnpm verify:public-export-tsdoc`**: `packages/*/src` 아래 변경된 public export가 repo-wide TSDoc 최소 기준을 놓치면 실패합니다.

--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -94,7 +94,7 @@ During the `0.x` phase, the **Minor** version is used for breaking changes. Ever
 Governance is enforced through automated gates and manual checklists.
 
 ### CI/CD Enforcement
-- **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints, starter scaffolding, and intended public package manifest dependency ranges without mutating `CHANGELOG.md` or release-readiness summary files by default.
+- **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints, starter scaffolding, and intended public package manifest dependency ranges without mutating `CHANGELOG.md` or release-readiness summary files by default. In CI-only single-package publish mode, pass `--target-package`, `--target-version`, and `--dist-tag` to enforce intended publish surface membership, semver/dist-tag prerelease alignment, and publish-safe internal `@fluojs/*` dependency shape for the requested package.
 - **`pnpm generate:release-readiness-drafts`**: Explicitly refreshes the release-readiness summary artifacts and the draft `CHANGELOG.md` block when maintainers are preparing release notes.
 - **`pnpm verify:platform-consistency-governance`**: Enforces structural parity between English and Korean documentation.
 - **`pnpm verify:public-export-tsdoc`**: Fails when changed public exports in `packages/*/src` miss the repo-wide TSDoc minimum baseline.

--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -103,7 +103,7 @@ await app.close();
 | :--- | :--- |
 | `pnpm test` | 워크스페이스 전체에서 Vitest 스위트를 실행합니다. |
 | `pnpm verify` | Build → Typecheck → Lint → Test 순서로 실행합니다. |
-| `pnpm verify:release-readiness` | 패키징된 CLI 검증을 포함한 공개 릴리스를 위한 읽기 전용 최종 관문입니다. |
+| `pnpm verify:release-readiness` | 패키징된 CLI 검증을 포함한 공개 릴리스를 위한 읽기 전용 최종 관문입니다. 같은 verifier는 CI 전용 단건 publish preflight를 위해 `--target-package`, `--target-version`, `--dist-tag`도 받습니다. |
 | `pnpm generate:release-readiness-drafts` | 릴리스 준비를 위해 release-readiness summary 산출물과 changelog 드래프트 블록을 명시적으로 씁니다. |
 | `pnpm verify:public-export-tsdoc:baseline` | public-export TSDoc 기준을 전체 governed 패키지 소스 표면에 적용합니다. |
 

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -103,7 +103,7 @@ Keep the module wiring real but override the low-level client tokens to avoid ne
 | :--- | :--- |
 | `pnpm test` | Runs the full Vitest suite across the workspace. |
 | `pnpm verify` | Sequential execution: Build → Typecheck → Lint → Test. |
-| `pnpm verify:release-readiness` | Comprehensive read-only gate for public releases, including packed CLI verification. |
+| `pnpm verify:release-readiness` | Comprehensive read-only gate for public releases, including packed CLI verification. The same verifier also accepts `--target-package`, `--target-version`, and `--dist-tag` for CI-only single-package publish preflight checks. |
 | `pnpm generate:release-readiness-drafts` | Explicitly writes release-readiness summary artifacts and the draft changelog block for release prep. |
 | `pnpm verify:public-export-tsdoc:baseline` | Runs the public-export TSDoc baseline against the full governed package source surface. |
 

--- a/tooling/release/verify-release-readiness.d.mts
+++ b/tooling/release/verify-release-readiness.d.mts
@@ -5,6 +5,10 @@ export type ReleaseReadinessCheck = {
 };
 
 export type ReleaseReadinessDependencies = {
+  workspacePackageManifests?: () => Array<{
+    manifest: Record<string, unknown> & { name: string };
+    packageJsonPath: string;
+  }>;
   isPublishedVersion?: (packageName: string, version: string) => boolean;
   run?: (command: string, args: string[]) => void;
   read?: (relativePath: string) => string;

--- a/tooling/release/verify-release-readiness.d.mts
+++ b/tooling/release/verify-release-readiness.d.mts
@@ -5,6 +5,7 @@ export type ReleaseReadinessCheck = {
 };
 
 export type ReleaseReadinessDependencies = {
+  isPublishedVersion?: (packageName: string, version: string) => boolean;
   run?: (command: string, args: string[]) => void;
   read?: (relativePath: string) => string;
   existsSync?: (targetPath: string) => boolean;
@@ -20,6 +21,11 @@ export type ReleaseReadinessResult = {
 };
 
 export function runReleaseReadinessVerification(
-  options?: { writeDrafts?: boolean },
+  options?: {
+    distTag?: string;
+    targetPackage?: string;
+    targetVersion?: string;
+    writeDrafts?: boolean;
+  },
   dependencies?: ReleaseReadinessDependencies,
 ): ReleaseReadinessResult;

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -10,15 +10,69 @@ const summaryKoPath = join(scriptDirectory, 'release-readiness-summary.ko.md');
 const changelogPath = join(repoRoot, 'CHANGELOG.md');
 
 function parseCliOptions(argv = process.argv.slice(2)) {
-  const writeDrafts = argv.includes('--write-drafts');
+  let writeDrafts = false;
+  let targetPackage;
+  let targetVersion;
+  let distTag;
 
-  for (const argument of argv) {
-    if (argument !== '--write-drafts') {
-      throw new Error(`Unknown option: ${argument}`);
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === '--write-drafts') {
+      writeDrafts = true;
+      continue;
     }
+
+    if (argument === '--target-package') {
+      targetPackage = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--target-package=')) {
+      targetPackage = argument.slice('--target-package='.length);
+      continue;
+    }
+
+    if (argument === '--target-version') {
+      targetVersion = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--target-version=')) {
+      targetVersion = argument.slice('--target-version='.length);
+      continue;
+    }
+
+    if (argument === '--dist-tag') {
+      distTag = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--dist-tag=')) {
+      distTag = argument.slice('--dist-tag='.length);
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${argument}`);
   }
 
-  return { writeDrafts };
+  const preflightInputs = [targetPackage, targetVersion, distTag].filter((value) => typeof value === 'string');
+
+  if (preflightInputs.length > 0 && preflightInputs.length < 3) {
+    throw new Error(
+      'Single-package release preflight requires --target-package, --target-version, and --dist-tag together.',
+    );
+  }
+
+  return {
+    distTag,
+    targetPackage,
+    targetVersion,
+    writeDrafts,
+  };
 }
 
 function languageToggle(current) {
@@ -41,6 +95,53 @@ function run(command, args) {
 
 function read(relativePath) {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
+}
+
+function packageRelativePath(packageName) {
+  return packageName.startsWith('@fluojs/') ? `packages/${packageName.slice('@fluojs/'.length)}` : null;
+}
+
+function workspaceManifestByName(packageManifests) {
+  return new Map(packageManifests.map(({ manifest, packageJsonPath }) => [manifest.name, { manifest, packageJsonPath }]));
+}
+
+function isValidSemver(version) {
+  return /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(
+    version,
+  );
+}
+
+function isPrereleaseVersion(version) {
+  return version.includes('-');
+}
+
+function isValidDistTag(distTag) {
+  return /^[A-Za-z][A-Za-z0-9._-]*$/.test(distTag) && !isValidSemver(distTag);
+}
+
+function isPublishedVersion(packageName, version) {
+  const result = spawnSync('npm', ['view', `${packageName}@${version}`, 'version', '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.status === 0) {
+    return true;
+  }
+
+  const stderr = `${result.stderr ?? ''}${result.stdout ?? ''}`;
+
+  if (
+    result.status === 1 &&
+    (stderr.includes('E404') || stderr.includes('No match found for version') || stderr.includes('not in this registry'))
+  ) {
+    return false;
+  }
+
+  throw new Error(
+    `Release readiness check failed: Unable to query npm for ${packageName}@${version}. ${stderr.trim() || 'npm view failed.'}`,
+  );
 }
 
 function assertCheck(checks, label, condition, detail) {
@@ -201,6 +302,123 @@ function collectWorkspaceProtocolViolations(packageManifests, publicPackageNames
   return sorted(violations);
 }
 
+function collectSinglePackageDependencyShapeViolations(targetManifest, workspaceManifestMap, publicPackageNames) {
+  const dependencyFields = ['dependencies', 'optionalDependencies', 'peerDependencies'];
+  const publicPackageSet = new Set(publicPackageNames);
+  const violations = [];
+
+  for (const field of dependencyFields) {
+    const dependencies = targetManifest[field];
+
+    if (!dependencies || typeof dependencies !== 'object') {
+      continue;
+    }
+
+    for (const [dependencyName, dependencyRange] of Object.entries(dependencies)) {
+      if (!dependencyName.startsWith('@fluojs/')) {
+        continue;
+      }
+
+      if (!workspaceManifestMap.has(dependencyName)) {
+        violations.push(`${targetManifest.name} → ${dependencyName} in ${field}: not a workspace package name`);
+        continue;
+      }
+
+      if (!publicPackageSet.has(dependencyName)) {
+        violations.push(`${targetManifest.name} → ${dependencyName} in ${field}: dependency is outside the intended publish surface`);
+        continue;
+      }
+
+      if (dependencyRange !== 'workspace:^') {
+        violations.push(`${targetManifest.name} → ${dependencyName} in ${field}: expected workspace:^ but found ${String(dependencyRange)}`);
+      }
+    }
+  }
+
+  return sorted(violations);
+}
+
+function verifySinglePackageReleasePreflight(checks, options, packageManifests, publicPackageNames, dependencies = {}) {
+  const { targetPackage, targetVersion, distTag } = options;
+
+  if (!targetPackage && !targetVersion && !distTag) {
+    return;
+  }
+
+  const manifestMap = workspaceManifestByName(packageManifests);
+  const publicPackageSet = new Set(publicPackageNames);
+  const registryVersionExists = dependencies.isPublishedVersion ?? isPublishedVersion;
+  const targetPackageRecord = manifestMap.get(targetPackage);
+  const targetPackagePath = packageRelativePath(targetPackage);
+  const isPrerelease = isPrereleaseVersion(targetVersion);
+
+  assertCheck(
+    checks,
+    'Single-package release target identity',
+    typeof targetPackage === 'string' && targetPackage.length > 0,
+    'Single-package release mode requires an explicit target package name.',
+  );
+  assertCheck(
+    checks,
+    'Single-package release target version',
+    typeof targetVersion === 'string' && isValidSemver(targetVersion),
+    'Single-package release mode requires a valid SemVer target version.',
+  );
+  assertCheck(
+    checks,
+    'Single-package release dist-tag',
+    typeof distTag === 'string' && isValidDistTag(distTag),
+    'Single-package release mode requires an npm dist-tag such as `latest`, `next`, `beta`, or `rc`.',
+  );
+  assertCheck(
+    checks,
+    'Single-package release prerelease alignment',
+    (isPrerelease && distTag !== 'latest') || (!isPrerelease && distTag === 'latest'),
+    isPrerelease
+      ? 'Prerelease versions must publish under a non-`latest` dist-tag.'
+      : 'Stable versions must publish under the `latest` dist-tag.',
+  );
+  assertCheck(
+    checks,
+    'Single-package release target workspace package',
+    Boolean(targetPackageRecord) && Boolean(targetPackagePath),
+    `The release target must match a workspace package manifest under packages/* (received ${targetPackage}).`,
+  );
+  assertCheck(
+    checks,
+    'Single-package release intended publish surface membership',
+    Boolean(targetPackageRecord) && publicPackageSet.has(targetPackage),
+    `${targetPackage} must be listed in docs/operations/release-governance.md intended publish surface before CI-only publish.`,
+  );
+  assertCheck(
+    checks,
+    'Single-package release public manifest contract',
+    Boolean(targetPackageRecord) &&
+      targetPackageRecord.manifest.private !== true &&
+      targetPackageRecord.manifest.publishConfig?.access === 'public',
+    `${targetPackage} must remain a public workspace package with publishConfig.access set to \`public\`.`,
+  );
+  assertCheck(
+    checks,
+    'Single-package release version publishability',
+    !registryVersionExists(targetPackage, targetVersion),
+    `${targetPackage}@${targetVersion} is already published on npm and cannot be republished.`,
+  );
+
+  const dependencyShapeViolations = targetPackageRecord
+    ? collectSinglePackageDependencyShapeViolations(targetPackageRecord.manifest, manifestMap, publicPackageNames)
+    : [];
+
+  assertCheck(
+    checks,
+    'Single-package release internal dependency shape',
+    dependencyShapeViolations.length === 0,
+    dependencyShapeViolations.length === 0
+      ? 'The target package only references intended public `@fluojs/*` packages through publish-safe `workspace:^` ranges.'
+      : dependencyShapeViolations.join('; '),
+  );
+}
+
 export function buildSummary(checks, writeDrafts) {
   const sideEffects = writeDrafts
     ? '- Side effects: `CHANGELOG.md`, `tooling/release/release-readiness-summary.md`, and `tooling/release/release-readiness-summary.ko.md` updated'
@@ -292,8 +510,9 @@ function upsertReleaseCandidateDraft(dependencies = {}) {
 }
 
 export function runReleaseReadinessVerification(options = {}, dependencies = {}) {
-  const { writeDrafts = false } = options;
+  const { distTag, targetPackage, targetVersion, writeDrafts = false } = options;
   const {
+    isPublishedVersion: registryVersionExists = isPublishedVersion,
     run: runCommand = run,
     read: readText = read,
     existsSync: pathExists = existsSync,
@@ -304,6 +523,7 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
     writeFileSync: writeFile = writeFileSync,
   } = dependencies;
   const checks = [];
+  const packageManifests = listWorkspacePackageManifests();
 
   runCommand('pnpm', ['build']);
   runCommand('pnpm', ['typecheck']);
@@ -323,7 +543,7 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
   const packageSurfaceList = parsePackageNamesFromFamilyTable(packageSurface, 'public package families');
   const workspacePackages = listWorkspacePackageNames();
   const publicWorkspaceProtocolViolations = collectWorkspaceProtocolViolations(
-    listWorkspacePackageManifests(),
+    packageManifests,
     governancePackageList,
   );
 
@@ -436,6 +656,9 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
       ? 'Intended public package manifests use `workspace:^` for internal `@fluojs/*` dependencies across dependency, optional, peer, and dev dependency fields.'
       : `Use exact \`workspace:^\` ranges for internal public package dependencies in: ${publicWorkspaceProtocolViolations.join('; ')}`,
   );
+  verifySinglePackageReleasePreflight(checks, { distTag, targetPackage, targetVersion }, packageManifests, governancePackageList, {
+    isPublishedVersion: registryVersionExists,
+  });
 
   if (writeDrafts) {
     upsertReleaseCandidateDraft({ existsSync: pathExists, readFileSync: readFile, writeFileSync: writeFile });

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { runReleaseReadinessVerification } from './verify-release-readiness.mjs';
 
+type WorkspacePackageManifestRecord = {
+  manifest: Record<string, unknown> & { name: string };
+  packageJsonPath: string;
+};
+
 function createDependencies() {
   const docs = new Map([
     ['docs/getting-started/quick-start.md', 'pnpm add -g @fluojs/cli\nfluo new my-fluo-app\nThe fluo CLI is your central tool for project scaffolding and component generation.'],
@@ -21,6 +26,7 @@ function createDependencies() {
   ]);
 
   return {
+    isPublishedVersion: vi.fn(() => false),
     run: vi.fn(),
     read: vi.fn((relativePath) => {
       const value = docs.get(relativePath);
@@ -32,10 +38,12 @@ function createDependencies() {
     }),
     existsSync: vi.fn((targetPath) => targetPath.endsWith('/LICENSE') || targetPath.endsWith('/CHANGELOG.md')),
     workspacePackageNames: vi.fn(() => ['@fluojs/cli', '@fluojs/core']),
-    workspacePackageManifests: vi.fn(() => [
+    workspacePackageManifests: vi.fn<() => WorkspacePackageManifestRecord[]>(() => [
       {
         manifest: {
           name: '@fluojs/cli',
+          private: false,
+          publishConfig: { access: 'public' },
           dependencies: {
             '@fluojs/core': 'workspace:^',
           },
@@ -45,6 +53,8 @@ function createDependencies() {
       {
         manifest: {
           name: '@fluojs/core',
+          private: false,
+          publishConfig: { access: 'public' },
         },
         packageJsonPath: '/repo/packages/core/package.json',
       },
@@ -88,6 +98,8 @@ describe('runReleaseReadinessVerification', () => {
       {
         manifest: {
           name: '@fluojs/cli',
+          private: false,
+          publishConfig: { access: 'public' },
           dependencies: {
             '@fluojs/core': invalidRange,
           },
@@ -97,6 +109,8 @@ describe('runReleaseReadinessVerification', () => {
       {
         manifest: {
           name: '@fluojs/core',
+          private: false,
+          publishConfig: { access: 'public' },
         },
         packageJsonPath: '/repo/packages/core/package.json',
       },
@@ -105,5 +119,142 @@ describe('runReleaseReadinessVerification', () => {
     expect(() => runReleaseReadinessVerification({}, dependencies)).toThrowError(
       'Release readiness check failed: Public internal dependency ranges use workspace:^.',
     );
+  });
+
+  it('accepts single-package publish preflight for a public prerelease target', () => {
+    const dependencies = createDependencies();
+
+    const result = runReleaseReadinessVerification(
+      {
+        distTag: 'next',
+        targetPackage: '@fluojs/cli',
+        targetVersion: '0.1.0-beta.1',
+      },
+      dependencies,
+    );
+
+    expect(result.checks.some((check) => check.label === 'Single-package release internal dependency shape')).toBe(true);
+    expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', '0.1.0-beta.1');
+  });
+
+  it('fails when a single-package prerelease tries to use the latest dist-tag', () => {
+    const dependencies = createDependencies();
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'latest',
+          targetPackage: '@fluojs/cli',
+          targetVersion: '0.1.0-beta.1',
+        },
+        dependencies,
+      ),
+    ).toThrowError('Release readiness check failed: Single-package release prerelease alignment.');
+  });
+
+  it('fails when the single-package target is outside the intended publish surface', () => {
+    const dependencies = createDependencies();
+    dependencies.workspacePackageNames = vi.fn(() => ['@fluojs/cli', '@fluojs/core', '@fluojs/private-devtool']);
+    dependencies.workspacePackageManifests = vi.fn(() => [
+      {
+        manifest: {
+          name: '@fluojs/cli',
+          dependencies: {
+            '@fluojs/core': 'workspace:^',
+          },
+          private: false,
+          publishConfig: { access: 'public' },
+        },
+        packageJsonPath: '/repo/packages/cli/package.json',
+      },
+      {
+        manifest: {
+          name: '@fluojs/core',
+          private: false,
+          publishConfig: { access: 'public' },
+        },
+        packageJsonPath: '/repo/packages/core/package.json',
+      },
+      {
+        manifest: {
+          name: '@fluojs/private-devtool',
+          private: false,
+          publishConfig: { access: 'public' },
+        },
+        packageJsonPath: '/repo/packages/private-devtool/package.json',
+      },
+    ]);
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'latest',
+          targetPackage: '@fluojs/private-devtool',
+          targetVersion: '0.1.0',
+        },
+        dependencies,
+      ),
+    ).toThrowError('Release readiness check failed: Single-package release intended publish surface membership.');
+  });
+
+  it('fails when a single-package target depends on a non-public internal workspace package', () => {
+    const dependencies = createDependencies();
+    dependencies.workspacePackageNames = vi.fn(() => ['@fluojs/cli', '@fluojs/core', '@fluojs/private-devtool']);
+    dependencies.workspacePackageManifests = vi.fn(() => [
+      {
+        manifest: {
+          name: '@fluojs/cli',
+          dependencies: {
+            '@fluojs/core': 'workspace:^',
+            '@fluojs/private-devtool': 'workspace:^',
+          },
+          private: false,
+          publishConfig: { access: 'public' },
+        },
+        packageJsonPath: '/repo/packages/cli/package.json',
+      },
+      {
+        manifest: {
+          name: '@fluojs/core',
+          private: false,
+          publishConfig: { access: 'public' },
+        },
+        packageJsonPath: '/repo/packages/core/package.json',
+      },
+      {
+        manifest: {
+          name: '@fluojs/private-devtool',
+          private: true,
+        },
+        packageJsonPath: '/repo/packages/private-devtool/package.json',
+      },
+    ]);
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'latest',
+          targetPackage: '@fluojs/cli',
+          targetVersion: '0.1.0',
+        },
+        dependencies,
+      ),
+    ).toThrowError('Release readiness check failed: Single-package release internal dependency shape.');
+  });
+
+  it('fails when the target version is already published', () => {
+    const dependencies = createDependencies();
+    dependencies.isPublishedVersion = vi.fn(() => true);
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'latest',
+          targetPackage: '@fluojs/cli',
+          targetVersion: '0.1.0',
+        },
+        dependencies,
+      ),
+    ).toThrowError('Release readiness check failed: Single-package release version publishability.');
   });
 });


### PR DESCRIPTION
## Summary
- extend `tooling/release/verify-release-readiness.mjs` so the canonical release gate can validate CI-only single-package publish inputs via `--target-package`, `--target-version`, and `--dist-tag`
- enforce intended publish surface membership, semver/dist-tag prerelease alignment, public publish manifest shape, already-published version rejection, and publish-safe internal `@fluojs/*` dependency shape in the existing verifier
- document the new preflight contract in the mirrored release governance and testing guide docs

## Changes
- added single-package preflight helpers, npm publishability lookup, and optional CLI argument parsing to the release-readiness verifier
- expanded `tooling/release/verify-release-readiness.test.ts` with success/failure coverage for prerelease alignment, publish-surface membership, non-public internal dependency shape, and already-published versions
- updated `tooling/release/verify-release-readiness.d.mts` plus the English/Korean governance docs that describe `pnpm verify:release-readiness`

## Testing
- `pnpm exec vitest run tooling/release/verify-release-readiness.test.ts`
- `pnpm verify:platform-consistency-governance`
- `pnpm build`
- `pnpm typecheck`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New release-gate contract is documented in the affected operational docs without changing public runtime/package behavior.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Changed governance docs include companion tooling enforcement and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Contract impact
- This PR does not change the public runtime package surface or publish workflow implementation.
- It strengthens the canonical `verify-release-readiness` gate for CI-only single-package publish preflight checks.

Closes #1126