### PR TITLE
Resolve #1389: make optional cookie auth explicit

### DIFF
--- a/.changeset/passport-cookie-optional-auth-security.md
+++ b/.changeset/passport-cookie-optional-auth-security.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/passport": patch
+---
+
+Reject protected cookie-auth routes without an access-token cookie even when `requireAccessToken: false`, and require explicit `@UseOptionalAuth(...)` opt-in for guest-capable cookie-auth endpoints.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -114,6 +114,32 @@ export class AuthModule {}
 
 `CookieAuthStrategy`는 `@fluojs/jwt`가 정규화한 JWT principal 계약을 보존하며, `subject`, `claims`, `issuer`, `audience`, `roles`, `scopes`를 그대로 전달합니다.
 
+보호된 라우트는 계속 `@UseAuth(COOKIE_AUTH_STRATEGY_NAME)`를 사용해야 합니다. `cookieAuth.requireAccessToken`을 `false`로 설정하더라도, 쿠키가 없으면 이제 익명 principal이 아니라 명시적인 미인증 결과를 반환하고 `AuthGuard`는 보호된 라우트를 계속 거부합니다.
+
+게스트 접근을 의도적으로 허용하는 엔드포인트에서만 `@UseOptionalAuth(COOKIE_AUTH_STRATEGY_NAME)`를 사용하세요. 유효한 쿠키가 있을 때는 `requestContext.principal`을 채우고, 쿠키가 없을 때만 미인증 상태로 통과시킵니다.
+
+```typescript
+import { Controller, Get, type RequestContext } from '@fluojs/http';
+import { COOKIE_AUTH_STRATEGY_NAME, UseAuth, UseOptionalAuth } from '@fluojs/passport';
+
+@Controller('/feed')
+export class FeedController {
+  @Get('/me')
+  @UseAuth(COOKIE_AUTH_STRATEGY_NAME)
+  getProtectedFeed(_input: never, ctx: RequestContext) {
+    return { user: ctx.principal };
+  }
+
+  @Get('/public')
+  @UseOptionalAuth(COOKIE_AUTH_STRATEGY_NAME)
+  getPublicFeed(_input: never, ctx: RequestContext) {
+    return { user: ctx.principal ?? null };
+  }
+}
+```
+
+`@RequireScopes(...)`는 계속 인증된 principal을 요구합니다. optional auth는 scope 검사를 우회하지 않습니다.
+
 ### 리프레시 토큰 수명 주기
 
 패키지에서 제공하는 `RefreshTokenStrategy`와 `RefreshTokenService`를 사용하여 안전한 토큰 로테이션 및 폐기 기능을 구현할 수 있습니다.
