### PR TITLE
Resolve #1137: make cron and event-bus teardown deterministic in tests

### DIFF
--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -173,6 +173,21 @@ function createDeferred<T = void>(): Deferred<T> {
   return { promise, reject, resolve };
 }
 
+async function settleCronTeardown(): Promise<void> {
+  await Promise.resolve();
+
+  if (vi.isFakeTimers()) {
+    await vi.runOnlyPendingTimersAsync();
+  }
+
+  await Promise.resolve();
+}
+
+async function closeApplication(app: { close(): Promise<void> }): Promise<void> {
+  await app.close();
+  await settleCronTeardown();
+}
+
 function createManualScheduler(): { records: ScheduledRecord[]; scheduler: CronScheduler } {
   const records: ScheduledRecord[] = [];
   const scheduler: CronScheduler = (expression, options, callback): CronScheduledJob => {
@@ -226,7 +241,8 @@ describe('@fluojs/cron', () => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await settleCronTeardown();
     vi.useRealTimers();
   });
 
@@ -365,7 +381,7 @@ describe('@fluojs/cron', () => {
 
     expect(store.count).toBe(1);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('isolates task errors so a failing cron task does not block others', async () => {
@@ -417,7 +433,7 @@ describe('@fluojs/cron', () => {
     expect(store.count).toBe(1);
     expect(loggerEvents.some((event) => event.includes('Cron task failing-task failed.'))).toBe(true);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('stops all scheduled jobs during application shutdown', async () => {
@@ -438,7 +454,7 @@ describe('@fluojs/cron', () => {
 
     expect(scheduled.records).toHaveLength(1);
 
-    await app.close();
+    await closeApplication(app);
 
     expect(scheduled.records[0]?.stop).toHaveBeenCalledTimes(1);
   });
@@ -516,7 +532,7 @@ describe('@fluojs/cron', () => {
       ),
     ).toBe(true);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('warns when @Cron() is declared on non-singleton controllers and skips scheduling', async () => {
@@ -565,7 +581,7 @@ describe('@fluojs/cron', () => {
       ),
     ).toBe(true);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('uses distributed Redis locking so only one app executes the same task tick', async () => {
@@ -751,7 +767,7 @@ describe('@fluojs/cron', () => {
 
     expect((await app.container.resolve(Store)).runs).toBe(1);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('releases owned distributed locks during shutdown so another node can continue', async () => {
@@ -874,7 +890,7 @@ describe('@fluojs/cron', () => {
     await vi.advanceTimersByTimeAsync(200);
     expect(store.count).toBe(1);
 
-    await app.close();
+    await closeApplication(app);
 
     await vi.advanceTimersByTimeAsync(2_000);
     expect(store.count).toBe(1);
@@ -957,7 +973,7 @@ describe('@fluojs/cron', () => {
 
     expect(events).toEqual(['before', 'run', 'success', 'after']);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('runs error lifecycle hooks when cron task fails', async () => {
@@ -995,7 +1011,7 @@ describe('@fluojs/cron', () => {
 
     expect(events).toEqual(['before', 'run', 'error:hook boom', 'after']);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('runs onError and afterRun when beforeRun throws', async () => {
@@ -1036,7 +1052,7 @@ describe('@fluojs/cron', () => {
 
     expect(events).toEqual(['before', 'error:before boom', 'after']);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('keeps afterRun deterministic when onError throws', async () => {
@@ -1078,7 +1094,7 @@ describe('@fluojs/cron', () => {
     expect(events).toEqual(['before', 'error:before boom', 'after']);
     expect(loggerEvents.some((event) => event.includes('Cron onError hook on-error-throwing-task failed.'))).toBe(true);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('treats lock ownership loss during renewal as a failed tick', async () => {
@@ -1145,7 +1161,7 @@ describe('@fluojs/cron', () => {
       'after',
     ]);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('treats lock renewal errors as a failed tick', async () => {
@@ -1212,7 +1228,7 @@ describe('@fluojs/cron', () => {
       'after',
     ]);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('logs successful distributed lock renewals and releases for operational tracing', async () => {
@@ -1267,7 +1283,7 @@ describe('@fluojs/cron', () => {
     expect(loggerEvents.some((event) => event.includes('log:CronLifecycleService:Renewed distributed cron lock for lock-trace-task.'))).toBe(true);
     expect(loggerEvents.some((event) => event.includes('log:CronLifecycleService:Released distributed cron lock for lock-trace-task.'))).toBe(true);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('awaits in-flight lock renewal attempts before deciding task success', async () => {
@@ -1337,7 +1353,7 @@ describe('@fluojs/cron', () => {
       'after',
     ]);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('evaluates due lock renewal even when interval callback has not fired yet', async () => {
@@ -1404,7 +1420,7 @@ describe('@fluojs/cron', () => {
       'after',
     ]);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('renews distributed locks before the minimum supported ttl expires', async () => {
@@ -1468,7 +1484,7 @@ describe('@fluojs/cron', () => {
     expect(redis.renewalCalls).toBeGreaterThanOrEqual(1);
     expect(events).toEqual(['run', 'success', 'after']);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('schedules @Interval() and @Timeout() tasks through lifecycle bootstrap', async () => {
@@ -1514,7 +1530,7 @@ describe('@fluojs/cron', () => {
     await vi.advanceTimersByTimeAsync(1_000);
     expect(store.timeoutCount).toBe(1);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('fails bootstrap on duplicate task names across cron/interval/timeout decorators', async () => {
@@ -1583,7 +1599,7 @@ describe('@fluojs/cron', () => {
     expect(registry.remove('dynamic-timeout')).toBe(true);
     expect(registry.get('dynamic-timeout')).toBeUndefined();
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('keeps timeout definitions in registry after firing and allows re-enable with full delay', async () => {
@@ -1655,7 +1671,7 @@ describe('@fluojs/cron', () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(store.intervalCount).toBe(1);
 
-    await app.close();
+    await closeApplication(app);
 
     await vi.advanceTimersByTimeAsync(5_000);
     expect(store.intervalCount).toBe(1);
@@ -1708,6 +1724,7 @@ describe('@fluojs/cron', () => {
 
     await vi.advanceTimersByTimeAsync(1);
     await closePromise;
+    await settleCronTeardown();
 
     expect(closeResolved).toBe(true);
     expect(scheduled.records[0]?.stop).toHaveBeenCalledTimes(1);
@@ -1788,8 +1805,13 @@ describe('@fluojs/cron', () => {
 
     expect(storeOne.count + storeTwo.count).toBe(1);
 
-    await appOne.close();
-    await appTwo.close();
+    await closeApplication(appOne);
+    await closeApplication(appTwo);
+    const countAfterShutdown = storeOne.count + storeTwo.count;
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(storeOne.count + storeTwo.count).toBe(countAfterShutdown);
   });
 
   it('warns and skips @Interval/@Timeout on non-singleton providers', async () => {

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Inject, Scope } from '@fluojs/core';
 import { defineControllerMetadata } from '@fluojs/core/internal';
@@ -40,6 +40,26 @@ function createDeferred<T = void>() {
   return { promise, reject, resolve };
 }
 
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function settleEventBusTeardown(): Promise<void> {
+  await flushAsyncWork();
+
+  if (vi.isFakeTimers()) {
+    await vi.runOnlyPendingTimersAsync();
+  }
+
+  await flushAsyncWork();
+}
+
+async function closeApplication(app: { close(): Promise<void> }): Promise<void> {
+  await app.close();
+  await settleEventBusTeardown();
+}
+
 class UserCreatedEvent {
   constructor(public readonly userId: string) {}
 }
@@ -55,6 +75,15 @@ class PasswordResetEvent {
 }
 
 describe('@fluojs/event-bus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await settleEventBusTeardown();
+    vi.useRealTimers();
+  });
+
   it('writes event metadata from @OnEvent() using standard decorators', () => {
     class EventHandler {
       @OnEvent(UserCreatedEvent)
@@ -255,8 +284,10 @@ describe('@fluojs/event-bus', () => {
   });
 
   it('keeps publish bounded and predictable with mixed success, failure, and hanging handlers', async () => {
+    vi.useFakeTimers();
     const loggerEvents: string[] = [];
     const gate = createDeferred<void>();
+    const completed = createDeferred<void>();
 
     class EventStore {
       successCalls = 0;
@@ -283,6 +314,7 @@ describe('@fluojs/event-bus', () => {
       @OnEvent(UserCreatedEvent)
       async onUserCreated(_event: UserCreatedEvent) {
         await gate.promise;
+        completed.resolve();
       }
     }
 
@@ -299,18 +331,25 @@ describe('@fluojs/event-bus', () => {
     const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
     const store = await app.container.resolve(EventStore);
 
-    await expect(eventBus.publish(new UserCreatedEvent('user-2-timeout'))).resolves.toBeUndefined();
+    const publishPromise = eventBus.publish(new UserCreatedEvent('user-2-timeout'));
+
+    await flushAsyncWork();
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(publishPromise).resolves.toBeUndefined();
 
     expect(store.successCalls).toBe(1);
     expect(loggerEvents.some((event) => event.includes('Event handler FailingHandler.onUserCreated failed.'))).toBe(true);
     expect(loggerEvents.some((event) => event.includes('exceeded publish timeout of 20ms.'))).toBe(true);
 
     gate.resolve();
-    await app.close();
+    await completed.promise;
+    await closeApplication(app);
   });
 
   it('supports non-blocking publish option without waiting for handler completion', async () => {
     const gate = createDeferred<void>();
+    const started = createDeferred<void>();
+    const completed = createDeferred<void>();
 
     class EventStore {
       completedCalls = 0;
@@ -324,8 +363,10 @@ describe('@fluojs/event-bus', () => {
       @OnEvent(UserCreatedEvent)
       async onUserCreated(_event: UserCreatedEvent) {
         this.store.startedCalls += 1;
+        started.resolve();
         await gate.promise;
         this.store.completedCalls += 1;
+        completed.resolve();
       }
     }
 
@@ -343,22 +384,25 @@ describe('@fluojs/event-bus', () => {
       eventBus.publish(new UserCreatedEvent('user-non-blocking'), { waitForHandlers: false }),
     ).resolves.toBeUndefined();
 
-    await Promise.resolve();
+    await started.promise;
 
     expect(store.startedCalls).toBe(1);
     expect(store.completedCalls).toBe(0);
 
     gate.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await completed.promise;
 
     expect(store.completedCalls).toBe(1);
 
-    await app.close();
+    await closeApplication(app);
   });
 
   it('does not apply timeout bounds when publish is non-blocking', async () => {
+    vi.useFakeTimers();
     const loggerEvents: string[] = [];
     const gate = createDeferred<void>();
+    const started = createDeferred<void>();
+    const completed = createDeferred<void>();
 
     class EventStore {
       startedCalls = 0;
@@ -371,7 +415,9 @@ describe('@fluojs/event-bus', () => {
       @OnEvent(UserCreatedEvent)
       async onUserCreated(_event: UserCreatedEvent) {
         this.store.startedCalls += 1;
+        started.resolve();
         await gate.promise;
+        completed.resolve();
       }
     }
 
@@ -389,13 +435,15 @@ describe('@fluojs/event-bus', () => {
     const store = await app.container.resolve(EventStore);
 
     await expect(eventBus.publish(new UserCreatedEvent('user-non-blocking-timeout'))).resolves.toBeUndefined();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await started.promise;
+    await vi.advanceTimersByTimeAsync(20);
 
     expect(store.startedCalls).toBe(1);
     expect(loggerEvents.some((event) => event.includes('exceeded publish timeout'))).toBe(false);
 
     gate.resolve();
-    await app.close();
+    await completed.promise;
+    await closeApplication(app);
   });
 
   it('supports publish cancellation signal before handler dispatch', async () => {
@@ -827,6 +875,7 @@ describe('@fluojs/event-bus', () => {
 
     it('does not block on transport.publish() when waitForHandlers is false', async () => {
       const gate = createDeferred<void>();
+      const completed = createDeferred<void>();
       const transport = {
         publishCompleted: false,
         published: [] as Array<{ channel: string; payload: unknown }>,
@@ -834,6 +883,7 @@ describe('@fluojs/event-bus', () => {
           this.published.push({ channel, payload });
           await gate.promise;
           this.publishCompleted = true;
+          completed.resolve();
         },
         async subscribe(_channel: string, _handler: (payload: unknown) => Promise<void>) {},
         async close() {},
@@ -858,11 +908,11 @@ describe('@fluojs/event-bus', () => {
       expect(transport.publishCompleted).toBe(false);
 
       gate.resolve();
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await completed.promise;
 
       expect(transport.publishCompleted).toBe(true);
 
-      await app.close();
+      await closeApplication(app);
     });
 
     it('subscribes to a channel per discovered local handler event type on bootstrap', async () => {
@@ -1243,8 +1293,43 @@ describe('@fluojs/event-bus', () => {
       const app = await bootstrapApplication({ rootModule: AppModule });
 
       expect(transport.closeCalls).toBe(0);
-      await app.close();
+      await closeApplication(app);
       expect(transport.closeCalls).toBe(1);
+    });
+
+    it('awaits transport.close() before shutdown resolves', async () => {
+      const releaseClose = createDeferred<void>();
+      let closeStarted = false;
+      const transport = {
+        async close() {
+          closeStarted = true;
+          await releaseClose.promise;
+        },
+        async publish(_channel: string, _payload: unknown) {},
+        async subscribe(_channel: string, _handler: (payload: unknown) => Promise<void>) {},
+      } satisfies EventBusTransport;
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [EventBusModule.forRoot({ transport })],
+      });
+
+      const app = await bootstrapApplication({ rootModule: AppModule });
+      let shutdownResolved = false;
+      const closePromise = app.close().then(() => {
+        shutdownResolved = true;
+      });
+
+      await flushAsyncWork();
+
+      expect(closeStarted).toBe(true);
+      expect(shutdownResolved).toBe(false);
+
+      releaseClose.resolve();
+      await closePromise;
+      await settleEventBusTeardown();
+
+      expect(shutdownResolved).toBe(true);
     });
 
     it('does not call transport when no transport is configured (backward compat)', async () => {

--- a/packages/event-bus/src/transports/redis-transport.test.ts
+++ b/packages/event-bus/src/transports/redis-transport.test.ts
@@ -118,6 +118,21 @@ describe('RedisEventBusTransport', () => {
     expect(subscribeClient.messageListeners).toHaveLength(0);
   });
 
+  it('ignores late messages after close detaches transport listeners', async () => {
+    const transport = new RedisEventBusTransport({
+      publishClient: new MockRedisClient() as never,
+      subscribeClient: new MockRedisClient() as never,
+    });
+    const handler = vi.fn(async (_payload: unknown) => undefined);
+    const subscribeClient = (transport as unknown as { subscribeClient: MockRedisClient }).subscribeClient;
+
+    await transport.subscribe('AuditEvent', handler);
+    await transport.close();
+    subscribeClient.emitMessage('AuditEvent', JSON.stringify({ ignored: true }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it('still detaches listeners when unsubscribe fails during close', async () => {
     const publishClient = new MockRedisClient();
     const subscribeClient = new MockRedisClient();


### PR DESCRIPTION
## Summary
- make `packages/cron/src/module.test.ts` settle fake-timer shutdown work explicitly and assert no additional interval work runs after both distributed test apps close
- make `packages/event-bus/src/module.test.ts` use deterministic fake-timer and deferred completion control for bounded publish/non-blocking publish teardown paths
- add transport-close regressions in `packages/event-bus/src/module.test.ts` and `packages/event-bus/src/transports/redis-transport.test.ts` so shutdown waits for `transport.close()` and ignores late messages after close

## Changes
- add package-local teardown helpers for fake timers and queued async work in the cron and event-bus hotspot suites
- replace timing sleeps with deferred completion checks in non-blocking/event timeout tests
- extend transport cleanup coverage without changing runtime implementation behavior

## Testing
- `FLUO_VITEST_SHUTDOWN_DEBUG=1 pnpm exec vitest run packages/cron/src/module.test.ts`
- `FLUO_VITEST_SHUTDOWN_DEBUG=1 pnpm exec vitest run packages/event-bus/src/module.test.ts`
- `FLUO_VITEST_SHUTDOWN_DEBUG=1 pnpm exec vitest run packages/event-bus/src/transports/redis-transport.test.ts`
- `pnpm typecheck`
- `pnpm build`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1137