### PR TITLE
Resolve #1164: align queue module entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Breaking changes
 
+- `@fluojs/queue`: the root barrel no longer exports `createQueueProviders(...)`. Migration note: register queues through `QueueModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/event-bus`: the root barrel no longer exports `createEventBusProviders(...)`. Migration note: switch root-package composition to `EventBusModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/cron`: the root barrel no longer exports `createCronProviders(...)`. Migration note: register scheduling through `CronModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/terminus`: the root barrel no longer exports `createTerminusProviders(...)`. Migration note: switch root-package composition to `TerminusModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.

--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -52,6 +52,8 @@ export class OrderWorker {
 
 `QueueModule`을 등록하고 `QueueLifecycleService`를 주입받아 작업을 큐에 추가합니다.
 
+`QueueModule.forRoot(...)`는 큐 등록을 위한 지원되는 루트 엔트리포인트입니다. 루트 패키지 사용자는 저수준 provider 조합을 루트 barrel API의 일부가 아니라 내부 구현 세부사항으로 취급해야 합니다.
+
 ```typescript
 import { Module, Inject } from '@fluojs/core';
 import { QueueModule, QueueLifecycleService } from '@fluojs/queue';
@@ -107,8 +109,11 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 ### 핵심 구성 요소
 - `QueueModule`: 큐 기능을 위한 기본 모듈입니다.
+- `QueueModule.forRoot(options)`: 애플리케이션 수준 큐 등록을 위한 지원되는 루트 엔트리포인트입니다.
 - `QueueLifecycleService`: 작업을 큐에 추가(`enqueue(job)`)하기 위한 기본 서비스입니다.
 - `@QueueWorker(JobClass, options?)`: 특정 작업을 처리할 핸들러를 지정하는 데코레이터입니다.
