### PR TITLE
feat(governance): forbid Node.js global Buffer in Deno and Cloudflare Workers service sources

### DIFF
--- a/tooling/governance/verify-platform-consistency-governance.d.mts
+++ b/tooling/governance/verify-platform-consistency-governance.d.mts
@@ -4,13 +4,27 @@ export interface DirectProcessEnvViolation {
   path: string;
 }
 
+export interface NodeGlobalBufferViolation {
+  excerpt: string;
+  line: number;
+  path: string;
+}
+
 export function isGovernedPackageSourcePath(relativePath: string): boolean;
 export function collectDirectProcessEnvViolations(
   relativePaths: readonly string[],
   readSource: (relativePath: string) => string,
 ): DirectProcessEnvViolation[];
+export function collectNodeGlobalBufferViolations(
+  relativePaths: readonly string[],
+  readSource: (relativePath: string) => string,
+): NodeGlobalBufferViolation[];
 export function parsePackageNamesFromFamilyTable(markdown: string, sectionTitle: string): string[];
 export function enforceNoDirectProcessEnvInOrdinaryPackageSource(
+  relativePaths?: readonly string[],
+  readSource?: (relativePath: string) => string,
+): void;
+export function enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices(
   relativePaths?: readonly string[],
   readSource?: (relativePath: string) => string,
 ): void;

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDirectory, '..', '..');
 const directProcessEnvPattern = /\bprocess\s*(?:\?\.|\.)\s*env\b/g;
