### PR TITLE
Resolve #1293: preserve DI provider ownership

### DIFF
--- a/.changeset/di-request-scope-provider-validation.md
+++ b/.changeset/di-request-scope-provider-validation.md
@@ -1,5 +1,7 @@
 ---
-"@fluojs/di": patch
+"@fluojs/di": minor
 ---
 
 Validate DI provider object shapes during registration and prevent request scopes from owning implicit singleton multi-provider registrations.
+
+Migration: consumers that registered default-scope multi providers directly on a request container must move those registrations to the root container before calling `createRequestScope()`. If the multi provider is intentionally request-local, declare it with `scope: 'request'`/`Scope.REQUEST`, or replace the request-local set with `override()` so the ownership boundary is explicit.

--- a/.changeset/di-request-scope-provider-validation.md
+++ b/.changeset/di-request-scope-provider-validation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/di": patch
+---
+
+Validate DI provider object shapes during registration and prevent request scopes from owning implicit singleton multi-provider registrations.

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -83,7 +83,7 @@ const requestContainer = container.createRequestScope();
 const scopedService = await requestContainer.resolve(RequestScopedService);
 ```
 
-request scope 컨테이너는 부모 체인의 provider를 해석할 수 있지만, request가 소유하는 등록은 새 singleton provider를 만들 수 없습니다. singleton provider는 request scope를 만들기 전에 루트 컨테이너에 등록하세요. request scope에 로컬 provider를 추가해야 한다면 `scope: 'request'`/`Scope.REQUEST`를 명시하거나 `override()`로 의도적인 request-local 교체를 표현하세요.
+request scope 컨테이너는 부모 체인의 provider를 해석할 수 있지만, request가 소유하는 등록은 새 singleton provider를 만들 수 없습니다. singleton provider는 request scope를 만들기 전에 루트 컨테이너에 등록하세요. request scope에 로컬 provider를 추가해야 한다면 `scope: 'request'`/`Scope.REQUEST`를 명시하거나 `override()`로 의도적인 request-local 교체를 표현하세요. multi provider에도 같은 규칙이 적용됩니다. 기본 scope의 multi provider는 루트 컨테이너에 등록하고, request-local multi provider는 request scope를 명시하거나 `override()`로 교체해야 합니다.
 
 provider 객체는 등록 시점에 검증됩니다. 모든 객체 provider는 null이 아닌 `provide` 토큰과 정확히 하나의 전략(`useClass`, `useValue`, `useFactory`, `useExisting`)을 포함해야 합니다. 잘못된 provider 형태는 컨테이너 그래프에 영향을 주기 전에 `InvalidProviderError`를 발생시킵니다.
 

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -83,6 +83,10 @@ const requestContainer = container.createRequestScope();
 const scopedService = await requestContainer.resolve(RequestScopedService);
 ```
 
+request scope 컨테이너는 부모 체인의 provider를 해석할 수 있지만, request가 소유하는 등록은 새 singleton provider를 만들 수 없습니다. singleton provider는 request scope를 만들기 전에 루트 컨테이너에 등록하세요. request scope에 로컬 provider를 추가해야 한다면 `scope: 'request'`/`Scope.REQUEST`를 명시하거나 `override()`로 의도적인 request-local 교체를 표현하세요.
+
+provider 객체는 등록 시점에 검증됩니다. 모든 객체 provider는 null이 아닌 `provide` 토큰과 정확히 하나의 전략(`useClass`, `useValue`, `useFactory`, `useExisting`)을 포함해야 합니다. 잘못된 provider 형태는 컨테이너 그래프에 영향을 주기 전에 `InvalidProviderError`를 발생시킵니다.
+
 ## 순환 의존성 처리
 
 컨테이너는 순환 의존성을 자동으로 감지하고 `CircularDependencyError`를 발생시켜 무한 루프를 방지합니다. 여기에는 직접 참조(A→A), 이중 노드(A→B→A), 깊은 순환(A→B→C→A)이 모두 포함됩니다.

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -83,6 +83,10 @@ const requestContainer = container.createRequestScope();
 const scopedService = await requestContainer.resolve(RequestScopedService);
 ```
 
+Request-scope containers may resolve providers from their parent chain, but request-owned registrations must not introduce new singleton providers. Register singleton providers on the root container before creating request scopes. If a request scope needs local additions, declare them with `scope: 'request'`/`Scope.REQUEST` or use `override()` for an explicit request-local replacement.
+
+Provider objects are validated at registration time: every object provider must include a non-null `provide` token and exactly one strategy (`useClass`, `useValue`, `useFactory`, or `useExisting`). Invalid provider shapes throw `InvalidProviderError` before they can affect the container graph.
+
 ## Circular Dependency Handling
 
 The container automatically detects circular dependencies and throws a `CircularDependencyError` to prevent infinite loops. This includes direct (A→A), two-node (A→B→A), and deep (A→B→C→A) cycles.

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -83,7 +83,7 @@ const requestContainer = container.createRequestScope();
 const scopedService = await requestContainer.resolve(RequestScopedService);
 ```
 
