### PR TITLE
Resolve #1264: add generate dry-run planning

### DIFF
--- a/docs/getting-started/generator-workflow.ko.md
+++ b/docs/getting-started/generator-workflow.ko.md
@@ -7,9 +7,9 @@
 ## Available Generators
 
 ```bash
-fluo generate <generator> <name> [--target-directory <path>] [--force]
-fluo g <generator> <name> [--target-directory <path>] [--force]
-fluo g request-dto <feature> <name> [--target-directory <path>] [--force]
+fluo generate <generator> <name> [--target-directory <path>] [--force] [--dry-run]
+fluo g <generator> <name> [--target-directory <path>] [--force] [--dry-run]
+fluo g request-dto <feature> <name> [--target-directory <path>] [--force] [--dry-run]
 ```
 
 | 생성기 | 허용 토큰 | 예시 문법 | 배선 방식 | 출력 범위 |
@@ -50,6 +50,7 @@ fluo g request-dto <feature> <name> [--target-directory <path>] [--force]
 | --- | --- | --- | --- |
 | `--target-directory <path>` | `-o` | 모든 생성기 | 지정한 소스 디렉터리 아래에 슬라이스를 기록합니다. |
 | `--force` | `-f` | 모든 생성기 | 기존 생성 파일을 건너뛰지 않고 덮어씁니다. |
+| `--dry-run` | 없음 | 모든 생성기 | 디렉터리 생성, 파일 쓰기, 모듈 갱신 없이 예정된 생성, 건너뛰기, 덮어쓰기, 모듈 갱신을 출력합니다. |
 | `--help` | `-h` | `fluo generate`, `fluo g` | generate 명령 사용법과 생성기 메타데이터를 출력합니다. |
 
 | 해석 규칙 | 결정되는 기본 디렉터리 |
@@ -67,7 +68,10 @@ fluo g request-dto <feature> <name> [--target-directory <path>] [--force]
 - Request DTO feature 타깃도 같은 검증을 거치며 kebab-case 디렉터리 이름으로 정규화됩니다. PascalCase feature 이름은 일반 리소스 plural 규칙을 따르므로 `fluo g req Post CreatePost`는 `posts/`에 기록하고, `posts` 같은 lower-case 디렉터리 토큰은 입력한 그대로 사용합니다. 1-인자 형식(`fluo g req CreatePost`)은 호환성을 위해 계속 지원하지만, 명시적 feature 형식을 사용하면 여러 DTO를 하나의 슬라이스에 모을 수 있습니다.
 - 유효한 `apps/*/src` 타깃이 둘 이상인 멀티 앱 워크스페이스 루트에서는 `--target-directory`가 필요합니다.
 - 기존 파일은 기본적으로 건너뜁니다. 덮어쓰기는 `--force`가 필요합니다.
+- `--dry-run`은 실제 실행과 같은 검증, 기본 타깃 해석, `--target-directory`, request DTO feature 타깃 규칙을 사용하지만 작업공간은 변경하지 않습니다.
+- Dry-run 출력은 파일만 생성하는 생성기와 자동 등록 생성기를 구분하며, 모듈이 생성, 갱신, 또는 변경 없음 상태인지도 표시합니다.
+- `--dry-run`과 `--force`를 함께 사용하면 덮어쓰기 결정을 적용하지 않고 미리 볼 수 있습니다.
 - 자동 등록 메타데이터가 해석되더라도 변경되지 않은 파일 내용은 다시 쓰지 않습니다.
 - 모듈 자동 등록은 controller, service, repository, guard, interceptor, middleware 생성기에만 적용됩니다.
 - DTO 생성기와 module 생성기는 상위 모듈 import를 자동으로 연결하지 않습니다.
-- generate 명령이 문서화하는 옵션은 `--target-directory`, `--force`, `--help`입니다. `fluo generate`와 `fluo g`에는 `--dry-run` 파서가 없습니다.
+- generate 명령이 문서화하는 옵션은 `--target-directory`, `--force`, `--dry-run`, `--help`입니다.

