### PR TITLE
Resolve #1219: tighten studio and socket.io validation contracts

### DIFF
--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -66,6 +66,11 @@ interface ClassProviderLike {
 }
 
 interface NodeHttpServerLike {
+  close(callback?: (error?: Error) => void): unknown;
+  emit(eventName: string | symbol, ...args: unknown[]): boolean;
+  listeners(eventName: string | symbol): Function[];
+  on(eventName: string | symbol, listener: (...args: unknown[]) => void): unknown;
+  removeAllListeners(eventName?: string | symbol): unknown;
 }
 
 interface FetchStyleRealtimeCapability {
@@ -198,7 +203,16 @@ function normalizeGatewayPath(path: string): string {
 }
 
 function isNodeHttpServerLike(value: unknown): value is NodeHttpServerLike {
-  return typeof value === 'object' && value !== null;
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<NodeHttpServerLike>;
+  return typeof candidate.close === 'function'
+    && typeof candidate.emit === 'function'
+    && typeof candidate.listeners === 'function'
+    && typeof candidate.on === 'function'
+    && typeof candidate.removeAllListeners === 'function';
 }
 
 function normalizeCorsForBunEngine(cors: SocketIoModuleOptions['cors']): BunEngineCorsOptions | undefined {

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -504,6 +504,30 @@ describe('@fluojs/socket.io', () => {
     expect(bunOptions.cors).toEqual({ credentials: false, origin: false });
   });
 
+  it('rejects incomplete server-like bridge objects before constructing Socket.IO', () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getRealtimeCapability() {
+          return createServerBackedHttpAdapterRealtimeCapability({
+            close() {},
+            on() {
+              return this;
+            },
+          });
+        },
+      } as never,
+      {},
+    );
+
+    expect(() => service.getServer()).toThrow(
+      'Socket.IO bootstrap requires the selected realtime capability to expose a Node HTTP/S server instance.',
+    );
+  });
+
   it('forwards configured engine payload bounds into Socket.IO server options', () => {
     const service = new SocketIoLifecycleService(
       {} as never,

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -195,4 +195,27 @@ describe('renderMermaid', () => {
     expect(output).toContain('-->');
     expect(output).toContain('degraded');
   });
+
+  it('uses distinct external node ids when dependency names sanitize to the same base', () => {
+    const output = renderMermaid({
+      ...snapshotFixture,
+      components: [
+        {
+          ...snapshotFixture.components[0],
+          dependencies: ['cache.one', 'cache-one'],
+          id: 'api.gateway',
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const dotNodeId = output.match(/  (EXT_[A-Za-z0-9_]+)\["cache\.one"\]/)?.[1];
+    const dashNodeId = output.match(/  (EXT_[A-Za-z0-9_]+)\["cache-one"\]/)?.[1];
+
+    expect(dotNodeId).toBeDefined();
+    expect(dashNodeId).toBeDefined();
+    expect(dotNodeId).not.toBe(dashNodeId);
+    expect(output).toContain(`  C1 --> ${dotNodeId}`);
+    expect(output).toContain(`  C1 --> ${dashNodeId}`);
+  });
 });

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -242,6 +242,25 @@ function escapeMermaidText(value: string): string {
   return value.replaceAll('"', '\\"');
 }
 
+function sanitizeMermaidNodeIdSegment(value: string): string {
+  return value.replaceAll(/[^a-zA-Z0-9_]/g, '_');
+}
+
+function hashMermaidNodeId(value: string): string {
+  let hash = 2_166_136_261;
+
+  for (const character of value) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16_777_619) >>> 0;
+  }
+
+  return hash.toString(16).padStart(8, '0');
+}
+
+function createExternalMermaidNodeId(value: string): string {
+  return `EXT_${sanitizeMermaidNodeIdSegment(value)}_${hashMermaidNodeId(value)}`;
+}
+
 /**
  * Renders the loaded platform snapshot as a Mermaid dependency graph.
  *
@@ -251,6 +270,7 @@ function escapeMermaidText(value: string): string {
 export function renderMermaid(snapshot: PlatformShellSnapshot): string {
   const lines: string[] = ['graph TD'];
   const nodeByComponent = new Map<string, string>();
+  const externalNodeByDependency = new Map<string, string>();
 
   if (snapshot.components.length === 0) {
     lines.push('  EMPTY["No registered platform components"]');
@@ -277,8 +297,14 @@ export function renderMermaid(snapshot: PlatformShellSnapshot): string {
         continue;
       }
 
-      const externalNode = `EXT_${dependency.replaceAll(/[^a-zA-Z0-9_]/g, '_')}`;
-      lines.push(`  ${externalNode}["${escapeMermaidText(dependency)}"]`);
+      let externalNode = externalNodeByDependency.get(dependency);
+
+      if (!externalNode) {
+        externalNode = createExternalMermaidNodeId(dependency);
+        externalNodeByDependency.set(dependency, externalNode);
+        lines.push(`  ${externalNode}["${escapeMermaidText(dependency)}"]`);
+      }
+
       lines.push(`  ${from} --> ${externalNode}`);
     }
   }


### PR DESCRIPTION
## Summary
- tighten Studio Mermaid external dependency node-id generation so sanitized-name collisions no longer alias distinct nodes
- reject incomplete server-backed bridge shapes before `@fluojs/socket.io` constructs a Socket.IO server
- add regression coverage for both validation gaps

## Changes
- add deterministic hashed suffixes for Studio external Mermaid node ids and memoize external dependency nodes per dependency string
- add a Studio regression test for dependency names that sanitize to the same Mermaid-safe base
- require the server-backed Socket.IO bridge to expose the Node HTTP/S event-emitter methods Socket.IO depends on
- add a Socket.IO regression test that rejects incomplete server-like bridge objects

## Testing
- `pnpm -r --filter @fluojs/studio... --filter @fluojs/socket.io... build`
- `pnpm -r --filter @fluojs/studio... --filter @fluojs/socket.io... typecheck`
- `pnpm --filter @fluojs/studio test`
- `pnpm --filter @fluojs/socket.io test`
- `lsp_diagnostics` clean on changed files after workspace dependency build

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

No public exports changed in this PR.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

The README-level package contracts remain intact; this PR hardens existing validation behavior and backs it with regression tests.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

No governance docs changed in this PR.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Closes #1219