### PR TITLE
Resolve #1294: close runtime lifecycle health gaps

### DIFF
--- a/.changeset/runtime-lifecycle-health-readiness.md
+++ b/.changeset/runtime-lifecycle-health-readiness.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Reset runtime health readiness markers as soon as application or context shutdown begins so `/ready` leaves traffic rotation before cleanup hooks and remains unavailable even when shutdown fails.

--- a/docs/architecture/lifecycle-and-shutdown.ko.md
+++ b/docs/architecture/lifecycle-and-shutdown.ko.md
@@ -21,11 +21,11 @@
 
 | 신호 또는 상태 | 보장 | 근거 소스 |
 | --- | --- | --- |
-| 모듈 readiness 표시 | 부트스트랩 중 `markStarting()`과 `markReady()`를 노출하는 compiled module은 라이프사이클 훅 전에 starting으로 설정되고, `platformShell.start()`가 성공한 뒤에만 ready로 전환됩니다. | `packages/runtime/src/bootstrap.ts:232-245`, `packages/runtime/src/bootstrap.ts:830-841` |
+| 모듈 readiness 표시 | 부트스트랩 중 `markStarting()`과 `markReady()`를 노출하는 compiled module은 라이프사이클 훅 전에 starting으로 설정되고, `platformShell.start()`가 성공한 뒤에만 ready로 전환됩니다. shutdown은 cleanup callback과 lifecycle shutdown hook 실행 전에 이 표시를 starting으로 되돌립니다. | `packages/runtime/src/bootstrap.ts:232-245`, `packages/runtime/src/bootstrap.ts:119-153`, `packages/runtime/src/bootstrap.ts:830-841` |
 | 애플리케이션 상태 모델 | 공개 런타임 상태는 `bootstrapped`, `ready`, `closed`입니다. | `packages/runtime/src/types.ts:91-92` |
 | listen 이전 readiness 게이트 | `Application.listen()`은 `ready()`를 호출하고, `ready()`는 `platformShell.assertCriticalReadiness()`에 위임합니다. 이 검사가 통과하기 전에는 어댑터 bind가 시작되지 않습니다. | `packages/runtime/src/bootstrap.ts:437-489` |
 | ready 전이 | `Application.listen()`은 `adapter.listen(this.dispatcher)`가 성공적으로 끝난 뒤에만 애플리케이션 상태를 `ready`로 설정합니다. | `packages/runtime/src/bootstrap.ts:481-490` |
-| closed 전이 | `Application.close()`는 런타임 정리, 라이프사이클 종료 훅, 어댑터 종료, 컨테이너 해제가 모두 오류 없이 끝난 뒤에만 상태를 `closed`로 설정합니다. | `packages/runtime/src/bootstrap.ts:500-528` |
+| closed 전이 | `Application.close()`는 readiness 표시 reset, 런타임 정리, 라이프사이클 종료 훅, 어댑터 종료, 컨테이너 해제가 모두 오류 없이 끝난 뒤에만 상태를 `closed`로 설정합니다. | `packages/runtime/src/bootstrap.ts:500-528` |
 
 이 보장들은 부트스트랩 완료와 리스너 바인딩을 분리합니다. 컴파일된 애플리케이션은 트래픽을 받기 전에 `bootstrapped` 상태로 존재할 수 있습니다.
 

--- a/docs/architecture/lifecycle-and-shutdown.md
+++ b/docs/architecture/lifecycle-and-shutdown.md
@@ -21,11 +21,11 @@ If any bootstrap step fails, the runtime runs failure cleanup with signal value 
 
 | Signal or state | Guarantee | Source anchor |
 | --- | --- | --- |
-| Module readiness markers | During bootstrap, compiled modules that expose `markStarting()` and `markReady()` are set to starting before lifecycle hooks run, then switched to ready only after `platformShell.start()` succeeds. | `packages/runtime/src/bootstrap.ts:232-245`, `packages/runtime/src/bootstrap.ts:830-841` |
+| Module readiness markers | During bootstrap, compiled modules that expose `markStarting()` and `markReady()` are set to starting before lifecycle hooks run, then switched to ready only after `platformShell.start()` succeeds. Shutdown resets those markers to starting before cleanup callbacks and lifecycle shutdown hooks run. | `packages/runtime/src/bootstrap.ts:232-245`, `packages/runtime/src/bootstrap.ts:119-153`, `packages/runtime/src/bootstrap.ts:830-841` |
 | Application state model | Public runtime state is `bootstrapped`, `ready`, or `closed`. | `packages/runtime/src/types.ts:91-92` |
 | Readiness gate before listen | `Application.listen()` calls `ready()`, and `ready()` delegates to `platformShell.assertCriticalReadiness()`. The adapter is not asked to bind until that check passes. | `packages/runtime/src/bootstrap.ts:437-489` |
 | Ready transition | `Application.listen()` sets the application state to `ready` only after `adapter.listen(this.dispatcher)` resolves successfully. | `packages/runtime/src/bootstrap.ts:481-490` |
