### PR TITLE
Resolve #1375: reduce config reload clone pressure

### DIFF
--- a/.changeset/config-reload-deep-clone-guard.md
+++ b/.changeset/config-reload-deep-clone-guard.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/config": patch
+---
+
+Reduce redundant config snapshot cloning during bootstrap and reloads, optimize multi-source deep merging, and serialize overlapping reload requests so consumers keep isolated snapshots without reload interleaving corrupting the active config state.

--- a/docs/contracts/behavioral-contract-policy.ko.md
+++ b/docs/contracts/behavioral-contract-policy.ko.md
@@ -17,6 +17,7 @@ Behavioral contract의 예시는 다음과 같습니다.
 - 데코레이터가 모듈 초기화 전에 실행된다.
 - provider가 필수 입력이 없을 때 configuration error를 던진다.
 - platform adapter가 종료 중 idle keep alive connection을 닫는다.
+- config reload manager가 겹치는 reload 요청을 직렬화하고 reload listener 실패 시 이전 snapshot으로 롤백한다.
 
 ## Rule 2: Breaking Change Policy
 

--- a/docs/contracts/behavioral-contract-policy.md
+++ b/docs/contracts/behavioral-contract-policy.md
@@ -17,6 +17,7 @@ Examples of behavioral contracts include:
 - A decorator runs before module initialization.
 - A provider throws a configuration error when required input is missing.
 - A platform adapter closes idle keep alive connections during shutdown.
+- A config reload manager serializes overlapping reload requests and rolls back to the previous snapshot when a reload listener fails.
 
 ## Rule 2: Breaking Change Policy
 

