### PR TITLE
Resolve #1302: harden Terminus diagnostics health regressions

### DIFF
--- a/.changeset/terminus-diagnostics-health-regressions.md
+++ b/.changeset/terminus-diagnostics-health-regressions.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/terminus": patch
+---
+
+Harden Terminus health diagnostics so malformed indicator results and platform health/readiness failures remain visible as deterministic down contributors.

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -111,7 +111,9 @@ TerminusModule.forRoot({
 - 준비 상태(readiness)와 관련된 인디케이터가 실패하면 `/ready`는 HTTP `503`을 반환합니다.
 - 응답 본문은 `status`, `contributors`, `info`, `error`, `details`를 포함한 구조화된 JSON 객체입니다.
 - 하나의 인디케이터가 여러 keyed entry를 반환할 수도 있으며, 이 경우 `/health`는 모든 entry를 `details`와 `contributors.up` / `contributors.down` 요약에 그대로 반영합니다.
+- 지원하지 않는 status, 빈 결과, 객체가 아닌 인디케이터 결과는 조용히 버려지지 않고 `down` 진단으로 보고됩니다.
 - 같은 실행에서 이미 보고된 key를 다른 인디케이터가 다시 사용하면, Terminus는 먼저 기록된 entry를 유지하고 데이터를 조용히 덮어쓰는 대신 결정적인 `*-duplicate-key-error` contributor를 추가합니다.
+- 플랫폼 health/readiness 실패는 `/health` 응답에서 결정적인 `fluo-platform-health`, `fluo-platform-readiness` contributor로 노출됩니다.
 
 ## 공개 API 개요
 

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -111,7 +111,9 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 - `/ready` returns HTTP `503` if any indicator associated with readiness fails.
 - The response body contains a structured JSON object with `status`, `contributors`, `info`, `error`, and `details`.
 - Indicators may emit multiple keyed entries in a single check result; `/health` preserves every keyed entry in `details` and in the `contributors.up` / `contributors.down` summaries.
+- Unsupported, empty, or non-object indicator results are reported as `down` diagnostics instead of being silently discarded.
 - If an indicator reuses a key that was already reported earlier in the same run, Terminus keeps the first entry and adds a deterministic `*-duplicate-key-error` contributor instead of silently overwriting data.
+- Platform health/readiness failures are surfaced as deterministic `fluo-platform-health` and `fluo-platform-readiness` contributors in `/health` responses.
 
 ## Public API Overview
 

--- a/packages/terminus/src/health-check.test.ts
+++ b/packages/terminus/src/health-check.test.ts
@@ -4,6 +4,12 @@ import { HealthCheckError } from './errors.js';
 import { assertHealthCheck, runHealthCheck } from './health-check.js';
 import type { HealthIndicator } from './types.js';
 
+type TestHealthIndicatorResult = Awaited<ReturnType<HealthIndicator['check']>>;
+
+function unsafeHealthIndicatorResult(result: unknown): TestHealthIndicatorResult {
+  return result as TestHealthIndicatorResult;
+}
+
 describe('runHealthCheck', () => {
   it('aggregates up and down results into a structured report', async () => {
     const indicators: HealthIndicator[] = [
@@ -127,6 +133,59 @@ describe('runHealthCheck', () => {
     expect(report.details).toEqual({
       database: { latencyMs: 4, status: 'up' },
       redis: { message: 'timeout', status: 'down' },
+    });
+  });
+
+  it('keeps malformed entries visible as down diagnostics in mixed indicator results', async () => {
+    const indicators: HealthIndicator[] = [
+      {
+        key: 'dependencies',
+        check: async () => unsafeHealthIndicatorResult({
+          database: { latencyMs: 4, status: 'up' },
+          redis: { message: 'unexpected status', status: 'degraded' },
+        }),
+      },
+    ];
+
+    const report = await runHealthCheck(indicators);
+
+    expect(report.status).toBe('error');
+    expect(report.contributors).toEqual({
+      down: ['redis'],
+      up: ['database'],
+    });
+    expect(report.details).toEqual({
+      database: { latencyMs: 4, status: 'up' },
+      redis: {
+        message: 'Indicator returned an unsupported status value for result key "redis".',
+        status: 'down',
+      },
+    });
+  });
+
+  it('reports non-object and empty indicator results as down diagnostics', async () => {
+    const reports = await Promise.all([
+      runHealthCheck([
+        {
+          key: 'nullish',
+          check: async () => unsafeHealthIndicatorResult(null),
+        },
+      ]),
+      runHealthCheck([
+        {
+          key: 'empty',
+          check: async () => ({}),
+        },
+      ]),
+    ]);
+
+    expect(reports[0]?.error.nullish).toEqual({
+      message: 'Indicator returned a non-object health result.',
+      status: 'down',
+    });
+    expect(reports[1]?.error.empty).toEqual({
+      message: 'Indicator returned no health result entries.',
+      status: 'down',
     });
   });
 

--- a/packages/terminus/src/health-check.test.ts
+++ b/packages/terminus/src/health-check.test.ts
@@ -189,6 +189,28 @@ describe('runHealthCheck', () => {
     });
   });
 
+  it('keeps first entries when malformed blank result keys fold to an existing indicator key', async () => {
+    const report = await runHealthCheck([
+      {
+        key: 'dependencies',
+        check: async () => unsafeHealthIndicatorResult({
+          dependencies: { status: 'up' },
+          ' ': { message: 'blank key should not overwrite', status: 'degraded' },
+        }),
+      },
+    ]);
+
+    expect(report.details.dependencies).toEqual({ status: 'up' });
+    expect(report.details['dependencies-duplicate-key-error']).toEqual({
+      message: 'Indicator produced duplicate result key(s): dependencies.',
+      status: 'down',
+    });
+    expect(report.contributors).toEqual({
+      down: ['dependencies-duplicate-key-error'],
+      up: ['dependencies'],
+    });
+  });
+
   it('marks hung indicators as down when an execution timeout is configured', async () => {
     const report = await runHealthCheck(
       [

--- a/packages/terminus/src/health-check.ts
+++ b/packages/terminus/src/health-check.ts
@@ -64,19 +64,47 @@ function hasIndicatorStatus(value: unknown): value is HealthIndicatorState {
   return status === 'up' || status === 'down';
 }
 
-function normalizeIndicatorResult(key: string, result: HealthIndicatorResult): HealthIndicatorResult {
-  const normalizedEntries = Object.entries(result).filter(([, entryValue]) => hasIndicatorStatus(entryValue));
+function createUnsupportedEntryMessage(entryKey: string): string {
+  return entryKey.trim().length > 0
+    ? `Indicator returned an unsupported status value for result key "${entryKey}".`
+    : 'Indicator returned an unsupported status value for an empty result key.';
+}
 
-  if (normalizedEntries.length > 0) {
-    return Object.fromEntries(normalizedEntries);
+function normalizeIndicatorResult(key: string, result: unknown): HealthIndicatorResult {
+  if (typeof result !== 'object' || result === null || Array.isArray(result)) {
+    return {
+      [key]: {
+        message: 'Indicator returned a non-object health result.',
+        status: 'down',
+      },
+    };
   }
 
-  return {
-    [key]: {
-      message: 'Indicator returned an unsupported status value.',
+  const normalizedResult: HealthIndicatorResult = {};
+  const entries = Object.entries(result as Record<string, unknown>);
+
+  if (entries.length === 0) {
+    return {
+      [key]: {
+        message: 'Indicator returned no health result entries.',
+        status: 'down',
+      },
+    };
+  }
+
+  for (const [entryKey, entryValue] of entries) {
+    if (hasIndicatorStatus(entryValue)) {
+      normalizedResult[entryKey] = entryValue;
+      continue;
+    }
+
+    normalizedResult[entryKey.trim().length > 0 ? entryKey : key] = {
+      message: createUnsupportedEntryMessage(entryKey),
       status: 'down',
-    },
-  };
+    };
+  }
+
+  return normalizedResult;
 }
 
 function inferIndicatorKey(indicator: HealthIndicator, index: number): string {

--- a/packages/terminus/src/health-check.ts
+++ b/packages/terminus/src/health-check.ts
@@ -70,41 +70,57 @@ function createUnsupportedEntryMessage(entryKey: string): string {
     : 'Indicator returned an unsupported status value for an empty result key.';
 }
 
-function normalizeIndicatorResult(key: string, result: unknown): HealthIndicatorResult {
+function normalizeIndicatorResult(key: string, result: unknown): HealthCheckEntry[] {
   if (typeof result !== 'object' || result === null || Array.isArray(result)) {
-    return {
-      [key]: {
+    return [
+      [key, {
         message: 'Indicator returned a non-object health result.',
         status: 'down',
-      },
-    };
+      }],
+    ];
   }
 
-  const normalizedResult: HealthIndicatorResult = {};
+  const normalizedEntries: HealthCheckEntry[] = [];
+  const seenKeys = new Set<string>();
+  const duplicateKeys: string[] = [];
   const entries = Object.entries(result as Record<string, unknown>);
 
   if (entries.length === 0) {
-    return {
-      [key]: {
+    return [
+      [key, {
         message: 'Indicator returned no health result entries.',
         status: 'down',
-      },
-    };
+      }],
+    ];
   }
 
   for (const [entryKey, entryValue] of entries) {
-    if (hasIndicatorStatus(entryValue)) {
-      normalizedResult[entryKey] = entryValue;
+    const normalizedKey = hasIndicatorStatus(entryValue) || entryKey.trim().length > 0 ? entryKey : key;
+
+    if (seenKeys.has(normalizedKey)) {
+      duplicateKeys.push(normalizedKey);
       continue;
     }
 
-    normalizedResult[entryKey.trim().length > 0 ? entryKey : key] = {
+    seenKeys.add(normalizedKey);
+
+    if (hasIndicatorStatus(entryValue)) {
+      normalizedEntries.push([normalizedKey, entryValue]);
+      continue;
+    }
+
+    normalizedEntries.push([normalizedKey, {
       message: createUnsupportedEntryMessage(entryKey),
       status: 'down',
-    };
+    }]);
   }
 
-  return normalizedResult;
+  if (duplicateKeys.length > 0) {
+    const duplicateFailure = createDuplicateKeyFailure(key, duplicateKeys, seenKeys);
+    normalizedEntries.push(duplicateFailure);
+  }
+
+  return normalizedEntries;
 }
 
 function inferIndicatorKey(indicator: HealthIndicator, index: number): string {
@@ -172,13 +188,13 @@ async function runIndicator(
       : await withTimeout(indicator.check(key), indicatorTimeoutMs);
 
     return {
-      entries: Object.entries(normalizeIndicatorResult(key, result)),
+      entries: normalizeIndicatorResult(key, result),
       indicatorKey: key,
     };
   } catch (error: unknown) {
     if (error instanceof HealthCheckError) {
       return {
-        entries: Object.entries(normalizeIndicatorResult(key, error.causes)),
+        entries: normalizeIndicatorResult(key, error.causes),
         indicatorKey: key,
       };
     }

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -465,8 +465,16 @@ describe('TerminusModule.forRoot', () => {
     expect(healthResponse.statusCode).toBe(503);
     expect(healthResponse.body).toMatchObject({
       contributors: {
-        down: [],
+        down: ['fluo-platform-readiness'],
         up: ['database'],
+      },
+      error: {
+        'fluo-platform-readiness': {
+          critical: true,
+          message: 'redis not ready',
+          platformStatus: 'not-ready',
+          status: 'down',
+        },
       },
       platform: {
         health: {
@@ -485,6 +493,78 @@ describe('TerminusModule.forRoot', () => {
 
     expect(readyResponse.statusCode).toBe(503);
     expect(readyResponse.body).toEqual({ status: 'unavailable' });
+
+    await app.close();
+  });
+
+  it('reports platform health failures as explicit Terminus diagnostics', async () => {
+    const component: PlatformComponent = {
+      async health() {
+        return { reason: 'database pool exhausted', status: 'unhealthy' };
+      },
+      id: 'database.default',
+      kind: 'database',
+      async ready() {
+        return { critical: true, status: 'ready' };
+      },
+      snapshot() {
+        return {
+          dependencies: [],
+          details: {},
+          health: { reason: 'database pool exhausted', status: 'unhealthy' },
+          id: 'database.default',
+          kind: 'database',
+          ownership: { externallyManaged: true, ownsResources: false },
+          readiness: { critical: true, status: 'ready' },
+          state: 'degraded',
+          telemetry: { namespace: 'database', tags: {} },
+        };
+      },
+      async start() {},
+      state() {
+        return 'degraded';
+      },
+      async stop() {},
+      async validate() {
+        return { issues: [], ok: true };
+      },
+    };
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [TerminusModule.forRoot()],
+    });
+
+    const app = await bootstrapApplication({
+      platform: {
+        components: [component],
+      },
+      rootModule: AppModule,
+    });
+
+    const healthResponse = createResponse();
+    await app.dispatch(createRequest('/health'), healthResponse);
+
+    expect(healthResponse.statusCode).toBe(503);
+    expect(healthResponse.body).toMatchObject({
+      contributors: {
+        down: ['fluo-platform-health'],
+        up: [],
+      },
+      error: {
+        'fluo-platform-health': {
+          message: 'database pool exhausted',
+          platformStatus: 'unhealthy',
+          status: 'down',
+        },
+      },
+      status: 'error',
+    });
+
+    const readyResponse = createResponse();
+    await app.dispatch(createRequest('/ready'), readyResponse);
+    expect(readyResponse.statusCode).toBe(200);
+    expect(readyResponse.body).toEqual({ status: 'ready' });
 
     await app.close();
   });

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -568,4 +568,88 @@ describe('TerminusModule.forRoot', () => {
 
     await app.close();
   });
+
+  it('does not overwrite user indicators that reuse fixed platform diagnostic keys', async () => {
+    const component: PlatformComponent = {
+      async health() {
+        return { reason: 'runtime unhealthy', status: 'unhealthy' };
+      },
+      id: 'runtime.default',
+      kind: 'runtime',
+      async ready() {
+        return { critical: true, reason: 'runtime not ready', status: 'not-ready' };
+      },
+      snapshot() {
+        return {
+          dependencies: [],
+          details: {},
+          health: { reason: 'runtime unhealthy', status: 'unhealthy' },
+          id: 'runtime.default',
+          kind: 'runtime',
+          ownership: { externallyManaged: true, ownsResources: false },
+          readiness: { critical: true, reason: 'runtime not ready', status: 'not-ready' },
+          state: 'degraded',
+          telemetry: { namespace: 'runtime', tags: {} },
+        };
+      },
+      async start() {},
+      state() {
+        return 'degraded';
+      },
+      async stop() {},
+      async validate() {
+        return { issues: [], ok: true };
+      },
+    };
+    const indicators: HealthIndicator[] = [
+      {
+        key: 'reserved-collision-probe',
+        check: async () => ({
+          'fluo-platform-health': { status: 'up' },
+          'fluo-platform-readiness': { status: 'up' },
+        }),
+      },
+    ];
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [TerminusModule.forRoot({ indicators })],
+    });
+
+    const app = await bootstrapApplication({
+      platform: {
+        components: [component],
+      },
+      rootModule: AppModule,
+    });
+
+    const healthResponse = createResponse();
+    await app.dispatch(createRequest('/health'), healthResponse);
+
+    expect(healthResponse.statusCode).toBe(503);
+    expect(healthResponse.body).toMatchObject({
+      contributors: {
+        down: [
+          'fluo-platform-health-duplicate-key-error',
+          'fluo-platform-readiness-duplicate-key-error',
+        ],
+        up: ['fluo-platform-health', 'fluo-platform-readiness'],
+      },
+      details: {
+        'fluo-platform-health': { status: 'up' },
+        'fluo-platform-health-duplicate-key-error': {
+          message: 'Platform diagnostic key "fluo-platform-health" collided with an existing health result key.',
+          status: 'down',
+        },
+        'fluo-platform-readiness': { status: 'up' },
+        'fluo-platform-readiness-duplicate-key-error': {
+          message: 'Platform diagnostic key "fluo-platform-readiness" collided with an existing health result key.',
+          status: 'down',
+        },
+      },
+      status: 'error',
+    });
+
+    await app.close();
+  });
 });

--- a/packages/terminus/src/module.ts
+++ b/packages/terminus/src/module.ts
@@ -11,7 +11,7 @@ import { PLATFORM_SHELL, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 
 import { TerminusHealthService } from './health-check.js';
 import { TERMINUS_HEALTH_INDICATORS, TERMINUS_INDICATOR_PROVIDER_TOKENS } from './tokens.js';
-import type { HealthIndicator, TerminusModuleOptions } from './types.js';
+import type { HealthCheckReport, HealthIndicator, HealthIndicatorState, TerminusModuleOptions } from './types.js';
 
 const TERMINUS_OPTIONS = Symbol.for('fluo.terminus.options');
 
@@ -108,6 +108,74 @@ function createTerminusProviders(options: TerminusModuleOptions = {}): Provider[
   ];
 }
 
+function createPlatformHealthDiagnostic(health: PlatformHealthReport): HealthIndicatorState | undefined {
+  if (health.status === 'healthy') {
+    return undefined;
+  }
+
+  return {
+    checks: health.checks,
+    message: health.reason ?? `Platform health reported ${health.status}.`,
+    platformStatus: health.status,
+    status: 'down',
+  };
+}
+
+function createPlatformReadinessDiagnostic(readiness: PlatformReadinessReport): HealthIndicatorState | undefined {
+  if (readiness.status === 'ready') {
+    return undefined;
+  }
+
+  return {
+    checks: readiness.checks,
+    critical: readiness.critical,
+    message: readiness.reason ?? `Platform readiness reported ${readiness.status}.`,
+    platformStatus: readiness.status,
+    status: 'down',
+  };
+}
+
+function withPlatformDiagnostics(
+  report: HealthCheckReport,
+  health: PlatformHealthReport,
+  readiness: PlatformReadinessReport,
+): HealthCheckReport {
+  const platformDiagnostics: Record<string, HealthIndicatorState> = {};
+  const healthDiagnostic = createPlatformHealthDiagnostic(health);
+  const readinessDiagnostic = createPlatformReadinessDiagnostic(readiness);
+
+  if (healthDiagnostic !== undefined) {
+    platformDiagnostics['fluo-platform-health'] = healthDiagnostic;
+  }
+
+  if (readinessDiagnostic !== undefined) {
+    platformDiagnostics['fluo-platform-readiness'] = readinessDiagnostic;
+  }
+
+  const platformDiagnosticKeys = Object.keys(platformDiagnostics);
+
+  return {
+    ...report,
+    contributors: {
+      down: [...report.contributors.down, ...platformDiagnosticKeys],
+      up: [...report.contributors.up],
+    },
+    details: {
+      ...report.details,
+      ...platformDiagnostics,
+    },
+    error: {
+      ...report.error,
+      ...platformDiagnostics,
+    },
+    platform: {
+      health,
+      readiness,
+    },
+    status: report.status === 'ok' && platformDiagnosticKeys.length === 0 ? 'ok' : 'error',
+  };
+}
+
 function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): ModuleType {
   const readinessChecks = [...(options.readinessChecks ?? [])];
   const healthModule = createHealthModule({
@@ -119,18 +187,11 @@ function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): Modul
         platformShell.ready(),
         platformShell.health(),
       ]);
-      const status = report.status === 'ok' && health.status === 'healthy' && readiness.status === 'ready' ? 'ok' : 'error';
+      const reportWithPlatform = withPlatformDiagnostics(report, health, readiness);
 
       return {
-        body: {
-          ...report,
-          platform: {
-            health,
-            readiness,
-          },
-          status,
-        },
-        statusCode: status === 'ok' ? 200 : 503,
+        body: reportWithPlatform,
+        statusCode: reportWithPlatform.status === 'ok' ? 200 : 503,
       };
     },
     path: options.path,

--- a/packages/terminus/src/module.ts
+++ b/packages/terminus/src/module.ts
@@ -135,6 +135,52 @@ function createPlatformReadinessDiagnostic(readiness: PlatformReadinessReport): 
   };
 }
 
+function createPlatformDiagnosticCollisionKey(
+  diagnosticKey: string,
+  seenKeys: ReadonlySet<string>,
+): string {
+  const baseKey = `${diagnosticKey}-duplicate-key-error`;
+
+  if (!seenKeys.has(baseKey)) {
+    return baseKey;
+  }
+
+  let suffix = 2;
+  let candidate = `${baseKey}-${String(suffix)}`;
+
+  while (seenKeys.has(candidate)) {
+    suffix += 1;
+    candidate = `${baseKey}-${String(suffix)}`;
+  }
+
+  return candidate;
+}
+
+function appendPlatformDiagnostic(
+  entries: Record<string, HealthIndicatorState>,
+  existingKeys: ReadonlySet<string>,
+  diagnosticKey: string,
+  diagnostic: HealthIndicatorState | undefined,
+): void {
+  if (diagnostic === undefined) {
+    return;
+  }
+
+  if (!existingKeys.has(diagnosticKey) && !(diagnosticKey in entries)) {
+    entries[diagnosticKey] = diagnostic;
+    return;
+  }
+
+  const collisionKey = createPlatformDiagnosticCollisionKey(diagnosticKey, new Set([
+    ...existingKeys,
+    ...Object.keys(entries),
+  ]));
+  entries[collisionKey] = {
+    message: `Platform diagnostic key "${diagnosticKey}" collided with an existing health result key.`,
+    status: 'down',
+  };
+}
+
 function withPlatformDiagnostics(
   report: HealthCheckReport,
   health: PlatformHealthReport,
@@ -143,14 +189,10 @@ function withPlatformDiagnostics(
   const platformDiagnostics: Record<string, HealthIndicatorState> = {};
   const healthDiagnostic = createPlatformHealthDiagnostic(health);
   const readinessDiagnostic = createPlatformReadinessDiagnostic(readiness);
+  const existingKeys = new Set(Object.keys(report.details));
 
-  if (healthDiagnostic !== undefined) {
-    platformDiagnostics['fluo-platform-health'] = healthDiagnostic;
-  }
-
-  if (readinessDiagnostic !== undefined) {
-    platformDiagnostics['fluo-platform-readiness'] = readinessDiagnostic;
-  }
+  appendPlatformDiagnostic(platformDiagnostics, existingKeys, 'fluo-platform-health', healthDiagnostic);
+  appendPlatformDiagnostic(platformDiagnostics, existingKeys, 'fluo-platform-readiness', readinessDiagnostic);
 
   const platformDiagnosticKeys = Object.keys(platformDiagnostics);
 


### PR DESCRIPTION
## Summary

Closes #1302.

Harden `@fluojs/terminus` health diagnostics so audited regressions cannot hide malformed indicator output or platform health/readiness failures behind an otherwise structured `/health` response.

## Changes

- Preserve malformed, empty, and non-object indicator results as deterministic `down` diagnostics instead of silently discarding them.
- Surface platform health/readiness failures in `/health` as `fluo-platform-health` and `fluo-platform-readiness` contributors with structured `error`/`details` entries.
- Add focused regression coverage for mixed malformed indicator results, non-object/empty results, platform readiness diagnostics, and platform health diagnostics.
- Align `packages/terminus/README.md` and `packages/terminus/README.ko.md` with the new public behavior.
- Add `.changeset/terminus-diagnostics-health-regressions.md` as a patch changeset for `@fluojs/terminus`.

## Testing

- LSP diagnostics on modified Terminus TS files: no diagnostics.
- `pnpm --filter @fluojs/terminus test` — 10 files / 36 tests passed.
- `pnpm --filter @fluojs/terminus typecheck` — passed.
- `pnpm --filter @fluojs/terminus build` — passed.
- `pnpm exec biome lint packages/terminus/src/health-check.ts packages/terminus/src/health-check.test.ts packages/terminus/src/module.ts packages/terminus/src/module.test.ts` — passed.
- `pnpm lint` — completed with existing repository warnings outside this change; `verify:public-export-tsdoc` passed in changed mode.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; the existing `@fluojs/terminus` README contract was updated in EN/KO for public diagnostic behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs were changed. The platform-related assertion is covered by Terminus runtime regression tests rather than a new conformance claim.