### PR TITLE
Resolve #1215: tighten platform runtime boundaries and contract coverage

### DIFF
--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1,3 +1,4 @@
+import { request as httpRequest } from 'node:http';
 import { createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
 
@@ -451,6 +452,47 @@ describe('@fluojs/platform-fastify', () => {
     await app.close();
   });
 
+  it('does not add CORS headers or preflight handling when cors is false', async () => {
+    @Controller('/ping')
+    class PingController {
+      @Get('/')
+      ping() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [PingController] });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const [response, corsPreflight] = await Promise.all([
+      fetch(`http://127.0.0.1:${String(port)}/ping`, {
+        headers: { origin: 'https://example.com' },
+      }),
+      fetch(`http://127.0.0.1:${String(port)}/ping`, {
+        headers: {
+          'access-control-request-method': 'GET',
+          origin: 'https://example.com',
+        },
+        method: 'OPTIONS',
+      }),
+    ]);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    expect(corsPreflight.status).toBe(404);
+    expect(corsPreflight.headers.get('access-control-allow-origin')).toBeNull();
+
+    await app.close();
+  });
+
   it('reports the configured host in startup logs', async () => {
     const loggerEvents: string[] = [];
     const logger: ApplicationLogger = {
@@ -693,6 +735,38 @@ describe('@fluojs/platform-fastify', () => {
     expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
   });
 
+  it('reuses the same in-flight close promise and stays idempotent after shutdown settles', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
+    const deferred = createDeferred<void>();
+    let closeCallCount = 0;
+    const app = {
+      close: () => {
+        closeCallCount += 1;
+        return deferred.promise;
+      },
+      server: {
+        listening: true,
+      },
+    };
+
+    Reflect.set(adapter, 'app', app);
+    Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
+
+    const firstClose = adapter.close();
+    const secondClose = adapter.close();
+
+    expect(closeCallCount).toBe(1);
+
+    deferred.resolve();
+    await Promise.all([firstClose, secondClose]);
+
+    expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
+
+    app.server.listening = false;
+    await expect(adapter.close()).resolves.toBeUndefined();
+    expect(closeCallCount).toBe(1);
+  });
+
   it('fails close() when the fastify server does not stop within the shutdown timeout', async () => {
     const adapter = new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
     const deferred = createDeferred<void>();
@@ -771,7 +845,7 @@ describe('@fluojs/platform-fastify', () => {
     });
 
     const originalExitCode = process.exitCode;
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => undefined as never) as typeof process.exit);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number | string | null) => undefined as never) as typeof process.exit);
     const port = await findAvailablePort();
     const app = await runFastifyApplication(AppModule, {
       cors: false,
@@ -846,5 +920,61 @@ describe('@fluojs/platform-fastify', () => {
       name: 'FastifyError',
       statusCode: 400,
     }))).toBe(false);
