### PR TITLE
Resolve #1396: preserve Fastify rawBody bytes

### DIFF
--- a/.changeset/quick-zebras-invite.md
+++ b/.changeset/quick-zebras-invite.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-fastify': patch
+---
+
+Preserve the original raw request bytes when `rawBody` capture is enabled so webhook verification and other byte-sensitive Fastify handlers receive the exact payload buffer.

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -276,6 +276,43 @@ describe('@fluojs/platform-fastify', () => {
     await app.close();
   });
 
+  it('does not add urlencoded parsing support when rawBody preservation is enabled', async () => {
+    @Controller('/webhooks')
+    class WebhookController {
+      @Post('/form')
+      handleForm(_input: undefined, context: RequestContext) {
+        return {
+          parsed: context.request.body,
+          raw: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('utf8'),
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [WebhookController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port,
+      rawBody: true,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/webhooks/form`, {
+      body: 'ping=1',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(415);
+
+    await app.close();
+  });
+
   it('supports SSE streaming', async () => {
     @Controller('/events')
     class EventsController {

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -236,6 +236,46 @@ describe('@fluojs/platform-fastify', () => {
     await app.close();
   });
 
+  it('preserves exact raw body bytes for byte-sensitive text requests when enabled', async () => {
+    @Controller('/webhooks')
+    class WebhookController {
+      @Post('/bytes')
+      handleBytes(_input: undefined, context: RequestContext) {
+        return {
+          rawHex: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('hex'),
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [WebhookController],
+    });
+
+    const payload = Buffer.from([0x66, 0x6c, 0x75, 0x6f, 0x00, 0xc3, 0x28, 0xff]);
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port,
+      rawBody: true,
+    });
+
+    await app.listen();
+
+    const response = await fetch(`http://127.0.0.1:${String(port)}/webhooks/bytes`, {
+      body: payload,
+      headers: { 'content-type': 'text/plain' },
+      method: 'POST',
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      rawHex: payload.toString('hex'),
+    });
+
+    await app.close();
+  });
+
   it('supports SSE streaming', async () => {
     @Controller('/events')
     class EventsController {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -70,7 +70,7 @@ export type CorsInput = false | string | string[] | CorsOptions;
 
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
-const RAW_BODY_BUFFER_CONTENT_TYPES = ['application/x-www-form-urlencoded', 'text/plain'] as const;
+const RAW_BODY_BUFFER_CONTENT_TYPES = ['text/plain'] as const;
 
 /**
  * Bootstrap options for creating a Fastify-backed application without
@@ -403,21 +403,13 @@ function registerRawBodyBufferParsers(app: ReturnType<typeof fastify>): void {
   app.addContentTypeParser(
     RAW_BODY_BUFFER_CONTENT_TYPES,
     { parseAs: 'buffer' },
-    (request: FastifyRequest, body: Buffer, done: (error: Error | null, body?: unknown) => void) => {
+    (_request: FastifyRequest, body: Buffer, done: (error: Error | null, body?: unknown) => void) => {
     if (body.length === 0) {
       done(null, undefined);
       return;
     }
 
-    const bodyText = body.toString('utf8');
-    const primaryContentType = readPrimaryHeaderValue(request.headers['content-type']);
-
-    if (typeof primaryContentType === 'string' && primaryContentType.includes('application/x-www-form-urlencoded')) {
-      done(null, parseUrlEncodedBody(bodyText));
-      return;
-    }
-
-    done(null, bodyText);
+    done(null, body.toString('utf8'));
     },
   );
 }
@@ -605,37 +597,6 @@ async function parseMultipartRequest(
   }
 
   return { fields, files };
-}
-
-function parseUrlEncodedBody(bodyText: string): Record<string, string | string[]> {
-  const fields: Record<string, string | string[]> = {};
-  const searchParams = new URLSearchParams(bodyText);
-
-  for (const [key, value] of searchParams.entries()) {
-    const existing = fields[key];
-
-    if (existing === undefined) {
-      fields[key] = value;
-      continue;
-    }
-
-    if (Array.isArray(existing)) {
-      existing.push(value);
-      continue;
-    }
-
-    fields[key] = [existing, value];
-  }
-
-  return fields;
-}
-
-function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {
-  if (Array.isArray(headerValue)) {
-    return headerValue[0];
-  }
-
-  return headerValue;
 }
 
 /**

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -70,6 +70,7 @@ export type CorsInput = false | string | string[] | CorsOptions;
 
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+const RAW_BODY_BUFFER_CONTENT_TYPES = ['application/x-www-form-urlencoded', 'text/plain'] as const;
 
 /**
  * Bootstrap options for creating a Fastify-backed application without
@@ -203,8 +204,10 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
     await this.app.register(multipart);
 
     if (this.preserveRawBody) {
+      registerRawBodyBufferParsers(this.app);
+
       await this.app.register(fastifyRawBody, {
-        encoding: 'utf8',
+        encoding: false,
         field: 'rawBody',
         global: true,
         runFirst: true,
@@ -396,6 +399,29 @@ function createFrameworkResponse(reply: FastifyReply): FastifyFrameworkResponse 
   };
 }
 
+function registerRawBodyBufferParsers(app: ReturnType<typeof fastify>): void {
+  app.addContentTypeParser(
+    RAW_BODY_BUFFER_CONTENT_TYPES,
+    { parseAs: 'buffer' },
+    (request: FastifyRequest, body: Buffer, done: (error: Error | null, body?: unknown) => void) => {
+    if (body.length === 0) {
+      done(null, undefined);
+      return;
+    }
+
+    const bodyText = body.toString('utf8');
+    const primaryContentType = readPrimaryHeaderValue(request.headers['content-type']);
+
+    if (typeof primaryContentType === 'string' && primaryContentType.includes('application/x-www-form-urlencoded')) {
+      done(null, parseUrlEncodedBody(bodyText));
+      return;
+    }
+
+    done(null, bodyText);
+    },
+  );
+}
+
 function createFrameworkResponseStream(reply: FastifyReply): FrameworkResponseStream {
   let hijacked = false;
 
@@ -505,10 +531,10 @@ async function createFrameworkRequest(
   }
 
   if (preserveRawBody && !isMultipart) {
-    const rawBodyValue = (request as FastifyRequest & { rawBody?: Buffer | string }).rawBody;
+    const rawBodyValue = (request as FastifyRequest & { rawBody?: Uint8Array }).rawBody;
 
-    if (rawBodyValue !== undefined) {
-      frameworkRequest.rawBody = typeof rawBodyValue === 'string' ? Buffer.from(rawBodyValue, 'utf8') : rawBodyValue;
+    if (rawBodyValue instanceof Uint8Array) {
+      frameworkRequest.rawBody = rawBodyValue;
     }
   }
 
@@ -579,6 +605,37 @@ async function parseMultipartRequest(
   }
 
   return { fields, files };
+}
+
+function parseUrlEncodedBody(bodyText: string): Record<string, string | string[]> {
+  const fields: Record<string, string | string[]> = {};
+  const searchParams = new URLSearchParams(bodyText);
+
+  for (const [key, value] of searchParams.entries()) {
+    const existing = fields[key];
+
+    if (existing === undefined) {
+      fields[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(existing)) {
+      existing.push(value);
+      continue;
+    }
+
+    fields[key] = [existing, value];
+  }
+
+  return fields;
+}
+
+function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {
+  if (Array.isArray(headerValue)) {
+    return headerValue[0];
+  }
+
+  return headerValue;
 }
 
 /**

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -188,6 +188,10 @@ export class HttpAdapterPortabilityHarness<
   }
 
   async assertPreservesRawBodyForJsonAndText(): Promise<void> {
+    const jsonPayload = JSON.stringify({ provider: 'stripe', emoji: '👩🏽‍🚀' });
+    const textPayload = 'ping=👩🏽‍🚀';
+    const binaryPayload = Buffer.from([0x66, 0x6c, 0x75, 0x6f, 0x00, 0xc3, 0x28, 0xff]);
+
     @Controller('/webhooks')
     class WebhookController {
       @Post('/json')
@@ -195,6 +199,7 @@ export class HttpAdapterPortabilityHarness<
         return {
           parsed: context.request.body,
           raw: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('utf8'),
+          rawHex: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('hex'),
         };
       }
 
@@ -203,6 +208,14 @@ export class HttpAdapterPortabilityHarness<
         return {
           parsed: context.request.body,
           raw: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('utf8'),
+          rawHex: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('hex'),
+        };
+      }
+
+      @Post('/bytes')
+      handleBytes(_input: undefined, context: RequestContext) {
+        return {
+          rawHex: Buffer.from(context.request.rawBody ?? new Uint8Array()).toString('hex'),
         };
       }
     }
@@ -218,31 +231,52 @@ export class HttpAdapterPortabilityHarness<
     await app.listen();
 
     try {
-      const [jsonResponse, textResponse] = await Promise.all([
+      const [jsonResponse, textResponse, bytesResponse] = await Promise.all([
         fetch(`http://127.0.0.1:${String(port)}/webhooks/json`, {
-          body: JSON.stringify({ provider: 'stripe' }),
+          body: jsonPayload,
           headers: { 'content-type': 'application/json' },
           method: 'POST',
         }),
         fetch(`http://127.0.0.1:${String(port)}/webhooks/text`, {
-          body: 'ping=1',
+          body: textPayload,
           headers: { 'content-type': 'text/plain; charset=utf-8' },
+          method: 'POST',
+        }),
+        fetch(`http://127.0.0.1:${String(port)}/webhooks/bytes`, {
+          body: binaryPayload,
+          headers: { 'content-type': 'text/plain' },
           method: 'POST',
         }),
       ]);
 
-      if (jsonResponse.status !== 201 || textResponse.status !== 201) {
+      if (jsonResponse.status !== 201 || textResponse.status !== 201 || bytesResponse.status !== 201) {
         throw new Error(`${this.options.name} adapter changed rawBody response status semantics.`);
       }
 
-      const [jsonBody, textBody] = await Promise.all([jsonResponse.json(), textResponse.json()]);
+      const [jsonBody, textBody, bytesBody] = await Promise.all([
+        jsonResponse.json(),
+        textResponse.json(),
+        bytesResponse.json(),
+      ]);
 
-      if (JSON.stringify(jsonBody) !== JSON.stringify({ parsed: { provider: 'stripe' }, raw: '{"provider":"stripe"}' })) {
+      if (JSON.stringify(jsonBody) !== JSON.stringify({
+        parsed: { provider: 'stripe', emoji: '👩🏽‍🚀' },
+        raw: jsonPayload,
+        rawHex: Buffer.from(jsonPayload).toString('hex'),
+      })) {
         throw new Error(`${this.options.name} adapter changed JSON rawBody semantics.`);
       }
 
-      if (JSON.stringify(textBody) !== JSON.stringify({ parsed: 'ping=1', raw: 'ping=1' })) {
+      if (JSON.stringify(textBody) !== JSON.stringify({
+        parsed: textPayload,
+        raw: textPayload,
+        rawHex: Buffer.from(textPayload).toString('hex'),
+      })) {
         throw new Error(`${this.options.name} adapter changed text rawBody semantics.`);
+      }
+
+      if (JSON.stringify(bytesBody) !== JSON.stringify({ rawHex: binaryPayload.toString('hex') })) {
+        throw new Error(`${this.options.name} adapter changed byte-sensitive rawBody semantics.`);
       }
     } finally {
       await closeSilently(app);


### PR DESCRIPTION
Closes #1396

## Summary

Fastify `rawBody` capture now preserves the original request bytes for JSON, text, and byte-sensitive payloads instead of round-tripping through UTF-8 first.

## Changes

- register Fastify raw-body capture in binary-safe mode and attach the original `Uint8Array` bytes directly to `FrameworkRequest.rawBody`
- add Fastify-specific regression coverage for byte-sensitive `rawBody` payloads
- strengthen `packages/testing/src/portability/http-adapter-portability.ts` so Fastify, Express, and Node all verify JSON/text byte preservation and non-UTF-8 raw-body stability
- add a patch changeset for `@fluojs/platform-fastify`

## Testing

- `pnpm build`
- `pnpm vitest run packages/platform-fastify/src/adapter.test.ts packages/testing/src/portability/http-adapter-portability.test.ts`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public export signatures changed in this PR.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

README raw-body guidance remains true as written; this PR restores Fastify's implementation to the existing documented contract without changing the public API type.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Portability evidence: `packages/testing/src/portability/http-adapter-portability.ts`