### PR TITLE
Resolve #1319: restore email queue boundary

### DIFF
--- a/.changeset/email-queue-boundary.md
+++ b/.changeset/email-queue-boundary.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Restore the email package's optional queue boundary by keeping queue workers behind the `@fluojs/email/queue` subpath and make queued email notification workers fail incomplete provider deliveries so retry/dead-letter handling can run.

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -208,7 +208,7 @@ Behavioral contract 메모:
 
 ### 큐 기반 대량 전달
 
-`@fluojs/notifications`가 대량 이메일 전달을 백그라운드로 넘겨야 한다면 `QueueLifecycleService`를 주입해 `createEmailNotificationsQueueAdapter(queue)`를 만들고 `QueueModule`을 함께 import합니다.
+`@fluojs/notifications`가 대량 이메일 전달을 백그라운드로 넘겨야 한다면 `QueueModule`을 import하고, `QueueLifecycleService`를 주입해 `createEmailNotificationsQueueAdapter(queue)`를 만든 뒤, `EmailNotificationsQueueWorker`를 애플리케이션 provider로 등록합니다. 루트 `EmailModule`은 worker를 자동 등록하지 않으므로 `@fluojs/email/queue`를 import하지 않는 애플리케이션은 런타임에서 `@fluojs/queue`를 필요로 하지 않습니다.
 
 ```typescript
 import { Module } from '@fluojs/core';
@@ -216,7 +216,7 @@ import {
   EmailModule,
   EMAIL_CHANNEL,
 } from '@fluojs/email';
-import { createEmailNotificationsQueueAdapter } from '@fluojs/email/queue';
+import { createEmailNotificationsQueueAdapter, EmailNotificationsQueueWorker } from '@fluojs/email/queue';
 import { NotificationsModule } from '@fluojs/notifications';
 import { QueueLifecycleService, QueueModule } from '@fluojs/queue';
 
@@ -242,6 +242,7 @@ import { QueueLifecycleService, QueueModule } from '@fluojs/queue';
       }),
     }),
   ],
+  providers: [EmailNotificationsQueueWorker],
 })
 export class AppModule {}
 ```
@@ -256,13 +257,19 @@ export class AppModule {}
 
 이 기본값은 `@fluojs/email/queue`에서 `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`로 export되므로, 호출 측에서 커스텀 queue adapter/worker를 만들 때 동일한 계약을 문서화하거나 반영할 수 있습니다.
 
+Behavioral contract 메모:
+
+- Queue 지원은 opt-in입니다. 루트 `@fluojs/email` 엔트리포인트와 `EmailModule`은 `@fluojs/queue`를 import하거나 `EmailNotificationsQueueWorker`를 등록하거나 queue peer 설치를 요구하지 않습니다.
+- `EmailNotificationsQueueWorker`는 `@fluojs/email/queue`에서 export되며, queue 기반 전달을 활성화하는 애플리케이션이 직접 등록해야 합니다.
+- worker는 `EmailChannel` 전달 semantics를 재사용하므로 transport가 수락된 수신자 0명 또는 `pending`/`rejected` 수신자를 보고하면 queued job이 실패합니다. 따라서 incomplete delivery는 성공한 job으로 승인되지 않고 `@fluojs/queue`의 retry/dead-letter 흐름으로 넘어갑니다.
+
 ### 의도적인 제한 사항
 
 email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 - `process.env`에서 transport 자격 증명을 직접 읽는 동작
 - 공유 루트 패키지에 내장된 SMTP 또는 Nodemailer transport 제공
-- `QueueModule` 자동 설정
+- `QueueModule` 설정 또는 queue worker 자동 등록
 - provider 전용 옵션 타입을 `@fluojs/notifications`에 누출하는 것
 
 이 제한 사항은 transport 선택, 템플릿 전략, 큐 도입 여부가 애플리케이션 경계에서 명시적으로 결정되도록 하기 위한 package contract의 일부입니다.
@@ -286,7 +293,7 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 ### 통합 서브패스
 
-- `@fluojs/email/queue`: `createEmailNotificationsQueueAdapter(queue)`, `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`
+- `@fluojs/email/queue`: `createEmailNotificationsQueueAdapter(queue)`, `EmailNotificationQueueJob`, `EmailNotificationsQueueWorker`, `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`
 
 ### 상태 및 에러
 
@@ -308,7 +315,7 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 | 관심사 | 서브패스 | export |
 | --- | --- | --- |
