### PR TITLE
Resolve #1230: isolate root singleton cache from request overrides

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -455,6 +455,33 @@ describe('Container', () => {
       expect(secondRequestResolved).toBe(rootAfterOverride);
     });
 
+    it('does not let request-scope overrides poison a root singleton dependency graph', async () => {
+      class ConfigService {
+        constructor(readonly value: string) {}
+      }
+
+      class RootSingletonConsumer {
+        constructor(readonly config: ConfigService) {}
+      }
+
+      const root = new Container().register(
+        { provide: ConfigService, useFactory: () => new ConfigService('root-config') },
+        { provide: RootSingletonConsumer, useClass: RootSingletonConsumer, inject: [ConfigService] },
+      );
+
+      const requestScope = root.createRequestScope();
+      requestScope.override({ provide: ConfigService, useFactory: () => new ConfigService('request-config') });
+
+      const requestResolved = await requestScope.resolve(RootSingletonConsumer);
+      const rootResolved = await root.resolve(RootSingletonConsumer);
+      const secondRequestResolved = await root.createRequestScope().resolve(RootSingletonConsumer);
+
+      expect(requestResolved).toBe(rootResolved);
+      expect(rootResolved).toBe(secondRequestResolved);
+      expect(rootResolved.config.value).toBe('root-config');
+      expect(requestResolved.config.value).not.toBe('request-config');
+    });
+
     it('throws ScopeMismatchError when registering a singleton on a request scope container', () => {
       const token = Symbol('singleton-token');
       const root = new Container();

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -519,6 +519,10 @@ export class Container {
     chain: Token[],
     activeTokens: Set<Token>,
   ): Promise<unknown> {
+    if (this.shouldResolveFromRoot(provider)) {
+      return await this.root().resolveScopedOrSingletonInstance(provider, chain, activeTokens);
+    }
+
     const cache = this.cacheFor(provider);
 
     if (!cache.has(provider.provide)) {
@@ -531,6 +535,10 @@ export class Container {
     }
 
     return cache.get(provider.provide);
+  }
+
+  private shouldResolveFromRoot(provider: NormalizedProvider): boolean {
+    return provider.scope === Scope.DEFAULT && this.requestScopeEnabled && !this.registrations.has(provider.provide);
   }
 
   private async resolveDepToken(


### PR DESCRIPTION
Closes #1230

## Summary

Fix the DI singleton cache poisoning bug where request-scope local overrides could participate in a root singleton dependency graph.

## Changes

- resolve root-owned default-scope providers from the root container context even when they are first requested through a request scope
- keep child-local overrides request-local instead of letting them seed the root singleton cache
- add a regression test proving a request-scope override cannot poison a root singleton dependency graph

## Testing

- `pnpm vitest run packages/di/src/container.test.ts`
- `pnpm --filter @fluojs/core build`
- `pnpm --filter @fluojs/core typecheck`
- `pnpm --filter @fluojs/di typecheck`
- `pnpm --filter @fluojs/di build`
- `pnpm verify`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No changed public exports in this PR.
- [x] No exported function TSDoc updates were required.
- [x] README examples and source examples remain unchanged because the fix preserves the documented behavior.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Existing request-scope isolation behavior remains the binding contract in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] Not applicable; no English/Korean governance docs changed.
- [x] Not applicable; no platform contract docs changed.
- [x] Not applicable; no package README conformance claims changed.