--- a/packages/config/README.ko.md
+++ b/packages/config/README.ko.md
@@ -84,7 +84,7 @@ class MyService {
 
 `ConfigService.get('a.b.c')`는 dot-path 세그먼트를 순서대로 탐색하므로 조회 비용은 path 깊이에 비례합니다. `get()`, `getOrThrow()`, `snapshot()`이 객체 형태의 값을 반환할 때는 분리된 clone을 반환합니다. 따라서 clone 비용은 반환되는 subtree 크기에 비례하며, 호출자 mutation은 활성 config snapshot에 영향을 주지 않습니다.
 
-`ConfigReloadManager.reload()`는 리로드 작업을 직렬화합니다. 현재 리로드가 listener 알림을 수행하는 동안 다른 리로드가 요청되면 후속 리로드는 큐에 들어가 활성 알림이 끝난 뒤 적용됩니다. 활성 알림이 실패하면 이전 snapshot을 복구하고 큐에 있던 리로드는 폐기합니다.
+`ConfigReloadManager.reload()`는 리로드 작업을 직렬화합니다. 현재 리로드가 listener 알림을 수행하는 동안 다른 리로드가 요청되면 후속 리로드는 큐에 들어가 활성 알림이 끝난 뒤 적용됩니다. 활성 알림이 실패하면 이전 snapshot을 복구하고 큐에 있던 리로드는 폐기합니다. 동일한 직렬화와 rollback 계약은 `createConfigReloader(...).reload()`에도 적용되며, watch로 시작된 알림 중 큐에 들어간 manual reload도 이 계약을 따릅니다.
 
 ## 공개 API
 
@@ -98,7 +98,7 @@ class MyService {
 | `loadConfig(options)` | 설정을 수동으로 로드하기 위한 함수형 엔트리 포인트입니다. |
 | `createConfigReloader(options)` | 동적 설정 업데이트를 위한 리로더를 생성합니다. |
 
-`ConfigReloadManager.reload()`는 기존 `ConfigService` 인스턴스를 갱신하므로 소비자는 주입받은 서비스 identity를 유지하면서 새 스냅샷을 관찰합니다. 리로드 listener가 에러를 던지면 매니저는 이전 스냅샷을 복구하고 listener 에러를 다시 던집니다.
+`ConfigReloadManager.reload()`는 기존 `ConfigService` 인스턴스를 갱신하므로 소비자는 주입받은 서비스 identity를 유지하면서 새 스냅샷을 관찰합니다. 리로드 listener가 에러를 던지면 매니저는 이전 스냅샷을 복구하고 listener 에러를 다시 던집니다. `createConfigReloader(...).reload()`도 standalone reloader snapshot에 대해 동일한 listener 직렬화와 rollback 동작을 따릅니다.
 
 ## 관련 패키지
 

--- a/packages/config/README.ko.md
+++ b/packages/config/README.ko.md
@@ -80,6 +80,12 @@ class MyService {
 
 `validate` 함수는 모든 소스가 합쳐진 뒤 실행되며, 에러를 던지면 부트스트랩이 즉시 중단됩니다.
 
+### 런타임 접근과 리로드 비용 모델
+
+`ConfigService.get('a.b.c')`는 dot-path 세그먼트를 순서대로 탐색하므로 조회 비용은 path 깊이에 비례합니다. `get()`, `getOrThrow()`, `snapshot()`이 객체 형태의 값을 반환할 때는 분리된 clone을 반환합니다. 따라서 clone 비용은 반환되는 subtree 크기에 비례하며, 호출자 mutation은 활성 config snapshot에 영향을 주지 않습니다.
+
+`ConfigReloadManager.reload()`는 리로드 작업을 직렬화합니다. 현재 리로드가 listener 알림을 수행하는 동안 다른 리로드가 요청되면 후속 리로드는 큐에 들어가 활성 알림이 끝난 뒤 적용됩니다. 활성 알림이 실패하면 이전 snapshot을 복구하고 큐에 있던 리로드는 폐기합니다.
+
 ## 공개 API
 
 | 클래스/헬퍼 | 설명 |

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -88,7 +88,7 @@ The `validate` function runs after all sources are merged but before the applica
 ### Runtime Access and Reload Cost Model
 `ConfigService.get('a.b.c')` resolves dot-path keys by walking each path segment, so lookup cost is proportional to path depth. When `get()`, `getOrThrow()`, or `snapshot()` returns an object-like value, the returned value is a detached clone; clone cost is proportional to the returned subtree size so caller mutations cannot affect the active config snapshot.
 
-`ConfigReloadManager.reload()` serializes reload work. If another reload is requested while the current reload is notifying listeners, the follow-up reload is queued and applied after the active notification finishes; if the active notification fails, the previous snapshot is restored and the queued reload is discarded.
+`ConfigReloadManager.reload()` serializes reload work. If another reload is requested while the current reload is notifying listeners, the follow-up reload is queued and applied after the active notification finishes; if the active notification fails, the previous snapshot is restored and the queued reload is discarded. The same serialization and rollback contract applies to `createConfigReloader(...).reload()`, including manual reloads queued during watch-triggered notifications.
 
 ## Public API
 
@@ -102,7 +102,7 @@ The `validate` function runs after all sources are merged but before the applica
 | `loadConfig(options)` | Functional entry point for loading configuration manually. |
 | `createConfigReloader(options)` | Creates a reloader for dynamic configuration updates. |
 
-`ConfigReloadManager.reload()` updates the existing `ConfigService` instance so consumers keep their injected service identity while observing the new snapshot. If a reload listener throws, the manager restores the previous snapshot and rethrows the listener error.
+`ConfigReloadManager.reload()` updates the existing `ConfigService` instance so consumers keep their injected service identity while observing the new snapshot. If a reload listener throws, the manager restores the previous snapshot and rethrows the listener error. `createConfigReloader(...).reload()` follows the same listener serialization and rollback behavior for its standalone reloader snapshot.
 
 ## Related Packages
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -85,6 +85,11 @@ Plain objects are deep-merged by key. Arrays and primitive values from higher-pr
 ### Validation
 The `validate` function runs after all sources are merged but before the application starts. If it throws, the application bootstrap fails immediately.
 
+### Runtime Access and Reload Cost Model
+`ConfigService.get('a.b.c')` resolves dot-path keys by walking each path segment, so lookup cost is proportional to path depth. When `get()`, `getOrThrow()`, or `snapshot()` returns an object-like value, the returned value is a detached clone; clone cost is proportional to the returned subtree size so caller mutations cannot affect the active config snapshot.
+
+`ConfigReloadManager.reload()` serializes reload work. If another reload is requested while the current reload is notifying listeners, the follow-up reload is queued and applied after the active notification finishes; if the active notification fails, the previous snapshot is restored and the queued reload is discarded.
+
 ## Public API
 
 | Class/Helper | Description |

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -2,11 +2,41 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { getModuleMetadata } from '@fluojs/core/internal';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createConfigReloader, loadConfig } from './load.js';
 import { ConfigModule } from './module.js';
 import { ConfigService, replaceConfigServiceSnapshot } from './service.js';
+
+const watchCallbacks = vi.hoisted(() => new Set<() => void>());
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+
+  return {
+    ...actual,
+    watch: vi.fn((_filename, _options, listener) => {
+      const callback = () => listener('change', null);
+      watchCallbacks.add(callback);
+
+      return {
+        close: vi.fn(() => {
+          watchCallbacks.delete(callback);
+        }),
+      };
+    }),
+  };
+});
+
+function emitWatchChange(): void {
+  for (const callback of [...watchCallbacks]) {
+    callback();
+  }
+}
+
+beforeEach(() => {
+  watchCallbacks.clear();
+});
 
 async function waitForCondition(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
   const startedAt = Date.now();
@@ -20,10 +50,6 @@ async function waitForCondition(predicate: () => boolean, timeoutMs = 2_000): Pr
   }
 
   throw new Error('Timed out waiting for condition.');
