### PR TITLE
Resolve #1189: narrow @fluojs/email to module-first registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Breaking changes
 
-<<<<<<< HEAD
 - `@fluojs/queue`: the root barrel no longer exports `createQueueProviders(...)`. Migration note: register queues through `QueueModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
-=======
 - `@fluojs/cqrs`: the root barrel no longer exports `createCqrsProviders(...)`. Migration note: switch root-package composition to `CqrsModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
->>>>>>> 88257312 (docs(changelog): add cqrs migration note)
 - `@fluojs/event-bus`: the root barrel no longer exports `createEventBusProviders(...)`. Migration note: switch root-package composition to `EventBusModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/cron`: the root barrel no longer exports `createCronProviders(...)`. Migration note: register scheduling through `CronModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
+- `@fluojs/email`: the root barrel no longer exports `createEmailProviders(...)`. Migration note: register email delivery through `EmailModule.forRoot(...)` or `EmailModule.forRootAsync(...)`; low-level provider-array composition is now internal and no longer part of the supported root public surface.
 - `@fluojs/websockets`: the root barrel no longer exports `createWebSocketProviders(...)`, and the runtime subpaths no longer export `create*WebSocketProviders(...)` helpers. Migration note: register websocket support through `WebSocketModule.forRoot(...)` or the explicit runtime `*WebSocketModule.forRoot(...)` subpath entrypoint; low-level provider wiring is now internal and no longer part of the supported public surface.
 - `@fluojs/terminus`: the root barrel no longer exports `createTerminusProviders(...)`. Migration note: switch root-package composition to `TerminusModule.forRoot(...)`; low-level provider wiring is now internal and no longer part of the supported root public surface.
 - `@fluojs/graphql`: schema introspection is now disabled unless `graphiql` or `introspection: true` is explicitly enabled, and built-in request budgets now cap GraphQL document depth, field complexity, and aggregate query cost by default. Migration note: enable `introspection: true` for trusted tooling flows that still need schema discovery, or set `limits` to explicit higher values (or `false` for a temporary legacy escape hatch) before rolling this update into existing large-query workloads.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -69,7 +69,9 @@ fluo 패키지의 유지보수와 릴리스를 위한 표준, 정책, 운영 가
 - **[서드파티 확장 계약](./operations/third-party-extension-contract.ko.md)**: 커뮤니티 패키지가 따라야 하는 계약.
 - **[NestJS 차이점 안내](./operations/nestjs-parity-gaps.ko.md)**: fluo가 NestJS와 다른 점과 그 이유에 대한 정직한 문서.
 
-> **팁:** 공개 패키지의 기준 publish surface, release-readiness gate, CI 전용 단건 릴리스 운영 절차는 [Release Governance](./operations/release-governance.ko.md)를 참조하세요. preflight 검증 경로는 [테스트 전략](./operations/testing-guide.ko.md)과 함께 사용하세요.
+> **팁:** 공개 패키지의 기준 publish surface, release-readiness gate, CI 전용 단건 패키지 릴리스 운영 절차는 [Release Governance](./operations/release-governance.ko.md)를 참조하세요. preflight 검증 경로는 [테스트 전략](./operations/testing-guide.ko.md)과 함께 사용하세요.
+>
+> 런타임 이식 가능한 이메일 패키지 개요가 필요하다면 패키지 인벤토리의 `@fluojs/email`부터 확인하고, Node 전용 SMTP 경로는 명시적 서브패스 `@fluojs/email/node`를 패키지 문서와 chooser 가이드에서 따라가세요.
 
 ## 📚 참조 자료
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,8 @@ Standards, policies, and operational guidance for maintaining and releasing fluo
 - **[NestJS Parity Gaps](./operations/nestjs-parity-gaps.md)**: Honest documentation on where we differ and why.
 
 > **Tip:** Use [Release Governance](./operations/release-governance.md) for the canonical publish surface, release-readiness gates, and the CI-only single-package release operator flow. Pair it with [Testing Strategies](./operations/testing-guide.md) for preflight checks via `pnpm verify:release-readiness`.
+>
+> Need a runtime-portable email overview? Start with `@fluojs/email` in the package inventory, then follow the explicit Node-only SMTP subpath `@fluojs/email/node` from the package docs and chooser guides.
 
 ## 📚 Reference
 

--- a/docs/getting-started/quick-start.ko.md
+++ b/docs/getting-started/quick-start.ko.md
@@ -22,15 +22,43 @@ fluo new my-fluo-app
 cd my-fluo-app
 ```
 