-| Closed transition | `Application.close()` sets the application state to `closed` only after runtime cleanup, lifecycle shutdown hooks, adapter close, and container disposal complete without error. | `packages/runtime/src/bootstrap.ts:500-528` |
+| Closed transition | `Application.close()` sets the application state to `closed` only after readiness markers have been reset, runtime cleanup, lifecycle shutdown hooks, adapter close, and container disposal complete without error. | `packages/runtime/src/bootstrap.ts:500-528` |
 
 These guarantees separate bootstrap completion from listener binding. A compiled application can exist in `bootstrapped` state before it begins accepting traffic.
 

--- a/docs/architecture/observability.ko.md
+++ b/docs/architecture/observability.ko.md
@@ -20,7 +20,7 @@
 | Surface | Source | Default path contract | Response contract |
 | --- | --- | --- | --- |
 | Runtime health endpoint | `@fluojs/runtime`의 `createHealthModule()` | base path가 없으면 `GET /health`다. base `path`가 있으면 경로는 `{path}/health`가 된다. | 커스텀 health callback이 없으면 응답 본문은 `{ "status": "ok" }`이고 HTTP 200이다. 커스텀 callback은 일반 본문 또는 `{ body, statusCode }`를 반환할 수 있다. |
-| Runtime readiness endpoint | `@fluojs/runtime`의 `createHealthModule()` | base path가 없으면 `GET /ready`다. base `path`가 있으면 경로는 `{path}/ready`가 된다. | `markReady()`가 실행되기 전에는 `{ "status": "starting" }`과 HTTP 503을 반환한다. readiness check 중 하나라도 false를 반환하면 `{ "status": "unavailable" }`과 HTTP 503을 반환한다. 앱이 준비되면 `{ "status": "ready" }`와 HTTP 200을 반환한다. |
+| Runtime readiness endpoint | `@fluojs/runtime`의 `createHealthModule()` | base path가 없으면 `GET /ready`다. base `path`가 있으면 경로는 `{path}/ready`가 된다. | `markReady()`가 실행되기 전과 애플리케이션/컨텍스트 종료가 시작된 뒤에는 `{ "status": "starting" }`과 HTTP 503을 반환한다. readiness check 중 하나라도 false를 반환하면 `{ "status": "unavailable" }`과 HTTP 503을 반환한다. 앱이 준비되면 `{ "status": "ready" }`와 HTTP 200을 반환한다. |
 | Terminus aggregated health endpoint | `@fluojs/terminus`의 `TerminusModule.forRoot(...)` | 런타임 health 경로 계약을 그대로 사용하며, 기본값은 `GET /health`다. | JSON 본문은 `checkedAt`, `contributors`, `details`, `error`, `info`, `platform`, `status`를 포함한다. 집계 상태가 `ok`이면 HTTP 200, 아니면 HTTP 503이다. |
 | Terminus readiness registration | 런타임 readiness check 위에 추가되는 `@fluojs/terminus` readiness hook | 런타임 readiness 경로 계약을 그대로 사용하며, 기본값은 `GET /ready`다. | Terminus는 indicator 건강 상태와 `platformShell.ready()`를 함께 검사하는 readiness check를 추가한다. 경로의 응답 본문 형태는 여전히 `starting`, `unavailable`, `ready`다. |
 
@@ -32,7 +32,7 @@
 
 | Concern | Route | Current repo behavior |
 | --- | --- | --- |
