### PR TITLE
Resolve #1311: preserve Passport strategy settlement contracts

### DIFF
--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -83,6 +83,8 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 });
 ```
 
+브릿지는 각 Passport.js 전략 실행을 정확히 한 번만 정착(settle)시킵니다. 전략은 바인딩된 Passport 액션(`success`, `fail`, `redirect`, `pass`, `error`) 중 하나를 호출해야 하며, promise rejection 또는 액션 없이 완료된 promise는 요청을 미해결 상태로 두지 않고 인증 실패로 처리됩니다. 커스텀 `mapPrincipal` 함수는 비어 있지 않은 `subject`와 객체 형태의 `claims`를 포함한 유효한 fluo `Principal`을 반환해야 합니다.
+
 ### 쿠키 인증 프리셋
 
 HTTP 쿠키에서 인증 정보를 읽는 애플리케이션이라면 `CookieAuthModule.forRoot(...)`를 사용합니다.
@@ -109,6 +111,8 @@ export class AuthModule {}
 ```
 
 애플리케이션 모듈에서 cookie-auth 지원이 필요하면 `CookieAuthModule.forRoot(...)`를 `PassportModule.forRoot(...)`와 함께 import 하세요.
+
+`CookieAuthStrategy`는 `@fluojs/jwt`가 정규화한 JWT principal 계약을 보존하며, `subject`, `claims`, `issuer`, `audience`, `roles`, `scopes`를 그대로 전달합니다.
 
 ### 리프레시 토큰 수명 주기
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -83,6 +83,8 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 });
 ```
 
+The bridge settles each Passport.js strategy execution exactly once. A strategy must call one of the bound Passport actions (`success`, `fail`, `redirect`, `pass`, or `error`); promise rejections and promise completion without an action become authentication failures instead of leaving the request unresolved. Custom `mapPrincipal` functions must return a valid fluo `Principal` with a non-empty `subject` and object `claims`.
+
 ### Cookie Auth Preset
 
 Use `CookieAuthModule.forRoot(...)` when your app authenticates requests from HTTP cookies.
@@ -109,6 +111,8 @@ export class AuthModule {}
 ```
 
 Import `CookieAuthModule.forRoot(...)` alongside `PassportModule.forRoot(...)` when you want cookie-auth support in an application module.
+
+`CookieAuthStrategy` preserves the normalized JWT principal contract from `@fluojs/jwt`, including `subject`, `claims`, `issuer`, `audience`, `roles`, and `scopes`.
 
 ### Refresh Token Lifecycle
 

