### PR TITLE
Resolve #1128: document CI-only single-package release operator flow

### DIFF
--- a/.github/workflows/release-single-package.yml
+++ b/.github/workflows/release-single-package.yml
@@ -1,3 +1,5 @@
+# Release single package
+# Governance: documents/operators runbook updated in issue #1128
 name: Release single package
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,14 @@ Release-readiness verification is now read-only by default:
 
 ## maintainer workflows
 
+### Supervised Release Orchestration
+
+fluo uses a `supervised-auto` policy for releases.
+
+1. **Automation**: Maintainers trigger the `.github/workflows/release-single-package.yml` workflow via GitHub Actions for single-package publishing. This handles validation, npm publish (via OIDC), git tag creation, and GitHub Release generation.
+2. **Supervision**: After the CI workflow completes, the central supervisor handles the final review of the release artifacts, branch merge (if any), and cleanup boundaries.
+3. **Consistency**: Do not manually tag or publish packages. Always use the canonical CI-only flow to maintain the integrity of behavioral contracts and release artifacts.
+
 ### CLI sandbox verification
 
 When modifying `@fluojs/cli` or core runtime packages, use the sandbox scripts to verify end-to-end behavior.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -41,9 +41,9 @@ fluo의 설계 철학과 그 이면의 "왜"와 "어떻게"를 이해합니다.
 - **[보안 미들웨어](./concepts/security-middleware.ko.md)**: API 보호를 위한 최선의 실천 방법.
 - **[프로덕션 배포](./operations/deployment.ko.md)**: `pnpm dev`에서 실제 운영 환경으로의 전환.
 
-[Release Governance](./operations/release-governance.ko.md)는 공개 패키지의 기준 intended publish surface, release-readiness gate, 그리고 내부 `workspace:^` dependency-range 정책을 확인할 때 기준 문서로 사용하세요.
+[Release Governance](./operations/release-governance.ko.md)는 공개 패키지의 기준 intended publish surface, release-readiness gate, 내부 `workspace:^` dependency-range 정책, 또는 CI 전용 단건 패키지 릴리스 운영 절차와 supervised-auto 릴리스 경계를 확인할 때 기준 문서로 사용하세요.
 
-CI 전용 단건 publish preflight 검증 경로(`pnpm verify:release-readiness --target-package --target-version --dist-tag`)를 확인할 때는 [테스트 전략](./operations/testing-guide.ko.md)을 Release Governance와 함께 기준 문서로 사용하세요.
+CI 전용 단건 publish preflight 검증 경로(`pnpm verify:release-readiness --target-package --target-version --dist-tag`)와 관련 런북을 확인할 때는 [테스트 전략](./operations/testing-guide.ko.md)을 Release Governance와 함께 기준 문서로 사용하세요.
 
 ## 📚 참조 자료
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,9 +41,9 @@ Practical, task-oriented documentation for day-to-day development.
 - **[Security Middleware](./concepts/security-middleware.md)**: Best practices for protecting your API.
 - **[Production Deployment](./operations/deployment.md)**: Moving from `pnpm dev` to a production environment.
 
-Use [Release Governance](./operations/release-governance.md) when you need the canonical intended publish surface, release-readiness gates, or the enforced internal `workspace:^` dependency-range policy for public packages.
+Use [Release Governance](./operations/release-governance.md) when you need the canonical intended publish surface, release-readiness gates, the enforced internal `workspace:^` dependency-range policy for public packages, or the CI-only single-package release operator flow and supervised-auto release boundaries.
 
-Use [Testing Strategies](./operations/testing-guide.md) alongside Release Governance when you need the canonical verification path for CI-only single-package publish preflight checks via `pnpm verify:release-readiness --target-package --target-version --dist-tag`.
+Use [Testing Strategies](./operations/testing-guide.md) alongside Release Governance when you need the canonical verification path for CI-only single-package publish preflight checks via `pnpm verify:release-readiness --target-package --target-version --dist-tag` and the associated runbook.
 
 ## 📚 Reference
 

