### PR TITLE
Resolve #1304: align validation DTO shape and public schema docs

### DIFF
--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -62,6 +62,28 @@ console.log(user.name); // "Ko"
 - **`materialize<T>(value, target)`**: **입력 처리**에 가장 적합합니다. plain 객체를 받아 대상 클래스의 인스턴스를 생성하고, 값을 복사하며, 중첩된 DTO를 재귀적으로 처리한 후 모든 검증 규칙을 실행합니다.
 - **`validate(instance, target)`**: **기존 객체 확인**에 적합합니다. 이미 생성된 인스턴스에 대해 검증 규칙만 실행합니다. 타입 변환이나 중첩된 객체의 실체화는 수행하지 않습니다.
 
+`materialize()`는 plain 입력 객체의 안전한 own enumerable 속성을 복사하고,
+DTO 바인딩 메타데이터를 적용한 뒤 `@ValidateNested(...)` 필드를 재귀적으로
+실체화합니다. 어떤 요청 소스를 선택하고 스칼라 값을 변환할지는 transport 또는
+binder가 검증 전에 담당한다는 request-pipeline 계약을 유지합니다.
+
+### 검증 이슈 형태
+
+`DtoValidationError.issues`는 request-pipeline 오류 상세에 사용하는 안정적인 DTO입니다.
+
+```ts
+type ValidationIssue = {
+  code: string;
+  field?: string;
+  message: string;
+  source?: 'path' | 'query' | 'header' | 'cookie' | 'body';
+};
+```
+
+중첩 DTO는 `address.city`, `items[0].name` 같은 dot path와 collection index를
+사용합니다. HTTP 바인딩에서 온 규칙은 `source`를 붙이며, standalone validation이나
+Standard Schema 이슈에서는 값이 없을 수 있습니다.
+
 ### Mapped Types (Pick, Omit, Partial)
 
 모든 검증 데코레이터와 바인딩 메타데이터를 보존하면서 새로운 DTO 클래스를 파생합니다.
