### PR TITLE
Resolve #1299: complete Bun adapter docs and conformance coverage

### DIFF
--- a/.changeset/bun-adapter-docs-conformance.md
+++ b/.changeset/bun-adapter-docs-conformance.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-bun": patch
+---
+
+Document Bun adapter API contracts and add package-local web-runtime portability conformance coverage.

--- a/packages/platform-bun/README.ko.md
+++ b/packages/platform-bun/README.ko.md
@@ -11,6 +11,8 @@
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
 - [공개 API 개요](#공개-api-개요)
+- [어댑터 계약](#어댑터-계약)
+- [Conformance 커버리지](#conformance-커버리지)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
 
@@ -75,6 +77,28 @@ export class MyGateway {}
 - `createBunFetchHandler(options)`: 커스텀 `Bun.serve()` 설정을 위한 네이티브 `fetch(request)` 핸들러를 생성합니다.
 - `bootstrapBunApplication(module, options)`: 암시적 시작 로그 없이 애플리케이션을 부트스트랩하는 고급 헬퍼입니다.
 - `runBunApplication(module, options)`: 시그널 연결을 포함한 빠른 시작을 위한 호환 헬퍼입니다.
+
+어댑터는 realtime 패키지가 사용하는 타입 지정 Bun 통합 seam도 함께 내보냅니다.
+
+- `BunHttpApplicationAdapter`: `Bun.serve()`를 기반으로 동작하는 `HttpApplicationAdapter` 구현체입니다.
+- `BunAdapterOptions`: `createBunAdapter()`가 받는 host, port, TLS, raw-body, multipart, shutdown 옵션입니다.
+- `BootstrapBunApplicationOptions` 및 `RunBunApplicationOptions`: Bun 호스팅 애플리케이션의 bootstrap/run 옵션입니다.
+- `BunWebSocketBinding` 및 `BunRealtimeBindingHost`: 일반 HTTP dispatch 전에 `@fluojs/websockets/bun`이 사용하는 binding 계약입니다.
+
+## 어댑터 계약
+
+- **런타임 host**: 이 패키지는 listen 시점에 `globalThis.Bun.serve()`가 필요합니다. 테스트에서는 Bun 호환 test double을 제공할 수 있지만, production 사용은 Bun 전용입니다.
+- **요청 portability**: Fetch 요청은 shared web dispatcher를 통해 변환되며 malformed cookie 값, query 배열, `rawBody: true`일 때 JSON/text raw body, SSE framing을 보존합니다.
+- **Multipart 동작**: Multipart 요청은 `rawBody`를 노출하지 않으며 multipart limit은 shared runtime parser를 통해 계속 적용됩니다.
+- **시작 target**: `hostname`, `port`, `tls`는 `Bun.serve()`로 전달됩니다. 시작 로그는 설정된 HTTP 또는 HTTPS listen URL을 보고합니다.
+- **종료 소유권**: `close()`는 새 유입을 중단하고, in-flight HTTP handler를 기다린 뒤, drain이 끝나면 adapter state를 정리하며 `runBunApplication()`이 등록한 signal listener를 제거합니다.
+- **Realtime seam**: Bun websocket binding은 서버를 시작하는 `listen()` 전에 구성해야 합니다. Upgrade 요청은 HTTP dispatch로 넘어가기 전에 구성된 binding에 먼저 전달됩니다.
+
+## Conformance 커버리지
+
+`packages/platform-bun/src/adapter.test.ts`는 문서화된 계약을 검증하는 package-local regression 대상입니다. 이 파일은 malformed cookie, JSON/text raw-body 보존, multipart raw-body 제외, SSE framing을 검증하는 Bun fetch-style portability assertion과 startup logging, shutdown listener cleanup, in-flight drain, timeout reporting, websocket binding delegation을 검증하는 집중 테스트를 포함합니다.
+
+저장소의 더 넓은 suite도 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`에서 `createWebRuntimeHttpAdapterPortabilityHarness(...)`로 Bun을 Deno 및 Cloudflare Workers와 함께 실행해 fetch-style platform 간 shared web-runtime portability baseline을 맞춥니다.
 
 ## 관련 패키지
 

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -11,6 +11,8 @@ Bun-backed HTTP adapter for the fluo runtime, built on native `Bun.serve()`.
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
 - [Public API Overview](#public-api-overview)
+- [Adapter Contract](#adapter-contract)
+- [Conformance Coverage](#conformance-coverage)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
 
@@ -75,6 +77,28 @@ export class MyGateway {}
 - `createBunFetchHandler(options)`: Creates a native `fetch(request)` handler for custom `Bun.serve()` setups.
 - `bootstrapBunApplication(module, options)`: Advanced bootstrap without implicit startup logging.
 - `runBunApplication(module, options)`: Compatibility helper for quick startup with signal wiring.
+
+The adapter also exports the typed Bun integration seams used by realtime packages:
+
+- `BunHttpApplicationAdapter`: `HttpApplicationAdapter` implementation backed by `Bun.serve()`.
+- `BunAdapterOptions`: host, port, TLS, raw-body, multipart, and shutdown options accepted by `createBunAdapter()`.
+- `BootstrapBunApplicationOptions` and `RunBunApplicationOptions`: application bootstrap/run options for Bun-hosted apps.
+- `BunWebSocketBinding` and `BunRealtimeBindingHost`: binding contracts used by `@fluojs/websockets/bun` before normal HTTP dispatch.
+
+## Adapter Contract
+
+- **Runtime host**: This package requires `globalThis.Bun.serve()` at listen time. Tests may provide a Bun-compatible test double, but production use is Bun-only.
+- **Request portability**: Fetch requests are translated through the shared web dispatcher, preserving malformed cookie values, query arrays, JSON/text raw bodies when `rawBody: true`, and SSE framing.
+- **Multipart behavior**: Multipart requests never expose `rawBody`, and multipart limits continue to flow through the shared runtime parser.
+- **Startup target**: `hostname`, `port`, and `tls` are forwarded to `Bun.serve()`. Startup logs report the configured HTTP or HTTPS listen URL.
+- **Shutdown ownership**: `close()` stops new ingress, waits for in-flight HTTP handlers, clears adapter state after drain settles, and removes signal listeners registered by `runBunApplication()`.
+- **Realtime seam**: Bun websocket bindings must be configured before `listen()` starts the server. Upgrade requests are offered to the configured binding before falling back to HTTP dispatch.
+
+## Conformance Coverage
+
+`packages/platform-bun/src/adapter.test.ts` is the package-local regression target for the documented contract. It includes Bun fetch-style portability assertions for malformed cookies, JSON/text raw-body preservation, multipart raw-body exclusion, and SSE framing, plus focused tests for startup logging, shutdown listener cleanup, in-flight drain behavior, timeout reporting, and websocket binding delegation.
+
+The broader repository suite also exercises Bun through `createWebRuntimeHttpAdapterPortabilityHarness(...)` alongside Deno and Cloudflare Workers in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`, keeping the shared web-runtime portability baseline aligned across fetch-style platforms.
 
 ## Related Packages
 

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -4,10 +4,12 @@ import { Controller, Get, Post, SseResponse, type FrameworkRequest, type Framewo
 import { defineModule, type ApplicationLogger } from '@fluojs/runtime';
 
 import {
+  bootstrapBunApplication,
   BunHttpApplicationAdapter,
   createBunAdapter,
   createBunFetchHandler,
   runBunApplication,
+  type BootstrapBunApplicationOptions,
   type BunServeOptions,
   type BunServerLike,
   type BunServerWebSocket,
@@ -116,7 +118,180 @@ function createMockServerWebSocket(data: unknown): BunServerWebSocket<unknown> {
   };
 }
 
+function registerBunWebRuntimePortabilitySuite(): void {
+  describe('Bun web-runtime portability conformance', () => {
+    it('preserves malformed cookie values', async () => {
+      const mockBun = installMockBun();
+
+      @Controller('/cookies')
+      class CookieController {
+        @Get('/')
+        readCookies(_input: undefined, context: RequestContext) {
+          return context.request.cookies;
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, { controllers: [CookieController] });
+
+      const app = await bootstrapAndListenBunApplication(AppModule, { cors: false });
+
+      try {
+        const response = await dispatchMockBunRequest(mockBun, new Request('https://runtime.test/cookies', {
+          headers: { cookie: 'good=hello%20world; bad=%E0%A4%A' },
+        }));
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({ bad: '%E0%A4%A', good: 'hello world' });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('preserves raw body for JSON and text requests when enabled', async () => {
+      const mockBun = installMockBun();
+
+      @Controller('/webhooks')
+      class WebhookController {
+        @Post('/json')
+        handleJson(_input: undefined, context: RequestContext) {
+          return {
+            parsed: context.request.body,
+            raw: decodeUtf8(context.request.rawBody),
+          };
+        }
+
+        @Post('/text')
+        handleText(_input: undefined, context: RequestContext) {
+          return {
+            parsed: context.request.body,
+            raw: decodeUtf8(context.request.rawBody),
+          };
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, { controllers: [WebhookController] });
+
+      const app = await bootstrapAndListenBunApplication(AppModule, { cors: false, rawBody: true });
+
+      try {
+        const [jsonResponse, textResponse] = await Promise.all([
+          dispatchMockBunRequest(mockBun, new Request('https://runtime.test/webhooks/json', {
+            body: JSON.stringify({ provider: 'stripe' }),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+          })),
+          dispatchMockBunRequest(mockBun, new Request('https://runtime.test/webhooks/text', {
+            body: 'ping=1',
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+            method: 'POST',
+          })),
+        ]);
+
+        expect(jsonResponse.status).toBe(201);
+        expect(textResponse.status).toBe(201);
+        await expect(jsonResponse.json()).resolves.toEqual({ parsed: { provider: 'stripe' }, raw: '{"provider":"stripe"}' });
+        await expect(textResponse.json()).resolves.toEqual({ parsed: 'ping=1', raw: 'ping=1' });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('does not preserve rawBody for multipart requests', async () => {
+      const mockBun = installMockBun();
+
+      @Controller('/uploads')
+      class UploadController {
+        @Post('/')
+        upload(_input: undefined, context: RequestContext) {
+          return {
+            body: context.request.body,
+            fileCount: context.request.files?.length ?? 0,
+            hasRawBody: context.request.rawBody !== undefined,
+          };
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, { controllers: [UploadController] });
+
+      const app = await bootstrapAndListenBunApplication(AppModule, { cors: false, rawBody: true });
+
+      try {
+        const form = new FormData();
+        form.set('name', 'Ada');
+        form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
+
+        const response = await dispatchMockBunRequest(mockBun, new Request('https://runtime.test/uploads', {
+          body: form,
+          method: 'POST',
+        }));
+
+        expect(response.status).toBe(201);
+        await expect(response.json()).resolves.toEqual({ body: { name: 'Ada' }, fileCount: 1, hasRawBody: false });
+      } finally {
+        await app.close();
+      }
+    });
+
+    it('supports SSE streaming', async () => {
+      const mockBun = installMockBun();
+
+      @Controller('/events')
+      class EventsController {
+        @Get('/')
+        stream(_input: undefined, context: RequestContext) {
+          const stream = new SseResponse(context);
+
+          stream.comment('connected');
+          stream.send({ ready: true }, { event: 'ready', id: 'evt-1' });
+          stream.close();
+
+          return stream;
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, { controllers: [EventsController] });
+
+      const app = await bootstrapAndListenBunApplication(AppModule, { cors: false });
+
+      try {
+        const response = await dispatchMockBunRequest(mockBun, new Request('https://runtime.test/events', {
+          headers: { accept: 'text/event-stream' },
+        }));
+        const body = await response.text();
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toContain('text/event-stream');
+        expect(body).toContain('event: ready');
+        expect(body).toContain('data: {"ready":true}');
+      } finally {
+        await app.close();
+      }
+    });
+  });
+}
+
+async function bootstrapAndListenBunApplication(rootModule: Parameters<typeof bootstrapBunApplication>[0], options: BootstrapBunApplicationOptions) {
+  const app = await bootstrapBunApplication(rootModule, options);
+
+  await app.listen();
+  return app;
+}
+
+async function dispatchMockBunRequest(mockBun: MockBun, request: Request): Promise<Response> {
+  return await mockBun.lastServer!.fetch(request) ?? new Response(null, { status: 404 });
+}
+
+function decodeUtf8(input: Uint8Array | undefined): string {
+  return new TextDecoder().decode(input ?? new Uint8Array());
+}
+
 describe('@fluojs/platform-bun', () => {
+  registerBunWebRuntimePortabilitySuite();
+
   it('translates Bun-style Request semantics into the framework request contract', async () => {
     const fetch = createBunFetchHandler({
       dispatcher: {
@@ -304,7 +479,7 @@ describe('@fluojs/platform-bun', () => {
     defineModule(AppModule, { controllers: [HealthController] });
 
     const originalExitCode = process.exitCode;
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number | string | null) => undefined as never) as typeof process.exit);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined as never) as typeof process.exit);
     const app = await runBunApplication(AppModule, {
       forceExitTimeoutMs: 25,
       hostname: '127.0.0.1',

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -37,11 +37,20 @@ type BunGlobal = {
 };
 
 type BunHostname = string;
+
+/** Shutdown signal names that `runBunApplication()` can register. */
 export type BunApplicationSignal = 'SIGINT' | 'SIGTERM';
+
+/** CORS input accepted by Bun application bootstrap helpers. */
 export type BunCorsInput = false | string | string[] | CorsOptions;
+
+/** TLS options forwarded to `Bun.serve()` without adapter-level normalization. */
 export type BunTlsOptions = Record<string, unknown>;
+
+/** Message payloads accepted by Bun server websocket bindings. */
 export type BunWebSocketMessage = string | ArrayBuffer | Uint8Array;
 
+/** Minimal Bun server websocket shape used by the official websocket binding seam. */
 export interface BunServerWebSocket<TData = unknown> {
   readonly data: TData;
   readonly readyState: number;
@@ -56,6 +65,7 @@ export interface BunServerWebSocket<TData = unknown> {
   unsubscribe(topic: string): void;
 }
 
+/** Callback contract forwarded to the `websocket` option of `Bun.serve()`. */
 export interface BunWebSocketHandler<TData = unknown> {
   backpressureLimit?: number;
   close?(socket: BunServerWebSocket<TData>, code: number, reason: string): void | Promise<void>;
@@ -77,6 +87,7 @@ export interface BunWebSocketHandler<TData = unknown> {
   sendPings?: boolean;
 }
 
+/** Fetch-style websocket binding consumed before normal HTTP dispatch. */
 export interface BunWebSocketBinding<TData = unknown> {
   fetch(request: Request, server: BunServerLike): Response | Promise<Response> | undefined | Promise<Response | undefined>;
   idleTimeout?: number;
@@ -84,14 +95,17 @@ export interface BunWebSocketBinding<TData = unknown> {
   websocket: BunWebSocketHandler<TData>;
 }
 
+/** Host contract exposed by Bun adapters that can install a realtime binding. */
 export interface BunRealtimeBindingHost {
   configureRealtimeBinding<TData>(binding: BunWebSocketBinding<TData> | undefined): void;
 }
 
+/** Backward-compatible host contract for Bun websocket-specific bindings. */
 export interface BunWebSocketBindingHost extends BunRealtimeBindingHost {
   configureWebSocketBinding<TData>(binding: BunWebSocketBinding<TData> | undefined): void;
 }
 
+/** Subset of `Bun.serve()` options used by the adapter and its tests. */
 export interface BunServeOptions {
   development?: boolean;
   error?: (error: Error) => Response | Promise<Response>;
@@ -104,6 +118,7 @@ export interface BunServeOptions {
   websocket?: BunWebSocketHandler;
 }
 
+/** Minimal Bun server handle used by fluo for fetch dispatch, upgrades, and shutdown. */
 export interface BunServerLike {
   fetch?(request: Request): Response | Promise<Response> | undefined | Promise<Response | undefined>;
   hostname?: BunHostname;
@@ -119,46 +134,81 @@ export interface BunServerLike {
   url?: URL;
 }
 
+/** Options for `createBunAdapter()`. */
 export interface BunAdapterOptions {
+  /** Enables Bun development-mode behavior when supported by the host runtime. */
   development?: boolean;
+  /** Hostname passed through to `Bun.serve()`. */
   hostname?: BunHostname;
+  /** Idle timeout passed through to `Bun.serve()`. */
   idleTimeout?: number;
+  /** Maximum request body size forwarded as Bun's `maxRequestBodySize`. */
   maxBodySize?: number;
+  /** Multipart parsing limits used by the shared web request dispatcher. */
   multipart?: MultipartOptions;
+  /** Port passed through to `Bun.serve()`, defaulting to 3000. */
   port?: number;
+  /** Preserves raw bodies for non-multipart requests when enabled. */
   rawBody?: boolean;
+  /** Whether shutdown asks Bun to stop active connections immediately. */
   stopActiveConnections?: boolean;
+  /** TLS options forwarded to `Bun.serve()` for HTTPS startup. */
   tls?: BunTlsOptions;
 }
 
+/** Options for creating a standalone Bun `fetch(request)` handler. */
 export interface CreateBunFetchHandlerOptions {
+  /** Dispatcher that receives translated fluo framework requests. */
   dispatcher: Dispatcher;
+  /** Error message used when a request arrives before dispatcher binding is ready. */
   dispatcherNotReadyMessage?: string;
+  /** Maximum request body size enforced by the shared web dispatcher. */
   maxBodySize?: number;
+  /** Multipart parsing limits used by the shared web dispatcher. */
   multipart?: MultipartOptions;
+  /** Preserves raw bodies for JSON and text requests when enabled. */
   rawBody?: boolean;
 }
 
+/** Bootstrap options for Bun applications that do not install shutdown signal wiring. */
 export interface BootstrapBunApplicationOptions extends Omit<CreateApplicationOptions, 'adapter' | 'logger' | 'middleware'> {
+  /** CORS policy applied by the shared HTTP bootstrap path. */
   cors?: BunCorsInput;
+  /** Enables Bun development-mode behavior when supported by the host runtime. */
   development?: boolean;
+  /** Global route prefix applied by the shared HTTP bootstrap path. */
   globalPrefix?: string;
+  /** Routes excluded from the global prefix. */
   globalPrefixExclude?: readonly string[];
+  /** Hostname passed through to `Bun.serve()`. */
   hostname?: BunHostname;
+  /** Idle timeout passed through to `Bun.serve()`. */
   idleTimeout?: number;
+  /** Application logger used for startup, shutdown, and failure reporting. */
   logger?: ApplicationLogger;
+  /** Maximum request body size forwarded as Bun's `maxRequestBodySize`. */
   maxBodySize?: number;
+  /** Middleware applied by the shared HTTP bootstrap path. */
   middleware?: MiddlewareLike[];
+  /** Multipart parsing limits used by the shared web request dispatcher. */
   multipart?: MultipartOptions;
+  /** Port passed through to `Bun.serve()`, defaulting to 3000. */
   port?: number;
+  /** Preserves raw bodies for non-multipart requests when enabled. */
   rawBody?: boolean;
+  /** Security header policy applied by the shared HTTP bootstrap path. */
   securityHeaders?: false | SecurityHeadersOptions;
+  /** Whether shutdown asks Bun to stop active connections immediately. */
   stopActiveConnections?: boolean;
+  /** TLS options forwarded to `Bun.serve()` for HTTPS startup. */
   tls?: BunTlsOptions;
 }
 
+/** Run options for Bun applications with optional shutdown signal wiring. */
 export interface RunBunApplicationOptions extends BootstrapBunApplicationOptions {
+  /** Maximum signal-driven shutdown duration before fluo reports timeout via `process.exitCode`. */
   forceExitTimeoutMs?: number;
+  /** Shutdown signals to register, or `false` to disable signal wiring. */
   shutdownSignals?: false | readonly BunApplicationSignal[];
 }
 
@@ -168,6 +218,7 @@ const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 const BUN_WEBSOCKET_SUPPORT_REASON =
   'Bun exposes Bun.serve() + server.upgrade() request-upgrade hosting. Use @fluojs/websockets/bun for the official raw websocket binding.';
 
+/** HTTP application adapter backed by native `Bun.serve()`. */
 export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWebSocketBindingHost {
   private closeInFlight?: Promise<void>;
   private dispatcher?: Dispatcher;
@@ -178,10 +229,12 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
 
   constructor(private readonly options: BunAdapterOptions = {}) {}
 
+  /** Returns the active Bun server handle after `listen()` starts. */
   getServer(): BunServerLike | undefined {
     return this.server;
   }
 
+  /** Returns the bind target and externally logged URL for the current Bun server. */
   getListenTarget(): HttpAdapterListenTarget {
     const protocol = this.options.tls ? 'https' : 'http';
     const configuredHostname = this.options.hostname ?? 'localhost';
@@ -195,6 +248,7 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
     };
   }
 
+  /** Reports Bun's fetch-style websocket capability for realtime package integration. */
   getRealtimeCapability() {
     return createFetchStyleHttpAdapterRealtimeCapability(
       BUN_WEBSOCKET_SUPPORT_REASON,
@@ -202,6 +256,7 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
     );
   }
 
+  /** Configures the official realtime binding before the Bun server starts. */
   configureRealtimeBinding<TData>(binding: BunWebSocketBinding<TData> | undefined): void {
     if (this.server && binding !== undefined) {
       throw new Error('Bun websocket binding must be configured before Bun adapter listen() starts the server.');
@@ -210,10 +265,12 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
     this.realtimeBinding = binding;
   }
 
+  /** Configures a Bun websocket binding through the legacy websocket host name. */
   configureWebSocketBinding<TData>(binding: BunWebSocketBinding<TData> | undefined): void {
     this.configureRealtimeBinding(binding);
   }
 
+  /** Starts the Bun server and binds framework dispatch to native fetch requests. */
   async listen(dispatcher: Dispatcher): Promise<void> {
     this.dispatcher = dispatcher;
 
@@ -250,6 +307,7 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
     });
   }
 
+  /** Stops ingress, waits for in-flight HTTP handlers, and releases adapter state. */
   async close(): Promise<void> {
     if (this.closeInFlight) {
       await waitForCloseWithTimeout(this.closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
@@ -333,6 +391,12 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   }
 }
 
+/**
+ * Creates a standalone Bun-compatible fetch handler.
+ *
+ * @param options - Dispatcher and request parsing options for translating native requests.
+ * @returns A `fetch(request)` handler suitable for custom `Bun.serve()` calls.
+ */
 export function createBunFetchHandler({
   dispatcher,
   dispatcherNotReadyMessage = DEFAULT_DISPATCHER_NOT_READY_MESSAGE,
@@ -352,10 +416,23 @@ export function createBunFetchHandler({
   };
 }
 
+/**
+ * Creates the recommended Bun HTTP adapter instance.
+ *
+ * @param options - Bun server and request parsing options.
+ * @returns A fluo HTTP application adapter backed by `Bun.serve()`.
+ */
 export function createBunAdapter(options: BunAdapterOptions = {}): HttpApplicationAdapter {
   return new BunHttpApplicationAdapter(options);
 }
 
+/**
+ * Bootstraps a fluo application with the Bun adapter without starting signal wiring.
+ *
+ * @param rootModule - Root fluo module to compile.
+ * @param options - Bun adapter and application bootstrap options.
+ * @returns The bootstrapped application; call `listen()` to start serving.
+ */
 export async function bootstrapBunApplication(
   rootModule: ModuleType,
   options: BootstrapBunApplicationOptions,
@@ -377,6 +454,13 @@ export async function bootstrapBunApplication(
   );
 }
 
+/**
+ * Bootstraps, starts, and wires shutdown handling for a Bun-hosted fluo application.
+ *
+ * @param rootModule - Root fluo module to compile.
+ * @param options - Bun adapter, application, and shutdown options.
+ * @returns The running application instance.
+ */
 export async function runBunApplication(
   rootModule: ModuleType,
   options: RunBunApplicationOptions,


### PR DESCRIPTION
## Summary

Closes #1299.

Completes `@fluojs/platform-bun` API contract documentation and package-local conformance regression coverage for the Bun fetch-style adapter path.

## Changes

- Added public-export TSDoc for the Bun adapter surface, including adapter options, bootstrap/run helpers, server/websocket binding seams, and lifecycle methods.
- Added Bun package regression coverage for malformed cookies, JSON/text raw-body preservation, multipart raw-body exclusion, and SSE framing, alongside the existing shutdown/startup/websocket tests.
- Documented Bun adapter contracts and conformance evidence in `packages/platform-bun/README.md` and `packages/platform-bun/README.ko.md`.
- Added `.changeset/bun-adapter-docs-conformance.md` for the public package docs/test contract update.

## Testing

- `lsp_diagnostics` on `packages/platform-bun/src/adapter.ts`, `packages/platform-bun/src/adapter.test.ts`, and `packages/platform-bun/vitest.config.ts`: no diagnostics.
- `pnpm --filter @fluojs/platform-bun test` ✅ (`15 passed`)
- `pnpm --filter @fluojs/platform-bun typecheck` ✅
- `pnpm --filter @fluojs/platform-bun build` ✅
- `pnpm lint` ⚠️ repository-wide existing Biome warnings reported outside this change; `pnpm verify:public-export-tsdoc` passed in changed mode.
- `pnpm verify:platform-consistency-governance` ✅
- `pnpm verify:release-readiness` ✅

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by package-local Bun adapter tests and the repository web-runtime portability harness evidence in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`.