-| Startup readiness gate | `GET /ready` | `createHealthModule()`가 소유한다. 런타임이 앱을 ready로 표시하기 전까지 이 경로는 HTTP 503과 `{ "status": "starting" }`을 유지한다. 추가 readiness check는 `{ "status": "unavailable" }`를 강제할 수 있다. |
+| Startup and shutdown readiness gate | `GET /ready` | `createHealthModule()`가 소유한다. 런타임이 앱을 ready로 표시하기 전까지 이 경로는 HTTP 503과 `{ "status": "starting" }`을 유지하고, shutdown이 시작되면 다시 `starting`으로 내려간다. 추가 readiness check는 `{ "status": "unavailable" }`를 강제할 수 있다. |
 | Runtime dependency readiness | `@fluojs/terminus`가 붙은 `GET /ready` | Terminus는 `TerminusHealthService.isHealthy()`와 `platformShell.ready().status === 'ready'`를 모두 만족해야 통과하는 추가 readiness check를 등록한다. |
 | Aggregated health report | `@fluojs/terminus`가 붙은 `GET /health` | Terminus는 indicator 상태가 `ok`이고, `platformShell.health().status === 'healthy'`이며, `platformShell.ready().status === 'ready'`일 때만 `status: 'ok'`를 계산한다. 그 외에는 HTTP 503과 `status: 'error'`를 반환한다. |
 | Metrics-side readiness view | `GET /metrics` | 런타임 플랫폼 텔레메트리는 component별 및 `runtime.shell`용 readiness와 health를 gauge 값으로 내보낸다. |

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -20,7 +20,7 @@
 | Surface | Source | Default path contract | Response contract |
 | --- | --- | --- | --- |
 | Runtime health endpoint | `createHealthModule()` in `@fluojs/runtime` | `GET /health` when no base path is provided. If a base `path` is configured, the route becomes `{path}/health`. | Without a custom health callback, the response body is `{ "status": "ok" }` with HTTP 200. A custom callback may return either a plain body or `{ body, statusCode }`. |
-| Runtime readiness endpoint | `createHealthModule()` in `@fluojs/runtime` | `GET /ready` when no base path is provided. If a base `path` is configured, the route becomes `{path}/ready`. | Returns `{ "status": "starting" }` with HTTP 503 until `markReady()` runs. Returns `{ "status": "unavailable" }` with HTTP 503 when any readiness check returns false. Returns `{ "status": "ready" }` with HTTP 200 when the app is ready. |
+| Runtime readiness endpoint | `createHealthModule()` in `@fluojs/runtime` | `GET /ready` when no base path is provided. If a base `path` is configured, the route becomes `{path}/ready`. | Returns `{ "status": "starting" }` with HTTP 503 until `markReady()` runs and again as soon as application/context shutdown begins. Returns `{ "status": "unavailable" }` with HTTP 503 when any readiness check returns false. Returns `{ "status": "ready" }` with HTTP 200 when the app is ready. |
 | Terminus aggregated health endpoint | `@fluojs/terminus` via `TerminusModule.forRoot(...)` | Uses the same health path contract as the runtime health module, defaulting to `GET /health`. | Returns a JSON body with `checkedAt`, `contributors`, `details`, `error`, `info`, `platform`, and `status`. HTTP status is 200 when the aggregated status is `ok`, otherwise 503. |
 | Terminus readiness registration | `@fluojs/terminus` readiness hooks layered on runtime readiness checks | Uses the same readiness path contract as the runtime health module, defaulting to `GET /ready`. | Terminus adds readiness checks that combine indicator health and `platformShell.ready()`. The route still returns the runtime readiness body shape of `starting`, `unavailable`, or `ready`. |
 
@@ -32,7 +32,7 @@
 
 | Concern | Route | Current repo behavior |
 | --- | --- | --- |
-| Startup readiness gate | `GET /ready` | Owned by `createHealthModule()`. The route stays at HTTP 503 with `{ "status": "starting" }` until the runtime marks the app ready. Additional readiness checks can force `{ "status": "unavailable" }`. |
+| Startup and shutdown readiness gate | `GET /ready` | Owned by `createHealthModule()`. The route stays at HTTP 503 with `{ "status": "starting" }` until the runtime marks the app ready, and it returns to `starting` when shutdown begins. Additional readiness checks can force `{ "status": "unavailable" }`. |
 | Runtime dependency readiness | `GET /ready` with `@fluojs/terminus` | Terminus registers an additional readiness check that requires both `TerminusHealthService.isHealthy()` and `platformShell.ready().status === 'ready'`. |
 | Aggregated health report | `GET /health` with `@fluojs/terminus` | Terminus computes `status: 'ok'` only when indicator status is `ok`, `platformShell.health().status === 'healthy'`, and `platformShell.ready().status === 'ready'`. Otherwise the route returns HTTP 503 and `status: 'error'`. |
 | Metrics-side readiness view | `GET /metrics` | Runtime platform telemetry exports readiness and health as gauge values per component and for `runtime.shell`. |

