### PR TITLE
Resolve #1274: document inspect report artifacts

### DIFF
--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -63,7 +63,7 @@
 
 런타임 패키지는 inspection snapshot과 timing diagnostics의 원천으로 남습니다. CLI는 그 런타임 값을 이동 가능한 artifact로 바꿉니다. Artifact는 raw JSON, timing envelope, report artifact, 또는 Studio가 설치된 경우 Mermaid text가 될 수 있습니다. Studio는 사람과 자동화 호출자를 위해 inspect artifact를 읽고, 검증하고, 필터링하고, 보여주고, 렌더링하는 책임을 맡습니다.
 
-이 경계는 graph semantics를 `@fluojs/cli` 밖에 둡니다. CLI는 `@fluojs/studio/contracts`를 찾아 `renderMermaid(snapshot)`을 호출할 수 있지만, 내부 dependency edge와 외부 dependency node를 Mermaid output으로 바꾸는 방식은 Studio가 정의합니다. 지속 보관할 artifact가 필요한 소비자는 raw snapshot에는 `fluo inspect --json --output <path>`, timing envelope에는 `fluo inspect --json --timing --output <path>`, support report에는 `fluo inspect --report --output <path>`를 사용해야 합니다.
+이 경계는 graph semantics를 `@fluojs/cli` 밖에 둡니다. CLI는 `@fluojs/studio/contracts`를 찾아 `renderMermaid(snapshot)`을 호출할 수 있지만, 내부 dependency edge와 외부 dependency node를 Mermaid output으로 바꾸는 방식은 Studio가 정의합니다. 지속 보관할 artifact가 필요한 소비자는 raw snapshot에는 `fluo inspect --json --output <path>`, standalone timing diagnostics에는 `fluo inspect --timing --output <path>`, snapshot-plus-timing envelope에는 `fluo inspect --json --timing --output <path>`, support report에는 `fluo inspect --report --output <path>`를 사용해야 합니다.
 
 ## 명명 규칙
 - **`platform-*`**: `PlatformAdapter`를 구현하는 런타임/프로토콜 어댑터 전용.

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -56,12 +56,12 @@
 
 ### tooling
 - **`@fluojs/cli`**: 프로젝트 스캐폴딩, 생성, codemod, 런타임이 생산한 snapshot에 대한 inspection 내보내기/위임. `fluo inspect`는 CLI argument validation, application bootstrap/close, JSON snapshot serialization, report artifact 쓰기, `--output <path>` file emission, Mermaid rendering을 위한 Studio handoff를 소유합니다.
-- **`@fluojs/studio`**: 파일 우선 snapshot/report 뷰어와 CLI 및 자동화 호출자를 위한 canonical 파싱, 필터링, 그래프 렌더링 헬퍼. Studio는 `fluo inspect --json` snapshot, `--json --timing` envelope, `--report` artifact, `renderMermaid(snapshot)`을 통한 Mermaid graph rendering을 소비하는 책임 경계를 소유합니다.
+- **`@fluojs/studio`**: 파일 우선 snapshot/report/timing 뷰어와 CLI 및 자동화 호출자를 위한 canonical 파싱, 필터링, 그래프 렌더링 헬퍼. Studio는 `fluo inspect --json` snapshot, standalone `--timing` diagnostics, `--json --timing` envelope, `--report` artifact, `renderMermaid(snapshot)`을 통한 Mermaid graph rendering을 소비하는 책임 경계를 소유합니다.
 - **`@fluojs/testing`**: 애플리케이션 및 플랫폼 계약을 검증하기 위한 conformance 및 통합 헬퍼.
 
 ## Studio inspect artifact ownership
 
