### PR TITLE
Resolve #1323: align Socket.IO room contract

### DIFF
--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -58,6 +58,13 @@ this.rooms.joinRoom(socket.id, 'room:123');
 this.rooms.broadcastToRoom('room:123', 'event', data);
 ```
 
+Room helper는 공유 `WebSocketRoomService` 계약을 따르면서 Socket.IO namespace 인식을 추가합니다. gateway handler 안에서는 현재 `@WebSocketGateway({ path })` namespace를 자동으로 추론합니다. gateway handler 밖에서 room helper를 실행할 때는 같은 이름의 room이 다른 Socket.IO namespace에 존재할 수 있으므로 대상 namespace path를 명시적으로 전달하세요.
+
+```ts
+this.rooms.broadcastToRoom('room:123', 'event', data, '/chat');
+this.rooms.joinRoom(socketId, 'room:123', '/chat');
+```
+
 ### Raw Socket.IO 서버 접근
 
 ```ts
@@ -109,6 +116,8 @@ Socket.IO 등록은 소유 모듈의 import 경로에서 구성하여 namespace/
 - `SocketIoModule.forRoot({ auth, cors, engine, ... })`
 - `SOCKETIO_SERVER`
 - `SOCKETIO_ROOM_SERVICE`
+- `SocketIoRoomService`: 공유 room 계약에 Socket.IO namespace-aware `joinRoom`, `leaveRoom`, `broadcastToRoom`, `getRooms` helper를 더한 타입입니다.
+- `SocketIoLifecycleService`: server와 room-service token 뒤에서 동작하는 lifecycle 기반 구현입니다. 애플리케이션 코드는 일반적으로 `SOCKETIO_SERVER` 또는 `SOCKETIO_ROOM_SERVICE`를 주입하세요.
 
 ## 지원 플랫폼
 
@@ -122,3 +131,4 @@ Socket.IO 등록은 소유 모듈의 import 경로에서 구성하여 namespace/
 ## 예제 소스
 
 - `packages/socket.io/src/module.test.ts`
+- `packages/socket.io/src/public-surface.test.ts`

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -59,6 +59,13 @@ this.rooms.joinRoom(socket.id, 'room:123');
 this.rooms.broadcastToRoom('room:123', 'event', data);
 ```
 
+Room helpers follow the shared `WebSocketRoomService` contract and add Socket.IO namespace awareness. Inside a gateway handler the current `@WebSocketGateway({ path })` namespace is inferred automatically. When room helpers run outside gateway handler context, pass the namespace path explicitly so room operations target the intended Socket.IO namespace instead of a same-named room elsewhere.
+
+```typescript
+this.rooms.broadcastToRoom('room:123', 'event', data, '/chat');
+this.rooms.joinRoom(socketId, 'room:123', '/chat');
+```
+
 ### Accessing the Raw Server
 You can inject the underlying Socket.IO `Server` instance for low-level control.
 
@@ -111,6 +118,8 @@ Register Socket.IO through module imports in the owning module so namespace/mess
 - `SocketIoModule.forRoot({ auth, cors, engine, ... })`: Configures namespace/message guards plus explicit CORS and Engine.IO payload bounds.
 - `SOCKETIO_SERVER`: Token to inject the raw Socket.IO `Server`.
 - `SOCKETIO_ROOM_SERVICE`: Token to inject the `SocketIoRoomService`.
+- `SocketIoRoomService`: Shared room contract plus Socket.IO namespace-aware `joinRoom`, `leaveRoom`, `broadcastToRoom`, and `getRooms` helpers.
+- `SocketIoLifecycleService`: Lifecycle-backed implementation behind the server and room-service tokens; application code should usually inject `SOCKETIO_SERVER` or `SOCKETIO_ROOM_SERVICE` instead.
 
 ## Supported Platforms
 
@@ -124,3 +133,4 @@ Register Socket.IO through module imports in the owning module so namespace/mess
 ## Example Sources
 
 - `packages/socket.io/src/module.test.ts`
+- `packages/socket.io/src/public-surface.test.ts`

--- a/packages/socket.io/src/public-surface.test.ts
+++ b/packages/socket.io/src/public-surface.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type { WebSocketRoomService } from '@fluojs/websockets';
+
+import * as socketIo from './index.js';
+import type { SocketIoRoomService } from './types.js';
+
+describe('@fluojs/socket.io public surface', () => {
+  it('keeps the root barrel aligned with the documented module and room contract', () => {
+    expect(socketIo).toHaveProperty('SocketIoModule');
+    expect((socketIo as { SocketIoModule: { forRoot: unknown } }).SocketIoModule).toHaveProperty('forRoot');
+    expect(socketIo).toHaveProperty('SocketIoLifecycleService');
+    expect(socketIo).toHaveProperty('SOCKETIO_ROOM_SERVICE');
+    expect(socketIo).toHaveProperty('SOCKETIO_SERVER');
+    expect(socketIo).not.toHaveProperty('createSocketIoProviders');
+    expect(socketIo).not.toHaveProperty('SOCKETIO_OPTIONS_INTERNAL');
+    expect(Object.keys(socketIo).sort()).toEqual([
+      'SOCKETIO_ROOM_SERVICE',
+      'SOCKETIO_SERVER',
+      'SocketIoLifecycleService',
+      'SocketIoModule',
+    ]);
+  });
+
+  it('keeps Socket.IO room helpers compatible with the shared websocket room contract', () => {
+    const roomContractIsSharedContract: WebSocketRoomService = {} as SocketIoRoomService;
+
+    expect(roomContractIsSharedContract).toBeDefined();
+    expectTypeOf<SocketIoRoomService['joinRoom']>().parameters.toEqualTypeOf<[
+      socketId: string,
+      room: string,
+      namespacePath?: string,
+    ]>();
+    expectTypeOf<SocketIoRoomService['leaveRoom']>().parameters.toEqualTypeOf<[
+      socketId: string,
+      room: string,
+      namespacePath?: string,
+    ]>();
+    expectTypeOf<SocketIoRoomService['broadcastToRoom']>().parameters.toEqualTypeOf<[
+      room: string,
+      event: string,
+      data: unknown,
+      namespacePath?: string,
+    ]>();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1323

Aligns the `@fluojs/socket.io` room contract documentation and public surface regression coverage with the existing namespace-aware Socket.IO room behavior.

## Changes

- Added a focused `@fluojs/socket.io` public surface regression test for the root barrel exports and `SocketIoRoomService` compatibility with the shared `WebSocketRoomService` contract.
- Documented Socket.IO room helper namespace inference and explicit namespace usage in `packages/socket.io/README.md` and `README.ko.md`.
- Kept changes scoped to `@fluojs/socket.io`; no shared `@fluojs/websockets` behavior was changed.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/socket.io... build`
- `pnpm --filter @fluojs/socket.io test -- public-surface.test.ts module.test.ts`
- `pnpm --filter @fluojs/socket.io typecheck`
- LSP diagnostics: `packages/socket.io/src/public-surface.test.ts` — no diagnostics

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.