### PR TITLE
Resolve #1300: clarify Deno HTTPS portability

### DIFF
--- a/.changeset/deno-https-portability.md
+++ b/.changeset/deno-https-portability.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-deno': patch
+---
+
+Document and verify Deno HTTPS startup portability by forwarding `https.cert` and `https.key` to `Deno.serve` and reporting HTTPS listen URLs.

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -10,6 +10,7 @@
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
+- [HTTPS와 런타임 이식성](#https와-런타임-이식성)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -66,12 +67,30 @@ const response = await adapter.handle(new Request('http://localhost:3000/health'
 export class MyGateway {}
 ```
 
+## HTTPS와 런타임 이식성
+
+`https` 옵션으로 Deno TLS 인증서 자료를 전달하면 `Deno.serve`를 HTTPS 모드로 시작할 수 있습니다. 어댑터는 `https.cert`와 `https.key`를 Deno의 `cert` 및 `key`로 전달하며, 시작 로그도 `https://` listen URL을 보고하므로 Deno 패키지가 공유 HTTP 어댑터 이식성 계약과 정렬됩니다.
+
+```typescript
+await runDenoApplication(AppModule, {
+  hostname: '127.0.0.1',
+  https: {
+    cert: await Deno.readTextFile('./cert.pem'),
+    key: await Deno.readTextFile('./key.pem'),
+  },
+  port: 3443,
+});
+```
+
+`hostname`은 Deno 네이티브 옵션 이름으로 유지됩니다. 공유 HTTP 어댑터 테스트와 교차 런타임 설정 헬퍼를 위해 `host`도 이식성 alias로 허용하며, 둘 다 제공하면 `hostname`이 우선합니다.
+
 ## 공개 API 개요
 
 - `createDenoAdapter(options)`: Deno HTTP 어댑터를 위한 팩토리입니다.
 - `bootstrapDenoApplication(module, options)`: 커스텀 오케스트레이션을 위한 고급 부트스트랩입니다.
 - `runDenoApplication(module, options)`: Deno를 위한 권장 빠른 시작 헬퍼입니다.
 - `handle(request)`: 수동 `Request` to `Response` 디스패처입니다.
+- `https: { cert, key }`: `Deno.serve`로 전달되고 보고되는 listen URL에 반영되는 HTTPS 시작 옵션입니다.
 
 ## 관련 패키지
 

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -10,6 +10,7 @@ Deno-backed HTTP adapter for the fluo runtime, built on native `Deno.serve`.
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
+- [HTTPS and Runtime Portability](#https-and-runtime-portability)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -66,12 +67,30 @@ The adapter supports Deno's native `Deno.upgradeWebSocket` through the `@fluojs/
 export class MyGateway {}
 ```
 
+## HTTPS and Runtime Portability
+
+Pass Deno TLS certificate material through the `https` option to start `Deno.serve` in HTTPS mode. The adapter forwards `https.cert` and `https.key` to Deno as `cert` and `key`, and startup logging reports an `https://` listen URL so the Deno package stays aligned with the shared HTTP adapter portability contract.
+
+```typescript
+await runDenoApplication(AppModule, {
+  hostname: '127.0.0.1',
+  https: {
+    cert: await Deno.readTextFile('./cert.pem'),
+    key: await Deno.readTextFile('./key.pem'),
+  },
+  port: 3443,
+});
+```
+
+`hostname` remains the Deno-native option name. The adapter also accepts `host` as a portability alias for shared HTTP adapter tests and cross-runtime configuration helpers; when both are provided, `hostname` wins.
+
 ## Public API Overview
 
 - `createDenoAdapter(options)`: Factory for the Deno HTTP adapter.
 - `bootstrapDenoApplication(module, options)`: Advanced bootstrap for custom orchestration.
 - `runDenoApplication(module, options)`: Recommended quick-start helper for Deno.
 - `handle(request)`: Manual `Request` to `Response` dispatcher.
+- `https: { cert, key }`: HTTPS startup options forwarded to `Deno.serve` and reflected in the reported listen URL.
 
 ## Related Packages
 

--- a/packages/platform-deno/package.json
+++ b/packages/platform-deno/package.json
@@ -43,6 +43,7 @@
     "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
+    "@fluojs/testing": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1,3 +1,6 @@
+import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { createServer as createHttpsServer } from 'node:https';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -9,14 +12,18 @@ import {
   type FrameworkResponse,
   type RequestContext,
 } from '@fluojs/http';
-import { defineModule, type ApplicationLogger } from '@fluojs/runtime';
+import { defineModule, type Application, type ApplicationLogger, type ModuleType } from '@fluojs/runtime';
+import { createHttpAdapterPortabilityHarness } from '../../testing/dist/portability/http-adapter-portability.js';
 
 import {
   bootstrapDenoApplication,
+  type BootstrapDenoApplicationOptions,
   DenoHttpApplicationAdapter,
   createDenoAdapter,
   runDenoApplication,
+  type RunDenoApplicationOptions,
   type DenoServeController,
+  type DenoServeFunction,
   type DenoServeHandler,
   type DenoServerWebSocket,
   type DenoServeOptions,
@@ -24,6 +31,53 @@ import {
   type DenoWebSocketMessage,
   type DenoUpgradeWebSocketFunction,
 } from './adapter.js';
+
+const TEST_TLS_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDBbj6DdMPNvDMr
+yNUM0dreceSBINfH+VDV750R3X57mdoqebUgjKOXjbjR7JRkloJ4PEgAic+840rq
+tyTN/MvmaAQg5OtNwsY7wp3Owaomr0sqw+wHM7NkPYMB0apxcWEBC7IWph1sKGcC
+iRxNDBBMEUmhxscatvhfkB/aqlQxLYjDylFcIX0A3NzIW0Rfaydk7/3R0hqkiF5x
+k/98U2cEPZn1E890q4IsfQ6mGMNi/fh1jMWiR5RFL9MlIhLEJPCyuW/sQMYSglan
+T2sKcABWjIShAc4gn87ncbmSv/6IDgfXtVRD6mehvFz9iHVSbV5sGM/bE4y3pgj2
+kQXpbdUnAgMBAAECggEAT8yIc7kPMmgrACw5YLGOxuhbqb3/51r+s1PIC9/B14IQ
+VCejxsrejp6EGe6tBZZmOu47kiVIk5d9h7mIsIZTJDnTQjLOtGTfXTYb3nldFdqJ
+exoa3JnCr18FFhIGbAinSUQm81sSllVQseYYy9xnOMqFAv27lFTZwKr3yUEtvJ9h
+oYqq5/yRNwwR1AT6lfWgSJa5S9cvs9YHK4k2XCnhKTqWkQ3Bh9awKy83142r1FWy
+rXk3IUwNaNAgRHSEw/9MGbcM6it+l55XjwzEBP/lI+DdDzhRhKgp3QsM/v26eHRl
+CwP0NA4d4i1m2kcT8dvtSTxrnwbylSxhVRDYXrsOMQKBgQDn+f9I9LlQJdGPWRda
+0YiyZtQZTGYfG/ZJvHPvhLA37rAfV7MGDqKgn22FJPJHT9vE+wVkUT531VErKKlO
+dOv6GIz/C3AolVTOTDKxTZnFkicxy4J7pZYHPRo8mIVGFlsKsPQVPz63UZMUkbR6
+0HkgcihnxKKlYFb+az7hNvPZbwKBgQDVdlglrw9jGreXtGplZLapsTmAc+GuL17R
+fqY4/aXNul0k6MNlSrm2/cUm/KI8AsHvRn2tvdFJnM1drmzEpTvcFx5a9N2F5HOU
+N1smlv31RT5B0XqoHTB7df2+zVeAGGcpDY8n27KI9/zigVdVQR/aR+fR7CFfNhCv
+sI8PQUkzyQKBgQDWKHckjEF0m6VuuGoWPvD6+nF+9Ygl2jOyeRdzHUVuLZ5NITK2
+OdargOOkEqrVaQVUQgYFSffou3eW54/+TXT5S6cHYjDmVo6XccMu6pw2yKoEj4Pj
+0MfD4QYSwR/wx3y/TwPXha7JoLavO6Cp7UKV0K46tk8Na/aEJNBFLO1MYwKBgElV
+jfTsTnn6rMYmikLpNcPYieuyY/8GcSnBu/NqWLLz6poKiU5cPK88QaYiNs4tGFlO
+u1CcHLGQeBFOIjnwlj8HhjszUoN0N6zc06jPSNIhhsDv6Zal6IkRwSnyu7PbLl2x
+NdQ4qv5ZS/y4+LrmU74W4/J/j/t4xITHQG66PB7ZAoGANNL4daB3T46IElDHnCbl
+j4hWQezWEMRCf4Ruqy24peC4Y8CXMaGA0oN6auePuTdLmGYa9nDn0J77rMqLIG7+
+v8OLobYRGfklwPOBs5puVFTEgihMq7Ejh2r9HhoRiCAZS5hIirS08BgrAskgVw9P
+dM+3fSZauOH3r+7JXAvrtMo=
+-----END PRIVATE KEY-----`;
+
+const TEST_TLS_CERTIFICATE = `-----BEGIN CERTIFICATE-----
+MIICpDCCAYwCCQCAEWnETUdMHDANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDDAkx
+MjcuMC4wLjEwHhcNMjYwMzE4MDEzNTQ2WhcNMjYwMzE5MDEzNTQ2WjAUMRIwEAYD
+VQQDDAkxMjcuMC4wLjEwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDB
+bj6DdMPNvDMryNUM0dreceSBINfH+VDV750R3X57mdoqebUgjKOXjbjR7JRkloJ4
+PEgAic+840rqtyTN/MvmaAQg5OtNwsY7wp3Owaomr0sqw+wHM7NkPYMB0apxcWEB
+C7IWph1sKGcCiRxNDBBMEUmhxscatvhfkB/aqlQxLYjDylFcIX0A3NzIW0Rfaydk
+7/3R0hqkiF5xk/98U2cEPZn1E890q4IsfQ6mGMNi/fh1jMWiR5RFL9MlIhLEJPCy
+uW/sQMYSglanT2sKcABWjIShAc4gn87ncbmSv/6IDgfXtVRD6mehvFz9iHVSbV5s
+GM/bE4y3pgj2kQXpbdUnAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAJhOoDgzUsiV
+XE0p5DznahRbv85K05BS6iXfMRnjgHziJyED0h6dD3vpFTnQLW9I7SQeMA21sZPx
+MNm+gL8/Jq2G2CGwx0naD9bsTFYboWhBk+SuQVj8f7g8xM7ya2nB8AJg07/n3VD5
+NJFlJnyXlpchaxikKeaLWWGJCzPosbqUDdS5Y9S3VkqxM3na4Z+04qLaLQSEEpSi
+WZWkDdOMceoMbJC0CpyVtWCW7mKKFOwL/yEtmJ0Uw0aaHwFOEj9+FQUPYjThCcbz
+fHFvqyh6pXZV7XKcPxCTNuIw2rpw2WqY5/H+lTmUFmSXieFZAAMRueGH8Y5trCHU
+JNCDpGwh8us=
+-----END CERTIFICATE-----`;
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -62,6 +116,95 @@ function createServeStub() {
     }),
     shutdown,
   };
+}
+
+function createNodeBackedDenoServe(): DenoServeFunction {
+  return (options, handler) => {
+    const finished = createDeferred<void>();
+    const server = options.cert && options.key
+      ? createHttpsServer({ cert: options.cert, key: options.key })
+      : createHttpServer();
+
+    server.on('request', (request, response) => {
+      void dispatchNodeRequest(request, response, options, handler).catch((error: unknown) => {
+        response.statusCode = 500;
+        response.end(error instanceof Error ? error.message : 'Unhandled test server error.');
+      });
+    });
+    server.on('close', () => {
+      finished.resolve();
+    });
+    server.on('error', (error) => {
+      finished.reject(error);
+    });
+    options.signal?.addEventListener('abort', () => {
+      server.close();
+    }, { once: true });
+    server.listen(options.port, options.hostname, () => {
+      const address = server.address();
+
+      if (address && typeof address !== 'string') {
+        options.onListen?.({ hostname: address.address, port: address.port });
+      }
+    });
+
+    return {
+      finished: finished.promise,
+      shutdown: async () => {
+        await new Promise<void>((resolve, reject) => {
+          if (!server.listening) {
+            resolve();
+            return;
+          }
+
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+
+            resolve();
+          });
+        });
+      },
+    };
+  };
+}
+
+async function dispatchNodeRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  options: DenoServeOptions,
+  handler: DenoServeHandler,
+): Promise<void> {
+  const protocol = options.cert && options.key ? 'https' : 'http';
+  const host = request.headers.host ?? `${options.hostname ?? '127.0.0.1'}:${String(options.port ?? 0)}`;
+  const headers = new Headers();
+
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        headers.append(name, item);
+      }
+      continue;
+    }
+
+    if (value !== undefined) {
+      headers.set(name, value);
+    }
+  }
+
+  const webResponse = await handler(new Request(`${protocol}://${host}${request.url ?? '/'}`, {
+    headers,
+    method: request.method,
+  }));
+  const body = Buffer.from(await webResponse.arrayBuffer());
+
+  response.statusCode = webResponse.status;
+  webResponse.headers.forEach((value, name) => {
+    response.setHeader(name, value);
+  });
+  response.end(body);
 }
 
 function createUpgradeWebSocketStub() {
@@ -296,6 +439,64 @@ describe('@fluojs/platform-deno', () => {
     );
 
     await app.close();
+  });
+
+  it('forwards HTTPS certificate options to Deno.serve and reports an HTTPS listen target', async () => {
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    const server = createServeStub();
+    const logger: ApplicationLogger = {
+      debug() {},
+      error() {},
+      log: vi.fn(),
+      warn() {},
+    };
+
+    const app = await runDenoApplication(AppModule, {
+      hostname: '127.0.0.1',
+      https: {
+        cert: TEST_TLS_CERTIFICATE,
+        key: TEST_TLS_PRIVATE_KEY,
+      },
+      logger,
+      port: 3443,
+      serve: server.serve,
+    });
+
+    expect(server.options).toMatchObject({
+      cert: TEST_TLS_CERTIFICATE,
+      hostname: '127.0.0.1',
+      key: TEST_TLS_PRIVATE_KEY,
+      port: 3443,
+    });
+    expect(logger.log).toHaveBeenCalledWith(
+      'Listening on https://127.0.0.1:3443',
+      'FluoFactory',
+    );
+
+    await app.close();
+  });
+
+  it('satisfies the shared HTTPS startup portability expectation', async () => {
+    const createServe = () => createNodeBackedDenoServe();
+    const harness = createHttpAdapterPortabilityHarness<BootstrapDenoApplicationOptions, RunDenoApplicationOptions>({
+      bootstrap: async (rootModule: ModuleType, options: BootstrapDenoApplicationOptions): Promise<Application> => await bootstrapDenoApplication(rootModule, {
+        ...options,
+        serve: createServe(),
+      }),
+      name: 'deno',
+      run: async (rootModule: ModuleType, options: RunDenoApplicationOptions): Promise<Application> => await runDenoApplication(rootModule, {
+        ...options,
+        serve: createServe(),
+        shutdownSignals: false,
+      }),
+    });
+
+    await harness.assertReportsHttpsStartupUrl({
+      cert: TEST_TLS_CERTIFICATE,
+      key: TEST_TLS_PRIVATE_KEY,
+    });
   });
 
   it('formats explicit IPv6 listen targets with brackets', () => {

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -13,7 +13,7 @@ import {
   type RequestContext,
 } from '@fluojs/http';
 import { defineModule, type Application, type ApplicationLogger, type ModuleType } from '@fluojs/runtime';
-import { createHttpAdapterPortabilityHarness } from '../../testing/dist/portability/http-adapter-portability.js';
+import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 
 import {
   bootstrapDenoApplication,

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -17,7 +17,9 @@ export interface DenoServeOnListenInfo {
 
 /** Options forwarded to the Deno-native `serve(...)` implementation. */
 export interface DenoServeOptions {
+  cert?: string;
   hostname?: string;
+  key?: string;
   onListen?: (localAddr: DenoServeOnListenInfo) => void;
   port?: number;
   signal?: AbortSignal;
@@ -81,9 +83,17 @@ type DenoGlobalLike = {
   upgradeWebSocket: DenoUpgradeWebSocketFunction;
 };
 
+/** TLS certificate and private key material forwarded to Deno.serve for HTTPS startup. */
+export interface DenoAdapterHttpsOptions {
+  cert: string;
+  key: string;
+}
+
 /** Transport and parsing options for the Deno HTTP adapter factory. */
 export interface DenoAdapterOptions {
+  host?: string;
   hostname?: string;
+  https?: DenoAdapterHttpsOptions;
   maxBodySize?: number;
   multipart?: MultipartOptions;
   onListen?: (localAddr: DenoServeOnListenInfo) => void;
@@ -131,7 +141,7 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
   }
 
   getListenTarget(): HttpAdapterListenTarget {
-    return createListenTarget(this.options.hostname, this.options.port);
+    return createListenTarget(this.options.hostname, this.options.port, this.options.https !== undefined);
   }
 
   getRealtimeCapability() {
@@ -192,7 +202,9 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
 
     this.abortController = abortController;
     this.server = serve({
+      cert: this.options.https?.cert,
       hostname: this.options.hostname,
+      key: this.options.https?.key,
       onListen: this.options.onListen,
       port: this.options.port,
       signal: abortController.signal,
@@ -279,7 +291,7 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
 export function createDenoAdapter(options: DenoAdapterOptions = {}): DenoHttpApplicationAdapter {
   return new DenoHttpApplicationAdapter({
     ...options,
-    hostname: options.hostname ?? DEFAULT_HOSTNAME,
+    hostname: options.hostname ?? options.host ?? DEFAULT_HOSTNAME,
     port: options.port ?? DEFAULT_PORT,
   });
 }
@@ -357,14 +369,15 @@ function createDenoShutdownSignalRegistration(
   };
 }
 
-function createListenTarget(hostname: string, port: number): HttpAdapterListenTarget {
+function createListenTarget(hostname: string, port: number, usesHttps: boolean): HttpAdapterListenTarget {
   const isWildcard = hostname === '0.0.0.0' || hostname === '::';
   const bindTarget = `${formatHostForAuthority(hostname)}:${String(port)}`;
   const publicHostname = isWildcard ? 'localhost' : formatHostForAuthority(hostname);
+  const scheme = usesHttps ? 'https' : 'http';
 
   return {
     bindTarget,
-    url: `http://${publicHostname}:${String(port)}`,
+    url: `${scheme}://${publicHostname}:${String(port)}`,
   };
 }
 

--- a/packages/platform-deno/vitest.config.ts
+++ b/packages/platform-deno/vitest.config.ts
@@ -1,6 +1,16 @@
+import { fileURLToPath } from 'node:url';
+
 import { createFluoVitestWorkspaceConfig } from '../../tooling/vitest/src';
 
 export default createFluoVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  resolve: {
+    alias: [
+      {
+        find: '@fluojs/testing/http-adapter-portability',
+        replacement: fileURLToPath(new URL('../testing/src/portability/http-adapter-portability.ts', import.meta.url)),
+      },
+    ],
+  },
   test: {
     include: ['src/**/*.test.ts'],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,6 +595,9 @@ importers:
         specifier: workspace:^
         version: link:../runtime
     devDependencies:
+      '@fluojs/testing':
+        specifier: workspace:^
+        version: link:../testing
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { configDefaults, defineConfig, mergeConfig } from 'vitest/config';
 
 import { createFluoVitestWorkspaceConfig } from './tooling/vitest/src';
@@ -5,6 +7,14 @@ import { createFluoVitestWorkspaceConfig } from './tooling/vitest/src';
 export default mergeConfig(
   createFluoVitestWorkspaceConfig(new URL('.', import.meta.url)),
   defineConfig({
+    resolve: {
+      alias: [
+        {
+          find: '@fluojs/testing/http-adapter-portability',
+          replacement: fileURLToPath(new URL('./packages/testing/src/portability/http-adapter-portability.ts', import.meta.url)),
+        },
+      ],
+    },
     test: {
       passWithNoTests: true,
       projects: [


### PR DESCRIPTION
## Summary

- Closes #1300.
- Adds explicit HTTPS startup support to `@fluojs/platform-deno` by forwarding `https.cert` and `https.key` to `Deno.serve`.
- Documents Deno HTTPS portability expectations and records the public package behavior update with a changeset.

## Changes

- Added `DenoAdapterHttpsOptions` and a `host` portability alias while preserving `hostname` as the Deno-native option.
- Updated listen target reporting so HTTPS configurations log/report `https://` URLs.
- Added regression coverage in `packages/platform-deno/src/adapter.test.ts`, including the shared `createHttpAdapterPortabilityHarness(...)` HTTPS startup assertion via a Node-backed Deno serve test double.
- Updated `packages/platform-deno/README.md` and `packages/platform-deno/README.ko.md` with HTTPS usage and portability notes.

## Testing

- `lsp_diagnostics` on `packages/platform-deno/src/adapter.ts`: no diagnostics.
- `lsp_diagnostics` on `packages/platform-deno/src/adapter.test.ts`: no diagnostics.
- `lsp_diagnostics` on `packages/platform-deno/vitest.config.ts`: no diagnostics.
- `pnpm build`
- `pnpm --filter @fluojs/platform-deno typecheck`
- `pnpm --filter @fluojs/platform-deno test`
- `pnpm --filter @fluojs/platform-deno build`
- `pnpm verify:platform-consistency-governance`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed platform contract docs were changed; package README EN/KO mirrors were updated together. The changed package README conformance claim is backed by `createHttpAdapterPortabilityHarness(...)` coverage in `packages/platform-deno/src/adapter.test.ts`.