-런타임 패키지는 inspection snapshot과 timing diagnostics의 원천으로 남습니다. CLI는 그 런타임 값을 이동 가능한 artifact로 바꿉니다. Artifact는 raw JSON, timing envelope, report artifact, 또는 Studio가 설치된 경우 Mermaid text가 될 수 있습니다. Studio는 사람과 자동화 호출자를 위해 inspect artifact를 읽고, 검증하고, 필터링하고, 보여주고, 렌더링하는 책임을 맡습니다.
+런타임 패키지는 inspection snapshot과 timing diagnostics의 원천으로 남습니다. CLI는 그 런타임 값을 이동 가능한 artifact로 바꿉니다. Artifact는 raw JSON, standalone timing diagnostics, snapshot-plus-timing envelope, report artifact, 또는 Studio가 설치된 경우 Mermaid text가 될 수 있습니다. Studio는 사람과 자동화 호출자를 위해 inspect artifact를 읽고, 검증하고, 필터링하고, 보여주고, 렌더링하는 책임을 맡습니다.
 
 이 경계는 graph semantics를 `@fluojs/cli` 밖에 둡니다. CLI는 `@fluojs/studio/contracts`를 찾아 `renderMermaid(snapshot)`을 호출할 수 있지만, 내부 dependency edge와 외부 dependency node를 Mermaid output으로 바꾸는 방식은 Studio가 정의합니다. 지속 보관할 artifact가 필요한 소비자는 raw snapshot에는 `fluo inspect --json --output <path>`, standalone timing diagnostics에는 `fluo inspect --timing --output <path>`, snapshot-plus-timing envelope에는 `fluo inspect --json --timing --output <path>`, support report에는 `fluo inspect --report --output <path>`를 사용해야 합니다.
 

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -14,7 +14,7 @@
 | **Persistence** | 데이터베이스 및 캐시. | `@fluojs/prisma`, `@fluojs/drizzle`, `@fluojs/mongoose`, `@fluojs/redis`, `@fluojs/cache-manager` |
 | **Patterns** | 메시징 및 아키텍처. | `@fluojs/microservices`, `@fluojs/cqrs`, `@fluojs/event-bus`, `@fluojs/cron`, `@fluojs/queue`, `@fluojs/notifications`, `@fluojs/email`, `@fluojs/slack`, `@fluojs/discord` |
 | **Operations** | 헬스 및 모니터링. | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
-| **Tooling** | CLI 검사 내보내기, Studio 그래프 보기/렌더링, 테스트 진단. | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing` |
+| **Tooling** | CLI 검사 내보내기, Studio를 통한 inspect artifact 보기/렌더링, 테스트 진단. | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing` |
 
 ## canonical runtime package matrix
 
@@ -55,9 +55,15 @@
 - **`@fluojs/prisma` / `@fluojs/drizzle`**: ORM 라이프사이클 및 ALS 기반 트랜잭션 컨텍스트.
 
 ### tooling
-- **`@fluojs/cli`**: 프로젝트 스캐폴딩, 생성, codemod, 런타임이 생산한 snapshot에 대한 inspection 내보내기/위임.
-- **`@fluojs/studio`**: 파일 우선 snapshot 뷰어와 CLI 및 자동화 호출자를 위한 canonical 파싱, 필터링, 그래프 렌더링 헬퍼.
+- **`@fluojs/cli`**: 프로젝트 스캐폴딩, 생성, codemod, 런타임이 생산한 snapshot에 대한 inspection 내보내기/위임. `fluo inspect`는 CLI argument validation, application bootstrap/close, JSON snapshot serialization, report artifact 쓰기, `--output <path>` file emission, Mermaid rendering을 위한 Studio handoff를 소유합니다.
+- **`@fluojs/studio`**: 파일 우선 snapshot/report 뷰어와 CLI 및 자동화 호출자를 위한 canonical 파싱, 필터링, 그래프 렌더링 헬퍼. Studio는 `fluo inspect --json` snapshot, `--json --timing` envelope, `--report` artifact, `renderMermaid(snapshot)`을 통한 Mermaid graph rendering을 소비하는 책임 경계를 소유합니다.
 - **`@fluojs/testing`**: 애플리케이션 및 플랫폼 계약을 검증하기 위한 conformance 및 통합 헬퍼.
+
+## Studio inspect artifact ownership
+
+런타임 패키지는 inspection snapshot과 timing diagnostics의 원천으로 남습니다. CLI는 그 런타임 값을 이동 가능한 artifact로 바꿉니다. Artifact는 raw JSON, timing envelope, report artifact, 또는 Studio가 설치된 경우 Mermaid text가 될 수 있습니다. Studio는 사람과 자동화 호출자를 위해 inspect artifact를 읽고, 검증하고, 필터링하고, 보여주고, 렌더링하는 책임을 맡습니다.
+
+이 경계는 graph semantics를 `@fluojs/cli` 밖에 둡니다. CLI는 `@fluojs/studio/contracts`를 찾아 `renderMermaid(snapshot)`을 호출할 수 있지만, 내부 dependency edge와 외부 dependency node를 Mermaid output으로 바꾸는 방식은 Studio가 정의합니다. 지속 보관할 artifact가 필요한 소비자는 raw snapshot에는 `fluo inspect --json --output <path>`, timing envelope에는 `fluo inspect --json --timing --output <path>`, support report에는 `fluo inspect --report --output <path>`를 사용해야 합니다.
 
 ## 명명 규칙
 - **`platform-*`**: `PlatformAdapter`를 구현하는 런타임/프로토콜 어댑터 전용.

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -63,7 +63,7 @@
 
 Runtime packages remain the source of inspection snapshots and timing diagnostics. The CLI turns those runtime values into transportable artifacts, either raw JSON, a timing envelope, a report artifact, or Mermaid text when Studio is installed. Studio is responsible for reading, validating, filtering, viewing, and rendering those inspect artifacts for humans and automation callers.
 
