### PR TITLE
Resolve #1374: reduce DI resolution hot-path overhead

### DIFF
--- a/.changeset/di-resolution-hot-path.md
+++ b/.changeset/di-resolution-hot-path.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/di": patch
+---
+
+Cache forwardRef token lookups and avoid extra singleton cache traversal work on repeated DI resolutions.

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -337,6 +337,30 @@ describe('Container', () => {
       expect(resolveServiceB).toHaveBeenCalledTimes(1);
     });
 
+    it('memoizes forwardRef token lookup when the resolved token is an empty string', async () => {
+      const emptyToken = '';
+
+      class ServiceA {
+        constructor(readonly value: string) {}
+      }
+
+      const resolveEmptyToken = vi.fn(() => emptyToken);
+      const container = new Container().register(
+        { provide: emptyToken, useValue: 'empty-token-value' },
+        { provide: ServiceA, scope: Scope.TRANSIENT, useClass: ServiceA, inject: [forwardRef(resolveEmptyToken)] },
+      );
+
+      expect(container.has(emptyToken)).toBe(true);
+
+      const first = await container.resolve(ServiceA);
+      const second = await container.resolve(ServiceA);
+
+      expect(first).not.toBe(second);
+      expect(first.value).toBe('empty-token-value');
+      expect(second.value).toBe('empty-token-value');
+      expect(resolveEmptyToken).toHaveBeenCalledTimes(1);
+    });
+
     it('fails fast for a true circular dependency even when both sides use forwardRef', async () => {
       class ServiceA {
         constructor(public b: ServiceB) {}

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Inject, Scope as ScopeDecorator } from '@fluojs/core';
 
@@ -315,6 +315,26 @@ describe('Container', () => {
       expect(a).toBeInstanceOf(ServiceA);
       expect(a.b).toBeInstanceOf(ServiceB);
       expect(a.b.value).toBe('b');
+    });
+
+    it('memoizes forwardRef token lookup across repeated singleton resolutions', async () => {
+      class ServiceA {
+        constructor(public b: ServiceB) {}
+      }
+
+      class ServiceB {}
+
+      const resolveServiceB = vi.fn(() => ServiceB);
+      const container = new Container().register(
+        { provide: ServiceA, useClass: ServiceA, inject: [forwardRef(resolveServiceB)] },
+        { provide: ServiceB, useClass: ServiceB, inject: [] },
+      );
+
+      const first = await container.resolve(ServiceA);
+      const second = await container.resolve(ServiceA);
+
+      expect(first).toBe(second);
+      expect(resolveServiceB).toHaveBeenCalledTimes(1);
     });
 
     it('fails fast for a true circular dependency even when both sides use forwardRef', async () => {
@@ -682,6 +702,60 @@ describe('Container', () => {
       expect(error).toBeInstanceOf(ScopeMismatchError);
       expect(error).not.toBeInstanceOf(CircularDependencyError);
     });
+
+    it('resolves a large alias graph without repeating factory construction after cache warmup', async () => {
+      const target = Symbol('LargeGraphTarget');
+      const aliases = Array.from({ length: 12 }, (_, index) => Symbol(`LargeGraphAlias${index}`));
+      const createTarget = vi.fn(() => ({ value: 'target' }));
+
+      const container = new Container().register(
+        { provide: target, useFactory: createTarget },
+        ...aliases.map((alias, index) => ({
+          provide: alias,
+          useExisting: index === 0 ? target : aliases[index - 1],
+        })),
+      );
+
+      const first = await container.resolve(aliases.at(-1)!);
+      const second = await container.resolve(aliases.at(-1)!);
+
+      expect(first).toBe(second);
+      expect(createTarget).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('has()', () => {
+    it('checks local, parent, shadowed, and missing single providers through the scope chain', () => {
+      const ROOT = Symbol('RootToken');
+      const SHADOWED = Symbol('ShadowedToken');
+      const CHILD_ONLY = Symbol('ChildOnlyToken');
+      const MISSING = Symbol('MissingToken');
+
+      const root = new Container().register(
+        { provide: ROOT, useValue: 'root' },
+        { provide: SHADOWED, useValue: 'root-shadowed' },
+      );
+      const child = root.createRequestScope().override({ provide: SHADOWED, useValue: 'child-shadowed' });
+      const grandchild = child.createRequestScope().register({ provide: CHILD_ONLY, useFactory: () => 'grandchild-only', scope: Scope.REQUEST });
+
+      expect(grandchild.has(ROOT)).toBe(true);
+      expect(grandchild.has(SHADOWED)).toBe(true);
+      expect(grandchild.has(CHILD_ONLY)).toBe(true);
+      expect(root.has(CHILD_ONLY)).toBe(false);
+      expect(grandchild.has(MISSING)).toBe(false);
+    });
+
+    it('checks parent-chain multi providers without leaking child registrations to parents', () => {
+      const PLUGINS = Symbol('Plugins');
+      const CHILD_PLUGINS = Symbol('ChildPlugins');
+
+      const root = new Container().register({ provide: PLUGINS, useValue: 'root-plugin', multi: true });
+      const child = root.createRequestScope().register({ provide: CHILD_PLUGINS, useFactory: () => 'child-plugin', multi: true, scope: Scope.REQUEST });
+
+      expect(child.has(PLUGINS)).toBe(true);
+      expect(child.has(CHILD_PLUGINS)).toBe(true);
+      expect(root.has(CHILD_PLUGINS)).toBe(false);
+    });
   });
 
   describe('multi-provider', () => {
@@ -796,6 +870,19 @@ describe('Container', () => {
       expect(rootResolved[0]).toBe(secondRequestResolved[0]);
       expect(rootResolved[0]?.config.value).toBe('root-config');
       expect(requestResolved[0]?.config.value).not.toBe('request-config');
+    });
+
+    it('keeps child-owned request providers out of parent lookup and caches', async () => {
+      const token = Symbol('ChildRequestProvider');
+      const root = new Container();
+      const child = root.createRequestScope().register({ provide: token, useFactory: () => ({ value: 'child' }), scope: Scope.REQUEST });
+
+      const first = await child.resolve<{ value: string }>(token);
+      const second = await child.resolve<{ value: string }>(token);
+
+      expect(first).toBe(second);
+      expect(root.has(token)).toBe(false);
+      await expect(root.resolve(token)).rejects.toThrow(ContainerResolutionError);
     });
   });
 

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -168,6 +168,7 @@ export class Container {
   private readonly staleDisposalTasks = new Set<Promise<void>>();
   private readonly staleDisposalErrors: unknown[] = [];
   private readonly singletonCache: Map<Token, Promise<unknown>>;
+  private readonly forwardRefTokenCache = new WeakMap<ForwardRefFn, Token>();
   private readonly childScopes = new Set<Container>();
   private disposePromise: Promise<void> | undefined;
   private disposed = false;
@@ -468,6 +469,12 @@ export class Container {
       return (await this.withTokenInChain(token, chain, activeTokens, async (c, at) => this.instantiate(provider, c, at))) as T;
     }
 
+    const cachedInstance = this.getCachedScopedOrSingletonInstance(provider);
+
+    if (cachedInstance) {
+      return (await cachedInstance) as T;
+    }
+
     return (await this.withTokenInChain(token, chain, activeTokens, async (c, at) =>
       this.resolveScopedOrSingletonInstance(provider, c, at),
     )) as T;
@@ -588,6 +595,18 @@ export class Container {
     return cache.get(provider.provide);
   }
 
+  private getCachedScopedOrSingletonInstance(provider: NormalizedProvider): Promise<unknown> | undefined {
+    if (provider.scope !== Scope.DEFAULT) {
+      return undefined;
+    }
+
+    if (this.shouldResolveFromRoot(provider)) {
+      return this.root().getCachedScopedOrSingletonInstance(provider);
+    }
+
+    return this.cacheFor(provider).get(provider.provide);
+  }
+
   private shouldResolveFromRoot(provider: NormalizedProvider): boolean {
     return provider.scope === Scope.DEFAULT && this.requestScopeEnabled && !this.registrations.has(provider.provide);
   }
@@ -612,7 +631,7 @@ export class Container {
     }
 
     if (isForwardRef(depEntry)) {
-      const resolvedToken = depEntry.forwardRef();
+      const resolvedToken = this.resolveForwardRefToken(depEntry);
 
       return this.resolveWithChain(resolvedToken, chain, activeTokens, /* allowForwardRef */ true);
     }
@@ -918,7 +937,7 @@ export class Container {
 
   private resolveProviderDependencyToken(depEntry: Token | ForwardRefFn | OptionalToken): Token {
     if (isForwardRef(depEntry)) {
-      return depEntry.forwardRef();
+      return this.resolveForwardRefToken(depEntry);
     }
 
     if (isOptionalToken(depEntry)) {
@@ -926,6 +945,18 @@ export class Container {
     }
 
     return depEntry as Token;
+  }
+
+  private resolveForwardRefToken(forwardRefEntry: ForwardRefFn): Token {
+    const cachedToken = this.forwardRefTokenCache.get(forwardRefEntry);
+
+    if (cachedToken) {
+      return cachedToken;
+    }
+
+    const resolvedToken = forwardRefEntry.forwardRef();
+    this.forwardRefTokenCache.set(forwardRefEntry, resolvedToken);
+    return resolvedToken;
   }
 
   private async resolveProviderDeps(provider: NormalizedProvider, chain: Token[], activeTokens: Set<Token>): Promise<unknown[]> {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -948,10 +948,8 @@ export class Container {
   }
 
   private resolveForwardRefToken(forwardRefEntry: ForwardRefFn): Token {
-    const cachedToken = this.forwardRefTokenCache.get(forwardRefEntry);
-
-    if (cachedToken) {
-      return cachedToken;
+    if (this.forwardRefTokenCache.has(forwardRefEntry)) {
+      return this.forwardRefTokenCache.get(forwardRefEntry)!;
     }
 
     const resolvedToken = forwardRefEntry.forwardRef();


### PR DESCRIPTION
## Summary

Closes #1374

`@fluojs/di` resolution hot-path에서 반복되는 `forwardRef` token lookup과 이미 캐시된 singleton의 불필요한 resolution chain 진입을 줄입니다.

## Changes

- `Container`에 container-local `WeakMap` 기반 `forwardRef` token cache를 추가했습니다.
- 이미 캐시된 singleton provider는 dependency chain wrapper에 다시 진입하지 않고 캐시된 promise를 바로 반환하도록 했습니다.
- request-scoped provider는 기존 GraphQL/request lifecycle ordering을 보존하기 위해 조기 반환 대상에서 제외했습니다.
- forwardRef memoization, 12-hop alias graph cache warmup, `has()` parent-chain traversal, child request provider parent pollution 방지 테스트를 추가했습니다.
- public package patch changeset을 추가했습니다.

## Testing

- LSP diagnostics: `packages/di/src/container.ts`, `packages/di/src/container.test.ts` — no diagnostics
- `pnpm --filter @fluojs/di test` — 72 passed
- `pnpm --filter @fluojs/di typecheck` — passed
- `pnpm exec vitest run packages/graphql/src/module.test.ts -t "reuses one request scope across all resolver fields"` — passed
- `pnpm build` — passed
- `pnpm typecheck` — passed
- `pnpm verify:release-readiness` — passed

## Public export documentation

- [x] Changed public exports include a source-level summary. (No public exports changed.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (No public exports changed.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (No README/API example changes.)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (No new user-facing behavior; performance-preserving internal change.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (Not applicable.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (Not applicable.)