### PR TITLE
Resolve #1231: align runtime public contracts

### DIFF
--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -129,10 +129,11 @@ class UsersModule {}
 
 ## 공개 API 개요
 
-- `fluoFactory`: 애플리케이션 라이프사이클 관리를 위한 정적 파사드입니다.
+- `fluoFactory`: 패키지 예제에서 사용하는 런타임 부트스트랩 파사드의 lower-camel-case 별칭입니다.
+- `FluoFactory`: 호환성과 명시적 static 접근을 위해 유지되는 클래스 기반 런타임 부트스트랩 파사드입니다.
 - `Application`: `ApplicationContext`를 확장하며 `listen()`, `dispatch()`, `state`를 포함합니다.
 - `ApplicationContext`: `get<T>(token)`, `close()` 기능을 제공하며 `container`와 `modules`에 접근할 수 있습니다.
-- `LifecycleHooks`: `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `OnApplicationShutdown`.
+- `LifecycleHooks`: `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `OnApplicationShutdown`를 묶는 편의 union 타입입니다.
 - `defineModule(cls, metadata)`: 프로그래밍 방식의 모듈 정의 헬퍼입니다.
 - `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다.
 
@@ -140,21 +141,32 @@ class UsersModule {}
 
 | 서브경로 | 용도 |
 | :--- | :--- |
-| `@fluojs/runtime/node` | Node.js 전용 로거 팩토리 (`createConsoleApplicationLogger`, `createJsonApplicationLogger`) 및 종료 시그널 등록. |
+| `@fluojs/runtime/node` | 로거 팩토리, Node 어댑터/부트스트랩 헬퍼, 종료 시그널 등록을 위한 지원되는 Node.js 전용 진입점입니다. |
 | `@fluojs/runtime/web` | Bun, Deno, Cloudflare Workers를 위한 공유 웹 표준 요청/응답 유틸리티. |
 | `@fluojs/runtime/internal` | 저수준 오케스트레이션 헬퍼 및 HTTP 어댑터 기본 로직. |
 | `@fluojs/runtime/internal-node` | 어댑터/패키지 호환 계층이 사용하는 Node 전용 내부 seam이며, 애플리케이션 코드에서는 `@fluojs/runtime/node`를 우선 사용하세요. |
 
 ### Node 전용 서브경로 (`@fluojs/runtime/node`)
 
-로거 팩토리 및 기타 Node 전용 헬퍼는 범용 루트 진입점에 포함되지 않습니다. `./node` 서브경로에서 가져오세요:
+로거 팩토리와 지원되는 기타 Node 전용 헬퍼는 범용 루트 진입점에 포함되지 않습니다. `./node` 서브경로에서 가져오세요:
 
 ```typescript