--- a/docs/operations/release-governance.ko.md
+++ b/docs/operations/release-governance.ko.md
@@ -96,18 +96,46 @@ fluo는 엄격한 **유의적 버전(Semantic Versioning, Semver)**을 따릅니
 ### CI/CD 강제 사항
 - **`pnpm verify:release-readiness`**: 기본적으로 `CHANGELOG.md`나 release-readiness summary 파일을 변경하지 않고 패키징된 CLI 엔트리포인트, 스타터 스캐폴딩, intended public package manifest dependency range를 검증합니다. CI 전용 단건 publish 모드에서는 `--target-package`, `--target-version`, `--dist-tag`를 함께 넘겨 요청한 패키지의 intended publish surface 소속 여부, semver/dist-tag의 프리릴리즈 정합성, 그리고 publish 가능한 내부 `@fluojs/*` dependency shape를 같은 canonical gate에서 강제합니다.
 - **`.github/workflows/release-single-package.yml`**: 신뢰된 단건 npm publish를 위한 수동 GitHub Actions 진입점입니다. `package_name`, `package_version`, `dist_tag`, `release_prerelease`를 입력으로 받고, canonical `pnpm verify:release-readiness --target-package --target-version --dist-tag` 게이트를 통과한 뒤에만 git tag와 GitHub Release를 생성합니다.
+- **Supervised Release Orchestration**: 릴리스는 `supervised-auto` 정책을 따릅니다. CI 워크플로가 publish 및 태그 생성을 자동화하지만, 리포지토리의 일관성을 위해 최종 리뷰, 머지 및 정리 작업은 중앙 supervisor가 처리합니다.
 - **`pnpm generate:release-readiness-drafts`**: 릴리스 노트를 준비할 때 release-readiness summary 산출물과 `CHANGELOG.md` 드래프트 블록을 명시적으로 갱신합니다.
-- **`pnpm verify:platform-consistency-governance`**: 영어와 한국어 문서 간의 구조적 일관성을 강제합니다.
-- **`pnpm verify:public-export-tsdoc`**: `packages/*/src` 아래 변경된 public export가 repo-wide TSDoc 최소 기준을 놓치면 실패합니다.
-- **`pnpm verify:public-export-tsdoc:baseline`**: 동일한 TSDoc 기준을 전체 governed `packages/*/src` 표면에 적용해 아직 수정되지 않은 누락 파일도 탐지합니다.
-- **동작 계약 체크**: `process.env`가 승인된 패턴(`@fluojs/config`) 외부에서 액세스될 경우 릴리스를 차단합니다.
 
-### 변경 이력 표준 (Changelog Standards)
-모든 공개 릴리스는 *Keep a Changelog* 형식을 따르는 루트 `CHANGELOG.md`에 일치하는 항목이 있어야 합니다. 단건 릴리스 워크플로는 패키지 범위 태그(예: `@fluojs/cli@0.1.0`)를 만들고, publish가 성공한 뒤에만 같은 버전의 루트 changelog 섹션으로 GitHub Release 본문을 생성합니다.
+---
+
+## 단건 패키지 릴리스 운영 절차 (Release Operator Flow)
+
+메인테이너는 npm에 개별 패키지를 배포할 때 다음 런북을 따라야 합니다.
+
+### 1. 사전 준비 (Pre-flight)
+CI 워크플로를 트리거하기 전에 다음 사항을 확인하십시오.
+- `package.json`의 패키지 버전이 업데이트되었으며 의도한 릴리스와 일치하는지 확인하십시오.
+- 루트 `CHANGELOG.md`에 일치하는 버전 섹션이 존재하는지 확인하십시오.
+- 게이트 실패를 미리 방지하기 위해 로컬에서 `pnpm verify:release-readiness`를 실행하십시오.
+
+### 2. 워크플로 트리거
+GitHub의 **Actions** > **Release single package**로 이동하여 **Run workflow**를 클릭하십시오.
+
+| 입력값 | 설명 | 예시 |
+| :--- | :--- | :--- |
+| `package_name` | 패키지 전체 이름. | `@fluojs/cli` |
+| `package_version` | `package.json`에 명시된 정확한 버전. | `0.1.0` |
+| `dist_tag` | npm 배포 태그. | `latest` (안정 버전) 또는 `next` |
+| `release_prerelease` | 버전명에 하이픈이 포함된 경우 `true`여야 함. | `false` |
+
+### 3. 실행 및 중단 지점 (Stop Points)
+워크플로는 다음 단계를 순차적으로 실행합니다.
+1. **검증**: 입력값으로 `pnpm verify:release-readiness`를 실행합니다. 패키지가 intended publish surface에 없거나 버전/태그가 일치하지 않으면 실패합니다.
+2. **Publish**: OIDC를 통해 npm에 배포합니다 (provenance 활성화). **배포에 실패하면 워크플로가 중단됩니다.**
+3. **태깅**: git 태그(예: `@fluojs/cli@0.1.0`)를 생성하고 푸시합니다.
+4. **GitHub Release**: 릴리스 요약 산출물(summary artifact)과 changelog 노트를 포함한 릴리스를 생성합니다.
+
+### 4. 롤백 및 재시도 (Rollback & Retry)
+- **배포 실패**: 원인(빌드 오류, 매니페스트 범위 등)을 수정하고 동일한 버전으로 워크플로를 재시도하십시오.
+- **태그/릴리스 실패**: 패키지가 이미 npm에 올라갔으나 태그/릴리스에 실패한 경우, 수동으로 태그를 생성하거나 워크플로를 다시 실행하십시오. (이미 배포된 버전인 경우 `pnpm publish`가 안전하게 처리하는지 확인하십시오.)
 
 ---
 
 ## 관련 문서
