### PR TITLE
Resolve #1256: Delegate CLI inspect graph rendering to Studio

### DIFF
--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -130,6 +130,14 @@ fluo inspect ./src/app.module.ts --mermaid
 fluo inspect ./src/app.module.ts --json > snapshot.json
 ```
 
+`fluo inspect --mermaid`는 CLI를 런타임 snapshot producer로 유지하고, 그래프 렌더링은 선택적 `@fluojs/studio` 계약에 위임합니다. Mermaid 출력이 필요하면 명령을 실행하는 프로젝트에 Studio를 설치하세요:
+
+```bash
+pnpm add -D @fluojs/studio
+```
+
+Studio가 없으면 CI와 non-interactive 실행은 prompt나 package manager 실행 없이 설치 안내와 함께 빠르게 실패합니다. Interactive 실행에서는 Studio 설치 여부를 물을 수 있지만, 명시적으로 승인되고 구현된 설치 흐름이 없는 한 `fluo inspect`가 package manager install을 실행하지 않습니다.
+
 ## 공개 API
 
 다른 도구 내에서 CLI 동작을 트리거하기 위해 패키지를 프로그래밍 방식으로 사용할 수 있습니다.
@@ -143,7 +151,7 @@ fluo inspect ./src/app.module.ts --json > snapshot.json
 ## 관련 패키지
 
 - **[@fluojs/runtime](../runtime/README.ko.md)**: 검사 및 부트스트랩에 사용되는 기본 엔진입니다.
-- **[@fluojs/studio](../studio/README.ko.md)**: `inspect --json` 출력을 시각화하기 위한 웹 기반 UI입니다.
+- **[@fluojs/studio](../studio/README.ko.md)**: `inspect --json` 출력을 시각화하고 `inspect --mermaid`가 사용하는 canonical renderer를 제공하는 웹 기반 UI입니다.
 - **[@fluojs/testing](../testing/README.ko.md)**: 통합 및 E2E 테스트를 위해 생성된 테스트 템플릿에서 사용됩니다.
 - **[Canonical Runtime Package Matrix](../../docs/reference/package-surface.ko.md)**: 공식 런타임/패키지 조합을 보여주는 기준 문서입니다.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -130,6 +130,14 @@ fluo inspect ./src/app.module.ts --mermaid
 fluo inspect ./src/app.module.ts --json > snapshot.json
 ```
 
+`fluo inspect --mermaid` keeps the CLI as the runtime snapshot producer and delegates graph rendering to the optional `@fluojs/studio` contract. Install Studio in the project that runs the command when you need Mermaid output:
+
+```bash
+pnpm add -D @fluojs/studio
+```
+
+If Studio is missing, CI and other non-interactive runs fail fast with install guidance instead of prompting or running a package manager. Interactive runs may ask whether you want to install Studio, but `fluo inspect` does not run installs unless an explicit install flow is implemented and approved.
+
 ## Public API
 
 The package can be used programmatically to trigger CLI actions from within other tools.
@@ -143,7 +151,7 @@ The package can be used programmatically to trigger CLI actions from within othe
 ## Related Packages
 
 - **[@fluojs/runtime](../runtime/README.md)**: The underlying engine used for inspection and bootstrap.
-- **[@fluojs/studio](../studio/README.md)**: The web-based UI for visualizing `inspect --json` exports.
+- **[@fluojs/studio](../studio/README.md)**: The web-based UI for visualizing `inspect --json` exports and the canonical renderer used by `inspect --mermaid`.
 - **[@fluojs/testing](../testing/README.md)**: Used by generated test templates for integration and E2E testing.
 - **[Canonical Runtime Package Matrix](../../docs/reference/package-surface.md)**: The source of truth for official runtime/package combinations.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,6 +58,14 @@
     "tsx": "^4.20.4",
     "typescript": "^6.0.2"
   },