-import { createConsoleApplicationLogger, createJsonApplicationLogger } from '@fluojs/runtime/node';
+import {
+  bootstrapNodeApplication,
+  createConsoleApplicationLogger,
+  createJsonApplicationLogger,
+  createNodeHttpAdapter,
+  runNodeApplication,
+} from '@fluojs/runtime/node';
 ```
 
 - `createConsoleApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 컬러 콘솔 로거.
 - `createJsonApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 구조화된 JSON 로거.
+- `createNodeHttpAdapter()`: 어댑터 우선 런타임 구성을 위한 raw Node `http`/`https` 어댑터 팩토리.
+- `bootstrapNodeApplication()` / `runNodeApplication()`: 호환 패키지와 직접 Node 런타임 흐름에서 사용하는 Node 전용 부트스트랩 헬퍼.
+- `createNodeShutdownSignalRegistration()`, `defaultNodeShutdownSignals()`, `registerShutdownSignals()`: 호스트가 명시적으로 시그널 wiring을 제어할 때 쓰는 종료 등록 헬퍼.
+
+더 저수준의 Node compression internals는 공개 `@fluojs/runtime/node` 계약이 아니라 `@fluojs/runtime/internal-node` seam 뒤에 둡니다.
 
 ## 관련 패키지
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -129,10 +129,11 @@ class UsersModule {}
 
 ## Public API Overview
 
-- `fluoFactory`: Static facade for application lifecycle management.
+- `fluoFactory`: Lower-camel-case alias for the runtime bootstrap facade used in the package examples.
+- `FluoFactory`: Class-based runtime bootstrap facade retained for compatibility and explicit static access.
 - `Application`: Extends `ApplicationContext` with `listen()`, `dispatch()`, and `state`.
 - `ApplicationContext`: Provides `get<T>(token)`, `close()`, and access to `container` and `modules`.
-- `LifecycleHooks`: `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `OnApplicationShutdown`.
+- `LifecycleHooks`: Convenience union covering `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, and `OnApplicationShutdown`.
 - `defineModule(cls, metadata)`: Programmatic module definition helper.
 - `bootstrapApplication(options)`: Lower-level async bootstrap function.
 
@@ -140,21 +141,32 @@ class UsersModule {}
 
 | Subpath | Purpose |
 | :--- | :--- |
-| `@fluojs/runtime/node` | Node.js-specific logger factories (`createConsoleApplicationLogger`, `createJsonApplicationLogger`) and shutdown signal registration. |
+| `@fluojs/runtime/node` | Supported Node.js entrypoint for logger factories, Node adapter/bootstrap helpers, and shutdown signal registration. |
 | `@fluojs/runtime/web` | Shared Web-standard request/response utilities for Bun, Deno, and Cloudflare Workers. |
 | `@fluojs/runtime/internal` | Low-level orchestration helpers and HTTP adapter base logic. |
 | `@fluojs/runtime/internal-node` | Node-only internal seam used by adapter/package compatibility layers; prefer `@fluojs/runtime/node` in application code. |
 
 ### Node-Specific Subpath (`@fluojs/runtime/node`)
 
-Logger factories and other Node-only helpers are **not** on the universal root entrypoint. Import them from the `./node` subpath:
+Logger factories and other supported Node-only helpers are **not** on the universal root entrypoint. Import them from the `./node` subpath:
 
 ```typescript
