### PR TITLE
Resolve #1291: harden core metadata docs and decorator coverage

### DIFF
--- a/packages/core/README.ko.md
+++ b/packages/core/README.ko.md
@@ -60,6 +60,14 @@ class UserService {
 
 fluo는 TC39 표준 데코레이터를 사용하므로 `experimentalDecorators: true`나 `emitDecoratorMetadata: true`에 의존하지 않습니다.
 
+core 메타데이터는 fluo가 소유한 저장소와 TC39 `Symbol.metadata` 통합 지점을 통해 기록되며, `reflect-metadata`나 컴파일러가 생성하는 design type 메타데이터를 사용하지 않습니다. 런타임이 사용자 정의 표준 데코레이터를 평가하기 전에 `Symbol.metadata` 폴리필을 설치해야 한다면 테스트나 부트스트랩 경계에서 `ensureMetadataSymbol()`을 호출하세요.
+
+```ts
+import { ensureMetadataSymbol } from '@fluojs/core';
+
+ensureMetadataSymbol();
+```
+
 ### 명시적인 의존성 메타데이터
 
 `@Inject(...)`는 리플렉션 기반 추론 대신 코드 안에서 의존성 토큰을 직접 드러냅니다. 상속된 constructor 토큰을 명시적으로 비우려면 `@Inject()`를 사용하면 됩니다.
@@ -75,9 +83,13 @@ class UsesConfigValue {
 
 여러 토큰을 지정할 때는 `@Inject(A, B)`처럼 variadic 호출을 사용하면 됩니다.
 
+마이그레이션 기간 동안 legacy 배열 형식인 `@Inject([A, B])`도 계속 정규화되지만, 새 코드는 constructor 토큰을 표준 데코레이터 사용 방식과 맞추기 위해 variadic 형식을 권장합니다.
+
 ### 형제 패키지를 위한 공용 메타데이터 헬퍼
 
 내부 메타데이터 reader/writer는 `@fluojs/core/internal` 아래에 있으며, `@fluojs/di`, `@fluojs/http`, `@fluojs/runtime` 같은 패키지들이 같은 메타데이터 모델을 공유할 수 있게 합니다.
+
+애플리케이션 코드는 공개 데코레이터와 `ensureMetadataSymbol()`을 `@fluojs/core`에서 import해야 합니다. `@fluojs/core/internal` 서브패스는 복제된 메타데이터 레코드를 읽거나, 명시적 저장소와 `Symbol.metadata`를 병합하거나, 프레임워크 수준 데코레이터를 만드는 fluo 패키지를 위한 경로입니다.
 
 ```ts
 import { getModuleMetadata } from '@fluojs/core/internal';
@@ -149,6 +161,7 @@ class Logger {}
 
 - **데코레이터**: `Module`, `Global`, `Inject`, `Scope`
 - **에러**: `FluoError`, `InvariantError`, `FluoCodeError`
+- **메타데이터 런타임**: `ensureMetadataSymbol`
 - **타입**: `Constructor<T>`, `Token<T>`, `MaybePromise<T>`, `AsyncModuleOptions`
 - **내부 서브패스**: `@fluojs/core/internal`을 통한 메타데이터 헬퍼
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -62,6 +62,14 @@ class UserService {
 
 fluo uses TC39 standard decorators. You do not need `experimentalDecorators: true` or `emitDecoratorMetadata: true` to use `@Module`, `@Inject`, `@Global`, or `@Scope`.
 
+Core metadata is written through fluo-owned stores and TC39 `Symbol.metadata` integration points, never through `reflect-metadata` or compiler-emitted design types. Call `ensureMetadataSymbol()` at test or bootstrap boundaries when a runtime needs the `Symbol.metadata` polyfill installed before evaluating custom standard decorators.
+
+```ts
+import { ensureMetadataSymbol } from '@fluojs/core';
+
+ensureMetadataSymbol();
+```
+
 ### Explicit dependency metadata
 
 `@Inject(...)` keeps dependency wiring visible in code instead of relying on emitted reflection metadata. Call `@Inject()` when you want to record an explicit empty override for inherited constructor tokens.
@@ -77,9 +85,13 @@ class UsesConfigValue {
 
 Pass multiple tokens as variadic arguments such as `@Inject(A, B)`.
 
+The legacy array form `@Inject([A, B])` remains normalized during the migration window, but new code should prefer the variadic form so constructor tokens stay aligned with standard decorator usage.
+
 ### Shared metadata helpers for sibling packages
 
 Internal readers and writers live under `@fluojs/core/internal`, which is how packages like `@fluojs/di`, `@fluojs/http`, and `@fluojs/runtime` consume the same metadata model.
+
+Application code should import public decorators and `ensureMetadataSymbol()` from `@fluojs/core`. The `@fluojs/core/internal` subpath is reserved for fluo packages that need to read cloned metadata records, merge explicit stores with `Symbol.metadata`, or build framework-level decorators.
 
 ```ts
 import { getModuleMetadata } from '@fluojs/core/internal';
@@ -151,6 +163,7 @@ Standard decorators cannot automatically infer types for abstract classes or int
 
 - **Decorators**: `Module`, `Global`, `Inject`, `Scope`
 - **Errors**: `FluoError`, `InvariantError`, `FluoCodeError`
+- **Metadata runtime**: `ensureMetadataSymbol`
 - **Types**: `Constructor<T>`, `Token<T>`, `MaybePromise<T>`, `AsyncModuleOptions`
 - **Internal subpath**: metadata helpers via `@fluojs/core/internal`
 

--- a/packages/core/src/decorators.test.ts
+++ b/packages/core/src/decorators.test.ts
@@ -38,6 +38,16 @@ describe('core decorators', () => {
     });
   });
 
