### PR TITLE
Resolve #1329: preserve testing module identity contracts

### DIFF
--- a/.changeset/testing-module-identity-contracts.md
+++ b/.changeset/testing-module-identity-contracts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/testing": patch
+---
+
+Preserve testing module identity during module overrides and align documented `createTestingModule` contracts with regression coverage.

--- a/book/beginner/ch20-testing.ko.md
+++ b/book/beginner/ch20-testing.ko.md
@@ -103,6 +103,7 @@ export class PostService {
 
 ```typescript
 import { createTestingModule } from '@fluojs/testing';
+import { Module } from '@fluojs/core';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { PostService } from './post.service';
 import { PostRepository } from './post.repository';
@@ -118,8 +119,13 @@ describe('PostService', () => {
     };
 
     // 2. 테스트 모듈 생성
+    @Module({
+      providers: [PostRepository, PostService],
+    })
+    class PostTestModule {}
+
     const module = await createTestingModule({
-      providers: [PostService],
+      rootModule: PostTestModule,
     })
       .overrideProvider(PostRepository, mockRepo)
       .compile();
@@ -171,7 +177,10 @@ class FakePostRepository {
   async save(post: any) { this.data.set(post.id, post); }
 }
 
-const module = await createTestingModule({ providers: [PostService] })
+@Module({ providers: [PostRepository, PostService] })
+class PostTestModule {}
+
+const module = await createTestingModule({ rootModule: PostTestModule })
   .overrideProvider(PostRepository, new FakePostRepository())
   .compile();
 ```
@@ -186,7 +195,10 @@ const module = await createTestingModule({ providers: [PostService] })
 실제 애플리케이션에서 프로바이더들은 종종 설정 값에 의존합니다. 테스트 중에는 로컬 `.env` 파일에 의존하지 않는 편이 안전합니다. 테스트를 위해 미리 정의된 값을 반환하는 모의 객체로 `ConfigService`를 교체할 수 있습니다. 이를 통해 테스트의 이식성을 유지하고 실행 중인 특정 환경에 의존하지 않게 만들 수 있습니다.
 
 ```typescript
-const module = await createTestingModule({ providers: [PostService] })
+@Module({ providers: [ConfigService, PostService] })
+class PostTestModule {}
+
+const module = await createTestingModule({ rootModule: PostTestModule })
   .overrideProvider(ConfigService, {
     get: vi.fn().mockReturnValue('test-secret'),
   })

--- a/book/beginner/ch20-testing.md
+++ b/book/beginner/ch20-testing.md
@@ -103,6 +103,7 @@ Use `createTestingModule` to compile the smallest Module Graph needed for the te
 
 ```typescript
 import { createTestingModule } from '@fluojs/testing';
+import { Module } from '@fluojs/core';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { PostService } from './post.service';
 import { PostRepository } from './post.repository';
@@ -118,8 +119,13 @@ describe('PostService', () => {
     };
 
     // 2. Create the testing module.
+    @Module({
+      providers: [PostRepository, PostService],
+    })
+    class PostTestModule {}
+
     const module = await createTestingModule({
-      providers: [PostService],
+      rootModule: PostTestModule,
     })
       .overrideProvider(PostRepository, mockRepo)
       .compile();
@@ -171,7 +177,10 @@ class FakePostRepository {
   async save(post: any) { this.data.set(post.id, post); }
 }
 
-const module = await createTestingModule({ providers: [PostService] })
+@Module({ providers: [PostRepository, PostService] })
+class PostTestModule {}
+
+const module = await createTestingModule({ rootModule: PostTestModule })
   .overrideProvider(PostRepository, new FakePostRepository())
   .compile();
 ```
@@ -186,7 +195,10 @@ If a service depends on an external library, such as `axios` or `aws-sdk`, use V
 In real applications, Providers often depend on configuration values. During tests, it is safer not to depend on a local `.env` file. You can replace `ConfigService` with a mock that returns predefined values for tests. This keeps tests portable and independent of the specific environment where they run.
 
 ```typescript
-const module = await createTestingModule({ providers: [PostService] })
+@Module({ providers: [ConfigService, PostService] })
+class PostTestModule {}
+
+const module = await createTestingModule({ rootModule: PostTestModule })
   .overrideProvider(ConfigService, {
     get: vi.fn().mockReturnValue('test-secret'),
   })

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -65,6 +65,19 @@ const module = await createTestingModule({ rootModule: AppModule })
   .compile();
 ```
 
+### `overrideModule()` 사용 시 모듈 identity 보존
+
+`createTestingModule({ rootModule })`에는 명시적인 루트 모듈이 필요합니다. 그래야 테스트가 프로덕션 bootstrap과 같은 모듈 그래프 형태를 컴파일합니다. `overrideModule(source, replacement)`로 import된 모듈을 교체해도, 컴파일된 testing module은 provider 해석에 replacement import를 사용하면서 원래 `rootModule`과 컴파일된 `modules[].type` identity를 보존합니다. 따라서 diagnostics, graph assertion, module introspection 헬퍼는 테스트 전용 synthetic wrapper 클래스가 아니라 사용자가 작성한 애플리케이션 모듈 클래스에 계속 연결됩니다.
+
+```typescript
+const module = await createTestingModule({ rootModule: AppModule })
+  .overrideModule(StripeModule, FakeStripeModule)
+  .compile();
+
+expect(module.rootModule).toBe(AppModule);
+expect(module.modules.some((compiledModule) => compiledModule.type === BillingModule)).toBe(true);
+```
+
 ### HTTP 통합 테스트
 
 ```typescript

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -63,6 +63,19 @@ const module = await createTestingModule({ rootModule: AppModule })
   .compile();
 ```
 
+### Preserve module identity with `overrideModule()`
+
+`createTestingModule({ rootModule })` requires an explicit root module so tests compile the same module graph shape that production bootstrap uses. When `overrideModule(source, replacement)` swaps imported modules, the compiled testing module preserves the original `rootModule` and compiled `modules[].type` identities while using the replacement imports for provider resolution. This keeps diagnostics, graph assertions, and module-introspection helpers tied to the application module classes you authored instead of synthetic test-only wrapper classes.
+
+```ts
+const module = await createTestingModule({ rootModule: AppModule })
+  .overrideModule(StripeModule, FakeStripeModule)
+  .compile();
+
+expect(module.rootModule).toBe(AppModule);
+expect(module.modules.some((compiledModule) => compiledModule.type === BillingModule)).toBe(true);
+```
+
 ### Request-level tests with `createTestApp()`
 
 ```ts

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -696,6 +696,44 @@ describe('overrideModule', () => {
     expect(extractModuleImports(FeatureModule)).toEqual([RealModule]);
     expect(consumer.dep.value()).toBe('fake');
   });
+
+  it('restores module metadata when replacement bootstrap fails', async () => {
+    class RealService {
+      value() {
+        return 'real';
+      }
+    }
+
+    @Inject(RealService)
+    class ConsumerService {
+      constructor(readonly dep: RealService) {}
+    }
+
+    @Module({ providers: [RealService], exports: [RealService] })
+    class RealModule {}
+
+    @Module({ exports: [RealService] })
+    class InvalidFakeModule {}
+
+    @Module({ imports: [RealModule], providers: [ConsumerService] })
+    class FeatureModule {}
+
+    @Module({ imports: [FeatureModule] })
+    class RootModule {}
+
+    await expect(
+      createTestingModule({ rootModule: RootModule })
+        .overrideModule(RealModule, InvalidFakeModule)
+        .compile(),
+    ).rejects.toThrow(/cannot export token/);
+
+    expect(extractModuleImports(FeatureModule)).toEqual([RealModule]);
+
+    const testingModule = await createTestingModule({ rootModule: RootModule }).compile();
+    const consumer = await testingModule.resolve<ConsumerService>(ConsumerService);
+
+    expect(consumer.dep.value()).toBe('real');
+  });
 });
 
 describe('createDeepMock', () => {

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -650,6 +650,52 @@ describe('overrideModule', () => {
     const consumer = await testingModule.resolve<ConsumerService>(ConsumerService);
     expect(consumer.dep.value()).toBe('fake');
   });
+
+  it('preserves original testing module identity while applying replacements', async () => {
+    class RealService {
+      value() {
+        return 'real';
+      }
+    }
+
+    class FakeService {
+      value() {
+        return 'fake';
+      }
+    }
+
+    @Inject(RealService)
+    class ConsumerService {
+      constructor(readonly dep: RealService) {}
+    }
+
+    @Module({ providers: [RealService], exports: [RealService] })
+    class RealModule {}
+
+    @Module({ providers: [{ provide: RealService, useClass: FakeService }], exports: [RealService] })
+    class FakeModule {}
+
+    @Module({ imports: [RealModule], providers: [ConsumerService] })
+    class FeatureModule {}
+
+    @Module({ imports: [FeatureModule] })
+    class RootModule {}
+
+    const testingModule = await createTestingModule({ rootModule: RootModule })
+      .overrideModule(RealModule, FakeModule)
+      .compile();
+
+    const moduleTypes = testingModule.modules.map((compiledModule) => compiledModule.type);
+    const featureModule = testingModule.modules.find((compiledModule) => compiledModule.type === FeatureModule);
+    const consumer = await testingModule.resolve<ConsumerService>(ConsumerService);
+
+    expect(testingModule.rootModule).toBe(RootModule);
+    expect(moduleTypes).toContain(FeatureModule);
+    expect(moduleTypes).not.toContainEqual(expect.objectContaining({ name: 'PatchedModule' }));
+    expect(featureModule?.definition.imports).toEqual([FakeModule]);
+    expect(extractModuleImports(FeatureModule)).toEqual([RealModule]);
+    expect(consumer.dep.value()).toBe('fake');
+  });
 });
 
 describe('createDeepMock', () => {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -393,9 +393,7 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
   }
 
   private bootstrapTestingModule(): BootstrapResult {
-    const rootModule = this._applyModuleReplacements(this.options.rootModule);
-
-    const bootstrapped = this.bootstrapWithPatchedModuleImports(rootModule);
+    const bootstrapped = this.bootstrapWithPatchedModuleImports();
 
     if (this.overrides.length > 0) {
       bootstrapped.container.override(...this.overrides);
@@ -404,8 +402,10 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
     return bootstrapped;
   }
 
-  private bootstrapWithPatchedModuleImports(rootModule: ModuleType): BootstrapResult {
+  private bootstrapWithPatchedModuleImports(): BootstrapResult {
     try {
+      const rootModule = this._applyModuleReplacements(this.options.rootModule);
+
       return bootstrapModule(rootModule, {
         providers: this.options.providers,
       });

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -335,6 +335,7 @@ class DefaultOverrideProviderBuilder<T> implements OverrideProviderBuilder<T> {
 class DefaultTestingModuleBuilder implements TestingModuleBuilder {
   private readonly overrides: Provider[] = [];
   private readonly moduleReplacements = new Map<ModuleType, ModuleType>();
+  private readonly originalModuleDefinitions = new Map<ModuleType, ModuleDefinition>();
 
   constructor(private readonly options: TestingModuleOptions) {}
 
@@ -394,15 +395,23 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
   private bootstrapTestingModule(): BootstrapResult {
     const rootModule = this._applyModuleReplacements(this.options.rootModule);
 
-    const bootstrapped = bootstrapModule(rootModule, {
-      providers: this.options.providers,
-    });
+    const bootstrapped = this.bootstrapWithPatchedModuleImports(rootModule);
 
     if (this.overrides.length > 0) {
       bootstrapped.container.override(...this.overrides);
     }
 
     return bootstrapped;
+  }
+
+  private bootstrapWithPatchedModuleImports(rootModule: ModuleType): BootstrapResult {
+    try {
+      return bootstrapModule(rootModule, {
+        providers: this.options.providers,
+      });
+    } finally {
+      this.restorePatchedModuleImports();
+    }
   }
 
   private createTestingModuleRef(bootstrapped: BootstrapResult): TestingModuleRef {
@@ -464,19 +473,32 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
       return module;
     }
 
-    class PatchedModule {}
-    const patchedModule: ModuleType = PatchedModule;
+    this.patchModuleImports(module, metadata as ModuleDefinition, rewrittenImports);
 
-    defineModule(patchedModule, {
-      ...(metadata as ModuleDefinition),
-      imports: rewrittenImports,
-    });
-
-    return patchedModule;
+    return module;
   }
 
   private rewriteModuleImports(imports: ModuleType[]): ModuleType[] {
     return imports.map((moduleImport) => this._applyModuleReplacements(moduleImport));
+  }
+
+  private patchModuleImports(module: ModuleType, metadata: ModuleDefinition, imports: ModuleType[]): void {
+    if (!this.originalModuleDefinitions.has(module)) {
+      this.originalModuleDefinitions.set(module, metadata);
+    }
+
+    defineModule(module, {
+      ...metadata,
+      imports,
+    });
+  }
+
+  private restorePatchedModuleImports(): void {
+    for (const [module, metadata] of this.originalModuleDefinitions) {
+      defineModule(module, metadata);
+    }
+
+    this.originalModuleDefinitions.clear();
   }
 }
 

--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -112,6 +112,16 @@ describe('@fluojs/testing surface', () => {
     expect(readFileSync(resolve(packageRootPath, 'README.ko.md'), 'utf8')).toContain('pnpm add -D @babel/core');
   });
 
+  it('documents the testing module identity contract in both README mirrors', () => {
+    const englishReadme = readFileSync(resolve(packageRootPath, 'README.md'), 'utf8');
+    const koreanReadme = readFileSync(resolve(packageRootPath, 'README.ko.md'), 'utf8');
+
+    expect(englishReadme).toContain('`createTestingModule({ rootModule })` requires an explicit root module');
+    expect(englishReadme).toContain('preserves the original `rootModule` and compiled `modules[].type` identities');
+    expect(koreanReadme).toContain('`createTestingModule({ rootModule })`에는 명시적인 루트 모듈이 필요합니다');
+    expect(koreanReadme).toContain('원래 `rootModule`과 컴파일된 `modules[].type` identity를 보존합니다');
+  });
+
   it('build emits the published harness subpath files without blocking the Vitest worker event loop', async () => {
     await runBuild();
 


### PR DESCRIPTION
## Summary

- Closes #1329.
- Preserves `@fluojs/testing` module identity when `overrideModule()` rewrites imported modules for testing.
- Aligns the package README mirrors and beginner testing docs with the explicit `createTestingModule({ rootModule })` contract.

## Changes

- Reworked `overrideModule()` import rewriting so compiled testing modules keep the original `rootModule` and `modules[].type` identities while still resolving providers from replacement modules.
- Added focused regression coverage for module identity preservation and README mirror contract text.
- Updated EN/KO testing package docs and beginner examples to avoid `providers`-only testing module setup.
- Added `.changeset/testing-module-identity-contracts.md` as a patch release note for `@fluojs/testing`.

## Testing

- `lsp_diagnostics` on `packages/testing/src/module.ts`, `packages/testing/src/module.test.ts`, and `packages/testing/src/surface.test.ts`: no diagnostics after workspace dependencies were installed.
- `pnpm --filter @fluojs/testing test`: 7 files / 116 tests passed.
- `pnpm --filter @fluojs/testing typecheck`: passed.
- `pnpm --filter @fluojs/testing build`: passed.
- `pnpm --filter @fluojs/testing exec vitest run -c vitest.config.ts src/surface.test.ts`: 1 file / 5 tests passed after final README formatting cleanup.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public export was added; the existing `overrideModule()` behavior contract is documented in README mirrors and covered by regression tests.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; EN/KO package and beginner docs were kept aligned.