### PR TITLE
Resolve #1383: complete runtime optimization follow-ups

### DIFF
--- a/.changeset/calm-rabbits-run.md
+++ b/.changeset/calm-rabbits-run.md
@@ -1,5 +1,5 @@
 ---
-"@fluojs/runtime": patch
+"@fluojs/runtime": minor
 ---
 
 Defer Node and Web request body materialization to the dispatch boundary while preserving synchronous `FrameworkRequest.body` and `rawBody` values for application code.

--- a/.changeset/calm-rabbits-run.md
+++ b/.changeset/calm-rabbits-run.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Defer Node and Web request body materialization to the dispatch boundary while preserving synchronous `FrameworkRequest.body` and `rawBody` values for application code.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -287,3 +289,27 @@ jobs:
           echo "verification mode: ${{ needs.resolve-pr-verification-scope.outputs.mode }}"
           echo "scope reason: ${{ needs.resolve-pr-verification-scope.outputs.reason }}"
           echo "scoped packages: ${{ needs.resolve-pr-verification-scope.outputs.package_names }}"
+
+  verify-release-readiness:
+    name: Verify release readiness
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify release readiness
+        run: pnpm verify:release-readiness

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      - name: Verify release readiness
+        run: pnpm verify:release-readiness
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -123,6 +123,7 @@ class UsersModule {}
 ## 동작 계약
 
 - 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다.
+- Node 기반 및 Web 표준 요청 wrapper는 바디 파싱 전에 저비용 요청 metadata를 snapshot으로 고정한 뒤 dispatch 경계에서 `body`/`rawBody`를 한 번 materialize하므로 userland는 계속 동기 parsed 값을 관찰합니다.
 - Node 기반 쿠키/쿼리 값과 Web 표준 헤더는 요청 wrapper가 생성되는 시점에 snapshot으로 고정된 뒤 요청별로 lazy하게 normalize되고 memoize됩니다. 이후 upstream 객체가 변경되어도 `FrameworkRequest` view는 바뀌지 않습니다.
 - `ApplicationContext.get()`과 `Application.get()`은 bootstrap 시점에 알려진 직접 root singleton class/factory provider 조회만 memoize하며, alias, request, transient, 종료 이후, multi-provider, `container.override()` 해석 의미는 그대로 유지합니다.
 - `multi: true` provider token은 context cache에 memoize되지 않습니다. 각 `get()` 호출은 DI로 위임되어 컨테이너가 새로운 contribution 배열을 조립하며, 각 contribution 자체는 해당 provider scope에 따라 재사용됩니다.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -123,6 +123,7 @@ class UsersModule {}
 ## Behavioral Contracts
 
 - Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests.
+- Node-backed and Web-standard request wrappers snapshot cheap request metadata before body parsing, then materialize `body`/`rawBody` once at the dispatch boundary so userland continues to observe synchronous parsed values.
 - Node-backed cookies/query values and Web-standard headers are snapshotted when the request wrapper is created, then lazily normalized and memoized per request; later upstream object mutations do not change the `FrameworkRequest` view.
 - `ApplicationContext.get()` and `Application.get()` memoize only direct root singleton class/factory provider lookups known at bootstrap, while preserving alias, request, transient, post-close, multi-provider, and `container.override()` resolution semantics.
 - `multi: true` provider tokens are not context-cache memoized: each `get()` call delegates to DI so the container can assemble a fresh contribution array while still reusing each contribution according to its own provider scope.