@@ -121,9 +143,13 @@ class UserDto {
 
 ## 공개 API
 
-- **검증 엔진**: `DefaultValidator`, `DtoValidationError`, `ValidationIssue`
-- **핵심 데코레이터**: `IsString`, `IsNumber`, `IsBoolean`, `IsEmail`, `IsUrl`, `ValidateNested`, `ValidateIf`, `IsOptional`, `ValidateClass`
+- **검증 엔진**: `DefaultValidator`, `DtoValidationError`, `ValidationIssue`, `Validator`
+- **핵심 데코레이터**: `IsString`, `IsNumber`, `IsBoolean`, `IsDate`, `IsArray`, `IsObject`, `IsEnum`, `IsInt`, `IsDefined`, `IsOptional`, `ValidateNested`, `ValidateIf`, `Validate`, `ValidateClass`
+- **문자열 및 네트워크 데코레이터**: `IsEmail`, `IsUrl`, `IsUUID`, `IsIP`, `IsAlpha`, `IsAlphanumeric`, `IsAscii`, `IsBase64`, `IsDateString`, `IsJSON`, `IsJWT`, `IsNumberString`, `IsISO8601`, `Matches`, `Length`, `MinLength`, `MaxLength`, `Contains`, `NotContains`
+- **숫자 및 날짜 데코레이터**: `Min`, `Max`, `IsPositive`, `IsNegative`, `IsDivisibleBy`, `MinDate`, `MaxDate`
+- **배열 데코레이터**: `ArrayContains`, `ArrayNotContains`, `ArrayNotEmpty`, `ArrayMinSize`, `ArrayMaxSize`, `ArrayUnique`
 - **Mapped DTO 헬퍼**: `PickType`, `OmitType`, `PartialType`, `IntersectionType`
+- **Standard Schema 계약**: `ValidateClass(...)` 스키마를 타입 지정하기 위한 `StandardSchemaV1Like`
 - **검증 흐름**: 실체화 및 검증을 위한 `materialize()`, 단순 검증을 위한 `validate()`
 
 ## 관련 패키지

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -64,6 +64,28 @@ try {
 - `materialize(value, Target)` builds a typed instance and validates it recursively
 - `validate(instance, Target)` only validates an already-created value
 
+`materialize()` copies safe own enumerable properties from plain input objects,
+applies DTO binding metadata, and recursively hydrates `@ValidateNested(...)`
+fields. It preserves the request-pipeline contract that transports or binders own
+source selection and scalar conversion before validation runs.
+
+### Validation issue shape
+
+`DtoValidationError.issues` is a stable DTO for request-pipeline error details:
+
+```ts
+type ValidationIssue = {
+  code: string;
+  field?: string;
+  message: string;
+  source?: 'path' | 'query' | 'header' | 'cookie' | 'body';
+};
+```
+
+Nested DTOs use dot paths and collection indexes, such as `address.city` or
+`items[0].name`. HTTP bindings attach `source` when the rule came from request
+metadata; standalone validation and Standard Schema issues may leave it unset.
+
 ### Mapped DTO helpers
 
 ```ts
@@ -100,9 +122,13 @@ class RestrictedUserDto {
 
 ## Public API
 
-- **Validator engine**: `DefaultValidator`, `DtoValidationError`, `ValidationIssue`
-- **Core decorators**: `IsString`, `IsNumber`, `IsBoolean`, `IsEmail`, `IsUrl`, `ValidateNested`, `ValidateIf`, `IsOptional`, `ValidateClass`
+- **Validator engine**: `DefaultValidator`, `DtoValidationError`, `ValidationIssue`, `Validator`
+- **Core decorators**: `IsString`, `IsNumber`, `IsBoolean`, `IsDate`, `IsArray`, `IsObject`, `IsEnum`, `IsInt`, `IsDefined`, `IsOptional`, `ValidateNested`, `ValidateIf`, `Validate`, `ValidateClass`
+- **String and network decorators**: `IsEmail`, `IsUrl`, `IsUUID`, `IsIP`, `IsAlpha`, `IsAlphanumeric`, `IsAscii`, `IsBase64`, `IsDateString`, `IsJSON`, `IsJWT`, `IsNumberString`, `IsISO8601`, `Matches`, `Length`, `MinLength`, `MaxLength`, `Contains`, `NotContains`
+- **Number and date decorators**: `Min`, `Max`, `IsPositive`, `IsNegative`, `IsDivisibleBy`, `MinDate`, `MaxDate`
+- **Array decorators**: `ArrayContains`, `ArrayNotContains`, `ArrayNotEmpty`, `ArrayMinSize`, `ArrayMaxSize`, `ArrayUnique`
 - **Mapped DTO helpers**: `PickType`, `OmitType`, `PartialType`, `IntersectionType`
+- **Standard Schema contract**: `StandardSchemaV1Like` for typing `ValidateClass(...)` schemas
 - **Validation flow**: `materialize()` for hydration + validation, `validate()` for validation-only checks
 
 ## Related Packages

--- a/packages/validation/src/index.ts
+++ b/packages/validation/src/index.ts
@@ -3,3 +3,4 @@ export * from './errors.js';
 export * from './mapped-types.js';
 export * from './types.js';
 export * from './validation.js';
+export type { StandardSchemaV1Like } from './standard-schema.js';

--- a/packages/validation/src/standard-schema.ts
+++ b/packages/validation/src/standard-schema.ts
@@ -3,6 +3,12 @@ import type { CustomClassValidator } from '@fluojs/core/internal';
 
 import type { ValidationIssue } from './types.js';
 
+/**
+ * Standard Schema v1-compatible validator accepted by `ValidateClass`.
+ *
+ * @typeParam Input Input DTO shape consumed by the schema validator.
+ * @typeParam Output Output DTO shape produced by the schema validator.
+ */
 export type StandardSchemaV1Like<Input = unknown, Output = Input> = StandardSchemaV1<Input, Output>;
 
 type StandardSchemaPathSegmentLike = StandardSchemaV1.PathSegment;
@@ -45,6 +51,12 @@ function normalizeCode(code: string | undefined, fallback: string): string {
   return code.replace(/[^A-Za-z0-9]+/g, '_').replace(/^_+|_+$/g, '').toUpperCase() || fallback;
 }
 
+/**
+ * Detect whether a value implements the Standard Schema v1 contract.
+ *
+ * @param value Candidate schema value supplied to validation decorators.
+ * @returns `true` when the candidate exposes a Standard Schema v1 validator.
+ */
 export function isStandardSchemaLike(value: unknown): value is StandardSchemaV1Like {
   if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
     return false;
@@ -107,6 +119,12 @@ function isStandardSchemaFailureResult(
   return typeof result === 'object' && result !== null && 'issues' in result;
 }
 
+/**
+ * Adapt a Standard Schema validator to fluo class-level validation.
+ *
+ * @param schema Standard Schema-compatible validator definition.
+ * @returns A class validator that reports normalized validation issues.
+ */
 export function createClassValidatorFromStandardSchema(schema: StandardSchemaV1Like): CustomClassValidator {
   return async (value: unknown) => {
     const result = await schema['~standard'].validate(value);

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { DefaultValidator } from './validation.js';
 import { DtoValidationError } from './errors.js';
 import { ArrayUnique, IsDateString, IsEmail, IsNotEmpty, MinLength, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
+import type { StandardSchemaV1Like } from './index.js';
 
 describe('DefaultValidator', () => {
   it('validates basic rules without HTTP bindings', async () => {
@@ -707,6 +708,48 @@ describe('DefaultValidator', () => {
       validator.validate(Object.assign(new CreateUserDto(), { email: 'bad' }), CreateUserDto),
     ).rejects.toMatchObject({
       issues: expect.arrayContaining([expect.objectContaining({ field: 'email' })]),
+    });
+  });
+
+  it('accepts the public StandardSchemaV1Like type for class-level DTO validation', async () => {
+    const schema: StandardSchemaV1Like<{ email: string }> = {
+      '~standard': {
+        validate: async (value) => {
+          if (
+            typeof value === 'object'
+            && value !== null
+            && 'email' in value
+            && typeof value.email === 'string'
+            && value.email === 'hello@fluo.dev'
+          ) {
+            return { value: { email: value.email } };
+          }
+
+          return {
+            issues: [
+              {
+                message: 'email must match the public schema contract',
+                path: ['email'],
+              },
+            ],
+          };
+        },
+        vendor: 'test',
+        version: 1,
+      },
+    };
+
+    @ValidateClass(schema)
+    class CreateUserDto {
+      email = '';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(Object.assign(new CreateUserDto(), { email: 'bad' }), CreateUserDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'INVALID_FIELD', field: 'email', message: 'email must match the public schema contract' }],
     });
   });
 


### PR DESCRIPTION
## Summary

- Closes #1304
- Aligns `@fluojs/validation` docs and public export coverage for request-pipeline validation DTO behavior.
- Exposes the Standard Schema typing contract used by `ValidateClass(...)` from the package root.

## Changes

- Export `StandardSchemaV1Like` from `@fluojs/validation` and add TSDoc for the Standard Schema public surface.
- Add focused regression coverage proving the public Standard Schema type works with class-level DTO validation.
- Update EN/KO package README docs for `ValidationIssue` shape, `materialize()` request-pipeline boundaries, and public API coverage.

## Testing

- `lsp_diagnostics` on changed TypeScript files: no errors.
- `pnpm --filter @fluojs/validation test` — 36 tests passed.
- `pnpm --filter @fluojs/validation typecheck` — passed.
- `pnpm --filter @fluojs/validation build` — passed.
- `pnpm verify:public-export-tsdoc` — passed.
- `pnpm --filter @fluojs/http test` — 131 tests passed.
- `pnpm --filter @fluojs/http typecheck` — passed after building workspace dependency `@fluojs/di`.
- `pnpm --filter @fluojs/http build` — passed after building workspace dependency `@fluojs/di`.
- `pnpm lint` — completed with existing repository warnings/infos; public export TSDoc gate passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform README conformance claims were changed.