--- a/docs/contracts/deployment.ko.md
+++ b/docs/contracts/deployment.ko.md
@@ -28,7 +28,7 @@
 | 엔드포인트 | 기본 계약 | 출처 |
 | --- | --- | --- |
 | `GET /health` | `createHealthModule()`이 제공하는 runtime health endpoint입니다. `TerminusModule.forRoot(...)`를 사용하면 응답에 `checkedAt`, `contributors`, `details`, `error`, `info`, `platform`, `status`가 포함됩니다. HTTP 200은 aggregate status `ok`, HTTP 503은 aggregate status `error`를 의미합니다. | `packages/terminus/src/module.ts`, `docs/architecture/observability.md` |
-| `GET /ready` | `createHealthModule()`이 제공하는 runtime readiness endpoint입니다. 앱이 준비되기 전에는 HTTP 503과 `{"status":"starting"}`, readiness check 실패 시 HTTP 503과 `{"status":"unavailable"}`, 준비 완료 시 HTTP 200과 `{"status":"ready"}`를 반환합니다. | `docs/architecture/observability.md` |
+| `GET /ready` | `createHealthModule()`이 제공하는 runtime readiness endpoint입니다. 앱이 준비되기 전과 애플리케이션/컨텍스트 종료가 시작된 뒤에는 HTTP 503과 `{"status":"starting"}`, readiness check 실패 시 HTTP 503과 `{"status":"unavailable"}`, 준비 완료 시 HTTP 200과 `{"status":"ready"}`를 반환합니다. | `docs/architecture/observability.md` |
 | Prefix가 붙은 health route | health module에 base path를 설정하면 runtime contract는 `{path}/health`, `{path}/ready`가 됩니다. | `docs/architecture/observability.md` |
 | 저장소 예제 검증 | `examples/ops-metrics-terminus/src/app.test.ts`는 현재 example app 설정에서 `/health`와 `/ready`가 HTTP 200을 반환하는지 검증합니다. | `examples/ops-metrics-terminus/src/app.test.ts` |
 

--- a/docs/contracts/deployment.md
+++ b/docs/contracts/deployment.md
@@ -28,7 +28,7 @@
 | Endpoint | Default contract | Source |
 | --- | --- | --- |
 | `GET /health` | Runtime health endpoint from `createHealthModule()`. With `TerminusModule.forRoot(...)`, the response includes `checkedAt`, `contributors`, `details`, `error`, `info`, `platform`, and `status`. HTTP 200 means aggregated status `ok`. HTTP 503 means aggregated status `error`. | `packages/terminus/src/module.ts`, `docs/architecture/observability.md` |
-| `GET /ready` | Runtime readiness endpoint from `createHealthModule()`. It returns HTTP 503 with `{"status":"starting"}` until the app is ready, HTTP 503 with `{"status":"unavailable"}` when a readiness check fails, and HTTP 200 with `{"status":"ready"}` when the app is ready. | `docs/architecture/observability.md` |
+| `GET /ready` | Runtime readiness endpoint from `createHealthModule()`. It returns HTTP 503 with `{"status":"starting"}` until the app is ready and again as soon as application/context shutdown begins, HTTP 503 with `{"status":"unavailable"}` when a readiness check fails, and HTTP 200 with `{"status":"ready"}` when the app is ready. | `docs/architecture/observability.md` |
 | Prefixed health routes | If a base path is configured for the health module, the runtime contracts become `{path}/health` and `{path}/ready`. | `docs/architecture/observability.md` |
 | Repository example coverage | `examples/ops-metrics-terminus/src/app.test.ts` verifies `/health` and `/ready` with HTTP 200 under the current example app configuration. | `examples/ops-metrics-terminus/src/app.test.ts` |
 

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -125,6 +125,7 @@ class UsersModule {}
 - 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다.
 - 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.
