### PR TITLE
Resolve #1316: preserve event-bus shutdown and public surface guardrails

### DIFF
--- a/packages/event-bus/README.ko.md
+++ b/packages/event-bus/README.ko.md
@@ -11,6 +11,7 @@ fluo를 위한 인프로세스(In-process) 이벤트 발행 및 구독 패키지
 - [빠른 시작](#빠른-시작)
 - [일반적인 패턴](#일반적인-패턴)
 - [공개 API 개요](#공개-api-개요)
+- [런타임별 및 통합 서브패스](#런타임별-및-통합-서브패스)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
 
@@ -104,13 +105,23 @@ class UserRegisteredEvent {
 ## 공개 API 개요
 
 ### 핵심 구성 요소
-- `EventBusModule`: 이벤트 버스 기능을 위한 기본 모듈입니다.
+- `EventBusModule.forRoot(...)`: 이벤트 버스 등록을 위한 기본 진입점입니다.
 - `EventBusLifecycleService`: 이벤트를 발행(`publish(event)`)하기 위한 기본 서비스입니다.
 - `@OnEvent(EventClass)`: 특정 메서드를 이벤트 핸들러로 지정하는 데코레이터입니다.
-- `EventBusModule.forRoot(...)`: in-process 이벤트 버스 구성을 설정합니다.
+- `EVENT_BUS`: 발행 facade를 위한 호환성 주입 토큰입니다.
+- `createEventBusPlatformStatusSnapshot(...)`: diagnostics와 health surface에서 사용하는 상태 스냅샷 헬퍼입니다.
 
 ### 인터페이스
 - `EventBusTransport`: 외부 트랜스포트 어댑터 구현을 위한 계약입니다.
+- `EventBus`, `EventPublishOptions`, `EventBusModuleOptions`, `EventType`: 발행, 기본값, 트랜스포트, 안정적인 이벤트 키를 위한 타입 전용 계약입니다.
+
+## 런타임별 및 통합 서브패스
+
+| 관심사 | 서브패스 | 내보내는 항목 |
+| --- | --- | --- |
+| Redis Pub/Sub 트랜스포트 | `@fluojs/event-bus/redis` | `RedisEventBusTransport`, `RedisEventBusTransportOptions` |
+
+`RedisEventBusTransport`는 명시적인 `@fluojs/event-bus/redis` 서브패스에만 유지되어 루트 `@fluojs/event-bus` 진입점이 모듈 등록, 로컬 발행, 데코레이터, 타입 전용 계약에 집중하도록 합니다. 이 트랜스포트는 shutdown 중 자신이 등록한 채널을 unsubscribe하고 message listener를 분리하지만, 호출자가 소유한 Redis 클라이언트를 disconnect하지 않습니다.
 
 ## 관련 패키지
 

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -11,6 +11,7 @@ In-process event publishing and subscription for fluo. It features decorator-bas
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
 - [Public API](#public-api)
+- [Runtime-Specific and Integration Subpaths](#runtime-specific-and-integration-subpaths)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
 
@@ -104,12 +105,23 @@ class UserRegisteredEvent {
 ## Public API Overview
 
 ### Core
-- `EventBusModule`: Main entry point for event bus registration.
+- `EventBusModule.forRoot(...)`: Main entry point for event bus registration.
 - `EventBusLifecycleService`: Primary service for publishing events (`publish(event)`).
 - `@OnEvent(EventClass)`: Decorator to mark a method as an event handler.
+- `EVENT_BUS`: Compatibility injection token for the publish facade.
+- `createEventBusPlatformStatusSnapshot(...)`: Status snapshot helper used by diagnostics and health surfaces.
 
 ### Interfaces
 - `EventBusTransport`: Contract for implementing external transport adapters.
+- `EventBus`, `EventPublishOptions`, `EventBusModuleOptions`, `EventType`: Type-only contracts for publishing, defaults, transports, and stable event keys.
+
+## Runtime-Specific and Integration Subpaths
+
+| Concern | Subpath | Exports |
+| --- | --- | --- |
+| Redis Pub/Sub transport | `@fluojs/event-bus/redis` | `RedisEventBusTransport`, `RedisEventBusTransportOptions` |
+
+`RedisEventBusTransport` stays on the explicit `@fluojs/event-bus/redis` subpath so the root `@fluojs/event-bus` entrypoint remains focused on module registration, local publishing, decorators, and type-only contracts. The transport unsubscribes the channels it registered and detaches its message listener during shutdown, but it does not disconnect caller-owned Redis clients.
 
 ## Related Packages
 

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -1332,6 +1332,45 @@ describe('@fluojs/event-bus', () => {
       expect(shutdownResolved).toBe(true);
     });
 
+    it('records transport close failures in the lifecycle status snapshot', async () => {
+      const loggerEvents: string[] = [];
+      const transport = {
+        async close() {
+          throw new Error('close failed');
+        },
+        async publish(_channel: string, _payload: unknown) {},
+        async subscribe(_channel: string, _handler: (payload: unknown) => Promise<void>) {},
+      } satisfies EventBusTransport;
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [EventBusModule.forRoot({ transport })],
+      });
+
+      const app = await bootstrapApplication({
+        logger: createLogger(loggerEvents),
+        rootModule: AppModule,
+      });
+      const service = await app.container.resolve(EventBusLifecycleService);
+
+      await expect(closeApplication(app)).resolves.toBeUndefined();
+
+      expect(loggerEvents.some((event) => event.includes('EventBusTransport failed to close.'))).toBe(true);
+      expect(service.createPlatformStatusSnapshot()).toMatchObject({
+        details: {
+          lifecycleState: 'failed',
+          transportCloseFailures: 1,
+          transportConfigured: true,
+        },
+        health: {
+          status: 'unhealthy',
+        },
+        readiness: {
+          status: 'not-ready',
+        },
+      });
+    });
+
     it('does not call transport when no transport is configured (backward compat)', async () => {
       class EventStore {
         calls = 0;

--- a/packages/event-bus/src/public-surface.test.ts
+++ b/packages/event-bus/src/public-surface.test.ts
@@ -1,6 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import * as eventBus from './index.js';
+import * as redisEventBus from './transports/redis-transport.js';
 
 describe('@fluojs/event-bus root barrel public surface', () => {
   it('keeps the documented root exports stable for 0.x governance', () => {
@@ -17,5 +21,27 @@ describe('@fluojs/event-bus root barrel public surface', () => {
     expect(eventBus).not.toHaveProperty('getEventHandlerMetadataEntries');
     expect(eventBus).not.toHaveProperty('eventBusMetadataSymbol');
     expect(Object.keys(eventBus).sort()).toMatchSnapshot();
+  });
+
+  it('keeps Redis transport isolated behind the documented redis subpath', () => {
+    expect(eventBus).not.toHaveProperty('RedisEventBusTransport');
+    expect(redisEventBus).toHaveProperty('RedisEventBusTransport');
+
+    const packageJson = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, '../package.json'), 'utf8'),
+    ) as {
+      exports: Record<string, { import: string; types: string }>;
+    };
+
+    expect(packageJson.exports).toEqual({
+      '.': {
+        import: './dist/index.js',
+        types: './dist/index.d.ts',
+      },
+      './redis': {
+        import: './dist/transports/redis-transport.js',
+        types: './dist/transports/redis-transport.d.ts',
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1316.

Preserves the `@fluojs/event-bus` shutdown and public surface guardrails identified by the infra messaging audit.

## Changes

- Added regression coverage that records transport close failures in the event-bus lifecycle status snapshot.
- Added public surface coverage for the root entrypoint vs `@fluojs/event-bus/redis` subpath export map.
- Aligned `packages/event-bus/README.md` and `README.ko.md` with the documented root API, Redis subpath, and Redis client ownership/shutdown contract.

## Testing

- `lsp_diagnostics` on `packages/event-bus/src/module.test.ts` — no diagnostics
- `lsp_diagnostics` on `packages/event-bus/src/public-surface.test.ts` — no diagnostics
- `pnpm --filter @fluojs/event-bus test` — 46 tests passed
- `pnpm --filter @fluojs/event-bus... build` — passed
- `pnpm --filter @fluojs/event-bus typecheck` — passed

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added. README EN/KO now documents the existing root API and `@fluojs/event-bus/redis` subpath boundary.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The Redis transport remains caller-owned for Redis clients: shutdown unsubscribes transport-owned channels and detaches listeners without disconnecting caller-owned clients.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs changed; only package README EN/KO mirror content changed.