### PR TITLE
Resolve #1154: align jwt module entrypoints

### DIFF
--- a/docs/concepts/auth-and-jwt.ko.md
+++ b/docs/concepts/auth-and-jwt.ko.md
@@ -34,6 +34,8 @@ fluo는 **일회용 로테이션(One-Time-Use Rotation)**을 구현하는 `Refre
 - 새로운 액세스/리프레시 토큰 쌍이 발급됩니다.
 - 이전 리프레시 토큰이 재사용되면(재생 공격), 해당 토큰 가족 전체가 자동으로 취소될 수 있어 탈취된 자격 증명으로부터 사용자를 보호합니다.
 
+애플리케이션 모듈 등록에서는 `JwtModule.forRoot(...)` 및 `JwtModule.forRootAsync(...)`를 `@fluojs/jwt`의 canonical entrypoint로 취급하세요. `createJwtCoreProviders(...)`는 기존 커스텀 모듈 내부에서 고급 직접 provider 구성이 필요할 때만 사용하세요.
+
 ## 다음 단계
 
 - **빠른 시작**: [Auth JWT Passport 예제](../../examples/auth-jwt-passport/README.ko.md)에서 토큰 발급 및 검증을 확인하세요.

--- a/docs/concepts/auth-and-jwt.md
+++ b/docs/concepts/auth-and-jwt.md
@@ -34,6 +34,8 @@ fluo provides a built-in `RefreshTokenService` that implements **One-Time-Use Ro
 - A new access/refresh token pair is issued.
 - If an old refresh token is reused (Replay Attack), the entire token family can be revoked automatically, protecting your users from stolen credentials.
 
+For application module registration, treat `JwtModule.forRoot(...)` and `JwtModule.forRootAsync(...)` as the canonical `@fluojs/jwt` entrypoints. Reserve `createJwtCoreProviders(...)` for advanced direct provider composition inside an existing custom module.
+
 ## Next Steps
 
 - **Quick Start**: issuance and verification in the [Auth JWT Passport Example](../../examples/auth-jwt-passport/README.md).

--- a/examples/auth-jwt-passport/README.ko.md
+++ b/examples/auth-jwt-passport/README.ko.md
@@ -52,7 +52,7 @@ examples/auth-jwt-passport/
 2. `src/auth/auth.service.ts` — JWT 발급
 3. `src/auth/bearer.strategy.ts` — passport core를 통한 bearer token 검증
 4. `src/auth/auth.controller.ts` — 토큰 발급 라우트 + 보호된 profile 라우트
-5. `src/auth/auth.module.ts` — JWT + passport provider 등록
+5. `src/auth/auth.module.ts` — `JwtModule.forRoot(...)` + `PassportModule.forRoot(...)` 기반 module-first 등록
 6. `src/app.test.ts` — integration 및 e2e 스타일 검증
 
 ## 관련 문서

--- a/examples/auth-jwt-passport/README.md
+++ b/examples/auth-jwt-passport/README.md
@@ -52,7 +52,7 @@ examples/auth-jwt-passport/
 2. `src/auth/auth.service.ts` — JWT issuance
 3. `src/auth/bearer.strategy.ts` — bearer token verification through passport core
 4. `src/auth/auth.controller.ts` — open token route + protected profile route
-5. `src/auth/auth.module.ts` — provider registration for JWT + passport
+5. `src/auth/auth.module.ts` — module-first registration via `JwtModule.forRoot(...)` + `PassportModule.forRoot(...)`
 6. `src/app.test.ts` — integration and e2e-style verification
 
 ## related docs

--- a/examples/auth-jwt-passport/src/auth/auth.module.ts
+++ b/examples/auth-jwt-passport/src/auth/auth.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@fluojs/core';
-import { createJwtCoreProviders } from '@fluojs/jwt';
+import { JwtModule } from '@fluojs/jwt';
 import { PassportModule } from '@fluojs/passport';
 
 import { AuthController, ProfileController } from './auth.controller';
@@ -9,6 +9,13 @@ import { BearerJwtStrategy } from './bearer.strategy';
 @Module({
   controllers: [AuthController, ProfileController],
   imports: [
+    JwtModule.forRoot({
+      accessTokenTtlSeconds: 3600,
+      algorithms: ['HS256'],
+      audience: 'fluo-auth-example-clients',
+      issuer: 'fluo-auth-example',
+      secret: 'fluo-auth-example-secret',
+    }),
     PassportModule.forRoot(
       { defaultStrategy: 'jwt' },
       [{ name: 'jwt', token: BearerJwtStrategy }],
@@ -17,13 +24,6 @@ import { BearerJwtStrategy } from './bearer.strategy';
   providers: [
     AuthService,
     BearerJwtStrategy,
-    ...createJwtCoreProviders({
-      accessTokenTtlSeconds: 3600,
-      algorithms: ['HS256'],
-      audience: 'fluo-auth-example-clients',
-      issuer: 'fluo-auth-example',
-      secret: 'fluo-auth-example-secret',
-    }),
   ],
 })
 export class AuthModule {}

--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -32,6 +32,8 @@ npm install @fluojs/jwt
 
 서명 키와 정책을 사용하여 JWT 모듈을 설정합니다.
 
+`JwtModule.forRoot(...)` 및 `JwtModule.forRootAsync(...)`가 애플리케이션의 canonical entrypoint입니다. `createJwtCoreProviders(...)`는 기존 커스텀 모듈 안에서 고급 직접 provider 구성이 정말 필요할 때만 사용하세요.
+
 ```typescript
 import { Module } from '@fluojs/core';
 import { JwtModule } from '@fluojs/jwt';
