### PR TITLE
Resolve #1261: align request DTO feature slice generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - Root release documentation now removes draft release-readiness placeholder text, uses the current public CLI commands (`fluo new`, `fluo g`) and package name (`@fluojs/websockets`), and aligns the documented Node.js baseline with the `>=20.0.0` contract declared by the root and published package manifests.
 
+## [1.0.0-beta.2] - 2026-04-25
+
+### @fluojs/cli
+
+- Request DTO generation now accepts an explicit feature target, so `fluo g req users CreateUser` and `fluo generate request-dto users CreateUser` write `create-user.request.dto.ts` inside `src/users/` while preserving the legacy one-name request DTO form.
+
 ## [1.0.0-beta.1] - 2026-04-24
 
 ### Changed

--- a/docs/getting-started/generator-workflow.ko.md
+++ b/docs/getting-started/generator-workflow.ko.md
@@ -9,6 +9,7 @@
 ```bash
 fluo generate <generator> <name> [--target-directory <path>] [--force]
 fluo g <generator> <name> [--target-directory <path>] [--force]
+fluo g request-dto <feature> <name> [--target-directory <path>] [--force]
 ```
 
 | 생성기 | 허용 토큰 | 예시 문법 | 배선 방식 | 출력 범위 |
@@ -20,14 +21,14 @@ fluo g <generator> <name> [--target-directory <path>] [--force]
 | Guard | `guard`, `gu` | `fluo generate guard Billing` | 자동 등록 | 가드 파일, 모듈 갱신 |
 | Interceptor | `interceptor`, `in` | `fluo generate interceptor Billing` | 자동 등록 | 인터셉터 파일, 모듈 갱신 |
 | Middleware | `middleware`, `mi` | `fluo generate middleware Billing` | 자동 등록 | 미들웨어 파일, 모듈 갱신 |
-| Request DTO | `request-dto`, `req` | `fluo generate request-dto CreateBilling` | 파일만 생성 | 요청 DTO 파일 |
+| Request DTO | `request-dto`, `req` | `fluo generate request-dto billing CreateBilling` | 파일만 생성 | 요청 DTO 파일 |
 | Response DTO | `response-dto`, `res` | `fluo generate response-dto Billing` | 파일만 생성 | 응답 DTO 파일 |
 
 자동 등록 생성기는 슬라이스 모듈을 생성하거나 갱신한 뒤 생성된 클래스를 `controllers`, `providers`, `middleware` 배열에 추가합니다. 파일만 생성하는 생성기는 부모 모듈 등록 없이 파일만 산출합니다.
 
 ## Generated Artifacts
 
-모든 생성 결과는 `<resolved-target>/<plural-resource>/` 아래에 기록됩니다. `fluo g service Post`를 실행하고 해석된 타깃 디렉터리가 `src/`이면 슬라이스 디렉터리는 `src/posts/`입니다.
+대부분의 생성 결과는 `<resolved-target>/<plural-resource>/` 아래에 기록됩니다. `fluo g service Post`를 실행하고 해석된 타깃 디렉터리가 `src/`이면 슬라이스 디렉터리는 `src/posts/`입니다. Request DTO는 명시적 feature 타깃도 받을 수 있습니다. `fluo g req posts CreatePost`는 DTO 클래스 이름에서 `create-posts/` 디렉터리를 추론하지 않고 `src/posts/`에 기록합니다.
 
 | 생성기 | 슬라이스 디렉터리에 생성되는 파일 | 모듈 영향 |
 | --- | --- | --- |
@@ -38,7 +39,7 @@ fluo g <generator> <name> [--target-directory <path>] [--force]
 | Guard | `post.guard.ts` | `post.module.ts`를 생성하거나 갱신하고 `PostGuard`를 `providers`에 추가합니다. |
 | Interceptor | `post.interceptor.ts` | `post.module.ts`를 생성하거나 갱신하고 `PostInterceptor`를 `providers`에 추가합니다. |
 | Middleware | `post.middleware.ts` | `post.module.ts`를 생성하거나 갱신하고 `PostMiddleware`를 `middleware`에 추가합니다. |