+
 - [동작 계약 정책 (Behavioral Contract Policy)](./behavioral-contract-policy.ko.md)
 - [Public Export TSDoc 기준선](./public-export-tsdoc-baseline.ko.md)
 - [NestJS 기능 격차 (NestJS Parity Gaps)](./nestjs-parity-gaps.ko.md)

--- a/docs/operations/release-governance.md
+++ b/docs/operations/release-governance.md
@@ -96,18 +96,46 @@ Governance is enforced through automated gates and manual checklists.
 ### CI/CD Enforcement
 - **`pnpm verify:release-readiness`**: Validates the packed CLI entrypoints, starter scaffolding, and intended public package manifest dependency ranges without mutating `CHANGELOG.md` or release-readiness summary files by default. In CI-only single-package publish mode, pass `--target-package`, `--target-version`, and `--dist-tag` to enforce intended publish surface membership, semver/dist-tag prerelease alignment, and publish-safe internal `@fluojs/*` dependency shape for the requested package.
 - **`.github/workflows/release-single-package.yml`**: Manual GitHub Actions entrypoint for trusted single-package npm publishing. It accepts `package_name`, `package_version`, `dist_tag`, and `release_prerelease`, runs the canonical `pnpm verify:release-readiness --target-package --target-version --dist-tag` gate, then creates the git tag and GitHub Release only after npm publish succeeds.
+- **Supervised Release Orchestration**: Releases follow a `supervised-auto` policy. While the CI workflow automates the publish and tag creation, the central supervisor handles final review, merge, and cleanup boundaries to ensure repository consistency.
 - **`pnpm generate:release-readiness-drafts`**: Explicitly refreshes the release-readiness summary artifacts and the draft `CHANGELOG.md` block when maintainers are preparing release notes.
-- **`pnpm verify:platform-consistency-governance`**: Enforces structural parity between English and Korean documentation.
-- **`pnpm verify:public-export-tsdoc`**: Fails when changed public exports in `packages/*/src` miss the repo-wide TSDoc minimum baseline.
-- **`pnpm verify:public-export-tsdoc:baseline`**: Runs the same TSDoc baseline against the full governed `packages/*/src` surface to catch untouched backlog files.
-- **Behavioral Contract Check**: Blocks releases if `process.env` is accessed outside of the sanctioned `@fluojs/config` patterns.
 
