### PR TITLE
Resolve #1147: isolate the packages Vitest worker-timeout hotspot

### DIFF
--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -1,4 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -11,7 +13,6 @@ import * as portability from './portability/http-adapter-portability.js';
 import * as webPortability from './portability/web-runtime-adapter-portability.js';
 import * as conformance from './conformance/platform-conformance.js';
 import * as fetchStyleWebsocket from './conformance/fetch-style-websocket-conformance.js';
-import { runWorkspaceBuildClosure } from '../../../tooling/scripts/run-workspace-build-closure.mjs';
 
 const packageRoot = new URL('..', import.meta.url);
 const packageRootPath = fileURLToPath(packageRoot);
@@ -24,10 +25,37 @@ const emittedHarnessSubpaths = [
   './fetch-style-websocket-conformance',
 ] as const;
 
-function runBuild(): void {
-  const result = runWorkspaceBuildClosure('@fluojs/testing', repoRootPath);
+async function runBuild(): Promise<void> {
+  const scriptPath = fileURLToPath(new URL('../../../tooling/scripts/run-workspace-build-closure.mjs', import.meta.url));
 
-  expect(result.status, [result.stdout, result.stderr].filter(Boolean).join('\n')).toBe(0);
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [scriptPath, '@fluojs/testing'], {
+      cwd: repoRootPath,
+      env: process.env,
+      stdio: 'pipe',
+    });
+    const childEvents = child as unknown as NodeJS.EventEmitter;
+
+    let stderr = '';
+    let stdout = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk);
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    void once(childEvents, 'error').then(([error]) => {
+      reject(error);
+    });
+
+    void once(childEvents, 'exit').then(([code, signal]) => {
+      expect(code, [stdout, stderr, signal ? `signal: ${signal}` : ''].filter(Boolean).join('\n')).toBe(0);
+      resolvePromise();
+    });
+  });
 }
 
 describe('@fluojs/testing surface', () => {
@@ -84,8 +112,8 @@ describe('@fluojs/testing surface', () => {
     expect(readFileSync(resolve(packageRootPath, 'README.ko.md'), 'utf8')).toContain('pnpm add -D @babel/core');
   });
 
-  it('build emits the published harness subpath files', () => {
-    runBuild();
+  it('build emits the published harness subpath files without blocking the Vitest worker event loop', async () => {
+    await runBuild();
 
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
       exports: Record<string, { import: string; types: string }>;


### PR DESCRIPTION
## Summary
- Use the current `packages` shutdown evidence from run `24494297229` to isolate the residual hotspot instead of reopening unrelated teardown fixes.
- Keep `packages/testing/src/surface.test.ts` coverage intact, but move the workspace build-closure execution into a child process so the Vitest worker event loop is not blocked during the long build proof.
- Preserve scope to the residual packages-project flake only; no runtime contract or CI orchestration behavior changes.

## Changes
- Replace the synchronous in-worker `runWorkspaceBuildClosure('@fluojs/testing', ...)` call in `packages/testing/src/surface.test.ts` with an async child-process invocation of `tooling/scripts/run-workspace-build-closure.mjs`.
- Keep the published harness subpath assertions, but rename the test to document the worker-event-loop intent.

## Evidence
- Current CI shutdown artifact: `vitest-shutdown-debug-24494297229-1/packages/run-end.json`
- The `packages` run ended with `reason: passed`, but `packages/testing/src/surface.test.ts` was the dominant hotspot at `duration: 61999.29708900001` ms.
- The matching worker snapshot `worker-4925-sigterm.json` points to `packages/testing/src/surface.test.ts` in `afterAll` with only stdio/pipe handles, which supports a worker-responsiveness hotspot rather than a fresh leaked-server path.

## Testing
- `pnpm vitest run --project packages packages/testing/src/surface.test.ts`
- `pnpm vitest run --project tooling tooling/scripts/run-workspace-build-closure.test.ts`
- `FLUO_VITEST_SHUTDOWN_DEBUG=1 FLUO_VITEST_SHUTDOWN_DEBUG_DIR=.artifacts/vitest-shutdown-debug/packages-postfix pnpm vitest run --project packages`
- `pnpm --filter @fluojs/testing run typecheck`
- `pnpm --filter @fluojs/testing run build`
- `pnpm typecheck` *(currently still fails in unrelated pre-existing packages: `@fluojs/discord`, `@fluojs/cqrs`, `@fluojs/cron`, `@fluojs/cache-manager`)*

## Behavioral contract
- No documented runtime contract changes.
- This PR keeps scope to the residual packages-project Vitest worker-timeout flake only.

Refs #1147