-| Request DTO | `create-post.request.dto.ts` | 없음. 컨트롤러에서 수동 import가 필요합니다. |
+| Request DTO | `fluo g req posts CreatePost` 사용 시 `posts/` 안의 `create-post.request.dto.ts` | 없음. 컨트롤러에서 수동 import가 필요합니다. |
 | Response DTO | `post.response.dto.ts` | 없음. 컨트롤러 반환 타입으로 수동 사용이 필요합니다. |
 
 컨트롤러와 서비스 템플릿은 렌더링 전에 같은 슬라이스의 형제 파일 존재 여부를 확인합니다. 컨트롤러 스텁은 같은 슬라이스에 서비스 파일이 있을 때만 `post.service.ts` import를 추가합니다. 서비스 스텁은 같은 슬라이스에 레포지토리 파일이 있을 때만 `post.repo.ts` import를 추가합니다.
@@ -63,6 +64,7 @@ fluo g <generator> <name> [--target-directory <path>] [--force]
 - 리소스 이름은 `-`로 시작할 수 없습니다.
 - 리소스 이름에는 경로 구분자나 `..` 탐색 세그먼트가 포함될 수 없습니다.
 - 허용되는 이름 문자는 영문자, 숫자, 공백, 밑줄, 하이픈입니다. 생성되는 파일 스템은 kebab case로 정규화됩니다.
+- Request DTO feature 타깃도 같은 검증을 거치며 kebab-case 디렉터리 이름으로 정규화됩니다. PascalCase feature 이름은 일반 리소스 plural 규칙을 따르므로 `fluo g req Post CreatePost`는 `posts/`에 기록하고, `posts` 같은 lower-case 디렉터리 토큰은 입력한 그대로 사용합니다. 1-인자 형식(`fluo g req CreatePost`)은 호환성을 위해 계속 지원하지만, 명시적 feature 형식을 사용하면 여러 DTO를 하나의 슬라이스에 모을 수 있습니다.
 - 유효한 `apps/*/src` 타깃이 둘 이상인 멀티 앱 워크스페이스 루트에서는 `--target-directory`가 필요합니다.
 - 기존 파일은 기본적으로 건너뜁니다. 덮어쓰기는 `--force`가 필요합니다.
 - 자동 등록 메타데이터가 해석되더라도 변경되지 않은 파일 내용은 다시 쓰지 않습니다.

--- a/docs/getting-started/generator-workflow.md
+++ b/docs/getting-started/generator-workflow.md
@@ -9,6 +9,7 @@
 ```bash
 fluo generate <generator> <name> [--target-directory <path>] [--force]
 fluo g <generator> <name> [--target-directory <path>] [--force]
+fluo g request-dto <feature> <name> [--target-directory <path>] [--force]
 ```
 
 | Generator | Accepted tokens | Example syntax | Wiring | Output scope |
@@ -20,14 +21,14 @@ fluo g <generator> <name> [--target-directory <path>] [--force]
 | Guard | `guard`, `gu` | `fluo generate guard Billing` | Auto-registered | Guard file, module update |
 | Interceptor | `interceptor`, `in` | `fluo generate interceptor Billing` | Auto-registered | Interceptor file, module update |
 | Middleware | `middleware`, `mi` | `fluo generate middleware Billing` | Auto-registered | Middleware file, module update |
-| Request DTO | `request-dto`, `req` | `fluo generate request-dto CreateBilling` | Files only | Request DTO file |
+| Request DTO | `request-dto`, `req` | `fluo generate request-dto billing CreateBilling` | Files only | Request DTO file |
 | Response DTO | `response-dto`, `res` | `fluo generate response-dto Billing` | Files only | Response DTO file |
 
 Auto-registered generators create or update the slice module and append the generated class to `controllers`, `providers`, or `middleware`. Files-only generators emit files without parent-module registration.
 
 ## Generated Artifacts
 
