### PR TITLE
Resolve #1232: hide ConfigService snapshot mutator from public API

### DIFF
--- a/packages/config/README.ko.md
+++ b/packages/config/README.ko.md
@@ -85,7 +85,7 @@ class MyService {
 | 클래스/헬퍼 | 설명 |
 |---|---|
 | `ConfigModule` | 설정을 전역 또는 지역으로 등록하기 위한 모듈입니다. |
-| `ConfigService` | 설정 값에 타입 안전하게 접근하기 위한 서비스입니다. |
+| `ConfigService` | 설정 값에 타입 안전하게 접근하기 위한 읽기 전용 서비스입니다. 스냅샷 교체는 config reload 경로 내부에만 남습니다. |
 | `loadConfig(options)` | 설정을 수동으로 로드하기 위한 함수형 엔트리 포인트입니다. |
 | `createConfigReloader(options)` | 동적 설정 업데이트를 위한 리로더를 생성합니다. |
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -90,7 +90,7 @@ The `validate` function runs after all sources are merged but before the applica
 | Class/Helper | Description |
 |---|---|
 | `ConfigModule` | Module for registering configuration globally or locally. |
-| `ConfigService` | Service for typed access to configuration values. |
+| `ConfigService` | Read-only service for typed access to configuration values. Snapshot replacement stays inside the config reload path. |
 | `loadConfig(options)` | Functional entry point for loading configuration manually. |
 | `createConfigReloader(options)` | Creates a reloader for dynamic configuration updates. |
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,5 +1,5 @@
 export * from './load.js';
 export * from './module.js';
 export * from './reload-module.js';
-export * from './service.js';
+export { ConfigService } from './service.js';
 export * from './types.js';

--- a/packages/config/src/public-api.test.ts
+++ b/packages/config/src/public-api.test.ts
@@ -11,6 +11,7 @@ describe('@fluojs/config public API surface', () => {
     expect(configPublicApi).toHaveProperty('ConfigService');
     expect(configPublicApi).toHaveProperty('createConfigReloader');
     expect(configPublicApi).toHaveProperty('loadConfig');
+    expect(configPublicApi).not.toHaveProperty('replaceConfigServiceSnapshot');
   });
 
   it('keeps ConfigService read-only from the public API', () => {


### PR DESCRIPTION
Closes #1232

## Summary

- hide `replaceConfigServiceSnapshot()` from the `@fluojs/config` root barrel so the documented public API stays read-only
- preserve the internal reload path by keeping the mutator available to package-internal consumers only

## Changes

- changed `packages/config/src/index.ts` to export only `ConfigService` from `service.ts` instead of re-exporting the entire module
- added a public API regression assertion that the root barrel does not expose `replaceConfigServiceSnapshot`
- clarified the read-only `ConfigService` contract in `packages/config/README.md` and `packages/config/README.ko.md`

## Testing

- `pnpm --filter @fluojs/config run test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm verify:public-export-tsdoc`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs (N/A: no governance docs changed).
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence (N/A: no platform contract docs changed).
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests (N/A: no platform conformance claim changes).