-### Changelog Standards
-Every public release must have a matching entry in the root `CHANGELOG.md` following the *Keep a Changelog* format. The single-package release workflow creates package-scoped tags (for example `@fluojs/cli@0.1.0`) and generates the GitHub Release body from the matching root changelog version section only after publish succeeds.
+---
+
+## Single-Package Release Operator Flow
+
+Maintainers should follow this runbook for publishing individual packages to npm.
+
+### 1. Pre-flight Preparation
+Before triggering the CI workflow, ensure the following:
+- The package version in its `package.json` is updated and matches your intended release.
+- A matching version section exists in the root `CHANGELOG.md`.
+- Run `pnpm verify:release-readiness` locally to catch obvious gate failures.
+
+### 2. Triggering the Workflow
+Navigate to **Actions** > **Release single package** in GitHub and click **Run workflow**.
+
+| Input | Description | Example |
+| :--- | :--- | :--- |
+| `package_name` | The full name of the package. | `@fluojs/cli` |
+| `package_version` | The exact version in `package.json`. | `0.1.0` |
+| `dist_tag` | npm distribution tag. | `latest` (stable) or `next` |
+| `release_prerelease` | Must be `true` if version contains a hyphen. | `false` |
+
+### 3. Execution & Stop Points
+The workflow executes the following steps sequentially:
+1. **Validation**: Runs `pnpm verify:release-readiness` with the provided inputs. Fails if the package is not in the intended publish surface or if versioning/tags are inconsistent.
+2. **Publish**: Publishes to npm via OIDC (provenance enabled). **If this fails, the workflow stops.**
+3. **Tagging**: Creates and pushes a git tag (e.g., `@fluojs/cli@0.1.0`).
+4. **GitHub Release**: Generates a release with the current-run release summary artifact and changelog notes.
+
+### 4. Rollback & Retry
+- **Publish Failure**: Fix the underlying issue (e.g., build error, manifest range) and retry the workflow with the same version.
+- **Tag/Release Failure**: If the package is already on npm but the tag/release failed, manually create the tag or rerun the workflow (ensure `pnpm publish` handles "already published" gracefully or skip it if allowed).
 
 ---
 
 ## Related Docs
+
 - [Behavioral Contract Policy](./behavioral-contract-policy.md)
 - [Public Export TSDoc Baseline](./public-export-tsdoc-baseline.md)
 - [NestJS Parity Gaps](./nestjs-parity-gaps.md)

--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -107,16 +107,35 @@ await app.close();
 | `pnpm generate:release-readiness-drafts` | 릴리스 준비를 위해 release-readiness summary 산출물과 changelog 드래프트 블록을 명시적으로 씁니다. |
 | `pnpm verify:public-export-tsdoc:baseline` | public-export TSDoc 기준을 전체 governed 패키지 소스 표면에 적용합니다. |
 
-수동 GitHub Actions 워크플로 `.github/workflows/release-single-package.yml`은 한 번에 하나의 공개 패키지만 publish하는 canonical publisher입니다. publish 전에 반드시 `pnpm verify:release-readiness --target-package --target-version --dist-tag`를 재사용해야 하며, npm publish가 성공한 뒤에만 git tag와 GitHub Release를 생성할 수 있습니다.
+---
 
-### 생성된 템플릿
-CLI(`fluo g repo <Name>`) 사용 시 기본적으로 제공되는 템플릿은 다음과 같습니다.
-- `<name>.repo.test.ts`: 비즈니스 로직을 위한 유닛 테스트 템플릿.
-- `<name>.repo.slice.test.ts`: `createTestingModule`을 사용하는 통합 테스트 템플릿.
+## 릴리스 Pre-flight 런북 (Release Pre-flight Runbook)
+
+메인테이너는 자동화된 릴리스를 트리거하기 전에 모든 검증이 통과되었는지 확인해야 합니다.
+
+### 1. 검증 체크리스트
+- [ ] 로컬에서 `pnpm verify`를 실행하여 통과했는지 확인하십시오.
+- [ ] public export가 TSDoc 기준을 따르는지 확인하십시오 (`pnpm lint`에 의해 검증됨).
+- [ ] `pnpm verify:release-readiness`를 실행하여 intended publish surface에 대한 오류가 없는지 확인하십시오.
+
+### 2. CI 전용 Preflight 실행
+수동 워크플로 `.github/workflows/release-single-package.yml`은 한 번에 하나의 패키지를 배포하는 canonical publisher입니다. 이 워크플로는 특정 입력값으로 `pnpm verify:release-readiness`를 재사용합니다.
+
+```bash
+pnpm verify:release-readiness --target-package <package_name> --target-version <version> --dist-tag <tag> --write-summary
+```
+
+이 관문은 다음을 보장합니다:
+1. 패키지가 **intended publish surface** 내에 있는지 확인합니다.
+2. 내부 `@fluojs/*` 의존성 범위가 배포에 안전한지 확인합니다 (canonical `workspace:^` 형태).
+3. 버전과 `dist-tag`가 올바르게 일치하는지 확인합니다 (예: `next` 태그에 안정 버전을 배포하지 않음).
+
+매 실행마다 `release-readiness-summary.md` 산출물이 생성되어 preflight 성공 증거로 GitHub Release에 첨부됩니다.
 
 ---
 
 ## 관련 문서