+  "peerDependencies": {
+    "@fluojs/studio": "workspace:^"
+  },
+  "peerDependenciesMeta": {
+    "@fluojs/studio": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/ejs": "^3.1.5",
     "vitest": "^3.2.4"

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -895,6 +895,7 @@ describe('CLI command runner', () => {
     const stderrBuffer: string[] = [];
 
     const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--mermaid'], {
+      ci: true,
       cwd: process.cwd(),
       interactive: false,
       loadStudioMermaidRenderer: async () => undefined,
@@ -916,6 +917,7 @@ describe('CLI command runner', () => {
     const promptMessages: string[] = [];
 
     const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--mermaid'], {
+      ci: true,
       cwd: process.cwd(),
       interactive: true,
       loadStudioMermaidRenderer: async () => undefined,

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -842,6 +842,7 @@ describe('CLI command runner', () => {
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Usage: fluo inspect <module-path> [options]');
     expect(stdoutBuffer.join('')).toContain('--mermaid');
+    expect(stdoutBuffer.join('')).toContain('@fluojs/studio');
     expect(stdoutBuffer.join('')).toContain('--timing');
     expect(stdoutBuffer.join('')).toContain('Docs: https://github.com/fluojs/fluo/tree/main/docs/getting-started/quick-start.md');
   });
@@ -876,17 +877,69 @@ describe('CLI command runner', () => {
     expect(payload.health.status).toBe('healthy');
   });
 
-  it('emits Mermaid dependency output for inspect', async () => {
+  it('delegates inspect --mermaid output to Studio when resolvable', async () => {
     const stdoutBuffer: string[] = [];
     const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--mermaid'], {
       cwd: process.cwd(),
+      loadStudioMermaidRenderer: async () => (snapshot) => `graph TD\n  STUDIO["components: ${snapshot.components.length}"]`,
       stderr: { write: () => undefined },
       stdout: { write: (message) => stdoutBuffer.push(message) },
     });
 
     expect(exitCode).toBe(0);
-    expect(stdoutBuffer.join('')).toContain('graph TD');
-    expect(stdoutBuffer.join('')).toContain('No registered platform components');
+    expect(stdoutBuffer.join('')).toBe('graph TD\n  STUDIO["components: 0"]\n');
+  });
+
+  it('fails inspect --mermaid without prompting when Studio is missing in non-interactive mode', async () => {
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--mermaid'], {
+      cwd: process.cwd(),
+      interactive: false,
+      loadStudioMermaidRenderer: async () => undefined,
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdin: { isTTY: false },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdoutBuffer.join('')).toBe('');
+    expect(stderrBuffer.join('')).toContain('Mermaid graph rendering is owned by @fluojs/studio');
+    expect(stderrBuffer.join('')).toContain('not resolvable from this project');
+    expect(stderrBuffer.join('')).toContain('pnpm add -D @fluojs/studio');
+  });
+
+  it('fails inspect --mermaid without installing when Studio installation is declined', async () => {
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const promptMessages: string[] = [];
+
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--mermaid'], {
+      cwd: process.cwd(),
+      interactive: true,
+      loadStudioMermaidRenderer: async () => undefined,
+      prompt: {
+        confirm: async (message) => {
+          promptMessages.push(message);
+          return false;
+        },
+        select: async () => {
+          throw new Error('inspect should not request select prompts');
+        },
+        text: async () => {
+          throw new Error('inspect should not request text prompts');
+        },
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdin: { isTTY: true },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(promptMessages).toEqual(['Install @fluojs/studio before rendering Mermaid output?']);
+    expect(stdoutBuffer.join('')).toBe('');
+    expect(stderrBuffer.join('')).toContain('Installation declined; no package-manager command was run.');
   });
 
   it('emits bootstrap timing diagnostics for inspect --timing', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,6 +18,7 @@ type CliStream = {
  * Runtime dependency overrides for embedding the CLI in tests or higher-level tooling.
  */
 export interface CliRuntimeOptions {
+  ci?: boolean;
   cwd?: string;
   stderr?: CliStream;
   stdout?: CliStream;
@@ -283,7 +284,7 @@ function parseCommand(argv: string[]): ParsedCommand {
  * ```
  *
  * @param argv Argument vector to execute. Defaults to the current process arguments without the node/bin prefix.
- * @param runtime Optional runtime overrides shared by the top-level dispatcher and the `new` command.
+ * @param runtime Optional runtime overrides shared by the top-level dispatcher and delegated commands.
  * @returns `0` when the command completes successfully, otherwise `1` after writing the error message to `stderr`.
  */
 export async function runCli(
@@ -388,5 +389,8 @@ export async function runCli(
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
-  process.exitCode = await runCli(undefined, { userAgent: process.env.npm_config_user_agent });
+  process.exitCode = await runCli(undefined, {
+    ci: process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true',
+    userAgent: process.env.npm_config_user_agent,
+  });
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,7 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { runGenerateCommand } from './commands/generate.js';
-import { inspectUsage, runInspectCommand } from './commands/inspect.js';
+import { type InspectCommandRuntimeOptions, inspectUsage, runInspectCommand } from './commands/inspect.js';
 import { migrateUsage, runMigrateCommand } from './commands/migrate.js';
 import { type NewCommandRuntimeOptions, newUsage, runNewCommand } from './commands/new.js';
 import { generatorManifest, resolveGeneratorKind } from './generators/manifest.js';
@@ -288,7 +288,7 @@ function parseCommand(argv: string[]): ParsedCommand {
  */
 export async function runCli(
   argv = process.argv.slice(2),
-  runtime: CliRuntimeOptions & NewCommandRuntimeOptions = {},
+  runtime: CliRuntimeOptions & NewCommandRuntimeOptions & InspectCommandRuntimeOptions = {},
 ): Promise<number> {
   const cwd = runtime.cwd ? resolve(runtime.cwd) : process.cwd();
   const stdout = runtime.stdout ?? process.stdout;

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -35,6 +35,8 @@ type StudioMermaidRendererLoader = (cwd: string) => Promise<StudioMermaidRendere
  * Runtime options for the inspect command when used programmatically.
  */
 export interface InspectCommandRuntimeOptions {
+  /** Whether the caller is running under CI/non-interactive automation. */
+  ci?: boolean;
   /** Current working directory for module resolution. */
   cwd?: string;
   /** Force or disable interactive prompts for optional Studio guidance. */
@@ -237,17 +239,13 @@ function createInspectPrompter(): InspectPrompter {
   };
 }
 
-function isCiEnvironment(): boolean {
-  return process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
-}
-
 function shouldPromptForStudio(runtime: InspectCommandRuntimeOptions): boolean {
-  if (isCiEnvironment()) {
-    return false;
-  }
-
   if (runtime.prompt !== undefined) {
     return runtime.interactive ?? true;
+  }
+
+  if (runtime.ci === true) {
+    return false;
   }
 
   return runtime.stdout === undefined

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,6 +1,8 @@
+import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
 
+import * as clack from '@clack/prompts';
 import {
   FluoFactory,
   type BootstrapTimingDiagnostics,
@@ -16,14 +18,35 @@ type CliStream = {
   write(message: string): unknown;
 };
 
+type InspectPrompter = {
+  close?(): void;
+  confirm(message: string, defaultValue: boolean): Promise<boolean>;
+};
+
+type ReadableStream = {
+  isTTY?: boolean;
+};
+
+type StudioMermaidRenderer = (snapshot: PlatformShellSnapshot) => string;
+
+type StudioMermaidRendererLoader = (cwd: string) => Promise<StudioMermaidRenderer | undefined>;
+
 /**
  * Runtime options for the inspect command when used programmatically.
  */
 export interface InspectCommandRuntimeOptions {
   /** Current working directory for module resolution. */
   cwd?: string;
+  /** Force or disable interactive prompts for optional Studio guidance. */
+  interactive?: boolean;
+  /** Optional test/editor hook for resolving Studio's Mermaid renderer. */
+  loadStudioMermaidRenderer?: StudioMermaidRendererLoader;
+  /** Custom prompt implementation used only when Studio is missing for Mermaid output. */
+  prompt?: InspectPrompter;
   /** Custom stream for error output. */
   stderr?: CliStream;
+  /** Custom stream for terminal detection. */
+  stdin?: ReadableStream;
   /** Custom stream for standard output. */
   stdout?: CliStream;
 }
@@ -50,7 +73,7 @@ const INSPECT_OPTION_HELP: InspectOptionHelpEntry[] = [
   },
   {
     aliases: [],
-    description: 'Emit platform component dependency chains as a Mermaid diagram.',
+    description: 'Emit a Mermaid graph through the optional @fluojs/studio rendering contract.',
     option: '--mermaid',
   },
   {
@@ -69,6 +92,12 @@ const INSPECT_OPTION_HELP: InspectOptionHelpEntry[] = [
     option: '--help',
   },
 ];
+
+const STUDIO_CONTRACT_ENTRYPOINT = '@fluojs/studio/contracts';
+const STUDIO_MISSING_MESSAGE = [
+  'Mermaid graph rendering is owned by @fluojs/studio, but @fluojs/studio is not resolvable from this project.',
+  'Install @fluojs/studio explicitly (for example: pnpm add -D @fluojs/studio) and rerun fluo inspect --mermaid.',
+].join('\n');
 
 function isHelpFlag(value: string | undefined): boolean {
   return value === '--help' || value === '-h';
@@ -190,48 +219,93 @@ function stringifySnapshot(snapshot: PlatformShellSnapshot): string {
   return JSON.stringify(snapshot, null, 2);
 }
 
-function renderPlatformSnapshotMermaid(snapshot: PlatformShellSnapshot): string {
-  const lines: string[] = ['graph TD'];
+function createInspectPrompter(): InspectPrompter {
+  return {
+    async confirm(message: string, defaultValue: boolean): Promise<boolean> {
+      const result = await clack.confirm({
+        initialValue: defaultValue,
+        message,
+      });
 
-  if (snapshot.components.length === 0) {
-    lines.push('  EMPTY["No registered platform components"]');
-    return lines.join('\n');
-  }
-
-  const nodeByComponentId = new Map<string, string>();
-
-  for (const [index, component] of snapshot.components.entries()) {
-    const nodeId = `C${String(index + 1)}`;
-    nodeByComponentId.set(component.id, nodeId);
-
-    const summary = [
-      component.id,
-      `kind: ${component.kind}`,
-      `state: ${component.state}`,
-      `readiness: ${component.readiness.status}`,
-      `health: ${component.health.status}`,
-    ].join('\\n');
-
-    lines.push(`  ${nodeId}["${summary}"]`);
-  }
-
-  for (const component of snapshot.components) {
-    const from = nodeByComponentId.get(component.id);
-    if (!from) {
-      continue;
-    }
-
-    for (const dependency of component.dependencies) {
-      const to = nodeByComponentId.get(dependency);
-      if (!to) {
-        continue;
+      if (clack.isCancel(result)) {
+        clack.cancel('Operation cancelled.');
+        process.exit(0);
       }
 
-      lines.push(`  ${from} --> ${to}`);
+      return result;
+    },
+  };
+}
+
+function isCiEnvironment(): boolean {
+  return process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
+}
+
+function shouldPromptForStudio(runtime: InspectCommandRuntimeOptions): boolean {
+  if (isCiEnvironment()) {
+    return false;
+  }
+
+  if (runtime.prompt !== undefined) {
+    return runtime.interactive ?? true;
+  }
+
+  return runtime.stdout === undefined
+    && runtime.stderr === undefined
+    && (runtime.interactive ?? true)
+    && Boolean(runtime.stdin?.isTTY ?? process.stdin.isTTY);
+}
+
+async function loadStudioMermaidRenderer(cwd: string): Promise<StudioMermaidRenderer | undefined> {
+  const resolvers = [
+    createRequire(resolve(cwd, 'package.json')),
+    createRequire(import.meta.url),
+  ];
+
+  for (const resolver of resolvers) {
+    try {
+      const resolvedEntrypoint = resolver.resolve(STUDIO_CONTRACT_ENTRYPOINT);
+      const importedContract = await import(pathToFileURL(resolvedEntrypoint).href) as { renderMermaid?: unknown };
+
+      if (typeof importedContract.renderMermaid !== 'function') {
+        throw new Error(`${STUDIO_CONTRACT_ENTRYPOINT} does not export renderMermaid(snapshot).`);
+      }
+
+      return importedContract.renderMermaid as StudioMermaidRenderer;
+    } catch (error: unknown) {
+      const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined;
+      if (code !== 'MODULE_NOT_FOUND' && code !== 'ERR_MODULE_NOT_FOUND') {
+        throw error;
+      }
     }
   }
 
-  return lines.join('\n');
+  return undefined;
+}
+
+async function resolveStudioMermaidRenderer(cwd: string, runtime: InspectCommandRuntimeOptions): Promise<StudioMermaidRenderer> {
+  const renderer = await (runtime.loadStudioMermaidRenderer ?? loadStudioMermaidRenderer)(cwd);
+
+  if (renderer) {
+    return renderer;
+  }
+
+  if (!shouldPromptForStudio(runtime)) {
+    throw new Error(STUDIO_MISSING_MESSAGE);
+  }
+
+  const prompt = runtime.prompt ?? createInspectPrompter();
+  try {
+    const approvedInstall = await prompt.confirm('Install @fluojs/studio before rendering Mermaid output?', false);
+
+    if (!approvedInstall) {
+      throw new Error(`${STUDIO_MISSING_MESSAGE}\nInstallation declined; no package-manager command was run.`);
+    }
+
+    throw new Error(`${STUDIO_MISSING_MESSAGE}\nAutomatic installation is not run by fluo inspect. Install @fluojs/studio explicitly, then rerun the command.`);
+  } finally {
+    prompt.close?.();
+  }
 }
 
 /**
@@ -295,7 +369,8 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
       }
 
       if (parsed.mermaid) {
-        stdout.write(`${renderPlatformSnapshotMermaid(snapshot)}\n`);
+        const renderMermaid = await resolveStudioMermaidRenderer(cwd, runtime);
+        stdout.write(`${renderMermaid(snapshot)}\n`);
       }
     } finally {
       await context.close();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@fluojs/runtime':
         specifier: workspace:^
         version: link:../runtime
+      '@fluojs/studio':
+        specifier: workspace:^
+        version: link:../studio
       ejs:
         specifier: ^3.1.10
         version: 3.1.10


### PR DESCRIPTION
## Summary

Closes #1256.

Move `fluo inspect --mermaid` graph rendering ownership out of `@fluojs/cli` by keeping CLI as the runtime snapshot producer and resolving Studio's canonical `renderMermaid(snapshot)` contract only when Mermaid output is requested.

## Changes

- Replaced the CLI-local full Mermaid renderer with optional dynamic resolution of `@fluojs/studio/contracts`.
- Added deterministic missing-Studio behavior: non-interactive/CI paths fail fast with install guidance, and interactive prompt decline exits non-zero without running any package-manager install.
- Marked `@fluojs/studio` as an optional peer, not a hard runtime dependency, and updated CLI README EN/KO help around the Studio rendering boundary.

## Testing

- `pnpm install --lockfile-only`
- `pnpm install`
- `pnpm build`
- `pnpm --dir packages/cli test`
- `pnpm --dir packages/cli typecheck`
- `pnpm verify:public-export-tsdoc`
- `pnpm lint` (exit 0; reported existing non-blocking Biome warnings outside this change)
- LSP diagnostics: `packages/cli/src/commands/inspect.ts`, `packages/cli/src/cli.ts`, `packages/cli/src/cli.test.ts` — no diagnostics after dependency install/build

## Public export documentation

- Changed the exported `InspectCommandRuntimeOptions` shape for programmatic CLI embedding and documented the new runtime option fields with source comments.
- No new public Studio exports were added; CLI consumes the already-merged Studio `renderMermaid(snapshot)` contract.

## Behavioral contract

- `FluoFactory.createApplicationContext(...)` and `PLATFORM_SHELL.snapshot()` remain the snapshot production path.
- `inspect --mermaid` now requires resolvable `@fluojs/studio`; missing Studio never triggers package-manager installs automatically and never prompts in non-interactive/CI paths.
- Regression tests cover Studio-present delegation, missing Studio in non-interactive mode, and missing Studio with declined interactive install prompt.

## Platform consistency governance (SSOT)

- No platform adapter contract or governance SSOT docs changed.
- CLI README English/Korean package docs were updated together for the affected CLI behavior.