### PR TITLE
Resolve #1153: introduce module-first public API for @fluojs/passport

### DIFF
--- a/book/chapters/chapter-12-auth-and-principal-flow.md
+++ b/book/chapters/chapter-12-auth-and-principal-flow.md
@@ -141,12 +141,18 @@ async canActivate(context: GuardContext): Promise<true> {
 
 ## auth module은 이 모든 조각을 어떻게 조립하는가
 
-`auth.module.ts`를 보면 발급, 검증, guard 연결이 한 providers 배열 안에 조립된다 `[ex:auth-jwt-passport/src/auth/auth.module.ts]`.
+`auth.module.ts`를 보면 발급, 검증, guard 연결이 auth module 안에서 조립된다 `[ex:auth-jwt-passport/src/auth/auth.module.ts]`.
 
 ```ts
 // source: ex:auth-jwt-passport/src/auth/auth.module.ts
 @Module({
   controllers: [AuthController, ProfileController],
+  imports: [
+    PassportModule.forRoot(
+      { defaultStrategy: 'jwt' },
+      [{ name: 'jwt', token: BearerJwtStrategy }],
+    ),
+  ],
   providers: [
     AuthService,
     BearerJwtStrategy,
@@ -157,16 +163,12 @@ async canActivate(context: GuardContext): Promise<true> {
       issuer: 'fluo-auth-example',
       secret: 'fluo-auth-example-secret',
     }),
-    ...createPassportProviders(
-      { defaultStrategy: 'jwt' },
-      [{ name: 'jwt', token: BearerJwtStrategy }],
-    ),
   ],
 })
 export class AuthModule {}
 ```
 
-이 코드는 auth 장의 중요한 메시지를 담고 있다. JWT core provider와 passport strategy provider는 별개지만, auth module 안에서 함께 조립된다. 즉, 인증은 한 클래스의 책임이 아니라 **여러 provider contract를 한 모듈 안에서 조합하는 문제**다.
+이 코드는 auth 장의 중요한 메시지를 담고 있다. JWT core provider와 passport strategy wiring은 별개지만, auth module 안에서 함께 조립된다. 즉, 인증은 한 클래스의 책임이 아니라 **여러 provider contract를 한 모듈 안에서 조합하는 문제**다.
 
 ## decorator는 auth requirement를 어떻게 기록하는가
 

--- a/examples/auth-jwt-passport/src/auth/auth.module.ts
+++ b/examples/auth-jwt-passport/src/auth/auth.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@fluojs/core';
 import { createJwtCoreProviders } from '@fluojs/jwt';
-import { createPassportProviders } from '@fluojs/passport';
+import { PassportModule } from '@fluojs/passport';
 
 import { AuthController, ProfileController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -8,6 +8,12 @@ import { BearerJwtStrategy } from './bearer.strategy';
 
 @Module({
   controllers: [AuthController, ProfileController],
+  imports: [
+    PassportModule.forRoot(
+      { defaultStrategy: 'jwt' },
+      [{ name: 'jwt', token: BearerJwtStrategy }],
+    ),
+  ],
   providers: [
     AuthService,
     BearerJwtStrategy,
@@ -18,10 +24,6 @@ import { BearerJwtStrategy } from './bearer.strategy';
       issuer: 'fluo-auth-example',
       secret: 'fluo-auth-example-secret',
     }),
-    ...createPassportProviders(
-      { defaultStrategy: 'jwt' },
-      [{ name: 'jwt', token: BearerJwtStrategy }],
-    ),
   ],
 })
 export class AuthModule {}

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -29,26 +29,28 @@ npm install @fluojs/passport
 
 ## 빠른 시작
 
-### 1. 프로바이더 등록
+### 1. 모듈 등록
 
-사용할 전략을 정의하고 `createPassportProviders`를 통해 등록합니다.
+사용할 전략을 정의하고 `PassportModule.forRoot(...)`를 통해 등록합니다.
 
 ```typescript
 import { Module } from '@fluojs/core';
-import { createPassportProviders } from '@fluojs/passport';
+import { PassportModule } from '@fluojs/passport';
 import { MyJwtStrategy } from './jwt.strategy';
 
 @Module({
-  providers: [
-    MyJwtStrategy,
-    ...createPassportProviders(
+  imports: [
+    PassportModule.forRoot(
       { defaultStrategy: 'jwt' },
       [{ name: 'jwt', token: MyJwtStrategy }]
     ),
   ],
+  providers: [MyJwtStrategy],
 })
 export class AuthModule {}
 ```
