### PR TITLE
Resolve #1267: strengthen inspect diagnostics reporting

### DIFF
--- a/docs/reference/toolchain-contract-matrix.ko.md
+++ b/docs/reference/toolchain-contract-matrix.ko.md
@@ -22,7 +22,8 @@
 | **프로젝트 생성 (mixed)** | `fluo new my-app --shape mixed --transport tcp --runtime node --platform fastify` | Fastify HTTP 앱 하나와 연결된(attached) TCP 마이크로서비스 하나를 함께 생성하는 혼합 단일 패키지 스타터를 생성합니다. |
 | **대화형 위저드 (Interactive wizard)** | TTY에서 `fluo new` 실행 | 비대화형(non-interactive) 플래그 경로와 동일한 shape-first 스키마(프로젝트 이름, shape, tooling preset, package manager, install 선택, git 선택)로 해석됩니다. |
 | **리소스 생성** | `fluo g <type>` | 일관된 명명 접미사 (`.service.ts`, `.controller.ts`) 산출. Request DTO는 `fluo g req users CreateUser`처럼 명시적 feature 디렉터리를 대상으로 지정할 수 있습니다. |
-| **진단 (JSON)** | `fluo inspect --json` | 런타임이 생산한 그래프, 준비성, 상태, 진단, 타이밍 snapshot 데이터를 JSON 형식으로 내보냅니다. |
+| **진단 (JSON)** | `fluo inspect --json` | 런타임이 생산한 그래프, 준비성, 상태, 진단 snapshot 데이터를 JSON 형식으로 내보냅니다. `--timing`은 `--json`과 함께 사용해 bootstrap timing diagnostics를 포함할 수 있습니다. |
+| **진단 report** | `fluo inspect --report --output artifacts/inspect-report.json` | 안정적인 요약, 런타임이 생산한 snapshot, diagnostics, bootstrap timing을 포함하는 CI/support triage JSON report를 씁니다. `--output <path>`는 명시적 artifact 경로이며 inspection이 애플리케이션 write를 소유하게 만들지 않습니다. |
 | **진단 (Mermaid)** | `fluo inspect --mermaid` | snapshot-to-Mermaid 렌더링을 선택적 `@fluojs/studio` 계약에 위임합니다. CLI는 그래프 렌더링 의미론을 소유하지 않습니다. |
 
 ## 명명 규칙 (CLI 출력)

--- a/docs/reference/toolchain-contract-matrix.md
+++ b/docs/reference/toolchain-contract-matrix.md
@@ -22,7 +22,8 @@
 | **Project Creation (mixed)** | `fluo new my-app --shape mixed --transport tcp --runtime node --platform fastify` | Generates the mixed single-package starter: one Fastify HTTP app with an attached TCP microservice. |
 | **Interactive wizard** | `fluo new` in a TTY | Resolves onto the same shape-first schema as the non-interactive flags path: project name, shape, tooling preset, package manager, install choice, and git choice. |
 | **Resource Generation** | `fluo g <type>` | Produces consistent naming suffixes (`.service.ts`, `.controller.ts`). Request DTOs may target an explicit feature directory with `fluo g req users CreateUser`. |
-| **Diagnostics (JSON)** | `fluo inspect --json` | Exports runtime-produced graph, readiness, health, diagnostics, and timing snapshot data in JSON format. |
+| **Diagnostics (JSON)** | `fluo inspect --json` | Exports runtime-produced graph, readiness, health, and diagnostics snapshot data in JSON format. `--timing` may be combined with `--json` to include bootstrap timing diagnostics. |
+| **Diagnostics report** | `fluo inspect --report --output artifacts/inspect-report.json` | Writes a CI/support triage JSON report containing a stable summary, the runtime-produced snapshot, diagnostics, and bootstrap timing. `--output <path>` is an explicit artifact path and does not make inspection own application writes. |
 | **Diagnostics (Mermaid)** | `fluo inspect --mermaid` | Delegates snapshot-to-Mermaid rendering to the optional `@fluojs/studio` contract; the CLI does not own graph rendering semantics. |
 
 ## naming conventions (CLI output)

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -131,9 +131,18 @@ fluo inspect ./src/app.module.ts --mermaid
 
 # @fluojs/studio용 snapshot 내보내기
 fluo inspect ./src/app.module.ts --json > snapshot.json