-This boundary keeps graph semantics out of `@fluojs/cli`: the CLI may locate `@fluojs/studio/contracts` and call `renderMermaid(snapshot)`, but Studio defines how internal dependency edges and external dependency nodes become Mermaid output. Consumers that need a persistent artifact should use `fluo inspect --json --output <path>` for raw snapshots, `fluo inspect --json --timing --output <path>` for timing envelopes, or `fluo inspect --report --output <path>` for support reports.
+This boundary keeps graph semantics out of `@fluojs/cli`: the CLI may locate `@fluojs/studio/contracts` and call `renderMermaid(snapshot)`, but Studio defines how internal dependency edges and external dependency nodes become Mermaid output. Consumers that need a persistent artifact should use `fluo inspect --json --output <path>` for raw snapshots, `fluo inspect --timing --output <path>` for standalone timing diagnostics, `fluo inspect --json --timing --output <path>` for snapshot-plus-timing envelopes, or `fluo inspect --report --output <path>` for support reports.
 
 ## naming conventions
 - **`platform-*`**: Reserved for runtime/protocol adapters implementing `PlatformAdapter`.

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -56,12 +56,12 @@
 
 ### tooling
 - **`@fluojs/cli`**: Project scaffolding, generation, codemods, and inspection export/delegation for runtime-produced snapshots. `fluo inspect` owns CLI argument validation, application bootstrap/close, JSON snapshot serialization, report artifact writing, `--output <path>` file emission, and the handoff to Studio for Mermaid rendering.
-- **`@fluojs/studio`**: File-first snapshot/report viewer plus canonical parsing, filtering, and graph rendering helpers for CLI and automation callers. Studio owns the responsibility boundary for consuming `fluo inspect --json` snapshots, `--json --timing` envelopes, `--report` artifacts, and Mermaid graph rendering through `renderMermaid(snapshot)`.
+- **`@fluojs/studio`**: File-first snapshot/report/timing viewer plus canonical parsing, filtering, and graph rendering helpers for CLI and automation callers. Studio owns the responsibility boundary for consuming `fluo inspect --json` snapshots, standalone `--timing` diagnostics, `--json --timing` envelopes, `--report` artifacts, and Mermaid graph rendering through `renderMermaid(snapshot)`.
 - **`@fluojs/testing`**: Conformance and integration helpers for verifying application and platform contracts.
 
 ## Studio inspect artifact ownership
 
-Runtime packages remain the source of inspection snapshots and timing diagnostics. The CLI turns those runtime values into transportable artifacts, either raw JSON, a timing envelope, a report artifact, or Mermaid text when Studio is installed. Studio is responsible for reading, validating, filtering, viewing, and rendering those inspect artifacts for humans and automation callers.
+Runtime packages remain the source of inspection snapshots and timing diagnostics. The CLI turns those runtime values into transportable artifacts, either raw JSON, standalone timing diagnostics, a snapshot-plus-timing envelope, a report artifact, or Mermaid text when Studio is installed. Studio is responsible for reading, validating, filtering, viewing, and rendering those inspect artifacts for humans and automation callers.
 
 This boundary keeps graph semantics out of `@fluojs/cli`: the CLI may locate `@fluojs/studio/contracts` and call `renderMermaid(snapshot)`, but Studio defines how internal dependency edges and external dependency nodes become Mermaid output. Consumers that need a persistent artifact should use `fluo inspect --json --output <path>` for raw snapshots, `fluo inspect --timing --output <path>` for standalone timing diagnostics, `fluo inspect --json --timing --output <path>` for snapshot-plus-timing envelopes, or `fluo inspect --report --output <path>` for support reports.
 

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -14,7 +14,7 @@
 | **Persistence** | Database and cache. | `@fluojs/prisma`, `@fluojs/drizzle`, `@fluojs/mongoose`, `@fluojs/redis`, `@fluojs/cache-manager` |
 | **Patterns** | Messaging and architecture. | `@fluojs/microservices`, `@fluojs/cqrs`, `@fluojs/event-bus`, `@fluojs/cron`, `@fluojs/queue`, `@fluojs/notifications`, `@fluojs/email`, `@fluojs/slack`, `@fluojs/discord` |
 | **Operations** | Health and monitoring. | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