+  });
+
+  it('propagates abort signal when the client disconnects', async () => {
+    const aborted = createDeferred<void>();
+
+    @Controller('/abort')
+    class AbortController {
+      @Get('/')
+      async wait(_input: undefined, context: RequestContext) {
+        await new Promise<void>((resolve) => {
+          context.request.signal?.addEventListener('abort', () => {
+            aborted.resolve();
+            resolve();
+          }, { once: true });
+        });
+
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [AbortController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    const request = httpRequest({
+      host: '127.0.0.1',
+      method: 'GET',
+      path: '/abort',
+      port,
+    });
+    request.on('error', () => {});
+    request.end();
+
+    setTimeout(() => {
+      request.destroy();
+    }, 20);
+
+    await expect(Promise.race([
+      aborted.promise,
+      new Promise<void>((_resolve, reject) => {
+        setTimeout(() => {
+          reject(new Error('Abort signal was not propagated.'));
+        }, 2_000);
+      }),
+    ])).resolves.toBeUndefined();
+
+    await app.close();
   });
 });

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -76,7 +76,7 @@ await runNodejsApplication(AppModule, {
 - `createNodejsAdapter(options)`: raw Node.js HTTP 어댑터를 위한 기본 팩토리입니다.
 - `bootstrapNodejsApplication(module, options)`: 리스너를 시작하지 않고 애플리케이션 인스턴스를 생성합니다.
 - `runNodejsApplication(module, options)`: 생명주기 관리를 포함하여 애플리케이션을 부트스트랩하고 시작합니다.
-- `NodejsHttpApplicationAdapter`: `createNodejsAdapter(...)`가 반환하는 어댑터 인스턴스를 설명하는 타입 전용 별칭입니다.
+- `NodejsHttpApplicationAdapter`: `createNodejsAdapter(...)`가 반환하는 어댑터 인스턴스를 설명하는 타입 전용 별칭이며, `@fluojs/runtime/node`가 공개하는 어댑터 surface를 그대로 보존합니다.
 
 ## 관련 패키지
 

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -76,7 +76,7 @@ await runNodejsApplication(AppModule, {
 - `createNodejsAdapter(options)`: Primary factory for the raw Node.js HTTP adapter.
 - `bootstrapNodejsApplication(module, options)`: Creates an application instance without starting the listener.
 - `runNodejsApplication(module, options)`: Bootstraps and starts the application with lifecycle management.
-- `NodejsHttpApplicationAdapter`: Type-only alias describing the adapter instances returned by `createNodejsAdapter(...)`.
+- `NodejsHttpApplicationAdapter`: Type-only alias describing the adapter instances returned by `createNodejsAdapter(...)`, while preserving the public adapter surface exported from `@fluojs/runtime/node`.
 
 ## Related Packages
 

--- a/packages/platform-nodejs/src/index.ts
+++ b/packages/platform-nodejs/src/index.ts
@@ -1,21 +1,49 @@
-import type { NodeHttpAdapterOptions, NodeHttpApplicationAdapter } from '@fluojs/runtime/internal-node';
-import { createNodeHttpAdapter } from '@fluojs/runtime/internal-node';
+import type { HttpApplicationAdapter } from '@fluojs/http';
+import { createNodeHttpAdapter, type NodeHttpAdapterOptions } from '@fluojs/runtime/node';
 
 export {
   bootstrapNodeApplication as bootstrapNodejsApplication,
   runNodeApplication as runNodejsApplication,
-} from '@fluojs/runtime/internal-node';
+} from '@fluojs/runtime/node';
 
 export type {
   BootstrapNodeApplicationOptions as BootstrapNodejsApplicationOptions,
   NodeApplicationSignal as NodejsApplicationSignal,
   NodeHttpAdapterOptions as NodejsAdapterOptions,
-  NodeHttpApplicationAdapter as NodejsHttpApplicationAdapter,
   RunNodeApplicationOptions as RunNodejsApplicationOptions,
-} from '@fluojs/runtime/internal-node';
+} from '@fluojs/runtime/node';
 
+/**
+ * Type-only alias for the adapter instances returned by `createNodejsAdapter(...)`.
+ */
+export interface NodejsHttpApplicationAdapter extends HttpApplicationAdapter {
+  getListenTarget(): { bindTarget: string; url: string };
+  getRealtimeCapability(): { kind: 'server-backed'; server: unknown };
+  getServer(): unknown;
+}
+
+/**
+ * Create the raw Node.js HTTP adapter exposed by `@fluojs/platform-nodejs`.
+ *
+ * @param options Transport-level Node.js settings such as port, retries, multipart, and HTTPS options.
+ * @returns The Node.js HTTP adapter instance used by the Fluo runtime.
+ */
 export function createNodejsAdapter(
   options: NodeHttpAdapterOptions = {},
-): NodeHttpApplicationAdapter {
-  return createNodeHttpAdapter(options) as NodeHttpApplicationAdapter;
+): NodejsHttpApplicationAdapter {
+  const adapter = createNodeHttpAdapter(options);
+
+  if (!isNodejsHttpApplicationAdapter(adapter)) {
+    throw new TypeError('Expected createNodeHttpAdapter() to return a Node.js-compatible HTTP adapter.');
+  }
+
+  return adapter;
+}
+
+function isNodejsHttpApplicationAdapter(
+  adapter: ReturnType<typeof createNodeHttpAdapter>,
+): adapter is NodejsHttpApplicationAdapter {
+  return typeof (adapter as { getListenTarget?: unknown }).getListenTarget === 'function'
+    && typeof (adapter as { getRealtimeCapability?: unknown }).getRealtimeCapability === 'function'
+    && typeof (adapter as { getServer?: unknown }).getServer === 'function';
 }

--- a/packages/platform-nodejs/src/index.ts
+++ b/packages/platform-nodejs/src/index.ts
@@ -1,5 +1,8 @@
-import type { HttpApplicationAdapter } from '@fluojs/http';
-import { createNodeHttpAdapter, type NodeHttpAdapterOptions } from '@fluojs/runtime/node';
+import {
+  createNodeHttpAdapter,
+  type NodeHttpAdapterOptions,
+  type NodeHttpApplicationAdapter,
+} from '@fluojs/runtime/node';
 
 export {
   bootstrapNodeApplication as bootstrapNodejsApplication,
@@ -10,17 +13,9 @@ export type {
   BootstrapNodeApplicationOptions as BootstrapNodejsApplicationOptions,
   NodeApplicationSignal as NodejsApplicationSignal,
   NodeHttpAdapterOptions as NodejsAdapterOptions,
+  NodeHttpApplicationAdapter as NodejsHttpApplicationAdapter,
   RunNodeApplicationOptions as RunNodejsApplicationOptions,
 } from '@fluojs/runtime/node';
-
-/**
- * Type-only alias for the adapter instances returned by `createNodejsAdapter(...)`.
- */
-export interface NodejsHttpApplicationAdapter extends HttpApplicationAdapter {
-  getListenTarget(): { bindTarget: string; url: string };
-  getRealtimeCapability(): { kind: 'server-backed'; server: unknown };
-  getServer(): unknown;
-}
 
 /**
  * Create the raw Node.js HTTP adapter exposed by `@fluojs/platform-nodejs`.
@@ -30,20 +25,6 @@ export interface NodejsHttpApplicationAdapter extends HttpApplicationAdapter {
  */
 export function createNodejsAdapter(
   options: NodeHttpAdapterOptions = {},
-): NodejsHttpApplicationAdapter {
-  const adapter = createNodeHttpAdapter(options);
-
-  if (!isNodejsHttpApplicationAdapter(adapter)) {
-    throw new TypeError('Expected createNodeHttpAdapter() to return a Node.js-compatible HTTP adapter.');
-  }
-
-  return adapter;
-}
-
-function isNodejsHttpApplicationAdapter(
-  adapter: ReturnType<typeof createNodeHttpAdapter>,
-): adapter is NodejsHttpApplicationAdapter {
-  return typeof (adapter as { getListenTarget?: unknown }).getListenTarget === 'function'
-    && typeof (adapter as { getRealtimeCapability?: unknown }).getRealtimeCapability === 'function'
-    && typeof (adapter as { getServer?: unknown }).getServer === 'function';
+): NodeHttpApplicationAdapter {
+  return createNodeHttpAdapter(options) as NodeHttpApplicationAdapter;
 }


### PR DESCRIPTION
Closes #1215

## Summary
- `@fluojs/platform-nodejs`가 `@fluojs/runtime/internal-node` 직접 결합 대신 `@fluojs/runtime/node` 경계를 사용하도록 정리했습니다.
- `@fluojs/platform-nodejs`의 `NodejsHttpApplicationAdapter` 공개 타입 surface가 `@fluojs/runtime/node`가 이미 공개하던 adapter contract를 그대로 보존함을 코드/README로 명시했습니다.
- `@fluojs/platform-fastify`에 문서화된 `cors: false`, client disconnect abort, concurrent/idempotent `close()` 계약을 지키는 회귀 테스트를 추가했습니다.
- 변경 범위를 `platform-nodejs` / `platform-fastify`로 제한하고 metrics 및 unrelated package 변경은 포함하지 않았습니다.

## Changes
- `packages/platform-nodejs/src/index.ts`에서 internal runtime seam 재수출 의존을 제거하고, `NodejsHttpApplicationAdapter`를 `@fluojs/runtime/node`의 공개 타입 alias로 다시 맞춰 public TS surface narrowing ambiguity를 제거했습니다.
- `packages/platform-nodejs/src/index.ts`의 공개 export에 TSDoc 요약과 `@param` / `@returns`를 보강했습니다.
- `packages/platform-nodejs/README.md`와 `README.ko.md`에 `NodejsHttpApplicationAdapter`가 public runtime-node adapter surface를 보존한다는 계약을 명시했습니다.
- `packages/platform-fastify/src/adapter.test.ts`에 `cors: false` preflight, disconnect abort, concurrent close 재사용/종료 후 idempotent close 회귀 테스트를 추가했습니다.

## Testing
- `pnpm build`
- `pnpm --filter @fluojs/platform-nodejs typecheck`
- `pnpm --filter @fluojs/platform-nodejs test`
- `pnpm --filter @fluojs/platform-fastify typecheck`
- `pnpm --filter @fluojs/platform-fastify test`
- `pnpm exec biome lint packages/platform-nodejs/src/index.ts packages/platform-fastify/src/adapter.test.ts`
- `pnpm verify:public-export-tsdoc`
- 참고: 전체 `pnpm lint`는 이 이슈 범위 밖의 기존 Biome 경고들(`packages/cli`, `packages/config`, `packages/core`, `packages/cqrs`, `tooling/...`) 때문에 여전히 실패합니다.

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.