### PR TITLE
Resolve #1266: Add scaffold plan preview

### DIFF
--- a/docs/reference/fluo-new-support-matrix.ko.md
+++ b/docs/reference/fluo-new-support-matrix.ko.md
@@ -19,6 +19,7 @@
 | **참조 문서** | 런타임/패키지 참조 문서는 shipped starter preset 바깥의 더 넓은 생태계 지도로 읽습니다. |
 | **애플리케이션 명령** | Fastify, Express, raw Node.js, Bun, Deno, Cloudflare Workers에 대한 명시적 `fluo new --shape application --transport http --runtime ... --platform ...` 명령을 runnable starter 계약으로 읽습니다. |
 | **마이크로서비스 명령** | 문서화된 `tcp`, `redis-streams`, `nats`, `kafka`, `rabbitmq`, `mqtt`, `grpc` 변형을 runnable starter 계약으로 읽습니다. 그 밖의 어댑터/패키지 언급은 더 넓은 생태계를 설명합니다. |
+| **plan preview** | `fluo new ... --print-plan`은 같은 resolved starter 계약을 사용하는 non-writing preview로 읽습니다. 선택된 recipe, package manager, install/git 선택, dependency 세트를 출력하지만 파일 생성, dependency 설치, git 초기화는 수행하지 않습니다. |
 
 ## 명시적 지원 스타터 값
 

--- a/docs/reference/fluo-new-support-matrix.md
+++ b/docs/reference/fluo-new-support-matrix.md
@@ -19,6 +19,7 @@
 | **Reference docs** | Read runtime and package references as the broader ecosystem map outside the shipped starter presets. |
 | **Application commands** | Treat explicit `fluo new --shape application --transport http --runtime ... --platform ...` commands for Fastify, Express, raw Node.js, Bun, Deno, and Cloudflare Workers as the runnable starter contract. |
 | **Microservice commands** | Treat documented `tcp`, `redis-streams`, `nats`, `kafka`, `rabbitmq`, `mqtt`, and `grpc` variants as the runnable starter contract. Other adapter or package mentions still describe the broader ecosystem. |
+| **Plan preview** | Treat `fluo new ... --print-plan` as a non-writing preview of the same resolved starter contract. It prints the selected recipe, package manager, install/git choices, and dependency sets without creating files, installing dependencies, or initializing git. |
 
 ## explicit supported starter values
 

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -90,6 +90,16 @@ fluo new my-mixed-app --shape mixed --transport tcp --runtime node --platform fa
 
 `fluo new`가 interactive TTY에서 실행되면 wizard는 기존 flags/config 모델을 그대로 사용합니다. wizard는 프로젝트 이름, shape-first 분기(`application` -> runtime + HTTP platform, `microservice` -> transport), 유지보수 가능한 tooling preset, package manager, 즉시 dependency를 설치할지 여부, git 저장소를 초기화할지 여부를 묻습니다. non-interactive 플래그 경로와 프로그래밍 방식의 `runNewCommand(...)` 호출도 동일한 resolved defaults를 사용합니다.
 
+side effect 없이 완전히 resolved starter를 미리 확인하려면 `--print-plan`을 사용하세요:
+
+```bash
+fluo new my-app --shape application --runtime node --platform fastify --print-plan
+fluo new my-service --shape microservice --transport tcp --print-plan
+fluo new my-mixed-app --shape mixed --print-plan
+```
+
+plan preview 모드는 실제 scaffold와 같은 프로젝트 이름, shape, runtime, platform, transport, tooling preset, package manager, install 선택, git 선택을 resolve합니다. 선택된 starter recipe와 dependency 세트를 출력한 뒤 파일 생성, dependency 설치, git 저장소 초기화 없이 종료합니다.
+
 현재 제공되는 스타터 매트릭스(Node.js Fastify/Express/raw Node.js HTTP, Bun, Deno, Cloudflare Workers, TCP/Redis Streams/NATS/Kafka/RabbitMQ/MQTT/gRPC microservice, 그리고 mixed)와 남아 있는 더 넓은 어댑터 생태계를 문서 수준에서 구분한 표는 [fluo new 지원 매트릭스](../../docs/reference/fluo-new-support-matrix.ko.md)를 확인하세요. `@fluojs/redis` 같은 패키지 수준 통합은 더 넓은 생태계에 남아 있지만, 추가 `fluo new --transport` 스타터 플래그는 아닙니다.
 
 ### 2. 기능 추가

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,6 +90,16 @@ fluo new my-mixed-app --shape mixed --transport tcp --runtime node --platform fa
 
 When `fluo new` runs in an interactive TTY, the wizard uses the same flags/config model. It asks for the project name, shape-first branch (`application` -> runtime + HTTP platform, `microservice` -> transport), the maintained tooling preset, package-manager choice, whether to install dependencies immediately, and whether to initialize a git repository. Non-interactive flags and programmatic `runNewCommand(...)` calls use the same resolved defaults.
 