-| **Tooling** | CLI inspection export, Studio graph viewing/rendering, and testing diagnostics. | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing` |
+| **Tooling** | CLI inspection export, inspect artifact viewing/rendering through Studio, and testing diagnostics. | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing` |
 
 ## canonical runtime package matrix
 
@@ -55,9 +55,15 @@
 - **`@fluojs/prisma` / `@fluojs/drizzle`**: ORM lifecycle and ALS-backed transaction context.
 
 ### tooling
-- **`@fluojs/cli`**: Project scaffolding, generation, codemods, and inspection export/delegation for runtime-produced snapshots.
-- **`@fluojs/studio`**: File-first snapshot viewer plus canonical parsing, filtering, and graph rendering helpers for CLI and automation callers.
+- **`@fluojs/cli`**: Project scaffolding, generation, codemods, and inspection export/delegation for runtime-produced snapshots. `fluo inspect` owns CLI argument validation, application bootstrap/close, JSON snapshot serialization, report artifact writing, `--output <path>` file emission, and the handoff to Studio for Mermaid rendering.
+- **`@fluojs/studio`**: File-first snapshot/report viewer plus canonical parsing, filtering, and graph rendering helpers for CLI and automation callers. Studio owns the responsibility boundary for consuming `fluo inspect --json` snapshots, `--json --timing` envelopes, `--report` artifacts, and Mermaid graph rendering through `renderMermaid(snapshot)`.
 - **`@fluojs/testing`**: Conformance and integration helpers for verifying application and platform contracts.
+
+## Studio inspect artifact ownership
+
+Runtime packages remain the source of inspection snapshots and timing diagnostics. The CLI turns those runtime values into transportable artifacts, either raw JSON, a timing envelope, a report artifact, or Mermaid text when Studio is installed. Studio is responsible for reading, validating, filtering, viewing, and rendering those inspect artifacts for humans and automation callers.
+
+This boundary keeps graph semantics out of `@fluojs/cli`: the CLI may locate `@fluojs/studio/contracts` and call `renderMermaid(snapshot)`, but Studio defines how internal dependency edges and external dependency nodes become Mermaid output. Consumers that need a persistent artifact should use `fluo inspect --json --output <path>` for raw snapshots, `fluo inspect --json --timing --output <path>` for timing envelopes, or `fluo inspect --report --output <path>` for support reports.
 
 ## naming conventions
 - **`platform-*`**: Reserved for runtime/protocol adapters implementing `PlatformAdapter`.

--- a/docs/reference/toolchain-contract-matrix.ko.md
+++ b/docs/reference/toolchain-contract-matrix.ko.md
@@ -23,20 +23,22 @@
 | **대화형 위저드 (Interactive wizard)** | TTY에서 `fluo new` 실행 | 비대화형(non-interactive) 플래그 경로와 동일한 shape-first 스키마(프로젝트 이름, shape, tooling preset, package manager, install 선택, git 선택)로 해석됩니다. |
 | **리소스 생성** | `fluo g <type>` | 일관된 명명 접미사 (`.service.ts`, `.controller.ts`) 산출. Request DTO는 `fluo g req users CreateUser`처럼 명시적 feature 디렉터리를 대상으로 지정할 수 있습니다. |
 | **진단 (JSON)** | `fluo inspect <module-path> --json` | 런타임이 생산한 그래프, 준비성, 상태, 진단 snapshot 데이터를 JSON 형식으로 내보냅니다. 출력 모드를 고르지 않으면 JSON이 기본 출력 모드입니다. `--timing`은 `--json`과 함께 사용해 snapshot 옆에 bootstrap timing diagnostics를 포함할 수 있습니다. |
+| **진단 (timing)** | `fluo inspect <module-path> --timing --output artifacts/inspect-timing.json` | Standalone bootstrap timing diagnostics를 JSON artifact로 씁니다. `--output`이 없으면 같은 timing JSON을 stdout에 씁니다. |
 | **진단 report** | `fluo inspect <module-path> --report --output artifacts/inspect-report.json` | 안정적인 요약, 런타임이 생산한 snapshot, diagnostics, bootstrap timing을 포함하는 CI/support triage JSON report를 씁니다. `--output <path>`는 명시적 artifact 경로이며 inspection이 애플리케이션 write를 소유하게 만들지 않습니다. |
 | **진단 (Mermaid)** | `fluo inspect <module-path> --mermaid` | snapshot-to-Mermaid 렌더링을 선택적 `@fluojs/studio` 계약에 위임합니다. CLI는 Studio renderer를 로드하고 Mermaid text를 stdout 또는 `--output <path>`에 쓰며, 그래프 렌더링 의미론을 소유하지 않습니다. |
 
 ## inspect artifact output contract
 
