### PR TITLE
Resolve #1320: preserve Slack transport lifecycle tutorials

### DIFF
--- a/.changeset/slack-lifecycle-tutorial-contracts.md
+++ b/.changeset/slack-lifecycle-tutorial-contracts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Preserve Slack transport lifecycle ownership and tutorial status snapshot contracts with focused regression coverage and aligned package/book documentation.

--- a/book/intermediate/ch17-slack-discord.ko.md
+++ b/book/intermediate/ch17-slack-discord.ko.md
@@ -33,7 +33,7 @@ const transport = createSlackWebhookTransport({
 });
 ```
 
-표준 `fetch` API에 의존하므로 이 트랜스포트는 Node.js 18+, Bun, Deno, Cloudflare Workers에서 별도 어댑터 없이 동작합니다.
+표준 `fetch` API에 의존하므로 이 트랜스포트는 저장소의 Node.js 20+ baseline, Bun, Deno, Cloudflare Workers에서 별도 어댑터 없이 동작합니다.
 
 ## 17.2 Registering the Chat Modules
 
@@ -201,8 +201,8 @@ async alertOps(event: OrderPlacedEvent) {
 채팅 연동은 웹훅 URL 만료, 권한 변경, 외부 서비스 장애로 중단될 수 있습니다. 상태 스냅샷을 운영 지표와 알림에 연결해 조기에 감지합니다. 이 정보를 주기적으로 확인하면 알림이 필요한 순간에야 채널 장애를 발견하는 상황을 줄일 수 있습니다.
 
 ```typescript
-const slackStatus = await createSlackPlatformStatusSnapshot(slackService);
-if (!slackStatus.isReady) {
+const slackStatus = slackService.createPlatformStatusSnapshot();
+if (slackStatus.readiness.status !== 'ready') {
   metrics.increment('notifications.slack.offline');
 }
 ```

--- a/book/intermediate/ch17-slack-discord.md
+++ b/book/intermediate/ch17-slack-discord.md
@@ -33,7 +33,7 @@ const transport = createSlackWebhookTransport({
 });
 ```
 
-Because it depends on the standard `fetch` API, this transport works in Node.js 18+, Bun, Deno, and Cloudflare Workers without a separate adapter.
+Because it depends on the standard `fetch` API, this transport works in the repository's Node.js 20+ baseline, Bun, Deno, and Cloudflare Workers without a separate adapter.
 
 ## 17.2 Registering the Chat Modules
 
@@ -203,8 +203,8 @@ The built-in webhook transports are designed around failure patterns seen in pro
 Chat integrations can stop working because webhook URLs expire, permissions change, or external services fail. Connect status snapshots to operational metrics and alerts so you can detect issues early.
 
 ```typescript
-const slackStatus = await createSlackPlatformStatusSnapshot(slackService);
-if (!slackStatus.isReady) {
+const slackStatus = slackService.createPlatformStatusSnapshot();
+if (slackStatus.readiness.status !== 'ready') {
   metrics.increment('notifications.slack.offline');
 }
 ```

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -126,6 +126,7 @@ Behavioral contract 메모:
 
 - `SlackService.send(...)`는 전달 전에 `defaultChannel`을 해석합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
+- `SlackService.createPlatformStatusSnapshot()`은 호출자가 내부 옵션에 접근하지 않아도 lifecycle, readiness, transport 소유권을 보고합니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.
 
 ### `@fluojs/notifications`와의 통합

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -126,6 +126,7 @@ Behavioral contract notes:
 
 - `SlackService.send(...)` resolves `defaultChannel` before delivery.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
+- `SlackService.createPlatformStatusSnapshot()` reports lifecycle, readiness, and transport ownership without requiring callers to reach into internal options.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.
 
 ### Integration with `@fluojs/notifications`

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { type Constructor, type Token } from '@fluojs/core';
+import type { Constructor, Token } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Container, type Provider } from '@fluojs/di';
 import { NOTIFICATION_CHANNELS, NotificationsModule, NotificationsService } from '@fluojs/notifications';
