### PR TITLE
Resolve #1157: align @fluojs/redis around RedisModule entrypoints

### DIFF
--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -30,6 +30,8 @@ npm install @fluojs/redis ioredis
 
 ### 모듈 등록
 
+`RedisModule.forRoot(options)`는 기본 Redis 클라이언트와 `RedisService` 파사드를 등록하는 지원되는 root entrypoint입니다.
+
 ```typescript
 import { Module } from '@fluojs/core';
 import { RedisModule } from '@fluojs/redis';
@@ -71,7 +73,7 @@ export class CacheRepository {
 
 ### 이름 있는 클라이언트
 
-하나의 애플리케이션에서 여러 Redis 연결이 필요하면 `RedisModule.forRootNamed(name, options)`를 사용하세요. `RedisModule.forRoot(options)`는 계속 기본 `REDIS_CLIENT`와 `RedisService` 별칭을 유지하고, 이름 있는 등록은 `getRedisClientToken(name)`과 `getRedisServiceToken(name)`으로 해석합니다.
+하나의 애플리케이션에서 여러 Redis 연결이 필요하면 `RedisModule.forRootNamed(name, options)`를 사용하세요. `RedisModule.forRoot(options)`는 계속 기본 `REDIS_CLIENT`와 `RedisService` 별칭을 유지하고, 이름 있는 등록은 `getRedisClientToken(name)`과 `getRedisServiceToken(name)`으로 해석합니다. 내부 provider 구성 helper는 지원되는 root-barrel API의 일부가 아닙니다.
 
 - `name`을 생략하면 기본 별칭인 `REDIS_CLIENT` / `RedisService`를 사용합니다.
 - `name`을 지정하면 `getRedisClientToken(name)` / `getRedisServiceToken(name)`으로 이름 있는 바인딩을 가져옵니다.
@@ -130,6 +132,7 @@ export class AdvancedService {
 
 ### 핵심 구성 요소
 - `RedisModule`: 전역 Redis 클라이언트 등록 및 수명 주기 훅을 관리합니다.
+- `RedisModule.forRoot(options)`: 기본 Redis 클라이언트와 `RedisService` 파사드를 위한 지원되는 root entrypoint입니다.
 - `RedisModule.forRootNamed(name, options)`: 기본 별칭을 유지한 채 추가 Redis 클라이언트를 등록합니다.
 - `RedisService`: JSON 코덱 지원 및 `get`/`set`/`del` 메서드를 제공하는 파사드입니다.
 - `REDIS_CLIENT`: 내부 `ioredis` 인스턴스에 접근하기 위한 DI 토큰입니다.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -30,6 +30,8 @@ npm install @fluojs/redis ioredis
 
 ### Register the Module
 
+`RedisModule.forRoot(options)` is the supported root entrypoint for registering the default Redis client and `RedisService` facade.
+
 ```typescript
 import { Module } from '@fluojs/core';
 import { RedisModule } from '@fluojs/redis';
@@ -71,7 +73,7 @@ export class CacheRepository {
 
 ### Named Clients
 
-Use `RedisModule.forRootNamed(name, options)` when one application needs more than one Redis connection. `RedisModule.forRoot(options)` still owns the default `REDIS_CLIENT` and `RedisService` aliases; named registrations are resolved with `getRedisClientToken(name)` and `getRedisServiceToken(name)`.
+Use `RedisModule.forRootNamed(name, options)` when one application needs more than one Redis connection. `RedisModule.forRoot(options)` still owns the default `REDIS_CLIENT` and `RedisService` aliases; named registrations are resolved with `getRedisClientToken(name)` and `getRedisServiceToken(name)`. Internal provider-construction helpers are not part of the supported root-barrel API.
 
 - Omit `name` when you want the default aliases: `REDIS_CLIENT` / `RedisService`.
 - Pass `name` when you want the named helpers: `getRedisClientToken(name)` / `getRedisServiceToken(name)`.
@@ -130,6 +132,7 @@ export class AdvancedService {
 
 ### Core
 - `RedisModule`: Registers the global Redis client and lifecycle hooks.
+- `RedisModule.forRoot(options)`: Supported root entrypoint for the default Redis client plus `RedisService` facade.
 - `RedisModule.forRootNamed(name, options)`: Registers an additional named Redis client without replacing the default aliases.
 - `RedisService`: Facade with JSON codec support and `get`/`set`/`del` methods.
 - `REDIS_CLIENT`: DI token for the underlying `ioredis` instance.

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -1,4 +1,4 @@
-export * from './module.js';
+export { RedisModule } from './module.js';
 export * from './redis-service.js';
 export * from './status.js';
 export * from './tokens.js';

--- a/packages/redis/src/module.ts
+++ b/packages/redis/src/module.ts
@@ -18,7 +18,7 @@ function getRedisLifecycleToken(name: string): symbol {
  * @param name Optional Redis client name for additional named registrations.
  * @returns Providers for the raw client token, the JSON-aware facade, and lifecycle hooks.
  */
-export function createRedisProviders(options: RedisModuleOptions, name?: string): Provider[] {
+function createRedisProviders(options: RedisModuleOptions, name?: string): Provider[] {
   const clientToken = getRedisClientToken(name);
 
   if (clientToken === REDIS_CLIENT) {

--- a/packages/redis/src/public-api.test.ts
+++ b/packages/redis/src/public-api.test.ts
@@ -5,7 +5,6 @@ import * as redisPublicApi from './index.js';
 describe('@fluojs/redis public API surface', () => {
   it('keeps documented supported root-barrel exports', () => {
     expect(redisPublicApi).toHaveProperty('RedisModule');
-    expect(redisPublicApi).toHaveProperty('createRedisProviders');
     expect(redisPublicApi).toHaveProperty('RedisService');
     expect(redisPublicApi).toHaveProperty('createRedisPlatformStatusSnapshot');
     expect(redisPublicApi).toHaveProperty('REDIS_CLIENT');
@@ -16,6 +15,7 @@ describe('@fluojs/redis public API surface', () => {
   });
 
   it('does not expose internal lifecycle wiring values from the root barrel', () => {
+    expect(redisPublicApi).not.toHaveProperty('createRedisProviders');
     expect(redisPublicApi).not.toHaveProperty('RedisLifecycleService');
     expect(redisPublicApi).not.toHaveProperty('normalizeRedisClientName');
     expect(redisPublicApi).not.toHaveProperty('decodeRedisValue');


### PR DESCRIPTION
Closes #1157

## Summary

- align `@fluojs/redis` around `RedisModule.forRoot(...)` / `forRootNamed(...)` as the supported root registration entrypoints
- stop exposing the internal Redis provider-construction helper from the root barrel
- document the supported root surface in the English and Korean package READMEs

## Changes

- changed `packages/redis/src/index.ts` to export `RedisModule` explicitly instead of re-exporting every symbol from `module.ts`
- internalized `createRedisProviders(...)` in `packages/redis/src/module.ts`
- updated `packages/redis/src/public-api.test.ts` to guard that the helper stays out of the root barrel
- clarified the supported module entrypoints and internal-helper limitation in `packages/redis/README.md` and `packages/redis/README.ko.md`

## Testing

- `pnpm --filter "@fluojs/redis" test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `lsp_diagnostics` on changed TypeScript files (`packages/redis/src/module.ts`, `packages/redis/src/index.ts`, `packages/redis/src/public-api.test.ts`)

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.