### PR TITLE
Resolve #1313: fix Queue Redis BullMQ startup contract

### DIFF
--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -90,6 +90,8 @@ export class OrderService {
 QueueModule.forRoot({ clientName: 'jobs' })
 ```
 
+`@fluojs/queue`는 애플리케이션 부트스트랩 중 해당 Redis 클라이언트를 조회한 뒤 BullMQ용으로 큐가 소유하는 duplicate 연결을 만듭니다. 공유 `@fluojs/redis` 클라이언트의 소유권은 `RedisModule`에 남아 있으며, Queue는 자신이 만든 BullMQ duplicate 연결만 닫습니다. 이 duplicate 연결은 BullMQ Worker가 요구하는 `maxRetriesPerRequest: null` 설정으로 구성되어 시작 동작이 BullMQ의 실제 런타임 제약과 일치합니다.
+
 ### 분산 재시도 (Distributed Retries)
 
 워커 설정에서 최대 시도 횟수와 백오프 전략을 지정하여 일시적인 실패를 자동으로 처리할 수 있습니다.

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -90,6 +90,8 @@ Leave `clientName` unset to keep using the default `@fluojs/redis` client from y
 QueueModule.forRoot({ clientName: 'jobs' })
 ```
 
+`@fluojs/queue` resolves that Redis client during application bootstrap, then creates queue-owned duplicate connections for BullMQ. The shared `@fluojs/redis` client remains owned by `RedisModule`; Queue closes only the duplicate BullMQ connections it creates. Those duplicate connections are configured with BullMQ's required `maxRetriesPerRequest: null` worker setting so startup behavior matches BullMQ's runtime constraints.
+
 ### Distributed Retries
 
 Workers can be configured with a maximum number of attempts and backoff strategies to handle transient failures automatically.

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -25,8 +25,13 @@ interface MockRedisConnection {
   connect: () => Promise<void>;
   disconnect: () => void;
   id: string;
+  maxRetriesPerRequest?: number | null;
   quit: () => Promise<'OK'>;
   status: string;
+}
+
+interface MockRedisDuplicateOptions {
+  maxRetriesPerRequest?: number | null;
 }
 
 type FailedListener = (job: MockQueueJob | undefined, error: Error) => void
@@ -198,6 +203,10 @@ vi.mock('bullmq', () => ({
         throw new Error(`worker construct fail:${name}`);
       }
 
+      if (options.connection.maxRetriesPerRequest !== null) {
+        throw new Error('BullMQ Worker requires Redis connections with maxRetriesPerRequest set to null.');
+      }
+
       this.worker = bullmqState.createWorker(name, processor, options);
     }
 
@@ -233,12 +242,14 @@ class MockRedisClient {
   failConnectOnDuplicate: number | undefined;
 
   readonly deadLetters = new Map<string, string[]>();
+  readonly duplicateOptions: MockRedisDuplicateOptions[] = [];
   readonly duplicates: MockRedisConnection[] = [];
 
-  duplicate(): MockRedisConnection {
+  duplicate(options: MockRedisDuplicateOptions = {}): MockRedisConnection {
     this.duplicateSequence += 1;
     const id = `dup-${this.duplicateSequence}`;
     const duplicateIndex = this.duplicateSequence;
+    this.duplicateOptions.push(options);
     const connection: MockRedisConnection = {
       connect: async () => {
         if (this.failConnectOnDuplicate === duplicateIndex) {
@@ -251,6 +262,7 @@ class MockRedisClient {
         connection.status = 'end';
       },
       id,
+      maxRetriesPerRequest: Object.hasOwn(options, 'maxRetriesPerRequest') ? options.maxRetriesPerRequest : 20,
       quit: async () => {
         connection.status = 'end';
         return 'OK';
@@ -496,6 +508,52 @@ describe('@fluojs/queue', () => {
     expect(workerStore.handled).toEqual(['user-9']);
 
     await app.close();
+  });
+
+  it('duplicates Redis with the BullMQ worker retry constraint without taking shared client ownership', async () => {
+    class BullMqStartupJob {
+      constructor(public readonly value: string) {}
+    }
+
+    class WorkerStore {
+      handled: string[] = [];
+    }
+
+    @Inject(WorkerStore)
+    @QueueWorker(BullMqStartupJob)
+    class BullMqStartupWorker {
+      constructor(private readonly store: WorkerStore) {}
+
+      async handle(job: BullMqStartupJob): Promise<void> {
+        this.store.handled.push(job.value);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot()],
+      providers: [BullMqStartupWorker, WorkerStore],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const queue = await app.container.resolve<Queue>(QUEUE);
+    const workerStore = await app.container.resolve(WorkerStore);
+
+    await expect(queue.enqueue(new BullMqStartupJob('ready'))).resolves.toBe('1');
+    expect(workerStore.handled).toEqual(['ready']);
+    expect(redis.duplicateOptions).toEqual([
+      { maxRetriesPerRequest: null },
+      { maxRetriesPerRequest: null },
+    ]);
+    expect(redis.duplicates.every((connection) => connection.maxRetriesPerRequest === null)).toBe(true);
+
+    await app.close();
+
+    expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
   });
 
   it('warns and skips @QueueWorker() classes registered with non-singleton scopes', async () => {

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -35,11 +35,16 @@ type QueueOwnedConnection = ConnectionOptions & {
   connect(): Promise<unknown>;
   disconnect(): void;
   quit(): Promise<unknown>;
+  maxRetriesPerRequest?: number | null;
   status?: string;
 };
 
+interface QueueBullMqConnectionOptions {
+  maxRetriesPerRequest: null;
+}
+
 interface QueueRedisClient extends QueueRedisDeadLetterClient {
-  duplicate(): QueueOwnedConnection;
+  duplicate(options?: QueueBullMqConnectionOptions): QueueOwnedConnection;
 }
 
 interface WorkerInitializationResources {
@@ -397,7 +402,9 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   }
 
   private async createOwnedConnection(redis: QueueRedisClient): Promise<QueueOwnedConnection> {
-    const connection = redis.duplicate();
+    const connection = redis.duplicate({
+      maxRetriesPerRequest: null,
+    });
 
     try {
       if (connection.status === 'wait' || connection.status === 'reconnecting') {


### PR DESCRIPTION
## Summary

Closes #1313

Fixes the Queue Redis/BullMQ startup contract so queue-owned Redis duplicates satisfy BullMQ Worker connection requirements while preserving RedisModule ownership of the shared client.

## Changes

- Configure queue-owned Redis duplicate connections with `maxRetriesPerRequest: null` before handing them to BullMQ.
- Strengthen Queue tests so the BullMQ mock enforces the Worker retry constraint instead of accepting unrealistic Redis doubles.
- Document Queue/Redis lifecycle ownership and BullMQ duplicate connection behavior in `packages/queue/README.md` and `packages/queue/README.ko.md`.

## Testing

- `pnpm install`
- `pnpm --dir packages/queue test` (baseline before changes: passed after install; strengthened regression initially reproduced the BullMQ startup failure before the implementation fix)
- `lsp_diagnostics` on `packages/queue/src/service.ts` and `packages/queue/src/module.test.ts`: no diagnostics after workspace build
- `pnpm build`
- `pnpm --dir packages/queue typecheck`
- `pnpm --dir packages/queue test`
- `pnpm --dir packages/queue build`
- `pnpm lint` (passes; reports existing `packages/config` Biome warnings unrelated to this PR, and public export TSDoc changed-mode passes)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public export surface changed in this PR.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed in this PR.