### PR TITLE
Resolve #1305: preserve serialization response ownership

### DIFF
--- a/packages/serialization/README.ko.md
+++ b/packages/serialization/README.ko.md
@@ -129,6 +129,8 @@ class UsersController {
 }
 ```
 
+`SerializerInterceptor`는 일반 HTTP 응답 writer가 아직 소유한 값만 직렬화합니다. 핸들러나 응답 헬퍼가 SSE 스트림처럼 `RequestContext.response`를 직접 커밋한 경우, 인터셉터는 해당 핸들러 소유 값을 그대로 반환하여 request pipeline의 응답 소유권을 보존합니다.
+
 ## 공개 API 개요
 
 ### 데코레이터

--- a/packages/serialization/README.md
+++ b/packages/serialization/README.md
@@ -97,6 +97,8 @@ class UsersController {
 }
 ```
 
+`SerializerInterceptor` only serializes values that still belong to the normal HTTP response writer. If a handler or response helper commits `RequestContext.response` directly, such as an SSE stream, the interceptor returns that handler-owned value unchanged so the request pipeline preserves response ownership.
+
 ### Cycle-safe serialization
 
 The serializer cuts cyclic references safely instead of recursing forever, so complex object graphs can still be turned into plain response-shaped objects without unbounded recursion.

--- a/packages/serialization/src/serializer-interceptor.test.ts
+++ b/packages/serialization/src/serializer-interceptor.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CallHandler, InterceptorContext } from '@fluojs/http';
+import type { CallHandler, FrameworkResponse, InterceptorContext, RequestContext } from '@fluojs/http';
 
 import { Exclude } from './decorators/exclude.js';
 import { SerializerInterceptor } from './serializer-interceptor.js';
+
+function createInterceptorContext(response: Partial<FrameworkResponse> = {}): InterceptorContext {
+  return {
+    requestContext: {
+      response: {
+        committed: false,
+        headers: {},
+        redirect() {},
+        send() {},
+        setHeader() {},
+        setStatus() {},
+        ...response,
+      } as FrameworkResponse,
+    } as RequestContext,
+  } as InterceptorContext;
+}
 
 describe('SerializerInterceptor', () => {
   it('serializes class instance responses with metadata', async () => {
@@ -20,7 +36,7 @@ describe('SerializerInterceptor', () => {
     }
 
     const interceptor = new SerializerInterceptor();
-    const context = {} as InterceptorContext;
+    const context = createInterceptorContext();
     const next: CallHandler = {
       async handle() {
         return new UserView('u-1', 'secret');
@@ -28,5 +44,26 @@ describe('SerializerInterceptor', () => {
     };
 
     await expect(interceptor.intercept(context, next)).resolves.toEqual({ id: 'u-1' });
+  });
+
+  it('preserves handler-owned responses once the response is committed', async () => {
+    class StreamOwner {
+      id = 'stream-1';
+
+      @Exclude()
+      internalState = 'owned-by-handler';
+    }
+
+    const owner = new StreamOwner();
+    const interceptor = new SerializerInterceptor();
+    const context = createInterceptorContext();
+    const next: CallHandler = {
+      async handle() {
+        context.requestContext.response.committed = true;
+        return owner;
+      },
+    };
+
+    await expect(interceptor.intercept(context, next)).resolves.toBe(owner);
   });
 });

--- a/packages/serialization/src/serializer-interceptor.ts
+++ b/packages/serialization/src/serializer-interceptor.ts
@@ -11,8 +11,13 @@ import { serialize } from './serialize.js';
  * automatically.
  */
 export class SerializerInterceptor implements Interceptor {
-  async intercept(_context: InterceptorContext, next: CallHandler): Promise<unknown> {
+  async intercept(context: InterceptorContext, next: CallHandler): Promise<unknown> {
     const value = await next.handle();
+
+    if (context.requestContext.response.committed) {
+      return value;
+    }
+
     return serialize(value);
   }
 }


### PR DESCRIPTION
## Summary

Closes #1305.

Preserves response ownership in `@fluojs/serialization` so `SerializerInterceptor` does not serialize or replace handler-owned values after the HTTP response has already been committed.

## Changes

- Add a committed-response guard to `SerializerInterceptor` after `next.handle()` completes.
- Add regression coverage proving committed handler-owned response values are returned by identity.
- Document the interceptor response ownership contract in `packages/serialization/README.md` and `packages/serialization/README.ko.md`.

## Testing

- `pnpm --filter @fluojs/serialization test`
- `pnpm --filter @fluojs/core build && pnpm --filter @fluojs/di build && pnpm --filter @fluojs/validation build && pnpm --filter @fluojs/http build && pnpm --filter @fluojs/serialization typecheck && pnpm --filter @fluojs/serialization build`
- `pnpm verify:platform-consistency-governance`
- LSP diagnostics: `packages/serialization/src/serializer-interceptor.ts`, `packages/serialization/src/serializer-interceptor.test.ts` — no diagnostics

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; the existing interceptor behavior is clarified in the package README pair.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. Package README EN/KO behavioral text was updated together and verified with the platform consistency governance checker.