### PR TITLE
Resolve #1155: narrow graphql root registration surface

### DIFF
--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -141,6 +141,7 @@ GraphqlModule.forRoot({
 ## 공개 API 개요
 
 - `GraphqlModule.forRoot(options)`: GraphQL 통합을 위한 메인 엔트리 포인트.
+- 루트 수준의 등록 계약은 의도적으로 `GraphqlModule.forRoot(...)`에만 맞춰져 있으며, `createGraphqlProviders(...)` 같은 저수준 provider helper는 문서화된 root barrel 계약에 포함되지 않습니다.
 - `Resolver`, `Query`, `Mutation`, `Subscription`: 작업 데코레이터.
 - `Arg`: 인자 매핑 데코레이터.
 - `createDataLoader`, `createDataLoaderMap`: DataLoader 팩토리 헬퍼.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -141,6 +141,7 @@ GraphqlModule.forRoot({
 ## Public API Overview
 
 - `GraphqlModule.forRoot(options)`: Main entry point for GraphQL integration.
+- Root-level registration support is intentionally centered on `GraphqlModule.forRoot(...)`; low-level provider helpers like `createGraphqlProviders(...)` are not part of the documented root-barrel contract.
 - `Resolver`, `Query`, `Mutation`, `Subscription`: Operation decorators.
 - `Arg`: Argument mapping decorator.
 - `createDataLoader`, `createDataLoaderMap`: DataLoader factory helpers.

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,6 +1,6 @@
 export * from './dataloader.js';
 export * from './decorators.js';
-export * from './module.js';
+export { GraphqlModule } from './module.js';
 export {
   isGraphqlListTypeRef,
   listOf,

--- a/packages/graphql/src/public-api.test.ts
+++ b/packages/graphql/src/public-api.test.ts
@@ -10,7 +10,6 @@ describe('@fluojs/graphql public API surface', () => {
     expect(graphqlPublicApi).toHaveProperty('Subscription');
     expect(graphqlPublicApi).toHaveProperty('Resolver');
     expect(graphqlPublicApi).toHaveProperty('GraphqlModule');
-    expect(graphqlPublicApi).toHaveProperty('createGraphqlProviders');
     expect(graphqlPublicApi).toHaveProperty('createDataLoader');
     expect(graphqlPublicApi).toHaveProperty('createDataLoaderMap');
     expect(graphqlPublicApi).toHaveProperty('DataLoader');
@@ -23,6 +22,10 @@ describe('@fluojs/graphql public API surface', () => {
   it('keeps GraphqlModule limited to the documented synchronous entrypoint', () => {
     expect(graphqlPublicApi.GraphqlModule).toHaveProperty('forRoot');
     expect(graphqlPublicApi.GraphqlModule).not.toHaveProperty('forRootAsync');
+  });
+
+  it('keeps low-level registration helpers out of the documented root barrel', () => {
+    expect(graphqlPublicApi).not.toHaveProperty('createGraphqlProviders');
   });
 
   it('does not expose internal metadata, lifecycle, or descriptor internals', () => {


### PR DESCRIPTION
Closes #1155

## Summary

Align `@fluojs/graphql` root-barrel registration exports with the documented package contract so applications are centered on `GraphqlModule.forRoot(...)` rather than a helper-only path.

## Changes

- narrow `packages/graphql/src/index.ts` to export `GraphqlModule` without re-exporting `createGraphqlProviders(...)` from the root barrel
- update `packages/graphql/src/public-api.test.ts` to lock the reduced root public surface in a regression test
- clarify the root registration contract in `packages/graphql/README.md` and `packages/graphql/README.ko.md`

## Testing

- `pnpm install`
- `pnpm --filter @fluojs/core --filter @fluojs/di --filter @fluojs/http --filter @fluojs/runtime --filter @fluojs/validation run build`
- `pnpm --filter @fluojs/graphql test`
- `pnpm --filter @fluojs/graphql typecheck`
- `pnpm --filter @fluojs/graphql build`
- `pnpm lint`
- `lsp_diagnostics` on `packages/graphql/src/index.ts` and `packages/graphql/src/public-api.test.ts`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.