+const nodeGlobalBufferPattern = /\bBuffer\b/g;
 
 const ssotPairs = [
   ['docs/architecture/platform-consistency-design.md', 'docs/architecture/platform-consistency-design.ko.md'],
@@ -58,6 +59,11 @@ const packageSourceExtensions = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs', '
 const directProcessEnvAllowedPackageSourcePaths = new Set([
   'packages/cli/src/cli.ts',
   'packages/cli/src/new/scaffold.ts',
+]);
+
+const denoAndCloudflareWorkerServiceSourcePaths = new Set([
+  'packages/websockets/src/deno/deno-service.ts',
+  'packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts',
 ]);
 
 function run(command, args, options = {}) {
@@ -390,6 +396,49 @@ export function enforceNoDirectProcessEnvInOrdinaryPackageSource(
   );
 }
 
+export function collectNodeGlobalBufferViolations(relativePaths, readSource) {
+  const violations = [];
+
+  for (const relativePath of relativePaths) {
+    if (!denoAndCloudflareWorkerServiceSourcePaths.has(relativePath)) {
+      continue;
+    }
+
+    const source = readSource(relativePath);
+    nodeGlobalBufferPattern.lastIndex = 0;
+
+    for (const match of source.matchAll(nodeGlobalBufferPattern)) {
+      const matchIndex = match.index ?? 0;
+      const lineNumber = findLineNumberFromIndex(source, matchIndex);
+      const excerpt = source.split('\n')[lineNumber - 1]?.trim() ?? 'Buffer';
+
+      violations.push({
+        excerpt,
+        line: lineNumber,
+        path: relativePath,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices(
+  relativePaths = [...denoAndCloudflareWorkerServiceSourcePaths],
+  readSource = read,
+) {
+  const violations = collectNodeGlobalBufferViolations(relativePaths, readSource);
+  assert(
+    violations.length === 0,
+    [
+      'Deno and Cloudflare Workers service source files must not use the Node.js global Buffer.',
+      'Use TextEncoder / TextDecoder or other Web-standard API equivalents instead.',
+      `Governed paths: ${[...denoAndCloudflareWorkerServiceSourcePaths].join(', ')}.`,
+      ...violations.map((violation) => `${violation.path}:${violation.line} ${violation.excerpt}`),
+    ].join('\n'),
+  );
+}
+
 function packageHasConformanceHarness(packageName) {
   const packageSource = join(repoRoot, 'packages', packageName, 'src');
   if (!existsSync(packageSource)) {
@@ -664,6 +713,7 @@ export function main() {
   enforceCanonicalRuntimeMatrixReferences();
   enforceRemovedRuntimeFactoryNamesNotUsedInDocs();
   enforceNoDirectProcessEnvInOrdinaryPackageSource();
+  enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices();
   enforceContractCompanionUpdates(changedFiles);
   enforceAlignmentClaimsBackedByHarness(changedFiles);
 

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   collectDirectProcessEnvViolations,
+  collectNodeGlobalBufferViolations,
   enforceNoDirectProcessEnvInOrdinaryPackageSource,
+  enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices,
   isGovernedPackageSourcePath,
   parsePackageNamesFromFamilyTable,
 } from './verify-platform-consistency-governance.mjs';
@@ -79,6 +81,61 @@ describe('enforceNoDirectProcessEnvInOrdinaryPackageSource', () => {
 
           return 'process.env.PORT = "4321";\n';
         },
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe('collectNodeGlobalBufferViolations', () => {
+  it('reports Buffer usage only in deno and cloudflare-workers service source files', () => {
+    const files = [
+      'packages/websockets/src/deno/deno-service.ts',
+      'packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts',
+      'packages/core/src/module.ts',
+    ];
+
+    const sources = new Map([
+      ['packages/websockets/src/deno/deno-service.ts', 'const data = Buffer.from("hello");\n'],
+      [
+        'packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts',
+        'export const size = Buffer.byteLength(payload);\n',
+      ],
+      ['packages/core/src/module.ts', 'const buf = Buffer.from("ignored");\n'],
+    ]);
+
+    expect(collectNodeGlobalBufferViolations(files, (path: string) => sources.get(path) ?? '')).toEqual([
+      {
+        excerpt: 'const data = Buffer.from("hello");',
+        line: 1,
+        path: 'packages/websockets/src/deno/deno-service.ts',
+      },
+      {
+        excerpt: 'export const size = Buffer.byteLength(payload);',
+        line: 1,
+        path: 'packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts',
+      },
+    ]);
+  });
+});
+
+describe('enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices', () => {
+  it('throws with actionable context when Buffer is used in a service file', () => {
+    expect(() =>
+      enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices(
+        ['packages/websockets/src/deno/deno-service.ts'],
+        () => 'const data = Buffer.from(payload);\n',
+      ),
+    ).toThrowError(/packages\/websockets\/src\/deno\/deno-service\.ts:1/);
+  });
+
+  it('passes when service files use Web-standard alternatives instead of Buffer', () => {
+    expect(() =>
+      enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices(
+        [
+          'packages/websockets/src/deno/deno-service.ts',
+          'packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts',
+        ],
+        () => 'const encoded = new TextEncoder().encode(payload);\n',
       ),
     ).not.toThrow();
   });


### PR DESCRIPTION
## Summary

Closes #1415

PR #1414 replaced all `Buffer` usages in `packages/websockets` with `TextEncoder`/`TextDecoder` equivalents. This PR adds the complementary CI guardrail so that `Buffer` cannot be silently reintroduced in the Deno and Cloudflare Workers service files.

## Changes

**`tooling/governance/verify-platform-consistency-governance.mjs`**
- Added `nodeGlobalBufferPattern = /\bBuffer\b/g`
- Added `denoAndCloudflareWorkerServiceSourcePaths` Set (two governed paths)
- Exported `collectNodeGlobalBufferViolations(relativePaths, readSource)` — follows the same shape as the existing `collectDirectProcessEnvViolations`
- Exported `enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices()` — called in `main()` after `enforceNoDirectProcessEnvInOrdinaryPackageSource()`

**`tooling/governance/verify-platform-consistency-governance.d.mts`**
- Added `NodeGlobalBufferViolation` interface
- Added type declarations for the two new exported functions

**`tooling/governance/verify-platform-consistency-governance.test.ts`**
- `collectNodeGlobalBufferViolations`: asserts Buffer violations are reported only for the two governed service files, not for other package sources
- `enforceNoNodeGlobalBufferInDenoAndCloudflareWorkerServices`: throws with file:line context on violation; passes cleanly when Web-standard alternatives are used

## Verification

```
node tooling/governance/verify-platform-consistency-governance.mjs
# → Platform consistency governance checks passed.

npx vitest run tooling/governance/verify-platform-consistency-governance.test.ts
# → 11 tests passed
```