### PR TITLE
Resolve #1318: align notifications injection docs and coverage

### DIFF
--- a/packages/notifications/README.ko.md
+++ b/packages/notifications/README.ko.md
@@ -71,8 +71,9 @@ export class AppModule {}
 import { Inject } from '@fluojs/core';
 import { NotificationsService } from '@fluojs/notifications';
 
+@Inject(NotificationsService)
 export class WelcomeService {
-  constructor(@Inject(NotificationsService) private readonly notifications: NotificationsService) {}
+  constructor(private readonly notifications: NotificationsService) {}
 
   async sendWelcomeEmail(userId: string, email: string) {
     await this.notifications.dispatch({
@@ -87,6 +88,8 @@ export class WelcomeService {
   }
 }
 ```
+
+`NotificationsModule.forRoot(...)`는 `NotificationsService`, `NOTIFICATIONS`, `NOTIFICATION_CHANNELS`를 global provider로 export합니다. 애플리케이션 서비스는 fluo의 class-level `@Inject(...)` decorator로 의존성을 선언해야 standard-decorator DI container가 legacy parameter decorator 없이 서비스를 resolve할 수 있습니다.
 
 ## 일반적인 패턴
 

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -71,8 +71,9 @@ export class AppModule {}
 import { Inject } from '@fluojs/core';
 import { NotificationsService } from '@fluojs/notifications';
 
+@Inject(NotificationsService)
 export class WelcomeService {
-  constructor(@Inject(NotificationsService) private readonly notifications: NotificationsService) {}
+  constructor(private readonly notifications: NotificationsService) {}
 
   async sendWelcomeEmail(userId: string, email: string) {
     await this.notifications.dispatch({
@@ -87,6 +88,8 @@ export class WelcomeService {
   }
 }
 ```
+
+`NotificationsModule.forRoot(...)` exports `NotificationsService`, `NOTIFICATIONS`, and `NOTIFICATION_CHANNELS` as global providers. Application services should declare dependencies with fluo's class-level `@Inject(...)` decorator so the standard-decorator DI container can resolve the service without legacy parameter decorators.
 
 ## Common Patterns
 

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { type Constructor, type Token } from '@fluojs/core';
+import { Inject, type Constructor, type Token } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Container, type Provider } from '@fluojs/di';
 
@@ -118,6 +118,49 @@ describe('NotificationsModule', () => {
         recipients: ['user@example.com'],
       },
     ]);
+  });
+
+  it('supports documented class-level service injection for application services', async () => {
+    const deliveries: string[] = [];
+
+    @Inject(NotificationsService)
+    class WelcomeService {
+      constructor(private readonly notifications: NotificationsService) {}
+
+      async sendWelcomeEmail(email: string): Promise<NotificationDispatchResult> {
+        return this.notifications.dispatch({
+          channel: 'email',
+          payload: { template: 'welcome-email' },
+          recipients: [email],
+          subject: 'Welcome to fluo',
+        });
+      }
+    }
+
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send(notification: NotificationDispatchRequest) {
+            deliveries.push(notification.recipients?.[0] ?? 'missing-recipient');
+
+            return { externalId: 'welcome-1' };
+          },
+        },
+      ],
+    });
+
+    container.register(...moduleProviders(moduleType), WelcomeService);
+    const service = await container.resolve(WelcomeService);
+
+    await expect(service.sendWelcomeEmail('user@example.com')).resolves.toMatchObject({
+      channel: 'email',
+      deliveryId: 'welcome-1',
+      queued: false,
+      status: 'delivered',
+    });
+    expect(deliveries).toEqual(['user@example.com']);
   });
 
   it('keeps single dispatch direct by default even when bulkThreshold is 1', async () => {


### PR DESCRIPTION
## Summary

Closes #1318.

Aligns the `@fluojs/notifications` injection documentation with fluo's standard class-level `@Inject(...)` decorator contract and adds regression coverage for resolving an application service through the notifications module providers.

## Changes

- Added focused coverage proving an application `WelcomeService` can inject `NotificationsService` through class-level `@Inject(NotificationsService)` and dispatch through the configured channel.
- Updated `packages/notifications/README.md` and `README.ko.md` to use the same standard-decorator injection pattern.
- Clarified that `NotificationsModule.forRoot(...)` exports `NotificationsService`, `NOTIFICATIONS`, and `NOTIFICATION_CHANNELS` as global providers.

## Testing

- `pnpm --filter @fluojs/notifications test` — passed (21 tests)
- `pnpm --filter @fluojs/notifications... build` — passed
- `pnpm --filter @fluojs/notifications typecheck` — passed
- `pnpm --filter @fluojs/notifications build` — passed
- LSP diagnostics on `packages/notifications/src/module.test.ts` — no diagnostics

## Public export documentation

- [x] No public exports changed.
- [x] README scenario examples remain aligned with source-level contracts.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Injection guidance now matches the existing standard-decorator DI contract.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT governance docs were not changed.
- [x] Package README English/Korean mirrors were updated together.