-All generator outputs are written under `<resolved-target>/<plural-resource>/`. For `fluo g service Post`, the slice directory is `src/posts/` when the resolved target directory is `src/`.
+Most generator outputs are written under `<resolved-target>/<plural-resource>/`. For `fluo g service Post`, the slice directory is `src/posts/` when the resolved target directory is `src/`. Request DTOs also accept an explicit feature target: `fluo g req posts CreatePost` writes into `src/posts/` instead of deriving a `create-posts/` directory from the DTO class name.
 
 | Generator | Files emitted in the slice directory | Module effect |
 | --- | --- | --- |
@@ -38,7 +39,7 @@ All generator outputs are written under `<resolved-target>/<plural-resource>/`. 
 | Guard | `post.guard.ts` | Creates or updates `post.module.ts`, adds `PostGuard` to `providers`. |
 | Interceptor | `post.interceptor.ts` | Creates or updates `post.module.ts`, adds `PostInterceptor` to `providers`. |
 | Middleware | `post.middleware.ts` | Creates or updates `post.module.ts`, adds `PostMiddleware` to `middleware`. |
-| Request DTO | `create-post.request.dto.ts` | None. Import into controllers manually. |
+| Request DTO | `create-post.request.dto.ts` in `posts/` when using `fluo g req posts CreatePost` | None. Import into controllers manually. |
 | Response DTO | `post.response.dto.ts` | None. Use as a controller return type manually. |
 
 Controller and service templates inspect sibling files before rendering. A controller stub imports `post.service.ts` only when that service file already exists in the same slice. A service stub imports `post.repo.ts` only when the repository file already exists in the same slice.
@@ -63,6 +64,7 @@ Controller and service templates inspect sibling files before rendering. A contr
 - Resource names must not start with `-`.
 - Resource names must not contain path separators or `..` traversal segments.
 - Accepted name characters are letters, numbers, spaces, underscores, and hyphens. The generated file stem is normalized to kebab case.
+- Request DTO feature targets use the same validation and normalize to a kebab-case directory name. PascalCase feature names follow the normal resource pluralization (`fluo g req Post CreatePost` writes to `posts/`), while lower-case directory tokens such as `posts` are used as written. The one-name form (`fluo g req CreatePost`) remains supported for compatibility, but the explicit feature form keeps multiple DTOs in one slice.
 - A multi-app workspace root with more than one valid `apps/*/src` target requires `--target-directory`.
 - Existing files are skipped by default. `--force` is required for overwrite behavior.
 - Unchanged file content is not rewritten, even when the command resolves auto-registration metadata.

--- a/docs/reference/toolchain-contract-matrix.ko.md
+++ b/docs/reference/toolchain-contract-matrix.ko.md
@@ -21,7 +21,7 @@
 | **프로젝트 생성 (microservice)** | `fluo new my-service --shape microservice --transport tcp --runtime node --platform none` | 실행 가능한 단일 패키지 TCP 마이크로서비스(microservice) 스타터를 생성합니다. `--transport redis-streams`, `--transport nats`, `--transport kafka`, `--transport rabbitmq`, `--transport mqtt`, `--transport grpc`는 전송별 dependency/env/proto 구성을 갖춘 다른 shipped starter 변형을 생성합니다. `@fluojs/redis` 같은 더 넓은 패키지는 추가 `fluo new --transport` 값이 아니라 스캐폴딩 이후에 붙이는 통합 선택지로 남습니다. |
 | **프로젝트 생성 (mixed)** | `fluo new my-app --shape mixed --transport tcp --runtime node --platform fastify` | Fastify HTTP 앱 하나와 연결된(attached) TCP 마이크로서비스 하나를 함께 생성하는 혼합 단일 패키지 스타터를 생성합니다. |
 | **대화형 위저드 (Interactive wizard)** | TTY에서 `fluo new` 실행 | 비대화형(non-interactive) 플래그 경로와 동일한 shape-first 스키마(프로젝트 이름, shape, tooling preset, package manager, install 선택, git 선택)로 해석됩니다. |