@@ -53,7 +53,12 @@ class RecordingTransport implements SlackTransport {
 }
 
 class PassiveTransport implements SlackTransport {
+  closeCalls = 0;
   readonly sent: string[] = [];
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
 
   async send(message: NormalizedSlackMessage) {
     this.sent.push(message.text ?? '');
@@ -555,6 +560,50 @@ describe('SlackModule', () => {
     expect(result.ok).toBe(true);
     expect(transport.sent).toEqual(['Provider transport']);
     expect(transportState.verifyCalls).toBe(0);
+  });
+
+  it('preserves direct transport ownership across bootstrap and shutdown lifecycle hooks', async () => {
+    const transport = new PassiveTransport();
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#owned-by-app',
+      transport,
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    await service.onModuleInit();
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        lifecycleState: 'ready',
+        transportKind: 'custom-instance',
+        verifiedOnModuleInit: true,
+      },
+      ownership: {
+        externallyManaged: true,
+        ownsResources: false,
+      },
+      readiness: { critical: true, status: 'ready' },
+    });
+
+    await service.send({ text: 'App-owned transport' });
+    await service.onApplicationShutdown();
+
+    expect(transport.sent).toEqual(['App-owned transport']);
+    expect(transport.closeCalls).toBe(0);
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'stopped' },
+      ownership: {
+        externallyManaged: true,
+        ownsResources: false,
+      },
+      readiness: {
+        reason: 'Slack transport is shutting down or already stopped.',
+        status: 'not-ready',
+      },
+    });
   });
 
   it('rejects module registration without an explicit transport contract', () => {

--- a/packages/slack/src/public-surface.test.ts
+++ b/packages/slack/src/public-surface.test.ts
@@ -42,6 +42,23 @@ describe('@fluojs/slack public API surface', () => {
     expect(koreanReadme).toContain('이 helper는 `SlackModule.forRoot(...)`가 구성하는 `SLACK`, `SLACK_CHANNEL`, `SlackService` wiring을 동일하게 유지합니다.');
   });
 
+  it('keeps the Slack tutorial lifecycle snapshot examples aligned with the service contract', () => {
+    const tutorial = readFileSync(resolve(import.meta.dirname, '../../../book/intermediate/ch17-slack-discord.md'), 'utf8');
+    const koreanTutorial = readFileSync(
+      resolve(import.meta.dirname, '../../../book/intermediate/ch17-slack-discord.ko.md'),
+      'utf8',
+    );
+
+    expect(tutorial).toContain('const slackStatus = slackService.createPlatformStatusSnapshot();');
+    expect(tutorial).toContain("if (slackStatus.readiness.status !== 'ready') {");
+    expect(koreanTutorial).toContain('const slackStatus = slackService.createPlatformStatusSnapshot();');
+    expect(koreanTutorial).toContain("if (slackStatus.readiness.status !== 'ready') {");
+    expect(tutorial).not.toContain('createSlackPlatformStatusSnapshot(slackService)');
+    expect(koreanTutorial).not.toContain('createSlackPlatformStatusSnapshot(slackService)');
+    expect(tutorial).not.toContain('slackStatus.isReady');
+    expect(koreanTutorial).not.toContain('slackStatus.isReady');
+  });
+
   it('keeps documented TypeScript-only contracts stable enough for downstream packages', () => {
     expectTypeOf<SlackMessage>().toHaveProperty('text');
     expectTypeOf<SlackMessage>().toHaveProperty('blocks');


### PR DESCRIPTION
## Summary

Closes #1320.

Preserves the `@fluojs/slack` transport lifecycle and tutorial contracts by locking down ownership/status behavior and aligning the documented Slack status snapshot examples with the actual service API.

## Changes

- Added focused regression coverage for direct transport lifecycle ownership: app-owned transports remain externally managed and are not closed by Slack shutdown hooks.
- Added tutorial contract regression coverage so EN/KO Chapter 17 examples use `slackService.createPlatformStatusSnapshot()` and `readiness.status` instead of a non-existent service overload/`isReady` field.
- Updated `packages/slack` EN/KO README lifecycle notes and Chapter 17 EN/KO tutorial text, including the Node.js 20+ baseline wording.
- Added a patch Changeset for `@fluojs/slack` because the package docs/behavioral contract surface changed.

## Testing

- LSP diagnostics: `packages/slack/src/module.test.ts` — no diagnostics.
- LSP diagnostics: `packages/slack/src/public-surface.test.ts` — no diagnostics.
- `pnpm install --frozen-lockfile` in the isolated worktree to restore dependency resolution.
- `pnpm --filter @fluojs/slack... build` — passed (Slack dependency graph and Slack package build).
- `pnpm exec biome lint packages/slack/src/module.test.ts packages/slack/src/public-surface.test.ts packages/slack/README.md packages/slack/README.ko.md book/intermediate/ch17-slack-discord.md book/intermediate/ch17-slack-discord.ko.md .changeset/slack-lifecycle-tutorial-contracts.md` — passed.
- `pnpm --filter @fluojs/slack typecheck` — passed.
- `pnpm --filter @fluojs/slack test` — passed (3 files, 22 tests).

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; this PR preserves existing `SlackService.createPlatformStatusSnapshot()` and root status helper contracts while aligning docs/tests around them.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The direct transport ownership contract is now covered by regression tests, and the tutorial status snapshot contract is pinned by public-surface tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs changed. EN/KO package README and book tutorial mirrors were updated together; the Slack lifecycle/status behavior is covered by package regression tests.