### PR TITLE
Version packages for beta.2

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": "@changesets/changelog-github",
+  "changelog": ["@changesets/changelog-github", { "repo": "fluojs/fluo" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -50,5 +50,7 @@
     "@fluojs-internal/tooling-vite": "0.0.0",
     "@fluojs-internal/tooling-vitest": "0.0.0"
   },
-  "changesets": []
+  "changesets": [
+    "beta-2-release"
+  ]
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,16 @@
+# @fluojs/cli
+
+## 1.0.0-beta.2
+
+### Minor Changes
+
+- [#1285](https://github.com/fluojs/fluo/pull/1285) [`185487f`](https://github.com/fluojs/fluo/commit/185487f01a8aaa0fe723b536f6bcaa2ab75cd84f) Thanks [@ayden94](https://github.com/ayden94)! - Expand CLI automation outputs for generation, inspection, migration, scaffolding, and generator metadata.
+
+  Expose Studio-owned snapshot-to-Mermaid rendering helpers and platform snapshot types.
+
+  Refresh the published Fastify adapter dependency metadata to fastify@^5.8.5.
+
+### Patch Changes
+
+- Updated dependencies [[`185487f`](https://github.com/fluojs/fluo/commit/185487f01a8aaa0fe723b536f6bcaa2ab75cd84f)]:
+  - @fluojs/studio@1.0.0-beta.2

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
     "migration",
     "diagnostics"
   ],
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -217,10 +217,11 @@ describe('scaffoldBootstrapApp', () => {
     expect(packageJson.devDependencies?.typescript).toBe('^6.0.2');
     expect(packageJson.dependencies).toMatchObject({
       '@fluojs/http': '^1.0.0-beta.1',
-      '@fluojs/platform-fastify': '^1.0.0-beta.1',
+      '@fluojs/platform-fastify': '^1.0.0-beta.2',
       '@fluojs/runtime': '^1.0.0-beta.1',
     });
     expect(packageJson.devDependencies).toMatchObject({
+      '@fluojs/cli': '^1.0.0-beta.2',
       '@fluojs/testing': '^1.0.0-beta.1',
     });
     expect(tsconfig).not.toContain('baseUrl');

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -32,6 +32,23 @@ const PUBLISHED_RUNTIME_DEPENDENCIES = {
   nats: '^2.29.3',
 } as const;
 
+const PUBLISHED_INTERNAL_DEPENDENCIES = {
+  '@fluojs/cli': '^1.0.0-beta.2',
+  '@fluojs/config': '^1.0.0-beta.1',
+  '@fluojs/core': '^1.0.0-beta.1',
+  '@fluojs/di': '^1.0.0-beta.1',
+  '@fluojs/http': '^1.0.0-beta.1',
+  '@fluojs/microservices': '^1.0.0-beta.1',
+  '@fluojs/platform-bun': '^1.0.0-beta.1',
+  '@fluojs/platform-cloudflare-workers': '^1.0.0-beta.1',
+  '@fluojs/platform-deno': '^1.0.0-beta.1',
+  '@fluojs/platform-express': '^1.0.0-beta.1',
+  '@fluojs/platform-fastify': '^1.0.0-beta.2',
+  '@fluojs/platform-nodejs': '^1.0.0-beta.1',
+  '@fluojs/runtime': '^1.0.0-beta.1',
+  '@fluojs/testing': '^1.0.0-beta.1',
+} as const;
+
 
 type ApplicationStarterDescriptor = {
   adapterCall?: string;
@@ -127,6 +144,7 @@ function createDependencySpec(
 ): string {
   return packageSpecs[packageName]
     ?? PUBLISHED_RUNTIME_DEPENDENCIES[packageName as keyof typeof PUBLISHED_RUNTIME_DEPENDENCIES]
+    ?? PUBLISHED_INTERNAL_DEPENDENCIES[packageName as keyof typeof PUBLISHED_INTERNAL_DEPENDENCIES]
     ?? createPublishedInternalDependencySpec(releaseVersion);
 }
 

--- a/packages/platform-fastify/CHANGELOG.md
+++ b/packages/platform-fastify/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @fluojs/platform-fastify
+
+## 1.0.0-beta.2
+
+### Patch Changes
+
+- [#1285](https://github.com/fluojs/fluo/pull/1285) [`185487f`](https://github.com/fluojs/fluo/commit/185487f01a8aaa0fe723b536f6bcaa2ab75cd84f) Thanks [@ayden94](https://github.com/ayden94)! - Expand CLI automation outputs for generation, inspection, migration, scaffolding, and generator metadata.
+
+  Expose Studio-owned snapshot-to-Mermaid rendering helpers and platform snapshot types.
+
+  Refresh the published Fastify adapter dependency metadata to fastify@^5.8.5.

--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -8,7 +8,7 @@
     "platform",
     "server"
   ],
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": false,
   "license": "MIT",
   "repository": {

--- a/packages/studio/CHANGELOG.md
+++ b/packages/studio/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @fluojs/studio
+
+## 1.0.0-beta.2
+
+### Minor Changes
+
+- [#1285](https://github.com/fluojs/fluo/pull/1285) [`185487f`](https://github.com/fluojs/fluo/commit/185487f01a8aaa0fe723b536f6bcaa2ab75cd84f) Thanks [@ayden94](https://github.com/ayden94)! - Expand CLI automation outputs for generation, inspection, migration, scaffolding, and generator metadata.
+
+  Expose Studio-owned snapshot-to-Mermaid rendering helpers and platform snapshot types.
+
+  Refresh the published Fastify adapter dependency metadata to fastify@^5.8.5.

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -9,7 +9,7 @@
     "module-graph",
     "devtools"
   ],
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "private": false,
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Version @fluojs/cli, @fluojs/studio, and @fluojs/platform-fastify to 1.0.0-beta.2 using Changesets prerelease mode.
- Add package-level changelogs and record the beta-2 changeset in prerelease state.
- Pin CLI scaffold dependency specs per package so beta.2 CLI does not generate unpublished beta.2 ranges for unchanged starter dependencies.

## Verification
- pnpm exec vitest run -c vitest.config.ts packages/cli/src/new/scaffold.test.ts
- pnpm verify:release-readiness

## Release notes
- Dist tag: beta
- Publish path: GitHub Actions release workflow after merge
- Local publish: not run