+
+`PassportModule.forRoot(...)`가 표준 public entrypoint입니다. 이미 존재하는 모듈 안에서 더 낮은 수준의 provider 조합이 필요할 때만 `createPassportProviders(...)`를 호환 shim으로 사용하세요.
 
 ### 2. 라우트 보호
 
@@ -81,6 +83,31 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 });
 ```
 
+### 쿠키 인증 프리셋
+
+HTTP 쿠키에서 인증 정보를 읽는 애플리케이션이라면 `CookieAuthModule.forRoot(...)`를 사용합니다.
+
+```typescript
+import { Module } from '@fluojs/core';
+import {
+  CookieAuthModule,
+  CookieAuthStrategy,
+  COOKIE_AUTH_STRATEGY_NAME,
+  PassportModule,
+} from '@fluojs/passport';
+
+@Module({
+  imports: [
+    CookieAuthModule.forRoot(),
+    PassportModule.forRoot(
+      { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
+      [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
+    ),
+  ],
+})
+export class AuthModule {}
+```
+
 ### 리프레시 토큰 수명 주기
 
 패키지에서 제공하는 `RefreshTokenStrategy`와 `RefreshTokenService`를 사용하여 안전한 토큰 로테이션 및 폐기 기능을 구현할 수 있습니다.
@@ -88,13 +115,23 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 ```typescript
 import { Module } from '@fluojs/core';
 import { Controller, Post, type RequestContext } from '@fluojs/http';
-import { UseAuth, createRefreshTokenProviders } from '@fluojs/passport';
+import {
+  PassportModule,
+  REFRESH_TOKEN_STRATEGY_NAME,
+  RefreshTokenModule,
+  RefreshTokenStrategy,
+  UseAuth,
+} from '@fluojs/passport';
 
 @Module({
-  providers: [
-    MyRefreshTokenService,
-    ...createRefreshTokenProviders(MyRefreshTokenService),
+  imports: [
+    RefreshTokenModule.forRoot(MyRefreshTokenService),
+    PassportModule.forRoot(
+      { defaultStrategy: REFRESH_TOKEN_STRATEGY_NAME },
+      [{ name: REFRESH_TOKEN_STRATEGY_NAME, token: RefreshTokenStrategy }],
+    ),
   ],
+  providers: [MyRefreshTokenService],
 })
 export class AuthModule {}
 
@@ -108,7 +145,7 @@ export class AuthController {
 }
 ```
 
-`createRefreshTokenProviders(...)`는 표준 DI alias provider를 반환하므로, `REFRESH_TOKEN_SERVICE`를 해석하면 등록한 구체 서비스 인스턴스와 동일한 객체를 받게 됩니다.
+`RefreshTokenModule.forRoot(...)`가 표준 프리셋 진입점입니다. 고급 조합이 필요할 때는 `createRefreshTokenProviders(...)`를 계속 사용할 수 있으며, 이 경우에도 `REFRESH_TOKEN_SERVICE`를 해석하면 등록한 구체 서비스 인스턴스와 동일한 객체를 받게 됩니다.
 
 ## 공개 API 개요
 
@@ -117,8 +154,11 @@ export class AuthController {
 - `@RequireScopes(...scopes)`: 특정 권한(스코프) 요구 사항을 강제합니다.
 
 ### 주요 클래스
+- `PassportModule`: passport 전략 wiring을 위한 표준 module-first 진입점입니다.
 - `AuthGuard`: 전략 체인을 실행하는 HTTP 가드입니다.
+- `CookieAuthModule`: 내장 cookie-auth 프리셋의 모듈 진입점입니다.
 - `CookieManager`: HttpOnly 인증 쿠키 관리를 위한 유틸리티입니다.
+- `RefreshTokenModule`: 내장 refresh-token 프리셋의 모듈 진입점입니다.
 - `JwtRefreshTokenAdapter`: `@fluojs/jwt`의 리프레시 로직을 패스포트 인터페이스로 연결합니다.
 
 ### 인터페이스

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -108,6 +108,8 @@ import {
 export class AuthModule {}
 ```
 
+`CookieAuthModule.forRoot(...)`가 표준 프리셋 진입점입니다. 이미 존재하는 모듈 정의 안에서 cookie preset provider를 수동으로 조합해야 할 때는 `createCookieAuthProviders(...)`를 호환 shim으로 계속 사용할 수 있습니다.
+
 ### 리프레시 토큰 수명 주기
 
 패키지에서 제공하는 `RefreshTokenStrategy`와 `RefreshTokenService`를 사용하여 안전한 토큰 로테이션 및 폐기 기능을 구현할 수 있습니다.

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -29,26 +29,28 @@ npm install @fluojs/passport
 
 ## Quick Start
 
-### 1. Register Providers
+### 1. Register Modules
 
-Define your strategies and register them using `createPassportProviders`.
+Define your strategies and register them using `PassportModule.forRoot(...)`.
 
 ```typescript
 import { Module } from '@fluojs/core';
-import { createPassportProviders } from '@fluojs/passport';
+import { PassportModule } from '@fluojs/passport';
 import { MyJwtStrategy } from './jwt.strategy';
 
 @Module({
-  providers: [
-    MyJwtStrategy,
-    ...createPassportProviders(
+  imports: [
+    PassportModule.forRoot(
       { defaultStrategy: 'jwt' },
       [{ name: 'jwt', token: MyJwtStrategy }]
     ),
   ],
+  providers: [MyJwtStrategy],
 })
 export class AuthModule {}
 ```
+
+`PassportModule.forRoot(...)` is the canonical public entrypoint. `createPassportProviders(...)` remains available as a compatibility shim when you need lower-level provider composition inside an existing module definition.
 
 ### 2. Protect Routes
 
@@ -81,6 +83,31 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 });
 ```
 
+### Cookie Auth Preset
+
+Use `CookieAuthModule.forRoot(...)` when your app authenticates requests from HTTP cookies.
+
+```typescript
+import { Module } from '@fluojs/core';
+import {
+  CookieAuthModule,
+  CookieAuthStrategy,
+  COOKIE_AUTH_STRATEGY_NAME,
+  PassportModule,
+} from '@fluojs/passport';
+
+@Module({
+  imports: [
+    CookieAuthModule.forRoot(),
+    PassportModule.forRoot(
+      { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
+      [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
+    ),
+  ],
+})
+export class AuthModule {}
+```
+
 ### Refresh Token Lifecycle
 
 The package provides a built-in `RefreshTokenStrategy` and `RefreshTokenService` to handle secure token rotation and revocation.
@@ -88,13 +115,23 @@ The package provides a built-in `RefreshTokenStrategy` and `RefreshTokenService`
 ```typescript
 import { Module } from '@fluojs/core';
 import { Controller, Post, type RequestContext } from '@fluojs/http';
-import { UseAuth, createRefreshTokenProviders } from '@fluojs/passport';
+import {
+  PassportModule,
+  REFRESH_TOKEN_STRATEGY_NAME,
+  RefreshTokenModule,
+  RefreshTokenStrategy,
+  UseAuth,
+} from '@fluojs/passport';
 
 @Module({
-  providers: [
-    MyRefreshTokenService,
-    ...createRefreshTokenProviders(MyRefreshTokenService),
+  imports: [
+    RefreshTokenModule.forRoot(MyRefreshTokenService),
+    PassportModule.forRoot(
+      { defaultStrategy: REFRESH_TOKEN_STRATEGY_NAME },
+      [{ name: REFRESH_TOKEN_STRATEGY_NAME, token: RefreshTokenStrategy }],
+    ),
   ],
+  providers: [MyRefreshTokenService],
 })
 export class AuthModule {}
 
@@ -108,7 +145,7 @@ export class AuthController {
 }
 ```
 
-`createRefreshTokenProviders(...)` returns standard DI alias providers, so resolving `REFRESH_TOKEN_SERVICE` yields the same concrete service instance you registered.
+`RefreshTokenModule.forRoot(...)` is the canonical preset entrypoint. `createRefreshTokenProviders(...)` still returns the DI alias provider for advanced composition, so resolving `REFRESH_TOKEN_SERVICE` yields the same concrete service instance you registered.
 
 ## Public API Overview
 
@@ -117,8 +154,11 @@ export class AuthController {
 - `@RequireScopes(...scopes)`: Enforces specific scope requirements.
 
 ### Core Classes
+- `PassportModule`: Canonical module-first entry point for passport strategy wiring.
 - `AuthGuard`: The HTTP guard that executes the strategy chain.
+- `CookieAuthModule`: Module entry point for the built-in cookie-auth preset.
 - `CookieManager`: Utility for managing HttpOnly auth cookies.
+- `RefreshTokenModule`: Module entry point for the built-in refresh-token preset.
 - `JwtRefreshTokenAdapter`: Bridges `@fluojs/jwt` refresh logic to the passport interface.
 
 ### Interfaces

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -108,6 +108,8 @@ import {
 export class AuthModule {}
 ```
 
+`CookieAuthModule.forRoot(...)` is the canonical preset entrypoint. `createCookieAuthProviders(...)` remains available as a compatibility shim when you need to compose the cookie preset providers manually inside an existing module definition.
+
 ### Refresh Token Lifecycle
 
 The package provides a built-in `RefreshTokenStrategy` and `RefreshTokenService` to handle secure token rotation and revocation.

--- a/packages/passport/src/cookie/cookie-auth-module.ts
+++ b/packages/passport/src/cookie/cookie-auth-module.ts
@@ -1,5 +1,5 @@
 import type { Provider } from '@fluojs/di';
-import { DefaultJwtVerifier } from '@fluojs/jwt';
+import { defineModule, type ModuleType } from '@fluojs/runtime';
 
 import {
   COOKIE_AUTH_OPTIONS,
@@ -10,11 +10,22 @@ import {
 import { CookieManager, type CookieManagerConfig } from './cookie-manager.js';
 import type { AuthStrategyRegistration } from '../types.js';
 
+type CookieAuthModuleType = ModuleType;
+
+/**
+ * Configures the built-in cookie-auth strategy and cookie manager preset.
+ */
 export interface CookieAuthPresetConfig {
   cookieAuth?: CookieAuthOptions;
   cookieManager?: CookieManagerConfig;
 }
 
+/**
+ * Creates the providers required by the built-in cookie-auth preset.
+ *
+ * @param config Optional cookie strategy and cookie manager configuration.
+ * @returns Provider definitions for `COOKIE_AUTH_OPTIONS`, `CookieAuthStrategy`, and `CookieManager`.
+ */
 export function createCookieAuthProviders(config?: CookieAuthPresetConfig): Provider[] {
   return [
     {
@@ -30,6 +41,11 @@ export function createCookieAuthProviders(config?: CookieAuthPresetConfig): Prov
   ];
 }
 
+/**
+ * Creates the passport strategy registration for the built-in cookie preset.
+ *
+ * @returns The named strategy registration consumed by `PassportModule.forRoot(...)`.
+ */
 export function createCookieAuthStrategyRegistration(): AuthStrategyRegistration {
   return {
     name: COOKIE_AUTH_STRATEGY_NAME,
@@ -37,6 +53,12 @@ export function createCookieAuthStrategyRegistration(): AuthStrategyRegistration
   };
 }
 
+/**
+ * Creates a compatibility preset bundle for manual provider composition.
+ *
+ * @param config Optional cookie strategy and cookie manager configuration.
+ * @returns The preset providers plus the matching cookie strategy registration.
+ */
 export function createCookieAuthPreset(config?: CookieAuthPresetConfig): {
   providers: Provider[];
   strategy: AuthStrategyRegistration;
@@ -45,4 +67,46 @@ export function createCookieAuthPreset(config?: CookieAuthPresetConfig): {
     providers: createCookieAuthProviders(config),
     strategy: createCookieAuthStrategyRegistration(),
   };
+}
+
+/**
+ * Canonical module-first entrypoint for the built-in cookie-auth preset.
+ */
+export class CookieAuthModule {
+  /**
+   * Registers the cookie-auth strategy and `CookieManager` preset as a module.
+   *
+   * @param config Optional cookie strategy and cookie manager configuration.
+   * @returns A module definition that exports `CookieAuthStrategy` and `CookieManager`.
+   *
+   * @example
+   * ```ts
+   * import { Module } from '@fluojs/core';
+   * import {
+   *   CookieAuthModule,
+   *   CookieAuthStrategy,
+   *   COOKIE_AUTH_STRATEGY_NAME,
+   *   PassportModule,
+   * } from '@fluojs/passport';
+   *
+   * @Module({
+   *   imports: [
+   *     CookieAuthModule.forRoot(),
+   *     PassportModule.forRoot(
+   *       { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
+   *       [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
+   *     ),
+   *   ],
+   * })
+   * export class AuthModule {}
+   * ```
+   */
+  static forRoot(config?: CookieAuthPresetConfig): CookieAuthModuleType {
+    class CookieAuthRuntimeModule extends CookieAuthModule {}
+
+    return defineModule(CookieAuthRuntimeModule, {
+      exports: [CookieAuthStrategy, CookieManager],
+      providers: createCookieAuthProviders(config),
+    });
+  }
 }

--- a/packages/passport/src/cookie/cookie-auth.test.ts
+++ b/packages/passport/src/cookie/cookie-auth.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getModuleMetadata } from '@fluojs/core/internal';
+
 import type { GuardContext, RequestContext } from '@fluojs/http';
 import type { DefaultJwtVerifier } from '@fluojs/jwt';
 
 import { CookieAuthStrategy, normalizeCookieAuthOptions } from './cookie-auth.js';
+import { CookieAuthModule, createCookieAuthProviders } from './cookie-auth-module.js';
 import { AuthenticationRequiredError } from '../errors.js';
 
 function createMockVerifier(overrides: Partial<DefaultJwtVerifier> = {}): DefaultJwtVerifier {
@@ -323,5 +326,27 @@ describe('CookieManager', () => {
     expect(cookies).toHaveLength(2);
     expect(cookies[0]).toContain('access_token=; Max-Age=0');
     expect(cookies[1]).toContain('refresh_token=; Max-Age=0');
+  });
+});
+
+describe('CookieAuthModule', () => {
+  it('creates a module-first runtime definition for the cookie preset', async () => {
+    const config = {
+      cookieAuth: { accessTokenCookieName: 'session' },
+    };
+    const moduleDefinition = CookieAuthModule.forRoot(config);
+
+    const metadata = getModuleMetadata(moduleDefinition);
+    const { CookieManager } = await import('./cookie-manager.js');
+    const expectedProviders = createCookieAuthProviders(config);
+
+    expect(metadata?.exports).toEqual([CookieAuthStrategy, CookieManager]);
+    expect(metadata?.providers).toHaveLength(expectedProviders.length);
+    expect(metadata?.providers?.[0]).toEqual(expectedProviders[0]);
+    expect(metadata?.providers?.[1]).toBe(CookieAuthStrategy);
+    expect(metadata?.providers?.[2]).toMatchObject({
+      inject: [],
+      provide: CookieManager,
+    });
   });
 });

--- a/packages/passport/src/decorators.ts
+++ b/packages/passport/src/decorators.ts
@@ -93,7 +93,7 @@ function createAuthRequirementDecorator(patch: RequirementPatch): ClassOrMethodD
  * getProfile() {}
  * ```
  *
- * @param strategy Strategy name previously registered through `createPassportProviders(...)`.
+ * @param strategy Strategy name previously registered through `PassportModule.forRoot(...)` or `createPassportProviders(...)`.
  * @returns A class-or-method decorator that stores the auth requirement metadata.
  */
 export function UseAuth(strategy: string): ClassOrMethodDecoratorLike {

--- a/packages/passport/src/module.test.ts
+++ b/packages/passport/src/module.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
+import { getModuleMetadata } from '@fluojs/core/internal';
+
 import { AuthStrategyResolutionError } from './errors.js';
+import { AuthGuard } from './guard.js';
 import { AUTH_STRATEGY_REGISTRY } from './internal-tokens.js';
-import { createPassportProviders } from './module.js';
+import { createPassportProviders, PassportModule } from './module.js';
 import type { AuthStrategy } from './types.js';
 
 describe('createPassportProviders', () => {
@@ -90,5 +93,28 @@ describe('createPassportProviders', () => {
         ],
       ),
     ).toThrow(AuthStrategyResolutionError);
+  });
+});
+
+describe('PassportModule', () => {
+  it('creates a module-first runtime definition that exports AuthGuard', () => {
+    class JwtStrategy implements AuthStrategy {
+      async authenticate() {
+        return { claims: {}, subject: 'jwt-user' };
+      }
+    }
+
+    const moduleDefinition = PassportModule.forRoot(
+      { defaultStrategy: 'jwt' },
+      [{ name: 'jwt', token: JwtStrategy }],
+    );
+
+    const metadata = getModuleMetadata(moduleDefinition);
+
+    expect(metadata?.exports).toContain(AuthGuard);
+    expect(metadata?.providers).toEqual(createPassportProviders(
+      { defaultStrategy: 'jwt' },
+      [{ name: 'jwt', token: JwtStrategy }],
+    ));
   });
 });

--- a/packages/passport/src/module.ts
+++ b/packages/passport/src/module.ts
@@ -1,4 +1,6 @@
 import type { Provider } from '@fluojs/di';
+import { defineModule, type ModuleType } from '@fluojs/runtime';
+
 import { AuthStrategyResolutionError } from './errors.js';
 import { AuthGuard } from './guard.js';
 import { AUTH_STRATEGY_REGISTRY, PASSPORT_OPTIONS } from './internal-tokens.js';
@@ -22,13 +24,17 @@ function createStrategyRegistry(strategies: AuthStrategyRegistration[]): AuthStr
   return registry;
 }
 
+type PassportModuleType = ModuleType;
+
 /**
  * Creates the provider set that wires passport options, strategy registry, and
  * the public {@link AuthGuard} into one module-friendly bundle.
  *
  * @remarks
- * Strategy names must be unique within the provided registration list. The
- * returned providers are typically spread into a module's `providers` array.
+ * Strategy names must be unique within the provided registration list. Prefer
+ * {@link PassportModule.forRoot} for the canonical module-first API, and use
+ * this helper when you need lower-level provider composition inside an
+ * existing module definition.
  *
  * @example
  * ```ts
@@ -64,4 +70,46 @@ export function createPassportProviders(
     },
     AuthGuard,
   ];
+}
+
+/**
+ * Canonical module-first entrypoint for passport strategy wiring.
+ */
+export class PassportModule {
+  /**
+   * Registers passport options, the auth strategy registry, and {@link AuthGuard}.
+   *
+   * @param options Module-level auth defaults such as `defaultStrategy`.
+   * @param strategies Named strategy registrations exposed to `@UseAuth(...)` and the fallback default strategy.
+   * @returns A module definition that exports `AuthGuard` and keeps the strategy registry internal.
+   * @throws {AuthStrategyResolutionError} When duplicate strategy names are registered.
+   *
+   * @example
+   * ```ts
+   * import { Module } from '@fluojs/core';
+   * import { PassportModule } from '@fluojs/passport';
+   *
+   * @Module({
+   *   imports: [
+   *     PassportModule.forRoot(
+   *       { defaultStrategy: 'jwt' },
+   *       [{ name: 'jwt', token: JwtStrategy }],
+   *     ),
+   *   ],
+   *   providers: [JwtStrategy],
+   * })
+   * export class AuthModule {}
+   * ```
+   */
+  static forRoot(
+    options: PassportModuleOptions = {},
+    strategies: AuthStrategyRegistration[] = [],
+  ): PassportModuleType {
+    class PassportRootModule extends PassportModule {}
+
+    return defineModule(PassportRootModule, {
+      exports: [AuthGuard],
+      providers: createPassportProviders(options, strategies),
+    });
+  }
 }

--- a/packages/passport/src/refresh/refresh-token.test.ts
+++ b/packages/passport/src/refresh/refresh-token.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getModuleMetadata } from '@fluojs/core/internal';
 import { Container } from '@fluojs/di';
 import type { DefaultJwtVerifier } from '@fluojs/jwt';
 import { JwtExpiredTokenError, JwtInvalidTokenError } from '@fluojs/jwt';
 
 import { AuthenticationExpiredError, AuthenticationFailedError, AuthenticationRequiredError } from '../errors.js';
-import { REFRESH_TOKEN_SERVICE, RefreshTokenStrategy, createRefreshTokenProviders, type RefreshTokenService } from './refresh-token.js';
+import { REFRESH_TOKEN_SERVICE, RefreshTokenModule, RefreshTokenStrategy, createRefreshTokenProviders, type RefreshTokenService } from './refresh-token.js';
 import type { AuthStrategyResult } from '../types.js';
 import type { GuardContext, RequestContext } from '@fluojs/http';
 
@@ -316,5 +317,35 @@ describe('RefreshTokenService contract', () => {
     const bySharedToken = await container.resolve(REFRESH_TOKEN_SERVICE);
 
     expect(bySharedToken).toBe(byClass);
+  });
+});
+
+describe('RefreshTokenModule', () => {
+  it('creates a module-first runtime definition for refresh-token strategy support', () => {
+    class RefreshTokenServiceImpl implements RefreshTokenService {
+      async issueRefreshToken(): Promise<string> {
+        return 'refresh-token';
+      }
+
+      async rotateRefreshToken(): Promise<{ accessToken: string; refreshToken: string }> {
+        return {
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+        };
+      }
+
+      async revokeRefreshToken(): Promise<void> {}
+
+      async revokeAllForSubject(): Promise<void> {}
+    }
+
+    const moduleDefinition = RefreshTokenModule.forRoot(RefreshTokenServiceImpl);
+    const metadata = getModuleMetadata(moduleDefinition);
+
+    expect(metadata?.exports).toEqual([RefreshTokenStrategy, REFRESH_TOKEN_SERVICE]);
+    expect(metadata?.providers).toEqual([
+      RefreshTokenStrategy,
+      ...createRefreshTokenProviders(RefreshTokenServiceImpl),
+    ]);
   });
 });

