### PR TITLE
Resolve #1169: align microservices helper contract docs parity

### DIFF
--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -93,6 +93,7 @@ await microservice.listen();
 ### 루트 배럴 (`@fluojs/microservices`)
 
 - `MicroservicesModule`, `createMicroservicesProviders`: 모듈 등록 진입점입니다.
+- `MicroservicesModule.forRoot(...)`는 여전히 표준 런타임 진입점이며, `createMicroservicesProviders(...)`는 provider 집합을 의도적으로 직접 조합하려는 호출자를 위한 공개 helper로 유지합니다.
 - `MessagePattern`, `EventPattern`, `ServerStreamPattern`, `ClientStreamPattern`, `BidiStreamPattern`: 라우팅/스트리밍 데코레이터입니다.
 - `TcpMicroserviceTransport`, `RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `KafkaMicroserviceTransport`, `RabbitMqMicroserviceTransport`, `GrpcMicroserviceTransport`, `MqttMicroserviceTransport`: 루트 배럴에서 제공하는 트랜스포트 어댑터입니다.
 - `MicroserviceLifecycleService`, `MICROSERVICE`: 런타임 접근용 서비스와 호환 토큰입니다.
@@ -118,7 +119,9 @@ await microservice.listen();
 
 ## 예제 소스
 
-- `packages/microservices/src/module.test.ts`
-- `packages/microservices/src/public-api.test.ts`
-- `packages/microservices/src/public-subpaths.test.ts`
-- `packages/microservices/src/public-surface.test.ts`
+- `packages/microservices/src/module.test.ts`: 모든 트랜스포트 통합 계약을 검증합니다.
+- `packages/microservices/src/public-api.test.ts`: 문서화된 `createMicroservicesProviders(...)` helper를 포함한 루트 배럴 export 계약을 검증합니다.
+- `packages/microservices/src/public-surface.test.ts`: 0.x 거버넌스 동안 helper가 공개 surface에 남아 있는지 스냅샷으로 고정합니다.
+- `packages/microservices/src/public-subpaths.test.ts`: 문서화된 트랜스포트 서브패스 export map 계약을 검증합니다.
+- `examples/microservices-tcp`: 기본 TCP 마이크로서비스 예제입니다.
+- `examples/microservices-kafka`: Kafka 기반 분산 아키텍처 예제입니다.

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -90,6 +90,7 @@ Microservice handlers fully support fluo's DI scopes. Request-scoped providers a
 ### Root barrel (`@fluojs/microservices`)
 
 - `MicroservicesModule`, `createMicroservicesProviders`: module registration helpers.
+- `MicroservicesModule.forRoot(...)` remains the canonical runtime entrypoint, while `createMicroservicesProviders(...)` stays public for callers that intentionally compose the provider set themselves.
 - `MessagePattern`, `EventPattern`, `ServerStreamPattern`, `ClientStreamPattern`, `BidiStreamPattern`: routing and streaming decorators.
 - `TcpMicroserviceTransport`, `RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `KafkaMicroserviceTransport`, `RabbitMqMicroserviceTransport`, `GrpcMicroserviceTransport`, `MqttMicroserviceTransport`: transport adapters exported from the root barrel.
 - `MicroserviceLifecycleService`, `MICROSERVICE`: programmatic runtime access and compatibility token.
@@ -116,7 +117,8 @@ Microservice handlers fully support fluo's DI scopes. Request-scoped providers a
 ## Example Sources
 
 - `packages/microservices/src/module.test.ts`: Integration tests for all transports.
-- `packages/microservices/src/public-api.test.ts`: Root-barrel contract coverage.
+- `packages/microservices/src/public-api.test.ts`: Root-barrel export coverage, including the documented `createMicroservicesProviders(...)` helper.
+- `packages/microservices/src/public-surface.test.ts`: Root-barrel snapshot coverage that keeps the helper public during 0.x governance.
 - `packages/microservices/src/public-subpaths.test.ts`: Export-map coverage for documented transport subpaths.
 - `examples/microservices-tcp`: Basic TCP microservice example.
 - `examples/microservices-kafka`: Distributed Kafka-based architecture example.


### PR DESCRIPTION
Closes #1169

## Summary

Align `@fluojs/microservices` EN/KO package docs around the intentional public helper contract so both mirrors point at the same public-surface evidence.

## Changes

- clarify that `MicroservicesModule.forRoot(...)` remains the canonical runtime entrypoint while `createMicroservicesProviders(...)` stays public for intentional manual provider composition
- align the English and Korean `Example Sources` sections so they reference the same helper/public-surface tests and examples
- keep the documented public surface consistent with the existing root-barrel contract tests

## Testing

- `pnpm exec vitest run packages/microservices/src/public-api.test.ts packages/microservices/src/public-surface.test.ts packages/microservices/src/public-subpaths.test.ts`
- `pnpm verify:platform-consistency-governance`
- `pnpm build`
- `pnpm typecheck`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No changed public exports required source-level TSDoc updates.
- [x] No changed exported functions required matching `@param` / `@returns` updates.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The affected package README now documents the intentional public helper contract consistently in English and Korean.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants remain covered by existing regression tests referenced from the README.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for the changed package README pair.
- [x] No platform contract docs changed, so no companion governance/tooling updates were required.
- [x] The README alignment claims are backed by the existing documented contract tests for this package.