### PR TITLE
Resolve #1328: preserve Studio report artifact handling

### DIFF
--- a/.changeset/studio-artifact-validation.md
+++ b/.changeset/studio-artifact-validation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/studio": patch
+---
+
+Preserve Studio report and timing artifact parsing by accepting standalone timing diagnostics while failing malformed report envelopes without summaries.

--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -41,7 +41,7 @@ pnpm add @fluojs/studio
 
 ## 빠른 시작
 
-Studio는 fluo CLI에서 내보낸 JSON 파일을 소비합니다. 런타임은 snapshot을 생산하고, CLI는 검사 데이터를 내보내거나 위임하며, Studio는 뷰어와 자동화 호출자가 사용할 수 있도록 snapshot을 파싱, 필터링, 보기, 렌더링하는 공개 헬퍼를 소유합니다.
+Studio는 fluo CLI에서 내보낸 JSON 파일을 소비합니다. 런타임은 snapshot을 생산하고, CLI는 검사 데이터를 내보내거나 위임하며, Studio는 뷰어와 자동화 호출자가 사용할 수 있도록 snapshot을 파싱, 필터링, 보기, 렌더링하는 공개 헬퍼를 소유합니다. 지원되는 inspect artifact에는 raw snapshot, standalone timing diagnostics, snapshot-plus-timing envelope, `fluo inspect --report`가 생성한 report artifact가 포함됩니다.
 
 1. **Snapshot 내보내기**:
    ```bash
@@ -79,6 +79,7 @@ Studio는 주로 웹 애플리케이션이지만, 배포된 패키지는 도구/
 | `PlatformShellSnapshot` | 애플리케이션 상태를 나타내는 핵심 데이터 구조입니다. |
 | `PlatformDiagnosticIssue` | 플랫폼 오류 보고 및 수정을 위한 스키마입니다. |
 | `parseStudioPayload(rawJson)` | CLI/export JSON을 Studio snapshot/timing envelope로 검증합니다. |
+| `StudioReportArtifact` | CI/support 자동화를 위해 summary, snapshot, timing 데이터를 함께 보존한 `fluo inspect --report` artifact입니다. |
 | `applyFilters(snapshot, filter)` | 원본 snapshot을 변경하지 않고 readiness/severity/query 필터를 적용합니다. |
 | `renderMermaid(snapshot)` | 내부 컴포넌트 dependency edge와 외부 dependency node를 포함해 로드된 플랫폼 그래프를 Mermaid 텍스트로 변환합니다. |
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -41,7 +41,7 @@ The published package serves two caller-facing entrypoints:
 
 ## Quick Start
 
-Studio consumes JSON exports from the fluo CLI. Runtime produces snapshots, the CLI exports or delegates inspection data, and Studio owns the public helpers that parse, filter, view, and render those snapshots for viewer and automation callers.
+Studio consumes JSON exports from the fluo CLI. Runtime produces snapshots, the CLI exports or delegates inspection data, and Studio owns the public helpers that parse, filter, view, and render those snapshots for viewer and automation callers. Supported inspect artifacts include raw snapshots, standalone timing diagnostics, snapshot-plus-timing envelopes, and report artifacts produced by `fluo inspect --report`.
 
 1. **Export a snapshot**:
    ```bash
@@ -79,6 +79,7 @@ Studio is primarily a web application, but the published package also exposes th
 | `PlatformShellSnapshot` | The core data structure representing the application state. |
 | `PlatformDiagnosticIssue` | Schema for reporting and fixing platform errors. |
 | `parseStudioPayload(rawJson)` | Validates CLI/exported JSON into the Studio snapshot/timing envelope. |
+| `StudioReportArtifact` | Preserved `fluo inspect --report` artifact with summary, snapshot, and timing data for CI/support automation. |
 | `applyFilters(snapshot, filter)` | Applies readiness/severity/query filters without mutating the source snapshot. |
 | `renderMermaid(snapshot)` | Produces Mermaid graph text from the loaded platform graph, including internal component dependency edges and external dependency nodes. |
 

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -131,6 +131,77 @@ describe('parseStudioPayload', () => {
     expect(parsed.payload.timing?.phases).toHaveLength(1);
   });
 