--- a/packages/passport/src/refresh/refresh-token.ts
+++ b/packages/passport/src/refresh/refresh-token.ts
@@ -2,13 +2,14 @@ import type { GuardContext, RequestContext } from '@fluojs/http';
 import { Inject, InvariantError, type Token } from '@fluojs/core';
 import type { Provider } from '@fluojs/di';
 import { DefaultJwtVerifier, JwtExpiredTokenError, JwtInvalidTokenError } from '@fluojs/jwt';
+import { defineModule, type ModuleType } from '@fluojs/runtime';
 
 import {
   AuthenticationExpiredError,
   AuthenticationFailedError,
   AuthenticationRequiredError,
 } from '../errors.js';
-import type { AuthStrategy, AuthStrategyResult } from '../types.js';
+import type { AuthStrategy, AuthStrategyRegistration, AuthStrategyResult } from '../types.js';
 
 /**
  * Defines the operations required to issue, rotate, and revoke refresh tokens.
@@ -41,7 +42,14 @@ export interface RefreshTokenAuthResult {
   subject: string;
 }
 
+/**
+ * Identifies the built-in refresh-token authentication strategy.
+ */
+export const REFRESH_TOKEN_STRATEGY_NAME = 'refresh-token';
+
 const MALFORMED_REFRESH_TOKEN = Symbol('MALFORMED_REFRESH_TOKEN');