@@ -157,6 +183,7 @@ export class AuthController {
 
 ### 데코레이터
 - `@UseAuth(strategyName)`: `AuthGuard`를 부착하고 사용할 전략을 설정합니다.
+- `@UseOptionalAuth(strategyName)`: 전략이 인증 정보를 찾지 못했을 때 게스트 허용 라우트가 계속 진행되도록 합니다.
 - `@RequireScopes(...scopes)`: 특정 권한(스코프) 요구 사항을 강제합니다.
 
 ### 주요 클래스

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -114,6 +114,32 @@ Import `CookieAuthModule.forRoot(...)` alongside `PassportModule.forRoot(...)` w
 
 `CookieAuthStrategy` preserves the normalized JWT principal contract from `@fluojs/jwt`, including `subject`, `claims`, `issuer`, `audience`, `roles`, and `scopes`.
 
+Protected routes must keep using `@UseAuth(COOKIE_AUTH_STRATEGY_NAME)`. If `cookieAuth.requireAccessToken` is set to `false`, a missing cookie now yields an explicit unauthenticated result instead of an anonymous principal, and `AuthGuard` still rejects protected routes.
+
+Use `@UseOptionalAuth(COOKIE_AUTH_STRATEGY_NAME)` only for endpoints that intentionally allow guest access while still populating `requestContext.principal` when a valid cookie is present.
+
+```typescript
+import { Controller, Get, type RequestContext } from '@fluojs/http';
+import { COOKIE_AUTH_STRATEGY_NAME, UseAuth, UseOptionalAuth } from '@fluojs/passport';
+
+@Controller('/feed')
+export class FeedController {
+  @Get('/me')
+  @UseAuth(COOKIE_AUTH_STRATEGY_NAME)
+  getProtectedFeed(_input: never, ctx: RequestContext) {
+    return { user: ctx.principal };
+  }
+
+  @Get('/public')
+  @UseOptionalAuth(COOKIE_AUTH_STRATEGY_NAME)
+  getPublicFeed(_input: never, ctx: RequestContext) {
+    return { user: ctx.principal ?? null };
+  }
+}
+```
+
+`@RequireScopes(...)` continues to enforce authenticated access. Optional auth does not bypass scope checks.
+
 ### Refresh Token Lifecycle
 
 The package provides a built-in `RefreshTokenStrategy` and `RefreshTokenService` to handle secure token rotation and revocation.
@@ -157,6 +183,7 @@ Import `RefreshTokenModule.forRoot(...)` alongside `PassportModule.forRoot(...)`
 
 ### Decorators
 - `@UseAuth(strategyName)`: Attaches `AuthGuard` and sets the active strategy.
+- `@UseOptionalAuth(strategyName)`: Allows guest-capable routes to continue when the strategy reports missing credentials.
 - `@RequireScopes(...scopes)`: Enforces specific scope requirements.
 
 ### Core Classes

--- a/packages/passport/src/cookie/cookie-auth.test.ts
+++ b/packages/passport/src/cookie/cookie-auth.test.ts
@@ -100,30 +100,26 @@ describe('CookieAuthStrategy', () => {
       await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
     });
 
-    it('allows anonymous access when requireAccessToken is false', async () => {
+    it('returns an explicit unauthenticated result when requireAccessToken is false and no cookie is present', async () => {
       const verifier = createMockVerifier();
       const strategy = new CookieAuthStrategy(verifier, { requireAccessToken: false });
       const context = createGuardContext({});
 
       const result = await strategy.authenticate(context);
 
-      expect(result).toMatchObject({
-        subject: 'anonymous',
-        claims: {},
-      });
+      expect(result).toEqual({ authenticated: false });
+      expect(verifier.verifyAccessToken).not.toHaveBeenCalled();
     });
 
-    it('allows anonymous access when cookies bag is undefined and requireAccessToken is false', async () => {
+    it('returns an explicit unauthenticated result when cookies bag is undefined and requireAccessToken is false', async () => {
       const verifier = createMockVerifier();
       const strategy = new CookieAuthStrategy(verifier, { requireAccessToken: false });
       const context = createGuardContext(undefined);
 
       const result = await strategy.authenticate(context);
 
-      expect(result).toMatchObject({
-        subject: 'anonymous',
-        claims: {},
-      });
+      expect(result).toEqual({ authenticated: false });
+      expect(verifier.verifyAccessToken).not.toHaveBeenCalled();
     });
 
     it('throws AuthenticationRequiredError when token verification fails', async () => {

--- a/packages/passport/src/cookie/cookie-auth.ts
+++ b/packages/passport/src/cookie/cookie-auth.ts
@@ -11,16 +11,19 @@ import type { AuthStrategy, AuthStrategyResult } from '../types.js';
 export const COOKIE_AUTH_OPTIONS = Symbol.for('fluo.passport.cookie-auth-options');
 
 /**
- * Configures cookie names and fallback behavior for cookie-based authentication.
+ * Configures cookie names and missing-cookie behavior for cookie-based authentication.
  */
 export interface CookieAuthOptions {
+  /** Cookie name used for access-token lookup. */
   accessTokenCookieName?: string;
+  /** Cookie name used for refresh-token lookup. */
   refreshTokenCookieName?: string;
+  /** Whether protected routes should fail immediately when the access-token cookie is missing. */
   requireAccessToken?: boolean;
 }
 
 /**
- * Supplies the default cookie names and access-token requirement for cookie auth.
+ * Supplies the default cookie names and protected-route requirement for cookie auth.
  */
 export const DEFAULT_COOKIE_AUTH_OPTIONS: Required<CookieAuthOptions> = {
   accessTokenCookieName: 'access_token',
@@ -44,6 +47,12 @@ export function normalizeCookieAuthOptions(options?: CookieAuthOptions): Require
 
 /**
  * Authenticates requests by reading and verifying JWTs from HTTP cookies.
+ *
+ * @remarks
+ * When `requireAccessToken` is `false`, missing cookies produce an explicit
+ * unauthenticated result. Routes still need `@UseOptionalAuth(...)` to allow
+ * guest access; protected `@UseAuth(...)` routes continue to reject requests
+ * without an access-token cookie.
  */
 @Inject(DefaultJwtVerifier, COOKIE_AUTH_OPTIONS)
 export class CookieAuthStrategy implements AuthStrategy {
@@ -65,10 +74,7 @@ export class CookieAuthStrategy implements AuthStrategy {
         throw new AuthenticationRequiredError('Access token cookie is required.');
       }
 
-      return {
-        claims: {},
-        subject: 'anonymous',
-      };
+      return { authenticated: false };
     }
 
     const accessToken = cookies[this.options.accessTokenCookieName];
@@ -78,10 +84,7 @@ export class CookieAuthStrategy implements AuthStrategy {
         throw new AuthenticationRequiredError('Access token cookie is required.');
       }
 
-      return {
-        claims: {},
-        subject: 'anonymous',
-      };
+      return { authenticated: false };
     }
 
     try {

--- a/packages/passport/src/decorators.ts
+++ b/packages/passport/src/decorators.ts
@@ -97,7 +97,28 @@ function createAuthRequirementDecorator(patch: RequirementPatch): ClassOrMethodD
  * @returns A class-or-method decorator that stores the auth requirement metadata.
  */
 export function UseAuth(strategy: string): ClassOrMethodDecoratorLike {
-  return createAuthRequirementDecorator({ strategy });
+  return createAuthRequirementDecorator({ optional: false, strategy });
+}
+
+/**
+ * Declares an explicit optional-auth route that may continue without a principal when the strategy reports missing credentials.
+ *
+ * @remarks
+ * Use this for guest-capable endpoints that should still populate `requestContext.principal`
+ * when credentials are present. Protected routes should keep using {@link UseAuth}.
+ *
+ * @example
+ * ```ts
+ * @UseOptionalAuth('cookie')
+ * @Get('/feed')
+ * getFeed() {}
+ * ```
+ *
+ * @param strategy Strategy name previously registered through `PassportModule.forRoot(...)`.
+ * @returns A class-or-method decorator that stores an optional-auth requirement.
+ */
+export function UseOptionalAuth(strategy: string): ClassOrMethodDecoratorLike {
+  return createAuthRequirementDecorator({ optional: true, strategy });
 }
 
 /**

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Controller, Get, UnauthorizedException, createDispatcher, createHandlerMapping } from '@fluojs/http';
@@ -7,7 +7,9 @@ import type { FrameworkRequest, FrameworkResponse, GuardContext } from '@fluojs/
 import { Container } from '@fluojs/di';
 import { DefaultJwtVerifier } from '@fluojs/jwt';
 
-import { RequireScopes, UseAuth } from './decorators.js';
+import { RequireScopes, UseAuth, UseOptionalAuth } from './decorators.js';
+import { CookieAuthModule } from './cookie/cookie-auth-module.js';
+import { COOKIE_AUTH_STRATEGY_NAME, CookieAuthStrategy } from './cookie/cookie-auth.js';
 import { AuthenticationExpiredError, AuthenticationFailedError, AuthenticationRequiredError } from './errors.js';
 import { AuthGuard } from './guard.js';
 import { PassportModule } from './module.js';
@@ -30,6 +32,18 @@ function createPassportModuleProviders(
   return metadata.providers;
 }
 
+function createCookieAuthModuleProviders(config?: Parameters<typeof CookieAuthModule.forRoot>[0]): Provider[] {
+  const metadata = getModuleMetadata(CookieAuthModule.forRoot(config)) as {
+    providers?: Provider[];
+  };
+
+  if (!Array.isArray(metadata.providers)) {
+    throw new Error('Expected CookieAuthModule.forRoot(...) to expose runtime providers.');
+  }
+
+  return metadata.providers;
+}
+
 function createRequest(path: string, headers: FrameworkRequest['headers'] = {}): FrameworkRequest {
   return {
     body: undefined,
@@ -42,6 +56,28 @@ function createRequest(path: string, headers: FrameworkRequest['headers'] = {}):
     raw: {},
     url: path,
   };
+}
+
+function createCookieRequest(
+  path: string,
+  cookies: FrameworkRequest['cookies'],
+  headers: FrameworkRequest['headers'] = {},
+): FrameworkRequest {
+  return {
+    ...createRequest(path, headers),
+    cookies,
+  };
+}
+
+function createMockVerifier(overrides: Partial<DefaultJwtVerifier> = {}): DefaultJwtVerifier {
+  return {
+    verifyAccessToken: vi.fn().mockResolvedValue({
+      claims: { sub: 'user-1', scopes: ['profile:read'] },
+      scopes: ['profile:read'],
+      subject: 'user-1',
+    }),
+    ...overrides,
+  } as unknown as DefaultJwtVerifier;
 }
 
 function createResponse(): FrameworkResponse & { body?: unknown } {
@@ -229,6 +265,181 @@ describe('AuthGuard', () => {
         status: 403,
       },
     });
+  });
+
+  it('rejects protected cookie-auth routes without an access token cookie even when requireAccessToken is false', async () => {
+    const verifier = createMockVerifier();
+
+    @Controller('/cookie-protected')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth(COOKIE_AUTH_STRATEGY_NAME)
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      {
+        provide: DefaultJwtVerifier,
+        useValue: verifier,
+      },
+      ...createCookieAuthModuleProviders({
+        cookieAuth: { requireAccessToken: false },
+      }),
+      ...createPassportModuleProviders(
+        { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
+        [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
+      ),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/cookie-protected', { 'x-request-id': 'req-cookie-protected' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(verifier.verifyAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('authenticates protected cookie-auth routes when a valid cookie is present', async () => {
+    const verifier = createMockVerifier();
+
+    @Controller('/cookie-protected')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth(COOKIE_AUTH_STRATEGY_NAME)
+      getProfile(_input: unknown, ctx: { principal?: { subject: string } }) {
+        return { subject: ctx.principal?.subject };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      {
+        provide: DefaultJwtVerifier,
+        useValue: verifier,
+      },
+      ...createCookieAuthModuleProviders({
+        cookieAuth: { requireAccessToken: false },
+      }),
+      ...createPassportModuleProviders(
+        { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
+        [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
+      ),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(
+      createCookieRequest('/cookie-protected', { access_token: 'valid-cookie-token' }),
+      response,
+    );
+
+    expect(response.body).toEqual({ subject: 'user-1' });
+    expect(verifier.verifyAccessToken).toHaveBeenCalledWith('valid-cookie-token');
+  });
+
+  it('allows explicit optional cookie-auth routes to continue without a principal', async () => {
+    const verifier = createMockVerifier();
+
+    @Controller('/cookie-optional')
+    class OptionalController {
+      @Get('/')
+      @UseOptionalAuth(COOKIE_AUTH_STRATEGY_NAME)
+      getFeed(_input: unknown, ctx: { principal?: { subject: string } }) {
+        return { subject: ctx.principal?.subject ?? null };
+      }
+    }
+
+    const root = new Container().register(
+      OptionalController,
+      {
+        provide: DefaultJwtVerifier,
+        useValue: verifier,
+      },
+      ...createCookieAuthModuleProviders({
+        cookieAuth: { requireAccessToken: false },
+      }),
+      ...createPassportModuleProviders(
+        { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
+        [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
+      ),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: OptionalController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/cookie-optional'), response);
+
+    expect(response.body).toEqual({ subject: null });
+    expect(verifier.verifyAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('preserves scope enforcement for cookie-auth routes when credentials are missing or valid', async () => {
+    const verifier = createMockVerifier({
+      verifyAccessToken: vi.fn().mockResolvedValue({
+        claims: { sub: 'scoped-user', scopes: ['profile:read'] },
+        scopes: ['profile:read'],
+        subject: 'scoped-user',
+      }),
+    });
+
+    @Controller('/cookie-scoped')
+    class ScopedController {
+      @Get('/')
+      @UseAuth(COOKIE_AUTH_STRATEGY_NAME)
+      @RequireScopes('profile:read')
+      getProfile(_input: unknown, ctx: { principal?: { subject: string } }) {
+        return { subject: ctx.principal?.subject };
+      }
+    }
+
+    const root = new Container().register(
+      ScopedController,
+      {
+        provide: DefaultJwtVerifier,
+        useValue: verifier,
+      },
+      ...createCookieAuthModuleProviders({
+        cookieAuth: { requireAccessToken: false },
+      }),
+      ...createPassportModuleProviders(
+        { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
+        [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
+      ),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ScopedController }]),
+      rootContainer: root,
+    });
+
+    const missingCookieResponse = createResponse();
+
+    await dispatcher.dispatch(
+      createRequest('/cookie-scoped', { 'x-request-id': 'req-cookie-scoped-missing' }),
+      missingCookieResponse,
+    );
+
+    expect(missingCookieResponse.statusCode).toBe(401);
+
+    const authenticatedResponse = createResponse();
+
+    await dispatcher.dispatch(
+      createCookieRequest('/cookie-scoped', { access_token: 'scoped-cookie-token' }),
+      authenticatedResponse,
+    );
+
+    expect(authenticatedResponse.body).toEqual({ subject: 'scoped-user' });
+    expect(verifier.verifyAccessToken).toHaveBeenCalledWith('scoped-cookie-token');
   });
 
   it('adapts a Passport.js-style strategy success callback to principal population', async () => {

--- a/packages/passport/src/guard.ts
+++ b/packages/passport/src/guard.ts
@@ -16,6 +16,7 @@ import type {
   AuthHandledResult,
   AuthStrategy,
   AuthStrategyResult,
+  AuthUnauthenticatedResult,
   AuthStrategyRegistry,
   PassportModuleOptions,
 } from './types.js';
@@ -24,9 +25,17 @@ function isAuthHandledResult(result: AuthStrategyResult): result is AuthHandledR
   return typeof result === 'object' && result !== null && 'handled' in result && result.handled === true;
 }
 
+function isAuthUnauthenticatedResult(result: AuthStrategyResult): result is AuthUnauthenticatedResult {
+  return typeof result === 'object' && result !== null && 'authenticated' in result && result.authenticated === false;
+}
+
 function resolvePrincipal(result: AuthStrategyResult): Principal | undefined {
   if (isAuthHandledResult(result)) {
     return result.principal;
+  }
+
+  if (isAuthUnauthenticatedResult(result)) {
+    return undefined;
   }
 
   return result;
@@ -161,6 +170,15 @@ export class AuthGuard implements AuthGuardContract {
 
     try {
       const result = await strategy.authenticate(context);
+
+      if (isAuthUnauthenticatedResult(result)) {
+        if (requirement?.optional && !requirement.scopes?.length) {
+          return true;
+        }
+
+        throw new AuthenticationRequiredError('Authentication strategy did not authenticate the request.');
+      }
+
       const principal = resolvePrincipal(result);
 
       if (isAuthHandledResult(result) && !principal) {

--- a/packages/passport/src/metadata.test.ts
+++ b/packages/passport/src/metadata.test.ts
@@ -1,7 +1,7 @@
 import { Controller, Get } from '@fluojs/http';
 import { describe, expect, it } from 'vitest';
 
-import { RequireScopes, UseAuth } from './decorators.js';
+import { RequireScopes, UseAuth, UseOptionalAuth } from './decorators.js';
 import { getAuthRequirement } from './metadata.js';
 
 describe('auth metadata scope merge', () => {
@@ -20,10 +20,12 @@ describe('auth metadata scope merge', () => {
     }
 
     expect(getAuthRequirement(ProfileController)).toEqual({
+      optional: false,
       scopes: ['profile:read', 'profile:write'],
       strategy: 'jwt',
     });
     expect(getAuthRequirement(ProfileController, 'getProfile')).toEqual({
+      optional: false,
       scopes: ['profile:read', 'profile:write'],
       strategy: 'jwt',
     });
@@ -43,8 +45,30 @@ describe('auth metadata scope merge', () => {
     }
 
     expect(getAuthRequirement(ProfileController, 'getProfile')).toEqual({
+      optional: false,
       scopes: ['profile:read', 'profile:write'],
       strategy: 'session',
+    });
+  });
+
+  it('lets protected routes override optional controller-level auth requirements', () => {
+    @Controller('/metadata')
+    @UseOptionalAuth('cookie')
+    class ProfileController {
+      @Get('/')
+      @UseAuth('cookie')
+      getProfile() {
+        return undefined;
+      }
+    }
+
+    expect(getAuthRequirement(ProfileController)).toEqual({
+      optional: true,
+      strategy: 'cookie',
+    });
+    expect(getAuthRequirement(ProfileController, 'getProfile')).toEqual({
+      optional: false,
+      strategy: 'cookie',
     });
   });
 

--- a/packages/passport/src/metadata.ts
+++ b/packages/passport/src/metadata.ts
@@ -17,14 +17,16 @@ function normalizeRequirement(requirement: AuthRequirement | undefined): AuthReq
     return undefined;
   }
 
+  const optional = requirement.optional;
   const strategy = requirement.strategy;
   const scopes = normalizeDeclaredScopes(requirement.scopes);
 
-  if (!strategy && !scopes) {
+  if (!strategy && !scopes && optional !== true) {
     return undefined;
   }
 
   return {
+    optional,
     scopes,
     strategy,
   };

--- a/packages/passport/src/scope.ts
+++ b/packages/passport/src/scope.ts
@@ -18,6 +18,12 @@ function normalizeScopeItems(items: Iterable<string>): string[] | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+/**
+ * Normalizes declared scope metadata into a unique ordered list.
+ *
+ * @param scopes Declared scope values from decorators or merged auth metadata.
+ * @returns A deduplicated scope list when valid strings are present.
+ */
 export function normalizeDeclaredScopes(scopes: unknown): string[] | undefined {
   if (!Array.isArray(scopes)) {
     return undefined;
@@ -27,6 +33,12 @@ export function normalizeDeclaredScopes(scopes: unknown): string[] | undefined {
   return normalizeScopeItems(scopeItems);
 }
 
+/**
+ * Extracts normalized scope values from principal claims.
+ *
+ * @param claims Principal claims returned by an authentication strategy.
+ * @returns A deduplicated scope list derived from `claims.scopes` or `claims.scope`.
+ */
 export function normalizePrincipalScopes(claims: Record<string, unknown>): string[] | undefined {
   if (Array.isArray(claims.scopes)) {
     const scopes = claims.scopes.filter((scope): scope is string => typeof scope === 'string');
@@ -40,6 +52,13 @@ export function normalizePrincipalScopes(claims: Record<string, unknown>): strin
   return undefined;
 }
 
+/**
+ * Merges auth requirement metadata while preserving strategy, optional-auth, and scope semantics.
+ *
+ * @param base Existing auth requirement metadata.
+ * @param extra New auth requirement metadata to apply on top of the base requirement.
+ * @returns The merged auth requirement, or `undefined` when no requirement remains.
+ */
 export function mergeAuthRequirements(
   base: AuthRequirement | undefined,
   extra: AuthRequirement | undefined,
@@ -49,13 +68,15 @@ export function mergeAuthRequirements(
   }
 
   const scopes = normalizeDeclaredScopes([...(base?.scopes ?? []), ...(extra?.scopes ?? [])]);
+  const optional = extra?.optional ?? base?.optional;
   const strategy = extra?.strategy ?? base?.strategy;
 
-  if (!strategy && !scopes) {
+  if (!strategy && !scopes && optional !== true) {
     return undefined;
   }
 
   return {
+    optional,
     scopes,
     strategy,
   };

--- a/packages/passport/src/types.ts
+++ b/packages/passport/src/types.ts
@@ -7,6 +7,8 @@ export interface AuthRequirement {
   strategy?: string;
   /** Required scopes that must be present on the resolved principal. */
   scopes?: string[];
+  /** Whether missing credentials may continue as an unauthenticated request. */
+  optional?: boolean;
 }
 
 /** Authentication result variant used when a strategy fully handled the response. */
@@ -15,8 +17,13 @@ export interface AuthHandledResult {
   principal?: Principal;
 }
 
+/** Authentication result variant used when a strategy intentionally leaves the request unauthenticated. */
+export interface AuthUnauthenticatedResult {
+  authenticated: false;
+}
+
 /** Return type of an `AuthStrategy.authenticate(...)` call. */
-export type AuthStrategyResult = Principal | AuthHandledResult;
+export type AuthStrategyResult = Principal | AuthHandledResult | AuthUnauthenticatedResult;
 
 /** Strategy contract implemented by authentication adapters. */
 export interface AuthStrategy {


### PR DESCRIPTION
Closes #1389

## Summary

Separate protected cookie auth from guest-capable cookie auth so missing cookies no longer authenticate protected routes as anonymous when `requireAccessToken: false`.

## Changes

- add explicit `@UseOptionalAuth(...)` metadata and guard handling for unauthenticated strategy results
- make `CookieAuthStrategy` return an explicit unauthenticated result instead of an anonymous principal when cookies are missing and `requireAccessToken: false`
- add regression coverage for protected routes, optional routes, and scoped cookie-auth routes
- document the protected vs optional auth distinction in `packages/passport/README.md` and `packages/passport/README.ko.md`
- add a patch changeset for this security-sensitive public package fix

## Testing

- `pnpm verify:public-export-tsdoc`
- `pnpm --filter @fluojs/passport build`
- `pnpm --filter @fluojs/passport typecheck`
- `pnpm --filter @fluojs/passport test`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Security note: protected `@UseAuth(...)` cookie routes now reject missing cookies even when `requireAccessToken: false`; guest behavior requires explicit `@UseOptionalAuth(...)` opt-in.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.