### PR TITLE
Resolve #1306: align OpenAPI schema surface

### DIFF
--- a/.changeset/openapi-schema-surface.md
+++ b/.changeset/openapi-schema-surface.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/openapi": patch
+---
+
+Align the documented OpenAPI request/schema surface with typed regression coverage for explicit schema keywords.

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -90,9 +90,11 @@ fluo는 컨트롤러와 메서드를 조사하여 전체 OpenAPI 3.1.0 문서를
 
 - `OpenApiModule`: OpenAPI 통합을 위한 메인 엔트리 포인트.
 - `ApiTag`, `ApiOperation`, `ApiResponse`: 문서화 데코레이터.
+- `ApiBody`, `ApiParam`, `ApiQuery`, `ApiHeader`, `ApiCookie`: 이름이 겹칠 때 추론된 요청 문서를 대체하는 명시적 요청 본문 및 파라미터 문서화 데코레이터.
 - `ApiBearerAuth`, `ApiSecurity`: 보안 요구사항 데코레이터.
 - `ApiExcludeEndpoint`: 특정 핸들러를 문서화에서 제외.
 - `buildOpenApiDocument`: 프로그래밍 방식의 문서 빌더 (저수준).
+- `OpenApiSchemaObject`: 명시적 `@ApiBody(...)` 및 `@ApiResponse(...)` 스키마를 위한 타입화된 스키마 표면입니다. OpenAPI 3.1 조합(`allOf`, `oneOf`, `anyOf`), 객체/배열 제약, examples/defaults, 읽기/쓰기/Deprecated 주석을 포함합니다.
 
 ## 관련 패키지
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -90,9 +90,11 @@ When `ui: true` is enabled, the generated `/docs` page references an exact `swag
 
 - `OpenApiModule`: Main entry point for OpenAPI integration.
 - `ApiTag`, `ApiOperation`, `ApiResponse`: Documentation decorators.
+- `ApiBody`, `ApiParam`, `ApiQuery`, `ApiHeader`, `ApiCookie`: Explicit request-body and parameter documentation decorators that override inferred request documentation when names overlap.
 - `ApiBearerAuth`, `ApiSecurity`: Security requirement decorators.
 - `ApiExcludeEndpoint`: Omit specific handlers from documentation.
 - `buildOpenApiDocument`: Programmatic document builder (low-level).
+- `OpenApiSchemaObject`: Typed schema surface for explicit `@ApiBody(...)` and `@ApiResponse(...)` schemas, including OpenAPI 3.1 composition (`allOf`, `oneOf`, `anyOf`), object/array constraints, examples/defaults, and read/write/deprecated annotations.
 
 ## Related Packages
 

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -417,4 +417,110 @@ describe('buildOpenApiDocument', () => {
       },
     });
   });
+
+  it('preserves explicit OpenAPI schema keywords from request and response decorators', () => {
+    @Controller('/schema-surface')
+    class SchemaSurfaceController {
+      @ApiResponse(200, {
+        description: 'Schema keyword response',
+        schema: {
+          additionalProperties: {
+            type: 'string',
+          },
+          deprecated: true,
+          examples: [{ mode: 'preview' }],
+          pattern: '^[a-z]+$',
+          properties: {
+            id: { readOnly: true, type: 'string' },
+            mode: { default: 'preview', enum: ['preview', 'live'], type: 'string' },
+          },
+          required: ['id'],
+          type: 'object',
+        },
+      })
+      @Get('/response')
+      response() {
+        return { id: 'schema-1', mode: 'preview' };
+      }
+
+      @ApiBody({
+        schema: {
+          properties: {
+            tags: {
+              items: { type: 'string' },
+              maxItems: 5,
+              minItems: 1,
+              type: 'array',
+              uniqueItems: true,
+            },
+            title: {
+              minLength: 1,
+              nullable: true,
+              type: ['string', 'null'],
+              writeOnly: true,
+            },
+          },
+          type: 'object',
+        },
+      })
+      @Post('/request')
+      request() {
+        return { ok: true };
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: SchemaSurfaceController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Schema Surface API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/schema-surface/response']?.get?.responses['200']).toEqual({
+      content: {
+        'application/json': {
+          schema: {
+            additionalProperties: {
+              type: 'string',
+            },
+            deprecated: true,
+            examples: [{ mode: 'preview' }],
+            pattern: '^[a-z]+$',
+            properties: {
+              id: { readOnly: true, type: 'string' },
+              mode: { default: 'preview', enum: ['preview', 'live'], type: 'string' },
+            },
+            required: ['id'],
+            type: 'object',
+          },
+        },
+      },
+      description: 'Schema keyword response',
+    });
+    expect(document.paths['/schema-surface/request']?.post?.requestBody).toEqual({
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              tags: {
+                items: { type: 'string' },
+                maxItems: 5,
+                minItems: 1,
+                type: 'array',
+                uniqueItems: true,
+              },
+              title: {
+                minLength: 1,
+                nullable: true,
+                type: ['string', 'null'],
+                writeOnly: true,
+              },
+            },
+            type: 'object',
+          },
+        },
+      },
+    });
+  });
 });

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -12,6 +12,11 @@ import {
 type OpenApiOperationMethod = Lowercase<HttpMethod>;
 
 /**
+ * JSON Schema primitive type names accepted by OpenAPI 3.1 schema objects.
+ */
+export type OpenApiSchemaPrimitiveType = 'array' | 'boolean' | 'integer' | 'null' | 'number' | 'object' | 'string';
+
+/**
  * OpenAPI `info` object emitted in the generated document.
  */
 export interface OpenApiInfoObject {
@@ -39,7 +44,7 @@ export interface OpenApiSecurityRequirementObject {
  */
 export interface OpenApiSchemaObject {
   $ref?: string;
-  type?: 'array' | 'boolean' | 'integer' | 'number' | 'object' | 'string';
+  type?: OpenApiSchemaPrimitiveType | readonly OpenApiSchemaPrimitiveType[];
   format?: string;
   description?: string;
   allOf?: OpenApiSchemaObject[];
@@ -54,11 +59,28 @@ export interface OpenApiSchemaObject {
   items?: OpenApiSchemaObject;
   required?: string[];
   enum?: unknown[];
+  const?: unknown;
+  default?: unknown;
+  example?: unknown;
+  examples?: unknown[];
   additionalProperties?: boolean | OpenApiSchemaObject;
+  deprecated?: boolean;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  nullable?: boolean;
   minimum?: number;
   maximum?: number;
+  exclusiveMinimum?: number | boolean;
+  exclusiveMaximum?: number | boolean;
+  multipleOf?: number;
   minLength?: number;
   maxLength?: number;
+  pattern?: string;
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+  minProperties?: number;
+  maxProperties?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #1306.

Align `@fluojs/openapi`'s documented request/schema surface with typed schema regression coverage for explicit OpenAPI schema declarations.

## Changes

- Broadened `OpenApiSchemaObject` with OpenAPI/JSON Schema keywords used by explicit `@ApiBody(...)` and `@ApiResponse(...)` schemas.
- Added regression coverage proving explicit request and response schemas preserve examples/defaults, read/write/deprecated annotations, array constraints, nullable union types, and object constraints.
- Updated English/Korean OpenAPI README Public API sections and added a patch changeset for `@fluojs/openapi`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/openapi... build`
- `pnpm --filter @fluojs/openapi typecheck`
- `pnpm --filter @fluojs/openapi test` — 4 files / 33 tests passed
- `pnpm lint` — changed-mode public export TSDoc passed; existing unrelated Biome warnings remain in `packages/config/*`
- `pnpm changeset status --since=main` — `@fluojs/openapi` patch bump detected
- LSP diagnostics: no diagnostics for `packages/openapi/src/schema-builder.ts` and `packages/openapi/src/schema-builder.test.ts`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform README conformance claims changed.