### PR TITLE
Resolve #1195: remove discord helper from public surface

### DIFF
--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -181,11 +181,12 @@ Discord 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 ### 핵심
 
 - `DiscordModule.forRoot(options)` / `DiscordModule.forRootAsync(options)`
-- `createDiscordProviders(options)`
 - `DiscordService`
 - `DiscordChannel`
 - `DISCORD`
 - `DISCORD_CHANNEL`
+
+`createDiscordProviders(...)`는 내부 wiring helper이며 더 이상 지원되는 루트 패키지 contract에 포함되지 않습니다. 애플리케이션 구성은 `DiscordModule`로, notifications 연동은 `DISCORD_CHANNEL`과 export된 transport 계약으로 조합해야 합니다.
 
 ### 계약과 헬퍼
 

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -181,11 +181,12 @@ These limitations are part of the package contract so runtime choice, provider c
 ### Core
 
 - `DiscordModule.forRoot(options)` / `DiscordModule.forRootAsync(options)`
-- `createDiscordProviders(options)`
 - `DiscordService`
 - `DiscordChannel`
 - `DISCORD`
 - `DISCORD_CHANNEL`
+
+`createDiscordProviders(...)` is an internal wiring helper and is no longer part of the supported root package contract. Compose applications through `DiscordModule` and integrate notifications through `DISCORD_CHANNEL` plus the exported transport contracts.
 
 ### Contracts and helpers
 

--- a/packages/discord/src/index.ts
+++ b/packages/discord/src/index.ts
@@ -4,7 +4,7 @@ export {
   DiscordTransportError,
 } from './errors.js';
 export { DiscordChannel } from './channel.js';
-export { DiscordModule, createDiscordProviders } from './module.js';
+export { DiscordModule } from './module.js';
 export { DiscordService } from './service.js';
 export { createDiscordPlatformStatusSnapshot } from './status.js';
 export type { DiscordLifecycleState, DiscordPlatformStatusSnapshot, DiscordStatusAdapterInput } from './status.js';

--- a/packages/discord/src/module.ts
+++ b/packages/discord/src/module.ts
@@ -77,7 +77,7 @@ function createDiscordRuntimeProviders(optionsProvider: Provider): Provider[] {
  * @param options Static Discord module options including explicit transport wiring.
  * @returns Provider definitions equivalent to {@link DiscordModule.forRoot} wiring.
  */
-export function createDiscordProviders(options: DiscordModuleOptions): Provider[] {
+function createDiscordProviders(options: DiscordModuleOptions): Provider[] {
   return createDiscordRuntimeProviders({
     provide: DISCORD_OPTIONS,
     useValue: normalizeDiscordModuleOptions(options),

--- a/packages/discord/src/public-surface.test.ts
+++ b/packages/discord/src/public-surface.test.ts
@@ -17,7 +17,6 @@ import type {
 describe('@fluojs/discord public API surface', () => {
   it('keeps documented root-barrel exports stable', () => {
     expect(discordPublicApi).toHaveProperty('DiscordModule');
-    expect(discordPublicApi).toHaveProperty('createDiscordProviders');
     expect(discordPublicApi).toHaveProperty('createDiscordWebhookTransport');
     expect(discordPublicApi).toHaveProperty('DiscordService');
     expect(discordPublicApi).toHaveProperty('DiscordChannel');
@@ -48,6 +47,7 @@ describe('@fluojs/discord public API surface', () => {
   });
 
   it('keeps internal normalized options token hidden from the root barrel', () => {
+    expect(discordPublicApi).not.toHaveProperty('createDiscordProviders');
     expect(discordPublicApi).not.toHaveProperty('DISCORD_OPTIONS');
     expect(discordPublicApi).not.toHaveProperty('NormalizedDiscordModuleOptions');
   });


### PR DESCRIPTION
Closes #1195

## Summary
- remove `createDiscordProviders(...)` from the published `@fluojs/discord` root barrel after the notifications-side cleanup landed
- keep `DiscordModule` plus `DISCORD_CHANNEL` and the exported transport contracts as the documented supported seams

## Changes
- internalized `createDiscordProviders(...)` inside `packages/discord/src/module.ts` and removed it from `packages/discord/src/index.ts`
- updated `packages/discord/src/public-surface.test.ts` to assert the helper no longer appears in the root public API
- updated `packages/discord/README.md` and `packages/discord/README.ko.md` to remove the helper from the public API overview and clarify the supported module-first seams

## Testing
- ✅ `pnpm --filter @fluojs/discord test`
- ✅ `pnpm lint` (includes `pnpm verify:public-export-tsdoc`)
- ⚠️ `pnpm --filter @fluojs/discord typecheck` currently fails on pre-existing workspace package resolution/type errors in unchanged files such as `packages/discord/src/service.ts` and sibling package imports
- ⚠️ `pnpm --filter @fluojs/discord build` currently fails for the same pre-existing workspace declaration-resolution issues

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.