### PR TITLE
Resolve #1376: reduce runtime bootstrap overhead

### DIFF
--- a/.changeset/runtime-request-bootstrap-hot-path.md
+++ b/.changeset/runtime-request-bootstrap-hot-path.md
@@ -2,4 +2,4 @@
 "@fluojs/runtime": patch
 ---
 
-Reduce runtime hot-path overhead by memoizing request metadata materialization, context singleton lookups, and independent bootstrap lifecycle provider resolution.
+Reduce runtime hot-path overhead by memoizing request metadata materialization, safe direct root singleton context lookups, and independent bootstrap lifecycle provider resolution.

--- a/.changeset/runtime-request-bootstrap-hot-path.md
+++ b/.changeset/runtime-request-bootstrap-hot-path.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Reduce runtime hot-path overhead by memoizing request metadata materialization, context singleton lookups, and independent bootstrap lifecycle provider resolution.

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -123,6 +123,9 @@ class UsersModule {}
 ## 동작 계약
 
 - 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다.
+- 쿠키와 쿼리 파라미터 같은 요청 메타데이터는 요청별로 lazy하게 materialize되고 memoize됩니다. 동일한 `FrameworkRequest` 필드를 반복 접근해도 공개 요청 shape은 유지하면서 같은 파싱 값을 재사용합니다.
+- `ApplicationContext.get()`과 `Application.get()`은 context 수준 singleton 토큰 조회를 memoize하며, request/transient provider 해석 의미는 그대로 유지합니다.
+- Bootstrap은 독립적인 singleton lifecycle provider를 병렬로 해석한 뒤 lifecycle hook은 결정적인 provider 순서대로 실행합니다.
 - 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.
 - 런타임 health 모듈은 bootstrap이 ready로 표시하기 전까지 `/ready`를 HTTP 503과 `starting`으로 보고하며, 애플리케이션/컨텍스트 종료가 시작되는 즉시, 종료 시도가 실패하더라도 다시 `starting`으로 내려갑니다.

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -124,7 +124,7 @@ class UsersModule {}
 
 - 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다.
 - 쿠키와 쿼리 파라미터 같은 요청 메타데이터는 요청별로 lazy하게 materialize되고 memoize됩니다. 동일한 `FrameworkRequest` 필드를 반복 접근해도 공개 요청 shape은 유지하면서 같은 파싱 값을 재사용합니다.
-- `ApplicationContext.get()`과 `Application.get()`은 context 수준 singleton 토큰 조회를 memoize하며, request/transient provider 해석 의미는 그대로 유지합니다.
+- `ApplicationContext.get()`과 `Application.get()`은 bootstrap 시점에 알려진 직접 root singleton class/factory provider 조회만 memoize하며, alias, request, transient, 종료 이후, `container.override()` 해석 의미는 그대로 유지합니다.
 - Bootstrap은 독립적인 singleton lifecycle provider를 병렬로 해석한 뒤 lifecycle hook은 결정적인 provider 순서대로 실행합니다.
 - 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -123,8 +123,11 @@ class UsersModule {}
 ## 동작 계약
 
 - 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다.
-- 쿠키와 쿼리 파라미터 같은 요청 메타데이터는 요청별로 lazy하게 materialize되고 memoize됩니다. 동일한 `FrameworkRequest` 필드를 반복 접근해도 공개 요청 shape은 유지하면서 같은 파싱 값을 재사용합니다.
-- `ApplicationContext.get()`과 `Application.get()`은 bootstrap 시점에 알려진 직접 root singleton class/factory provider 조회만 memoize하며, alias, request, transient, 종료 이후, `container.override()` 해석 의미는 그대로 유지합니다.
+- Node 기반 쿠키/쿼리 값과 Web 표준 헤더는 요청 wrapper가 생성되는 시점에 snapshot으로 고정된 뒤 요청별로 lazy하게 normalize되고 memoize됩니다. 이후 upstream 객체가 변경되어도 `FrameworkRequest` view는 바뀌지 않습니다.
+- `ApplicationContext.get()`과 `Application.get()`은 bootstrap 시점에 알려진 직접 root singleton class/factory provider 조회만 memoize하며, alias, request, transient, 종료 이후, multi-provider, `container.override()` 해석 의미는 그대로 유지합니다.
+- `multi: true` provider token은 context cache에 memoize되지 않습니다. 각 `get()` 호출은 DI로 위임되어 컨테이너가 새로운 contribution 배열을 조립하며, 각 contribution 자체는 해당 provider scope에 따라 재사용됩니다.
+- `duplicateProviderPolicy`가 `warn` 또는 `ignore`일 때 context cache 적격성과 lifecycle hook 실행은 bootstrap이 선택한 effective winning provider를 기준으로 결정됩니다. stale losing provider는 cache entry나 lifecycle hook을 만들지 않습니다.
+- 애플리케이션 또는 컨텍스트 bootstrap이 런타임 리소스나 lifecycle instance 생성 이후 실패하면 fluo는 readiness를 초기화하고, 등록된 runtime cleanup callback을 실행하며, 그 시점까지 해석된 instance의 shutdown hook을 `bootstrap-failed`로 호출하고, 컨테이너를 dispose하고, cleanup 실패를 로그로 남긴 뒤 원래 bootstrap error를 다시 던집니다.
 - Bootstrap은 독립적인 singleton lifecycle provider를 병렬로 해석한 뒤 lifecycle hook은 결정적인 provider 순서대로 실행합니다.
 - 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -124,7 +124,7 @@ class UsersModule {}
 
 - Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests.
 - Request metadata such as cookies and query parameters is materialized lazily and memoized per request; accessing the same `FrameworkRequest` field repeatedly returns the same parsed value without changing the public request shape.
-- `ApplicationContext.get()` and `Application.get()` memoize context-level singleton token lookups while preserving request and transient provider resolution semantics.
+- `ApplicationContext.get()` and `Application.get()` memoize only direct root singleton class/factory provider lookups known at bootstrap, while preserving alias, request, transient, post-close, and `container.override()` resolution semantics.
 - Bootstrap resolves independent singleton lifecycle providers concurrently, then runs lifecycle hooks in deterministic provider order.
 - Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -123,8 +123,11 @@ class UsersModule {}
 ## Behavioral Contracts
 
 - Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests.
-- Request metadata such as cookies and query parameters is materialized lazily and memoized per request; accessing the same `FrameworkRequest` field repeatedly returns the same parsed value without changing the public request shape.
-- `ApplicationContext.get()` and `Application.get()` memoize only direct root singleton class/factory provider lookups known at bootstrap, while preserving alias, request, transient, post-close, and `container.override()` resolution semantics.
+- Node-backed cookies/query values and Web-standard headers are snapshotted when the request wrapper is created, then lazily normalized and memoized per request; later upstream object mutations do not change the `FrameworkRequest` view.
+- `ApplicationContext.get()` and `Application.get()` memoize only direct root singleton class/factory provider lookups known at bootstrap, while preserving alias, request, transient, post-close, multi-provider, and `container.override()` resolution semantics.
+- `multi: true` provider tokens are not context-cache memoized: each `get()` call delegates to DI so the container can assemble a fresh contribution array while still reusing each contribution according to its own provider scope.
+- When `duplicateProviderPolicy` is `warn` or `ignore`, context-cache eligibility and lifecycle hook execution are based on the effective winning provider selected by bootstrap; stale losing providers do not seed cache entries or lifecycle hooks.
+- If application or context bootstrap fails after runtime resources or lifecycle instances have been created, fluo resets readiness, runs registered runtime cleanup callbacks, invokes shutdown hooks for instances resolved so far with `bootstrap-failed`, disposes the container, logs cleanup failures, and rethrows the original bootstrap error.
 - Bootstrap resolves independent singleton lifecycle providers concurrently, then runs lifecycle hooks in deterministic provider order.
 - Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -123,6 +123,9 @@ class UsersModule {}
 ## Behavioral Contracts
 
 - Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests.
