### PR TITLE
Resolve #1135: harden workspace Vitest CI execution split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,27 @@ jobs:
 
       - name: Test (full)
         if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
-        run: pnpm test
+        env:
+          FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug/packages
+        run: pnpm vitest run --project packages
+
+      - name: Test (full apps project)
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
+        env:
+          FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug/apps
+        run: pnpm vitest run --project apps
+
+      - name: Test (full examples project)
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
+        env:
+          FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug/examples
+        run: pnpm vitest run --project examples
+
+      - name: Test (full tooling project)
+        if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'
+        env:
+          FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug/tooling
+        run: pnpm vitest run --project tooling
 
       - name: Print Vitest shutdown debug summary
         if: ${{ always() }}
@@ -147,9 +167,22 @@ jobs:
             process.exit(0);
           }
 
-          const files = readdirSync(directory)
-            .filter((entry) => entry.endsWith('.json'))
-            .sort();
+          const collectJsonFiles = (currentDirectory) => {
+            const entries = readdirSync(currentDirectory, { withFileTypes: true });
+
+            return entries
+              .flatMap((entry) => {
+                const entryPath = join(currentDirectory, entry.name);
+                if (entry.isDirectory()) {
+                  return collectJsonFiles(entryPath);
+                }
+
+                return entry.name.endsWith('.json') ? [entryPath] : [];
+              })
+              .sort();
+          };
+
+          const files = collectJsonFiles(directory);
 
           if (files.length === 0) {
             console.log('No Vitest shutdown debug artifacts were produced.');
@@ -157,12 +190,12 @@ jobs:
           }
 
           for (const file of files) {
-            const artifact = JSON.parse(readFileSync(join(directory, file), 'utf8'));
+            const artifact = JSON.parse(readFileSync(file, 'utf8'));
             const activeHandleSummary = Array.isArray(artifact.process?.activeHandles?.types)
               ? artifact.process.activeHandles.types.map((entry) => `${entry.constructorName}x${String(entry.count)}`).join(', ')
               : '';
 
-            console.log(`artifact: ${file}`);
+            console.log(`artifact: ${file.slice(directory.length + 1)}`);
             console.log(`  kind: ${String(artifact.kind ?? 'unknown')}`);
             if (artifact.lastTestReady?.fullName) {
               console.log(`  last ready test: ${artifact.lastTestReady.fullName}`);
@@ -177,11 +210,11 @@ jobs:
           EOF
 
       - name: Upload Vitest shutdown debug artifacts
-        if: ${{ always() && hashFiles('.artifacts/vitest-shutdown-debug/*.json') != '' }}
+        if: ${{ always() && hashFiles('.artifacts/vitest-shutdown-debug/**/*.json') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: vitest-shutdown-debug-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .artifacts/vitest-shutdown-debug/*.json
+          path: .artifacts/vitest-shutdown-debug/**/*.json
           if-no-files-found: error
 
   official-web-runtime-adapter-portability:

--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -115,6 +115,8 @@ await app.close();
 - 출력 디렉터리가 필요하면 `FLUO_VITEST_SHUTDOWN_DEBUG_DIR`로 덮어쓸 수 있으며, 기본값은 `.artifacts/vitest-shutdown-debug`입니다.
 - 이 Vitest 통합은 실행이 unhandled error로 끝나거나 `onProcessTimeout`에 걸릴 때 현재 실행(current-run)의 JSON evidence를 남기며, 마지막 active module/test와 active handle/request class 요약을 함께 기록합니다.
 - worker 프로세스도 signal-time snapshot을 남기므로, 메인 프로세스가 워커를 정리할 때 CI가 해당 워커의 마지막 file/suite/test 문맥을 보존할 수 있습니다.
+- canonical full-suite CI 경로는 이제 workspace Vitest project(`packages`, `apps`, `examples`, `tooling`)를 각각 `pnpm vitest run --project ...`로 분리 실행하므로, 하나의 shutdown leak 때문에 전체 workspace가 단일 장수 실행으로 묶이지 않게 합니다.
+- CI는 `.artifacts/vitest-shutdown-debug/` 아래 project별 하위 디렉터리에 attribution artifact를 저장해 #1134 evidence path를 유지하면서도 각 workspace project의 shutdown trace를 분리 보존합니다.
 
 이 경로는 attribution 전용으로 취급해야 합니다. 특정 leak 또는 teardown contract를 겨냥한 후속 이슈 전까지는 runtime behavior, pool 선택, timeout 값은 보존하십시오.
 

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -115,6 +115,8 @@ The canonical CI attribution path for the recurring Vitest worker-timeout shutdo
 - Optionally override the output directory with `FLUO_VITEST_SHUTDOWN_DEBUG_DIR`; the default is `.artifacts/vitest-shutdown-debug`.
 - The Vitest integration writes current-run JSON evidence when the run ends with unhandled errors or hits `onProcessTimeout`, including the last active module/test and active handle/request class summaries.
 - Worker processes also emit a signal-time snapshot so CI can preserve the lingering worker's final file/suite/test context when the main process tears it down.
+- The canonical full-suite CI path now runs the workspace Vitest projects (`packages`, `apps`, `examples`, `tooling`) as separate `pnpm vitest run --project ...` invocations so one shutdown leak does not collapse the entire workspace into a single long-lived run.
+- CI stores attribution artifacts under per-project subdirectories of `.artifacts/vitest-shutdown-debug/` to preserve the #1134 evidence path while keeping each workspace project's shutdown traces isolated.
 
 Treat this path as attribution only: preserve runtime behavior, pool selection, and timeout values until a follow-up issue is targeting a specific leak or teardown contract.
 

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -191,6 +191,13 @@ describe('platform consistency governance docs', () => {
       'run: pnpm vitest run $' + '{{ needs.resolve-pr-verification-scope.outputs.test_paths }}',
     );
     expect(ciWorkflow).toContain("if: github.event_name != 'pull_request' || needs.resolve-pr-verification-scope.outputs.mode != 'scoped'");
+    expect(ciWorkflow).toContain('run: pnpm vitest run --project packages');
+    expect(ciWorkflow).toContain('run: pnpm vitest run --project apps');
+    expect(ciWorkflow).toContain('run: pnpm vitest run --project examples');
+    expect(ciWorkflow).toContain('run: pnpm vitest run --project tooling');
+    expect(ciWorkflow).toContain('FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug/packages');
+    expect(ciWorkflow).toContain('FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug/tooling');
+    expect(ciWorkflow).toContain("hashFiles('.artifacts/vitest-shutdown-debug/**/*.json') != ''");
     expect(ciWorkflow).toContain('build-and-typecheck:');
     expect(ciWorkflow).toContain("if: github.event_name == 'pull_request'");
     expect(ciWorkflow).toContain('verify-platform-consistency-governance');


### PR DESCRIPTION
## Summary
- split the full-suite CI Vitest path into separate `packages`, `apps`, `examples`, and `tooling` project runs instead of one monolithic `pnpm test` execution
- keep the #1134 shutdown attribution path intact by writing debug artifacts into per-project subdirectories and teaching the CI summary/upload steps to read them recursively
- document the canonical shared CI/Vitest execution model in the English/Korean testing guides and lock it in with governance coverage

## Changes
- replace the full `pnpm test` CI fallback with project-specific `pnpm vitest run --project ...` steps for the workspace suite
- preserve shutdown evidence isolation with project-specific `FLUO_VITEST_SHUTDOWN_DEBUG_DIR` values and recursive artifact discovery/upload
- extend `packages/testing/src/conformance/platform-consistency-governance-docs.test.ts` to assert the split execution model
- update `docs/operations/testing-guide.md` and `docs/operations/testing-guide.ko.md` to reflect the new canonical CI path

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run --project packages packages/testing/src/conformance/platform-consistency-governance-docs.test.ts packages/testing/src/surface.test.ts`
- `pnpm exec vitest run --project tooling tooling/vitest/src/index.test.ts tooling/vitest/src/shutdown-debug.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm verify:platform-consistency-governance`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Related: #1135