+
 - [동작 계약 정책 (Behavioral Contract Policy)](./behavioral-contract-policy.ko.md)
 - [플랫폼 준수 작성 체크리스트 (Platform Conformance Authoring Checklist)](./platform-conformance-authoring-checklist.ko.md)
 - [릴리스 거버넌스 (Release Governance)](./release-governance.ko.md)

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -107,16 +107,35 @@ Keep the module wiring real but override the low-level client tokens to avoid ne
 | `pnpm generate:release-readiness-drafts` | Explicitly writes release-readiness summary artifacts and the draft changelog block for release prep. |
 | `pnpm verify:public-export-tsdoc:baseline` | Runs the public-export TSDoc baseline against the full governed package source surface. |
 
-The manual GitHub Actions workflow `.github/workflows/release-single-package.yml` is the canonical publisher for one public package per run. It must reuse `pnpm verify:release-readiness --target-package --target-version --dist-tag` before publishing and may create the git tag plus GitHub Release only after npm publish succeeds.
+---
 
-### Generated Templates
-When using the CLI (`fluo g repo <Name>`), the following templates are provided as the baseline:
-- `<name>.repo.test.ts`: Unit test template for business logic.
-- `<name>.repo.slice.test.ts`: Integration template using `createTestingModule`.
+## Release Pre-flight Runbook
+
+Maintainers must ensure verification passes before triggering automated releases.
+
+### 1. Verification Checklist
+- [ ] `pnpm verify` passes locally.
+- [ ] Public exports follow TSDoc baseline (verified by `pnpm lint`).
+- [ ] `pnpm verify:release-readiness` returns no errors for the intended publish surface.
+
+### 2. CI-only Preflight Execution
+The manual workflow `.github/workflows/release-single-package.yml` is the canonical publisher for one public package per run. It reuses `pnpm verify:release-readiness` with specific inputs:
+
+```bash
+pnpm verify:release-readiness --target-package <package_name> --target-version <version> --dist-tag <tag> --write-summary
+```
+
+This gate ensures:
+1. The package is within the **intended publish surface**.
+2. Its internal `@fluojs/*` dependency ranges are publish-safe (canonical `workspace:^` shape).
+3. The version and `dist-tag` are correctly aligned (e.g., no stable release on a `next` tag).
+
+A `release-readiness-summary.md` artifact is generated for each run and attached to the GitHub Release as evidence of preflight success.
 
 ---
 
 ## Related Docs
+
 - [Behavioral Contract Policy](./behavioral-contract-policy.md)
 - [Platform Conformance Authoring Checklist](./platform-conformance-authoring-checklist.md)
 - [Release Governance](./release-governance.md)

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -132,6 +132,14 @@ describe('platform consistency governance docs', () => {
     expect(docsReadmeKo).toContain('operations/public-export-tsdoc-baseline.ko.md');
   });
 
+  it('verifies CI-only single-package release runbook discoverability', () => {
+    const docsReadme = readFileSync(resolve(repoRoot, 'docs/README.md'), 'utf8');
+    const docsReadmeKo = readFileSync(resolve(repoRoot, 'docs/README.ko.md'), 'utf8');
+
+    expect(docsReadme).toContain('CI-only single-package release operator flow');
+    expect(docsReadmeKo).toContain('CI 전용 단건 패키지 릴리스 운영 절차');
+  });
+
   it('keeps intended publish surface synchronized between English and Korean release-governance docs', () => {
     const releaseGovernance = readFileSync(resolve(repoRoot, 'docs/operations/release-governance.md'), 'utf8');
     const releaseGovernanceKo = readFileSync(resolve(repoRoot, 'docs/operations/release-governance.ko.md'), 'utf8');


### PR DESCRIPTION
## Summary
- Documents the final CI-only single-package release operator flow and `supervised-auto` release boundaries.
- Updates `release-governance.md`, `testing-guide.md`, and their Korean mirrors with runbook details.
- Clarifies maintenance workflows in `CONTRIBUTING.md`.
- Synchronizes English and Korean documentation structure.

## Verification
- Ran `pnpm verify:platform-consistency-governance` to ensure bilingual synchronization.
- Verified workflow inputs and steps against `.github/workflows/release-single-package.yml`.

Closes #1128