### PR TITLE
Resolve #1144: make empty split Vitest projects pass cleanly

### DIFF
--- a/docs/operations/testing-guide.ko.md
+++ b/docs/operations/testing-guide.ko.md
@@ -116,6 +116,7 @@ await app.close();
 - 이 Vitest 통합은 실행이 unhandled error로 끝나거나 `onProcessTimeout`에 걸릴 때 현재 실행(current-run)의 JSON evidence를 남기며, 마지막 active module/test와 active handle/request class 요약을 함께 기록합니다.
 - worker 프로세스도 signal-time snapshot을 남기므로, 메인 프로세스가 워커를 정리할 때 CI가 해당 워커의 마지막 file/suite/test 문맥을 보존할 수 있습니다.
 - canonical full-suite CI 경로는 이제 workspace Vitest project(`packages`, `apps`, `examples`, `tooling`)를 각각 `pnpm vitest run --project ...`로 분리 실행하므로, 하나의 shutdown leak 때문에 전체 workspace가 단일 장수 실행으로 묶이지 않게 합니다.
+- 분리된 workspace project가 의도적으로 비어 있다면 해당 Vitest project에 `passWithNoTests: true`를 설정하여 `pnpm vitest run --project ...`가 녹색 상태를 유지하고 monolithic workspace test command로 되돌아가지 않도록 합니다.
 - CI는 `.artifacts/vitest-shutdown-debug/` 아래 project별 하위 디렉터리에 attribution artifact를 저장해 #1134 evidence path를 유지하면서도 각 workspace project의 shutdown trace를 분리 보존합니다.
 
 이 경로는 attribution 전용으로 취급해야 합니다. 특정 leak 또는 teardown contract를 겨냥한 후속 이슈 전까지는 runtime behavior, pool 선택, timeout 값은 보존하십시오.

--- a/docs/operations/testing-guide.md
+++ b/docs/operations/testing-guide.md
@@ -116,6 +116,7 @@ The canonical CI attribution path for the recurring Vitest worker-timeout shutdo
 - The Vitest integration writes current-run JSON evidence when the run ends with unhandled errors or hits `onProcessTimeout`, including the last active module/test and active handle/request class summaries.
 - Worker processes also emit a signal-time snapshot so CI can preserve the lingering worker's final file/suite/test context when the main process tears it down.
 - The canonical full-suite CI path now runs the workspace Vitest projects (`packages`, `apps`, `examples`, `tooling`) as separate `pnpm vitest run --project ...` invocations so one shutdown leak does not collapse the entire workspace into a single long-lived run.
+- If a split workspace project is intentionally empty, set `passWithNoTests: true` on that Vitest project so `pnpm vitest run --project ...` stays green without collapsing back to a monolithic workspace test command.
 - CI stores attribution artifacts under per-project subdirectories of `.artifacts/vitest-shutdown-debug/` to preserve the #1134 evidence path while keeping each workspace project's shutdown traces isolated.
 
 Treat this path as attribution only: preserve runtime behavior, pool selection, and timeout values until a follow-up issue is targeting a specific leak or teardown contract.

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -183,6 +183,7 @@ describe('platform consistency governance docs', () => {
 
   it('keeps PR CI governance-gated while reserving release-readiness for main pushes', () => {
     const ciWorkflow = readFileSync(resolve(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+    const vitestConfig = readFileSync(resolve(repoRoot, 'vitest.config.ts'), 'utf8');
 
     expect(ciWorkflow).toContain('resolve-pr-verification-scope:');
     expect(ciWorkflow).toContain('run: node tooling/ci/detect-pr-verification-scope.mjs');
@@ -198,6 +199,7 @@ describe('platform consistency governance docs', () => {
     expect(ciWorkflow).toContain('FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug/packages');
     expect(ciWorkflow).toContain('FLUO_VITEST_SHUTDOWN_DEBUG_DIR: .artifacts/vitest-shutdown-debug/tooling');
     expect(ciWorkflow).toContain("hashFiles('.artifacts/vitest-shutdown-debug/**/*.json') != ''");
+    expect(vitestConfig).toContain('passWithNoTests: true');
     expect(ciWorkflow).toContain('build-and-typecheck:');
     expect(ciWorkflow).toContain("if: github.event_name == 'pull_request'");
     expect(ciWorkflow).toContain('verify-platform-consistency-governance');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default mergeConfig(
   createFluoVitestWorkspaceConfig(new URL('.', import.meta.url)),
   defineConfig({
     test: {
+      passWithNoTests: true,
       projects: [
         {
           extends: true,


### PR DESCRIPTION
## 요약
- `vitest.config.ts`의 공유 Vitest 설정에 `passWithNoTests: true`를 추가해, split full-suite 경로에서 테스트 파일이 0개인 프로젝트가 실패하지 않도록 했습니다.
- 거버넌스 테스트로 이 CI 계약을 고정했습니다.
- `docs/operations/testing-guide.md` / `.ko.md`에 빈 split 프로젝트의 canonical contract를 문서화했습니다.

## 검증
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run --project apps`
- `pnpm exec vitest run packages/testing/src/conformance/platform-consistency-governance-docs.test.ts`

## 계약 영향
- 분리 실행 모델은 유지합니다.
- `apps`처럼 테스트 파일이 0개인 split 프로젝트는 이제 harmless하게 통과합니다.

Closes #1144