-| queue 기반 notifications 통합 | `@fluojs/email/queue` | `createEmailNotificationsQueueAdapter(queue)`, `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS` |
+| queue 기반 notifications 통합 | `@fluojs/email/queue` | `createEmailNotificationsQueueAdapter(queue)`, `EmailNotificationQueueJob`, `EmailNotificationsQueueWorker`, `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS` |
 
 ## 관련 패키지
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -208,7 +208,7 @@ Behavioral contract notes:
 
 ### Queue-backed bulk delivery
 
-When `@fluojs/notifications` should offload bulk email delivery to the background, inject `QueueLifecycleService`, call `createEmailNotificationsQueueAdapter(queue)`, and import `QueueModule`.
+When `@fluojs/notifications` should offload bulk email delivery to the background, import `QueueModule`, inject `QueueLifecycleService`, call `createEmailNotificationsQueueAdapter(queue)`, and register `EmailNotificationsQueueWorker` as an application provider. The root `EmailModule` does not register the worker automatically, so applications that never import `@fluojs/email/queue` do not need `@fluojs/queue` at runtime.
 
 ```typescript
 import { Module } from '@fluojs/core';
@@ -216,7 +216,7 @@ import {
   EmailModule,
   EMAIL_CHANNEL,
 } from '@fluojs/email';
-import { createEmailNotificationsQueueAdapter } from '@fluojs/email/queue';
+import { createEmailNotificationsQueueAdapter, EmailNotificationsQueueWorker } from '@fluojs/email/queue';
 import { NotificationsModule } from '@fluojs/notifications';
 import { QueueLifecycleService, QueueModule } from '@fluojs/queue';
 
@@ -242,6 +242,7 @@ import { QueueLifecycleService, QueueModule } from '@fluojs/queue';
       }),
     }),
   ],
+  providers: [EmailNotificationsQueueWorker],
 })
 export class AppModule {}
 ```
@@ -256,13 +257,19 @@ The built-in queue worker contract uses these defaults:
 
 These defaults are exported from `@fluojs/email/queue` as `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS` so callers can document or mirror them when they build custom queue adapters/workers.
 
+Behavioral contract notes:
+
+- Queue support is opt-in. The root `@fluojs/email` entrypoint and `EmailModule` do not import `@fluojs/queue`, register `EmailNotificationsQueueWorker`, or require queue peer installation.
+- `EmailNotificationsQueueWorker` is exported from `@fluojs/email/queue` and must be registered by applications that enable queue-backed delivery.
+- The worker reuses `EmailChannel` delivery semantics, so a queued job fails when the underlying transport reports zero accepted recipients or any `pending`/`rejected` recipients. This lets `@fluojs/queue` retry and dead-letter incomplete deliveries instead of acknowledging them as successful jobs.
+
 ### Intentional limitations
 
 The email package intentionally does **not**:
 
 - read transport credentials from `process.env`
 - ship a built-in SMTP or Nodemailer transport in the shared root package
-- configure `QueueModule` automatically
+- configure `QueueModule` or register queue workers automatically
 - leak provider-specific option types into `@fluojs/notifications`
 
 These limitations are part of the package contract so transport selection, template strategy, and queue rollout stay explicit at the application boundary.
@@ -286,7 +293,7 @@ These limitations are part of the package contract so transport selection, templ
 
 ### Integration subpaths
 
-- `@fluojs/email/queue`: `createEmailNotificationsQueueAdapter(queue)`, `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`
+- `@fluojs/email/queue`: `createEmailNotificationsQueueAdapter(queue)`, `EmailNotificationQueueJob`, `EmailNotificationsQueueWorker`, `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`
 
 ### Status and errors
 
@@ -308,7 +315,7 @@ These limitations are part of the package contract so transport selection, templ
 
 | Concern | Subpath | Exports |
 | --- | --- | --- |
-| Queue-backed notifications integration | `@fluojs/email/queue` | `createEmailNotificationsQueueAdapter(queue)`, `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS` |
+| Queue-backed notifications integration | `@fluojs/email/queue` | `createEmailNotificationsQueueAdapter(queue)`, `EmailNotificationQueueJob`, `EmailNotificationsQueueWorker`, `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS` |
 
 ## Related Packages
 

--- a/packages/email/src/constants.ts
+++ b/packages/email/src/constants.ts
@@ -1,10 +1,8 @@
-import type { EmailQueueWorkerOptions } from './types.js';
-
 /** Stable queue job name used by the email notifications worker contract. */
 export const EMAIL_QUEUE_JOB_NAME = 'fluo.email.notification';
 
 /** Default worker options used by the built-in email notifications queue seam. */
