### PR TITLE
Resolve #1161: clarify cache-manager CacheModule entrypoints

### DIFF
--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -14,6 +14,7 @@
 - [공통 패턴](#공통-패턴)
   - [Redis 저장소 사용](#redis-저장소-사용)
   - [쿼리 매개변수 기반 캐싱](#쿼리-매개변수-기반-캐싱)
+  - [수동 모듈 조합](#수동-모듈-조합)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -130,6 +131,24 @@ CacheModule.forRoot({
 })
 ```
 
+### 수동 모듈 조합
+
+일반적인 애플리케이션 설정에서는 `CacheModule.forRoot(...)`가 기본 진입점입니다.
+동일한 cache-manager provider 그래프를 커스텀 `defineModule(...)` 등록 안에 직접 배치해야 할 때는
+`createCacheProviders(...)`를 계속 지원되는 공개 API로 사용할 수 있습니다.
+
+```typescript
+import { defineModule } from '@fluojs/runtime';
+import { CacheInterceptor, CacheService, createCacheProviders } from '@fluojs/cache-manager';
+
+class ManualCacheModule {}
+
+defineModule(ManualCacheModule, {
+  exports: [CacheService, CacheInterceptor],
+  providers: createCacheProviders({ store: 'memory', ttl: 60 }),
+});
+```
+
 ### 메모리 저장소 운영 한계
 
 내장 메모리 저장소는 단일 프로세스의 bounded cache 용도로 설계되어 있습니다.
@@ -146,6 +165,10 @@ CacheModule.forRoot({
 
 ### 모듈
 - `CacheModule.forRoot(options)`: 캐시 저장소(memory/redis), 기본 TTL, 키 전략 등을 설정합니다.
+  애플리케이션 모듈에서 사용하는 기본 패키지 진입점입니다.
+
+### Provider 조합
+- `createCacheProviders(options)`: `CacheModule.forRoot(options)`와 동일한 provider 집합을 반환하며, 지원되는 수동 `defineModule(...)` 조합에 사용합니다.
 
 ### 서비스
 - `CacheService`: 수동 캐시 작업(`get`, `set`, `del`, `remember`, `reset`)을 위한 기본 API입니다.

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -14,6 +14,7 @@ General-purpose cache manager for fluo with pluggable memory and Redis stores. P
 - [Common Patterns](#common-patterns)
   - [Redis Storage](#redis-storage)
   - [Query-Sensitive Caching](#query-sensitive-caching)
+  - [Manual Module Composition](#manual-module-composition)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -130,6 +131,24 @@ CacheModule.forRoot({
 })
 ```
 
+### Manual Module Composition
+
+`CacheModule.forRoot(...)` remains the default entrypoint for normal application setup.
+When you need to wire the same cache-manager providers into a custom `defineModule(...)`
+registration, `createCacheProviders(...)` remains a supported public API.
+
+```typescript
+import { defineModule } from '@fluojs/runtime';
+import { CacheInterceptor, CacheService, createCacheProviders } from '@fluojs/cache-manager';
+
+class ManualCacheModule {}
+
+defineModule(ManualCacheModule, {
+  exports: [CacheService, CacheInterceptor],
+  providers: createCacheProviders({ store: 'memory', ttl: 60 }),
+});
+```
+
 ### Memory Store Operational Limits
 
 The built-in memory store is designed for single-process, bounded caching:
@@ -146,6 +165,10 @@ For non-GET handlers decorated with `@CacheEvict(...)`, eviction is deferred unt
 
 ### Modules
 - `CacheModule.forRoot(options)`: Configures the cache store (memory/redis), default TTL, and key strategies.
+  This is the primary package entrypoint for application modules.
+
+### Provider composition
+- `createCacheProviders(options)`: Returns the provider set used by `CacheModule.forRoot(options)` for supported manual `defineModule(...)` composition.
 
 ### Services
 - `CacheService`: Main API for manual cache operations (`get`, `set`, `del`, `remember`, `reset`).

--- a/packages/cache-manager/src/module.test.ts
+++ b/packages/cache-manager/src/module.test.ts
@@ -117,6 +117,34 @@ describe('CacheModule.forRoot', () => {
     });
   });
 
+  it('keeps createCacheProviders as a supported manual-composition API', async () => {
+    @Inject(CacheService)
+    class Consumer {
+      constructor(readonly cache: CacheService) {}
+    }
+
+    class ManualCacheModule {}
+    defineModule(ManualCacheModule, {
+      exports: [CacheService, CacheInterceptor],
+      providers: createCacheProviders({ store: 'memory' }),
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [ManualCacheModule],
+      providers: [Consumer],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const consumer = await app.container.resolve(Consumer);
+
+    await consumer.cache.set('/manual', { ok: true }, 30);
+
+    await expect(consumer.cache.get('/manual')).resolves.toEqual({ ok: true });
+
+    await app.close();
+  });
+
   it('supports memory store without redis module/client installed', async () => {
     @Inject(CacheService)
     class Consumer {

--- a/packages/cache-manager/src/module.ts
+++ b/packages/cache-manager/src/module.ts
@@ -155,6 +155,11 @@ async function createStore(options: NormalizedCacheModuleOptions, container: Con
 /**
  * Create the cache-manager provider set for manual module composition.
  *
+ * @remarks
+ * `CacheModule.forRoot(...)` remains the default documented entrypoint for most
+ * applications. Use this helper when you need to compose the cache-manager
+ * provider graph inside a custom `defineModule(...)` registration.
+ *
  * @param options Cache module options with optional store and HTTP caching configuration.
  * @returns Providers for normalized options, cache store resolution, `CacheService`, and `CacheInterceptor`.
  *
@@ -213,6 +218,11 @@ export function createCacheProviders(options: CacheModuleOptions = {}): Provider
 export class CacheModule {
   /**
    * Register cache providers for the current application module graph.
+   *
+   * @remarks
+   * This is the primary package entrypoint. Reach for `createCacheProviders(...)`
+   * only when you need equivalent provider wiring inside a manually composed
+   * runtime module definition.
    *
    * @param options Cache module options.
    * @returns A runtime module exporting `CacheService` and `CacheInterceptor`.


### PR DESCRIPTION
Closes #1161

## Summary
- align `@fluojs/cache-manager` around `CacheModule.forRoot(...)` as the primary package entrypoint
- document that `createCacheProviders(...)` remains a supported public API for manual `defineModule(...)` composition
- add a regression test so the helper contract cannot drift silently

## Changes
- add source-level API remarks in `packages/cache-manager/src/module.ts` to distinguish the default module entrypoint from the supported manual-composition helper
- add a `module.test.ts` regression that boots an application through `createCacheProviders(...)` inside a manual module definition
- update `packages/cache-manager/README.md` and `packages/cache-manager/README.ko.md` with a manual composition section and aligned public API wording

## Testing
- `pnpm exec vitest run packages/cache-manager/src/module.test.ts packages/cache-manager/src/public-api.test.ts packages/cache-manager/src/optional-peer.test.ts`
- `pnpm exec biome lint packages/cache-manager/src/module.ts packages/cache-manager/src/module.test.ts packages/cache-manager/README.md packages/cache-manager/README.ko.md`
- `pnpm verify:public-export-tsdoc`
- `pnpm build`
- `pnpm typecheck`
- `lsp_diagnostics packages/cache-manager` → 0 errors after workspace build/install in the fresh worktree

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Not applicable: this PR changes package README guidance and cache-manager tests only; no governance docs or platform conformance claims changed.