### PR TITLE
Resolve #1167: clarify socket.io helper contract

### DIFF
--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -98,13 +98,35 @@ SocketIoModule.forRoot({
 
 이제 `cors`를 생략하면 `@fluojs/socket.io`는 `origin: false`를 기본값으로 사용하므로 cross-origin 노출은 명시적 opt-in이 필요합니다. `engine.maxHttpBufferSize`를 생략하면 어댑터가 1 MiB Engine.IO payload 상한을 적용합니다.
 
+### 수동 모듈 조합
+일반적인 애플리케이션 모듈에서는 `SocketIoModule.forRoot(...)`가 표준 진입점입니다.
+이미 존재하는 커스텀 `defineModule(...)` 등록 안에 같은 Socket.IO provider 집합을 배선해야 할 때는
+`createSocketIoProviders(...)`를 지원되는 저수준 공개 API로 계속 사용할 수 있습니다.
+
+```ts
+import { defineModule } from '@fluojs/runtime';
+import {
+  SOCKETIO_ROOM_SERVICE,
+  SOCKETIO_SERVER,
+  createSocketIoProviders,
+} from '@fluojs/socket.io';
+
+class ManualSocketIoModule {}
+
+defineModule(ManualSocketIoModule, {
+  exports: [SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER],
+  global: true,
+  providers: createSocketIoProviders(),
+});
+```
+
 ## 공개 API 개요
 
 - `SocketIoModule.forRoot(options)`
 - `SocketIoModule.forRoot({ auth, cors, engine, ... })`
 - `SOCKETIO_SERVER`
 - `SOCKETIO_ROOM_SERVICE`
-- `createSocketIoProviders(options)`
+- `createSocketIoProviders(options)`: `SocketIoModule.forRoot(options)`가 사용하는 provider 집합을 반환하며, 지원되는 수동 `defineModule(...)` 조합에 사용할 수 있습니다.
 
 ## 지원 플랫폼
 

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -100,13 +100,35 @@ SocketIoModule.forRoot({
 
 When `cors` is omitted, `@fluojs/socket.io` now defaults to `origin: false` so cross-origin exposure stays opt-in. When `engine.maxHttpBufferSize` is omitted, the adapter applies a bounded 1 MiB Engine.IO payload limit.
 
+### Manual Module Composition
+`SocketIoModule.forRoot(...)` remains the canonical entrypoint for normal application modules.
+When you need to wire the same Socket.IO providers into an existing custom `defineModule(...)`
+registration, `createSocketIoProviders(...)` remains a supported low-level public API.
+
+```typescript
+import { defineModule } from '@fluojs/runtime';
+import {
+  SOCKETIO_ROOM_SERVICE,
+  SOCKETIO_SERVER,
+  createSocketIoProviders,
+} from '@fluojs/socket.io';
+
+class ManualSocketIoModule {}
+
+defineModule(ManualSocketIoModule, {
+  exports: [SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER],
+  global: true,
+  providers: createSocketIoProviders(),
+});
+```
+
 ## Public API Overview
 
 - `SocketIoModule.forRoot(options)`: Main module for Socket.IO integration.
 - `SocketIoModule.forRoot({ auth, cors, engine, ... })`: Configures namespace/message guards plus explicit CORS and Engine.IO payload bounds.
 - `SOCKETIO_SERVER`: Token to inject the raw Socket.IO `Server`.
 - `SOCKETIO_ROOM_SERVICE`: Token to inject the `SocketIoRoomService`.
-- `createSocketIoProviders(options)`: Helper for custom provider composition.
+- `createSocketIoProviders(options)`: Returns the provider set used by `SocketIoModule.forRoot(options)` for supported manual `defineModule(...)` composition.
 
 ## Supported Platforms
 

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -293,6 +293,7 @@ describe('@fluojs/socket.io', () => {
   it('keeps lifecycle and options tokens out of the root public entrypoint', () => {
     expect(publicApi.SOCKETIO_ROOM_SERVICE).toBeDefined();
     expect(publicApi.SOCKETIO_SERVER).toBeDefined();
+    expect(publicApi.createSocketIoProviders).toBe(createSocketIoProviders);
     expect('SOCKETIO_LIFECYCLE_SERVICE' in publicApi).toBe(false);
     expect('SOCKETIO_OPTIONS' in publicApi).toBe(false);
   });
@@ -351,6 +352,40 @@ describe('@fluojs/socket.io', () => {
     const probe = await app.container.resolve(ServerProbe);
 
     expect(probe.server).toBeDefined();
+
+    await app.close();
+  });
+
+  it('supports manual defineModule composition through createSocketIoProviders', async () => {
+    @Inject(SOCKETIO_SERVER, SOCKETIO_ROOM_SERVICE)
+    class ManualProbe {
+      constructor(
+        public readonly server: SocketIoServer,
+        public readonly rooms: SocketIoRoomService,
+      ) {}
+    }
+
+    class ManualSocketIoModule {}
+    defineModule(ManualSocketIoModule, {
+      exports: [SOCKETIO_ROOM_SERVICE, SOCKETIO_SERVER],
+      global: true,
+      providers: createSocketIoProviders(),
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [ManualSocketIoModule],
+      providers: [ManualProbe],
+    });
+
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port: await findAvailablePort(),
+    });
+    const probe = await app.container.resolve(ManualProbe);
+
+    expect(probe.server).toBeDefined();
+    expect(probe.rooms).toBeInstanceOf(SocketIoLifecycleService);
 
     await app.close();
   });


### PR DESCRIPTION
Closes #1167

## Summary

Clarify that `@fluojs/socket.io` remains module-first through `SocketIoModule.forRoot(...)` while keeping `createSocketIoProviders(...)` as a supported low-level composition API.

## Changes

- document a dedicated manual `defineModule(...)` composition path in `packages/socket.io/README.md`
- mirror the same helper contract in `packages/socket.io/README.ko.md`
- add regression coverage that the root barrel still exports `createSocketIoProviders(...)` and that manual composition resolves the public Socket.IO tokens

## Testing

- `pnpm --filter @fluojs/socket.io test`
- `pnpm --filter @fluojs/socket.io typecheck`
- `pnpm --filter @fluojs/socket.io build`
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck` *(currently fails on pre-existing workspace module-resolution errors under `packages/http` and `packages/runtime`, unrelated to this PR's changes)*

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.