### PR TITLE
Resolve #1298: restore Express adapter portability parity

### DIFF
--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -53,7 +53,7 @@ async streamEvents(@Res() res: FrameworkResponse) {
 ```
 
 ### 바디 파싱 및 멀티파트
-`rawBody` 및 멀티파트 form-data 파싱을 즉시 사용할 수 있습니다. 어댑터를 직접 생성할 때는 멀티파트 제한을 두 번째 인자로 전달하고, `bootstrapExpressApplication(...)` 및 `runExpressApplication(...)`에서는 같은 설정을 `options.multipart` 아래에 전달하면 됩니다.
+`rawBody` 및 멀티파트 form-data 파싱을 즉시 사용할 수 있습니다. 어댑터를 직접 생성할 때는 멀티파트 제한을 두 번째 인자로 전달하고, `bootstrapExpressApplication(...)` 및 `runExpressApplication(...)`에서는 같은 설정을 `options.multipart` 아래에 전달하면 됩니다. `multipart.maxTotalSize`를 지정하지 않으면 `maxBodySize`가 기본 총 멀티파트 payload 제한으로 사용되어 HTTP 어댑터 간 바디 크기 제한 동작이 portable하게 유지됩니다.
 
 ```typescript
 const adapter = createExpressAdapter(

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -53,7 +53,7 @@ async streamEvents(@Res() res: FrameworkResponse) {
 ```
 
 ### Body Parsing and Multipart
-The adapter handles `rawBody` and multipart form-data parsing out of the box. When you construct the adapter directly, pass multipart limits as the second argument. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` accept the same multipart settings under `options.multipart`.
+The adapter handles `rawBody` and multipart form-data parsing out of the box. When you construct the adapter directly, pass multipart limits as the second argument. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` accept the same multipart settings under `options.multipart`. When `multipart.maxTotalSize` is not set, `maxBodySize` becomes the default total multipart payload cap so body-size limits stay portable across HTTP adapters.
 
 ```typescript
 const adapter = createExpressAdapter(

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -297,6 +297,54 @@ describe('@fluojs/platform-express', () => {
     await app.close();
   });
 
+  it('defaults multipart.maxTotalSize to maxBodySize when no explicit multipart total is provided', async () => {
+    @Controller('/uploads')
+    class UploadController {
+      @Post('/')
+      upload(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+          fileCount: context.request.files?.length ?? 0,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UploadController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      maxBodySize: 8,
+      multipart: {
+        maxFileSize: 1024,
+      },
+      port,
+    });
+
+    await app.listen();
+
+    const form = new FormData();
+    form.set('name', 'Ada');
+    form.set('payload', new Blob(['12345678'], { type: 'text/plain' }), 'payload.txt');
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+      body: form,
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(413);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: 'PAYLOAD_TOO_LARGE',
+      },
+    });
+
+    await app.close();
+  });
+
   it('accepts a cors string and merges framework defaults', async () => {
     @Controller('/ping')
     class PingController {
@@ -746,7 +794,7 @@ describe('@fluojs/platform-express', () => {
     });
 
     const originalExitCode = process.exitCode;
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => undefined as never) as typeof process.exit);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number | string | null) => undefined as never) as typeof process.exit);
     const port = await findAvailablePort();
     const app = await runExpressApplication(AppModule, {
       cors: false,

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -408,7 +408,10 @@ async function createFrameworkRequest(
   let rawBody: Uint8Array | undefined;
 
   if (isMultipart) {
-    const parsed = await parseMultipartRequest(request, multipartOptions);
+    const parsed = await parseMultipartRequest(request, {
+      ...multipartOptions,
+      maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
+    });
     body = parsed.fields;
     files = parsed.files;
   } else {

--- a/packages/testing/src/portability/http-adapter-portability.test.ts
+++ b/packages/testing/src/portability/http-adapter-portability.test.ts
@@ -67,6 +67,7 @@ JNCDpGwh8us=
 -----END CERTIFICATE-----`;
 
 interface PortabilityAssertions {
+  assertDefaultsMultipartTotalLimitToMaxBodySize(): Promise<void>;
   assertExcludesRawBodyForMultipart(): Promise<void>;
   assertPreservesMalformedCookieValues(): Promise<void>;
   assertPreservesRawBodyForJsonAndText(): Promise<void>;
@@ -88,6 +89,10 @@ function registerPortabilitySuite(name: string, harness: PortabilityAssertions):
 
     it('does not preserve rawBody for multipart requests', async () => {
       await harness.assertExcludesRawBodyForMultipart();
+    });
+
+    it('defaults multipart.maxTotalSize to maxBodySize', async () => {
+      await harness.assertDefaultsMultipartTotalLimitToMaxBodySize();
     });
 
     it('supports SSE streaming', async () => {

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -295,6 +295,62 @@ export class HttpAdapterPortabilityHarness<
     }
   }
 
+  async assertDefaultsMultipartTotalLimitToMaxBodySize(): Promise<void> {
+    @Controller('/uploads')
+    class UploadController {
+      @Post('/')
+      upload(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+          fileCount: context.request.files?.length ?? 0,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UploadController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      maxBodySize: 8,
+      multipart: {
+        maxFileSize: 1024,
+      },
+      port,
+    } as TBootstrapOptions);
+
+    await app.listen();
+
+    try {
+      const form = new FormData();
+      form.set('name', 'Ada');
+      form.set('payload', new Blob(['12345678'], { type: 'text/plain' }), 'payload.txt');
+
+      const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+        body: form,
+        method: 'POST',
+      });
+
+      if (response.status !== 413) {
+        throw new Error(`${this.options.name} adapter did not default multipart.maxTotalSize to maxBodySize.`);
+      }
+
+      const body = await response.json();
+      if (
+        typeof body !== 'object' ||
+        body === null ||
+        (body as { error?: { code?: unknown } }).error?.code !== 'PAYLOAD_TOO_LARGE'
+      ) {
+        throw new Error(`${this.options.name} adapter changed multipart limit error semantics.`);
+      }
+    } finally {
+      await closeSilently(app);
+    }
+  }
+
   async assertSupportsSseStreaming(): Promise<void> {
     @Controller('/events')
     class EventsController {


### PR DESCRIPTION
## Summary

- Closes #1298.
- Restores Express multipart body-size behavior so `maxBodySize` becomes the default `multipart.maxTotalSize` when no explicit multipart total cap is provided.
- Extends shared HTTP adapter portability coverage to keep Node, Node.js platform, Express, and Fastify aligned for multipart total-limit semantics.

## Changes

- Updated `packages/platform-express/src/adapter.ts` to pass an adapter-level multipart total cap derived from `maxBodySize`.
- Added focused Express regression coverage for multipart requests that exceed the defaulted total limit.
- Added a shared `@fluojs/testing/http-adapter-portability` assertion and registered it for all Node HTTP adapter portability suites.
- Documented the Express EN/KO README body parsing contract for the `maxBodySize` / `multipart.maxTotalSize` relationship.

## Testing

- `lsp_diagnostics` on changed TS files: no diagnostics.
- `pnpm vitest run packages/platform-express/src/adapter.test.ts packages/testing/src/portability/http-adapter-portability.test.ts`
- `pnpm --filter @fluojs/platform-express typecheck`
- `pnpm --filter @fluojs/testing typecheck`
- `pnpm --filter @fluojs/platform-express test`
- `pnpm --filter @fluojs/testing test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (completed with existing repo warnings/info; public export TSDoc changed-mode passed)
- `pnpm verify:platform-consistency-governance`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; the existing testing harness method surface is covered by the surrounding class/function TSDoc and package README harness guidance.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

This PR changes package README contract text rather than governed SSOT docs; the behavioral invariant is backed by package regression coverage and the shared HTTP adapter portability harness.