### PR TITLE
Resolve #1390: re-run release readiness and exit prerelease state

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@fluojs/example-auth-jwt-passport": "0.0.0",

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 coverage/
 .turbo/
 .sisyphus/
+.worktrees/

--- a/packages/cli/scripts/local-test-env.mjs
+++ b/packages/cli/scripts/local-test-env.mjs
@@ -149,6 +149,13 @@ function isGeneratedSandboxDirectory(projectDirectory) {
   }
 }
 
+function isTransientSandboxDirectory(projectDirectory) {
+  const entries = readdirSync(projectDirectory, { withFileTypes: true });
+
+  return entries.length > 0
+    && entries.every((entry) => entry.isDirectory() && entry.name === 'node_modules');
+}
+
 function assertSafeToResetSandbox(projectDirectory) {
   const resolvedProjectDirectory = resolve(projectDirectory);
 
@@ -160,6 +167,7 @@ function assertSafeToResetSandbox(projectDirectory) {
     isManagedSandboxDirectory(resolvedProjectDirectory)
     || isLegacySandboxDirectory(resolvedProjectDirectory)
     || isGeneratedSandboxDirectory(resolvedProjectDirectory)
+    || isTransientSandboxDirectory(resolvedProjectDirectory)
   ) {
     return;
   }


### PR DESCRIPTION
Closes #1390

## Summary
- 현재 릴리스 거버넌스 상태를 다시 확인해 stable publish 전제 조건을 재검증했습니다.
- active prerelease 상태와 root worktree 청결성 문제를 정리한 뒤 `pnpm verify:release-readiness`를 다시 실행해 통과를 확인했습니다.
- release workflow가 Changesets publish 전에 `pnpm verify:release-readiness`를 계속 강제하는지도 재확인했습니다.

## Changes
- `.changeset/pre.json`의 prerelease 상태를 `pnpm changeset pre exit`로 `mode: \"exit\"`로 전환했습니다.
- 실수로 추적되던 `.worktrees/issue-1383-lazy-body-remaining-optimizations` gitlink를 제거하고 `.gitignore`에 `.worktrees/`를 추가해 root worktree 청결성 검증이 실제 worktree 운영과 충돌하지 않도록 정리했습니다.
- `pnpm verify:release-readiness` 재실행 중 드러난 `packages/cli/scripts/local-test-env.mjs` sandbox cleanup 실패를 수정해 `node_modules/`만 남아 있는 transient sandbox도 안전하게 정리하도록 했습니다.
- public package 동작/배포 surface 변경은 아니므로 `.changeset/*.md`는 추가하지 않았습니다.

## Testing
- `pnpm changeset pre exit`
- `pnpm vitest run --project packages packages/cli/src/cli.test.ts`
- `pnpm verify:release-readiness` ✅
- `git status --short` 확인: 검증 재실행 직전 tracked modified files 없음

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

변경 대상은 public export가 아니라 prerelease metadata / git hygiene / CLI sandbox tooling입니다.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

`docs/contracts/release-governance.md`의 stable publish prerequisites(ready state rerun, prerelease exit, dist-tag alignment)와 `.github/workflows/release.yml`의 `Verify release readiness` gate가 현재 상태와 일치함을 확인했습니다. CLI sandbox cleanup regression은 기존 `packages/cli/src/cli.test.ts`로 재검증했습니다.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

거버넌스 문서 본문은 변경하지 않았고, existing release workflow gate 및 release-readiness verifier를 실제 재실행해 현재 상태를 검증했습니다.