### PR TITLE
Resolve #1292: align config reload surface

### DIFF
--- a/packages/config/README.ko.md
+++ b/packages/config/README.ko.md
@@ -85,9 +85,14 @@ class MyService {
 | 클래스/헬퍼 | 설명 |
 |---|---|
 | `ConfigModule` | 설정을 전역 또는 지역으로 등록하기 위한 모듈입니다. |
+| `ConfigReloadModule` | 리로드 매니저를 등록하고 의존성 주입용 공유 `CONFIG_RELOADER` 토큰을 내보냅니다. |
+| `ConfigReloadManager` | 주입된 `ConfigService`의 리로드를 조정하며, 서비스 identity는 유지하고 스냅샷만 리로드 경로로 교체합니다. |
+| `CONFIG_RELOADER` | 공유 config reloader 계약을 위한 주입 토큰입니다. |
 | `ConfigService` | 설정 값에 타입 안전하게 접근하기 위한 읽기 전용 서비스입니다. 스냅샷 교체는 config reload 경로 내부에만 남습니다. |
 | `loadConfig(options)` | 설정을 수동으로 로드하기 위한 함수형 엔트리 포인트입니다. |
 | `createConfigReloader(options)` | 동적 설정 업데이트를 위한 리로더를 생성합니다. |
+
+`ConfigReloadManager.reload()`는 기존 `ConfigService` 인스턴스를 갱신하므로 소비자는 주입받은 서비스 identity를 유지하면서 새 스냅샷을 관찰합니다. 리로드 listener가 에러를 던지면 매니저는 이전 스냅샷을 복구하고 listener 에러를 다시 던집니다.
 
 ## 관련 패키지
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -90,9 +90,14 @@ The `validate` function runs after all sources are merged but before the applica
 | Class/Helper | Description |
 |---|---|
 | `ConfigModule` | Module for registering configuration globally or locally. |
+| `ConfigReloadModule` | Registers the reload manager and exports the shared `CONFIG_RELOADER` token for dependency injection. |
+| `ConfigReloadManager` | Coordinates reloads for the injected `ConfigService`, preserving service identity while replacing snapshots through the reload path. |
+| `CONFIG_RELOADER` | Injection token for the shared config reloader contract. |
 | `ConfigService` | Read-only service for typed access to configuration values. Snapshot replacement stays inside the config reload path. |
 | `loadConfig(options)` | Functional entry point for loading configuration manually. |
 | `createConfigReloader(options)` | Creates a reloader for dynamic configuration updates. |
+
+`ConfigReloadManager.reload()` updates the existing `ConfigService` instance so consumers keep their injected service identity while observing the new snapshot. If a reload listener throws, the manager restores the previous snapshot and rethrows the listener error.
 
 ## Related Packages
 

--- a/packages/config/src/reload-module.test.ts
+++ b/packages/config/src/reload-module.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { ConfigReloadManager } from './reload-module.js';
+import { ConfigService } from './service.js';
+import type { ConfigDictionary } from './types.js';
+
+describe('ConfigReloadManager', () => {
+  it('reloads the shared ConfigService snapshot without replacing the service identity', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-manager-reload-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const service = new ConfigService<ConfigDictionary>({ PORT: '4000' });
+    const manager = new ConfigReloadManager(service, {
+      cwd,
+      envFile: envPath,
+      processEnv: {},
+    });
+
+    try {
+      const updates: string[] = [];
+      const subscription = manager.subscribe((snapshot, reason) => {
+        if (reason !== 'manual') {
+          return;
+        }
+
+        const port = snapshot['PORT'];
+        if (typeof port === 'string') {
+          updates.push(port);
+        }
+      });
+
+      writeFileSync(envPath, 'PORT=4100\n');
+      const reloaded = manager.reload();
+
+      expect(reloaded['PORT']).toBe('4100');
+      expect(service.get('PORT')).toBe('4100');
+      expect(updates).toEqual(['4100']);
+
+      subscription.unsubscribe();
+    } finally {
+      manager.close();
+    }
+  });
+
+  it('restores the previous ConfigService snapshot when reload listeners throw', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-manager-rollback-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const service = new ConfigService<ConfigDictionary>({ PORT: '4000' });
+    const manager = new ConfigReloadManager(service, {
+      cwd,
+      envFile: envPath,
+      processEnv: {},
+    });
+
+    try {
+      manager.subscribe((_snapshot, reason) => {
+        if (reason === 'manual') {
+          throw new Error('manager listener failed');
+        }
+      });
+
+      writeFileSync(envPath, 'PORT=4200\n');
+
+      expect(() => manager.reload()).toThrow('manager listener failed');
+      expect(service.get('PORT')).toBe('4000');
+      expect(manager.current()['PORT']).toBe('4000');
+    } finally {
+      manager.close();
+    }
+  });
+});

--- a/packages/config/src/reload-module.ts
+++ b/packages/config/src/reload-module.ts
@@ -47,7 +47,7 @@ export class ConfigReloadManager implements ConfigReloader {
   ) {}
 
   current(): ConfigDictionary {
-    return this.ensureReloader().current();
+    return this.config.snapshot();
   }
 
   reload(): ConfigDictionary {


### PR DESCRIPTION
## Summary

Closes #1292

Aligns the `@fluojs/config` reload surface so the DI-facing reload manager reports the shared `ConfigService` snapshot consistently, including listener-failure rollback.

## Changes

- Make `ConfigReloadManager.current()` read the injected `ConfigService` snapshot instead of a separate lazy reloader snapshot.
- Add focused regression coverage for manual reload updates and listener-failure rollback through `ConfigReloadManager`.
- Document the reload DI surface (`ConfigReloadModule`, `ConfigReloadManager`, `CONFIG_RELOADER`) and rollback behavior in EN/KO package READMEs.

## Testing

- `pnpm --filter @fluojs/config test`
- `pnpm --filter @fluojs/core build`
- `pnpm --filter @fluojs/config typecheck`
- `pnpm --filter @fluojs/config build`
- `lsp_diagnostics` on `packages/config/src/reload-module.ts`
- `lsp_diagnostics` on `packages/config/src/reload-module.test.ts`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; existing reload public surface is now reflected in the package README contract.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Only package README mirrors changed; no platform governance SSOT docs or platform conformance claims changed.