--- a/docs/getting-started/generator-workflow.md
+++ b/docs/getting-started/generator-workflow.md
@@ -7,9 +7,9 @@
 ## Available Generators
 
 ```bash
-fluo generate <generator> <name> [--target-directory <path>] [--force]
-fluo g <generator> <name> [--target-directory <path>] [--force]
-fluo g request-dto <feature> <name> [--target-directory <path>] [--force]
+fluo generate <generator> <name> [--target-directory <path>] [--force] [--dry-run]
+fluo g <generator> <name> [--target-directory <path>] [--force] [--dry-run]
+fluo g request-dto <feature> <name> [--target-directory <path>] [--force] [--dry-run]
 ```
 
 | Generator | Accepted tokens | Example syntax | Wiring | Output scope |
@@ -50,6 +50,7 @@ Controller and service templates inspect sibling files before rendering. A contr
 | --- | --- | --- | --- |
 | `--target-directory <path>` | `-o` | All generators | Writes the slice under the provided source directory. |
 | `--force` | `-f` | All generators | Overwrites existing generated files instead of skipping them. |
+| `--dry-run` | None | All generators | Prints the planned creates, skips, overwrites, and module updates without creating directories, writing files, or updating modules. |
 | `--help` | `-h` | `fluo generate`, `fluo g` | Prints generate-command usage and generator metadata. |
 
 | Resolution rule | Resolved base directory |
@@ -67,7 +68,10 @@ Controller and service templates inspect sibling files before rendering. A contr
 - Request DTO feature targets use the same validation and normalize to a kebab-case directory name. PascalCase feature names follow the normal resource pluralization (`fluo g req Post CreatePost` writes to `posts/`), while lower-case directory tokens such as `posts` are used as written. The one-name form (`fluo g req CreatePost`) remains supported for compatibility, but the explicit feature form keeps multiple DTOs in one slice.
 - A multi-app workspace root with more than one valid `apps/*/src` target requires `--target-directory`.
 - Existing files are skipped by default. `--force` is required for overwrite behavior.
+- `--dry-run` uses the same validation, default target resolution, `--target-directory`, and request DTO feature-target rules as a real run, but it leaves the workspace unchanged.
+- Dry-run output distinguishes files-only generators from auto-registered generators, including whether a module would be created, updated, or left unchanged.
+- Combining `--dry-run` with `--force` previews overwrite decisions without applying them.
 - Unchanged file content is not rewritten, even when the command resolves auto-registration metadata.
 - Module auto-registration is limited to controller, service, repository, guard, interceptor, and middleware generators.
 - DTO and module generators do not wire parent-module imports automatically.
-- The generate command surface documents `--target-directory`, `--force`, and `--help`. No `--dry-run` option is parsed for `fluo generate` or `fluo g`.
+- The generate command surface documents `--target-directory`, `--force`, `--dry-run`, and `--help`.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -100,9 +100,12 @@ fluo generate module users
 fluo generate controller users
 fluo generate service users
 fluo generate request-dto users CreateUser
+fluo generate service users --dry-run
 ```
 
 Request DTO 생성은 feature 디렉터리와 DTO 클래스 이름을 분리해서 받습니다. 따라서 `CreateUser`, `UpdateUser` 같은 여러 입력 계약을 같은 `src/users/` 슬라이스 안에 둘 수 있습니다.
+
+`--dry-run`을 추가하면 실제 실행과 같은 타깃 해석, 기존 파일 건너뛰기 또는 덮어쓰기 판단, 모듈 자동 등록 계획, 파일만 생성하는 wiring 상태, 다음 단계 힌트를 미리 볼 수 있습니다. 이 모드는 디렉터리 생성, 파일 쓰기, 모듈 갱신을 수행하지 않습니다. `--force`는 내용이 달라질 기존 파일의 계획 항목을 `SKIP`에서 `OVERWRITE`로 바꾸며, `--target-directory`는 실제 실행과 동일하게 지정한 소스 디렉터리 기준으로 preview 범위를 제한합니다.
 
 ## 주요 패턴
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -100,9 +100,12 @@ fluo generate module users
 fluo generate controller users
 fluo generate service users
 fluo generate request-dto users CreateUser
+fluo generate service users --dry-run
 ```
 
 Request DTO generation accepts the feature directory separately from the DTO class name, so multiple input contracts such as `CreateUser` and `UpdateUser` can live inside the same `src/users/` slice.