-}
-
-async function delay(ms: number): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 describe('loadConfig', () => {
@@ -362,13 +388,13 @@ describe('loadConfig', () => {
         errors.push(message);
       });
 
-      await delay(100);
       writeFileSync(envPath, 'PORT=oops\n');
+      emitWatchChange();
       await waitForCondition(() => errors.length > 0);
       expect(reloader.current()['PORT']).toBe('4000');
 
-      await delay(100);
       writeFileSync(envPath, 'PORT=4300\n');
+      emitWatchChange();
       await waitForCondition(() => updates.includes('4300'));
       expect(reloader.current()['PORT']).toBe('4300');
 
@@ -407,6 +433,82 @@ describe('loadConfig', () => {
     }
   });
 
+  it('serializes reentrant reload calls until the active notification finishes', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-reload-serialized-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      envFile: envPath,
+      processEnv: {},
+    });
+
+    try {
+      const updates: string[] = [];
+      let requestedNestedReload = false;
+
+      reloader.subscribe((snapshot, reason) => {
+        if (reason !== 'manual') {
+          return;
+        }
+
+        const port = snapshot['PORT'];
+        if (typeof port === 'string') {
+          updates.push(port);
+        }
+
+        if (!requestedNestedReload) {
+          requestedNestedReload = true;
+          writeFileSync(envPath, 'PORT=4200\n');
+          reloader.reload();
+        }
+      });
+
+      writeFileSync(envPath, 'PORT=4100\n');
+      const reloaded = reloader.reload();
+
+      expect(reloaded['PORT']).toBe('4200');
+      expect(reloader.current()['PORT']).toBe('4200');
+      expect(updates).toEqual(['4100', '4200']);
+    } finally {
+      reloader.close();
+    }
+  });
+
+  it('drops queued reentrant reloads when the active notification rolls back', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-reload-serialized-rollback-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      envFile: envPath,
+      processEnv: {},
+    });
+
+    try {
+      reloader.subscribe((_snapshot, reason) => {
+        if (reason !== 'manual') {
+          return;
+        }
+
+        writeFileSync(envPath, 'PORT=4300\n');
+        reloader.reload();
+        throw new Error('listener failed after nested reload');
+      });
+
+      writeFileSync(envPath, 'PORT=4100\n');
+
+      expect(() => reloader.reload()).toThrow('listener failed after nested reload');
+      expect(reloader.current()['PORT']).toBe('4000');
+    } finally {
+      reloader.close();
+    }
+  });
+
   it('stops watch notifications after close', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-watch-close-'));
     const envPath = join(cwd, '.env.dev');
@@ -435,7 +537,7 @@ describe('loadConfig', () => {
     reloader.close();
 
     writeFileSync(envPath, 'PORT=4400\n');
-    await delay(150);
+    emitWatchChange();
 
     expect(updates).toHaveLength(0);
   });
@@ -475,8 +577,8 @@ describe('loadConfig', () => {
         }
       });
 