+- 런타임 health 모듈은 bootstrap이 ready로 표시하기 전까지 `/ready`를 HTTP 503과 `starting`으로 보고하며, 애플리케이션/컨텍스트 종료가 시작되는 즉시, 종료 시도가 실패하더라도 다시 `starting`으로 내려갑니다.
 - 시그널 기반 종료 헬퍼는 bounded drain semantics를 유지하면서 timeout/실패 상황을 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료 소유권은 주변 호스트 런타임에 남겨 둡니다.
 - 플랫폼 snapshot 생산은 런타임에 남아 있고, 그래프 보기와 Mermaid 렌더링은 CLI 및 자동화 호출자가 소비하는 Studio 소유 계약입니다.
 
@@ -135,6 +136,7 @@ class UsersModule {}
 - `Application`: `ApplicationContext`를 확장하며 `listen()`, `dispatch()`, `state`를 포함합니다.
 - `ApplicationContext`: `get<T>(token)`, `close()` 기능을 제공하며 `container`와 `modules`에 접근할 수 있습니다.
 - `LifecycleHooks`: `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `OnApplicationShutdown`를 묶는 편의 union 타입입니다.
+- `createHealthModule(options)`: bootstrap 및 shutdown 라이프사이클 전이에 맞춰 readiness marker를 관리하는 런타임 소유 `/health`, `/ready` 모듈 팩토리입니다.
 - `defineModule(cls, metadata)`: 프로그래밍 방식의 모듈 정의 헬퍼입니다.
 - `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -125,6 +125,7 @@ class UsersModule {}
 - Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests.
 - Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.
+- Runtime health modules report `/ready` as `starting` with HTTP 503 until bootstrap marks them ready, and they return to `starting` as soon as application/context shutdown begins, including failed shutdown attempts.
 - Signal-driven shutdown helpers preserve bounded drain semantics, log timeout/failure conditions, and set `process.exitCode` when shutdown does not finish cleanly, but they leave final process termination ownership to the surrounding host runtime.
 - Platform snapshot production stays in runtime; graph viewing and Mermaid rendering are Studio-owned contracts consumed by CLI and automation callers.
 