+
+type RefreshTokenModuleType = ModuleType;
 
 /**
  * Authenticates refresh-token requests and exchanges them for a fresh token pair.
@@ -136,6 +144,10 @@ export class RefreshTokenStrategy implements AuthStrategy {
 /**
  * Creates alias providers that expose a refresh-token service under the shared token.
  *
+ * @remarks
+ * Prefer {@link RefreshTokenModule.forRoot} for the canonical module-first API,
+ * and use this helper when you need to compose the alias provider directly.
+ *
  * @param service DI token for the concrete refresh-token service implementation.
  * @returns Providers that bind the shared refresh-token token to the supplied service.
  */
@@ -148,4 +160,59 @@ export function createRefreshTokenProviders(
       useExisting: service,
     },
   ];
+}
+
+/**
+ * Creates the passport strategy registration for the built-in refresh-token strategy.
+ *
+ * @returns The named strategy registration consumed by `PassportModule.forRoot(...)`.
+ */
+export function createRefreshTokenStrategyRegistration(): AuthStrategyRegistration {
+  return {
+    name: REFRESH_TOKEN_STRATEGY_NAME,
+    token: RefreshTokenStrategy,
+  };
+}
+
+/**
+ * Canonical module-first entrypoint for refresh-token strategy support.
+ */
+export class RefreshTokenModule {
+  /**
+   * Registers the shared refresh-token service alias together with `RefreshTokenStrategy`.
+   *
+   * @param service DI token for the concrete refresh-token service implementation.
+   * @returns A module definition that exports `RefreshTokenStrategy` and `REFRESH_TOKEN_SERVICE`.
+   *
+   * @example
+   * ```ts
+   * import { Module } from '@fluojs/core';
+   * import {
+   *   PassportModule,
+   *   RefreshTokenModule,
+   *   RefreshTokenStrategy,
+   *   REFRESH_TOKEN_STRATEGY_NAME,
+   * } from '@fluojs/passport';
+   *
+   * @Module({
+   *   imports: [
+   *     RefreshTokenModule.forRoot(MyRefreshTokenService),
+   *     PassportModule.forRoot(
+   *       { defaultStrategy: REFRESH_TOKEN_STRATEGY_NAME },
+   *       [{ name: REFRESH_TOKEN_STRATEGY_NAME, token: RefreshTokenStrategy }],
+   *     ),
+   *   ],
+   *   providers: [MyRefreshTokenService],
+   * })
+   * export class AuthModule {}
+   * ```
+   */
+  static forRoot(service: Token<RefreshTokenService>): RefreshTokenModuleType {
+    class RefreshTokenRuntimeModule extends RefreshTokenModule {}
+
+    return defineModule(RefreshTokenRuntimeModule, {
+      exports: [RefreshTokenStrategy, REFRESH_TOKEN_SERVICE],
+      providers: [RefreshTokenStrategy, ...createRefreshTokenProviders(service)],
+    });
+  }
 }

