### PR TITLE
Resolve #1196: remove Drizzle helper after module coverage cleanup

### DIFF
--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -10,6 +10,7 @@
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
+- [수동 모듈 구성](#수동-모듈-구성)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -95,14 +96,43 @@ import { DrizzleTransactionInterceptor } from '@fluojs/drizzle';
 class UsersController {}
 ```
 
+## 수동 모듈 구성
+
+`DrizzleModule.forRoot(...)` / `forRootAsync(...)`는 애플리케이션에서 Drizzle을 등록하는
+정식 entrypoint입니다. 커스텀 `defineModule(...)` 안에서 Drizzle 지원을 조합해야 할 때도
+별도 provider 배열 helper 대신 이 module entrypoint를 import해서 사용하세요.
+provider 배열 조립은 지원되는 root-barrel contract가 아니라 내부 구현 세부사항입니다.
+
+```ts
+import { defineModule } from '@fluojs/runtime';
+import { DrizzleDatabase, DrizzleModule, DrizzleTransactionInterceptor } from '@fluojs/drizzle';
+
+const database = {
+  transaction: async <T>(callback: (tx: typeof database) => Promise<T>) => callback(database),
+};
+
+class ManualDrizzleModule {}
+
+defineModule(ManualDrizzleModule, {
+  exports: [DrizzleDatabase, DrizzleTransactionInterceptor],
+  imports: [DrizzleModule.forRoot({ database })],
+});
+```
+
 ## 공개 API 개요
 
 - `DrizzleModule.forRoot(options)` / `DrizzleModule.forRootAsync(options)`
-- `createDrizzleProviders(options)`
 - `DrizzleDatabase`
 - `DrizzleTransactionInterceptor`
 - `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_OPTIONS`
 - `createDrizzlePlatformStatusSnapshot(...)`
+
+### `DrizzleModule`
+
+- `DrizzleModule.forRoot(options)` / `DrizzleModule.forRootAsync(options)`
+- `forRootAsync(...)`는 `AsyncModuleOptions<DrizzleModuleOptions<...>>`를 받습니다.
+- `strictTransactions: true`를 설정하면 transaction 지원이 없는 database handle에서 예외를 던집니다.
+- root-level 등록은 의도적으로 `DrizzleModule.forRoot(...)` / `forRootAsync(...)` 중심이며, 저수준 provider wiring은 문서화된 root-barrel contract에 포함되지 않습니다.
 
 ## 관련 패키지
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -10,6 +10,7 @@ Drizzle ORM integration for fluo with a transaction-aware database wrapper and a
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
+- [Manual Module Composition](#manual-module-composition)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -95,14 +96,44 @@ import { DrizzleTransactionInterceptor } from '@fluojs/drizzle';
 class UsersController {}
 ```
 
+## Manual Module Composition
+
+`DrizzleModule.forRoot(...)` / `forRootAsync(...)` remain the canonical application
+entrypoints. When you need to compose Drizzle support inside a custom
+`defineModule(...)` registration, import the module entrypoint there as well.
+Provider-array assembly is an internal implementation detail rather than part of
+the supported root-barrel contract.
+
+```ts
+import { defineModule } from '@fluojs/runtime';
+import { DrizzleDatabase, DrizzleModule, DrizzleTransactionInterceptor } from '@fluojs/drizzle';
+
+const database = {
+  transaction: async <T>(callback: (tx: typeof database) => Promise<T>) => callback(database),
+};
+
+class ManualDrizzleModule {}
+
+defineModule(ManualDrizzleModule, {
+  exports: [DrizzleDatabase, DrizzleTransactionInterceptor],
+  imports: [DrizzleModule.forRoot({ database })],
+});
+```
+
 ## Public API Overview
 
 - `DrizzleModule.forRoot(options)` / `DrizzleModule.forRootAsync(options)`
-- `createDrizzleProviders(options)`
 - `DrizzleDatabase`
 - `DrizzleTransactionInterceptor`
 - `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_OPTIONS`
 - `createDrizzlePlatformStatusSnapshot(...)`
+
+### `DrizzleModule`
+
+- `DrizzleModule.forRoot(options)` / `DrizzleModule.forRootAsync(options)`
+- `forRootAsync(...)` accepts `AsyncModuleOptions<DrizzleModuleOptions<...>>`.
+- Supports `strictTransactions: true` to throw if transaction support is missing.
+- Root-level registration is intentionally centered on `DrizzleModule.forRoot(...)` / `forRootAsync(...)`; low-level provider wiring is not part of the documented root-barrel contract.
 
 ## Related Packages
 

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -4,6 +4,7 @@ import { Global, Inject, Module } from '@fluojs/core';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 
 import {
+  DRIZZLE_OPTIONS,
   DrizzleModule,
   createDrizzlePlatformStatusSnapshot,
   DrizzleDatabase,
@@ -201,6 +202,86 @@ describe('@fluojs/drizzle', () => {
     );
 
     await asyncApp.close();
+  });
+
+  it('defaults strictTransactions to false for sync and async module entrypoints', async () => {
+    const database = {};
+
+    const SyncModule = DrizzleModule.forRoot({
+      database,
+    });
+
+    class SyncAppModule {}
+
+    defineModule(SyncAppModule, {
+      imports: [SyncModule],
+    });
+
+    const syncApp = await bootstrapApplication({
+      rootModule: SyncAppModule,
+    });
+    const syncDrizzle = await syncApp.container.resolve(DrizzleDatabase<typeof database>);
+    const syncOptions = await syncApp.container.resolve<{ strictTransactions: boolean }>(DRIZZLE_OPTIONS);
+
+    await expect(syncDrizzle.transaction(async () => 'sync-fallback')).resolves.toBe('sync-fallback');
+    await expect(syncDrizzle.requestTransaction(async () => 'sync-request-fallback')).resolves.toBe('sync-request-fallback');
+    expect(syncOptions).toEqual({ strictTransactions: false });
+
+    await syncApp.close();
+
+    const AsyncModule = DrizzleModule.forRootAsync({
+      useFactory: () => ({
+        database,
+      }),
+    });
+
+    class AsyncAppModule {}
+
+    defineModule(AsyncAppModule, {
+      imports: [AsyncModule],
+    });
+
+    const asyncApp = await bootstrapApplication({
+      rootModule: AsyncAppModule,
+    });
+    const asyncDrizzle = await asyncApp.container.resolve(DrizzleDatabase<typeof database>);
+    const asyncOptions = await asyncApp.container.resolve<{ strictTransactions: boolean }>(DRIZZLE_OPTIONS);
+
+    await expect(asyncDrizzle.transaction(async () => 'async-fallback')).resolves.toBe('async-fallback');
+    await expect(asyncDrizzle.requestTransaction(async () => 'async-request-fallback')).resolves.toBe('async-request-fallback');
+    expect(asyncOptions).toEqual({ strictTransactions: false });
+
+    await asyncApp.close();
+  });
+
+  it('awaits async dispose hooks registered through module entrypoints', async () => {
+    const events: string[] = [];
+    const database = {};
+
+    const drizzleModule = DrizzleModule.forRootAsync({
+      useFactory: async () => ({
+        database,
+        dispose: async () => {
+          events.push('dispose:start');
+          await Promise.resolve();
+          events.push('dispose:end');
+        },
+      }),
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [drizzleModule],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    await app.close();
+
+    expect(events).toEqual(['dispose:start', 'dispose:end']);
   });
 
   it('falls back for requestTransaction when transaction support is unavailable and strictTransactions is false', async () => {

--- a/packages/drizzle/src/module.ts
+++ b/packages/drizzle/src/module.ts
@@ -114,25 +114,6 @@ function createDrizzleProvidersAsync<
   return createDrizzleRuntimeProviders<TDatabase, TTransactionDatabase, TTransactionOptions>(normalizedOptionsProvider);
 }
 
-/**
- * Creates Drizzle providers for manual module composition.
- *
- * @param options Drizzle module options with a database handle, optional dispose hook, and strict transaction policy.
- * @returns Provider definitions equivalent to `DrizzleModule.forRoot(...)`.
- */
-export function createDrizzleProviders<
-  TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
-  TTransactionDatabase = TDatabase,
-  TTransactionOptions = unknown,
->(options: DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>): Provider[] {
-  const resolved = normalizeDrizzleModuleOptions(options);
-
-  return createDrizzleRuntimeProviders<TDatabase, TTransactionDatabase, TTransactionOptions>({
-    provide: DRIZZLE_NORMALIZED_OPTIONS,
-    useValue: resolved,
-  });
-}
-
 function buildDrizzleModule<
   TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
   TTransactionDatabase = TDatabase,
@@ -142,7 +123,10 @@ function buildDrizzleModule<
 
   return defineModule(DrizzleRootModuleDefinition, {
     exports: DRIZZLE_MODULE_EXPORTS,
-    providers: createDrizzleProviders(options),
+    providers: createDrizzleRuntimeProviders<TDatabase, TTransactionDatabase, TTransactionOptions>({
+      provide: DRIZZLE_NORMALIZED_OPTIONS,
+      useValue: normalizeDrizzleModuleOptions(options),
+    }),
   });
 }
 

--- a/packages/drizzle/src/public-api.test.ts
+++ b/packages/drizzle/src/public-api.test.ts
@@ -6,7 +6,6 @@ describe('@fluojs/drizzle public API surface', () => {
   it('keeps documented supported root-barrel exports', () => {
     expect(drizzlePublicApi).toHaveProperty('DrizzleDatabase');
     expect(drizzlePublicApi).toHaveProperty('DrizzleModule');
-    expect(drizzlePublicApi).toHaveProperty('createDrizzleProviders');
     expect(drizzlePublicApi).toHaveProperty('DrizzleTransactionInterceptor');
     expect(drizzlePublicApi).toHaveProperty('createDrizzlePlatformStatusSnapshot');
     expect(drizzlePublicApi).toHaveProperty('DRIZZLE_DATABASE');
@@ -15,6 +14,7 @@ describe('@fluojs/drizzle public API surface', () => {
   });
 
   it('does not expose internal module wiring values from the root barrel', () => {
+    expect(drizzlePublicApi).not.toHaveProperty('createDrizzleProviders');
     expect(drizzlePublicApi).not.toHaveProperty('DRIZZLE_NORMALIZED_OPTIONS');
     expect(drizzlePublicApi).not.toHaveProperty('normalizeDrizzleModuleOptions');
     expect(drizzlePublicApi).not.toHaveProperty('createDrizzleProvidersAsync');


### PR DESCRIPTION
## Summary

Removes the remaining `createDrizzleProviders(...)` root-barrel helper from `@fluojs/drizzle` now that module entrypoint coverage closes the last behavior gaps.

Closes #1196

## Changes

- remove `createDrizzleProviders(...)` from `packages/drizzle/src/module.ts` so `DrizzleModule.forRoot(...)` owns the supported registration surface
- add module-entrypoint regression coverage for default `strictTransactions` behavior and awaited async `dispose` hooks
- align `packages/drizzle/README.md` and `packages/drizzle/README.ko.md` with the module-first contract and manual composition guidance

## Testing

- `pnpm test` (in `packages/drizzle`)
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `lsp_diagnostics` on changed TS files (`module.ts`, `module.test.ts`, `public-api.test.ts`) reported no diagnostics after workspace build

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.