-import { createConsoleApplicationLogger, createJsonApplicationLogger } from '@fluojs/runtime/node';
+import {
+  bootstrapNodeApplication,
+  createConsoleApplicationLogger,
+  createJsonApplicationLogger,
+  createNodeHttpAdapter,
+  runNodeApplication,
+} from '@fluojs/runtime/node';
 ```
 
 - `createConsoleApplicationLogger()`: Colorized console logger using `process.stdout`/`process.stderr`.
 - `createJsonApplicationLogger()`: Structured JSON logger using `process.stdout`/`process.stderr`.
+- `createNodeHttpAdapter()`: Raw Node `http`/`https` adapter factory for adapter-first runtime setup.
+- `bootstrapNodeApplication()` / `runNodeApplication()`: Node-specific bootstrap helpers used by compatibility packages and direct Node runtime flows.
+- `createNodeShutdownSignalRegistration()`, `defaultNodeShutdownSignals()`, `registerShutdownSignals()`: Shutdown registration helpers for hosts that need explicit signal wiring.
+
+Lower-level Node compression internals stay behind the `@fluojs/runtime/internal-node` seam rather than the public `@fluojs/runtime/node` contract.
 
 ## Related Packages
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1188,3 +1188,15 @@ export class FluoFactory {
     }
   }
 }
+
+/**
+ * Lower-camel-case compatibility alias that matches the documented runtime entrypoint.
+ *
+ * @example
+ * ```ts
+ * import { fluoFactory } from '@fluojs/runtime';
+ *
+ * const app = await fluoFactory.create(AppModule);
+ * ```
+ */
+export const fluoFactory = FluoFactory;

--- a/packages/runtime/src/exports.test.ts
+++ b/packages/runtime/src/exports.test.ts
@@ -20,6 +20,7 @@ describe('runtime export boundaries', () => {
 
   it('keeps only bootstrap-scoped operational helpers on the runtime root barrel', () => {
     expect(runtime.createHealthModule).toBeTypeOf('function');
+    expect(runtime.fluoFactory).toBe(runtime.FluoFactory);
     expect(runtime).not.toHaveProperty('createConsoleApplicationLogger');
     expect(runtime).not.toHaveProperty('createJsonApplicationLogger');
     expect(runtime).toHaveProperty('APPLICATION_LOGGER');
@@ -50,6 +51,11 @@ describe('runtime export boundaries', () => {
   it('exposes Node-only logger factories only on the ./node subpath', () => {
     expect(runtimeNode.createConsoleApplicationLogger).toBeTypeOf('function');
     expect(runtimeNode.createJsonApplicationLogger).toBeTypeOf('function');
+    expect(runtimeNode.createNodeHttpAdapter).toBeTypeOf('function');
+    expect(runtimeNode.bootstrapNodeApplication).toBeTypeOf('function');
+    expect(runtimeNode.runNodeApplication).toBeTypeOf('function');
+    expect(runtimeNode).not.toHaveProperty('compressNodeResponse');
+    expect(runtimeNode).not.toHaveProperty('createNodeResponseCompression');
   });
 
   it('declares the narrowed package export map', () => {

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -1,3 +1,18 @@
 export * from './logging/json-logger.js';
 export * from './logging/logger.js';
-export * from './node/internal-node.js';
+export {
+  bootstrapNodeApplication,
+  createNodeHttpAdapter,
+  NodeHttpApplicationAdapter,
+  createNodeShutdownSignalRegistration,
+  defaultNodeShutdownSignals,
+  registerShutdownSignals,
+  runNodeApplication,
+} from './node/internal-node.js';
+export type {
+  BootstrapNodeApplicationOptions,
+  CorsInput,
+  NodeApplicationSignal,
+  NodeHttpAdapterOptions,
+  RunNodeApplicationOptions,
+} from './node/internal-node.js';

--- a/packages/runtime/src/node/internal-node.test.ts
+++ b/packages/runtime/src/node/internal-node.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import * as internalNodeApi from './internal-node.js';
-import * as compatibilityNodeApi from './node.js';
+import * as publicNodeApi from '../node.js';
 
 describe('runtime internal node seam', () => {
-  it('keeps the public runtime/node path as a compatibility wrapper over the internal seam', () => {
-    expect(compatibilityNodeApi.bootstrapNodeApplication).toBe(internalNodeApi.bootstrapNodeApplication);
-    expect(compatibilityNodeApi.createNodeHttpAdapter).toBe(internalNodeApi.createNodeHttpAdapter);
-    expect(compatibilityNodeApi.runNodeApplication).toBe(internalNodeApi.runNodeApplication);
-    expect(compatibilityNodeApi.createNodeResponseCompression).toBe(internalNodeApi.createNodeResponseCompression);
-    expect(compatibilityNodeApi.createNodeShutdownSignalRegistration).toBe(internalNodeApi.createNodeShutdownSignalRegistration);
+  it('keeps the public runtime/node path focused on supported node helpers', () => {
+    expect(publicNodeApi.bootstrapNodeApplication).toBe(internalNodeApi.bootstrapNodeApplication);
+    expect(publicNodeApi.createNodeHttpAdapter).toBe(internalNodeApi.createNodeHttpAdapter);
+    expect(publicNodeApi.runNodeApplication).toBe(internalNodeApi.runNodeApplication);
+    expect(publicNodeApi.createNodeShutdownSignalRegistration).toBe(internalNodeApi.createNodeShutdownSignalRegistration);
+    expect(publicNodeApi).not.toHaveProperty('compressNodeResponse');
+    expect(publicNodeApi).not.toHaveProperty('createNodeResponseCompression');
   });
 });

--- a/packages/runtime/src/node/node.test.ts
+++ b/packages/runtime/src/node/node.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import * as rootRuntimeApi from '../index.js';
-import { createNodeHttpAdapter, type NodeHttpApplicationAdapter } from './node.js';
+import * as publicNodeApi from '../node.js';
+import type { NodeHttpApplicationAdapter } from '../node.js';
 
 describe('createNodeHttpAdapter', () => {
   it('keeps Node lifecycle helpers out of the runtime root barrel', () => {
@@ -15,7 +16,7 @@ describe('createNodeHttpAdapter', () => {
     process.env.PORT = '4321';
 
     try {
-      const adapter = createNodeHttpAdapter() as NodeHttpApplicationAdapter;
+      const adapter = publicNodeApi.createNodeHttpAdapter() as NodeHttpApplicationAdapter;
 
       expect(adapter.getListenTarget().url).toBe('http://localhost:3000');
       await adapter.close();
@@ -33,7 +34,7 @@ describe('createNodeHttpAdapter', () => {
     process.env.PORT = 'not-a-number';
 
     try {
-      const adapter = createNodeHttpAdapter() as NodeHttpApplicationAdapter;
+      const adapter = publicNodeApi.createNodeHttpAdapter() as NodeHttpApplicationAdapter;
 
       expect(adapter.getListenTarget().url).toBe('http://localhost:3000');
       await adapter.close();
@@ -44,5 +45,11 @@ describe('createNodeHttpAdapter', () => {
         process.env.PORT = previousPort;
       }
     }
+  });
+
+  it('does not expose node compression internals on the public node subpath', () => {
+    expect(publicNodeApi.createNodeHttpAdapter).toBeTypeOf('function');
+    expect(publicNodeApi).not.toHaveProperty('compressNodeResponse');
+    expect(publicNodeApi).not.toHaveProperty('createNodeResponseCompression');
   });
 });

--- a/packages/runtime/src/public-surface.test.ts
+++ b/packages/runtime/src/public-surface.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import * as runtimeApi from './index.js';
+import type { LifecycleHooks } from './types.js';
+
+function acceptLifecycleHook(_hook: LifecycleHooks): void {}
+
+describe('runtime public surface', () => {
+  it('keeps the documented runtime facade alias on the root barrel', () => {
+    expect(runtimeApi.fluoFactory).toBe(runtimeApi.FluoFactory);
+  });
+
+  it('exports the documented LifecycleHooks convenience type', () => {
+    acceptLifecycleHook({
+      onModuleInit() {},
+    });
+  });
+});

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -73,6 +73,13 @@ export interface OnApplicationShutdown {
   onApplicationShutdown(signal?: string): MaybePromise<void>;
 }
 
+/** Convenience union covering every public runtime lifecycle hook contract. */
+export type LifecycleHooks =
+  | OnModuleInit
+  | OnApplicationBootstrap
+  | OnModuleDestroy
+  | OnApplicationShutdown;
+
 /** Logger contract used by runtime bootstrap and lifecycle diagnostics. */
 export interface ApplicationLogger {
   debug(message: string, context?: string): void;


### PR DESCRIPTION
Closes #1231

## Summary

Align `@fluojs/runtime` public exports with the documented contract without silently breaking supported Node compatibility flows.

## Changes

- add the documented root-surface `fluoFactory` alias and `LifecycleHooks` convenience type while retaining `FluoFactory`
- narrow `@fluojs/runtime/node` to the supported logger, adapter/bootstrap, and shutdown helpers while keeping compression internals behind `@fluojs/runtime/internal-node`
- update the English/Korean runtime READMEs to describe the actual supported public surface

## Testing

- `pnpm --filter @fluojs/runtime test`
- `pnpm --filter @fluojs/runtime typecheck`
- `pnpm --filter @fluojs/runtime build`
- `pnpm build`
- `pnpm exec biome lint packages/runtime/src/bootstrap.ts packages/runtime/src/types.ts packages/runtime/src/node.ts packages/runtime/src/exports.test.ts packages/runtime/src/public-surface.test.ts packages/runtime/src/node/internal-node.test.ts packages/runtime/src/node/node.test.ts`
- `pnpm verify:public-export-tsdoc`

## Public export documentation

See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] No platform contract docs changed, so companion governance updates were not required for this runtime README alignment.
- [x] No platform-conformance README claims changed, so `createPlatformConformanceHarness(...)` scope was unaffected.