### PR TITLE
Resolve #1236: isolate root-owned multi-provider caches from request overrides

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -718,6 +718,36 @@ describe('Container', () => {
       expect(a1[0]).toBe(a2[0]);
       expect(a1[0]).not.toBe(b1[0]);
     });
+
+    it('does not let request-scope overrides poison a root multi-provider dependency graph', async () => {
+      const PLUGINS = Symbol('Plugins');
+
+      class ConfigService {
+        constructor(readonly value: string) {}
+      }
+
+      class RootPlugin {
+        constructor(readonly config: ConfigService) {}
+      }
+
+      const root = new Container().register(
+        { provide: ConfigService, useFactory: () => new ConfigService('root-config') },
+        { provide: PLUGINS, useClass: RootPlugin, inject: [ConfigService], multi: true },
+      );
+
+      const requestScope = root.createRequestScope();
+      requestScope.override({ provide: ConfigService, useFactory: () => new ConfigService('request-config') });
+
+      const requestResolved = await requestScope.resolve<RootPlugin[]>(PLUGINS);
+      const rootResolved = await root.resolve<RootPlugin[]>(PLUGINS);
+      const secondRequestResolved = await root.createRequestScope().resolve<RootPlugin[]>(PLUGINS);
+
+      expect(requestResolved).toHaveLength(1);
+      expect(requestResolved[0]).toBe(rootResolved[0]);
+      expect(rootResolved[0]).toBe(secondRequestResolved[0]);
+      expect(rootResolved[0]?.config.value).toBe('root-config');
+      expect(requestResolved[0]?.config.value).not.toBe('request-config');
+    });
   });
 
   describe('dispose', () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -482,28 +482,38 @@ export class Container {
     const instances: unknown[] = [];
 
     for (const provider of providers) {
-      if (provider.type === 'existing') {
-        instances.push(await this.resolveWithChain(provider.useExisting as Token, chain, activeTokens));
-        continue;
-      }
-
-      if (provider.scope === 'transient') {
-        instances.push(await this.instantiate(provider, chain, activeTokens));
-        continue;
-      }
-
-      const cache = this.multiCacheFor(provider);
-
-      if (!cache.has(provider)) {
-        const promise = this.instantiate(provider, chain, activeTokens);
-        cache.set(provider, promise);
-        promise.catch(() => cache.delete(provider));
-      }
-
-      instances.push(await cache.get(provider)!);
+      instances.push(await this.resolveMultiProviderInstance(provider, chain, activeTokens));
     }
 
     return instances;
+  }
+
+  private async resolveMultiProviderInstance(
+    provider: NormalizedProvider,
+    chain: Token[],
+    activeTokens: Set<Token>,
+  ): Promise<unknown> {
+    if (provider.type === 'existing') {
+      return await this.resolveWithChain(provider.useExisting as Token, chain, activeTokens);
+    }
+
+    if (provider.scope === 'transient') {
+      return await this.instantiate(provider, chain, activeTokens);
+    }
+
+    if (this.shouldResolveMultiProviderFromRoot(provider)) {
+      return await this.root().resolveMultiProviderInstance(provider, chain, activeTokens);
+    }
+
+    const cache = this.multiCacheFor(provider);
+
+    if (!cache.has(provider)) {
+      const promise = this.instantiate(provider, chain, activeTokens);
+      cache.set(provider, promise);
+      promise.catch(() => cache.delete(provider));
+    }
+
+    return await cache.get(provider)!;
   }
 
   private resolveExistingProviderTarget(provider: NormalizedProvider): Token | undefined {
@@ -539,6 +549,10 @@ export class Container {
 
   private shouldResolveFromRoot(provider: NormalizedProvider): boolean {
     return provider.scope === Scope.DEFAULT && this.requestScopeEnabled && !this.registrations.has(provider.provide);
+  }
+
+  private shouldResolveMultiProviderFromRoot(provider: NormalizedProvider): boolean {
+    return provider.scope === Scope.DEFAULT && this.requestScopeEnabled && !this.hasLocalMultiProvider(provider);
   }
 
   private async resolveDepToken(
@@ -632,9 +646,7 @@ export class Container {
 
   private multiCacheFor(provider: NormalizedProvider): Map<NormalizedProvider, Promise<unknown>> {
     if (provider.scope === Scope.DEFAULT) {
-      const localMultiProviders = this.multiRegistrations.get(provider.provide);
-
-      if (this.requestScopeEnabled && localMultiProviders?.includes(provider)) {
+      if (this.requestScopeEnabled && this.hasLocalMultiProvider(provider)) {
         return this.multiRequestCache;
       }
 
@@ -653,6 +665,10 @@ export class Container {
     }
 
     return this.multiRequestCache;
+  }
+
+  private hasLocalMultiProvider(provider: NormalizedProvider): boolean {
+    return this.multiRegistrations.get(provider.provide)?.includes(provider) ?? false;
   }
 
   private disposalCacheEntries(): Array<[NormalizedProvider | Token, Promise<unknown>]> {


### PR DESCRIPTION
Closes #1236

## Summary
- Extend the root-context ownership rule from the single-provider cache fix to root-owned default-scope multi providers in `@fluojs/di`.
- Prevent request-scope dependency overrides from contaminating multi-provider instances cached in the root container.

## Changes
- Route inherited default-scope multi providers through root-owned instantiation before storing them in the root multi-provider cache.
- Keep request-local multi providers on the child request cache so local registrations still behave as isolated overrides.
- Add a regression test proving a request-scoped `ConfigService` override cannot poison a root-owned multi-provider dependency graph.

## Testing
- `pnpm --filter @fluojs/di test`
- `pnpm build`
- `pnpm typecheck`
- `lsp_diagnostics` on `packages/di/src/container.ts` and `packages/di/src/container.test.ts` returned no diagnostics after the workspace build/typecheck refresh.

## Public export documentation
See [docs/operations/public-export-tsdoc-baseline.md](docs/operations/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No changed public exports required additional source-level TSDoc updates.
- [x] No changed exported functions required new `@param` / `@returns` tags.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/operations/behavioral-contract-policy.md](docs/operations/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract text was required in the affected package README because this change preserves the documented request-scope isolation contract.
- [x] Intentional limitations remain explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/concepts/platform-consistency-design.md](docs/concepts/platform-consistency-design.md) and [docs/operations/release-governance.md](docs/operations/release-governance.md).

- [x] No governance docs changed, so EN/KO mirror structure remains unchanged.
- [x] No platform contract docs changed, so no companion governance updates were required.
- [x] No package README conformance claims changed.