### PR TITLE
Resolve #1213: add terminus health execution guardrails

### DIFF
--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -88,6 +88,21 @@ TerminusModule.forRoot({
 });
 ```
 
+### 실행 가드레일
+
+커스텀 인디케이터가 멈추거나 느린 하위 서비스에 의존할 수 있다면 `execution.indicatorTimeoutMs`를 사용하세요. probe가 설정된 시간을 넘기면 Terminus는 무기한 대기하지 않고 해당 인디케이터를 `down`으로 표시합니다.
+
+```typescript
+TerminusModule.forRoot({
+  execution: {
+    indicatorTimeoutMs: 1_500,
+  },
+  indicators: [
+    new HttpHealthIndicator({ key: 'upstream-api', url: 'https://example.com/health' }),
+  ],
+});
+```
+
 ### 실패 시맨틱
 
 인디케이터가 실패하면 `HealthCheckError`를 던집니다. `TerminusHealthService`는 이 실패들을 모아 보고서를 작성합니다.
@@ -96,6 +111,7 @@ TerminusModule.forRoot({
 - 준비 상태(readiness)와 관련된 인디케이터가 실패하면 `/ready`는 HTTP `503`을 반환합니다.
 - 응답 본문은 `status`, `contributors`, `info`, `error`, `details`를 포함한 구조화된 JSON 객체입니다.
 - 하나의 인디케이터가 여러 keyed entry를 반환할 수도 있으며, 이 경우 `/health`는 모든 entry를 `details`와 `contributors.up` / `contributors.down` 요약에 그대로 반영합니다.
+- 같은 실행에서 이미 보고된 key를 다른 인디케이터가 다시 사용하면, Terminus는 먼저 기록된 entry를 유지하고 데이터를 조용히 덮어쓰는 대신 결정적인 `*-duplicate-key-error` contributor를 추가합니다.
 
 ## 공개 API 개요
 

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -88,6 +88,21 @@ TerminusModule.forRoot({
 });
 ```
 