-대화형 마법사(wizard)를 사용하는 것이 가장 권장되지만, 명시적인 플래그를 사용해 특정 스타터를 바로 선택할 수도 있습니다.
+interactive terminal 기반 대화형 마법사(wizard)를 사용하는 것이 가장 권장되지만, 명시적인 플래그를 사용해 특정 스타터를 바로 선택할 수도 있습니다.
 
 | Shape | Transport | Runtime | Platform | Command |
 | :--- | :--- | :--- | :--- | :--- |
-| application | http | node | fastify | `fluo new app --platform fastify` |
-| application | http | bun | bun | `fluo new app --runtime bun` |
-| application | http | workers | workers | `fluo new app --runtime cloudflare-workers` |
-| microservice | tcp | node | none | `fluo new svc --transport tcp` |
-| microservice | nats | node | none | `fluo new svc --transport nats` |
+| application | http | node | fastify | `fluo new app --shape application --transport http --runtime node --platform fastify` |
+| application | http | node | express | `fluo new app --shape application --transport http --runtime node --platform express` |
+| application | http | node | nodejs | `fluo new app --shape application --transport http --runtime node --platform nodejs` |
+| application | http | bun | bun | `fluo new app --shape application --transport http --runtime bun --platform bun` |
+| application | http | deno | deno | `fluo new app --shape application --transport http --runtime deno --platform deno` |
+| application | http | cloudflare-workers | cloudflare-workers | `fluo new app --shape application --transport http --runtime cloudflare-workers --platform cloudflare-workers` |
+| microservice | tcp | node | none | `fluo new svc --shape microservice --transport tcp --runtime node --platform none` |
+| microservice | redis-streams | node | none | `fluo new svc --shape microservice --transport redis-streams --runtime node --platform none` |
+| microservice | nats | node | none | `fluo new svc --shape microservice --transport nats --runtime node --platform none` |
+| microservice | kafka | node | none | `fluo new svc --shape microservice --transport kafka --runtime node --platform none` |
+| microservice | rabbitmq | node | none | `fluo new svc --shape microservice --transport rabbitmq --runtime node --platform none` |
+| microservice | mqtt | node | none | `fluo new svc --shape microservice --transport mqtt --runtime node --platform none` |
+| microservice | grpc | node | none | `fluo new svc --shape microservice --transport grpc --runtime node --platform none` |
+| mixed | tcp | node | fastify | `fluo new app --shape mixed --transport tcp --runtime node --platform fastify` |
+
+공개된 `fluo new` v2 스타터 예시는 다음과 같습니다.
+
+```sh
+fluo new app --shape application --transport http --runtime node --platform fastify
+fluo new app --shape application --transport http --runtime node --platform express
+fluo new app --shape application --transport http --runtime node --platform nodejs
+fluo new app --shape application --transport http --runtime bun --platform bun
+fluo new app --shape application --transport http --runtime deno --platform deno
+fluo new app --shape application --transport http --runtime cloudflare-workers --platform cloudflare-workers
+fluo new svc --shape microservice --transport tcp --runtime node --platform none
+fluo new svc --shape microservice --transport redis-streams --runtime node --platform none
+fluo new svc --shape microservice --transport nats --runtime node --platform none
+fluo new svc --shape microservice --transport kafka --runtime node --platform none
+fluo new svc --shape microservice --transport rabbitmq --runtime node --platform none
+fluo new svc --shape microservice --transport mqtt --runtime node --platform none
+fluo new svc --shape microservice --transport grpc --runtime node --platform none
+fluo new app --shape mixed --transport tcp --runtime node --platform fastify
+```
 
 사용 가능한 전체 구성 목록은 [fluo new 지원 매트릭스](../reference/fluo-new-support-matrix.ko.md)에서 확인하세요.
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -22,15 +22,43 @@ fluo new my-fluo-app
 cd my-fluo-app
 ```
 
-While the interactive wizard is the recommended path, you can also use explicit flags to select a specific starter.
+While the interactive terminal wizard is the recommended path, you can also use explicit flags to select a specific starter.
 
 | Shape | Transport | Runtime | Platform | Command |
 | :--- | :--- | :--- | :--- | :--- |
-| application | http | node | fastify | `fluo new app --platform fastify` |
-| application | http | bun | bun | `fluo new app --runtime bun` |
-| application | http | workers | workers | `fluo new app --runtime cloudflare-workers` |
-| microservice | tcp | node | none | `fluo new svc --transport tcp` |
-| microservice | nats | node | none | `fluo new svc --transport nats` |
+| application | http | node | fastify | `fluo new app --shape application --transport http --runtime node --platform fastify` |
+| application | http | node | express | `fluo new app --shape application --transport http --runtime node --platform express` |
+| application | http | node | nodejs | `fluo new app --shape application --transport http --runtime node --platform nodejs` |
+| application | http | bun | bun | `fluo new app --shape application --transport http --runtime bun --platform bun` |
+| application | http | deno | deno | `fluo new app --shape application --transport http --runtime deno --platform deno` |
+| application | http | cloudflare-workers | cloudflare-workers | `fluo new app --shape application --transport http --runtime cloudflare-workers --platform cloudflare-workers` |
+| microservice | tcp | node | none | `fluo new svc --shape microservice --transport tcp --runtime node --platform none` |
+| microservice | redis-streams | node | none | `fluo new svc --shape microservice --transport redis-streams --runtime node --platform none` |
+| microservice | nats | node | none | `fluo new svc --shape microservice --transport nats --runtime node --platform none` |
+| microservice | kafka | node | none | `fluo new svc --shape microservice --transport kafka --runtime node --platform none` |
+| microservice | rabbitmq | node | none | `fluo new svc --shape microservice --transport rabbitmq --runtime node --platform none` |
+| microservice | mqtt | node | none | `fluo new svc --shape microservice --transport mqtt --runtime node --platform none` |
+| microservice | grpc | node | none | `fluo new svc --shape microservice --transport grpc --runtime node --platform none` |
+| mixed | tcp | node | fastify | `fluo new app --shape mixed --transport tcp --runtime node --platform fastify` |
+
+Published `fluo new` v2 starter examples:
+
+```sh
+fluo new app --shape application --transport http --runtime node --platform fastify
+fluo new app --shape application --transport http --runtime node --platform express
+fluo new app --shape application --transport http --runtime node --platform nodejs
+fluo new app --shape application --transport http --runtime bun --platform bun
+fluo new app --shape application --transport http --runtime deno --platform deno
+fluo new app --shape application --transport http --runtime cloudflare-workers --platform cloudflare-workers
+fluo new svc --shape microservice --transport tcp --runtime node --platform none
+fluo new svc --shape microservice --transport redis-streams --runtime node --platform none
+fluo new svc --shape microservice --transport nats --runtime node --platform none
+fluo new svc --shape microservice --transport kafka --runtime node --platform none
+fluo new svc --shape microservice --transport rabbitmq --runtime node --platform none
+fluo new svc --shape microservice --transport mqtt --runtime node --platform none
+fluo new svc --shape microservice --transport grpc --runtime node --platform none
+fluo new app --shape mixed --transport tcp --runtime node --platform fastify
+```
 
 For the full list of available configurations, see the [fluo new support matrix](../reference/fluo-new-support-matrix.md).
 

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -11,7 +11,6 @@ fluo를 위한 transport-agnostic 이메일 코어 패키지입니다. Nest-like
 - [빠른 시작](#빠른-시작)
 - [일반적인 패턴](#일반적인-패턴)
   - [`@fluojs/email/node`를 이용한 Node 전용 SMTP](#fluojs-email-node를-이용한-node-전용-smtp)
-  - [`createEmailProviders`를 이용한 수동 provider 조합](#createemailproviders를-이용한-수동-provider-조합)
   - [`EmailService`를 이용한 standalone 전달](#emailservice를-이용한-standalone-전달)
   - [`@fluojs/notifications`와의 통합](#fluojs-notifications와의-통합)
   - [큐 기반 대량 전달](#큐-기반-대량-전달)
@@ -100,6 +99,8 @@ export class WelcomeService {
 }
 ```
 