+- Request metadata such as cookies and query parameters is materialized lazily and memoized per request; accessing the same `FrameworkRequest` field repeatedly returns the same parsed value without changing the public request shape.
+- `ApplicationContext.get()` and `Application.get()` memoize context-level singleton token lookups while preserving request and transient provider resolution semantics.
+- Bootstrap resolves independent singleton lifecycle providers concurrently, then runs lifecycle hooks in deterministic provider order.
 - Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.
 - Runtime health modules report `/ready` as `starting` with HTTP 503 until bootstrap marks them ready, and they return to `starting` as soon as application/context shutdown begins, including failed shutdown attempts.

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -3,7 +3,7 @@ import { request as httpsRequest } from 'node:https';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { Inject } from '@fluojs/core';
+import { Inject, Scope } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
 import {
   Controller,
@@ -2175,6 +2175,51 @@ describe('bootstrapApplication', () => {
     expect(response.body).toEqual({ ok: true });
     expect(loggerEvents).toContain('error:HttpDispatcher:Request observer threw an unhandled error.:observer seam failed');
     expect(loggerEvents).toContain('error:HttpDispatcher:Request-scoped container dispose threw an error.:scope dispose failed');
+  });
+
+  it('isolates request-scoped providers during concurrent dispatch', async () => {
+    const seenIds = new Set<number>();
+    let nextId = 0;
+
+    @Scope('request')
+    class RequestScopedCounter {
+      readonly id = ++nextId;
+    }
+
+    @Controller('/concurrent-scope')
+    class ConcurrentScopeController {
+      @Get('/')
+      async get(_input: unknown, ctx: RequestContext) {
+        const counter = await ctx.container.resolve(RequestScopedCounter);
+        seenIds.add(counter.id);
+        return { id: counter.id };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [ConcurrentScopeController],
+      providers: [RequestScopedCounter],
+    });
+
+    const port = await findAvailablePort();
+    const app = registerAppForCleanup(await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    }));
+
+    await app.listen();
+
+    const responses = await Promise.all(
+      Array.from({ length: 20 }, () => fetchForTest(`http://127.0.0.1:${String(port)}/concurrent-scope`)),
+    );
+    const bodies = await Promise.all(responses.map(async (response) => response.json() as Promise<{ id: number }>));
+
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    expect(new Set(bodies.map((body) => body.id)).size).toBe(20);
+    expect(seenIds.size).toBe(20);
+
+    await app.close();
   });
 
   it('parses Cookie header and exposes individual cookies via FromCookie', async () => {

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -2489,6 +2489,111 @@ describe('bootstrapApplication', () => {
 });
 
 describe('FluoFactory facade', () => {
+  it('does not memoize useExisting aliases that target transient providers', async () => {
+    const TRANSIENT_ALIAS = Symbol('TransientAlias');
+
+    @Scope('transient')
+    class TransientService {
+      readonly instance = Symbol('transient-instance');
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      providers: [
+        TransientService,
+        { provide: TRANSIENT_ALIAS, useExisting: TransientService },
+      ],
+    });
+
+    const context = registerAppForCleanup(await FluoFactory.createApplicationContext(AppModule));
+
+    const first = await context.get<TransientService>(TRANSIENT_ALIAS);
+    const second = await context.get<TransientService>(TRANSIENT_ALIAS);
+
+    expect(first).not.toBe(second);
+    expect(first.instance).not.toBe(second.instance);
+  });
+
+  it('does not keep alias cache entries when a request-scoped alias target is later overridden', async () => {
+    const REQUEST_ALIAS = Symbol('RequestAlias');
+
+    @Scope('request')
+    class RequestScopedService {}
+
+    class ReplacementService {
+      readonly replacement = true;
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      providers: [
+        RequestScopedService,
+        { provide: REQUEST_ALIAS, useExisting: RequestScopedService },
+      ],
+    });
+
+    const context = registerAppForCleanup(await FluoFactory.createApplicationContext(AppModule));
+
+    await expect(context.get(REQUEST_ALIAS)).rejects.toThrow('cannot be resolved outside request scope');
+
+    context.container.override({ provide: REQUEST_ALIAS, useClass: ReplacementService });
+
+    await expect(context.get(REQUEST_ALIAS)).resolves.toBeInstanceOf(ReplacementService);
+  });
+
+  it('invalidates memoized direct singleton lookups after container.override()', async () => {
+    const SERVICE_TOKEN = Symbol('ServiceToken');
+
+    class InitialService {
+      readonly value = 'initial';
+    }
+
+    class ReplacementService {
+      readonly value = 'replacement';
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      providers: [
+        { provide: SERVICE_TOKEN, useClass: InitialService },
+      ],
+    });
+
+    const context = registerAppForCleanup(await FluoFactory.createApplicationContext(AppModule));
+
+    await expect(context.get<InitialService>(SERVICE_TOKEN)).resolves.toBeInstanceOf(InitialService);
+
+    context.container.override({ provide: SERVICE_TOKEN, useClass: ReplacementService });
+
+    const resolved = await context.get<ReplacementService>(SERVICE_TOKEN);
+
+    expect(resolved).toBeInstanceOf(ReplacementService);
+    expect(resolved.value).toBe('replacement');
+  });
+
+  it('preserves post-close get() failures instead of returning memoized values', async () => {
+    class SingletonService {}
+
+    class AppModule {}
+    defineModule(AppModule, {
+      providers: [SingletonService],
+    });
+
+    const context = await FluoFactory.createApplicationContext(AppModule);
+    await expect(context.get(SingletonService)).resolves.toBeInstanceOf(SingletonService);
+
+    await context.close();
+
+    await expect(context.get(SingletonService)).rejects.toThrow('Container has been disposed');
+
+    const app = await FluoFactory.create(AppModule);
+    await expect(app.get(SingletonService)).resolves.toBeInstanceOf(SingletonService);
+
+    await app.close();
+
+    await expect(app.get(SingletonService)).rejects.toThrow('Container has been disposed');
+  });
+
   it('creates an application shell without requiring options', async () => {
     class AppModule {}
     defineModule(AppModule, {});

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -9,6 +9,17 @@ import type { PlatformComponent, PlatformState } from './platform-contract.js';
 import { HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL } from './tokens.js';
 import type { MicroserviceRuntime } from './types.js';
 
+function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, reject, resolve };
+}
+
 describe('bootstrapModule', () => {
   it('boots a simple module graph deterministically', () => {
     class Logger {}
@@ -536,6 +547,78 @@ describe('FluoFactory.createApplicationContext', () => {
     await expect(context.get(AppService)).resolves.toBeInstanceOf(AppService);
     await expect(context.get(HTTP_APPLICATION_ADAPTER)).rejects.toThrow('No provider registered');
     await expect(context.get(PLATFORM_SHELL)).resolves.toBeDefined();
+
+    await context.close();
+  });
+
+  it('memoizes ApplicationContext.get() for singleton tokens', async () => {
+    class AppService {}
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const context = await FluoFactory.createApplicationContext(AppModule, {
+    });
+    const resolve = vi.spyOn(context.container, 'resolve');
+
+    const first = await context.get(AppService);
+    const second = await context.get(AppService);
+
+    expect(first).toBe(second);
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    await context.close();
+  });
+
+  it('resolves independent singleton lifecycle providers concurrently before ordered hooks', async () => {
+    const events: string[] = [];
+    const FIRST = Symbol('first');
+    const SECOND = Symbol('second');
+    const firstCanResolve = createDeferred<void>();
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [
+        {
+          provide: FIRST,
+          async useFactory() {
+            events.push('first:resolve:start');
+            await firstCanResolve.promise;
+            events.push('first:resolve:end');
+            return {
+              onModuleInit() {
+                events.push('first:init');
+              },
+            };
+          },
+        },
+        {
+          provide: SECOND,
+          useFactory() {
+            events.push('second:resolve');
+            firstCanResolve.resolve();
+            return {
+              onModuleInit() {
+                events.push('second:init');
+              },
+            };
+          },
+        },
+      ],
+    });
+
+    const context = await FluoFactory.createApplicationContext(AppModule, {
+    });
+
+    expect(events).toEqual([
+      'first:resolve:start',
+      'second:resolve',
+      'first:resolve:end',
+      'first:init',
+      'second:init',
+    ]);
 
     await context.close();
   });

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -653,6 +653,50 @@ describe('FluoFactory.createApplicationContext', () => {
     await context.close();
   });
 
+  it('cleans up lifecycle instances resolved before parallel provider resolution failure', async () => {
+    const events: string[] = [];
+    const SUCCESS = Symbol('success');
+    const FAILING = Symbol('failing');
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [
+        {
+          provide: SUCCESS,
+          async useFactory() {
+            events.push('success:resolve');
+
+            return {
+              onApplicationShutdown(signal?: string) {
+                events.push(`success:shutdown:${signal ?? 'none'}`);
+              },
+              onModuleDestroy() {
+                events.push('success:destroy');
+              },
+            };
+          },
+        },
+        {
+          provide: FAILING,
+          async useFactory() {
+            events.push('failing:resolve');
+            throw new Error('lifecycle provider failed');
+          },
+        },
+      ],
+    });
+
+    await expect(FluoFactory.createApplicationContext(AppModule, {
+    })).rejects.toThrow('lifecycle provider failed');
+
+    expect(events).toEqual([
+      'success:resolve',
+      'failing:resolve',
+      'success:destroy',
+      'success:shutdown:bootstrap-failed',
+    ]);
+  });
+
   it('runs startup and shutdown lifecycle hooks around close()', async () => {
     const events: string[] = [];
 

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -602,6 +602,81 @@ describe('FluoFactory.createApplicationContext', () => {
     await context.close();
   });
 
+  it.each(['warn', 'ignore'] as const)(
+    'does not cache losing duplicate root singleton providers when policy is %s',
+    async (duplicateProviderPolicy) => {
+      const CACHE_TOKEN = Symbol('cache-token');
+      let resolutionCount = 0;
+
+      class AppModule {}
+      defineModuleMetadata(AppModule, {
+        providers: [
+          {
+            provide: CACHE_TOKEN,
+            useFactory: () => ({ id: 0 }),
+          },
+          {
+            provide: CACHE_TOKEN,
+            scope: 'transient',
+            useFactory: () => ({ id: ++resolutionCount }),
+          },
+        ],
+      });
+
+      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+      const context = await FluoFactory.createApplicationContext(AppModule, {
+        duplicateProviderPolicy,
+        logger,
+      });
+
+      const first = await context.get<{ id: number }>(CACHE_TOKEN);
+      const second = await context.get<{ id: number }>(CACHE_TOKEN);
+
+      expect(first).toEqual({ id: 1 });
+      expect(second).toEqual({ id: 2 });
+      expect(first).not.toBe(second);
+
+      await context.close();
+    },
+  );
+
+  it.each(['warn', 'ignore'] as const)(
+    'does not cache losing duplicate runtime singleton providers when policy is %s',
+    async (duplicateProviderPolicy) => {
+      const CACHE_TOKEN = Symbol('runtime-cache-token');
+      let resolutionCount = 0;
+
+      class AppModule {}
+      defineModuleMetadata(AppModule, {});
+
+      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+      const context = await FluoFactory.createApplicationContext(AppModule, {
+        duplicateProviderPolicy,
+        logger,
+        providers: [
+          {
+            provide: CACHE_TOKEN,
+            useFactory: () => ({ id: 0 }),
+          },
+          {
+            provide: CACHE_TOKEN,
+            scope: 'transient',
+            useFactory: () => ({ id: ++resolutionCount }),
+          },
+        ],
+      });
+
+      const first = await context.get<{ id: number }>(CACHE_TOKEN);
+      const second = await context.get<{ id: number }>(CACHE_TOKEN);
+
+      expect(first).toEqual({ id: 1 });
+      expect(second).toEqual({ id: 2 });
+      expect(first).not.toBe(second);
+
+      await context.close();
+    },
+  );
+
   it('resolves independent singleton lifecycle providers concurrently before ordered hooks', async () => {
     const events: string[] = [];
     const FIRST = Symbol('first');
@@ -779,6 +854,228 @@ describe('FluoFactory.createApplicationContext', () => {
       'value:shutdown:SIGTERM',
     ]);
   });
+
+  it.each(['warn', 'ignore'] as const)(
+    'runs lifecycle hooks only on winning duplicate useValue providers when policy is %s',
+    async (duplicateProviderPolicy) => {
+      const events: string[] = [];
+      const LIFECYCLE_VALUE = Symbol('lifecycle-value');
+
+      class AppModule {}
+      defineModuleMetadata(AppModule, {
+        providers: [
+          {
+            provide: LIFECYCLE_VALUE,
+            useValue: {
+              onApplicationBootstrap() {
+                events.push('losing:bootstrap');
+              },
+              onApplicationShutdown(signal?: string) {
+                events.push(`losing:shutdown:${signal ?? 'none'}`);
+              },
+              onModuleDestroy() {
+                events.push('losing:destroy');
+              },
+              onModuleInit() {
+                events.push('losing:init');
+              },
+            },
+          },
+          {
+            provide: LIFECYCLE_VALUE,
+            useValue: {
+              onApplicationBootstrap() {
+                events.push('winning:bootstrap');
+              },
+              onApplicationShutdown(signal?: string) {
+                events.push(`winning:shutdown:${signal ?? 'none'}`);
+              },
+              onModuleDestroy() {
+                events.push('winning:destroy');
+              },
+              onModuleInit() {
+                events.push('winning:init');
+              },
+            },
+          },
+        ],
+      });
+
+      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+      const context = await FluoFactory.createApplicationContext(AppModule, {
+        duplicateProviderPolicy,
+        logger,
+      });
+
+      expect(events).toEqual(['winning:init', 'winning:bootstrap']);
+
+      await context.close('SIGTERM');
+
+      expect(events).toEqual([
+        'winning:init',
+        'winning:bootstrap',
+        'winning:destroy',
+        'winning:shutdown:SIGTERM',
+      ]);
+    },
+  );
+
+  it.each(['warn', 'ignore'] as const)(
+    'runs lifecycle hooks only on winning duplicate runtime useValue providers when policy is %s',
+    async (duplicateProviderPolicy) => {
+      const events: string[] = [];
+      const LIFECYCLE_VALUE = Symbol('runtime-lifecycle-value');
+
+      class AppModule {}
+      defineModuleMetadata(AppModule, {});
+
+      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+      const context = await FluoFactory.createApplicationContext(AppModule, {
+        duplicateProviderPolicy,
+        logger,
+        providers: [
+          {
+            provide: LIFECYCLE_VALUE,
+            useValue: {
+              onApplicationBootstrap() {
+                events.push('losing:bootstrap');
+              },
+              onApplicationShutdown(signal?: string) {
+                events.push(`losing:shutdown:${signal ?? 'none'}`);
+              },
+              onModuleDestroy() {
+                events.push('losing:destroy');
+              },
+              onModuleInit() {
+                events.push('losing:init');
+              },
+            },
+          },
+          {
+            provide: LIFECYCLE_VALUE,
+            useValue: {
+              onApplicationBootstrap() {
+                events.push('winning:bootstrap');
+              },
+              onApplicationShutdown(signal?: string) {
+                events.push(`winning:shutdown:${signal ?? 'none'}`);
+              },
+              onModuleDestroy() {
+                events.push('winning:destroy');
+              },
+              onModuleInit() {
+                events.push('winning:init');
+              },
+            },
+          },
+        ],
+      });
+
+      expect(events).toEqual(['winning:init', 'winning:bootstrap']);
+
+      await context.close('SIGTERM');
+
+      expect(events).toEqual([
+        'winning:init',
+        'winning:bootstrap',
+        'winning:destroy',
+        'winning:shutdown:SIGTERM',
+      ]);
+    },
+  );
+
+  it.each(['warn', 'ignore'] as const)(
+    'ignores stale losing lifecycle hooks when the duplicate winner has no hooks and policy is %s',
+    async (duplicateProviderPolicy) => {
+      const events: string[] = [];
+      const LIFECYCLE_VALUE = Symbol('lifecycle-value');
+
+      class AppModule {}
+      defineModuleMetadata(AppModule, {
+        providers: [
+          {
+            provide: LIFECYCLE_VALUE,
+            useValue: {
+              onApplicationBootstrap() {
+                events.push('losing:bootstrap');
+              },
+              onApplicationShutdown(signal?: string) {
+                events.push(`losing:shutdown:${signal ?? 'none'}`);
+              },
+              onModuleDestroy() {
+                events.push('losing:destroy');
+              },
+              onModuleInit() {
+                events.push('losing:init');
+              },
+            },
+          },
+          {
+            provide: LIFECYCLE_VALUE,
+            useValue: { marker: 'winning-without-hooks' },
+          },
+        ],
+      });
+
+      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+      const context = await FluoFactory.createApplicationContext(AppModule, {
+        duplicateProviderPolicy,
+        logger,
+      });
+
+      expect(events).toEqual([]);
+
+      await context.close('SIGTERM');
+
+      expect(events).toEqual([]);
+    },
+  );
+
+  it.each(['warn', 'ignore'] as const)(
+    'ignores stale losing runtime lifecycle hooks when the duplicate winner has no hooks and policy is %s',
+    async (duplicateProviderPolicy) => {
+      const events: string[] = [];
+      const LIFECYCLE_VALUE = Symbol('runtime-lifecycle-value-without-hooks');
+
+      class AppModule {}
+      defineModuleMetadata(AppModule, {});
+
+      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+      const context = await FluoFactory.createApplicationContext(AppModule, {
+        duplicateProviderPolicy,
+        logger,
+        providers: [
+          {
+            provide: LIFECYCLE_VALUE,
+            useValue: {
+              onApplicationBootstrap() {
+                events.push('losing:bootstrap');
+              },
+              onApplicationShutdown(signal?: string) {
+                events.push(`losing:shutdown:${signal ?? 'none'}`);
+              },
+              onModuleDestroy() {
+                events.push('losing:destroy');
+              },
+              onModuleInit() {
+                events.push('losing:init');
+              },
+            },
+          },
+          {
+            provide: LIFECYCLE_VALUE,
+            useValue: { marker: 'winning-without-hooks' },
+          },
+        ],
+      });
+
+      expect(events).toEqual([]);
+
+      await context.close('SIGTERM');
+
+      expect(events).toEqual([]);
+    },
+  );
 
   it('does not collect bootstrap timing diagnostics by default', async () => {
     class AppModule {}

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -677,6 +677,84 @@ describe('FluoFactory.createApplicationContext', () => {
     },
   );
 
+  it('does not memoize multi-provider tokens through ApplicationContext.get()', async () => {
+    const MULTI_TOKEN = Symbol('context-multi-token');
+    const firstContribution = { id: 'first' };
+    const secondContribution = { id: 'second' };
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [
+        {
+          multi: true,
+          provide: MULTI_TOKEN,
+          useFactory: () => firstContribution,
+        },
+        {
+          multi: true,
+          provide: MULTI_TOKEN,
+          useFactory: () => secondContribution,
+        },
+      ],
+    });
+
+    const context = await FluoFactory.createApplicationContext(AppModule, {
+    });
+    const resolve = vi.spyOn(context.container, 'resolve');
+
+    const first = await context.get<Array<{ id: string }>>(MULTI_TOKEN);
+    const second = await context.get<Array<{ id: string }>>(MULTI_TOKEN);
+
+    expect(first).toEqual([firstContribution, secondContribution]);
+    expect(second).toEqual([firstContribution, secondContribution]);
+    expect(first).not.toBe(second);
+    expect(first[0]).toBe(second[0]);
+    expect(first[1]).toBe(second[1]);
+    expect(resolve).toHaveBeenCalledTimes(2);
+
+    await context.close();
+  });
+
+  it('does not memoize multi-provider tokens through Application.get()', async () => {
+    const MULTI_TOKEN = Symbol('application-multi-token');
+    const moduleContribution = { id: 'module' };
+    const runtimeContribution = { id: 'runtime' };
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [
+        {
+          multi: true,
+          provide: MULTI_TOKEN,
+          useFactory: () => moduleContribution,
+        },
+      ],
+    });
+
+    const app = await FluoFactory.create(AppModule, {
+      providers: [
+        {
+          multi: true,
+          provide: MULTI_TOKEN,
+          useFactory: () => runtimeContribution,
+        },
+      ],
+    });
+    const resolve = vi.spyOn(app.container, 'resolve');
+
+    const first = await app.get<Array<{ id: string }>>(MULTI_TOKEN);
+    const second = await app.get<Array<{ id: string }>>(MULTI_TOKEN);
+
+    expect(first).toEqual([runtimeContribution, moduleContribution]);
+    expect(second).toEqual([runtimeContribution, moduleContribution]);
+    expect(first).not.toBe(second);
+    expect(first[0]).toBe(second[0]);
+    expect(first[1]).toBe(second[1]);
+    expect(resolve).toHaveBeenCalledTimes(2);
+
+    await app.close();
+  });
+
   it('resolves independent singleton lifecycle providers concurrently before ordered hooks', async () => {
     const events: string[] = [];
     const FIRST = Symbol('first');

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -572,6 +572,36 @@ describe('FluoFactory.createApplicationContext', () => {
     await context.close();
   });
 
+  it('recomputes ApplicationContext.get() cacheability after singleton provider overrides', async () => {
+    class AppService {}
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const context = await FluoFactory.createApplicationContext(AppModule, {
+    });
+
+    const singleton = await context.get(AppService);
+    expect(await context.get(AppService)).toBe(singleton);
+
+    context.container.override({
+      provide: AppService,
+      scope: 'transient',
+      useFactory: () => ({ marker: Symbol('app-service') }) as AppService,
+    });
+
+    const firstOverride = await context.get(AppService);
+    const secondOverride = await context.get(AppService);
+
+    expect(firstOverride).not.toBe(singleton);
+    expect(secondOverride).not.toBe(singleton);
+    expect(firstOverride).not.toBe(secondOverride);
+
+    await context.close();
+  });
+
   it('resolves independent singleton lifecycle providers concurrently before ordered hooks', async () => {
     const events: string[] = [];
     const FIRST = Symbol('first');
@@ -661,6 +691,48 @@ describe('FluoFactory.createApplicationContext', () => {
       'app:bootstrap',
       'module:destroy',
       'app:shutdown:SIGTERM',
+    ]);
+  });
+
+  it('runs lifecycle hooks exposed by singleton useValue providers', async () => {
+    const events: string[] = [];
+    const LIFECYCLE_VALUE = Symbol('lifecycle-value');
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [
+        {
+          provide: LIFECYCLE_VALUE,
+          useValue: {
+            onApplicationBootstrap() {
+              events.push('value:bootstrap');
+            },
+            onApplicationShutdown(signal?: string) {
+              events.push(`value:shutdown:${signal ?? 'none'}`);
+            },
+            onModuleDestroy() {
+              events.push('value:destroy');
+            },
+            onModuleInit() {
+              events.push('value:init');
+            },
+          },
+        },
+      ],
+    });
+
+    const context = await FluoFactory.createApplicationContext(AppModule, {
+    });
+
+    expect(events).toEqual(['value:init', 'value:bootstrap']);
+
+    await context.close('SIGTERM');
+
+    expect(events).toEqual([
+      'value:init',
+      'value:bootstrap',
+      'value:destroy',
+      'value:shutdown:SIGTERM',
     ]);
   });
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -46,6 +46,8 @@ const runtimePerformance = globalThis.performance;
 
 type ContextResolutionCache = Map<Token, Promise<unknown>>;
 
+type CacheInvalidatingContainer = Container & { override(...providers: Provider[]): Container };
+
 async function runExceptionFilters(
   filters: readonly ExceptionFilterHandler[],
   error: unknown,
@@ -431,6 +433,7 @@ class FluoApplication implements Application {
     private readonly contextCacheableTokens: ReadonlySet<Token>,
   ) {
     this.lifecycleInstances = lifecycleInstances;
+    installContextCacheInvalidation(this.container, this.contextResolutionCache);
   }
 
   get state(): ApplicationState {
@@ -438,6 +441,10 @@ class FluoApplication implements Application {
   }
 
   async get<T>(token: Token<T>): Promise<T> {
+    if (this.closed) {
+      return this.container.resolve(token);
+    }
+
     return resolveContextToken(this.container, token, this.contextCacheableTokens, this.contextResolutionCache);
   }
 
@@ -552,9 +559,15 @@ class FluoApplicationContext implements ApplicationContext {
     private readonly lifecycleInstances: unknown[],
     private readonly runtimeCleanup: Array<() => void>,
     private readonly contextCacheableTokens: ReadonlySet<Token>,
-  ) {}
+  ) {
+    installContextCacheInvalidation(this.container, this.contextResolutionCache);
+  }
 
   async get<T>(token: Token<T>): Promise<T> {
+    if (this.closed) {
+      return this.container.resolve(token);
+    }
+
     return resolveContextToken(this.container, token, this.contextCacheableTokens, this.contextResolutionCache);
   }
 
@@ -682,9 +695,7 @@ async function resolveLifecycleInstances(container: Container, providers: Provid
   const seen = new Set<Token>();
 
   for (const provider of providers) {
-    const scope = providerScope(provider);
-
-    if (scope === 'request' || scope === 'transient') {
+    if (!isDirectSingletonContextProvider(provider)) {
       continue;
     }
 
@@ -703,13 +714,14 @@ async function resolveLifecycleInstances(container: Container, providers: Provid
 
 function createContextCacheableTokenSet(
   modules: readonly CompiledModule[],
+  rootModule: ModuleType,
   runtimeProviders: readonly Provider[],
   runtimeTokens: readonly Token[],
 ): Set<Token> {
   const cacheableTokens = new Set<Token>(runtimeTokens);
 
   for (const provider of runtimeProviders) {
-    if (providerScope(provider) !== 'singleton') {
+    if (!isDirectSingletonContextProvider(provider)) {
       continue;
     }
 
@@ -717,8 +729,12 @@ function createContextCacheableTokenSet(
   }
 
   for (const compiledModule of modules) {
+    if (compiledModule.type !== rootModule) {
+      continue;
+    }
+
     for (const provider of compiledModule.definition.providers ?? []) {
-      if (providerScope(provider) !== 'singleton') {
+      if (!isDirectSingletonContextProvider(provider)) {
         continue;
       }
 
@@ -727,6 +743,30 @@ function createContextCacheableTokenSet(
   }
 
   return cacheableTokens;
+}
+
+function isDirectSingletonContextProvider(provider: Provider): boolean {
+  if (typeof provider === 'function') {
+    return providerScope(provider) === 'singleton';
+  }
+
+  if ('useExisting' in provider || 'useValue' in provider) {
+    return false;
+  }
+
+  return providerScope(provider) === 'singleton';
+}
+
+function installContextCacheInvalidation(container: Container, cache: ContextResolutionCache): void {
+  const cacheInvalidatingContainer = container as CacheInvalidatingContainer;
+  const override = cacheInvalidatingContainer.override.bind(container);
+
+  cacheInvalidatingContainer.override = (...providers: Provider[]): Container => {
+    const result = override(...providers);
+    cache.clear();
+
+    return result;
+  };
 }
 
 async function resolveContextToken<T>(
@@ -1080,6 +1120,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
       runtimeCleanup,
       createContextCacheableTokenSet(
         bootstrapped.modules,
+        options.rootModule,
         runtimeProviders,
         [RUNTIME_CONTAINER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL],
       ),
@@ -1211,6 +1252,7 @@ export class FluoFactory {
         runtimeCleanup,
         createContextCacheableTokenSet(
           bootstrapped.modules,
+          rootModule,
           runtimeProviders,
           [RUNTIME_CONTAINER, COMPILED_MODULES, PLATFORM_SHELL],
         ),

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -44,6 +44,8 @@ import type {
 const DEFAULT_MICROSERVICE_TOKEN = Symbol.for('fluo.microservices.service') as Token<MicroserviceRuntime>;
 const runtimePerformance = globalThis.performance;
 
+type ContextResolutionCache = Map<Token, Promise<unknown>>;
+
 async function runExceptionFilters(
   filters: readonly ExceptionFilterHandler[],
   error: unknown,
@@ -410,6 +412,7 @@ class FluoApplication implements Application {
   private applicationState: ApplicationState = 'bootstrapped';
   private closed = false;
   private closingPromise: Promise<void> | undefined;
+  private readonly contextResolutionCache: ContextResolutionCache = new Map();
   private readonly lifecycleInstances: unknown[];
   private readonly connectedMicroservices: MicroserviceApplication[] = [];
 
@@ -425,6 +428,7 @@ class FluoApplication implements Application {
     lifecycleInstances: unknown[],
     private readonly logger: ApplicationLogger,
     private readonly runtimeCleanup: Array<() => void>,
+    private readonly contextCacheableTokens: ReadonlySet<Token>,
   ) {
     this.lifecycleInstances = lifecycleInstances;
   }
@@ -434,7 +438,7 @@ class FluoApplication implements Application {
   }
 
   async get<T>(token: Token<T>): Promise<T> {
-    return this.container.resolve(token);
+    return resolveContextToken(this.container, token, this.contextCacheableTokens, this.contextResolutionCache);
   }
 
   /**
@@ -538,6 +542,7 @@ class FluoApplication implements Application {
 class FluoApplicationContext implements ApplicationContext {
   private closed = false;
   private closingPromise: Promise<void> | undefined;
+  private readonly contextResolutionCache: ContextResolutionCache = new Map();
 
   constructor(
     readonly container: Container,
@@ -546,10 +551,11 @@ class FluoApplicationContext implements ApplicationContext {
     readonly bootstrapTiming: ApplicationContext['bootstrapTiming'],
     private readonly lifecycleInstances: unknown[],
     private readonly runtimeCleanup: Array<() => void>,
+    private readonly contextCacheableTokens: ReadonlySet<Token>,
   ) {}
 
   async get<T>(token: Token<T>): Promise<T> {
-    return this.container.resolve(token);
+    return resolveContextToken(this.container, token, this.contextCacheableTokens, this.contextResolutionCache);
   }
 
   async close(signal?: string): Promise<void> {
@@ -672,7 +678,7 @@ class FluoMicroserviceApplication implements MicroserviceApplication {
  * lifecycle hook이 있는 singleton provider 인스턴스를 미리 해석해 둔다.
  */
 async function resolveLifecycleInstances(container: Container, providers: Provider[]): Promise<unknown[]> {
-  const instances: unknown[] = [];
+  const tokens: Token[] = [];
   const seen = new Set<Token>();
 
   for (const provider of providers) {
@@ -689,10 +695,63 @@ async function resolveLifecycleInstances(container: Container, providers: Provid
     }
 
     seen.add(token);
-    instances.push(await container.resolve(token));
+    tokens.push(token);
   }
 
-  return instances;
+  return Promise.all(tokens.map((token) => container.resolve(token)));
+}
+
+function createContextCacheableTokenSet(
+  modules: readonly CompiledModule[],
+  runtimeProviders: readonly Provider[],
+  runtimeTokens: readonly Token[],
+): Set<Token> {
+  const cacheableTokens = new Set<Token>(runtimeTokens);
+
+  for (const provider of runtimeProviders) {
+    if (providerScope(provider) !== 'singleton') {
+      continue;
+    }
+
+    cacheableTokens.add(providerToken(provider));
+  }
+
+  for (const compiledModule of modules) {
+    for (const provider of compiledModule.definition.providers ?? []) {
+      if (providerScope(provider) !== 'singleton') {
+        continue;
+      }
+
+      cacheableTokens.add(providerToken(provider));
+    }
+  }
+
+  return cacheableTokens;
+}
+
+async function resolveContextToken<T>(
+  container: Container,
+  token: Token<T>,
+  cacheableTokens: ReadonlySet<Token>,
+  cache: ContextResolutionCache,
+): Promise<T> {
+  if (!cacheableTokens.has(token)) {
+    return container.resolve(token);
+  }
+
+  const cached = cache.get(token);
+
+  if (cached) {
+    return cached as Promise<T>;
+  }
+
+  const resolution = container.resolve(token).catch((error: unknown) => {
+    cache.delete(token);
+    throw error;
+  });
+  cache.set(token, resolution);
+
+  return resolution;
 }
 
 /**
@@ -1019,6 +1078,11 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
       lifecycleInstances,
       logger,
       runtimeCleanup,
+      createContextCacheableTokenSet(
+        bootstrapped.modules,
+        runtimeProviders,
+        [RUNTIME_CONTAINER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL],
+      ),
     );
   } catch (error: unknown) {
     logger.error(
@@ -1145,6 +1209,11 @@ export class FluoFactory {
         bootstrapTiming,
         lifecycleInstances,
         runtimeCleanup,
+        createContextCacheableTokenSet(
+          bootstrapped.modules,
+          runtimeProviders,
+          [RUNTIME_CONTAINER, COMPILED_MODULES, PLATFORM_SHELL],
+        ),
       );
     } catch (error: unknown) {
       logger.error(

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -45,6 +45,7 @@ const DEFAULT_MICROSERVICE_TOKEN = Symbol.for('fluo.microservices.service') as T
 const runtimePerformance = globalThis.performance;
 
 type ContextResolutionCache = Map<Token, Promise<unknown>>;
+type ContextCacheableTokens = Set<Token>;
 
 type CacheInvalidatingContainer = Container & { override(...providers: Provider[]): Container };
 
@@ -430,10 +431,10 @@ class FluoApplication implements Application {
     lifecycleInstances: unknown[],
     private readonly logger: ApplicationLogger,
     private readonly runtimeCleanup: Array<() => void>,
-    private readonly contextCacheableTokens: ReadonlySet<Token>,
+    private readonly contextCacheableTokens: ContextCacheableTokens,
   ) {
     this.lifecycleInstances = lifecycleInstances;
-    installContextCacheInvalidation(this.container, this.contextResolutionCache);
+    installContextCacheInvalidation(this.container, this.contextResolutionCache, this.contextCacheableTokens);
   }
 
   get state(): ApplicationState {
@@ -558,9 +559,9 @@ class FluoApplicationContext implements ApplicationContext {
     readonly bootstrapTiming: ApplicationContext['bootstrapTiming'],
     private readonly lifecycleInstances: unknown[],
     private readonly runtimeCleanup: Array<() => void>,
-    private readonly contextCacheableTokens: ReadonlySet<Token>,
+    private readonly contextCacheableTokens: ContextCacheableTokens,
   ) {
-    installContextCacheInvalidation(this.container, this.contextResolutionCache);
+    installContextCacheInvalidation(this.container, this.contextResolutionCache, this.contextCacheableTokens);
   }
 
   async get<T>(token: Token<T>): Promise<T> {
@@ -691,25 +692,31 @@ class FluoMicroserviceApplication implements MicroserviceApplication {
  * lifecycle hook이 있는 singleton provider 인스턴스를 미리 해석해 둔다.
  */
 async function resolveLifecycleInstances(container: Container, providers: Provider[]): Promise<unknown[]> {
-  const tokens: Token[] = [];
+  const lifecycleEntries: Array<{ token: Token; useValue?: unknown }> = [];
   const seen = new Set<Token>();
 
   for (const provider of providers) {
-    if (!isDirectSingletonContextProvider(provider)) {
-      continue;
-    }
-
     const token = providerToken(provider);
 
     if (seen.has(token)) {
       continue;
     }
 
+    if (isHookBearingValueProvider(provider)) {
+      seen.add(token);
+      lifecycleEntries.push({ token, useValue: provider.useValue });
+      continue;
+    }
+
+    if (!isDirectSingletonContextProvider(provider)) {
+      continue;
+    }
+
     seen.add(token);
-    tokens.push(token);
+    lifecycleEntries.push({ token });
   }
 
-  return Promise.all(tokens.map((token) => container.resolve(token)));
+  return Promise.all(lifecycleEntries.map((entry) => entry.useValue ?? container.resolve(entry.token)));
 }
 
 function createContextCacheableTokenSet(
@@ -757,13 +764,41 @@ function isDirectSingletonContextProvider(provider: Provider): boolean {
   return providerScope(provider) === 'singleton';
 }
 
-function installContextCacheInvalidation(container: Container, cache: ContextResolutionCache): void {
+function isHookBearingValueProvider(provider: Provider): provider is Provider & { useValue: unknown } {
+  return typeof provider === 'object'
+    && provider !== null
+    && 'useValue' in provider
+    && hasLifecycleHook(provider.useValue);
+}
+
+function hasLifecycleHook(value: unknown): boolean {
+  return isOnModuleInit(value)
+    || isOnApplicationBootstrap(value)
+    || isOnModuleDestroy(value)
+    || isOnApplicationShutdown(value);
+}
+
+function installContextCacheInvalidation(
+  container: Container,
+  cache: ContextResolutionCache,
+  cacheableTokens: ContextCacheableTokens,
+): void {
   const cacheInvalidatingContainer = container as CacheInvalidatingContainer;
   const override = cacheInvalidatingContainer.override.bind(container);
 
   cacheInvalidatingContainer.override = (...providers: Provider[]): Container => {
     const result = override(...providers);
     cache.clear();
+
+    for (const provider of providers) {
+      const token = providerToken(provider);
+
+      if (isDirectSingletonContextProvider(provider)) {
+        cacheableTokens.add(token);
+      } else {
+        cacheableTokens.delete(token);
+      }
+    }
 
     return result;
   };

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -330,14 +330,23 @@ function selectEffectiveBootstrapProviders(
 ): BootstrapEffectiveProviders {
   const selectedRuntimeProviderIndexes = new Map<Token, number>();
   const selectedModuleProviderIndexes = new Map<Token, number>();
+  const runtimeMultiTokens = new Set<Token>();
+  const runtimeSingleTokens = new Set<Token>();
   const runtimeProviderEntries: SelectedProviderEntry[] = [];
   const moduleProviderEntries: SelectedProviderEntry[] = [];
 
   for (const runtimeProvider of runtimeProviders ?? []) {
     const token = providerToken(runtimeProvider);
+    const multi = isMultiProvider(runtimeProvider);
     const existingRuntimeProviderIndex = selectedRuntimeProviderIndexes.get(token);
 
-    if (existingRuntimeProviderIndex !== undefined) {
+    if (multi) {
+      runtimeMultiTokens.add(token);
+    } else {
+      runtimeSingleTokens.add(token);
+    }
+
+    if (!multi && existingRuntimeProviderIndex !== undefined) {
       handleDuplicateRuntimeProvider(token, policy, logger);
     }
 
@@ -347,20 +356,22 @@ function selectEffectiveBootstrapProviders(
       source: 'runtime',
       token,
     });
-    selectedRuntimeProviderIndexes.set(token, runtimeProviderEntries.length - 1);
-  }
 
-  const runtimeProviderTokens = new Set(selectedRuntimeProviderIndexes.keys());
+    if (!multi) {
+      selectedRuntimeProviderIndexes.set(token, runtimeProviderEntries.length - 1);
+    }
+  }
 
   for (const compiledModule of modules) {
     for (const provider of compiledModule.definition.providers ?? []) {
       const token = providerToken(provider);
+      const multi = isMultiProvider(provider);
       const existingModuleProviderIndex = selectedModuleProviderIndexes.get(token);
       const existing = existingModuleProviderIndex === undefined
         ? undefined
         : moduleProviderEntries[existingModuleProviderIndex];
 
-      if (existing && existing.source === 'module') {
+      if (!multi && existing && existing.source === 'module') {
         handleDuplicateProvider(token, compiledModule.type.name, existing.moduleName, policy, logger);
       }
 
@@ -373,7 +384,10 @@ function selectEffectiveBootstrapProviders(
       };
 
       moduleProviderEntries.push(entry);
-      selectedModuleProviderIndexes.set(token, moduleProviderEntries.length - 1);
+
+      if (!multi) {
+        selectedModuleProviderIndexes.set(token, moduleProviderEntries.length - 1);
+      }
     }
   }
 
@@ -382,15 +396,17 @@ function selectEffectiveBootstrapProviders(
   const moduleProviders: Provider[] = [];
   const rootModuleProviders: Provider[] = [];
   const effectiveRuntimeProviders = runtimeProviderEntries
-    .filter((_, index) => selectedRuntimeProviderIndexesSet.has(index))
+    .filter((entry, index) => isMultiProvider(entry.provider) || selectedRuntimeProviderIndexesSet.has(index))
     .map((entry) => entry.provider);
 
   moduleProviderEntries.forEach((entry, index) => {
-    if (entry.source !== 'module' || !selectedModuleProviderIndexesSet.has(index)) {
+    const multi = isMultiProvider(entry.provider);
+
+    if (entry.source !== 'module' || (!multi && !selectedModuleProviderIndexesSet.has(index))) {
       return;
     }
 
-    if (runtimeProviderTokens.has(entry.token)) {
+    if (runtimeSingleTokens.has(entry.token) || (runtimeMultiTokens.has(entry.token) && !multi)) {
       return;
     }
 
@@ -406,6 +422,13 @@ function selectEffectiveBootstrapProviders(
     rootModuleProviders,
     runtimeProviders: effectiveRuntimeProviders,
   };
+}
+
+function isMultiProvider(provider: Provider): boolean {
+  return typeof provider === 'object'
+    && provider !== null
+    && 'multi' in provider
+    && provider.multi === true;
 }
 
 function registerControllers(container: Container, modules: CompiledModule[]): void {
@@ -863,6 +886,10 @@ function createContextCacheableTokenSet(
 }
 
 function isDirectSingletonContextProvider(provider: Provider): boolean {
+  if (isMultiProvider(provider)) {
+    return false;
+  }
+
   if (typeof provider === 'function') {
     return providerScope(provider) === 'singleton';
   }

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -15,7 +15,7 @@ import {
 import { DuplicateProviderError } from './errors.js';
 import { createBootstrapTimingDiagnostics, type BootstrapTimingPhase } from './health/diagnostics.js';
 import { createConsoleApplicationLogger } from './logging/logger.js';
-import { compileModuleGraph, createRuntimeTokenSet, providerToken } from './module-graph.js';
+import { compileModuleGraph, providerToken } from './module-graph.js';
 import { createRuntimePlatformShell, type RuntimePlatformShell } from './platform-shell.js';
 import { APPLICATION_LOGGER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL, RUNTIME_CONTAINER } from './tokens.js';
 import type {
@@ -28,6 +28,7 @@ import type {
   BootstrapApplicationOptions,
   BootstrapModuleOptions,
   BootstrapResult,
+  BootstrapEffectiveProviders,
   CompiledModule,
   CreateApplicationOptions,
   CreateApplicationContextOptions,
@@ -260,6 +261,7 @@ type DuplicateProviderPolicy = Exclude<BootstrapModuleOptions['duplicateProvider
 
 interface SelectedProviderEntry {
   moduleName: string;
+  moduleType?: ModuleType;
   provider: Provider;
   source: 'module' | 'runtime';
   token: Token;
@@ -270,56 +272,140 @@ function createDuplicateProviderMessage(token: Token, moduleName: string, existi
   return `Duplicate provider token "${tokenLabel}" registered in module "${moduleName}". Previously registered in module "${existingModuleName}".`;
 }
 
-function collectProvidersForContainer(
-  modules: CompiledModule[],
-  runtimeProviders: Provider[] | undefined,
+function createDuplicateRuntimeProviderMessage(token: Token): string {
+  const tokenLabel = typeof token === 'function' ? token.name || '<anonymous>' : String(token);
+  return `Duplicate runtime provider token "${tokenLabel}" registered.`;
+}
+
+function handleDuplicateProvider(
+  token: Token,
+  moduleName: string,
+  existingModuleName: string,
   policy: DuplicateProviderPolicy,
   logger?: ApplicationLogger,
-): Provider[] {
-  const selectedProviders = new Map<Token, SelectedProviderEntry>();
+): void {
+  const message = createDuplicateProviderMessage(token, moduleName, existingModuleName);
+
+  if (policy === 'throw') {
+    throw new DuplicateProviderError(message, {
+      module: moduleName,
+      token,
+      phase: 'provider registration',
+      hint: `Remove the duplicate registration from one of the modules, use container.override() for intentional replacements, or set duplicateProviderPolicy to 'warn' or 'ignore'.`,
+    });
+  }
+
+  if (policy === 'warn') {
+    logger?.warn(message, 'BootstrapModule');
+  }
+}
+
+function handleDuplicateRuntimeProvider(
+  token: Token,
+  policy: DuplicateProviderPolicy,
+  logger?: ApplicationLogger,
+): void {
+  const message = createDuplicateRuntimeProviderMessage(token);
+
+  if (policy === 'throw') {
+    throw new DuplicateProviderError(message, {
+      module: '<runtime>',
+      token,
+      phase: 'provider registration',
+      hint: `Remove the duplicate runtime provider registration, use container.override() after bootstrap for intentional replacements, or set duplicateProviderPolicy to 'warn' or 'ignore'.`,
+    });
+  }
+
+  if (policy === 'warn') {
+    logger?.warn(message, 'BootstrapModule');
+  }
+}
+
+function selectEffectiveBootstrapProviders(
+  modules: CompiledModule[],
+  runtimeProviders: Provider[] | undefined,
+  rootModule: ModuleType,
+  policy: DuplicateProviderPolicy,
+  logger?: ApplicationLogger,
+): BootstrapEffectiveProviders {
+  const selectedRuntimeProviderIndexes = new Map<Token, number>();
+  const selectedModuleProviderIndexes = new Map<Token, number>();
+  const runtimeProviderEntries: SelectedProviderEntry[] = [];
+  const moduleProviderEntries: SelectedProviderEntry[] = [];
 
   for (const runtimeProvider of runtimeProviders ?? []) {
     const token = providerToken(runtimeProvider);
-    selectedProviders.set(token, {
+    const existingRuntimeProviderIndex = selectedRuntimeProviderIndexes.get(token);
+
+    if (existingRuntimeProviderIndex !== undefined) {
+      handleDuplicateRuntimeProvider(token, policy, logger);
+    }
+
+    runtimeProviderEntries.push({
       moduleName: '<runtime>',
       provider: runtimeProvider,
       source: 'runtime',
       token,
     });
+    selectedRuntimeProviderIndexes.set(token, runtimeProviderEntries.length - 1);
   }
+
+  const runtimeProviderTokens = new Set(selectedRuntimeProviderIndexes.keys());
 
   for (const compiledModule of modules) {
     for (const provider of compiledModule.definition.providers ?? []) {
       const token = providerToken(provider);
-      const existing = selectedProviders.get(token);
+      const existingModuleProviderIndex = selectedModuleProviderIndexes.get(token);
+      const existing = existingModuleProviderIndex === undefined
+        ? undefined
+        : moduleProviderEntries[existingModuleProviderIndex];
 
       if (existing && existing.source === 'module') {
-        const message = createDuplicateProviderMessage(token, compiledModule.type.name, existing.moduleName);
-
-        if (policy === 'throw') {
-          throw new DuplicateProviderError(message, {
-            module: compiledModule.type.name,
-            token,
-            phase: 'provider registration',
-            hint: `Remove the duplicate registration from one of the modules, use container.override() for intentional replacements, or set duplicateProviderPolicy to 'warn' or 'ignore'.`,
-          });
-        }
-
-        if (policy === 'warn') {
-          logger?.warn(message, 'BootstrapModule');
-        }
+        handleDuplicateProvider(token, compiledModule.type.name, existing.moduleName, policy, logger);
       }
 
-      selectedProviders.set(token, {
+      const entry: SelectedProviderEntry = {
         moduleName: compiledModule.type.name,
+        moduleType: compiledModule.type,
         provider,
         source: 'module',
         token,
-      });
+      };
+
+      moduleProviderEntries.push(entry);
+      selectedModuleProviderIndexes.set(token, moduleProviderEntries.length - 1);
     }
   }
 
-  return [...selectedProviders.values()].map((entry) => entry.provider);
+  const selectedModuleProviderIndexesSet = new Set(selectedModuleProviderIndexes.values());
+  const selectedRuntimeProviderIndexesSet = new Set(selectedRuntimeProviderIndexes.values());
+  const moduleProviders: Provider[] = [];
+  const rootModuleProviders: Provider[] = [];
+  const effectiveRuntimeProviders = runtimeProviderEntries
+    .filter((_, index) => selectedRuntimeProviderIndexesSet.has(index))
+    .map((entry) => entry.provider);
+
+  moduleProviderEntries.forEach((entry, index) => {
+    if (entry.source !== 'module' || !selectedModuleProviderIndexesSet.has(index)) {
+      return;
+    }
+
+    if (runtimeProviderTokens.has(entry.token)) {
+      return;
+    }
+
+    moduleProviders.push(entry.provider);
+
+    if (entry.moduleType === rootModule) {
+      rootModuleProviders.push(entry.provider);
+    }
+  });
+
+  return {
+    moduleProviders,
+    rootModuleProviders,
+    runtimeProviders: effectiveRuntimeProviders,
+  };
 }
 
 function registerControllers(container: Container, modules: CompiledModule[]): void {
@@ -386,16 +472,20 @@ export function bootstrapModule(rootModule: ModuleType, options: BootstrapModule
   const policy: DuplicateProviderPolicy = options.duplicateProviderPolicy ?? 'warn';
 
   const runtimeProviders = options.providers ?? [];
-  const runtimeProviderTokens = createRuntimeTokenSet(runtimeProviders);
-  const moduleProviders = collectProvidersForContainer(modules, runtimeProviders, policy, options.logger)
-    .filter((provider) => !runtimeProviderTokens.has(providerToken(provider)));
+  const effectiveProviders = selectEffectiveBootstrapProviders(
+    modules,
+    runtimeProviders,
+    rootModule,
+    policy,
+    options.logger,
+  );
 
-  if (runtimeProviders.length > 0) {
-    container.register(...runtimeProviders);
+  if (effectiveProviders.runtimeProviders.length > 0) {
+    container.register(...effectiveProviders.runtimeProviders);
   }
 
-  if (moduleProviders.length > 0) {
-    container.register(...moduleProviders);
+  if (effectiveProviders.moduleProviders.length > 0) {
+    container.register(...effectiveProviders.moduleProviders);
   }
 
   registerControllers(container, modules);
@@ -403,6 +493,7 @@ export function bootstrapModule(rootModule: ModuleType, options: BootstrapModule
 
   return {
     container,
+    effectiveProviders,
     modules,
     rootModule,
   };
@@ -747,14 +838,12 @@ async function resolveLifecycleInstances(
 }
 
 function createContextCacheableTokenSet(
-  modules: readonly CompiledModule[],
-  rootModule: ModuleType,
-  runtimeProviders: readonly Provider[],
+  effectiveProviders: BootstrapEffectiveProviders,
   runtimeTokens: readonly Token[],
 ): Set<Token> {
   const cacheableTokens = new Set<Token>(runtimeTokens);
 
-  for (const provider of runtimeProviders) {
+  for (const provider of effectiveProviders.runtimeProviders) {
     if (!isDirectSingletonContextProvider(provider)) {
       continue;
     }
@@ -762,18 +851,12 @@ function createContextCacheableTokenSet(
     cacheableTokens.add(providerToken(provider));
   }
 
-  for (const compiledModule of modules) {
-    if (compiledModule.type !== rootModule) {
+  for (const provider of effectiveProviders.rootModuleProviders) {
+    if (!isDirectSingletonContextProvider(provider)) {
       continue;
     }
 
-    for (const provider of compiledModule.definition.providers ?? []) {
-      if (!isDirectSingletonContextProvider(provider)) {
-        continue;
-      }
-
-      cacheableTokens.add(providerToken(provider));
-    }
+    cacheableTokens.add(providerToken(provider));
   }
 
   return cacheableTokens;
@@ -986,12 +1069,11 @@ function registerRuntimeApplicationContextTokens(bootstrapped: BootstrapResult, 
 
 async function resolveBootstrapLifecycleInstances(
   bootstrapped: BootstrapResult,
-  runtimeProviders: Provider[],
   resolvedInstances?: unknown[],
 ): Promise<unknown[]> {
   const lifecycleProviders = [
-    ...runtimeProviders,
-    ...bootstrapped.modules.flatMap((compiledModule) => compiledModule.definition.providers ?? []),
+    ...bootstrapped.effectiveProviders.runtimeProviders,
+    ...bootstrapped.effectiveProviders.moduleProviders,
   ];
 
   return resolveLifecycleInstances(bootstrapped.container, lifecycleProviders, resolvedInstances);
@@ -1134,7 +1216,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     bootstrappedModules = bootstrapped.modules;
 
     const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
-    lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders, lifecycleInstances);
+    lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, lifecycleInstances);
     lifecycleInstances.push({
       onModuleDestroy() {
         return platformShell.stop();
@@ -1182,9 +1264,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
       logger,
       runtimeCleanup,
       createContextCacheableTokenSet(
-        bootstrapped.modules,
-        options.rootModule,
-        runtimeProviders,
+        bootstrapped.effectiveProviders,
         [RUNTIME_CONTAINER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL],
       ),
     );
@@ -1280,7 +1360,7 @@ export class FluoFactory {
       bootstrappedModules = bootstrapped.modules;
 
       const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
-      lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders, lifecycleInstances);
+      lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, lifecycleInstances);
       lifecycleInstances.push({
         onModuleDestroy() {
           return platformShell.stop();
@@ -1314,9 +1394,7 @@ export class FluoFactory {
         lifecycleInstances,
         runtimeCleanup,
         createContextCacheableTokenSet(
-          bootstrapped.modules,
-          rootModule,
-          runtimeProviders,
+          bootstrapped.effectiveProviders,
           [RUNTIME_CONTAINER, COMPILED_MODULES, PLATFORM_SHELL],
         ),
       );

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -691,7 +691,11 @@ class FluoMicroserviceApplication implements MicroserviceApplication {
 /**
  * lifecycle hook이 있는 singleton provider 인스턴스를 미리 해석해 둔다.
  */
-async function resolveLifecycleInstances(container: Container, providers: Provider[]): Promise<unknown[]> {
+async function resolveLifecycleInstances(
+  container: Container,
+  providers: Provider[],
+  resolvedInstances: unknown[] = [],
+): Promise<unknown[]> {
   const lifecycleEntries: Array<{ token: Token; useValue?: unknown }> = [];
   const seen = new Set<Token>();
 
@@ -716,7 +720,30 @@ async function resolveLifecycleInstances(container: Container, providers: Provid
     lifecycleEntries.push({ token });
   }
 
-  return Promise.all(lifecycleEntries.map((entry) => entry.useValue ?? container.resolve(entry.token)));
+  const resolutionResults = await Promise.allSettled(
+    lifecycleEntries.map((entry) => entry.useValue ?? container.resolve(entry.token)),
+  );
+
+  let resolutionError: unknown;
+  let hasResolutionError = false;
+
+  for (const result of resolutionResults) {
+    if (result.status === 'fulfilled') {
+      resolvedInstances.push(result.value);
+      continue;
+    }
+
+    if (!hasResolutionError) {
+      resolutionError = result.reason;
+      hasResolutionError = true;
+    }
+  }
+
+  if (hasResolutionError) {
+    throw resolutionError;
+  }
+
+  return resolvedInstances;
 }
 
 function createContextCacheableTokenSet(
@@ -960,13 +987,14 @@ function registerRuntimeApplicationContextTokens(bootstrapped: BootstrapResult, 
 async function resolveBootstrapLifecycleInstances(
   bootstrapped: BootstrapResult,
   runtimeProviders: Provider[],
+  resolvedInstances?: unknown[],
 ): Promise<unknown[]> {
   const lifecycleProviders = [
     ...runtimeProviders,
     ...bootstrapped.modules.flatMap((compiledModule) => compiledModule.definition.providers ?? []),
   ];
 
-  return resolveLifecycleInstances(bootstrapped.container, lifecycleProviders);
+  return resolveLifecycleInstances(bootstrapped.container, lifecycleProviders, resolvedInstances);
 }
 
 async function runBootstrapLifecycle(
@@ -1106,7 +1134,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     bootstrappedModules = bootstrapped.modules;
 
     const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
-    lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
+    lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders, lifecycleInstances);
     lifecycleInstances.push({
       onModuleDestroy() {
         return platformShell.stop();
@@ -1252,7 +1280,7 @@ export class FluoFactory {
       bootstrappedModules = bootstrapped.modules;
 
       const resolveLifecycleStart = timingEnabled ? runtimePerformance.now() : 0;
-      lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders);
+      lifecycleInstances = await resolveBootstrapLifecycleInstances(bootstrapped, runtimeProviders, lifecycleInstances);
       lifecycleInstances.push({
         onModuleDestroy() {
           return platformShell.stop();

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -255,9 +255,15 @@ function resolveImportedModules(
 }
 
 function createImportedExportedTokenSet(importedModules: CompiledModule[]): Set<Token> {
-  return new Set<Token>(
-    importedModules.flatMap((imported) => Array.from(imported.exportedTokens)),
-  );
+  const importedExportedTokens = new Set<Token>();
+
+  for (const importedModule of importedModules) {
+    for (const token of importedModule.exportedTokens) {
+      importedExportedTokens.add(token);
+    }
+  }
+
+  return importedExportedTokens;
 }
 
 function createAccessibleTokenSet(
@@ -381,8 +387,7 @@ function validateCompiledModules(
 
   for (const compiledModule of modules) {
     const scope = `module ${compiledModule.type.name}`;
-    const importedModules = resolveImportedModules(compiledModule, compiledByType);
-    const importedExportedTokens = createImportedExportedTokenSet(importedModules);
+    const importedExportedTokens = createImportedExportedTokenSet(resolveImportedModules(compiledModule, compiledByType));
     const accessibleTokens = createAccessibleTokenSet(
       runtimeProviderTokens,
       compiledModule.providerTokens,

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -67,8 +67,10 @@ export async function createFrameworkRequest(
 ): Promise<FrameworkRequest> {
   const url = new URL(request.url ?? '/', 'http://localhost');
   const headers = cloneRequestHeaders(request.headers);
-  const cookies = createMemoizedValue(() => parseCookieHeader(headers.cookie));
-  const query = createMemoizedValue(() => parseQueryParams(url.searchParams));
+  const cookieHeader = cloneHeaderValue(headers.cookie);
+  const searchParams = new URLSearchParams(url.searchParams);
+  const cookies = createMemoizedValue(() => parseCookieHeader(cookieHeader));
+  const query = createMemoizedValue(() => parseQueryParams(searchParams));
   const contentType = readPrimaryHeaderValue(headers['content-type']);
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
 
@@ -196,9 +198,13 @@ function parseQueryParams(searchParams: URLSearchParams): Record<string, string 
 }
 
 function cloneRequestHeaders(headers: IncomingHttpHeaders): FrameworkRequest['headers'] {
-  const clonedEntries = Object.entries(headers).map(([name, value]) => [name, Array.isArray(value) ? [...value] : value]);
+  const clonedEntries = Object.entries(headers).map(([name, value]) => [name, cloneHeaderValue(value)]);
 
   return Object.fromEntries(clonedEntries);
+}
+
+function cloneHeaderValue<T extends string | string[] | undefined>(value: T): T {
+  return (Array.isArray(value) ? [...value] : value) as T;
 }
 
 function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -23,6 +23,11 @@ type NodeFrameworkRequest = FrameworkRequest & {
   rawBody?: Uint8Array;
 };
 
+type MemoizedValue<T> = () => T;
+
+/**
+ * HTTP payload-size error that closes the underlying Node request stream after the response commits.
+ */
 export class NodeRequestPayloadTooLargeException extends PayloadTooLargeException {
   constructor(private readonly request: IncomingMessage) {
     super('Request body exceeds the size limit.');
@@ -62,6 +67,8 @@ export async function createFrameworkRequest(
 ): Promise<FrameworkRequest> {
   const url = new URL(request.url ?? '/', 'http://localhost');
   const headers = cloneRequestHeaders(request.headers);
+  const cookies = createMemoizedValue(() => parseCookieHeader(headers.cookie));
+  const query = createMemoizedValue(() => parseQueryParams(url.searchParams));
   const contentType = readPrimaryHeaderValue(headers['content-type']);
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
 
@@ -92,12 +99,16 @@ export async function createFrameworkRequest(
 
   const frameworkRequest: NodeFrameworkRequest = {
     body,
-    cookies: parseCookieHeader(headers.cookie),
+    get cookies() {
+      return cookies();
+    },
     headers,
     method: request.method ?? 'GET',
     params: {},
     path: url.pathname,
-    query: parseQueryParams(url.searchParams),
+    get query() {
+      return query();
+    },
     raw: request,
     signal,
     url: url.pathname + url.search,
@@ -112,6 +123,20 @@ export async function createFrameworkRequest(
   }
 
   return frameworkRequest;
+}
+
+function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
+  let initialized = false;
+  let value: T;
+
+  return () => {
+    if (!initialized) {
+      value = factory();
+      initialized = true;
+    }
+
+    return value;
+  };
 }
 
 /**

--- a/packages/runtime/src/node/node-request.test.ts
+++ b/packages/runtime/src/node/node-request.test.ts
@@ -72,7 +72,7 @@ describe('node request adapter', () => {
     });
   });
 
-  it('materializes cookies lazily and memoizes the parsed object', async () => {
+  it('captures cookies at creation, then materializes and memoizes the parsed object lazily', async () => {
     const request = createIncomingMessage({
       headers: {
         cookie: 'session=before',
@@ -83,16 +83,19 @@ describe('node request adapter', () => {
     const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
     const mutableHeaders = frameworkRequest.headers as Record<string, string | string[] | undefined>;
 
-    mutableHeaders.cookie = 'session=after';
-    const firstCookies = frameworkRequest.cookies;
+    request.headers.cookie = 'session=after';
     mutableHeaders.cookie = 'session=ignored';
+    const firstCookies = frameworkRequest.cookies;
+    request.headers.cookie = 'session=after-second-access';
+    mutableHeaders.cookie = 'session=ignored-second-access';
     const secondCookies = frameworkRequest.cookies;
 
-    expect(firstCookies).toEqual({ session: 'after' });
+    expect(firstCookies).toEqual({ session: 'before' });
     expect(secondCookies).toBe(firstCookies);
+    expect(secondCookies).toEqual({ session: 'before' });
   });
 
-  it('materializes query parameters lazily and memoizes the parsed object', async () => {
+  it('captures query parameters at creation, then materializes and memoizes the parsed object lazily', async () => {
     const entries = vi.spyOn(URLSearchParams.prototype, 'entries');
     const request = createIncomingMessage({
       headers: {},
@@ -102,13 +105,16 @@ describe('node request adapter', () => {
     try {
       const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
 
+      request.url = '/search?tag=after';
       expect(entries).not.toHaveBeenCalled();
 
       const firstQuery = frameworkRequest.query;
+      request.url = '/search?tag=ignored';
       const secondQuery = frameworkRequest.query;
 
       expect(firstQuery).toEqual({ tag: ['one', 'two'] });
       expect(secondQuery).toBe(firstQuery);
+      expect(secondQuery).toEqual({ tag: ['one', 'two'] });
       expect(entries).toHaveBeenCalledTimes(1);
     } finally {
       entries.mockRestore();

--- a/packages/runtime/src/node/node-request.test.ts
+++ b/packages/runtime/src/node/node-request.test.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from 'node:http';
 import { EventEmitter } from 'node:events';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createFrameworkRequest } from './node-request.js';
 import { NodeRequestPayloadTooLargeException } from './internal-node-request.js';
@@ -70,6 +70,49 @@ describe('node request adapter', () => {
       session: 'abc',
       theme: 'dark',
     });
+  });
+
+  it('materializes cookies lazily and memoizes the parsed object', async () => {
+    const request = createIncomingMessage({
+      headers: {
+        cookie: 'session=before',
+      },
+      url: '/cookies',
+    });
+
+    const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+    const mutableHeaders = frameworkRequest.headers as Record<string, string | string[] | undefined>;
+
+    mutableHeaders.cookie = 'session=after';
+    const firstCookies = frameworkRequest.cookies;
+    mutableHeaders.cookie = 'session=ignored';
+    const secondCookies = frameworkRequest.cookies;
+
+    expect(firstCookies).toEqual({ session: 'after' });
+    expect(secondCookies).toBe(firstCookies);
+  });
+
+  it('materializes query parameters lazily and memoizes the parsed object', async () => {
+    const entries = vi.spyOn(URLSearchParams.prototype, 'entries');
+    const request = createIncomingMessage({
+      headers: {},
+      url: '/search?tag=one&tag=two',
+    });
+
+    try {
+      const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+
+      expect(entries).not.toHaveBeenCalled();
+
+      const firstQuery = frameworkRequest.query;
+      const secondQuery = frameworkRequest.query;
+
+      expect(firstQuery).toEqual({ tag: ['one', 'two'] });
+      expect(secondQuery).toBe(firstQuery);
+      expect(entries).toHaveBeenCalledTimes(1);
+    } finally {
+      entries.mockRestore();
+    }
   });
 
   it('uses the primary content-type value when duplicate content-type headers are present', async () => {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -46,9 +46,17 @@ export interface CompiledModule {
   providerTokens: Set<Token>;
 }
 
+/** Provider declarations that actually win runtime bootstrap registration after duplicate-policy selection. */
+export interface BootstrapEffectiveProviders {
+  moduleProviders: Provider[];
+  rootModuleProviders: Provider[];
+  runtimeProviders: Provider[];
+}
+
 /** Result returned by low-level bootstrap compilation helpers. */
 export interface BootstrapResult {
   container: Container;
+  effectiveProviders: BootstrapEffectiveProviders;
   modules: CompiledModule[];
   rootModule: ModuleType;
 }

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -146,7 +146,7 @@ describe('dispatchWebRequest', () => {
 });
 
 describe('createWebFrameworkRequest', () => {
-  it('materializes headers lazily and memoizes the cloned object', async () => {
+  it('captures headers at creation, then materializes and memoizes the cloned object lazily', async () => {
     const request = new Request('https://runtime.test/headers', {
       headers: {
         'x-runtime': 'before',
@@ -160,8 +160,8 @@ describe('createWebFrameworkRequest', () => {
     request.headers.set('x-runtime', 'ignored');
     const secondHeaders = frameworkRequest.headers;
 
-    expect(firstHeaders['x-runtime']).toBe('after');
+    expect(firstHeaders['x-runtime']).toBe('before');
     expect(secondHeaders).toBe(firstHeaders);
-    expect(secondHeaders['x-runtime']).toBe('after');
+    expect(secondHeaders['x-runtime']).toBe('before');
   });
 });

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { SseResponse, type FrameworkRequest, type FrameworkResponse } from '@fluojs/http';
 
-import { dispatchWebRequest } from './web.js';
+import { createWebFrameworkRequest, dispatchWebRequest } from './web.js';
 
 describe('dispatchWebRequest', () => {
   it('translates Web Request semantics into the framework request contract', async () => {
@@ -142,5 +142,26 @@ describe('dispatchWebRequest', () => {
       },
     });
     expect(producedChunks).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('createWebFrameworkRequest', () => {
+  it('materializes headers lazily and memoizes the cloned object', async () => {
+    const request = new Request('https://runtime.test/headers', {
+      headers: {
+        'x-runtime': 'before',
+      },
+    });
+
+    const frameworkRequest = await createWebFrameworkRequest(request, new AbortController().signal);
+
+    request.headers.set('x-runtime', 'after');
+    const firstHeaders = frameworkRequest.headers;
+    request.headers.set('x-runtime', 'ignored');
+    const secondHeaders = frameworkRequest.headers;
+
+    expect(firstHeaders['x-runtime']).toBe('after');
+    expect(secondHeaders).toBe(firstHeaders);
+    expect(secondHeaders['x-runtime']).toBe('after');
   });
 });

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -316,9 +316,12 @@ export async function createWebFrameworkRequest(
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
   const url = new URL(request.url);
-  const headers = createMemoizedValue(() => cloneWebHeaders(request.headers));
-  const cookies = createMemoizedValue(() => parseCookieHeader(request.headers.get('cookie') ?? undefined));
-  const query = createMemoizedValue(() => parseQueryParams(url.searchParams));
+  const headerEntries = Array.from(request.headers.entries());
+  const cookieHeader = request.headers.get('cookie') ?? undefined;
+  const searchParams = new URLSearchParams(url.searchParams);
+  const headers = createMemoizedValue(() => cloneWebHeaders(headerEntries));
+  const cookies = createMemoizedValue(() => parseCookieHeader(cookieHeader));
+  const query = createMemoizedValue(() => parseQueryParams(searchParams));
   const contentType = request.headers.get('content-type') ?? undefined;
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
 
@@ -405,10 +408,10 @@ function parseQueryParams(searchParams: URLSearchParams): Record<string, string 
   return query;
 }
 
-function cloneWebHeaders(headers: Headers): FrameworkRequest['headers'] {
+function cloneWebHeaders(headers: Array<[string, string]>): FrameworkRequest['headers'] {
   const clonedHeaders: Record<string, string | string[] | undefined> = {};
 
-  for (const [name, value] of headers.entries()) {
+  for (const [name, value] of headers) {
     clonedHeaders[name] = value;
   }
 

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -72,6 +72,8 @@ type WebFrameworkRequest = FrameworkRequest & {
   rawBody?: Uint8Array;
 };
 
+type MemoizedValue<T> = () => T;
+
 class WebResponseStream implements WebFrameworkResponseStream {
   private readonly closeListeners = new Set<() => void>();
   private controller?: ReadableStreamDefaultController<Uint8Array>;
@@ -314,7 +316,9 @@ export async function createWebFrameworkRequest(
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
   const url = new URL(request.url);
-  const headers = cloneWebHeaders(request.headers);
+  const headers = createMemoizedValue(() => cloneWebHeaders(request.headers));
+  const cookies = createMemoizedValue(() => parseCookieHeader(request.headers.get('cookie') ?? undefined));
+  const query = createMemoizedValue(() => parseQueryParams(url.searchParams));
   const contentType = request.headers.get('content-type') ?? undefined;
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
 
@@ -337,12 +341,18 @@ export async function createWebFrameworkRequest(
 
   const frameworkRequest: WebFrameworkRequest = {
     body,
-    cookies: parseCookieHeader(request.headers.get('cookie') ?? undefined),
-    headers,
+    get cookies() {
+      return cookies();
+    },
+    get headers() {
+      return headers();
+    },
     method: request.method,
     params: {},
     path: url.pathname,
-    query: parseQueryParams(url.searchParams),
+    get query() {
+      return query();
+    },
     raw: request,
     signal,
     url: url.pathname + url.search,
@@ -357,6 +367,20 @@ export async function createWebFrameworkRequest(
   }
 
   return frameworkRequest;
+}
+
+function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
+  let initialized = false;
+  let value: T;
+
+  return () => {
+    if (!initialized) {
+      value = factory();
+      initialized = true;
+    }
+
+    return value;
+  };
 }
 
 function parseQueryParams(searchParams: URLSearchParams): Record<string, string | string[]> {


### PR DESCRIPTION
## Summary

Refs #1376

- Reduces `@fluojs/runtime` request/bootstrap hot-path overhead while preserving the public request and application context contracts.
- Documents the new runtime behavioral guarantees in both EN/KO package READMEs and records a patch changeset.
- Fixes the latest review blocker by excluding `multi: true` provider tokens from the context get() fast-path and preserving DI multi-provider array assembly semantics.
- This PR intentionally covers the runtime request/bootstrap hot-path slice only. Remaining #1376 scope, if still desired, should stay tracked separately for lazy body/rawBody follow-ups, broader platform snapshot work, and module-graph items not covered by these runtime-cache regressions.

## Changes

- Adds memoized request metadata getters for cookies/query, plus Web header cloning, without changing `FrameworkRequest` shape.
- Memoizes `Application.get()` / `ApplicationContext.get()` only for safe direct root singleton class/factory providers known at bootstrap; `useExisting` aliases, request/transient providers, post-close lookups, multi-provider tokens, and `container.override()` keep container semantics.
- Resolves independent direct singleton lifecycle providers in parallel before running lifecycle hooks in deterministic provider order, and preserves partially resolved lifecycle instances for bootstrap-failure cleanup when another provider rejects.
- Reduces module-graph imported token set allocation by avoiding intermediate `flatMap` arrays.
- Adds regression tests for singleton context lookup memoization, alias-to-transient/request cache safety, override invalidation, post-close get behavior, multi-provider get() cache exclusion, parallel lifecycle resolution, partial lifecycle cleanup after provider resolution failure, concurrent request-scope dispatch isolation, and creation-time request metadata snapshots.

## Testing

- `lsp_diagnostics` on `packages/runtime/src/bootstrap.ts` and `packages/runtime/src/bootstrap.test.ts`: no diagnostics.
- `lsp_diagnostics` on `packages/runtime/src/web.ts`, `packages/runtime/src/node/internal-node-request.ts`, `packages/runtime/src/web.test.ts`, and `packages/runtime/src/node/node-request.test.ts`: no diagnostics.
- `pnpm --filter @fluojs/runtime exec vitest run -c vitest.config.ts src/bootstrap.test.ts` ✅ passed.
- `pnpm --filter @fluojs/runtime exec vitest run -c vitest.config.ts src/web.test.ts src/node/node-request.test.ts` from `packages/runtime` ✅ 2 files / 11 tests passed.
- `pnpm --filter @fluojs/runtime test` ✅ 16 files / 178 tests passed.
- `pnpm --filter @fluojs/runtime typecheck` ✅ passed.
- `pnpm typecheck` ✅ passed across the workspace after rerun; the first parallel attempt raced with release-readiness dist packaging and failed on transient missing `packages/core/dist` declarations.
- `pnpm verify:release-readiness` ✅ passed; release readiness checks passed without writing draft artifacts.
- `pnpm verify:platform-consistency-governance` ✅ passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.