+  it('preserves inspect report artifacts with summary, snapshot, and timing', () => {
+    const parsed = parseStudioPayload(
+      JSON.stringify({
+        generatedAt: snapshotFixture.generatedAt,
+        snapshot: snapshotFixture,
+        summary: {
+          componentCount: 2,
+          diagnosticCount: 1,
+          errorCount: 0,
+          healthStatus: 'degraded',
+          readinessStatus: 'degraded',
+          timingTotalMs: 4.56,
+          warningCount: 1,
+        },
+        timing: {
+          phases: [{ durationMs: 4.56, name: 'bootstrap_module' }],
+          totalMs: 4.56,
+          version: 1,
+        },
+        version: 1,
+      }),
+    );
+
+    expect(parsed.payload.report).toEqual({
+      generatedAt: snapshotFixture.generatedAt,
+      snapshot: snapshotFixture,
+      summary: {
+        componentCount: 2,
+        diagnosticCount: 1,
+        errorCount: 0,
+        healthStatus: 'degraded',
+        readinessStatus: 'degraded',
+        timingTotalMs: 4.56,
+        warningCount: 1,
+      },
+      timing: {
+        phases: [{ durationMs: 4.56, name: 'bootstrap_module' }],
+        totalMs: 4.56,
+        version: 1,
+      },
+      version: 1,
+    });
+    expect(parsed.payload.snapshot).toBe(parsed.payload.report?.snapshot);
+    expect(parsed.payload.timing).toBe(parsed.payload.report?.timing);
+  });
+
+  it('rejects malformed inspect report summaries before automation consumes them', () => {
+    expect(() =>
+      parseStudioPayload(
+        JSON.stringify({
+          generatedAt: snapshotFixture.generatedAt,
+          snapshot: snapshotFixture,
+          summary: {
+            componentCount: 2,
+            diagnosticCount: 1,
+            errorCount: 0,
+            healthStatus: 'degraded',
+            readinessStatus: 'degraded',
+            warningCount: 1,
+          },
+          timing: {
+            phases: [{ durationMs: 4.56, name: 'bootstrap_module' }],
+            totalMs: 4.56,
+            version: 1,
+          },
+          version: 1,
+        }),
+      )
+    ).toThrow('Invalid inspect report summary payload.');
+  });
+
   it('keeps the Studio release contract aligned across manifest and README docs', () => {
     const packageManifest = JSON.parse(readFileSync(resolve(packageDir, 'package.json'), 'utf8')) as {
       name: string;
@@ -164,10 +235,12 @@ describe('parseStudioPayload', () => {
     expect(readme).toContain('pnpm add @fluojs/studio');
     expect(readme).toContain('@fluojs/studio/contracts');
     expect(readme).toContain('@fluojs/studio/viewer');
+    expect(readme).toContain('report artifacts');
     expect(readme).toContain('intended public publish surface');
     expect(readmeKo).toContain('pnpm add @fluojs/studio');
     expect(readmeKo).toContain('@fluojs/studio/contracts');
     expect(readmeKo).toContain('@fluojs/studio/viewer');
+    expect(readmeKo).toContain('report artifact');
     expect(readmeKo).toContain('공개 배포 패키지');
   });
 

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -1,13 +1,11 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import { describe, expect, it } from 'vitest';
-
-import * as studio from './index.js';
-import { applyFilters, parseStudioPayload, renderMermaid } from './contracts.js';
 import type { PlatformShellSnapshot } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
 import { runWorkspaceBuildClosure } from '../../../tooling/scripts/run-workspace-build-closure.mjs';
+import { applyFilters, parseStudioPayload, renderMermaid } from './contracts.js';
+import * as studio from './index.js';
 
 const packageDir = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
 const repoRoot = resolve(packageDir, '..', '..');
@@ -131,6 +129,23 @@ describe('parseStudioPayload', () => {
     expect(parsed.payload.timing?.phases).toHaveLength(1);
   });
 
+  it('parses standalone timing diagnostics without requiring a snapshot', () => {
+    const parsed = parseStudioPayload(
+      JSON.stringify({
+        phases: [{ durationMs: 1.23, name: 'bootstrap_module' }],
+        totalMs: 1.23,
+        version: 1,
+      }),
+    );
+
+    expect(parsed.payload.snapshot).toBeUndefined();
+    expect(parsed.payload.timing).toEqual({
+      phases: [{ durationMs: 1.23, name: 'bootstrap_module' }],
+      totalMs: 1.23,
+      version: 1,
+    });
+  });
+
   it('preserves inspect report artifacts with summary, snapshot, and timing', () => {
     const parsed = parseStudioPayload(
       JSON.stringify({
@@ -200,6 +215,23 @@ describe('parseStudioPayload', () => {
         }),
       )
     ).toThrow('Invalid inspect report summary payload.');
+  });
+
+  it('rejects inspect report artifacts missing the required summary', () => {
+    expect(() =>
+      parseStudioPayload(
+        JSON.stringify({
+          generatedAt: snapshotFixture.generatedAt,
+          snapshot: snapshotFixture,
+          timing: {
+            phases: [{ durationMs: 4.56, name: 'bootstrap_module' }],
+            totalMs: 4.56,
+            version: 1,
+          },
+          version: 1,
+        }),
+      )
+    ).toThrow('Invalid inspect report artifact payload.');
   });
 
   it('keeps the Studio release contract aligned across manifest and README docs', () => {

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -18,9 +18,34 @@ export type PlatformReadinessStatus = PlatformSnapshot['readiness']['status'];
 export type PlatformDiagnosticSeverity = PlatformDiagnosticIssue['severity'];
 
 /**
+ * Stable summary emitted by `fluo inspect --report` for support and CI triage.
+ */
+export interface StudioReportSummary {
+  componentCount: number;
+  diagnosticCount: number;
+  errorCount: number;
+  healthStatus: PlatformShellSnapshot['health']['status'];
+  readinessStatus: PlatformShellSnapshot['readiness']['status'];
+  timingTotalMs: number;
+  warningCount: number;
+}
+
+/**
+ * CI-friendly report artifact emitted by `fluo inspect --report`.
+ */
+export interface StudioReportArtifact {
+  generatedAt: string;
+  snapshot: PlatformShellSnapshot;
+  summary: StudioReportSummary;
+  timing: BootstrapTimingDiagnostics;
+  version: 1;
+}
+
+/**
  * Serializable Studio payload envelope built from inspect snapshot/timing exports.
  */
 export interface StudioPayload {
+  report?: StudioReportArtifact;
   snapshot?: PlatformShellSnapshot;
   timing?: BootstrapTimingDiagnostics;
 }
@@ -171,6 +196,44 @@ function validateTiming(value: unknown): BootstrapTimingDiagnostics | null {
   return value as unknown as BootstrapTimingDiagnostics;
 }
 
+function validateReportSummary(value: unknown): StudioReportSummary {
+  if (!isRecord(value)) {
+    throw new Error('Invalid inspect report summary payload.');
+  }
+
+  if (
+    typeof value.componentCount !== 'number'
+    || typeof value.diagnosticCount !== 'number'
+    || typeof value.errorCount !== 'number'
+    || !isHealthStatus(value.healthStatus)
+    || !isReadinessStatus(value.readinessStatus)
+    || typeof value.timingTotalMs !== 'number'
+    || typeof value.warningCount !== 'number'
+  ) {
+    throw new Error('Invalid inspect report summary payload.');
+  }
+
+  return value as unknown as StudioReportSummary;
+}
+
+function validateReport(value: unknown, snapshot: PlatformShellSnapshot | null, timing: BootstrapTimingDiagnostics | null): StudioReportArtifact | null {
+  if (!isRecord(value) || value.summary === undefined) {
+    return null;
+  }
+
+  if (value.version !== 1 || typeof value.generatedAt !== 'string' || !snapshot || !timing) {
+    throw new Error('Invalid inspect report artifact payload.');
+  }
+
+  return {
+    generatedAt: value.generatedAt,
+    snapshot,
+    summary: validateReportSummary(value.summary),
+    timing,
+    version: 1,
+  };
+}
+
 /**
  * Parses a Studio JSON file into the documented snapshot/timing envelope.
  *
@@ -184,6 +247,7 @@ export function parseStudioPayload(rawJson: string): ParsedPayload {
 
   const snapshot = validateSnapshot(envelope?.snapshot ?? parsed);
   const timing = validateTiming(envelope?.timing ?? (!snapshot ? parsed : undefined));
+  const report = validateReport(parsed, snapshot, timing);
 
   if (!snapshot && !timing) {
     throw new Error('Unsupported file format. Expected platform snapshot JSON or timing JSON.');
@@ -191,6 +255,7 @@ export function parseStudioPayload(rawJson: string): ParsedPayload {
 
   return {
     payload: {
+      ...(report ? { report } : {}),
       ...(snapshot ? { snapshot } : {}),
       ...(timing ? { timing } : {}),
     },

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -71,6 +71,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(value, key);
+}
+
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
 }
@@ -216,12 +220,17 @@ function validateReportSummary(value: unknown): StudioReportSummary {
   return value as unknown as StudioReportSummary;
 }
 
+function isReportArtifactEnvelope(value: Record<string, unknown>): boolean {
+  return value.summary !== undefined
+    || (hasOwn(value, 'snapshot') && hasOwn(value, 'timing') && (hasOwn(value, 'generatedAt') || hasOwn(value, 'version')));
+}
+
 function validateReport(value: unknown, snapshot: PlatformShellSnapshot | null, timing: BootstrapTimingDiagnostics | null): StudioReportArtifact | null {
-  if (!isRecord(value) || value.summary === undefined) {
+  if (!isRecord(value) || !isReportArtifactEnvelope(value)) {
     return null;
   }
 
-  if (value.version !== 1 || typeof value.generatedAt !== 'string' || !snapshot || !timing) {
+  if (value.summary === undefined || value.version !== 1 || typeof value.generatedAt !== 'string' || !snapshot || !timing) {
     throw new Error('Invalid inspect report artifact payload.');
   }
 
@@ -244,9 +253,17 @@ function validateReport(value: unknown, snapshot: PlatformShellSnapshot | null, 
 export function parseStudioPayload(rawJson: string): ParsedPayload {
   const parsed = JSON.parse(rawJson) as unknown;
   const envelope = isRecord(parsed) ? parsed : undefined;
+  const hasSnapshotEnvelope = envelope !== undefined && hasOwn(envelope, 'snapshot');
+  const hasTimingEnvelope = envelope !== undefined && hasOwn(envelope, 'timing');
+  const standaloneTiming = envelope !== undefined
+    && !hasSnapshotEnvelope
+    && !hasTimingEnvelope
+    && hasOwn(envelope, 'version')
+    && hasOwn(envelope, 'totalMs')
+    && hasOwn(envelope, 'phases');
 
-  const snapshot = validateSnapshot(envelope?.snapshot ?? parsed);
-  const timing = validateTiming(envelope?.timing ?? (!snapshot ? parsed : undefined));
+  const snapshot = validateSnapshot(hasSnapshotEnvelope ? envelope.snapshot : standaloneTiming ? undefined : parsed);
+  const timing = validateTiming(hasTimingEnvelope ? envelope.timing : !snapshot ? parsed : undefined);
   const report = validateReport(parsed, snapshot, timing);
 
   if (!snapshot && !timing) {

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -7,6 +7,8 @@ export {
   type PlatformDiagnosticIssue,
   type PlatformDiagnosticSeverity,
   type PlatformReadinessStatus,
+  type StudioReportArtifact,
+  type StudioReportSummary,
   type PlatformShellSnapshot,
   type StudioPayload,
 } from './contracts.js';


### PR DESCRIPTION
## Summary

Preserve the documented Studio handling contract for `fluo inspect --report` artifacts so automation callers do not lose report metadata when using `parseStudioPayload`.

Closes #1328

## Changes

- Added `StudioReportArtifact` and `StudioReportSummary` public contract types.
- Updated `parseStudioPayload` to validate and preserve report artifacts while keeping snapshot/timing payload access intact.
- Added focused Studio regression coverage for valid and malformed report artifacts.
- Updated `packages/studio` EN/KO README contract docs for report artifact support.

## Testing

- `pnpm install` (fresh worktree dependency setup)
- `pnpm --dir packages/studio test`
- `pnpm --filter @fluojs/runtime build`
- `pnpm --dir packages/studio typecheck`
- `pnpm --dir packages/studio build`
- `pnpm --dir packages/cli exec vitest run -c vitest.config.ts src/cli.test.ts -t "inspect"`
- `pnpm --dir packages/cli typecheck`
- LSP diagnostics on `packages/studio/src/contracts.ts`, `packages/studio/src/index.ts`, and `packages/studio/src/contracts.test.ts`: no diagnostics

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.