-      await delay(100);
       writeFileSync(envPath, 'PORT=4500\n');
+      emitWatchChange();
       await waitForCondition(() => observedBySecondListener !== undefined);
 
       expect(observedBySecondListener).toBe('4500');
@@ -591,6 +693,42 @@ describe('ConfigService', () => {
 });
 
 describe('ConfigModule', () => {
+  it('loads configuration once during provider creation and reuses the service snapshot', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-module-bootstrap-once-'));
+    const envPath = join(cwd, '.env.dev');
+    let parseCalls = 0;
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const moduleRef = ConfigModule.forRoot({
+      envFile: envPath,
+      parse: (content) => {
+        parseCalls += 1;
+        const result: Record<string, string> = {};
+
+        for (const line of content.trim().split('\n')) {
+          const [key, value] = line.split('=');
+          if (key && value) {
+            result[key] = value;
+          }
+        }
+
+        return result;
+      },
+      processEnv: {},
+    });
+    const providers = getModuleMetadata(moduleRef)?.providers as
+      | Array<{ provide?: unknown; useFactory?: () => unknown }>
+      | undefined;
+    const configProvider = providers?.find((provider) => provider.provide === ConfigService);
+    const service = configProvider?.useFactory?.() as ConfigService | undefined;
+
+    expect(service?.get('PORT')).toBe('4000');
+    expect(service?.getOrThrow('PORT')).toBe('4000');
+    expect(service?.snapshot()['PORT']).toBe('4000');
+    expect(parseCalls).toBe(1);
+  });
+
   it('uses the provided processEnv snapshot through ConfigService registration', () => {
     const previousValue = process.env.FLUO_CONFIG_MODULE_TEST_ONLY;
     process.env.FLUO_CONFIG_MODULE_TEST_ONLY = 'from-module-process-env';

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -509,6 +509,49 @@ describe('loadConfig', () => {
     }
   });
 
+  it('reports queued manual reload failures with the manual reason during watch reloads', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-watch-manual-error-reason-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const reloader = createConfigReloader({
+      cwd,
+      envFile: envPath,
+      processEnv: {},
+      watch: true,
+    });
+
+    try {
+      const errorReasons: string[] = [];
+      let queuedManualReload = false;
+
+      reloader.subscribe((_snapshot, reason) => {
+        if (reason === 'watch' && !queuedManualReload) {
+          queuedManualReload = true;
+          writeFileSync(envPath, 'PORT=4200\n');
+          reloader.reload();
+          return;
+        }
+
+        if (reason === 'manual') {
+          throw new Error('queued manual listener failed');
+        }
+      });
+      reloader.subscribeError((_error, reason) => {
+        errorReasons.push(reason);
+      });
+
+      writeFileSync(envPath, 'PORT=4100\n');
+      emitWatchChange();
+
+      expect(errorReasons).toEqual(['manual']);
+      expect(reloader.current()['PORT']).toBe('4100');
+    } finally {
+      reloader.close();
+    }
+  });
+
   it('stops watch notifications after close', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-watch-close-'));
     const envPath = join(cwd, '.env.dev');

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -60,11 +60,15 @@ function normalizeLoadOptions(options: ConfigLoadOptions): NormalizedLoadOptions
 }
 
 function readEnvFileValues(options: NormalizedLoadOptions): ConfigDictionary {
-  if (!existsSync(options.envFile)) {
-    return {};
-  }
+  try {
+    return parseEnvContent(readFileSync(options.envFile, 'utf8'), options.safeProcessEnv, options.parse);
+  } catch (error: unknown) {
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+      return {};
+    }
 
-  return parseEnvContent(readFileSync(options.envFile, 'utf8'), options.safeProcessEnv, options.parse);
+    throw error;
+  }
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -75,20 +79,23 @@ function mergeConfigEntries(
   target: Record<string, unknown>,
   source: Record<string, unknown>,
 ): Record<string, unknown> {
-  const merged: Record<string, unknown> = { ...target };
-
   for (const [key, sourceValue] of Object.entries(source)) {
-    const targetValue = merged[key];
+    const targetValue = target[key];
 
     if (isPlainObject(targetValue) && isPlainObject(sourceValue)) {
-      merged[key] = mergeConfigEntries(targetValue, sourceValue);
+      mergeConfigEntries(targetValue, sourceValue);
       continue;
     }
 
-    merged[key] = cloneConfigDictionary(sourceValue);
+    if (isPlainObject(sourceValue)) {
+      target[key] = mergeConfigEntries({}, sourceValue);
+      continue;
+    }
+
+    target[key] = cloneConfigDictionary(sourceValue);
   }
 
-  return merged;
+  return target;
 }
 
 function mergeConfigSources(...sources: ConfigDictionary[]): ConfigDictionary {
@@ -139,6 +146,8 @@ function createSubscription<T>(listeners: Set<T>, listener: T): ConfigReloadSubs
 
 type ReloaderState = {
   current: ConfigDictionary;
+  pendingReloadReason: ConfigReloadReason | undefined;
+  reloading: boolean;
   watcher: FSWatcher | undefined;
 };
 
@@ -162,7 +171,7 @@ function notifyReloadErrorListeners(
   }
 }
 
-function applyReload(
+function applyReloadNow(
   normalized: NormalizedLoadOptions,
   state: ReloaderState,
   listeners: ReadonlySet<ConfigReloadListener>,
@@ -181,6 +190,35 @@ function applyReload(
   }
 
   return cloneConfigDictionary(next);
+}
+
+function applyReload(
+  normalized: NormalizedLoadOptions,
+  state: ReloaderState,
+  listeners: ReadonlySet<ConfigReloadListener>,
+  reason: ConfigReloadReason,
+): ConfigDictionary {
+  if (state.reloading) {
+    state.pendingReloadReason = reason;
+    return cloneConfigDictionary(state.current);
+  }
+
+  state.reloading = true;
+
+  try {
+    let latest = applyReloadNow(normalized, state, listeners, reason);
+
+    while (state.pendingReloadReason) {
+      const pendingReason = state.pendingReloadReason;
+      state.pendingReloadReason = undefined;
+      latest = applyReloadNow(normalized, state, listeners, pendingReason);
+    }
+
+    return latest;
+  } finally {
+    state.pendingReloadReason = undefined;
+    state.reloading = false;
+  }
 }
 
 function startReloaderWatcher(
@@ -241,6 +279,8 @@ export function createConfigReloader(options: ConfigLoadOptions): ConfigReloader
   const normalized = normalizeLoadOptions(options);
   const state: ReloaderState = {
     current: resolveConfig(normalized),
+    pendingReloadReason: undefined,
+    reloading: false,
     watcher: undefined,
   };
   const listeners = new Set<ConfigReloadListener>();

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -26,6 +26,22 @@ interface NormalizedLoadOptions {
   validate?: (raw: ConfigDictionary) => ConfigDictionary;
 }
 
+const reloadFailureReasons = new WeakMap<object, ConfigReloadReason>();
+
+function markReloadFailure(error: unknown, reason: ConfigReloadReason): void {
+  if (typeof error === 'object' && error !== null) {
+    reloadFailureReasons.set(error, reason);
+  }
+}
+
+function getReloadFailureReason(error: unknown): ConfigReloadReason | undefined {
+  if (typeof error !== 'object' || error === null) {
+    return undefined;
+  }
+
+  return reloadFailureReasons.get(error);
+}
+
 function parseEnvContent(content: string, safeProcessEnv: Record<string, string>, customParser?: (content: string) => Record<string, string>): Record<string, string> {
   if (customParser) {
     return customParser(content);
@@ -204,17 +220,22 @@ function applyReload(
   }
 
   state.reloading = true;
+  let activeReason = reason;
 
   try {
-    let latest = applyReloadNow(normalized, state, listeners, reason);
+    let latest = applyReloadNow(normalized, state, listeners, activeReason);
 
     while (state.pendingReloadReason) {
       const pendingReason = state.pendingReloadReason;
       state.pendingReloadReason = undefined;
+      activeReason = pendingReason;
       latest = applyReloadNow(normalized, state, listeners, pendingReason);
     }
 
     return latest;
+  } catch (error: unknown) {
+    markReloadFailure(error, activeReason);
+    throw error;
   } finally {
     state.pendingReloadReason = undefined;
     state.reloading = false;
@@ -236,7 +257,7 @@ function startReloaderWatcher(
     try {
       applyReload(normalized, state, listeners, 'watch');
     } catch (error: unknown) {
-      notifyReloadErrorListeners(errorListeners, error, 'watch');
+      notifyReloadErrorListeners(errorListeners, error, getReloadFailureReason(error) ?? 'watch');
     }
   });
 }

--- a/packages/config/src/module.ts
+++ b/packages/config/src/module.ts
@@ -1,7 +1,7 @@
 import { defineModuleMetadata } from '@fluojs/core/internal';
 
 import { loadConfig } from './load.js';
-import { ConfigService } from './service.js';
+import { ConfigService, createConfigServiceFromSnapshot } from './service.js';
 import type { ConfigModuleOptions } from './types.js';
 
 /**
@@ -36,7 +36,7 @@ export class ConfigModule {
       providers: [
         {
           provide: ConfigService,
-          useFactory: () => new ConfigService(loadConfig(options ?? {})),
+          useFactory: () => createConfigServiceFromSnapshot(loadConfig(options ?? {})),
         },
       ],
     });

--- a/packages/config/src/reload-module.test.ts
+++ b/packages/config/src/reload-module.test.ts
@@ -76,4 +76,50 @@ describe('ConfigReloadManager', () => {
       manager.close();
     }
   });
+
+  it('serializes nested manager reloads without corrupting the shared service snapshot', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'fluo-config-manager-serialized-'));
+    const envPath = join(cwd, '.env.dev');
+
+    writeFileSync(envPath, 'PORT=4000\n');
+
+    const service = new ConfigService<ConfigDictionary>({ PORT: '4000' });
+    const manager = new ConfigReloadManager(service, {
+      cwd,
+      envFile: envPath,
+      processEnv: {},
+    });
+
+    try {
+      const updates: string[] = [];
+      let requestedNestedReload = false;
+
+      manager.subscribe((snapshot, reason) => {
+        if (reason !== 'manual') {
+          return;
+        }
+
+        const port = snapshot['PORT'];
+        if (typeof port === 'string') {
+          updates.push(port);
+        }
+
+        if (!requestedNestedReload) {
+          requestedNestedReload = true;
+          writeFileSync(envPath, 'PORT=4300\n');
+          manager.reload();
+        }
+      });
+
+      writeFileSync(envPath, 'PORT=4200\n');
+      const reloaded = manager.reload();
+
+      expect(reloaded['PORT']).toBe('4300');
+      expect(service.get('PORT')).toBe('4300');
+      expect(manager.current()['PORT']).toBe('4300');
+      expect(updates).toEqual(['4200', '4300']);
+    } finally {
+      manager.close();
+    }
+  });
 });

--- a/packages/config/src/reload-module.ts
+++ b/packages/config/src/reload-module.ts
@@ -3,7 +3,10 @@ import { defineModuleMetadata } from '@fluojs/core/internal';
 
 import { cloneConfigDictionary } from './clone.js';
 import { createConfigReloader } from './load.js';
-import { ConfigService, replaceConfigServiceSnapshot } from './service.js';
+import {
+  ConfigService,
+  replaceConfigServiceSnapshotUnchecked,
+} from './service.js';
 import type {
   ConfigDictionary,
   ConfigLoadOptions,
@@ -100,13 +103,13 @@ export class ConfigReloadManager implements ConfigReloader {
       const previousConfig = this.config.snapshot();
 
       try {
-        replaceConfigServiceSnapshot(this.config, nextConfig);
+        replaceConfigServiceSnapshotUnchecked(this.config, nextConfig);
 
         for (const listener of this.reloadListeners) {
           listener(cloneConfigDictionary(nextConfig), reason);
         }
       } catch (error: unknown) {
-        replaceConfigServiceSnapshot(this.config, previousConfig);
+        replaceConfigServiceSnapshotUnchecked(this.config, previousConfig);
         throw error;
       }
     });

--- a/packages/config/src/service.ts
+++ b/packages/config/src/service.ts
@@ -90,3 +90,29 @@ export function replaceConfigServiceSnapshot<T extends Record<string, unknown>>(
 ): void {
   service['values'] = cloneConfigDictionary(values);
 }
+
+/**
+ * Replaces the underlying configuration snapshot with an already-detached value.
+ *
+ * @param service The `ConfigService` instance to update.
+ * @param values A trusted configuration dictionary that must not be mutated after adoption.
+ */
+export function replaceConfigServiceSnapshotUnchecked<T extends Record<string, unknown>>(
+  service: ConfigService<T>,
+  values: T,
+): void {
+  service['values'] = values;
+}
+
+/**
+ * Creates a `ConfigService` by adopting an already-detached configuration snapshot.
+ *
+ * @param values A trusted configuration dictionary produced by the config loader.
+ * @returns A `ConfigService` backed by the provided snapshot without an additional constructor clone.
+ */
+export function createConfigServiceFromSnapshot<T extends Record<string, unknown>>(values: T): ConfigService<T> {
+  const service = Object.create(ConfigService.prototype) as ConfigService<T>;
+  service['values'] = values;
+
+  return service;
+}


### PR DESCRIPTION
## Summary

Closes #1375.

Reduces redundant snapshot cloning in `@fluojs/config`, makes reload reentrancy deterministic, and documents the resulting runtime contract for config access and reload behavior.

## Changes

- Replaced env file `existsSync + readFileSync` loading with `readFileSync`/`ENOENT` handling and changed deep merge to a single-accumulator algorithm.
- Added internal trusted snapshot adoption paths so ConfigModule bootstrap and reload manager propagation do not clone the same detached snapshot again.
- Serialized reentrant reload requests and discarded queued reloads when the active notification rolls back.
- Replaced watch-mode sleep-based tests with a deterministic `node:fs.watch` mock and added bootstrap-once/reentrant reload regression tests.
- Documented `ConfigService.get()` object clone cost, reload serialization behavior, and added a patch changeset for `@fluojs/config`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --dir packages/core build`
- `pnpm --dir packages/config typecheck`
- `pnpm --dir packages/config test` (45 tests passed)
- `pnpm --dir packages/config build`
- `pnpm verify:platform-consistency-governance`
- `pnpm lint` (public export TSDoc passed; existing repo-wide Biome warnings remain reported)
- `lsp_diagnostics` on modified TypeScript files: no diagnostics after dependency build

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A — this change does not affect platform adapter conformance.