+  it.each(['singleton', 'request', 'transient'] as const)('writes %s scope metadata through @Scope', (scope) => {
+    @Scope(scope)
+    class ScopedService {}
+
+    expect(getClassDiMetadata(ScopedService)).toEqual({
+      inject: undefined,
+      scope,
+    });
+  });
+
   it('inherits DI metadata through decorators while keeping own reads separate', () => {
     const LOGGER = Symbol('LOGGER');
 

--- a/packages/core/src/metadata.test.ts
+++ b/packages/core/src/metadata.test.ts
@@ -20,6 +20,14 @@ import {
   getOwnClassDiMetadata,
   getRouteMetadata,
 } from './metadata.js';
+import {
+  getStandardConstructorMetadataBag,
+  getStandardConstructorMetadataMap,
+  getStandardConstructorMetadataRecord,
+  getStandardMetadataBag,
+  standardMetadataKeys,
+  type StandardMetadataBag,
+} from './metadata/shared.js';
 
 describe('metadata helpers', () => {
   it('round-trips module metadata', () => {
@@ -479,6 +487,44 @@ describe('metadata helpers', () => {
 
   it('ensures Symbol.metadata is available through the exported initializer', () => {
     expect(ensureMetadataSymbol()).toBe((Symbol as typeof Symbol & { metadata?: symbol }).metadata);
+  });
+
+  it('reads standard metadata bags and constructor-level records through Symbol.metadata', () => {
+    const metadataSymbol = ensureMetadataSymbol();
+    const injectionMetadata = new Map([['service', { optional: true, token: 'LOGGER' }]]);
+    const metadataBag: StandardMetadataBag = {
+      [standardMetadataKeys.controller]: { basePath: '/users' },
+      [standardMetadataKeys.injection]: injectionMetadata,
+    };
+
+    class ExampleController {
+      service!: string;
+    }
+
+    Object.defineProperty(ExampleController, metadataSymbol, {
+      configurable: true,
+      value: metadataBag,
+    });
+
+    expect(getStandardMetadataBag(ExampleController)).toBe(metadataBag);
+    expect(getStandardConstructorMetadataBag(ExampleController.prototype)).toBe(metadataBag);
+    expect(getStandardConstructorMetadataRecord<{ basePath: string }>(
+      ExampleController.prototype,
+      standardMetadataKeys.controller,
+    )).toEqual({ basePath: '/users' });
+    expect(getStandardConstructorMetadataMap(ExampleController.prototype, standardMetadataKeys.injection)).toBe(injectionMetadata);
+  });
+
+  it('ignores non-object standard metadata payloads', () => {
+    class ExampleController {}
+
+    Object.defineProperty(ExampleController, ensureMetadataSymbol(), {
+      configurable: true,
+      value: 'invalid metadata',
+    });
+
+    expect(getStandardMetadataBag(ExampleController)).toBeUndefined();
+    expect(getStandardConstructorMetadataBag(ExampleController.prototype)).toBeUndefined();
   });
 
   it('does not retain caller-owned module metadata arrays across partial writes', () => {


### PR DESCRIPTION
## Summary

Closes #1291.

Harden `@fluojs/core` standard-decorator metadata documentation and regression coverage for the audited foundation-lane gap.

## Changes

- Added focused regression coverage for `Symbol.metadata` standard metadata bag readers and constructor-level record/map helpers.
- Added parameterized `@Scope` coverage for `singleton`, `request`, and `transient` lifecycle literals.
- Clarified the `@fluojs/core` README contract for `ensureMetadataSymbol()`, `@Inject()` empty overrides, legacy array normalization, and the `@fluojs/core/internal` boundary in English and Korean.

## Testing

- `lsp_diagnostics` on `packages/core/src/metadata.test.ts` — no diagnostics
- `lsp_diagnostics` on `packages/core/src/decorators.test.ts` — no diagnostics
- `pnpm --filter @fluojs/core test` — passed (5 files, 37 tests)
- `pnpm --filter @fluojs/core typecheck` — passed
- `pnpm --filter @fluojs/core build` — passed
- `pnpm exec biome lint packages/core/src/metadata.test.ts packages/core/src/decorators.test.ts packages/core/README.md packages/core/README.ko.md` — passed for changed TypeScript files
- `pnpm lint` — public export TSDoc gate passed; Biome reported existing warnings in `packages/config/*` unrelated to this PR

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.