### PR TITLE
Recover lane changeset metadata

### DIFF
--- a/.changeset/recover-lane-2026-04-27-metadata.md
+++ b/.changeset/recover-lane-2026-04-27-metadata.md
@@ -1,0 +1,18 @@
+---
+"@fluojs/serialization": patch
+"@fluojs/passport": patch
+"@fluojs/config": patch
+"@fluojs/platform-express": patch
+"@fluojs/testing": patch
+"@fluojs/notifications": patch
+"@fluojs/event-bus": patch
+"@fluojs/drizzle": patch
+"@fluojs/socket.io": patch
+"@fluojs/redis": patch
+---
+
+Recover release metadata for the already-merged audit fixes that restored package behavioral contracts, documentation, and regression coverage.
+
+Record the serialization response ownership fix, Passport strategy settlement and cookie-auth guardrails, config reload surface alignment, and Express adapter portability parity test helpers.
+
+Record the notifications injection coverage update, event-bus shutdown and public-surface guardrails, Drizzle request transaction shutdown docs, Socket.IO room contract alignment, and Redis lifecycle regression coverage.


### PR DESCRIPTION
## Summary
- Recover missing Changesets release metadata for already-merged lane PRs #1338, #1339, #1340, #1341, #1342, #1343, #1344, #1346, and #1348.
- Add patch-level changelog entries for the affected public packages only: serialization, passport, config, platform-express, testing, notifications, event-bus, drizzle, socket.io, and redis.
- Keep this PR changeset-only; it does not modify package source, docs, tests, versions, changelogs, or the existing beta-2 changeset.

## Verification
- GIT_MASTER=1 git diff --check
- pnpm dlx @changesets/cli status --since=origin/main
- Attempted pnpm changeset status --since=main, but the worktree has no node_modules and local main is behind origin/main, so the command could not provide a useful repository-base preview.

## Release metadata recovery note
These lane PRs were already merged without committed changesets. This PR records the missing semver intent so Changesets can version and publish the affected public packages in the next Version Packages PR.