### PR TITLE
Resolve #1312: tighten Redis docs and lifecycle regression coverage

### DIFF
--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -71,12 +71,22 @@ export class CacheRepository {
 
 ## 일반적인 패턴
 
+### 수명 주기 소유권
+
+`@fluojs/redis`는 `RedisModule.forRootNamed(...)`로 등록한 연결을 포함해, 자신이 생성한 모든 Redis 클라이언트의 수명 주기를 직접 관리합니다.
+
+- 호출자가 옵션을 강제로 캐스팅하더라도 Fluo는 항상 `lazyConnect: true`를 강제하므로, 소켓은 import 시점이 아니라 애플리케이션 bootstrap 중에 열립니다.
+- bootstrap 단계에서는 클라이언트가 ioredis `wait` 상태일 때만 lifecycle service가 `connect()`를 호출합니다.
+- shutdown 단계에서는 ready/connecting 계열 상태에 `quit()`를 우선 시도해 정상 종료를 노리고, wait/종료 전이 상태에서는 `disconnect()`를 직접 사용합니다.
+- `quit()`가 실패하면 Fluo는 `disconnect()`로 fallback하고, 그 뒤에도 클라이언트가 닫히지 않은 경우에만 에러를 다시 던집니다.
+
 ### 이름 있는 클라이언트
 
 하나의 애플리케이션에서 여러 Redis 연결이 필요하면 `RedisModule.forRootNamed(name, options)`를 사용하세요. `RedisModule.forRoot(options)`는 기본 `REDIS_CLIENT`와 `RedisService` 별칭을 제공하고, 이름 있는 등록은 `getRedisClientToken(name)`과 `getRedisServiceToken(name)`으로 해석합니다.
 
 - `name`을 생략하면 기본 별칭인 `REDIS_CLIENT` / `RedisService`를 사용합니다.
 - `name`을 지정하면 `getRedisClientToken(name)` / `getRedisServiceToken(name)`으로 이름 있는 바인딩을 가져옵니다.
+- 이름 있는 클라이언트도 기본 클라이언트와 동일한 bootstrap/shutdown 계약을 따르며, `REDIS_CLIENT` / `RedisService` 별칭은 기본 등록에서만 export됩니다.
 
 ```typescript
 import { Module, Inject } from '@fluojs/core';
@@ -132,8 +142,8 @@ export class AdvancedService {
 
 ### 핵심 구성 요소
 - `RedisModule`: 전역 Redis 클라이언트 등록 및 수명 주기 훅을 관리합니다.
-- `RedisModule.forRoot(options)`: 기본 Redis 클라이언트와 `RedisService` 파사드를 위한 지원되는 root entrypoint입니다.
-- `RedisModule.forRootNamed(name, options)`: 기본 별칭을 유지한 채 추가 Redis 클라이언트를 등록합니다.
+- `RedisModule.forRoot(options)`: `lazyConnect` 수명 주기 제어를 Fluo 내부에서 유지하면서 기본 Redis 클라이언트와 `RedisService` 파사드를 등록하는 지원되는 root entrypoint입니다.
+- `RedisModule.forRootNamed(name, options)`: 동일한 수명 주기 계약을 유지한 채 기본 별칭을 건드리지 않고 추가 Redis 클라이언트를 등록합니다.
 - `RedisService`: JSON 코덱 지원 및 `get`/`set`/`del` 메서드를 제공하는 파사드입니다.
 - `REDIS_CLIENT`: 내부 `ioredis` 인스턴스에 접근하기 위한 DI 토큰입니다.
 - `getRedisClientToken(name)`: 이름 있는 raw client 토큰 헬퍼입니다. `name`을 생략하면 기본 `REDIS_CLIENT` 토큰을 돌려줍니다.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -71,12 +71,22 @@ export class CacheRepository {
 
 ## Common Patterns
 
+### Lifecycle Ownership
+
+`@fluojs/redis` owns the lifecycle of every client it creates, including clients registered through `RedisModule.forRootNamed(...)`.
+
+- Fluo always forces `lazyConnect: true`, even if callers cast options manually, so sockets open during application bootstrap instead of import time.
+- During bootstrap, the lifecycle service only calls `connect()` while the client is still in ioredis `wait` state.
+- During shutdown, ready/connecting clients attempt `quit()` first for graceful teardown, while wait/closed-transition states use `disconnect()` directly.
+- If `quit()` fails, Fluo falls back to `disconnect()` and only rethrows when the client still remains open afterward.
+
 ### Named Clients
 
 Use `RedisModule.forRootNamed(name, options)` when one application needs more than one Redis connection. `RedisModule.forRoot(options)` provides the default `REDIS_CLIENT` and `RedisService` aliases, and named registrations are resolved with `getRedisClientToken(name)` and `getRedisServiceToken(name)`.
 
 - Omit `name` when you want the default aliases: `REDIS_CLIENT` / `RedisService`.
 - Pass `name` when you want the named helpers: `getRedisClientToken(name)` / `getRedisServiceToken(name)`.
+- Named clients follow the same bootstrap/shutdown contract as the default client; only the default registration exports the `REDIS_CLIENT` / `RedisService` aliases.
 
 ```typescript
 import { Module, Inject } from '@fluojs/core';
@@ -132,8 +142,8 @@ export class AdvancedService {
 
 ### Core
 - `RedisModule`: Registers the global Redis client and lifecycle hooks.
-- `RedisModule.forRoot(options)`: Registers the default Redis client plus `RedisService` facade.
-- `RedisModule.forRootNamed(name, options)`: Registers an additional named Redis client without replacing the default aliases.
+- `RedisModule.forRoot(options)`: Registers the default Redis client plus `RedisService` facade, with `lazyConnect` lifecycle ownership kept inside Fluo.
+- `RedisModule.forRootNamed(name, options)`: Registers an additional named Redis client without replacing the default aliases, using the same lifecycle contract.
 - `RedisService`: Facade with JSON codec support and `get`/`set`/`del` methods.
 - `REDIS_CLIENT`: DI token for the underlying `ioredis` instance.
 - `getRedisClientToken(name)`: DI token helper for a named raw client. Omitting `name` returns the default `REDIS_CLIENT` token.

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -141,6 +141,27 @@ describe('@fluojs/redis', () => {
     expect(mockRedisState.events).toEqual(['connect', 'quit']);
   });
 
+  it('forces lazyConnect for default and named clients so bootstrap owns connection timing', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        RedisModule.forRoot({ host: '127.0.0.1', lazyConnect: false, port: 6379 } as never),
+        RedisModule.forRootNamed('cache', { host: '127.0.0.1', lazyConnect: false, port: 6380 } as never),
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    expect(mockRedisState.instances).toHaveLength(2);
+    expect(mockRedisState.instances[0]?.options.lazyConnect).toBe(true);
+    expect(mockRedisState.instances[1]?.options.lazyConnect).toBe(true);
+    expect(mockRedisState.events).toEqual(['connect', 'connect']);
+
+    await app.close();
+
+    expect(mockRedisState.events).toEqual(['connect', 'connect', 'quit', 'quit']);
+  });
+
   it('registers named Redis clients without changing the default aliases', async () => {
     const NAMED_REDIS_CLIENT = getRedisClientToken('cache');
     const NAMED_REDIS_SERVICE = getRedisServiceToken('cache');
@@ -222,6 +243,23 @@ describe('@fluojs/redis', () => {
 
     await expect(app.close()).resolves.toBeUndefined();
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
+  });
+
+  it('falls back to disconnect for each named client when quit fails after bootstrap', async () => {
+    mockRedisState.quitError = new Error('quit failed');
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        RedisModule.forRoot({ db: 0, host: '127.0.0.1', port: 6379 }),
+        RedisModule.forRootNamed('cache', { db: 1, host: '127.0.0.1', port: 6380 }),
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    await expect(app.close()).resolves.toBeUndefined();
+    expect(mockRedisState.events).toEqual(['connect', 'connect', 'quit', 'disconnect', 'quit', 'disconnect']);
   });
 
   it('rethrows quit failures when disconnect does not close the client', async () => {


### PR DESCRIPTION
Closes #1312

## Summary
- Tighten the documented lifecycle contract for `@fluojs/redis` so bootstrap/shutdown ownership is explicit.
- Lock the Redis lifecycle behavior behind focused regression coverage for default and named clients.

## Changes
- Added lifecycle regression tests covering forced `lazyConnect` ownership and named-client shutdown fallback behavior in `packages/redis/src/module.test.ts`.
- Updated `packages/redis/README.md` and `packages/redis/README.ko.md` to document bootstrap/shutdown lifecycle ownership, named-client alias boundaries, and `quit()` -> `disconnect()` fallback semantics.

## Testing
- `pnpm --filter @fluojs/redis test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.