### PR TITLE
Resolve #1303: harden metrics telemetry cleanup docs

### DIFF
--- a/.changeset/clean-metrics-telemetry.md
+++ b/.changeset/clean-metrics-telemetry.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/metrics': patch
+---
+
+Clear stale runtime platform telemetry series when `PLATFORM_SHELL` becomes unavailable after a prior scrape, and align the documented metrics public surface with exported contracts.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -145,6 +145,7 @@ MetricsModule.forRoot({
 플랫폼 텔레메트리는 매 `/metrics` 스크레이프마다 `PLATFORM_SHELL`을 resolve하여 `fluo_component_ready`와 `fluo_component_health`를 갱신합니다.
 
 - `PLATFORM_SHELL` 등록 자체가 빠진 경우에는 스크레이프가 계속 성공하고 플랫폼 텔레메트리 시리즈만 생략됩니다.
+- 이전 스크레이프에서 플랫폼 텔레메트리를 노출한 뒤 `PLATFORM_SHELL`을 사용할 수 없게 되면, stale `fluo_component_ready` 및 `fluo_component_health` 시리즈를 제거한 뒤 메트릭을 반환합니다.
 - 그 외의 `PLATFORM_SHELL` resolve 실패는 조용히 삼키지 않고 스크레이프 실패로 그대로 드러납니다.
 
 ### 기본 프로세스/Node 메트릭 비활성화
@@ -162,7 +163,9 @@ MetricsModule.forRoot({
 - `MetricsModule.forRoot(options)`
 - `MetricsService`
 - `METER_PROVIDER` (Token)
-- 카운터, 게이지, 히스토그램 및 레지스트리 접근을 위한 Prometheus 기반 헬퍼
+- `PrometheusMeterProvider`
+- `HttpMetricsMiddleware` 및 HTTP path-label 옵션 타입
+- `prom-client`의 `Registry`
 
 ### 운영 기본값
 
@@ -172,6 +175,7 @@ MetricsModule.forRoot({
 - HTTP 메트릭은 기본적으로 템플릿 기반 경로 라벨 정규화를 사용합니다.
 - raw path 라벨은 `allowUnsafeRawPathLabelMode: true`를 명시한 bounded internal route에서만 사용해야 합니다.
 - 플랫폼 텔레메트리는 `PLATFORM_SHELL`이 실제로 누락된 경우에만 생략되며, 그 외 resolve 실패는 스크레이프를 실패시킵니다.
+- 이전에 노출된 플랫폼 텔레메트리 시리즈는 `PLATFORM_SHELL`을 사용할 수 없게 된 스크레이프에서 제거됩니다.
 
 ## 관련 패키지
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -126,6 +126,7 @@ MetricsModule.forRoot({
 Platform telemetry refreshes `fluo_component_ready` and `fluo_component_health` on each `/metrics` scrape by resolving `PLATFORM_SHELL`.
 
 - If `PLATFORM_SHELL` is not registered, the scrape still succeeds and omits the platform telemetry series.
+- If `PLATFORM_SHELL` becomes unavailable after a previous successful scrape, stale `fluo_component_ready` and `fluo_component_health` series are removed before metrics are returned.
 - If resolving `PLATFORM_SHELL` fails for any other reason, the scrape surfaces that failure instead of swallowing it.
 
 ### Disable default process and Node metrics
@@ -143,7 +144,9 @@ MetricsModule.forRoot({
 - `MetricsModule.forRoot(options)`
 - `MetricsService`
 - `METER_PROVIDER`
-- Prometheus-backed helpers for counters, gauges, histograms, and registry access
+- `PrometheusMeterProvider`
+- `HttpMetricsMiddleware` and HTTP path-label option types
+- `Registry` from `prom-client`
 
 ### Operational defaults
 
@@ -153,6 +156,7 @@ MetricsModule.forRoot({
 - HTTP metrics default to template-normalized path labels.
 - Raw path labels require `allowUnsafeRawPathLabelMode: true` and should stay limited to bounded internal routes.
 - Platform telemetry is omitted only when `PLATFORM_SHELL` is genuinely missing; other resolution failures fail the scrape.
+- Stale platform telemetry series are removed when `PLATFORM_SHELL` becomes unavailable after a prior successful scrape.
 
 ## Related Packages
 

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -476,6 +476,59 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
+  it('clears stale platform telemetry series when the platform shell becomes unavailable', async () => {
+    const missingPlatformShellError = new ContainerResolutionError(
+      `No provider registered for token ${String(PLATFORM_SHELL)}.`,
+      {
+        hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
+        token: PLATFORM_SHELL,
+      },
+    );
+    let platformShellAvailable = true;
+    const intermittentPlatformShellMiddleware = {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        const originalResolve = context.requestContext.container.resolve.bind(context.requestContext.container);
+
+        context.requestContext.container.resolve = (async (token: Parameters<typeof originalResolve>[0]) => {
+          if (token === PLATFORM_SHELL && !platformShellAvailable) {
+            throw missingPlatformShellError;
+          }
+
+          return await originalResolve(token);
+        }) as typeof context.requestContext.container.resolve;
+
+        await next();
+      },
+    };
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, middleware: [intermittentPlatformShellMiddleware] })],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const initialResponse = createResponse();
+    await app.dispatch(createRequest('/metrics'), initialResponse);
+    expect(String(initialResponse.body)).toContain('fluo_component_ready{');
+    expect(String(initialResponse.body)).toContain('fluo_component_health{');
+
+    platformShellAvailable = false;
+    const missingShellResponse = createResponse();
+    await app.dispatch(createRequest('/metrics'), missingShellResponse);
+
+    const metricsText = String(missingShellResponse.body);
+    expect(missingShellResponse.statusCode).toBe(200);
+    expect(metricsText).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
+    expect(metricsText).not.toContain('fluo_component_ready{');
+    expect(metricsText).not.toContain('fluo_component_health{');
+
+    await app.close();
+  });
+
   it('surfaces unexpected platform shell resolution failures during scrape refresh', async () => {
     const resolutionFailure = new ContainerResolutionError(
       `Failed to resolve token ${String(PLATFORM_SHELL)} because the provider factory threw an unexpected error.`,

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -222,9 +222,9 @@ class RuntimePlatformTelemetry {
   }
 
   async refresh(ctx: RequestContext): Promise<void> {
-
     const platformShell = await this.resolvePlatformShell(ctx);
     if (!platformShell) {
+      this.clearPlatformTelemetry();
       return;
     }
 
@@ -267,6 +267,51 @@ class RuntimePlatformTelemetry {
       statuses: READINESS_STATUSES,
       toMetricValue: toReadinessValue,
     });
+  }
+
+  private clearPlatformTelemetry(): void {
+    this.clearGaugeStatuses({
+      env: this.labels?.env ?? 'unknown',
+      gauge: this.healthGauge,
+      instance: this.labels?.instance ?? 'local',
+      lastStatuses: this.lastHealthStatuses,
+      operation: 'health',
+      statuses: HEALTH_STATUSES,
+    });
+    this.clearGaugeStatuses({
+      env: this.labels?.env ?? 'unknown',
+      gauge: this.readinessGauge,
+      instance: this.labels?.instance ?? 'local',
+      lastStatuses: this.lastReadinessStatuses,
+      operation: 'readiness',
+      statuses: READINESS_STATUSES,
+    });
+  }
+
+  private clearGaugeStatuses<TStatus extends string>({
+    env,
+    gauge,
+    instance,
+    lastStatuses,
+    operation,
+    statuses,
+  }: {
+    env: string;
+    gauge: Gauge<string>;
+    instance: string;
+    lastStatuses: Map<string, TStatus>;
+    operation: 'health' | 'readiness';
+    statuses: readonly TStatus[];
+  }): void {
+    for (const componentKey of lastStatuses.keys()) {
+      const [componentId, componentKind] = this.fromComponentKey(componentKey);
+
+      for (const status of statuses) {
+        gauge.remove(componentId, componentKind, operation, status, env, instance);
+      }
+    }
+
+    lastStatuses.clear();
   }
 
   private syncGaugeStatuses<TStatus extends string>({

--- a/packages/metrics/src/public-surface.test.ts
+++ b/packages/metrics/src/public-surface.test.ts
@@ -10,7 +10,9 @@ describe('@fluojs/metrics public surface', () => {
     expect(metrics).toHaveProperty('MetricsService');
     expect(metrics).toHaveProperty('METER_PROVIDER');
     expect(metrics).toHaveProperty('PrometheusMeterProvider');
+    expect(metrics).toHaveProperty('HttpMetricsMiddleware');
     expect(metrics).toHaveProperty('Registry');
+    expect(metrics).not.toHaveProperty('RuntimePlatformTelemetry');
     expect(metrics).not.toHaveProperty('createMetricsModule');
   });
 


### PR DESCRIPTION
## Summary

Closes #1303.

Hardens `@fluojs/metrics` runtime platform telemetry cleanup so stale platform gauge series do not survive after `PLATFORM_SHELL` becomes unavailable, and aligns the documented public surface with the root barrel exports.

## Changes

- Clear previously emitted `fluo_component_ready` and `fluo_component_health` series when a later scrape can no longer resolve `PLATFORM_SHELL` because it is genuinely missing.
- Add regression coverage for the stale telemetry cleanup path and public-surface coverage for `HttpMetricsMiddleware` while keeping `RuntimePlatformTelemetry` internal.
- Update English/Korean metrics READMEs and add a patch changeset for the public behavior/docs contract update.

## Testing

- Reproduced the audited gap first: the new regression test failed before implementation because stale `fluo_component_ready` remained after `PLATFORM_SHELL` became unavailable.
- `pnpm --filter @fluojs/metrics test` — passed (28 tests).
- `pnpm --filter @fluojs/metrics... build && pnpm --filter @fluojs/metrics typecheck && pnpm --filter @fluojs/metrics build` — passed.
- `lsp_diagnostics` on modified TS files — passed after dependency build (`metrics-module.ts`, `metrics-module.test.ts`, `public-surface.test.ts`: no diagnostics).
- `pnpm lint` — completed with pre-existing repo-wide Biome warnings outside `@fluojs/metrics`; changed-mode public export TSDoc check passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

The root public-surface docs now name `MetricsModule`, `MetricsService`, `METER_PROVIDER`, `PrometheusMeterProvider`, `HttpMetricsMiddleware`, HTTP path-label option types, and `Registry`; package-only `RuntimePlatformTelemetry` remains unexported.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The cleanup contract now states that stale platform telemetry series are removed when `PLATFORM_SHELL` becomes unavailable after a prior successful scrape.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs were changed; only the `@fluojs/metrics` EN/KO README pair was updated with matching contract language.

## Changeset decision

Added `.changeset/clean-metrics-telemetry.md` as a patch changeset because this PR changes public `@fluojs/metrics` behavior/docs contracts and is not test-only.

## Remaining risks

- `pnpm lint` still reports unrelated pre-existing Biome warnings in packages such as `@fluojs/config`, `@fluojs/core`, and `@fluojs/cqrs`; no metrics lint failures were introduced.