### PR TITLE
Resolve #1263: update vulnerable dependency resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "protobufjs"
-    ]
+    ],
+    "overrides": {
+      "protobufjs": "7.5.5"
+    }
   }
 }

--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -45,7 +45,7 @@
     "@fastify/multipart": "^9.2.1",
     "@fluojs/http": "workspace:^",
     "@fluojs/runtime": "workspace:^",
-    "fastify": "^5.6.1",
+    "fastify": "^5.8.5",
     "fastify-raw-body": "^5.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  protobufjs: 7.5.5
+
 importers:
 
   .:
@@ -621,8 +624,8 @@ importers:
         specifier: workspace:^
         version: link:../runtime
       fastify:
-        specifier: ^5.6.1
-        version: 5.8.2
+        specifier: ^5.8.5
+        version: 5.8.5
       fastify-raw-body:
         specifier: ^5.0.0
         version: 5.0.0
@@ -2452,8 +2455,8 @@ packages:
     resolution: {integrity: sha512-2qfoaQ3BQDhZ1gtbkKZd6n0kKxJISJGM6u/skD9ljdWItAscjXrtZ1lnjr7PavmXX9j4EyCPmBDiIsLn07d5vA==}
     engines: {node: '>= 10'}
 
-  fastify@5.8.2:
-    resolution: {integrity: sha512-lZmt3navvZG915IE+f7/TIVamxIwmBd+OMB+O9WBzcpIwOo6F0LTh0sluoMFk5VkrKTvvrwIaoJPkir4Z+jtAg==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2911,8 +2914,8 @@ packages:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -3935,7 +3938,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@ioredis/commands@1.5.0': {}
@@ -4753,7 +4756,7 @@ snapshots:
       raw-body: 3.0.2
       secure-json-parse: 2.7.0
 
-  fastify@5.8.2:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -5234,7 +5237,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       tdigest: 0.1.2
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary

Resolve the Dependabot alerts tracked in #1263 by updating the Fastify direct dependency range and pinning the vulnerable protobufjs transitive resolution through pnpm overrides.

Closes #1263

## Changes

- Updated `@fluojs/platform-fastify` to require `fastify` `^5.8.5`, resolving the vulnerable `5.8.2` lockfile resolution.
- Added a root `pnpm.overrides` entry for `protobufjs` `7.5.5`, covering the transitive `@grpc/proto-loader` / microservices gRPC path.
- Refreshed `pnpm-lock.yaml` so `fastify@5.8.5` and `protobufjs@7.5.5` are resolved.

## Testing

- `pnpm install --no-frozen-lockfile`
- `pnpm install --frozen-lockfile`
- `pnpm list fastify protobufjs --depth 20 --filter @fluojs/platform-fastify --filter @fluojs/microservices`
- `pnpm --filter @fluojs/platform-fastify... run build`
- `pnpm --filter @fluojs/microservices... run build`
- `pnpm --filter @fluojs/platform-fastify run typecheck`
- `pnpm --filter @fluojs/platform-fastify run test`
- `pnpm --filter @fluojs/microservices run typecheck`
- `pnpm --filter @fluojs/microservices run test`
- `pnpm verify`

## Public export documentation

- [x] No public exports changed.
- [x] No exported function documentation changes required.
- [x] README examples remain unchanged because this PR only updates dependency resolution.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contracts were introduced.
- [x] Intentional limitations are unchanged.
- [x] Runtime invariants are covered by the existing package and workspace verification above.

## Platform consistency governance (SSOT)

- [x] Governance docs were not changed.
- [x] Platform contract docs were not changed.
- [x] Package README alignment/conformance claims were not changed.