### PR TITLE
Resolve #1389: make optional cookie auth explicit

### DIFF
--- a/.changeset/khaki-bugs-tell.md
+++ b/.changeset/khaki-bugs-tell.md
@@ -1,0 +1,7 @@
+---
+'@fluojs/passport': minor
+---
+
+Make cookie-auth guest access explicit by requiring `@UseOptionalAuth(...)` when routes intentionally allow missing credentials.
+
+Protected routes now reject missing cookie credentials even when `requireAccessToken: false`, so applications that previously relied on anonymous cookie principals should switch those guest-capable handlers to `@UseOptionalAuth('cookie')`.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -114,6 +114,24 @@ export class AuthModule {}
 
 `CookieAuthStrategy`는 `@fluojs/jwt`가 정규화한 JWT principal 계약을 보존하며, `subject`, `claims`, `issuer`, `audience`, `roles`, `scopes`를 그대로 전달합니다.
 
+보호된 라우트는 계속 `@UseAuth(...)`를 사용해야 합니다. `requireAccessToken: false`를 설정해도 쿠키가 없을 때는 이제 익명 principal이 아니라 명시적인 미인증 결과를 반환하므로, 보호된 라우트는 요청을 계속 거부합니다.
+
+로그인 사용자와 게스트 호출자를 모두 허용하려는 라우트에서만 `@UseOptionalAuth(...)`를 사용하세요.
+
+```typescript
+import { Controller, Get, type RequestContext } from '@fluojs/http';
+import { UseOptionalAuth } from '@fluojs/passport';
+
+@Controller('/session')
+export class SessionController {
+  @Get('/')
+  @UseOptionalAuth('cookie')
+  getSession(_input: never, ctx: RequestContext) {
+    return { subject: ctx.principal?.subject ?? null };
+  }
+}
+```
+
 ### 리프레시 토큰 수명 주기
 
 패키지에서 제공하는 `RefreshTokenStrategy`와 `RefreshTokenService`를 사용하여 안전한 토큰 로테이션 및 폐기 기능을 구현할 수 있습니다.