+
+루트 수준 등록은 의도적으로 `QueueModule.forRoot(...)`를 중심으로 유지되며, 저수준 provider helper는 문서화된 루트 barrel 계약에 포함되지 않습니다.
 
 ### 타입
 - `QueueModuleOptions`: 전역 큐 설정(clientName, 기본 시도 횟수, 동시성, 전송률 제한 등)을 위한 타입입니다.

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -52,6 +52,8 @@ export class OrderWorker {
 
 Import `QueueModule` and inject `QueueLifecycleService` to enqueue jobs.
 
+`QueueModule.forRoot(...)` is the supported root entrypoint for queue registration. Root-package consumers should treat low-level provider assembly as an internal implementation detail instead of part of the root-barrel API.
+
 ```typescript
 import { Module, Inject } from '@fluojs/core';
 import { QueueModule, QueueLifecycleService } from '@fluojs/queue';
@@ -107,8 +109,11 @@ Jobs that fail all retry attempts are automatically moved to a dead-letter list 
 
 ### Core
 - `QueueModule`: Main entry point for queue registration.
+- `QueueModule.forRoot(options)`: Supported root entrypoint for application-level queue registration.
 - `QueueLifecycleService`: Primary service for enqueuing jobs (`enqueue(job)`).
 - `@QueueWorker(JobClass, options?)`: Decorator to mark a class as a job handler.
+
+Root-level registration is intentionally centered on `QueueModule.forRoot(...)`; low-level provider helpers are not part of the documented root-barrel contract.
 
 ### Types
 - `QueueModuleOptions`: Global queue settings (clientName, default attempts, concurrency, rate limiting).

--- a/packages/queue/src/__snapshots__/public-surface.test.ts.snap
+++ b/packages/queue/src/__snapshots__/public-surface.test.ts.snap
@@ -7,6 +7,5 @@ exports[`@fluojs/queue root barrel public surface > keeps the documented root ex
   "QueueModule",
   "QueueWorker",
   "createQueuePlatformStatusSnapshot",
-  "createQueueProviders",
 ]
 `;

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -1,5 +1,5 @@
 export { QueueWorker } from './decorators.js';
-export { QueueModule, createQueueProviders } from './module.js';
+export { QueueModule } from './module.js';
 export { QueueLifecycleService } from './service.js';
 export * from './status.js';
 export { QUEUE } from './tokens.js';

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -24,13 +24,7 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
   };
 }
 
-/**
- * Creates queue lifecycle providers and normalized queue options.
- *
- * @param options Queue module defaults for attempts, backoff, concurrency, and rate limiting.
- * @returns Provider definitions that register normalized `QUEUE_OPTIONS`, `QueueLifecycleService`, and the compatibility alias `QUEUE`.
- */
-export function createQueueProviders(options: QueueModuleOptions = {}): Provider[] {
+function createQueueProviders(options: QueueModuleOptions = {}): Provider[] {
   return [
     {
       provide: QUEUE_OPTIONS,

--- a/packages/queue/src/public-surface.test.ts
+++ b/packages/queue/src/public-surface.test.ts
@@ -9,13 +9,25 @@ describe('@fluojs/queue root barrel public surface', () => {
   it('keeps the documented root exports stable for 0.x governance', () => {
     expect(queue).toHaveProperty('QueueModule');
     expect(queue).not.toHaveProperty('createQueueModule');
-    expect(queue).toHaveProperty('createQueueProviders');
+    expect(queue).not.toHaveProperty('createQueueProviders');
     expect(queue).toHaveProperty('QueueLifecycleService');
     expect(queue).toHaveProperty('QUEUE');
     expect(queue).toHaveProperty('QueueWorker');
     expect(queue).toHaveProperty('createQueuePlatformStatusSnapshot');
     expect(queue).not.toHaveProperty('QUEUE_OPTIONS');
     expect(Object.keys(queue).sort()).toMatchSnapshot();
+  });
+
+  it('keeps the README helper and module entrypoints aligned with the supported public contract', () => {
+    const readme = readFileSync(resolve(import.meta.dirname, '../README.md'), 'utf8');
+    const koreanReadme = readFileSync(resolve(import.meta.dirname, '../README.ko.md'), 'utf8');
+
+    expect(readme).toContain('`QueueModule.forRoot(...)` is the supported root entrypoint for queue registration.');
+    expect(readme).toContain('low-level provider assembly as an internal implementation detail');
+    expect(readme).toContain('low-level provider helpers are not part of the documented root-barrel contract.');
+    expect(koreanReadme).toContain('`QueueModule.forRoot(...)`는 큐 등록을 위한 지원되는 루트 엔트리포인트입니다.');
+    expect(koreanReadme).toContain('저수준 provider 조합을 루트 barrel API의 일부가 아니라 내부 구현 세부사항으로 취급해야 합니다.');
+    expect(koreanReadme).toContain('저수준 provider helper는 문서화된 루트 barrel 계약에 포함되지 않습니다.');
   });
 
   it('keeps the README worker options aligned with the supported public contract', () => {


### PR DESCRIPTION
Closes #1164

## Summary
- align `@fluojs/queue` with the module-first helper-surface policy used by adjacent packages in the same audit wave
- keep the documented root registration path centered on `QueueModule.forRoot(...)`

## Changes
- remove `createQueueProviders(...)` from the `@fluojs/queue` root barrel while keeping the internal module wiring unchanged
- update `packages/queue` public-surface tests and snapshot to guard the narrowed root export contract
- clarify the supported queue entrypoint in `packages/queue/README.md` and `packages/queue/README.ko.md`, and add a migration note to `CHANGELOG.md`

## Testing
- `pnpm test` (in `packages/queue`)
- `pnpm typecheck` (in `packages/queue`)
- `pnpm build` (in `packages/queue`)
- `pnpm lint`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] No SSOT governance docs changed in this PR.
- [x] Companion discoverability/tooling updates were not required because platform contract docs were unchanged.
- [x] Queue README contract changes are backed by root public-surface regression tests.