-`fluo inspect`는 한 번에 하나의 주요 artifact 출력 모드만 지원합니다. 가능한 모드는 `--json`, `--mermaid`, `--report`입니다. `--output <path>`는 선택된 payload를 요청한 경로에 쓰고, 필요한 parent directory를 생성하며, 해당 payload의 terminal 출력을 생략합니다. `--output`이 없으면 선택된 payload를 stdout에 쓰므로 CI artifact용 shell redirection도 계속 유효합니다.
+`fluo inspect`는 한 번에 하나의 주요 artifact 출력 모드만 지원합니다. 가능한 모드는 `--json`, `--mermaid`, `--report`, standalone `--timing`입니다. `--output <path>`는 선택된 payload를 요청한 경로에 쓰고, 필요한 parent directory를 생성하며, 해당 payload의 terminal 출력을 생략합니다. `--output`이 없으면 선택된 payload를 stdout에 쓰므로 CI artifact용 shell redirection도 계속 유효합니다.
 
 | 모드 | payload | artifact 계약 |
 | --- | --- | --- |
 | `--json` | 런타임 platform shell이 생산한 `PlatformShellSnapshot` JSON. | Studio, script, support triage가 사용할 수 있는 안정적인 machine-readable snapshot입니다. `--timing`을 함께 쓰면 payload는 `{ snapshot, timing }`이 되며, `timing`은 versioned bootstrap timing diagnostics입니다. |
+| `--timing` | Versioned bootstrap timing diagnostics JSON. | 전체 snapshot 없이 bootstrap 작업을 profiling하기 위한 standalone timing artifact입니다. `--timing --output <path>`는 해당 timing JSON을 요청한 artifact 경로에 씁니다. |
 | `--mermaid` | 런타임 snapshot에서 `@fluojs/studio`가 렌더링한 Mermaid graph text. | 검사 대상 프로젝트나 CLI 패키지에서 `@fluojs/studio`를 resolve할 수 있어야 합니다. Non-interactive 실행에서 Studio가 없으면 설치 안내와 함께 빠르게 실패합니다. |
 | `--report` | `summary`, `snapshot`, `timing`, `generatedAt`을 포함한 versioned JSON report. | `artifacts/inspect-report.json` 같은 CI/support artifact에 쓰기 위한 형식입니다. Summary에는 component, diagnostic, warning, error, readiness, health, timing total이 포함됩니다. |
 
-`--timing`은 JSON 및 report workflow에 bootstrap timing diagnostics를 기록합니다. Mermaid rendering은 timing artifact 형식이 아니라 Studio가 소유한 snapshot rendering 계약이므로 `--mermaid`와 함께 사용할 수 없습니다.
+`--timing`은 standalone timing JSON artifact로 또는 JSON/report workflow 옆에 bootstrap timing diagnostics를 기록합니다. Mermaid rendering은 timing artifact 형식이 아니라 Studio가 소유한 snapshot rendering 계약이므로 `--mermaid`와 함께 사용할 수 없습니다.
 
 ## 명명 규칙 (CLI 출력)
 

--- a/docs/reference/toolchain-contract-matrix.ko.md
+++ b/docs/reference/toolchain-contract-matrix.ko.md
@@ -22,9 +22,21 @@
 | **프로젝트 생성 (mixed)** | `fluo new my-app --shape mixed --transport tcp --runtime node --platform fastify` | Fastify HTTP 앱 하나와 연결된(attached) TCP 마이크로서비스 하나를 함께 생성하는 혼합 단일 패키지 스타터를 생성합니다. |
 | **대화형 위저드 (Interactive wizard)** | TTY에서 `fluo new` 실행 | 비대화형(non-interactive) 플래그 경로와 동일한 shape-first 스키마(프로젝트 이름, shape, tooling preset, package manager, install 선택, git 선택)로 해석됩니다. |
 | **리소스 생성** | `fluo g <type>` | 일관된 명명 접미사 (`.service.ts`, `.controller.ts`) 산출. Request DTO는 `fluo g req users CreateUser`처럼 명시적 feature 디렉터리를 대상으로 지정할 수 있습니다. |
