### PR TITLE
Resolve #1192: add microservices module-first replacement path

### DIFF
--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -10,6 +10,7 @@ fluo용 트랜스포트 기반 마이크로서비스 패키지입니다. TCP, Re
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 기능](#주요-기능)
+- [공통 패턴](#공통-패턴)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -88,12 +89,60 @@ await microservice.listen();
 - `messageRetentionMaxLen`과 `eventRetentionMaxLen`은 고급 opt-in 설정으로 남아 있습니다. 이를 켜면 Redis가 ACK 전 pending live-stream 엔트리를 먼저 trim할 수 있으므로 broker-managed recovery 보장을 일부 포기하는 운영 판단이 됩니다.
 - RabbitMQ 요청-응답은 기본적으로 인스턴스별 response queue를 사용합니다. 공유 reply topology를 의도적으로 운영할 때만 `responseQueue`를 명시적으로 지정하세요.
 
+## 공통 패턴
+
+### module-first custom registration
+
+custom provider/export/non-global 구성이 필요할 때도 raw provider array로 내려가지 말고 `MicroservicesModule.forRoot({ transport, module: { ... } })`를 우선 사용하세요.
+
+```ts
+import { Module } from '@fluojs/core';
+import { MicroservicesModule } from '@fluojs/microservices';
+
+const EXTRA_MICROSERVICE_EXPORT = Symbol('extra-microservice-export');
+
+@Module({
+  imports: [
+    MicroservicesModule.forRoot({
+      transport: customTransport,
+      module: {
+        global: false,
+        providers: [{ provide: EXTRA_MICROSERVICE_EXPORT, useValue: 'custom-module-value' }],
+        additionalExports: [EXTRA_MICROSERVICE_EXPORT],
+      },
+    }),
+  ],
+})
+class FeatureModule {}
+```
+
+Behavioral contract notes:
+
+- 이 모듈 경로는 기본 `MicroservicesModule.forRoot(...)` 호출과 동일한 `MICROSERVICE_OPTIONS`, `MicroserviceLifecycleService`, `MICROSERVICE` wiring을 그대로 설치합니다.
+- `module.providers`는 내장 런타임 wiring 뒤에 추가 provider를 붙이고, `module.additionalExports`는 기본 export 토큰을 교체하지 않고 확장합니다.
+- `module.global`을 사용하면 raw provider graph를 다시 조립하지 않고도 고급 호출자가 등록 범위를 로컬로 제한할 수 있습니다.
+
+### low-level helper for raw provider arrays
+
+`createMicroservicesProviders(...)`는 실제로 low-level provider array 자체가 필요한 호출자에게만 남아 있습니다.
+
+```ts
+import { Module } from '@fluojs/core';
+import { createMicroservicesProviders } from '@fluojs/microservices';
+
+@Module({
+  providers: [...createMicroservicesProviders({ transport: customTransport })],
+})
+class ManualMicroserviceProvidersModule {}
+```
+
 ## 공개 API 개요
 
 ### 루트 배럴 (`@fluojs/microservices`)
 
 - `MicroservicesModule`, `createMicroservicesProviders`: 모듈 등록 진입점입니다.
-- `MicroservicesModule.forRoot(...)`는 여전히 표준 런타임 진입점이며, `createMicroservicesProviders(...)`는 provider 집합을 의도적으로 직접 조합하려는 호출자를 위한 공개 helper로 유지합니다.
+- `MicroservicesModule.forRoot(...)`는 여전히 표준 런타임 진입점입니다. 고급 호출자가 raw provider graph를 다시 조립하지 않고 모듈 경로에서 커스터마이즈해야 할 때는 `module: { global, providers, additionalExports }`를 함께 넘기세요.
+- `createMicroservicesProviders(...)`는 low-level provider array 자체가 필요한 호출자를 위한 공개 helper로 유지합니다.
 - `MessagePattern`, `EventPattern`, `ServerStreamPattern`, `ClientStreamPattern`, `BidiStreamPattern`: 라우팅/스트리밍 데코레이터입니다.
 - `TcpMicroserviceTransport`, `RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `KafkaMicroserviceTransport`, `RabbitMqMicroserviceTransport`, `GrpcMicroserviceTransport`, `MqttMicroserviceTransport`: 루트 배럴에서 제공하는 트랜스포트 어댑터입니다.
 - `MicroserviceLifecycleService`, `MICROSERVICE`: 런타임 접근용 서비스와 호환 토큰입니다.
@@ -120,8 +169,8 @@ await microservice.listen();
 ## 예제 소스
 
 - `packages/microservices/src/module.test.ts`: 모든 트랜스포트 통합 계약을 검증합니다.
-- `packages/microservices/src/public-api.test.ts`: 문서화된 `createMicroservicesProviders(...)` helper를 포함한 루트 배럴 export 계약을 검증합니다.
-- `packages/microservices/src/public-surface.test.ts`: 0.x 거버넌스 동안 helper가 공개 surface에 남아 있는지 스냅샷으로 고정합니다.
+- `packages/microservices/src/public-api.test.ts`: module-first registration override와 `createMicroservicesProviders(...)` helper 계약을 포함한 루트 배럴 export 계약을 검증합니다.
+- `packages/microservices/src/public-surface.test.ts`: 0.x 거버넌스 동안 helper를 유지하면서 module-first replacement path도 문서화되었는지 고정합니다.
 - `packages/microservices/src/public-subpaths.test.ts`: 문서화된 트랜스포트 서브패스 export map 계약을 검증합니다.
 - `examples/microservices-tcp`: 기본 TCP 마이크로서비스 예제입니다.
 - `examples/microservices-kafka`: Kafka 기반 분산 아키텍처 예제입니다.

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -10,6 +10,7 @@ Transport-driven microservices for fluo. Build scalable, message-driven architec
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Core Capabilities](#core-capabilities)
+- [Common Patterns](#common-patterns)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -85,12 +86,60 @@ Microservice handlers fully support fluo's DI scopes. Request-scoped providers a
 - `messageRetentionMaxLen` and `eventRetentionMaxLen` remain available as advanced opt-in knobs. Enabling them can trade away broker-managed recovery guarantees because Redis may trim pending live-stream entries before they are acknowledged.
 - RabbitMQ request/reply uses an instance-scoped response queue by default. Pass `responseQueue` explicitly only when you intentionally own and coordinate a shared reply topology.
 
+## Common Patterns
+
+### Module-first custom registration
+
+Use `MicroservicesModule.forRoot({ transport, module: { ... } })` when you want custom providers, exports, or non-global registration without dropping back to raw provider arrays.
+
+```typescript
+import { Module } from '@fluojs/core';
+import { MicroservicesModule, MicroserviceLifecycleService, MICROSERVICE } from '@fluojs/microservices';
+
+const EXTRA_MICROSERVICE_EXPORT = Symbol('extra-microservice-export');
+
+@Module({
+  imports: [
+    MicroservicesModule.forRoot({
+      transport: customTransport,
+      module: {
+        global: false,
+        providers: [{ provide: EXTRA_MICROSERVICE_EXPORT, useValue: 'custom-module-value' }],
+        additionalExports: [EXTRA_MICROSERVICE_EXPORT],
+      },
+    }),
+  ],
+})
+class FeatureModule {}
+```
+
+Behavioral contract notes:
+
+- The module path still installs the same built-in `MICROSERVICE_OPTIONS`, `MicroserviceLifecycleService`, and `MICROSERVICE` wiring as the default `MicroservicesModule.forRoot(...)` call.
+- `module.providers` appends extra providers after the built-in runtime wiring, while `module.additionalExports` extends the default exported tokens instead of replacing them.
+- `module.global` lets advanced callers keep the registration local without reassembling the raw provider graph themselves.
+
+### Low-level helper for raw provider arrays
+
+`createMicroservicesProviders(...)` remains available only for callers that truly need the low-level provider array itself.
+
+```typescript
+import { Module } from '@fluojs/core';
+import { createMicroservicesProviders } from '@fluojs/microservices';
+
+@Module({
+  providers: [...createMicroservicesProviders({ transport: customTransport })],
+})
+class ManualMicroserviceProvidersModule {}
+```
+
 ## Public API Overview
 
 ### Root barrel (`@fluojs/microservices`)
 
 - `MicroservicesModule`, `createMicroservicesProviders`: module registration helpers.
-- `MicroservicesModule.forRoot(...)` remains the canonical runtime entrypoint, while `createMicroservicesProviders(...)` stays public for callers that intentionally compose the provider set themselves.
+- `MicroservicesModule.forRoot(...)` remains the canonical runtime entrypoint. Pass `module: { global, providers, additionalExports }` when advanced callers need module-first customization without reassembling the raw provider graph.
+- `createMicroservicesProviders(...)` stays public for callers that intentionally need the low-level provider array itself.
 - `MessagePattern`, `EventPattern`, `ServerStreamPattern`, `ClientStreamPattern`, `BidiStreamPattern`: routing and streaming decorators.
 - `TcpMicroserviceTransport`, `RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `KafkaMicroserviceTransport`, `RabbitMqMicroserviceTransport`, `GrpcMicroserviceTransport`, `MqttMicroserviceTransport`: transport adapters exported from the root barrel.
 - `MicroserviceLifecycleService`, `MICROSERVICE`: programmatic runtime access and compatibility token.
@@ -117,8 +166,8 @@ Microservice handlers fully support fluo's DI scopes. Request-scoped providers a
 ## Example Sources
 
 - `packages/microservices/src/module.test.ts`: Integration tests for all transports.
-- `packages/microservices/src/public-api.test.ts`: Root-barrel export coverage, including the documented `createMicroservicesProviders(...)` helper.
-- `packages/microservices/src/public-surface.test.ts`: Root-barrel snapshot coverage that keeps the helper public during 0.x governance.
+- `packages/microservices/src/public-api.test.ts`: Root-barrel export coverage, including the module-first registration overrides and `createMicroservicesProviders(...)` helper contract.
+- `packages/microservices/src/public-surface.test.ts`: Root-barrel snapshot coverage that keeps the helper public while documenting the module-first replacement path during 0.x governance.
 - `packages/microservices/src/public-subpaths.test.ts`: Export-map coverage for documented transport subpaths.
 - `examples/microservices-tcp`: Basic TCP microservice example.
 - `examples/microservices-kafka`: Distributed Kafka-based architecture example.

--- a/packages/microservices/src/index.ts
+++ b/packages/microservices/src/index.ts
@@ -27,4 +27,11 @@ export {
 export * from './status.js';
 export { TcpMicroserviceTransport } from './transports/tcp-transport.js';
 export { MICROSERVICE } from './tokens.js';
-export type { Microservice, MicroserviceModuleOptions, MicroserviceTransport, Pattern, ServerStreamWriter } from './types.js';
+export type {
+  Microservice,
+  MicroserviceModuleOptions,
+  MicroserviceModuleRegistrationOptions,
+  MicroserviceTransport,
+  Pattern,
+  ServerStreamWriter,
+} from './types.js';

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -2,14 +2,15 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Inject, Scope } from '@fluojs/core';
 import { defineControllerMetadata, defineModuleMetadata } from '@fluojs/core/internal';
+import type { Provider } from '@fluojs/di';
 import { bootstrapApplication, FluoFactory } from '@fluojs/runtime';
-import type { ApplicationLogger } from '@fluojs/runtime';
+import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
 
 import { BidiStreamPattern, ClientStreamPattern, EventPattern, MessagePattern, ServerStreamPattern } from './decorators.js';
 import { KafkaMicroserviceTransport } from './transports/kafka-transport.js';
-import { MicroservicesModule } from './module.js';
+import { MicroservicesModule, createMicroservicesProviders } from './module.js';
 import { MicroserviceLifecycleService } from './service.js';
-import { MICROSERVICE } from './tokens.js';
+import { MICROSERVICE, MICROSERVICE_OPTIONS } from './tokens.js';
 import { RedisPubSubMicroserviceTransport } from './transports/redis-transport.js';
 import { TcpMicroserviceTransport } from './transports/tcp-transport.js';
 import type {
@@ -21,6 +22,8 @@ import type {
   TransportHandler,
   TransportServerStreamHandler,
 } from './types.js';
+
+const EXTRA_MICROSERVICE_EXPORT = Symbol('extra-microservice-export');
 
 async function* streamFrom(values: readonly unknown[]): AsyncIterable<unknown> {
   for (const value of values) {
@@ -247,6 +250,80 @@ describe('@fluojs/microservices', () => {
     expect(typeof microserviceByToken.close).toBe('function');
     expect(typeof microserviceByToken.send).toBe('function');
     expect(typeof microserviceByToken.emit).toBe('function');
+
+    await app.close();
+  });
+
+  it('supports module-first custom registration through MicroservicesModule.forRoot module overrides', async () => {
+    const transport = new InMemoryLoopbackTransport();
+    const customProvider: Provider = {
+      provide: EXTRA_MICROSERVICE_EXPORT,
+      useValue: 'module-first-registration',
+    };
+    const microserviceModule = MicroservicesModule.forRoot({
+      module: {
+        additionalExports: [EXTRA_MICROSERVICE_EXPORT],
+        global: false,
+        providers: [customProvider],
+      },
+      transport,
+    });
+
+    class FeatureModule {}
+    defineModuleMetadata(FeatureModule, {
+      imports: [microserviceModule],
+    });
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [FeatureModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const exportedValue = await app.container.resolve(EXTRA_MICROSERVICE_EXPORT);
+    const lifecycleService = await app.container.resolve(MicroserviceLifecycleService);
+    const compiledMicroserviceModule = app.modules.find((compiledModule: CompiledModule) => compiledModule.type === microserviceModule);
+
+    expect(exportedValue).toBe('module-first-registration');
+    expect(lifecycleService).toBeInstanceOf(MicroserviceLifecycleService);
+    expect(compiledMicroserviceModule?.definition.global).toBe(false);
+    expect(compiledMicroserviceModule?.definition.exports).toContain(EXTRA_MICROSERVICE_EXPORT);
+
+    await app.close();
+  });
+
+  it('keeps createMicroservicesProviders aligned with the built-in runtime wiring', async () => {
+    const transport = new InMemoryLoopbackTransport();
+    const helperProviders = createMicroservicesProviders({ transport });
+    const optionsProvider = helperProviders.find(
+      (provider) => typeof provider === 'object' && provider !== null && 'provide' in provider && provider.provide === MICROSERVICE_OPTIONS,
+    );
+
+    expect(helperProviders).toHaveLength(3);
+    expect(optionsProvider).toMatchObject({
+      provide: MICROSERVICE_OPTIONS,
+      useValue: { transport },
+    });
+
+    class HelperModule {}
+    defineModuleMetadata(HelperModule, {
+      exports: [MicroserviceLifecycleService, MICROSERVICE],
+      providers: helperProviders,
+    });
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [HelperModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const lifecycleService = await app.container.resolve(MicroserviceLifecycleService);
+    const compatibilityToken = await app.container.resolve(MICROSERVICE);
+    const configuredOptions = await app.container.resolve(MICROSERVICE_OPTIONS);
+
+    expect(lifecycleService).toBeInstanceOf(MicroserviceLifecycleService);
+    expect(typeof compatibilityToken.listen).toBe('function');
+    expect(configuredOptions.transport).toBe(transport);
 
     await app.close();
   });

--- a/packages/microservices/src/module.ts
+++ b/packages/microservices/src/module.ts
@@ -53,10 +53,17 @@ export class MicroservicesModule {
   static forRoot(options: MicroserviceModuleOptions): ModuleType {
     class MicroservicesModuleDefinition {}
 
+    const additionalExports = options.module?.additionalExports ?? [];
+    const additionalProviders = options.module?.providers ?? [];
+    const global = options.module?.global ?? true;
+
     return defineModule(MicroservicesModuleDefinition, {
-      exports: [MicroserviceLifecycleService, MICROSERVICE],
-      global: true,
-      providers: createMicroservicesProviders(options),
+      exports: [MicroserviceLifecycleService, MICROSERVICE, ...additionalExports],
+      global,
+      providers: [
+        ...createMicroservicesProviders({ transport: options.transport }),
+        ...additionalProviders,
+      ],
     });
   }
 }

--- a/packages/microservices/src/public-api.test.ts
+++ b/packages/microservices/src/public-api.test.ts
@@ -6,6 +6,7 @@ import type {
   KafkaMicroserviceTransportOptions,
   Microservice,
   MicroserviceModuleOptions,
+  MicroserviceModuleRegistrationOptions,
   MicroserviceTransport,
   MqttMicroserviceTransportOptions,
   NatsMicroserviceTransportOptions,
@@ -49,6 +50,10 @@ describe('@fluojs/microservices public API surface', () => {
     expectTypeOf<MicroserviceTransport>().toHaveProperty('emit');
     expectTypeOf<Microservice>().toHaveProperty('listen');
     expectTypeOf<MicroserviceModuleOptions>().toMatchTypeOf<{ transport: MicroserviceTransport }>();
+    expectTypeOf<MicroserviceModuleOptions>().toHaveProperty('module');
+    expectTypeOf<MicroserviceModuleRegistrationOptions>().toHaveProperty('additionalExports');
+    expectTypeOf<MicroserviceModuleRegistrationOptions>().toHaveProperty('global');
+    expectTypeOf<MicroserviceModuleRegistrationOptions>().toHaveProperty('providers');
     expectTypeOf<GrpcMicroserviceTransportOptions>().toHaveProperty('protoPath');
     expectTypeOf<KafkaMicroserviceTransportOptions>().toHaveProperty('consumer');
     expectTypeOf<MqttMicroserviceTransportOptions>().toHaveProperty('requestTimeoutMs');

--- a/packages/microservices/src/public-surface.test.ts
+++ b/packages/microservices/src/public-surface.test.ts
@@ -45,4 +45,14 @@ describe('@fluojs/microservices root barrel public surface', () => {
     expect(readme).toContain('Package-managed optional peers loaded by `@fluojs/microservices`: `@grpc/grpc-js`, `@grpc/proto-loader`, `ioredis`, `mqtt`');
     expect(readme).toContain('Caller-owned broker clients passed explicitly to transports: `nats`, `kafkajs`, `amqplib`');
   });
+
+  it('keeps the module-first replacement path documented while the helper remains public', () => {
+    const readme = readFileSync(resolve(import.meta.dirname, '../README.md'), 'utf8');
+    const koreanReadme = readFileSync(resolve(import.meta.dirname, '../README.ko.md'), 'utf8');
+
+    expect(readme).toContain('Use `MicroservicesModule.forRoot({ transport, module: { ... } })` when you want custom providers, exports, or non-global registration without dropping back to raw provider arrays.');
+    expect(readme).toContain('`createMicroservicesProviders(...)` remains available only for callers that truly need the low-level provider array itself.');
+    expect(koreanReadme).toContain('custom provider/export/non-global 구성이 필요할 때도 raw provider array로 내려가지 말고 `MicroservicesModule.forRoot({ transport, module: { ... } })`를 우선 사용하세요.');
+    expect(koreanReadme).toContain('`createMicroservicesProviders(...)`는 실제로 low-level provider array 자체가 필요한 호출자에게만 남아 있습니다.');
+  });
 });

--- a/packages/microservices/src/types.ts
+++ b/packages/microservices/src/types.ts
@@ -1,5 +1,5 @@
 import type { MetadataPropertyKey, Token } from '@fluojs/core';
-import type { Scope } from '@fluojs/di';
+import type { Provider, Scope } from '@fluojs/di';
 import type { ApplicationLogger } from '@fluojs/runtime';
 
 /** Pattern matcher used to route messages and events to handler methods. */
@@ -98,8 +98,20 @@ export interface MicroserviceTransport {
   serverStream?(pattern: string, payload: unknown, signal?: AbortSignal): AsyncIterable<unknown>;
 }
 
+/** Optional module-definition overrides for callers that want module-first custom registration. */
+export interface MicroserviceModuleRegistrationOptions {
+  /** Extra tokens exported in addition to `MicroserviceLifecycleService` and `MICROSERVICE`. */
+  additionalExports?: Token[];
+  /** Whether the configured microservice module should register globally. Defaults to `true`. */
+  global?: boolean;
+  /** Additional providers appended after the built-in microservice runtime wiring. */
+  providers?: Provider[];
+}
+
 /** Module options accepted by {@link MicroservicesModule.forRoot}. */
 export interface MicroserviceModuleOptions {
+  /** Optional module-definition overrides that provide a module-first alternative to raw provider-array composition. */
+  module?: MicroserviceModuleRegistrationOptions;
   transport: MicroserviceTransport;
 }
 


### PR DESCRIPTION
Closes #1192

## Summary

Add a module-first replacement path for `@fluojs/microservices` before any future removal of `createMicroservicesProviders(...)`.

## Changes

- extend `MicroservicesModule.forRoot(...)` with `module` overrides for `global`, appended `providers`, and additive `additionalExports`
- keep `createMicroservicesProviders(...)` public, but add direct regression coverage that locks its provider graph to `MICROSERVICE_OPTIONS`, `MicroserviceLifecycleService`, and `MICROSERVICE`
- document the new module-first path in `packages/microservices/README.md` and `README.ko.md` while clarifying that the helper remains available only for callers that truly need raw provider arrays

## Testing

- [x] `pnpm --filter @fluojs/microservices test`
- [x] `pnpm --filter @fluojs/microservices run typecheck`
- [x] `pnpm build`
- [x] `pnpm vitest run packages/microservices/src/module.test.ts packages/microservices/src/public-api.test.ts packages/microservices/src/public-surface.test.ts`
- [ ] `pnpm typecheck` *(currently fails in this fresh worktree because unrelated workspace path-resolution errors already exist in packages such as `@fluojs/http`/`@fluojs/runtime`)*
- [ ] `pnpm lint` *(currently reports pre-existing repo warnings outside this change set, e.g. `packages/cli/src/commands/new.ts`, `packages/config/src/load.test.ts`, `packages/core/src/utils.test.ts`, `packages/cqrs/src/*`)*

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.