-| **리소스 생성** | `fluo g <type>` | 일관된 명명 접미사 (`.service.ts`, `.controller.ts`) 산출. |
+| **리소스 생성** | `fluo g <type>` | 일관된 명명 접미사 (`.service.ts`, `.controller.ts`) 산출. Request DTO는 `fluo g req users CreateUser`처럼 명시적 feature 디렉터리를 대상으로 지정할 수 있습니다. |
 | **진단 (JSON)** | `fluo inspect --json` | 런타임이 생산한 그래프, 준비성, 상태, 진단, 타이밍 snapshot 데이터를 JSON 형식으로 내보냅니다. |
 | **진단 (Mermaid)** | `fluo inspect --mermaid` | snapshot-to-Mermaid 렌더링을 선택적 `@fluojs/studio` 계약에 위임합니다. CLI는 그래프 렌더링 의미론을 소유하지 않습니다. |
 
@@ -32,7 +32,7 @@
 | **Controller** | `.controller.ts` | `users.controller.ts` |
 | **Service** | `.service.ts` | `users.service.ts` |
 | **Repository** | `.repo.ts` | `users.repo.ts` |
-| **DTO (입력)** | `.request.dto.ts` | `create-user.request.dto.ts` |
+| **DTO (입력)** | `.request.dto.ts` | `fluo g req users CreateUser`가 생성하는 `users/create-user.request.dto.ts` |
 | **DTO (출력)** | `.response.dto.ts` | `user.response.dto.ts` |
 
 ## 빌드 구성

--- a/docs/reference/toolchain-contract-matrix.md
+++ b/docs/reference/toolchain-contract-matrix.md
@@ -21,7 +21,7 @@
 | **Project Creation (microservice)** | `fluo new my-service --shape microservice --transport tcp --runtime node --platform none` | Generates the runnable single-package TCP microservice starter. `--transport redis-streams`, `--transport nats`, `--transport kafka`, `--transport rabbitmq`, `--transport mqtt`, and `--transport grpc` scaffold the other shipped starter variants with transport-specific dependency/env/proto wiring. Broader packages such as `@fluojs/redis` remain post-scaffold integration choices instead of extra `fluo new --transport` values. |
 | **Project Creation (mixed)** | `fluo new my-app --shape mixed --transport tcp --runtime node --platform fastify` | Generates the mixed single-package starter: one Fastify HTTP app with an attached TCP microservice. |
 | **Interactive wizard** | `fluo new` in a TTY | Resolves onto the same shape-first schema as the non-interactive flags path: project name, shape, tooling preset, package manager, install choice, and git choice. |
-| **Resource Generation** | `fluo g <type>` | Produces consistent naming suffixes (`.service.ts`, `.controller.ts`). |
+| **Resource Generation** | `fluo g <type>` | Produces consistent naming suffixes (`.service.ts`, `.controller.ts`). Request DTOs may target an explicit feature directory with `fluo g req users CreateUser`. |
 | **Diagnostics (JSON)** | `fluo inspect --json` | Exports runtime-produced graph, readiness, health, diagnostics, and timing snapshot data in JSON format. |
 | **Diagnostics (Mermaid)** | `fluo inspect --mermaid` | Delegates snapshot-to-Mermaid rendering to the optional `@fluojs/studio` contract; the CLI does not own graph rendering semantics. |
 
@@ -32,7 +32,7 @@
 | **Controller** | `.controller.ts` | `users.controller.ts` |
 | **Service** | `.service.ts` | `users.service.ts` |
 | **Repository** | `.repo.ts` | `users.repo.ts` |
-| **DTO (Input)** | `.request.dto.ts` | `create-user.request.dto.ts` |
+| **DTO (Input)** | `.request.dto.ts` | `users/create-user.request.dto.ts` from `fluo g req users CreateUser` |
 | **DTO (Output)** | `.response.dto.ts` | `user.response.dto.ts` |
 
 ## build configuration

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -99,7 +99,10 @@ fluo new my-mixed-app --shape mixed --transport tcp --runtime node --platform fa
 fluo generate module users
 fluo generate controller users
 fluo generate service users
