### PR TITLE
Resolve #1273: refresh CLI getting started guides

### DIFF
--- a/docs/getting-started/generator-workflow.ko.md
+++ b/docs/getting-started/generator-workflow.ko.md
@@ -53,6 +53,20 @@ fluo g request-dto <feature> <name> [--target-directory <path>] [--force] [--dry
 | `--dry-run` | 없음 | 모든 생성기 | 디렉터리 생성, 파일 쓰기, 모듈 갱신 없이 예정된 생성, 건너뛰기, 덮어쓰기, 모듈 갱신을 출력합니다. |
 | `--help` | `-h` | `fluo generate`, `fluo g` | generate 명령 사용법과 생성기 메타데이터를 출력합니다. |
 
+## Dry-run Preview
+
+공유 작업공간이나 이미 손으로 수정한 생성 슬라이스를 바꾸기 전에 `--dry-run`을 사용하세요:
+
+```bash
+fluo generate service Billing --dry-run
+fluo g request-dto billing CreateInvoice --target-directory ./src --dry-run
+fluo g controller Billing --force --dry-run
+```
+
+Dry-run 모드는 `Dry run: no files were written.`를 출력한 뒤 각 예정 파일 동작을 나열합니다. 가능한 동작에는 `CREATE`, `SKIP`, `OVERWRITE`, `UNCHANGED`, `MODULE-CREATE`, `MODULE-UPDATE`, `MODULE-UNCHANGED`가 포함됩니다. Preview는 실제 실행과 같은 validation, target-directory 해석, request DTO feature-target 파싱, `--force` overwrite planning을 사용하지만 디렉터리를 만들거나, 생성 파일을 쓰거나, 모듈을 갱신하지 않습니다.
+
+자동 등록 생성기는 dry-run 중에도 module plan을 해석합니다. `module`, `request-dto`, `response-dto`처럼 파일만 생성하는 생성기도 파일 동작을 보고하며, parent-module wiring은 호출자가 직접 처리해야 합니다.
+
 ## Generator Collections
 
 `fluo generate`는 현재 결정적인 단일 collection인 `@fluojs/cli/builtin`만 discovery합니다. 이 collection은 `@fluojs/cli`에 함께 포함되며, 위에 나열된 generator metadata와 CLI help output, option schema, alias, wiring behavior, test의 기준입니다.

--- a/docs/getting-started/generator-workflow.md
+++ b/docs/getting-started/generator-workflow.md
@@ -53,6 +53,20 @@ Controller and service templates inspect sibling files before rendering. A contr
 | `--dry-run` | None | All generators | Prints the planned creates, skips, overwrites, and module updates without creating directories, writing files, or updating modules. |
 | `--help` | `-h` | `fluo generate`, `fluo g` | Prints generate-command usage and generator metadata. |
 
+## Dry-run Preview
+
+Use `--dry-run` before changing a shared workspace or a generated slice that already has hand edits:
+
+```bash
+fluo generate service Billing --dry-run
+fluo g request-dto billing CreateInvoice --target-directory ./src --dry-run
+fluo g controller Billing --force --dry-run
+```
+
+Dry-run mode prints `Dry run: no files were written.`, followed by each planned file action. Possible actions include `CREATE`, `SKIP`, `OVERWRITE`, `UNCHANGED`, `MODULE-CREATE`, `MODULE-UPDATE`, and `MODULE-UNCHANGED`. The preview uses the same validation, target-directory resolution, request DTO feature-target parsing, and `--force` overwrite planning as a real run, but it never creates directories, writes generated files, or updates modules.
+
+Auto-registered generators still resolve the module plan during dry-run. Files-only generators such as `module`, `request-dto`, and `response-dto` still report their file actions and leave parent-module wiring to the caller.
+
 ## Generator Collections
 
 `fluo generate` currently discovers exactly one deterministic collection: `@fluojs/cli/builtin`. It is bundled with `@fluojs/cli`, contains the generator metadata listed above, and is the source of truth for CLI help output, option schemas, aliases, wiring behavior, and tests.

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -52,6 +52,28 @@
 - `emitDecoratorMetadata`는 DI 연결에 사용되지 않으므로 반드시 비활성 상태를 유지해야 한다.
 - 메타데이터 emit이나 `reflect-metadata`에 의존하던 코드는 반드시 명시적 토큰과 명시적 등록 방식으로 옮겨야 한다.
 
+## CLI Migration Preview
+
+`fluo migrate`는 기본적으로 dry-run 모드로 실행됩니다. 파일을 쓰기 전에 NestJS-to-fluo codemod report를 확인하려면 다음 명령을 사용하세요:
+
+```bash
+fluo migrate ./src
+fluo migrate ./src --json
+```
+
+Report와 warning을 검토한 뒤에만 `--apply`를 사용하세요:
+
+```bash
+fluo migrate ./src --apply
+fluo migrate ./src --apply --json
+```
+
+기본 출력은 사람이 읽는 형식입니다. CI 작업, dashboard, migration report에서 안정적인 machine-readable output이 필요하면 `--json`을 추가하세요. JSON 모드는 성공 시 stdout에 structured migration report만 씁니다. Parser 오류와 잘못된 flag 조합은 기존처럼 stderr에 메시지를 쓰고 exit code `1`을 반환하며 partial JSON을 출력하지 않습니다.
+
+JSON report에는 `mode`(`dry-run` 또는 `apply`), `dryRun`, `apply`, 활성화된 `transforms`, `scannedFiles`, `changedFiles`, 전체 `warningCount`, 파일별 metadata가 포함됩니다. 각 파일 항목은 `filePath`, 파일 변경 여부, 적용된 transform, warning count, category label과 source line number가 포함된 warning detail을 기록합니다.
+
+Codemod는 import 재작성, `@Injectable()` 제거, provider scope 매핑, decorator compiler flag 갱신, `baseUrl` path alias 설정 재작성을 수행할 수 있습니다. 그래도 수동 검토는 필요합니다. 마이그레이션을 수락하기 전에 모든 warning category를 post-codemod checklist 항목으로 처리하세요.
+
 ## Related Docs
 
 - [NestJS Parity Gaps](../contracts/nestjs-parity-gaps.ko.md)

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -52,6 +52,28 @@ Migration MUST remove legacy NestJS-era decorator assumptions from `tsconfig.jso
 - `emitDecoratorMetadata` is not used for DI wiring and MUST remain disabled.
 - Code that depended on metadata emission or `reflect-metadata` MUST be migrated to explicit tokens and explicit registration.
 
+## CLI Migration Preview
+
+`fluo migrate` runs in dry-run mode by default. Use it to inspect the NestJS-to-fluo codemod report before writing any files:
+
+```bash
+fluo migrate ./src
+fluo migrate ./src --json
+```
+
+Use `--apply` only after reviewing the report and warnings:
+
+```bash
+fluo migrate ./src --apply
+fluo migrate ./src --apply --json
+```
+
+Human-readable output is the default. Add `--json` when CI jobs, dashboards, or migration reports need stable machine-readable output. JSON mode writes only the structured migration report to stdout on success. Parser errors and invalid flag combinations still write their message to stderr, return exit code `1`, and do not emit partial JSON.
+
+The JSON report includes `mode` (`dry-run` or `apply`), `dryRun`, `apply`, enabled `transforms`, `scannedFiles`, `changedFiles`, aggregate `warningCount`, and per-file metadata. Each file entry records `filePath`, whether the file changed, applied transforms, warning count, and warning details with category labels and source line numbers.
+
+The codemod can rewrite imports, remove `@Injectable()`, map provider scopes, update decorator compiler flags, and rewrite `baseUrl` path alias configuration. It does not remove the need for manual review. Treat every warning category as a post-codemod checklist item before accepting the migration.
+
 ## Related Docs
 
 - [NestJS Parity Gaps](../contracts/nestjs-parity-gaps.md)

--- a/docs/getting-started/quick-start.ko.md
+++ b/docs/getting-started/quick-start.ko.md
@@ -89,6 +89,18 @@ my-fluo-app/
 
 interactive terminal에서 `fluo new` wizard를 실행할 경우, 파일을 쓰기 전에 동일한 유지보수 대상 스타터 매트릭스를 기준으로 선택지가 해석됩니다.
 
+### Previewing a starter plan
+
+파일시스템을 건드리지 않고 해석된 스타터를 확인해야 할 때는 `--print-plan`을 사용하세요:
+
+```bash
+fluo new my-fluo-app --print-plan
+fluo new my-service --shape microservice --transport tcp --print-plan
+fluo new my-mixed-app --shape mixed --print-plan
+```
+
+Plan preview 모드는 실제 scaffold와 같은 프로젝트 이름, target directory, shape, runtime, platform, transport, tooling preset, package manager, dependency installation 선택, git initialization 선택을 resolve합니다. 선택된 starter recipe와 runtime/dev dependency 세트를 출력한 뒤 side effect 없이 종료합니다. 파일을 생성하거나, dependency를 설치하거나, git을 초기화하지 않습니다.
+
 ## Development Server
 
 프로젝트 루트 기준 생성된 프로젝트 시작 명령:
@@ -124,3 +136,4 @@ curl http://localhost:3000/hello
 - 기본 생성 애플리케이션은 `pnpm dev` 중 포트 `3000`에서 리슨합니다.
 - 기본 생성 애플리케이션은 `/health`와 `/hello`를 노출합니다.
 - `fluo new` 스타터 변형은 CLI README와 지원 매트릭스에 문서화된 유지보수 대상 스타터 매트릭스에 맞춰집니다.
+- `fluo new --print-plan`은 읽기 전용 preview 경로입니다. 프로젝트 파일 작성, dependency 설치, git 초기화 없이 starter plan과 dependency 세트를 해석합니다.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -89,6 +89,18 @@ Authoritative starter matrix: [fluo new support matrix](../reference/fluo-new-su
 
 In an interactive terminal, the `fluo new` wizard resolves the same maintained starter matrix before writing files.
 
+### Previewing a starter plan
+
+Use `--print-plan` when you need to inspect the resolved starter without touching the filesystem:
+
+```bash
+fluo new my-fluo-app --print-plan
+fluo new my-service --shape microservice --transport tcp --print-plan
+fluo new my-mixed-app --shape mixed --print-plan
+```
+
+Plan preview mode resolves the same project name, target directory, shape, runtime, platform, transport, tooling preset, package manager, dependency installation choice, and git initialization choice as a real scaffold. It prints the selected starter recipe and runtime/dev dependency sets, then exits with no side effects. It does not create files, install dependencies, or initialize git.
+
 ## Development Server
 
 Generated project start command from the project root:
@@ -124,3 +136,4 @@ Expected output:
 - The default generated application listens on port `3000` during `pnpm dev`.
 - The default generated application exposes `/health` and `/hello`.
 - `fluo new` starter variants map to the maintained starter matrix documented in the CLI README and the support matrix.
+- `fluo new --print-plan` is a read-only preview path. It resolves the starter plan and dependency sets without writing project files, running dependency installation, or initializing git.


### PR DESCRIPTION
## Summary

Refresh the getting-started CLI guide pages so the documented generate, new, and migrate workflows match the recently merged command behavior.

Closes #1273

## Changes

- Document `fluo generate --dry-run` preview behavior in the generator workflow EN/KO pair.
- Add `fluo new --print-plan` examples and no-write guarantees to the quick-start EN/KO pair.
- Add `fluo migrate --json` and `fluo migrate --apply --json` guidance to the NestJS migration EN/KO pair.
- Keep changed EN/KO headings and content aligned across the three document pairs.

## Testing

- `lsp_diagnostics` on all six changed markdown files: no diagnostics.
- EN/KO heading check for changed getting-started pairs: aligned.
- `pnpm verify:platform-consistency-governance`: passed.
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts`: 8 tests passed.

## Public export documentation

- [x] No public exports changed.
- [x] No exported function documentation changed.
- [x] Source examples and README examples remain complementary.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New CLI behavior references are documented in guide pages already backed by the CLI README.
- [x] Intentional no-write and JSON-output boundaries are explicitly stated.
- [x] Runtime invariants were not changed, docs-only PR.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed docs.
- [x] Platform governance verifier passed.
- [x] No package README alignment or platform conformance claims changed.