+### Execution Guardrails
+
+Use `execution.indicatorTimeoutMs` when custom indicators might hang or depend on slow downstreams. When a probe exceeds the configured timeout, Terminus marks that indicator as `down` instead of waiting forever.
+
+```typescript
+TerminusModule.forRoot({
+  execution: {
+    indicatorTimeoutMs: 1_500,
+  },
+  indicators: [
+    new HttpHealthIndicator({ key: 'upstream-api', url: 'https://example.com/health' }),
+  ],
+});
+```
+
 ### Failure Semantics
 
 When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthService` aggregates these failures into a report:
@@ -96,6 +111,7 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 - `/ready` returns HTTP `503` if any indicator associated with readiness fails.
 - The response body contains a structured JSON object with `status`, `contributors`, `info`, `error`, and `details`.
 - Indicators may emit multiple keyed entries in a single check result; `/health` preserves every keyed entry in `details` and in the `contributors.up` / `contributors.down` summaries.
+- If an indicator reuses a key that was already reported earlier in the same run, Terminus keeps the first entry and adds a deterministic `*-duplicate-key-error` contributor instead of silently overwriting data.
 
 ## Public API Overview
 

--- a/packages/terminus/src/health-check.test.ts
+++ b/packages/terminus/src/health-check.test.ts
@@ -129,6 +129,82 @@ describe('runHealthCheck', () => {
       redis: { message: 'timeout', status: 'down' },
     });
   });
+
+  it('marks hung indicators as down when an execution timeout is configured', async () => {
+    const report = await runHealthCheck(
+      [
+        {
+          key: 'database',
+          check: async () => new Promise(() => undefined),
+        },
+        {
+          key: 'memory',
+          check: async (key: string) => ({
+            [key]: {
+              status: 'up',
+            },
+          }),
+        },
+      ],
+      { indicatorTimeoutMs: 5 },
+    );
+
+    expect(report.status).toBe('error');
+    expect(report.contributors).toEqual({
+      down: ['database'],
+      up: ['memory'],
+    });
+    expect(report.error.database).toEqual({
+      message: 'Health indicator timed out after 5ms.',
+      status: 'down',
+    });
+    expect(report.info.memory).toEqual({
+      status: 'up',
+    });
+  });
+
+  it('fails deterministically when a later indicator reuses an existing result key', async () => {
+    const report = await runHealthCheck([
+      {
+        key: 'database',
+        check: async (key: string) => ({
+          [key]: {
+            latencyMs: 4,
+            status: 'up',
+          },
+        }),
+      },
+      {
+        key: 'cache',
+        check: async () => ({
+          database: {
+            message: 'stale cache snapshot',
+            status: 'down',
+          },
+        }),
+      },
+    ]);
+
+    expect(report.status).toBe('error');
+    expect(report.details.database).toEqual({
+      latencyMs: 4,
+      status: 'up',
+    });
+    expect(report.details['cache-duplicate-key-error']).toEqual({
+      message: 'Indicator produced duplicate result key(s): database.',
+      status: 'down',
+    });
+    expect(report.error).toEqual({
+      'cache-duplicate-key-error': {
+        message: 'Indicator produced duplicate result key(s): database.',
+        status: 'down',
+      },
+    });
+    expect(report.contributors).toEqual({
+      down: ['cache-duplicate-key-error'],
+      up: ['database'],
+    });
+  });
 });
 
 describe('assertHealthCheck', () => {

--- a/packages/terminus/src/health-check.ts
+++ b/packages/terminus/src/health-check.ts
@@ -1,8 +1,49 @@
-import { Inject } from '@fluojs/core';
-
 import { HealthCheckError } from './errors.js';
-import { TERMINUS_HEALTH_INDICATORS } from './tokens.js';
-import type { HealthCheckReport, HealthIndicator, HealthIndicatorResult, HealthIndicatorState } from './types.js';
+import type {
+  HealthCheckExecutionOptions,
+  HealthCheckReport,
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthIndicatorState,
+} from './types.js';
+
+type HealthCheckEntry = [string, HealthIndicatorState];
+
+type ExecutedIndicatorResult = {
+  entries: HealthCheckEntry[];
+  indicatorKey: string;
+};
+
+function normalizeIndicatorTimeoutMs(value: number | undefined): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+
+  return Math.floor(value);
+}
+
+function createTimeoutMessage(timeoutMs: number): string {
+  return `Health indicator timed out after ${String(timeoutMs)}ms.`;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(createTimeoutMessage(timeoutMs)));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
 
 function toFailureResult(key: string, error: unknown): HealthIndicatorResult {
   return {
@@ -57,29 +98,113 @@ function inferIndicatorKey(indicator: HealthIndicator, index: number): string {
   return `indicator-${String(index + 1)}`;
 }
 
+function createDuplicateKeyFailureKey(indicatorKey: string, seenKeys: ReadonlySet<string>): string {
+  const baseKey = `${indicatorKey}-duplicate-key-error`;
+
+  if (!seenKeys.has(baseKey)) {
+    return baseKey;
+  }
+
+  let suffix = 2;
+  let candidate = `${baseKey}-${String(suffix)}`;
+
+  while (seenKeys.has(candidate)) {
+    suffix += 1;
+    candidate = `${baseKey}-${String(suffix)}`;
+  }
+
+  return candidate;
+}
+
+function createDuplicateKeyFailure(
+  indicatorKey: string,
+  duplicateKeys: readonly string[],
+  seenKeys: ReadonlySet<string>,
+): HealthCheckEntry {
+  return [
+    createDuplicateKeyFailureKey(indicatorKey, seenKeys),
+    {
+      message: `Indicator produced duplicate result key(s): ${duplicateKeys.join(', ')}.`,
+      status: 'down',
+    },
+  ];
+}
+
+async function runIndicator(
+  indicator: HealthIndicator,
+  index: number,
+  executionOptions: HealthCheckExecutionOptions,
+): Promise<ExecutedIndicatorResult> {
+  const key = inferIndicatorKey(indicator, index);
+  const indicatorTimeoutMs = normalizeIndicatorTimeoutMs(executionOptions.indicatorTimeoutMs);
+
+  try {
+    const result = indicatorTimeoutMs === undefined
+      ? await indicator.check(key)
+      : await withTimeout(indicator.check(key), indicatorTimeoutMs);
+
+    return {
+      entries: Object.entries(normalizeIndicatorResult(key, result)),
+      indicatorKey: key,
+    };
+  } catch (error: unknown) {
+    if (error instanceof HealthCheckError) {
+      return {
+        entries: Object.entries(normalizeIndicatorResult(key, error.causes)),
+        indicatorKey: key,
+      };
+    }
+
+    return {
+      entries: Object.entries(toFailureResult(key, error)),
+      indicatorKey: key,
+    };
+  }
+}
+
+function aggregateIndicatorEntries(checks: readonly ExecutedIndicatorResult[]): HealthCheckEntry[] {
+  const aggregatedEntries: HealthCheckEntry[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const check of checks) {
+    const duplicateKeys: string[] = [];
+
+    for (const entry of check.entries) {
+      const [entryKey] = entry;
+
+      if (seenKeys.has(entryKey)) {
+        duplicateKeys.push(entryKey);
+        continue;
+      }
+
+      seenKeys.add(entryKey);
+      aggregatedEntries.push(entry);
+    }
+
+    if (duplicateKeys.length > 0) {
+      const duplicateFailure = createDuplicateKeyFailure(check.indicatorKey, duplicateKeys, seenKeys);
+      seenKeys.add(duplicateFailure[0]);
+      aggregatedEntries.push(duplicateFailure);
+    }
+  }
+
+  return aggregatedEntries;
+}
+
 /**
  * Run every registered health indicator and aggregate their results.
  *
  * @param indicators Indicator instances to execute for the current health probe.
+ * @param executionOptions Optional timeout guardrails for indicator execution.
  * @returns A structured report containing `info`, `error`, and full `details` maps.
  */
-export async function runHealthCheck(indicators: readonly HealthIndicator[]): Promise<HealthCheckReport> {
-  const checks = (await Promise.all(
-    indicators.map(async (indicator, index) => {
-      const key = inferIndicatorKey(indicator, index);
-
-      try {
-        const result = await indicator.check(key);
-        return Object.entries(normalizeIndicatorResult(key, result));
-      } catch (error: unknown) {
-        if (error instanceof HealthCheckError) {
-          return Object.entries(normalizeIndicatorResult(key, error.causes));
-        }
-
-        return Object.entries(toFailureResult(key, error));
-      }
-    }),
-  )).flat();
+export async function runHealthCheck(
+  indicators: readonly HealthIndicator[],
+  executionOptions: HealthCheckExecutionOptions = {},
+): Promise<HealthCheckReport> {
+  const checks = aggregateIndicatorEntries(
+    await Promise.all(indicators.map((indicator, index) => runIndicator(indicator, index, executionOptions))),
+  );
 
   const details = Object.fromEntries(checks);
   const infoEntries = checks.filter(([, result]) => result.status === 'up');
@@ -115,9 +240,11 @@ export function assertHealthCheck(report: HealthCheckReport, message = 'Health c
 }
 
 /** Service facade that resolves and runs the health indicators registered in Terminus. */
-@Inject(TERMINUS_HEALTH_INDICATORS)
 export class TerminusHealthService {
-  constructor(private readonly indicators: readonly HealthIndicator[]) {}
+  constructor(
+    private readonly indicators: readonly HealthIndicator[],
+    private readonly executionOptions: HealthCheckExecutionOptions = {},
+  ) {}
 
   /**
    * Execute all registered indicators once.
@@ -125,7 +252,7 @@ export class TerminusHealthService {
    * @returns The aggregated health report for this check cycle.
    */
   async check(): Promise<HealthCheckReport> {
-    return runHealthCheck(this.indicators);
+    return runHealthCheck(this.indicators, this.executionOptions);
   }
 
   /**

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -148,6 +148,55 @@ describe('TerminusModule.forRoot', () => {
     await app.close();
   });
 
+  it('applies execution timeouts to /health and /ready checks', async () => {
+    const indicators: HealthIndicator[] = [
+      {
+        key: 'database',
+        check: async () => new Promise(() => undefined),
+      },
+    ];
+    const terminusModule = TerminusModule.forRoot({
+      execution: {
+        indicatorTimeoutMs: 5,
+      },
+      indicators,
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [terminusModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    const healthResponse = createResponse();
+    await app.dispatch(createRequest('/health'), healthResponse);
+
+    expect(healthResponse.statusCode).toBe(503);
+    expect(healthResponse.body).toMatchObject({
+      contributors: {
+        down: ['database'],
+        up: [],
+      },
+      error: {
+        database: {
+          message: 'Health indicator timed out after 5ms.',
+          status: 'down',
+        },
+      },
+      status: 'error',
+    });
+
+    const readyResponse = createResponse();
+    await app.dispatch(createRequest('/ready'), readyResponse);
+
+    expect(readyResponse.statusCode).toBe(503);
+    expect(readyResponse.body).toEqual({ status: 'unavailable' });
+
+    await app.close();
+  });
+
   it('supports custom indicators that transition from up to down after bootstrap', async () => {
     let healthy = true;
     const indicators: HealthIndicator[] = [

--- a/packages/terminus/src/module.ts
+++ b/packages/terminus/src/module.ts
@@ -42,6 +42,7 @@ function providerToken(provider: Provider): unknown {
 function createTerminusProviders(options: TerminusModuleOptions = {}): Provider[] {
   const normalizedOptions: TerminusModuleOptions = {
     ...options,
+    execution: { ...(options.execution ?? {}) },
     indicators: copyIndicators(options.indicators),
     indicatorProviders: copyProviders(options.indicatorProviders),
     readinessChecks: [...(options.readinessChecks ?? [])],
@@ -88,7 +89,22 @@ function createTerminusProviders(options: TerminusModuleOptions = {}): Provider[
       },
     },
     ...indicatorProviders,
-    TerminusHealthService,
+    {
+      inject: [TERMINUS_HEALTH_INDICATORS, TERMINUS_OPTIONS],
+      provide: TerminusHealthService,
+      useFactory: (resolvedIndicators: unknown, resolvedOptions: unknown) => {
+        const indicators = Array.isArray(resolvedIndicators) ? (resolvedIndicators as readonly HealthIndicator[]) : [];
+        const execution = typeof resolvedOptions === 'object'
+          && resolvedOptions !== null
+          && 'execution' in resolvedOptions
+          && typeof (resolvedOptions as { execution?: unknown }).execution === 'object'
+          && (resolvedOptions as { execution?: unknown }).execution !== null
+          ? ((resolvedOptions as { execution?: TerminusModuleOptions['execution'] }).execution ?? {})
+          : {};
+
+        return new TerminusHealthService(indicators, execution);
+      },
+    },
   ];
 }
 
@@ -133,6 +149,7 @@ function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): Modul
     imports: [healthModule],
     providers: [
       ...createTerminusProviders({
+        execution: options.execution,
         indicatorProviders: options.indicatorProviders,
         indicators: options.indicators,
         path: options.path,

--- a/packages/terminus/src/types.ts
+++ b/packages/terminus/src/types.ts
@@ -37,10 +37,20 @@ export interface HealthCheckReport {
   status: 'ok' | 'error';
 }
 
+/** Optional execution guardrails applied while Terminus runs health indicators. */
+export interface HealthCheckExecutionOptions {
+  /**
+   * Maximum time in milliseconds allowed for a single indicator execution before
+   * Terminus marks it as `down`.
+   */
+  indicatorTimeoutMs?: number;
+}
+
 /**
  * Module options for registering health indicators, providers, and readiness hooks.
  */
 export interface TerminusModuleOptions {
+  execution?: HealthCheckExecutionOptions;
   indicators?: readonly HealthIndicator[];
   indicatorProviders?: readonly Provider[];
   path?: string;


### PR DESCRIPTION
## Summary
- harden `@fluojs/terminus` health aggregation so hung indicators time out deterministically instead of stalling `/health`
- fail duplicate result-key collisions with explicit `*-duplicate-key-error` contributors instead of silently overwriting earlier data
- document the new execution guardrail option and preserve EN/KO README contract parity

Closes #1213

## Changes
- add `HealthCheckExecutionOptions` / `TerminusModuleOptions.execution` and wire the option through `TerminusHealthService`
- apply per-indicator timeout guardrails in `runHealthCheck(...)` and convert duplicate result-key collisions into deterministic down entries
- add regression coverage for direct aggregation behavior and module-level `/health` + `/ready` timeout handling
- update `packages/terminus/README.md` and `packages/terminus/README.ko.md` with execution guardrail and duplicate-key behavior details

## Testing
- `pnpm build`
- `pnpm --filter @fluojs/terminus typecheck`
- `pnpm --filter @fluojs/terminus test`
- `pnpm lint` (`pnpm verify:public-export-tsdoc` passed; `biome lint` continues to report unrelated pre-existing workspace warnings in `packages/cli`, `packages/config`, and `packages/core`)

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. Not applicable; no governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable; no platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable; this PR does not add platform-conformance claims.