### PR TITLE
Resolve #1215: improve metrics platform diagnostic visibility

### DIFF
--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -122,6 +122,10 @@ const ordersTotal = new Counter({
 class AppModule {}
 ```
 
+### 메트릭 스크레이프에서 런타임 진단 정보 확인
+
+`MetricsModule`은 누적된 런타임 플랫폼 diagnostics를 `fluo_platform_diagnostic_issues` 메트릭으로 함께 노출합니다. 라벨은 `component_id`, `severity`, `code`, 그리고 설정한 `env`/`instance`로 제한되며, 자유 형식 메시지나 원인 문자열은 라벨로 올리지 않아 카디널리티 폭증을 방지합니다.
+
 ### 런타임 플랫폼 텔레메트리
 
 이 모듈은 플랫폼 셸 및 등록된 컴포넌트의 내부 상태를 반영하는 fluo 전용 Gauge를 자동으로 생성합니다.
@@ -158,6 +162,13 @@ MetricsModule.forRoot({
 - 카운터, 게이지, 히스토그램 및 레지스트리 접근을 위한 Prometheus 기반 헬퍼
 
 ### 운영 기본값
+
+- `path`의 기본값은 `'/metrics'`이며, `path: false`를 주면 스크레이프 엔드포인트를 완전히 비활성화합니다.
+- `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`를 주면 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 비활성화합니다.
+- `endpointMiddleware`는 스크레이프 엔드포인트에만 route-scoped middleware를 바인딩합니다.
+- HTTP 메트릭은 기본적으로 템플릿 기반 경로 라벨을 사용합니다.
+- Raw path 라벨은 `allowUnsafeRawPathLabelMode: true`를 명시한 경우에만 허용되며, 유한한 내부 경로 집합에서만 사용해야 합니다.
+- 런타임 플랫폼 diagnostics는 `fluo_platform_diagnostic_issues`로 노출되며 `component_id`, `severity`, `code`처럼 제한된 라벨만 사용합니다.
 
 ## 관련 패키지
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -103,6 +103,10 @@ class AppModule {}
 
 Prometheus metric names must stay unique inside a registry. Shared-registry mode keeps that behavior intact instead of silently shadowing metrics.
 
+### Inspect runtime diagnostics from the metrics scrape
+
+`MetricsModule` now mirrors accumulated runtime platform diagnostics into `fluo_platform_diagnostic_issues` with bounded labels for `component_id`, `severity`, and `code` plus the configured `env` and `instance` labels. This keeps scrape-time telemetry aligned with runtime warnings and failures without exposing free-form diagnostic messages as metric labels.
+
 ### Disable default process and Node metrics
 
 `defaultMetrics` defaults to `true`, so `MetricsModule.forRoot()` registers Prometheus default process and Node.js collectors once per registry unless you opt out.
@@ -127,6 +131,7 @@ MetricsModule.forRoot({
 - `endpointMiddleware` binds route-scoped middleware only to the scrape endpoint.
 - HTTP metrics default to template-normalized path labels.
 - Raw path labels require `allowUnsafeRawPathLabelMode: true` and should stay limited to bounded internal routes.
+- Runtime platform diagnostics are exported as `fluo_platform_diagnostic_issues` with bounded `component_id`, `severity`, and `code` labels.
 
 ## Related Packages
 

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -428,6 +428,73 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
+  it('exports accumulated platform diagnostics as bounded metrics labels', async () => {
+    const component: PlatformComponent = {
+      async health() {
+        return { status: 'healthy' };
+      },
+      id: 'cache.default',
+      kind: 'cache',
+      async ready() {
+        return { critical: false, status: 'ready' };
+      },
+      snapshot() {
+        return {
+          dependencies: [],
+          details: { mode: 'memory' },
+          health: { status: 'healthy' },
+          id: 'cache.default',
+          kind: 'cache',
+          ownership: { externallyManaged: false, ownsResources: true },
+          readiness: { critical: false, status: 'ready' },
+          state: 'ready',
+          telemetry: { namespace: 'cache', tags: {} },
+        };
+      },
+      async start() {},
+      state() {
+        return 'ready';
+      },
+      async stop() {},
+      async validate() {
+        return {
+          issues: [],
+          ok: true,
+          warnings: [
+            {
+              code: 'CACHE_WARN_HIGH_LATENCY',
+              componentId: 'cache.default',
+              fixHint: 'Inspect cache latency and connection pressure.',
+              message: 'Cache latency is elevated.',
+              severity: 'warning',
+            },
+          ],
+        };
+      },
+    };
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
+    });
+
+    const app = await bootstrapApplication({
+      platform: { components: [component] },
+      rootModule: AppModule,
+    });
+
+    const response = createResponse();
+    await app.dispatch(createRequest('/metrics'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(String(response.body)).toContain(
+      'fluo_platform_diagnostic_issues{component_id="cache.default",severity="warning",code="CACHE_WARN_HIGH_LATENCY",env="unknown",instance="local"} 1',
+    );
+
+    await app.close();
+  });
+
   it('serializes overlapping scrapes and removes stale platform status series', async () => {
     let currentReadiness: 'ready' | 'degraded' = 'ready';
     let currentHealth: 'healthy' | 'degraded' = 'healthy';

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -1,6 +1,6 @@
 import type { Provider } from '@fluojs/di';
 import { Controller, Get, forRoutes, type Middleware, type MiddlewareLike, type RequestContext } from '@fluojs/http';
-import { defineModule, type ModuleType, PLATFORM_SHELL, type PlatformShellSnapshot } from '@fluojs/runtime';
+import { defineModule, type ModuleType, PLATFORM_SHELL, type PlatformDiagnosticIssue, type PlatformShellSnapshot } from '@fluojs/runtime';
 import { collectDefaultMetrics, Gauge, Registry as PrometheusRegistry, type Registry } from 'prom-client';
 
 import {
@@ -129,6 +129,7 @@ export class MetricsModule {
 }
 
 type RegistryMode = 'isolated' | 'shared';
+type PlatformDiagnosticSeverity = PlatformDiagnosticIssue['severity'];
 type PlatformHealthStatus = PlatformShellSnapshot['health']['status'];
 type PlatformReadinessStatus = PlatformShellSnapshot['readiness']['status'];
 type RuntimeTelemetryComponent = {
@@ -139,6 +140,7 @@ type RuntimeTelemetryComponent = {
 };
 
 const PLATFORM_COMPONENT_LABELS = ['component_id', 'component_kind', 'operation', 'result', 'env', 'instance'] as const;
+const PLATFORM_DIAGNOSTIC_LABELS = ['component_id', 'severity', 'code', 'env', 'instance'] as const;
 const REGISTRY_MODE_LABELS = ['mode'] as const;
 const HEALTH_STATUSES = ['healthy', 'unhealthy', 'degraded'] as const satisfies readonly PlatformHealthStatus[];
 const READINESS_STATUSES = ['ready', 'not-ready', 'degraded'] as const satisfies readonly PlatformReadinessStatus[];
@@ -176,7 +178,9 @@ function getOrCreateGauge(
 class RuntimePlatformTelemetry {
   private readonly readinessGauge: Gauge<string>;
   private readonly healthGauge: Gauge<string>;
+  private readonly diagnosticsGauge: Gauge<string>;
   private readonly registryModeGauge: Gauge<string>;
+  private readonly lastDiagnosticCounts = new Map<string, number>();
   private readonly lastHealthStatuses = new Map<string, PlatformHealthStatus>();
   private readonly lastReadinessStatuses = new Map<string, PlatformReadinessStatus>();
   private scrapeChain: Promise<unknown> = Promise.resolve();
@@ -200,6 +204,11 @@ class RuntimePlatformTelemetry {
       help: 'Metrics module registry mode: isolated or shared.',
       labelNames: REGISTRY_MODE_LABELS,
       name: 'fluo_metrics_registry_mode',
+    });
+    this.diagnosticsGauge = getOrCreateGauge(registry, {
+      help: 'Current runtime platform diagnostic issue counts by component, severity, and code.',
+      labelNames: PLATFORM_DIAGNOSTIC_LABELS,
+      name: 'fluo_platform_diagnostic_issues',
     });
 
     this.registryModeGauge.labels(this.registryMode).set(1);
@@ -265,6 +274,11 @@ class RuntimePlatformTelemetry {
       statuses: READINESS_STATUSES,
       toMetricValue: toReadinessValue,
     });
+    this.syncDiagnosticCounts({
+      currentCounts: this.toDiagnosticCounts(snapshot.diagnostics),
+      env,
+      instance,
+    });
   }
 
   private syncGaugeStatuses<TStatus extends string>({
@@ -316,6 +330,56 @@ class RuntimePlatformTelemetry {
   private fromComponentKey(componentKey: string): [string, string] {
     const separatorIndex = componentKey.indexOf('::');
     return [componentKey.slice(0, separatorIndex), componentKey.slice(separatorIndex + 2)];
+  }
+
+  private syncDiagnosticCounts({
+    currentCounts,
+    env,
+    instance,
+  }: {
+    currentCounts: Map<string, number>;
+    env: string;
+    instance: string;
+  }): void {
+    for (const [diagnosticKey, previousCount] of this.lastDiagnosticCounts) {
+      const nextCount = currentCounts.get(diagnosticKey);
+      if (nextCount === previousCount) {
+        continue;
+      }
+
+      const [componentId, severity, code] = this.fromDiagnosticKey(diagnosticKey);
+      this.diagnosticsGauge.remove(componentId, severity, code, env, instance);
+    }
+
+    for (const [diagnosticKey, count] of currentCounts) {
+      const [componentId, severity, code] = this.fromDiagnosticKey(diagnosticKey);
+      this.diagnosticsGauge.labels(componentId, severity, code, env, instance).set(count);
+    }
+
+    this.lastDiagnosticCounts.clear();
+    for (const [diagnosticKey, count] of currentCounts) {
+      this.lastDiagnosticCounts.set(diagnosticKey, count);
+    }
+  }
+
+  private toDiagnosticCounts(diagnostics: PlatformDiagnosticIssue[]): Map<string, number> {
+    const diagnosticCounts = new Map<string, number>();
+
+    for (const diagnostic of diagnostics) {
+      const diagnosticKey = this.toDiagnosticKey(diagnostic.componentId, diagnostic.severity, diagnostic.code);
+      diagnosticCounts.set(diagnosticKey, (diagnosticCounts.get(diagnosticKey) ?? 0) + 1);
+    }
+
+    return diagnosticCounts;
+  }
+
+  private fromDiagnosticKey(diagnosticKey: string): [string, PlatformDiagnosticSeverity, string] {
+    const [componentId, severity, ...codeParts] = diagnosticKey.split('::');
+    return [componentId, severity as PlatformDiagnosticSeverity, codeParts.join('::')];
+  }
+
+  private toDiagnosticKey(componentId: string, severity: PlatformDiagnosticSeverity, code: string): string {
+    return `${componentId}::${severity}::${code}`;
   }
 
   private toComponentKey(componentId: string, componentKind: string): string {


### PR DESCRIPTION
Closes #1215

## Summary
- expose accumulated runtime platform diagnostics from `@fluojs/metrics` scrapes with bounded metric labels
- keep the change scoped to the metrics module and document the new telemetry contract in both package READMEs

## Changes
- add `fluo_platform_diagnostic_issues` gauge emission in `MetricsModule` based on `PlatformShellSnapshot.diagnostics`
- keep labels bounded to `component_id`, `severity`, `code`, `env`, and `instance`
- add regression coverage for warning diagnostics surfacing through `/metrics`
- document the new diagnostic visibility behavior in `packages/metrics/README.md` and `packages/metrics/README.ko.md`

## Testing
- `pnpm install`
- `pnpm --filter @fluojs/metrics... build`
- `pnpm --filter @fluojs/metrics typecheck`
- `pnpm --filter @fluojs/metrics test`
- `pnpm verify:public-export-tsdoc`
- `lsp_diagnostics`: clean for `packages/metrics/src/metrics-module.ts` and `packages/metrics/src/metrics-module.test.ts`

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.