+Use `--print-plan` when you want to preview the fully resolved starter without side effects:
+
+```bash
+fluo new my-app --shape application --runtime node --platform fastify --print-plan
+fluo new my-service --shape microservice --transport tcp --print-plan
+fluo new my-mixed-app --shape mixed --print-plan
+```
+
+Plan preview mode resolves the same project name, shape, runtime, platform, transport, tooling preset, package manager, install choice, and git choice as a real scaffold. It prints the selected starter recipe and dependency sets, then exits without creating files, installing dependencies, or initializing a git repository.
+
 For a docs-level table that separates the shipped starter matrix (Node.js Fastify/Express/raw Node.js HTTP, Bun, Deno, Cloudflare Workers, TCP/Redis Streams/NATS/Kafka/RabbitMQ/MQTT/gRPC microservices, plus mixed) from the remaining broader adapter ecosystem, see the [fluo new support matrix](../../docs/reference/fluo-new-support-matrix.md). Package-level integrations such as `@fluojs/redis` remain part of the broader ecosystem, but they are not extra `fluo new --transport` starter flags.
 
 ### 2. Generate a feature

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -651,6 +651,125 @@ describe('CLI command runner', () => {
     expect(appTestFile).toContain('InMemoryLoopbackTransport');
   });
 
+  it('prints an application scaffold plan without writing files, installing dependencies, or initializing git', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli([
+      'new',
+      'starter-app',
+      '--shape',
+      'application',
+      '--runtime',
+      'node',
+      '--platform',
+      'fastify',
+      '--transport',
+      'http',
+      '--install',
+      '--git',
+      '--print-plan',
+    ], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('fluo new scaffold plan');
+    expect(output).toContain('Shape: application');
+    expect(output).toContain('Runtime: node');
+    expect(output).toContain('Platform: fastify');
+    expect(output).toContain('Transport: http');
+    expect(output).toContain('Starter recipe: application-node-fastify-http');
+    expect(output).toContain('Package manager: pnpm');
+    expect(output).toContain('Install dependencies: yes');
+    expect(output).toContain('Initialize git: yes');
+    expect(output).toContain('@fluojs/platform-fastify');
+    expect(output).toContain('Side effects: none.');
+    expect(output).not.toContain('Skipping dependency installation.');
+    expect(output).not.toContain('Done.');
+    expect(existsSync(join(workspaceDirectory, 'starter-app'))).toBe(false);
+  });
+
+  it('prints a microservice scaffold plan with resolved defaults and no scaffold side effects', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli([
+      'new',
+      'starter-microservice',
+      '--shape',
+      'microservice',
+      '--transport',
+      'tcp',
+      '--no-install',
+      '--no-git',
+      '--print-plan',
+    ], {
+      cwd: workspaceDirectory,
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Project name: starter-microservice');
+    expect(output).toContain('Shape: microservice');
+    expect(output).toContain('Runtime: node');
+    expect(output).toContain('Platform: none');
+    expect(output).toContain('Transport: tcp');
+    expect(output).toContain('Starter recipe: microservice-node-none-tcp');
+    expect(output).toContain('Install dependencies: no');
+    expect(output).toContain('Initialize git: no');
+    expect(output).toContain('@fluojs/microservices');
+    expect(existsSync(join(workspaceDirectory, 'starter-microservice'))).toBe(false);
+  });
+
+  it('prints an interactive mixed scaffold plan without creating the selected project', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli(['new', '--print-plan'], {
+      cwd: workspaceDirectory,
+      interactive: true,
+      prompt: {
+        confirm: async (message) => message === 'Install dependencies now',
+        select: async <T extends string>(message: string, _choices: readonly { label: string; value: T }[], defaultValue?: T) => {
+          if (message === 'Starter shape') {
+            return 'mixed' as T;
+          }
+
+          return (defaultValue ?? 'pnpm') as T;
+        },
+        text: async () => 'starter-mixed-preview',
+      },
+      stderr: { write: () => undefined },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const output = stdoutBuffer.join('');
+
+    expect(exitCode).toBe(0);
+    expect(output).toContain('Project name: starter-mixed-preview');
+    expect(output).toContain('Shape: mixed');
+    expect(output).toContain('Runtime: node');
+    expect(output).toContain('Platform: fastify');
+    expect(output).toContain('Transport: tcp');
+    expect(output).toContain('Starter recipe: mixed-node-fastify-tcp');
+    expect(output).toContain('Install dependencies: yes');
+    expect(output).toContain('Initialize git: no');
+    expect(output).toContain('@fluojs/microservices');
+    expect(output).toContain('@fluojs/platform-fastify');
+    expect(existsSync(join(workspaceDirectory, 'starter-mixed-preview'))).toBe(false);
+  });
+
   it('rejects transport values that are outside the shipped microservice starter contract', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);

--- a/packages/cli/src/commands/new.ts
+++ b/packages/cli/src/commands/new.ts
@@ -5,6 +5,7 @@ import { spinner as clackSpinner, log as clackLog } from '@clack/prompts';
 import { renderAliasList, renderHelpTable } from '../help.js';
 import { installDependencies } from '../new/install.js';
 import { collectBootstrapAnswers, type BootstrapPrompter } from '../new/prompt.js';
+import { resolveBootstrapPlan } from '../new/resolver.js';
 import { scaffoldBootstrapApp } from '../new/scaffold.js';
 import {
   SUPPORTED_BOOTSTRAP_PLATFORMS,
@@ -132,6 +133,11 @@ const NEW_OPTION_HELP: NewOptionHelpEntry[] = [
     option: '--no-git',
   },
   {
+    aliases: [],
+    description: 'Print the resolved scaffold plan without writing files, installing dependencies, or initializing git.',
+    option: '--print-plan',
+  },
+  {
     aliases: ['-h'],
     description: 'Show help for the new command.',
     option: '--help',
@@ -182,8 +188,8 @@ function setBooleanSelection(
   return nextValue;
 }
 
-function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolean } {
-  const parsed: Partial<BootstrapAnswers> & { force?: boolean } = {};
+function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolean; printPlan?: boolean } {
+  const parsed: Partial<BootstrapAnswers> & { force?: boolean; printPlan?: boolean } = {};
   let hasExplicitTargetDirectory = false;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -254,7 +260,7 @@ function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolea
 
         parsed.platform = readOptionValue(argv, index, '--platform') as BootstrapAnswers['platform'];
         if (!SUPPORTED_PLATFORMS.has(parsed.platform)) {
-          throw new Error('Invalid --platform value "' + parsed.platform + '". Use one of: bun, cloudflare-workers, deno, fastify, express, nodejs, none.');
+          throw new Error(`Invalid --platform value "${parsed.platform}". Use one of: bun, cloudflare-workers, deno, fastify, express, nodejs, none.`);
         }
         index += 1;
         break;
@@ -299,6 +305,9 @@ function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolea
       case '--force':
         parsed.force = true;
         break;
+      case '--print-plan':
+        parsed.printPlan = true;
+        break;
       case '--install':
         parsed.installDependencies = setBooleanSelection(
           parsed.installDependencies,
@@ -339,6 +348,39 @@ function parseArgs(argv: string[]): Partial<BootstrapAnswers> & { force?: boolea
   }
 
   return parsed;
+}
+
+function renderDependencyList(dependencies: readonly string[]): string {
+  return dependencies.length > 0 ? dependencies.join(', ') : '(none)';
+}
+
+function renderScaffoldPlanPreview(answers: BootstrapAnswers, resolvedTargetDirectory: string): string {
+  const bootstrapPlan = resolveBootstrapPlan(answers);
+
+  return [
+    'fluo new scaffold plan',
+    '',
+    `Project name: ${answers.projectName}`,
+    `Target directory: ${answers.targetDirectory}`,
+    `Resolved target: ${resolvedTargetDirectory}`,
+    `Shape: ${answers.shape}`,
+    `Runtime: ${answers.runtime}`,
+    `Platform: ${answers.platform}`,
+    `Transport: ${answers.transport}`,
+    `Tooling preset: ${answers.tooling}`,
+    `Topology: ${answers.topology.mode}${answers.topology.deferred ? ' (deferred)' : ''}`,
+    `Starter recipe: ${bootstrapPlan.profile.id}`,
+    `Emitter: ${bootstrapPlan.emitter.type}`,
+    `Package manager: ${answers.packageManager}`,
+    `Install dependencies: ${answers.installDependencies ? 'yes' : 'no'}`,
+    `Initialize git: ${answers.initializeGit ? 'yes' : 'no'}`,
+    '',
+    'Dependencies:',
+    `  runtime: ${renderDependencyList(bootstrapPlan.dependencies.dependencies)}`,
+    `  dev: ${renderDependencyList(bootstrapPlan.dependencies.devDependencies)}`,
+    '',
+    'Side effects: none. Preview mode does not create files, install dependencies, or initialize git.',
+  ].join('\n');
 }
 
 /**
@@ -415,11 +457,18 @@ export async function runNewCommand(argv: string[], runtime: NewCommandRuntimeOp
 
     const answers = await collectBootstrapAnswers(partialAnswers, runtime.cwd ?? process.cwd(), runtime.userAgent, {
       interactive: runtime.interactive,
+      completionMessage: parsed.printPlan ? 'Scaffold plan resolved. No files were written.' : undefined,
       prompt: runtime.prompt,
       stdin: runtime.stdin,
       stdout,
     });
     const targetDirectory = resolve(runtime.cwd ?? process.cwd(), answers.targetDirectory);
+
+    if (parsed.printPlan) {
+      stdout.write(`${renderScaffoldPlanPreview(answers, targetDirectory)}\n`);
+      return 0;
+    }
+
     const options = {
       ...answers,
       dependencySource: runtime.dependencySource,

--- a/packages/cli/src/new/prompt.ts
+++ b/packages/cli/src/new/prompt.ts
@@ -44,10 +44,22 @@ export interface BootstrapPrompter {
 
 /** Runtime overrides for resolving bootstrap answers in tests and editors. */
 export interface ResolveBootstrapAnswersOptions {
+  completionMessage?: string | ((answers: BootstrapAnswers) => string);
   interactive?: boolean;
   prompt?: BootstrapPrompter;
   stdin?: ReadableStream;
   stdout?: WritableStream;
+}
+
+function resolveCompletionMessage(
+  completionMessage: ResolveBootstrapAnswersOptions['completionMessage'],
+  answers: BootstrapAnswers,
+): string {
+  if (typeof completionMessage === 'function') {
+    return completionMessage(answers);
+  }
+
+  return completionMessage ?? `Project created! Run: cd ${answers.targetDirectory}`;
 }
 
 function hasOwnValue<Key extends keyof BootstrapAnswers>(
@@ -364,7 +376,7 @@ export async function collectBootstrapAnswers(
     const answers = await resolveInteractiveBootstrapAnswers(partial, cwd, userAgent, prompt);
 
     if (isInteractiveShell) {
-      clack.outro(`Project created! Run: cd ${answers.targetDirectory}`);
+      clack.outro(resolveCompletionMessage(options.completionMessage, answers));
     }
 
     return answers;


### PR DESCRIPTION
## Summary

- Add `fluo new --print-plan` to preview the resolved starter plan without scaffold side effects.
- Document the preview contract in the CLI README EN/KO and the `fluo new` support matrix EN/KO.

Closes #1266

## Changes

- Resolves the same project name, shape, runtime, platform, transport, tooling, package manager, install, and git choices used by real scaffolding.
- Prints the selected starter recipe, emitter, dependency sets, package manager, install choice, and git choice.
- Returns before `scaffoldBootstrapApp(...)`, dependency installation, or git initialization so preview mode does not create files.
- Keeps interactive and non-interactive option resolution on the existing `collectBootstrapAnswers(...)` path.

## Testing

- `lsp_diagnostics` on `packages/cli/src/commands/new.ts`, `packages/cli/src/new/prompt.ts`, and `packages/cli/src/cli.test.ts`: no diagnostics.
- `pnpm --dir packages/cli exec vitest run -c vitest.config.ts src/cli.test.ts src/new/prompt.test.ts src/new/scaffold.test.ts`: 111 tests passed.
- `pnpm typecheck`: passed.
- `pnpm build`: passed.
- `pnpm --dir packages/cli build`: passed after final source edit.
- `pnpm --dir packages/cli exec vitest run -c vitest.config.ts src/cli.test.ts src/new/prompt.test.ts`: 92 tests passed after final source edit.
- `pnpm --dir packages/cli sandbox:matrix`: passed on clean retry for representative application, microservice, and mixed starters. First run failed in generated app build because the fresh sandbox could not resolve `@babel/cli/bin/babel.js`; clean retry passed.
- `pnpm verify:platform-consistency-governance`: passed.
- `pnpm exec biome lint packages/cli/src/commands/new.ts packages/cli/src/new/prompt.ts packages/cli/src/cli.test.ts`: passed.
- `pnpm lint`: command completed with existing repo-wide Biome warning/info output outside the touched CLI files; `verify:public-export-tsdoc` passed.

## Public export documentation

- [x] Changed public exports include a source-level summary. No new public package exports were added.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. Existing exported command/prompt docs remain valid.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Remaining risks

- `pnpm lint` still reports pre-existing repo-wide Biome warnings/infos in unrelated packages; touched CLI TypeScript files lint clean.