-| **진단 (JSON)** | `fluo inspect --json` | 런타임이 생산한 그래프, 준비성, 상태, 진단 snapshot 데이터를 JSON 형식으로 내보냅니다. `--timing`은 `--json`과 함께 사용해 bootstrap timing diagnostics를 포함할 수 있습니다. |
-| **진단 report** | `fluo inspect --report --output artifacts/inspect-report.json` | 안정적인 요약, 런타임이 생산한 snapshot, diagnostics, bootstrap timing을 포함하는 CI/support triage JSON report를 씁니다. `--output <path>`는 명시적 artifact 경로이며 inspection이 애플리케이션 write를 소유하게 만들지 않습니다. |
-| **진단 (Mermaid)** | `fluo inspect --mermaid` | snapshot-to-Mermaid 렌더링을 선택적 `@fluojs/studio` 계약에 위임합니다. CLI는 그래프 렌더링 의미론을 소유하지 않습니다. |
+| **진단 (JSON)** | `fluo inspect <module-path> --json` | 런타임이 생산한 그래프, 준비성, 상태, 진단 snapshot 데이터를 JSON 형식으로 내보냅니다. 출력 모드를 고르지 않으면 JSON이 기본 출력 모드입니다. `--timing`은 `--json`과 함께 사용해 snapshot 옆에 bootstrap timing diagnostics를 포함할 수 있습니다. |
+| **진단 report** | `fluo inspect <module-path> --report --output artifacts/inspect-report.json` | 안정적인 요약, 런타임이 생산한 snapshot, diagnostics, bootstrap timing을 포함하는 CI/support triage JSON report를 씁니다. `--output <path>`는 명시적 artifact 경로이며 inspection이 애플리케이션 write를 소유하게 만들지 않습니다. |
+| **진단 (Mermaid)** | `fluo inspect <module-path> --mermaid` | snapshot-to-Mermaid 렌더링을 선택적 `@fluojs/studio` 계약에 위임합니다. CLI는 Studio renderer를 로드하고 Mermaid text를 stdout 또는 `--output <path>`에 쓰며, 그래프 렌더링 의미론을 소유하지 않습니다. |
+
+## inspect artifact output contract
+
+`fluo inspect`는 한 번에 하나의 주요 artifact 출력 모드만 지원합니다. 가능한 모드는 `--json`, `--mermaid`, `--report`입니다. `--output <path>`는 선택된 payload를 요청한 경로에 쓰고, 필요한 parent directory를 생성하며, 해당 payload의 terminal 출력을 생략합니다. `--output`이 없으면 선택된 payload를 stdout에 쓰므로 CI artifact용 shell redirection도 계속 유효합니다.
+
+| 모드 | payload | artifact 계약 |
+| --- | --- | --- |
+| `--json` | 런타임 platform shell이 생산한 `PlatformShellSnapshot` JSON. | Studio, script, support triage가 사용할 수 있는 안정적인 machine-readable snapshot입니다. `--timing`을 함께 쓰면 payload는 `{ snapshot, timing }`이 되며, `timing`은 versioned bootstrap timing diagnostics입니다. |
+| `--mermaid` | 런타임 snapshot에서 `@fluojs/studio`가 렌더링한 Mermaid graph text. | 검사 대상 프로젝트나 CLI 패키지에서 `@fluojs/studio`를 resolve할 수 있어야 합니다. Non-interactive 실행에서 Studio가 없으면 설치 안내와 함께 빠르게 실패합니다. |
+| `--report` | `summary`, `snapshot`, `timing`, `generatedAt`을 포함한 versioned JSON report. | `artifacts/inspect-report.json` 같은 CI/support artifact에 쓰기 위한 형식입니다. Summary에는 component, diagnostic, warning, error, readiness, health, timing total이 포함됩니다. |
+
+`--timing`은 JSON 및 report workflow에 bootstrap timing diagnostics를 기록합니다. Mermaid rendering은 timing artifact 형식이 아니라 Studio가 소유한 snapshot rendering 계약이므로 `--mermaid`와 함께 사용할 수 없습니다.
 
 ## 명명 규칙 (CLI 출력)
 