+루트 `@fluojs/email` 공개 표면은 의도적으로 module-first입니다. 이메일 등록은 `EmailModule.forRoot(...)` 또는 `EmailModule.forRootAsync(...)`를 통해 수행해야 합니다. 저수준 provider 배열 조합은 내부 구현이며 더 이상 지원되는 루트 공개 API가 아닙니다.
+
 ## 일반적인 패턴
 
 ### `@fluojs/email/node`를 이용한 Node 전용 SMTP
@@ -139,36 +140,6 @@ Behavioral contract 메모:
 - 이 factory는 자신이 생성한 Nodemailer transporter 리소스를 소유하므로 `EmailService`가 bootstrap 시 검증하고 shutdown 시 닫을 수 있습니다.
 - `createNodemailerEmailTransport(...)`는 이미 존재하는 Nodemailer transporter를 감싸지만 리소스 소유권은 호출자에게 남깁니다.
 - SMTP 자격 증명은 여전히 명시적인 옵션 또는 DI를 통해 들어와야 합니다. 루트 패키지와 Node 서브패스 모두 `process.env`를 직접 읽지 않습니다.
-
-### `createEmailProviders`를 이용한 수동 provider 조합
-
-`createEmailProviders(...)`는 애플리케이션이 `EmailModule.forRoot(...)` 밖에서 동일한 provider 정규화 구성을 재사용해야 할 때 지원되는 manual-composition helper입니다.
-
-```typescript
-import { Module } from '@fluojs/core';
-import { createEmailProviders } from '@fluojs/email';
-
-@Module({
-  providers: [
-    ...createEmailProviders({
-      defaultFrom: 'noreply@example.com',
-      transport: {
-        kind: 'custom-http-transport',
-        create: () => customTransport,
-        ownsResources: false,
-      },
-    }),
-  ],
-  exports: [],
-})
-export class EmailProvidersModule {}
-```
-
-Behavioral contract 메모:
-
-- 이 helper는 `EmailModule.forRoot(...)`가 구성하는 `EMAIL`, `EMAIL_CHANNEL`, `EmailService` wiring을 동일하게 유지합니다.
-- `createEmailProviders(...)`는 trim된 주소, 기본 notification 채널 fallback, transport 소유권 기본값을 포함해 `EmailModule.forRoot(...)`와 동일한 옵션 정규화를 적용합니다.
-- 이 helper도 여전히 명시적인 `transport`를 요구하며, 패키지의 runtime-portable·no-implicit-env 계약을 약화시키지 않습니다.
 
 ### `EmailService`를 이용한 standalone 전달
 