+
+# shell redirection 없이 같은 JSON snapshot을 CI artifact 경로에 쓰기
+fluo inspect ./src/app.module.ts --json --output artifacts/inspect-snapshot.json
+
+# 런타임이 생산한 snapshot 옆에 bootstrap timing 포함하기
+fluo inspect ./src/app.module.ts --json --timing
+
+# 요약, snapshot, diagnostics, timing을 포함한 support triage report 내보내기
+fluo inspect ./src/app.module.ts --report --output artifacts/inspect-report.json
 ```
 
-런타임이 inspection snapshot을 생산합니다. `fluo inspect`는 그 snapshot을 JSON으로 직렬화하고, `fluo inspect --mermaid`는 snapshot-to-Mermaid 렌더링을 선택적 `@fluojs/studio` 계약에 위임합니다. Mermaid 출력이 필요하면 명령을 실행하는 프로젝트에 Studio를 설치하세요:
+런타임이 inspection snapshot을 생산합니다. `fluo inspect`는 그 snapshot을 JSON으로 직렬화하고, `fluo inspect --mermaid`는 snapshot-to-Mermaid 렌더링을 선택적 `@fluojs/studio` 계약에 위임합니다. `--timing`은 JSON 출력에 bootstrap timing diagnostics를 기록하고, `--report`는 CI/support triage를 위해 런타임이 생산한 snapshot을 안정적인 요약과 함께 감쌉니다. `--output <path>`는 선택한 inspect payload를 stdout 대신 명시적 artifact 경로에 씁니다. 이 동작은 검사 대상 애플리케이션을 writable하게 만들지 않으며, 일반 bootstrap/close cycle 외에 module graph state를 바꾸지 않습니다. Mermaid 출력이 필요하면 명령을 실행하는 프로젝트에 Studio를 설치하세요:
 
 ```bash
 pnpm add -D @fluojs/studio

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -131,9 +131,18 @@ fluo inspect ./src/app.module.ts --mermaid
 
 # Export snapshot for @fluojs/studio
 fluo inspect ./src/app.module.ts --json > snapshot.json
+
+# Write the same JSON snapshot to a CI artifact path without shell redirection
+fluo inspect ./src/app.module.ts --json --output artifacts/inspect-snapshot.json
+
+# Include bootstrap timing next to the runtime-produced snapshot
+fluo inspect ./src/app.module.ts --json --timing
+
+# Emit a support triage report with summary, snapshot, diagnostics, and timing
+fluo inspect ./src/app.module.ts --report --output artifacts/inspect-report.json
 ```
 
-The runtime produces the inspection snapshot. `fluo inspect` serializes that snapshot as JSON, and `fluo inspect --mermaid` delegates snapshot-to-Mermaid rendering to the optional `@fluojs/studio` contract. Install Studio in the project that runs the command when you need Mermaid output:
+The runtime produces the inspection snapshot. `fluo inspect` serializes that snapshot as JSON, and `fluo inspect --mermaid` delegates snapshot-to-Mermaid rendering to the optional `@fluojs/studio` contract. `--timing` records bootstrap timing diagnostics for JSON output, and `--report` wraps the runtime-produced snapshot with a stable summary for CI/support triage. `--output <path>` writes the selected inspect payload to an explicit artifact path instead of stdout; it does not make the inspected application writable or change module graph state beyond the normal bootstrap/close cycle. Install Studio in the project that runs the command when you need Mermaid output:
 
 ```bash
 pnpm add -D @fluojs/studio

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -844,6 +844,8 @@ describe('CLI command runner', () => {
     expect(stdoutBuffer.join('')).toContain('--mermaid');
     expect(stdoutBuffer.join('')).toContain('@fluojs/studio');
     expect(stdoutBuffer.join('')).toContain('--timing');
+    expect(stdoutBuffer.join('')).toContain('--report');
+    expect(stdoutBuffer.join('')).toContain('--output <path>');
     expect(stdoutBuffer.join('')).toContain('Docs: https://github.com/fluojs/fluo/tree/main/docs/getting-started/quick-start.md');
   });
 
