### PR TITLE
Resolve #1160: align @fluojs/cqrs around CqrsModule entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Breaking changes
 
+<<<<<<< HEAD
 - `@fluojs/queue`: the root barrel no longer exports `createQueueProviders(...)`. Migration note: register queues through `QueueModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
+=======
+- `@fluojs/cqrs`: the root barrel no longer exports `createCqrsProviders(...)`. Migration note: switch root-package composition to `CqrsModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
+>>>>>>> 88257312 (docs(changelog): add cqrs migration note)
 - `@fluojs/event-bus`: the root barrel no longer exports `createEventBusProviders(...)`. Migration note: switch root-package composition to `EventBusModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/cron`: the root barrel no longer exports `createCronProviders(...)`. Migration note: register scheduling through `CronModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/websockets`: the root barrel no longer exports `createWebSocketProviders(...)`, and the runtime subpaths no longer export `create*WebSocketProviders(...)` helpers. Migration note: register websocket support through `WebSocketModule.forRoot(...)` or the explicit runtime `*WebSocketModule.forRoot(...)` subpath entrypoint; low-level provider wiring is now internal and no longer part of the supported public surface.

--- a/packages/cqrs/README.ko.md
+++ b/packages/cqrs/README.ko.md
@@ -33,6 +33,8 @@ npm install @fluojs/cqrs
 
 `CqrsModule`을 등록하고 첫 번째 Command와 Handler를 정의합니다.
 