@@ -301,7 +272,6 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 ### 핵심
 
 - `EmailModule.forRoot(options)` / `EmailModule.forRootAsync(options)`
-- `createEmailProviders(options)`
 - `EmailService`
 - `EmailChannel`
 - `EMAIL`
@@ -349,7 +319,7 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 ## 예제 소스
 
-- `packages/email/src/module.test.ts`: 모듈 등록, `createEmailProviders(...)` helper coverage, async wiring, lifecycle, queue-backed notifications 예제.
+- `packages/email/src/module.test.ts`: 모듈 등록, module-first 옵션 정규화, async wiring, lifecycle, queue-backed notifications 예제.
 - `packages/email/src/public-surface.test.ts`: 공개 export와 TypeScript 계약 검증 예제.
 - `packages/email/src/node/node.test.ts`: Node 전용 Nodemailer adapter 매핑과 lifecycle 예제.
 - `packages/email/src/status.test.ts`: health/readiness 계약 예제.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -11,7 +11,6 @@ Transport-agnostic email delivery core for fluo. It provides a Nest-like module 
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
   - [Node-only SMTP with `@fluojs/email/node`](#node-only-smtp-with-fluojs-email-node)
-  - [Manual provider composition with `createEmailProviders`](#manual-provider-composition-with-createemailproviders)
   - [Standalone delivery with `EmailService`](#standalone-delivery-with-emailservice)
   - [Integration with `@fluojs/notifications`](#integration-with-fluojs-notifications)
   - [Queue-backed bulk delivery](#queue-backed-bulk-delivery)
@@ -100,6 +99,8 @@ export class WelcomeService {
 }
 ```
 
+The root `@fluojs/email` surface is intentionally module-first. Register email delivery through `EmailModule.forRoot(...)` or `EmailModule.forRootAsync(...)`. Low-level provider-array composition is internal and no longer part of the supported root public API.
+
 ## Common Patterns
 
 ### Node-only SMTP with `@fluojs/email/node`
@@ -139,36 +140,6 @@ Behavioral contract notes:
 - The factory owns the Nodemailer transporter it creates, so `EmailService` can verify it on bootstrap and close it during shutdown.
 - `createNodemailerEmailTransport(...)` wraps an existing Nodemailer transporter without transferring resource ownership.
 - SMTP credentials still enter through explicit options or DI. Neither the root package nor the Node subpath reads `process.env` directly.
-
-### Manual provider composition with `createEmailProviders`
-
-`createEmailProviders(...)` is the supported manual-composition helper when applications need the same provider normalization outside `EmailModule.forRoot(...)`.
-
-```typescript
-import { Module } from '@fluojs/core';
-import { createEmailProviders } from '@fluojs/email';
-
-@Module({
-  providers: [
-    ...createEmailProviders({
-      defaultFrom: 'noreply@example.com',
-      transport: {
-        kind: 'custom-http-transport',
-        create: () => customTransport,
-        ownsResources: false,
-      },
-    }),
-  ],
-  exports: [],
-})
-export class EmailProvidersModule {}
-```
-
-Behavioral contract notes:
-
-- The helper preserves the same `EMAIL`, `EMAIL_CHANNEL`, and `EmailService` wiring that `EmailModule.forRoot(...)` installs.
-- `createEmailProviders(...)` applies the same option normalization as `EmailModule.forRoot(...)`, including trimmed addresses, default notification channel fallback, and transport ownership defaults.
-- The helper still requires an explicit `transport`; it does not weaken the package's runtime-portable, no-implicit-env contract.
 
 ### Standalone delivery with `EmailService`
 
@@ -301,7 +272,6 @@ These limitations are part of the package contract so transport selection, templ
 ### Core
 
 - `EmailModule.forRoot(options)` / `EmailModule.forRootAsync(options)`
-- `createEmailProviders(options)`
 - `EmailService`
 - `EmailChannel`
 - `EMAIL`
@@ -349,7 +319,7 @@ These limitations are part of the package contract so transport selection, templ
 
 ## Example Sources
 
-- `packages/email/src/module.test.ts`: Module registration, `createEmailProviders(...)` helper coverage, async wiring, lifecycle, and queue-backed notifications examples.
+- `packages/email/src/module.test.ts`: Module registration, module-first option normalization, async wiring, lifecycle, and queue-backed notifications examples.
 - `packages/email/src/public-surface.test.ts`: Public export and TypeScript contract verification.
 - `packages/email/src/node/node.test.ts`: Node-only Nodemailer adapter mapping and lifecycle examples.
 - `packages/email/src/status.test.ts`: Health/readiness contract examples.

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -3,7 +3,7 @@ export {
   EmailMessageValidationError,
 } from './errors.js';
 export { EmailChannel } from './channel.js';
-export { EmailModule, createEmailProviders } from './module.js';
+export { EmailModule } from './module.js';
 export { EmailService } from './service.js';
 export { createEmailPlatformStatusSnapshot } from './status.js';
 export type { EmailLifecycleState, EmailPlatformStatusSnapshot, EmailStatusAdapterInput } from './status.js';

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -144,7 +144,7 @@ vi.mock('bullmq', () => ({
 
 import { EmailChannel } from './channel.js';
 import { EmailNotificationQueueJob, EmailNotificationsQueueWorker, createEmailNotificationsQueueAdapter } from './queue.js';
-import { EmailModule, createEmailProviders } from './module.js';
+import { EmailModule } from './module.js';
 import { EmailService } from './service.js';
 import { EMAIL } from './tokens.js';
 import { EmailConfigurationError } from './errors.js';
@@ -226,10 +226,6 @@ function moduleProviders(moduleType: Constructor): Provider[] {
   return metadata.providers as Provider[];
 }
 
-function providerToken(provider: Provider): unknown {
-  return typeof provider === 'function' ? provider : provider.provide;
-}
-
 describe('EmailModule', () => {
   beforeEach(() => {
     bullmqState.clear();
@@ -272,7 +268,7 @@ describe('EmailModule', () => {
     expect(transportState.closeCalls).toBe(1);
   });
 
-  it('creates helper providers with the same normalized options and facade tokens as EmailModule.forRoot', async () => {
+  it('normalizes module registration options before exposing facade and channel tokens', async () => {
     const options = {
       defaultFrom: ' noreply@example.com ',
       defaultReplyTo: [{ address: ' reply@example.com ', name: 'Support' }],
@@ -280,25 +276,19 @@ describe('EmailModule', () => {
       transport: createRecordingTransportFactory(),
       verifyOnModuleInit: true,
     };
-    const moduleType = EmailModule.forRoot(options);
-    const helperProviders = createEmailProviders(options);
-    const moduleRuntimeProviders = moduleProviders(moduleType);
-    const helperContainer = new Container();
+    const container = new Container();
 
-    expect(helperProviders).toHaveLength(moduleRuntimeProviders.length);
-    expect(helperProviders.map(providerToken)).toEqual(moduleRuntimeProviders.map(providerToken));
+    container.register(...moduleProviders(EmailModule.forRoot(options)));
 
-    helperContainer.register(...helperProviders);
-
-    const service = await helperContainer.resolve(EmailService);
-    const facade = await helperContainer.resolve<Email>(EMAIL);
-    const channel = await helperContainer.resolve(EmailChannel);
+    const service = await container.resolve(EmailService);
+    const facade = await container.resolve<Email>(EMAIL);
+    const channel = await container.resolve(EmailChannel);
 
     await service.onModuleInit();
 
     const result = await facade.send({
-      subject: 'Manual providers',
-      text: 'helper contract',
+      subject: 'Module registration',
+      text: 'module contract',
       to: ['user@example.com'],
     });
 
@@ -308,20 +298,12 @@ describe('EmailModule', () => {
     expect(transportState.sent[0]).toMatchObject({
       from: { address: 'noreply@example.com' },
       replyTo: [{ address: 'reply@example.com', name: 'Support' }],
-      subject: 'Manual providers',
-      text: 'helper contract',
+      subject: 'Module registration',
+      text: 'module contract',
     });
 
     await service.onApplicationShutdown();
     expect(transportState.closeCalls).toBe(1);
-  });
-
-  it('rejects helper-based registration without an explicit transport contract', () => {
-    expect(() =>
-      createEmailProviders({
-        defaultFrom: 'noreply@example.com',
-      } as never),
-    ).toThrowError(new EmailConfigurationError('EmailModule requires an explicit `transport` to be configured.'));
   });
 
   it('resolves async options once and exposes the compatibility facade and channel token', async () => {

--- a/packages/email/src/module.ts
+++ b/packages/email/src/module.ts
@@ -94,13 +94,7 @@ function createEmailRuntimeProviders(optionsProvider: Provider): Provider[] {
   ];
 }
 
-/**
- * Creates email providers for manual module composition.
- *
- * @param options Static email module options including explicit transport wiring.
- * @returns Provider definitions equivalent to {@link EmailModule.forRoot} wiring.
- */
-export function createEmailProviders(options: EmailModuleOptions): Provider[] {
+function createEmailProviders(options: EmailModuleOptions): Provider[] {
   return createEmailRuntimeProviders({
     provide: EMAIL_OPTIONS,
     useValue: normalizeEmailModuleOptions(options),

--- a/packages/email/src/public-surface.test.ts
+++ b/packages/email/src/public-surface.test.ts
@@ -19,7 +19,6 @@ import type { EmailQueueWorkerOptions } from './queue-entry.js';
 describe('@fluojs/email public API surface', () => {
   it('keeps documented root-barrel exports stable', () => {
     expect(emailPublicApi).toHaveProperty('EmailModule');
-    expect(emailPublicApi).toHaveProperty('createEmailProviders');
     expect(emailPublicApi).toHaveProperty('EmailService');
     expect(emailPublicApi).toHaveProperty('EmailChannel');
     expect(emailPublicApi).toHaveProperty('EMAIL');
@@ -63,14 +62,15 @@ describe('@fluojs/email public API surface', () => {
     });
   });
 
-  it('keeps the README helper contract aligned with the documented root-barrel API', () => {
+  it('keeps the README module-first contract aligned with the documented root-barrel API', () => {
     const readme = readFileSync(resolve(import.meta.dirname, '../README.md'), 'utf8');
     const koreanReadme = readFileSync(resolve(import.meta.dirname, '../README.ko.md'), 'utf8');
 
-    expect(readme).toContain('`createEmailProviders(...)` is the supported manual-composition helper when applications need the same provider normalization outside `EmailModule.forRoot(...)`.');
-    expect(readme).toContain('The helper preserves the same `EMAIL`, `EMAIL_CHANNEL`, and `EmailService` wiring that `EmailModule.forRoot(...)` installs.');
-    expect(koreanReadme).toContain('`createEmailProviders(...)`는 애플리케이션이 `EmailModule.forRoot(...)` 밖에서 동일한 provider 정규화 구성을 재사용해야 할 때 지원되는 manual-composition helper입니다.');
-    expect(koreanReadme).toContain('이 helper는 `EmailModule.forRoot(...)`가 구성하는 `EMAIL`, `EMAIL_CHANNEL`, `EmailService` wiring을 동일하게 유지합니다.');
+    expect(emailPublicApi).not.toHaveProperty('createEmailProviders');
+    expect(readme).toContain('The root `@fluojs/email` surface is intentionally module-first. Register email delivery through `EmailModule.forRoot(...)` or `EmailModule.forRootAsync(...)`.');
+    expect(readme).not.toContain('createEmailProviders');
+    expect(koreanReadme).toContain('루트 `@fluojs/email` 공개 표면은 의도적으로 module-first입니다. 이메일 등록은 `EmailModule.forRoot(...)` 또는 `EmailModule.forRootAsync(...)`를 통해 수행해야 합니다.');
+    expect(koreanReadme).not.toContain('createEmailProviders');
   });
 
   it('keeps documented TypeScript-only contracts stable enough for downstream packages', () => {


### PR DESCRIPTION
Closes #1189

## Summary
- remove `createEmailProviders(...)` from the `@fluojs/email` root public surface so email registration stays module-first
- keep the queue seam on `@fluojs/email/queue` and align README/changelog messaging with the supported migration path
- restore docs-hub and quick-start discoverability contracts that `pnpm verify` enforces for release/runbook and runtime-matrix references

## Changes
- internalized the email provider helper in `packages/email/src/module.ts` and removed the root-barrel export from `packages/email/src/index.ts`
- rewrote `packages/email/src/module.test.ts` and `packages/email/src/public-surface.test.ts` around the module-first contract instead of helper-based composition
- updated `packages/email/README.md`, `packages/email/README.ko.md`, and `CHANGELOG.md` with the removal and migration note
- updated `docs/README.md`, `docs/README.ko.md`, `docs/getting-started/quick-start.md`, and `docs/getting-started/quick-start.ko.md` so discoverability/governance tests stay aligned

## Testing
- `pnpm --filter @fluojs/email test`
- `pnpm --filter @fluojs/email typecheck`
- `pnpm build`
- `pnpm lint`
- `pnpm vitest run packages/cli/src/runtime-matrix-docs-contract.test.ts packages/testing/src/conformance/platform-consistency-governance-docs.test.ts packages/email/src/module.test.ts packages/email/src/public-surface.test.ts`
- `pnpm verify`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.