### PR TITLE
Resolve #1308: preserve cache ownership docs accuracy

### DIFF
--- a/.changeset/cache-manager-ownership-reset.md
+++ b/.changeset/cache-manager-ownership-reset.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cache-manager": patch
+---
+
+Preserve Redis cache ownership during reset and document the cache namespace contract.

--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -14,6 +14,7 @@
 - [공통 패턴](#공통-패턴)
   - [Redis 저장소 사용](#redis-저장소-사용)
   - [쿼리 매개변수 기반 캐싱](#쿼리-매개변수-기반-캐싱)
+  - [캐시 소유권과 reset 범위](#캐시-소유권과-reset-범위)
   - [수동 모듈 조합](#수동-모듈-조합)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
@@ -120,6 +121,8 @@ CacheModule.forRoot({
 
 내장 `RedisStore`는 엔트리를 `JSON.stringify(...)`로 저장합니다. 따라서 캐시 값은 JSON 호환 형태여야 합니다. 일반 객체, 배열, 문자열, 숫자, 불리언, `null`은 안정적으로 round-trip 되지만, `Date`는 JSON 결과(예: ISO 문자열)로 돌아오고, 함수/`undefined`/`symbol`은 유지되지 않으며, `bigint`나 순환 그래프처럼 직렬화 불가능한 값은 캐싱 전에 정규화해야 합니다.
 
+Redis reset 소유권은 기본값이 `fluo:cache:`인 `keyPrefix`로 제한됩니다. Redis 기반 저장소에서 `CacheService.reset()`은 해당 prefix 아래의 키만 삭제하므로, cache prefix 밖의 애플리케이션 소유 Redis 데이터는 유지됩니다. 의도적으로 빈 `keyPrefix`를 설정하면 reset은 `*`를 scan하지 않고 현재 `RedisStore` 인스턴스가 쓴 키로만 제한됩니다. 재시작 이후나 여러 프로세스에 걸친 캐시 엔트리까지 reset해야 한다면 비어 있지 않은 애플리케이션 전용 prefix를 사용하세요.
+
 ### 쿼리 매개변수 기반 캐싱
 
 기본적으로 캐시 키는 쿼리 매개변수를 무시합니다. 검색 조건 등에 따라 다른 응답을 캐싱하려면 `httpKeyStrategy: 'route+query'`를 활성화하세요.
@@ -130,6 +133,19 @@ CacheModule.forRoot({
   httpKeyStrategy: 'route+query',
 })
 ```
+
+### 캐시 소유권과 reset 범위
+
+`CacheService.reset()`은 관련 없는 애플리케이션 상태가 아니라 설정된 store가 소유한 엔트리만 삭제합니다. 내장 메모리 저장소에서는 해당 store 인스턴스가 보유한 in-process 엔트리를 의미합니다. Redis에서는 설정된 `keyPrefix` namespace가 소유권 경계입니다. 공유 Redis 배포에서는 기본 `fluo:cache:`를 유지하거나 `myapp:cache:`처럼 전용 prefix를 선택하세요.
+
+```typescript
+CacheModule.forRoot({
+  store: 'redis',
+  keyPrefix: 'myapp:cache:',
+})
+```
+
+Redis cache prefix를 cache가 아닌 데이터와 공유하지 마세요. `del(key)`은 이 패키지가 해석한 정확한 캐시 키를 삭제하고, `reset()`은 위에서 설명한 store 소유 캐시 namespace만 삭제합니다.
 
 ### 수동 모듈 조합
 

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -14,6 +14,7 @@ General-purpose cache manager for fluo with pluggable memory and Redis stores. P
 - [Common Patterns](#common-patterns)
   - [Redis Storage](#redis-storage)
   - [Query-Sensitive Caching](#query-sensitive-caching)
+  - [Cache Ownership and Reset Scope](#cache-ownership-and-reset-scope)
   - [Manual Module Composition](#manual-module-composition)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
@@ -120,6 +121,8 @@ CacheModule.forRoot({
 
 The built-in `RedisStore` persists entries with `JSON.stringify(...)`. Cache values therefore need to be JSON-compatible: plain objects, arrays, strings, numbers, booleans, and `null` round-trip cleanly, while values such as `Date` come back as JSON output (for example ISO strings), functions/`undefined`/symbols do not survive, and non-serializable values like `bigint` or cyclic graphs should be normalized before caching.
 
+Redis reset ownership is scoped by `keyPrefix`, which defaults to `fluo:cache:`. `CacheService.reset()` deletes only keys under that prefix for Redis-backed stores, so application-owned Redis data outside the cache prefix is preserved. If you intentionally configure an empty `keyPrefix`, reset is limited to keys written by the current `RedisStore` instance instead of scanning `*`; use a non-empty, application-specific prefix when you need reset to cover cache entries across restarts or multiple processes.
+
 ### Query-Sensitive Caching
 
 By default, the cache key ignores query parameters. Enable `httpKeyStrategy: 'route+query'` to cache different responses for different search parameters.
@@ -130,6 +133,19 @@ CacheModule.forRoot({
   httpKeyStrategy: 'route+query',
 })
 ```
+
+### Cache Ownership and Reset Scope
+
+`CacheService.reset()` clears entries owned by the configured store, not unrelated application state. For the built-in memory store that means the in-process entries held by that store instance. For Redis, ownership is the configured `keyPrefix` namespace; keep the default `fluo:cache:` or choose a dedicated prefix such as `myapp:cache:` for shared Redis deployments.
+
+```typescript
+CacheModule.forRoot({
+  store: 'redis',
+  keyPrefix: 'myapp:cache:',
+})
+```
+
+Avoid sharing a Redis cache prefix with non-cache data. `del(key)` removes the exact cache key resolved by this package, while `reset()` removes only the store-owned cache namespace described above.
 
 ### Manual Module Composition
 

--- a/packages/cache-manager/src/stores/redis-store.test.ts
+++ b/packages/cache-manager/src/stores/redis-store.test.ts
@@ -113,6 +113,18 @@ describe('RedisStore', () => {
     expect(client.storage.get('external:owned-by-app')).toBe(JSON.stringify({ value: 'keep' }));
   });
 
+  it('deletes an owned empty-string key when keyPrefix is empty', async () => {
+    const client = new MockRedisClient();
+    const store = new RedisStore(client, { keyPrefix: '' });
+
+    await store.set('', { value: 'remove' });
+
+    await store.reset();
+
+    expect(client.deletedKeys).toContainEqual(['']);
+    expect(client.storage.has('')).toBe(false);
+  });
+
   it('stores ttl=0 entries without redis expiry arguments', async () => {
     const client = new MockRedisClient();
     const store = new RedisStore(client, { keyPrefix: 'cache:' });

--- a/packages/cache-manager/src/stores/redis-store.test.ts
+++ b/packages/cache-manager/src/stores/redis-store.test.ts
@@ -99,6 +99,20 @@ describe('RedisStore', () => {
     expect(client.storage.has('another-prefix:noop')).toBe(true);
   });
 
+  it('preserves non-owned redis keys when keyPrefix is empty', async () => {
+    const client = new MockRedisClient();
+    const store = new RedisStore(client, { keyPrefix: '' });
+
+    client.storage.set('external:owned-by-app', JSON.stringify({ value: 'keep' }));
+    await store.set('cache:owned-by-store', { value: 'remove' });
+
+    await store.reset();
+
+    expect(client.scanCalls).toEqual([]);
+    expect(client.storage.has('cache:owned-by-store')).toBe(false);
+    expect(client.storage.get('external:owned-by-app')).toBe(JSON.stringify({ value: 'keep' }));
+  });
+
   it('stores ttl=0 entries without redis expiry arguments', async () => {
     const client = new MockRedisClient();
     const store = new RedisStore(client, { keyPrefix: 'cache:' });

--- a/packages/cache-manager/src/stores/redis-store.ts
+++ b/packages/cache-manager/src/stores/redis-store.ts
@@ -101,12 +101,18 @@ export class RedisStore implements CacheStore {
       entry.expiresAt = now + ttlMilliseconds;
       const ttlSecondsRounded = Math.max(1, Math.ceil(ttlMilliseconds / 1000));
       await this.client.set(redisKey, JSON.stringify(entry), 'EX', ttlSecondsRounded);
-      this.ownedKeys.add(redisKey);
+      this.trackOwnedKey(redisKey);
       return;
     }
 
     await this.client.set(redisKey, JSON.stringify(entry));
-    this.ownedKeys.add(redisKey);
+    this.trackOwnedKey(redisKey);
+  }
+
+  private trackOwnedKey(redisKey: string): void {
+    if (this.keyPrefix.length === 0) {
+      this.ownedKeys.add(redisKey);
+    }
   }
 
   async del(key: string): Promise<void> {
@@ -123,7 +129,7 @@ export class RedisStore implements CacheStore {
       if (keys.length > 0) {
         const [firstKey, ...restKeys] = keys;
 
-        if (firstKey) {
+        if (firstKey !== undefined) {
           await this.client.del(firstKey, ...restKeys);
         }
       }

--- a/packages/cache-manager/src/stores/redis-store.ts
+++ b/packages/cache-manager/src/stores/redis-store.ts
@@ -1,7 +1,16 @@
 import type { CacheStore, RedisCompatibleClient } from '../types.js';
 
+/**
+ * Redis store configuration for key ownership and reset scanning.
+ */
 export interface RedisStoreOptions {
+  /**
+   * Prefix used to scope keys owned by this cache store when deleting entries or resetting the store.
+   */
   keyPrefix?: string;
+  /**
+   * Maximum number of keys requested per Redis SCAN iteration during reset.
+   */
   scanCount?: number;
 }
 
@@ -43,7 +52,11 @@ function normalizeScanResponse(result: [string | number, string[]]): { cursor: s
   };
 }
 
+/**
+ * Cache store implementation backed by a Redis-compatible client.
+ */
 export class RedisStore implements CacheStore {
+  private readonly ownedKeys = new Set<string>();
   private readonly keyPrefix: string;
   private readonly scanCount: number;
 
@@ -78,6 +91,7 @@ export class RedisStore implements CacheStore {
 
   async set<T = unknown>(key: string, value: T, ttlSeconds = 0): Promise<void> {
     const now = Date.now();
+    const redisKey = this.toRedisKey(key);
     const entry: RedisCacheEntry<T> = {
       value,
     };
@@ -86,18 +100,38 @@ export class RedisStore implements CacheStore {
       const ttlMilliseconds = Math.max(1, Math.floor(ttlSeconds * 1000));
       entry.expiresAt = now + ttlMilliseconds;
       const ttlSecondsRounded = Math.max(1, Math.ceil(ttlMilliseconds / 1000));
-      await this.client.set(this.toRedisKey(key), JSON.stringify(entry), 'EX', ttlSecondsRounded);
+      await this.client.set(redisKey, JSON.stringify(entry), 'EX', ttlSecondsRounded);
+      this.ownedKeys.add(redisKey);
       return;
     }
 
-    await this.client.set(this.toRedisKey(key), JSON.stringify(entry));
+    await this.client.set(redisKey, JSON.stringify(entry));
+    this.ownedKeys.add(redisKey);
   }
 
   async del(key: string): Promise<void> {
-    await this.client.del(this.toRedisKey(key));
+    const redisKey = this.toRedisKey(key);
+
+    await this.client.del(redisKey);
+    this.ownedKeys.delete(redisKey);
   }
 
   async reset(): Promise<void> {
+    if (this.keyPrefix.length === 0) {
+      const keys = Array.from(this.ownedKeys);
+
+      if (keys.length > 0) {
+        const [firstKey, ...restKeys] = keys;
+
+        if (firstKey) {
+          await this.client.del(firstKey, ...restKeys);
+        }
+      }
+
+      this.ownedKeys.clear();
+      return;
+    }
+
     let cursor = '0';
     const pattern = `${this.keyPrefix}*`;
 
@@ -115,5 +149,7 @@ export class RedisStore implements CacheStore {
         }
       }
     } while (cursor !== '0');
+
+    this.ownedKeys.clear();
   }
 }


### PR DESCRIPTION
## Summary

Closes #1308.

Preserves `@fluojs/cache-manager` Redis cache ownership boundaries and documents the reset namespace contract so cache resets do not imply ownership of unrelated Redis data.

## Changes

- Characterized the audited gap: `RedisStore.reset()` could scan `*` when `keyPrefix` was intentionally empty, making unrelated Redis keys part of the reset deletion scope.
- Updated `RedisStore` to track keys written by the current store instance and avoid broad Redis scans when `keyPrefix` is empty.
- Added focused regression coverage for empty-prefix reset ownership preservation.
- Documented cache ownership/reset scope in both `packages/cache-manager/README.md` and `packages/cache-manager/README.ko.md`.
- Added patch changeset `.changeset/cache-manager-ownership-reset.md` for the public docs/behavioral contract update.

## Testing

- `lsp_diagnostics` on `packages/cache-manager/src/stores/redis-store.ts`: no diagnostics
- `lsp_diagnostics` on `packages/cache-manager/src/stores/redis-store.test.ts`: no diagnostics
- `pnpm --filter @fluojs/cache-manager test` → 9 files / 93 tests passed
- `pnpm --filter @fluojs/cache-manager typecheck` → passed
- `pnpm --filter @fluojs/cache-manager build` → passed
- `pnpm verify:public-export-tsdoc` → passed
- `pnpm exec biome lint packages/cache-manager/src/stores/redis-store.ts packages/cache-manager/src/stores/redis-store.test.ts` → passed
- `pnpm lint` was also attempted; it still reports pre-existing repo-wide Biome findings outside this change (for example `packages/config/src/load.test.ts`) before the TSDoc check, so this PR relies on the targeted lint plus public-export TSDoc evidence above.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed; this PR only updates the package README mirror pair and cache-manager package behavior/tests.