@@ -135,6 +136,7 @@ class UsersModule {}
 - `Application`: Extends `ApplicationContext` with `listen()`, `dispatch()`, and `state`.
 - `ApplicationContext`: Provides `get<T>(token)`, `close()`, and access to `container` and `modules`.
 - `LifecycleHooks`: Convenience union covering `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, and `OnApplicationShutdown`.
+- `createHealthModule(options)`: Runtime-owned `/health` and `/ready` module factory whose readiness marker follows bootstrap and shutdown lifecycle transitions.
 - `defineModule(cls, metadata)`: Programmatic module definition helper.
 - `bootstrapApplication(options)`: Lower-level async bootstrap function.
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -120,10 +120,13 @@ async function closeRuntimeResources(options: {
   adapter?: HttpApplicationAdapter;
   container: Container;
   lifecycleInstances: readonly unknown[];
+  modules: CompiledModule[];
   runtimeCleanup: readonly (() => void)[];
   signal?: string;
 }): Promise<void> {
   const errors: unknown[] = [];
+
+  resetReadinessState(options.modules);
 
   errors.push(...(await runCleanupCallbacks(options.runtimeCleanup)));
 
@@ -156,10 +159,13 @@ async function runBootstrapFailureCleanup(options: {
   container?: Container;
   lifecycleInstances: readonly unknown[];
   logger: ApplicationLogger;
+  modules: CompiledModule[];
   runtimeCleanup: readonly (() => void)[];
   scope: 'application' | 'application context';
 }): Promise<void> {
   const errors: unknown[] = [];
+
+  resetReadinessState(options.modules);
 
   errors.push(...(await runCleanupCallbacks(options.runtimeCleanup)));
 
@@ -512,6 +518,7 @@ class FluoApplication implements Application {
         adapter: this.adapter,
         container: this.container,
         lifecycleInstances: this.lifecycleInstances,
+        modules: this.modules,
         runtimeCleanup: this.runtimeCleanup,
         signal,
       });
@@ -559,6 +566,7 @@ class FluoApplicationContext implements ApplicationContext {
       await closeRuntimeResources({
         container: this.container,
         lifecycleInstances: this.lifecycleInstances,
+        modules: this.modules,
         runtimeCleanup: this.runtimeCleanup,
         signal,
       });
@@ -921,6 +929,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
   const logger = options.logger ?? createConsoleApplicationLogger();
   let lifecycleInstances: unknown[] = [];
   let bootstrappedContainer: Container | undefined;
+  let bootstrappedModules: CompiledModule[] = [];
   const hasHttpAdapter = options.adapter !== undefined;
   const adapter = options.adapter ?? {
     async close() {},
@@ -960,6 +969,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     }
 
     bootstrappedContainer = bootstrapped.container;
+    bootstrappedModules = bootstrapped.modules;
 
     const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
     lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
@@ -1021,6 +1031,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
       container: bootstrappedContainer,
       lifecycleInstances,
       logger,
+      modules: bootstrappedModules,
       runtimeCleanup,
       scope: 'application',
     });
@@ -1063,17 +1074,18 @@ export class FluoFactory {
     const logger = options.logger ?? createConsoleApplicationLogger();
     let lifecycleInstances: unknown[] = [];
     let bootstrappedContainer: Container | undefined;
+    let bootstrappedModules: CompiledModule[] = [];
     const runtimeCleanup: Array<() => void> = [];
     const platformShell = createRuntimePlatformShell(options.platform?.components);
     const timingEnabled = options.diagnostics?.timing === true;
-  const timingStart = timingEnabled ? runtimePerformance.now() : 0;
+    const timingStart = timingEnabled ? runtimePerformance.now() : 0;
     const timingPhases: BootstrapTimingPhase[] = [];
 
     try {
       logger.log('Starting fluo application context...', 'FluoFactory');
       const runtimeProviders = createRuntimeProviders(options, logger);
 
-  const moduleBootstrapStart = timingEnabled ? runtimePerformance.now() : 0;
+      const moduleBootstrapStart = timingEnabled ? runtimePerformance.now() : 0;
       const bootstrapped = bootstrapModule(rootModule, {
         duplicateProviderPolicy: options.duplicateProviderPolicy,
         logger,
@@ -1082,23 +1094,24 @@ export class FluoFactory {
       });
       if (timingEnabled) {
         timingPhases.push({
-        durationMs: runtimePerformance.now() - moduleBootstrapStart,
+          durationMs: runtimePerformance.now() - moduleBootstrapStart,
           name: 'bootstrap_module',
         });
       }
 
-    const registerTokensStart = timingEnabled ? runtimePerformance.now() : 0;
+      const registerTokensStart = timingEnabled ? runtimePerformance.now() : 0;
       registerRuntimeApplicationContextTokens(bootstrapped, platformShell);
       if (timingEnabled) {
         timingPhases.push({
-        durationMs: runtimePerformance.now() - registerTokensStart,
+          durationMs: runtimePerformance.now() - registerTokensStart,
           name: 'register_runtime_tokens',
         });
       }
 
       bootstrappedContainer = bootstrapped.container;
+      bootstrappedModules = bootstrapped.modules;
 
-    const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
+      const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
       lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
       lifecycleInstances.push({
         onModuleDestroy() {
@@ -1107,22 +1120,22 @@ export class FluoFactory {
       });
       if (timingEnabled) {
         timingPhases.push({
-        durationMs: runtimePerformance.now() - resolveLifecycleStart,
+          durationMs: runtimePerformance.now() - resolveLifecycleStart,
           name: 'resolve_lifecycle_instances',
         });
       }
 
-    const lifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
+      const lifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
       await runBootstrapLifecycle(bootstrapped.modules, lifecycleInstances, logger, platformShell);
       if (timingEnabled) {
         timingPhases.push({
-        durationMs: runtimePerformance.now() - lifecycleStart,
+          durationMs: runtimePerformance.now() - lifecycleStart,
           name: 'run_bootstrap_lifecycle',
         });
       }
 
       const bootstrapTiming = timingEnabled
-    ? createBootstrapTimingDiagnostics(timingPhases, runtimePerformance.now() - timingStart)
+        ? createBootstrapTimingDiagnostics(timingPhases, runtimePerformance.now() - timingStart)
         : undefined;
 
       return new FluoApplicationContext(
@@ -1144,6 +1157,7 @@ export class FluoFactory {
         container: bootstrappedContainer,
         lifecycleInstances,
         logger,
+        modules: bootstrappedModules,
         runtimeCleanup,
         scope: 'application context',
       });

--- a/packages/runtime/src/health/health.test.ts
+++ b/packages/runtime/src/health/health.test.ts
@@ -12,6 +12,20 @@ type ReadinessManagedModule = ReturnType<typeof createHealthModule> & {
   markStarting(): void;
 };
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
 function createRequest(path: string): FrameworkRequest {
   return {
     body: undefined,
@@ -138,5 +152,81 @@ describe('createHealthModule', () => {
     expect(readyResponse.body).toEqual({ status: 'ready' });
 
     await app.close();
+  });
+
+  it('marks readiness as starting as soon as application close begins', async () => {
+    const healthModule = createHealthModule() as ReadinessManagedModule;
+    const shutdownBlocker = createDeferred<void>();
+    const shutdownStarted = createDeferred<void>();
+
+    class BlockingShutdownService {
+      onApplicationShutdown() {
+        shutdownStarted.resolve();
+        return shutdownBlocker.promise;
+      }
+    }
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [healthModule],
+      providers: [BlockingShutdownService],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const readyBeforeClose = createResponse();
+    await app.dispatch(createRequest('/ready'), readyBeforeClose);
+    expect(readyBeforeClose.statusCode).toBe(200);
+    expect(readyBeforeClose.body).toEqual({ status: 'ready' });
+
+    const closePromise = app.close('SIGTERM');
+    await shutdownStarted.promise;
+
+    const readyDuringClose = createResponse();
+    await app.dispatch(createRequest('/ready'), readyDuringClose);
+    expect(readyDuringClose.statusCode).toBe(503);
+    expect(readyDuringClose.body).toEqual({ status: 'starting' });
+
+    shutdownBlocker.resolve();
+    await closePromise;
+  });
+
+  it('keeps readiness out of rotation when shutdown hooks fail', async () => {
+    const healthModule = createHealthModule() as ReadinessManagedModule;
+    const shutdownBlocker = createDeferred<void>();
+    const shutdownStarted = createDeferred<void>();
+
+    class FailingShutdownService {
+      async onApplicationShutdown() {
+        shutdownStarted.resolve();
+        await shutdownBlocker.promise;
+        throw new Error('shutdown failed');
+      }
+    }
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [healthModule],
+      providers: [FailingShutdownService],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const closePromise = app.close('SIGTERM');
+    await shutdownStarted.promise;
+
+    const readyDuringFailedClose = createResponse();
+    await app.dispatch(createRequest('/ready'), readyDuringFailedClose);
+    expect(readyDuringFailedClose.statusCode).toBe(503);
+    expect(readyDuringFailedClose.body).toEqual({ status: 'starting' });
+
+    shutdownBlocker.resolve();
+    await expect(closePromise).rejects.toThrow('shutdown failed');
   });
 });


### PR DESCRIPTION
## Summary

Closes #1294.

- Reset `@fluojs/runtime` health readiness markers as soon as application/context shutdown begins, including failed shutdown attempts.
- Added regression coverage for runtime `/ready` behavior during normal and failing shutdown paths.
- Aligned runtime README, observability docs, lifecycle/shutdown docs, and added a patch changeset for the behavioral contract change.

## Changes

- `packages/runtime/src/bootstrap.ts`: passes compiled modules into close/failure cleanup and resets readiness markers before cleanup callbacks and shutdown hooks run.
- `packages/runtime/src/health/health.test.ts`: covers `/ready` returning HTTP 503 `{ status: 'starting' }` while close is in progress and when shutdown hooks later fail.
- `packages/runtime/README*.md`, `docs/architecture/observability*.md`, `docs/architecture/lifecycle-and-shutdown*.md`: documents the shutdown readiness contract in EN/KO.
- `.changeset/runtime-lifecycle-health-readiness.md`: records the `@fluojs/runtime` patch behavior change.

## Testing

- LSP diagnostics: `packages/runtime/src/bootstrap.ts` — no diagnostics.
- LSP diagnostics: `packages/runtime/src/health/health.test.ts` — no diagnostics.
- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/runtime test -- src/health/health.test.ts src/bootstrap.test.ts` — 16 files / 151 tests passed.
- `pnpm --filter @fluojs/runtime test -- src/health/health.test.ts` — 16 files / 151 tests passed.
- `pnpm --filter @fluojs/runtime... build`
- `pnpm --filter @fluojs/runtime typecheck`
- `pnpm --filter @fluojs/runtime build`
- `pnpm verify:platform-consistency-governance`
- `pnpm lint` — `verify:public-export-tsdoc` passed; Biome reported existing warnings in `packages/config/*` unrelated to this PR.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public export was added; the README now documents the existing `createHealthModule(options)` public API entry.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Platform conformance harness claims were not changed; governance verification passed for the changed EN/KO docs.