### PR TITLE
Resolve #1295: align HTTP request cleanup and docs

### DIFF
--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -126,7 +126,7 @@ stream(_input: undefined, ctx: RequestContext) {
 - **실행 데코레이터**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
 - **핵심 런타임 타입**: `RequestContext`, `FrameworkRequest`, `FrameworkResponse`, `SseResponse`
 - **예외**: `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `InternalServerErrorException`, `PayloadTooLargeException`
-- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createSecurityHeadersMiddleware`, `getCurrentRequestContext`, `encodeSseComment`, `encodeSseMessage`
+- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createSecurityHeadersMiddleware`, `getCurrentRequestContext`, `encodeSseComment`, `encodeSseMessage`
 
 ## 내부 서브경로 (`@fluojs/http/internal`)
 

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -10,6 +10,7 @@
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
+- [요청 정리와 런타임 이식성](#요청-정리와-런타임-이식성)
 - [공개 API](#공개-api)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -112,14 +113,20 @@ stream(_input: undefined, ctx: RequestContext) {
 }
 ```
 
+## 요청 정리와 런타임 이식성
+
+디스패처는 활성 dispatch 동안에만 `AsyncLocalStorage`로 `RequestContext`를 바인딩하고, 요청 observer가 끝난 뒤 `finally` 경로에서 request-scoped DI 컨테이너를 dispose합니다. 이 동작은 정상 성공, 처리된 오류, 중단된 요청 경로에서 request-scoped provider가 다음 요청으로 새지 않게 합니다.
+
+어댑터는 플랫폼이 제공한다면 `FrameworkRequest.signal`에 `AbortSignal`을 전달해야 합니다. SSE에서는 가능하면 `FrameworkResponse.stream.onClose(...)`도 노출해야 합니다. `SseResponse`는 request abort와 raw stream close를 모두 구독하고, 멱등하게 닫히며, 어느 쪽이 먼저 종료되더라도 등록한 listener를 제거합니다.
+
 ## 공개 API
 
-- **라우팅 데코레이터**: `Controller`, `Get`, `Post`, `Put`, `Patch`, `Delete`, `All`
-- **바인딩 데코레이터**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `RequestDto`
-- **실행 데코레이터**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`
+- **라우팅 데코레이터**: `Controller`, `Get`, `Post`, `Put`, `Patch`, `Delete`, `All`, `Options`, `Head`
+- **바인딩 데코레이터**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `RequestDto`, `Optional`, `Convert`
+- **실행 데코레이터**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
 - **핵심 런타임 타입**: `RequestContext`, `FrameworkRequest`, `FrameworkResponse`, `SseResponse`
 - **예외**: `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `InternalServerErrorException`, `PayloadTooLargeException`
-- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `createCorsMiddleware`, `createRateLimitMiddleware`, `getCurrentRequestContext`
+- **헬퍼**: `createHandlerMapping`, `createDispatcher`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createSecurityHeadersMiddleware`, `getCurrentRequestContext`, `encodeSseComment`, `encodeSseMessage`
 
 ## 내부 서브경로 (`@fluojs/http/internal`)
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -10,6 +10,7 @@ The HTTP execution layer that turns route metadata into a request pipeline with 
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
+- [Request Cleanup and Portability](#request-cleanup-and-portability)
 - [Public API](#public-api)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -114,14 +115,20 @@ stream(_input: undefined, ctx: RequestContext) {
 }
 ```
 
+## Request Cleanup and Portability
+
+The dispatcher binds `RequestContext` with `AsyncLocalStorage` for the active dispatch only and disposes the request-scoped DI container from its `finally` path after request observers finish. This keeps per-request providers from leaking across normal success, handled error, and aborted request paths.
+
+Adapters should pass an `AbortSignal` on `FrameworkRequest.signal` when the platform exposes one. For SSE, adapters should also expose `FrameworkResponse.stream.onClose(...)` when possible; `SseResponse` listens to both request abort and raw stream close, closes idempotently, and removes registered listeners when either side terminates first.
+
 ## Public API
 
-- **Routing decorators**: `Controller`, `Get`, `Post`, `Put`, `Patch`, `Delete`, `All`
-- **Binding decorators**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `RequestDto`
-- **Execution decorators**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`
+- **Routing decorators**: `Controller`, `Get`, `Post`, `Put`, `Patch`, `Delete`, `All`, `Options`, `Head`
+- **Binding decorators**: `FromBody`, `FromQuery`, `FromPath`, `FromHeader`, `FromCookie`, `RequestDto`, `Optional`, `Convert`
+- **Execution decorators**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
 - **Core runtime types**: `RequestContext`, `FrameworkRequest`, `FrameworkResponse`, `SseResponse`
 - **Exceptions**: `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `InternalServerErrorException`, `PayloadTooLargeException`
-- **Helpers**: `createHandlerMapping`, `createDispatcher`, `createCorsMiddleware`, `createRateLimitMiddleware`, `getCurrentRequestContext`
+- **Helpers**: `createHandlerMapping`, `createDispatcher`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createSecurityHeadersMiddleware`, `getCurrentRequestContext`, `encodeSseComment`, `encodeSseMessage`
 
 ## Internal Subpath (`@fluojs/http/internal`)
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -128,7 +128,7 @@ Adapters should pass an `AbortSignal` on `FrameworkRequest.signal` when the plat
 - **Execution decorators**: `UseGuards`, `UseInterceptors`, `HttpCode`, `Version`, `Header`, `Redirect`, `Produces`
 - **Core runtime types**: `RequestContext`, `FrameworkRequest`, `FrameworkResponse`, `SseResponse`
 - **Exceptions**: `BadRequestException`, `UnauthorizedException`, `ForbiddenException`, `NotFoundException`, `InternalServerErrorException`, `PayloadTooLargeException`
-- **Helpers**: `createHandlerMapping`, `createDispatcher`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createSecurityHeadersMiddleware`, `getCurrentRequestContext`, `encodeSseComment`, `encodeSseMessage`
+- **Helpers**: `createHandlerMapping`, `createDispatcher`, `forRoutes`, `normalizeRoutePattern`, `matchRoutePattern`, `isMiddlewareRouteConfig`, `createCorrelationMiddleware`, `createCorsMiddleware`, `createRateLimitMiddleware`, `createSecurityHeadersMiddleware`, `getCurrentRequestContext`, `encodeSseComment`, `encodeSseMessage`
 
 ## Internal Subpath (`@fluojs/http/internal`)
 

--- a/packages/http/src/context/sse.test.ts
+++ b/packages/http/src/context/sse.test.ts
@@ -239,6 +239,34 @@ describe('SseResponse', () => {
     expect(stream.writes).toEqual([]);
   });
 
+  it('does not leak a late abort listener when raw onClose closes synchronously', () => {
+    const stream = createMockSseStream();
+    stream._closed = true;
+    stream.onClose = (listener: () => void) => {
+      stream.onCloseCalls += 1;
+      listener();
+
+      return () => {
+        stream.removeCloseListenerCalls += 1;
+      };
+    };
+    const response = createMockResponse(stream);
+    const controller = new AbortController();
+    const addEventListener = vi.spyOn(controller.signal, 'addEventListener');
+    const removeEventListener = vi.spyOn(controller.signal, 'removeEventListener');
+    const sse = new SseResponse(createContext(response, controller.signal));
+
+    controller.abort(new Error('late-client-disconnect'));
+    sse.send('ignored-after-sync-close');
+
+    expect(addEventListener).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(stream.onCloseCalls).toBe(1);
+    expect(stream.closeCalls).toBe(0);
+    expect(stream.removeCloseListenerCalls).toBe(1);
+    expect(stream.writes).toEqual([]);
+  });
+
   it('throws when the adapter does not expose response.stream support', () => {
     expect(() => new SseResponse(createContext(createMockResponse()))).toThrow(
       'SseResponse requires adapter-provided response.stream support.',

--- a/packages/http/src/context/sse.test.ts
+++ b/packages/http/src/context/sse.test.ts
@@ -267,6 +267,36 @@ describe('SseResponse', () => {
     expect(stream.writes).toEqual([]);
   });
 
+  it('does not keep an abort listener for an already-closed stream with passive onClose', () => {
+    const stream = createMockSseStream();
+    stream._closed = true;
+    stream.onClose = (listener: () => void) => {
+      stream.onCloseCalls += 1;
+      stream.closeListeners.push(listener);
+
+      return () => {
+        stream.removeCloseListenerCalls += 1;
+        stream.closeListeners = stream.closeListeners.filter((entry) => entry !== listener);
+      };
+    };
+    const response = createMockResponse(stream);
+    const controller = new AbortController();
+    const addEventListener = vi.spyOn(controller.signal, 'addEventListener');
+    const removeEventListener = vi.spyOn(controller.signal, 'removeEventListener');
+    const sse = new SseResponse(createContext(response, controller.signal));
+
+    controller.abort(new Error('late-client-disconnect'));
+    sse.send('ignored-after-passive-close');
+
+    expect(addEventListener).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(stream.onCloseCalls).toBe(1);
+    expect(stream.closeListeners).toEqual([]);
+    expect(stream.closeCalls).toBe(0);
+    expect(stream.removeCloseListenerCalls).toBe(1);
+    expect(stream.writes).toEqual([]);
+  });
+
   it('throws when the adapter does not expose response.stream support', () => {
     expect(() => new SseResponse(createContext(createMockResponse()))).toThrow(
       'SseResponse requires adapter-provided response.stream support.',

--- a/packages/http/src/context/sse.test.ts
+++ b/packages/http/src/context/sse.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { FrameworkResponse, FrameworkResponseStream, RequestContext } from '../types.js';
 import { SseResponse, encodeSseComment, encodeSseMessage } from './sse.js';
@@ -155,7 +155,7 @@ describe('SseResponse', () => {
     expect(stream.flushCalls).toBe(1);
     expect(stream.writes).toEqual(['event: message\nid: 1\ndata: hello\n\n', ': note\n\n']);
     expect(stream.closeCalls).toBe(1);
-    expect(stream.removeCloseListenerCalls).toBe(0);
+    expect(stream.removeCloseListenerCalls).toBe(1);
   });
 
   it('closes the stream when the request signal aborts', () => {
@@ -169,7 +169,8 @@ describe('SseResponse', () => {
 
     expect(stream.closeCalls).toBe(1);
     expect(stream.writes).toEqual([]);
-    expect(stream.onCloseCalls).toBe(0);
+    expect(stream.onCloseCalls).toBe(1);
+    expect(stream.removeCloseListenerCalls).toBe(1);
   });
 
   it('surfaces backpressure from send and comment calls', () => {
@@ -220,14 +221,22 @@ describe('SseResponse', () => {
     expect(stream.writes).toEqual([]);
   });
 
-  it('does not register a raw close listener when the request signal exists', () => {
+  it('removes the request abort listener when the raw stream closes first', () => {
     const stream = createMockSseStream();
     const response = createMockResponse(stream);
     const controller = new AbortController();
+    const removeEventListener = vi.spyOn(controller.signal, 'removeEventListener');
+    const sse = new SseResponse(createContext(response, controller.signal));
 
-    new SseResponse(createContext(response, controller.signal));
+    expect(stream.onCloseCalls).toBe(1);
 
-    expect(stream.onCloseCalls).toBe(0);
+    stream.emitClose();
+    sse.send('ignored-after-close');
+
+    expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(stream.closeCalls).toBe(1);
+    expect(stream.removeCloseListenerCalls).toBe(1);
+    expect(stream.writes).toEqual([]);
   });
 
   it('throws when the adapter does not expose response.stream support', () => {

--- a/packages/http/src/context/sse.ts
+++ b/packages/http/src/context/sse.ts
@@ -116,14 +116,21 @@ export class SseResponse {
     context.response.committed = true;
     this.stream.flush?.();
 
-    this.removeCloseListener = this.stream.onClose?.(this.onAbort) ?? undefined;
-
     if (context.request.signal?.aborted) {
       this.close();
       return;
     }
 
     context.request.signal?.addEventListener('abort', this.onAbort, { once: true });
+
+    const removeCloseListener = this.stream.onClose?.(this.onAbort) ?? undefined;
+
+    if (this.closed) {
+      removeCloseListener?.();
+      return;
+    }
+
+    this.removeCloseListener = removeCloseListener;
   }
 
   /**

--- a/packages/http/src/context/sse.ts
+++ b/packages/http/src/context/sse.ts
@@ -131,6 +131,10 @@ export class SseResponse {
     }
 
     this.removeCloseListener = removeCloseListener;
+
+    if (this.stream.closed) {
+      this.close();
+    }
   }
 
   /**

--- a/packages/http/src/context/sse.ts
+++ b/packages/http/src/context/sse.ts
@@ -1,8 +1,12 @@
 import type { FrameworkResponse, FrameworkResponseStream, RequestContext } from '../types.js';
 
+/** Options that customize the fields emitted for one server-sent event frame. */
 export interface SseSendOptions {
+  /** Optional SSE event name. Newline characters are stripped before writing. */
   event?: string;
+  /** Optional SSE event id. Newline characters are stripped before writing. */
   id?: string | number;
+  /** Optional client retry delay in milliseconds. Non-finite or negative values are ignored. */
   retry?: number;
 }
 
@@ -40,6 +44,12 @@ function resolveSseStream(response: FrameworkResponse): FrameworkResponseStream 
   return response.stream;
 }
 
+/**
+ * Encodes a comment as a canonical server-sent event comment frame.
+ *
+ * @param comment Comment text to split into SSE comment lines.
+ * @returns A complete SSE comment frame ending in a blank line.
+ */
 export function encodeSseComment(comment: string): string {
   const lines = splitSseLines(comment);
   const encoded = lines.map((line) => (line.length === 0 ? ':' : `: ${line}`));
@@ -47,6 +57,14 @@ export function encodeSseComment(comment: string): string {
   return `${encoded.join('\n')}\n\n`;
 }
 
+/**
+ * Encodes data and optional event fields as a server-sent event message frame.
+ *
+ * @param data Payload to write. Strings are sent as-is; other values are JSON serialized.
+ * @param options Optional event metadata fields.
+ * @returns A complete SSE message frame ending in a blank line.
+ * @throws {TypeError} When `data` cannot be represented as an SSE data field.
+ */
 export function encodeSseMessage(data: unknown, options: SseSendOptions = {}): string {
   const lines: string[] = [];
 
@@ -69,6 +87,12 @@ export function encodeSseMessage(data: unknown, options: SseSendOptions = {}): s
   return `${lines.join('\n')}\n\n`;
 }
 
+/**
+ * Response helper for server-sent event streams backed by an adapter-provided response stream.
+ *
+ * The helper commits SSE headers immediately, closes idempotently on request abort
+ * or raw stream close, and removes all registered close/abort listeners during cleanup.
+ */
 export class SseResponse {
   private closed = false;
   private readonly stream: FrameworkResponseStream;
@@ -92,26 +116,38 @@ export class SseResponse {
     context.response.committed = true;
     this.stream.flush?.();
 
+    this.removeCloseListener = this.stream.onClose?.(this.onAbort) ?? undefined;
+
     if (context.request.signal?.aborted) {
       this.close();
       return;
     }
 
     context.request.signal?.addEventListener('abort', this.onAbort, { once: true });
-
-    if (context.request.signal === undefined) {
-      this.removeCloseListener = this.stream.onClose?.(this.onAbort) ?? undefined;
-    }
   }
 
+  /**
+   * Writes one SSE data message when the stream is still open.
+   *
+   * @param data Payload to encode into `data:` lines.
+   * @param options Optional event metadata fields.
+   * @returns `true` when the underlying stream accepted the frame without backpressure.
+   */
   send(data: unknown, options: SseSendOptions = {}): boolean {
     return this.writeFrame(encodeSseMessage(data, options));
   }
 
+  /**
+   * Writes one SSE comment frame when the stream is still open.
+   *
+   * @param comment Comment text to encode.
+   * @returns `true` when the underlying stream accepted the frame without backpressure.
+   */
   comment(comment: string): boolean {
     return this.writeFrame(encodeSseComment(comment));
   }
 
+  /** Closes the SSE stream and removes registered abort/close listeners exactly once. */
   close(): void {
     if (this.closed) {
       return;

--- a/packages/http/src/public-api.test.ts
+++ b/packages/http/src/public-api.test.ts
@@ -34,6 +34,13 @@ describe('@fluojs/http public API surface', () => {
     expect(httpPublicApi).toHaveProperty('normalizeRoutePattern');
     expect(httpPublicApi).toHaveProperty('matchRoutePattern');
     expect(httpPublicApi).toHaveProperty('isMiddlewareRouteConfig');
+    expect(httpPublicApi).toHaveProperty('createCorrelationMiddleware');
+    expect(httpPublicApi).toHaveProperty('createCorsMiddleware');
+    expect(httpPublicApi).toHaveProperty('createRateLimitMiddleware');
+    expect(httpPublicApi).toHaveProperty('createSecurityHeadersMiddleware');
+    expect(httpPublicApi).toHaveProperty('SseResponse');
+    expect(httpPublicApi).toHaveProperty('encodeSseComment');
+    expect(httpPublicApi).toHaveProperty('encodeSseMessage');
   });
 
   it('does not expose internal pipeline runners or implementation classes', () => {


### PR DESCRIPTION
## Summary

- Align `@fluojs/http` SSE cleanup so `SseResponse` listens to both request abort and raw stream close, then removes registered listeners whichever path terminates first, including already-closed streams with passive `onClose` implementations.
- Document HTTP request cleanup/runtime portability expectations in EN/KO package READMEs.
- Expand the public API regression to cover documented root-barrel helpers and SSE exports.

Closes #1295

## Changes

- Updated `packages/http/src/context/sse.ts` listener ownership and public TSDoc for SSE exports.
- Updated `packages/http/src/context/sse.test.ts` with regression coverage for abort/close listener cleanup ordering, including already-closed passive `onClose` streams.
- Updated `packages/http/README.md` and `packages/http/README.ko.md` to describe request cleanup and align the public API list.
- Updated `packages/http/src/public-api.test.ts` to enforce the documented public surface.

## Testing

- `lsp_diagnostics` on `packages/http/src/context/sse.ts`, `packages/http/src/context/sse.test.ts`, `packages/http/src/public-api.test.ts` — no diagnostics.
- `pnpm --filter @fluojs/http test -- --run packages/http/src/context/sse.test.ts packages/http/src/public-api.test.ts` — 14 files / 133 tests passed.
- `pnpm --filter @fluojs/http typecheck`
- `pnpm --filter @fluojs/http build`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; this PR updates the `@fluojs/http` package README pair and package tests only.