@@ -875,6 +877,106 @@ describe('CLI command runner', () => {
     expect(payload.diagnostics).toEqual([]);
     expect(payload.readiness.status).toBe('ready');
     expect(payload.health.status).toBe('healthy');
+  });
+
+  it('writes inspect JSON artifacts to an explicit output path without stdout payloads', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const outputPath = join(workspaceDirectory, 'artifacts', 'snapshot.json');
+
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--json', '--output', outputPath], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const payload = JSON.parse(readFileSync(outputPath, 'utf8')) as {
+      components: unknown[];
+      diagnostics: unknown[];
+      health: { status: string };
+      readiness: { status: string };
+    };
+
+    expect(exitCode).toBe(0);
+    expect(stdoutBuffer.join('')).toBe('');
+    expect(stderrBuffer.join('')).toBe('');
+    expect(payload.components).toEqual([]);
+    expect(payload.diagnostics).toEqual([]);
+    expect(payload.readiness.status).toBe('ready');
+    expect(payload.health.status).toBe('healthy');
+  });
+
+  it('emits snapshot JSON with timing diagnostics when --json and --timing are combined', async () => {
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--json', '--timing'], {
+      cwd: process.cwd(),
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const payload = JSON.parse(stdoutBuffer.join('')) as {
+      snapshot: {
+        diagnostics: unknown[];
+        health: { status: string };
+        readiness: { status: string };
+      };
+      timing: {
+        phases: Array<{ name: string }>;
+        totalMs: number;
+        version: number;
+      };
+    };
+
+    expect(exitCode).toBe(0);
+    expect(payload.snapshot.diagnostics).toEqual([]);
+    expect(payload.snapshot.readiness.status).toBe('ready');
+    expect(payload.snapshot.health.status).toBe('healthy');
+    expect(payload.timing.version).toBe(1);
+    expect(payload.timing.totalMs).toBeGreaterThanOrEqual(0);
+    expect(payload.timing.phases.some((phase) => phase.name === 'bootstrap_module')).toBe(true);
+  });
+
+  it('emits a CI-friendly inspect report with summary, snapshot, and timing', async () => {
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--report'], {
+      cwd: process.cwd(),
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const report = JSON.parse(stdoutBuffer.join('')) as {
+      snapshot: { diagnostics: unknown[] };
+      summary: {
+        componentCount: number;
+        diagnosticCount: number;
+        errorCount: number;
+        healthStatus: string;
+        readinessStatus: string;
+        timingTotalMs: number;
+        warningCount: number;
+      };
+      timing: { totalMs: number; version: number };
+      version: number;
+    };
+
+    expect(exitCode).toBe(0);
+    expect(report.version).toBe(1);
+    expect(report.summary).toEqual({
+      componentCount: 0,
+      diagnosticCount: 0,
+      errorCount: 0,
+      healthStatus: 'healthy',
+      readinessStatus: 'ready',
+      timingTotalMs: report.timing.totalMs,
+      warningCount: 0,
+    });
+    expect(report.snapshot.diagnostics).toEqual([]);
+    expect(report.timing.version).toBe(1);
+    expect(report.timing.totalMs).toBeGreaterThanOrEqual(0);
   });
 
   it('delegates inspect --mermaid output to Studio when resolvable', async () => {
@@ -964,10 +1066,10 @@ describe('CLI command runner', () => {
     expect(timing.phases.some((phase) => phase.name === 'bootstrap_module')).toBe(true);
   });
 
-  it('rejects conflicting inspect output modes', async () => {
+  it('rejects conflicting inspect JSON and Mermaid output modes', async () => {
     const stderrBuffer: string[] = [];
 
-    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--json', '--timing'], {
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--json', '--mermaid'], {
       cwd: process.cwd(),
       stderr: { write: (message) => stderrBuffer.push(message) },
       stdout: { write: () => undefined },
@@ -975,6 +1077,19 @@ describe('CLI command runner', () => {
 
     expect(exitCode).toBe(1);
     expect(stderrBuffer.join('')).toContain('Choose only one inspect output mode');
+  });
+
+  it('rejects Mermaid timing because graph rendering stays Studio-owned', async () => {
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--mermaid', '--timing'], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('Mermaid rendering remains delegated to @fluojs/studio');
   });
 
   it('prints generate usage for `generate --help`', async () => {

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,12 +1,14 @@
+import { mkdir, writeFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { resolve } from 'node:path';
 
 import * as clack from '@clack/prompts';
 import {
   FluoFactory,
   type BootstrapTimingDiagnostics,
   type ModuleType,
+  type PlatformDiagnosticIssue,
   type PlatformShell,
   type PlatformShellSnapshot,
   PLATFORM_SHELL,
@@ -58,7 +60,25 @@ type ParsedInspectArgs = {
   json: boolean;
   mermaid: boolean;
   modulePath: string;
+  outputPath?: string;
+  report: boolean;
   timing: boolean;
+};
+
+type InspectReport = {
+  generatedAt: string;
+  snapshot: PlatformShellSnapshot;
+  summary: {
+    componentCount: number;
+    diagnosticCount: number;
+    errorCount: number;
+    healthStatus: PlatformShellSnapshot['health']['status'];
+    readinessStatus: PlatformShellSnapshot['readiness']['status'];
+    timingTotalMs: number;
+    warningCount: number;
+  };
+  timing: BootstrapTimingDiagnostics;
+  version: 1;
 };
 
 type InspectOptionHelpEntry = {
@@ -82,6 +102,16 @@ const INSPECT_OPTION_HELP: InspectOptionHelpEntry[] = [
     aliases: [],
     description: 'Bootstrap the application context and emit versioned timing diagnostics.',
     option: '--timing',
+  },
+  {
+    aliases: [],
+    description: 'Emit a CI-friendly JSON report with summary, snapshot, diagnostics, and timing.',
+    option: '--report',
+  },
+  {
+    aliases: [],
+    description: 'Write the selected inspect payload to a file instead of stdout.',
+    option: '--output <path>',
   },
   {
     aliases: [],
@@ -130,6 +160,8 @@ function parseInspectArgs(argv: string[]): ParsedInspectArgs {
   let exportName = 'AppModule';
   let json = false;
   let mermaid = false;
+  let outputPath: string | undefined;
+  let report = false;
   let timing = false;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -151,6 +183,22 @@ function parseInspectArgs(argv: string[]): ParsedInspectArgs {
 
     if (option === '--timing') {
       timing = true;
+      continue;
+    }
+
+    if (option === '--report') {
+      report = true;
+      continue;
+    }
+
+    if (option === '--output') {
+      const next = argv[index + 1];
+      if (!next || next.startsWith('-')) {
+        throw new Error('Expected --output to have a file path value.');
+      }
+
+      outputPath = next;
+      index += 1;
       continue;
     }
 
@@ -180,14 +228,18 @@ function parseInspectArgs(argv: string[]): ParsedInspectArgs {
     throw new Error(inspectUsage());
   }
 
-  if (!json && !mermaid && !timing) {
+  if (!json && !mermaid && !timing && !report) {
     json = true;
   }
 
-  const selectedModes = [json, mermaid, timing].filter(Boolean).length;
+  const selectedModes = [json, mermaid, report].filter(Boolean).length;
 
   if (selectedModes > 1) {
-    throw new Error('Choose only one inspect output mode: --json, --mermaid, or --timing.');
+    throw new Error('Choose only one inspect output mode: --json, --mermaid, or --report.');
+  }
+
+  if (mermaid && timing) {
+    throw new Error('Use --timing only with JSON inspect output or --report. Mermaid rendering remains delegated to @fluojs/studio.');
   }
 
   return {
@@ -195,6 +247,8 @@ function parseInspectArgs(argv: string[]): ParsedInspectArgs {
     json,
     mermaid,
     modulePath,
+    outputPath,
+    report,
     timing,
   };
 }
@@ -219,6 +273,54 @@ function stringifyTiming(timing: BootstrapTimingDiagnostics | undefined): string
 
 function stringifySnapshot(snapshot: PlatformShellSnapshot): string {
   return JSON.stringify(snapshot, null, 2);
+}
+
+function createEmptyTimingDiagnostics(): BootstrapTimingDiagnostics {
+  return {
+    phases: [],
+    totalMs: 0,
+    version: 1,
+  };
+}
+
+function createInspectReport(snapshot: PlatformShellSnapshot, timing: BootstrapTimingDiagnostics | undefined): InspectReport {
+  const resolvedTiming = timing ?? createEmptyTimingDiagnostics();
+  const errorCount = snapshot.diagnostics.filter((diagnostic: PlatformDiagnosticIssue) => diagnostic.severity === 'error').length;
+  const warningCount = snapshot.diagnostics.filter((diagnostic: PlatformDiagnosticIssue) => diagnostic.severity === 'warning').length;
+
+  return {
+    generatedAt: snapshot.generatedAt,
+    snapshot,
+    summary: {
+      componentCount: snapshot.components.length,
+      diagnosticCount: snapshot.diagnostics.length,
+      errorCount,
+      healthStatus: snapshot.health.status,
+      readinessStatus: snapshot.readiness.status,
+      timingTotalMs: resolvedTiming.totalMs,
+      warningCount,
+    },
+    timing: resolvedTiming,
+    version: 1,
+  };
+}
+
+function stringifySnapshotWithTiming(snapshot: PlatformShellSnapshot, timing: BootstrapTimingDiagnostics | undefined): string {
+  return JSON.stringify({
+    snapshot,
+    timing: timing ?? createEmptyTimingDiagnostics(),
+  }, null, 2);
+}
+
+async function emitInspectPayload(payload: string, parsed: ParsedInspectArgs, cwd: string, stdout: CliStream): Promise<void> {
+  if (!parsed.outputPath) {
+    stdout.write(`${payload}\n`);
+    return;
+  }
+
+  const outputPath = resolve(cwd, parsed.outputPath);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${payload}\n`, 'utf8');
 }
 
 function createInspectPrompter(): InspectPrompter {
@@ -329,7 +431,7 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
     const importedModule = await import(pathToFileURL(modulePath).href);
     const rootModule = resolveRootModule(importedModule[parsed.exportName], parsed.exportName);
 
-    if (parsed.timing) {
+    if (parsed.timing && !parsed.json && !parsed.report) {
       const context = await FluoFactory.createApplicationContext(rootModule, {
         diagnostics: { timing: true },
         logger: {
@@ -341,7 +443,7 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
       });
 
       try {
-        stdout.write(`${stringifyTiming(context.bootstrapTiming)}\n`);
+        await emitInspectPayload(stringifyTiming(context.bootstrapTiming), parsed, cwd, stdout);
       } finally {
         await context.close();
       }
@@ -350,6 +452,7 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
     }
 
     const context = await FluoFactory.createApplicationContext(rootModule, {
+      diagnostics: parsed.timing || parsed.report ? { timing: true } : undefined,
       logger: {
         debug() {},
         error() {},
@@ -363,12 +466,16 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
       const snapshot = await platformShell.snapshot();
 
       if (parsed.json) {
-        stdout.write(`${stringifySnapshot(snapshot)}\n`);
+        await emitInspectPayload(parsed.timing ? stringifySnapshotWithTiming(snapshot, context.bootstrapTiming) : stringifySnapshot(snapshot), parsed, cwd, stdout);
+      }
+
+      if (parsed.report) {
+        await emitInspectPayload(JSON.stringify(createInspectReport(snapshot, context.bootstrapTiming), null, 2), parsed, cwd, stdout);
       }
 
       if (parsed.mermaid) {
         const renderMermaid = await resolveStudioMermaidRenderer(cwd, runtime);
-        stdout.write(`${renderMermaid(snapshot)}\n`);
+        await emitInspectPayload(renderMermaid(snapshot), parsed, cwd, stdout);
       }
     } finally {
       await context.close();


### PR DESCRIPTION
## Summary

- Closes #1267.
- Strengthens `fluo inspect` diagnostics/reporting with artifact-friendly JSON output while preserving read-only inspection and Studio-owned Mermaid rendering.

## Changes

- Adds `--output <path>` so `inspect` can write JSON, timing, report, or Studio-rendered Mermaid payloads to explicit CI artifact paths.
- Allows `--json --timing` to emit the runtime-produced snapshot next to bootstrap timing diagnostics.
- Adds `--report` for a CI/support triage JSON document containing a stable summary, snapshot, diagnostics, and timing.
- Keeps `--mermaid` delegated to `@fluojs/studio` and rejects Mermaid timing/report mixing so the CLI does not own graph rendering semantics.
- Updates CLI README EN/KO and toolchain contract matrix EN/KO for the new inspect diagnostics contract.

## Testing

- `lsp_diagnostics` on `packages/cli/src/commands/inspect.ts`: no diagnostics found after workspace package build.
- `lsp_diagnostics` on `packages/cli/src/cli.test.ts`: no diagnostics found.
- `pnpm --filter @fluojs/runtime... build`: passed, preparing workspace package entries needed by CLI verification.
- `pnpm --dir packages/cli typecheck`: passed.
- `pnpm --dir packages/cli test`: passed, 10 files / 220 tests.
- `pnpm --dir packages/cli build`: passed.
- `pnpm verify:platform-consistency-governance`: passed.

## Public export documentation

- [x] Changed public exports include a source-level summary. No new public package exports were added; the existing programmatic inspect runtime option docs were extended through CLI behavior tests/docs.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No exported function signatures changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

`fluo inspect` remains read-only for the inspected application: output file writes are explicit caller-selected artifacts, and inspection still only bootstraps/closes the application context. Studio graph rendering remains delegated to `@fluojs/studio`; Mermaid output does not gain CLI-owned graph semantics.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Companion updates include docs contract matrix alignment and regression-test evidence.
- [x] No platform adapter conformance claim changed.