### PR TITLE
Resolve #1134: attribute Vitest worker-timeout shutdown flakes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - resolve-pr-verification-scope
+    env:
+      FLUO_VITEST_SHUTDOWN_DEBUG: '1'
+      FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug
 
     steps:
       - name: Checkout
@@ -125,6 +128,61 @@ jobs:
       - name: Test (full)
         if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
         run: pnpm test
+
+      - name: Print Vitest shutdown debug summary
+        if: ${{ always() }}
+        run: |
+          if [ ! -d "$FLUO_VITEST_SHUTDOWN_DEBUG_DIR" ]; then
+            echo "No Vitest shutdown debug artifacts were produced."
+            exit 0
+          fi
+
+          node --input-type=module <<'EOF'
+          import { existsSync, readdirSync, readFileSync } from 'node:fs';
+          import { join } from 'node:path';
+
+          const directory = process.env.FLUO_VITEST_SHUTDOWN_DEBUG_DIR;
+          if (!directory || !existsSync(directory)) {
+            console.log('No Vitest shutdown debug artifacts were produced.');
+            process.exit(0);
+          }
+
+          const files = readdirSync(directory)
+            .filter((entry) => entry.endsWith('.json'))
+            .sort();
+
+          if (files.length === 0) {
+            console.log('No Vitest shutdown debug artifacts were produced.');
+            process.exit(0);
+          }
+
+          for (const file of files) {
+            const artifact = JSON.parse(readFileSync(join(directory, file), 'utf8'));
+            const activeHandleSummary = Array.isArray(artifact.process?.activeHandles?.types)
+              ? artifact.process.activeHandles.types.map((entry) => `${entry.constructorName}x${String(entry.count)}`).join(', ')
+              : '';
+
+            console.log(`artifact: ${file}`);
+            console.log(`  kind: ${String(artifact.kind ?? 'unknown')}`);
+            if (artifact.lastTestReady?.fullName) {
+              console.log(`  last ready test: ${artifact.lastTestReady.fullName}`);
+            }
+            if (artifact.lastActivity?.file) {
+              console.log(`  worker last activity: ${artifact.lastActivity.file} (${artifact.lastActivity.phase})`);
+            }
+            if (activeHandleSummary.length > 0) {
+              console.log(`  active handles: ${activeHandleSummary}`);
+            }
+          }
+          EOF
+
+      - name: Upload Vitest shutdown debug artifacts
+        if: ${{ always() && hashFiles('.artifacts/vitest-shutdown-debug/*.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vitest-shutdown-debug-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/vitest-shutdown-debug/*.json
+          if-no-files-found: error
 
   official-web-runtime-adapter-portability:
     name: Official web runtime adapter portability (${{ matrix.adapter }})

--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -107,6 +107,17 @@ await app.close();
 | `pnpm generate:release-readiness-drafts` | 릴리스 준비를 위해 release-readiness summary 산출물과 changelog 드래프트 블록을 명시적으로 씁니다. |
 | `pnpm verify:public-export-tsdoc:baseline` | public-export TSDoc 기준을 전체 governed 패키지 소스 표면에 적용합니다. |
 
+### CI shutdown flake attribution
+
+반복되는 Vitest worker-timeout shutdown flake에 대한 canonical CI attribution 경로는 opt-in이며 evidence-only입니다.
+
+- 조사할 `pnpm test` 또는 `pnpm vitest run ...` 실행에 `FLUO_VITEST_SHUTDOWN_DEBUG=1`을 설정합니다.
+- 출력 디렉터리가 필요하면 `FLUO_VITEST_SHUTDOWN_DEBUG_DIR`로 덮어쓸 수 있으며, 기본값은 `.artifacts/vitest-shutdown-debug`입니다.
+- 이 Vitest 통합은 실행이 unhandled error로 끝나거나 `onProcessTimeout`에 걸릴 때 현재 실행(current-run)의 JSON evidence를 남기며, 마지막 active module/test와 active handle/request class 요약을 함께 기록합니다.
+- worker 프로세스도 signal-time snapshot을 남기므로, 메인 프로세스가 워커를 정리할 때 CI가 해당 워커의 마지막 file/suite/test 문맥을 보존할 수 있습니다.
+
+이 경로는 attribution 전용으로 취급해야 합니다. 특정 leak 또는 teardown contract를 겨냥한 후속 이슈 전까지는 runtime behavior, pool 선택, timeout 값은 보존하십시오.
+
 ---
 
 ## 릴리스 Pre-flight 런북 (Release Pre-flight Runbook)

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -107,6 +107,17 @@ Keep the module wiring real but override the low-level client tokens to avoid ne
 | `pnpm generate:release-readiness-drafts` | Explicitly writes release-readiness summary artifacts and the draft changelog block for release prep. |
 | `pnpm verify:public-export-tsdoc:baseline` | Runs the public-export TSDoc baseline against the full governed package source surface. |
 
+### CI shutdown-flake attribution
+
+The canonical CI attribution path for the recurring Vitest worker-timeout shutdown flake is opt-in and evidence-only:
+
+- Set `FLUO_VITEST_SHUTDOWN_DEBUG=1` on the `pnpm test`/`pnpm vitest run ...` invocation that you want to inspect.
+- Optionally override the output directory with `FLUO_VITEST_SHUTDOWN_DEBUG_DIR`; the default is `.artifacts/vitest-shutdown-debug`.
+- The Vitest integration writes current-run JSON evidence when the run ends with unhandled errors or hits `onProcessTimeout`, including the last active module/test and active handle/request class summaries.
+- Worker processes also emit a signal-time snapshot so CI can preserve the lingering worker's final file/suite/test context when the main process tears it down.
+
+Treat this path as attribution only: preserve runtime behavior, pool selection, and timeout values until a follow-up issue is targeting a specific leak or teardown contract.
+
 ---
 
 ## Release Pre-flight Runbook

--- a/tooling/vitest/src/index.test.ts
+++ b/tooling/vitest/src/index.test.ts
@@ -3,9 +3,10 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { collectWorkspaceAliases } from './index.js';
+import { FLUO_VITEST_SHUTDOWN_DEBUG_ENV } from './shutdown-debug.js';
+import { collectWorkspaceAliases, createFluoVitestWorkspaceConfig } from './index.js';
 
 function writePackage(root: string, directoryName: string, packageName: string, sourceFiles: Record<string, string>) {
   const packageRoot = join(root, 'packages', directoryName);
@@ -45,5 +46,37 @@ describe('collectWorkspaceAliases', () => {
     expect(aliases['@fluojs/socket.io/module']).toBe(join(repoRoot, 'packages', 'platform-socket.io', 'src', 'module.ts'));
     expect(aliases).not.toHaveProperty('@fluojs/websocket');
     expect(aliases).not.toHaveProperty('@fluojs/platform-socket.io');
+  });
+});
+
+const originalShutdownDebugValue = process.env[FLUO_VITEST_SHUTDOWN_DEBUG_ENV];
+
+afterEach(() => {
+  if (originalShutdownDebugValue === undefined) {
+    delete process.env[FLUO_VITEST_SHUTDOWN_DEBUG_ENV];
+    return;
+  }
+
+  process.env[FLUO_VITEST_SHUTDOWN_DEBUG_ENV] = originalShutdownDebugValue;
+});
+
+describe('createFluoVitestWorkspaceConfig', () => {
+  it('keeps shutdown debug hooks disabled by default', () => {
+    delete process.env[FLUO_VITEST_SHUTDOWN_DEBUG_ENV];
+
+    const config = createFluoVitestWorkspaceConfig(new URL('../../../', import.meta.url));
+
+    expect(config.test?.reporters).toBeUndefined();
+    expect(config.test?.setupFiles).toBeUndefined();
+  });
+
+  it('enables shutdown debug hooks when the CI attribution path is requested', () => {
+    process.env[FLUO_VITEST_SHUTDOWN_DEBUG_ENV] = '1';
+
+    const config = createFluoVitestWorkspaceConfig(new URL('../../../', import.meta.url));
+
+    expect(config.test?.reporters).toBeDefined();
+    expect(config.test?.reporters).toMatchObject(['default', { onProcessTimeout: expect.any(Function) }]);
+    expect(config.test?.setupFiles).toEqual(expect.arrayContaining([expect.stringContaining('shutdown-debug.setup.ts')]));
   });
 });

--- a/tooling/vitest/src/index.ts
+++ b/tooling/vitest/src/index.ts
@@ -4,6 +4,10 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig, type UserConfig } from 'vitest/config';
 
 import { fluoBabelDecoratorsPlugin } from '../../vite/src';
+import {
+  createFluoVitestShutdownDebugReporter,
+  isFluoVitestShutdownDebugEnabled,
+} from './shutdown-debug.js';
 
 function collectWorkspaceAliasesFromRoot(repoRoot: string): Record<string, string> {
   const packagesRoot = join(repoRoot, 'packages');
@@ -53,6 +57,15 @@ export function collectWorkspaceAliases(repoRootUrl: string | URL): Record<strin
 }
 
 export function createFluoVitestWorkspaceConfig(repoRootUrl: string | URL, overrides: UserConfig = {}) {
+  const repoRoot = fileURLToPath(repoRootUrl);
+  const shutdownDebugEnabled = isFluoVitestShutdownDebugEnabled();
+  const shutdownDebugConfig = shutdownDebugEnabled
+    ? {
+        reporters: ['default', createFluoVitestShutdownDebugReporter(repoRoot)],
+        setupFiles: [fileURLToPath(new URL('./shutdown-debug.setup.ts', import.meta.url))],
+      }
+    : {};
+
   return mergeConfig(
     defineConfig({
       plugins: [fluoBabelDecoratorsPlugin()],
@@ -61,6 +74,7 @@ export function createFluoVitestWorkspaceConfig(repoRootUrl: string | URL, overr
       },
       test: {
         environment: 'node',
+        ...shutdownDebugConfig,
       },
     }),
     defineConfig(overrides),

--- a/tooling/vitest/src/shutdown-debug.setup.ts
+++ b/tooling/vitest/src/shutdown-debug.setup.ts
@@ -1,0 +1,129 @@
+import process from 'node:process';
+
+import { afterAll, afterEach, beforeAll, beforeEach } from 'vitest';
+
+import {
+  collectVitestProcessLeakSnapshot,
+  isFluoVitestShutdownDebugEnabled,
+  writeVitestShutdownDebugSnapshot,
+} from './shutdown-debug.js';
+
+type ActivityPhase = 'beforeAll' | 'afterAll' | 'beforeEach' | 'afterEach';
+
+interface WorkerActivity {
+  at: string;
+  file: string;
+  phase: ActivityPhase;
+  suite: string | null;
+  test: string | null;
+}
+
+interface WorkerDebugState {
+  listenersInstalled: boolean;
+  lastActivity?: WorkerActivity;
+}
+
+const workerDebugStateKey = Symbol.for('fluo.vitest.shutdownDebugState');
+
+function getWorkerDebugState(): WorkerDebugState {
+  const globalState = globalThis as typeof globalThis & {
+    [workerDebugStateKey]?: WorkerDebugState;
+  };
+
+  if (!globalState[workerDebugStateKey]) {
+    globalState[workerDebugStateKey] = {
+      listenersInstalled: false,
+    };
+  }
+
+  return globalState[workerDebugStateKey];
+}
+
+function normalizeFilePath(filePath: string): string {
+  return filePath.startsWith(process.cwd()) ? filePath.slice(process.cwd().length + 1) : filePath;
+}
+
+function updateLastActivity(activity: WorkerActivity) {
+  getWorkerDebugState().lastActivity = activity;
+}
+
+function writeWorkerSignalSnapshot(trigger: 'SIGINT' | 'SIGTERM') {
+  const workerState = getWorkerDebugState();
+  const filePath = writeVitestShutdownDebugSnapshot(process.cwd(), `worker-${String(process.pid)}-${trigger.toLowerCase()}`, {
+    kind: 'worker-signal',
+    detectedAt: new Date().toISOString(),
+    pid: process.pid,
+    trigger,
+    lastActivity: workerState.lastActivity,
+    process: collectVitestProcessLeakSnapshot(),
+  });
+
+  console.error(`[fluo-vitest-shutdown-debug] worker ${String(process.pid)} wrote ${trigger} evidence to ${filePath}`);
+}
+
+function installSignalListener(trigger: 'SIGINT' | 'SIGTERM') {
+  const listener = () => {
+    process.removeListener(trigger, listener);
+    writeWorkerSignalSnapshot(trigger);
+    process.kill(process.pid, trigger);
+  };
+
+  process.on(trigger, listener);
+}
+
+function installProcessListeners() {
+  const workerState = getWorkerDebugState();
+  if (workerState.listenersInstalled || !isFluoVitestShutdownDebugEnabled()) {
+    return;
+  }
+
+  workerState.listenersInstalled = true;
+  installSignalListener('SIGINT');
+  installSignalListener('SIGTERM');
+}
+
+if (isFluoVitestShutdownDebugEnabled()) {
+  installProcessListeners();
+
+  beforeAll((suite) => {
+    const filePath = 'filepath' in suite ? suite.filepath : suite.file.filepath;
+    updateLastActivity({
+      at: new Date().toISOString(),
+      file: normalizeFilePath(filePath),
+      phase: 'beforeAll',
+      suite: suite.name.length > 0 ? suite.name : null,
+      test: null,
+    });
+  });
+
+  beforeEach((context, suite) => {
+    updateLastActivity({
+      at: new Date().toISOString(),
+      file: normalizeFilePath(context.task.file.filepath),
+      phase: 'beforeEach',
+      suite: suite.name.length > 0 ? suite.name : null,
+      test: context.task.name,
+    });
+  });
+
+  afterEach((context, suite) => {
+    updateLastActivity({
+      at: new Date().toISOString(),
+      file: normalizeFilePath(context.task.file.filepath),
+      phase: 'afterEach',
+      suite: suite.name.length > 0 ? suite.name : null,
+      test: context.task.name,
+    });
+  });
+
+  afterAll((suite) => {
+    const filePath = 'filepath' in suite ? suite.filepath : suite.file.filepath;
+    updateLastActivity({
+      at: new Date().toISOString(),
+      file: normalizeFilePath(filePath),
+      phase: 'afterAll',
+      suite: suite.name.length > 0 ? suite.name : null,
+      test: null,
+    });
+  });
+}

--- a/tooling/vitest/src/shutdown-debug.setup.ts
+++ b/tooling/vitest/src/shutdown-debug.setup.ts
@@ -23,6 +23,23 @@ interface WorkerDebugState {
   lastActivity?: WorkerActivity;
 }
 
+interface SuiteLike {
+  file?: {
+    filepath?: string;
+  };
+  filepath?: string;
+  name?: string;
+}
+
+interface ContextLike {
+  task?: {
+    file?: {
+      filepath?: string;
+    };
+    name?: string;
+  };
+}
+
 const workerDebugStateKey = Symbol.for('fluo.vitest.shutdownDebugState');
 
 function getWorkerDebugState(): WorkerDebugState {
@@ -41,6 +58,32 @@ function getWorkerDebugState(): WorkerDebugState {
 
 function normalizeFilePath(filePath: string): string {
   return filePath.startsWith(process.cwd()) ? filePath.slice(process.cwd().length + 1) : filePath;
+}
+
+export function resolveWorkerActivitySuiteName(suite: SuiteLike | undefined): string | null {
+  const name = suite?.name;
+  return typeof name === 'string' && name.length > 0 ? name : null;
+}
+
+export function resolveWorkerActivityFilePath(
+  source: SuiteLike | ContextLike | undefined,
+  fallbackFilePath = '[unknown-file]',
+): string {
+  const candidate = source as (SuiteLike & ContextLike) | undefined;
+  const suiteFilePath = candidate?.filepath;
+  const nestedFilePath = candidate?.file?.filepath;
+  const taskFilePath = candidate?.task?.file?.filepath;
+
+  const filePath = [suiteFilePath, nestedFilePath, taskFilePath, fallbackFilePath].find(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  );
+
+  return normalizeFilePath(filePath ?? fallbackFilePath);
+}
+
+export function resolveWorkerActivityTestName(context: ContextLike | undefined): string | null {
+  const name = context?.task?.name;
+  return typeof name === 'string' && name.length > 0 ? name : null;
 }
 
 function updateLastActivity(activity: WorkerActivity) {
@@ -86,12 +129,11 @@ if (isFluoVitestShutdownDebugEnabled()) {
   installProcessListeners();
 
   beforeAll((suite) => {
-    const filePath = 'filepath' in suite ? suite.filepath : suite.file.filepath;
     updateLastActivity({
       at: new Date().toISOString(),
-      file: normalizeFilePath(filePath),
+      file: resolveWorkerActivityFilePath(suite),
       phase: 'beforeAll',
-      suite: suite.name.length > 0 ? suite.name : null,
+      suite: resolveWorkerActivitySuiteName(suite),
       test: null,
     });
   });
@@ -99,30 +141,29 @@ if (isFluoVitestShutdownDebugEnabled()) {
   beforeEach((context, suite) => {
     updateLastActivity({
       at: new Date().toISOString(),
-      file: normalizeFilePath(context.task.file.filepath),
+      file: resolveWorkerActivityFilePath(context),
       phase: 'beforeEach',
-      suite: suite.name.length > 0 ? suite.name : null,
-      test: context.task.name,
+      suite: resolveWorkerActivitySuiteName(suite),
+      test: resolveWorkerActivityTestName(context),
     });
   });
 
   afterEach((context, suite) => {
     updateLastActivity({
       at: new Date().toISOString(),
-      file: normalizeFilePath(context.task.file.filepath),
+      file: resolveWorkerActivityFilePath(context),
       phase: 'afterEach',
-      suite: suite.name.length > 0 ? suite.name : null,
-      test: context.task.name,
+      suite: resolveWorkerActivitySuiteName(suite),
+      test: resolveWorkerActivityTestName(context),
     });
   });
 
   afterAll((suite) => {
-    const filePath = 'filepath' in suite ? suite.filepath : suite.file.filepath;
     updateLastActivity({
       at: new Date().toISOString(),
-      file: normalizeFilePath(filePath),
+      file: resolveWorkerActivityFilePath(suite),
       phase: 'afterAll',
-      suite: suite.name.length > 0 ? suite.name : null,
+      suite: resolveWorkerActivitySuiteName(suite),
       test: null,
     });
   });

--- a/tooling/vitest/src/shutdown-debug.test.ts
+++ b/tooling/vitest/src/shutdown-debug.test.ts
@@ -11,6 +11,11 @@ import {
   resolveFluoVitestShutdownDebugDirectory,
   writeVitestShutdownDebugSnapshot,
 } from './shutdown-debug.js';
+import {
+  resolveWorkerActivityFilePath,
+  resolveWorkerActivitySuiteName,
+  resolveWorkerActivityTestName,
+} from './shutdown-debug.setup.js';
 
 describe('shutdown debug helpers', () => {
   it('treats the attribution path as opt-in', () => {
@@ -51,5 +56,34 @@ describe('shutdown debug helpers', () => {
       reason: 'failed',
       schemaVersion: 1,
     });
+  });
+
+  it('tolerates missing hook metadata when deriving worker activity', () => {
+    expect(resolveWorkerActivitySuiteName(undefined)).toBeNull();
+    expect(resolveWorkerActivitySuiteName({})).toBeNull();
+    expect(resolveWorkerActivityTestName(undefined)).toBeNull();
+    expect(resolveWorkerActivityTestName({})).toBeNull();
+    expect(resolveWorkerActivityFilePath(undefined)).toBe('[unknown-file]');
+    expect(resolveWorkerActivityFilePath({})).toBe('[unknown-file]');
+  });
+
+  it('prefers available suite and task paths when metadata exists', () => {
+    expect(
+      resolveWorkerActivityFilePath({
+        filepath: '/repo/root/tooling/vitest/src/example.test.ts',
+      }),
+    ).toContain('tooling/vitest/src/example.test.ts');
+    expect(
+      resolveWorkerActivityFilePath({
+        task: {
+          file: {
+            filepath: '/repo/root/packages/runtime/src/application.test.ts',
+          },
+          name: 'example test',
+        },
+      }),
+    ).toContain('packages/runtime/src/application.test.ts');
+    expect(resolveWorkerActivitySuiteName({ name: 'example suite' })).toBe('example suite');
+    expect(resolveWorkerActivityTestName({ task: { name: 'example test' } })).toBe('example test');
   });
 });

--- a/tooling/vitest/src/shutdown-debug.test.ts
+++ b/tooling/vitest/src/shutdown-debug.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  FLUO_VITEST_SHUTDOWN_DEBUG_DIR_ENV,
+  FLUO_VITEST_SHUTDOWN_DEBUG_ENV,
+  isFluoVitestShutdownDebugEnabled,
+  resolveFluoVitestShutdownDebugDirectory,
+  writeVitestShutdownDebugSnapshot,
+} from './shutdown-debug.js';
+
+describe('shutdown debug helpers', () => {
+  it('treats the attribution path as opt-in', () => {
+    expect(isFluoVitestShutdownDebugEnabled({ [FLUO_VITEST_SHUTDOWN_DEBUG_ENV]: '1' })).toBe(true);
+    expect(isFluoVitestShutdownDebugEnabled({ [FLUO_VITEST_SHUTDOWN_DEBUG_ENV]: 'true' })).toBe(true);
+    expect(isFluoVitestShutdownDebugEnabled({ [FLUO_VITEST_SHUTDOWN_DEBUG_ENV]: '0' })).toBe(false);
+    expect(isFluoVitestShutdownDebugEnabled({})).toBe(false);
+  });
+
+  it('resolves the debug directory from the environment when present', () => {
+    expect(
+      resolveFluoVitestShutdownDebugDirectory('/repo/root', {
+        [FLUO_VITEST_SHUTDOWN_DEBUG_DIR_ENV]: 'custom/debug-dir',
+      }),
+    ).toBe('custom/debug-dir');
+  });
+
+  it('writes structured current-run evidence snapshots', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'fluo-vitest-shutdown-debug-'));
+    const filePath = writeVitestShutdownDebugSnapshot(
+      repoRoot,
+      'run-end',
+      {
+        kind: 'run-end',
+        reason: 'failed',
+      },
+      {},
+    );
+
+    const written = JSON.parse(readFileSync(filePath, 'utf8')) as {
+      kind: string;
+      reason: string;
+      schemaVersion: number;
+    };
+
+    expect(written).toEqual({
+      kind: 'run-end',
+      reason: 'failed',
+      schemaVersion: 1,
+    });
+  });
+});

--- a/tooling/vitest/src/shutdown-debug.ts
+++ b/tooling/vitest/src/shutdown-debug.ts
@@ -1,0 +1,371 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import process from 'node:process';
+
+import type { TestCase, TestModule, TestSuite } from 'vitest/node';
+import type { Reporter } from 'vitest/reporters';
+
+export const FLUO_VITEST_SHUTDOWN_DEBUG_ENV = 'FLUO_VITEST_SHUTDOWN_DEBUG';
+export const FLUO_VITEST_SHUTDOWN_DEBUG_DIR_ENV = 'FLUO_VITEST_SHUTDOWN_DEBUG_DIR';
+
+declare global {
+  namespace NodeJS {
+    interface Process {
+      _getActiveHandles?(): unknown[];
+      _getActiveRequests?(): unknown[];
+    }
+  }
+}
+
+type PrimitiveDetail = boolean | number | string | null;
+
+interface ResourceSample {
+  constructorName: string;
+  details?: Record<string, PrimitiveDetail>;
+}
+
+interface ResourceSummary {
+  count: number;
+  types: Array<{
+    constructorName: string;
+    count: number;
+    samples: ResourceSample[];
+  }>;
+}
+
+interface TestModuleSnapshot {
+  moduleId: string;
+  projectName: string | null;
+  state: string;
+  ok: boolean;
+  diagnostic: ReturnType<TestModule['diagnostic']>;
+}
+
+interface TestSuiteSnapshot {
+  moduleId: string;
+  projectName: string | null;
+  fullName: string;
+  state: string;
+}
+
+interface TestCaseSnapshot {
+  moduleId: string;
+  projectName: string | null;
+  fullName: string;
+  state: string;
+  diagnostic: ReturnType<TestCase['diagnostic']>;
+}
+
+function getEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key]?.trim();
+  return value && value.length > 0 ? value : undefined;
+}
+
+function toRelativePath(repoRoot: string, value: string): string {
+  if (!value.startsWith(repoRoot)) {
+    return value;
+  }
+
+  const relativePath = relative(repoRoot, value);
+  return relativePath.length > 0 ? relativePath : '.';
+}
+
+function serializeError(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    value: String(error),
+  };
+}
+
+function extractPrimitiveDetail(value: unknown): PrimitiveDetail | undefined {
+  if (value === null) {
+    return null;
+  }
+
+  switch (typeof value) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function summarizeResource(resource: unknown): ResourceSample {
+  const candidate = resource as {
+    address?: () => { address?: string; family?: string; port?: number };
+    bytesRead?: number;
+    bytesWritten?: number;
+    connected?: boolean;
+    destroyed?: boolean;
+    fd?: number;
+    hasRef?: () => boolean;
+    localAddress?: string;
+    localPort?: number;
+    path?: string;
+    pending?: boolean;
+    readable?: boolean;
+    readyState?: string;
+    remoteAddress?: string;
+    remotePort?: number;
+    writable?: boolean;
+  };
+
+  const constructorName =
+    typeof resource === 'object' && resource !== null && 'constructor' in resource
+      ? ((resource.constructor as { name?: string }).name ?? 'Unknown')
+      : typeof resource;
+
+  const details: Record<string, PrimitiveDetail> = {};
+  const knownDetails: Record<string, unknown> = {
+    bytesRead: candidate.bytesRead,
+    bytesWritten: candidate.bytesWritten,
+    connected: candidate.connected,
+    destroyed: candidate.destroyed,
+    fd: candidate.fd,
+    hasRef: candidate.hasRef?.(),
+    localAddress: candidate.localAddress,
+    localPort: candidate.localPort,
+    path: candidate.path,
+    pending: candidate.pending,
+    readable: candidate.readable,
+    readyState: candidate.readyState,
+    remoteAddress: candidate.remoteAddress,
+    remotePort: candidate.remotePort,
+    writable: candidate.writable,
+  };
+
+  const serverAddress = candidate.address?.();
+  if (serverAddress) {
+    knownDetails.boundAddress = serverAddress.address;
+    knownDetails.boundFamily = serverAddress.family;
+    knownDetails.boundPort = serverAddress.port;
+  }
+
+  for (const [key, value] of Object.entries(knownDetails)) {
+    const primitive = extractPrimitiveDetail(value);
+    if (primitive !== undefined) {
+      details[key] = primitive;
+    }
+  }
+
+  return {
+    constructorName,
+    details: Object.keys(details).length > 0 ? details : undefined,
+  };
+}
+
+function collectResourceSummary(resources: readonly unknown[]): ResourceSummary {
+  const types = new Map<string, { count: number; samples: ResourceSample[] }>();
+
+  for (const resource of resources) {
+    const sample = summarizeResource(resource);
+    const existing = types.get(sample.constructorName) ?? {
+      count: 0,
+      samples: [],
+    };
+
+    existing.count += 1;
+    if (existing.samples.length < 3) {
+      existing.samples.push(sample);
+    }
+
+    types.set(sample.constructorName, existing);
+  }
+
+  return {
+    count: resources.length,
+    types: [...types.entries()]
+      .map(([constructorName, entry]) => ({
+        constructorName,
+        count: entry.count,
+        samples: entry.samples,
+      }))
+      .sort((left, right) => right.count - left.count || left.constructorName.localeCompare(right.constructorName)),
+  };
+}
+
+export function isFluoVitestShutdownDebugEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = getEnvValue(env, FLUO_VITEST_SHUTDOWN_DEBUG_ENV);
+  return value === '1' || value === 'true';
+}
+
+export function resolveFluoVitestShutdownDebugDirectory(
+  repoRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return getEnvValue(env, FLUO_VITEST_SHUTDOWN_DEBUG_DIR_ENV) ?? join(repoRoot, '.artifacts', 'vitest-shutdown-debug');
+}
+
+export function collectVitestProcessLeakSnapshot(): {
+  activeHandles: ResourceSummary;
+  activeRequests: ResourceSummary;
+} {
+  return {
+    activeHandles: collectResourceSummary(process._getActiveHandles?.() ?? []),
+    activeRequests: collectResourceSummary(process._getActiveRequests?.() ?? []),
+  };
+}
+
+export function writeVitestShutdownDebugSnapshot(
+  repoRoot: string,
+  fileName: string,
+  payload: Record<string, unknown>,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const directory = resolveFluoVitestShutdownDebugDirectory(repoRoot, env);
+  mkdirSync(directory, { recursive: true });
+
+  const filePath = join(directory, `${fileName}.json`);
+  writeFileSync(
+    filePath,
+    JSON.stringify(
+      {
+        schemaVersion: 1,
+        ...payload,
+      },
+      null,
+      2,
+    ),
+  );
+
+  return filePath;
+}
+
+function createTestModuleSnapshot(testModule: TestModule, repoRoot: string): TestModuleSnapshot {
+  return {
+    moduleId: toRelativePath(repoRoot, testModule.moduleId),
+    projectName: testModule.project.name ?? null,
+    state: testModule.state(),
+    ok: testModule.ok(),
+    diagnostic: testModule.diagnostic(),
+  };
+}
+
+function createTestSuiteSnapshot(testSuite: TestSuite, repoRoot: string): TestSuiteSnapshot {
+  return {
+    moduleId: toRelativePath(repoRoot, testSuite.module.moduleId),
+    projectName: testSuite.project.name ?? null,
+    fullName: testSuite.fullName,
+    state: testSuite.state(),
+  };
+}
+
+function createTestCaseSnapshot(testCase: TestCase, repoRoot: string): TestCaseSnapshot {
+  return {
+    moduleId: toRelativePath(repoRoot, testCase.module.moduleId),
+    projectName: testCase.project.name ?? null,
+    fullName: testCase.fullName,
+    state: testCase.result().state,
+    diagnostic: testCase.diagnostic(),
+  };
+}
+
+function formatUnhandledErrors(errors: ReadonlyArray<unknown>): Record<string, unknown>[] {
+  return errors.map((error) => serializeError(error));
+}
+
+class FluoVitestShutdownDebugReporter implements Reporter {
+  private readonly activeModules = new Map<string, TestModuleSnapshot>();
+
+  private lastRunStartedAt?: string;
+  private lastModuleStart?: TestModuleSnapshot;
+  private lastModuleEnd?: TestModuleSnapshot;
+  private lastSuiteReady?: TestSuiteSnapshot;
+  private lastSuiteResult?: TestSuiteSnapshot;
+  private lastTestReady?: TestCaseSnapshot;
+  private lastTestResult?: TestCaseSnapshot;
+
+  constructor(private readonly repoRoot: string) {}
+
+  onTestRunStart() {
+    this.lastRunStartedAt = new Date().toISOString();
+  }
+
+  onTestModuleStart(testModule: TestModule) {
+    const snapshot = createTestModuleSnapshot(testModule, this.repoRoot);
+    this.activeModules.set(snapshot.moduleId, snapshot);
+    this.lastModuleStart = snapshot;
+  }
+
+  onTestModuleEnd(testModule: TestModule) {
+    const snapshot = createTestModuleSnapshot(testModule, this.repoRoot);
+    this.activeModules.delete(snapshot.moduleId);
+    this.lastModuleEnd = snapshot;
+  }
+
+  onTestSuiteReady(testSuite: TestSuite) {
+    this.lastSuiteReady = createTestSuiteSnapshot(testSuite, this.repoRoot);
+  }
+
+  onTestSuiteResult(testSuite: TestSuite) {
+    this.lastSuiteResult = createTestSuiteSnapshot(testSuite, this.repoRoot);
+  }
+
+  onTestCaseReady(testCase: TestCase) {
+    this.lastTestReady = createTestCaseSnapshot(testCase, this.repoRoot);
+  }
+
+  onTestCaseResult(testCase: TestCase) {
+    this.lastTestResult = createTestCaseSnapshot(testCase, this.repoRoot);
+  }
+
+  onProcessTimeout() {
+    const snapshot = {
+      kind: 'main-process-timeout',
+      detectedAt: new Date().toISOString(),
+      runStartedAt: this.lastRunStartedAt,
+      activeModules: [...this.activeModules.values()],
+      lastModuleStart: this.lastModuleStart,
+      lastModuleEnd: this.lastModuleEnd,
+      lastSuiteReady: this.lastSuiteReady,
+      lastSuiteResult: this.lastSuiteResult,
+      lastTestReady: this.lastTestReady,
+      lastTestResult: this.lastTestResult,
+      process: collectVitestProcessLeakSnapshot(),
+    };
+
+    const filePath = writeVitestShutdownDebugSnapshot(this.repoRoot, 'main-process-timeout', snapshot);
+    const handleSummary = snapshot.process.activeHandles.types
+      .map((entry) => `${entry.constructorName}×${String(entry.count)}`)
+      .join(', ');
+
+    console.error(`[fluo-vitest-shutdown-debug] wrote timeout evidence to ${filePath}`);
+    if (this.lastTestReady) {
+      console.error(`[fluo-vitest-shutdown-debug] last ready test: ${this.lastTestReady.fullName}`);
+    }
+    if (handleSummary.length > 0) {
+      console.error(`[fluo-vitest-shutdown-debug] active handles: ${handleSummary}`);
+    }
+  }
+
+  onTestRunEnd(testModules: ReadonlyArray<TestModule>, unhandledErrors: ReadonlyArray<unknown>, reason: string) {
+    if (reason === 'passed' && unhandledErrors.length === 0) {
+      return;
+    }
+
+    const filePath = writeVitestShutdownDebugSnapshot(this.repoRoot, 'run-end', {
+      kind: 'run-end',
+      finishedAt: new Date().toISOString(),
+      runStartedAt: this.lastRunStartedAt,
+      reason,
+      testModules: testModules.map((testModule) => createTestModuleSnapshot(testModule, this.repoRoot)),
+      unhandledErrors: formatUnhandledErrors(unhandledErrors),
+      process: collectVitestProcessLeakSnapshot(),
+    });
+
+    console.error(`[fluo-vitest-shutdown-debug] wrote run-end evidence to ${filePath}`);
+  }
+}
+
+export function createFluoVitestShutdownDebugReporter(repoRoot: string): Reporter {
+  return new FluoVitestShutdownDebugReporter(repoRoot);
+}


### PR DESCRIPTION
## Summary
- add an opt-in Vitest shutdown debug path in `tooling/vitest/src` that records current-run timeout evidence, including last active module/test context plus active handle/request summaries
- surface the evidence from `.github/workflows/ci.yml` so failing CI runs print a summary and upload JSON artifacts for downstream issues to inspect
- document the canonical attribution path in the English/Korean testing guides without changing runtime behavior, pool selection, or timeout tuning

## Changes
- add a custom Vitest reporter and worker signal-time setup hook behind `FLUO_VITEST_SHUTDOWN_DEBUG`
- wire the debug hook into `createFluoVitestWorkspaceConfig(...)` only when the CI attribution path is enabled
- upload `.artifacts/vitest-shutdown-debug/*.json` from the `Test` job and print artifact summaries in logs
- document the opt-in env vars and artifact path in `docs/operations/testing-guide.md` and `.ko.md`

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run tooling/vitest/src/index.test.ts tooling/vitest/src/shutdown-debug.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm exec biome lint tooling/vitest/src .github/workflows/ci.yml docs/operations/testing-guide.md docs/operations/testing-guide.ko.md`
- `pnpm verify:platform-consistency-governance`
- `pnpm lint` (passes with existing repo-wide Biome warnings unrelated to this PR)

## Behavioral contract
- no documented runtime behavior or public API contracts changed
- this PR only adds evidence capture and deterministic attribution for the CI shutdown flake so follow-up issues can target specific lingering resources
- pool selection, timeout values, and package-local teardown behavior remain unchanged in this PR

Closes #1134