--- a/packages/passport/src/adapters/passport-js.ts
+++ b/packages/passport/src/adapters/passport-js.ts
@@ -167,6 +167,15 @@ function cloneStrategyStateValue(value: unknown): unknown {
   return value;
 }
 
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && 'then' in value
+    && typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
 /**
  * A bridge strategy that allows using Passport.js strategies within the fluo
  * authentication framework.
@@ -198,7 +207,22 @@ export class PassportJsAuthStrategy implements AuthStrategy {
       this.bindStrategyActions(strategy);
 
       try {
-        strategy.authenticate(request, this.options.authenticateOptions);
+        const result = strategy.authenticate(request, this.options.authenticateOptions);
+
+        if (isPromiseLike(result)) {
+          result.then(
+            () => {
+              this.settle(strategy, (state) => {
+                state.reject(new AuthenticationRequiredError('Passport strategy did not settle authentication.'));
+              });
+            },
+            (error: unknown) => {
+              this.settle(strategy, (state) => {
+                state.reject(error);
+              });
+            },
+          );
+        }
       } catch (error: unknown) {
         this.settle(strategy, () => reject(error));
       }

--- a/packages/passport/src/cookie/cookie-auth.test.ts
+++ b/packages/passport/src/cookie/cookie-auth.test.ts
@@ -146,10 +146,12 @@ describe('CookieAuthStrategy', () => {
       await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
     });
 
-    it('preserves principal claims, roles, and scopes', async () => {
+    it('preserves jwt principal claims, issuer, audience, roles, and scopes', async () => {
       const verifier = createMockVerifier({
         verifyAccessToken: vi.fn().mockResolvedValue({
+          audience: ['dashboard', 'api'],
           claims: { sub: 'user-2', custom: 'data', roles: ['user'], scopes: ['write:data'] },
+          issuer: 'auth.example.test',
           roles: ['user'],
           scopes: ['write:data'],
           subject: 'user-2',
@@ -161,7 +163,9 @@ describe('CookieAuthStrategy', () => {
       const result = await strategy.authenticate(context);
 
       expect(result).toMatchObject({
+        audience: ['dashboard', 'api'],
         subject: 'user-2',
+        issuer: 'auth.example.test',
         roles: ['user'],
         scopes: ['write:data'],
         claims: { sub: 'user-2', custom: 'data', roles: ['user'], scopes: ['write:data'] },

--- a/packages/passport/src/cookie/cookie-auth.ts
+++ b/packages/passport/src/cookie/cookie-auth.ts
@@ -88,7 +88,9 @@ export class CookieAuthStrategy implements AuthStrategy {
       const principal = await this.verifier.verifyAccessToken(accessToken);
 
       return {
+        audience: principal.audience,
         claims: principal.claims,
+        issuer: principal.issuer,
         roles: principal.roles,
         scopes: principal.scopes,
         subject: principal.subject,

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -319,6 +319,145 @@ describe('AuthGuard', () => {
     });
   });
 
+  it('maps invalid Passport.js mapped principals to the canonical 401 path', async () => {
+    class PassportLikeInvalidPrincipalStrategy {
+      success?: (user: unknown, info?: unknown) => void;
+
+      authenticate() {
+        this.success?.({ id: 'google-user-1' });
+      }
+    }
+
+    const bridge = createPassportJsStrategyBridge('google-invalid-principal', PassportLikeInvalidPrincipalStrategy, {
+      mapPrincipal: () => ({ claims: {}, subject: '' }),
+    });
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-invalid-principal')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikeInvalidPrincipalStrategy,
+      ...bridge.providers,
+      ...createPassportModuleProviders({ defaultStrategy: 'google-invalid-principal' }, [bridge.strategy]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/oauth/profile', { 'x-request-id': 'req-invalid-principal' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-invalid-principal',
+        status: 401,
+      },
+    });
+  });
+
+  it('settles Passport.js promise rejections as authentication failures', async () => {
+    class PassportLikeAsyncFailureStrategy {
+      async authenticate(): Promise<void> {
+        throw new AuthenticationRequiredError('Async passport failure.');
+      }
+    }
+
+    const bridge = createPassportJsStrategyBridge('google-async-failure', PassportLikeAsyncFailureStrategy);
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-async-failure')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikeAsyncFailureStrategy,
+      ...bridge.providers,
+      ...createPassportModuleProviders({ defaultStrategy: 'google-async-failure' }, [bridge.strategy]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/oauth/profile', { 'x-request-id': 'req-async-failure' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-async-failure',
+        status: 401,
+      },
+    });
+  });
+
+  it('rejects Passport.js promise completion that never settles a strategy action', async () => {
+    class PassportLikeUnsettledStrategy {
+      async authenticate(): Promise<void> {
+        return undefined;
+      }
+    }
+
+    const bridge = createPassportJsStrategyBridge('google-unsettled', PassportLikeUnsettledStrategy);
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-unsettled')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikeUnsettledStrategy,
+      ...bridge.providers,
+      ...createPassportModuleProviders({ defaultStrategy: 'google-unsettled' }, [bridge.strategy]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/oauth/profile', { 'x-request-id': 'req-unsettled' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-unsettled',
+        status: 401,
+      },
+    });
+  });
+
   it('isolates Passport.js bridge request state across concurrent authentications', async () => {
     let sequence = 0;
 

--- a/packages/passport/src/guard.ts
+++ b/packages/passport/src/guard.ts
@@ -32,6 +32,50 @@ function resolvePrincipal(result: AuthStrategyResult): Principal | undefined {
   return result;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isPrincipal(value: unknown): value is Principal {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (typeof value.subject !== 'string' || value.subject.length === 0) {
+    return false;
+  }
+
+  if (!isRecord(value.claims)) {
+    return false;
+  }
+
+  if (value.issuer !== undefined && typeof value.issuer !== 'string') {
+    return false;
+  }
+
+  if (
+    value.audience !== undefined
+    && typeof value.audience !== 'string'
+    && !isStringArray(value.audience)
+  ) {
+    return false;
+  }
+
+  if (value.roles !== undefined && !isStringArray(value.roles)) {
+    return false;
+  }
+
+  if (value.scopes !== undefined && !isStringArray(value.scopes)) {
+    return false;
+  }
+
+  return true;
+}
+
 function hasRequiredScopes(principal: { scopes?: string[] }, scopes: string[]): boolean {
   return scopes.every((scope) => principal.scopes?.includes(scope));
 }
@@ -45,7 +89,7 @@ function isAuthenticationFailure(error: unknown): boolean {
 }
 
 function hasRegisteredStrategy(registry: AuthStrategyRegistry, strategyName: string): boolean {
-  return  Object.hasOwn(registry, strategyName);
+  return Object.hasOwn(registry, strategyName);
 }
 
 function toErrorMessage(error: unknown): string {
@@ -131,6 +175,10 @@ export class AuthGuard implements AuthGuardContract {
 
       if (!principal) {
         throw new AuthenticationFailedError('Authentication strategy did not return a principal.');
+      }
+
+      if (!isPrincipal(principal)) {
+        throw new AuthenticationFailedError('Authentication strategy returned an invalid principal.');
       }
 
       if (requirement?.scopes?.length && !hasRequiredScopes(principal, requirement.scopes)) {


### PR DESCRIPTION
## Summary

Closes #1311

Preserves `@fluojs/passport` strategy settlement and principal contracts after the JWT guardrail baseline from #1310.

## Changes

- Harden `PassportJsAuthStrategy` so promise rejections and promise completion without a Passport action settle as authentication failures instead of leaving requests unresolved.
- Validate resolved principals before writing `requestContext.principal`, preventing malformed strategy or mapper output from bypassing the auth contract.
- Preserve `issuer` and `audience` from `@fluojs/jwt` principals in `CookieAuthStrategy`.
- Document the Passport.js bridge settlement and principal requirements in `packages/passport/README.md` and `README.ko.md`.

## Testing

- `pnpm --filter @fluojs/passport test` — 8 files / 80 tests passed
- `pnpm --filter @fluojs/passport... build` — passed
- `pnpm --filter @fluojs/passport typecheck` — passed after dependency build outputs were generated
- `pnpm vitest run examples/auth-jwt-passport` — 1 file / 5 tests passed
- LSP diagnostics on modified passport source/test files — no errors; one pre-existing unused-variable hint remains in `cookie-auth.test.ts`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added. Existing public behavior is clarified in the package README pair.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform SSOT/governance docs changed; README EN/KO package mirrors were updated together.