--- a/docs/reference/toolchain-contract-matrix.md
+++ b/docs/reference/toolchain-contract-matrix.md
@@ -23,20 +23,22 @@
 | **Interactive wizard** | `fluo new` in a TTY | Resolves onto the same shape-first schema as the non-interactive flags path: project name, shape, tooling preset, package manager, install choice, and git choice. |
 | **Resource Generation** | `fluo g <type>` | Produces consistent naming suffixes (`.service.ts`, `.controller.ts`). Request DTOs may target an explicit feature directory with `fluo g req users CreateUser`. |
 | **Diagnostics (JSON)** | `fluo inspect <module-path> --json` | Exports runtime-produced graph, readiness, health, and diagnostics snapshot data in JSON format. JSON is also the default output mode when no output mode is selected. `--timing` may be combined with `--json` to include bootstrap timing diagnostics next to the snapshot. |
+| **Diagnostics (timing)** | `fluo inspect <module-path> --timing --output artifacts/inspect-timing.json` | Writes standalone bootstrap timing diagnostics as a JSON artifact. Without `--output`, the same timing JSON is written to stdout. |
 | **Diagnostics report** | `fluo inspect <module-path> --report --output artifacts/inspect-report.json` | Writes a CI/support triage JSON report containing a stable summary, the runtime-produced snapshot, diagnostics, and bootstrap timing. `--output <path>` is an explicit artifact path and does not make inspection own application writes. |
 | **Diagnostics (Mermaid)** | `fluo inspect <module-path> --mermaid` | Delegates snapshot-to-Mermaid rendering to the optional `@fluojs/studio` contract. The CLI loads Studio's renderer, writes the Mermaid text to stdout or `--output <path>`, and does not own graph rendering semantics. |
 
 ## inspect artifact output contract
 
-`fluo inspect` supports exactly one primary artifact output mode at a time: `--json`, `--mermaid`, or `--report`. `--output <path>` writes the selected payload to the requested path, creating parent directories when needed, and omits terminal output for that payload. Without `--output`, the selected payload is written to stdout so shell redirection remains valid for CI artifacts.
+`fluo inspect` supports exactly one primary artifact output mode at a time: `--json`, `--mermaid`, `--report`, or standalone `--timing`. `--output <path>` writes the selected payload to the requested path, creating parent directories when needed, and omits terminal output for that payload. Without `--output`, the selected payload is written to stdout so shell redirection remains valid for CI artifacts.
 
 | mode | payload | artifact contract |
 | --- | --- | --- |
 | `--json` | `PlatformShellSnapshot` JSON produced by the runtime platform shell. | Stable machine-readable snapshot for Studio, scripts, and support triage. With `--timing`, the payload becomes `{ snapshot, timing }`, where `timing` is versioned bootstrap timing diagnostics. |
+| `--timing` | Versioned bootstrap timing diagnostics JSON. | Standalone timing artifact for profiling bootstrap work without carrying the full snapshot. `--timing --output <path>` writes that timing JSON to the requested artifact path. |
 | `--mermaid` | Mermaid graph text rendered by `@fluojs/studio` from the runtime snapshot. | Requires `@fluojs/studio` to be resolvable from the inspected project or CLI package. Non-interactive runs fail fast with install guidance when Studio is missing. |
 | `--report` | Versioned JSON report with `summary`, `snapshot`, `timing`, and `generatedAt`. | Intended for CI/support artifacts such as `artifacts/inspect-report.json`. The summary includes component, diagnostic, warning, error, readiness, health, and timing totals. |
 
-`--timing` records bootstrap timing diagnostics for JSON and report workflows. It is not valid with `--mermaid`, because Mermaid rendering remains a Studio-owned snapshot rendering contract rather than a timing artifact format.
+`--timing` records bootstrap timing diagnostics either as a standalone timing JSON artifact or next to JSON/report workflows. It is not valid with `--mermaid`, because Mermaid rendering remains a Studio-owned snapshot rendering contract rather than a timing artifact format.
 
 ## naming conventions (CLI output)
 

--- a/docs/reference/toolchain-contract-matrix.md
+++ b/docs/reference/toolchain-contract-matrix.md
@@ -22,9 +22,21 @@
 | **Project Creation (mixed)** | `fluo new my-app --shape mixed --transport tcp --runtime node --platform fastify` | Generates the mixed single-package starter: one Fastify HTTP app with an attached TCP microservice. |
 | **Interactive wizard** | `fluo new` in a TTY | Resolves onto the same shape-first schema as the non-interactive flags path: project name, shape, tooling preset, package manager, install choice, and git choice. |
 | **Resource Generation** | `fluo g <type>` | Produces consistent naming suffixes (`.service.ts`, `.controller.ts`). Request DTOs may target an explicit feature directory with `fluo g req users CreateUser`. |