-Request-scope containers may resolve providers from their parent chain, but request-owned registrations must not introduce new singleton providers. Register singleton providers on the root container before creating request scopes. If a request scope needs local additions, declare them with `scope: 'request'`/`Scope.REQUEST` or use `override()` for an explicit request-local replacement.
+Request-scope containers may resolve providers from their parent chain, but request-owned registrations must not introduce new singleton providers. Register singleton providers on the root container before creating request scopes. If a request scope needs local additions, declare them with `scope: 'request'`/`Scope.REQUEST` or use `override()` for an explicit request-local replacement. The same rule applies to multi providers: default-scope multi providers belong on the root container, while request-local multi providers must opt into request scope or be replaced through `override()`.
 
 Provider objects are validated at registration time: every object provider must include a non-null `provide` token and exactly one strategy (`useClass`, `useValue`, `useFactory`, or `useExisting`). Invalid provider shapes throw `InvalidProviderError` before they can affect the container graph.
 

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { Inject, Scope as ScopeDecorator } from '@fluojs/core';
 
 import { Container } from './container.js';
-import { CircularDependencyError, ContainerResolutionError, DuplicateProviderError, RequestScopeResolutionError, ScopeMismatchError } from './errors.js';
-import { Scope, forwardRef, optional } from './types.js';
+import { CircularDependencyError, ContainerResolutionError, DuplicateProviderError, InvalidProviderError, RequestScopeResolutionError, ScopeMismatchError } from './errors.js';
+import { Scope, forwardRef, optional, type Provider } from './types.js';
 
 describe('Container', () => {
   it('caches singleton providers', async () => {
@@ -489,6 +489,55 @@ describe('Container', () => {
 
       expect(() => requestScope.register({ provide: token, useValue: 'request-only' })).toThrow(ScopeMismatchError);
     });
+
+    it('throws ScopeMismatchError when registering singleton multi providers on a request scope container', () => {
+      const token = Symbol('singleton-multi-token');
+      const root = new Container();
+      const requestScope = root.createRequestScope();
+
+      expect(() => requestScope.register({ provide: token, useValue: 'request-only', multi: true })).toThrow(ScopeMismatchError);
+    });
+  });
+
+  describe('provider validation', () => {
+    it('throws InvalidProviderError when an object provider omits provide', () => {
+      const provider = { useValue: 'missing-token' } as unknown as Provider;
+
+      expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
+      expect(() => new Container().register(provider)).toThrow('provide token');
+    });
+
+    it('throws InvalidProviderError when an object provider has more than one strategy', () => {
+      const token = Symbol('ambiguous-provider');
+      const provider = { provide: token, useValue: 'value', useFactory: () => 'factory' } as unknown as Provider;
+
+      expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
+      expect(() => new Container().register(provider)).toThrow('exactly one');
+    });
+
+    it('throws InvalidProviderError when useFactory is not callable', () => {
+      const token = Symbol('invalid-factory');
+      const provider = { provide: token, useFactory: 'factory' } as unknown as Provider;
+
+      expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
+      expect(() => new Container().register(provider)).toThrow('useFactory');
+    });
+
+    it('throws InvalidProviderError when useClass is not callable', () => {
+      const token = Symbol('invalid-class');
+      const provider = { provide: token, useClass: 'Service' } as unknown as Provider;
+
+      expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
+      expect(() => new Container().register(provider)).toThrow('useClass');
+    });
+
+    it('throws InvalidProviderError when useExisting is nullish', () => {
+      const token = Symbol('invalid-alias');
+      const provider = { provide: token, useExisting: undefined } as unknown as Provider;
+
+      expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
+      expect(() => new Container().register(provider)).toThrow('useExisting');
+    });
   });
 
   describe('optional injection', () => {
@@ -660,7 +709,7 @@ describe('Container', () => {
         { provide: PLUGINS, useValue: 'root-a', multi: true },
         { provide: PLUGINS, useValue: 'root-b', multi: true },
       );
-      const child = root.createRequestScope().register({ provide: PLUGINS, useValue: 'child-c', multi: true });
+      const child = root.createRequestScope().register({ provide: PLUGINS, useFactory: () => 'child-c', multi: true, scope: Scope.REQUEST });
 
       await expect(root.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b']);
       await expect(child.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b', 'child-c']);

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -23,6 +23,8 @@ import type {
 } from './types.js';
 import { Scope, isForwardRef, isOptionalToken } from './types.js';
 
+type ObjectProvider = ClassProvider | ExistingProvider | FactoryProvider | ValueProvider;
+
 function isClassConstructor(value: Provider): value is ClassType {
   return typeof value === 'function';
 }
@@ -41,6 +43,25 @@ function isClassProvider(value: Provider): value is ClassProvider {
 
 function isExistingProvider(value: Provider): value is ExistingProvider {
   return typeof value === 'object' && value !== null && 'useExisting' in value;
+}
+
+function assertProviderToken(provider: ObjectProvider): void {
+  if (!('provide' in provider) || provider.provide == null) {
+    throw new InvalidProviderError('Provider object must include a non-null provide token.');
+  }
+}
+
+function assertProviderStrategy(provider: ObjectProvider): void {
+  const strategyCount = Number('useValue' in provider) + Number('useFactory' in provider) + Number('useClass' in provider) + Number('useExisting' in provider);
+
+  if (strategyCount !== 1) {
+    throw new InvalidProviderError('Provider object must declare exactly one of useValue, useFactory, useClass, or useExisting.');
+  }
+}
+
+function assertObjectProvider(provider: ObjectProvider): void {
+  assertProviderToken(provider);
+  assertProviderStrategy(provider);
 }
 
 function normalizeInjectToken(token: Token | ForwardRefFn | OptionalToken): Token | ForwardRefFn | OptionalToken {
@@ -65,6 +86,8 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
   }
 
   if (isValueProvider(provider)) {
+    assertObjectProvider(provider);
+
     return {
       inject: [],
       multi: provider.multi,
@@ -76,6 +99,12 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
   }
 
   if (isFactoryProvider(provider)) {
+    assertObjectProvider(provider);
+
+    if (typeof provider.useFactory !== 'function') {
+      throw new InvalidProviderError('Factory provider useFactory must be a function.', { token: provider.provide });
+    }
+
     const metadata = provider.resolverClass ? getClassDiMetadata(provider.resolverClass) : undefined;
 
     return {
@@ -89,6 +118,12 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
   }
 
   if (isClassProvider(provider)) {
+    assertObjectProvider(provider);
+
+    if (typeof provider.useClass !== 'function') {
+      throw new InvalidProviderError('Class provider useClass must be a constructor.', { token: provider.provide });
+    }
+
     const metadata = getClassDiMetadata(provider.useClass);
 
     return {
@@ -102,6 +137,12 @@ function normalizeProvider(provider: Provider): NormalizedProvider {
   }
 
   if (isExistingProvider(provider)) {
+    assertObjectProvider(provider);
+
+    if (provider.useExisting == null) {
+      throw new InvalidProviderError('Alias provider useExisting must be a non-null token.', { token: provider.provide });
+    }
+
     return {
       inject: [],
       provide: provider.provide,
@@ -160,7 +201,7 @@ export class Container {
     for (const provider of providers) {
       const normalized = normalizeProvider(provider);
 
-      if (this.requestScopeEnabled && normalized.scope === Scope.DEFAULT && normalized.multi !== true) {
+      if (this.requestScopeEnabled && normalized.scope === Scope.DEFAULT) {
         throw new ScopeMismatchError(
           `Singleton provider ${String(normalized.provide)} cannot be registered on a request-scope container.`,
           {


### PR DESCRIPTION
## Summary

Closes #1293.

Preserves `@fluojs/di` request-scope ownership boundaries and validates malformed provider objects before they can enter the container graph.

## Changes

- Added registration-time validation that object providers include a non-null `provide` token and exactly one strategy (`useClass`, `useValue`, `useFactory`, or `useExisting`).
- Rejected default-scope multi-provider registrations directly on request-scope containers, matching singleton ownership rules.
- Added focused regression coverage for malformed provider shapes and request-scope singleton multi-provider registration.
- Documented the request-local provider rule and provider validation behavior in `packages/di/README.md` and `packages/di/README.ko.md`.
- Added `.changeset/di-request-scope-provider-validation.md` for `@fluojs/di` patch release notes.

## Testing

- `lsp_diagnostics` on `packages/di/src/container.ts`: passed, no diagnostics.
- `lsp_diagnostics` on `packages/di/src/container.test.ts`: passed, no diagnostics.
- `pnpm --filter @fluojs/core build`: passed (required before DI typecheck/build in the fresh worktree).
- `pnpm --filter @fluojs/di test`: passed, 67 tests.
- `pnpm --filter @fluojs/di typecheck`: passed.
- `pnpm --filter @fluojs/di build`: passed.
- `pnpm lint`: changed-file public export TSDoc check passed; Biome reported pre-existing warnings/infos in `packages/config/*` unrelated to this PR.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed in this PR.