@@ -114,6 +116,9 @@ const verifier = new DefaultJwtVerifier({
 - `DefaultJwtSigner`: 클레임 자동 채우기 기능이 포함된 토큰 발행 클래스입니다.
 - `DefaultJwtVerifier`: 토큰 검증 및 정규화를 담당하는 클래스입니다.
 - `JwtService`: 서명과 검증 기능을 결합한 편의용 파사드(facade)입니다.
+
+### 고급 헬퍼
+- `createJwtCoreProviders(...)`: `JwtModule.forRoot(...)` / `forRootAsync(...)`로 충분하지 않을 때만 사용하는 저수준 provider 팩토리입니다.
 
 ### 타입
 - `JwtPrincipal`: 정규화된 사용자 식별 객체 (`subject`, `roles`, `scopes`, `claims`).

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -32,6 +32,8 @@ npm install @fluojs/jwt
 
 Configure the JWT module with your signing keys and policy.
 
+`JwtModule.forRoot(...)` and `JwtModule.forRootAsync(...)` are the canonical application entrypoints. Use `createJwtCoreProviders(...)` only when you intentionally need advanced direct provider composition inside an existing custom module.
+
 ```typescript
 import { Module } from '@fluojs/core';
 import { JwtModule } from '@fluojs/jwt';
@@ -114,6 +116,9 @@ const verifier = new DefaultJwtVerifier({
 - `DefaultJwtSigner`: Handles token issuance with default claim filling.
 - `DefaultJwtVerifier`: Handles token validation and normalization.
 - `JwtService`: A convenience facade combining signing and verification.
+
+### Advanced Helpers
+- `createJwtCoreProviders(...)`: Low-level provider factory for custom composition when `JwtModule.forRoot(...)` / `forRootAsync(...)` is not a fit.
 
 ### Types
 - `JwtPrincipal`: The normalized identity object (`subject`, `roles`, `scopes`, `claims`).

--- a/packages/jwt/src/module.ts
+++ b/packages/jwt/src/module.ts
@@ -94,7 +94,11 @@ function createJwtModuleProviders(
 }
 
 /**
- * Creates the core JWT providers for direct module composition.
+ * Creates the core JWT providers for advanced direct module composition.
+ *
+ * Prefer {@link JwtModule.forRoot} or {@link JwtModule.forRootAsync} for the canonical
+ * application entrypoint so JWT registration stays aligned with the published module
+ * surface.
  *
  * @param options JWT verification and signing options used for provider registration.
  * @returns Providers for the JWT verifier, signer, facade, and optional refresh token service.


### PR DESCRIPTION
Closes #1154

## Summary
- align `@fluojs/jwt` docs and examples around `JwtModule.forRoot(...)` / `forRootAsync(...)` as the canonical entrypoints
- keep `createJwtCoreProviders(...)` available, but demote it to an advanced direct-composition helper in the public contract

## Changes
- updated `packages/jwt/src/module.ts` TSDoc to steer consumers toward `JwtModule` entrypoints
- updated `packages/jwt/README.md` and `packages/jwt/README.ko.md` to document the module-first registration path and reposition `createJwtCoreProviders(...)`
- updated `docs/concepts/auth-and-jwt.md` and `docs/concepts/auth-and-jwt.ko.md` to describe the canonical `JwtModule` entrypoints
- switched `examples/auth-jwt-passport/src/auth/auth.module.ts` to `JwtModule.forRoot(...)` and aligned the example README pair

## Testing
- `pnpm exec vitest run packages/jwt/src/module.test.ts examples/auth-jwt-passport/src/app.test.ts`
- `pnpm --filter @fluojs/jwt typecheck`
- `pnpm --filter @fluojs/example-auth-jwt-passport typecheck`
- `pnpm --filter @fluojs/jwt build`
- `pnpm verify:public-export-tsdoc`
- `pnpm lint` *(passes for this change set, but surfaces pre-existing repo warnings outside this issue scope)*
- `pnpm typecheck` *(fails due pre-existing unrelated workspace errors in `@fluojs/discord`, `@fluojs/cqrs`, `@fluojs/cron`, and `@fluojs/cache-manager`)*

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.