### PR TITLE
Resolve #1326: preserve Mongoose transaction shutdown lifecycle

### DIFF
--- a/.changeset/mongoose-transaction-shutdown-docs.md
+++ b/.changeset/mongoose-transaction-shutdown-docs.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/mongoose": patch
+---
+
+Document and preserve Mongoose request transaction shutdown lifecycle guarantees, including session cleanup before dispose and lifecycle status reporting while transactions drain.

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -9,6 +9,7 @@ fluo 애플리케이션을 위한 Mongoose 라이프사이클 및 세션 기반 
 - [설치](#설치)
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
+- [라이프사이클과 종료](#라이프사이클과-종료)
 - [공통 패턴](#공통-패턴)
 - [공개 API](#공개-api)
 - [관련 패키지](#관련-패키지)
@@ -49,6 +50,18 @@ const connection = mongoose.createConnection('mongodb://localhost:27017/test');
 })
 class AppModule {}
 ```
+
+## 라이프사이클과 종료
+
+`MongooseModule`은 `MongooseConnection`을 fluo 애플리케이션 라이프사이클에 등록합니다. 이 패키지는 원본 Mongoose 연결을 직접 생성하거나 소유하지 않습니다. 애플리케이션 종료 시 외부 연결을 닫아야 한다면 `dispose` 훅을 전달하세요.
+
+종료 과정은 요청 트랜잭션 정리 순서를 보존합니다.
+
+1. 열려 있는 요청 범위 트랜잭션은 `Application shutdown interrupted an open request transaction.` 오류로 abort됩니다.
+2. 해당 Mongoose 세션은 `abortTransaction()`과 `endSession()` 정리를 끝냅니다.
+3. 설정한 `dispose(connection)` 훅은 활성 요청 트랜잭션이 모두 settled된 뒤에만 실행됩니다.
+
+`createMongoosePlatformStatusSnapshot(...)`은 트래픽 처리 중에는 `ready`, 요청 트랜잭션 drain 중에는 `shutting-down`, dispose 훅 완료 뒤에는 `stopped`를 보고합니다. 수동 `transaction()`도 요청 범위 트랜잭션과 같은 명시적 세션 계약을 사용하므로, 트랜잭션에 참여해야 하는 Mongoose 모델 작업에는 repository 코드가 `conn.currentSession()`을 전달해야 합니다.
 
 ## 공통 패턴
 

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -9,6 +9,7 @@ Mongoose integration for fluo with session-aware transaction handling and lifecy
 - [Installation](#installation)
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
+- [Lifecycle and Shutdown](#lifecycle-and-shutdown)
 - [Common Patterns](#common-patterns)
 - [Public API](#public-api)
 - [Related Packages](#related-packages)
@@ -46,6 +47,18 @@ const connection = mongoose.createConnection('mongodb://localhost:27017/test');
 })
 class AppModule {}
 ```
+
+## Lifecycle and Shutdown
+
+`MongooseModule` registers `MongooseConnection` with the fluo application lifecycle. The package does not create or own the raw Mongoose connection for you; pass a `dispose` hook when the application should close that external connection during shutdown.
+
+Shutdown preserves request transaction cleanup order:
+
+1. Open request-scoped transactions are aborted with `Application shutdown interrupted an open request transaction.`
+2. Their Mongoose sessions finish `abortTransaction()` and `endSession()` cleanup.
+3. The configured `dispose(connection)` hook runs only after active request transactions have settled.
+
+`createMongoosePlatformStatusSnapshot(...)` reports `ready` while serving traffic, `shutting-down` while request transactions are draining, and `stopped` after the dispose hook completes. Manual `transaction()` calls still use the same explicit-session contract as request-scoped transactions: repository code must pass `conn.currentSession()` into Mongoose model operations that participate in the transaction.
 
 ## Common Patterns
 

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -278,6 +278,116 @@ describe('@fluojs/mongoose', () => {
     ]);
   });
 
+  it('reports lifecycle status while shutdown drains request transaction sessions', async () => {
+    const events: string[] = [];
+    let resolveRequestStarted!: () => void;
+    let resolveEndSessionStarted!: () => void;
+    let resolveEndSession!: () => void;
+
+    const requestStarted = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve;
+    });
+    const endSessionStarted = new Promise<void>((resolve) => {
+      resolveEndSessionStarted = resolve;
+    });
+    const endSessionDeferred = new Promise<void>((resolve) => {
+      resolveEndSession = resolve;
+    });
+
+    const session: MongooseSessionLike = {
+      abortTransaction() {
+        events.push('transaction:abort');
+      },
+      commitTransaction() {
+        events.push('transaction:commit');
+      },
+      async endSession() {
+        events.push('session:end:start');
+        resolveEndSessionStarted();
+        await endSessionDeferred;
+        events.push('session:end:done');
+      },
+      startTransaction() {
+        events.push('transaction:start');
+      },
+    };
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    const mongooseModule = MongooseModule.forRoot<typeof connection>({
+      connection,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [mongooseModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
+
+    const openTransaction = mongoose.requestTransaction(async () => {
+      events.push('request:open');
+      resolveRequestStarted();
+      return new Promise<never>(() => undefined);
+    });
+
+    await requestStarted;
+
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 1,
+        lifecycleState: 'ready',
+      },
+      health: { status: 'healthy' },
+      readiness: { status: 'ready' },
+    });
+
+    const closePromise = app.close();
+    await endSessionStarted;
+
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 1,
+        lifecycleState: 'shutting-down',
+      },
+      health: { status: 'degraded' },
+      readiness: { status: 'not-ready' },
+    });
+
+    resolveEndSession();
+
+    await closePromise;
+    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 0,
+        lifecycleState: 'stopped',
+      },
+      health: { status: 'unhealthy' },
+      readiness: { status: 'not-ready' },
+    });
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'request:open',
+      'transaction:abort',
+      'session:end:start',
+      'session:end:done',
+      'dispose',
+    ]);
+  });
+
   it('defaults strictTransactions to false for sync and async module entrypoints', async () => {
     const connection = {};
 


### PR DESCRIPTION
## Summary

Closes #1326

Preserves the `@fluojs/mongoose` transaction shutdown contract by documenting the lifecycle behavior and pinning the request-transaction drain/status sequence with focused regression coverage.

## Changes

- Added regression coverage for `MongooseConnection` lifecycle snapshots during request transaction shutdown drain (`ready` -> `shutting-down` -> `stopped`).
- Documented Mongoose shutdown ordering in English and Korean READMEs, including abort, session cleanup, dispose ordering, and explicit session usage.
- Added a patch changeset for `@fluojs/mongoose` describing the consumer-facing lifecycle contract preservation.

## Testing

- `pnpm --filter @fluojs/mongoose test` (baseline after dependency install; 21 passed)
- `pnpm --filter @fluojs/mongoose test` (after changes; 22 passed)
- `pnpm build`
- `pnpm --filter @fluojs/mongoose typecheck`
- `pnpm --filter @fluojs/mongoose build`
- `pnpm lint` (completed; existing repository warnings were reported by Biome, and changed-mode public export TSDoc passed)
- `pnpm changeset status --since=main`
- `lsp_diagnostics packages/mongoose/src/module.test.ts` (no diagnostics after workspace build)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public source exports were changed; this PR updates package README contract docs and tests.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs or platform adapter conformance claims were changed.