### PR TITLE
Resolve #1307: align GraphQL resolver lifecycle contracts

### DIFF
--- a/.changeset/graphql-resolver-lifecycle-contracts.md
+++ b/.changeset/graphql-resolver-lifecycle-contracts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Align resolver input and request-scoped lifecycle contracts with focused regression coverage and package documentation.

--- a/book/intermediate/ch18-graphql.ko.md
+++ b/book/intermediate/ch18-graphql.ko.md
@@ -48,14 +48,19 @@ import { Resolver, Query, Mutation, Arg } from '@fluojs/graphql';
 import { Inject } from '@fluojs/core';
 import { ProductService } from './product.service';
 
+class ProductInput {
+  @Arg('id')
+  id = '';
+}
+
 @Inject(ProductService)
 @Resolver()
 export class ProductResolver {
   constructor(private readonly productService: ProductService) {}
 
-  @Query()
-  async product(@Arg('id') id: string) {
-    return this.productService.findById(id);
+  @Query({ input: ProductInput })
+  async product(input: ProductInput) {
+    return this.productService.findById(input.id);
   }
 
   @Query()
@@ -64,6 +69,8 @@ export class ProductResolver {
   }
 }
 ```
+
+`@Arg(...)`는 resolver input DTO용 필드 데코레이터입니다. GraphQL 인자로 노출할 DTO 필드에 표시한 뒤, operation의 `input` 옵션으로 해당 DTO 클래스를 전달합니다.
 
 ### Registering the Module
 
@@ -103,11 +110,16 @@ const authorLoader = createDataLoader(async (ids: string[]) => {
 ### Using the Loader in a Resolver
 
 ```typescript
+class BookInput {
+  @Arg('id')
+  id = '';
+}
+
 @Resolver()
 export class BookResolver {
-  @Query()
-  async book(@Arg('id') id: string) {
-    return bookService.findById(id);
+  @Query({ input: BookInput })
+  async book(input: BookInput) {
+    return bookService.findById(input.id);
   }
 
   // Book의 'author' 필드에 대한 필드 리졸버

--- a/book/intermediate/ch18-graphql.ko.md
+++ b/book/intermediate/ch18-graphql.ko.md
@@ -188,12 +188,17 @@ GraphqlModule.forRoot({
 FluoShop에서는 제품 카탈로그 조회 경험을 세밀하게 제공하기 위해 GraphQL을 사용합니다. 카테고리 조회에는 DataLoader를 적용하고, 검색 엔드포인트에는 복잡도 제한을 둬 성능과 안전성을 함께 관리합니다. 이 조합은 클라이언트가 필요한 필드를 유연하게 고르면서도, 서버가 감당하기 어려운 쿼리를 미리 제한하게 해줍니다.
 
 ```typescript
+class CatalogSearchInput {
+  @Arg('query')
+  query = '';
+}
+
 @Resolver()
 export class CatalogResolver {
-  @Query()
-  async search(@Arg('query') query: string) {
+  @Query({ input: CatalogSearchInput })
+  async search(input: CatalogSearchInput) {
     // 복잡도는 결과 세트 크기에 따라 자동으로 계산됩니다.
-    return this.catalogService.search(query);
+    return this.catalogService.search(input.query);
   }
 }
 ```

--- a/book/intermediate/ch18-graphql.md
+++ b/book/intermediate/ch18-graphql.md
@@ -48,14 +48,19 @@ import { Resolver, Query, Mutation, Arg } from '@fluojs/graphql';
 import { Inject } from '@fluojs/core';
 import { ProductService } from './product.service';
 
+class ProductInput {
+  @Arg('id')
+  id = '';
+}
+
 @Inject(ProductService)
 @Resolver()
 export class ProductResolver {
   constructor(private readonly productService: ProductService) {}
 
-  @Query()
-  async product(@Arg('id') id: string) {
-    return this.productService.findById(id);
+  @Query({ input: ProductInput })
+  async product(input: ProductInput) {
+    return this.productService.findById(input.id);
   }
 
   @Query()
@@ -64,6 +69,8 @@ export class ProductResolver {
   }
 }
 ```
+
+`@Arg(...)` is a field decorator for resolver input DTOs. Mark the DTO fields you want to expose as GraphQL arguments, then pass that DTO class through the operation's `input` option.
 
 ### Registering the Module
 
@@ -103,11 +110,16 @@ const authorLoader = createDataLoader(async (ids: string[]) => {
 ### Using the Loader in a Resolver
 
 ```typescript
+class BookInput {
+  @Arg('id')
+  id = '';
+}
+
 @Resolver()
 export class BookResolver {
-  @Query()
-  async book(@Arg('id') id: string) {
-    return bookService.findById(id);
+  @Query({ input: BookInput })
+  async book(input: BookInput) {
+    return bookService.findById(input.id);
   }
 
   // Field resolver for the 'author' field on Book

--- a/book/intermediate/ch18-graphql.md
+++ b/book/intermediate/ch18-graphql.md
@@ -188,12 +188,17 @@ GraphqlModule.forRoot({
 FluoShop uses GraphQL to provide a more fine-grained product catalog query experience. It applies DataLoader to category lookups and puts complexity limits on search endpoints so performance and safety are managed together.
 
 ```typescript
+class CatalogSearchInput {
+  @Arg('query')
+  query = '';
+}
+
 @Resolver()
 export class CatalogResolver {
-  @Query()
-  async search(@Arg('query') query: string) {
+  @Query({ input: CatalogSearchInput })
+  async search(input: CatalogSearchInput) {
     // Complexity is calculated automatically based on the result set size.
-    return this.catalogService.search(query);
+    return this.catalogService.search(input.query);
   }
 }
 ```

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -10,6 +10,7 @@ fluo를 위한 데코레이터 기반 GraphQL 통합 패키지입니다. **Graph
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [핵심 기능](#핵심-기능)
+- [Resolver Lifecycle 계약](#resolver-lifecycle-계약)
 - [운영 가드레일](#운영-가드레일)
 - [공개 API](#공개-api)
 - [관련 패키지](#관련-패키지)
@@ -37,11 +38,16 @@ import { Module } from '@fluojs/core';
 import { bootstrapNodeApplication } from '@fluojs/runtime/node';
 import { GraphqlModule, Query, Resolver, Arg } from '@fluojs/graphql';
 
+class HelloInput {
+  @Arg('name')
+  name = '';
+}
+
 @Resolver()
 class HelloResolver {
-  @Query()
-  hello(@Arg('name') name: string): string {
-    return `Hello, ${name}!`;
+  @Query({ input: HelloInput })
+  hello(input: HelloInput): string {
+    return `Hello, ${input.name}!`;
   }
 }
 
@@ -65,7 +71,7 @@ await app.listen(3000);
 ## 핵심 기능
 
 ### Code-first Resolvers
-fluo는 표준 데코레이터를 사용하여 GraphQL 스키마를 정의합니다. `@Resolver`, `@Query`, `@Mutation`, `@Subscription`을 사용하여 클래스 메서드를 GraphQL 작업에 매핑합니다.
+fluo는 표준 데코레이터를 사용하여 GraphQL 스키마를 정의합니다. `@Resolver`, `@Query`, `@Mutation`, `@Subscription`을 사용하여 클래스 메서드를 GraphQL 작업에 매핑합니다. GraphQL 인자는 input DTO 필드에 `@Arg(...)`로 선언하고, resolver 메서드는 작업의 `input` 옵션을 통해 해당 DTO를 받습니다.
 
 ### Request-Scoped DataLoaders
 내장된 DataLoader 통합을 통해 N+1 문제를 효율적으로 해결합니다. Loader는 각 GraphQL 작업마다 자동으로 격리됩니다.
@@ -83,6 +89,36 @@ class UserResolver {
   @Query()
   async user(@Arg('id') id: string, context: GraphQLContext) {
     return userLoader(context).load(id);
+  }
+}
+```
+
+## Resolver Lifecycle 계약
+
+- Singleton resolver가 기본값이며, 각 operation에서 애플리케이션 컨테이너를 통해 resolve됩니다.
+- Request-scoped provider를 주입하는 resolver는 resolver 자체에도 `@Scope('request')`를 지정해야 합니다. 이렇게 해야 DI lifetime 규칙이 명시적으로 유지되고 singleton-to-request dependency mismatch를 피할 수 있습니다.
+- `@fluojs/graphql`은 HTTP GraphQL 요청 또는 WebSocket subscription operation마다 operation-scoped DI 컨테이너를 하나 만들고, 해당 operation 안의 resolver 호출들이 이를 공유하며, operation 완료 또는 WebSocket operation 종료 시 dispose합니다.
+- Request-scoped DataLoader helper는 같은 `GraphQLContext` operation 경계를 사용하므로 loader cache는 하나의 GraphQL operation 안에서만 공유됩니다.
+
+```typescript
+import { Inject, Scope } from '@fluojs/core';
+import { Query, Resolver } from '@fluojs/graphql';
+
+@Scope('request')
+class RequestState {
+  private static nextId = 0;
+  readonly requestId = `request-${++RequestState.nextId}`;
+}
+
+@Inject(RequestState)
+@Scope('request')
+@Resolver()
+class RequestResolver {
+  constructor(private readonly state: RequestState) {}
+
+  @Query('requestId')
+  requestId(): string {
+    return this.state.requestId;
   }
 }
 ```
@@ -142,7 +178,7 @@ GraphqlModule.forRoot({
 
 - `GraphqlModule.forRoot(options)`: GraphQL 통합을 위한 메인 엔트리 포인트.
 - `Resolver`, `Query`, `Mutation`, `Subscription`: 작업 데코레이터.
-- `Arg`: 인자 매핑 데코레이터.
+- `Arg`: Input DTO 필드를 GraphQL 인자로 매핑하는 데코레이터.
 - `createDataLoader`, `createDataLoaderMap`: DataLoader 팩토리 헬퍼.
 - `GraphQLContext`: GraphQL 실행 컨텍스트를 위한 타입 정의.
 

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -84,11 +84,16 @@ const userLoader = createDataLoader(async (ids: string[]) => {
   return ids.map(id => users.find(u => u.id === id));
 });
 
+class UserInput {
+  @Arg('id')
+  id = '';
+}
+
 @Resolver()
 class UserResolver {
-  @Query()
-  async user(@Arg('id') id: string, context: GraphQLContext) {
-    return userLoader(context).load(id);
+  @Query({ input: UserInput })
+  async user(input: UserInput, context: GraphQLContext) {
+    return userLoader(context).load(input.id);
   }
 }
 ```

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -10,6 +10,7 @@ Decorator-based GraphQL integration for fluo. Built on **GraphQL Yoga**, it prov
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Core Capabilities](#core-capabilities)
+- [Resolver Lifecycle Contracts](#resolver-lifecycle-contracts)
 - [Operational Guardrails](#operational-guardrails)
 - [Public API](#public-api)
 - [Related Packages](#related-packages)
@@ -37,11 +38,16 @@ import { Module } from '@fluojs/core';
 import { bootstrapNodeApplication } from '@fluojs/runtime/node';
 import { GraphqlModule, Query, Resolver, Arg } from '@fluojs/graphql';
 
+class HelloInput {
+  @Arg('name')
+  name = '';
+}
+
 @Resolver()
 class HelloResolver {
-  @Query()
-  hello(@Arg('name') name: string): string {
-    return `Hello, ${name}!`;
+  @Query({ input: HelloInput })
+  hello(input: HelloInput): string {
+    return `Hello, ${input.name}!`;
   }
 }
 
@@ -65,7 +71,7 @@ await app.listen(3000);
 ## Core Capabilities
 
 ### Code-first Resolvers
-fluo uses standard decorators to define your GraphQL schema. Use `@Resolver`, `@Query`, `@Mutation`, and `@Subscription` to map class methods to GraphQL operations.
+fluo uses standard decorators to define your GraphQL schema. Use `@Resolver`, `@Query`, `@Mutation`, and `@Subscription` to map class methods to GraphQL operations. GraphQL arguments are declared on input DTO fields with `@Arg(...)`, then passed to the resolver method through the operation `input` option.
 
 ### Request-Scoped DataLoaders
 Efficiently solve the N+1 problem with built-in DataLoader integration. Loaders are automatically isolated per GraphQL operation.
@@ -83,6 +89,36 @@ class UserResolver {
   @Query()
   async user(@Arg('id') id: string, context: GraphQLContext) {
     return userLoader(context).load(id);
+  }
+}
+```
+
+## Resolver Lifecycle Contracts
+
+- Singleton resolvers are the default and are resolved from the application container for every operation.
+- Resolvers that inject request-scoped providers must also be marked with `@Scope('request')`; this keeps DI lifetime rules explicit and avoids singleton-to-request dependency mismatches.
+- `@fluojs/graphql` creates one operation-scoped DI container for each HTTP GraphQL request or websocket subscription operation, shares it across resolver calls in that operation, and disposes it when the operation completes or the websocket operation disconnects.
+- Request-scoped DataLoader helpers use the same `GraphQLContext` operation boundary, so loader caches are shared only within one GraphQL operation.
+
+```typescript
+import { Inject, Scope } from '@fluojs/core';
+import { Query, Resolver } from '@fluojs/graphql';
+
+@Scope('request')
+class RequestState {
+  private static nextId = 0;
+  readonly requestId = `request-${++RequestState.nextId}`;
+}
+
+@Inject(RequestState)
+@Scope('request')
+@Resolver()
+class RequestResolver {
+  constructor(private readonly state: RequestState) {}
+
+  @Query('requestId')
+  requestId(): string {
+    return this.state.requestId;
   }
 }
 ```
@@ -142,7 +178,7 @@ GraphqlModule.forRoot({
 
 - `GraphqlModule.forRoot(options)`: Main entry point for GraphQL integration.
 - `Resolver`, `Query`, `Mutation`, `Subscription`: Operation decorators.
-- `Arg`: Argument mapping decorator.
+- `Arg`: Input DTO field-to-GraphQL-argument mapping decorator.
 - `createDataLoader`, `createDataLoaderMap`: DataLoader factory helpers.
 - `GraphQLContext`: Type definition for the GraphQL execution context.
 

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -84,11 +84,16 @@ const userLoader = createDataLoader(async (ids: string[]) => {
   return ids.map(id => users.find(u => u.id === id));
 });
 
+class UserInput {
+  @Arg('id')
+  id = '';
+}
+
 @Resolver()
 class UserResolver {
-  @Query()
-  async user(@Arg('id') id: string, context: GraphQLContext) {
-    return userLoader(context).load(id);
+  @Query({ input: UserInput })
+  async user(input: UserInput, context: GraphQLContext) {
+    return userLoader(context).load(input.id);
   }
 }
 ```

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -254,6 +254,11 @@ class IncrementInput {
   count = 0;
 }
 
+class RequestLifecycleInput {
+  @Arg('marker')
+  marker = '';
+}
+
 class ValuesInput {
   @Arg('values')
   values: string[] = [];
@@ -535,6 +540,90 @@ describe('@fluojs/graphql', () => {
     expect(missingArgResult.errors[0]?.message).toBe('Validation failed.');
     expect(missingArgResult.errors[0]?.extensions?.code).toBe('BAD_USER_INPUT');
     expect(missingArgResult.data.echo).toBeNull();
+
+    await app.close();
+  });
+
+  it('keeps request-scoped resolver providers isolated and disposed per GraphQL operation', async () => {
+    let nextRequestId = 0;
+    const lifecycleEvents: string[] = [];
+
+    @Inject()
+    @Scope('request')
+    class RequestLifecycleState {
+      readonly id = ++nextRequestId;
+
+      onDestroy(): void {
+        lifecycleEvents.push(`state:${String(this.id)}:destroy`);
+      }
+    }
+
+    @Inject(RequestLifecycleState)
+    @Scope('request')
+    @Resolver('RequestLifecycleResolver')
+    class RequestLifecycleResolver {
+      constructor(private readonly state: RequestLifecycleState) {}
+
+      @Query({ fieldName: 'requestLifecycleId', input: RequestLifecycleInput })
+      requestLifecycleId(input: RequestLifecycleInput): string {
+        lifecycleEvents.push(`resolve:${input.marker}:${String(this.state.id)}`);
+        return `${input.marker}:${String(this.state.id)}`;
+      }
+
+      onDestroy(): void {
+        lifecycleEvents.push(`resolver:${String(this.state.id)}:destroy`);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [RequestLifecycleResolver],
+        }),
+      ],
+      providers: [RequestLifecycleState, RequestLifecycleResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    await expect(
+      postGraphql(port, '{ first: requestLifecycleId(marker: "first") second: requestLifecycleId(marker: "second") }'),
+    ).resolves.toEqual({
+      data: {
+        first: 'first:1',
+        second: 'second:1',
+      },
+    });
+
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        'resolve:first:1',
+        'resolve:second:1',
+        'resolver:1:destroy',
+        'state:1:destroy',
+      ]),
+    );
+
+    await expect(postGraphql(port, '{ requestLifecycleId(marker: "next") }')).resolves.toEqual({
+      data: {
+        requestLifecycleId: 'next:2',
+      },
+    });
+
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        'resolve:next:2',
+        'resolver:2:destroy',
+        'state:2:destroy',
+      ]),
+    );
 
     await app.close();
   });


### PR DESCRIPTION
## Summary

Closes #1307.

Aligns the documented `@fluojs/graphql` resolver contract with the implemented input DTO and operation-scoped lifecycle behavior.

## Changes

- Updated package README EN/KO examples so `@Arg(...)` is shown as an input DTO field decorator instead of a method-parameter decorator.
- Documented resolver lifecycle rules: singleton default, `@Scope('request')` for resolvers injecting request-scoped providers, per-operation DI scope sharing, and operation completion disposal.
- Added focused regression coverage that proves request-scoped resolver/provider instances are shared within one GraphQL operation, disposed after the operation, and recreated for the next operation.
- Updated intermediate GraphQL book examples EN/KO to match the same input DTO resolver contract.
- Added a patch Changeset for the public `@fluojs/graphql` docs/behavioral contract alignment.

## Testing

- `lsp_diagnostics` on `packages/graphql/src/module.test.ts`: passed after workspace dependency build (`No diagnostics found`). Markdown files have no configured LSP server.
- `pnpm --filter @fluojs/graphql test`: passed (8 files, 74 tests).
- `pnpm --filter @fluojs/graphql... build`: passed.
- `pnpm --filter @fluojs/graphql typecheck`: passed.
- `pnpm lint`: completed; `verify:public-export-tsdoc` passed, with existing unrelated Biome warnings in packages such as `packages/config` and `packages/cqrs`.
- `pnpm verify:release-readiness`: passed without writing draft artifacts.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No root-barrel exports were added or removed; the public API section now clarifies the existing `Arg` contract.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; package README EN/KO and book EN/KO examples were kept aligned.