### PR TITLE
Resolve #1388: remove Node-only payload byte counting from Deno and Workers websockets

### DIFF
--- a/.changeset/fair-taxis-care.md
+++ b/.changeset/fair-taxis-care.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/websockets': patch
+---
+
+Fix Deno and Cloudflare Workers websocket payload limit checks so string frames no longer depend on Node's `Buffer` global before runtime handlers run.

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
@@ -118,7 +118,7 @@ function isHttpExceptionLike(error: unknown): error is { message: string; status
 
 function resolveMessageByteLength(message: CloudflareWorkerWebSocketMessage): number {
   if (typeof message === 'string') {
-    return Buffer.byteLength(message);
+    return new TextEncoder().encode(message).byteLength;
   }
 
   if (message instanceof Blob) {

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -151,7 +151,7 @@ class TestWorkerServer {
   }
 
   upgrade(): CloudflareWorkerWebSocketUpgradeResult {
-    const _clientSocket = new MockWorkerSocket();
+    new MockWorkerSocket();
     const serverSocket = new MockWorkerSocket();
     this.lastSocket = serverSocket;
 
@@ -197,6 +197,23 @@ class TestWorkerAdapter implements HttpApplicationAdapter, CloudflareWorkerWebSo
 
 async function flushAsyncWork(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function withoutNodeBuffer<T>(callback: () => Promise<T>): Promise<T> {
+  const runtimeGlobal = globalThis as typeof globalThis & { Buffer?: unknown };
+  const originalBuffer = runtimeGlobal.Buffer;
+
+  Reflect.deleteProperty(runtimeGlobal, 'Buffer');
+
+  try {
+    return await callback();
+  } finally {
+    if (originalBuffer === undefined) {
+      Reflect.deleteProperty(runtimeGlobal, 'Buffer');
+    } else {
+      runtimeGlobal.Buffer = originalBuffer;
+    }
+  }
 }
 
 function createDeferred<T = void>() {
@@ -449,56 +466,61 @@ describe('@fluojs/websockets/cloudflare-workers', () => {
     await app.close();
   });
 
-  it('closes Worker sockets when inbound payloads exceed the configured limit', async () => {
-    const adapter = new TestWorkerAdapter();
+  it('closes Worker sockets when string payloads exceed the configured limit without Node globals', async () => {
+    await withoutNodeBuffer(async () => {
+      const adapter = new TestWorkerAdapter();
 
-    class GatewayState {
-      messages: unknown[] = [];
-    }
-
-    @Inject(GatewayState)
-    @WebSocketGateway({ path: '/payload' })
-    class PayloadGateway {
-      constructor(private readonly state: GatewayState) {}
-
-      @OnMessage('ping')
-      onPing(payload: unknown) {
-        this.state.messages.push(payload);
+      class GatewayState {
+        messages: unknown[] = [];
       }
-    }
 
-    class AppModule {}
-    defineModule(AppModule, {
-      imports: [CloudflareWorkersWebSocketModule.forRoot({
-        limits: {
-          maxPayloadBytes: 4,
-        },
-      })],
-      providers: [GatewayState, PayloadGateway],
+      @Inject(GatewayState)
+      @WebSocketGateway({ path: '/payload' })
+      class PayloadGateway {
+        constructor(private readonly state: GatewayState) {}
+
+        @OnMessage('ping')
+        onPing(payload: unknown) {
+          this.state.messages.push(payload);
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [CloudflareWorkersWebSocketModule.forRoot({
+          limits: {
+            maxPayloadBytes: 4,
+          },
+        })],
+        providers: [GatewayState, PayloadGateway],
+      });
+
+      const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+
+      try {
+        const state = await app.container.resolve<GatewayState>(GatewayState);
+        await app.listen();
+
+        const server = adapter.getServer();
+        await server?.fetch(new Request('https://worker.test/payload', {
+          headers: { upgrade: 'websocket' },
+        }));
+        await flushAsyncWork();
+
+        const socket = server?.lastSocket;
+
+        if (!socket) {
+          throw new Error('Expected Worker test socket to be available after websocket upgrade.');
+        }
+
+        socket.emitMessage('hello');
+        await flushAsyncWork();
+
+        expect(socket.readyState).toBe(WEBSOCKET_CLOSED_READY_STATE);
+        expect(state.messages).toEqual([]);
+      } finally {
+        await app.close();
+      }
     });
-
-    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
-    const state = await app.container.resolve<GatewayState>(GatewayState);
-    await app.listen();
-
-    const server = adapter.getServer();
-    await server?.fetch(new Request('https://worker.test/payload', {
-      headers: { upgrade: 'websocket' },
-    }));
-    await flushAsyncWork();
-
-    const socket = server?.lastSocket;
-
-    if (!socket) {
-      throw new Error('Expected Worker test socket to be available after websocket upgrade.');
-    }
-
-    socket.emitMessage('hello');
-    await flushAsyncWork();
-
-    expect(socket.readyState).toBe(WEBSOCKET_CLOSED_READY_STATE);
-    expect(state.messages).toEqual([]);
-
-    await app.close();
   });
 });

--- a/packages/websockets/src/deno/deno-service.ts
+++ b/packages/websockets/src/deno/deno-service.ts
@@ -118,7 +118,7 @@ function isHttpExceptionLike(error: unknown): error is { message: string; status
 
 function resolveMessageByteLength(message: DenoWebSocketMessage): number {
   if (typeof message === 'string') {
-    return Buffer.byteLength(message);
+    return new TextEncoder().encode(message).byteLength;
   }
 
   return message.size;

--- a/packages/websockets/src/deno/deno.test.ts
+++ b/packages/websockets/src/deno/deno.test.ts
@@ -202,6 +202,23 @@ async function flushAsyncWork(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+async function withoutNodeBuffer<T>(callback: () => Promise<T>): Promise<T> {
+  const runtimeGlobal = globalThis as typeof globalThis & { Buffer?: unknown };
+  const originalBuffer = runtimeGlobal.Buffer;
+
+  Reflect.deleteProperty(runtimeGlobal, 'Buffer');
+
+  try {
+    return await callback();
+  } finally {
+    if (originalBuffer === undefined) {
+      Reflect.deleteProperty(runtimeGlobal, 'Buffer');
+    } else {
+      runtimeGlobal.Buffer = originalBuffer;
+    }
+  }
+}
+
 function createDeferred<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (reason?: unknown) => void;
@@ -451,56 +468,61 @@ describe('@fluojs/websockets/deno', () => {
     await app.close();
   });
 
-  it('closes Deno sockets when inbound payloads exceed the configured limit', async () => {
-    const adapter = new TestDenoAdapter();
+  it('closes Deno sockets when string payloads exceed the configured limit without Node globals', async () => {
+    await withoutNodeBuffer(async () => {
+      const adapter = new TestDenoAdapter();
 
-    class GatewayState {
-      messages: unknown[] = [];
-    }
-
-    @Inject(GatewayState)
-    @WebSocketGateway({ path: '/payload' })
-    class PayloadGateway {
-      constructor(private readonly state: GatewayState) {}
-
-      @OnMessage('ping')
-      onPing(payload: unknown) {
-        this.state.messages.push(payload);
+      class GatewayState {
+        messages: unknown[] = [];
       }
-    }
 
-    class AppModule {}
-    defineModule(AppModule, {
-      imports: [DenoWebSocketModule.forRoot({
-        limits: {
-          maxPayloadBytes: 4,
-        },
-      })],
-      providers: [GatewayState, PayloadGateway],
+      @Inject(GatewayState)
+      @WebSocketGateway({ path: '/payload' })
+      class PayloadGateway {
+        constructor(private readonly state: GatewayState) {}
+
+        @OnMessage('ping')
+        onPing(payload: unknown) {
+          this.state.messages.push(payload);
+        }
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [DenoWebSocketModule.forRoot({
+          limits: {
+            maxPayloadBytes: 4,
+          },
+        })],
+        providers: [GatewayState, PayloadGateway],
+      });
+
+      const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+
+      try {
+        const state = await app.container.resolve<GatewayState>(GatewayState);
+        await app.listen();
+
+        const server = adapter.getServer();
+        await server?.fetch(new Request('https://runtime.test/payload', {
+          headers: { upgrade: 'websocket' },
+        }));
+        await flushAsyncWork();
+
+        const socket = server?.lastSocket;
+
+        if (!socket) {
+          throw new Error('Expected Deno test socket to be available after websocket upgrade.');
+        }
+
+        socket.emitMessage('hello');
+        await flushAsyncWork();
+
+        expect(socket.readyState).toBe(WEBSOCKET_CLOSED_READY_STATE);
+        expect(state.messages).toEqual([]);
+      } finally {
+        await app.close();
+      }
     });
-
-    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
-    const state = await app.container.resolve<GatewayState>(GatewayState);
-    await app.listen();
-
-    const server = adapter.getServer();
-    await server?.fetch(new Request('https://runtime.test/payload', {
-      headers: { upgrade: 'websocket' },
-    }));
-    await flushAsyncWork();
-
-    const socket = server?.lastSocket;
-
-    if (!socket) {
-      throw new Error('Expected Deno test socket to be available after websocket upgrade.');
-    }
-
-    socket.emitMessage('hello');
-    await flushAsyncWork();
-
-    expect(socket.readyState).toBe(WEBSOCKET_CLOSED_READY_STATE);
-    expect(state.messages).toEqual([]);
-
-    await app.close();
   });
 });


### PR DESCRIPTION
Closes #1388

## Summary

Fix Deno and Cloudflare Workers websocket payload size enforcement so string frames use a web-standard byte counter instead of the Node-only `Buffer` global.

## Changes

- replace `Buffer.byteLength(...)` with `new TextEncoder().encode(message).byteLength` in the Deno websocket lifecycle service
- replace `Buffer.byteLength(...)` with `new TextEncoder().encode(message).byteLength` in the Cloudflare Workers websocket lifecycle service
- extend the Deno and Workers runtime tests to remove `globalThis.Buffer` and verify oversized string frames still close the socket before handler execution
- add a patch changeset for `@fluojs/websockets`

## Testing

- `pnpm --filter @fluojs/websockets... build`
- `pnpm typecheck` (in `packages/websockets`)
- `pnpm --filter @fluojs/websockets exec vitest run -c vitest.config.ts src/deno/deno.test.ts src/cloudflare-workers/cloudflare-workers.test.ts`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed in this PR.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This preserves the existing runtime contract that bounded string payloads work on the documented Deno and Workers subpaths without Node-only globals.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs or README contract text changed in this PR.