--- a/packages/runtime/src/adapters/request-response-factory.test.ts
+++ b/packages/runtime/src/adapters/request-response-factory.test.ts
@@ -46,6 +46,10 @@ describe('dispatchWithRequestResponseFactory', () => {
         events.push(`response:${rawResponse.id}`);
         return response;
       },
+      async materializeRequest(request) {
+        events.push('materialize');
+        request.body = { ready: true };
+      },
       resolveRequestId(rawRequest) {
         return rawRequest.id;
       },
@@ -57,6 +61,7 @@ describe('dispatchWithRequestResponseFactory', () => {
     const frameworkResponse = await dispatchWithRequestResponseFactory({
       dispatcher: {
         async dispatch(request: FrameworkRequest, frameworkResponse: FrameworkResponse) {
+          expect(request.body).toEqual({ ready: true });
           events.push(`dispatch:${String(request.raw === (request.raw as { id: string }))}`);
           expect(frameworkResponse).toBe(response);
         },
@@ -73,6 +78,7 @@ describe('dispatchWithRequestResponseFactory', () => {
       'response:res-1',
       'signal',
       'request:req-1:false',
+      'materialize',
       'dispatch:true',
       'send',
     ]);

--- a/packages/runtime/src/adapters/request-response-factory.ts
+++ b/packages/runtime/src/adapters/request-response-factory.ts
@@ -1,5 +1,6 @@
 import type { Dispatcher, FrameworkRequest, FrameworkResponse } from '@fluojs/http';
 
+/** Request/response factory seam used by shared HTTP adapter dispatch helpers. */
 export interface RequestResponseFactory<
   RawRequest,
   RawResponse,
@@ -8,10 +9,12 @@ export interface RequestResponseFactory<
   createRequest(rawRequest: RawRequest, signal: AbortSignal): Promise<FrameworkRequest>;
   createRequestSignal(rawResponse: RawResponse): AbortSignal;
   createResponse(rawResponse: RawResponse, rawRequest: RawRequest): Response;
+  materializeRequest?(request: FrameworkRequest): Promise<void>;
   resolveRequestId(rawRequest: RawRequest): string | undefined;
   writeErrorResponse(error: unknown, response: Response, requestId?: string): Promise<void>;
 }
 
+/** Options for dispatching one raw platform request through a request/response factory. */
 export interface DispatchWithRequestResponseFactoryOptions<
   RawRequest,
   RawResponse,
@@ -24,6 +27,12 @@ export interface DispatchWithRequestResponseFactoryOptions<
   rawResponse: RawResponse;
 }
 
+/**
+ * Dispatches one raw platform request through the shared request/response factory lifecycle.
+ *
+ * @param options - Factory, dispatcher, and raw platform request/response values for one dispatch.
+ * @returns The framework response after dispatch, error serialization, or default finalization.
+ */
 export async function dispatchWithRequestResponseFactory<
   RawRequest,
   RawResponse,
@@ -40,6 +49,7 @@ export async function dispatchWithRequestResponseFactory<
 
   try {
     const frameworkRequest = await factory.createRequest(rawRequest, signal);
+    await factory.materializeRequest?.(frameworkRequest);
 
     if (!dispatcher) {
       throw new Error(dispatcherNotReadyMessage);

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -49,6 +49,42 @@ describe('bootstrapModule', () => {
     ]);
   });
 
+  it('memoizes imported and accessible token sets while preserving re-export visibility', () => {
+    class Logger {}
+
+    class SharedModule {}
+    defineModuleMetadata(SharedModule, {
+      exports: [Logger],
+      providers: [Logger],
+    });
+
+    class ReExportModule {}
+    defineModuleMetadata(ReExportModule, {
+      exports: [Logger],
+      imports: [SharedModule],
+    });
+
+    @Inject(Logger)
+    class AppService {
+      constructor(readonly logger: Logger) {}
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [ReExportModule],
+      providers: [AppService],
+    });
+
+    const result = bootstrapModule(AppModule);
+    const reExportModule = result.modules.find((compiledModule) => compiledModule.type === ReExportModule);
+    const appModule = result.modules.find((compiledModule) => compiledModule.type === AppModule);
+
+    expect(reExportModule?.importedExportedTokens.has(Logger)).toBe(true);
+    expect(reExportModule?.exportedTokens.has(Logger)).toBe(true);
+    expect(appModule?.importedExportedTokens.has(Logger)).toBe(true);
+    expect(appModule?.accessibleTokens.has(Logger)).toBe(true);
+  });
+
   it('fails when a provider is not exported across modules', () => {
     class InternalRepository {}
 

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -221,7 +221,9 @@ function compileModule(
   const compiledModule: CompiledModule = {
     type: moduleType,
     definition,
+    accessibleTokens: new Set<Token>(),
     exportedTokens: new Set<Token>(),
+    importedExportedTokens: new Set<Token>(),
     providerTokens,
   };
 
@@ -278,6 +280,21 @@ function createAccessibleTokenSet(
     ...importedExportedTokens,
     ...globalExportedTokens,
   ]);
+}
+
+function memoizeAccessibleTokenSet(
+  compiledModule: CompiledModule,
+  importedModules: CompiledModule[],
+  runtimeProviderTokens: Set<Token>,
+  globalExportedTokens: Set<Token>,
+): void {
+  compiledModule.importedExportedTokens = createImportedExportedTokenSet(importedModules);
+  compiledModule.accessibleTokens = createAccessibleTokenSet(
+    runtimeProviderTokens,
+    compiledModule.providerTokens,
+    compiledModule.importedExportedTokens,
+    globalExportedTokens,
+  );
 }
 
 function validateProviderVisibility(
@@ -387,17 +404,16 @@ function validateCompiledModules(
 
   for (const compiledModule of modules) {
     const scope = `module ${compiledModule.type.name}`;
-    const importedExportedTokens = createImportedExportedTokenSet(resolveImportedModules(compiledModule, compiledByType));
-    const accessibleTokens = createAccessibleTokenSet(
+    memoizeAccessibleTokenSet(
+      compiledModule,
+      resolveImportedModules(compiledModule, compiledByType),
       runtimeProviderTokens,
-      compiledModule.providerTokens,
-      importedExportedTokens,
       globalExportedTokens,
     );
 
-    validateProviderVisibility(compiledModule, scope, accessibleTokens);
-    validateControllerVisibility(compiledModule, scope, accessibleTokens);
-    compiledModule.exportedTokens = createExportedTokenSet(compiledModule, importedExportedTokens);
+    validateProviderVisibility(compiledModule, scope, compiledModule.accessibleTokens);
+    validateControllerVisibility(compiledModule, scope, compiledModule.accessibleTokens);
+    compiledModule.exportedTokens = createExportedTokenSet(compiledModule, compiledModule.importedExportedTokens);
   }
 }
 

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -20,6 +20,7 @@ import {
 
 type NodeFrameworkRequest = FrameworkRequest & {
   files?: UploadedFile[];
+  materializeBody?: () => Promise<void>;
   rawBody?: Uint8Array;
 };
 
@@ -65,6 +66,35 @@ export async function createFrameworkRequest(
   maxBodySize = 1 * 1024 * 1024,
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
+  const frameworkRequest = createDeferredFrameworkRequest(
+    request,
+    signal,
+    multipartOptions,
+    maxBodySize,
+    preserveRawBody,
+  );
+  await materializeFrameworkRequestBody(frameworkRequest);
+
+  return frameworkRequest;
+}
+
+/**
+ * Creates the cheap Node framework request shell before consuming the body stream.
+ *
+ * @param request - Raw Node request carrying headers, URL, and body stream.
+ * @param signal - Abort signal tied to the response lifecycle.
+ * @param multipartOptions - Multipart parser options applied when materializing multipart requests.
+ * @param maxBodySize - Maximum allowed non-multipart body size in bytes.
+ * @param preserveRawBody - Whether materialization should retain raw request body bytes.
+ * @returns The framework request shell with metadata snapshotted and body materialization deferred.
+ */
+export function createDeferredFrameworkRequest(
+  request: IncomingMessage,
+  signal: AbortSignal,
+  multipartOptions?: MultipartOptions,
+  maxBodySize = 1 * 1024 * 1024,
+  preserveRawBody = false,
+): FrameworkRequest {
   const url = new URL(request.url ?? '/', 'http://localhost');
   const headers = cloneRequestHeaders(request.headers);
   const cookieHeader = cloneHeaderValue(headers.cookie);
@@ -73,34 +103,34 @@ export async function createFrameworkRequest(
   const query = createMemoizedValue(() => parseQueryParams(searchParams));
   const contentType = readPrimaryHeaderValue(headers['content-type']);
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
+  const materializeBody = createMemoizedAsyncValue(async () => {
+    if (isMultipart) {
+      const result = await parseMultipart(
+        {
+          body: Readable.toWeb(request),
+          headers,
+          method: request.method,
+          url: url.toString(),
+        },
+        {
+          ...multipartOptions,
+          maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
+        },
+      );
+      frameworkRequest.body = result.fields;
+      frameworkRequest.files = result.files;
+      return;
+    }
 
-  let body: unknown;
-  let files: UploadedFile[] | undefined;
-  let rawBody: Uint8Array | undefined;
-
-  if (isMultipart) {
-    const result = await parseMultipart(
-      {
-        body: Readable.toWeb(request),
-        headers,
-        method: request.method,
-        url: url.toString(),
-      },
-      {
-        ...multipartOptions,
-        maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
-      },
-    );
-    body = result.fields;
-    files = result.files;
-  } else {
     const bodyResult = await readRequestBody(request, headers['content-type'], maxBodySize, preserveRawBody);
-    body = bodyResult.body;
-    rawBody = bodyResult.rawBody;
-  }
+    frameworkRequest.body = bodyResult.body;
+
+    if (bodyResult.rawBody) {
+      frameworkRequest.rawBody = bodyResult.rawBody;
+    }
+  });
 
   const frameworkRequest: NodeFrameworkRequest = {
-    body,
     get cookies() {
       return cookies();
     },
@@ -114,17 +144,21 @@ export async function createFrameworkRequest(
     raw: request,
     signal,
     url: url.pathname + url.search,
+    materializeBody,
   };
 
-  if (files) {
-    frameworkRequest.files = files;
-  }
-
-  if (rawBody) {
-    frameworkRequest.rawBody = rawBody;
-  }
-
   return frameworkRequest;
+}
+
+/**
+ * Materializes a deferred Node framework request body exactly once.
+ *
+ * @param request - Framework request returned by {@link createDeferredFrameworkRequest}.
+ * @returns A promise that settles after body, rawBody, and files fields are populated when applicable.
+ */
+export async function materializeFrameworkRequestBody(request: FrameworkRequest): Promise<void> {
+  await (request as NodeFrameworkRequest).materializeBody?.();
+  delete (request as NodeFrameworkRequest).materializeBody;
 }
 
 function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
@@ -138,6 +172,15 @@ function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
     }
 
     return value;
+  };
+}
+
+function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<void> {
+  let promise: Promise<void> | undefined;
+
+  return () => {
+    promise ??= factory();
+    return promise;
   };
 }
 

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -20,9 +20,10 @@ import {
   compressNodeResponse,
 } from './internal-node-compression.js';
 import {
-  createFrameworkRequest,
+  createDeferredFrameworkRequest,
   NodeRequestPayloadTooLargeException,
   createRequestSignal,
+  materializeFrameworkRequestBody,
   resolveRequestIdFromHeaders,
 } from './internal-node-request.js';
 import {
@@ -205,13 +206,16 @@ function createNodeRequestResponseFactory(
 > {
   return {
     async createRequest(request, signal) {
-      return createFrameworkRequest(
+      return createDeferredFrameworkRequest(
         request,
         signal,
         multipartOptions,
         maxBodySize,
         preserveRawBody,
       );
+    },
+    materializeRequest(request) {
+      return materializeFrameworkRequestBody(request);
     },
     createRequestSignal(response) {
       return createRequestSignal(response);

--- a/packages/runtime/src/node/node-request.test.ts
+++ b/packages/runtime/src/node/node-request.test.ts
@@ -3,7 +3,11 @@ import { EventEmitter } from 'node:events';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { createFrameworkRequest } from './node-request.js';
+import {
+  createDeferredFrameworkRequest,
+  createFrameworkRequest,
+  materializeFrameworkRequestBody,
+} from './node-request.js';
 import { NodeRequestPayloadTooLargeException } from './internal-node-request.js';
 
 function createIncomingMessage(options: {
@@ -134,6 +138,40 @@ describe('node request adapter', () => {
     const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
 
     expect(frameworkRequest.body).toEqual({ ok: true });
+  });
+
+  it('creates the request shell before materializing body and rawBody', async () => {
+    let chunksRead = 0;
+    const request = {
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+      async *[Symbol.asyncIterator]() {
+        chunksRead += 1;
+        yield Buffer.from('{"ok":true}', 'utf8');
+      },
+      url: '/body?tag=one',
+    } as unknown as IncomingMessage;
+
+    const frameworkRequest = createDeferredFrameworkRequest(
+      request,
+      new AbortController().signal,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(chunksRead).toBe(0);
+    expect(frameworkRequest.path).toBe('/body');
+    expect(frameworkRequest.query).toEqual({ tag: 'one' });
+
+    await materializeFrameworkRequestBody(frameworkRequest);
+    await materializeFrameworkRequestBody(frameworkRequest);
+
+    expect(chunksRead).toBe(1);
+    expect(frameworkRequest.body).toEqual({ ok: true });
+    expect(Buffer.from(frameworkRequest.rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
   });
 
   it('destroys the raw Node request stream when maxBodySize is exceeded', async () => {

--- a/packages/runtime/src/node/node-request.ts
+++ b/packages/runtime/src/node/node-request.ts
@@ -1,5 +1,7 @@
 export {
+  createDeferredFrameworkRequest,
   createFrameworkRequest,
   createRequestSignal,
+  materializeFrameworkRequestBody,
   resolveRequestIdFromHeaders,
 } from './internal-node-request.js';

--- a/packages/runtime/src/platform-shell.test.ts
+++ b/packages/runtime/src/platform-shell.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type {
   PlatformComponent,
@@ -175,6 +175,34 @@ describe('RuntimePlatformShell', () => {
     expect(snapshot.components.find((component) => component.id === 'search.default')?.dependencies).toEqual(['cache.default']);
 
     await shell.stop();
+  });
+
+  it('collects snapshot readiness and health without re-entering shell probe methods', async () => {
+    const events: string[] = [];
+    const component = new StubPlatformComponent(
+      'cache.default',
+      'cache',
+      events,
+      { critical: false, status: 'ready' },
+      { status: 'healthy' },
+    );
+
+    const shell = RuntimePlatformShell.fromInputs([
+      { component, dependencies: [] },
+    ]);
+    const shellReady = vi.spyOn(shell, 'ready');
+    const shellHealth = vi.spyOn(shell, 'health');
+    const componentReady = vi.spyOn(component, 'ready');
+    const componentHealth = vi.spyOn(component, 'health');
+
+    const snapshot = await shell.snapshot();
+
+    expect(snapshot.readiness.status).toBe('ready');
+    expect(snapshot.health.status).toBe('healthy');
+    expect(shellReady).not.toHaveBeenCalled();
+    expect(shellHealth).not.toHaveBeenCalled();
+    expect(componentReady).toHaveBeenCalledTimes(1);
+    expect(componentHealth).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the original start failure as primary and allows follow-up cleanup when rollback stop fails', async () => {

--- a/packages/runtime/src/platform-shell.ts
+++ b/packages/runtime/src/platform-shell.ts
@@ -130,6 +130,28 @@ function normalizeSnapshot(snapshot: PlatformSnapshot, component: PlatformCompon
   };
 }
 
+interface PlatformSnapshotProbeResult {
+  diagnostics: PlatformDiagnosticIssue[];
+  health: PlatformHealthReport;
+  readiness: PlatformReadinessReport;
+  snapshot: PlatformSnapshot;
+}
+
+interface PlatformSnapshotResult {
+  diagnostics: PlatformDiagnosticIssue[];
+  snapshot: PlatformSnapshot;
+}
+
+interface PlatformReadinessResult {
+  diagnostics: PlatformDiagnosticIssue[];
+  readiness: PlatformReadinessReport;
+}
+
+interface PlatformHealthResult {
+  diagnostics: PlatformDiagnosticIssue[];
+  health: PlatformHealthReport;
+}
+
 /**
  * A runtime implementation of the {@link PlatformShell} that manages the lifecycle
  * of registered platform components, including dependency ordering and diagnostics.
@@ -282,15 +304,55 @@ export class RuntimePlatformShell implements PlatformShell {
       return createEmptyShellSnapshot([...this.diagnostics]);
     }
 
-    const components: PlatformSnapshot[] = [];
-    for (const registration of this.registeredComponents) {
-      try {
-        const snapshot = registration.component.snapshot();
-        components.push(normalizeSnapshot(snapshot, registration.component, registration.dependencies));
-      } catch (error) {
-        const issue = createUnknownFailureIssue(registration.component.id, 'snapshot', error);
-        this.diagnostics.push(issue);
-        components.push({
+    const probeResults = await Promise.all(
+      this.registeredComponents.map((registration) => this.collectSnapshotProbe(registration)),
+    );
+    const components = probeResults.map((result) => result.snapshot);
+    const readiness = aggregateReadiness(probeResults.map((result) => result.readiness));
+    const health = aggregateHealth(probeResults.map((result) => result.health));
+    const diagnostics = probeResults.flatMap((result) => result.diagnostics);
+    this.diagnostics.push(...diagnostics);
+
+    return {
+      components,
+      diagnostics: [...this.diagnostics],
+      generatedAt: new Date().toISOString(),
+      health,
+      readiness,
+    };
+  }
+
+  private async collectSnapshotProbe(registration: RegisteredPlatformComponent): Promise<PlatformSnapshotProbeResult> {
+    const [snapshot, readiness, health] = await Promise.all([
+      this.collectComponentSnapshot(registration),
+      this.collectComponentReadiness(registration),
+      this.collectComponentHealth(registration),
+    ]);
+
+    return {
+      diagnostics: [
+        ...snapshot.diagnostics,
+        ...readiness.diagnostics,
+        ...health.diagnostics,
+      ],
+      health: health.health,
+      readiness: readiness.readiness,
+      snapshot: snapshot.snapshot,
+    };
+  }
+
+  private collectComponentSnapshot(registration: RegisteredPlatformComponent): PlatformSnapshotResult {
+    try {
+      const snapshot = registration.component.snapshot();
+      return {
+        diagnostics: [],
+        snapshot: normalizeSnapshot(snapshot, registration.component, registration.dependencies),
+      };
+    } catch (error) {
+      const issue = createUnknownFailureIssue(registration.component.id, 'snapshot', error);
+      return {
+        diagnostics: [issue],
+        snapshot: {
           dependencies: [...registration.dependencies],
           details: {},
           health: {
@@ -313,19 +375,46 @@ export class RuntimePlatformShell implements PlatformShell {
             namespace: 'fluo.platform',
             tags: {},
           },
-        });
-      }
+        },
+      };
     }
+  }
 
-    const [readiness, health] = await Promise.all([this.ready(), this.health()]);
+  private async collectComponentReadiness(registration: RegisteredPlatformComponent): Promise<PlatformReadinessResult> {
+    try {
+      return {
+        diagnostics: [],
+        readiness: await registration.component.ready(),
+      };
+    } catch (error) {
+      const issue = createUnknownFailureIssue(registration.component.id, 'ready', error);
+      return {
+        diagnostics: [issue],
+        readiness: {
+          critical: true,
+          reason: issue.cause,
+          status: 'not-ready',
+        },
+      };
+    }
+  }
 
-    return {
-      components,
-      diagnostics: [...this.diagnostics],
-      generatedAt: new Date().toISOString(),
-      health,
-      readiness,
-    };
+  private async collectComponentHealth(registration: RegisteredPlatformComponent): Promise<PlatformHealthResult> {
+    try {
+      return {
+        diagnostics: [],
+        health: await registration.component.health(),
+      };
+    } catch (error) {
+      const issue = createUnknownFailureIssue(registration.component.id, 'health', error);
+      return {
+        diagnostics: [issue],
+        health: {
+          reason: issue.cause,
+          status: 'unhealthy',
+        },
+      };
+    }
   }
 
   async assertCriticalReadiness(): Promise<void> {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -42,7 +42,9 @@ export interface BootstrapModuleOptions {
 export interface CompiledModule {
   type: ModuleType;
   definition: ModuleDefinition;
+  accessibleTokens: Set<Token>;
   exportedTokens: Set<Token>;
+  importedExportedTokens: Set<Token>;
   providerTokens: Set<Token>;
 }
 

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -210,4 +210,24 @@ describe('createWebFrameworkRequest', () => {
     expect(frameworkRequest.body).toEqual({ ok: true });
     expect(Buffer.from(frameworkRequest.rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
   });
+
+  it('uses creation-time metadata when materializing deferred multipart bodies', async () => {
+    const formData = new FormData();
+    formData.set('title', 'before');
+    const request = new Request('https://runtime.test/upload?tag=one', {
+      body: formData,
+      method: 'POST',
+    });
+    const factory = createWebRequestResponseFactory();
+    const frameworkRequest = await factory.createRequest(request, new AbortController().signal);
+
+    request.headers.set('content-type', 'text/plain');
+    request.headers.set('x-runtime', 'after');
+
+    await factory.materializeRequest?.(frameworkRequest);
+
+    expect(frameworkRequest.body).toEqual({ title: 'before' });
+    expect(frameworkRequest.headers['content-type']).toContain('multipart/form-data');
+    expect(frameworkRequest.headers['x-runtime']).toBeUndefined();
+  });
 });

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { SseResponse, type FrameworkRequest, type FrameworkResponse } from '@fluojs/http';
 
-import { createWebFrameworkRequest, dispatchWebRequest } from './web.js';
+import {
+  createWebFrameworkRequest,
+  createWebRequestResponseFactory,
+  dispatchWebRequest,
+} from './web.js';
 
 describe('dispatchWebRequest', () => {
   it('translates Web Request semantics into the framework request contract', async () => {
@@ -163,5 +167,47 @@ describe('createWebFrameworkRequest', () => {
     expect(firstHeaders['x-runtime']).toBe('before');
     expect(secondHeaders).toBe(firstHeaders);
     expect(secondHeaders['x-runtime']).toBe('before');
+  });
+
+  it('creates the request shell before materializing body and rawBody', async () => {
+    let pulls = 0;
+    const request = new Request('https://runtime.test/body?tag=one', {
+      body: new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pulls += 1;
+          controller.enqueue(new TextEncoder().encode('{"ok":true}'));
+          controller.close();
+        },
+      }),
+      duplex: 'half',
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    } as RequestInit & { duplex: 'half' });
+    const originalClone = request.clone.bind(request);
+    let cloneCalls = 0;
+
+    Object.defineProperty(request, 'clone', {
+      value: () => {
+        cloneCalls += 1;
+        return originalClone();
+      },
+    });
+
+    const factory = createWebRequestResponseFactory({ rawBody: true });
+    const frameworkRequest = await factory.createRequest(request, new AbortController().signal);
+
+    expect(cloneCalls).toBe(0);
+    expect(frameworkRequest.path).toBe('/body');
+    expect(frameworkRequest.query).toEqual({ tag: 'one' });
+
+    await factory.materializeRequest?.(frameworkRequest);
+    await factory.materializeRequest?.(frameworkRequest);
+
+    expect(cloneCalls).toBe(1);
+    expect(pulls).toBe(1);
+    expect(frameworkRequest.body).toEqual({ ok: true });
+    expect(Buffer.from(frameworkRequest.rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
   });
 });

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -69,6 +69,7 @@ interface WebFrameworkResponseStream {
 
 type WebFrameworkRequest = FrameworkRequest & {
   files?: UploadedFile[];
+  materializeBody?: () => Promise<void>;
   rawBody?: Uint8Array;
 };
 
@@ -250,13 +251,16 @@ export function createWebRequestResponseFactory(
 ): RequestResponseFactory<Request, AbortSignal | undefined, WebFrameworkResponse> {
   return {
     async createRequest(request: Request, signal: AbortSignal) {
-      return await createWebFrameworkRequest(
+      return createDeferredWebFrameworkRequest(
         request,
         signal,
         options.multipart,
         options.maxBodySize ?? DEFAULT_MAX_BODY_SIZE,
         options.rawBody ?? false,
       );
+    },
+    materializeRequest(request) {
+      return materializeWebFrameworkRequestBody(request);
     },
     createRequestSignal(signal) {
       return signal ?? new AbortController().signal;
@@ -315,6 +319,35 @@ export async function createWebFrameworkRequest(
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
+  const frameworkRequest = createDeferredWebFrameworkRequest(
+    request,
+    signal,
+    multipartOptions,
+    maxBodySize,
+    preserveRawBody,
+  );
+  await materializeWebFrameworkRequestBody(frameworkRequest);
+
+  return frameworkRequest;
+}
+
+/**
+ * Creates the cheap Web framework request shell before consuming the body stream.
+ *
+ * @param request - Native Web request to normalize.
+ * @param signal - Abort signal propagated to the framework request.
+ * @param multipartOptions - Multipart parser options applied when materializing multipart requests.
+ * @param maxBodySize - Maximum allowed non-multipart body size in bytes.
+ * @param preserveRawBody - Whether materialization should retain raw request body bytes.
+ * @returns The framework request shell with metadata snapshotted and body materialization deferred.
+ */
+function createDeferredWebFrameworkRequest(
+  request: Request,
+  signal: AbortSignal,
+  multipartOptions?: MultipartOptions,
+  maxBodySize = DEFAULT_MAX_BODY_SIZE,
+  preserveRawBody = false,
+): FrameworkRequest {
   const url = new URL(request.url);
   const headerEntries = Array.from(request.headers.entries());
   const cookieHeader = request.headers.get('cookie') ?? undefined;
@@ -324,26 +357,26 @@ export async function createWebFrameworkRequest(
   const query = createMemoizedValue(() => parseQueryParams(searchParams));
   const contentType = request.headers.get('content-type') ?? undefined;
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
+  const materializeBody = createMemoizedAsyncValue(async () => {
+    if (isMultipart) {
+      const result = await parseMultipart(request.clone(), {
+        ...multipartOptions,
+        maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
+      });
+      frameworkRequest.body = result.fields;
+      frameworkRequest.files = result.files;
+      return;
+    }
 
-  let body: unknown;
-  let files: UploadedFile[] | undefined;
-  let rawBody: Uint8Array | undefined;
-
-  if (isMultipart) {
-    const result = await parseMultipart(request.clone(), {
-      ...multipartOptions,
-      maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
-    });
-    body = result.fields;
-    files = result.files;
-  } else {
     const bodyResult = await readWebRequestBody(request.clone(), contentType, maxBodySize, preserveRawBody);
-    body = bodyResult.body;
-    rawBody = bodyResult.rawBody;
-  }
+    frameworkRequest.body = bodyResult.body;
+
+    if (bodyResult.rawBody) {
+      frameworkRequest.rawBody = bodyResult.rawBody;
+    }
+  });
 
   const frameworkRequest: WebFrameworkRequest = {
-    body,
     get cookies() {
       return cookies();
     },
@@ -359,17 +392,21 @@ export async function createWebFrameworkRequest(
     raw: request,
     signal,
     url: url.pathname + url.search,
+    materializeBody,
   };
 
-  if (files) {
-    frameworkRequest.files = files;
-  }
-
-  if (rawBody) {
-    frameworkRequest.rawBody = rawBody;
-  }
-
   return frameworkRequest;
+}
+
+/**
+ * Materializes a deferred Web framework request body exactly once.
+ *
+ * @param request - Framework request returned by {@link createDeferredWebFrameworkRequest}.
+ * @returns A promise that settles after body, rawBody, and files fields are populated when applicable.
+ */
+async function materializeWebFrameworkRequestBody(request: FrameworkRequest): Promise<void> {
+  await (request as WebFrameworkRequest).materializeBody?.();
+  delete (request as WebFrameworkRequest).materializeBody;
 }
 
 function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
@@ -383,6 +420,15 @@ function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
     }
 
     return value;
+  };
+}
+
+function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<void> {
+  let promise: Promise<void> | undefined;
+
+  return () => {
+    promise ??= factory();
+    return promise;
   };
 }
 

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -350,6 +350,7 @@ function createDeferredWebFrameworkRequest(
 ): FrameworkRequest {
   const url = new URL(request.url);
   const headerEntries = Array.from(request.headers.entries());
+  const method = request.method;
   const cookieHeader = request.headers.get('cookie') ?? undefined;
   const searchParams = new URLSearchParams(url.searchParams);
   const headers = createMemoizedValue(() => cloneWebHeaders(headerEntries));
@@ -359,7 +360,13 @@ function createDeferredWebFrameworkRequest(
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
   const materializeBody = createMemoizedAsyncValue(async () => {
     if (isMultipart) {
-      const result = await parseMultipart(request.clone(), {
+      const materializedRequest = request.clone();
+      const result = await parseMultipart({
+        body: materializedRequest.body,
+        headers: new Headers(headerEntries),
+        method,
+        url: url.toString(),
+      }, {
         ...multipartOptions,
         maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
       });
@@ -383,7 +390,7 @@ function createDeferredWebFrameworkRequest(
     get headers() {
       return headers();
     },
-    method: request.method,
+    method,
     params: {},
     path: url.pathname,
     get query() {


### PR DESCRIPTION
## Summary

Completes the remaining @fluojs/runtime optimization work for request materialization, module graph validation, and platform snapshots, then aligns the release-readiness workflow gates with the governance tests already fixed on changeset-release/main.

Closes #1383

## Changes

- Deferred Node/Web request body parsing until the shared dispatch boundary while preserving synchronous userland FrameworkRequest body/rawBody values.
- Cached module visibility token sets on compiled modules and used those cached sets during validation.
- Collected platform snapshot/readiness/health probes in one per-component pass with deterministic diagnostic aggregation.
- Added runtime README/README.ko behavioral contract notes and a minor changeset for @fluojs/runtime.
- Added the verify:release-readiness gate to CI and release workflows to satisfy platform consistency governance.

## Testing

- PASS: pnpm vitest run packages/runtime/src/node/node-request.test.ts packages/runtime/src/web.test.ts packages/runtime/src/adapters/request-response-factory.test.ts packages/runtime/src/bootstrap.test.ts packages/runtime/src/platform-shell.test.ts
- PASS: pnpm vitest run packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
- PASS: pnpm verify:platform-consistency-governance
- PASS: pnpm build
- PASS: pnpm typecheck
- PASS: pnpm verify:public-export-tsdoc
- PASS: pnpm lint (exits 0; existing warnings remain in unrelated packages)
- PASS: pnpm test (197 files, 2177 tests)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.