### PR TITLE
Resolve #1159: align event-bus root entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Breaking changes
 
+- `@fluojs/event-bus`: the root barrel no longer exports `createEventBusProviders(...)`. Migration note: switch root-package composition to `EventBusModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/cron`: the root barrel no longer exports `createCronProviders(...)`. Migration note: register scheduling through `CronModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/terminus`: the root barrel no longer exports `createTerminusProviders(...)`. Migration note: switch root-package composition to `TerminusModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/graphql`: schema introspection is now disabled unless `graphiql` or `introspection: true` is explicitly enabled, and built-in request budgets now cap GraphQL document depth, field complexity, and aggregate query cost by default. Migration note: enable `introspection: true` for trusted tooling flows that still need schema discovery, or set `limits` to explicit higher values (or `false` for a temporary legacy escape hatch) before rolling this update into existing large-query workloads.

--- a/packages/event-bus/README.ko.md
+++ b/packages/event-bus/README.ko.md
@@ -51,6 +51,8 @@ export class NotificationService {
 
 `EventBusModule`을 등록하고 `EventBusLifecycleService`를 주입받아 이벤트를 발행합니다.
 
+`EventBusModule.forRoot(...)`가 인프로세스 이벤트 버스를 구성하는 지원되는 root 진입점입니다. root만 소비하는 사용자는 저수준 provider 조합을 root barrel API의 일부가 아니라 내부 구현 상세로 취급해야 합니다.
+
 ```typescript
 import { Module, Inject } from '@fluojs/core';
 import { EventBusModule, EventBusLifecycleService } from '@fluojs/event-bus';
@@ -105,6 +107,7 @@ class UserRegisteredEvent {
 - `EventBusModule`: 이벤트 버스 기능을 위한 기본 모듈입니다.
 - `EventBusLifecycleService`: 이벤트를 발행(`publish(event)`)하기 위한 기본 서비스입니다.
 - `@OnEvent(EventClass)`: 특정 메서드를 이벤트 핸들러로 지정하는 데코레이터입니다.
+- root 수준 등록은 의도적으로 `EventBusModule.forRoot(...)` 중심이며, 저수준 provider helper는 문서화된 root barrel 계약에 포함되지 않습니다.
 
 ### 인터페이스
 - `EventBusTransport`: 외부 트랜스포트 어댑터 구현을 위한 계약입니다.

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -51,6 +51,8 @@ export class NotificationService {
 
 Import `EventBusModule` and inject `EventBusLifecycleService` to publish events.
 
+`EventBusModule.forRoot(...)` is the supported root entrypoint for wiring the in-process event bus. Root-only consumers should treat low-level provider assembly as an internal implementation detail instead of part of the root-barrel API.
+
 ```typescript
 import { Module, Inject } from '@fluojs/core';
 import { EventBusModule, EventBusLifecycleService } from '@fluojs/event-bus';
@@ -105,6 +107,7 @@ class UserRegisteredEvent {
 - `EventBusModule`: Main entry point for event bus registration.
 - `EventBusLifecycleService`: Primary service for publishing events (`publish(event)`).
 - `@OnEvent(EventClass)`: Decorator to mark a method as an event handler.
+- Root-level registration is intentionally centered on `EventBusModule.forRoot(...)`; low-level provider helpers are not part of the documented root-barrel contract.
 
 ### Interfaces
 - `EventBusTransport`: Contract for implementing external transport adapters.

--- a/packages/event-bus/src/__snapshots__/public-surface.test.ts.snap
+++ b/packages/event-bus/src/__snapshots__/public-surface.test.ts.snap
@@ -7,6 +7,5 @@ exports[`@fluojs/event-bus root barrel public surface > keeps the documented roo
   "EventBusModule",
   "OnEvent",
   "createEventBusPlatformStatusSnapshot",
-  "createEventBusProviders",
 ]
 `;

--- a/packages/event-bus/src/index.ts
+++ b/packages/event-bus/src/index.ts
@@ -1,5 +1,5 @@
 export { OnEvent } from './decorators.js';
-export { EventBusModule, createEventBusProviders } from './module.js';
+export { EventBusModule } from './module.js';
 export { EventBusLifecycleService } from './service.js';
 export * from './status.js';
 export { EVENT_BUS } from './tokens.js';

--- a/packages/event-bus/src/module.ts
+++ b/packages/event-bus/src/module.ts
@@ -5,13 +5,7 @@ import { EventBusLifecycleService } from './service.js';
 import { EVENT_BUS, EVENT_BUS_OPTIONS } from './tokens.js';
 import type { EventBusModuleOptions, EventPublishOptions } from './types.js';
 
-/**
- * Creates event-bus lifecycle providers and module options wiring.
- *
- * @param options Event bus configuration used for publish defaults and optional transport integration.
- * @returns Provider definitions that register `EVENT_BUS_OPTIONS`, `EventBusLifecycleService`, and the compatibility alias `EVENT_BUS`.
- */
-export function createEventBusProviders(options: EventBusModuleOptions = {}): Provider[] {
+function createEventBusProviders(options: EventBusModuleOptions = {}): Provider[] {
   return [
     {
       provide: EVENT_BUS_OPTIONS,
@@ -36,7 +30,7 @@ export class EventBusModule {
   /**
    * Registers the event-bus providers as a global module.
    *
-   * @param options Event bus module options forwarded to {@link createEventBusProviders}.
+   * @param options Event bus module options for publish defaults and optional transport integration.
    * @returns A module definition that exports `EventBusLifecycleService` and the compatibility token `EVENT_BUS`.
    */
   static forRoot(options: EventBusModuleOptions = {}): ModuleType {

--- a/packages/event-bus/src/public-api.test.ts
+++ b/packages/event-bus/src/public-api.test.ts
@@ -12,7 +12,6 @@ import type {
 describe('@fluojs/event-bus public API surface', () => {
   it('keeps documented supported root-barrel exports', () => {
     expect(eventBusPublicApi).toHaveProperty('EventBusModule');
-    expect(eventBusPublicApi).toHaveProperty('createEventBusProviders');
     expect(eventBusPublicApi).toHaveProperty('EventBusLifecycleService');
     expect(eventBusPublicApi).toHaveProperty('EVENT_BUS');
     expect(eventBusPublicApi).toHaveProperty('OnEvent');
@@ -40,6 +39,7 @@ describe('@fluojs/event-bus public API surface', () => {
   });
 
   it('hides internal descriptors and metadata helpers from the root barrel', () => {
+    expect(eventBusPublicApi).not.toHaveProperty('createEventBusProviders');
     expect(eventBusPublicApi).not.toHaveProperty('defineEventHandlerMetadata');
     expect(eventBusPublicApi).not.toHaveProperty('getEventHandlerMetadata');
     expect(eventBusPublicApi).not.toHaveProperty('getEventHandlerMetadataEntries');

--- a/packages/event-bus/src/public-surface.test.ts
+++ b/packages/event-bus/src/public-surface.test.ts
@@ -6,7 +6,7 @@ describe('@fluojs/event-bus root barrel public surface', () => {
   it('keeps the documented root exports stable for 0.x governance', () => {
     expect(eventBus).toHaveProperty('EventBusModule');
     expect(eventBus).not.toHaveProperty('createEventBusModule');
-    expect(eventBus).toHaveProperty('createEventBusProviders');
+    expect(eventBus).not.toHaveProperty('createEventBusProviders');
     expect(eventBus).toHaveProperty('EventBusLifecycleService');
     expect(eventBus).toHaveProperty('EVENT_BUS');
     expect(eventBus).not.toHaveProperty('EVENT_BUS_OPTIONS');


### PR DESCRIPTION
Closes #1159

## Summary
- align `@fluojs/event-bus` root entrypoints around `EventBusModule.forRoot(...)`
- stop treating `createEventBusProviders(...)` as part of the documented root-barrel contract
- keep the package README mirrors and public-surface regression coverage in sync

## Changes
- internalized `createEventBusProviders(...)` inside `packages/event-bus/src/module.ts` and removed it from `packages/event-bus/src/index.ts`
- updated `packages/event-bus/src/public-api.test.ts`, `packages/event-bus/src/public-surface.test.ts`, and the snapshot to assert the narrower root public surface
- clarified the module-first contract in `packages/event-bus/README.md` and `packages/event-bus/README.ko.md`

## Testing
- `pnpm exec vitest run packages/event-bus/src/public-api.test.ts packages/event-bus/src/public-surface.test.ts packages/event-bus/src/module.test.ts`
- `pnpm build`
- `pnpm --filter @fluojs/event-bus typecheck`
- `pnpm --filter @fluojs/event-bus build`
- `pnpm exec biome lint packages/event-bus/src/module.ts packages/event-bus/src/index.ts packages/event-bus/src/public-api.test.ts packages/event-bus/src/public-surface.test.ts`
- `pnpm verify:public-export-tsdoc`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] N/A — no SSOT governance docs changed in this PR.
- [x] N/A — no platform contract docs changed, so no companion governance/tooling updates were required.
- [x] N/A — this PR narrows the event-bus root barrel and does not make platform conformance claims requiring `createPlatformConformanceHarness(...)` coverage.