-export const DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS: Required<EmailQueueWorkerOptions> = Object.freeze({
+export const DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS = Object.freeze({
   attempts: 3,
   backoff: {
     delayMs: 1_000,

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -161,6 +161,17 @@ class PartialDeliveryTransport implements EmailTransport {
   }
 }
 
+class ZeroAcceptedTransport implements EmailTransport {
+  async send(): Promise<{ accepted: []; messageId: string; pending: []; rejected: [] }> {
+    return {
+      accepted: [],
+      messageId: 'zero-accepted-1',
+      pending: [],
+      rejected: [],
+    };
+  }
+}
+
 class RecordingTransport implements EmailTransport {
   constructor(private readonly messagePrefix: string) {}
 
@@ -473,6 +484,35 @@ describe('EmailModule', () => {
       ),
     ).rejects.toMatchObject({
       message: 'Email transport reported an incomplete delivery (accepted=1, pending=1, rejected=1).',
+      name: 'EmailDeliveryError',
+    });
+  });
+
+  it('fails queued notifications when the transport accepts zero recipients', async () => {
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: new ZeroAcceptedTransport(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const channel = await container.resolve(EmailChannel);
+    const worker = new EmailNotificationsQueueWorker(channel);
+
+    await expect(
+      worker.handle(
+        new EmailNotificationQueueJob(
+          {
+            channel: 'email',
+            payload: { text: 'Queued hello' },
+            recipients: ['user@example.com'],
+            subject: 'Queued subject',
+          },
+          '2026-04-27T00:00:00.000Z',
+        ),
+      ),
+    ).rejects.toMatchObject({
+      message: 'Email transport reported an incomplete delivery (accepted=0, pending=0, rejected=0).',
       name: 'EmailDeliveryError',
     });
   });

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { type Constructor, type Token } from '@fluojs/core';
+import type { Constructor, Token } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Container, type Provider } from '@fluojs/di';
 import { NotificationsModule, NotificationsService } from '@fluojs/notifications';
@@ -397,7 +397,7 @@ describe('EmailModule', () => {
     emailContainer.register(...moduleProviders(emailModuleType));
 
     const channel = await emailContainer.resolve(EmailChannel);
-    const worker = await emailContainer.resolve(EmailNotificationsQueueWorker);
+    const worker = new EmailNotificationsQueueWorker(channel);
 
     const notificationsContainer = new Container();
     const notificationsModuleType = NotificationsModule.forRoot({
@@ -433,6 +433,48 @@ describe('EmailModule', () => {
     await worker.handle(enqueued[1] as EmailNotificationQueueJob);
 
     expect(transportState.sent).toHaveLength(2);
+  });
+
+  it('keeps the queue worker outside EmailModule providers so queue support stays opt-in', () => {
+    const providers = moduleProviders(
+      EmailModule.forRoot({
+        defaultFrom: 'noreply@example.com',
+        transport: new PassiveTransport(),
+      }),
+    );
+
+    expect(providers).toContain(EmailService);
+    expect(providers).toContain(EmailChannel);
+    expect(providers).not.toContain(EmailNotificationsQueueWorker);
+  });
+
+  it('propagates incomplete delivery failures from queue-backed email notification workers', async () => {
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: new PartialDeliveryTransport(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const channel = await container.resolve(EmailChannel);
+    const worker = new EmailNotificationsQueueWorker(channel);
+
+    await expect(
+      worker.handle(
+        new EmailNotificationQueueJob(
+          {
+            channel: 'email',
+            payload: { text: 'Queued hello' },
+            recipients: ['user@example.com'],
+            subject: 'Queued subject',
+          },
+          '2026-04-27T00:00:00.000Z',
+        ),
+      ),
+    ).rejects.toMatchObject({
+      message: 'Email transport reported an incomplete delivery (accepted=1, pending=1, rejected=1).',
+      name: 'EmailDeliveryError',
+    });
   });
 
   it('fails notifications delivery when the transport reports pending or rejected recipients', async () => {

--- a/packages/email/src/module.ts
+++ b/packages/email/src/module.ts
@@ -4,7 +4,6 @@ import { defineModule, type ModuleType } from '@fluojs/runtime';
 
 import { EmailConfigurationError } from './errors.js';
 import { EmailChannel } from './channel.js';
-import { EmailNotificationsQueueWorker } from './queue.js';
 import { EmailService } from './service.js';
 import { EMAIL, EMAIL_CHANNEL, EMAIL_OPTIONS } from './tokens.js';
 import type {
@@ -76,7 +75,6 @@ function createEmailRuntimeProviders(optionsProvider: Provider): Provider[] {
     optionsProvider,
     EmailService,
     EmailChannel,
-    EmailNotificationsQueueWorker,
     {
       inject: [EmailService],
       provide: EMAIL,
@@ -143,7 +141,7 @@ export class EmailModule {
    * Registers email providers using static options.
    *
    * @param options Static email module options including transport wiring and optional template rendering behavior.
-   * @returns A global module definition that exports {@link EmailService}, {@link EmailChannel}, and queue integration tokens.
+   * @returns A global module definition that exports {@link EmailService}, {@link EmailChannel}, and email facade tokens.
    *
    * @example
     * ```ts

--- a/packages/email/src/public-surface.test.ts
+++ b/packages/email/src/public-surface.test.ts
@@ -33,8 +33,21 @@ describe('@fluojs/email public API surface', () => {
     expect(emailPublicApi).not.toHaveProperty('DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS');
     expect(emailQueuePublicApi).toHaveProperty('createEmailNotificationsQueueAdapter');
     expect(emailQueuePublicApi).toHaveProperty('DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS');
+    expect(emailQueuePublicApi).toHaveProperty('EmailNotificationQueueJob');
+    expect(emailQueuePublicApi).toHaveProperty('EmailNotificationsQueueWorker');
     expectTypeOf<EmailQueueWorkerOptions>().toHaveProperty('attempts');
     expectTypeOf<EmailQueueWorkerOptions>().toHaveProperty('concurrency');
+  });
+
+  it('keeps concrete queue dependencies out of the root entrypoint implementation graph', () => {
+    const rootEntrypointFiles = ['index.ts', 'module.ts', 'types.ts', 'service.ts', 'channel.ts', 'constants.ts'];
+
+    for (const fileName of rootEntrypointFiles) {
+      const source = readFileSync(resolve(import.meta.dirname, fileName), 'utf8');
+
+      expect(source, fileName).not.toContain('@fluojs/queue');
+      expect(source, fileName).not.toContain('./queue.js');
+    }
   });
 
   it('keeps queue install requirements behind an optional peer dependency', () => {
@@ -95,6 +108,7 @@ describe('@fluojs/email public API surface', () => {
     expect(emailPublicApi).not.toHaveProperty('EMAIL_OPTIONS');
     expect(emailPublicApi).not.toHaveProperty('NormalizedEmailModuleOptions');
     expect(emailPublicApi).not.toHaveProperty('EmailNotificationQueueJob');
+    expect(emailPublicApi).not.toHaveProperty('EmailNotificationsQueueWorker');
     expect(emailPublicApi).not.toHaveProperty('NodemailerEmailTransport');
     expect(emailPublicApi).not.toHaveProperty('createNodemailerEmailTransport');
     expect(emailPublicApi).not.toHaveProperty('createNodemailerEmailTransportFactory');

--- a/packages/email/src/queue-entry.ts
+++ b/packages/email/src/queue-entry.ts
@@ -1,3 +1,3 @@
 export { DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS } from './constants.js';
-export { createEmailNotificationsQueueAdapter } from './queue.js';
-export type { EmailQueueWorkerOptions } from './types.js';
+export { EmailNotificationQueueJob, EmailNotificationsQueueWorker, createEmailNotificationsQueueAdapter } from './queue.js';
+export type { EmailQueueWorkerOptions } from './queue.js';

--- a/packages/email/src/queue.ts
+++ b/packages/email/src/queue.ts
@@ -1,13 +1,22 @@
 import { Inject } from '@fluojs/core';
 import type { NotificationsQueueAdapter, NotificationsQueueJob } from '@fluojs/notifications';
-import { QueueLifecycleService, QueueWorker } from '@fluojs/queue';
+import { QueueWorker, type QueueLifecycleService, type QueueWorkerOptions } from '@fluojs/queue';
 
 import { DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS } from './constants.js';
-import { EmailService } from './service.js';
+import { EmailChannel } from './channel.js';
 import type { EmailNotificationDispatchRequest } from './types.js';
+
+/** Queue worker execution defaults used by the built-in notifications queue integration. */
+export type EmailQueueWorkerOptions = QueueWorkerOptions;
 
 /** Serialized queue payload used by the built-in notifications queue adapter. */
 export class EmailNotificationQueueJob {
+  /**
+   * Creates one queued email notification job payload.
+   *
+   * @param notification Notification envelope that will be delivered by the email channel worker.
+   * @param queuedAt ISO timestamp captured when the notifications foundation delegated the job.
+   */
   constructor(
     public readonly notification: EmailNotificationDispatchRequest,
     public readonly queuedAt: string,
@@ -47,13 +56,19 @@ export function createEmailNotificationsQueueAdapter(queue: QueueLifecycleServic
   };
 }
 
-/** Internal queue worker that converts queued notification jobs back into email delivery. */
+/** Queue worker that converts queued notification jobs back into email delivery. */
 @QueueWorker(EmailNotificationQueueJob, DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS)
-@Inject(EmailService)
+@Inject(EmailChannel)
 export class EmailNotificationsQueueWorker {
-  constructor(private readonly email: EmailService) {}
+  constructor(private readonly channel: EmailChannel) {}
 
+  /**
+   * Delivers one queued email notification through the same channel semantics as direct dispatch.
+   *
+   * @param job Queued notification payload created by `createEmailNotificationsQueueAdapter(...)`.
+   * @returns A promise that resolves only when email delivery is accepted by the channel contract.
+   */
   async handle(job: EmailNotificationQueueJob): Promise<void> {
-    await this.email.sendNotification(job.notification);
+    await this.channel.send(job.notification, {});
   }
 }

--- a/packages/email/src/types.ts
+++ b/packages/email/src/types.ts
@@ -1,6 +1,5 @@
 import type { AsyncModuleOptions, MaybePromise } from '@fluojs/core';
 import type { NotificationDispatchRequest } from '@fluojs/notifications';
-import type { QueueBackoffOptions, QueueRateLimiterOptions } from '@fluojs/queue';
 
 /** RFC 5322-style email address with an optional display name. */
 export interface EmailAddress {
@@ -201,15 +200,6 @@ export interface EmailSendOptions {
 /** Additional controls applied to one batch send operation. */
 export interface EmailSendManyOptions extends EmailSendOptions {
   continueOnError?: boolean;
-}
-
-/** Queue worker execution defaults used by the built-in notifications queue integration. */
-export interface EmailQueueWorkerOptions {
-  attempts?: number;
-  backoff?: QueueBackoffOptions;
-  concurrency?: number;
-  jobName?: string;
-  rateLimiter?: QueueRateLimiterOptions;
 }
 
 /** Module options accepted by {@link EmailModule.forRoot} and `forRootAsync`. */


### PR DESCRIPTION
## Summary

Closes #1319.

Restore the `@fluojs/email` optional queue boundary and make queue-backed email workers preserve the same incomplete-delivery failure semantics as direct notification dispatch.

## Changes

- Removed the `EmailModule` dependency on `EmailNotificationsQueueWorker` so root email registration no longer imports `@fluojs/queue`.
- Exported `EmailNotificationQueueJob` and `EmailNotificationsQueueWorker` from `@fluojs/email/queue` as the explicit opt-in worker API.
- Changed the queue worker to deliver through `EmailChannel`, causing zero accepted recipients or any `pending`/`rejected` recipients to fail the job for retry/dead-letter handling.
- Updated EN/KO README queue guidance and added a patch changeset for `@fluojs/email`.

## Testing

- `lsp_diagnostics` on changed TypeScript files: no diagnostics after workspace dependency build.
- `pnpm --filter @fluojs/email test` — 4 files / 22 tests passed.
- `pnpm --filter @fluojs/email typecheck` — passed.
- `pnpm --filter @fluojs/email build` — passed.
- `pnpm exec biome lint packages/email/src/constants.ts packages/email/src/module.test.ts packages/email/src/module.ts packages/email/src/public-surface.test.ts packages/email/src/queue-entry.ts packages/email/src/queue.ts packages/email/src/types.ts` — passed.
- `pnpm verify:public-export-tsdoc` — passed.
- `pnpm changeset status --since=origin/main` — reports `@fluojs/email` patch.
- `pnpm lint` — public-export step passed, but full Biome lint is blocked by pre-existing warnings in `packages/config` and `packages/core` unrelated to this branch.
- `pnpm verify:release-readiness` — started and passed package/tooling/example suites visible in output, but the command exceeded the 120s local timeout during CLI sandbox verification.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; package README EN/KO updates are mirrored and covered by package regression tests.