### PR TITLE
Improve package-aware release readiness

### DIFF
--- a/.github/workflows/release-single-package.yml
+++ b/.github/workflows/release-single-package.yml
@@ -22,6 +22,11 @@ on:
         required: true
         default: false
         type: boolean
+      release_intent_file:
+        description: Committed release-intent JSON record consumed by release-readiness for 1.0.0-beta.2+ publishes
+        required: true
+        default: tooling/release/intents/release-intent.json
+        type: string
 
 concurrency:
   group: release-single-package-${{ inputs.package_name }}
@@ -38,6 +43,7 @@ jobs:
       DIST_TAG: ${{ inputs.dist_tag }}
       GH_TOKEN: ${{ github.token }}
       RELEASE_PRERELEASE: ${{ inputs.release_prerelease }}
+      RELEASE_INTENT_FILE: ${{ inputs.release_intent_file }}
       TARGET_PACKAGE: ${{ inputs.package_name }}
       TARGET_VERSION: ${{ inputs.package_version }}
 
@@ -122,13 +128,20 @@ jobs:
           EOF
 
       - name: Canonical release-readiness preflight
-        run: pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"
-
-      - name: Publish package to npm
-        run: pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks
+        run: pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --release-intent-file "$RELEASE_INTENT_FILE" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"
 
       - name: Prepare GitHub Release notes
         run: node tooling/release/prepare-github-release.mjs "${{ steps.resolve.outputs.release_tag }}"
+
+      - name: Validate target git tag is absent
+        run: |
+          if git rev-parse --verify --quiet "refs/tags/${{ steps.resolve.outputs.release_tag }}"; then
+            echo "::error::Release tag ${{ steps.resolve.outputs.release_tag }} already exists."
+            exit 1
+          fi
+
+      - name: Publish package to npm
+        run: pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks
 
       - name: Create and push git tag
         run: |

--- a/.github/workflows/release-single-package.yml
+++ b/.github/workflows/release-single-package.yml
@@ -23,8 +23,8 @@ on:
         default: false
         type: boolean
       release_intent_file:
-        description: Committed release-intent JSON record consumed by release-readiness for 1.0.0-beta.2+ publishes
-        required: true
+        description: Optional committed release-intent JSON record; required by release-readiness for 1.0.0-beta.2+ publishes
+        required: false
         type: string
 
 concurrency:

--- a/.github/workflows/release-single-package.yml
+++ b/.github/workflows/release-single-package.yml
@@ -25,7 +25,6 @@ on:
       release_intent_file:
         description: Committed release-intent JSON record consumed by release-readiness for 1.0.0-beta.2+ publishes
         required: true
-        default: tooling/release/intents/release-intent.json
         type: string
 
 concurrency:

--- a/docs/contracts/release-governance.ko.md
+++ b/docs/contracts/release-governance.ko.md
@@ -38,6 +38,44 @@
 4. 릴리스 검증은 canonical 저장소 명령을 통과해야 합니다: `pnpm build`, `pnpm typecheck`, `pnpm vitest run --project packages`, `pnpm vitest run --project apps`, `pnpm vitest run --project examples`, `pnpm vitest run --project tooling`, `pnpm --dir packages/cli sandbox:matrix`, `pnpm verify:platform-consistency-governance`, `pnpm verify:release-readiness`.
 5. `CHANGELOG.md`는 `## [Unreleased]` 섹션을 유지해야 하고, 모든 `0.x` 파괴적 릴리스는 안정적인 `1.0+` 계약을 선언하기 전에 마이그레이션 노트를 포함해야 합니다.
 
+## Release Metadata Contract
+
+커밋된 release-intent record는 릴리스 준비를 위한 장기 canonical machine input입니다. 루트 `CHANGELOG.md`는 사람이 읽는 narrative로 남고, GitHub Releases는 supervised CI-only flow가 만드는 generated artifact입니다.
+
+각 release intent entry는 다음 필드를 포함해야 합니다.
+
+1. 패키지 이름, published `@fluojs/*` package name을 사용합니다.
+2. Semver intent, `major`, `minor`, `patch`, 또는 패키지 릴리스가 없을 때의 `none` 중 하나입니다.
+3. Prerelease 또는 stable intent, 패키지를 릴리스하는 경우 expected dist-tag를 포함합니다.
+4. Summary, maintainer와 release reviewer가 읽는 설명입니다.
+5. 패키지의 stability tier에서 breaking으로 분류되는 semver intent인 경우 migration note입니다.
+6. Affected-package rationale, 패키지가 release set에 포함되거나 제외되는 이유입니다.
+
+릴리스 준비 run의 모든 패키지는 하나의 disposition을 사용해야 합니다.
+
+- `release`: release-readiness가 통과한 뒤 supervised CI-only release workflow를 통해 이 패키지를 publish합니다.
+- `no-release`: 현재 release set에서 이 패키지를 publish하지 않고, release-intent record에 rationale을 남깁니다.
+- `downstream-evaluate`: upstream 변경이 이 패키지에 영향을 줄 수 있어 review하지만, 이 disposition을 automatic downstream publishing으로 취급하지 않습니다.
+
+이 작업이 landing된 뒤 준비되는 릴리스에는 package-scoped notes와 release-intent records가 필요합니다. `1.0.0-beta.2`는 첫 enforced fixture/candidate version이며, `1.0.0-beta.1` 이하의 릴리스는 legacy-compatible로 유지됩니다.
+
+
+## Migration Assessment: Changesets and Beachball
+
+현재 repo-local intent model이 승인된 release metadata path로 남습니다. 이 모델은 release decision을 committed JSON records 안에 두고, package disposition을 명시적으로 요구하며, `downstream-evaluate`를 automatic publish trigger가 아니라 review decision으로 취급합니다. `.github/workflows/release-single-package.yml`이 release-readiness 통과 뒤 `refs/heads/main`에서 요청된 패키지 하나만 publish하므로 supervised CI-only workflow와도 맞습니다.
+
+Changesets는 contributor가 작성한 semver intent와 changelog text를 committed files에 기록한 뒤 version과 publish step에서 소비하므로 좋은 비교 대상입니다. Beachball은 PR에서 review 가능한 change files를 기록하고, 해당 파일 존재를 검증하며, version bump를 계산하고, changelog를 생성하고, package publish까지 수행할 수 있으므로 좋은 비교 대상입니다. 두 도구 모두 fluo의 release contract를 유지하면서 local publish path를 추가하지 않고 single-package CI boundary를 넓히지 않는다는 점이 증명되기 전까지는 승인하지 않습니다.
+
+향후 migration proposal의 go/no-go criteria는 다음과 같습니다.
+
+1. **Packages per release**: 일반 릴리스가 여러 `@fluojs/*` 패키지를 자주 포함하고 현재 single-package intent records가 generated release files보다 review하기 어려워질 때만 migration을 다시 검토합니다.
+2. **Downstream evaluation frequency**: migration은 `downstream-evaluate` decision이 얼마나 자주 발생하는지 보여야 하며, 이를 automatic dependent-package release가 아니라 human review gate로 유지해야 합니다.
+3. **Intent maintenance cost**: migration은 generated 또는 tool-managed change files가 repo-local intent JSON보다 maintainer work를 줄인다는 점을 증명해야 하며, package rationale을 review에서 숨기면 안 됩니다.
+4. **Generated package changelog need**: migration은 maintainer가 root `CHANGELOG.md` narrative와 generated GitHub Release notes를 넘어 package-level changelogs를 필요로 할 때까지 기다려야 합니다.
+5. **CI-only single-package compatibility**: migration은 main-only workflow dispatch, release-readiness preflight, OIDC npm publish, tag creation, GitHub Release generation을 `.github/workflows/release-single-package.yml` 안에 유지해야 하며, local `npm publish` replacement를 만들면 안 됩니다.
+
+Recommendation: migration을 defer합니다. Package-aware release notes와 release intent gates가 적어도 한 번의 실제 release cycle을 완료하고 위 criteria가 migration이 release surface를 넓히는 대신 risk를 줄인다는 점을 보여주기 전까지 Changesets, Beachball, 또는 다른 release automation dependency를 설치하지 않습니다.
+
 ## intended publish surface
 
 - `@fluojs/cache-manager`

--- a/docs/contracts/release-governance.md
+++ b/docs/contracts/release-governance.md
@@ -38,6 +38,44 @@ A package is ready for `1.0` and the Official tier only when all of the followin
 4. Release verification passes the canonical repository commands: `pnpm build`, `pnpm typecheck`, `pnpm vitest run --project packages`, `pnpm vitest run --project apps`, `pnpm vitest run --project examples`, `pnpm vitest run --project tooling`, `pnpm --dir packages/cli sandbox:matrix`, `pnpm verify:platform-consistency-governance`, and `pnpm verify:release-readiness`.
 5. `CHANGELOG.md` keeps the `## [Unreleased]` section, and every `0.x` breaking release includes migration notes before a stable `1.0+` contract is declared.
 