@@ -157,6 +175,7 @@ export class AuthController {
 
 ### 데코레이터
 - `@UseAuth(strategyName)`: `AuthGuard`를 부착하고 사용할 전략을 설정합니다.
+- `@UseOptionalAuth(strategyName)`: `AuthGuard`를 부착하지만 전략이 자격 증명 누락을 보고하면 스코프가 없는 라우트는 계속 진행할 수 있게 합니다.
 - `@RequireScopes(...scopes)`: 특정 권한(스코프) 요구 사항을 강제합니다.
 
 ### 주요 클래스

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -114,6 +114,24 @@ Import `CookieAuthModule.forRoot(...)` alongside `PassportModule.forRoot(...)` w
 
 `CookieAuthStrategy` preserves the normalized JWT principal contract from `@fluojs/jwt`, including `subject`, `claims`, `issuer`, `audience`, `roles`, and `scopes`.
 
+Protected routes must keep using `@UseAuth(...)`. If you configure `requireAccessToken: false`, a missing cookie now resolves to an explicit unauthenticated result instead of an anonymous principal, so protected routes still reject the request.
+
+Use `@UseOptionalAuth(...)` only on routes that intentionally support both signed-in and guest callers:
+
+```typescript
+import { Controller, Get, type RequestContext } from '@fluojs/http';
+import { UseOptionalAuth } from '@fluojs/passport';
+
+@Controller('/session')
+export class SessionController {
+  @Get('/')
+  @UseOptionalAuth('cookie')
+  getSession(_input: never, ctx: RequestContext) {
+    return { subject: ctx.principal?.subject ?? null };
+  }
+}
+```
+
 ### Refresh Token Lifecycle
 
 The package provides a built-in `RefreshTokenStrategy` and `RefreshTokenService` to handle secure token rotation and revocation.
@@ -157,6 +175,7 @@ Import `RefreshTokenModule.forRoot(...)` alongside `PassportModule.forRoot(...)`
 
 ### Decorators
 - `@UseAuth(strategyName)`: Attaches `AuthGuard` and sets the active strategy.
+- `@UseOptionalAuth(strategyName)`: Attaches `AuthGuard` but allows routes without scopes to continue when the strategy reports missing credentials.
 - `@RequireScopes(...scopes)`: Enforces specific scope requirements.
 
 ### Core Classes

--- a/packages/passport/src/cookie/cookie-auth.test.ts
+++ b/packages/passport/src/cookie/cookie-auth.test.ts
@@ -100,30 +100,24 @@ describe('CookieAuthStrategy', () => {
       await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
     });
 
-    it('allows anonymous access when requireAccessToken is false', async () => {
+    it('returns an explicit unauthenticated result when requireAccessToken is false', async () => {
       const verifier = createMockVerifier();
       const strategy = new CookieAuthStrategy(verifier, { requireAccessToken: false });
       const context = createGuardContext({});
 
       const result = await strategy.authenticate(context);
 
-      expect(result).toMatchObject({
-        subject: 'anonymous',
-        claims: {},
-      });
+      expect(result).toEqual({ authenticated: false });
     });
 
-    it('allows anonymous access when cookies bag is undefined and requireAccessToken is false', async () => {
+    it('returns an explicit unauthenticated result when cookies bag is undefined and requireAccessToken is false', async () => {
       const verifier = createMockVerifier();
       const strategy = new CookieAuthStrategy(verifier, { requireAccessToken: false });
       const context = createGuardContext(undefined);
 
       const result = await strategy.authenticate(context);
 
-      expect(result).toMatchObject({
-        subject: 'anonymous',
-        claims: {},
-      });
+      expect(result).toEqual({ authenticated: false });
     });
 
     it('throws AuthenticationRequiredError when token verification fails', async () => {

--- a/packages/passport/src/cookie/cookie-auth.ts
+++ b/packages/passport/src/cookie/cookie-auth.ts
@@ -3,7 +3,11 @@ import type { GuardContext } from '@fluojs/http';
 import { DefaultJwtVerifier } from '@fluojs/jwt';
 
 import { AuthenticationRequiredError } from '../errors.js';
-import type { AuthStrategy, AuthStrategyResult } from '../types.js';
+import type { AuthOptionalResult, AuthStrategy, AuthStrategyResult } from '../types.js';
+
+const unauthenticatedCookieAuthResult: AuthOptionalResult = {
+  authenticated: false,
+};
 
 /**
  * Provides cookie-auth strategy options through dependency injection.
@@ -11,7 +15,7 @@ import type { AuthStrategy, AuthStrategyResult } from '../types.js';
 export const COOKIE_AUTH_OPTIONS = Symbol.for('fluo.passport.cookie-auth-options');
 
 /**
- * Configures cookie names and fallback behavior for cookie-based authentication.
+ * Configures cookie names and missing-cookie behavior for cookie-based authentication.
  */
 export interface CookieAuthOptions {
   accessTokenCookieName?: string;
@@ -44,6 +48,11 @@ export function normalizeCookieAuthOptions(options?: CookieAuthOptions): Require
 
 /**
  * Authenticates requests by reading and verifying JWTs from HTTP cookies.
+ *
+ * @remarks
+ * When `requireAccessToken` is `false`, missing cookies now resolve to an explicit
+ * unauthenticated result. Protected routes still reject that result unless they opt in
+ * with `@UseOptionalAuth(...)`.
  */
 @Inject(DefaultJwtVerifier, COOKIE_AUTH_OPTIONS)
 export class CookieAuthStrategy implements AuthStrategy {
@@ -65,10 +74,7 @@ export class CookieAuthStrategy implements AuthStrategy {
         throw new AuthenticationRequiredError('Access token cookie is required.');
       }
 
-      return {
-        claims: {},
-        subject: 'anonymous',
-      };
+      return unauthenticatedCookieAuthResult;
     }
 
     const accessToken = cookies[this.options.accessTokenCookieName];
@@ -78,10 +84,7 @@ export class CookieAuthStrategy implements AuthStrategy {
         throw new AuthenticationRequiredError('Access token cookie is required.');
       }
 
-      return {
-        claims: {},
-        subject: 'anonymous',
-      };
+      return unauthenticatedCookieAuthResult;
     }
 
     try {

--- a/packages/passport/src/decorators.ts
+++ b/packages/passport/src/decorators.ts
@@ -101,6 +101,29 @@ export function UseAuth(strategy: string): ClassOrMethodDecoratorLike {
 }
 
 /**
+ * Declares a strategy that may leave `requestContext.principal` unset when credentials are absent.
+ *
+ * @remarks
+ * Use this decorator only for routes that intentionally accept both authenticated and
+ * unauthenticated callers. Scope requirements still require a resolved principal.
+ *
+ * @example
+ * ```ts
+ * @UseOptionalAuth('cookie')
+ * @Get('/session')
+ * getSession(_input: unknown, ctx: RequestContext) {
+ *   return { subject: ctx.principal?.subject ?? null };
+ * }
+ * ```
+ *
+ * @param strategy Strategy name previously registered through `PassportModule.forRoot(...)`.
+ * @returns A class-or-method decorator that stores the optional auth requirement metadata.
+ */
+export function UseOptionalAuth(strategy: string): ClassOrMethodDecoratorLike {
+  return createAuthRequirementDecorator({ optional: true, strategy });
+}
+
+/**
  * Declares scope requirements that `AuthGuard` must enforce after authentication succeeds.
  *
  * @remarks

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -258,6 +258,49 @@ describe('AuthGuard', () => {
     expect(response.body).toEqual({ subject: null });
   });
 
+  it('rejects missing cookie auth when a protected method overrides class-level optional auth', async () => {
+    class MissingCookieStrategy implements AuthStrategy {
+      async authenticate() {
+        return { authenticated: false } as const;
+      }
+    }
+
+    @Controller('/session')
+    @UseOptionalAuth('mock')
+    class MixedAuthController {
+      @Get('/me')
+      @UseAuth('mock')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      MixedAuthController,
+      MissingCookieStrategy,
+      ...createPassportModuleProviders({ defaultStrategy: 'mock' }, [{ name: 'mock', token: MissingCookieStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: MixedAuthController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/session/me', { 'x-request-id': 'req-auth-cookie-method-override' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-auth-cookie-method-override',
+        status: 401,
+      },
+    });
+  });
+
   it('still rejects optional auth routes when scopes are required but no principal is available', async () => {
     class MissingCookieStrategy implements AuthStrategy {
       async authenticate() {

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -7,7 +7,7 @@ import type { FrameworkRequest, FrameworkResponse, GuardContext } from '@fluojs/
 import { Container } from '@fluojs/di';
 import { DefaultJwtVerifier } from '@fluojs/jwt';
 
-import { RequireScopes, UseAuth } from './decorators.js';
+import { RequireScopes, UseAuth, UseOptionalAuth } from './decorators.js';
 import { AuthenticationExpiredError, AuthenticationFailedError, AuthenticationRequiredError } from './errors.js';
 import { AuthGuard } from './guard.js';
 import { PassportModule } from './module.js';
@@ -179,6 +179,123 @@ describe('AuthGuard', () => {
         message: 'Authentication required.',
         meta: undefined,
         requestId: 'req-auth-401',
+        status: 401,
+      },
+    });
+  });
+
+  it('rejects a missing cookie principal on protected routes even when the cookie strategy is optional', async () => {
+    class MissingCookieStrategy implements AuthStrategy {
+      async authenticate() {
+        return { authenticated: false } as const;
+      }
+    }
+
+    @Controller('/profile')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth('mock')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      MissingCookieStrategy,
+      ...createPassportModuleProviders({ defaultStrategy: 'mock' }, [{ name: 'mock', token: MissingCookieStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/profile', { 'x-request-id': 'req-auth-cookie-protected' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-auth-cookie-protected',
+        status: 401,
+      },
+    });
+  });
+
+  it('allows a missing cookie principal on routes that explicitly opt into optional auth', async () => {
+    class MissingCookieStrategy implements AuthStrategy {
+      async authenticate() {
+        return { authenticated: false } as const;
+      }
+    }
+
+    @Controller('/session')
+    class OptionalController {
+      @Get('/')
+      @UseOptionalAuth('mock')
+      getSession(_input: unknown, ctx: { principal?: { subject: string } }) {
+        return { subject: ctx.principal?.subject ?? null };
+      }
+    }
+
+    const root = new Container().register(
+      OptionalController,
+      MissingCookieStrategy,
+      ...createPassportModuleProviders({ defaultStrategy: 'mock' }, [{ name: 'mock', token: MissingCookieStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: OptionalController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/session'), response);
+
+    expect(response.body).toEqual({ subject: null });
+  });
+
+  it('still rejects optional auth routes when scopes are required but no principal is available', async () => {
+    class MissingCookieStrategy implements AuthStrategy {
+      async authenticate() {
+        return { authenticated: false } as const;
+      }
+    }
+
+    @Controller('/session')
+    class OptionalScopedController {
+      @Get('/')
+      @UseOptionalAuth('mock')
+      @RequireScopes('profile:read')
+      getSession() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      OptionalScopedController,
+      MissingCookieStrategy,
+      ...createPassportModuleProviders({ defaultStrategy: 'mock' }, [{ name: 'mock', token: MissingCookieStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: OptionalScopedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/session', { 'x-request-id': 'req-auth-cookie-optional-scoped' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-auth-cookie-optional-scoped',
         status: 401,
       },
     });

--- a/packages/passport/src/guard.ts
+++ b/packages/passport/src/guard.ts
@@ -14,6 +14,7 @@ import { getAuthRequirement } from './metadata.js';
 import type {
   AuthGuardContract,
   AuthHandledResult,
+  AuthOptionalResult,
   AuthStrategy,
   AuthStrategyResult,
   AuthStrategyRegistry,
@@ -24,9 +25,17 @@ function isAuthHandledResult(result: AuthStrategyResult): result is AuthHandledR
   return typeof result === 'object' && result !== null && 'handled' in result && result.handled === true;
 }
 
+function isAuthOptionalResult(result: AuthStrategyResult): result is AuthOptionalResult {
+  return typeof result === 'object' && result !== null && 'authenticated' in result && result.authenticated === false;
+}
+
 function resolvePrincipal(result: AuthStrategyResult): Principal | undefined {
   if (isAuthHandledResult(result)) {
     return result.principal;
+  }
+
+  if (isAuthOptionalResult(result)) {
+    return undefined;
   }
 
   return result;
@@ -170,10 +179,14 @@ export class AuthGuard implements AuthGuardContract {
           );
         }
 
-        return true;
+       return true;
       }
 
       if (!principal) {
+        if (isAuthOptionalResult(result) && requirement?.optional && !requirement.scopes?.length) {
+          return true;
+        }
+
         throw new AuthenticationFailedError('Authentication strategy did not return a principal.');
       }
 

--- a/packages/passport/src/metadata.ts
+++ b/packages/passport/src/metadata.ts
@@ -18,13 +18,15 @@ function normalizeRequirement(requirement: AuthRequirement | undefined): AuthReq
   }
 
   const strategy = requirement.strategy;
+  const optional = requirement.optional;
   const scopes = normalizeDeclaredScopes(requirement.scopes);
 
-  if (!strategy && !scopes) {
+  if (!strategy && !scopes && optional !== true) {
     return undefined;
   }
 
   return {
+    optional,
     scopes,
     strategy,
   };

--- a/packages/passport/src/scope.ts
+++ b/packages/passport/src/scope.ts
@@ -68,7 +68,12 @@ export function mergeAuthRequirements(
   }
 
   const scopes = normalizeDeclaredScopes([...(base?.scopes ?? []), ...(extra?.scopes ?? [])]);
-  const optional = extra?.optional ?? base?.optional;
+  const optional =
+    extra && Object.hasOwn(extra, 'optional')
+      ? extra.optional
+      : base?.optional === true && extra?.strategy
+        ? false
+        : base?.optional;
   const strategy = extra?.strategy ?? base?.strategy;
 
   if (!strategy && !scopes && optional !== true) {

--- a/packages/passport/src/scope.ts
+++ b/packages/passport/src/scope.ts
@@ -68,13 +68,15 @@ export function mergeAuthRequirements(
   }
 
   const scopes = normalizeDeclaredScopes([...(base?.scopes ?? []), ...(extra?.scopes ?? [])]);
+  const optional = extra?.optional ?? base?.optional;
   const strategy = extra?.strategy ?? base?.strategy;
 
-  if (!strategy && !scopes) {
+  if (!strategy && !scopes && optional !== true) {
     return undefined;
   }
 
   return {
+    optional,
     scopes,
     strategy,
   };

--- a/packages/passport/src/types.ts
+++ b/packages/passport/src/types.ts
@@ -5,8 +5,15 @@ import type { Guard, GuardContext, Principal } from '@fluojs/http';
 export interface AuthRequirement {
   /** Named strategy to resolve from the strategy registry. */
   strategy?: string;
+  /** Allows the request to continue without a resolved principal. */
+  optional?: boolean;
   /** Required scopes that must be present on the resolved principal. */
   scopes?: string[];
+}
+
+/** Authentication result variant used when a route explicitly allows missing credentials. */
+export interface AuthOptionalResult {
+  authenticated: false;
 }
 
 /** Authentication result variant used when a strategy fully handled the response. */
@@ -16,7 +23,7 @@ export interface AuthHandledResult {
 }
 
 /** Return type of an `AuthStrategy.authenticate(...)` call. */
-export type AuthStrategyResult = Principal | AuthHandledResult;
+export type AuthStrategyResult = Principal | AuthHandledResult | AuthOptionalResult;
 
 /** Strategy contract implemented by authentication adapters. */
 export interface AuthStrategy {


### PR DESCRIPTION
Closes #1389

## Summary

Make `@fluojs/passport` treat missing cookie credentials as unauthenticated by default, and require an explicit route-level opt-in for guest-capable cookie auth.

## Changes

- added `@UseOptionalAuth(...)` and optional auth metadata so routes can explicitly allow missing credentials without synthesizing an anonymous principal
- changed `CookieAuthStrategy` and `AuthGuard` so protected routes reject missing cookie credentials even when `requireAccessToken: false`
- added regression coverage for protected, optional, and scoped optional cookie-auth flows, and documented the migration path in `packages/passport/README.md` and `README.ko.md`
- added a Changesets minor release note for `@fluojs/passport` because prerelease consumers relying on anonymous cookie principals must move those handlers to `@UseOptionalAuth('cookie')`

## Testing

- `pnpm verify`
- `lsp_diagnostics` clean for changed TypeScript files in `packages/passport/src`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] No governance SSOT documents changed in this PR.
- [x] No platform contract docs changed, so companion governance updates were not required.
- [x] No platform README conformance claims changed in this PR.