+fluo generate request-dto users CreateUser
 ```
+
+Request DTO 생성은 feature 디렉터리와 DTO 클래스 이름을 분리해서 받습니다. 따라서 `CreateUser`, `UpdateUser` 같은 여러 입력 계약을 같은 `src/users/` 슬라이스 안에 둘 수 있습니다.
 
 ## 주요 패턴
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -99,7 +99,10 @@ Add a new resource with a controller and service, automatically wired into the m
 fluo generate module users
 fluo generate controller users
 fluo generate service users
+fluo generate request-dto users CreateUser
 ```
+
+Request DTO generation accepts the feature directory separately from the DTO class name, so multiple input contracts such as `CreateUser` and `UpdateUser` can live inside the same `src/users/` slice.
 
 ## Common Patterns
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1062,7 +1062,69 @@ describe('CLI command runner', () => {
     expect(existsSync(join(workspaceDirectory, 'src', 'users', 'user.module.ts'))).toBe(true);
   });
 
-  it('accepts `request-dto` as a request DTO schematic', async () => {
+  it('accepts `request-dto` as a request DTO schematic with an explicit feature target', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'package.json'),
+      JSON.stringify({ name: 'test-app', private: true }, null, 2),
+    );
+
+    const exitCode = await runCli(['g', 'request-dto', 'users', 'CreateUser'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'src', 'users', 'create-user.request.dto.ts'))).toBe(true);
+    expect(existsSync(join(workspaceDirectory, 'src', 'create-users', 'create-user.request.dto.ts'))).toBe(false);
+  });
+
+  it('supports the canonical generate request-dto command with an explicit feature target', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'package.json'),
+      JSON.stringify({ name: 'test-app', private: true }, null, 2),
+    );
+
+    const exitCode = await runCli(['generate', 'request-dto', 'users', 'CreateUser'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'src', 'users', 'create-user.request.dto.ts'))).toBe(true);
+  });
+
+  it('normalizes PascalCase request DTO feature targets to plural slice directories', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'package.json'),
+      JSON.stringify({ name: 'test-app', private: true }, null, 2),
+    );
+
+    const exitCode = await runCli(['g', 'req', 'User', 'CreateUser'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'src', 'users', 'create-user.request.dto.ts'))).toBe(true);
+    expect(existsSync(join(workspaceDirectory, 'src', 'user', 'create-user.request.dto.ts'))).toBe(false);
+  });
+
+  it('keeps the legacy one-name request DTO form as a compatibility path', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);
 
