### PR TITLE
fix(release): add single-package publish workflow

### DIFF
--- a/.github/workflows/release-single-package.yml
+++ b/.github/workflows/release-single-package.yml
@@ -1,0 +1,147 @@
+name: Release single package
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: Public workspace package to publish (for example @fluojs/cli)
+        required: true
+        type: string
+      package_version:
+        description: Exact package.json version expected for this publish
+        required: true
+        type: string
+      dist_tag:
+        description: npm dist-tag to publish under (latest for stable releases, next/beta/rc for prereleases)
+        required: true
+        type: string
+      release_prerelease:
+        description: Mark the GitHub Release as a prerelease (must match whether package_version is a prerelease)
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: release-single-package-${{ inputs.package_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish-and-release:
+    name: Publish package and create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      DIST_TAG: ${{ inputs.dist_tag }}
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
+      TARGET_PACKAGE: ${{ inputs.package_name }}
+      TARGET_VERSION: ${{ inputs.package_version }}
+
+    steps:
+      - name: Require main branch dispatch
+        run: |
+          if [ "$GITHUB_REF" != 'refs/heads/main' ]; then
+            echo "::error::Single-package release workflow must run from refs/heads/main."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version: '20'
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve single-package release target
+        id: resolve
+        run: |
+          node --input-type=module <<'EOF'
+          import { appendFileSync, readdirSync, readFileSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const packagesDirectory = 'packages';
+          const targetPackage = process.env.TARGET_PACKAGE;
+          const targetVersion = process.env.TARGET_VERSION;
+          const releasePrerelease = process.env.RELEASE_PRERELEASE === 'true';
+
+          let packageDirectory = null;
+          let packageVersion = null;
+
+          for (const entry of readdirSync(packagesDirectory, { withFileTypes: true })) {
+            if (!entry.isDirectory()) {
+              continue;
+            }
+
+            const packageJsonPath = join(packagesDirectory, entry.name, 'package.json');
+
+            try {
+              const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+              if (manifest.name === targetPackage) {
+                packageDirectory = join(packagesDirectory, entry.name);
+                packageVersion = manifest.version;
+                break;
+              }
+            } catch {
+              continue;
+            }
+          }
+
+          if (!packageDirectory || !packageVersion) {
+            throw new Error(`Could not resolve ${targetPackage} to a workspace package under packages/*.`);
+          }
+
+          if (packageVersion !== targetVersion) {
+            throw new Error(`${targetPackage} package.json version is ${packageVersion}, expected ${targetVersion}.`);
+          }
+
+          const versionIsPrerelease = targetVersion.includes('-');
+          if (versionIsPrerelease !== releasePrerelease) {
+            throw new Error(
+              `release_prerelease=${String(releasePrerelease)} does not match package_version prerelease state for ${targetVersion}.`,
+            );
+          }
+
+          const output = process.env.GITHUB_OUTPUT;
+          const releaseTag = `${targetPackage}@${targetVersion}`;
+          appendFileSync(output, `package_dir=${packageDirectory}\nrelease_tag=${releaseTag}\n`, 'utf8');
+          EOF
+
+      - name: Canonical release-readiness preflight
+        run: pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG"
+
+      - name: Publish package to npm
+        run: pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks
+
+      - name: Prepare GitHub Release notes
+        run: node tooling/release/prepare-github-release.mjs "${{ steps.resolve.outputs.release_tag }}"
+
+      - name: Create and push git tag
+        run: |
+          git tag "${{ steps.resolve.outputs.release_tag }}"
+          git push origin "refs/tags/${{ steps.resolve.outputs.release_tag }}"
+
+      - name: Create GitHub Release
+        run: |
+          prerelease_flag=''
+          if [ "$RELEASE_PRERELEASE" = 'true' ]; then
+            prerelease_flag='--prerelease'
+          fi
+
+          gh release create "${{ steps.resolve.outputs.release_tag }}" \
+            --title "${{ steps.resolve.outputs.release_tag }}" \
+            --notes-file tooling/release/github-release-notes.md \
+            $prerelease_flag \
+            tooling/release/release-readiness-summary.md#release-readiness-summary.md

--- a/.github/workflows/release-single-package.yml
+++ b/.github/workflows/release-single-package.yml
@@ -120,7 +120,7 @@ jobs:
           EOF
 
       - name: Canonical release-readiness preflight
-        run: pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG"
+        run: pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"
 
       - name: Publish package to npm
         run: pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks
@@ -144,4 +144,4 @@ jobs:
             --title "${{ steps.resolve.outputs.release_tag }}" \
             --notes-file tooling/release/github-release-notes.md \
             $prerelease_flag \
-            tooling/release/release-readiness-summary.md#release-readiness-summary.md
+            "$RUNNER_TEMP/release-readiness/release-readiness-summary.md#release-readiness-summary.md"

--- a/docs/operations/release-governance.ko.md
+++ b/docs/operations/release-governance.ko.md
@@ -95,6 +95,7 @@ fluo는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅니
 
 ### CI/CD 강제 사항
 - **`pnpm verify:release-readiness`**: 기본적으로 `CHANGELOG.md`나 release-readiness summary 파일을 변경하지 않고 패키징된 CLI 엔트리포인트, 스타터 스캐폴딩, intended public package manifest dependency range를 검증합니다. CI 전용 단건 publish 모드에서는 `--target-package`, `--target-version`, `--dist-tag`를 함께 넘겨 요청한 패키지의 intended publish surface 소속 여부, semver/dist-tag의 프리릴리즈 정합성, 그리고 publish 가능한 내부 `@fluojs/*` dependency shape를 같은 canonical gate에서 강제합니다.
+- **`.github/workflows/release-single-package.yml`**: 신뢰된 단건 npm publish를 위한 수동 GitHub Actions 진입점입니다. `package_name`, `package_version`, `dist_tag`, `release_prerelease`를 입력으로 받고, canonical `pnpm verify:release-readiness --target-package --target-version --dist-tag` 게이트를 통과한 뒤에만 git tag와 GitHub Release를 생성합니다.
 - **`pnpm generate:release-readiness-drafts`**: 릴리스 노트를 준비할 때 release-readiness summary 산출물과 `CHANGELOG.md` 드래프트 블록을 명시적으로 갱신합니다.
 - **`pnpm verify:platform-consistency-governance`**: 영어와 한국어 문서 간의 구조적 일관성을 강제합니다.
 - **`pnpm verify:public-export-tsdoc`**: `packages/*/src` 아래 변경된 public export가 repo-wide TSDoc 최소 기준을 놓치면 실패합니다.
@@ -102,7 +103,7 @@ fluo는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅니
 - **동작 계약 체크**: `process.env`가 승인된 패턴(`@fluojs/config`) 외부에서 액세스될 경우 릴리스를 차단합니다.
 
 ### 변경 이력 표준 (Changelog Standards)
-모든 공개 릴리스는 *Keep a Changelog* 형식을 따르는 루트 `CHANGELOG.md`에 일치하는 항목이 있어야 합니다. GitHub 릴리스는 배포 단계에서 이 내용을 바탕으로 자동으로 생성됩니다.
+모든 공개 릴리스는 *Keep a Changelog* 형식을 따르는 루트 `CHANGELOG.md`에 일치하는 항목이 있어야 합니다. 단건 릴리스 워크플로는 패키지 범위 태그(예: `@fluojs/cli@0.1.0`)를 만들고, publish가 성공한 뒤에만 같은 버전의 루트 changelog 섹션으로 GitHub Release 본문을 생성합니다.
 
 ---
 

--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -95,6 +95,7 @@ Governance is enforced through automated gates and manual checklists.
 
 ### CI/CD Enforcement
 - **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints, starter scaffolding, and intended public package manifest dependency ranges without mutating `CHANGELOG.md` or release-readiness summary files by default. In CI-only single-package publish mode, pass `--target-package`, `--target-version`, and `--dist-tag` to enforce intended publish surface membership, semver/dist-tag prerelease alignment, and publish-safe internal `@fluojs/*` dependency shape for the requested package.
+- **`.github/workflows/release-single-package.yml`**: Manual GitHub Actions entrypoint for trusted single-package npm publishing. It accepts `package_name`, `package_version`, `dist_tag`, and `release_prerelease`, runs the canonical `pnpm verify:release-readiness --target-package --target-version --dist-tag` gate, then creates the git tag and GitHub Release only after npm publish succeeds.
 - **`pnpm generate:release-readiness-drafts`**: Explicitly refreshes the release-readiness summary artifacts and the draft `CHANGELOG.md` block when maintainers are preparing release notes.
 - **`pnpm verify:platform-consistency-governance`**: Enforces structural parity between English and Korean documentation.
 - **`pnpm verify:public-export-tsdoc`**: Fails when changed public exports in `packages/*/src` miss the repo-wide TSDoc minimum baseline.
@@ -102,7 +103,7 @@ Governance is enforced through automated gates and manual checklists.
 - **Behavioral Contract Check**: Blocks releases if `process.env` is accessed outside of the sanctioned `@fluojs/config` patterns.
 
 ### Changelog Standards
-Every public release must have a matching entry in the root `CHANGELOG.md` following the *Keep a Changelog* format. GitHub Releases are automatically populated from this content during the deployment phase.
+Every public release must have a matching entry in the root `CHANGELOG.md` following the *Keep a Changelog* format. The single-package release workflow creates package-scoped tags (for example `@fluojs/cli@0.1.0`) and generates the GitHub Release body from the matching root changelog version section only after publish succeeds.
 
 ---
 

--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -107,6 +107,8 @@ await app.close();
 | `pnpm generate:release-readiness-drafts` | 릴리스 준비를 위해 release-readiness summary 산출물과 changelog 드래프트 블록을 명시적으로 씁니다. |
 | `pnpm verify:public-export-tsdoc:baseline` | public-export TSDoc 기준을 전체 governed 패키지 소스 표면에 적용합니다. |
 
+수동 GitHub Actions 워크플로 `.github/workflows/release-single-package.yml`은 한 번에 하나의 공개 패키지만 publish하는 canonical publisher입니다. publish 전에 반드시 `pnpm verify:release-readiness --target-package --target-version --dist-tag`를 재사용해야 하며, npm publish가 성공한 뒤에만 git tag와 GitHub Release를 생성할 수 있습니다.
+
 ### 생성된 템플릿
 CLI(`fluo g repo <Name>`) 사용 시 기본적으로 제공되는 템플릿은 다음과 같습니다.
 - `<name>.repo.test.ts`: 비즈니스 로직을 위한 유닛 테스트 템플릿.

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -107,6 +107,8 @@ Keep the module wiring real but override the low-level client tokens to avoid ne
 | `pnpm generate:release-readiness-drafts` | Explicitly writes release-readiness summary artifacts and the draft changelog block for release prep. |
 | `pnpm verify:public-export-tsdoc:baseline` | Runs the public-export TSDoc baseline against the full governed package source surface. |
 
+The manual GitHub Actions workflow `.github/workflows/release-single-package.yml` is the canonical publisher for one public package per run. It must reuse `pnpm verify:release-readiness --target-package --target-version --dist-tag` before publishing and may create the git tag plus GitHub Release only after npm publish succeeds.
+
 ### Generated Templates
 When using the CLI (`fluo g repo <Name>`), the following templates are provided as the baseline:
 - `<name>.repo.test.ts`: Unit test template for business logic.

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -190,6 +190,31 @@ describe('platform consistency governance docs', () => {
     expect(ciWorkflow).toContain('run: pnpm verify:release-readiness');
   });
 
+  it('keeps single-package release automation bound to the canonical preflight and post-publish release creation', () => {
+    const releaseWorkflow = readFileSync(resolve(repoRoot, '.github/workflows/release-single-package.yml'), 'utf8');
+
+    expect(releaseWorkflow).toContain('workflow_dispatch:');
+    expect(releaseWorkflow).toContain('package_name:');
+    expect(releaseWorkflow).toContain('package_version:');
+    expect(releaseWorkflow).toContain('dist_tag:');
+    expect(releaseWorkflow).toContain('release_prerelease:');
+    expect(releaseWorkflow).toContain('id-token: write');
+    expect(releaseWorkflow).toContain('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG"');
+    expect(releaseWorkflow).toContain('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks');
+    expect(releaseWorkflow).toContain('node tooling/release/prepare-github-release.mjs "${{ steps.resolve.outputs.release_tag }}"');
+    expect(releaseWorkflow).toContain('git tag "${{ steps.resolve.outputs.release_tag }}"');
+    expect(releaseWorkflow).toContain('gh release create "${{ steps.resolve.outputs.release_tag }}"');
+    expect(releaseWorkflow.indexOf('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG"')).toBeLessThan(
+      releaseWorkflow.indexOf('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks'),
+    );
+    expect(releaseWorkflow.indexOf('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks')).toBeLessThan(
+      releaseWorkflow.indexOf('git tag "${{ steps.resolve.outputs.release_tag }}"'),
+    );
+    expect(releaseWorkflow.indexOf('git tag "${{ steps.resolve.outputs.release_tag }}"')).toBeLessThan(
+      releaseWorkflow.indexOf('gh release create "${{ steps.resolve.outputs.release_tag }}"'),
+    );
+  });
+
   it('blocks removed runtime module factory names from docs/prose surfaces', () => {
     const markdownFiles = [
       ...collectMarkdownFiles('docs'),

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -199,12 +199,13 @@ describe('platform consistency governance docs', () => {
     expect(releaseWorkflow).toContain('dist_tag:');
     expect(releaseWorkflow).toContain('release_prerelease:');
     expect(releaseWorkflow).toContain('id-token: write');
-    expect(releaseWorkflow).toContain('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG"');
+    expect(releaseWorkflow).toContain('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"');
     expect(releaseWorkflow).toContain('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks');
     expect(releaseWorkflow).toContain('node tooling/release/prepare-github-release.mjs "${{ steps.resolve.outputs.release_tag }}"');
     expect(releaseWorkflow).toContain('git tag "${{ steps.resolve.outputs.release_tag }}"');
     expect(releaseWorkflow).toContain('gh release create "${{ steps.resolve.outputs.release_tag }}"');
-    expect(releaseWorkflow.indexOf('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG"')).toBeLessThan(
+    expect(releaseWorkflow).toContain('"$RUNNER_TEMP/release-readiness/release-readiness-summary.md#release-readiness-summary.md"');
+    expect(releaseWorkflow.indexOf('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"')).toBeLessThan(
       releaseWorkflow.indexOf('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks'),
     );
     expect(releaseWorkflow.indexOf('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks')).toBeLessThan(

--- a/tooling/release/prepare-github-release.d.mts
+++ b/tooling/release/prepare-github-release.d.mts
@@ -1,0 +1,11 @@
+export function parseReleaseTag(tag: string): {
+  packageName: string | null;
+  tag: string;
+  version: string;
+};
+
+export function sectionForVersion(changelog: string, version: string): string;
+
+export function buildGitHubReleaseNotes(tag: string, changelog: string): string;
+
+export function main(argv?: string[]): void;

--- a/tooling/release/prepare-github-release.mjs
+++ b/tooling/release/prepare-github-release.mjs
@@ -11,7 +11,36 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function sectionForVersion(changelog, version) {
+export function parseReleaseTag(tag) {
+  if (!tag) {
+    throw new Error('Usage: node tooling/release/prepare-github-release.mjs <tag>');
+  }
+
+  if (tag.startsWith('v')) {
+    return {
+      packageName: null,
+      tag,
+      version: tag.slice(1),
+    };
+  }
+
+  const scopedPackageMatch = tag.match(/^(?<packageName>@[^/]+\/[^@]+)@(?<version>.+)$/u);
+  if (scopedPackageMatch?.groups) {
+    return {
+      packageName: scopedPackageMatch.groups.packageName,
+      tag,
+      version: scopedPackageMatch.groups.version,
+    };
+  }
+
+  return {
+    packageName: null,
+    tag,
+    version: tag,
+  };
+}
+
+export function sectionForVersion(changelog, version) {
   const lines = changelog.split('\n');
   const headerRegex = new RegExp(`^## \\[${escapeRegExp(version)}\\] - `);
   const start = lines.findIndex((line) => headerRegex.test(line));
@@ -32,24 +61,36 @@ function sectionForVersion(changelog, version) {
   return lines.slice(start, end).join('\n').trim();
 }
 
-const tag = process.argv[2];
+export function buildGitHubReleaseNotes(tag, changelog) {
+  const { packageName, version } = parseReleaseTag(tag);
+  const section = sectionForVersion(changelog, version);
 
-if (!tag) {
-  throw new Error('Usage: node tooling/release/prepare-github-release.mjs <tag>');
+  return [
+    `# ${tag}`,
+    '',
+    ...(packageName ? [`- Release package: \`${packageName}\``, ''] : []),
+    section,
+    '',
+    '---',
+    '',
+    'Release-readiness verification summary is attached as `release-readiness-summary.md`.',
+  ].join('\n');
 }
 
-const version = tag.startsWith('v') ? tag.slice(1) : tag;
-const changelog = readFileSync(changelogPath, 'utf8');
-const section = sectionForVersion(changelog, version);
-const notes = [
-  `# ${tag}`,
-  '',
-  section,
-  '',
-  '---',
-  '',
-  'Release-readiness verification summary is attached as `release-readiness-summary.md`.',
-].join('\n');
+export function main(argv = process.argv.slice(2)) {
+  const tag = argv[0];
 
-writeFileSync(releaseNotesPath, `${notes}\n`, 'utf8');
-console.log(`GitHub release notes written to ${releaseNotesPath}`);
+  if (!tag) {
+    throw new Error('Usage: node tooling/release/prepare-github-release.mjs <tag>');
+  }
+
+  const changelog = readFileSync(changelogPath, 'utf8');
+  const notes = buildGitHubReleaseNotes(tag, changelog);
+
+  writeFileSync(releaseNotesPath, `${notes}\n`, 'utf8');
+  console.log(`GitHub release notes written to ${releaseNotesPath}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tooling/release/prepare-github-release.test.ts
+++ b/tooling/release/prepare-github-release.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildGitHubReleaseNotes, parseReleaseTag, sectionForVersion } from './prepare-github-release.mjs';
+
+describe('parseReleaseTag', () => {
+  it('keeps legacy v-prefixed tags mapped to the matching changelog version', () => {
+    expect(parseReleaseTag('v0.2.0')).toEqual({
+      packageName: null,
+      tag: 'v0.2.0',
+      version: '0.2.0',
+    });
+  });
+
+  it('extracts package and version from scoped package tags', () => {
+    expect(parseReleaseTag('@fluojs/cli@0.2.0-beta.1')).toEqual({
+      packageName: '@fluojs/cli',
+      tag: '@fluojs/cli@0.2.0-beta.1',
+      version: '0.2.0-beta.1',
+    });
+  });
+});
+
+describe('sectionForVersion', () => {
+  it('returns the exact changelog section for the requested version', () => {
+    const changelog = `# Changelog\n\n## [0.2.0] - 2026-04-16\n\n### Added\n\n- Shipped release automation.\n\n## [0.1.0] - 2026-04-15\n`;
+
+    expect(sectionForVersion(changelog, '0.2.0')).toBe('## [0.2.0] - 2026-04-16\n\n### Added\n\n- Shipped release automation.');
+  });
+});
+
+describe('buildGitHubReleaseNotes', () => {
+  it('includes package metadata for single-package release tags', () => {
+    const changelog = `# Changelog\n\n## [0.2.0] - 2026-04-16\n\n### Added\n\n- Shipped release automation.\n`;
+
+    expect(buildGitHubReleaseNotes('@fluojs/cli@0.2.0', changelog)).toContain('- Release package: `@fluojs/cli`');
+    expect(buildGitHubReleaseNotes('@fluojs/cli@0.2.0', changelog)).toContain('## [0.2.0] - 2026-04-16');
+  });
+});

--- a/tooling/release/verify-release-readiness.d.mts
+++ b/tooling/release/verify-release-readiness.d.mts
@@ -22,14 +22,17 @@ export type ReleaseReadinessDependencies = {
 export type ReleaseReadinessResult = {
   checks: ReleaseReadinessCheck[];
   writeDrafts: boolean;
+  writeSummary: boolean;
 };
 
 export function runReleaseReadinessVerification(
   options?: {
     distTag?: string;
+    summaryOutputDirectory?: string;
     targetPackage?: string;
     targetVersion?: string;
     writeDrafts?: boolean;
+    writeSummary?: boolean;
   },
   dependencies?: ReleaseReadinessDependencies,
 ): ReleaseReadinessResult;

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -9,8 +9,17 @@ const summaryPath = join(scriptDirectory, 'release-readiness-summary.md');
 const summaryKoPath = join(scriptDirectory, 'release-readiness-summary.ko.md');
 const changelogPath = join(repoRoot, 'CHANGELOG.md');
 
+function resolveSummaryOutputPaths(outputDirectory = scriptDirectory) {
+  return {
+    summaryKoPath: join(outputDirectory, 'release-readiness-summary.ko.md'),
+    summaryPath: join(outputDirectory, 'release-readiness-summary.md'),
+  };
+}
+
 function parseCliOptions(argv = process.argv.slice(2)) {
   let writeDrafts = false;
+  let writeSummary = false;
+  let summaryOutputDirectory;
   let targetPackage;
   let targetVersion;
   let distTag;
@@ -20,6 +29,22 @@ function parseCliOptions(argv = process.argv.slice(2)) {
 
     if (argument === '--write-drafts') {
       writeDrafts = true;
+      continue;
+    }
+
+    if (argument === '--write-summary') {
+      writeSummary = true;
+      continue;
+    }
+
+    if (argument === '--summary-output-dir') {
+      summaryOutputDirectory = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--summary-output-dir=')) {
+      summaryOutputDirectory = argument.slice('--summary-output-dir='.length);
       continue;
     }
 
@@ -69,9 +94,11 @@ function parseCliOptions(argv = process.argv.slice(2)) {
 
   return {
     distTag,
+    summaryOutputDirectory,
     targetPackage,
     targetVersion,
     writeDrafts,
+    writeSummary,
   };
 }
 
@@ -419,13 +446,19 @@ function verifySinglePackageReleasePreflight(checks, options, packageManifests, 
   );
 }
 
-export function buildSummary(checks, writeDrafts) {
-  const sideEffects = writeDrafts
-    ? '- Side effects: `CHANGELOG.md`, `tooling/release/release-readiness-summary.md`, and `tooling/release/release-readiness-summary.ko.md` updated'
-    : '- Side effects: none by default; use `pnpm generate:release-readiness-drafts` to refresh draft artifacts explicitly.';
-  const sideEffectsKo = writeDrafts
-    ? '- 부수 효과: `CHANGELOG.md`, `tooling/release/release-readiness-summary.md`, `tooling/release/release-readiness-summary.ko.md` 갱신'
-    : '- 부수 효과: 기본값은 없음; 초안 산출물을 갱신하려면 `pnpm generate:release-readiness-drafts`를 명시적으로 실행하세요.';
+export function buildSummary(checks, sideEffectMode = 'none') {
+  const sideEffects =
+    sideEffectMode === 'drafts'
+      ? '- Side effects: `CHANGELOG.md`, `tooling/release/release-readiness-summary.md`, and `tooling/release/release-readiness-summary.ko.md` updated'
+      : sideEffectMode === 'summary'
+        ? '- Side effects: current-run release-readiness summary artifacts generated without mutating `CHANGELOG.md`.'
+        : '- Side effects: none by default; use `pnpm generate:release-readiness-drafts` to refresh draft artifacts explicitly.';
+  const sideEffectsKo =
+    sideEffectMode === 'drafts'
+      ? '- 부수 효과: `CHANGELOG.md`, `tooling/release/release-readiness-summary.md`, `tooling/release/release-readiness-summary.ko.md` 갱신'
+      : sideEffectMode === 'summary'
+        ? '- 부수 효과: `CHANGELOG.md`를 변경하지 않고 현재 실행 기준의 release-readiness summary 산출물을 생성합니다.'
+        : '- 부수 효과: 기본값은 없음; 초안 산출물을 갱신하려면 `pnpm generate:release-readiness-drafts`를 명시적으로 실행하세요.';
   const summary = [
     '# release readiness summary',
     '',
@@ -450,12 +483,14 @@ export function buildSummary(checks, writeDrafts) {
   return { summary, summaryKo };
 }
 
-function writeSummary(checks, writeDrafts, dependencies = {}) {
+function writeSummary(checks, sideEffectMode, dependencies = {}) {
   const { mkdirSync: createDirectory = mkdirSync, writeFileSync: writeFile = writeFileSync } = dependencies;
-  createDirectory(scriptDirectory, { recursive: true });
-  const { summary, summaryKo } = buildSummary(checks, writeDrafts);
-  writeFile(summaryPath, `${summary}\n`, 'utf8');
-  writeFile(summaryKoPath, `${summaryKo}\n`, 'utf8');
+  const outputDirectory = dependencies.outputDirectory ?? scriptDirectory;
+  const { summaryPath: nextSummaryPath, summaryKoPath: nextSummaryKoPath } = resolveSummaryOutputPaths(outputDirectory);
+  createDirectory(outputDirectory, { recursive: true });
+  const { summary, summaryKo } = buildSummary(checks, sideEffectMode);
+  writeFile(nextSummaryPath, `${summary}\n`, 'utf8');
+  writeFile(nextSummaryKoPath, `${summaryKo}\n`, 'utf8');
 }
 
 export function withReleaseCandidateDraft(changelog, draftDate = new Date().toISOString().slice(0, 10)) {
@@ -510,7 +545,7 @@ function upsertReleaseCandidateDraft(dependencies = {}) {
 }
 
 export function runReleaseReadinessVerification(options = {}, dependencies = {}) {
-  const { distTag, targetPackage, targetVersion, writeDrafts = false } = options;
+  const { distTag, summaryOutputDirectory, targetPackage, targetVersion, writeDrafts = false, writeSummary: shouldWriteSummary = false } = options;
   const {
     isPublishedVersion: registryVersionExists = isPublishedVersion,
     run: runCommand = run,
@@ -662,10 +697,16 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
 
   if (writeDrafts) {
     upsertReleaseCandidateDraft({ existsSync: pathExists, readFileSync: readFile, writeFileSync: writeFile });
-    writeSummary(checks, true, { mkdirSync: createDirectory, writeFileSync: writeFile });
+    writeSummary(checks, 'drafts', { mkdirSync: createDirectory, outputDirectory: scriptDirectory, writeFileSync: writeFile });
+  } else if (shouldWriteSummary) {
+    writeSummary(checks, 'summary', {
+      mkdirSync: createDirectory,
+      outputDirectory: summaryOutputDirectory,
+      writeFileSync: writeFile,
+    });
   }
 
-  return { checks, writeDrafts };
+  return { checks, writeDrafts, writeSummary: shouldWriteSummary };
 }
 
 export function main(argv = process.argv.slice(2)) {
@@ -674,6 +715,9 @@ export function main(argv = process.argv.slice(2)) {
 
   if (result.writeDrafts) {
     console.log(`Release readiness drafts written to ${summaryPath}, ${summaryKoPath}, and ${changelogPath}`);
+  } else if (result.writeSummary) {
+    const { summaryPath: nextSummaryPath, summaryKoPath: nextSummaryKoPath } = resolveSummaryOutputPaths(options.summaryOutputDirectory);
+    console.log(`Release readiness summaries written to ${nextSummaryPath} and ${nextSummaryKoPath} without mutating ${changelogPath}`);
   } else {
     console.log('Release readiness checks passed without writing draft artifacts.');
   }

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -92,6 +92,29 @@ describe('runReleaseReadinessVerification', () => {
     ).toBe(true);
   });
 
+  it('can write current-run summaries without mutating changelog drafts', () => {
+    const dependencies = createDependencies();
+
+    const result = runReleaseReadinessVerification(
+      {
+        summaryOutputDirectory: '/tmp/release-readiness',
+        writeSummary: true,
+      },
+      dependencies,
+    );
+
+    expect(result.writeDrafts).toBe(false);
+    expect(result.writeSummary).toBe(true);
+    expect(dependencies.writeFileSync).toHaveBeenCalledTimes(2);
+    expect(dependencies.writeFileSync.mock.calls.every(([targetPath]) => !String(targetPath).endsWith('/CHANGELOG.md'))).toBe(true);
+    expect(dependencies.writeFileSync.mock.calls.some(([targetPath]) => String(targetPath).includes('/tmp/release-readiness/release-readiness-summary.md'))).toBe(true);
+    expect(
+      dependencies.writeFileSync.mock.calls.some(([, content]) =>
+        String(content).includes('current-run release-readiness summary artifacts generated without mutating `CHANGELOG.md`.'),
+      ),
+    ).toBe(true);
+  });
+
   it.each(['workspace:*', 'workspace:~', 'workspace:^1.2.3'])('fails when a documented public package uses %s instead of workspace:^', (invalidRange) => {
     const dependencies = createDependencies();
     dependencies.workspacePackageManifests = vi.fn(() => [


### PR DESCRIPTION
## Summary

Refs #1127.

## Changes

- add a manual `.github/workflows/release-single-package.yml` workflow that accepts one package/version/dist-tag/prerelease input set, reuses `pnpm verify:release-readiness --target-package --target-version --dist-tag`, publishes through npm trusted publishing, and only creates the git tag plus GitHub Release after publish succeeds
- extend `tooling/release/prepare-github-release.mjs` to support package-scoped tags such as `@fluojs/cli@0.1.0`, add a type surface, and cover the behavior with dedicated Vitest cases
- document the new automation contract in release/testing governance docs and add a workflow-focused conformance assertion

## Testing

- `pnpm exec vitest run "tooling/release/verify-release-readiness.test.ts" "tooling/release/prepare-github-release.test.ts" "packages/testing/src/conformance/platform-consistency-governance-docs.test.ts"`
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck` (passed after build in this workspace state)
- `pnpm verify:release-readiness --target-package @fluojs/cli --target-version 0.0.0 --dist-tag latest`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.