-| **Diagnostics (JSON)** | `fluo inspect --json` | Exports runtime-produced graph, readiness, health, and diagnostics snapshot data in JSON format. `--timing` may be combined with `--json` to include bootstrap timing diagnostics. |
-| **Diagnostics report** | `fluo inspect --report --output artifacts/inspect-report.json` | Writes a CI/support triage JSON report containing a stable summary, the runtime-produced snapshot, diagnostics, and bootstrap timing. `--output <path>` is an explicit artifact path and does not make inspection own application writes. |
-| **Diagnostics (Mermaid)** | `fluo inspect --mermaid` | Delegates snapshot-to-Mermaid rendering to the optional `@fluojs/studio` contract; the CLI does not own graph rendering semantics. |
+| **Diagnostics (JSON)** | `fluo inspect <module-path> --json` | Exports runtime-produced graph, readiness, health, and diagnostics snapshot data in JSON format. JSON is also the default output mode when no output mode is selected. `--timing` may be combined with `--json` to include bootstrap timing diagnostics next to the snapshot. |
+| **Diagnostics report** | `fluo inspect <module-path> --report --output artifacts/inspect-report.json` | Writes a CI/support triage JSON report containing a stable summary, the runtime-produced snapshot, diagnostics, and bootstrap timing. `--output <path>` is an explicit artifact path and does not make inspection own application writes. |
+| **Diagnostics (Mermaid)** | `fluo inspect <module-path> --mermaid` | Delegates snapshot-to-Mermaid rendering to the optional `@fluojs/studio` contract. The CLI loads Studio's renderer, writes the Mermaid text to stdout or `--output <path>`, and does not own graph rendering semantics. |
+
+## inspect artifact output contract
+
+`fluo inspect` supports exactly one primary artifact output mode at a time: `--json`, `--mermaid`, or `--report`. `--output <path>` writes the selected payload to the requested path, creating parent directories when needed, and omits terminal output for that payload. Without `--output`, the selected payload is written to stdout so shell redirection remains valid for CI artifacts.
+
+| mode | payload | artifact contract |
+| --- | --- | --- |
+| `--json` | `PlatformShellSnapshot` JSON produced by the runtime platform shell. | Stable machine-readable snapshot for Studio, scripts, and support triage. With `--timing`, the payload becomes `{ snapshot, timing }`, where `timing` is versioned bootstrap timing diagnostics. |
+| `--mermaid` | Mermaid graph text rendered by `@fluojs/studio` from the runtime snapshot. | Requires `@fluojs/studio` to be resolvable from the inspected project or CLI package. Non-interactive runs fail fast with install guidance when Studio is missing. |
+| `--report` | Versioned JSON report with `summary`, `snapshot`, `timing`, and `generatedAt`. | Intended for CI/support artifacts such as `artifacts/inspect-report.json`. The summary includes component, diagnostic, warning, error, readiness, health, and timing totals. |
+
+`--timing` records bootstrap timing diagnostics for JSON and report workflows. It is not valid with `--mermaid`, because Mermaid rendering remains a Studio-owned snapshot rendering contract rather than a timing artifact format.
 
 ## naming conventions (CLI output)
 


### PR DESCRIPTION
## Summary

- Documents the `fluo inspect` artifact contracts for raw JSON, Mermaid, timing, `--output`, and report workflows in the reference toolchain matrix.
- Clarifies the Studio ownership boundary for consuming inspect snapshots, timing envelopes, report artifacts, and Mermaid rendering in the package surface reference.

Closes #1274

## Changes

- Updated `docs/reference/toolchain-contract-matrix.md` and `.ko.md` with output mode and artifact location contracts.
- Updated `docs/reference/package-surface.md` and `.ko.md` with CLI, runtime, and Studio responsibility boundaries.
- Kept the change docs-only and avoided book advanced chapter files owned by #1276.

## Testing

- `lsp_diagnostics` on all four changed Markdown files: no diagnostics.
- `pnpm verify:platform-consistency-governance`: passed.
- `pnpm exec vitest run tooling/governance/verify-platform-consistency-governance.test.ts`: passed, 8 tests.

## Public export documentation

- [x] No public exports changed.
- [x] No exported function documentation changed.
- [x] Source examples and README examples are unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New CLI/Studio artifact documentation is reflected in reference docs only.
- [x] Intentional limitations remain explicit, including Mermaid rendering ownership by Studio.
- [x] Runtime invariants were not changed.

## Platform consistency governance (SSOT)

- [x] English/Korean reference updates were kept synchronized.
- [x] Platform governance verification passed.
- [x] No package README alignment or conformance claims were changed.