### PR TITLE
ci: remove duplicate jobs between PR and main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -270,30 +268,6 @@ jobs:
       - name: Verify platform consistency governance
         run: pnpm verify:platform-consistency-governance
 
-  verify-release-readiness:
-    name: Verify release readiness
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: "20"
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify release readiness
-        run: pnpm verify:release-readiness
-
   verify:
     name: Verify
     if: github.event_name == 'pull_request'
@@ -313,18 +287,3 @@ jobs:
           echo "verification mode: ${{ needs.resolve-pr-verification-scope.outputs.mode }}"
           echo "scope reason: ${{ needs.resolve-pr-verification-scope.outputs.reason }}"
           echo "scoped packages: ${{ needs.resolve-pr-verification-scope.outputs.package_names }}"
-
-  release-verify:
-    name: Release verify
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs:
-      - build-and-typecheck
-      - lint
-      - test
-      - verify-platform-consistency-governance
-      - verify-release-readiness
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Main branch release-grade gate passed
-        run: echo "Main branch release-grade verification jobs passed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Verify release readiness
-        run: pnpm verify:release-readiness
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1


### PR DESCRIPTION
## Summary

- `ci.yml`의 `push: main` 트리거를 제거하여 CI workflow를 PR 전용으로 전환
- main push 시에만 동작하는 불필요한 `verify-release-readiness`, `release-verify` job 제거
- `release.yml`에서 CI와 중복되던 `Verify release readiness` step 제거

## Changes

**`.github/workflows/ci.yml`**
- `on.push.branches: [main]` 트리거 제거 → CI는 PR에서만 실행
- `verify-release-readiness` job 제거 (main-push 전용 조건 `if: github.event_name == 'push'`이었으므로 이제 불필요)
- `release-verify` gate job 제거 (마찬가지)

**`.github/workflows/release.yml`**
- `Verify release readiness` step 제거 (PR 단계에서 이미 수행됨)
- `Build packages`는 유지 — `publish-packages`가 실제 dist 결과물을 요구하므로 필수

## Before / After

**이전 흐름:**
```
PR 생성  → ci.yml (6 jobs: build, lint, test, portability, governance, release-verify)
main push → ci.yml (위 6 jobs 전부 재실행) + release.yml (build 중복, verify 중복)
```

**변경 후 흐름:**
```
PR 생성  → ci.yml (4 jobs: build, lint, test, portability, governance, verify gate)
main push → release.yml 단독 실행 (build → publish, 중복 검증 없음)
```

## Testing

PR workflow에서 CI jobs가 정상 실행되는지 확인. main에 머지 후 release.yml 단독 실행 확인 필요.

## Behavioral contract

CI/tooling 변경. runtime 동작 변화 없음. release governance 문서와 정합 확인 완료.