### PR TITLE
Resolve #1217: split infra messaging lifecycle helpers and transport logging

### DIFF
--- a/packages/cron/src/distributed-lock-manager.ts
+++ b/packages/cron/src/distributed-lock-manager.ts
@@ -1,0 +1,304 @@
+import { getRedisClientToken } from '@fluojs/redis';
+import type { Container } from '@fluojs/di';
+import type { ApplicationLogger } from '@fluojs/runtime';
+
+import type { CronTaskDescriptor, NormalizedCronModuleOptions } from './types.js';
+
+export interface RedisLockClient {
+  eval(script: string, keysLength: number, ...keysAndArgs: string[]): Promise<unknown>;
+  set(key: string, value: string, mode: 'PX', ttl: number, existence: 'NX'): Promise<'OK' | null | undefined>;
+}
+
+export interface LockRenewalMonitor {
+  getPostRunError(): Promise<Error | undefined>;
+  stop(): void;
+}
+
+interface LockRenewalState {
+  lockPostRunError: Error | undefined;
+  nextRenewalDueAt: number;
+  renewalChain: Promise<void>;
+  renewalIntervalMs: number;
+  stopped: boolean;
+}
+
+type LockRenewalOutcome = 'renewed' | 'ownership-lost' | 'renewal-failed';
+
+const RELEASE_LOCK_SCRIPT =
+  'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end';
+const RENEW_LOCK_SCRIPT =
+  'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("PEXPIRE", KEYS[1], ARGV[2]) else return 0 end';
+
+export class CronDistributedLockManager {
+  private readonly ownedLockKeys = new Set<string>();
+  private redisClient: RedisLockClient | undefined;
+  private lockOwnershipLosses = 0;
+  private lockRenewalFailures = 0;
+
+  constructor(
+    private readonly options: NormalizedCronModuleOptions,
+    private readonly runtimeContainer: Container,
+    private readonly logger: ApplicationLogger,
+  ) {}
+
+  get resolvedClient(): RedisLockClient | undefined {
+    return this.redisClient;
+  }
+
+  get ownedLocks(): number {
+    return this.ownedLockKeys.size;
+  }
+
+  get ownershipLosses(): number {
+    return this.lockOwnershipLosses;
+  }
+
+  get renewalFailures(): number {
+    return this.lockRenewalFailures;
+  }
+
+  async resolveClient(): Promise<void> {
+    if (!this.options.distributed.enabled) {
+      return;
+    }
+
+    const redisToken = getRedisClientToken(this.options.distributed.clientName);
+
+    if (!this.runtimeContainer.has(redisToken)) {
+      throw new Error('Cron distributed mode requires the configured Redis client to be registered.');
+    }
+
+    const redisClient = await this.runtimeContainer.resolve(redisToken);
+
+    if (!hasRedisLockClient(redisClient)) {
+      throw new Error('Cron distributed mode requires the configured Redis client to implement set/eval lock operations.');
+    }
+
+    this.redisClient = redisClient;
+  }
+
+  reset(): void {
+    this.redisClient = undefined;
+  }
+
+  async tryAcquireLock(descriptor: CronTaskDescriptor): Promise<boolean> {
+    const redis = this.redisClient;
+
+    if (!redis) {
+      return true;
+    }
+
+    try {
+      const result = await redis.set(
+        descriptor.lockKey,
+        this.options.distributed.ownerId,
+        'PX',
+        descriptor.lockTtlMs,
+        'NX',
+      );
+
+      if (result === 'OK') {
+        this.ownedLockKeys.add(descriptor.lockKey);
+      }
+
+      return result === 'OK';
+    } catch (error) {
+      this.logger.error(
+        `Failed to acquire distributed cron lock for ${descriptor.taskName}.`,
+        error,
+        'CronLifecycleService',
+      );
+      return false;
+    }
+  }
+
+  startLockRenewalMonitor(descriptor: CronTaskDescriptor): LockRenewalMonitor {
+    const renewalState = this.createLockRenewalState(descriptor.lockTtlMs);
+    const renewalTimer = setInterval(() => {
+      if (renewalState.stopped) {
+        return;
+      }
+
+      renewalState.nextRenewalDueAt += renewalState.renewalIntervalMs;
+      renewalState.renewalChain = renewalState.renewalChain.then(async () => {
+        await this.runLockRenewalAttempt(descriptor, renewalState);
+      });
+    }, renewalState.renewalIntervalMs);
+
+    return {
+      getPostRunError: async (): Promise<Error | undefined> => {
+        this.queueDueLockRenewalAttempts(descriptor, renewalState);
+        await renewalState.renewalChain;
+        return renewalState.lockPostRunError;
+      },
+      stop: (): void => {
+        if (renewalState.stopped) {
+          return;
+        }
+
+        renewalState.stopped = true;
+        clearInterval(renewalTimer);
+      },
+    };
+  }
+
+  async releaseLock(descriptor: CronTaskDescriptor): Promise<void> {
+    await this.releaseLockKey(descriptor.lockKey, descriptor.taskName);
+  }
+
+  async releaseOwnedLocks(): Promise<void> {
+    if (!this.redisClient || this.ownedLockKeys.size === 0) {
+      return;
+    }
+
+    const lockKeys = Array.from(this.ownedLockKeys);
+
+    await Promise.all(
+      lockKeys.map(async (lockKey) => {
+        await this.releaseLockKey(lockKey, lockKey);
+      }),
+    );
+  }
+
+  private createLockRenewalState(lockTtlMs: number): LockRenewalState {
+    const renewalIntervalMs = Math.max(250, Math.floor(lockTtlMs / 2));
+
+    return {
+      lockPostRunError: undefined,
+      nextRenewalDueAt: Date.now() + renewalIntervalMs,
+      renewalChain: Promise.resolve(),
+      renewalIntervalMs,
+      stopped: false,
+    };
+  }
+
+  private queueDueLockRenewalAttempts(
+    descriptor: CronTaskDescriptor,
+    renewalState: LockRenewalState,
+  ): void {
+    const now = Date.now();
+
+    while (now >= renewalState.nextRenewalDueAt) {
+      renewalState.nextRenewalDueAt += renewalState.renewalIntervalMs;
+      renewalState.renewalChain = renewalState.renewalChain.then(async () => {
+        await this.runLockRenewalAttempt(descriptor, renewalState);
+      });
+    }
+  }
+
+  private async runLockRenewalAttempt(
+    descriptor: CronTaskDescriptor,
+    renewalState: LockRenewalState,
+  ): Promise<void> {
+    const outcome = await this.renewLock(descriptor);
+
+    if (outcome === 'ownership-lost') {
+      this.lockOwnershipLosses += 1;
+    }
+
+    if (outcome === 'renewal-failed') {
+      this.lockRenewalFailures += 1;
+    }
+
+    if (renewalState.lockPostRunError) {
+      return;
+    }
+
+    renewalState.lockPostRunError = this.toLockPostRunError(outcome, descriptor.taskName);
+  }
+
+  private toLockPostRunError(outcome: LockRenewalOutcome, taskName: string): Error | undefined {
+    if (outcome === 'ownership-lost') {
+      return new Error(`Distributed cron lock ownership lost for ${taskName}.`);
+    }
+
+    if (outcome === 'renewal-failed') {
+      return new Error(`Distributed cron lock renewal failed for ${taskName}.`);
+    }
+
+    return undefined;
+  }
+
+  private async renewLock(descriptor: CronTaskDescriptor): Promise<LockRenewalOutcome> {
+    const redis = this.redisClient;
+
+    if (!redis) {
+      return 'renewed';
+    }
+
+    try {
+      const result = await redis.eval(
+        RENEW_LOCK_SCRIPT,
+        1,
+        descriptor.lockKey,
+        this.options.distributed.ownerId,
+        String(descriptor.lockTtlMs),
+      );
+
+      if (typeof result === 'number' && result <= 0) {
+        this.logger.warn(
+          `Distributed cron lock ownership was lost for ${descriptor.taskName}.`,
+          'CronLifecycleService',
+        );
+        return 'ownership-lost';
+      }
+
+      this.logger.log(
+        `Renewed distributed cron lock for ${descriptor.taskName}.`,
+        'CronLifecycleService',
+      );
+
+      return 'renewed';
+    } catch (error) {
+      this.logger.error(
+        `Failed to renew distributed cron lock for ${descriptor.taskName}.`,
+        error,
+        'CronLifecycleService',
+      );
+      return 'renewal-failed';
+    }
+  }
+
+  private async releaseLockKey(lockKey: string, taskName: string): Promise<void> {
+    const redis = this.redisClient;
+
+    if (!redis) {
+      return;
+    }
+
+    try {
+      const result = await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, this.options.distributed.ownerId);
+
+      if (typeof result === 'number' && result <= 0) {
+        this.logger.warn(
+          `Distributed cron lock for ${taskName} was already released or owned by another node.`,
+          'CronLifecycleService',
+        );
+        return;
+      }
+
+      this.logger.log(
+        `Released distributed cron lock for ${taskName}.`,
+        'CronLifecycleService',
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to release distributed cron lock for ${taskName}.`,
+        error,
+        'CronLifecycleService',
+      );
+    } finally {
+      this.ownedLockKeys.delete(lockKey);
+    }
+  }
+}
+
+function hasRedisLockClient(value: unknown): value is RedisLockClient {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const client = value as { eval?: unknown; set?: unknown };
+
+  return typeof client.set === 'function' && typeof client.eval === 'function';
+}

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -1,7 +1,6 @@
-import { Inject, type MetadataPropertyKey, type Token } from '@fluojs/core';
-import { getClassDiMetadata } from '@fluojs/core/internal';
-import type { Container, Provider } from '@fluojs/di';
-import { getRedisClientToken, getRedisComponentId } from '@fluojs/redis';
+import { Inject } from '@fluojs/core';
+import type { Container } from '@fluojs/di';
+import { getRedisComponentId } from '@fluojs/redis';
 import { Cron as CronValidator } from 'croner';
 import {
   type ApplicationLogger,
@@ -12,8 +11,10 @@ import {
 } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 
-import { getSchedulingTaskMetadataEntries } from './metadata.js';
+import { CronDistributedLockManager } from './distributed-lock-manager.js';
 import { createCronPlatformStatusSnapshot } from './status.js';
+import { createLockKey, discoverCronTaskDescriptors } from './task-discovery.js';
+import { CronTaskRunner } from './task-runner.js';
 import { CRON_OPTIONS } from './tokens.js';
 import type {
   CronTaskDescriptor,
@@ -26,43 +27,6 @@ import type {
   TimeoutTaskOptions,
 } from './types.js';
 
-interface RedisLockClient {
-  eval(script: string, keysLength: number, ...keysAndArgs: string[]): Promise<unknown>;
-  set(key: string, value: string, mode: 'PX', ttl: number, existence: 'NX'): Promise<'OK' | null | undefined>;
-}
-
-const RELEASE_LOCK_SCRIPT =
-  'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end';
-const RENEW_LOCK_SCRIPT =
-  'if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("PEXPIRE", KEYS[1], ARGV[2]) else return 0 end';
-
-interface DiscoveryCandidate {
-  moduleName: string;
-  scope: 'request' | 'singleton' | 'transient';
-  targetType: Function;
-  token: Token;
-}
-
-interface LockRenewalMonitor {
-  getPostRunError(): Promise<Error | undefined>;
-  stop(): void;
-}
-
-interface LockRenewalState {
-  lockPostRunError: Error | undefined;
-  nextRenewalDueAt: number;
-  renewalChain: Promise<void>;
-  renewalIntervalMs: number;
-  stopped: boolean;
-}
-
-interface ResolvedTaskInvocation {
-  callable: (this: unknown) => Promise<void>;
-  instance: unknown;
-}
-
-type LockRenewalOutcome = 'renewed' | 'ownership-lost' | 'renewal-failed';
-
 interface RuntimeScheduledTask {
   stop(): void;
 }
@@ -73,44 +37,6 @@ interface RuntimeTaskState {
   running: boolean;
   scheduledHandle: RuntimeScheduledTask | undefined;
   source: 'decorator' | 'dynamic';
-}
-
-function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
-  if (typeof provider === 'function') {
-    return getClassDiMetadata(provider)?.scope ?? 'singleton';
-  }
-
-  if ('useClass' in provider) {
-    return provider.scope ?? getClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
-  }
-
-  return 'scope' in provider ? provider.scope ?? 'singleton' : 'singleton';
-}
-
-function methodKeyToName(methodKey: MetadataPropertyKey): string {
-  return typeof methodKey === 'symbol' ? methodKey.toString() : methodKey;
-}
-
-function buildDefaultTaskName(targetName: string, methodName: string): string {
-  return `${targetName}.${methodName}`;
-}
-
-function isClassProvider(provider: Provider): provider is Extract<Provider, { provide: Token; useClass: Function }> {
-  return typeof provider === 'object' && provider !== null && 'useClass' in provider;
-}
-
-function createLockKey(prefix: string, taskName: string): string {
-  return `${prefix}:${taskName}`;
-}
-
-function hasRedisLockClient(value: unknown): value is RedisLockClient {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const client = value as { eval?: unknown; set?: unknown };
-
-  return typeof client.set === 'function' && typeof client.eval === 'function';
 }
 
 function assertValidLockTtlMs(lockTtlMs: number): void {
@@ -152,20 +78,21 @@ export class CronLifecycleService
 {
   private readonly tasks = new Map<string, RuntimeTaskState>();
   private readonly activeTasks = new Set<Promise<void>>();
-  private readonly ownedLockKeys = new Set<string>();
+  private readonly distributedLocks: CronDistributedLockManager;
+  private readonly taskRunner: CronTaskRunner;
   private lifecycleState: 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'created';
-  private lockOwnershipLosses = 0;
-  private lockRenewalFailures = 0;
   private started = false;
   private shutdownPromise: Promise<void> | undefined;
-  private redisClient: RedisLockClient | undefined;
 
   constructor(
     private readonly options: NormalizedCronModuleOptions,
     private readonly runtimeContainer: Container,
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
-  ) {}
+  ) {
+    this.distributedLocks = new CronDistributedLockManager(this.options, this.runtimeContainer, this.logger);
+    this.taskRunner = new CronTaskRunner(this.runtimeContainer, this.logger);
+  }
 
   /**
    * Registers a cron task at runtime.
@@ -419,10 +346,10 @@ export class CronLifecycleService
       distributedEnabled: this.options.distributed.enabled,
       enabledTasks,
       lifecycleState: this.lifecycleState,
-      lockOwnershipLosses: this.lockOwnershipLosses,
-      lockRenewalFailures: this.lockRenewalFailures,
-      ownedLocks: this.ownedLockKeys.size,
-      redisDependencyResolved: this.redisClient !== undefined,
+      lockOwnershipLosses: this.distributedLocks.ownershipLosses,
+      lockRenewalFailures: this.distributedLocks.renewalFailures,
+      ownedLocks: this.distributedLocks.ownedLocks,
+      redisDependencyResolved: this.distributedLocks.resolvedClient !== undefined,
       runningTasks,
       totalTasks: this.tasks.size,
     });
@@ -458,7 +385,7 @@ export class CronLifecycleService
   }
 
   private async startLifecycle(): Promise<void> {
-    await this.resolveDistributedClient();
+    await this.distributedLocks.resolveClient();
     this.validateDistributedLockConfiguration();
     this.registerDecoratorTasks();
     this.started = true;
@@ -477,7 +404,7 @@ export class CronLifecycleService
     this.started = false;
     this.stopAllScheduledTasks();
     this.tasks.clear();
-    this.redisClient = undefined;
+    this.distributedLocks.reset();
   }
 
   private async runShutdownLifecycle(): Promise<void> {
@@ -493,32 +420,12 @@ export class CronLifecycleService
       );
     }
 
-    await this.releaseOwnedLocks();
+    await this.distributedLocks.releaseOwnedLocks();
     this.lifecycleState = 'stopped';
   }
 
-  private async resolveDistributedClient(): Promise<void> {
-    if (!this.options.distributed.enabled) {
-      return;
-    }
-
-    const redisToken = getRedisClientToken(this.options.distributed.clientName);
-
-    if (!this.runtimeContainer.has(redisToken)) {
-      throw new Error('Cron distributed mode requires the configured Redis client to be registered.');
-    }
-
-    const redisClient = await this.runtimeContainer.resolve(redisToken);
-
-    if (!hasRedisLockClient(redisClient)) {
-      throw new Error('Cron distributed mode requires the configured Redis client to implement set/eval lock operations.');
-    }
-
-    this.redisClient = redisClient;
-  }
-
   private registerDecoratorTasks(): void {
-    const descriptors = this.discoverTaskDescriptors();
+    const descriptors = discoverCronTaskDescriptors(this.compiledModules, this.options, this.logger);
 
     for (const descriptor of descriptors) {
       this.registerTask(descriptor, 'decorator');
@@ -646,106 +553,6 @@ export class CronLifecycleService
     }
   }
 
-  private discoverTaskDescriptors(): CronTaskDescriptor[] {
-    const seen = new Map<Function, Set<string>>();
-    const descriptors: CronTaskDescriptor[] = [];
-
-    for (const candidate of this.discoveryCandidates()) {
-      const entries = getSchedulingTaskMetadataEntries(candidate.targetType.prototype);
-
-      if (candidate.scope !== 'singleton') {
-        if (entries.length > 0) {
-          this.logger.warn(
-            `${candidate.targetType.name} in module ${candidate.moduleName} declares scheduling methods (@Cron/@Interval/@Timeout) but is registered with ${candidate.scope} scope. Scheduling tasks are run only for singleton providers.`,
-            'CronLifecycleService',
-          );
-        }
-
-        continue;
-      }
-
-      for (const entry of entries) {
-        const methodName = methodKeyToName(entry.propertyKey);
-        const taskName = entry.metadata.options.name ?? buildDefaultTaskName(candidate.targetType.name, methodName);
-        const seenMethods = seen.get(candidate.targetType) ?? new Set<string>();
-        const lockTtlMs = entry.metadata.options.lockTtlMs ?? this.options.distributed.lockTtlMs;
-
-        if (seenMethods.has(methodName)) {
-          continue;
-        }
-
-        seenMethods.add(methodName);
-        seen.set(candidate.targetType, seenMethods);
-
-        const descriptor: CronTaskDescriptor = {
-          afterRun: entry.metadata.options.afterRun,
-          beforeRun: entry.metadata.options.beforeRun,
-          distributed: entry.metadata.options.distributed ?? true,
-          kind: entry.metadata.kind,
-          lockKey: createLockKey(this.options.distributed.keyPrefix, entry.metadata.options.key ?? taskName),
-          lockTtlMs,
-          methodKey: entry.propertyKey,
-          methodName,
-          moduleName: candidate.moduleName,
-          onError: entry.metadata.options.onError,
-          onSuccess: entry.metadata.options.onSuccess,
-          targetName: candidate.targetType.name,
-          taskName,
-          token: candidate.token,
-        };
-
-        if (entry.metadata.kind === 'cron') {
-          descriptor.expression = entry.metadata.expression;
-          descriptor.timezone = entry.metadata.options.timezone;
-        } else {
-          descriptor.ms = entry.metadata.ms;
-        }
-
-        descriptors.push(descriptor);
-      }
-    }
-
-    return descriptors;
-  }
-
-  private discoveryCandidates(): DiscoveryCandidate[] {
-    const candidates: DiscoveryCandidate[] = [];
-
-    for (const compiledModule of this.compiledModules) {
-      for (const provider of compiledModule.definition.providers ?? []) {
-        if (typeof provider === 'function') {
-          candidates.push({
-            moduleName: compiledModule.type.name,
-            scope: scopeFromProvider(provider),
-            targetType: provider,
-            token: provider,
-          });
-          continue;
-        }
-
-        if (isClassProvider(provider)) {
-          candidates.push({
-            moduleName: compiledModule.type.name,
-            scope: scopeFromProvider(provider),
-            targetType: provider.useClass,
-            token: provider.provide,
-          });
-        }
-      }
-
-      for (const controller of compiledModule.definition.controllers ?? []) {
-        candidates.push({
-          moduleName: compiledModule.type.name,
-          scope: scopeFromProvider(controller),
-          targetType: controller,
-          token: controller,
-        });
-      }
-    }
-
-    return candidates;
-  }
-
   private async handleTaskTick(taskName: string): Promise<void> {
     const taskState = this.tasks.get(taskName);
 
@@ -775,17 +582,17 @@ export class CronLifecycleService
   }
 
   private shouldUseDistributedExecution(descriptor: CronTaskDescriptor): boolean {
-    return this.options.distributed.enabled && descriptor.distributed && this.redisClient !== undefined;
+    return this.options.distributed.enabled && descriptor.distributed && this.distributedLocks.resolvedClient !== undefined;
   }
 
   private async runDistributedTaskTick(descriptor: CronTaskDescriptor, taskState: RuntimeTaskState): Promise<void> {
-    const lockAcquired = await this.tryAcquireLock(descriptor);
+    const lockAcquired = await this.distributedLocks.tryAcquireLock(descriptor);
 
     if (!lockAcquired) {
       return;
     }
 
-    const lockRenewalMonitor = this.startLockRenewalMonitor(descriptor);
+    const lockRenewalMonitor = this.distributedLocks.startLockRenewalMonitor(descriptor);
 
     try {
       await this.executeTask(descriptor, taskState, async () => {
@@ -794,125 +601,8 @@ export class CronLifecycleService
       });
     } finally {
       lockRenewalMonitor.stop();
-      await this.releaseLock(descriptor);
+      await this.distributedLocks.releaseLock(descriptor);
     }
-  }
-
-  private startLockRenewalMonitor(descriptor: CronTaskDescriptor): LockRenewalMonitor {
-    const renewalState = this.createLockRenewalState(descriptor.lockTtlMs);
-    const renewalTimer = this.startLockRenewalTimer(descriptor, renewalState);
-
-    return {
-      getPostRunError: async (): Promise<Error | undefined> =>
-        await this.resolveLockRenewalPostRunError(descriptor, renewalState),
-      stop: (): void => {
-        this.stopLockRenewalMonitor(renewalState, renewalTimer);
-      },
-    };
-  }
-
-  private createLockRenewalState(lockTtlMs: number): LockRenewalState {
-    const renewalIntervalMs = Math.max(250, Math.floor(lockTtlMs / 2));
-
-    return {
-      lockPostRunError: undefined,
-      nextRenewalDueAt: Date.now() + renewalIntervalMs,
-      renewalChain: Promise.resolve(),
-      renewalIntervalMs,
-      stopped: false,
-    };
-  }
-
-  private startLockRenewalTimer(
-    descriptor: CronTaskDescriptor,
-    renewalState: LockRenewalState,
-  ): ReturnType<typeof setInterval> {
-    return setInterval(() => {
-      if (renewalState.stopped) {
-        return;
-      }
-
-      renewalState.nextRenewalDueAt += renewalState.renewalIntervalMs;
-      this.queueLockRenewalAttempt(descriptor, renewalState);
-    }, renewalState.renewalIntervalMs);
-  }
-
-  private queueLockRenewalAttempt(
-    descriptor: CronTaskDescriptor,
-    renewalState: LockRenewalState,
-  ): void {
-    renewalState.renewalChain = renewalState.renewalChain.then(async () => {
-      await this.runLockRenewalAttempt(descriptor, renewalState);
-    });
-  }
-
-  private queueDueLockRenewalAttempts(
-    descriptor: CronTaskDescriptor,
-    renewalState: LockRenewalState,
-  ): void {
-    const now = Date.now();
-
-    while (now >= renewalState.nextRenewalDueAt) {
-      renewalState.nextRenewalDueAt += renewalState.renewalIntervalMs;
-      this.queueLockRenewalAttempt(descriptor, renewalState);
-    }
-  }
-
-  private async runLockRenewalAttempt(
-    descriptor: CronTaskDescriptor,
-    renewalState: LockRenewalState,
-  ): Promise<void> {
-    const outcome = await this.renewLock(descriptor);
-
-    if (outcome === 'ownership-lost') {
-      this.lockOwnershipLosses += 1;
-    }
-
-    if (outcome === 'renewal-failed') {
-      this.lockRenewalFailures += 1;
-    }
-
-    if (renewalState.lockPostRunError) {
-      return;
-    }
-
-    renewalState.lockPostRunError = this.toLockPostRunError(outcome, descriptor.taskName);
-  }
-
-  private toLockPostRunError(
-    outcome: LockRenewalOutcome,
-    taskName: string,
-  ): Error | undefined {
-    if (outcome === 'ownership-lost') {
-      return new Error(`Distributed cron lock ownership lost for ${taskName}.`);
-    }
-
-    if (outcome === 'renewal-failed') {
-      return new Error(`Distributed cron lock renewal failed for ${taskName}.`);
-    }
-
-    return undefined;
-  }
-
-  private async resolveLockRenewalPostRunError(
-    descriptor: CronTaskDescriptor,
-    renewalState: LockRenewalState,
-  ): Promise<Error | undefined> {
-    this.queueDueLockRenewalAttempts(descriptor, renewalState);
-    await renewalState.renewalChain;
-    return renewalState.lockPostRunError;
-  }
-
-  private stopLockRenewalMonitor(
-    renewalState: LockRenewalState,
-    renewalTimer: ReturnType<typeof setInterval>,
-  ): void {
-    if (renewalState.stopped) {
-      return;
-    }
-
-    renewalState.stopped = true;
-    clearInterval(renewalTimer);
   }
 
   private async waitForActiveTasks(): Promise<boolean> {
@@ -953,258 +643,13 @@ export class CronLifecycleService
     taskState: RuntimeTaskState,
     postRunErrorProvider?: () => Error | Promise<Error | undefined> | undefined,
   ): Promise<void> {
-    const taskInvocation = await this.resolveTaskInvocation(descriptor);
-
-    if (!taskInvocation) {
-      return;
-    }
-
-    const taskError = await this.executeTaskBody(
-      descriptor,
-      taskInvocation,
-      postRunErrorProvider,
-    );
-    await this.runTaskErrorHook(descriptor, taskError);
-    await this.runTaskAfterHook(descriptor);
+    await this.taskRunner.executeTask(descriptor, postRunErrorProvider);
 
     if (descriptor.kind === 'timeout') {
       taskState.enabled = false;
       taskState.scheduledHandle = undefined;
     }
   }
-
-  private async resolveTaskInvocation(descriptor: CronTaskDescriptor): Promise<ResolvedTaskInvocation | undefined> {
-    if (descriptor.callback) {
-      return {
-        callable: descriptor.callback as (this: unknown) => Promise<void>,
-        instance: undefined,
-      };
-    }
-
-    if (!descriptor.token || descriptor.methodKey === undefined || !descriptor.targetName || !descriptor.moduleName || !descriptor.methodName) {
-      this.logger.error(
-        `Scheduling task ${descriptor.taskName} is missing invocation metadata and was skipped.`,
-        undefined,
-        'CronLifecycleService',
-      );
-      return undefined;
-    }
-
-    let instance: unknown;
-
-    try {
-      instance = await this.runtimeContainer.resolve(descriptor.token);
-    } catch (error) {
-      this.logger.error(
-        `Failed to resolve cron task target ${descriptor.targetName} from module ${descriptor.moduleName}.`,
-        error,
-        'CronLifecycleService',
-      );
-      return undefined;
-    }
-
-    const value = (instance as Record<MetadataPropertyKey, unknown>)[descriptor.methodKey];
-
-    if (typeof value !== 'function') {
-      this.logger.warn(
-        `Cron method ${descriptor.targetName}.${descriptor.methodName} is not callable and was skipped.`,
-        'CronLifecycleService',
-      );
-      return undefined;
-    }
-
-    return {
-      callable: value as (this: unknown) => Promise<void>,
-      instance,
-    };
-  }
-
-  private async executeTaskBody(
-    descriptor: CronTaskDescriptor,
-    taskInvocation: ResolvedTaskInvocation,
-    postRunErrorProvider?: () => Error | Promise<Error | undefined> | undefined,
-  ): Promise<unknown> {
-    let taskError: unknown;
-
-    try {
-      await this.runTaskBeforeHook(descriptor);
-      await Promise.resolve(taskInvocation.callable.call(taskInvocation.instance));
-
-      const postRunError = await postRunErrorProvider?.();
-
-      if (postRunError) {
-        throw postRunError;
-      }
-
-      await this.runTaskSuccessHook(descriptor);
-    } catch (error) {
-      taskError = error;
-      this.logger.error(`Cron task ${descriptor.taskName} failed.`, error, 'CronLifecycleService');
-    }
-
-    return taskError;
-  }
-
-  private async runTaskBeforeHook(descriptor: CronTaskDescriptor): Promise<void> {
-    if (!descriptor.beforeRun) {
-      return;
-    }
-
-    await Promise.resolve(descriptor.beforeRun());
-  }
-
-  private async runTaskSuccessHook(descriptor: CronTaskDescriptor): Promise<void> {
-    if (!descriptor.onSuccess) {
-      return;
-    }
-
-    await Promise.resolve(descriptor.onSuccess());
-  }
-
-  private async runTaskErrorHook(descriptor: CronTaskDescriptor, taskError: unknown): Promise<void> {
-    if (taskError && descriptor.onError) {
-      try {
-        await Promise.resolve(descriptor.onError(taskError));
-      } catch (hookError) {
-        this.logger.error(`Cron onError hook ${descriptor.taskName} failed.`, hookError, 'CronLifecycleService');
-      }
-    }
-  }
-
-  private async runTaskAfterHook(descriptor: CronTaskDescriptor): Promise<void> {
-    if (!descriptor.afterRun) {
-      return;
-    }
-
-    try {
-      await Promise.resolve(descriptor.afterRun());
-    } catch (hookError) {
-      this.logger.error(`Cron afterRun hook ${descriptor.taskName} failed.`, hookError, 'CronLifecycleService');
-    }
-  }
-
-  private async tryAcquireLock(descriptor: CronTaskDescriptor): Promise<boolean> {
-    const redis = this.redisClient;
-
-    if (!redis) {
-      return true;
-    }
-
-    try {
-      const result = await redis.set(
-        descriptor.lockKey,
-        this.options.distributed.ownerId,
-        'PX',
-        descriptor.lockTtlMs,
-        'NX',
-      );
-
-      if (result === 'OK') {
-        this.ownedLockKeys.add(descriptor.lockKey);
-      }
-
-      return result === 'OK';
-    } catch (error) {
-      this.logger.error(
-        `Failed to acquire distributed cron lock for ${descriptor.taskName}.`,
-        error,
-        'CronLifecycleService',
-      );
-      return false;
-    }
-  }
-
-  private async releaseLock(descriptor: CronTaskDescriptor): Promise<void> {
-    await this.releaseLockKey(descriptor.lockKey, descriptor.taskName);
-  }
-
-  private async renewLock(descriptor: CronTaskDescriptor): Promise<LockRenewalOutcome> {
-    const redis = this.redisClient;
-
-    if (!redis) {
-      return 'renewed';
-    }
-
-    try {
-      const result = await redis.eval(
-        RENEW_LOCK_SCRIPT,
-        1,
-        descriptor.lockKey,
-        this.options.distributed.ownerId,
-        String(descriptor.lockTtlMs),
-      );
-
-      if (typeof result === 'number' && result <= 0) {
-        this.logger.warn(
-          `Distributed cron lock ownership was lost for ${descriptor.taskName}.`,
-          'CronLifecycleService',
-        );
-        return 'ownership-lost';
-      }
-
-      this.logger.log(
-        `Renewed distributed cron lock for ${descriptor.taskName}.`,
-        'CronLifecycleService',
-      );
-
-      return 'renewed';
-    } catch (error) {
-      this.logger.error(
-        `Failed to renew distributed cron lock for ${descriptor.taskName}.`,
-        error,
-        'CronLifecycleService',
-      );
-      return 'renewal-failed';
-    }
-  }
-
-  private async releaseOwnedLocks(): Promise<void> {
-    if (!this.redisClient || this.ownedLockKeys.size === 0) {
-      return;
-    }
-
-    const lockKeys = Array.from(this.ownedLockKeys);
-
-    await Promise.all(
-      lockKeys.map(async (lockKey) => {
-        await this.releaseLockKey(lockKey, lockKey);
-      }),
-    );
-  }
-
-  private async releaseLockKey(lockKey: string, taskName: string): Promise<void> {
-    const redis = this.redisClient;
-
-    if (!redis) {
-      return;
-    }
-
-    try {
-      const result = await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, this.options.distributed.ownerId);
-
-      if (typeof result === 'number' && result <= 0) {
-        this.logger.warn(
-          `Distributed cron lock for ${taskName} was already released or owned by another node.`,
-          'CronLifecycleService',
-        );
-        return;
-      }
-
-      this.logger.log(
-        `Released distributed cron lock for ${taskName}.`,
-        'CronLifecycleService',
-      );
-    } catch (error) {
-      this.logger.error(
-        `Failed to release distributed cron lock for ${taskName}.`,
-        error,
-        'CronLifecycleService',
-      );
-    } finally {
-      this.ownedLockKeys.delete(lockKey);
-    }
-  }
-
   private stopAllScheduledTasks(): void {
     for (const task of this.tasks.values()) {
       this.unscheduleTask(task);

--- a/packages/cron/src/task-discovery.ts
+++ b/packages/cron/src/task-discovery.ts
@@ -1,0 +1,146 @@
+import { type MetadataPropertyKey, type Token } from '@fluojs/core';
+import { getClassDiMetadata } from '@fluojs/core/internal';
+import type { Provider } from '@fluojs/di';
+import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
+
+import { getSchedulingTaskMetadataEntries } from './metadata.js';
+import type { CronTaskDescriptor, NormalizedCronModuleOptions } from './types.js';
+
+interface DiscoveryCandidate {
+  moduleName: string;
+  scope: 'request' | 'singleton' | 'transient';
+  targetType: Function;
+  token: Token;
+}
+
+export function buildDefaultTaskName(targetName: string, methodName: string): string {
+  return `${targetName}.${methodName}`;
+}
+
+export function createLockKey(prefix: string, taskName: string): string {
+  return `${prefix}:${taskName}`;
+}
+
+export function methodKeyToName(methodKey: MetadataPropertyKey): string {
+  return typeof methodKey === 'symbol' ? methodKey.toString() : methodKey;
+}
+
+export function discoverCronTaskDescriptors(
+  compiledModules: readonly CompiledModule[],
+  options: NormalizedCronModuleOptions,
+  logger: ApplicationLogger,
+): CronTaskDescriptor[] {
+  const seen = new Map<Function, Set<string>>();
+  const descriptors: CronTaskDescriptor[] = [];
+
+  for (const candidate of collectDiscoveryCandidates(compiledModules)) {
+    const entries = getSchedulingTaskMetadataEntries(candidate.targetType.prototype);
+
+    if (candidate.scope !== 'singleton') {
+      if (entries.length > 0) {
+        logger.warn(
+          `${candidate.targetType.name} in module ${candidate.moduleName} declares scheduling methods (@Cron/@Interval/@Timeout) but is registered with ${candidate.scope} scope. Scheduling tasks are run only for singleton providers.`,
+          'CronLifecycleService',
+        );
+      }
+
+      continue;
+    }
+
+    for (const entry of entries) {
+      const methodName = methodKeyToName(entry.propertyKey);
+      const taskName = entry.metadata.options.name ?? buildDefaultTaskName(candidate.targetType.name, methodName);
+      const seenMethods = seen.get(candidate.targetType) ?? new Set<string>();
+      const lockTtlMs = entry.metadata.options.lockTtlMs ?? options.distributed.lockTtlMs;
+
+      if (seenMethods.has(methodName)) {
+        continue;
+      }
+
+      seenMethods.add(methodName);
+      seen.set(candidate.targetType, seenMethods);
+
+      const descriptor: CronTaskDescriptor = {
+        afterRun: entry.metadata.options.afterRun,
+        beforeRun: entry.metadata.options.beforeRun,
+        distributed: entry.metadata.options.distributed ?? true,
+        kind: entry.metadata.kind,
+        lockKey: createLockKey(options.distributed.keyPrefix, entry.metadata.options.key ?? taskName),
+        lockTtlMs,
+        methodKey: entry.propertyKey,
+        methodName,
+        moduleName: candidate.moduleName,
+        onError: entry.metadata.options.onError,
+        onSuccess: entry.metadata.options.onSuccess,
+        targetName: candidate.targetType.name,
+        taskName,
+        token: candidate.token,
+      };
+
+      if (entry.metadata.kind === 'cron') {
+        descriptor.expression = entry.metadata.expression;
+        descriptor.timezone = entry.metadata.options.timezone;
+      } else {
+        descriptor.ms = entry.metadata.ms;
+      }
+
+      descriptors.push(descriptor);
+    }
+  }
+
+  return descriptors;
+}
+
+function scopeFromProvider(provider: Provider): 'request' | 'singleton' | 'transient' {
+  if (typeof provider === 'function') {
+    return getClassDiMetadata(provider)?.scope ?? 'singleton';
+  }
+
+  if ('useClass' in provider) {
+    return provider.scope ?? getClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
+  }
+
+  return 'scope' in provider ? provider.scope ?? 'singleton' : 'singleton';
+}
+
+function isClassProvider(provider: Provider): provider is Extract<Provider, { provide: Token; useClass: Function }> {
+  return typeof provider === 'object' && provider !== null && 'useClass' in provider;
+}
+
+function collectDiscoveryCandidates(compiledModules: readonly CompiledModule[]): DiscoveryCandidate[] {
+  const candidates: DiscoveryCandidate[] = [];
+
+  for (const compiledModule of compiledModules) {
+    for (const provider of compiledModule.definition.providers ?? []) {
+      if (typeof provider === 'function') {
+        candidates.push({
+          moduleName: compiledModule.type.name,
+          scope: scopeFromProvider(provider),
+          targetType: provider,
+          token: provider,
+        });
+        continue;
+      }
+
+      if (isClassProvider(provider)) {
+        candidates.push({
+          moduleName: compiledModule.type.name,
+          scope: scopeFromProvider(provider),
+          targetType: provider.useClass,
+          token: provider.provide,
+        });
+      }
+    }
+
+    for (const controller of compiledModule.definition.controllers ?? []) {
+      candidates.push({
+        moduleName: compiledModule.type.name,
+        scope: scopeFromProvider(controller),
+        targetType: controller,
+        token: controller,
+      });
+    }
+  }
+
+  return candidates;
+}

--- a/packages/cron/src/task-runner.ts
+++ b/packages/cron/src/task-runner.ts
@@ -1,0 +1,134 @@
+import type { MetadataPropertyKey } from '@fluojs/core';
+import type { Container } from '@fluojs/di';
+import type { ApplicationLogger } from '@fluojs/runtime';
+
+import type { CronTaskDescriptor } from './types.js';
+
+interface ResolvedTaskInvocation {
+  callable: (this: unknown) => Promise<void>;
+  instance: unknown;
+}
+
+export class CronTaskRunner {
+  constructor(
+    private readonly runtimeContainer: Container,
+    private readonly logger: ApplicationLogger,
+  ) {}
+
+  async executeTask(
+    descriptor: CronTaskDescriptor,
+    postRunErrorProvider?: () => Error | Promise<Error | undefined> | undefined,
+  ): Promise<unknown> {
+    const taskInvocation = await this.resolveTaskInvocation(descriptor);
+
+    if (!taskInvocation) {
+      return undefined;
+    }
+
+    let taskError: unknown;
+
+    try {
+      await this.runTaskBeforeHook(descriptor);
+      await Promise.resolve(taskInvocation.callable.call(taskInvocation.instance));
+
+      const postRunError = await postRunErrorProvider?.();
+
+      if (postRunError) {
+        throw postRunError;
+      }
+
+      await this.runTaskSuccessHook(descriptor);
+    } catch (error) {
+      taskError = error;
+      this.logger.error(`Cron task ${descriptor.taskName} failed.`, error, 'CronLifecycleService');
+    }
+
+    await this.runTaskErrorHook(descriptor, taskError);
+    await this.runTaskAfterHook(descriptor);
+    return taskError;
+  }
+
+  private async resolveTaskInvocation(descriptor: CronTaskDescriptor): Promise<ResolvedTaskInvocation | undefined> {
+    if (descriptor.callback) {
+      return {
+        callable: descriptor.callback as (this: unknown) => Promise<void>,
+        instance: undefined,
+      };
+    }
+
+    if (!descriptor.token || descriptor.methodKey === undefined || !descriptor.targetName || !descriptor.moduleName || !descriptor.methodName) {
+      this.logger.error(
+        `Scheduling task ${descriptor.taskName} is missing invocation metadata and was skipped.`,
+        undefined,
+        'CronLifecycleService',
+      );
+      return undefined;
+    }
+
+    let instance: unknown;
+
+    try {
+      instance = await this.runtimeContainer.resolve(descriptor.token);
+    } catch (error) {
+      this.logger.error(
+        `Failed to resolve cron task target ${descriptor.targetName} from module ${descriptor.moduleName}.`,
+        error,
+        'CronLifecycleService',
+      );
+      return undefined;
+    }
+
+    const value = (instance as Record<MetadataPropertyKey, unknown>)[descriptor.methodKey];
+
+    if (typeof value !== 'function') {
+      this.logger.warn(
+        `Cron method ${descriptor.targetName}.${descriptor.methodName} is not callable and was skipped.`,
+        'CronLifecycleService',
+      );
+      return undefined;
+    }
+
+    return {
+      callable: value as (this: unknown) => Promise<void>,
+      instance,
+    };
+  }
+
+  private async runTaskBeforeHook(descriptor: CronTaskDescriptor): Promise<void> {
+    if (!descriptor.beforeRun) {
+      return;
+    }
+
+    await Promise.resolve(descriptor.beforeRun());
+  }
+
+  private async runTaskSuccessHook(descriptor: CronTaskDescriptor): Promise<void> {
+    if (!descriptor.onSuccess) {
+      return;
+    }
+
+    await Promise.resolve(descriptor.onSuccess());
+  }
+
+  private async runTaskErrorHook(descriptor: CronTaskDescriptor, taskError: unknown): Promise<void> {
+    if (taskError && descriptor.onError) {
+      try {
+        await Promise.resolve(descriptor.onError(taskError));
+      } catch (hookError) {
+        this.logger.error(`Cron onError hook ${descriptor.taskName} failed.`, hookError, 'CronLifecycleService');
+      }
+    }
+  }
+
+  private async runTaskAfterHook(descriptor: CronTaskDescriptor): Promise<void> {
+    if (!descriptor.afterRun) {
+      return;
+    }
+
+    try {
+      await Promise.resolve(descriptor.afterRun());
+    } catch (hookError) {
+      this.logger.error(`Cron afterRun hook ${descriptor.taskName} failed.`, hookError, 'CronLifecycleService');
+    }
+  }
+}

--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -89,6 +89,7 @@ await microservice.listen();
 - Redis Streams는 `close()` 중 인스턴스별 response stream은 항상 삭제하지만, 활성 fleet 전체에서 ownership를 증명할 수 없으면 공유 request consumer group은 보수적으로 유지합니다. lease-capable listener는 coordination metadata만 정리하고, mixed/fallback fleet에서는 살아 있는 다른 listener가 여전히 필요로 할 수 있으므로 공유 request group을 제거하지 않습니다.
 - `messageRetentionMaxLen`과 `eventRetentionMaxLen`은 고급 opt-in 설정으로 남아 있습니다. 이를 켜면 Redis가 ACK 전 pending live-stream 엔트리를 먼저 trim할 수 있으므로 broker-managed recovery 보장을 일부 포기하는 운영 판단이 됩니다.
 - RabbitMQ 요청-응답은 기본적으로 인스턴스별 response queue를 사용합니다. 공유 reply topology를 의도적으로 운영할 때만 `responseQueue`를 명시적으로 지정하세요.
+- transport logger를 통해 이벤트 핸들러 실패를 기록하는 경로(`RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `MqttMicroserviceTransport`, gRPC event emit)는 끝까지 logger-driven observability를 유지합니다. transport logger를 주입하지 않으면 fluo는 해당 실패를 raw `console.error` fallback으로 복제하지 않습니다.
 
 ## 공통 패턴
 

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -86,6 +86,7 @@ Microservice handlers fully support fluo's DI scopes. Request-scoped providers a
 - Redis Streams always deletes each per-consumer response stream during `close()`, but it retains the shared request consumer group conservatively once ownership cannot be proven across the active fleet. Lease-capable listeners clean up only their coordination metadata, and mixed or fallback listener fleets keep the shared request group in place so one peer cannot destroy a group that another live listener still needs.
 - `messageRetentionMaxLen` and `eventRetentionMaxLen` remain available as advanced opt-in knobs. Enabling them can trade away broker-managed recovery guarantees because Redis may trim pending live-stream entries before they are acknowledged.
 - RabbitMQ request/reply uses an instance-scoped response queue by default. Pass `responseQueue` explicitly only when you intentionally own and coordinate a shared reply topology.
+- Event-handler failures that flow through the transport logger (`RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `MqttMicroserviceTransport`, and gRPC event emits) remain logger-driven. If you do not inject a transport logger, fluo does not mirror those failures through a raw `console.error` fallback.
 
 ## Common Patterns
 

--- a/packages/microservices/src/transports/event-handler-logger.ts
+++ b/packages/microservices/src/transports/event-handler-logger.ts
@@ -1,0 +1,9 @@
+import type { MicroserviceTransportLogger } from '../types.js';
+
+export function logTransportEventHandlerFailure(
+  logger: MicroserviceTransportLogger | undefined,
+  transportName: string,
+  error: unknown,
+): void {
+  logger?.error('Event handler failed.', error, transportName);
+}

--- a/packages/microservices/src/transports/grpc-transport.test.ts
+++ b/packages/microservices/src/transports/grpc-transport.test.ts
@@ -729,6 +729,25 @@ describe('GrpcMicroserviceTransport', () => {
     await transport.close();
   });
 
+  it('does not fall back to console.error when no logger is configured', async () => {
+    const { transport } = createGrpcTransport();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'event') {
+        throw new Error('grpc event failed without logger');
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.emit('MathService.Notify', { value: 'bad' })).resolves.toBeUndefined();
+
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await transport.close();
+  });
+
   it('rejects pending requests when close() is called before reply', async () => {
     const { transport } = createGrpcTransport();
     await transport.listen(async () => {

--- a/packages/microservices/src/transports/grpc-transport.ts
+++ b/packages/microservices/src/transports/grpc-transport.ts
@@ -1,4 +1,5 @@
 import type { MicroserviceTransport, MicroserviceTransportLogger, ServerStreamWriter, TransportBidiStreamHandler, TransportClientStreamHandler, TransportHandler, TransportServerStreamHandler } from '../types.js';
+import { logTransportEventHandlerFailure } from './event-handler-logger.js';
 
 type DynamicImport = (specifier: string) => Promise<unknown>;
 
@@ -1276,12 +1277,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
   }
 
   private logEventHandlerFailure(error: unknown): void {
-    if (this.logger) {
-      this.logger.error('Event handler failed.', error, 'GrpcMicroserviceTransport');
-      return;
-    }
-
-    console.error('[fluo][GrpcMicroserviceTransport] event handler failed:', error);
+    logTransportEventHandlerFailure(this.logger, 'GrpcMicroserviceTransport', error);
   }
 }
 

--- a/packages/microservices/src/transports/mqtt-transport.test.ts
+++ b/packages/microservices/src/transports/mqtt-transport.test.ts
@@ -340,6 +340,27 @@ describe('MqttMicroserviceTransport', () => {
     await transport.close();
   });
 
+  it('does not fall back to console.error when no logger is configured', async () => {
+    const broker = new InMemoryMqttBroker();
+    const transport = new MqttMicroserviceTransport({ client: new InMemoryMqttClient(broker) });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'event') {
+        throw new Error('mqtt event failed without logger');
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.emit('audit.event', { value: 'bad' })).resolves.toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await transport.close();
+  });
+
   it('ends internally-created client on close()', async () => {
     const broker = new InMemoryMqttBroker();
     const ownedClient = new InMemoryMqttClient(broker);

--- a/packages/microservices/src/transports/mqtt-transport.ts
+++ b/packages/microservices/src/transports/mqtt-transport.ts
@@ -1,4 +1,5 @@
 import type { MicroserviceTransport, MicroserviceTransportLogger, TransportHandler } from '../types.js';
+import { logTransportEventHandlerFailure } from './event-handler-logger.js';
 
 type DynamicImport = (specifier: string) => Promise<unknown>;
 
@@ -576,12 +577,7 @@ export class MqttMicroserviceTransport implements MicroserviceTransport {
   }
 
   private logEventHandlerFailure(error: unknown): void {
-    if (this.logger) {
-      this.logger.error('Event handler failed.', error, 'MqttMicroserviceTransport');
-      return;
-    }
-
-    console.error('[fluo][MqttMicroserviceTransport] event handler failed:', error);
+    logTransportEventHandlerFailure(this.logger, 'MqttMicroserviceTransport', error);
   }
 }
 

--- a/packages/microservices/src/transports/nats-transport.test.ts
+++ b/packages/microservices/src/transports/nats-transport.test.ts
@@ -150,6 +150,35 @@ describe('NatsMicroserviceTransport', () => {
     await transport.close();
   });
 
+  it('does not fall back to console.error when no logger is configured', async () => {
+    const nats = new InMemoryNatsClient();
+    const codec = {
+      decode(data: Uint8Array) {
+        return new TextDecoder().decode(data);
+      },
+      encode(value: string) {
+        return new TextEncoder().encode(value);
+      },
+    };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const transport = new NatsMicroserviceTransport({ client: nats, codec });
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'event') {
+        throw new Error('nats event failed without logger');
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.emit('audit.value', { value: 9 })).resolves.toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await transport.close();
+  });
+
   it('isolates malformed inbound event frames from the NATS subscription callback', async () => {
     const nats = new InMemoryNatsClient();
     const codec = {

--- a/packages/microservices/src/transports/nats-transport.ts
+++ b/packages/microservices/src/transports/nats-transport.ts
@@ -1,4 +1,5 @@
 import type { MicroserviceTransport, MicroserviceTransportLogger, TransportHandler } from '../types.js';
+import { logTransportEventHandlerFailure } from './event-handler-logger.js';
 
 interface NatsMessageLike {
   readonly data: Uint8Array;
@@ -64,12 +65,7 @@ export class NatsMicroserviceTransport implements MicroserviceTransport {
   private subscriptions: NatsSubscriptionLike[] = [];
 
   private logEventHandlerFailure(error: unknown): void {
-    if (this.logger) {
-      this.logger.error('Event handler failed.', error, 'NatsMicroserviceTransport');
-      return;
-    }
-
-    console.error('[fluo][NatsMicroserviceTransport] event handler failed:', error);
+    logTransportEventHandlerFailure(this.logger, 'NatsMicroserviceTransport', error);
   }
 
   private handleEventMessageSafely(message: NatsMessageLike): void {

--- a/packages/microservices/src/transports/redis-streams-transport.test.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.test.ts
@@ -1126,4 +1126,23 @@ describe('RedisStreamsMicroserviceTransport', () => {
 
     await transport.close();
   });
+
+  it('does not fall back to console.error when no logger is configured', async () => {
+    const bus = new InMemoryStreamBus();
+    const { transport } = createTransport(bus, {
+      requestTimeoutMs: 1_000,
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await transport.listen(async () => {
+      throw new Error('redis streams event handler failed without logger');
+    });
+
+    await expect(transport.emit('audit.login', { message: 'ok' })).resolves.toBeUndefined();
+    await sleep(30);
+
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await transport.close();
+  });
 });

--- a/packages/microservices/src/transports/redis-streams-transport.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.ts
@@ -1,4 +1,5 @@
 import type { MicroserviceTransport, MicroserviceTransportLogger, TransportHandler } from '../types.js';
+import { logTransportEventHandlerFailure } from './event-handler-logger.js';
 
 interface StreamReadGroupResult {
   readonly id: string;
@@ -600,12 +601,7 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
   }
 
   private logEventHandlerFailure(error: unknown): void {
-    if (this.logger) {
-      this.logger.error('Event handler failed.', error, 'RedisStreamsMicroserviceTransport');
-      return;
-    }
-
-    console.error('[fluo][RedisStreamsMicroserviceTransport] event handler failed:', error);
+    logTransportEventHandlerFailure(this.logger, 'RedisStreamsMicroserviceTransport', error);
   }
 
   private isBusyGroupError(error: unknown): boolean {

--- a/packages/microservices/src/transports/redis-transport.test.ts
+++ b/packages/microservices/src/transports/redis-transport.test.ts
@@ -139,6 +139,31 @@ describe('RedisPubSubMicroserviceTransport', () => {
     await transport.close();
   });
 
+  it('does not fall back to console.error when no logger is configured', async () => {
+    const bus = new InMemoryRedisBus();
+    const { publishClient, subscribeClient } = bus.createClient();
+    const transport = new RedisPubSubMicroserviceTransport({
+      publishClient,
+      subscribeClient,
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'event') {
+        throw new Error('redis event failed without logger');
+      }
+
+      return undefined;
+    });
+
+    await expect(transport.emit('audit.value', { value: 9 })).resolves.toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(consoleError).not.toHaveBeenCalled();
+
+    await transport.close();
+  });
+
   it('cleans up subscriptions on close', async () => {
     const bus = new InMemoryRedisBus();
     const { publishClient, subscribeClient } = bus.createClient();

--- a/packages/microservices/src/transports/redis-transport.ts
+++ b/packages/microservices/src/transports/redis-transport.ts
@@ -1,4 +1,5 @@
 import type { MicroserviceTransport, MicroserviceTransportLogger, TransportHandler } from '../types.js';
+import { logTransportEventHandlerFailure } from './event-handler-logger.js';
 
 interface RedisPubSubMessage {
   kind: 'event';
@@ -39,12 +40,7 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
   private readonly namespace: string;
 
   private logEventHandlerFailure(error: unknown): void {
-    if (this.logger) {
-      this.logger.error('Event handler failed.', error, 'RedisPubSubMicroserviceTransport');
-      return;
-    }
-
-    console.error('[fluo][RedisPubSubMicroserviceTransport] event handler failed:', error);
+    logTransportEventHandlerFailure(this.logger, 'RedisPubSubMicroserviceTransport', error);
   }
 
   /**

--- a/packages/queue/src/dead-letter-manager.ts
+++ b/packages/queue/src/dead-letter-manager.ts
@@ -1,0 +1,117 @@
+import { cloneWithFallback } from '@fluojs/core/internal';
+import type { ApplicationLogger } from '@fluojs/runtime';
+
+import { normalizePositiveInteger, withTimeout } from './helpers.js';
+import type { NormalizedQueueModuleOptions, QueueWorkerDescriptor } from './types.js';
+
+const DEAD_LETTER_DRAIN_TIMEOUT_MS = 5_000;
+
+type QueuePayload = Record<string, unknown>;
+
+export interface QueueDeadLetterJob {
+  attemptsMade: number;
+  data: unknown;
+  finishedOn?: number;
+  id?: string;
+  opts: {
+    attempts?: number;
+  };
+}
+
+export interface QueueRedisDeadLetterClient {
+  ltrim(key: string, start: number, stop: number): Promise<unknown>;
+  rpush(key: string, value: string): Promise<unknown>;
+}
+
+export class QueueDeadLetterManager {
+  private readonly pendingWrites = new Set<Promise<void>>();
+
+  constructor(
+    private readonly options: NormalizedQueueModuleOptions,
+    private readonly logger: ApplicationLogger,
+    private readonly getRedisClient: () => QueueRedisDeadLetterClient,
+  ) {}
+
+  get pendingWriteCount(): number {
+    return this.pendingWrites.size;
+  }
+
+  trackTerminalFailure(descriptor: QueueWorkerDescriptor, job: QueueDeadLetterJob | undefined, error: Error): void {
+    if (!job || !this.isTerminalFailure(job, descriptor.attempts)) {
+      return;
+    }
+
+    const pendingWrite = this.appendDeadLetterRecord(descriptor, job, error);
+    this.pendingWrites.add(pendingWrite);
+    pendingWrite.finally(() => {
+      this.pendingWrites.delete(pendingWrite);
+    });
+  }
+
+  async drainPendingWrites(): Promise<void> {
+    while (this.pendingWrites.size > 0) {
+      await Promise.allSettled(
+        Array.from(this.pendingWrites).map(async (write) => {
+          try {
+            await withTimeout(write, DEAD_LETTER_DRAIN_TIMEOUT_MS, () => new Error('dead-letter write timed out'));
+          } catch (error) {
+            this.pendingWrites.delete(write);
+            this.logger.error(
+              'Dead-letter write did not complete within shutdown timeout.',
+              error,
+              'QueueLifecycleService',
+            );
+          }
+        }),
+      );
+    }
+  }
+
+  private async appendDeadLetterRecord(
+    descriptor: QueueWorkerDescriptor,
+    job: QueueDeadLetterJob,
+    error: Error,
+  ): Promise<void> {
+    try {
+      const key = deadLetterKey(descriptor.jobName);
+      const deadLetter = {
+        attemptsMade: job.attemptsMade,
+        errorMessage: error.message,
+        failedAt: new Date(job.finishedOn ?? Date.now()).toISOString(),
+        jobId: job.id ?? '',
+        jobName: descriptor.jobName,
+        payload: isQueuePayload(job.data) ? cloneWithFallback(job.data) : job.data,
+      };
+
+      const redis = this.getRedisClient();
+      await redis.rpush(key, JSON.stringify(deadLetter));
+
+      if (this.options.defaultDeadLetterMaxEntries !== false) {
+        await redis.ltrim(key, -this.options.defaultDeadLetterMaxEntries, -1);
+      }
+    } catch (deadLetterError) {
+      this.logger.error(
+        `Failed to append dead-letter record for queue job ${descriptor.jobName}.`,
+        deadLetterError,
+        'QueueLifecycleService',
+      );
+    }
+  }
+
+  private isTerminalFailure(job: QueueDeadLetterJob, attemptsFallback: number): boolean {
+    const configuredAttempts =
+      typeof job.opts.attempts === 'number' && Number.isFinite(job.opts.attempts)
+        ? normalizePositiveInteger(job.opts.attempts, attemptsFallback)
+        : attemptsFallback;
+
+    return job.attemptsMade >= configuredAttempts;
+  }
+}
+
+function deadLetterKey(jobName: string): string {
+  return `fluo:queue:dead-letter:${jobName}`;
+}
+
+function isQueuePayload(value: unknown): value is QueuePayload {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -12,16 +12,11 @@ import {
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 import { Queue as BullQueue, Worker as BullWorker, type ConnectionOptions, type JobsOptions, type Job as BullJob } from 'bullmq';
 
-import { getQueueWorkerMetadata } from './metadata.js';
-import {
-  collectDiscoveryCandidates,
-  normalizePositiveInteger,
-  normalizeRateLimiter,
-  withTimeout,
-  type DiscoveryCandidate,
-} from './helpers.js';
+import { QueueDeadLetterManager, type QueueRedisDeadLetterClient } from './dead-letter-manager.js';
+import { normalizePositiveInteger } from './helpers.js';
 import { createQueuePlatformStatusSnapshot } from './status.js';
 import { QUEUE_OPTIONS } from './tokens.js';
+import { discoverQueueWorkerDescriptors } from './worker-discovery.js';
 import type {
   NormalizedQueueModuleOptions,
   Queue,
@@ -33,7 +28,6 @@ import type {
 type QueuePayload = Record<string, unknown>;
 type QueueInstance = BullQueue;
 type WorkerInstance = BullWorker;
-const DEAD_LETTER_DRAIN_TIMEOUT_MS = 5_000;
 
 type QueueLifecycleState = 'idle' | 'starting' | 'started' | 'stopping' | 'stopped';
 
@@ -44,10 +38,8 @@ type QueueOwnedConnection = ConnectionOptions & {
   status?: string;
 };
 
-interface QueueRedisClient {
+interface QueueRedisClient extends QueueRedisDeadLetterClient {
   duplicate(): QueueOwnedConnection;
-  ltrim(key: string, start: number, stop: number): Promise<unknown>;
-  rpush(key: string, value: string): Promise<unknown>;
 }
 
 interface WorkerInitializationResources {
@@ -63,8 +55,6 @@ interface InitializedWorkerResources {
   worker: WorkerInstance;
   workerConnection: QueueOwnedConnection;
 }
-
-type QueueWorkerMetadata = NonNullable<ReturnType<typeof getQueueWorkerMetadata>>;
 
 interface ResolvedWorkerHandler {
   handler: (this: unknown, payload: object) => Promise<void>;
@@ -110,10 +100,6 @@ function toBullBackoff(backoff: QueueBackoffOptions | undefined): JobsOptions['b
   };
 }
 
-function deadLetterKey(jobName: string): string {
-  return `fluo:queue:dead-letter:${jobName}`;
-}
-
 async function closeConnection(connection: QueueOwnedConnection): Promise<void> {
   if (connection.status === 'end') {
     return;
@@ -142,7 +128,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   private readonly queuesByJobName = new Map<string, QueueInstance>();
   private readonly workersByJobName = new Map<string, WorkerInstance>();
   private readonly ownedConnections: QueueOwnedConnection[] = [];
-  private readonly pendingDeadLetterWrites = new Set<Promise<void>>();
+  private readonly deadLetterManager: QueueDeadLetterManager;
   private lifecycleState: QueueLifecycleState = 'idle';
   private redisClient: QueueRedisClient | undefined;
   private startPromise: Promise<void> | undefined;
@@ -153,7 +139,9 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     private readonly runtimeContainer: Container,
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
-  ) {}
+  ) {
+    this.deadLetterManager = new QueueDeadLetterManager(this.options, this.logger, () => this.getRedisClient());
+  }
 
   async onApplicationBootstrap(): Promise<void> {
     await this.ensureStarted();
@@ -207,7 +195,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     return createQueuePlatformStatusSnapshot({
       dependencyId: getRedisComponentId(this.options.clientName),
       lifecycleState: this.lifecycleState,
-      pendingDeadLetterWrites: this.pendingDeadLetterWrites.size,
+      pendingDeadLetterWrites: this.deadLetterManager.pendingWriteCount,
       queuesReady: this.queuesByJobName.size,
       workersDiscovered: this.descriptorsByJobType.size,
       workersReady: this.workersByJobName.size,
@@ -241,7 +229,12 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   private async startLifecycle(): Promise<void> {
     const redis = await this.resolveRedisClient();
     this.redisClient = redis;
-    this.discoverWorkers();
+    this.descriptorsByJobType.clear();
+
+    for (const [jobType, descriptor] of discoverQueueWorkerDescriptors(this.compiledModules, this.options, this.logger)) {
+      this.descriptorsByJobType.set(jobType, descriptor);
+    }
+
     await this.initializeWorkers(redis);
     this.lifecycleState = 'started';
   }
@@ -275,96 +268,6 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     }
 
     return this.redisClient;
-  }
-
-  private discoverWorkers(): void {
-    this.descriptorsByJobType.clear();
-    const seenJobNames = new Set<string>();
-
-    for (const candidate of this.discoveryCandidates()) {
-      const metadata = getQueueWorkerMetadata(candidate.targetType);
-
-      if (!metadata) {
-        continue;
-      }
-
-      if (this.shouldSkipNonSingletonWorker(candidate)) {
-        continue;
-      }
-
-      const jobType = metadata.jobType;
-
-      if (this.isDuplicateWorkerRegistration(jobType, candidate.moduleName)) {
-        continue;
-      }
-
-      const jobName = metadata.options.jobName ?? jobType.name;
-
-      if (this.isDuplicateJobName(jobName, candidate.moduleName, seenJobNames)) {
-        continue;
-      }
-
-      seenJobNames.add(jobName);
-      this.descriptorsByJobType.set(jobType, this.createWorkerDescriptor(candidate, metadata, jobName));
-    }
-  }
-
-  private shouldSkipNonSingletonWorker(candidate: DiscoveryCandidate): boolean {
-    if (candidate.scope === 'singleton') {
-      return false;
-    }
-
-    this.logger.warn(
-      `${candidate.targetType.name} in module ${candidate.moduleName} declares @QueueWorker() but is registered with ${candidate.scope} scope. Queue workers are registered only for singleton providers.`,
-      'QueueLifecycleService',
-    );
-    return true;
-  }
-
-  private isDuplicateWorkerRegistration(jobType: QueueJobType, moduleName: string): boolean {
-    if (!this.descriptorsByJobType.has(jobType)) {
-      return false;
-    }
-
-    this.logger.warn(
-      `Duplicate @QueueWorker() registration for job type ${jobType.name} was ignored in ${moduleName}.`,
-      'QueueLifecycleService',
-    );
-    return true;
-  }
-
-  private isDuplicateJobName(jobName: string, moduleName: string, seenJobNames: Set<string>): boolean {
-    if (!seenJobNames.has(jobName)) {
-      return false;
-    }
-
-    this.logger.warn(
-      `Duplicate queue job name ${jobName} was ignored in ${moduleName}.`,
-      'QueueLifecycleService',
-    );
-    return true;
-  }
-
-  private createWorkerDescriptor(
-    candidate: DiscoveryCandidate,
-    metadata: QueueWorkerMetadata,
-    jobName: string,
-  ): QueueWorkerDescriptor {
-    return {
-      attempts: normalizePositiveInteger(metadata.options.attempts, this.options.defaultAttempts),
-      backoff: metadata.options.backoff ?? this.options.defaultBackoff,
-      concurrency: normalizePositiveInteger(metadata.options.concurrency, this.options.defaultConcurrency),
-      jobName,
-      jobType: metadata.jobType,
-      moduleName: candidate.moduleName,
-      rateLimiter: normalizeRateLimiter(metadata.options.rateLimiter ?? this.options.defaultRateLimiter),
-      token: candidate.token,
-      workerName: candidate.targetType.name,
-    };
-  }
-
-  private discoveryCandidates(): DiscoveryCandidate[] {
-    return collectDiscoveryCandidates(this.compiledModules);
   }
 
   private async initializeWorkers(redis: QueueRedisClient): Promise<void> {
@@ -462,15 +365,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     worker: WorkerInstance,
   ): void {
     worker.on('failed', (job: BullJob | undefined, error: Error) => {
-      if (!job || !this.isTerminalFailure(job, descriptor.attempts)) {
-        return;
-      }
-
-      const pendingWrite = this.handleFailedJob(descriptor, job, error);
-      this.pendingDeadLetterWrites.add(pendingWrite);
-      pendingWrite.finally(() => {
-        this.pendingDeadLetterWrites.delete(pendingWrite);
-      });
+      this.deadLetterManager.trackTerminalFailure(descriptor, job, error);
     });
   }
 
@@ -556,54 +451,6 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     return rehydrateJobPayload(descriptor.jobType, job.data);
   }
 
-  private async handleFailedJob(
-    descriptor: QueueWorkerDescriptor,
-    job: BullJob | undefined,
-    error: Error,
-  ): Promise<void> {
-    if (!job) {
-      return;
-    }
-
-    if (!this.isTerminalFailure(job, descriptor.attempts)) {
-      return;
-    }
-
-    try {
-      const key = deadLetterKey(descriptor.jobName);
-      const deadLetter = {
-        attemptsMade: job.attemptsMade,
-        errorMessage: error.message,
-        failedAt: new Date(job.finishedOn ?? Date.now()).toISOString(),
-        jobId: job.id ?? '',
-        jobName: descriptor.jobName,
-        payload: isQueuePayload(job.data) ? cloneWithFallback(job.data) : job.data,
-      };
-
-      const redis = this.getRedisClient();
-      await redis.rpush(key, JSON.stringify(deadLetter));
-
-      if (this.options.defaultDeadLetterMaxEntries !== false) {
-        await redis.ltrim(key, -this.options.defaultDeadLetterMaxEntries, -1);
-      }
-    } catch (deadLetterError) {
-      this.logger.error(
-        `Failed to append dead-letter record for queue job ${descriptor.jobName}.`,
-        deadLetterError,
-        'QueueLifecycleService',
-      );
-    }
-  }
-
-  private isTerminalFailure(job: BullJob, attemptsFallback: number): boolean {
-    const configuredAttempts =
-      typeof job.opts.attempts === 'number' && Number.isFinite(job.opts.attempts)
-        ? normalizePositiveInteger(job.opts.attempts, attemptsFallback)
-        : attemptsFallback;
-
-    return job.attemptsMade >= configuredAttempts;
-  }
-
   private async shutdown(): Promise<void> {
     if (this.shutdownPromise) {
       await this.shutdownPromise;
@@ -618,7 +465,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
 
     this.shutdownPromise = (async () => {
       await this.closeInitializedResources();
-      await this.drainDeadLetterWrites();
+      await this.deadLetterManager.drainPendingWrites();
       this.lifecycleState = 'stopped';
       this.startPromise = undefined;
     })();
@@ -644,29 +491,6 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
 
     for (const connection of ownedConnections) {
       await this.tryCloseOwnedConnection(connection);
-    }
-  }
-
-  private async drainDeadLetterWrites(): Promise<void> {
-    while (this.pendingDeadLetterWrites.size > 0) {
-      await this.drainDeadLetterWriteBatch(Array.from(this.pendingDeadLetterWrites));
-    }
-  }
-
-  private async drainDeadLetterWriteBatch(writes: readonly Promise<void>[]): Promise<void> {
-    await Promise.allSettled(writes.map(async (write) => this.awaitDeadLetterWriteWithTimeout(write)));
-  }
-
-  private async awaitDeadLetterWriteWithTimeout(write: Promise<void>): Promise<void> {
-    try {
-      await withTimeout(write, DEAD_LETTER_DRAIN_TIMEOUT_MS, () => new Error('dead-letter write timed out'));
-    } catch (error) {
-      this.pendingDeadLetterWrites.delete(write);
-      this.logger.error(
-        'Dead-letter write did not complete within shutdown timeout.',
-        error,
-        'QueueLifecycleService',
-      );
     }
   }
 

--- a/packages/queue/src/worker-discovery.ts
+++ b/packages/queue/src/worker-discovery.ts
@@ -1,0 +1,76 @@
+import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
+
+import { getQueueWorkerMetadata } from './metadata.js';
+import { collectDiscoveryCandidates, normalizePositiveInteger, normalizeRateLimiter } from './helpers.js';
+import type { NormalizedQueueModuleOptions, QueueJobType, QueueWorkerDescriptor, QueueWorkerMetadata } from './types.js';
+
+export function discoverQueueWorkerDescriptors(
+  compiledModules: readonly CompiledModule[],
+  options: NormalizedQueueModuleOptions,
+  logger: ApplicationLogger,
+): Map<QueueJobType, QueueWorkerDescriptor> {
+  const descriptorsByJobType = new Map<QueueJobType, QueueWorkerDescriptor>();
+  const seenJobNames = new Set<string>();
+
+  for (const candidate of collectDiscoveryCandidates(compiledModules)) {
+    const metadata = getQueueWorkerMetadata(candidate.targetType);
+
+    if (!metadata) {
+      continue;
+    }
+
+    if (candidate.scope !== 'singleton') {
+      logger.warn(
+        `${candidate.targetType.name} in module ${candidate.moduleName} declares @QueueWorker() but is registered with ${candidate.scope} scope. Queue workers are registered only for singleton providers.`,
+        'QueueLifecycleService',
+      );
+      continue;
+    }
+
+    const jobType = metadata.jobType;
+
+    if (descriptorsByJobType.has(jobType)) {
+      logger.warn(
+        `Duplicate @QueueWorker() registration for job type ${jobType.name} was ignored in ${candidate.moduleName}.`,
+        'QueueLifecycleService',
+      );
+      continue;
+    }
+
+    const jobName = metadata.options.jobName ?? jobType.name;
+
+    if (seenJobNames.has(jobName)) {
+      logger.warn(
+        `Duplicate queue job name ${jobName} was ignored in ${candidate.moduleName}.`,
+        'QueueLifecycleService',
+      );
+      continue;
+    }
+
+    seenJobNames.add(jobName);
+    descriptorsByJobType.set(jobType, createWorkerDescriptor(candidate.moduleName, candidate.token, candidate.targetType.name, metadata, jobName, options));
+  }
+
+  return descriptorsByJobType;
+}
+
+function createWorkerDescriptor(
+  moduleName: string,
+  token: QueueWorkerDescriptor['token'],
+  workerName: string,
+  metadata: QueueWorkerMetadata,
+  jobName: string,
+  options: NormalizedQueueModuleOptions,
+): QueueWorkerDescriptor {
+  return {
+    attempts: normalizePositiveInteger(metadata.options.attempts, options.defaultAttempts),
+    backoff: metadata.options.backoff ?? options.defaultBackoff,
+    concurrency: normalizePositiveInteger(metadata.options.concurrency, options.defaultConcurrency),
+    jobName,
+    jobType: metadata.jobType,
+    moduleName,
+    rateLimiter: normalizeRateLimiter(metadata.options.rateLimiter ?? options.defaultRateLimiter),
+    token,
+    workerName,
+  };
+}


### PR DESCRIPTION
Closes #1217

## Summary
- split oversized `@fluojs/queue` and `@fluojs/cron` lifecycle services into focused internal collaborators while keeping the public runtime contract intact
- remove raw `console.error` fallbacks from microservice transports so event-handler failures flow only through injected transport loggers
- add regression coverage for loggerless transport failure paths alongside the existing shutdown/lifecycle coverage

## Changes
- extracted queue worker discovery and dead-letter coordination into `packages/queue/src/worker-discovery.ts` and `packages/queue/src/dead-letter-manager.ts`
- extracted cron task discovery, distributed lock coordination, and task execution into `packages/cron/src/task-discovery.ts`, `packages/cron/src/distributed-lock-manager.ts`, and `packages/cron/src/task-runner.ts`
- added a shared transport event-handler logging helper and migrated Redis Pub/Sub, NATS, MQTT, gRPC, and Redis Streams transports away from `console.error` fallback behavior
- added targeted tests that assert transports stay quiet when no logger is injected

## Testing
- `pnpm exec vitest run packages/queue/src/module.test.ts packages/cron/src/module.test.ts packages/microservices/src/transports/redis-transport.test.ts packages/microservices/src/transports/nats-transport.test.ts packages/microservices/src/transports/mqtt-transport.test.ts packages/microservices/src/transports/grpc-transport.test.ts packages/microservices/src/transports/redis-streams-transport.test.ts`
- `pnpm build`
- `pnpm typecheck`

## Public export documentation
- Not applicable; this PR does not change documented public exports.

## Behavioral contract
- No documented package behavior was intentionally narrowed or removed.
- Queue, cron, and transport changes stay within the existing package contracts and retain regression coverage for failure-path logging and shutdown coordination.
- Intentional limitations remain unchanged, including Redis Pub/Sub staying event-only and cron distributed locking continuing to require explicit Redis support.

## Platform consistency governance (SSOT)
- Not applicable; no governance docs or platform contract documents changed.