@@ -1639,13 +1701,14 @@ describe('CLI command runner', () => {
       JSON.stringify({ name: 'test-app', private: true }, null, 2),
     );
 
-    const exitCode = await runCli(['g', 'req', 'CreateUser'], {
+    const exitCode = await runCli(['g', 'req', 'users', 'CreateUser'], {
       cwd: workspaceDirectory,
       stderr: { write: () => undefined },
       stdout: { write: () => undefined },
     });
 
     expect(exitCode).toBe(0);
+    expect(existsSync(join(workspaceDirectory, 'src', 'users', 'create-user.request.dto.ts'))).toBe(true);
   });
 
   it('resolves `res` alias to response-dto', async () => {
@@ -1718,7 +1781,7 @@ describe('CLI command runner', () => {
     );
 
     const stdoutBuffer: string[] = [];
-    const exitCode = await runCli(['g', 'request-dto', 'CreateUser'], {
+    const exitCode = await runCli(['g', 'request-dto', 'users', 'CreateUser'], {
       cwd: workspaceDirectory,
       stderr: { write: () => undefined },
       stdout: { write: (message) => stdoutBuffer.push(message) },
@@ -1728,6 +1791,7 @@ describe('CLI command runner', () => {
 
     expect(exitCode).toBe(0);
     expect(output).toContain('CREATE');
+    expect(output).toContain('users/create-user.request.dto.ts');
     expect(output).toContain('Wiring: files only');
     expect(output).toContain('manual registration required');
     expect(output).toContain('Next steps:');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -105,6 +105,7 @@ function isHelpFlag(value: string | undefined): boolean {
 function generateUsage(): string {
   return [
     'Usage: fluo generate|g <kind> <name> [options]',
+    '       fluo generate|g request-dto|req <feature> <name> [options]',
     '',
     'Schematics',
     renderHelpTable(GENERATE_KIND_HELP, [
@@ -174,22 +175,24 @@ function resolveDefaultTargetDirectory(startDirectory: string): string {
 }
 
 function parseGenerateArgs(argv: string[]): ParsedCliArgs {
-  const [command, rawKind, name, ...optionArgs] = argv;
+  const [command, rawKind, firstName, ...optionArgs] = argv;
   const kind = normalizeGeneratorKind(rawKind);
 
   if (!(command === 'g' || command === 'generate')) {
     throw new Error(usage());
   }
 
-  if (!kind || !name) {
+  if (!kind || !firstName) {
     throw new Error(generateUsage());
   }
 
-  if (name.startsWith('-')) {
-    throw new Error(`Invalid resource name "${name}": names cannot start with "-".`);
+  if (firstName.startsWith('-')) {
+    throw new Error(`Invalid resource name "${firstName}": names cannot start with "-".`);
   }
 
   const parsedOptions: GenerateOptions = {};
+  let name = firstName;
+  let seenRequestDtoName = false;
   let targetDirectory: string | undefined;
   let seenForce = false;
   let seenTargetDirectory = false;
@@ -197,6 +200,13 @@ function parseGenerateArgs(argv: string[]): ParsedCliArgs {
   for (let index = 0; index < optionArgs.length; index += 1) {
     const option = optionArgs[index];
     const next = optionArgs[index + 1];
+
+    if (kind === 'request-dto' && !seenRequestDtoName && !option.startsWith('-')) {
+      parsedOptions.targetFeature = firstName;
+      name = option;
+      seenRequestDtoName = true;
+      continue;
+    }
 
     if (option === '--target-directory' || option === '-o') {
       if (seenTargetDirectory) {

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -178,6 +178,47 @@ export { PostModule };
     expect(result.nextStepHint).toContain('@FromBody');
   });
 
+  it('writes request DTOs into an explicit feature directory when provided', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const result = runGenerateCommand('request-dto', 'CreateUser', sourceDirectory, { targetFeature: 'users' });
+
+    expect(result.generatedFiles).toEqual([join(sourceDirectory, 'users', 'create-user.request.dto.ts')]);
+    expect(existsSync(join(sourceDirectory, 'users', 'create-user.request.dto.ts'))).toBe(true);
+    expect(existsSync(join(sourceDirectory, 'create-users', 'create-user.request.dto.ts'))).toBe(false);
+    expect(result.wiringBehavior).toBe('files-only');
+    expect(result.moduleRegistered).toBe(false);
+  });
+
+  it('normalizes PascalCase request DTO feature names to plural slice directories', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const result = runGenerateCommand('request-dto', 'CreateUser', sourceDirectory, { targetFeature: 'User' });
+
+    expect(result.generatedFiles).toEqual([join(sourceDirectory, 'users', 'create-user.request.dto.ts')]);
+    expect(existsSync(join(sourceDirectory, 'users', 'create-user.request.dto.ts'))).toBe(true);
+    expect(existsSync(join(sourceDirectory, 'user', 'create-user.request.dto.ts'))).toBe(false);
+  });
+
+  it('validates explicit request DTO feature names before writing files', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+
+    expect(() => runGenerateCommand('request-dto', 'CreateUser', sourceDirectory, { targetFeature: '../users' })).toThrow(
+      'path separators or traversal sequences',
+    );
+    expect(() => runGenerateCommand('request-dto', 'CreateUser', sourceDirectory, { targetFeature: '..\\users' })).toThrow(
+      'path separators or traversal sequences',
+    );
+    expect(existsSync(join(sourceDirectory, 'create-users', 'create-user.request.dto.ts'))).toBe(false);
+  });
+
   it('returns GenerateResult with module wiring hint for standalone module kind', () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
     tempDirectories.push(workspaceDirectory);

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -30,6 +30,18 @@ function createGeneratorOptions(
   };
 }
 
+function resolveDomainDirectory(kind: GeneratorKind, resolvedBase: string, kebab: string, options: GenerateOptions): string {
+  if (kind === 'request-dto' && options.targetFeature !== undefined) {
+    const normalizedFeature = options.targetFeature.trim();
+    const featureKebab = assertValidResourceName(normalizedFeature);
+    const featureDirectory = /^[A-Z]/u.test(normalizedFeature) ? toPlural(featureKebab) : featureKebab;
+
+    return join(resolvedBase, featureDirectory);
+  }
+
+  return join(resolvedBase, toPlural(kebab));
+}
+
 function assertValidResourceName(name: string): string {
   const kebab = toKebabCase(name);
 
@@ -130,7 +142,7 @@ export type GenerateResult = {
  * @param kind Generator kind to execute.
  * @param name Resource name supplied by the caller before normalization.
  * @param baseDirectory Source directory that should receive the generated domain folder.
- * @param options Optional generation flags that control overwrites and sibling-aware templates.
+ * @param options Optional generation flags that control overwrites, request DTO feature placement, and sibling-aware templates.
  * @returns Structured file and wiring metadata for the completed generation run.
  * @throws {Error} When the resource name is invalid, the generator kind is unknown, or the target module source cannot be updated safely.
  */
@@ -140,7 +152,7 @@ export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirect
   const generator = findGeneratorDefinition(kind);
 
   const resolvedBase = resolve(baseDirectory);
-  const domainDirectory = join(resolvedBase, toPlural(kebab));
+  const domainDirectory = resolveDomainDirectory(kind, resolvedBase, kebab, options);
   const generatorOptions = createGeneratorOptions(kind, domainDirectory, kebab, options);
   const files = generator.factory(normalizedName, generatorOptions);
   const moduleRegistration = 'moduleRegistration' in generator ? generator.moduleRegistration : undefined;

--- a/packages/cli/src/generator-types.ts
+++ b/packages/cli/src/generator-types.ts
@@ -4,11 +4,15 @@ export interface GeneratedFile {
   path: string;
 }
 
-/** Optional generation flags that influence overwrite behavior and sibling-aware templates. */
+/** Optional generation flags that influence overwrite behavior, target placement, and sibling-aware templates. */
 export interface GenerateOptions {
   force?: boolean;
   hasRepo?: boolean;
   hasService?: boolean;
+  /**
+   * Feature or slice directory that should receive feature-local files such as request DTOs.
+   */
+  targetFeature?: string;
 }
 
 /**

--- a/tooling/release/intents/cli-request-dto-feature-target.json
+++ b/tooling/release/intents/cli-request-dto-feature-target.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0-beta.2",
+  "packages": [
+    {
+      "package": "@fluojs/cli",
+      "disposition": "release",
+      "semver": "minor",
+      "summary": "Allow request DTO generation to target an explicit feature slice directory.",
+      "rationale": "The CLI package owns generator argument parsing, generated DTO placement, and the related documentation contract."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #1261

Align request DTO generation with feature/slice workflows by letting callers provide the target feature separately from the DTO class name.

## Changes

- Add `fluo g req <feature> <name>` / `fluo generate request-dto <feature> <name>` parsing while preserving the legacy one-name request DTO form.
- Route explicit request DTO targets into the requested slice, including PascalCase feature-name pluralization and traversal validation.
- Update CLI README, generator workflow docs, toolchain contract docs, changelog, and release intent coverage for the public CLI behavior.

## Testing

- `pnpm --dir packages/cli test -- src/cli.test.ts src/commands/generate.test.ts src/generators.test.ts` — 216 tests passed.
- `pnpm --dir packages/cli typecheck` — passed.
- `pnpm --filter @fluojs/cli build` — passed.
- `pnpm verify:public-export-tsdoc` — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm verify:release-readiness --target-package @fluojs/cli --target-version 1.0.0-beta.2 --dist-tag beta --release-intent-file tooling/release/intents/cli-request-dto-feature-target.json` — passed.
- LSP diagnostics for changed TypeScript files — no diagnostics.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.