### PR TITLE
Resolve #1325: preserve Drizzle request transaction shutdown and status docs

### DIFF
--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -10,6 +10,10 @@
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
+  - [repository에서 `DrizzleDatabase.current()` 사용하기](#repository에서-drizzledatabasecurrent-사용하기)
+  - [수동 트랜잭션 경계](#수동-트랜잭션-경계)
+  - [인터셉터 기반 요청 단위 트랜잭션](#인터셉터-기반-요청-단위-트랜잭션)
+  - [종료와 상태 계약](#종료와-상태-계약)
 - [수동 모듈 구성](#수동-모듈-구성)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
@@ -95,6 +99,17 @@ import { DrizzleTransactionInterceptor } from '@fluojs/drizzle';
 @UseInterceptors(DrizzleTransactionInterceptor)
 class UsersController {}
 ```
+
+### 종료와 상태 계약
+
+`DrizzleTransactionInterceptor`는 각 HTTP 요청을 `DrizzleDatabase.requestTransaction(...)`으로 실행합니다. 애플리케이션 종료 중에는 `DrizzleDatabase`가 아직 활성 상태인 요청 트랜잭션을 abort하고, 해당 transaction callback이 settle되거나 rollback될 때까지 기다린 뒤 선택적 `dispose(database)` hook을 실행합니다. 이 순서는 pool이나 외부 관리 리소스를 닫기 전에 driver가 rollback/cleanup 작업을 끝낼 수 있게 보장합니다.
+
+`createDrizzlePlatformStatusSnapshot(...)`과 `DrizzleDatabase.createPlatformStatusSnapshot()`은 같은 계약을 진단 surface에 노출합니다.
+
+- Drizzle이 종료 중이거나 중지된 상태이면, 또는 `strictTransactions`가 켜져 있는데 `database.transaction(...)` 지원이 없으면 `readiness.status`는 `not-ready`입니다.
+- 요청 트랜잭션을 drain하는 종료 중에는 `health.status`가 `degraded`이고, dispose 이후에는 `unhealthy`입니다.
+- `details.activeRequestTransactions`, `details.lifecycleState`, `details.strictTransactions`, `details.supportsTransaction`은 현재 요청 트랜잭션과 트랜잭션 지원 상태를 설명합니다.
+- `ownership.externallyManaged: true`와 `ownership.ownsResources: false`는 이 패키지가 설정된 dispose hook은 실행하지만 underlying driver resource의 소유권을 주장하지 않는다는 뜻입니다.
 
 ## 수동 모듈 구성
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -10,6 +10,10 @@ Drizzle ORM integration for fluo with a transaction-aware database wrapper and a
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
+  - [Use `DrizzleDatabase.current()` inside repositories](#use-drizzledatabasecurrent-inside-repositories)
+  - [Manual transaction boundaries](#manual-transaction-boundaries)
+  - [Request-scoped transactions with an interceptor](#request-scoped-transactions-with-an-interceptor)
+  - [Shutdown and status contracts](#shutdown-and-status-contracts)
 - [Manual Module Composition](#manual-module-composition)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
@@ -95,6 +99,17 @@ import { DrizzleTransactionInterceptor } from '@fluojs/drizzle';
 @UseInterceptors(DrizzleTransactionInterceptor)
 class UsersController {}
 ```
+
+### Shutdown and status contracts
+
+`DrizzleTransactionInterceptor` runs each HTTP request through `DrizzleDatabase.requestTransaction(...)`. During application shutdown, `DrizzleDatabase` aborts any still-active request transaction, waits for its transaction callback to settle or roll back, and only then runs the optional `dispose(database)` hook. This ordering lets drivers finish rollback/cleanup work before pools or externally managed resources are closed.
+
+`createDrizzlePlatformStatusSnapshot(...)` and `DrizzleDatabase.createPlatformStatusSnapshot()` expose the same contract to diagnostics surfaces:
+
+- `readiness.status` is `not-ready` while Drizzle is shutting down or stopped, and when `strictTransactions` is enabled without `database.transaction(...)` support.
+- `health.status` is `degraded` while request transactions are draining during shutdown and `unhealthy` after disposal.
+- `details.activeRequestTransactions`, `details.lifecycleState`, `details.strictTransactions`, and `details.supportsTransaction` describe the current request transaction and transaction-capability state.
+- `ownership.externallyManaged: true` and `ownership.ownsResources: false` mean the package runs your configured dispose hook but does not claim ownership of the underlying driver resources.
 
 ## Manual Module Composition
 

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -154,6 +154,76 @@ describe('@fluojs/drizzle', () => {
     ]);
   });
 
+  it('waits for delayed request transaction settlement before dispose on shutdown', async () => {
+    const events: string[] = [];
+    const transactionDatabase = {};
+    let releaseRollback!: () => void;
+    const rollbackBarrier = new Promise<void>((resolve) => {
+      releaseRollback = resolve;
+    });
+    const database = {
+      async transaction<T>(callback: (value: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        events.push('transaction:start');
+
+        try {
+          return await callback(transactionDatabase);
+        } catch (error) {
+          events.push('transaction:rollback:pending');
+          await rollbackBarrier;
+          events.push('transaction:rollback:done');
+          throw error;
+        } finally {
+          events.push('transaction:end');
+        }
+      },
+    };
+
+    const drizzleModule = DrizzleModule.forRoot<typeof database, typeof transactionDatabase>({
+      database,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [drizzleModule],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+    const drizzle = await app.container.resolve(DrizzleDatabase<typeof database, typeof transactionDatabase>);
+    const requestAbortController = new AbortController();
+    const openTransaction = drizzle.requestTransaction(
+      async () => new Promise<never>(() => undefined),
+      requestAbortController.signal,
+    );
+
+    requestAbortController.abort(new Error('request aborted'));
+    await Promise.resolve();
+
+    const shutdownPromise = app.close();
+
+    await Promise.resolve();
+    expect(events).toContain('transaction:rollback:pending');
+    expect(events).not.toContain('dispose');
+
+    releaseRollback();
+
+    await expect(openTransaction).rejects.toThrow();
+    await shutdownPromise;
+
+    expect(events).toEqual([
+      'transaction:start',
+      'transaction:rollback:pending',
+      'transaction:rollback:done',
+      'transaction:end',
+      'dispose',
+    ]);
+  });
+
   it('enforces strictTransactions for sync and async module builders', async () => {
     const database = {};
 


### PR DESCRIPTION
## Summary

Closes #1325.

Preserves the audited `@fluojs/drizzle` request transaction shutdown and status contracts by locking the shutdown ordering in regression coverage and documenting the package-facing diagnostics semantics.

## Changes

- Added a Drizzle regression test proving application shutdown waits for delayed request transaction rollback/settlement before running `dispose`.
- Documented request transaction shutdown ordering and platform status snapshot semantics in `packages/drizzle/README.md`.
- Mirrored the same contract update in `packages/drizzle/README.ko.md`.

## Testing

- `pnpm --filter @fluojs/drizzle test`
- `pnpm --filter @fluojs/drizzle typecheck`
- `pnpm --filter @fluojs/drizzle... build`
- LSP diagnostics: `packages/drizzle/src/module.test.ts` — no diagnostics

## Public export documentation

- [x] No public exports changed.
- [x] Existing public status API documentation remains aligned with the package README.
- [x] Source examples and README scenario examples remain complementary.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] The Drizzle request transaction shutdown/status contract is documented in the affected package README.
- [x] Intentional resource ownership semantics are explicitly stated.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] No governed SSOT platform contract docs changed.
- [x] EN/KO package README updates remain structurally aligned.
- [x] Package-scoped regression coverage backs the Drizzle persistence behavior.