--- a/packages/passport/src/status.ts
+++ b/packages/passport/src/status.ts
@@ -5,6 +5,7 @@ import type {
   PlatformSnapshot,
 } from '@fluojs/runtime';
 
+/** Snapshot payload describing passport readiness, health, ownership, and diagnostic details. */
 export interface PassportPlatformStatusSnapshot {
   readiness: PlatformReadinessReport;
   health: PlatformHealthReport;
@@ -12,6 +13,7 @@ export interface PassportPlatformStatusSnapshot {
   details: Record<string, unknown>;
 }
 
+/** Input contract for deriving passport platform health and readiness diagnostics. */
 export interface PassportStatusAdapterInput {
   componentId?: string;
   readinessCritical?: boolean;
@@ -108,6 +110,12 @@ function createHealth(input: PassportStatusAdapterInput): PlatformHealthReport {
   };
 }
 
+/**
+ * Creates a platform snapshot for passport strategy wiring and preset readiness.
+ *
+ * @param input Passport readiness inputs such as registered strategies, default strategy, and preset readiness flags.
+ * @returns A platform snapshot containing passport health, readiness, ownership, and structured details.
+ */
 export function createPassportPlatformStatusSnapshot(input: PassportStatusAdapterInput): PassportPlatformStatusSnapshot {
   const componentId = input.componentId ?? 'passport.default';
   const degraded = collectReadinessReasons(input).length > 0;
@@ -164,6 +172,12 @@ export function createPassportPlatformStatusSnapshot(input: PassportStatusAdapte
   };
 }
 
+/**
+ * Creates platform diagnostic issues for passport registry and preset readiness problems.
+ *
+ * @param input Passport readiness inputs such as registered strategies, default strategy, and preset readiness flags.
+ * @returns Diagnostic issues describing empty registries, strategy mismatches, and preset dependency failures.
+ */
 export function createPassportPlatformDiagnosticIssues(input: PassportStatusAdapterInput): PlatformDiagnosticIssue[] {
   const componentId = input.componentId ?? 'passport.default';
   const critical = input.readinessCritical ?? false;
@@ -174,7 +188,7 @@ export function createPassportPlatformDiagnosticIssues(input: PassportStatusAdap
     issues.push({
       code: 'AUTH_PASSPORT_STRATEGY_REGISTRY_EMPTY',
       componentId,
-      fixHint: 'Register at least one auth strategy via createPassportProviders(..., strategies).',
+      fixHint: 'Register at least one auth strategy via PassportModule.forRoot(..., strategies) or createPassportProviders(..., strategies).',
       message: 'Passport strategy registry has no registered auth strategies.',
       severity,
     });

--- a/packages/passport/src/types.ts
+++ b/packages/passport/src/types.ts
@@ -23,7 +23,7 @@ export interface AuthStrategy {
   authenticate(context: GuardContext): MaybePromise<AuthStrategyResult>;
 }
 
-/** Registration entry used by `createPassportProviders(...)`. */
+/** Registration entry used by `PassportModule.forRoot(...)` and `createPassportProviders(...)`. */
 export interface AuthStrategyRegistration {
   name: string;
   token: Token<AuthStrategy>;


### PR DESCRIPTION
Closes #1153

## Summary

- introduce `PassportModule.forRoot(...)` plus module entrypoints for the built-in cookie and refresh-token presets in `@fluojs/passport`
- keep the existing helper APIs as compatibility shims while moving package docs and the auth example to the module-first path
- preserve the documented auth contracts by pairing the new public API with regression tests and updated source-level TSDoc

## Changes

- added `PassportModule`, `CookieAuthModule`, and `RefreshTokenModule` as module-first public entrypoints
- added regression coverage for the new module metadata wiring in `module.test.ts`, `cookie-auth.test.ts`, and `refresh-token.test.ts`
- updated `packages/passport/README.md`, `packages/passport/README.ko.md`, `examples/auth-jwt-passport/src/auth/auth.module.ts`, and the auth book chapter to teach the module-first flow
- aligned source contract text in `decorators.ts`, `types.ts`, and `status.ts` with the new API surface

## Testing

- [x] `pnpm --filter @fluojs/passport test`
- [x] `pnpm vitest run examples/auth-jwt-passport`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint` (`verify-public-export-tsdoc` passed; Biome emitted pre-existing workspace warnings outside this PR scope)

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.