+## Release Metadata Contract
+
+Committed release-intent records are the canonical long-term machine input for release preparation. The root `CHANGELOG.md` remains the human-facing narrative, and GitHub Releases are generated artifacts produced by the supervised CI-only flow.
+
+Each release intent entry must include these fields:
+
+1. Package name, using the published `@fluojs/*` package name.
+2. Semver intent, one of `major`, `minor`, `patch`, or `none` when the package has no release.
+3. Prerelease or stable intent, including the expected dist-tag when a package is released.
+4. Summary, written for maintainers and release reviewers.
+5. Migration note when the semver intent is breaking for the package's stability tier.
+6. Affected-package rationale, explaining why the package is included in the release set or why it is excluded.
+
+Every package in a release preparation run must use one disposition:
+
+- `release`: publish this package through the supervised CI-only release workflow after release-readiness passes.
+- `no-release`: do not publish this package in the current release set, while preserving the rationale in the release-intent record.
+- `downstream-evaluate`: review this package because upstream changes may affect it, but do not treat the disposition as automatic downstream publishing.
+
+Package-scoped notes and release-intent records are required for releases prepared after this work lands. `1.0.0-beta.2` is the first enforced fixture/candidate version; releases at or before `1.0.0-beta.1` stay legacy-compatible.
+
+
+## Migration Assessment: Changesets and Beachball
+
+The current repo-local intent model remains the approved release metadata path. It keeps the release decision inside committed JSON records, requires explicit package dispositions, and treats `downstream-evaluate` as a review decision rather than an automatic publish trigger. This matches the supervised CI-only workflow because `.github/workflows/release-single-package.yml` still publishes exactly one requested package from `refs/heads/main` after release-readiness passes.
+
+Changesets is a useful comparison point because it records contributor-authored semver intent and changelog text in committed files, then consumes those records during version and publish steps. Beachball is a useful comparison point because it records PR-reviewed change files, validates their presence, computes version bumps, generates changelogs, and can publish packages. Neither tool is approved here until its workflow can preserve fluo's release contract without adding local publish paths or broadening the single-package CI boundary.
+
+Go/no-go criteria for any future migration proposal:
+
+1. **Packages per release**: migration is only worth reconsidering if normal releases routinely include multiple `@fluojs/*` packages and the current single-package intent records become harder to review than generated release files.
+2. **Downstream evaluation frequency**: migration must show how often `downstream-evaluate` decisions occur and must keep them as human review gates, not automatic dependent-package releases.
+3. **Intent maintenance cost**: migration must prove that generated or tool-managed change files reduce maintainer work compared with repo-local intent JSON, without hiding package rationale from review.
+4. **Generated package changelog need**: migration must wait until maintainers need package-level changelogs beyond the root `CHANGELOG.md` narrative and generated GitHub Release notes.
+5. **CI-only single-package compatibility**: migration must keep main-only workflow dispatch, release-readiness preflight, OIDC npm publish, tag creation, and GitHub Release generation inside `.github/workflows/release-single-package.yml`, with no local `npm publish` replacement.
+
+Recommendation: defer migration. Do not install Changesets, Beachball, or another release automation dependency until package-aware release notes and release intent gates complete at least one real release cycle and the criteria above show that migration would reduce risk instead of expanding the release surface.
+
 ## intended publish surface
 
 - `@fluojs/cache-manager`

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -247,6 +247,8 @@ describe('platform consistency governance docs', () => {
     expect(releaseWorkflow).toContain('dist_tag:');
     expect(releaseWorkflow).toContain('release_prerelease:');
     expect(releaseWorkflow).toContain('release_intent_file:');
+    expect(releaseWorkflow).toContain('Optional committed release-intent JSON record; required by release-readiness for 1.0.0-beta.2+ publishes');
+    expect(releaseWorkflow).toContain('required: false');
     expect(releaseWorkflow).not.toContain('default: tooling/release/intents/release-intent.json');
     expect(releaseWorkflow).toContain('RELEASE_INTENT_FILE: ${{ inputs.release_intent_file }}');
     expect(releaseWorkflow).toContain('id-token: write');

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -132,6 +132,14 @@ function collectMarkdownFiles(relativeRoot: string): string[] {
   return markdownFiles;
 }
 
+function requireWorkflowStepIndex(workflow: string, stepName: string): number {
+  const index = workflow.indexOf(`- name: ${stepName}`);
+
+  expect(index, `Expected workflow step "${stepName}" to exist`).toBeGreaterThanOrEqual(0);
+
+  return index;
+}
+
 describe('platform consistency governance docs', () => {
   it('keeps SSOT English/Korean heading structures synchronized', () => {
     for (const [englishPath, koreanPath] of ssotPairs) {
@@ -238,22 +246,54 @@ describe('platform consistency governance docs', () => {
     expect(releaseWorkflow).toContain('package_version:');
     expect(releaseWorkflow).toContain('dist_tag:');
     expect(releaseWorkflow).toContain('release_prerelease:');
+    expect(releaseWorkflow).toContain('release_intent_file:');
+    expect(releaseWorkflow).toContain('default: tooling/release/intents/release-intent.json');
+    expect(releaseWorkflow).toContain('RELEASE_INTENT_FILE: ${{ inputs.release_intent_file }}');
     expect(releaseWorkflow).toContain('id-token: write');
-    expect(releaseWorkflow).toContain('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"');
+    expect(releaseWorkflow).toContain('registry-url: https://registry.npmjs.org');
+    expect(releaseWorkflow).toContain('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --release-intent-file "$RELEASE_INTENT_FILE" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"');
     expect(releaseWorkflow).toContain('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks');
     expect(releaseWorkflow).toContain('node tooling/release/prepare-github-release.mjs "${{ steps.resolve.outputs.release_tag }}"');
     expect(releaseWorkflow).toContain('git tag "${{ steps.resolve.outputs.release_tag }}"');
     expect(releaseWorkflow).toContain('gh release create "${{ steps.resolve.outputs.release_tag }}"');
     expect(releaseWorkflow).toContain('"$RUNNER_TEMP/release-readiness/release-readiness-summary.md#release-readiness-summary.md"');
-    expect(releaseWorkflow.indexOf('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"')).toBeLessThan(
-      releaseWorkflow.indexOf('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks'),
+    expect(requireWorkflowStepIndex(releaseWorkflow, 'Canonical release-readiness preflight')).toBeLessThan(
+      requireWorkflowStepIndex(releaseWorkflow, 'Publish package to npm'),
     );
-    expect(releaseWorkflow.indexOf('pnpm --dir "${{ steps.resolve.outputs.package_dir }}" publish --access public --tag "$DIST_TAG" --provenance --no-git-checks')).toBeLessThan(
-      releaseWorkflow.indexOf('git tag "${{ steps.resolve.outputs.release_tag }}"'),
+    expect(requireWorkflowStepIndex(releaseWorkflow, 'Publish package to npm')).toBeLessThan(
+      requireWorkflowStepIndex(releaseWorkflow, 'Create and push git tag'),
     );
-    expect(releaseWorkflow.indexOf('git tag "${{ steps.resolve.outputs.release_tag }}"')).toBeLessThan(
-      releaseWorkflow.indexOf('gh release create "${{ steps.resolve.outputs.release_tag }}"'),
+    expect(requireWorkflowStepIndex(releaseWorkflow, 'Create and push git tag')).toBeLessThan(
+      requireWorkflowStepIndex(releaseWorkflow, 'Create GitHub Release'),
     );
+  });
+
+  it('keeps single-package release safety gates before publish in the intended resolve/preflight/notes/tag/readiness/publish/release order', () => {
+    const releaseWorkflow = readFileSync(resolve(repoRoot, '.github/workflows/release-single-package.yml'), 'utf8');
+
+    const mainBranchGuard = requireWorkflowStepIndex(releaseWorkflow, 'Require main branch dispatch');
+    const resolveTarget = requireWorkflowStepIndex(releaseWorkflow, 'Resolve single-package release target');
+    const validatePackageVersionDistTag = requireWorkflowStepIndex(releaseWorkflow, 'Canonical release-readiness preflight');
+    const validatePackageSpecificNotes = requireWorkflowStepIndex(releaseWorkflow, 'Prepare GitHub Release notes');
+    const validateTargetTagAbsence = requireWorkflowStepIndex(releaseWorkflow, 'Validate target git tag is absent');
+    const publishPackage = requireWorkflowStepIndex(releaseWorkflow, 'Publish package to npm');
+    const createTag = requireWorkflowStepIndex(releaseWorkflow, 'Create and push git tag');
+    const createGitHubRelease = requireWorkflowStepIndex(releaseWorkflow, 'Create GitHub Release');
+
+    expect(releaseWorkflow).toContain("if [ \"$GITHUB_REF\" != 'refs/heads/main' ]; then");
+    expect(releaseWorkflow).toContain('Single-package release workflow must run from refs/heads/main.');
+    expect(releaseWorkflow).toContain('node tooling/release/prepare-github-release.mjs "${{ steps.resolve.outputs.release_tag }}"');
+    expect(releaseWorkflow).toContain('git rev-parse --verify --quiet "refs/tags/${{ steps.resolve.outputs.release_tag }}"');
+    expect(releaseWorkflow).toContain('pnpm verify:release-readiness --target-package "$TARGET_PACKAGE" --target-version "$TARGET_VERSION" --dist-tag "$DIST_TAG" --release-intent-file "$RELEASE_INTENT_FILE" --write-summary --summary-output-dir "$RUNNER_TEMP/release-readiness"');
+
+    expect(mainBranchGuard).toBeLessThan(resolveTarget);
+    expect(resolveTarget).toBeLessThan(validatePackageVersionDistTag);
+    expect(validatePackageVersionDistTag).toBeLessThan(validatePackageSpecificNotes);
+    expect(validatePackageSpecificNotes).toBeLessThan(validateTargetTagAbsence);
+    expect(validateTargetTagAbsence).toBeLessThan(publishPackage);
+    expect(validatePackageVersionDistTag).toBeLessThan(publishPackage);
+    expect(publishPackage).toBeLessThan(createTag);
+    expect(createTag).toBeLessThan(createGitHubRelease);
   });
 
   it('blocks removed runtime module factory names from docs/prose surfaces', () => {

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -247,7 +247,7 @@ describe('platform consistency governance docs', () => {
     expect(releaseWorkflow).toContain('dist_tag:');
     expect(releaseWorkflow).toContain('release_prerelease:');
     expect(releaseWorkflow).toContain('release_intent_file:');
-    expect(releaseWorkflow).toContain('default: tooling/release/intents/release-intent.json');
+    expect(releaseWorkflow).not.toContain('default: tooling/release/intents/release-intent.json');
     expect(releaseWorkflow).toContain('RELEASE_INTENT_FILE: ${{ inputs.release_intent_file }}');
     expect(releaseWorkflow).toContain('id-token: write');
     expect(releaseWorkflow).toContain('registry-url: https://registry.npmjs.org');

--- a/tooling/release/__fixtures__/ambiguous-version-only-changelog.md
+++ b/tooling/release/__fixtures__/ambiguous-version-only-changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [1.0.0-beta.2] - 2026-04-25
+
+### Changed
+
+- Generic beta.2 note without a package subsection.
+
+## [1.0.0-beta.1] - 2026-04-24
+
+### Changed
+
+- Bootstrap beta train for all 39 public `@fluojs/*` packages.

--- a/tooling/release/__fixtures__/legacy-version-only-changelog.md
+++ b/tooling/release/__fixtures__/legacy-version-only-changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [1.0.0-beta.1] - 2026-04-24
+
+### Changed
+
+- Bootstrap beta train for all 39 public `@fluojs/*` packages, publishing the existing package surface at `1.0.0-beta.1` with the npm `beta` dist-tag for first-time registry registration.
+
+## [0.0.0] - 2026-03-11
+
+### Breaking changes
+
+- Initial public `0.x` baseline release.

--- a/tooling/release/__fixtures__/missing-package-changelog.md
+++ b/tooling/release/__fixtures__/missing-package-changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [1.0.0-beta.2] - 2026-04-25
+
+### @fluojs/studio
+
+- Studio package-specific release note for beta.2.
+
+## [1.0.0-beta.1] - 2026-04-24
+
+### Changed
+
+- Bootstrap beta train for all 39 public `@fluojs/*` packages.

--- a/tooling/release/__fixtures__/package-scoped-changelog.md
+++ b/tooling/release/__fixtures__/package-scoped-changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [1.0.0-beta.2] - 2026-04-25
+
+### @fluojs/cli
+
+- CLI package-specific release note for beta.2.
+
+### @fluojs/studio
+
+- Studio package-specific release note for beta.2.
+
+## [1.0.0-beta.1] - 2026-04-24
+
+### Changed
+
+- Bootstrap beta train for all 39 public `@fluojs/*` packages.

--- a/tooling/release/dependency-impact.d.mts
+++ b/tooling/release/dependency-impact.d.mts
@@ -1,0 +1,29 @@
+import type { ReleaseIntentPackageEntry, WorkspacePackageManifestRecord } from './release-intents.mjs';
+
+export type PublicPackageDependencyField = 'dependencies' | 'peerDependencies' | 'optionalDependencies';
+
+export type PublicPackageDependencyGraph = {
+  dependenciesByPackage: Record<string, string[]>;
+  dependentsByPackage: Record<string, string[]>;
+  publicPackageNames: string[];
+};
+
+export type PublicPackageDependencyImpactEntry = {
+  disposition: Extract<ReleaseIntentPackageEntry['disposition'], 'release' | 'downstream-evaluate'>;
+  package: string;
+};
+
+export type PublicPackageDependencyImpactOptions = {
+  graph?: PublicPackageDependencyGraph;
+  packageManifests?: WorkspacePackageManifestRecord[];
+};
+
+export const publicPackageDependencyFields: ReadonlyArray<PublicPackageDependencyField>;
+
+export function buildPublicPackageDependencyGraph(
+  packageManifests?: WorkspacePackageManifestRecord[],
+): PublicPackageDependencyGraph;
+export function expandPublicPackageDependencyImpact(
+  releasedPackageNames: string[],
+  options?: PublicPackageDependencyImpactOptions,
+): PublicPackageDependencyImpactEntry[];

--- a/tooling/release/dependency-impact.mjs
+++ b/tooling/release/dependency-impact.mjs
@@ -1,0 +1,117 @@
+import { releaseIntentDispositions, publicWorkspacePackageNames, workspacePackageManifests } from './release-intents.mjs';
+
+export const publicPackageDependencyFields = ['dependencies', 'peerDependencies', 'optionalDependencies'];
+
+const releaseDisposition = releaseIntentDispositions.find((disposition) => disposition === 'release');
+const downstreamEvaluateDisposition = releaseIntentDispositions.find(
+  (disposition) => disposition === 'downstream-evaluate',
+);
+
+function sorted(values) {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+function isPackagesWorkspaceManifest({ packageJsonPath }) {
+  const pathParts = String(packageJsonPath).split(/[\\/]+/u);
+  return pathParts.at(-1) === 'package.json' && pathParts.at(-3) === 'packages';
+}
+
+function publicPackageManifestRecords(packageManifests) {
+  const packageSurfaceManifests = packageManifests.filter(isPackagesWorkspaceManifest);
+  const publicPackageSet = new Set(publicWorkspacePackageNames(packageSurfaceManifests));
+
+  return packageSurfaceManifests.filter(({ manifest }) => publicPackageSet.has(manifest.name));
+}
+
+function dependencyNamesForManifest(manifest, publicPackageSet) {
+  const dependencyNames = new Set();
+
+  for (const field of publicPackageDependencyFields) {
+    const dependencies = manifest[field];
+
+    if (!dependencies || typeof dependencies !== 'object') {
+      continue;
+    }
+
+    for (const dependencyName of Object.keys(dependencies)) {
+      if (dependencyName !== manifest.name && publicPackageSet.has(dependencyName)) {
+        dependencyNames.add(dependencyName);
+      }
+    }
+  }
+
+  return sorted(dependencyNames);
+}
+
+function graphEntriesToObject(graphEntries) {
+  return Object.fromEntries(
+    sorted(graphEntries.keys()).map((packageName) => [packageName, sorted(graphEntries.get(packageName) ?? [])]),
+  );
+}
+
+export function buildPublicPackageDependencyGraph(packageManifests = workspacePackageManifests()) {
+  const publicPackageManifests = publicPackageManifestRecords(packageManifests);
+  const publicPackageNames = publicPackageManifests.map(({ manifest }) => manifest.name).sort((left, right) => left.localeCompare(right));
+  const publicPackageSet = new Set(publicPackageNames);
+  const dependenciesByPackage = new Map(publicPackageNames.map((packageName) => [packageName, []]));
+  const dependentsByPackage = new Map(publicPackageNames.map((packageName) => [packageName, []]));
+
+  for (const { manifest } of publicPackageManifests) {
+    const dependencyNames = dependencyNamesForManifest(manifest, publicPackageSet);
+    dependenciesByPackage.set(manifest.name, dependencyNames);
+
+    for (const dependencyName of dependencyNames) {
+      dependentsByPackage.get(dependencyName)?.push(manifest.name);
+    }
+  }
+
+  return {
+    dependenciesByPackage: graphEntriesToObject(dependenciesByPackage),
+    dependentsByPackage: graphEntriesToObject(dependentsByPackage),
+    publicPackageNames,
+  };
+}
+
+function normalizeReleasedPackages(releasedPackageNames) {
+  if (!Array.isArray(releasedPackageNames)) {
+    throw new Error('Dependency impact analysis failed: releasedPackageNames must be an array.');
+  }
+
+  return sorted(new Set(releasedPackageNames));
+}
+
+export function expandPublicPackageDependencyImpact(releasedPackageNames, options = {}) {
+  const graph = options.graph ?? buildPublicPackageDependencyGraph(options.packageManifests);
+  const publicPackageSet = new Set(graph.publicPackageNames);
+  const releasePackageNames = normalizeReleasedPackages(releasedPackageNames);
+  const releasePackageSet = new Set(releasePackageNames);
+  const unknownPackages = releasePackageNames.filter((packageName) => !publicPackageSet.has(packageName));
+
+  if (unknownPackages.length > 0) {
+    throw new Error(
+      `Dependency impact analysis failed: unknown public workspace package(s): ${unknownPackages.join(', ')}.`,
+    );
+  }
+
+  const downstreamEvaluatePackageSet = new Set();
+  const queue = [...releasePackageNames];
+
+  for (let index = 0; index < queue.length; index += 1) {
+    const packageName = queue[index];
+    const dependents = graph.dependentsByPackage[packageName] ?? [];
+
+    for (const dependentName of dependents) {
+      if (releasePackageSet.has(dependentName) || downstreamEvaluatePackageSet.has(dependentName)) {
+        continue;
+      }
+
+      downstreamEvaluatePackageSet.add(dependentName);
+      queue.push(dependentName);
+    }
+  }
+
+  return sorted([...releasePackageSet, ...downstreamEvaluatePackageSet]).map((packageName) => ({
+    disposition: releasePackageSet.has(packageName) ? releaseDisposition : downstreamEvaluateDisposition,
+    package: packageName,
+  }));
+}

--- a/tooling/release/dependency-impact.test.ts
+++ b/tooling/release/dependency-impact.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { buildPublicPackageDependencyGraph, expandPublicPackageDependencyImpact } from './dependency-impact.mjs';
+
+function packageManifest(
+  name: string,
+  options: {
+    dependencies?: Record<string, string>;
+    directory?: string;
+    optionalDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    private?: boolean;
+    publishAccess?: string;
+  } = {},
+) {
+  const packageDirectory = options.directory ?? `packages/${name.slice('@fluojs/'.length)}`;
+
+  return {
+    manifest: {
+      name,
+      private: options.private ?? false,
+      publishConfig: { access: options.publishAccess ?? 'public' },
+      ...(options.dependencies ? { dependencies: options.dependencies } : {}),
+      ...(options.peerDependencies ? { peerDependencies: options.peerDependencies } : {}),
+      ...(options.optionalDependencies ? { optionalDependencies: options.optionalDependencies } : {}),
+    },
+    packageJsonPath: `/repo/${packageDirectory}/package.json`,
+  };
+}
+
+const runtimeCliStudioManifests = [
+  packageManifest('@fluojs/cli', {
+    dependencies: {
+      '@fluojs/runtime': 'workspace:^',
+    },
+  }),
+  packageManifest('@fluojs/runtime'),
+  packageManifest('@fluojs/studio', {
+    dependencies: {
+      '@fluojs/runtime': 'workspace:^',
+    },
+  }),
+];
+
+describe('buildPublicPackageDependencyGraph', () => {
+  it('excludes non-public, tooling, and example manifests from the public package graph', () => {
+    const graph = buildPublicPackageDependencyGraph([
+      ...runtimeCliStudioManifests,
+      packageManifest('@fluojs/private-runtime-consumer', {
+        dependencies: { '@fluojs/runtime': 'workspace:^' },
+        private: true,
+      }),
+      packageManifest('@fluojs/tooling-runtime-consumer', {
+        dependencies: { '@fluojs/runtime': 'workspace:^' },
+        directory: 'tooling/runtime-consumer',
+      }),
+      packageManifest('@fluojs/example-runtime-consumer', {
+        dependencies: { '@fluojs/runtime': 'workspace:^' },
+        directory: 'examples/runtime-consumer',
+      }),
+      packageManifest('@fluojs/restricted-runtime-consumer', {
+        dependencies: { '@fluojs/runtime': 'workspace:^' },
+        publishAccess: 'restricted',
+      }),
+    ]);
+
+    expect(graph.publicPackageNames).toEqual(['@fluojs/cli', '@fluojs/runtime', '@fluojs/studio']);
+    expect(graph.dependentsByPackage['@fluojs/runtime']).toEqual(['@fluojs/cli', '@fluojs/studio']);
+    expect(graph.dependentsByPackage).not.toHaveProperty('@fluojs/tooling-runtime-consumer');
+    expect(graph.dependentsByPackage).not.toHaveProperty('@fluojs/example-runtime-consumer');
+  });
+});
+
+describe('expandPublicPackageDependencyImpact', () => {
+  it('marks CLI and Studio for downstream evaluation when Runtime is explicitly released', () => {
+    expect(expandPublicPackageDependencyImpact(['@fluojs/runtime'], { packageManifests: runtimeCliStudioManifests })).toEqual([
+      { disposition: 'downstream-evaluate', package: '@fluojs/cli' },
+      { disposition: 'release', package: '@fluojs/runtime' },
+      { disposition: 'downstream-evaluate', package: '@fluojs/studio' },
+    ]);
+  });
+
+  it('does not expand a CLI leaf release to unrelated downstream packages', () => {
+    expect(expandPublicPackageDependencyImpact(['@fluojs/cli'], { packageManifests: runtimeCliStudioManifests })).toEqual([
+      { disposition: 'release', package: '@fluojs/cli' },
+    ]);
+  });
+
+  it('keeps explicit releases as release and does not auto-release downstream dependents', () => {
+    const impact = expandPublicPackageDependencyImpact(['@fluojs/runtime', '@fluojs/cli'], {
+      packageManifests: runtimeCliStudioManifests,
+    });
+
+    expect(impact).toEqual([
+      { disposition: 'release', package: '@fluojs/cli' },
+      { disposition: 'release', package: '@fluojs/runtime' },
+      { disposition: 'downstream-evaluate', package: '@fluojs/studio' },
+    ]);
+    expect(impact.filter((entry) => entry.disposition === 'release').map((entry) => entry.package)).toEqual([
+      '@fluojs/cli',
+      '@fluojs/runtime',
+    ]);
+  });
+
+  it('follows transitive downstream dependencies through runtime linkage fields', () => {
+    const impact = expandPublicPackageDependencyImpact(['@fluojs/core'], {
+      packageManifests: [
+        packageManifest('@fluojs/adapter', {
+          optionalDependencies: { '@fluojs/runtime': 'workspace:^' },
+        }),
+        packageManifest('@fluojs/core'),
+        packageManifest('@fluojs/runtime', {
+          peerDependencies: { '@fluojs/core': 'workspace:^' },
+        }),
+      ],
+    });
+
+    expect(impact).toEqual([
+      { disposition: 'downstream-evaluate', package: '@fluojs/adapter' },
+      { disposition: 'release', package: '@fluojs/core' },
+      { disposition: 'downstream-evaluate', package: '@fluojs/runtime' },
+    ]);
+  });
+});

--- a/tooling/release/intents/README.md
+++ b/tooling/release/intents/README.md
@@ -1,0 +1,45 @@
+# Committed release intent records
+
+Release intent records are the repo-local machine input for future release preparation. They complement the human-facing root `CHANGELOG.md`; GitHub Releases remain generated CI artifacts, and this schema does not adopt Changesets, Beachball, or any other release automation dependency.
+
+## Record shape
+
+Use one committed JSON record per fixture/candidate release under this directory. The shape is intentionally close to Changesets-style committed change files: a small version header plus package-scoped intent entries that can be converted later without changing the governed release policy.
+
+```json
+{
+  "version": "1.0.0-beta.2",
+  "packages": [
+    {
+      "package": "@fluojs/cli",
+      "disposition": "release",
+      "semver": "patch",
+      "summary": "Clarify CLI startup behavior for the beta.2 candidate.",
+      "rationale": "The CLI package owns the affected generated starter contract."
+    }
+  ]
+}
+```
+
+Each package entry must include:
+
+- `package`: a public workspace package name from `packages/*/package.json` with the `@fluojs/*` scope and `publishConfig.access: "public"`.
+- `disposition`: exactly one of `release`, `no-release`, or `downstream-evaluate`.
+- `semver`: exactly one of `patch`, `minor`, `major`, or `none`.
+- `summary`: maintainer-facing release review summary, aligned with the changelog's concise package/release-note language.
+- `rationale`: why the package is included, excluded, or marked for downstream evaluation.
+- `migrationNote`: required when `semver` is `major` or the entry sets `breaking: true`; optional for non-breaking intents.
+
+## Cutoff policy
+
+Release intent records are not backfilled for legacy releases. Releases at or before `1.0.0-beta.1` remain compatible without committed intent records, while fixture/candidate releases from `1.0.0-beta.2` onward must provide them.
+
+## Validation helper
+
+`tooling/release/release-intents.mjs` exports lightweight Node ESM helpers for tests and later readiness integration:
+
+- `validateReleaseIntentRecord(record, dependencies)` validates a single record.
+- `validateReleaseIntentRecords(records, { candidateVersion, ...dependencies })` enforces the cutoff behavior.
+- `workspacePackageManifests()` and `publicWorkspacePackageNames(...)` derive the public package surface from local package manifests.
+
+The validator is intentionally local and side-effect free so Task 9 can wire it into release readiness without changing package versions, tags, publishing workflows, or external tooling.

--- a/tooling/release/local-release-dry-run-matrix.test.ts
+++ b/tooling/release/local-release-dry-run-matrix.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildGitHubReleaseNotes } from './prepare-github-release.mjs';
+import { runReleaseReadinessVerification } from './verify-release-readiness.mjs';
+
+type ReleaseDisposition = 'release' | 'no-release' | 'downstream-evaluate';
+type SemverIntent = 'patch' | 'minor' | 'major' | 'none';
+type WorkspacePackageManifestRecord = {
+  manifest: Record<string, unknown> & { name: string };
+  packageJsonPath: string;
+};
+
+const betaVersion = '1.0.0-beta.2';
+const stableVersion = '1.0.0';
+
+const packageScopedChangelog = `# Changelog
+
+## [Unreleased]
+
+## [${stableVersion}] - 2026-04-26
+
+### @fluojs/cli
+
+- CLI stable release note.
+
+## [${betaVersion}] - 2026-04-25
+
+### @fluojs/cli
+
+- CLI package-specific release note for beta.2.
+
+### @fluojs/studio
+
+- Studio package-specific release note for beta.2.
+
+### @fluojs/runtime
+
+- Runtime package-specific release note for beta.2.
+
+## [0.0.0]
+`;
+
+function packageManifest(
+  name: string,
+  options: {
+    dependencies?: Record<string, string>;
+    private?: boolean;
+    publishAccess?: string;
+  } = {},
+): WorkspacePackageManifestRecord {
+  return {
+    manifest: {
+      name,
+      private: options.private ?? false,
+      publishConfig: { access: options.publishAccess ?? 'public' },
+      ...(options.dependencies ? { dependencies: options.dependencies } : {}),
+    },
+    packageJsonPath: `/repo/packages/${name.slice('@fluojs/'.length)}/package.json`,
+  };
+}
+
+function createReleaseIntentRecord(
+  version: string,
+  packages: Array<{
+    disposition: ReleaseDisposition;
+    package: string;
+    semver?: SemverIntent;
+  }>,
+) {
+  return {
+    version,
+    packages: packages.map((packageIntent) => ({
+      disposition: packageIntent.disposition,
+      package: packageIntent.package,
+      rationale: `${packageIntent.package} ${packageIntent.disposition} dry-run rationale`,
+      semver: packageIntent.semver ?? (packageIntent.disposition === 'release' ? 'patch' : 'none'),
+      summary: `${packageIntent.package} ${packageIntent.disposition} dry-run summary`,
+    })),
+  };
+}
+
+function docsFor(publicPackageNames: string[], changelog = packageScopedChangelog) {
+  const packageList = publicPackageNames.map((packageName) => `- \`${packageName}\``).join('\n');
+  const packageSurface = publicPackageNames.map((packageName) => `\`${packageName}\``).join(' ');
+
+  return new Map([
+    [
+      'docs/getting-started/quick-start.md',
+      'pnpm add -g @fluojs/cli\nfluo new my-fluo-app\nThe fluo CLI is your central tool for project scaffolding and component generation.',
+    ],
+    ['CONTRIBUTING.md', 'pnpm sandbox:create\npnpm sandbox:verify\npnpm sandbox:test'],
+    [
+      'docs/contracts/release-governance.md',
+      `## intended publish surface\n${packageList}\n\npnpm verify:release-readiness\npnpm verify:platform-consistency-governance`,
+    ],
+    ['docs/reference/package-surface.md', `## public package families\n| Runtime | ${packageSurface} |`],
+    [
+      'docs/reference/toolchain-contract-matrix.md',
+      '## generated app baseline\n## CLI & scaffolding contracts\n## naming conventions (CLI output)\nfluo new\nfluo inspect',
+    ],
+    ['packages/cli/README.md', 'canonical CLI'],
+    [
+      'packages/cli/src/new/scaffold.ts',
+      "const RuntimeHealthModule = createHealthModule();\n@Controller('/health-info')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateHealthModule\ncreateFastifyAdapter",
+    ],
+    ['packages/cli/package.json', JSON.stringify({ bin: { fluo: './bin/fluo.mjs' }, main: './dist/index.js' })],
+    ['CHANGELOG.md', changelog],
+  ]);
+}
+
+function createDryRunDependencies(
+  options: {
+    changelog?: string;
+    manifests?: WorkspacePackageManifestRecord[];
+    publicPackageNames?: string[];
+    releaseTagExists?: (tag: string) => boolean;
+    versionPublished?: (packageName: string, version: string) => boolean;
+    workspacePackageNames?: string[];
+  } = {},
+) {
+  const publicPackageNames = options.publicPackageNames ?? ['@fluojs/cli', '@fluojs/runtime', '@fluojs/studio'];
+  const manifests = options.manifests ?? [
+    packageManifest('@fluojs/cli', { dependencies: { '@fluojs/runtime': 'workspace:^' } }),
+    packageManifest('@fluojs/runtime'),
+    packageManifest('@fluojs/studio', { dependencies: { '@fluojs/runtime': 'workspace:^' } }),
+  ];
+  const docs = docsFor(publicPackageNames, options.changelog);
+
+  return {
+    existsSync: vi.fn((targetPath: string) => targetPath.endsWith('/LICENSE') || targetPath.endsWith('/CHANGELOG.md')),
+    isPublishedVersion: vi.fn(options.versionPublished ?? (() => false)),
+    isReleaseTagExisting: vi.fn(options.releaseTagExists ?? (() => false)),
+    read: vi.fn((relativePath: string) => {
+      const value = docs.get(relativePath);
+      if (typeof value !== 'string') {
+        throw new Error(`Unexpected dry-run read: ${relativePath}`);
+      }
+
+      return value;
+    }),
+    run: vi.fn(),
+    workspacePackageManifests: vi.fn(() => manifests),
+    workspacePackageNames: vi.fn(() => options.workspacePackageNames ?? publicPackageNames),
+  };
+}
+
+function runDryRunMatrixCase(
+  targetPackage: string,
+  options: {
+    changedPackages?: string[];
+    dependencies?: ReturnType<typeof createDryRunDependencies>;
+    distTag?: string;
+    releaseIntentRecords?: ReturnType<typeof createReleaseIntentRecord>[];
+    targetVersion?: string;
+  } = {},
+) {
+  return runReleaseReadinessVerification(
+    {
+      changedPackages: options.changedPackages,
+      distTag: options.distTag ?? 'beta',
+      releaseIntentRecords:
+        options.releaseIntentRecords ??
+        [createReleaseIntentRecord(options.targetVersion ?? betaVersion, [{ disposition: 'release', package: targetPackage }])],
+      targetPackage,
+      targetVersion: options.targetVersion ?? betaVersion,
+    },
+    options.dependencies ?? createDryRunDependencies(),
+  );
+}
+
+function expectWorkflowPreflightWasLocal(dependencies: ReturnType<typeof createDryRunDependencies>) {
+  expect(dependencies.run.mock.calls).toEqual([
+    ['pnpm', ['build']],
+    ['pnpm', ['typecheck']],
+    ['pnpm', ['vitest', 'run', '--project', 'packages']],
+    ['pnpm', ['vitest', 'run', '--project', 'apps']],
+    ['pnpm', ['vitest', 'run', '--project', 'examples']],
+    ['pnpm', ['vitest', 'run', '--project', 'tooling']],
+    ['pnpm', ['--dir', 'packages/cli', 'sandbox:matrix']],
+  ]);
+}
+
+describe('local release dry-run matrix', () => {
+  it('keeps same-version CLI and Studio package-specific notes isolated while passing readiness', () => {
+    const dependencies = createDryRunDependencies();
+    const cliNotes = buildGitHubReleaseNotes(`@fluojs/cli@${betaVersion}`, packageScopedChangelog);
+    const studioNotes = buildGitHubReleaseNotes(`@fluojs/studio@${betaVersion}`, packageScopedChangelog);
+
+    const cliResult = runDryRunMatrixCase('@fluojs/cli', { dependencies });
+    const studioResult = runDryRunMatrixCase('@fluojs/studio', { dependencies: createDryRunDependencies() });
+
+    expect(cliNotes).toContain('- CLI package-specific release note for beta.2.');
+    expect(cliNotes).not.toContain('- Studio package-specific release note for beta.2.');
+    expect(studioNotes).toContain('- Studio package-specific release note for beta.2.');
+    expect(studioNotes).not.toContain('- CLI package-specific release note for beta.2.');
+    expect(cliResult.checks).toEqual(expect.arrayContaining([expect.objectContaining({ label: 'Single-package release package notes', pass: true })]));
+    expect(studioResult.checks).toEqual(expect.arrayContaining([expect.objectContaining({ label: 'Single-package release package notes', pass: true })]));
+    expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', betaVersion);
+    expectWorkflowPreflightWasLocal(dependencies);
+  });
+
+  it('rejects missing package notes before tag and publishability checks', () => {
+    const dependencies = createDryRunDependencies({
+      changelog: `# Changelog
+
+## [Unreleased]
+
+## [${betaVersion}] - 2026-04-25
+
+### @fluojs/studio
+
+- Studio package-specific release note for beta.2.
+
+## [0.0.0]
+`,
+    });
+
+    expect(() => runDryRunMatrixCase('@fluojs/cli', { dependencies })).toThrowError(/Missing package release notes.*@fluojs\/cli.*1\.0\.0-beta\.2/u);
+    expect(dependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('rejects ambiguous generic package notes before tag and publishability checks', () => {
+    const dependencies = createDryRunDependencies({
+      changelog: `# Changelog
+
+## [Unreleased]
+
+## [${betaVersion}] - 2026-04-25
+
+### Changed
+
+- Generic beta.2 note without a package subsection.
+
+## [0.0.0]
+`,
+    });
+
+    expect(() => runDryRunMatrixCase('@fluojs/cli', { dependencies })).toThrowError(/Ambiguous generic release notes.*@fluojs\/cli.*1\.0\.0-beta\.2/u);
+    expect(dependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('rejects an existing target tag before publishability checks', () => {
+    const dependencies = createDryRunDependencies({ releaseTagExists: (tag) => tag === `@fluojs/cli@${betaVersion}` });
+
+    expect(() => runDryRunMatrixCase('@fluojs/cli', { dependencies })).toThrowError(/Single-package release target git tag absence.*@fluojs\/cli@1\.0\.0-beta\.2/u);
+    expect(dependencies.isReleaseTagExisting).toHaveBeenCalledWith(`@fluojs/cli@${betaVersion}`);
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('passes runtime release only with explicit CLI and Studio downstream decisions and no downstream publish', () => {
+    const dependencies = createDryRunDependencies();
+    const result = runDryRunMatrixCase('@fluojs/runtime', {
+      changedPackages: ['@fluojs/runtime'],
+      dependencies,
+      releaseIntentRecords: [
+        createReleaseIntentRecord(betaVersion, [
+          { disposition: 'release', package: '@fluojs/runtime' },
+          { disposition: 'downstream-evaluate', package: '@fluojs/cli', semver: 'none' },
+          { disposition: 'no-release', package: '@fluojs/studio', semver: 'none' },
+        ]),
+      ],
+    });
+
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Release intent coverage for affected packages', pass: true }),
+        expect.objectContaining({ label: 'Release intent downstream evaluation decisions', pass: true }),
+        expect.objectContaining({ label: 'Single-package release target intent disposition', pass: true }),
+      ]),
+    );
+    expect(dependencies.isPublishedVersion.mock.calls).toEqual([['@fluojs/runtime', betaVersion]]);
+    expect(dependencies.isReleaseTagExisting.mock.calls).toEqual([[`@fluojs/runtime@${betaVersion}`]]);
+  });
+
+  it('rejects runtime changes when CLI and Studio downstream decisions are missing', () => {
+    const dependencies = createDryRunDependencies();
+
+    expect(() =>
+      runDryRunMatrixCase('@fluojs/runtime', {
+        changedPackages: ['@fluojs/runtime'],
+        dependencies,
+        releaseIntentRecords: [createReleaseIntentRecord(betaVersion, [{ disposition: 'release', package: '@fluojs/runtime' }])],
+      }),
+    ).toThrowError(/Missing release intent or evaluation decision.*@fluojs\/cli, @fluojs\/studio/u);
+    expect(dependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('rejects private or unknown single-package targets before publishability checks', () => {
+    const privateDependencies = createDryRunDependencies({
+      manifests: [
+        packageManifest('@fluojs/cli', { dependencies: { '@fluojs/runtime': 'workspace:^' } }),
+        packageManifest('@fluojs/runtime'),
+        packageManifest('@fluojs/private-devtool', { private: true }),
+      ],
+      publicPackageNames: ['@fluojs/cli', '@fluojs/runtime'],
+      workspacePackageNames: ['@fluojs/cli', '@fluojs/runtime', '@fluojs/private-devtool'],
+    });
+    const unknownDependencies = createDryRunDependencies();
+
+    expect(() =>
+      runDryRunMatrixCase('@fluojs/private-devtool', {
+        dependencies: privateDependencies,
+        distTag: 'latest',
+        releaseIntentRecords: undefined,
+        targetVersion: stableVersion,
+      }),
+    ).toThrowError(/Release intent validation failed: packages\[0\]\.package references unknown public workspace package @fluojs\/private-devtool/u);
+    expect(privateDependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(privateDependencies.isPublishedVersion).not.toHaveBeenCalled();
+
+    expect(() =>
+      runDryRunMatrixCase('@fluojs/unknown', {
+        dependencies: unknownDependencies,
+        distTag: 'latest',
+        releaseIntentRecords: undefined,
+        targetVersion: stableVersion,
+      }),
+    ).toThrowError(/Release intent validation failed: packages\[0\]\.package references unknown public workspace package @fluojs\/unknown/u);
+    expect(unknownDependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(unknownDependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('enforces prerelease/beta and stable/latest dist-tag alignment', () => {
+    const betaDependencies = createDryRunDependencies();
+    const latestDependencies = createDryRunDependencies();
+    const invalidPrereleaseDependencies = createDryRunDependencies();
+    const invalidStableDependencies = createDryRunDependencies();
+
+    runDryRunMatrixCase('@fluojs/cli', { dependencies: betaDependencies, distTag: 'beta' });
+    runDryRunMatrixCase('@fluojs/cli', {
+      dependencies: latestDependencies,
+      distTag: 'latest',
+      releaseIntentRecords: [createReleaseIntentRecord(stableVersion, [{ disposition: 'release', package: '@fluojs/cli' }])],
+      targetVersion: stableVersion,
+    });
+
+    expect(() => runDryRunMatrixCase('@fluojs/cli', { dependencies: invalidPrereleaseDependencies, distTag: 'latest' })).toThrowError(
+      'Release readiness check failed: Single-package release prerelease alignment.',
+    );
+    expect(() =>
+      runDryRunMatrixCase('@fluojs/cli', {
+        dependencies: invalidStableDependencies,
+        distTag: 'beta',
+        releaseIntentRecords: [createReleaseIntentRecord(stableVersion, [{ disposition: 'release', package: '@fluojs/cli' }])],
+        targetVersion: stableVersion,
+      }),
+    ).toThrowError('Release readiness check failed: Single-package release prerelease alignment.');
+    expect(betaDependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', betaVersion);
+    expect(latestDependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', stableVersion);
+    expect(invalidPrereleaseDependencies.isPublishedVersion).not.toHaveBeenCalled();
+    expect(invalidStableDependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+});

--- a/tooling/release/prepare-github-release.d.mts
+++ b/tooling/release/prepare-github-release.d.mts
@@ -6,6 +6,8 @@ export function parseReleaseTag(tag: string): {
 
 export function sectionForVersion(changelog: string, version: string): string;
 
+export function packageSectionForVersion(section: string, packageName: string, version: string): string;
+
 export function buildGitHubReleaseNotes(tag: string, changelog: string): string;
 
 export function main(argv?: string[]): void;

--- a/tooling/release/prepare-github-release.mjs
+++ b/tooling/release/prepare-github-release.mjs
@@ -6,6 +6,7 @@ const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDirectory, '..', '..');
 const changelogPath = join(repoRoot, 'CHANGELOG.md');
 const releaseNotesPath = join(scriptDirectory, 'github-release-notes.md');
+const firstPackageScopedNotesVersion = '1.0.0-beta.2';
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -61,15 +62,145 @@ export function sectionForVersion(changelog, version) {
   return lines.slice(start, end).join('\n').trim();
 }
 
+function comparePrerelease(left, right) {
+  if (left === right) {
+    return 0;
+  }
+
+  if (!left) {
+    return 1;
+  }
+
+  if (!right) {
+    return -1;
+  }
+
+  const leftParts = left.split('.');
+  const rightParts = right.split('.');
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+
+    if (leftPart === undefined) {
+      return -1;
+    }
+
+    if (rightPart === undefined) {
+      return 1;
+    }
+
+    const leftNumber = /^\d+$/u.test(leftPart) ? Number(leftPart) : null;
+    const rightNumber = /^\d+$/u.test(rightPart) ? Number(rightPart) : null;
+
+    if (leftNumber !== null && rightNumber !== null) {
+      if (leftNumber !== rightNumber) {
+        return leftNumber > rightNumber ? 1 : -1;
+      }
+
+      continue;
+    }
+
+    if (leftNumber !== null) {
+      return -1;
+    }
+
+    if (rightNumber !== null) {
+      return 1;
+    }
+
+    if (leftPart !== rightPart) {
+      return leftPart > rightPart ? 1 : -1;
+    }
+  }
+
+  return 0;
+}
+
+function parseComparableVersion(version) {
+  const match = version.match(/^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<prerelease>[0-9A-Za-z.-]+))?$/u);
+
+  if (!match?.groups) {
+    throw new Error(`Cannot compare release version ${version}.`);
+  }
+
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+    prerelease: match.groups.prerelease ?? '',
+  };
+}
+
+function compareVersions(left, right) {
+  const leftVersion = parseComparableVersion(left);
+  const rightVersion = parseComparableVersion(right);
+
+  for (const key of ['major', 'minor', 'patch']) {
+    if (leftVersion[key] !== rightVersion[key]) {
+      return leftVersion[key] > rightVersion[key] ? 1 : -1;
+    }
+  }
+
+  return comparePrerelease(leftVersion.prerelease, rightVersion.prerelease);
+}
+
+function requiresPackageScopedNotes(version) {
+  return compareVersions(version, firstPackageScopedNotesVersion) >= 0;
+}
+
+function packageSubsectionHeadings(section) {
+  return section
+    .split('\n')
+    .map((line, index) => {
+      const match = line.match(/^###\s+(?<title>.+?)\s*$/u);
+
+      return match?.groups ? { index, title: match.groups.title } : null;
+    })
+    .filter(Boolean);
+}
+
+export function packageSectionForVersion(section, packageName, version) {
+  const lines = section.split('\n');
+  const headings = packageSubsectionHeadings(section);
+  const matchingHeadings = headings.filter((heading) => heading.title === packageName);
+
+  if (matchingHeadings.length > 1) {
+    throw new Error(`Duplicate package release notes found for ${packageName} ${version}.`);
+  }
+
+  const matchingHeading = matchingHeadings[0];
+
+  if (!matchingHeading) {
+    const packageHeadings = headings.filter((heading) => /^@[^/]+\/[^@]+$/u.test(heading.title));
+
+    if (packageHeadings.length === 0) {
+      throw new Error(
+        `Ambiguous generic release notes found for ${packageName} ${version}; package releases after ${firstPackageScopedNotesVersion} require package-specific notes instead of shared generic notes.`,
+      );
+    }
+
+    throw new Error(`Missing package release notes for ${packageName} ${version}; add a \`### ${packageName}\` subsection.`);
+  }
+
+  const nextHeading = headings.find((heading) => heading.index > matchingHeading.index);
+  const versionHeader = lines[0];
+  const packageLines = lines.slice(matchingHeading.index, nextHeading?.index ?? lines.length).join('\n').trim();
+
+  return [versionHeader, '', packageLines].join('\n').trim();
+}
+
 export function buildGitHubReleaseNotes(tag, changelog) {
   const { packageName, version } = parseReleaseTag(tag);
   const section = sectionForVersion(changelog, version);
+  const releaseSection = packageName && requiresPackageScopedNotes(version) ? packageSectionForVersion(section, packageName, version) : section;
 
   return [
     `# ${tag}`,
     '',
     ...(packageName ? [`- Release package: \`${packageName}\``, ''] : []),
-    section,
+    releaseSection,
     '',
     '---',
     '',

--- a/tooling/release/prepare-github-release.test.ts
+++ b/tooling/release/prepare-github-release.test.ts
@@ -1,5 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { buildGitHubReleaseNotes, parseReleaseTag, sectionForVersion } from './prepare-github-release.mjs';
+
+const fixtureDirectory = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+
+function readFixture(name: string): string {
+  return readFileSync(join(fixtureDirectory, name), 'utf8');
+}
 
 describe('parseReleaseTag', () => {
   it('keeps legacy v-prefixed tags mapped to the matching changelog version', () => {
@@ -33,5 +42,117 @@ describe('buildGitHubReleaseNotes', () => {
 
     expect(buildGitHubReleaseNotes('@fluojs/cli@0.2.0', changelog)).toContain('- Release package: `@fluojs/cli`');
     expect(buildGitHubReleaseNotes('@fluojs/cli@0.2.0', changelog)).toContain('## [0.2.0] - 2026-04-16');
+  });
+
+  it('keeps legacy version-only notes compatible through 1.0.0-beta.1', () => {
+    const changelog = readFixture('legacy-version-only-changelog.md');
+
+    expect(buildGitHubReleaseNotes('@fluojs/cli@1.0.0-beta.1', changelog)).toContain(
+      'Bootstrap beta train for all 39 public `@fluojs/*` packages',
+    );
+    expect(buildGitHubReleaseNotes('@fluojs/cli@1.0.0-beta.1', changelog)).toContain(
+      '- Release package: `@fluojs/cli`',
+    );
+  });
+});
+
+describe('package-aware changelog fixtures', () => {
+  it('defines valid package-specific extraction format for @fluojs/cli@1.0.0-beta.2', () => {
+    const changelog = readFixture('package-scoped-changelog.md');
+    const section = sectionForVersion(changelog, '1.0.0-beta.2');
+
+    expect(section).toContain('## [1.0.0-beta.2] - 2026-04-25');
+    expect(section).toContain('### @fluojs/cli');
+    expect(section).toContain('- CLI package-specific release note for beta.2.');
+  });
+
+  it('defines same-version multi-package notes with isolated CLI and Studio subsections', () => {
+    const section = sectionForVersion(readFixture('package-scoped-changelog.md'), '1.0.0-beta.2');
+    const cliStart = section.indexOf('### @fluojs/cli');
+    const studioStart = section.indexOf('### @fluojs/studio');
+    const cliNotes = section.slice(cliStart, studioStart);
+    const studioNotes = section.slice(studioStart);
+
+    expect(cliStart).toBeGreaterThan(-1);
+    expect(studioStart).toBeGreaterThan(cliStart);
+    expect(cliNotes).toContain('- CLI package-specific release note for beta.2.');
+    expect(cliNotes).not.toContain('- Studio package-specific release note for beta.2.');
+    expect(studioNotes).toContain('- Studio package-specific release note for beta.2.');
+    expect(studioNotes).not.toContain('- CLI package-specific release note for beta.2.');
+  });
+
+  it('documents missing package notes after the cutoff as a future package-specific error', () => {
+    const section = sectionForVersion(readFixture('missing-package-changelog.md'), '1.0.0-beta.2');
+
+    expect(section).toContain('### @fluojs/studio');
+    expect(section).not.toContain('### @fluojs/cli');
+  });
+
+  it('documents ambiguous generic version-only notes after the cutoff for package release extraction', () => {
+    const section = sectionForVersion(readFixture('ambiguous-version-only-changelog.md'), '1.0.0-beta.2');
+
+    expect(section).toContain('### Changed');
+    expect(section).toContain('Generic beta.2 note without a package subsection.');
+    expect(section).not.toContain('### @fluojs/cli');
+    expect(section).not.toContain('### @fluojs/studio');
+  });
+
+  it('extracts only valid package-specific notes for @fluojs/cli@1.0.0-beta.2', () => {
+    const notes = buildGitHubReleaseNotes('@fluojs/cli@1.0.0-beta.2', readFixture('package-scoped-changelog.md'));
+
+    expect(notes).toContain('- Release package: `@fluojs/cli`');
+    expect(notes).toContain('## [1.0.0-beta.2] - 2026-04-25');
+    expect(notes).toContain('### @fluojs/cli');
+    expect(notes).toContain('- CLI package-specific release note for beta.2.');
+    expect(notes).not.toContain('### @fluojs/studio');
+    expect(notes).not.toContain('- Studio package-specific release note for beta.2.');
+  });
+
+  it('throws a package/version-specific error when @fluojs/cli@1.0.0-beta.2 notes are missing', () => {
+    expect(() => buildGitHubReleaseNotes('@fluojs/cli@1.0.0-beta.2', readFixture('missing-package-changelog.md'))).toThrow(
+      /Missing package release notes.*@fluojs\/cli.*1\.0\.0-beta\.2/u,
+    );
+  });
+
+  it('rejects ambiguous generic version-only notes after 1.0.0-beta.1 for package releases', () => {
+    expect(() => buildGitHubReleaseNotes('@fluojs/cli@1.0.0-beta.2', readFixture('ambiguous-version-only-changelog.md'))).toThrow(
+      /Ambiguous generic release notes.*@fluojs\/cli.*1\.0\.0-beta\.2/u,
+    );
+  });
+
+  it('throws a package/version-specific error when duplicate package notes exist', () => {
+    const changelog = `# Changelog
+
+## [1.0.0-beta.2] - 2026-04-25
+
+### @fluojs/cli
+
+- First CLI note.
+
+### @fluojs/cli
+
+- Duplicate CLI note.
+`;
+
+    expect(() => buildGitHubReleaseNotes('@fluojs/cli@1.0.0-beta.2', changelog)).toThrow(
+      /Duplicate package release notes.*@fluojs\/cli.*1\.0\.0-beta\.2/u,
+    );
+  });
+
+  it('requires package-specific notes for later prerelease and stable versions', () => {
+    for (const version of ['1.0.0-beta.10', '1.0.0-rc.0', '1.0.0']) {
+      const changelog = `# Changelog
+
+## [${version}] - 2026-04-25
+
+### Changed
+
+- Generic post-cutoff note.
+`;
+
+      expect(() => buildGitHubReleaseNotes(`@fluojs/cli@${version}`, changelog)).toThrow(
+        new RegExp(`Ambiguous generic release notes.*@fluojs/cli.*${version.replace(/\./gu, '\\.')}`, 'u'),
+      );
+    }
   });
 });

--- a/tooling/release/release-intents.d.mts
+++ b/tooling/release/release-intents.d.mts
@@ -43,6 +43,6 @@ export function validateReleaseIntentRecord(
   dependencies?: ReleaseIntentValidationDependencies,
 ): ReleaseIntentRecord;
 export function validateReleaseIntentRecords(
-  records: unknown[],
+  records: unknown,
   options: ReleaseIntentValidationDependencies & { candidateVersion: string },
 ): ReleaseIntentRecord[];

--- a/tooling/release/release-intents.d.mts
+++ b/tooling/release/release-intents.d.mts
@@ -1,0 +1,48 @@
+export type WorkspacePackageManifestRecord = {
+  manifest: Record<string, unknown> & {
+    name: string;
+    private?: boolean;
+    publishConfig?: {
+      access?: string;
+    };
+  };
+  packageJsonPath: string;
+};
+
+export type ReleaseIntentPackageEntry = {
+  breaking?: boolean;
+  disposition: 'release' | 'no-release' | 'downstream-evaluate';
+  migrationNote?: string;
+  package: string;
+  rationale: string;
+  semver: 'patch' | 'minor' | 'major' | 'none';
+  summary: string;
+};
+
+export type ReleaseIntentRecord = {
+  packages: ReleaseIntentPackageEntry[];
+  version: string;
+};
+
+export type ReleaseIntentValidationDependencies = {
+  packageManifests?: WorkspacePackageManifestRecord[];
+  publicPackageNames?: string[];
+  repoRoot?: string;
+};
+
+export const firstEnforcedReleaseIntentVersion: string;
+export const releaseIntentDispositions: ReadonlyArray<ReleaseIntentPackageEntry['disposition']>;
+export const releaseIntentSemverIntents: ReadonlyArray<ReleaseIntentPackageEntry['semver']>;
+
+export function compareVersions(left: string, right: string): number;
+export function requiresReleaseIntentRecords(version: string): boolean;
+export function workspacePackageManifests(rootDirectory?: string): WorkspacePackageManifestRecord[];
+export function publicWorkspacePackageNames(packageManifests: WorkspacePackageManifestRecord[]): string[];
+export function validateReleaseIntentRecord(
+  record: unknown,
+  dependencies?: ReleaseIntentValidationDependencies,
+): ReleaseIntentRecord;
+export function validateReleaseIntentRecords(
+  records: unknown[],
+  options: ReleaseIntentValidationDependencies & { candidateVersion: string },
+): ReleaseIntentRecord[];

--- a/tooling/release/release-intents.mjs
+++ b/tooling/release/release-intents.mjs
@@ -188,6 +188,17 @@ export function validateReleaseIntentRecord(record, dependencies = {}) {
       errors.push(`${location}.semver must be one of ${releaseIntentSemverIntents.join(', ')}.`);
     }
 
+    if (packageIntent.disposition === 'release' && packageIntent.semver === 'none') {
+      errors.push(`${location}.semver must be patch, minor, or major when disposition is release.`);
+    }
+
+    if (
+      (packageIntent.disposition === 'no-release' || packageIntent.disposition === 'downstream-evaluate') &&
+      packageIntent.semver !== 'none'
+    ) {
+      errors.push(`${location}.semver must be none when disposition is ${packageIntent.disposition}.`);
+    }
+
     if (!isNonEmptyString(packageIntent.summary)) {
       errors.push(`${location}.summary is required.`);
     }
@@ -219,15 +230,17 @@ export function validateReleaseIntentRecords(records, options = {}) {
     throw new Error('Release intent validation failed: candidateVersion is required.');
   }
 
-  if ((!Array.isArray(records) || records.length === 0) && !requiresReleaseIntentRecords(candidateVersion)) {
+  const normalizedRecords = Array.isArray(records) ? records : records && typeof records === 'object' ? [records] : [];
+
+  if (normalizedRecords.length === 0 && !requiresReleaseIntentRecords(candidateVersion)) {
     return [];
   }
 
-  if (!Array.isArray(records) || records.length === 0) {
+  if (normalizedRecords.length === 0) {
     throw new Error(
       `Release intent validation failed: release intent records are required for ${candidateVersion}; ${firstEnforcedReleaseIntentVersion} is the first enforced fixture/candidate version.`,
     );
   }
 
-  return records.map((record) => validateReleaseIntentRecord(record, options));
+  return normalizedRecords.map((record) => validateReleaseIntentRecord(record, options));
 }

--- a/tooling/release/release-intents.mjs
+++ b/tooling/release/release-intents.mjs
@@ -242,5 +242,28 @@ export function validateReleaseIntentRecords(records, options = {}) {
     );
   }
 
-  return normalizedRecords.map((record) => validateReleaseIntentRecord(record, options));
+  const validatedRecords = normalizedRecords.map((record) => validateReleaseIntentRecord(record, options));
+  const seenCandidatePackageIntents = new Set();
+  const duplicateCandidatePackageIntents = [];
+
+  for (const record of validatedRecords) {
+    for (const packageIntent of record.packages) {
+      const key = `${record.version}:${packageIntent.package}`;
+
+      if (seenCandidatePackageIntents.has(key)) {
+        duplicateCandidatePackageIntents.push(`${record.version} ${packageIntent.package}`);
+        continue;
+      }
+
+      seenCandidatePackageIntents.add(key);
+    }
+  }
+
+  if (duplicateCandidatePackageIntents.length > 0) {
+    throw new Error(
+      `Release intent validation failed: duplicate package intents across records: ${duplicateCandidatePackageIntents.join(', ')}.`,
+    );
+  }
+
+  return validatedRecords;
 }

--- a/tooling/release/release-intents.mjs
+++ b/tooling/release/release-intents.mjs
@@ -1,0 +1,233 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDirectory, '..', '..');
+
+export const firstEnforcedReleaseIntentVersion = '1.0.0-beta.2';
+export const releaseIntentDispositions = ['release', 'no-release', 'downstream-evaluate'];
+export const releaseIntentSemverIntents = ['patch', 'minor', 'major', 'none'];
+
+function comparePrerelease(left, right) {
+  if (left === right) {
+    return 0;
+  }
+
+  if (!left) {
+    return 1;
+  }
+
+  if (!right) {
+    return -1;
+  }
+
+  const leftParts = left.split('.');
+  const rightParts = right.split('.');
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = leftParts[index];
+    const rightPart = rightParts[index];
+
+    if (leftPart === undefined) {
+      return -1;
+    }
+
+    if (rightPart === undefined) {
+      return 1;
+    }
+
+    const leftNumber = /^\d+$/u.test(leftPart) ? Number(leftPart) : null;
+    const rightNumber = /^\d+$/u.test(rightPart) ? Number(rightPart) : null;
+
+    if (leftNumber !== null && rightNumber !== null) {
+      if (leftNumber !== rightNumber) {
+        return leftNumber > rightNumber ? 1 : -1;
+      }
+
+      continue;
+    }
+
+    if (leftNumber !== null) {
+      return -1;
+    }
+
+    if (rightNumber !== null) {
+      return 1;
+    }
+
+    if (leftPart !== rightPart) {
+      return leftPart > rightPart ? 1 : -1;
+    }
+  }
+
+  return 0;
+}
+
+function parseComparableVersion(version) {
+  const match = String(version).match(/^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<prerelease>[0-9A-Za-z.-]+))?$/u);
+
+  if (!match?.groups) {
+    throw new Error(`Cannot compare release intent version ${version}.`);
+  }
+
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+    prerelease: match.groups.prerelease ?? '',
+  };
+}
+
+export function compareVersions(left, right) {
+  const leftVersion = parseComparableVersion(left);
+  const rightVersion = parseComparableVersion(right);
+
+  for (const key of ['major', 'minor', 'patch']) {
+    if (leftVersion[key] !== rightVersion[key]) {
+      return leftVersion[key] > rightVersion[key] ? 1 : -1;
+    }
+  }
+
+  return comparePrerelease(leftVersion.prerelease, rightVersion.prerelease);
+}
+
+export function requiresReleaseIntentRecords(version) {
+  return compareVersions(version, firstEnforcedReleaseIntentVersion) >= 0;
+}
+
+export function workspacePackageManifests(rootDirectory = repoRoot) {
+  const packagesDirectory = join(rootDirectory, 'packages');
+  const manifests = [];
+
+  for (const entry of readdirSync(packagesDirectory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const packageJsonPath = join(packagesDirectory, entry.name, 'package.json');
+
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+    if (typeof manifest.name === 'string') {
+      manifests.push({ manifest, packageJsonPath });
+    }
+  }
+
+  return manifests.sort((left, right) => left.manifest.name.localeCompare(right.manifest.name));
+}
+
+export function publicWorkspacePackageNames(packageManifests) {
+  return packageManifests
+    .filter(
+      ({ manifest }) =>
+        typeof manifest.name === 'string' &&
+        manifest.name.startsWith('@fluojs/') &&
+        manifest.private !== true &&
+        manifest.publishConfig?.access === 'public',
+    )
+    .map(({ manifest }) => manifest.name)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function locationFor(index) {
+  return `packages[${index}]`;
+}
+
+export function validateReleaseIntentRecord(record, dependencies = {}) {
+  const errors = [];
+  const packageManifests = dependencies.packageManifests ?? workspacePackageManifests(dependencies.repoRoot ?? repoRoot);
+  const publicPackageSet = new Set(dependencies.publicPackageNames ?? publicWorkspacePackageNames(packageManifests));
+
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    throw new Error('Release intent validation failed: intent record must be an object.');
+  }
+
+  if (!isNonEmptyString(record.version)) {
+    errors.push('version is required.');
+  }
+
+  if (!Array.isArray(record.packages) || record.packages.length === 0) {
+    errors.push('packages must include at least one affected package entry.');
+  }
+
+  const seenPackages = new Set();
+
+  for (const [index, packageIntent] of Array.isArray(record.packages) ? record.packages.entries() : []) {
+    const location = locationFor(index);
+
+    if (!packageIntent || typeof packageIntent !== 'object' || Array.isArray(packageIntent)) {
+      errors.push(`${location} must be an object.`);
+      continue;
+    }
+
+    if (!isNonEmptyString(packageIntent.package)) {
+      errors.push(`${location}.package is required.`);
+    } else if (!publicPackageSet.has(packageIntent.package)) {
+      errors.push(`${location}.package references unknown public workspace package ${packageIntent.package}.`);
+    } else if (seenPackages.has(packageIntent.package)) {
+      errors.push(`${location}.package duplicates ${packageIntent.package}.`);
+    } else {
+      seenPackages.add(packageIntent.package);
+    }
+
+    if (!releaseIntentDispositions.includes(packageIntent.disposition)) {
+      errors.push(`${location}.disposition must be one of ${releaseIntentDispositions.join(', ')}.`);
+    }
+
+    if (!releaseIntentSemverIntents.includes(packageIntent.semver)) {
+      errors.push(`${location}.semver must be one of ${releaseIntentSemverIntents.join(', ')}.`);
+    }
+
+    if (!isNonEmptyString(packageIntent.summary)) {
+      errors.push(`${location}.summary is required.`);
+    }
+
+    if (!isNonEmptyString(packageIntent.rationale)) {
+      errors.push(`${location}.rationale is required.`);
+    }
+
+    const isBreakingIntent = packageIntent.semver === 'major' || packageIntent.breaking === true;
+    if (isBreakingIntent && !isNonEmptyString(packageIntent.migrationNote)) {
+      errors.push(`${location}.migrationNote is required for major or breaking release intents.`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Release intent validation failed: ${errors.join(' ')}`);
+  }
+
+  return {
+    packages: record.packages.map((packageIntent) => ({ ...packageIntent })),
+    version: record.version,
+  };
+}
+
+export function validateReleaseIntentRecords(records, options = {}) {
+  const candidateVersion = options.candidateVersion;
+
+  if (!isNonEmptyString(candidateVersion)) {
+    throw new Error('Release intent validation failed: candidateVersion is required.');
+  }
+
+  if ((!Array.isArray(records) || records.length === 0) && !requiresReleaseIntentRecords(candidateVersion)) {
+    return [];
+  }
+
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error(
+      `Release intent validation failed: release intent records are required for ${candidateVersion}; ${firstEnforcedReleaseIntentVersion} is the first enforced fixture/candidate version.`,
+    );
+  }
+
+  return records.map((record) => validateReleaseIntentRecord(record, options));
+}

--- a/tooling/release/release-intents.test.ts
+++ b/tooling/release/release-intents.test.ts
@@ -148,6 +148,44 @@ describe('validateReleaseIntentRecord', () => {
       ),
     ).toThrowError(/unknown public workspace package @fluojs\/not-a-package/u);
   });
+
+  it('fails when a release intent omits a semver bump', () => {
+    expect(() =>
+      validateReleaseIntentRecord(
+        createRecord({
+          packages: [
+            {
+              disposition: 'release',
+              package: '@fluojs/cli',
+              rationale: 'The CLI package is being published.',
+              semver: 'none',
+              summary: 'Invalid release intent should fail validation.',
+            },
+          ],
+        }),
+        dependencies(),
+      ),
+    ).toThrowError(/semver must be patch, minor, or major when disposition is release/u);
+  });
+
+  it.each(['no-release', 'downstream-evaluate'])('fails when %s carries a semver bump', (disposition) => {
+    expect(() =>
+      validateReleaseIntentRecord(
+        createRecord({
+          packages: [
+            {
+              disposition,
+              package: '@fluojs/cli',
+              rationale: 'The CLI package is not being published.',
+              semver: 'patch',
+              summary: 'Invalid non-release intent should fail validation.',
+            },
+          ],
+        }),
+        dependencies(),
+      ),
+    ).toThrowError(new RegExp(`semver must be none when disposition is ${disposition}`, 'u'));
+  });
 });
 
 describe('validateReleaseIntentRecords', () => {
@@ -162,5 +200,11 @@ describe('validateReleaseIntentRecords', () => {
     expect(() => validateReleaseIntentRecords([], { ...dependencies(), candidateVersion: '1.0.0-beta.2' })).toThrowError(
       /release intent records are required.*1\.0\.0-beta\.2/u,
     );
+  });
+
+  it('accepts one committed JSON record object as a release intent record set', () => {
+    expect(validateReleaseIntentRecords(createRecord(), { ...dependencies(), candidateVersion: '1.0.0-beta.2' })).toEqual([
+      expect.objectContaining({ version: '1.0.0-beta.2' }),
+    ]);
   });
 });

--- a/tooling/release/release-intents.test.ts
+++ b/tooling/release/release-intents.test.ts
@@ -207,4 +207,35 @@ describe('validateReleaseIntentRecords', () => {
       expect.objectContaining({ version: '1.0.0-beta.2' }),
     ]);
   });
+
+  it('fails when the same package intent appears in multiple records for the same version', () => {
+    expect(() =>
+      validateReleaseIntentRecords(
+        [
+          createRecord({
+            packages: [
+              {
+                disposition: 'no-release',
+                package: '@fluojs/cli',
+                rationale: 'The CLI package is not being published in this candidate.',
+                semver: 'none',
+                summary: 'Do not release CLI in beta.2.',
+              },
+            ],
+          }),
+          createRecord(),
+        ],
+        { ...dependencies(), candidateVersion: '1.0.0-beta.2' },
+      ),
+    ).toThrowError(/duplicate package intents across records: 1\.0\.0-beta\.2 @fluojs\/cli/u);
+  });
+
+  it('allows the same package to appear in records for different versions', () => {
+    const result = validateReleaseIntentRecords(
+      [createRecord({ version: '1.0.0-beta.2' }), createRecord({ version: '1.0.0-beta.3' })],
+      { ...dependencies(), candidateVersion: '1.0.0-beta.3' },
+    );
+
+    expect(result.map((record) => record.version)).toEqual(['1.0.0-beta.2', '1.0.0-beta.3']);
+  });
 });

--- a/tooling/release/release-intents.test.ts
+++ b/tooling/release/release-intents.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest';
+import {
+  firstEnforcedReleaseIntentVersion,
+  requiresReleaseIntentRecords,
+  validateReleaseIntentRecord,
+  validateReleaseIntentRecords,
+} from './release-intents.mjs';
+
+const publicPackageNames = ['@fluojs/cli', '@fluojs/core'];
+const packageManifests = publicPackageNames.map((packageName) => ({
+  manifest: {
+    name: packageName,
+    private: false,
+    publishConfig: { access: 'public' },
+  },
+  packageJsonPath: `/repo/packages/${packageName.slice('@fluojs/'.length)}/package.json`,
+}));
+
+function createRecord(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    packages: [
+      {
+        disposition: 'release',
+        package: '@fluojs/cli',
+        rationale: 'The CLI package owns the affected generated starter contract.',
+        semver: 'patch',
+        summary: 'Clarify CLI startup behavior for the beta.2 candidate.',
+      },
+    ],
+    version: firstEnforcedReleaseIntentVersion,
+    ...overrides,
+  };
+}
+
+function dependencies() {
+  return {
+    packageManifests,
+    publicPackageNames,
+  };
+}
+
+describe('validateReleaseIntentRecord', () => {
+  it('accepts a valid @fluojs/cli patch release intent', () => {
+    const result = validateReleaseIntentRecord(createRecord(), dependencies());
+
+    expect(result.version).toBe('1.0.0-beta.2');
+    expect(result.packages).toEqual([
+      expect.objectContaining({
+        disposition: 'release',
+        package: '@fluojs/cli',
+        semver: 'patch',
+        summary: 'Clarify CLI startup behavior for the beta.2 candidate.',
+      }),
+    ]);
+  });
+
+  it('fails when required fields are missing', () => {
+    expect(() =>
+      validateReleaseIntentRecord(
+        createRecord({
+          packages: [
+            {
+              package: '@fluojs/cli',
+            },
+          ],
+          version: '',
+        }),
+        dependencies(),
+      ),
+    ).toThrowError(/version is required.*disposition.*semver.*summary.*rationale/u);
+  });
+
+  it('fails when a major intent omits a migration note', () => {
+    expect(() =>
+      validateReleaseIntentRecord(
+        createRecord({
+          packages: [
+            {
+              disposition: 'release',
+              package: '@fluojs/cli',
+              rationale: 'The CLI package owns the affected generated starter contract.',
+              semver: 'major',
+              summary: 'Remove a documented CLI option.',
+            },
+          ],
+        }),
+        dependencies(),
+      ),
+    ).toThrowError(/migrationNote is required for major or breaking release intents/u);
+  });
+
+  it('fails when an explicit breaking intent omits a migration note', () => {
+    expect(() =>
+      validateReleaseIntentRecord(
+        createRecord({
+          packages: [
+            {
+              breaking: true,
+              disposition: 'release',
+              package: '@fluojs/cli',
+              rationale: 'The CLI package owns the affected generated starter contract.',
+              semver: 'minor',
+              summary: 'Change CLI bootstrap defaults during preview stabilization.',
+            },
+          ],
+        }),
+        dependencies(),
+      ),
+    ).toThrowError(/migrationNote is required for major or breaking release intents/u);
+  });
+
+  it('accepts a breaking intent when a migration note is present', () => {
+    expect(() =>
+      validateReleaseIntentRecord(
+        createRecord({
+          packages: [
+            {
+              breaking: true,
+              disposition: 'release',
+              migrationNote: 'Regenerate starters with `fluo new` or update `src/main.ts` to the adapter-first bootstrap.',
+              package: '@fluojs/cli',
+              rationale: 'The CLI package owns the affected generated starter contract.',
+              semver: 'minor',
+              summary: 'Change CLI bootstrap defaults during preview stabilization.',
+            },
+          ],
+        }),
+        dependencies(),
+      ),
+    ).not.toThrow();
+  });
+
+  it('fails when an intent references an unknown public package', () => {
+    expect(() =>
+      validateReleaseIntentRecord(
+        createRecord({
+          packages: [
+            {
+              disposition: 'release',
+              package: '@fluojs/not-a-package',
+              rationale: 'This package does not exist in the public workspace surface.',
+              semver: 'patch',
+              summary: 'Invalid package should fail validation.',
+            },
+          ],
+        }),
+        dependencies(),
+      ),
+    ).toThrowError(/unknown public workspace package @fluojs\/not-a-package/u);
+  });
+});
+
+describe('validateReleaseIntentRecords', () => {
+  it('does not require backfilled intent records through 1.0.0-beta.1', () => {
+    expect(validateReleaseIntentRecords([], { ...dependencies(), candidateVersion: '1.0.0-beta.1' })).toEqual([]);
+    expect(requiresReleaseIntentRecords('1.0.0-beta.1')).toBe(false);
+  });
+
+  it('requires fixture/candidate intent records from 1.0.0-beta.2 onward', () => {
+    expect(requiresReleaseIntentRecords('1.0.0-beta.2')).toBe(true);
+    expect(requiresReleaseIntentRecords('1.0.0')).toBe(true);
+    expect(() => validateReleaseIntentRecords([], { ...dependencies(), candidateVersion: '1.0.0-beta.2' })).toThrowError(
+      /release intent records are required.*1\.0\.0-beta\.2/u,
+    );
+  });
+});

--- a/tooling/release/verify-release-readiness.d.mts
+++ b/tooling/release/verify-release-readiness.d.mts
@@ -1,3 +1,5 @@
+import type { ReleaseIntentRecord } from './release-intents.mjs';
+
 export type ReleaseReadinessCheck = {
   detail: string;
   label: string;
@@ -10,6 +12,8 @@ export type ReleaseReadinessDependencies = {
     packageJsonPath: string;
   }>;
   isPublishedVersion?: (packageName: string, version: string) => boolean;
+  isReleaseTagExisting?: (tag: string) => boolean;
+  hasReleaseNotesForPackage?: (changelog: string, packageName: string, version: string) => boolean;
   run?: (command: string, args: string[]) => void;
   read?: (relativePath: string) => string;
   existsSync?: (targetPath: string) => boolean;
@@ -27,7 +31,10 @@ export type ReleaseReadinessResult = {
 
 export function runReleaseReadinessVerification(
   options?: {
+    changedPackages?: string[];
     distTag?: string;
+    releaseIntentFile?: string;
+    releaseIntentRecords?: ReleaseIntentRecord[];
     summaryOutputDirectory?: string;
     targetPackage?: string;
     targetVersion?: string;

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -2,6 +2,9 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { expandPublicPackageDependencyImpact } from './dependency-impact.mjs';
+import { buildGitHubReleaseNotes } from './prepare-github-release.mjs';
+import { requiresReleaseIntentRecords, validateReleaseIntentRecords } from './release-intents.mjs';
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDirectory, '..', '..');
@@ -32,6 +35,8 @@ function parseCliOptions(argv = process.argv.slice(2)) {
   let targetPackage;
   let targetVersion;
   let distTag;
+  let releaseIntentFile;
+  const changedPackages = [];
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
@@ -90,6 +95,28 @@ function parseCliOptions(argv = process.argv.slice(2)) {
       continue;
     }
 
+    if (argument === '--changed-package') {
+      changedPackages.push(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--changed-package=')) {
+      changedPackages.push(argument.slice('--changed-package='.length));
+      continue;
+    }
+
+    if (argument === '--release-intent-file') {
+      releaseIntentFile = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (argument.startsWith('--release-intent-file=')) {
+      releaseIntentFile = argument.slice('--release-intent-file='.length);
+      continue;
+    }
+
     throw new Error(`Unknown option: ${argument}`);
   }
 
@@ -102,10 +129,12 @@ function parseCliOptions(argv = process.argv.slice(2)) {
   }
 
   return {
+    changedPackages: changedPackages.filter((packageName) => typeof packageName === 'string' && packageName.length > 0),
     distTag,
     summaryOutputDirectory,
     targetPackage,
     targetVersion,
+    releaseIntentFile,
     writeDrafts,
     writeSummary,
   };
@@ -189,6 +218,51 @@ function isPublishedVersion(packageName, version) {
   throw new Error(
     `Release readiness check failed: Unable to query npm for ${packageName}@${version}. ${stderr.trim() || 'npm view failed.'}`,
   );
+}
+
+function releaseTagForPackageVersion(packageName, version) {
+  return `${packageName}@${version}`;
+}
+
+function isReleaseTagExisting(tag) {
+  const localResult = spawnSync('git', ['rev-parse', '--verify', '--quiet', `refs/tags/${tag}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (localResult.status === 0) {
+    return true;
+  }
+
+  if (localResult.status !== 1) {
+    throw new Error(
+      `Release readiness check failed: Unable to query local git tag ${tag}. ${(localResult.stderr ?? '').trim() || 'git rev-parse failed.'}`,
+    );
+  }
+
+  const remoteResult = spawnSync('git', ['ls-remote', '--exit-code', '--tags', 'origin', `refs/tags/${tag}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (remoteResult.status === 0) {
+    return true;
+  }
+
+  if (remoteResult.status === 2) {
+    return false;
+  }
+
+  throw new Error(
+    `Release readiness check failed: Unable to query remote git tag ${tag}. ${(remoteResult.stderr ?? '').trim() || 'git ls-remote failed.'}`,
+  );
+}
+
+function hasReleaseNotesForPackage(changelog, packageName, version) {
+  buildGitHubReleaseNotes(releaseTagForPackageVersion(packageName, version), changelog);
+  return true;
 }
 
 function assertCheck(checks, label, condition, detail) {
@@ -385,6 +459,138 @@ function collectSinglePackageDependencyShapeViolations(targetManifest, workspace
   return sorted(violations);
 }
 
+
+function uniqueSortedPackageNames(packageNames) {
+  if (!Array.isArray(packageNames)) {
+    throw new Error('Release readiness check failed: changedPackages must be an array of package names.');
+  }
+
+  return sorted(
+    new Set(
+      packageNames.map((packageName) => {
+        if (typeof packageName !== 'string' || packageName.trim().length === 0) {
+          throw new Error('Release readiness check failed: changedPackages entries must be non-empty package names.');
+        }
+
+        return packageName.trim();
+      }),
+    ),
+  );
+}
+
+function releaseIntentRecordsFromOptions(options, dependencies = {}) {
+  if (Array.isArray(options.releaseIntentRecords)) {
+    return options.releaseIntentRecords;
+  }
+
+  if (typeof options.releaseIntentFile === 'string' && options.releaseIntentFile.length > 0) {
+    const readFile = dependencies.readFileSync ?? readFileSync;
+    const releaseIntentPath = resolve(repoRoot, options.releaseIntentFile);
+    return JSON.parse(readFile(releaseIntentPath, 'utf8'));
+  }
+
+  return [];
+}
+
+function collectReleaseIntentPackageEntries(records) {
+  const entries = new Map();
+
+  for (const record of records) {
+    for (const packageIntent of record.packages) {
+      entries.set(packageIntent.package, packageIntent);
+    }
+  }
+
+  return entries;
+}
+
+function verifyReleaseIntentReadiness(checks, options, packageManifests, publicPackageNames, dependencies = {}) {
+  const { targetPackage, targetVersion } = options;
+  const hasTargetRelease = typeof targetPackage === 'string' && typeof targetVersion === 'string';
+  const targetRequiresIntent = hasTargetRelease && requiresReleaseIntentRecords(targetVersion);
+  const rawChangedPackages = Array.isArray(options.changedPackages) && options.changedPackages.length > 0
+    ? options.changedPackages
+    : targetRequiresIntent
+      ? [targetPackage]
+      : [];
+  const changedPackages = uniqueSortedPackageNames(rawChangedPackages);
+  const rawReleaseIntentRecords = releaseIntentRecordsFromOptions(options, dependencies);
+  const hasExplicitReleaseIntentRecords = rawReleaseIntentRecords.length > 0;
+  const shouldValidateIntentRecords = targetRequiresIntent || hasExplicitReleaseIntentRecords;
+
+  if (!shouldValidateIntentRecords) {
+    return;
+  }
+
+  assertCheck(
+    checks,
+    'Release intent candidate version',
+    typeof targetVersion === 'string' && isValidSemver(targetVersion),
+    'Release intent readiness requires a target SemVer candidate version when changed packages or intent records are supplied.',
+  );
+
+  const validatedRecords = validateReleaseIntentRecords(rawReleaseIntentRecords, {
+    candidateVersion: targetVersion,
+    packageManifests,
+    publicPackageNames,
+  });
+  const candidateIntentRecords = validatedRecords.filter((record) => record.version === targetVersion);
+  const intentByPackage = collectReleaseIntentPackageEntries(candidateIntentRecords);
+  const publicPackageSet = new Set(publicPackageNames);
+  const unknownChangedPackages = changedPackages.filter((packageName) => !publicPackageSet.has(packageName));
+
+  assertCheck(
+    checks,
+    'Release intent affected package membership',
+    unknownChangedPackages.length === 0,
+    unknownChangedPackages.length === 0
+      ? 'All explicitly changed packages are public packages in the intended publish surface.'
+      : `Changed package(s) must be public packages in the intended publish surface: ${unknownChangedPackages.join(', ')}.`,
+  );
+
+  const impactedPackages = expandPublicPackageDependencyImpact(changedPackages, { packageManifests });
+  const missingIntentPackages = impactedPackages
+    .filter(({ package: packageName }) => !intentByPackage.has(packageName))
+    .map(({ package: packageName }) => packageName);
+
+  assertCheck(
+    checks,
+    'Release intent coverage for affected packages',
+    missingIntentPackages.length === 0,
+    missingIntentPackages.length === 0
+      ? 'Every changed public package and downstream public impact has an explicit release intent or evaluation decision.'
+      : `Missing release intent or evaluation decision for affected package(s): ${missingIntentPackages.join(', ')}.`,
+  );
+
+  if (hasTargetRelease && requiresReleaseIntentRecords(targetVersion)) {
+    const targetIntent = intentByPackage.get(targetPackage);
+
+    assertCheck(
+      checks,
+      'Single-package release target intent disposition',
+      targetIntent?.disposition === 'release',
+      `Target package ${targetPackage} must have a release intent with disposition \`release\` for ${targetVersion}.`,
+    );
+  }
+
+  const invalidDownstreamDecisions = impactedPackages
+    .filter(({ disposition }) => disposition === 'downstream-evaluate')
+    .filter(({ package: packageName }) => {
+      const intent = intentByPackage.get(packageName);
+      return intent?.disposition !== 'downstream-evaluate' && intent?.disposition !== 'no-release';
+    })
+    .map(({ package: packageName }) => `${packageName} (${intentByPackage.get(packageName)?.disposition ?? 'missing'})`);
+
+  assertCheck(
+    checks,
+    'Release intent downstream evaluation decisions',
+    invalidDownstreamDecisions.length === 0,
+    invalidDownstreamDecisions.length === 0
+      ? 'Downstream public package impacts have explicit `downstream-evaluate` or `no-release` decisions.'
+      : `Downstream package(s) need explicit \`downstream-evaluate\` or \`no-release\` decisions: ${invalidDownstreamDecisions.join(', ')}.`,
+  );
+}
+
 function verifySinglePackageReleasePreflight(checks, options, packageManifests, publicPackageNames, dependencies = {}) {
   const { targetPackage, targetVersion, distTag } = options;
 
@@ -395,9 +601,12 @@ function verifySinglePackageReleasePreflight(checks, options, packageManifests, 
   const manifestMap = workspaceManifestByName(packageManifests);
   const publicPackageSet = new Set(publicPackageNames);
   const registryVersionExists = dependencies.isPublishedVersion ?? isPublishedVersion;
+  const releaseTagExists = dependencies.isReleaseTagExisting ?? isReleaseTagExisting;
+  const validateReleaseNotes = dependencies.hasReleaseNotesForPackage ?? hasReleaseNotesForPackage;
   const targetPackageRecord = manifestMap.get(targetPackage);
   const targetPackagePath = packageRelativePath(targetPackage);
   const isPrerelease = isPrereleaseVersion(targetVersion);
+  const releaseTag = releaseTagForPackageVersion(targetPackage, targetVersion);
 
   assertCheck(
     checks,
@@ -444,6 +653,18 @@ function verifySinglePackageReleasePreflight(checks, options, packageManifests, 
       targetPackageRecord.manifest.private !== true &&
       targetPackageRecord.manifest.publishConfig?.access === 'public',
     `${targetPackage} must remain a public workspace package with publishConfig.access set to \`public\`.`,
+  );
+  assertCheck(
+    checks,
+    'Single-package release package notes',
+    validateReleaseNotes(dependencies.changelog, targetPackage, targetVersion),
+    `CHANGELOG.md must include package release notes for ${targetPackage} ${targetVersion} before publish.`,
+  );
+  assertCheck(
+    checks,
+    'Single-package release target git tag absence',
+    !releaseTagExists(releaseTag),
+    `${releaseTag} already exists locally or on origin and cannot be recreated.`,
   );
   assertCheck(
     checks,
@@ -565,7 +786,7 @@ function upsertReleaseCandidateDraft(dependencies = {}) {
 }
 
 export function runReleaseReadinessVerification(options = {}, dependencies = {}) {
-  const { distTag, summaryOutputDirectory, targetPackage, targetVersion, writeDrafts = false, writeSummary: shouldWriteSummary = false } = options;
+  const { changedPackages = [], distTag, releaseIntentFile, releaseIntentRecords, summaryOutputDirectory, targetPackage, targetVersion, writeDrafts = false, writeSummary: shouldWriteSummary = false } = options;
   const {
     isPublishedVersion: registryVersionExists = isPublishedVersion,
     run: runCommand = run,
@@ -708,8 +929,18 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
       ? 'Intended public package manifests use `workspace:^` for internal `@fluojs/*` dependencies across dependency, optional, peer, and dev dependency fields.'
       : `Use exact \`workspace:^\` ranges for internal public package dependencies in: ${publicWorkspaceProtocolViolations.join('; ')}`,
   );
+  verifyReleaseIntentReadiness(
+    checks,
+    { changedPackages, releaseIntentFile, releaseIntentRecords, targetPackage, targetVersion },
+    packageManifests,
+    governancePackageList,
+    { readFileSync: readFile },
+  );
   verifySinglePackageReleasePreflight(checks, { distTag, targetPackage, targetVersion }, packageManifests, governancePackageList, {
+    changelog,
+    hasReleaseNotesForPackage: dependencies.hasReleaseNotesForPackage,
     isPublishedVersion: registryVersionExists,
+    isReleaseTagExisting: dependencies.isReleaseTagExisting,
   });
 
   if (writeDrafts) {

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -349,6 +349,39 @@ describe('runReleaseReadinessVerification', () => {
     expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', '1.0.0-beta.2');
   });
 
+  it('accepts a file-based single release intent record matching the committed schema example', () => {
+    const dependencies = createDependencies();
+    dependencies.readFileSync = vi.fn((targetPath: string) => {
+      if (String(targetPath).endsWith('/tooling/release/intents/cli-beta.2.json')) {
+        return JSON.stringify(createCliReleaseIntentRecord());
+      }
+
+      throw new Error(`Unexpected file read: ${targetPath}`);
+    });
+
+    const result = runReleaseReadinessVerification(
+      {
+        distTag: 'beta',
+        releaseIntentFile: 'tooling/release/intents/cli-beta.2.json',
+        targetPackage: '@fluojs/cli',
+        targetVersion: '1.0.0-beta.2',
+      },
+      dependencies,
+    );
+
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Release intent coverage for affected packages', pass: true }),
+        expect.objectContaining({ label: 'Single-package release target intent disposition', pass: true }),
+      ]),
+    );
+    expect(dependencies.readFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('/tooling/release/intents/cli-beta.2.json'),
+      'utf8',
+    );
+    expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', '1.0.0-beta.2');
+  });
+
   it('fails when a changed public package has no release intent after the cutoff', () => {
     const dependencies = createDependencies();
 

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -7,6 +7,40 @@ type WorkspacePackageManifestRecord = {
 };
 
 function createDependencies() {
+  const changelog = `# Changelog
+
+## [Unreleased]
+
+## [1.0.0-beta.2] - 2026-04-25
+
+### @fluojs/cli
+
+- CLI package-specific release note for beta.2.
+
+### @fluojs/studio
+
+- Studio package-specific release note for beta.2.
+
+## [1.0.0-beta.1] - 2026-04-24
+
+### Changed
+
+- Legacy prerelease CLI release note before intent enforcement.
+
+## [0.1.0] - 2026-04-16
+
+### Changed
+
+- Stable CLI release note.
+
+## [0.1.0-beta.1] - 2026-04-15
+
+### Changed
+
+- Prerelease CLI release note.
+
+## [0.0.0]
+`;
   const docs = new Map([
     ['docs/getting-started/quick-start.md', 'pnpm add -g @fluojs/cli\nfluo new my-fluo-app\nThe fluo CLI is your central tool for project scaffolding and component generation.'],
     ['CONTRIBUTING.md', 'pnpm sandbox:create\npnpm sandbox:verify\npnpm sandbox:test'],
@@ -22,10 +56,11 @@ function createDependencies() {
       "const RuntimeHealthModule = createHealthModule();\n@Controller('/health-info')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateHealthModule\ncreateFastifyAdapter",
     ],
     ['packages/cli/package.json', JSON.stringify({ bin: { fluo: './bin/fluo.mjs' }, main: './dist/index.js' })],
-    ['CHANGELOG.md', '# Changelog\n\n## [Unreleased]\n\n## [0.0.0]\n'],
+    ['CHANGELOG.md', changelog],
   ]);
 
   return {
+    isReleaseTagExisting: vi.fn(() => false),
     isPublishedVersion: vi.fn(() => false),
     run: vi.fn(),
     read: vi.fn((relativePath) => {
@@ -60,9 +95,83 @@ function createDependencies() {
       },
     ]),
     mkdirSync: vi.fn(),
-    readFileSync: vi.fn(() => '# Changelog\n\n## [Unreleased]\n'),
+    readFileSync: vi.fn(() => changelog),
     writeFileSync: vi.fn(),
   };
+}
+
+function createReleaseIntentRecord(
+  version: string,
+  packages: Array<{
+    disposition: 'release' | 'no-release' | 'downstream-evaluate';
+    package: string;
+    semver?: 'patch' | 'minor' | 'major' | 'none';
+  }>,
+) {
+  return {
+    version,
+    packages: packages.map((packageIntent) => ({
+      disposition: packageIntent.disposition,
+      package: packageIntent.package,
+      rationale: `${packageIntent.package} ${packageIntent.disposition} rationale`,
+      semver: packageIntent.semver ?? (packageIntent.disposition === 'release' ? 'patch' : 'none'),
+      summary: `${packageIntent.package} ${packageIntent.disposition} summary`,
+    })),
+  };
+}
+
+function createCliReleaseIntentRecord(version = '1.0.0-beta.2') {
+  return createReleaseIntentRecord(version, [{ disposition: 'release', package: '@fluojs/cli' }]);
+}
+
+function modelCoreWithCliAndStudioDownstreams(dependencies: ReturnType<typeof createDependencies>) {
+  const baseRead = dependencies.read;
+
+  dependencies.read = vi.fn((relativePath) => {
+    if (relativePath === 'docs/contracts/release-governance.md') {
+      return '## intended publish surface\n- `@fluojs/cli`\n- `@fluojs/core`\n- `@fluojs/studio`\n\npnpm verify:release-readiness\npnpm verify:platform-consistency-governance';
+    }
+
+    if (relativePath === 'docs/reference/package-surface.md') {
+      return '## public package families\n| Core | `@fluojs/cli` `@fluojs/core` `@fluojs/studio` |';
+    }
+
+    return baseRead(relativePath);
+  });
+  dependencies.workspacePackageNames = vi.fn(() => ['@fluojs/cli', '@fluojs/core', '@fluojs/studio']);
+  dependencies.workspacePackageManifests = vi.fn<() => WorkspacePackageManifestRecord[]>(() => [
+    {
+      manifest: {
+        name: '@fluojs/cli',
+        private: false,
+        publishConfig: { access: 'public' },
+        dependencies: {
+          '@fluojs/core': 'workspace:^',
+        },
+      },
+      packageJsonPath: '/repo/packages/cli/package.json',
+    },
+    {
+      manifest: {
+        name: '@fluojs/core',
+        private: false,
+        publishConfig: { access: 'public' },
+      },
+      packageJsonPath: '/repo/packages/core/package.json',
+    },
+    {
+      manifest: {
+        name: '@fluojs/studio',
+        private: false,
+        publishConfig: { access: 'public' },
+        dependencies: {
+          '@fluojs/core': 'workspace:^',
+        },
+      },
+      packageJsonPath: '/repo/packages/studio/package.json',
+    },
+  ]);
+  (dependencies as ReturnType<typeof createDependencies> & { hasReleaseNotesForPackage: ReturnType<typeof vi.fn> }).hasReleaseNotesForPackage = vi.fn(() => true);
 }
 
 describe('runReleaseReadinessVerification', () => {
@@ -186,7 +295,155 @@ describe('runReleaseReadinessVerification', () => {
     );
 
     expect(result.checks.some((check) => check.label === 'Single-package release internal dependency shape')).toBe(true);
+    expect(result.checks.some((check) => check.label === 'Single-package release package notes')).toBe(true);
+    expect(result.checks.some((check) => check.label === 'Single-package release target git tag absence')).toBe(true);
+    expect(dependencies.isReleaseTagExisting).toHaveBeenCalledWith('@fluojs/cli@0.1.0-beta.1');
     expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', '0.1.0-beta.1');
+  });
+
+  it('does not require release intents for explicit changed packages before the intent cutoff', () => {
+    const dependencies = createDependencies();
+
+    const result = runReleaseReadinessVerification(
+      {
+        changedPackages: ['@fluojs/cli'],
+        distTag: 'next',
+        targetPackage: '@fluojs/cli',
+        targetVersion: '1.0.0-beta.1',
+      },
+      dependencies,
+    );
+
+    expect(result.checks.some((check) => check.label.startsWith('Release intent'))).toBe(false);
+    expect(result.checks.some((check) => check.label === 'Single-package release package notes')).toBe(true);
+    expect(dependencies.isReleaseTagExisting).toHaveBeenCalledWith('@fluojs/cli@1.0.0-beta.1');
+    expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', '1.0.0-beta.1');
+  });
+
+  it('accepts single-package publish preflight for valid package-specific notes after the package-note cutoff', () => {
+    const dependencies = createDependencies();
+
+    const result = runReleaseReadinessVerification(
+      {
+        distTag: 'beta',
+        releaseIntentRecords: [createCliReleaseIntentRecord()],
+        targetPackage: '@fluojs/cli',
+        targetVersion: '1.0.0-beta.2',
+      },
+      dependencies,
+    );
+
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: 'Single-package release package notes',
+          pass: true,
+        }),
+        expect.objectContaining({
+          label: 'Single-package release target git tag absence',
+          pass: true,
+        }),
+      ]),
+    );
+    expect(dependencies.isReleaseTagExisting).toHaveBeenCalledWith('@fluojs/cli@1.0.0-beta.2');
+    expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', '1.0.0-beta.2');
+  });
+
+  it('fails when a changed public package has no release intent after the cutoff', () => {
+    const dependencies = createDependencies();
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          changedPackages: ['@fluojs/cli'],
+          distTag: 'beta',
+          releaseIntentRecords: [
+            createReleaseIntentRecord('1.0.0-beta.2', [{ disposition: 'no-release', package: '@fluojs/core', semver: 'none' }]),
+          ],
+          targetPackage: '@fluojs/cli',
+          targetVersion: '1.0.0-beta.2',
+        },
+        dependencies,
+      ),
+    ).toThrowError(/Missing release intent or evaluation decision for affected package\(s\): @fluojs\/cli/u);
+    expect(dependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('fails when release intent records reference unknown public packages', () => {
+    const dependencies = createDependencies();
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          changedPackages: ['@fluojs/cli'],
+          distTag: 'beta',
+          releaseIntentRecords: [
+            createReleaseIntentRecord('1.0.0-beta.2', [
+              { disposition: 'release', package: '@fluojs/cli' },
+              { disposition: 'no-release', package: '@fluojs/unknown', semver: 'none' },
+            ]),
+          ],
+          targetPackage: '@fluojs/cli',
+          targetVersion: '1.0.0-beta.2',
+        },
+        dependencies,
+      ),
+    ).toThrowError(/references unknown public workspace package @fluojs\/unknown/u);
+  });
+
+  it('fails when downstream impacted packages have no evaluation decision', () => {
+    const dependencies = createDependencies();
+    modelCoreWithCliAndStudioDownstreams(dependencies);
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          changedPackages: ['@fluojs/core'],
+          distTag: 'beta',
+          releaseIntentRecords: [
+            createReleaseIntentRecord('1.0.0-beta.2', [{ disposition: 'release', package: '@fluojs/core' }]),
+          ],
+          targetPackage: '@fluojs/core',
+          targetVersion: '1.0.0-beta.2',
+        },
+        dependencies,
+      ),
+    ).toThrowError(/Missing release intent or evaluation decision.*@fluojs\/cli, @fluojs\/studio/u);
+    expect(dependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('passes with a target release intent and downstream no-release or evaluation decisions', () => {
+    const dependencies = createDependencies();
+    modelCoreWithCliAndStudioDownstreams(dependencies);
+
+    const result = runReleaseReadinessVerification(
+      {
+        changedPackages: ['@fluojs/core'],
+        distTag: 'beta',
+        releaseIntentRecords: [
+          createReleaseIntentRecord('1.0.0-beta.2', [
+            { disposition: 'release', package: '@fluojs/core' },
+            { disposition: 'no-release', package: '@fluojs/cli', semver: 'none' },
+            { disposition: 'downstream-evaluate', package: '@fluojs/studio', semver: 'none' },
+          ]),
+        ],
+        targetPackage: '@fluojs/core',
+        targetVersion: '1.0.0-beta.2',
+      },
+      dependencies,
+    );
+
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Release intent coverage for affected packages', pass: true }),
+        expect.objectContaining({ label: 'Release intent downstream evaluation decisions', pass: true }),
+        expect.objectContaining({ label: 'Single-package release target intent disposition', pass: true }),
+      ]),
+    );
+    expect(dependencies.isReleaseTagExisting).toHaveBeenCalledWith('@fluojs/core@1.0.0-beta.2');
+    expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/core', '1.0.0-beta.2');
   });
 
   it('fails when a single-package prerelease tries to use the latest dist-tag', () => {
@@ -202,6 +459,169 @@ describe('runReleaseReadinessVerification', () => {
         dependencies,
       ),
     ).toThrowError('Release readiness check failed: Single-package release prerelease alignment.');
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('keeps stable releases aligned to the latest dist-tag', () => {
+    const dependencies = createDependencies();
+
+    runReleaseReadinessVerification(
+      {
+        distTag: 'latest',
+        targetPackage: '@fluojs/cli',
+        targetVersion: '0.1.0',
+      },
+      dependencies,
+    );
+
+    expect(dependencies.isPublishedVersion).toHaveBeenCalledWith('@fluojs/cli', '0.1.0');
+  });
+
+  it('fails when a stable single-package release uses a non-latest dist-tag', () => {
+    const dependencies = createDependencies();
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'beta',
+          targetPackage: '@fluojs/cli',
+          targetVersion: '0.1.0',
+        },
+        dependencies,
+      ),
+    ).toThrowError('Release readiness check failed: Single-package release prerelease alignment.');
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('fails before publish when package-specific notes are missing for the target package and version', () => {
+    const dependencies = createDependencies();
+    dependencies.read = vi.fn((relativePath) => {
+      if (relativePath === 'CHANGELOG.md') {
+        return `# Changelog
+
+## [Unreleased]
+
+## [1.0.0-beta.2] - 2026-04-25
+
+### @fluojs/studio
+
+- Studio package-specific release note for beta.2.
+
+## [0.0.0]
+`;
+      }
+
+      return createDependencies().read(relativePath);
+    });
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'beta',
+          releaseIntentRecords: [createCliReleaseIntentRecord()],
+          targetPackage: '@fluojs/cli',
+          targetVersion: '1.0.0-beta.2',
+        },
+        dependencies,
+      ),
+    ).toThrowError(/Missing package release notes.*@fluojs\/cli.*1\.0\.0-beta\.2/u);
+    expect(dependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('fails before publish when post-cutoff package notes are ambiguous generic notes', () => {
+    const dependencies = createDependencies();
+    dependencies.read = vi.fn((relativePath) => {
+      if (relativePath === 'CHANGELOG.md') {
+        return `# Changelog
+
+## [Unreleased]
+
+## [1.0.0-beta.2] - 2026-04-25
+
+### Changed
+
+- Generic beta.2 note without a package subsection.
+
+## [0.0.0]
+`;
+      }
+
+      return createDependencies().read(relativePath);
+    });
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'beta',
+          releaseIntentRecords: [createCliReleaseIntentRecord()],
+          targetPackage: '@fluojs/cli',
+          targetVersion: '1.0.0-beta.2',
+        },
+        dependencies,
+      ),
+    ).toThrowError(/Ambiguous generic release notes.*@fluojs\/cli.*1\.0\.0-beta\.2/u);
+    expect(dependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('fails before publish when duplicate package notes exist for the target package and version', () => {
+    const dependencies = createDependencies();
+    dependencies.read = vi.fn((relativePath) => {
+      if (relativePath === 'CHANGELOG.md') {
+        return `# Changelog
+
+## [Unreleased]
+
+## [1.0.0-beta.2] - 2026-04-25
+
+### @fluojs/cli
+
+- First CLI note.
+
+### @fluojs/cli
+
+- Duplicate CLI note.
+
+## [0.0.0]
+`;
+      }
+
+      return createDependencies().read(relativePath);
+    });
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'beta',
+          releaseIntentRecords: [createCliReleaseIntentRecord()],
+          targetPackage: '@fluojs/cli',
+          targetVersion: '1.0.0-beta.2',
+        },
+        dependencies,
+      ),
+    ).toThrowError(/Duplicate package release notes.*@fluojs\/cli.*1\.0\.0-beta\.2/u);
+    expect(dependencies.isReleaseTagExisting).not.toHaveBeenCalled();
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
+  });
+
+  it('fails before publish when the target release tag already exists', () => {
+    const dependencies = createDependencies();
+    dependencies.isReleaseTagExisting = vi.fn(() => true);
+
+    expect(() =>
+      runReleaseReadinessVerification(
+        {
+          distTag: 'beta',
+          releaseIntentRecords: [createCliReleaseIntentRecord()],
+          targetPackage: '@fluojs/cli',
+          targetVersion: '1.0.0-beta.2',
+        },
+        dependencies,
+      ),
+    ).toThrowError(/Release readiness check failed: Single-package release target git tag absence.*@fluojs\/cli@1\.0\.0-beta\.2/u);
+    expect(dependencies.isReleaseTagExisting).toHaveBeenCalledWith('@fluojs/cli@1.0.0-beta.2');
+    expect(dependencies.isPublishedVersion).not.toHaveBeenCalled();
   });
 
   it('fails when the single-package target is outside the intended publish surface', () => {


### PR DESCRIPTION
## Summary
- Define package-scoped release metadata governance and defer Changesets/Beachball migration until local intent records are proven.
- Make GitHub Release note extraction package/version-aware and gate single-package publishes on release notes, tag absence, and release intent records.
- Add release-intent validation, dependency-impact evaluation, and a local dry-run matrix for CLI/Studio/Runtime release safety.

## Verification
- pnpm vitest run packages/testing/src/conformance/platform-consistency-governance-docs.test.ts --project packages
- pnpm vitest run --project tooling
- pnpm build
- pnpm typecheck && pnpm verify:platform-consistency-governance && pnpm verify:release-readiness

## Release Safety
- Preserves main-only workflow dispatch, OIDC `id-token: write`, npm registry setup, and `pnpm publish --provenance`.
- Does not publish, create tags, push tags, or dispatch GitHub Actions during local verification.