### PR TITLE
Resolve #1216: preserve metrics platform shell diagnostics

### DIFF
--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -140,6 +140,13 @@ MetricsModule.forRoot({
 })
 ```
 
+### 런타임 플랫폼 텔레메트리 스크레이프 계약
+
+플랫폼 텔레메트리는 매 `/metrics` 스크레이프마다 `PLATFORM_SHELL`을 resolve하여 `fluo_component_ready`와 `fluo_component_health`를 갱신합니다.
+
+- `PLATFORM_SHELL` 등록 자체가 빠진 경우에는 스크레이프가 계속 성공하고 플랫폼 텔레메트리 시리즈만 생략됩니다.
+- 그 외의 `PLATFORM_SHELL` resolve 실패는 조용히 삼키지 않고 스크레이프 실패로 그대로 드러납니다.
+
 ### 기본 프로세스/Node 메트릭 비활성화
 
 `defaultMetrics`의 기본값은 `true`입니다. 따라서 별도 설정이 없으면 Registry마다 Prometheus 기본 프로세스/Node.js collector를 한 번 등록합니다. 최소 Registry만 노출하고 싶다면 비활성화하세요.
@@ -158,6 +165,13 @@ MetricsModule.forRoot({
 - 카운터, 게이지, 히스토그램 및 레지스트리 접근을 위한 Prometheus 기반 헬퍼
 
 ### 운영 기본값
+
+- `path`의 기본값은 `'/metrics'`이며, `path: false`로 스크레이프 엔드포인트를 완전히 비활성화할 수 있습니다.
+- `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`로 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 끌 수 있습니다.
+- `endpointMiddleware`는 스크레이프 엔드포인트에만 route-scoped middleware를 바인딩합니다.
+- HTTP 메트릭은 기본적으로 템플릿 기반 경로 라벨 정규화를 사용합니다.
+- raw path 라벨은 `allowUnsafeRawPathLabelMode: true`를 명시한 bounded internal route에서만 사용해야 합니다.
+- 플랫폼 텔레메트리는 `PLATFORM_SHELL`이 실제로 누락된 경우에만 생략되며, 그 외 resolve 실패는 스크레이프를 실패시킵니다.
 
 ## 관련 패키지
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -103,6 +103,31 @@ class AppModule {}
 
 Prometheus metric names must stay unique inside a registry. Shared-registry mode keeps that behavior intact instead of silently shadowing metrics.
 
+### Runtime platform telemetry
+
+The module emits fluo-specific gauges that mirror the platform shell and registered component state.
+
+- `fluo_component_ready`: `1` when a component is ready, otherwise `0`.
+- `fluo_component_health`: `1` when a component is healthy, otherwise `0`.
+
+The platform snapshot is refreshed during each scrape, and you can attach environment labels up front.
+
+```ts
+MetricsModule.forRoot({
+  platformTelemetry: {
+    env: 'production',
+    instance: 'web-01',
+  },
+});
+```
+
+### Runtime platform telemetry scrape contract
+
+Platform telemetry refreshes `fluo_component_ready` and `fluo_component_health` on each `/metrics` scrape by resolving `PLATFORM_SHELL`.
+
+- If `PLATFORM_SHELL` is not registered, the scrape still succeeds and omits the platform telemetry series.
+- If resolving `PLATFORM_SHELL` fails for any other reason, the scrape surfaces that failure instead of swallowing it.
+
 ### Disable default process and Node metrics
 
 `defaultMetrics` defaults to `true`, so `MetricsModule.forRoot()` registers Prometheus default process and Node.js collectors once per registry unless you opt out.
@@ -127,6 +152,7 @@ MetricsModule.forRoot({
 - `endpointMiddleware` binds route-scoped middleware only to the scrape endpoint.
 - HTTP metrics default to template-normalized path labels.
 - Raw path labels require `allowUnsafeRawPathLabelMode: true` and should stay limited to bounded internal routes.
+- Platform telemetry is omitted only when `PLATFORM_SHELL` is genuinely missing; other resolution failures fail the scrape.
 
 ## Related Packages
 

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -430,16 +430,20 @@ describe('MetricsModule', () => {
   });
 
   it('suppresses only missing platform shell registration errors during scrape refresh', async () => {
+    const missingPlatformShellError = new ContainerResolutionError(
+      `No provider registered for token ${String(PLATFORM_SHELL)}.`,
+      {
+        hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
+        token: PLATFORM_SHELL,
+      },
+    );
     const missingPlatformShellMiddleware = {
       async handle(context: MiddlewareContext, next: Next): Promise<void> {
         const originalResolve = context.requestContext.container.resolve.bind(context.requestContext.container);
 
         context.requestContext.container.resolve = (async (token: Parameters<typeof originalResolve>[0]) => {
           if (token === PLATFORM_SHELL) {
-            throw new ContainerResolutionError('No provider registered for token PLATFORM_SHELL.', {
-              hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
-              token: PLATFORM_SHELL,
-            });
+            throw missingPlatformShellError;
           }
 
           return await originalResolve(token);
@@ -473,7 +477,13 @@ describe('MetricsModule', () => {
   });
 
   it('surfaces unexpected platform shell resolution failures during scrape refresh', async () => {
-    const resolutionFailure = new Error('unexpected platform shell resolution failure');
+    const resolutionFailure = new ContainerResolutionError(
+      `Failed to resolve token ${String(PLATFORM_SHELL)} because the provider factory threw an unexpected error.`,
+      {
+        hint: 'Inspect the PLATFORM_SHELL provider registration and its factory dependencies.',
+        token: PLATFORM_SHELL,
+      },
+    );
     const unexpectedPlatformShellMiddleware = {
       async handle(context: MiddlewareContext, next: Next): Promise<void> {
         const originalResolve = context.requestContext.container.resolve.bind(context.requestContext.container);
@@ -504,6 +514,14 @@ describe('MetricsModule', () => {
     await app.dispatch(createRequest('/metrics'), response);
 
     expect(response.statusCode).toBe(500);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: 'Internal server error.',
+          status: 500,
+        }),
+      }),
+    );
 
     await app.close();
   });

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -1,5 +1,6 @@
+import { ContainerResolutionError } from '@fluojs/di';
 import { ForbiddenException, type FrameworkRequest, type FrameworkResponse, type MiddlewareContext, type Next } from '@fluojs/http';
-import { bootstrapApplication, defineModule, type PlatformComponent } from '@fluojs/runtime';
+import { bootstrapApplication, defineModule, PLATFORM_SHELL, type PlatformComponent } from '@fluojs/runtime';
 import { Counter, Registry } from 'prom-client';
 import { describe, expect, it } from 'vitest';
 import { METER_PROVIDER } from './providers/meter-provider.js';
@@ -424,6 +425,85 @@ describe('MetricsModule', () => {
     expect(response.statusCode).toBe(200);
     expect(metricsText).toContain('fluo_component_ready{component_id="cache.default",component_kind="cache",operation="readiness",result="degraded"');
     expect(metricsText).toContain('fluo_component_health{component_id="cache.default",component_kind="cache",operation="health",result="degraded"');
+
+    await app.close();
+  });
+
+  it('suppresses only missing platform shell registration errors during scrape refresh', async () => {
+    const missingPlatformShellMiddleware = {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        const originalResolve = context.requestContext.container.resolve.bind(context.requestContext.container);
+
+        context.requestContext.container.resolve = (async (token: Parameters<typeof originalResolve>[0]) => {
+          if (token === PLATFORM_SHELL) {
+            throw new ContainerResolutionError('No provider registered for token PLATFORM_SHELL.', {
+              hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
+              token: PLATFORM_SHELL,
+            });
+          }
+
+          return await originalResolve(token);
+        }) as typeof context.requestContext.container.resolve;
+
+        await next();
+      },
+    };
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, middleware: [missingPlatformShellMiddleware] })],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const response = createResponse();
+    await app.dispatch(createRequest('/metrics'), response);
+
+    const metricsText = String(response.body);
+
+    expect(response.statusCode).toBe(200);
+    expect(metricsText).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
+    expect(metricsText).not.toContain('fluo_component_ready{');
+    expect(metricsText).not.toContain('fluo_component_health{');
+
+    await app.close();
+  });
+
+  it('surfaces unexpected platform shell resolution failures during scrape refresh', async () => {
+    const resolutionFailure = new Error('unexpected platform shell resolution failure');
+    const unexpectedPlatformShellMiddleware = {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        const originalResolve = context.requestContext.container.resolve.bind(context.requestContext.container);
+
+        context.requestContext.container.resolve = (async (token: Parameters<typeof originalResolve>[0]) => {
+          if (token === PLATFORM_SHELL) {
+            throw resolutionFailure;
+          }
+
+          return await originalResolve(token);
+        }) as typeof context.requestContext.container.resolve;
+
+        await next();
+      },
+    };
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, middleware: [unexpectedPlatformShellMiddleware] })],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const response = createResponse();
+    await app.dispatch(createRequest('/metrics'), response);
+
+    expect(response.statusCode).toBe(500);
 
     await app.close();
   });

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -143,6 +143,7 @@ const REGISTRY_MODE_LABELS = ['mode'] as const;
 const HEALTH_STATUSES = ['healthy', 'unhealthy', 'degraded'] as const satisfies readonly PlatformHealthStatus[];
 const READINESS_STATUSES = ['ready', 'not-ready', 'degraded'] as const satisfies readonly PlatformReadinessStatus[];
 const PLATFORM_SHELL_TOKEN_NAME = 'PLATFORM_SHELL';
+const PLATFORM_SHELL_TOKEN_NAMES = new Set([PLATFORM_SHELL_TOKEN_NAME, String(PLATFORM_SHELL)]);
 
 function toReadinessValue(status: PlatformShellSnapshot['readiness']['status']): number {
   return status === 'ready' ? 1 : 0;
@@ -343,15 +344,17 @@ function isMissingPlatformShellResolutionError(error: unknown): error is Contain
 
   const containerError = error as ContainerResolutionError & { meta?: Record<string, unknown> };
   const token = typeof containerError.meta?.['token'] === 'string' ? containerError.meta['token'] : undefined;
-  if (token === PLATFORM_SHELL_TOKEN_NAME) {
-    return containerError.message.startsWith('No provider registered for token ');
+  if (token && PLATFORM_SHELL_TOKEN_NAMES.has(token)) {
+    return containerError.message.startsWith(`No provider registered for token ${token}.`);
   }
 
-  if (PLATFORM_SHELL_TOKEN_NAME.length === 0) {
-    return false;
+  for (const tokenName of PLATFORM_SHELL_TOKEN_NAMES) {
+    if (containerError.message.startsWith(`No provider registered for token ${tokenName}.`)) {
+      return true;
+    }
   }
 
-  return containerError.message.startsWith(`No provider registered for token ${PLATFORM_SHELL_TOKEN_NAME}.`);
+  return false;
 }
 
 function resolveHttpOptions(http: MetricsModuleOptions['http']): HttpMetricsMiddlewareOptions | undefined {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -1,4 +1,4 @@
-import type { Provider } from '@fluojs/di';
+import { ContainerResolutionError, type Provider } from '@fluojs/di';
 import { Controller, Get, forRoutes, type Middleware, type MiddlewareLike, type RequestContext } from '@fluojs/http';
 import { defineModule, type ModuleType, PLATFORM_SHELL, type PlatformShellSnapshot } from '@fluojs/runtime';
 import { collectDefaultMetrics, Gauge, Registry as PrometheusRegistry, type Registry } from 'prom-client';
@@ -142,6 +142,7 @@ const PLATFORM_COMPONENT_LABELS = ['component_id', 'component_kind', 'operation'
 const REGISTRY_MODE_LABELS = ['mode'] as const;
 const HEALTH_STATUSES = ['healthy', 'unhealthy', 'degraded'] as const satisfies readonly PlatformHealthStatus[];
 const READINESS_STATUSES = ['ready', 'not-ready', 'degraded'] as const satisfies readonly PlatformReadinessStatus[];
+const PLATFORM_SHELL_TOKEN_NAME = 'PLATFORM_SHELL';
 
 function toReadinessValue(status: PlatformShellSnapshot['readiness']['status']): number {
   return status === 'ready' ? 1 : 0;
@@ -325,10 +326,32 @@ class RuntimePlatformTelemetry {
   private async resolvePlatformShell(ctx: RequestContext): Promise<{ snapshot(): Promise<PlatformShellSnapshot> } | undefined> {
     try {
       return await ctx.container.resolve(PLATFORM_SHELL);
-    } catch {
-      return undefined;
+    } catch (error) {
+      if (isMissingPlatformShellResolutionError(error)) {
+        return undefined;
+      }
+
+      throw error;
     }
   }
+}
+
+function isMissingPlatformShellResolutionError(error: unknown): error is ContainerResolutionError {
+  if (!(error instanceof ContainerResolutionError)) {
+    return false;
+  }
+
+  const containerError = error as ContainerResolutionError & { meta?: Record<string, unknown> };
+  const token = typeof containerError.meta?.['token'] === 'string' ? containerError.meta['token'] : undefined;
+  if (token === PLATFORM_SHELL_TOKEN_NAME) {
+    return containerError.message.startsWith('No provider registered for token ');
+  }
+
+  if (PLATFORM_SHELL_TOKEN_NAME.length === 0) {
+    return false;
+  }
+
+  return containerError.message.startsWith(`No provider registered for token ${PLATFORM_SHELL_TOKEN_NAME}.`);
 }
 
 function resolveHttpOptions(http: MetricsModuleOptions['http']): HttpMetricsMiddlewareOptions | undefined {


### PR DESCRIPTION
Closes #1216

## Summary

Prevent `@fluojs/metrics` from swallowing unexpected platform-shell resolution failures so metrics scrapes still surface diagnostic drift.

## Changes

- narrow the `PLATFORM_SHELL` resolution fallback to the expected missing-provider path only
- rethrow unexpected platform-shell resolution failures during scrape refreshes
- add regression tests for missing-vs-unexpected platform-shell resolution failures

## Testing

- `pnpm --filter @fluojs/metrics... build`
- `pnpm --filter @fluojs/metrics typecheck`
- `pnpm --filter @fluojs/metrics test`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.