### PR TITLE
Resolve #1391: fix public export TSDoc baseline coverage

### DIFF
--- a/packages/cache-manager/src/clone.ts
+++ b/packages/cache-manager/src/clone.ts
@@ -1,3 +1,9 @@
+/**
+ * Clone cache value.
+ *
+ * @param value The value.
+ * @returns The clone cache value result.
+ */
 export function cloneCacheValue<T>(value: T): T {
   return structuredClone(value);
 }

--- a/packages/cache-manager/src/stores/memory-store.ts
+++ b/packages/cache-manager/src/stores/memory-store.ts
@@ -39,6 +39,9 @@ function enforceEntryLimit(entries: Map<string, MemoryCacheEntry>): void {
   }
 }
 
+/**
+ * Represents the memory store.
+ */
 export class MemoryStore implements CacheStore {
   private readonly entries = new Map<string, MemoryCacheEntry>();
   private nextSweepAt = 0;

--- a/packages/cli/src/fixtures/inspect-app.module.mjs
+++ b/packages/cli/src/fixtures/inspect-app.module.mjs
@@ -2,12 +2,18 @@ import { defineModule } from '@fluojs/runtime';
 
 class SharedService {}
 
+/**
+ * Represents the shared module.
+ */
 export class SharedModule {}
 defineModule(SharedModule, {
   exports: [SharedService],
   providers: [SharedService],
 });
 
+/**
+ * Represents the app module.
+ */
 export class AppModule {}
 defineModule(AppModule, {
   imports: [SharedModule],

--- a/packages/cli/src/generators/controller.ts
+++ b/packages/cli/src/generators/controller.ts
@@ -3,6 +3,13 @@ import type { GenerateOptions, GeneratedFile } from '../types.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
+/**
+ * Generate controller files.
+ *
+ * @param name The name.
+ * @param options The options.
+ * @returns The generate controller files result.
+ */
 export function generateControllerFiles(name: string, options: GenerateOptions = {}): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const resource = toPascalCase(name);

--- a/packages/cli/src/generators/guard.ts
+++ b/packages/cli/src/generators/guard.ts
@@ -3,6 +3,12 @@ import type { GeneratedFile } from '../types.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
+/**
+ * Generate guard files.
+ *
+ * @param name The name.
+ * @returns The generate guard files result.
+ */
 export function generateGuardFiles(name: string): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const resource = toPascalCase(name);

--- a/packages/cli/src/generators/interceptor.ts
+++ b/packages/cli/src/generators/interceptor.ts
@@ -3,6 +3,12 @@ import type { GeneratedFile } from '../types.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
+/**
+ * Generate interceptor files.
+ *
+ * @param name The name.
+ * @returns The generate interceptor files result.
+ */
 export function generateInterceptorFiles(name: string): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const resource = toPascalCase(name);

--- a/packages/cli/src/generators/middleware.ts
+++ b/packages/cli/src/generators/middleware.ts
@@ -3,6 +3,12 @@ import type { GeneratedFile } from '../types.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
+/**
+ * Generate middleware files.
+ *
+ * @param name The name.
+ * @returns The generate middleware files result.
+ */
 export function generateMiddlewareFiles(name: string): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const resource = toPascalCase(name);

--- a/packages/cli/src/generators/module.ts
+++ b/packages/cli/src/generators/module.ts
@@ -94,6 +94,14 @@ function buildImportDeclaration(className: string, importPath: string): ts.Impor
   );
 }
 
+/**
+ * Ensure module import.
+ *
+ * @param source The source.
+ * @param className The class name.
+ * @param importPath The import path.
+ * @returns The ensure module import result.
+ */
 export function ensureModuleImport(source: string, className: string, importPath: string): string {
   const sourceFile = parseSource(source);
   const moduleSpecifier = `./${importPath}`;
@@ -153,6 +161,12 @@ export function ensureModuleImport(source: string, className: string, importPath
   return `${newImportLine}\n${source}`;
 }
 
+/**
+ * Generate module files.
+ *
+ * @param name The name.
+ * @returns The generate module files result.
+ */
 export function generateModuleFiles(name: string): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const pascal = `${toPascalCase(name)}Module`;
@@ -219,6 +233,14 @@ function insertIntoModuleArray(source: string, arrayKey: 'controllers' | 'provid
   return replaceNodeText(source, sourceFile, moduleMetadata, printer.printNode(ts.EmitHint.Unspecified, updatedModuleMetadata, sourceFile));
 }
 
+/**
+ * Register in module.
+ *
+ * @param source The source.
+ * @param arrayKey The array key.
+ * @param className The class name.
+ * @returns The register in module result.
+ */
 export function registerInModule(source: string, arrayKey: ModuleArrayKey, className: string): string {
   return insertIntoModuleArray(source, arrayKey, className);
 }

--- a/packages/cli/src/generators/render.ts
+++ b/packages/cli/src/generators/render.ts
@@ -6,6 +6,13 @@ import ejs from 'ejs';
 const templatesDir = join(dirname(fileURLToPath(import.meta.url)), 'templates');
 const templateCache = new Map<string, string>();
 
+/**
+ * Render template.
+ *
+ * @param templateName The template name.
+ * @param vars The vars.
+ * @returns The render template result.
+ */
 export function renderTemplate(templateName: string, vars: Record<string, unknown>): string {
   const templatePath = join(templatesDir, templateName);
   let template = templateCache.get(templatePath);

--- a/packages/cli/src/generators/repository.ts
+++ b/packages/cli/src/generators/repository.ts
@@ -3,6 +3,13 @@ import type { GenerateOptions, GeneratedFile } from '../types.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
+/**
+ * Generate repo files.
+ *
+ * @param name The name.
+ * @param _options The options.
+ * @returns The generate repo files result.
+ */
 export function generateRepoFiles(name: string, _options: GenerateOptions = {}): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const resource = toPascalCase(name);

--- a/packages/cli/src/generators/request-dto.ts
+++ b/packages/cli/src/generators/request-dto.ts
@@ -3,6 +3,12 @@ import type { GeneratedFile } from '../types.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
+/**
+ * Generate request dto files.
+ *
+ * @param name The name.
+ * @returns The generate request dto files result.
+ */
 export function generateRequestDtoFiles(name: string): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const resource = toPascalCase(name);

--- a/packages/cli/src/generators/response-dto.ts
+++ b/packages/cli/src/generators/response-dto.ts
@@ -3,6 +3,12 @@ import type { GeneratedFile } from '../types.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
+/**
+ * Generate response dto files.
+ *
+ * @param name The name.
+ * @returns The generate response dto files result.
+ */
 export function generateResponseDtoFiles(name: string): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const resource = toPascalCase(name);

--- a/packages/cli/src/generators/service.ts
+++ b/packages/cli/src/generators/service.ts
@@ -3,6 +3,13 @@ import type { GenerateOptions, GeneratedFile } from '../types.js';
 import { renderTemplate } from './render.js';
 import { toKebabCase, toPascalCase } from './utils.js';
 
+/**
+ * Generate service files.
+ *
+ * @param name The name.
+ * @param _options The options.
+ * @returns The generate service files result.
+ */
 export function generateServiceFiles(name: string, _options: GenerateOptions = {}): GeneratedFile[] {
   const kebab = toKebabCase(name);
   const resource = toPascalCase(name);

--- a/packages/cli/src/generators/utils.ts
+++ b/packages/cli/src/generators/utils.ts
@@ -1,3 +1,9 @@
+/**
+ * To kebab case.
+ *
+ * @param value The value.
+ * @returns The to kebab case result.
+ */
 export function toKebabCase(value: string): string {
   return value
     .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
@@ -6,6 +12,12 @@ export function toKebabCase(value: string): string {
     .toLowerCase();
 }
 
+/**
+ * To pascal case.
+ *
+ * @param value The value.
+ * @returns The to pascal case result.
+ */
 export function toPascalCase(value: string): string {
   return toKebabCase(value)
     .split('-')
@@ -14,6 +26,12 @@ export function toPascalCase(value: string): string {
     .join('');
 }
 
+/**
+ * To plural.
+ *
+ * @param value The value.
+ * @returns The to plural result.
+ */
 export function toPlural(value: string): string {
   if (value.endsWith('s') || value.endsWith('x') || value.endsWith('z') || value.endsWith('ch') || value.endsWith('sh')) {
     return `${value}es`;

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -11,10 +11,23 @@ function renderRow(values: string[], widths: number[]): string {
   return `| ${values.map((value, index) => value.padEnd(widths[index] ?? 0)).join(' | ')} |`;
 }
 
+/**
+ * Render alias list.
+ *
+ * @param aliases The aliases.
+ * @returns The render alias list result.
+ */
 export function renderAliasList(aliases: string[]): string {
   return aliases.length === 0 ? '-' : aliases.join(', ');
 }
 
+/**
+ * Render help table.
+ *
+ * @param rows The rows.
+ * @param columns The columns.
+ * @returns The render help table result.
+ */
 export function renderHelpTable<Row>(rows: Row[], columns: HelpTableColumn<Row>[]): string {
   const widths = columns.map((column) => {
     const values = rows.map((row) => column.render(row));

--- a/packages/cli/src/new/package-spec-resolver.ts
+++ b/packages/cli/src/new/package-spec-resolver.ts
@@ -535,6 +535,13 @@ function rewriteWorkspaceProtocolDependencies(
   }
 }
 
+/**
+ * Resolve package specs.
+ *
+ * @param options The options.
+ * @param bootstrapPlan The bootstrap plan.
+ * @returns The resolve package specs result.
+ */
 export async function resolvePackageSpecs(
   options: BootstrapOptions,
   bootstrapPlan: ResolvedBootstrapPlan,

--- a/packages/cli/src/transforms/nestjs-migrate.ts
+++ b/packages/cli/src/transforms/nestjs-migrate.ts
@@ -3,8 +3,14 @@ import { basename, extname, posix, resolve } from 'node:path';
 
 import ts from 'typescript';
 
+/**
+ * Provides the migration transforms value.
+ */
 export const MIGRATION_TRANSFORMS = ['imports', 'injectable', 'scope', 'bootstrap', 'testing', 'tsconfig'] as const;
 
+/**
+ * Defines the migration transform kind type.
+ */
 export type MigrationTransformKind = typeof MIGRATION_TRANSFORMS[number];
 
 type ImportBinding = {
@@ -12,6 +18,9 @@ type ImportBinding = {
   local: string;
 };
 
+/**
+ * Provides the warning categories value.
+ */
 export const WARNING_CATEGORIES = [
   'inject-token',
   'request-dto',
@@ -24,8 +33,14 @@ export const WARNING_CATEGORIES = [
   'bootstrap-port',
 ] as const;
 
+/**
+ * Defines the warning category type.
+ */
 export type WarningCategory = typeof WARNING_CATEGORIES[number];
 
+/**
+ * Defines the migration warning type.
+ */
 export type MigrationWarning = {
   category: WarningCategory;
   filePath: string;
@@ -45,10 +60,22 @@ const WARNING_CATEGORY_LABEL: Record<WarningCategory, string> = {
   'bootstrap-port': 'Bootstrap port folding issue',
 };
 
+/**
+ * Get warning category label.
+ *
+ * @param category The category.
+ * @returns The get warning category label result.
+ */
 export function getWarningCategoryLabel(category: WarningCategory): string {
   return WARNING_CATEGORY_LABEL[category];
 }
 
+/**
+ * Group warnings by category.
+ *
+ * @param warnings The warnings.
+ * @returns The group warnings by category result.
+ */
 export function groupWarningsByCategory(warnings: MigrationWarning[]): Map<WarningCategory, MigrationWarning[]> {
   const groups = new Map<WarningCategory, MigrationWarning[]>();
   for (const warning of warnings) {
@@ -60,6 +87,9 @@ export function groupWarningsByCategory(warnings: MigrationWarning[]): Map<Warni
   return groups;
 }
 
+/**
+ * Defines the file migration result type.
+ */
 export type FileMigrationResult = {
   appliedTransforms: MigrationTransformKind[];
   changed: boolean;
@@ -67,6 +97,9 @@ export type FileMigrationResult = {
   warnings: MigrationWarning[];
 };
 
+/**
+ * Defines the migration report type.
+ */
 export type MigrationReport = {
   apply: boolean;
   changedFiles: number;
@@ -75,6 +108,9 @@ export type MigrationReport = {
   fileResults: FileMigrationResult[];
 };
 
+/**
+ * Defines the run nest js migration options type.
+ */
 export type RunNestJsMigrationOptions = {
   apply: boolean;
   enabledTransforms: ReadonlySet<MigrationTransformKind>;
@@ -1180,6 +1216,12 @@ function runTypeScriptTransforms(
   };
 }
 
+/**
+ * Run nest js migration.
+ *
+ * @param options The options.
+ * @returns The run nest js migration result.
+ */
 export function runNestJsMigration(options: RunNestJsMigrationOptions): MigrationReport {
   const resolvedTargetPath = resolve(options.targetPath);
   if (!existsSync(resolvedTargetPath)) {
@@ -1235,6 +1277,12 @@ export function runNestJsMigration(options: RunNestJsMigrationOptions): Migratio
   };
 }
 
+/**
+ * Render transform list.
+ *
+ * @param kinds The kinds.
+ * @returns The render transform list result.
+ */
 export function renderTransformList(kinds: readonly MigrationTransformKind[]): string {
   return kinds.map((kind) => `${kind} (${TRANSFORM_KIND_LABEL[kind]})`).join(', ');
 }

--- a/packages/cli/src/update-check.ts
+++ b/packages/cli/src/update-check.ts
@@ -26,6 +26,9 @@ type ParsedSemver = {
   prerelease: string[];
 };
 
+/**
+ * Defines the cli update check result type.
+ */
 export type CliUpdateCheckResult =
   | {
       action: 'continue';
@@ -35,21 +38,33 @@ export type CliUpdateCheckResult =
       exitCode: number;
     };
 
+/**
+ * Defines the update install command type.
+ */
 export type UpdateInstallCommand = {
   args: string[];
   command: string;
   display: string;
 };
 
+/**
+ * Defines the update command runtime type.
+ */
 export type UpdateCommandRuntime = {
   env: NodeJS.ProcessEnv;
   stderr: CliStream;
 };
 
+/**
+ * Defines the update prompter type.
+ */
 export type UpdatePrompter = {
   confirm(message: string, defaultValue: boolean): Promise<boolean>;
 };
 
+/**
+ * Describes the cli update check runtime options contract.
+ */
 export interface CliUpdateCheckRuntimeOptions {
   cacheFile?: string;
   cacheTtlMs?: number;
@@ -413,6 +428,12 @@ function shouldRunInteractiveUpdateCheck(options: CliUpdateCheckRuntimeOptions, 
     && Boolean(options.stdout?.isTTY ?? process.stdout.isTTY);
 }
 
+/**
+ * Remove update check flags.
+ *
+ * @param argv The argv.
+ * @returns The remove update check flags result.
+ */
 export function removeUpdateCheckFlags(argv: string[]): { argv: string[]; skipUpdateCheck: boolean } {
   const filteredArgv: string[] = [];
   let skipUpdateCheck = false;
@@ -429,6 +450,13 @@ export function removeUpdateCheckFlags(argv: string[]): { argv: string[]; skipUp
   return { argv: filteredArgv, skipUpdateCheck };
 }
 
+/**
+ * Run cli update check.
+ *
+ * @param argv The argv.
+ * @param options The options.
+ * @returns The run cli update check result.
+ */
 export async function runCliUpdateCheck(argv: string[], options: CliUpdateCheckRuntimeOptions = {}): Promise<CliUpdateCheckResult> {
   const env = options.env ?? {};
   const stderr = options.stderr ?? process.stderr;

--- a/packages/config/src/clone.ts
+++ b/packages/config/src/clone.ts
@@ -1,5 +1,11 @@
 import { fallbackClone } from '@fluojs/core/internal';
 
+/**
+ * Clone config dictionary.
+ *
+ * @param value The value.
+ * @returns The clone config dictionary result.
+ */
 export function cloneConfigDictionary<T>(value: T): T {
   try {
     return structuredClone(value);

--- a/packages/core/src/metadata/controller-route.ts
+++ b/packages/core/src/metadata/controller-route.ts
@@ -71,10 +71,22 @@ function getStandardRouteMetadata(target: object, propertyKey: MetadataPropertyK
   });
 }
 
+/**
+ * Define controller metadata.
+ *
+ * @param target The target.
+ * @param metadata The metadata.
+ */
 export function defineControllerMetadata(target: Function, metadata: ControllerMetadata): void {
   controllerMetadataStore.write(target, metadata);
 }
 
+/**
+ * Get controller metadata.
+ *
+ * @param target The target.
+ * @returns The get controller metadata result.
+ */
 export function getControllerMetadata(target: Function): ControllerMetadata | undefined {
   const stored = controllerMetadataStore.read(target);
   const standard = getStandardControllerMetadata(target);
@@ -91,6 +103,13 @@ export function getControllerMetadata(target: Function): ControllerMetadata | un
   };
 }
 
+/**
+ * Define route metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineRouteMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -135,6 +154,13 @@ function mergeRouteMetadata(
   };
 }
 
+/**
+ * Get route metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get route metadata result.
+ */
 export function getRouteMetadata(target: object, propertyKey: MetadataPropertyKey): RouteMetadata | undefined {
   const stored = routeMetadataStore.get(target)?.get(propertyKey);
   const standard = getStandardRouteMetadata(target, propertyKey);

--- a/packages/core/src/metadata/injection.ts
+++ b/packages/core/src/metadata/injection.ts
@@ -8,6 +8,13 @@ function getStandardInjectionMap(target: object): Map<MetadataPropertyKey, Stand
   return getStandardConstructorMetadataMap<StandardInjectionRecord>(target, standardMetadataKeys.injection);
 }
 
+/**
+ * Define injection metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineInjectionMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -16,6 +23,12 @@ export function defineInjectionMetadata(
   getOrCreatePropertyMap(injectionMetadataStore, target).set(propertyKey, { ...metadata });
 }
 
+/**
+ * Get injection schema.
+ *
+ * @param target The target.
+ * @returns The get injection schema result.
+ */
 export function getInjectionSchema(target: object): InjectionSchemaEntry[] {
   const stored = injectionMetadataStore.get(target) ?? new Map<MetadataPropertyKey, InjectionMetadata>();
   const standard = getStandardInjectionMap(target) ?? new Map<MetadataPropertyKey, StandardInjectionRecord>();

--- a/packages/core/src/metadata/symbol-metadata-polyfill.ts
+++ b/packages/core/src/metadata/symbol-metadata-polyfill.ts
@@ -1,5 +1,10 @@
 import { ensureMetadataSymbol } from './shared.js';
 
+/**
+ * Ensure symbol metadata polyfill.
+ *
+ * @returns The ensure symbol metadata polyfill result.
+ */
 export function ensureSymbolMetadataPolyfill(): symbol {
   return ensureMetadataSymbol();
 }

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -1,7 +1,13 @@
 import type { Constructor, MaybePromise, MetadataPropertyKey, MetadataSource, Token } from '../types.js';
 
+/**
+ * Defines the metadata collection type.
+ */
 export type MetadataCollection<T = unknown> = T[];
 
+/**
+ * Describes the module metadata contract.
+ */
 export interface ModuleMetadata {
   imports?: MetadataCollection;
   providers?: MetadataCollection;
@@ -11,6 +17,9 @@ export interface ModuleMetadata {
   global?: boolean;
 }
 
+/**
+ * Describes the controller metadata contract.
+ */
 export interface ControllerMetadata {
   basePath: string;
   guards?: MetadataCollection;
@@ -18,16 +27,25 @@ export interface ControllerMetadata {
   version?: string;
 }
 
+/**
+ * Describes the route header contract.
+ */
 export interface RouteHeader {
   name: string;
   value: string;
 }
 
+/**
+ * Describes the route redirect contract.
+ */
 export interface RouteRedirect {
   url: string;
   statusCode?: number;
 }
 
+/**
+ * Describes the route metadata contract.
+ */
 export interface RouteMetadata {
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
   path: string;
@@ -40,6 +58,9 @@ export interface RouteMetadata {
   version?: string;
 }
 
+/**
+ * Describes the dto field binding metadata contract.
+ */
 export interface DtoFieldBindingMetadata {
   source: MetadataSource;
   key?: string;
@@ -47,6 +68,9 @@ export interface DtoFieldBindingMetadata {
   converter?: Token | { convert(value: unknown, target: unknown): MaybePromise<unknown> };
 }
 
+/**
+ * Describes the validation issue metadata contract.
+ */
 export interface ValidationIssueMetadata {
   code: string;
   field?: string;
@@ -54,35 +78,59 @@ export interface ValidationIssueMetadata {
   source?: MetadataSource;
 }
 
+/**
+ * Defines the validation rule result type.
+ */
 export type ValidationRuleResult = boolean | void | ValidationIssueMetadata | readonly ValidationIssueMetadata[];
 
+/**
+ * Describes the validation decorator options contract.
+ */
 export interface ValidationDecoratorOptions {
   code?: string;
   each?: boolean;
   message?: string;
 }
 
+/**
+ * Describes the custom validation decorator options contract.
+ */
 export interface CustomValidationDecoratorOptions extends ValidationDecoratorOptions {
   source?: MetadataSource;
 }
 
+/**
+ * Describes the custom field validation context contract.
+ */
 export interface CustomFieldValidationContext<T = unknown> {
   dto: T;
   propertyKey: MetadataPropertyKey;
 }
 
+/**
+ * Defines the custom field validator type.
+ */
 export type CustomFieldValidator<T = unknown> = (
   value: unknown,
   context: CustomFieldValidationContext<T>,
 ) => MaybePromise<ValidationRuleResult>;
 
+/**
+ * Defines the custom class validator type.
+ */
 export type CustomClassValidator<T = unknown> = (value: T) => MaybePromise<ValidationRuleResult>;
 
+/**
+ * Defines the conditional field validator type.
+ */
 export type ConditionalFieldValidator<T = unknown> = (
   dto: T,
   value: unknown,
 ) => MaybePromise<boolean>;
 
+/**
+ * Defines the dto field validation rule type.
+ */
 export type DtoFieldValidationRule =
   | ({ kind: 'validateIf'; validateIf: ConditionalFieldValidator } & ValidationDecoratorOptions)
   | ({ kind: 'defined' } & ValidationDecoratorOptions)
@@ -165,37 +213,58 @@ export type DtoFieldValidationRule =
   | ({ kind: 'arrayUnique'; selector?: (value: unknown) => unknown } & ValidationDecoratorOptions)
   | ({ kind: 'custom'; validate: CustomFieldValidator; source?: MetadataSource } & ValidationDecoratorOptions);
 
+/**
+ * Describes the class validation rule contract.
+ */
 export interface ClassValidationRule {
   code?: string;
   message?: string;
   validate: CustomClassValidator;
 }
 
+/**
+ * Describes the injection metadata contract.
+ */
 export interface InjectionMetadata {
   token: unknown;
   optional?: boolean;
 }
 
+/**
+ * Describes the class di metadata contract.
+ */
 export interface ClassDiMetadata {
   inject?: Token[];
   scope?: 'singleton' | 'request' | 'transient';
 }
 
+/**
+ * Describes the dto binding schema entry contract.
+ */
 export interface DtoBindingSchemaEntry {
   propertyKey: MetadataPropertyKey;
   metadata: DtoFieldBindingMetadata;
 }
 
+/**
+ * Describes the dto validation schema entry contract.
+ */
 export interface DtoValidationSchemaEntry {
   propertyKey: MetadataPropertyKey;
   rules: readonly DtoFieldValidationRule[];
 }
 
+/**
+ * Describes the injection schema entry contract.
+ */
 export interface InjectionSchemaEntry {
   propertyKey: MetadataPropertyKey;
   metadata: InjectionMetadata;
 }
 
+/**
+ * Describes the standard route metadata record contract.
+ */
 export interface StandardRouteMetadataRecord {
   guards?: MetadataCollection;
   headers?: RouteHeader[];
@@ -208,6 +277,15 @@ export interface StandardRouteMetadataRecord {
   version?: string;
 }
 
+/**
+ * Defines the standard dto binding record type.
+ */
 export type StandardDtoBindingRecord = Partial<DtoFieldBindingMetadata>;
+/**
+ * Defines the standard dto validation record type.
+ */
 export type StandardDtoValidationRecord = DtoFieldValidationRule[];
+/**
+ * Defines the standard injection record type.
+ */
 export type StandardInjectionRecord = Partial<InjectionMetadata>;

--- a/packages/core/src/metadata/validation.ts
+++ b/packages/core/src/metadata/validation.ts
@@ -39,6 +39,13 @@ function getStandardClassValidationRules(target: Function): ClassValidationRule[
   return rules ? rules.map((rule) => cloneMutableValue(rule)) : undefined;
 }
 
+/**
+ * Get dto field binding metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get dto field binding metadata result.
+ */
 export function getDtoFieldBindingMetadata(target: object, propertyKey: MetadataPropertyKey): DtoFieldBindingMetadata | undefined {
   const stored = dtoFieldBindingStore.get(target)?.get(propertyKey);
   const standard = getStandardDtoBindingMap(target)?.get(propertyKey);
@@ -58,6 +65,13 @@ export function getDtoFieldBindingMetadata(target: object, propertyKey: Metadata
   };
 }
 
+/**
+ * Define dto field binding metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineDtoFieldBindingMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -66,6 +80,13 @@ export function defineDtoFieldBindingMetadata(
   getOrCreatePropertyMap(dtoFieldBindingStore, target).set(propertyKey, { ...metadata });
 }
 
+/**
+ * Append dto field validation rule.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param rule The rule.
+ */
 export function appendDtoFieldValidationRule(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -74,12 +95,24 @@ export function appendDtoFieldValidationRule(
   appendPropertyMapValue(dtoFieldValidationStore, target, propertyKey, cloneMutableValue(rule));
 }
 
+/**
+ * Append class validation rule.
+ *
+ * @param target The target.
+ * @param rule The rule.
+ */
 export function appendClassValidationRule(target: Function, rule: ClassValidationRule): void {
   const rules = classValidationStore.read(target) ?? [];
   rules.push(cloneMutableValue(rule));
   classValidationStore.write(target, rules);
 }
 
+/**
+ * Get dto binding schema.
+ *
+ * @param dto The dto.
+ * @returns The get dto binding schema result.
+ */
 export function getDtoBindingSchema(dto: Constructor): DtoBindingSchemaEntry[] {
   const stored = dtoFieldBindingStore.get(dto.prototype) ?? new Map<MetadataPropertyKey, DtoFieldBindingMetadata>();
   const standard =
@@ -112,6 +145,13 @@ export function getDtoBindingSchema(dto: Constructor): DtoBindingSchemaEntry[] {
   });
 }
 
+/**
+ * Get dto field validation rules.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get dto field validation rules result.
+ */
 export function getDtoFieldValidationRules(target: object, propertyKey: MetadataPropertyKey): readonly DtoFieldValidationRule[] {
   const stored = dtoFieldValidationStore.get(target)?.get(propertyKey) ?? [];
   const standard = getStandardDtoValidationMap(target)?.get(propertyKey) ?? [];
@@ -122,6 +162,12 @@ export function getDtoFieldValidationRules(target: object, propertyKey: Metadata
   ];
 }
 
+/**
+ * Get dto validation schema.
+ *
+ * @param dto The dto.
+ * @returns The get dto validation schema result.
+ */
 export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEntry[] {
   const stored = dtoFieldValidationStore.get(dto.prototype) ?? new Map<MetadataPropertyKey, DtoFieldValidationRule[]>();
   const standard = getStandardDtoValidationMap(dto.prototype) ?? new Map<MetadataPropertyKey, StandardDtoValidationRecord>();
@@ -141,6 +187,12 @@ export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEnt
   });
 }
 
+/**
+ * Get class validation rules.
+ *
+ * @param target The target.
+ * @returns The get class validation rules result.
+ */
 export function getClassValidationRules(target: Function): readonly ClassValidationRule[] {
   return [...(getStandardClassValidationRules(target) ?? []), ...(classValidationStore.read(target) ?? [])];
 }

--- a/packages/cqrs/src/discovery.ts
+++ b/packages/cqrs/src/discovery.ts
@@ -3,6 +3,9 @@ import { getClassDiMetadata } from '@fluojs/core/internal';
 import type { Container, Provider } from '@fluojs/di';
 import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
 
+/**
+ * Describes the discovery candidate contract.
+ */
 export interface DiscoveryCandidate {
   moduleName: string;
   scope: 'request' | 'singleton' | 'transient';
@@ -26,6 +29,15 @@ function isClassProvider(provider: Provider): provider is Extract<Provider, { pr
   return typeof provider === 'object' && provider !== null && 'useClass' in provider;
 }
 
+/**
+ * Create duplicate handler message.
+ *
+ * @param kind The kind.
+ * @param messageType The message type.
+ * @param first The first.
+ * @param second The second.
+ * @returns The create duplicate handler message result.
+ */
 export function createDuplicateHandlerMessage(
   kind: 'command' | 'query' | 'event',
   messageType: Function,
@@ -35,6 +47,9 @@ export function createDuplicateHandlerMessage(
   return `Duplicate ${kind} handler for ${messageType.name} was discovered in ${first.moduleName}.${first.targetType.name} and ${second.moduleName}.${second.targetType.name}.`;
 }
 
+/**
+ * Represents the cqrs bus base.
+ */
 export abstract class CqrsBusBase {
   protected readonly handlerInstances = new Map<Token, Promise<unknown>>();
 

--- a/packages/cqrs/src/status.ts
+++ b/packages/cqrs/src/status.ts
@@ -1,7 +1,13 @@
 import type { PlatformHealthReport, PlatformReadinessReport, PlatformSnapshot } from '@fluojs/runtime';
 
+/**
+ * Defines the cqrs lifecycle state type.
+ */
 export type CqrsLifecycleState = 'created' | 'discovering' | 'ready' | 'stopping' | 'stopped' | 'failed';
 
+/**
+ * Describes the cqrs status adapter input contract.
+ */
 export interface CqrsStatusAdapterInput {
   eventHandlersDiscovered: number;
   inFlightSagaExecutions: number;
@@ -10,6 +16,9 @@ export interface CqrsStatusAdapterInput {
   sagasDiscovered: number;
 }
 
+/**
+ * Describes the cqrs platform status snapshot contract.
+ */
 export interface CqrsPlatformStatusSnapshot {
   readiness: PlatformReadinessReport;
   health: PlatformHealthReport;
@@ -91,6 +100,12 @@ function createHealth(input: CqrsStatusAdapterInput): PlatformHealthReport {
   };
 }
 
+/**
+ * Create cqrs platform status snapshot.
+ *
+ * @param input The input.
+ * @returns The create cqrs platform status snapshot result.
+ */
 export function createCqrsPlatformStatusSnapshot(input: CqrsStatusAdapterInput): CqrsPlatformStatusSnapshot {
   return {
     details: {

--- a/packages/cron/src/expressions.ts
+++ b/packages/cron/src/expressions.ts
@@ -1,3 +1,6 @@
+/**
+ * Provides the cron expression value.
+ */
 export const CronExpression = {
   EVERY_SECOND: '* * * * * *',
   EVERY_5_SECONDS: '*/5 * * * * *',

--- a/packages/cron/src/metadata.ts
+++ b/packages/cron/src/metadata.ts
@@ -49,6 +49,13 @@ function getOrCreateSchedulingMap(target: object): Map<MetadataPropertyKey, Sche
   return map;
 }
 
+/**
+ * Define scheduling task metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineSchedulingTaskMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -57,10 +64,24 @@ export function defineSchedulingTaskMetadata(
   getOrCreateSchedulingMap(target).set(propertyKey, cloneTaskMetadata(metadata));
 }
 
+/**
+ * Define cron task metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineCronTaskMetadata(target: object, propertyKey: MetadataPropertyKey, metadata: CronTaskMetadata): void {
   defineSchedulingTaskMetadata(target, propertyKey, metadata);
 }
 
+/**
+ * Get scheduling task metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get scheduling task metadata result.
+ */
 export function getSchedulingTaskMetadata(target: object, propertyKey: MetadataPropertyKey): SchedulingTaskMetadata | undefined {
   const stored = schedulingMetadataStore.get(target)?.get(propertyKey);
   const standard = getStandardSchedulingMap(target)?.get(propertyKey);
@@ -72,12 +93,25 @@ export function getSchedulingTaskMetadata(target: object, propertyKey: MetadataP
   return cloneTaskMetadata(stored ?? standard!);
 }
 
+/**
+ * Get cron task metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get cron task metadata result.
+ */
 export function getCronTaskMetadata(target: object, propertyKey: MetadataPropertyKey): CronTaskMetadata | undefined {
   const metadata = getSchedulingTaskMetadata(target, propertyKey);
 
   return metadata?.kind === 'cron' ? metadata : undefined;
 }
 
+/**
+ * Get scheduling task metadata entries.
+ *
+ * @param target The target.
+ * @returns The get scheduling task metadata entries result.
+ */
 export function getSchedulingTaskMetadataEntries(
   target: object,
 ): Array<{ metadata: SchedulingTaskMetadata; propertyKey: MetadataPropertyKey }> {
@@ -93,11 +127,23 @@ export function getSchedulingTaskMetadataEntries(
     .filter((entry): entry is { metadata: SchedulingTaskMetadata; propertyKey: MetadataPropertyKey } => entry.metadata !== undefined);
 }
 
+/**
+ * Get cron task metadata entries.
+ *
+ * @param target The target.
+ * @returns The get cron task metadata entries result.
+ */
 export function getCronTaskMetadataEntries(target: object): Array<{ metadata: CronTaskMetadata; propertyKey: MetadataPropertyKey }> {
   return getSchedulingTaskMetadataEntries(target).filter(
     (entry): entry is { metadata: CronTaskMetadata; propertyKey: MetadataPropertyKey } => entry.metadata.kind === 'cron',
   );
 }
 
+/**
+ * Provides the scheduling metadata symbol value.
+ */
 export const schedulingMetadataSymbol = standardSchedulingMetadataKey;
+/**
+ * Provides the cron metadata symbol value.
+ */
 export const cronMetadataSymbol = standardSchedulingMetadataKey;

--- a/packages/cron/src/scheduler.ts
+++ b/packages/cron/src/scheduler.ts
@@ -2,6 +2,13 @@ import { Cron as Croner } from 'croner';
 
 import type { CronScheduler } from './types.js';
 
+/**
+ * Provides the default cron scheduler value.
+ *
+ * @param expression The expression.
+ * @param options The options.
+ * @param callback The callback.
+ */
 export const defaultCronScheduler: CronScheduler = (expression, options, callback) => {
   return new Croner(expression, {
     name: options.name,

--- a/packages/cron/src/task-discovery.ts
+++ b/packages/cron/src/task-discovery.ts
@@ -13,18 +13,46 @@ interface DiscoveryCandidate {
   token: Token;
 }
 
+/**
+ * Build default task name.
+ *
+ * @param targetName The target name.
+ * @param methodName The method name.
+ * @returns The build default task name result.
+ */
 export function buildDefaultTaskName(targetName: string, methodName: string): string {
   return `${targetName}.${methodName}`;
 }
 
+/**
+ * Create lock key.
+ *
+ * @param prefix The prefix.
+ * @param taskName The task name.
+ * @returns The create lock key result.
+ */
 export function createLockKey(prefix: string, taskName: string): string {
   return `${prefix}:${taskName}`;
 }
 
+/**
+ * Method key to name.
+ *
+ * @param methodKey The method key.
+ * @returns The method key to name result.
+ */
 export function methodKeyToName(methodKey: MetadataPropertyKey): string {
   return typeof methodKey === 'symbol' ? methodKey.toString() : methodKey;
 }
 
+/**
+ * Discover cron task descriptors.
+ *
+ * @param compiledModules The compiled modules.
+ * @param options The options.
+ * @param logger The logger.
+ * @returns The discover cron task descriptors result.
+ */
 export function discoverCronTaskDescriptors(
   compiledModules: readonly CompiledModule[],
   options: NormalizedCronModuleOptions,

--- a/packages/cron/src/task-runner.ts
+++ b/packages/cron/src/task-runner.ts
@@ -9,6 +9,9 @@ interface ResolvedTaskInvocation {
   instance: unknown;
 }
 
+/**
+ * Represents the cron task runner.
+ */
 export class CronTaskRunner {
   constructor(
     private readonly runtimeContainer: Container,

--- a/packages/event-bus/src/metadata.ts
+++ b/packages/event-bus/src/metadata.ts
@@ -31,6 +31,13 @@ function getOrCreateEventHandlerMap(target: object): Map<MetadataPropertyKey, Ev
   return map;
 }
 
+/**
+ * Define event handler metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineEventHandlerMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -39,6 +46,13 @@ export function defineEventHandlerMetadata(
   getOrCreateEventHandlerMap(target).set(propertyKey, cloneEventHandlerMetadata(metadata));
 }
 
+/**
+ * Get event handler metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get event handler metadata result.
+ */
 export function getEventHandlerMetadata(target: object, propertyKey: MetadataPropertyKey): EventHandlerMetadata | undefined {
   const stored = eventHandlerMetadataStore.get(target)?.get(propertyKey);
   const standard = getStandardEventHandlerMap(target)?.get(propertyKey);
@@ -50,6 +64,12 @@ export function getEventHandlerMetadata(target: object, propertyKey: MetadataPro
   return cloneEventHandlerMetadata(stored ?? standard!);
 }
 
+/**
+ * Get event handler metadata entries.
+ *
+ * @param target The target.
+ * @returns The get event handler metadata entries result.
+ */
 export function getEventHandlerMetadataEntries(
   target: object,
 ): Array<{ metadata: EventHandlerMetadata; propertyKey: MetadataPropertyKey }> {
@@ -65,4 +85,7 @@ export function getEventHandlerMetadataEntries(
     .filter((entry): entry is { metadata: EventHandlerMetadata; propertyKey: MetadataPropertyKey } => entry.metadata !== undefined);
 }
 
+/**
+ * Provides the event bus metadata symbol value.
+ */
 export const eventBusMetadataSymbol = standardEventHandlerMetadataKey;

--- a/packages/event-bus/src/status.ts
+++ b/packages/event-bus/src/status.ts
@@ -1,7 +1,13 @@
 import type { PlatformHealthReport, PlatformReadinessReport, PlatformSnapshot } from '@fluojs/runtime';
 
+/**
+ * Defines the event bus lifecycle state type.
+ */
 export type EventBusLifecycleState = 'created' | 'discovering' | 'ready' | 'stopping' | 'stopped' | 'failed';
 
+/**
+ * Describes the event bus status adapter input contract.
+ */
 export interface EventBusStatusAdapterInput {
   handlersDiscovered: number;
   lifecycleState: EventBusLifecycleState;
@@ -13,6 +19,9 @@ export interface EventBusStatusAdapterInput {
   waitForHandlersDefault: boolean;
 }
 
+/**
+ * Describes the event bus platform status snapshot contract.
+ */
 export interface EventBusPlatformStatusSnapshot {
   readiness: PlatformReadinessReport;
   health: PlatformHealthReport;
@@ -106,6 +115,12 @@ function resolveOperationMode(input: EventBusStatusAdapterInput): 'local-only' |
   return input.transportConfigured ? 'transport-backed' : 'local-only';
 }
 
+/**
+ * Create event bus platform status snapshot.
+ *
+ * @param input The input.
+ * @returns The create event bus platform status snapshot result.
+ */
 export function createEventBusPlatformStatusSnapshot(input: EventBusStatusAdapterInput): EventBusPlatformStatusSnapshot {
   return {
     details: {

--- a/packages/graphql/src/decorators.ts
+++ b/packages/graphql/src/decorators.ts
@@ -12,6 +12,9 @@ type StandardClassDecoratorFn = (value: Function, context: ClassDecoratorContext
 type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecoratorContext) => void;
 type StandardFieldDecoratorFn = <This, Value>(value: undefined, context: ClassFieldDecoratorContext<This, Value>) => void;
 
+/**
+ * Describes the resolver method options contract.
+ */
 export interface ResolverMethodOptions {
   fieldName?: string;
   input?: Function;
@@ -122,6 +125,12 @@ function createMethodDecorator(
   return decorator as MethodDecoratorLike;
 }
 
+/**
+ * Resolver.
+ *
+ * @param typeName The type name.
+ * @returns The resolver result.
+ */
 export function Resolver(typeName?: string): ClassDecoratorLike {
   const decorator = (value: Function, context: ClassDecoratorContext) => {
     defineStandardResolverMetadata(context.metadata, {
@@ -132,18 +141,42 @@ export function Resolver(typeName?: string): ClassDecoratorLike {
   return decorator as ClassDecoratorLike;
 }
 
+/**
+ * Query.
+ *
+ * @param fieldNameOrOptions The field name or options.
+ * @returns The query result.
+ */
 export function Query(fieldNameOrOptions?: string | ResolverMethodOptions): MethodDecoratorLike {
   return createMethodDecorator('query', fieldNameOrOptions);
 }
 
+/**
+ * Mutation.
+ *
+ * @param fieldNameOrOptions The field name or options.
+ * @returns The mutation result.
+ */
 export function Mutation(fieldNameOrOptions?: string | ResolverMethodOptions): MethodDecoratorLike {
   return createMethodDecorator('mutation', fieldNameOrOptions);
 }
 
+/**
+ * Subscription.
+ *
+ * @param fieldNameOrOptions The field name or options.
+ * @returns The subscription result.
+ */
 export function Subscription(fieldNameOrOptions?: string | ResolverMethodOptions): MethodDecoratorLike {
   return createMethodDecorator('subscription', fieldNameOrOptions);
 }
 
+/**
+ * Arg.
+ *
+ * @param argName The arg name.
+ * @returns The arg result.
+ */
 export function Arg(argName?: string): FieldDecoratorLike {
   const decorator = <This, Value>(_value: undefined, context: ClassFieldDecoratorContext<This, Value>) => {
     if (context.private) {

--- a/packages/graphql/src/discovery.ts
+++ b/packages/graphql/src/discovery.ts
@@ -134,6 +134,13 @@ function discoveryCandidates(compiledModules: readonly CompiledModule[]): Discov
   return candidates;
 }
 
+/**
+ * Discover resolver descriptors.
+ *
+ * @param compiledModules The compiled modules.
+ * @param options The options.
+ * @returns The discover resolver descriptors result.
+ */
 export function discoverResolverDescriptors(
   compiledModules: readonly CompiledModule[],
   options: GraphqlModuleOptions,

--- a/packages/graphql/src/metadata.ts
+++ b/packages/graphql/src/metadata.ts
@@ -104,10 +104,22 @@ function getMergedMetadataEntries<T>(
     );
 }
 
+/**
+ * Define resolver metadata.
+ *
+ * @param target The target.
+ * @param metadata The metadata.
+ */
 export function defineResolverMetadata(target: object, metadata: ResolverMetadata): void {
   resolverMetadataStore.set(target, cloneResolverMetadata(metadata));
 }
 
+/**
+ * Get resolver metadata.
+ *
+ * @param target The target.
+ * @returns The get resolver metadata result.
+ */
 export function getResolverMetadata(target: object): ResolverMetadata | undefined {
   const stored = resolverMetadataStore.get(target);
   const standard = getStandardResolverMetadata(target);
@@ -119,6 +131,13 @@ export function getResolverMetadata(target: object): ResolverMetadata | undefine
   return cloneResolverMetadata(stored ?? standard!);
 }
 
+/**
+ * Define resolver handler metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineResolverHandlerMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -127,6 +146,13 @@ export function defineResolverHandlerMetadata(
   getOrCreateHandlerMetadataMap(target).set(propertyKey, cloneHandlerMetadata(metadata));
 }
 
+/**
+ * Get resolver handler metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get resolver handler metadata result.
+ */
 export function getResolverHandlerMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -141,6 +167,12 @@ export function getResolverHandlerMetadata(
   return cloneHandlerMetadata(stored ?? standard!);
 }
 
+/**
+ * Get resolver handler metadata entries.
+ *
+ * @param target The target.
+ * @returns The get resolver handler metadata entries result.
+ */
 export function getResolverHandlerMetadataEntries(
   target: object,
 ): Array<{ metadata: ResolverHandlerMetadata; propertyKey: MetadataPropertyKey }> {
@@ -152,10 +184,24 @@ export function getResolverHandlerMetadataEntries(
   );
 }
 
+/**
+ * Define arg field metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineArgFieldMetadata(target: object, propertyKey: MetadataPropertyKey, metadata: ArgFieldMetadata): void {
   getOrCreateArgFieldMetadataMap(target).set(propertyKey, cloneArgFieldMetadata(metadata));
 }
 
+/**
+ * Get arg field metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get arg field metadata result.
+ */
 export function getArgFieldMetadata(target: object, propertyKey: MetadataPropertyKey): ArgFieldMetadata | undefined {
   const stored = argFieldMetadataStore.get(target)?.get(propertyKey);
   const standard = getStandardArgFieldMap(target)?.get(propertyKey);
@@ -167,12 +213,27 @@ export function getArgFieldMetadata(target: object, propertyKey: MetadataPropert
   return cloneArgFieldMetadata(stored ?? standard!);
 }
 
+/**
+ * Get arg field metadata entries.
+ *
+ * @param target The target.
+ * @returns The get arg field metadata entries result.
+ */
 export function getArgFieldMetadataEntries(
   target: object,
 ): Array<{ metadata: ArgFieldMetadata; propertyKey: MetadataPropertyKey }> {
   return getMergedMetadataEntries(target, argFieldMetadataStore.get(target), getStandardArgFieldMap(target), getArgFieldMetadata);
 }
 
+/**
+ * Provides the resolver metadata symbol value.
+ */
 export const resolverMetadataSymbol = standardResolverMetadataKey;
+/**
+ * Provides the handler metadata symbol value.
+ */
 export const handlerMetadataSymbol = standardHandlerMetadataKey;
+/**
+ * Provides the arg metadata symbol value.
+ */
 export const argMetadataSymbol = standardArgFieldMetadataKey;

--- a/packages/graphql/src/module.ts
+++ b/packages/graphql/src/module.ts
@@ -22,6 +22,9 @@ export function createGraphqlProviders(options: GraphqlModuleOptions): Provider[
   ];
 }
 
+/**
+ * Represents the graphql module.
+ */
 export class GraphqlModule {
   /**
    * Registers the GraphQL endpoint controller together with lifecycle providers.

--- a/packages/graphql/src/schema/schema.ts
+++ b/packages/graphql/src/schema/schema.ts
@@ -457,6 +457,15 @@ function createOptionalRootType(
   });
 }
 
+/**
+ * Resolve schema.
+ *
+ * @param deps The deps.
+ * @param optionsSchema The options schema.
+ * @param createCodeFirstSchema The create code first schema.
+ * @param markAllowedCrossRealmGraphqlObjects The mark allowed cross realm graphql objects.
+ * @returns The resolve schema result.
+ */
 export function resolveSchema(
   deps: YogaGraphqlDeps,
   optionsSchema: GraphQLSchemaType | string | undefined,
@@ -475,6 +484,15 @@ export function resolveSchema(
   return createCodeFirstSchema();
 }
 
+/**
+ * Create code first schema.
+ *
+ * @param deps The deps.
+ * @param runtimeContainer The runtime container.
+ * @param resolverDescriptors The resolver descriptors.
+ * @param markAllowedCrossRealmGraphqlObjects The mark allowed cross realm graphql objects.
+ * @returns The create code first schema result.
+ */
 export function createCodeFirstSchema(
   deps: YogaGraphqlDeps,
   runtimeContainer: Container,

--- a/packages/graphql/src/transport/transport.ts
+++ b/packages/graphql/src/transport/transport.ts
@@ -1,5 +1,11 @@
 import type { FrameworkRequest, FrameworkResponse, FrameworkResponseStream } from '@fluojs/http';
 
+/**
+ * Is graphql path.
+ *
+ * @param path The path.
+ * @returns The is graphql path result.
+ */
 export function isGraphqlPath(path: string): boolean {
   return path === '/graphql' || path === '/graphql/';
 }
@@ -72,6 +78,12 @@ function createFetchBody(request: FrameworkRequest, headers: Headers): BodyInit 
   return JSON.stringify(request.body);
 }
 
+/**
+ * To fetch request.
+ *
+ * @param request The request.
+ * @returns The to fetch request result.
+ */
 export function toFetchRequest(request: FrameworkRequest): Request {
   const headers = createFetchHeaders(request);
   const body = createFetchBody(request, headers);
@@ -104,6 +116,13 @@ function readSetCookieValues(headers: Headers): string[] {
   return values;
 }
 
+/**
+ * Write fetch response.
+ *
+ * @param fetchResponse The fetch response.
+ * @param frameworkResponse The framework response.
+ * @returns The write fetch response result.
+ */
 export async function writeFetchResponse(fetchResponse: Response, frameworkResponse: FrameworkResponse): Promise<void> {
   frameworkResponse.setStatus(fetchResponse.status);
 

--- a/packages/http/src/adapter.ts
+++ b/packages/http/src/adapter.ts
@@ -2,17 +2,26 @@ import type { MaybePromise } from '@fluojs/core';
 
 import type { Dispatcher } from './types.js';
 
+/**
+ * Describes the server backed http adapter realtime capability contract.
+ */
 export interface ServerBackedHttpAdapterRealtimeCapability {
   kind: 'server-backed';
   server: unknown;
 }
 
+/**
+ * Describes the unsupported http adapter realtime capability contract.
+ */
 export interface UnsupportedHttpAdapterRealtimeCapability {
   kind: 'unsupported';
   mode: 'no-op';
   reason: string;
 }
 
+/**
+ * Describes the fetch style http adapter realtime capability contract.
+ */
 export interface FetchStyleHttpAdapterRealtimeCapability {
   contract: 'raw-websocket-expansion';
   kind: 'fetch-style';
@@ -22,11 +31,20 @@ export interface FetchStyleHttpAdapterRealtimeCapability {
   version: 1;
 }
 
+/**
+ * Defines the http adapter realtime capability type.
+ */
 export type HttpAdapterRealtimeCapability =
   | ServerBackedHttpAdapterRealtimeCapability
   | FetchStyleHttpAdapterRealtimeCapability
   | UnsupportedHttpAdapterRealtimeCapability;
 
+/**
+ * Create server backed http adapter realtime capability.
+ *
+ * @param server The server.
+ * @returns The create server backed http adapter realtime capability result.
+ */
 export function createServerBackedHttpAdapterRealtimeCapability(
   server: unknown,
 ): ServerBackedHttpAdapterRealtimeCapability {
@@ -36,6 +54,12 @@ export function createServerBackedHttpAdapterRealtimeCapability(
   };
 }
 
+/**
+ * Create unsupported http adapter realtime capability.
+ *
+ * @param reason The reason.
+ * @returns The create unsupported http adapter realtime capability result.
+ */
 export function createUnsupportedHttpAdapterRealtimeCapability(
   reason: string,
 ): UnsupportedHttpAdapterRealtimeCapability {
@@ -46,6 +70,13 @@ export function createUnsupportedHttpAdapterRealtimeCapability(
   };
 }
 
+/**
+ * Create fetch style http adapter realtime capability.
+ *
+ * @param reason The reason.
+ * @param options The options.
+ * @returns The create fetch style http adapter realtime capability result.
+ */
 export function createFetchStyleHttpAdapterRealtimeCapability(
   reason: string,
   options: {

--- a/packages/http/src/adapters/binding.ts
+++ b/packages/http/src/adapters/binding.ts
@@ -95,6 +95,9 @@ function validateBodyKeys(
   }
 }
 
+/**
+ * Represents the default converter.
+ */
 export class DefaultConverter implements Converter {
   convert(value: unknown, _target: ConverterTarget): unknown {
     return value;
@@ -156,6 +159,9 @@ async function resolveConverter(
   }
 }
 
+/**
+ * Represents the default binder.
+ */
 export class DefaultBinder implements Binder {
   constructor(private readonly converters: readonly ConverterLike[] = []) {}
 

--- a/packages/http/src/adapters/dto-validation-adapter.ts
+++ b/packages/http/src/adapters/dto-validation-adapter.ts
@@ -6,6 +6,9 @@ import { BadRequestException } from '../exceptions.js';
 import { toInputErrorDetail } from '../input-error-detail.js';
 import type { ValidationIssue, Validator } from '../types.js';
 
+/**
+ * Represents the http dto validation adapter.
+ */
 export class HttpDtoValidationAdapter implements Validator {
   private readonly validator = new BaseDefaultValidator();
 

--- a/packages/http/src/dispatch/dispatch-content-negotiation.ts
+++ b/packages/http/src/dispatch/dispatch-content-negotiation.ts
@@ -12,6 +12,9 @@ interface AcceptToken {
   specificity: number;
 }
 
+/**
+ * Describes the resolved content negotiation contract.
+ */
 export interface ResolvedContentNegotiation {
   defaultFormatter: ResponseFormatter;
   formatters: ResponseFormatter[];
@@ -123,6 +126,12 @@ function matchesMediaRange(mediaRange: string, mediaType: string): boolean {
   return rangeSubtype === '*' || rangeSubtype === mediaTypeSubtype;
 }
 
+/**
+ * Resolve content negotiation.
+ *
+ * @param options The options.
+ * @returns The resolve content negotiation result.
+ */
 export function resolveContentNegotiation(options: ContentNegotiationOptions | undefined): ResolvedContentNegotiation | undefined {
   if (!options?.formatters?.length) {
     return undefined;
@@ -191,6 +200,14 @@ function resolveDefaultFormatter(
   return idx >= 0 ? allowedFormatters[idx]! : (allowedFormatters[0] ?? contentNegotiation.defaultFormatter);
 }
 
+/**
+ * Select response formatter.
+ *
+ * @param handler The handler.
+ * @param request The request.
+ * @param contentNegotiation The content negotiation.
+ * @returns The select response formatter result.
+ */
 export function selectResponseFormatter(
   handler: HandlerDescriptor,
   request: FrameworkRequest,

--- a/packages/http/src/dispatch/dispatch-error-policy.ts
+++ b/packages/http/src/dispatch/dispatch-error-policy.ts
@@ -22,6 +22,14 @@ function toHttpException(error: unknown): HttpException {
   });
 }
 
+/**
+ * Write error response.
+ *
+ * @param error The error.
+ * @param response The response.
+ * @param requestId The request id.
+ * @returns The write error response result.
+ */
 export async function writeErrorResponse(error: unknown, response: FrameworkResponse, requestId?: string): Promise<void> {
   if (response.committed) {
     return;

--- a/packages/http/src/dispatch/dispatch-handler-policy.ts
+++ b/packages/http/src/dispatch/dispatch-handler-policy.ts
@@ -7,6 +7,14 @@ import type { ArgumentResolverContext, Binder, HandlerDescriptor, RequestContext
 const defaultBinder = new DefaultBinder();
 const defaultValidator = new HttpDtoValidationAdapter();
 
+/**
+ * Invoke controller handler.
+ *
+ * @param handler The handler.
+ * @param requestContext The request context.
+ * @param binder The binder.
+ * @returns The invoke controller handler result.
+ */
 export async function invokeControllerHandler(
   handler: HandlerDescriptor,
   requestContext: RequestContext,

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -22,6 +22,16 @@ function resolveDefaultSuccessStatus(handler: HandlerDescriptor, value: unknown)
   }
 }
 
+/**
+ * Write success response.
+ *
+ * @param handler The handler.
+ * @param request The request.
+ * @param response The response.
+ * @param value The value.
+ * @param contentNegotiation The content negotiation.
+ * @returns The write success response result.
+ */
 export async function writeSuccessResponse(
   handler: HandlerDescriptor,
   request: FrameworkRequest,

--- a/packages/http/src/dispatch/dispatch-routing-policy.ts
+++ b/packages/http/src/dispatch/dispatch-routing-policy.ts
@@ -1,6 +1,13 @@
 import { HandlerNotFoundError } from '../errors.js';
 import type { FrameworkRequest, HandlerMapping, HandlerMatch, RequestContext } from '../types.js';
 
+/**
+ * Match handler or throw.
+ *
+ * @param handlerMapping The handler mapping.
+ * @param request The request.
+ * @returns The match handler or throw result.
+ */
 export function matchHandlerOrThrow(handlerMapping: HandlerMapping, request: FrameworkRequest): HandlerMatch {
   const match = handlerMapping.match(request);
 
@@ -11,6 +18,12 @@ export function matchHandlerOrThrow(handlerMapping: HandlerMapping, request: Fra
   return match;
 }
 
+/**
+ * Update request params.
+ *
+ * @param requestContext The request context.
+ * @param params The params.
+ */
 export function updateRequestParams(requestContext: RequestContext, params: Readonly<Record<string, string>>): void {
   requestContext.request = {
     ...requestContext.request,

--- a/packages/http/src/errors.ts
+++ b/packages/http/src/errors.ts
@@ -9,6 +9,9 @@ export class RouteConflictError extends FluoError {
   }
 }
 
+/**
+ * Represents the invalid route path error.
+ */
 export class InvalidRoutePathError extends FluoError {
   constructor(message: string) {
     super(message, { code: 'INVALID_ROUTE_PATH' });

--- a/packages/http/src/guards.ts
+++ b/packages/http/src/guards.ts
@@ -15,6 +15,13 @@ async function resolveGuard(definition: GuardLike, requestContext: RequestContex
   return requestContext.container.resolve(definition as Token<Guard>);
 }
 
+/**
+ * Run guard chain.
+ *
+ * @param definitions The definitions.
+ * @param context The context.
+ * @returns The run guard chain result.
+ */
 export async function runGuardChain(definitions: GuardLike[], context: GuardContext): Promise<void> {
   for (const definition of definitions) {
     const guard = await resolveGuard(definition, context.requestContext);

--- a/packages/http/src/input-error-detail.ts
+++ b/packages/http/src/input-error-detail.ts
@@ -2,6 +2,9 @@ import type { MetadataSource } from '@fluojs/core';
 
 import type { HttpExceptionDetail } from './exceptions.js';
 
+/**
+ * Describes the input error detail contract.
+ */
 export interface InputErrorDetail {
   code: string;
   field?: string;
@@ -9,6 +12,12 @@ export interface InputErrorDetail {
   source?: MetadataSource;
 }
 
+/**
+ * To input error detail.
+ *
+ * @param detail The detail.
+ * @returns The to input error detail result.
+ */
 export function toInputErrorDetail(detail: InputErrorDetail): HttpExceptionDetail {
   return {
     code: detail.code,

--- a/packages/http/src/interceptors.ts
+++ b/packages/http/src/interceptors.ts
@@ -23,6 +23,14 @@ async function resolveInterceptor(
   return requestContext.container.resolve(definition as Token<Interceptor>);
 }
 
+/**
+ * Run interceptor chain.
+ *
+ * @param definitions The definitions.
+ * @param context The context.
+ * @param terminal The terminal.
+ * @returns The run interceptor chain result.
+ */
 export async function runInterceptorChain(
   definitions: InterceptorLike[],
   context: InterceptorContext,

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -284,6 +284,13 @@ function buildDescriptorList(sources: HandlerSource[], versioning: ResolvedVersi
   return descriptors;
 }
 
+/**
+ * Create handler mapping.
+ *
+ * @param sources The sources.
+ * @param options The options.
+ * @returns The create handler mapping result.
+ */
 export function createHandlerMapping(sources: HandlerSource[], options?: CreateHandlerMappingOptions): HandlerMapping {
   const versioning = resolveVersioning(options);
   const descriptors = buildDescriptorList(sources, versioning);

--- a/packages/http/src/middleware/correlation.ts
+++ b/packages/http/src/middleware/correlation.ts
@@ -12,6 +12,11 @@ function resolveInboundRequestId(headers: Readonly<Record<string, string | strin
   return value ?? randomUUID();
 }
 
+/**
+ * Create correlation middleware.
+ *
+ * @returns The create correlation middleware result.
+ */
 export function createCorrelationMiddleware(): Middleware {
   return {
     async handle(context, next) {

--- a/packages/http/src/middleware/cors.ts
+++ b/packages/http/src/middleware/cors.ts
@@ -1,5 +1,8 @@
 import type { Middleware } from '../types.js';
 
+/**
+ * Describes the cors options contract.
+ */
 export interface CorsOptions {
   allowCredentials?: boolean;
   allowHeaders?: string[];
@@ -35,6 +38,12 @@ function setHeaderIfValue(
   }
 }
 
+/**
+ * Create cors middleware.
+ *
+ * @param options The options.
+ * @returns The create cors middleware result.
+ */
 export function createCorsMiddleware(options: CorsOptions = {}): Middleware {
   if (options.allowCredentials === true) {
     if (options.allowOrigin === '*' || options.allowOrigin === undefined) {

--- a/packages/http/src/middleware/middleware.ts
+++ b/packages/http/src/middleware/middleware.ts
@@ -7,10 +7,22 @@ function isMiddleware(value: MiddlewareLike): value is Middleware {
   return typeof value === 'object' && value !== null && 'handle' in value;
 }
 
+/**
+ * Is middleware route config.
+ *
+ * @param value The value.
+ * @returns The is middleware route config result.
+ */
 export function isMiddlewareRouteConfig(value: MiddlewareLike): value is MiddlewareRouteConfig {
   return typeof value === 'object' && value !== null && 'middleware' in value && 'routes' in value;
 }
 
+/**
+ * Normalize route pattern.
+ *
+ * @param path The path.
+ * @returns The normalize route pattern result.
+ */
 export function normalizeRoutePattern(path: string): string {
   if (path.endsWith('/*')) {
     return `${normalizeRoutePattern(path.slice(0, -2))}/*`;
@@ -19,6 +31,13 @@ export function normalizeRoutePattern(path: string): string {
   return normalizeRoutePath(path);
 }
 
+/**
+ * Match route pattern.
+ *
+ * @param pattern The pattern.
+ * @param path The path.
+ * @returns The match route pattern result.
+ */
 export function matchRoutePattern(pattern: string, path: string): boolean {
   const normalizedPath = normalizeRoutePattern(path);
   const normalizedPattern = normalizeRoutePattern(pattern);
@@ -31,6 +50,13 @@ export function matchRoutePattern(pattern: string, path: string): boolean {
   return normalizedPath === normalizedPattern;
 }
 
+/**
+ * For routes.
+ *
+ * @param middlewareClass The middleware class.
+ * @param routes The routes.
+ * @returns The for routes result.
+ */
 export function forRoutes<T extends Constructor<Middleware>>(
   middlewareClass: T,
   ...routes: string[]
@@ -79,6 +105,14 @@ function deferNext(next: Next): Next {
   };
 }
 
+/**
+ * Run middleware chain.
+ *
+ * @param definitions The definitions.
+ * @param context The context.
+ * @param terminal The terminal.
+ * @returns The run middleware chain result.
+ */
 export async function runMiddlewareChain(
   definitions: MiddlewareLike[],
   context: MiddlewareContext,

--- a/packages/http/src/middleware/security-headers.ts
+++ b/packages/http/src/middleware/security-headers.ts
@@ -1,5 +1,8 @@
 import type { Middleware } from '../types.js';
 
+/**
+ * Describes the security headers options contract.
+ */
 export interface SecurityHeadersOptions {
   contentSecurityPolicy?: string | false;
   crossOriginOpenerPolicy?: string | false;
@@ -20,6 +23,12 @@ const DEFAULTS = {
   xXssProtection: '0',
 } as const;
 
+/**
+ * Create security headers middleware.
+ *
+ * @param options The options.
+ * @returns The create security headers middleware result.
+ */
 export function createSecurityHeadersMiddleware(options: SecurityHeadersOptions = {}): Middleware {
   const csp = 'contentSecurityPolicy' in options ? options.contentSecurityPolicy : DEFAULTS.contentSecurityPolicy;
   const coop = 'crossOriginOpenerPolicy' in options ? options.crossOriginOpenerPolicy : DEFAULTS.crossOriginOpenerPolicy;

--- a/packages/http/src/route-path.ts
+++ b/packages/http/src/route-path.ts
@@ -1,15 +1,24 @@
 import { InvalidRoutePathError } from './errors.js';
 
+/**
+ * Describes the route path literal segment contract.
+ */
 export interface RoutePathLiteralSegment {
   kind: 'literal';
   value: string;
 }
 
+/**
+ * Describes the route path param segment contract.
+ */
 export interface RoutePathParamSegment {
   kind: 'param';
   name: string;
 }
 
+/**
+ * Defines the route path segment type.
+ */
 export type RoutePathSegment = RoutePathLiteralSegment | RoutePathParamSegment;
 
 const routeParamNamePattern = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
@@ -64,6 +73,12 @@ function parseRoutePathSegment(segment: string, path: string, label?: string): R
   };
 }
 
+/**
+ * Normalize route path.
+ *
+ * @param path The path.
+ * @returns The normalize route path result.
+ */
 export function normalizeRoutePath(path: string): string {
   const segments = path.split('/').filter(Boolean);
   const normalized = `/${segments.join('/')}`;
@@ -71,6 +86,13 @@ export function normalizeRoutePath(path: string): string {
   return normalized === '' ? '/' : normalized;
 }
 
+/**
+ * Parse route path.
+ *
+ * @param path The path.
+ * @param label The label.
+ * @returns The parse route path result.
+ */
 export function parseRoutePath(path: string, label?: string): RoutePathSegment[] {
   const normalizedPath = normalizeRoutePath(path);
   const segments = normalizedPath.split('/').filter(Boolean);
@@ -78,14 +100,33 @@ export function parseRoutePath(path: string, label?: string): RoutePathSegment[]
   return segments.map((segment) => parseRoutePathSegment(segment, path, label));
 }
 
+/**
+ * Validate route path.
+ *
+ * @param path The path.
+ * @param label The label.
+ */
 export function validateRoutePath(path: string, label?: string): void {
   void parseRoutePath(path, label);
 }
 
+/**
+ * Extract route path params.
+ *
+ * @param path The path.
+ * @returns The extract route path params result.
+ */
 export function extractRoutePathParams(path: string): string[] {
   return parseRoutePath(path).flatMap((segment) => segment.kind === 'param' ? [segment.name] : []);
 }
 
+/**
+ * Match route path.
+ *
+ * @param registeredSegments The registered segments.
+ * @param incomingSegments The incoming segments.
+ * @returns The match route path result.
+ */
 export function matchRoutePath(
   registeredSegments: readonly RoutePathSegment[],
   incomingSegments: readonly string[],

--- a/packages/jwt/src/refresh/refresh-token.ts
+++ b/packages/jwt/src/refresh/refresh-token.ts
@@ -5,6 +5,9 @@ import type { DefaultJwtSigner } from '../signing/signer.js';
 import type { JwtClaims } from '../types.js';
 import type { DefaultJwtVerifier } from '../signing/verifier.js';
 
+/**
+ * Describes the refresh token store contract.
+ */
 export interface RefreshTokenStore {
   save(token: RefreshTokenRecord): Promise<void>;
   find(tokenId: string): Promise<RefreshTokenRecord | undefined>;
@@ -13,6 +16,9 @@ export interface RefreshTokenStore {
   consume?(input: RefreshTokenConsumeInput): Promise<RefreshTokenConsumeResult>;
 }
 
+/**
+ * Describes the refresh token consume input contract.
+ */
 export interface RefreshTokenConsumeInput {
   tokenId: string;
   subject: string;
@@ -20,8 +26,14 @@ export interface RefreshTokenConsumeInput {
   now: Date;
 }
 
+/**
+ * Defines the refresh token consume result type.
+ */
 export type RefreshTokenConsumeResult = 'consumed' | 'already_used' | 'expired' | 'not_found' | 'mismatch' | 'invalid';
 
+/**
+ * Describes the refresh token record contract.
+ */
 export interface RefreshTokenRecord {
   id: string;
   subject: string;
@@ -31,6 +43,9 @@ export interface RefreshTokenRecord {
   createdAt: Date;
 }
 
+/**
+ * Describes the refresh token options contract.
+ */
 export interface RefreshTokenOptions {
   secret: string;
   expiresInSeconds: number;
@@ -39,6 +54,12 @@ export interface RefreshTokenOptions {
   store: RefreshTokenStore;
 }
 
+/**
+ * Normalize refresh token options.
+ *
+ * @param options The options.
+ * @returns The normalize refresh token options result.
+ */
 export function normalizeRefreshTokenOptions(options: RefreshTokenOptions | undefined): RefreshTokenOptions {
   if (!options) {
     throw new JwtConfigurationError('JWT refresh token options are not configured.');
@@ -74,6 +95,9 @@ interface RefreshTokenClaims extends JwtClaims {
   type: 'refresh';
 }
 
+/**
+ * Represents the refresh token service.
+ */
 export class RefreshTokenService {
   private readonly options: RefreshTokenOptions;
 

--- a/packages/jwt/src/signing/jwks.ts
+++ b/packages/jwt/src/signing/jwks.ts
@@ -11,6 +11,9 @@ interface JwksResponse {
   keys?: Jwk[];
 }
 
+/**
+ * Represents the jwks client.
+ */
 export class JwksClient {
   private readonly cache = new Map<string, { expiresAt: number; key: KeyObject }>();
 

--- a/packages/jwt/src/status.ts
+++ b/packages/jwt/src/status.ts
@@ -5,6 +5,9 @@ import type {
   PlatformSnapshot,
 } from '@fluojs/runtime';
 
+/**
+ * Describes the jwt platform status snapshot contract.
+ */
 export interface JwtPlatformStatusSnapshot {
   readiness: PlatformReadinessReport;
   health: PlatformHealthReport;
@@ -12,6 +15,9 @@ export interface JwtPlatformStatusSnapshot {
   details: Record<string, unknown>;
 }
 
+/**
+ * Describes the jwt status adapter input contract.
+ */
 export interface JwtStatusAdapterInput {
   componentId?: string;
   readinessCritical?: boolean;
@@ -60,6 +66,12 @@ function createHealth(input: JwtStatusAdapterInput): PlatformHealthReport {
   };
 }
 
+/**
+ * Create jwt platform status snapshot.
+ *
+ * @param input The input.
+ * @returns The create jwt platform status snapshot result.
+ */
 export function createJwtPlatformStatusSnapshot(input: JwtStatusAdapterInput): JwtPlatformStatusSnapshot {
   const componentId = input.componentId ?? 'jwt.default';
   const refreshStoreReady = isRefreshTokenStoreReady(input);
@@ -106,6 +118,12 @@ export function createJwtPlatformStatusSnapshot(input: JwtStatusAdapterInput): J
   };
 }
 
+/**
+ * Create jwt platform diagnostic issues.
+ *
+ * @param input The input.
+ * @returns The create jwt platform diagnostic issues result.
+ */
 export function createJwtPlatformDiagnosticIssues(input: JwtStatusAdapterInput): PlatformDiagnosticIssue[] {
   if (isRefreshTokenStoreReady(input)) {
     return [];

--- a/packages/jwt/src/types.ts
+++ b/packages/jwt/src/types.ts
@@ -2,8 +2,14 @@ import type { KeyObject } from 'node:crypto';
 
 import type { RefreshTokenOptions } from './refresh/refresh-token.js';
 
+/**
+ * Defines the jwt algorithm type.
+ */
 export type JwtAlgorithm = 'HS256' | 'HS384' | 'HS512' | 'RS256' | 'RS384' | 'RS512' | 'ES256' | 'ES384' | 'ES512';
 
+/**
+ * Describes the jwt key entry contract.
+ */
 export interface JwtKeyEntry {
   kid: string;
   secret?: string;
@@ -11,6 +17,9 @@ export interface JwtKeyEntry {
   publicKey?: string | KeyObject;
 }
 
+/**
+ * Describes the jwt verifier options contract.
+ */
 export interface JwtVerifierOptions {
   algorithms: JwtAlgorithm[];
   accessTokenTtlSeconds?: number;
@@ -30,6 +39,9 @@ export interface JwtVerifierOptions {
   refreshToken?: RefreshTokenOptions;
 }
 
+/**
+ * Describes the jwt claims contract.
+ */
 export interface JwtClaims extends Record<string, unknown> {
   aud?: string | string[];
   exp?: number;
@@ -41,6 +53,9 @@ export interface JwtClaims extends Record<string, unknown> {
   sub?: string;
 }
 
+/**
+ * Describes the jwt principal contract.
+ */
 export interface JwtPrincipal {
   subject: string;
   issuer?: string;
@@ -50,10 +65,16 @@ export interface JwtPrincipal {
   claims: Record<string, unknown>;
 }
 
+/**
+ * Describes the jwt verifier contract.
+ */
 export interface JwtVerifier {
   verifyAccessToken(token: string): Promise<JwtPrincipal>;
 }
 
+/**
+ * Describes the jwt signer contract.
+ */
 export interface JwtSigner {
   signAccessToken(claims: JwtClaims): Promise<string>;
 }

--- a/packages/microservices/src/metadata.ts
+++ b/packages/microservices/src/metadata.ts
@@ -32,6 +32,13 @@ function getOrCreateHandlerMap(target: object): Map<MetadataPropertyKey, Handler
   return map;
 }
 
+/**
+ * Define handler metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineHandlerMetadata(target: object, propertyKey: MetadataPropertyKey, metadata: HandlerMetadata): void {
   const map = getOrCreateHandlerMap(target);
   const current = map.get(propertyKey) ?? [];
@@ -39,6 +46,12 @@ export function defineHandlerMetadata(target: object, propertyKey: MetadataPrope
   map.set(propertyKey, current);
 }
 
+/**
+ * Get handler metadata entries.
+ *
+ * @param target The target.
+ * @returns The get handler metadata entries result.
+ */
 export function getHandlerMetadataEntries(
   target: object,
 ): Array<{ metadata: HandlerMetadata; propertyKey: MetadataPropertyKey }> {
@@ -61,4 +74,7 @@ export function getHandlerMetadataEntries(
   return entries;
 }
 
+/**
+ * Provides the microservice metadata symbol value.
+ */
 export const microserviceMetadataSymbol = standardMicroserviceMetadataKey;

--- a/packages/microservices/src/status.ts
+++ b/packages/microservices/src/status.ts
@@ -1,7 +1,13 @@
 import type { PlatformHealthReport, PlatformReadinessReport, PlatformSnapshot } from '@fluojs/runtime';
 
+/**
+ * Defines the microservice lifecycle state type.
+ */
 export type MicroserviceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
 
+/**
+ * Describes the microservice handler counts contract.
+ */
 export interface MicroserviceHandlerCounts {
   'bidi-stream': number;
   'client-stream': number;
@@ -10,6 +16,9 @@ export interface MicroserviceHandlerCounts {
   'server-stream': number;
 }
 
+/**
+ * Describes the microservice transport capabilities contract.
+ */
 export interface MicroserviceTransportCapabilities {
   bidiStream: boolean;
   clientStream: boolean;
@@ -18,6 +27,9 @@ export interface MicroserviceTransportCapabilities {
   serverStream: boolean;
 }
 
+/**
+ * Describes the microservice status adapter input contract.
+ */
 export interface MicroserviceStatusAdapterInput {
   handlerCounts: MicroserviceHandlerCounts;
   lastListenError?: string;
@@ -25,6 +37,9 @@ export interface MicroserviceStatusAdapterInput {
   transportCapabilities: MicroserviceTransportCapabilities;
 }
 
+/**
+ * Describes the microservice platform status snapshot contract.
+ */
 export interface MicroservicePlatformStatusSnapshot {
   readiness: PlatformReadinessReport;
   health: PlatformHealthReport;
@@ -99,6 +114,12 @@ function createHealth(input: MicroserviceStatusAdapterInput): PlatformHealthRepo
   };
 }
 
+/**
+ * Create microservice platform status snapshot.
+ *
+ * @param input The input.
+ * @returns The create microservice platform status snapshot result.
+ */
 export function createMicroservicePlatformStatusSnapshot(
   input: MicroserviceStatusAdapterInput,
 ): MicroservicePlatformStatusSnapshot {

--- a/packages/microservices/src/transports/event-handler-logger.ts
+++ b/packages/microservices/src/transports/event-handler-logger.ts
@@ -1,5 +1,12 @@
 import type { MicroserviceTransportLogger } from '../types.js';
 
+/**
+ * Log transport event handler failure.
+ *
+ * @param logger The logger.
+ * @param transportName The transport name.
+ * @param error The error.
+ */
 export function logTransportEventHandlerFailure(
   logger: MicroserviceTransportLogger | undefined,
   transportName: string,

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -462,9 +462,20 @@ function normalizeApiResponseOptions(
   return statusOrOptions;
 }
 
-/** Declare an expected HTTP response for a controller method. */
+/**
+ *  Declare an expected HTTP response for a controller method.
+ *
+ * @param status The status.
+ * @param options The options.
+ * @returns The api response result.
+ */
 export function ApiResponse(status: number, options?: Omit<ApiResponseOptions, 'status'>): MethodDecoratorFn;
-/** Declare an expected HTTP response for a controller method. */
+/**
+ *  Declare an expected HTTP response for a controller method.
+ *
+ * @param options The options.
+ * @returns The api response result.
+ */
 export function ApiResponse(options: ApiResponseOptions): MethodDecoratorFn;
 /**
  * Declare an expected HTTP response for a controller method.

--- a/packages/passport/src/cookie/cookie-manager.ts
+++ b/packages/passport/src/cookie/cookie-manager.ts
@@ -2,6 +2,9 @@ import type { FrameworkResponse } from '@fluojs/http';
 
 import { DEFAULT_COOKIE_AUTH_OPTIONS, type CookieAuthOptions, normalizeCookieAuthOptions } from './cookie-auth.js';
 
+/**
+ * Describes the cookie options contract.
+ */
 export interface CookieOptions {
   httpOnly?: boolean;
   secure?: boolean;
@@ -11,11 +14,17 @@ export interface CookieOptions {
   maxAge?: number;
 }
 
+/**
+ * Describes the set cookie options contract.
+ */
 export interface SetCookieOptions extends CookieOptions {
   accessTokenTtlSeconds?: number;
   refreshTokenTtlSeconds?: number;
 }
 
+/**
+ * Describes the cookie manager config contract.
+ */
 export interface CookieManagerConfig extends CookieAuthOptions {
   cookieOptions?: CookieOptions;
 }
@@ -23,6 +32,9 @@ export interface CookieManagerConfig extends CookieAuthOptions {
 type NormalizedCookieOptions = Omit<Required<CookieOptions>, 'domain' | 'maxAge'> &
   Pick<CookieOptions, 'domain' | 'maxAge'>;
 
+/**
+ * Provides the default cookie options value.
+ */
 export const DEFAULT_COOKIE_OPTIONS: NormalizedCookieOptions = {
   httpOnly: true,
   secure: true,
@@ -69,6 +81,9 @@ function buildClearCookieHeader(name: string, options: NormalizedCookieOptions):
   });
 }
 
+/**
+ * Represents the cookie manager.
+ */
 export class CookieManager {
   private readonly options: Required<CookieAuthOptions>;
   private readonly cookieOptions: NormalizedCookieOptions;
@@ -161,6 +176,12 @@ export class CookieManager {
   }
 }
 
+/**
+ * Create cookie manager.
+ *
+ * @param config The config.
+ * @returns The create cookie manager result.
+ */
 export function createCookieManager(config?: CookieManagerConfig): CookieManager {
   return new CookieManager(config);
 }

--- a/packages/passport/src/internal-tokens.ts
+++ b/packages/passport/src/internal-tokens.ts
@@ -1,5 +1,11 @@
 const PASSPORT_OPTIONS_KEY = 'fluo.passport.options';
 const AUTH_STRATEGY_REGISTRY_KEY = 'fluo.passport.strategy-registry';
 
+/**
+ * Provides the passport options value.
+ */
 export const PASSPORT_OPTIONS = Symbol.for(PASSPORT_OPTIONS_KEY);
+/**
+ * Provides the auth strategy registry value.
+ */
 export const AUTH_STRATEGY_REGISTRY = Symbol.for(AUTH_STRATEGY_REGISTRY_KEY);

--- a/packages/passport/src/metadata.ts
+++ b/packages/passport/src/metadata.ts
@@ -67,6 +67,13 @@ function getStandardMethodRequirement(target: object, propertyKey: MetadataPrope
   return normalizeRequirement(map?.get(propertyKey));
 }
 
+/**
+ * Define auth requirement.
+ *
+ * @param target The target.
+ * @param requirement The requirement.
+ * @param propertyKey The property key.
+ */
 export function defineAuthRequirement(target: Function | object, requirement: AuthRequirement, propertyKey?: MetadataPropertyKey): void {
   const normalizedRequirement = normalizeRequirement(requirement);
 
@@ -103,6 +110,13 @@ export function defineAuthRequirement(target: Function | object, requirement: Au
   }
 }
 
+/**
+ * Get own auth requirement.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get own auth requirement result.
+ */
 export function getOwnAuthRequirement(target: Function | object, propertyKey?: MetadataPropertyKey): AuthRequirement | undefined {
   if (propertyKey === undefined) {
     return mergeAuthRequirements(classRequirementStore.get(target as Function), getStandardClassRequirement(target as Function));
@@ -111,6 +125,13 @@ export function getOwnAuthRequirement(target: Function | object, propertyKey?: M
   return mergeAuthRequirements(methodRequirementStore.get(target)?.get(propertyKey), getStandardMethodRequirement(target, propertyKey));
 }
 
+/**
+ * Get auth requirement.
+ *
+ * @param controllerType The controller type.
+ * @param propertyKey The property key.
+ * @returns The get auth requirement result.
+ */
 export function getAuthRequirement(controllerType: Function, propertyKey?: MetadataPropertyKey): AuthRequirement | undefined {
   if (propertyKey === undefined) {
     if (mergedClassRequirementCache.has(controllerType)) {

--- a/packages/passport/src/scope.ts
+++ b/packages/passport/src/scope.ts
@@ -18,6 +18,12 @@ function normalizeScopeItems(items: Iterable<string>): string[] | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+/**
+ * Normalize declared scopes.
+ *
+ * @param scopes The scopes.
+ * @returns The normalize declared scopes result.
+ */
 export function normalizeDeclaredScopes(scopes: unknown): string[] | undefined {
   if (!Array.isArray(scopes)) {
     return undefined;
@@ -27,6 +33,12 @@ export function normalizeDeclaredScopes(scopes: unknown): string[] | undefined {
   return normalizeScopeItems(scopeItems);
 }
 
+/**
+ * Normalize principal scopes.
+ *
+ * @param claims The claims.
+ * @returns The normalize principal scopes result.
+ */
 export function normalizePrincipalScopes(claims: Record<string, unknown>): string[] | undefined {
   if (Array.isArray(claims.scopes)) {
     const scopes = claims.scopes.filter((scope): scope is string => typeof scope === 'string');
@@ -40,6 +52,13 @@ export function normalizePrincipalScopes(claims: Record<string, unknown>): strin
   return undefined;
 }
 
+/**
+ * Merge auth requirements.
+ *
+ * @param base The base.
+ * @param extra The extra.
+ * @returns The merge auth requirements result.
+ */
 export function mergeAuthRequirements(
   base: AuthRequirement | undefined,
   extra: AuthRequirement | undefined,

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -63,6 +63,9 @@ declare module '@fluojs/http' {
   }
 }
 
+/**
+ * Describes the express adapter options contract.
+ */
 export interface ExpressAdapterOptions {
   host?: string;
   https?: HttpsServerOptions;
@@ -74,12 +77,21 @@ export interface ExpressAdapterOptions {
   shutdownTimeoutMs?: number;
 }
 
+/**
+ * Defines the express application signal type.
+ */
 export type ExpressApplicationSignal = 'SIGINT' | 'SIGTERM';
+/**
+ * Defines the cors input type.
+ */
 export type CorsInput = false | string | string[] | CorsOptions;
 
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 
+/**
+ * Describes the bootstrap express application options contract.
+ */
 export interface BootstrapExpressApplicationOptions extends Omit<CreateApplicationOptions, 'adapter' | 'logger' | 'middleware'> {
   cors?: CorsInput;
   globalPrefix?: string;
@@ -98,6 +110,9 @@ export interface BootstrapExpressApplicationOptions extends Omit<CreateApplicati
   shutdownTimeoutMs?: number;
 }
 
+/**
+ * Describes the run express application options contract.
+ */
 export interface RunExpressApplicationOptions extends BootstrapExpressApplicationOptions {
   forceExitTimeoutMs?: number;
   shutdownSignals?: false | readonly ExpressApplicationSignal[];
@@ -122,6 +137,9 @@ type ExpressMultipartLikeError = Error & {
   type?: unknown;
 };
 
+/**
+ * Represents the express http application adapter.
+ */
 export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
   private closeInFlight?: Promise<void>;
   private dispatcher?: Dispatcher;
@@ -264,6 +282,13 @@ function createExpressRequestResponseFactory(
   };
 }
 
+/**
+ * Create express adapter.
+ *
+ * @param options The options.
+ * @param multipartOptions The multipart options.
+ * @returns The create express adapter result.
+ */
 export function createExpressAdapter(
   options: ExpressAdapterOptions = {},
   multipartOptions?: MultipartOptions,
@@ -281,6 +306,13 @@ export function createExpressAdapter(
   );
 }
 
+/**
+ * Bootstrap express application.
+ *
+ * @param rootModule The root module.
+ * @param options The options.
+ * @returns The bootstrap express application result.
+ */
 export async function bootstrapExpressApplication(
   rootModule: ModuleType,
   options: BootstrapExpressApplicationOptions,
@@ -292,6 +324,13 @@ export async function bootstrapExpressApplication(
   );
 }
 
+/**
+ * Run express application.
+ *
+ * @param rootModule The root module.
+ * @param options The options.
+ * @returns The run express application result.
+ */
 export async function runExpressApplication(
   rootModule: ModuleType,
   options: RunExpressApplicationOptions,
@@ -471,6 +510,12 @@ async function parseMultipartRequest(
   }
 }
 
+/**
+ * Is express multipart too large error.
+ *
+ * @param error The error.
+ * @returns The is express multipart too large error result.
+ */
 export function isExpressMultipartTooLargeError(error: unknown): boolean {
   if (error instanceof PayloadTooLargeException) {
     return true;

--- a/packages/prisma/src/status.ts
+++ b/packages/prisma/src/status.ts
@@ -67,6 +67,12 @@ function createHealth(input: PrismaPlatformStatusSnapshotInput): PlatformHealthR
   };
 }
 
+/**
+ * Create prisma platform status snapshot.
+ *
+ * @param input The input.
+ * @returns The create prisma platform status snapshot result.
+ */
 export function createPrismaPlatformStatusSnapshot(
   input: PrismaPlatformStatusSnapshotInput,
 ): PersistencePlatformStatusSnapshot {

--- a/packages/queue/src/dead-letter-manager.ts
+++ b/packages/queue/src/dead-letter-manager.ts
@@ -8,6 +8,9 @@ const DEAD_LETTER_DRAIN_TIMEOUT_MS = 5_000;
 
 type QueuePayload = Record<string, unknown>;
 
+/**
+ * Describes the queue dead letter job contract.
+ */
 export interface QueueDeadLetterJob {
   attemptsMade: number;
   data: unknown;
@@ -18,11 +21,17 @@ export interface QueueDeadLetterJob {
   };
 }
 
+/**
+ * Describes the queue redis dead letter client contract.
+ */
 export interface QueueRedisDeadLetterClient {
   ltrim(key: string, start: number, stop: number): Promise<unknown>;
   rpush(key: string, value: string): Promise<unknown>;
 }
 
+/**
+ * Represents the queue dead letter manager.
+ */
 export class QueueDeadLetterManager {
   private readonly pendingWrites = new Set<Promise<void>>();
 

--- a/packages/queue/src/helpers.ts
+++ b/packages/queue/src/helpers.ts
@@ -5,8 +5,14 @@ import type { CompiledModule } from '@fluojs/runtime';
 
 import type { QueueRateLimiterOptions } from './types.js';
 
+/**
+ * Defines the scope type.
+ */
 export type Scope = 'request' | 'singleton' | 'transient';
 
+/**
+ * Describes the discovery candidate contract.
+ */
 export interface DiscoveryCandidate {
   moduleName: string;
   scope: Scope;
@@ -14,6 +20,12 @@ export interface DiscoveryCandidate {
   token: Token;
 }
 
+/**
+ * Scope from provider.
+ *
+ * @param provider The provider.
+ * @returns The scope from provider result.
+ */
 export function scopeFromProvider(provider: Provider): Scope {
   if (typeof provider === 'function') {
     return getClassDiMetadata(provider)?.scope ?? 'singleton';
@@ -26,10 +38,22 @@ export function scopeFromProvider(provider: Provider): Scope {
   return 'scope' in provider ? provider.scope ?? 'singleton' : 'singleton';
 }
 
+/**
+ * Is class provider.
+ *
+ * @param provider The provider.
+ * @returns The is class provider result.
+ */
 export function isClassProvider(provider: Provider): provider is Extract<Provider, { provide: Token; useClass: Function }> {
   return typeof provider === 'object' && provider !== null && 'useClass' in provider;
 }
 
+/**
+ * Collect discovery candidates.
+ *
+ * @param compiledModules The compiled modules.
+ * @returns The collect discovery candidates result.
+ */
 export function collectDiscoveryCandidates(compiledModules: readonly CompiledModule[]): DiscoveryCandidate[] {
   const candidates: DiscoveryCandidate[] = [];
 
@@ -68,6 +92,13 @@ export function collectDiscoveryCandidates(compiledModules: readonly CompiledMod
   return candidates;
 }
 
+/**
+ * Normalize positive integer.
+ *
+ * @param value The value.
+ * @param fallback The fallback.
+ * @returns The normalize positive integer result.
+ */
 export function normalizePositiveInteger(value: number | undefined, fallback: number): number {
   if (value === undefined || !Number.isFinite(value)) {
     return fallback;
@@ -82,6 +113,13 @@ export function normalizePositiveInteger(value: number | undefined, fallback: nu
   return normalized;
 }
 
+/**
+ * Normalize positive integer or false.
+ *
+ * @param value The value.
+ * @param fallback The fallback.
+ * @returns The normalize positive integer or false result.
+ */
 export function normalizePositiveIntegerOrFalse(
   value: number | false | undefined,
   fallback: number | false,
@@ -103,6 +141,12 @@ export function normalizePositiveIntegerOrFalse(
   return normalized;
 }
 
+/**
+ * Normalize rate limiter.
+ *
+ * @param rateLimiter The rate limiter.
+ * @returns The normalize rate limiter result.
+ */
 export function normalizeRateLimiter(rateLimiter: QueueRateLimiterOptions | undefined): QueueRateLimiterOptions | undefined {
   if (!rateLimiter) {
     return undefined;
@@ -114,6 +158,14 @@ export function normalizeRateLimiter(rateLimiter: QueueRateLimiterOptions | unde
   };
 }
 
+/**
+ * With timeout.
+ *
+ * @param promise The promise.
+ * @param timeoutMs The timeout ms.
+ * @param timeoutErrorFactory The timeout error factory.
+ * @returns The with timeout result.
+ */
 export async function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,

--- a/packages/queue/src/metadata.ts
+++ b/packages/queue/src/metadata.ts
@@ -18,10 +18,22 @@ function getStandardQueueWorkerMetadata(target: Function): QueueWorkerMetadata |
   return getStandardMetadataBag(target)?.[standardQueueWorkerMetadataKey] as QueueWorkerMetadata | undefined;
 }
 
+/**
+ * Define queue worker metadata.
+ *
+ * @param target The target.
+ * @param metadata The metadata.
+ */
 export function defineQueueWorkerMetadata(target: Function, metadata: QueueWorkerMetadata): void {
   queueWorkerMetadataStore.set(target, cloneQueueWorkerMetadata(metadata));
 }
 
+/**
+ * Get queue worker metadata.
+ *
+ * @param target The target.
+ * @returns The get queue worker metadata result.
+ */
 export function getQueueWorkerMetadata(target: Function): QueueWorkerMetadata | undefined {
   const stored = queueWorkerMetadataStore.get(target);
   const standard = getStandardQueueWorkerMetadata(target);
@@ -33,4 +45,7 @@ export function getQueueWorkerMetadata(target: Function): QueueWorkerMetadata | 
   return cloneQueueWorkerMetadata(stored ?? standard!);
 }
 
+/**
+ * Provides the queue worker metadata symbol value.
+ */
 export const queueWorkerMetadataSymbol = standardQueueWorkerMetadataKey;

--- a/packages/queue/src/worker-discovery.ts
+++ b/packages/queue/src/worker-discovery.ts
@@ -4,6 +4,14 @@ import { getQueueWorkerMetadata } from './metadata.js';
 import { collectDiscoveryCandidates, normalizePositiveInteger, normalizeRateLimiter } from './helpers.js';
 import type { NormalizedQueueModuleOptions, QueueJobType, QueueWorkerDescriptor, QueueWorkerMetadata } from './types.js';
 
+/**
+ * Discover queue worker descriptors.
+ *
+ * @param compiledModules The compiled modules.
+ * @param options The options.
+ * @param logger The logger.
+ * @returns The discover queue worker descriptors result.
+ */
 export function discoverQueueWorkerDescriptors(
   compiledModules: readonly CompiledModule[],
   options: NormalizedQueueModuleOptions,

--- a/packages/runtime/src/health/diagnostics.ts
+++ b/packages/runtime/src/health/diagnostics.ts
@@ -4,6 +4,9 @@ import type { Provider, Scope } from '@fluojs/di';
 
 import type { CompiledModule, ModuleType } from '../types.js';
 
+/**
+ * Describes the runtime diagnostics graph contract.
+ */
 export interface RuntimeDiagnosticsGraph {
   version: 1;
   rootModule: string;
@@ -11,6 +14,9 @@ export interface RuntimeDiagnosticsGraph {
   relationships: RuntimeDiagnosticsRelationships;
 }
 
+/**
+ * Describes the runtime diagnostics module contract.
+ */
 export interface RuntimeDiagnosticsModule {
   name: string;
   global: boolean;
@@ -20,6 +26,9 @@ export interface RuntimeDiagnosticsModule {
   exports: string[];
 }
 
+/**
+ * Describes the runtime diagnostics provider contract.
+ */
 export interface RuntimeDiagnosticsProvider {
   token: string;
   type: 'class' | 'factory' | 'value' | 'existing';
@@ -27,6 +36,9 @@ export interface RuntimeDiagnosticsProvider {
   multi: boolean;
 }
 
+/**
+ * Describes the runtime diagnostics relationships contract.
+ */
 export interface RuntimeDiagnosticsRelationships {
   moduleImports: Array<{
     from: string;
@@ -49,6 +61,9 @@ export interface RuntimeDiagnosticsRelationships {
   }>;
 }
 
+/**
+ * Describes the bootstrap timing phase contract.
+ */
 export interface BootstrapTimingPhase {
   durationMs: number;
   name:
@@ -59,6 +74,9 @@ export interface BootstrapTimingPhase {
     | 'create_dispatcher';
 }
 
+/**
+ * Describes the bootstrap timing diagnostics contract.
+ */
 export interface BootstrapTimingDiagnostics {
   phases: BootstrapTimingPhase[];
   totalMs: number;
@@ -144,6 +162,13 @@ function normalizeProvider(provider: Provider): RuntimeDiagnosticsProvider {
   };
 }
 
+/**
+ * Create runtime diagnostics graph.
+ *
+ * @param modules The modules.
+ * @param rootModule The root module.
+ * @returns The create runtime diagnostics graph result.
+ */
 export function createRuntimeDiagnosticsGraph(modules: readonly CompiledModule[], rootModule: ModuleType): RuntimeDiagnosticsGraph {
   const moduleDiagnostics: RuntimeDiagnosticsModule[] = [];
   const moduleImports: RuntimeDiagnosticsRelationships['moduleImports'] = [];
@@ -212,6 +237,12 @@ export function createRuntimeDiagnosticsGraph(modules: readonly CompiledModule[]
   };
 }
 
+/**
+ * Render runtime diagnostics mermaid.
+ *
+ * @param graph The graph.
+ * @returns The render runtime diagnostics mermaid result.
+ */
 export function renderRuntimeDiagnosticsMermaid(graph: RuntimeDiagnosticsGraph): string {
   const lines: string[] = ['graph TD'];
   const nodeByModule = new Map<string, string>();
@@ -250,6 +281,13 @@ export function renderRuntimeDiagnosticsMermaid(graph: RuntimeDiagnosticsGraph):
   return lines.join('\n');
 }
 
+/**
+ * Create bootstrap timing diagnostics.
+ *
+ * @param phases The phases.
+ * @param totalMs The total ms.
+ * @returns The create bootstrap timing diagnostics result.
+ */
 export function createBootstrapTimingDiagnostics(
   phases: BootstrapTimingPhase[],
   totalMs: number,

--- a/packages/runtime/src/health/health.ts
+++ b/packages/runtime/src/health/health.ts
@@ -3,19 +3,31 @@ import { Controller, Get } from '@fluojs/http';
 import { defineModule } from '../bootstrap.js';
 import type { ModuleType } from '../types.js';
 
+/**
+ * Describes the health status contract.
+ */
 export interface HealthStatus {
   status: 'ok' | 'unavailable';
 }
 
+/**
+ * Describes the health check response contract.
+ */
 export interface HealthCheckResponse {
   body: unknown;
   statusCode?: number;
 }
 
+/**
+ * Describes the readiness status contract.
+ */
 export interface ReadinessStatus {
   status: 'ready' | 'starting' | 'unavailable';
 }
 
+/**
+ * Describes the health module options contract.
+ */
 export interface HealthModuleOptions {
   healthCheck?: (ctx: import('@fluojs/http').RequestContext) =>
     | HealthStatus
@@ -24,8 +36,17 @@ export interface HealthModuleOptions {
   path?: string;
 }
 
+/**
+ * Defines the readiness check type.
+ */
 export type ReadinessCheck = () => boolean | Promise<boolean>;
 
+/**
+ * Create health module.
+ *
+ * @param options The options.
+ * @returns The create health module result.
+ */
 export function createHealthModule(options: HealthModuleOptions = {}): ModuleType {
   const basePath = options.path ?? '';
   const readinessChecks: ReadinessCheck[] = [];

--- a/packages/runtime/src/logging/json-logger.ts
+++ b/packages/runtime/src/logging/json-logger.ts
@@ -37,6 +37,11 @@ function buildEntry(level: LogLevel, message: string, context?: string, error?: 
   return entry;
 }
 
+/**
+ * Create json application logger.
+ *
+ * @returns The create json application logger result.
+ */
 export function createJsonApplicationLogger(): ApplicationLogger {
   return {
     debug(message, context) {

--- a/packages/runtime/src/logging/logger.ts
+++ b/packages/runtime/src/logging/logger.ts
@@ -21,6 +21,11 @@ function formatLog(level: 'DEBUG' | 'ERROR' | 'LOG' | 'WARN', context: string, m
   return `${prefix} ${pid} - ${timestamp} ${levelLabel} ${contextLabel} ${message}`;
 }
 
+/**
+ * Create console application logger.
+ *
+ * @returns The create console application logger result.
+ */
 export function createConsoleApplicationLogger(): ApplicationLogger {
   return {
     debug(message, context = 'fluo') {

--- a/packages/runtime/src/node/internal-node-compression.ts
+++ b/packages/runtime/src/node/internal-node-compression.ts
@@ -23,6 +23,13 @@ const SKIP_CONTENT_TYPES = new Set([
 
 type Encoding = 'br' | 'gzip' | 'identity';
 
+/**
+ * Create node response compression.
+ *
+ * @param response The response.
+ * @param acceptEncoding The accept encoding.
+ * @returns The create node response compression result.
+ */
 export function createNodeResponseCompression(
   response: ServerResponse,
   acceptEncoding: string | undefined,
@@ -49,6 +56,14 @@ export function createNodeResponseCompression(
   };
 }
 
+/**
+ * Compress node response.
+ *
+ * @param response The response.
+ * @param body The body.
+ * @param encoding The encoding.
+ * @returns The compress node response result.
+ */
 export function compressNodeResponse(
   response: ServerResponse,
   body: Uint8Array,

--- a/packages/runtime/src/node/internal-node-response.ts
+++ b/packages/runtime/src/node/internal-node-response.ts
@@ -9,6 +9,9 @@ import {
   type FrameworkResponseStream,
 } from '@fluojs/http';
 
+/**
+ * Defines the mutable framework response type.
+ */
 export type MutableFrameworkResponse = FrameworkResponse & { statusSet?: boolean };
 
 function createFrameworkResponseStream(response: ServerResponse): FrameworkResponseStream {
@@ -54,6 +57,13 @@ function createFrameworkResponseStream(response: ServerResponse): FrameworkRespo
   };
 }
 
+/**
+ * Create framework response.
+ *
+ * @param response The response.
+ * @param compression The compression.
+ * @returns The create framework response result.
+ */
 export function createFrameworkResponse(
   response: ServerResponse,
   compression?: FrameworkResponseCompression,
@@ -154,6 +164,14 @@ export function createFrameworkResponse(
   return frameworkResponse;
 }
 
+/**
+ * Write node adapter error response.
+ *
+ * @param error The error.
+ * @param response The response.
+ * @param requestId The request id.
+ * @returns The write node adapter error response result.
+ */
 export async function writeNodeAdapterErrorResponse(
   error: unknown,
   response: FrameworkResponse,

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -50,6 +50,9 @@ declare module '@fluojs/http' {
   }
 }
 
+/**
+ * Describes the node http adapter options contract.
+ */
 export interface NodeHttpAdapterOptions {
   host?: string;
   https?: HttpsServerOptions;
@@ -61,12 +64,21 @@ export interface NodeHttpAdapterOptions {
   shutdownTimeoutMs?: number;
 }
 
+/**
+ * Defines the node application signal type.
+ */
 export type NodeApplicationSignal = 'SIGINT' | 'SIGTERM';
 
+/**
+ * Defines the cors input type.
+ */
 export type CorsInput = false | string | string[] | CorsOptions;
 
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 
+/**
+ * Describes the bootstrap node application options contract.
+ */
 export interface BootstrapNodeApplicationOptions extends Omit<CreateApplicationOptions, 'adapter' | 'logger' | 'middleware'> {
   compression?: boolean;
   cors?: CorsInput;
@@ -86,6 +98,9 @@ export interface BootstrapNodeApplicationOptions extends Omit<CreateApplicationO
   shutdownTimeoutMs?: number;
 }
 
+/**
+ * Describes the run node application options contract.
+ */
 export interface RunNodeApplicationOptions extends BootstrapNodeApplicationOptions {
   forceExitTimeoutMs?: number;
   shutdownSignals?: false | readonly NodeApplicationSignal[];
@@ -106,6 +121,9 @@ interface NodeListenRetryOptions {
 type NodeServer = ReturnType<typeof createHttpServer> | ReturnType<typeof createHttpsServer>;
 type NodeRequestListener = RequestListener;
 
+/**
+ * Represents the node http application adapter.
+ */
 export class NodeHttpApplicationAdapter implements HttpApplicationAdapter {
   private readonly server: NodeServer;
   private dispatcher?: Dispatcher;
@@ -241,6 +259,14 @@ function createNodeRequestResponseFactory(
   };
 }
 
+/**
+ * Create node http adapter.
+ *
+ * @param options The options.
+ * @param compression The compression.
+ * @param multipartOptions The multipart options.
+ * @returns The create node http adapter result.
+ */
 export function createNodeHttpAdapter(options: NodeHttpAdapterOptions = {}, compression = false, multipartOptions?: MultipartOptions): HttpApplicationAdapter {
   return new NodeHttpApplicationAdapter(
     resolveNodePort(options.port),
@@ -256,6 +282,13 @@ export function createNodeHttpAdapter(options: NodeHttpAdapterOptions = {}, comp
   );
 }
 
+/**
+ * Bootstrap node application.
+ *
+ * @param rootModule The root module.
+ * @param options The options.
+ * @returns The bootstrap node application result.
+ */
 export async function bootstrapNodeApplication(
   rootModule: ModuleType,
   options: BootstrapNodeApplicationOptions,
@@ -267,6 +300,13 @@ export async function bootstrapNodeApplication(
   );
 }
 
+/**
+ * Run node application.
+ *
+ * @param rootModule The root module.
+ * @param options The options.
+ * @returns The run node application result.
+ */
 export async function runNodeApplication(
   rootModule: ModuleType,
   options: RunNodeApplicationOptions,

--- a/packages/runtime/src/request-transaction.ts
+++ b/packages/runtime/src/request-transaction.ts
@@ -1,19 +1,34 @@
+/**
+ * Defines the request abort context type.
+ */
 export type RequestAbortContext = {
   controller: AbortController;
   cleanup(): void;
   signal: AbortSignal;
 };
 
+/**
+ * Defines the active request transaction type.
+ */
 export type ActiveRequestTransaction = {
   abort(reason?: unknown): void;
   settled: Promise<void>;
 };
 
+/**
+ * Defines the active request transaction handle type.
+ */
 export type ActiveRequestTransactionHandle = {
   active: ActiveRequestTransaction;
   settle(): void;
 };
 
+/**
+ * Create request abort context.
+ *
+ * @param signal The signal.
+ * @returns The create request abort context result.
+ */
 export function createRequestAbortContext(signal?: AbortSignal): RequestAbortContext {
   const controller = new AbortController();
   const forwardAbort = () => controller.abort(signal?.reason);
@@ -33,6 +48,13 @@ export function createRequestAbortContext(signal?: AbortSignal): RequestAbortCon
   };
 }
 
+/**
+ * Track active request transaction.
+ *
+ * @param activeRequestTransactions The active request transactions.
+ * @param controller The controller.
+ * @returns The track active request transaction result.
+ */
 export function trackActiveRequestTransaction(
   activeRequestTransactions: Set<ActiveRequestTransaction>,
   controller: AbortController,
@@ -54,6 +76,12 @@ export function trackActiveRequestTransaction(
   return { active, settle };
 }
 
+/**
+ * Untrack active request transaction.
+ *
+ * @param activeRequestTransactions The active request transactions.
+ * @param handle The handle.
+ */
 export function untrackActiveRequestTransaction(
   activeRequestTransactions: Set<ActiveRequestTransaction>,
   handle: ActiveRequestTransactionHandle,

--- a/packages/serialization/src/metadata.ts
+++ b/packages/serialization/src/metadata.ts
@@ -3,12 +3,21 @@ import { getOwnStandardConstructorMetadataBag, metadataSymbol } from '@fluojs/co
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
+/**
+ * Defines the transform function type.
+ */
 export type TransformFunction = (value: unknown) => unknown;
 
+/**
+ * Describes the class serialization options contract.
+ */
 export interface ClassSerializationOptions {
   excludeExtraneous?: boolean;
 }
 
+/**
+ * Describes the serialization field metadata contract.
+ */
 export interface SerializationFieldMetadata {
   excluded?: boolean;
   exposed?: boolean;
@@ -74,10 +83,23 @@ function getConstructorMetadataBags(constructor: Function): StandardMetadataBag[
   return bags;
 }
 
+/**
+ * Update class serialization options.
+ *
+ * @param metadata The metadata.
+ * @param partial The partial.
+ */
 export function updateClassSerializationOptions(metadata: unknown, partial: ClassSerializationOptions): void {
   Object.assign(getClassMetadataObject(metadata), partial);
 }
 
+/**
+ * Update field serialization metadata.
+ *
+ * @param metadata The metadata.
+ * @param propertyKey The property key.
+ * @param update The update.
+ */
 export function updateFieldSerializationMetadata(
   metadata: unknown,
   propertyKey: MetadataPropertyKey,
@@ -87,6 +109,12 @@ export function updateFieldSerializationMetadata(
   map.set(propertyKey, update(map.get(propertyKey)));
 }
 
+/**
+ * Get class serialization options.
+ *
+ * @param constructor The constructor.
+ * @returns The get class serialization options result.
+ */
 export function getClassSerializationOptions(constructor: Function): ClassSerializationOptions {
   return getConstructorMetadataBags(constructor).reduce<ClassSerializationOptions>((options, bag) => ({
     ...options,
@@ -94,6 +122,12 @@ export function getClassSerializationOptions(constructor: Function): ClassSerial
   }), {});
 }
 
+/**
+ * Get field serialization metadata.
+ *
+ * @param constructor The constructor.
+ * @returns The get field serialization metadata result.
+ */
 export function getFieldSerializationMetadata(constructor: Function): Map<MetadataPropertyKey, SerializationFieldMetadata> {
   const merged = new Map<MetadataPropertyKey, SerializationFieldMetadata>();
 

--- a/packages/terminus/src/errors.ts
+++ b/packages/terminus/src/errors.ts
@@ -1,5 +1,8 @@
 import type { HealthIndicatorResult } from './types.js';
 
+/**
+ * Represents the health check error.
+ */
 export class HealthCheckError extends Error {
   readonly causes: HealthIndicatorResult;
 

--- a/packages/testing/src/conformance/fetch-style-websocket-conformance.ts
+++ b/packages/testing/src/conformance/fetch-style-websocket-conformance.ts
@@ -1,5 +1,8 @@
 import type { FetchStyleHttpAdapterRealtimeCapability, HttpApplicationAdapter } from '@fluojs/http';
 
+/**
+ * Describes the fetch style web socket conformance harness options contract.
+ */
 export interface FetchStyleWebSocketConformanceHarnessOptions<
   TAdapter extends HttpApplicationAdapter = HttpApplicationAdapter,
 > {
@@ -9,6 +12,9 @@ export interface FetchStyleWebSocketConformanceHarnessOptions<
   name: string;
 }
 
+/**
+ * Represents the fetch style web socket conformance harness.
+ */
 export class FetchStyleWebSocketConformanceHarness<
   TAdapter extends HttpApplicationAdapter = HttpApplicationAdapter,
 > {
@@ -52,6 +58,12 @@ export class FetchStyleWebSocketConformanceHarness<
   }
 }
 
+/**
+ * Create fetch style web socket conformance harness.
+ *
+ * @param options The options.
+ * @returns The create fetch style web socket conformance harness result.
+ */
 export function createFetchStyleWebSocketConformanceHarness<
   TAdapter extends HttpApplicationAdapter = HttpApplicationAdapter,
 >(

--- a/packages/testing/src/conformance/platform-conformance.ts
+++ b/packages/testing/src/conformance/platform-conformance.ts
@@ -7,6 +7,9 @@ import type {
   PlatformValidationResult,
 } from '@fluojs/runtime';
 
+/**
+ * Describes the platform conformance scenario contract.
+ */
 export interface PlatformConformanceScenario {
   createComponent: () => PlatformComponent;
   enterState: (component: PlatformComponent) => MaybePromise<void>;
@@ -14,6 +17,9 @@ export interface PlatformConformanceScenario {
   expectedState?: PlatformState;
 }
 
+/**
+ * Describes the platform conformance diagnostics options contract.
+ */
 export interface PlatformConformanceDiagnosticsOptions {
   collect?: (
     component: PlatformComponent,
@@ -23,6 +29,9 @@ export interface PlatformConformanceDiagnosticsOptions {
   requireFixHintForSeverities?: ReadonlyArray<PlatformDiagnosticIssue['severity']>;
 }
 
+/**
+ * Describes the platform conformance snapshot options contract.
+ */
 export interface PlatformConformanceSnapshotOptions {
   allowKeyPatterns?: readonly RegExp[];
   compare?: (left: unknown, right: unknown) => boolean;
@@ -30,6 +39,9 @@ export interface PlatformConformanceSnapshotOptions {
   sanitize?: (snapshot: PlatformSnapshot) => PlatformSnapshot;
 }
 
+/**
+ * Describes the platform conformance harness options contract.
+ */
 export interface PlatformConformanceHarnessOptions {
   captureValidationSideEffects?: (component: PlatformComponent) => MaybePromise<unknown>;
   createComponent: () => PlatformComponent;
@@ -115,6 +127,9 @@ function collectForbiddenKeyPaths(
   }
 }
 
+/**
+ * Represents the platform conformance harness.
+ */
 export class PlatformConformanceHarness {
   constructor(private readonly options: PlatformConformanceHarnessOptions) {}
 
@@ -296,6 +311,12 @@ export class PlatformConformanceHarness {
   }
 }
 
+/**
+ * Create platform conformance harness.
+ *
+ * @param options The options.
+ * @returns The create platform conformance harness result.
+ */
 export function createPlatformConformanceHarness(
   options: PlatformConformanceHarnessOptions,
 ): PlatformConformanceHarness {

--- a/packages/testing/src/mock.ts
+++ b/packages/testing/src/mock.ts
@@ -6,12 +6,19 @@ import type { ValueProvider } from '@fluojs/di';
 
 import type { DeepMocked } from './types.js';
 
+/**
+ * Defines the mocked methods type.
+ */
 export type MockedMethods<T> = {
   [K in keyof T]: T[K] extends (...args: never[]) => unknown ? Mock<T[K]> : T[K];
 };
 
 /**
  * Creates a proxy mock object with optional strict missing-property checks.
+ *
+ * @param partial The partial.
+ * @param options The options.
+ * @returns The create mock result.
  */
 export function createMock<T extends object>(
   partial: Partial<MockedMethods<T>> = {},
@@ -42,6 +49,9 @@ export function createMock<T extends object>(
 
 /**
  * Casts a function to a strongly typed Vitest mock.
+ *
+ * @param fn The fn.
+ * @returns The as mock result.
  */
 export function asMock<T extends (...args: never[]) => unknown>(fn: T): Mock<T> {
   return vi.mocked(fn);
@@ -49,6 +59,9 @@ export function asMock<T extends (...args: never[]) => unknown>(fn: T): Mock<T> 
 
 /**
  * Creates a deep mock by replacing prototype methods with `vi.fn()` spies.
+ *
+ * @param type The type.
+ * @returns The create deep mock result.
  */
 export function createDeepMock<T extends object>(type: new (...args: unknown[]) => T): DeepMocked<T> {
   const spies: Record<string | symbol, unknown> = {};
@@ -72,6 +85,10 @@ export function createDeepMock<T extends object>(type: new (...args: unknown[]) 
 
 /**
  * Creates a `useValue` provider for overriding a token in tests.
+ *
+ * @param token The token.
+ * @param partial The partial.
+ * @returns The mock token result.
  */
 export function mockToken<T>(token: Token<T>, partial: Partial<T> = {}): ValueProvider<T> {
   return { provide: token, useValue: partial as T };

--- a/packages/testing/src/portability/web-runtime-adapter-portability.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.ts
@@ -15,6 +15,9 @@ type WebRuntimePortabilityAppLike = {
   dispatch(request: Request): Promise<Response>;
 };
 
+/**
+ * Describes the web runtime http adapter portability harness options contract.
+ */
 export interface WebRuntimeHttpAdapterPortabilityHarnessOptions<
   TBootstrapOptions extends object,
   TApp extends WebRuntimePortabilityAppLike = WebRuntimePortabilityAppLike,
@@ -33,6 +36,9 @@ async function closeSilently(app: WebRuntimePortabilityAppLike): Promise<void> {
   } catch {}
 }
 
+/**
+ * Represents the web runtime http adapter portability harness.
+ */
 export class WebRuntimeHttpAdapterPortabilityHarness<
   TBootstrapOptions extends object,
   TApp extends WebRuntimePortabilityAppLike = WebRuntimePortabilityAppLike,
@@ -231,6 +237,12 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
   }
 }
 
+/**
+ * Create web runtime http adapter portability harness.
+ *
+ * @param options The options.
+ * @returns The create web runtime http adapter portability harness result.
+ */
 export function createWebRuntimeHttpAdapterPortabilityHarness<
   TBootstrapOptions extends object,
   TApp extends WebRuntimePortabilityAppLike = WebRuntimePortabilityAppLike,

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -164,19 +164,61 @@ export const ValidateIf = (
   options?: ValidationDecoratorOptions,
 ) => createValidationDecorator(() => ({ kind: 'validateIf', validateIf, ...options }));
 
+/**
+ * Provides the is defined value.
+ */
 export const IsDefined = createFlagValidationDecorator((options) => ({ kind: 'defined', ...options }));
+/**
+ * Provides the is optional value.
+ */
 export const IsOptional = createFlagValidationDecorator((options) => ({ kind: 'optional', ...options }));
+/**
+ * Provides the equals value.
+ */
 export const Equals = createValidationOptionsWithConfigDecorator<unknown>((value, options) => ({ kind: 'equals', value, ...options }));
+/**
+ * Provides the not equals value.
+ */
 export const NotEquals = createValidationOptionsWithConfigDecorator<unknown>((value, options) => ({ kind: 'notEquals', value, ...options }));
+/**
+ * Provides the is empty value.
+ */
 export const IsEmpty = createFlagValidationDecorator((options) => ({ kind: 'empty', ...options }));
+/**
+ * Provides the is not empty value.
+ */
 export const IsNotEmpty = createFlagValidationDecorator((options) => ({ kind: 'notEmpty', ...options }));
+/**
+ * Provides the is in value.
+ */
 export const IsIn = createArrayValidationDecorator<unknown>((values, options) => ({ kind: 'in', values, ...options }));
+/**
+ * Provides the is not in value.
+ */
 export const IsNotIn = createArrayValidationDecorator<unknown>((values, options) => ({ kind: 'notIn', values, ...options }));
+/**
+ * Provides the is date value.
+ */
 export const IsDate = createFlagValidationDecorator((options) => ({ kind: 'date', ...options }));
+/**
+ * Provides the is array value.
+ */
 export const IsArray = createFlagValidationDecorator((options) => ({ kind: 'array', ...options }));
+/**
+ * Provides the is object value.
+ */
 export const IsObject = createFlagValidationDecorator((options) => ({ kind: 'object', ...options }));
+/**
+ * Provides the is int value.
+ */
 export const IsInt = createFlagValidationDecorator((options) => ({ kind: 'int', ...options }));
+/**
+ * Provides the is positive value.
+ */
 export const IsPositive = createFlagValidationDecorator((options) => ({ kind: 'positive', ...options }));
+/**
+ * Provides the is negative value.
+ */
 export const IsNegative = createFlagValidationDecorator((options) => ({ kind: 'negative', ...options }));
 
 /**
@@ -191,12 +233,33 @@ export function IsEnum(values: Record<string, unknown> | readonly unknown[], opt
   return createValidationDecorator(() => ({ kind: 'enum', values: normalized, ...options }));
 }
 
+/**
+ * Provides the is divisible by value.
+ */
 export const IsDivisibleBy = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'divisibleBy', value, ...options }));
+/**
+ * Provides the min value.
+ */
 export const Min = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'min', value, ...options }));
+/**
+ * Provides the max value.
+ */
 export const Max = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'max', value, ...options }));
+/**
+ * Provides the min date value.
+ */
 export const MinDate = createValidationOptionsWithConfigDecorator<Date>((value, options) => ({ kind: 'minDate', value, ...options }));
+/**
+ * Provides the max date value.
+ */
 export const MaxDate = createValidationOptionsWithConfigDecorator<Date>((value, options) => ({ kind: 'maxDate', value, ...options }));
+/**
+ * Provides the contains value.
+ */
 export const Contains = createValidationOptionsWithConfigDecorator<string>((value, options) => ({ kind: 'contains', value, ...options }));
+/**
+ * Provides the not contains value.
+ */
 export const NotContains = createValidationOptionsWithConfigDecorator<string>((value, options) => ({ kind: 'notContains', value, ...options }));
 
 /**
@@ -226,7 +289,13 @@ export function ValidateNested(dto: Constructor | (() => Constructor), options?:
   }));
 }
 
+/**
+ * Provides the min length value.
+ */
 export const MinLength = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'minLength', value, ...options }));
+/**
+ * Provides the max length value.
+ */
 export const MaxLength = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'maxLength', value, ...options }));
 
 /**
@@ -261,77 +330,290 @@ export function Matches(
   } as DtoFieldValidationRule));
 }
 
+/**
+ * Provides the is alpha value.
+ *
+ * @param options The options.
+ */
 export const IsAlpha = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('alpha')(undefined, options);
+/**
+ * Provides the is alphanumeric value.
+ *
+ * @param options The options.
+ */
 export const IsAlphanumeric = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('alphanumeric')(undefined, options);
+/**
+ * Provides the is ascii value.
+ *
+ * @param options The options.
+ */
 export const IsAscii = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('ascii')(undefined, options);
+/**
+ * Provides the is base64 value.
+ *
+ * @param options The options.
+ */
 export const IsBase64 = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('base64')(undefined, options);
+/**
+ * Provides the is boolean string value.
+ *
+ * @param options The options.
+ */
 export const IsBooleanString = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('booleanString')(undefined, options);
+/**
+ * Provides the is data uri value.
+ *
+ * @param options The options.
+ */
 export const IsDataURI = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('dataURI')(undefined, options);
+/**
+ * Provides the is date string value.
+ *
+ * @param options The options.
+ */
 export const IsDateString = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('dateString')(undefined, options);
+/**
+ * Provides the is decimal value.
+ *
+ * @param options The options.
+ */
 export const IsDecimal = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('decimal')(undefined, options);
+/**
+ * Provides the is email value.
+ *
+ * @param options The options.
+ */
 export const IsEmail = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('email')(undefined, options);
+/**
+ * Provides the is fqdn value.
+ *
+ * @param options The options.
+ */
 export const IsFQDN = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('fqdn')(undefined, options);
+/**
+ * Provides the is hex color value.
+ *
+ * @param options The options.
+ */
 export const IsHexColor = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('hexColor')(undefined, options);
+/**
+ * Provides the is hexadecimal value.
+ *
+ * @param options The options.
+ */
 export const IsHexadecimal = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('hexadecimal')(undefined, options);
+/**
+ * Provides the is json value.
+ *
+ * @param options The options.
+ */
 export const IsJSON = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('json')(undefined, options);
+/**
+ * Provides the is jwt value.
+ *
+ * @param options The options.
+ */
 export const IsJWT = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('jwt')(undefined, options);
+/**
+ * Provides the is locale value.
+ *
+ * @param options The options.
+ */
 export const IsLocale = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('locale')(undefined, options);
+/**
+ * Provides the is lowercase value.
+ *
+ * @param options The options.
+ */
 export const IsLowercase = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('lowercase')(undefined, options);
+/**
+ * Provides the is magnet uri value.
+ *
+ * @param options The options.
+ */
 export const IsMagnetURI = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('magnetURI')(undefined, options);
+/**
+ * Provides the is mime type value.
+ *
+ * @param options The options.
+ */
 export const IsMimeType = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('mimeType')(undefined, options);
+/**
+ * Provides the is mongo id value.
+ *
+ * @param options The options.
+ */
 export const IsMongoId = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('mongoId')(undefined, options);
+/**
+ * Provides the is number string value.
+ *
+ * @param options The options.
+ */
 export const IsNumberString = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('numberString')(undefined, options);
+/**
+ * Provides the is port value.
+ *
+ * @param options The options.
+ */
 export const IsPort = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('port')(undefined, options);
+/**
+ * Provides the is rfc3339 value.
+ *
+ * @param options The options.
+ */
 export const IsRFC3339 = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('rfc3339')(undefined, options);
+/**
+ * Provides the is sem ver value.
+ *
+ * @param options The options.
+ */
 export const IsSemVer = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('semVer')(undefined, options);
+/**
+ * Provides the is uppercase value.
+ *
+ * @param options The options.
+ */
 export const IsUppercase = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('uppercase')(undefined, options);
+/**
+ * Provides the is iso8601 value.
+ *
+ * @param options The options.
+ */
 export const IsISO8601 = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('iso8601')(undefined, options);
+/**
+ * Provides the is latitude value.
+ *
+ * @param options The options.
+ */
 export const IsLatitude = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('latitude')(undefined, options);
+/**
+ * Provides the is longitude value.
+ *
+ * @param options The options.
+ */
 export const IsLongitude = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('longitude')(undefined, options);
+/**
+ * Provides the is lat long value.
+ *
+ * @param options The options.
+ */
 export const IsLatLong = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('latLong')(undefined, options);
 
-/** Validates that a value is an IPv4/IPv6 address. */
+/**
+ *  Validates that a value is an IPv4/IPv6 address.
+ *
+ * @param version The version.
+ * @param options The options.
+ * @returns The is ip result.
+ */
 export function IsIP(version?: '4' | '6' | '4_or_6', options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('ip')(version ? [version] : undefined, options);
 }
 
-/** Validates that a value is an ISBN string. */
+/**
+ *  Validates that a value is an ISBN string.
+ *
+ * @param version The version.
+ * @param options The options.
+ * @returns The is isbn result.
+ */
 export function IsISBN(version?: 10 | 13, options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('isbn')(version ? [String(version)] : undefined, options);
 }
 
+/**
+ * Is issn.
+ *
+ * @param options The options.
+ * @returns The is issn result.
+ */
 export function IsISSN(options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('issn')(undefined, options);
 }
 
+/**
+ * Is mobile phone.
+ *
+ * @param locale The locale.
+ * @param options The options.
+ * @returns The is mobile phone result.
+ */
 export function IsMobilePhone(locale?: string | readonly string[], options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('mobilePhone')(locale ? [locale] : undefined, options);
 }
 
+/**
+ * Is postal code.
+ *
+ * @param locale The locale.
+ * @param options The options.
+ * @returns The is postal code result.
+ */
 export function IsPostalCode(locale?: string, options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('postalCode')(locale ? [locale] : undefined, options);
 }
 
+/**
+ * Is rgb color.
+ *
+ * @param includePercentValues The include percent values.
+ * @param options The options.
+ * @returns The is rgb color result.
+ */
 export function IsRgbColor(includePercentValues?: boolean, options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('rgbColor')(includePercentValues === undefined ? undefined : [includePercentValues], options);
 }
 
+/**
+ * Is url.
+ *
+ * @param options The options.
+ * @returns The is url result.
+ */
 export function IsUrl(options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('url')(undefined, options);
 }
 
+/**
+ * Is uuid.
+ *
+ * @param version The version.
+ * @param options The options.
+ * @returns The is uuid result.
+ */
 export function IsUUID(version?: '3' | '4' | '5' | 'all', options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('uuid')(version ? [version] : undefined, options);
 }
 
+/**
+ * Is currency.
+ *
+ * @param options The options.
+ * @returns The is currency result.
+ */
 export function IsCurrency(options?: ValidationDecoratorOptions): FieldDecoratorFn {
   return createValidatorJsDecorator('currency')(undefined, options);
 }
 
+/**
+ * Provides the array contains value.
+ */
 export const ArrayContains = createArrayValidationDecorator<unknown>((values, options) => ({ kind: 'arrayContains', values, ...options }));
+/**
+ * Provides the array not contains value.
+ */
 export const ArrayNotContains = createArrayValidationDecorator<unknown>((values, options) => ({ kind: 'arrayNotContains', values, ...options }));
+/**
+ * Provides the array not empty value.
+ */
 export const ArrayNotEmpty = createFlagValidationDecorator((options) => ({ kind: 'arrayNotEmpty', ...options }));
+/**
+ * Provides the array min size value.
+ */
 export const ArrayMinSize = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'arrayMinSize', value, ...options }));
+/**
+ * Provides the array max size value.
+ */
 export const ArrayMaxSize = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'arrayMaxSize', value, ...options }));
 
 /**

--- a/packages/validation/src/errors.ts
+++ b/packages/validation/src/errors.ts
@@ -1,5 +1,8 @@
 import type { ValidationIssue } from './types.js';
 
+/**
+ * Represents the dto validation error.
+ */
 export class DtoValidationError extends Error {
   constructor(
     message: string,

--- a/packages/validation/src/types.ts
+++ b/packages/validation/src/types.ts
@@ -1,5 +1,8 @@
 import type { Constructor, MaybePromise, MetadataSource } from '@fluojs/core';
 
+/**
+ * Describes the validation issue contract.
+ */
 export interface ValidationIssue {
   /** Stable issue code for programmatic error handling. */
   code: string;

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -793,6 +793,9 @@ async function collectValidationIssuesInternal<T>(
   }
 }
 
+/**
+ * Represents the default validator.
+ */
 export class DefaultValidator implements Validator {
   async validate(value: unknown, target: Constructor): Promise<void> {
     const issues = await collectValidationIssues(target, value);

--- a/packages/websockets/src/bun/bun-types.ts
+++ b/packages/websockets/src/bun/bun-types.ts
@@ -1,7 +1,13 @@
 import type { WebSocketModuleOptions as SharedWebSocketModuleOptions } from '../types.js';
 
+/**
+ * Defines the bun web socket message type.
+ */
 export type BunWebSocketMessage = string | ArrayBuffer | Uint8Array;
 
+/**
+ * Describes the bun server web socket contract.
+ */
 export interface BunServerWebSocket<TData = unknown> {
   readonly data: TData;
   readonly readyState: number;
@@ -16,6 +22,9 @@ export interface BunServerWebSocket<TData = unknown> {
   unsubscribe(topic: string): void;
 }
 
+/**
+ * Describes the bun server like contract.
+ */
 export interface BunServerLike {
   fetch?(request: Request): Response | Promise<Response> | undefined | Promise<Response | undefined>;
   hostname?: string;
@@ -31,6 +40,9 @@ export interface BunServerLike {
   url?: URL;
 }
 
+/**
+ * Describes the bun web socket handler contract.
+ */
 export interface BunWebSocketHandler<TData = unknown> {
   backpressureLimit?: number;
   close?(socket: BunServerWebSocket<TData>, code: number, reason: string): void | Promise<void>;
@@ -52,24 +64,39 @@ export interface BunWebSocketHandler<TData = unknown> {
   sendPings?: boolean;
 }
 
+/**
+ * Describes the bun web socket binding contract.
+ */
 export interface BunWebSocketBinding<TData = unknown> {
   fetch(request: Request, server: BunServerLike): Response | Promise<Response> | undefined | Promise<Response | undefined>;
   websocket: BunWebSocketHandler<TData>;
 }
 
+/**
+ * Describes the bun web socket binding host contract.
+ */
 export interface BunWebSocketBindingHost {
   configureWebSocketBinding<TData>(binding: BunWebSocketBinding<TData> | undefined): void;
 }
 
+/**
+ * Defines the typed on message handler type.
+ */
 export type TypedOnMessageHandler<TEvents extends Record<string, unknown>, K extends keyof TEvents> = (
   payload: TEvents[K],
   socket: BunServerWebSocket,
   request: Request,
 ) => void | Promise<void>;
 
+/**
+ * Describes the web socket gateway context contract.
+ */
 export interface WebSocketGatewayContext {
   request: Request;
   socket: BunServerWebSocket;
 }
 
+/**
+ * Defines the web socket module options type.
+ */
 export type WebSocketModuleOptions = SharedWebSocketModuleOptions;

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers-types.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers-types.ts
@@ -1,44 +1,74 @@
 import type { WebSocketModuleOptions as SharedWebSocketModuleOptions } from '../types.js';
 
+/**
+ * Defines the cloudflare worker web socket message type.
+ */
 export type CloudflareWorkerWebSocketMessage = ArrayBuffer | ArrayBufferView | Blob | string;
 
+/**
+ * Describes the cloudflare worker web socket contract.
+ */
 export interface CloudflareWorkerWebSocket
   extends Pick<WebSocket, 'addEventListener' | 'close' | 'removeEventListener' | 'send'> {
   readonly readyState: number;
   accept(): void;
 }
 
+/**
+ * Describes the cloudflare worker web socket pair contract.
+ */
 export interface CloudflareWorkerWebSocketPair {
   0: CloudflareWorkerWebSocket;
   1: CloudflareWorkerWebSocket;
 }
 
+/**
+ * Describes the cloudflare worker web socket upgrade result contract.
+ */
 export interface CloudflareWorkerWebSocketUpgradeResult {
   response: Response;
   serverSocket: CloudflareWorkerWebSocket;
 }
 
+/**
+ * Describes the cloudflare worker web socket upgrade host contract.
+ */
 export interface CloudflareWorkerWebSocketUpgradeHost {
   upgrade(request: Request): CloudflareWorkerWebSocketUpgradeResult;
 }
 
+/**
+ * Describes the cloudflare worker web socket binding contract.
+ */
 export interface CloudflareWorkerWebSocketBinding {
   fetch(request: Request, host: CloudflareWorkerWebSocketUpgradeHost): Response | Promise<Response>;
 }
 
+/**
+ * Describes the cloudflare worker web socket binding host contract.
+ */
 export interface CloudflareWorkerWebSocketBindingHost {
   configureWebSocketBinding(binding: CloudflareWorkerWebSocketBinding | undefined): void;
 }
 
+/**
+ * Defines the typed on message handler type.
+ */
 export type TypedOnMessageHandler<TEvents extends Record<string, unknown>, K extends keyof TEvents> = (
   payload: TEvents[K],
   socket: CloudflareWorkerWebSocket,
   request: Request,
 ) => void | Promise<void>;
 
+/**
+ * Describes the web socket gateway context contract.
+ */
 export interface WebSocketGatewayContext {
   request: Request;
   socket: CloudflareWorkerWebSocket;
 }
 
+/**
+ * Defines the web socket module options type.
+ */
 export type WebSocketModuleOptions = SharedWebSocketModuleOptions;

--- a/packages/websockets/src/deno/deno-types.ts
+++ b/packages/websockets/src/deno/deno-types.ts
@@ -1,37 +1,64 @@
 import type { WebSocketModuleOptions as SharedWebSocketModuleOptions } from '../types.js';
 
+/**
+ * Defines the deno web socket message type.
+ */
 export type DenoWebSocketMessage = Blob | string;
 
+/**
+ * Describes the deno server web socket contract.
+ */
 export interface DenoServerWebSocket extends Pick<WebSocket, 'addEventListener' | 'close' | 'removeEventListener' | 'send'> {
   readonly readyState: number;
 }
 
+/**
+ * Describes the deno web socket upgrade result contract.
+ */
 export interface DenoWebSocketUpgradeResult<TSocket extends DenoServerWebSocket = DenoServerWebSocket> {
   response: Response;
   socket: TSocket;
 }
 
+/**
+ * Describes the deno web socket upgrade host contract.
+ */
 export interface DenoWebSocketUpgradeHost<TSocket extends DenoServerWebSocket = DenoServerWebSocket> {
   upgrade(request: Request): DenoWebSocketUpgradeResult<TSocket>;
 }
 
+/**
+ * Describes the deno web socket binding contract.
+ */
 export interface DenoWebSocketBinding<TSocket extends DenoServerWebSocket = DenoServerWebSocket> {
   fetch(request: Request, host: DenoWebSocketUpgradeHost<TSocket>): Response | Promise<Response>;
 }
 
+/**
+ * Describes the deno web socket binding host contract.
+ */
 export interface DenoWebSocketBindingHost<TSocket extends DenoServerWebSocket = DenoServerWebSocket> {
   configureWebSocketBinding(binding: DenoWebSocketBinding<TSocket> | undefined): void;
 }
 
+/**
+ * Defines the typed on message handler type.
+ */
 export type TypedOnMessageHandler<TEvents extends Record<string, unknown>, K extends keyof TEvents> = (
   payload: TEvents[K],
   socket: DenoServerWebSocket,
   request: Request,
 ) => void | Promise<void>;
 
+/**
+ * Describes the web socket gateway context contract.
+ */
 export interface WebSocketGatewayContext {
   request: Request;
   socket: DenoServerWebSocket;
 }
 
+/**
+ * Defines the web socket module options type.
+ */
 export type WebSocketModuleOptions = SharedWebSocketModuleOptions;

--- a/packages/websockets/src/internal/shared.ts
+++ b/packages/websockets/src/internal/shared.ts
@@ -11,6 +11,9 @@ import type {
 
 const textDecoder = new TextDecoder();
 
+/**
+ * Describes the discovery candidate contract.
+ */
 export interface DiscoveryCandidate {
   moduleName: string;
   scope: 'request' | 'singleton' | 'transient';
@@ -24,26 +27,47 @@ interface ClassProviderLike {
   useClass: new (...args: unknown[]) => unknown;
 }
 
+/**
+ * Describes the resolved gateway instance contract.
+ */
 export interface ResolvedGatewayInstance {
   descriptor: WebSocketGatewayDescriptor;
   instance: unknown;
 }
 
+/**
+ * Defines the parsed web socket message type.
+ */
 export type ParsedWebSocketMessage = {
   event?: string;
   payload: unknown;
 };
 
+/**
+ * Defines the shared web socket incoming message type.
+ */
 export type SharedWebSocketIncomingMessage =
   | ArrayBuffer
   | ArrayBufferView
   | Uint8Array[]
   | string;
 
+/**
+ * Is finite positive integer.
+ *
+ * @param value The value.
+ * @returns The is finite positive integer result.
+ */
 export function isFinitePositiveInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 && Number.isInteger(value);
 }
 
+/**
+ * Normalize gateway path.
+ *
+ * @param path The path.
+ * @returns The normalize gateway path result.
+ */
 export function normalizeGatewayPath(path: string): string {
   if (path === '/') {
     return '/';
@@ -54,6 +78,12 @@ export function normalizeGatewayPath(path: string): string {
   return normalized === '' ? '/' : normalized;
 }
 
+/**
+ * Parse incoming message.
+ *
+ * @param data The data.
+ * @returns The parse incoming message result.
+ */
 export function parseIncomingMessage(data: SharedWebSocketIncomingMessage): ParsedWebSocketMessage {
   let text: string;
 
@@ -100,6 +130,14 @@ export function parseIncomingMessage(data: SharedWebSocketIncomingMessage): Pars
   };
 }
 
+/**
+ * Discover gateway descriptors.
+ *
+ * @param compiledModules The compiled modules.
+ * @param logger The logger.
+ * @param loggerContext The logger context.
+ * @returns The discover gateway descriptors result.
+ */
 export function discoverGatewayDescriptors(
   compiledModules: readonly CompiledModule[],
   logger: ApplicationLogger,
@@ -134,6 +172,15 @@ export function discoverGatewayDescriptors(
   return descriptors;
 }
 
+/**
+ * Resolve gateway instance.
+ *
+ * @param runtimeContainer The runtime container.
+ * @param descriptor The descriptor.
+ * @param logger The logger.
+ * @param loggerContext The logger context.
+ * @returns The resolve gateway instance result.
+ */
 export async function resolveGatewayInstance(
   runtimeContainer: Container,
   descriptor: WebSocketGatewayDescriptor,
@@ -152,6 +199,17 @@ export async function resolveGatewayInstance(
   }
 }
 
+/**
+ * Dispatch gateway message.
+ *
+ * @param resolved The resolved.
+ * @param socket The socket.
+ * @param request The request.
+ * @param data The data.
+ * @param logger The logger.
+ * @param loggerContext The logger context.
+ * @returns The dispatch gateway message result.
+ */
 export async function dispatchGatewayMessage<TSocket, TRequest>(
   resolved: readonly ResolvedGatewayInstance[],
   socket: TSocket,
@@ -175,6 +233,18 @@ export async function dispatchGatewayMessage<TSocket, TRequest>(
   }
 }
 
+/**
+ * Dispatch gateway disconnect.
+ *
+ * @param resolved The resolved.
+ * @param socket The socket.
+ * @param code The code.
+ * @param reason The reason.
+ * @param socketId The socket id.
+ * @param logger The logger.
+ * @param loggerContext The logger context.
+ * @returns The dispatch gateway disconnect result.
+ */
 export async function dispatchGatewayDisconnect<TSocket>(
   resolved: readonly ResolvedGatewayInstance[],
   socket: TSocket,
@@ -189,6 +259,17 @@ export async function dispatchGatewayDisconnect<TSocket>(
   }
 }
 
+/**
+ * Run gateway handlers.
+ *
+ * @param instance The instance.
+ * @param descriptor The descriptor.
+ * @param type The type.
+ * @param args The args.
+ * @param logger The logger.
+ * @param loggerContext The logger context.
+ * @returns The run gateway handlers result.
+ */
 export async function runGatewayHandlers(
   instance: unknown,
   descriptor: WebSocketGatewayDescriptor,

--- a/packages/websockets/src/metadata.ts
+++ b/packages/websockets/src/metadata.ts
@@ -63,10 +63,22 @@ function getOrCreateHandlerMetadataMap(target: object): Map<MetadataPropertyKey,
   return map;
 }
 
+/**
+ * Define web socket gateway metadata.
+ *
+ * @param target The target.
+ * @param metadata The metadata.
+ */
 export function defineWebSocketGatewayMetadata(target: object, metadata: WebSocketGatewayMetadata): void {
   gatewayMetadataStore.set(target, cloneGatewayMetadata(metadata));
 }
 
+/**
+ * Get web socket gateway metadata.
+ *
+ * @param target The target.
+ * @returns The get web socket gateway metadata result.
+ */
 export function getWebSocketGatewayMetadata(target: object): WebSocketGatewayMetadata | undefined {
   const stored = gatewayMetadataStore.get(target);
   const standard = getStandardGatewayMetadata(target);
@@ -78,6 +90,13 @@ export function getWebSocketGatewayMetadata(target: object): WebSocketGatewayMet
   return cloneGatewayMetadata(stored ?? standard!);
 }
 
+/**
+ * Define web socket handler metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @param metadata The metadata.
+ */
 export function defineWebSocketHandlerMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -86,6 +105,13 @@ export function defineWebSocketHandlerMetadata(
   getOrCreateHandlerMetadataMap(target).set(propertyKey, cloneHandlerMetadata(metadata));
 }
 
+/**
+ * Get web socket handler metadata.
+ *
+ * @param target The target.
+ * @param propertyKey The property key.
+ * @returns The get web socket handler metadata result.
+ */
 export function getWebSocketHandlerMetadata(
   target: object,
   propertyKey: MetadataPropertyKey,
@@ -100,6 +126,12 @@ export function getWebSocketHandlerMetadata(
   return cloneHandlerMetadata(stored ?? standard!);
 }
 
+/**
+ * Get web socket handler metadata entries.
+ *
+ * @param target The target.
+ * @returns The get web socket handler metadata entries result.
+ */
 export function getWebSocketHandlerMetadataEntries(
   target: object,
 ): Array<{ metadata: WebSocketGatewayHandlerMetadata; propertyKey: MetadataPropertyKey }> {
@@ -118,5 +150,11 @@ export function getWebSocketHandlerMetadataEntries(
     );
 }
 
+/**
+ * Provides the web socket gateway metadata symbol value.
+ */
 export const webSocketGatewayMetadataSymbol = standardWebSocketGatewayMetadataKey;
+/**
+ * Provides the web socket handler metadata symbol value.
+ */
 export const webSocketHandlerMetadataSymbol = standardWebSocketHandlerMetadataKey;


### PR DESCRIPTION
Closes #1391

## Summary
- restore the governed public-export TSDoc baseline across the retained package surface before 1.0
- add missing source-level summaries plus matching `@param` / `@returns` tags where the baseline reported gaps
- keep the public API surface intact and avoid release-impacting runtime changes

## Changes
- added baseline-compliant TSDoc comments to the retained public exports flagged by `pnpm verify:public-export-tsdoc:baseline`
- covered the remaining gaps across CLI, cache/config, core/runtime/HTTP, messaging/realtime, auth/data, and testing/validation packages
- left exports in place and limited the PR to documentation-only source comment updates

## Testing
- `pnpm verify:public-export-tsdoc:baseline` ✅ (exit code 0)
- `pnpm lint` ✅ (completed successfully; existing Biome warnings remain in the repository output and are unrelated to this TSDoc-only change)

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No release artifact is needed: this PR changes only source-level TSDoc comments and does not change runtime behavior, generated output, or the public API surface.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This PR does not change runtime behavior, so existing behavioral contracts and regression coverage remain unchanged.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs or platform contract docs changed in this PR.