+
+Add `--dry-run` to preview the same target resolution, skipped or overwritten file decisions, module auto-registration plan, files-only wiring status, and next-step hint without creating directories, writing files, or updating modules. `--force` still changes existing-file plan entries from `SKIP` to `OVERWRITE` when content would change, and `--target-directory` scopes the preview to that source directory exactly as it does for a real run.
 
 ## Common Patterns
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -824,6 +824,7 @@ describe('CLI command runner', () => {
     }
 
     expect(stdoutBuffer.join('')).toContain('| Option                    | Aliases | Description');
+    expect(stdoutBuffer.join('')).toContain('--dry-run');
     expect(stdoutBuffer.join('')).not.toContain('Usage: fluo new|create');
     expect(stdoutBuffer.join('')).toContain('Next steps:');
     expect(stdoutBuffer.join('')).toContain("Run 'pnpm typecheck'");
@@ -1618,6 +1619,19 @@ describe('CLI command runner', () => {
     expect(stderrBuffer.join('')).toContain('Duplicate --target-directory option.');
   });
 
+  it('rejects duplicate --dry-run flags', async () => {
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['g', 'service', 'User', '--dry-run', '--dry-run'], {
+      cwd: process.cwd(),
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stderrBuffer.join('')).toContain('Duplicate --dry-run option.');
+  });
+
   it('rejects --target-directory values that look like options', async () => {
     const stderrBuffer: string[] = [];
 
@@ -1768,6 +1782,86 @@ describe('CLI command runner', () => {
     expect(output).toContain('Wiring: auto-registered in');
     expect(output).toContain('Next steps:');
     expect(output).toContain('pnpm typecheck');
+  });
+
+  it('prints a dry-run plan without writing files for auto-registered generate commands', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'package.json'),
+      JSON.stringify({ name: 'test-app', private: true }, null, 2),
+    );
+
+    const stdoutBuffer: string[] = [];
+    const exitCode = await runCli(['g', 'service', 'Post', '--dry-run'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Dry run: no files were written.');
+    expect(output).toContain('CREATE');
+    expect(output).toContain('MODULE-CREATE');
+    expect(output).toContain('Wiring: auto-registered in');
+    expect(existsSync(join(workspaceDirectory, 'src', 'posts'))).toBe(false);
+  });
+
+  it('prints request DTO feature-target dry-run plans without creating feature directories', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(
+      join(workspaceDirectory, 'package.json'),
+      JSON.stringify({ name: 'test-app', private: true }, null, 2),
+    );
+
+    const stdoutBuffer: string[] = [];
+    const exitCode = await runCli(['g', 'req', 'users', 'CreateUser', '--dry-run'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Dry run: no files were written.');
+    expect(output).toContain('users/create-user.request.dto.ts');
+    expect(output).toContain('Wiring: files only');
+    expect(existsSync(join(workspaceDirectory, 'src', 'users'))).toBe(false);
+  });
+
+  it('combines --dry-run with --force and --target-directory while leaving existing files untouched', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+
+    const customSourceDirectory = join(workspaceDirectory, 'custom-src');
+    const userDirectory = join(customSourceDirectory, 'users');
+    const servicePath = join(userDirectory, 'user.service.ts');
+    mkdirSync(userDirectory, { recursive: true });
+    writeFileSync(servicePath, 'export class CustomUserService {}\n', 'utf8');
+
+    const stdoutBuffer: string[] = [];
+    const exitCode = await runCli(['g', 'service', 'User', '--dry-run', '--force', '--target-directory', 'custom-src'], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('OVERWRITE');
+    expect(output).toContain('custom-src/users/user.service.ts');
+    expect(output).toContain('MODULE-CREATE');
+    expect(readFileSync(servicePath, 'utf8')).toBe('export class CustomUserService {}\n');
+    expect(existsSync(join(userDirectory, 'user.module.ts'))).toBe(false);
   });
 
   it('generate output shows files-only wiring and manual hint for non-registered kinds', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -83,6 +83,7 @@ const GENERATE_KIND_HELP: GenerateKindHelpEntry[] = [
 const GENERATE_OPTION_HELP: GenerateOptionHelpEntry[] = [
   { aliases: ['-o'], description: 'Write generated files under a specific source directory.', option: '--target-directory <path>' },
   { aliases: ['-f'], description: 'Overwrite files that already exist.', option: '--force' },
+  { aliases: [], description: 'Preview planned writes, skips, and module wiring without touching files.', option: '--dry-run' },
   { aliases: ['-h'], description: 'Show help for the generate command.', option: '--help' },
 ];
 
@@ -195,6 +196,7 @@ function parseGenerateArgs(argv: string[]): ParsedCliArgs {
   let seenRequestDtoName = false;
   let targetDirectory: string | undefined;
   let seenForce = false;
+  let seenDryRun = false;
   let seenTargetDirectory = false;
 
   for (let index = 0; index < optionArgs.length; index += 1) {
@@ -230,6 +232,16 @@ function parseGenerateArgs(argv: string[]): ParsedCliArgs {
 
       parsedOptions.force = true;
       seenForce = true;
+      continue;
+    }
+
+    if (option === '--dry-run') {
+      if (seenDryRun) {
+        throw new Error('Duplicate --dry-run option.');
+      }
+
+      parsedOptions.dryRun = true;
+      seenDryRun = true;
       continue;
     }
 
@@ -375,9 +387,17 @@ export async function runCli(
 
     const result = runGenerateCommand(parsedCommand.parsed.kind, parsedCommand.parsed.name, targetDirectory, parsedCommand.parsed.options);
 
-    stdout.write(`Generated ${result.generatedFiles.length} file(s):\n`);
-    for (const file of result.generatedFiles) {
-      stdout.write(`  CREATE ${file}\n`);
+    if (parsedCommand.parsed.options.dryRun) {
+      stdout.write('Dry run: no files were written.\n');
+      stdout.write(`Planned ${result.plannedFiles.length} file action(s):\n`);
+      for (const file of result.plannedFiles) {
+        stdout.write(`  ${file.action.toUpperCase()} ${file.path}\n`);
+      }
+    } else {
+      stdout.write(`Generated ${result.generatedFiles.length} file(s):\n`);
+      for (const file of result.generatedFiles) {
+        stdout.write(`  CREATE ${file}\n`);
+      }
     }
 
     stdout.write('\n');

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -196,6 +196,39 @@ export { PostModule };
     expect(existsSync(join(sourceDirectory, 'posts'))).toBe(false);
   });
 
+  it('previews module updates without changing existing module files during dry-run', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const domainDirectory = join(sourceDirectory, 'posts');
+    const modulePath = join(domainDirectory, 'post.module.ts');
+    const initialModuleContent = `import { Module } from '@fluojs/core';
+import { ExistingService } from './existing.service';
+
+@Module({ providers: [ExistingService], controllers: [] })
+class PostModule {}
+
+export { PostModule };
+`;
+    mkdirSync(domainDirectory, { recursive: true });
+    writeFileSync(modulePath, initialModuleContent, 'utf8');
+
+    const result = runGenerateCommand('service', 'Post', sourceDirectory, { dryRun: true });
+
+    expect(result.generatedFiles).toEqual([]);
+    expect(result.plannedFiles).toEqual([
+      { action: 'create', path: join(domainDirectory, 'post.service.ts') },
+      { action: 'create', path: join(domainDirectory, 'post.service.test.ts') },
+      { action: 'module-update', path: modulePath },
+    ]);
+    expect(result.wiringBehavior).toBe('auto-registered');
+    expect(result.moduleRegistered).toBe(true);
+    expect(readFileSync(modulePath, 'utf8')).toBe(initialModuleContent);
+    expect(existsSync(join(domainDirectory, 'post.service.ts'))).toBe(false);
+    expect(existsSync(join(domainDirectory, 'post.service.test.ts'))).toBe(false);
+  });
+
   it('previews explicit request DTO feature targets without writing files during dry-run', () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
     tempDirectories.push(workspaceDirectory);

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -178,6 +178,58 @@ export { PostModule };
     expect(result.nextStepHint).toContain('@FromBody');
   });
 
+  it('previews auto-registered generation without writing files during dry-run', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const result = runGenerateCommand('service', 'Post', sourceDirectory, { dryRun: true });
+
+    expect(result.generatedFiles).toEqual([]);
+    expect(result.plannedFiles).toEqual([
+      { action: 'create', path: join(sourceDirectory, 'posts', 'post.service.ts') },
+      { action: 'create', path: join(sourceDirectory, 'posts', 'post.service.test.ts') },
+      { action: 'module-create', path: join(sourceDirectory, 'posts', 'post.module.ts') },
+    ]);
+    expect(result.wiringBehavior).toBe('auto-registered');
+    expect(result.moduleRegistered).toBe(true);
+    expect(existsSync(join(sourceDirectory, 'posts'))).toBe(false);
+  });
+
+  it('previews explicit request DTO feature targets without writing files during dry-run', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const result = runGenerateCommand('request-dto', 'CreateUser', sourceDirectory, { dryRun: true, targetFeature: 'users' });
+
+    expect(result.generatedFiles).toEqual([]);
+    expect(result.plannedFiles).toEqual([{ action: 'create', path: join(sourceDirectory, 'users', 'create-user.request.dto.ts') }]);
+    expect(result.wiringBehavior).toBe('files-only');
+    expect(result.moduleRegistered).toBe(false);
+    expect(existsSync(join(sourceDirectory, 'users'))).toBe(false);
+    expect(existsSync(join(sourceDirectory, 'create-users'))).toBe(false);
+  });
+
+  it('previews skip versus force overwrite decisions without changing existing files', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const domainDirectory = join(sourceDirectory, 'posts');
+    const servicePath = join(domainDirectory, 'post.service.ts');
+    mkdirSync(domainDirectory, { recursive: true });
+    writeFileSync(servicePath, 'export class CustomPostService {}\n', 'utf8');
+
+    const skipped = runGenerateCommand('service', 'Post', sourceDirectory, { dryRun: true });
+    const overwritten = runGenerateCommand('service', 'Post', sourceDirectory, { dryRun: true, force: true });
+
+    expect(skipped.plannedFiles).toContainEqual({ action: 'skip', path: servicePath });
+    expect(overwritten.plannedFiles).toContainEqual({ action: 'overwrite', path: servicePath });
+    expect(readFileSync(servicePath, 'utf8')).toBe('export class CustomPostService {}\n');
+    expect(existsSync(join(domainDirectory, 'post.module.ts'))).toBe(false);
+  });
+
   it('writes request DTOs into an explicit feature directory when provided', () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
     tempDirectories.push(workspaceDirectory);

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -17,6 +17,45 @@ function writeFileIfChanged(filePath: string, content: string): boolean {
   return true;
 }
 
+/** Describes how one generated artifact would interact with the workspace. */
+export type GeneratePlanAction = 'create' | 'module-create' | 'module-unchanged' | 'module-update' | 'overwrite' | 'skip' | 'unchanged';
+
+/** One path-level action reported by generate dry-run previews and structured results. */
+export type GeneratePlanEntry = {
+  /** Planned action for this path. */
+  action: GeneratePlanAction;
+  /** Absolute path affected by the plan entry. */
+  path: string;
+};
+
+function planFileWrite(filePath: string, content: string, options: GenerateOptions): GeneratePlanEntry {
+  if (!existsSync(filePath)) {
+    return { action: 'create', path: filePath };
+  }
+
+  if (!options.force) {
+    return { action: 'skip', path: filePath };
+  }
+
+  if (readFileSync(filePath, 'utf8') === content) {
+    return { action: 'unchanged', path: filePath };
+  }
+
+  return { action: 'overwrite', path: filePath };
+}
+
+function planModuleWrite(modulePath: string, content: string): GeneratePlanEntry {
+  if (!existsSync(modulePath)) {
+    return { action: 'module-create', path: modulePath };
+  }
+
+  if (readFileSync(modulePath, 'utf8') === content) {
+    return { action: 'module-unchanged', path: modulePath };
+  }
+
+  return { action: 'module-update', path: modulePath };
+}
+
 function createGeneratorOptions(
   kind: GeneratorKind,
   domainDirectory: string,
@@ -121,6 +160,7 @@ export type GenerateResult = {
   moduleRegistered: boolean;
   modulePath: string | undefined;
   nextStepHint: string;
+  plannedFiles: GeneratePlanEntry[];
   wiringBehavior: GeneratorManifestEntry['wiringBehavior'];
 };
 
@@ -161,6 +201,20 @@ export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirect
     ? prepareModuleUpdate(domainDirectory, normalizedName, kind, moduleRegistration.classSuffix, moduleRegistration.arrayKey)
     : undefined;
 
+  const plannedFiles = files.map((file) => planFileWrite(join(domainDirectory, file.path), file.content, options));
+  const modulePlan = moduleUpdate ? planModuleWrite(moduleUpdate.modulePath, moduleUpdate.source) : undefined;
+
+  if (options.dryRun) {
+    return {
+      generatedFiles: [],
+      moduleRegistered: moduleUpdate !== undefined,
+      modulePath: moduleUpdate?.modulePath,
+      nextStepHint: generator.nextStepHint,
+      plannedFiles: modulePlan ? [...plannedFiles, modulePlan] : plannedFiles,
+      wiringBehavior: generator.wiringBehavior,
+    };
+  }
+
   mkdirSync(domainDirectory, { recursive: true });
 
   const writtenPaths = files.map((file) => {
@@ -193,6 +247,7 @@ export function runGenerateCommand(kind: GeneratorKind, name: string, baseDirect
     moduleRegistered: moduleRegistered,
     modulePath: resolvedModulePath,
     nextStepHint: generator.nextStepHint,
+    plannedFiles: modulePlan ? [...plannedFiles, modulePlan] : plannedFiles,
     wiringBehavior: generator.wiringBehavior,
   };
 }

--- a/packages/cli/src/generator-types.ts
+++ b/packages/cli/src/generator-types.ts
@@ -4,8 +4,10 @@ export interface GeneratedFile {
   path: string;
 }
 
-/** Optional generation flags that influence overwrite behavior, target placement, and sibling-aware templates. */
+/** Optional generation flags that influence overwrite behavior, target placement, plan previews, and sibling-aware templates. */
 export interface GenerateOptions {
+  /** Preview planned writes and module updates without mutating the workspace. */
+  dryRun?: boolean;
   force?: boolean;
   hasRepo?: boolean;
   hasService?: boolean;


### PR DESCRIPTION
## Summary

Closes #1264

Add safe dry-run planning for `fluo generate` / `fluo g` so users can preview creates, skips, overwrites, module wiring, files-only behavior, and next-step hints before touching the workspace.

## Changes

- Added `--dry-run` parsing and help output for generate commands.
- Added structured `plannedFiles` output while preserving existing real-run file generation and module auto-registration behavior.
- Covered dry-run write prevention, request DTO feature-target dry-run, and `--force` + `--target-directory` preview interactions with regression tests.
- Updated CLI README and generator workflow docs in EN/KO.

## Testing

- `lsp_diagnostics` on changed TS files: no diagnostics.
- `pnpm install` in the isolated worktree to hydrate dependencies.
- `pnpm build` ✅
- `pnpm --dir packages/cli exec vitest run -c vitest.config.ts src/commands/generate.test.ts src/cli.test.ts` ✅ (100 tests)
- `pnpm --dir packages/cli typecheck` ✅
- `pnpm lint` ✅ (`verify:public-export-tsdoc` passed; Biome reported existing warnings/info outside this change set)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] No platform contract docs changed.
- [x] Package README alignment is backed by CLI regression tests rather than platform conformance harnesses.

## Remaining risks

- `pnpm lint` currently reports pre-existing Biome warning/info output in unrelated files; no changed-file TSDoc failures were reported.