+`CqrsModule.forRoot(...)`는 CQRS 버스와 핸들러 탐색을 연결하는 지원되는 루트 진입점입니다. 루트만 사용하는 소비자는 low-level provider 조립을 루트 배럴 API의 일부가 아니라 내부 구현 세부사항으로 취급해야 합니다.
+
 ```typescript
 import { Inject, Module } from '@fluojs/core';
 import {
@@ -123,6 +125,7 @@ class LegacyService {
 
 ### 모듈 및 프로바이더
 - `CqrsModule.forRoot(options)`: 메인 진입점입니다. 버스를 등록하고 탐색을 시작합니다.
+- 루트 수준 등록은 의도적으로 `CqrsModule.forRoot(...)`를 중심으로 하며, low-level provider helper는 문서화된 루트 배럴 계약의 일부가 아닙니다.
 - `CommandBusLifecycleService`: Command 실행을 위한 기본 서비스입니다.
 - `QueryBusLifecycleService`: Query 실행을 위한 기본 서비스입니다.
 - `CqrsEventBusService`: Event 발행을 위한 기본 서비스입니다.

--- a/packages/cqrs/README.md
+++ b/packages/cqrs/README.md
@@ -33,6 +33,8 @@ npm install @fluojs/cqrs
 
 Register the `CqrsModule` and define your first command and handler.
 
+`CqrsModule.forRoot(...)` is the supported root entrypoint for wiring CQRS buses and handler discovery. Root-only consumers should treat low-level provider assembly as an internal implementation detail instead of part of the root-barrel API.
+
 ```typescript
 import { Inject, Module } from '@fluojs/core';
 import {
@@ -123,6 +125,7 @@ class LegacyService {
 
 ### Modules & Providers
 - `CqrsModule.forRoot(options)`: Main entry point. Registers buses and starts discovery.
+- Root-level registration is intentionally centered on `CqrsModule.forRoot(...)`; low-level provider helpers are not part of the documented root-barrel contract.
 - `CommandBusLifecycleService`: Primary service for executing commands.
 - `QueryBusLifecycleService`: Primary service for executing queries.
 - `CqrsEventBusService`: Primary service for publishing events.

--- a/packages/cqrs/src/__snapshots__/public-surface.test.ts.snap
+++ b/packages/cqrs/src/__snapshots__/public-surface.test.ts.snap
@@ -22,7 +22,6 @@ exports[`@fluojs/cqrs root barrel public surface > keeps the documented root exp
   "SagaTopologyError",
   "commandHandlerMetadataSymbol",
   "createCqrsPlatformStatusSnapshot",
-  "createCqrsProviders",
   "defineCommandHandlerMetadata",
   "defineEventHandlerMetadata",
   "defineQueryHandlerMetadata",

--- a/packages/cqrs/src/index.ts
+++ b/packages/cqrs/src/index.ts
@@ -24,7 +24,7 @@ export {
   getSagaMetadata,
   sagaMetadataSymbol,
 } from './metadata.js';
-export { CqrsModule, createCqrsProviders, type CqrsModuleOptions } from './module.js';
+export { CqrsModule, type CqrsModuleOptions } from './module.js';
 export * from './status.js';
 export { CommandBusLifecycleService } from './buses/command-bus.js';
 export { CqrsEventBusService } from './buses/event-bus.js';

--- a/packages/cqrs/src/public-api.test.ts
+++ b/packages/cqrs/src/public-api.test.ts
@@ -5,7 +5,6 @@ import * as cqrsPublicApi from './index.js';
 describe('@fluojs/cqrs public API surface', () => {
   it('keeps documented supported root-barrel exports', () => {
     expect(cqrsPublicApi).toHaveProperty('CqrsModule');
-    expect(cqrsPublicApi).toHaveProperty('createCqrsProviders');
     expect(cqrsPublicApi).toHaveProperty('CommandBusLifecycleService');
     expect(cqrsPublicApi).toHaveProperty('QueryBusLifecycleService');
     expect(cqrsPublicApi).toHaveProperty('CqrsEventBusService');
@@ -20,6 +19,10 @@ describe('@fluojs/cqrs public API surface', () => {
     expect(cqrsPublicApi).toHaveProperty('QueryHandlerNotFoundException');
     expect(cqrsPublicApi).toHaveProperty('SagaTopologyError');
     expect(cqrsPublicApi).toHaveProperty('createCqrsPlatformStatusSnapshot');
+  });
+
+  it('hides low-level provider assembly from the root barrel', () => {
+    expect(cqrsPublicApi).not.toHaveProperty('createCqrsProviders');
   });
 
   it('does not expose removed legacy error aliases', () => {

--- a/packages/cqrs/src/public-surface.test.ts
+++ b/packages/cqrs/src/public-surface.test.ts
@@ -6,7 +6,7 @@ describe('@fluojs/cqrs root barrel public surface', () => {
   it('keeps the documented root exports stable for 0.x governance', () => {
     expect(cqrs).toHaveProperty('CqrsModule');
     expect(cqrs).not.toHaveProperty('createCqrsModule');
-    expect(cqrs).toHaveProperty('createCqrsProviders');
+    expect(cqrs).not.toHaveProperty('createCqrsProviders');
     expect(cqrs).toHaveProperty('CommandBusLifecycleService');
     expect(cqrs).toHaveProperty('QueryBusLifecycleService');
     expect(cqrs).toHaveProperty('CqrsEventBusService');


### PR DESCRIPTION
Closes #1160

## Summary
- align `@fluojs/cqrs` with the module-first entrypoint contract used across infra-messaging packages
- keep `CqrsModule.forRoot(...)` as the supported root entrypoint and stop treating `createCqrsProviders(...)` as part of the root-barrel public surface

## Changes
- remove `createCqrsProviders(...)` from the `@fluojs/cqrs` root barrel and update root public-surface coverage
- clarify the supported `CqrsModule.forRoot(...)` entrypoint contract in `packages/cqrs/README.md` and `packages/cqrs/README.ko.md`
- add an unreleased changelog migration note for the root-barrel surface change

## Testing
- `pnpm --filter @fluojs/cqrs test` ✅
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `pnpm verify:public-export-tsdoc` ✅
- `pnpm lint` ⚠️ fails on pre-existing repository warnings outside this change set (for example `packages/cli/src/commands/new.ts`, `packages/config/src/load.test.ts`, `packages/core/src/utils.test.ts`, and existing `useImportType` warnings in `packages/cqrs`)
- `lsp_diagnostics` on changed `packages/cqrs/src/*.ts` files ✅

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.