### PR TITLE
Resolve #1162: align throttler module entrypoints

### DIFF
--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -111,6 +111,7 @@ ThrottlerModule.forRoot({
 
 ### 모듈
 - `ThrottlerModule.forRoot(options)`: 글로벌 속도 제한 동작 및 저장소를 설정합니다.
+- 패키지 수준 등록은 `ThrottlerModule.forRoot(options)`를 통해 지원합니다. 내부 프로바이더 조합 헬퍼는 공개 계약에 포함되지 않습니다.
 
 ### 데코레이터
 - `@Throttle({ ttl, limit })`: 클래스나 메서드에 특정 속도 제한을 설정합니다.

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -111,6 +111,7 @@ ThrottlerModule.forRoot({
 
 ### Modules
 - `ThrottlerModule.forRoot(options)`: Configures the global throttling behavior and storage.
+- Package-level registration is supported through `ThrottlerModule.forRoot(options)`. Internal provider-composition helpers are not part of the public contract.
 
 ### Decorators
 - `@Throttle({ ttl, limit })`: Sets a specific rate limit for a class or method.

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { metadataSymbol } from '@fluojs/core/internal';
 import type { GuardContext, HandlerDescriptor, RequestContext } from '@fluojs/http';
 
+import * as throttlerExports from './index.js';
 import { SkipThrottle, Throttle, getThrottleMetadata } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
-import { ThrottlerModule, createThrottlerProviders } from './module.js';
+import { ThrottlerModule } from './module.js';
 import { createMemoryThrottlerStore } from './store.js';
-import { THROTTLER_OPTIONS } from './tokens.js';
 import type {
   ThrottlerConsumeInput,
   ThrottlerModuleOptions,
@@ -96,43 +96,11 @@ function createGuardContext(
   };
 }
 
-type ObjectProvider = {
-  provide: unknown;
-  useClass?: unknown;
-  useExisting?: unknown;
-  useValue?: unknown;
-};
-
-function isObjectProvider(provider: unknown): provider is ObjectProvider {
-  return typeof provider === 'object' && provider !== null && 'provide' in provider;
-}
-
-describe('createThrottlerProviders', () => {
-  it('registers class-first ThrottlerGuard identity and keeps THROTTLER_OPTIONS token-based', () => {
-    const providers = createThrottlerProviders({
-      limit: 10,
-      ttl: 60,
-    });
-    const optionsProvider = providers.find(
-      (provider) => isObjectProvider(provider) && provider.provide === THROTTLER_OPTIONS,
-    );
-    const classProvider = providers.find(
-      (provider) => isObjectProvider(provider) && provider.provide === ThrottlerGuard,
-    );
-
-    expect(optionsProvider).toMatchObject({
-      provide: THROTTLER_OPTIONS,
-      useValue: {
-        limit: 10,
-        ttl: 60,
-      },
-    });
-    expect(classProvider).toMatchObject({
-      provide: ThrottlerGuard,
-      useClass: ThrottlerGuard,
-    });
-
-    expect(providers).toHaveLength(2);
+describe('@fluojs/throttler public entrypoints', () => {
+  it('keeps ThrottlerModule.forRoot as the supported registration entrypoint without exporting internal provider helpers', () => {
+    expect(throttlerExports).not.toHaveProperty('createThrottlerProviders');
+    expect(throttlerExports.ThrottlerModule).toBe(ThrottlerModule);
+    expect(typeof throttlerExports.ThrottlerModule.forRoot).toBe('function');
   });
 });
 

--- a/packages/throttler/src/module.ts
+++ b/packages/throttler/src/module.ts
@@ -6,21 +6,7 @@ import { THROTTLER_OPTIONS } from './tokens.js';
 import type { ThrottlerModuleOptions } from './types.js';
 import { validateThrottlerModuleOptions } from './validation.js';
 
-/**
- * Create the throttler provider set for manual module composition.
- *
- * @param options Module-wide throttling policy.
- * @returns Providers for validated options and `ThrottlerGuard`.
- *
- * @example
- * ```ts
- * const providers = createThrottlerProviders({
- *   ttl: 60,
- *   limit: 10,
- * });
- * ```
- */
-export function createThrottlerProviders(options: ThrottlerModuleOptions): Provider[] {
+function createThrottlerProviders(options: ThrottlerModuleOptions): Provider[] {
   const validatedOptions = validateThrottlerModuleOptions(options);
 
   return [


### PR DESCRIPTION
## Summary
- Align `@fluojs/throttler` around `ThrottlerModule.forRoot(...)` as the supported package-level registration entrypoint.
- Closes #1162.

## Changes
- Remove the public export for `createThrottlerProviders(...)` so provider wiring stays internal to `packages/throttler/src/module.ts`.
- Replace the direct helper regression with a root-entrypoint test that verifies `@fluojs/throttler` exposes `ThrottlerModule.forRoot(...)` but not the internal helper.
- Clarify the supported registration contract in both `packages/throttler/README.md` and `packages/throttler/README.ko.md`.

## Testing
- `pnpm --filter @fluojs/throttler test`
- `pnpm build`
- `pnpm --filter @fluojs/throttler typecheck`
- `pnpm --filter @fluojs/throttler build`
- `pnpm lint`
- `pnpm typecheck` *(currently fails in this fresh worktree because existing workspace-wide `@fluojs/*` cross-package module resolution errors surface outside the throttler change set.)*

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary where applicable.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed docs.
- [x] No platform contract docs, tooling/CI enforcement, or conformance claims changed in this PR.
- [x] No `createPlatformConformanceHarness(...)`-backed package README conformance claims were added or changed.

Closes #1162