### PR TITLE
Resolve #1165: clarify email helper contract

### DIFF
--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -11,6 +11,7 @@ fluo를 위한 transport-agnostic 이메일 코어 패키지입니다. Nest-like
 - [빠른 시작](#빠른-시작)
 - [일반적인 패턴](#일반적인-패턴)
   - [`@fluojs/email/node`를 이용한 Node 전용 SMTP](#fluojs-email-node를-이용한-node-전용-smtp)
+  - [`createEmailProviders`를 이용한 수동 provider 조합](#createemailproviders를-이용한-수동-provider-조합)
   - [`EmailService`를 이용한 standalone 전달](#emailservice를-이용한-standalone-전달)
   - [`@fluojs/notifications`와의 통합](#fluojs-notifications와의-통합)
   - [큐 기반 대량 전달](#큐-기반-대량-전달)
@@ -138,6 +139,36 @@ Behavioral contract 메모:
 - 이 factory는 자신이 생성한 Nodemailer transporter 리소스를 소유하므로 `EmailService`가 bootstrap 시 검증하고 shutdown 시 닫을 수 있습니다.
 - `createNodemailerEmailTransport(...)`는 이미 존재하는 Nodemailer transporter를 감싸지만 리소스 소유권은 호출자에게 남깁니다.
 - SMTP 자격 증명은 여전히 명시적인 옵션 또는 DI를 통해 들어와야 합니다. 루트 패키지와 Node 서브패스 모두 `process.env`를 직접 읽지 않습니다.
+
+### `createEmailProviders`를 이용한 수동 provider 조합
+
+`createEmailProviders(...)`는 애플리케이션이 `EmailModule.forRoot(...)` 밖에서 동일한 provider 정규화 구성을 재사용해야 할 때 지원되는 manual-composition helper입니다.
+
+```typescript
+import { Module } from '@fluojs/core';
+import { createEmailProviders } from '@fluojs/email';
+
+@Module({
+  providers: [
+    ...createEmailProviders({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        kind: 'custom-http-transport',
+        create: () => customTransport,
+        ownsResources: false,
+      },
+    }),
+  ],
+  exports: [],
+})
+export class EmailProvidersModule {}
+```
+
+Behavioral contract 메모:
+
+- 이 helper는 `EmailModule.forRoot(...)`가 구성하는 `EMAIL`, `EMAIL_CHANNEL`, `EmailService` wiring을 동일하게 유지합니다.
+- `createEmailProviders(...)`는 trim된 주소, 기본 notification 채널 fallback, transport 소유권 기본값을 포함해 `EmailModule.forRoot(...)`와 동일한 옵션 정규화를 적용합니다.
+- 이 helper도 여전히 명시적인 `transport`를 요구하며, 패키지의 runtime-portable·no-implicit-env 계약을 약화시키지 않습니다.
 
 ### `EmailService`를 이용한 standalone 전달
 
@@ -318,7 +349,7 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 ## 예제 소스
 
-- `packages/email/src/module.test.ts`: 모듈 등록, async wiring, lifecycle, queue-backed notifications 예제.
+- `packages/email/src/module.test.ts`: 모듈 등록, `createEmailProviders(...)` helper coverage, async wiring, lifecycle, queue-backed notifications 예제.
 - `packages/email/src/public-surface.test.ts`: 공개 export와 TypeScript 계약 검증 예제.
 - `packages/email/src/node/node.test.ts`: Node 전용 Nodemailer adapter 매핑과 lifecycle 예제.
 - `packages/email/src/status.test.ts`: health/readiness 계약 예제.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -11,6 +11,7 @@ Transport-agnostic email delivery core for fluo. It provides a Nest-like module 
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
   - [Node-only SMTP with `@fluojs/email/node`](#node-only-smtp-with-fluojs-email-node)
+  - [Manual provider composition with `createEmailProviders`](#manual-provider-composition-with-createemailproviders)
   - [Standalone delivery with `EmailService`](#standalone-delivery-with-emailservice)
   - [Integration with `@fluojs/notifications`](#integration-with-fluojs-notifications)
   - [Queue-backed bulk delivery](#queue-backed-bulk-delivery)
@@ -138,6 +139,36 @@ Behavioral contract notes:
 - The factory owns the Nodemailer transporter it creates, so `EmailService` can verify it on bootstrap and close it during shutdown.
 - `createNodemailerEmailTransport(...)` wraps an existing Nodemailer transporter without transferring resource ownership.
 - SMTP credentials still enter through explicit options or DI. Neither the root package nor the Node subpath reads `process.env` directly.
+
+### Manual provider composition with `createEmailProviders`
+
+`createEmailProviders(...)` is the supported manual-composition helper when applications need the same provider normalization outside `EmailModule.forRoot(...)`.
+
+```typescript
+import { Module } from '@fluojs/core';
+import { createEmailProviders } from '@fluojs/email';
+
+@Module({
+  providers: [
+    ...createEmailProviders({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        kind: 'custom-http-transport',
+        create: () => customTransport,
+        ownsResources: false,
+      },
+    }),
+  ],
+  exports: [],
+})
+export class EmailProvidersModule {}
+```
+
+Behavioral contract notes:
+
+- The helper preserves the same `EMAIL`, `EMAIL_CHANNEL`, and `EmailService` wiring that `EmailModule.forRoot(...)` installs.
+- `createEmailProviders(...)` applies the same option normalization as `EmailModule.forRoot(...)`, including trimmed addresses, default notification channel fallback, and transport ownership defaults.
+- The helper still requires an explicit `transport`; it does not weaken the package's runtime-portable, no-implicit-env contract.
 
 ### Standalone delivery with `EmailService`
 
@@ -318,7 +349,7 @@ These limitations are part of the package contract so transport selection, templ
 
 ## Example Sources
 
-- `packages/email/src/module.test.ts`: Module registration, async wiring, lifecycle, and queue-backed notifications examples.
+- `packages/email/src/module.test.ts`: Module registration, `createEmailProviders(...)` helper coverage, async wiring, lifecycle, and queue-backed notifications examples.
 - `packages/email/src/public-surface.test.ts`: Public export and TypeScript contract verification.
 - `packages/email/src/node/node.test.ts`: Node-only Nodemailer adapter mapping and lifecycle examples.
 - `packages/email/src/status.test.ts`: Health/readiness contract examples.

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -144,7 +144,7 @@ vi.mock('bullmq', () => ({
 
 import { EmailChannel } from './channel.js';
 import { EmailNotificationQueueJob, EmailNotificationsQueueWorker, createEmailNotificationsQueueAdapter } from './queue.js';
-import { EmailModule } from './module.js';
+import { EmailModule, createEmailProviders } from './module.js';
 import { EmailService } from './service.js';
 import { EMAIL } from './tokens.js';
 import { EmailConfigurationError } from './errors.js';
@@ -226,6 +226,10 @@ function moduleProviders(moduleType: Constructor): Provider[] {
   return metadata.providers as Provider[];
 }
 
+function providerToken(provider: Provider): unknown {
+  return typeof provider === 'function' ? provider : provider.provide;
+}
+
 describe('EmailModule', () => {
   beforeEach(() => {
     bullmqState.clear();
@@ -266,6 +270,58 @@ describe('EmailModule', () => {
 
     await service.onApplicationShutdown();
     expect(transportState.closeCalls).toBe(1);
+  });
+
+  it('creates helper providers with the same normalized options and facade tokens as EmailModule.forRoot', async () => {
+    const options = {
+      defaultFrom: ' noreply@example.com ',
+      defaultReplyTo: [{ address: ' reply@example.com ', name: 'Support' }],
+      notifications: { channel: ' transactional-email ' },
+      transport: createRecordingTransportFactory(),
+      verifyOnModuleInit: true,
+    };
+    const moduleType = EmailModule.forRoot(options);
+    const helperProviders = createEmailProviders(options);
+    const moduleRuntimeProviders = moduleProviders(moduleType);
+    const helperContainer = new Container();
+
+    expect(helperProviders).toHaveLength(moduleRuntimeProviders.length);
+    expect(helperProviders.map(providerToken)).toEqual(moduleRuntimeProviders.map(providerToken));
+
+    helperContainer.register(...helperProviders);
+
+    const service = await helperContainer.resolve(EmailService);
+    const facade = await helperContainer.resolve<Email>(EMAIL);
+    const channel = await helperContainer.resolve(EmailChannel);
+
+    await service.onModuleInit();
+
+    const result = await facade.send({
+      subject: 'Manual providers',
+      text: 'helper contract',
+      to: ['user@example.com'],
+    });
+
+    expect(result.messageId).toBe('message-1');
+    expect(channel.channel).toBe('transactional-email');
+    expect(transportState.verifyCalls).toBe(1);
+    expect(transportState.sent[0]).toMatchObject({
+      from: { address: 'noreply@example.com' },
+      replyTo: [{ address: 'reply@example.com', name: 'Support' }],
+      subject: 'Manual providers',
+      text: 'helper contract',
+    });
+
+    await service.onApplicationShutdown();
+    expect(transportState.closeCalls).toBe(1);
+  });
+
+  it('rejects helper-based registration without an explicit transport contract', () => {
+    expect(() =>
+      createEmailProviders({
+        defaultFrom: 'noreply@example.com',
+      } as never),
+    ).toThrowError(new EmailConfigurationError('EmailModule requires an explicit `transport` to be configured.'));
   });
 
   it('resolves async options once and exposes the compatibility facade and channel token', async () => {

--- a/packages/email/src/public-surface.test.ts
+++ b/packages/email/src/public-surface.test.ts
@@ -63,6 +63,16 @@ describe('@fluojs/email public API surface', () => {
     });
   });
 
+  it('keeps the README helper contract aligned with the documented root-barrel API', () => {
+    const readme = readFileSync(resolve(import.meta.dirname, '../README.md'), 'utf8');
+    const koreanReadme = readFileSync(resolve(import.meta.dirname, '../README.ko.md'), 'utf8');
+
+    expect(readme).toContain('`createEmailProviders(...)` is the supported manual-composition helper when applications need the same provider normalization outside `EmailModule.forRoot(...)`.');
+    expect(readme).toContain('The helper preserves the same `EMAIL`, `EMAIL_CHANNEL`, and `EmailService` wiring that `EmailModule.forRoot(...)` installs.');
+    expect(koreanReadme).toContain('`createEmailProviders(...)`는 애플리케이션이 `EmailModule.forRoot(...)` 밖에서 동일한 provider 정규화 구성을 재사용해야 할 때 지원되는 manual-composition helper입니다.');
+    expect(koreanReadme).toContain('이 helper는 `EmailModule.forRoot(...)`가 구성하는 `EMAIL`, `EMAIL_CHANNEL`, `EmailService` wiring을 동일하게 유지합니다.');
+  });
+
   it('keeps documented TypeScript-only contracts stable enough for downstream packages', () => {
     expectTypeOf<EmailMessage>().toHaveProperty('to');
     expectTypeOf<EmailMessage>().toHaveProperty('subject');


### PR DESCRIPTION
Closes #1165

## Summary
- clarify the supported `createEmailProviders(...)` contract in the `@fluojs/email` package docs
- add helper-focused regression coverage so manual provider composition stays aligned with `EmailModule.forRoot(...)`

## Changes
- add module-level tests that verify `createEmailProviders(...)` preserves normalized provider wiring and still requires an explicit transport
- add public-surface assertions that lock the new README helper contract wording in both English and Korean
- document the helper as the supported manual-composition path in `packages/email/README.md` and `packages/email/README.ko.md`

## Testing
- [x] `pnpm --filter @fluojs/email test`
- [x] `pnpm build`
- [x] `pnpm --filter @fluojs/email typecheck`
- [x] `pnpm --filter @fluojs/email build`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.