### PR TITLE
Resolve #1215: stabilize Node adapter exports and Fastify regressions

### DIFF
--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -451,6 +451,41 @@ describe('@fluojs/platform-fastify', () => {
     await app.close();
   });
 
+  it('keeps explicit cors: false preflight requests outside the CORS contract', async () => {
+    @Controller('/ping')
+    class PingController {
+      @Get('/')
+      ping() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [PingController] });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/ping`, {
+      headers: {
+        'access-control-request-method': 'GET',
+        origin: 'https://my-frontend.com',
+      },
+      method: 'OPTIONS',
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    expect(response.headers.get('access-control-allow-methods')).toBeNull();
+
+    await app.close();
+  });
+
   it('reports the configured host in startup logs', async () => {
     const loggerEvents: string[] = [];
     const logger: ApplicationLogger = {
@@ -742,6 +777,34 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('deduplicates concurrent close() calls against the same Fastify shutdown', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
+    const deferred = createDeferred<void>();
+    let closeCallCount = 0;
+    const app = {
+      close: () => {
+        closeCallCount += 1;
+        return deferred.promise;
+      },
+      server: {
+        listening: true,
+      },
+    };
+
+    Reflect.set(adapter, 'app', app);
+    Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
+
+    const firstClose = adapter.close();
+    const secondClose = adapter.close();
+
+    expect(closeCallCount).toBe(1);
+
+    deferred.resolve();
+    await Promise.all([firstClose, secondClose]);
+
+    expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
+  });
+
   it('marks shutdown timeout via exitCode without forcing process termination', async () => {
     vi.useFakeTimers();
 
@@ -771,7 +834,10 @@ describe('@fluojs/platform-fastify', () => {
     });
 
     const originalExitCode = process.exitCode;
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => undefined as never) as typeof process.exit);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((((code?: number | string | null) => {
+      void code;
+      return undefined as never;
+    }) as typeof process.exit));
     const port = await findAvailablePort();
     const app = await runFastifyApplication(AppModule, {
       cors: false,

--- a/packages/platform-nodejs/src/index.ts
+++ b/packages/platform-nodejs/src/index.ts
@@ -1,10 +1,10 @@
-import type { NodeHttpAdapterOptions, NodeHttpApplicationAdapter } from '@fluojs/runtime/internal-node';
-import { createNodeHttpAdapter } from '@fluojs/runtime/internal-node';
+import type { NodeHttpAdapterOptions } from '@fluojs/runtime/node';
+import { createNodeHttpAdapter, NodeHttpApplicationAdapter } from '@fluojs/runtime/node';
 
 export {
   bootstrapNodeApplication as bootstrapNodejsApplication,
   runNodeApplication as runNodejsApplication,
-} from '@fluojs/runtime/internal-node';
+} from '@fluojs/runtime/node';
 
 export type {
   BootstrapNodeApplicationOptions as BootstrapNodejsApplicationOptions,
@@ -12,10 +12,22 @@ export type {
   NodeHttpAdapterOptions as NodejsAdapterOptions,
   NodeHttpApplicationAdapter as NodejsHttpApplicationAdapter,
   RunNodeApplicationOptions as RunNodejsApplicationOptions,
-} from '@fluojs/runtime/internal-node';
+} from '@fluojs/runtime/node';
 
+/**
+ * Create the stable raw Node.js adapter without exposing runtime-internal imports.
+ *
+ * @param options Transport-level Node.js adapter settings such as host, port, and body limits.
+ * @returns The public Node.js HTTP adapter contract exposed by `@fluojs/platform-nodejs`.
+ */
 export function createNodejsAdapter(
   options: NodeHttpAdapterOptions = {},
 ): NodeHttpApplicationAdapter {
-  return createNodeHttpAdapter(options) as NodeHttpApplicationAdapter;
+  const adapter = createNodeHttpAdapter(options);
+
+  if (!(adapter instanceof NodeHttpApplicationAdapter)) {
+    throw new TypeError('Expected createNodeHttpAdapter() to return the stable Node.js adapter contract.');
+  }
+
+  return adapter;
 }


### PR DESCRIPTION
## Summary
- stabilize `@fluojs/platform-nodejs` on the public `@fluojs/runtime/node` seam instead of re-exporting the internal-node boundary
- add targeted Fastify regression coverage for explicit `cors: false` preflight behavior and concurrent `close()` deduplication
- keep the scope limited to contract visibility and diagnostic safety for the http-runtime lane

Closes #1215

## Changes
- switched `@fluojs/platform-nodejs` imports/re-exports from `@fluojs/runtime/internal-node` to `@fluojs/runtime/node`
- added a runtime guard plus TSDoc on `createNodejsAdapter(...)` so the public surface fails loudly if the adapter boundary drifts
- added Fastify tests for `OPTIONS` preflight when CORS is disabled and for concurrent shutdown calls sharing one Fastify close flow

## Testing
- `pnpm --filter @fluojs/platform-nodejs build`
- `pnpm --filter @fluojs/platform-nodejs typecheck`
- `pnpm --filter @fluojs/platform-nodejs exec vitest run -c vitest.config.ts src/index.test.ts`
- `pnpm --filter @fluojs/platform-fastify build`
- `pnpm --filter @fluojs/platform-fastify typecheck`
- `pnpm --filter @fluojs/platform-fastify exec vitest run -c vitest.config.ts src/adapter.test.ts`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.