### PR TITLE
Resolve #1394: anchor Redis windows to Redis time

### DIFF
--- a/.changeset/friendly-lions-fry.md
+++ b/.changeset/friendly-lions-fry.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/throttler': patch
+---
+
+Anchor `RedisThrottlerStore` rate-limit windows to Redis server time so distributed deployments keep one shared reset boundary even when application node clocks drift.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -69,7 +69,7 @@ class AuthController {
 
 ### Redis 저장소 사용
 
-다중 인스턴스 배포 환경에서는 `RedisThrottlerStore`를 사용하여 모든 인스턴스 간에 속도 제한 상태를 공유하세요.
+다중 인스턴스 배포 환경에서는 `RedisThrottlerStore`를 사용하여 모든 인스턴스 간에 속도 제한 상태를 공유하세요. Redis 기반 윈도우는 Redis 서버 시간을 기준으로 고정되므로, 애플리케이션 노드 간 시계 오차가 있어도 하나의 공통 reset 경계를 강제합니다.
 
 ```typescript
 import { ThrottlerModule, RedisThrottlerStore } from '@fluojs/throttler';

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -69,7 +69,7 @@ class AuthController {
 
 ### Redis Storage
 
-For multi-instance deployments, use `RedisThrottlerStore` to share the rate limit state across all instances.
+For multi-instance deployments, use `RedisThrottlerStore` to share the rate limit state across all instances. Redis-backed windows are anchored to Redis server time, so distributed app nodes with clock skew still enforce one shared reset boundary.
 
 ```typescript
 import { ThrottlerModule, RedisThrottlerStore } from '@fluojs/throttler';

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -10,9 +10,10 @@ import {
   getThrottleMetadata,
   throttleRouteMetadataKey,
 } from './decorators.js';
+import { throttlerRetryAfterMsSymbol } from './store-internals.js';
 import { createMemoryThrottlerStore } from './store.js';
 import { THROTTLER_OPTIONS } from './tokens.js';
-import type { ThrottlerModuleOptions, ThrottlerStore } from './types.js';
+import type { ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
 import { validateThrottleOptions, validateThrottlerModuleOptions, validateThrottlerStoreEntry } from './validation.js';
 
 type MetadataBag = Record<PropertyKey, unknown>;
@@ -53,6 +54,18 @@ function buildHandlerKey(handler: GuardContext['handler']): string {
     `version:${encodeURIComponent(version)}`,
     `handler:${encodeURIComponent(handler.methodName)}`,
   ].join('|');
+}
+
+function resolveRetryAfterSeconds(entry: ThrottlerStoreEntry, now: number): number {
+  const retryAfterMs = (entry as ThrottlerStoreEntry & { [throttlerRetryAfterMsSymbol]?: number })[
+    throttlerRetryAfterMsSymbol
+  ];
+
+  if (typeof retryAfterMs === 'number' && Number.isFinite(retryAfterMs)) {
+    return Math.max(1, Math.ceil(retryAfterMs / 1000));
+  }
+
+  return Math.max(1, Math.ceil((entry.resetAt - now) / 1000));
 }
 
 /**
@@ -116,7 +129,7 @@ export class ThrottlerGuard implements Guard {
     }));
 
     if (entry.count > limit) {
-      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+      const retryAfter = resolveRetryAfterSeconds(entry, now);
       requestContext.response.setHeader('Retry-After', String(retryAfter));
       throw new TooManyRequestsException('Too Many Requests', { meta: { retryAfter } });
     }

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -123,13 +123,14 @@ export class ThrottlerGuard implements Guard {
     const handlerKey = buildHandlerKey(handler);
     const storeKey = buildStoreKey(handlerKey, clientKey);
     const now = Date.now();
-    const entry = validateThrottlerStoreEntry(await this.store.consume(storeKey, {
+    const rawEntry = await this.store.consume(storeKey, {
       now,
       ttlSeconds,
-    }));
+    });
+    const entry = validateThrottlerStoreEntry(rawEntry);
 
     if (entry.count > limit) {
-      const retryAfter = resolveRetryAfterSeconds(entry, now);
+      const retryAfter = resolveRetryAfterSeconds(rawEntry, now);
       requestContext.response.setHeader('Retry-After', String(retryAfter));
       throw new TooManyRequestsException('Too Many Requests', { meta: { retryAfter } });
     }

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type Redis from 'ioredis';
+
 import { metadataSymbol } from '@fluojs/core/internal';
 import type { GuardContext, HandlerDescriptor, RequestContext } from '@fluojs/http';
 
@@ -7,6 +9,7 @@ import * as throttlerExports from './index.js';
 import { SkipThrottle, Throttle, getThrottleMetadata } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
 import { ThrottlerModule } from './module.js';
+import { RedisThrottlerStore } from './redis-store.js';
 import { createMemoryThrottlerStore } from './store.js';
 import type {
   ThrottlerConsumeInput,
@@ -591,6 +594,36 @@ describe('ThrottlerGuard — Redis store mock', () => {
 
     await expect(guard.canActivate(createGuardContext(TestController, 'action', ctx))).rejects.toThrow(storeFailure);
     expect(ctx.response.headers['Retry-After']).toBeUndefined();
+  });
+
+  it('keeps Retry-After consistent across skewed app clocks when Redis provides the shared window', async () => {
+    const client = {
+      eval: vi.fn(async () => [2, 1_710_000_090_000, 45_000]),
+    } as unknown as Pick<Redis, 'eval'>;
+    const store = new RedisThrottlerStore(client as Redis);
+
+    class TestController {
+      action() {}
+    }
+
+    const fastNodeGuard = new ThrottlerGuard({ limit: 1, store, ttl: 60 });
+    const slowNodeGuard = new ThrottlerGuard({ limit: 1, store, ttl: 60 });
+    const fastNodeContext = createRequestContext('10.0.0.1');
+    const slowNodeContext = createRequestContext('10.0.0.2');
+    const dateNowSpy = vi.spyOn(Date, 'now');
+
+    dateNowSpy.mockReturnValueOnce(1_710_000_045_000);
+    await expect(
+      fastNodeGuard.canActivate(createGuardContext(TestController, 'action', fastNodeContext)),
+    ).rejects.toThrow('Too Many Requests');
+
+    dateNowSpy.mockReturnValueOnce(1_710_000_000_000);
+    await expect(
+      slowNodeGuard.canActivate(createGuardContext(TestController, 'action', slowNodeContext)),
+    ).rejects.toThrow('Too Many Requests');
+
+    expect(fastNodeContext.response.headers['Retry-After']).toBe('45');
+    expect(slowNodeContext.response.headers['Retry-After']).toBe('45');
   });
 
   it('builds store keys from route and token identity context', async () => {

--- a/packages/throttler/src/redis-store.test.ts
+++ b/packages/throttler/src/redis-store.test.ts
@@ -25,7 +25,7 @@ function createRedisTimeAnchoredClient(baseNow: number) {
             resetAt: redisNow + ttlMs,
           };
 
-          return [entry.count, entry.resetAt];
+          return [entry.count, entry.resetAt, entry.resetAt - redisNow];
         }
 
         entry = {
@@ -33,7 +33,7 @@ function createRedisTimeAnchoredClient(baseNow: number) {
           resetAt: entry.resetAt,
         };
 
-        return [entry.count, entry.resetAt];
+        return [entry.count, entry.resetAt, entry.resetAt - redisNow];
       }),
     } as unknown as Pick<Redis, 'eval'>,
     setRedisNow(nextNow: number) {
@@ -45,7 +45,7 @@ function createRedisTimeAnchoredClient(baseNow: number) {
 describe('RedisThrottlerStore', () => {
   it('persists the reset window at the TTL boundary with millisecond precision', async () => {
     const now = 1_710_000_000_000;
-    const client = createRedisClientMock([1, now + 60_000]);
+    const client = createRedisClientMock([1, now + 60_000, 60_000]);
     const store = new RedisThrottlerStore(client as Redis);
 
     const entry = await store.consume('throttle:auth:127.0.0.1', {
@@ -92,9 +92,9 @@ describe('RedisThrottlerStore', () => {
       ttlSeconds: 60,
     });
 
-    expect(first).toEqual({ count: 1, resetAt: baseNow + 60_000 });
-    expect(second).toEqual({ count: 2, resetAt: baseNow + 60_000 });
-    expect(third).toEqual({ count: 1, resetAt: baseNow + 120_001 });
+    expect(first).toEqual({ count: 1, resetAt: baseNow + 30_000 });
+    expect(second).toEqual({ count: 2, resetAt: baseNow + 31_000 });
+    expect(third).toEqual({ count: 1, resetAt: baseNow + 15_000 });
     expect(client.eval).toHaveBeenCalledTimes(3);
   });
 

--- a/packages/throttler/src/redis-store.test.ts
+++ b/packages/throttler/src/redis-store.test.ts
@@ -92,9 +92,9 @@ describe('RedisThrottlerStore', () => {
       ttlSeconds: 60,
     });
 
-    expect(first).toEqual({ count: 1, resetAt: baseNow + 30_000 });
-    expect(second).toEqual({ count: 2, resetAt: baseNow + 31_000 });
-    expect(third).toEqual({ count: 1, resetAt: baseNow + 15_000 });
+    expect(first).toEqual({ count: 1, resetAt: baseNow + 60_000 });
+    expect(second).toEqual({ count: 2, resetAt: baseNow + 60_000 });
+    expect(third).toEqual({ count: 1, resetAt: baseNow + 120_001 });
     expect(client.eval).toHaveBeenCalledTimes(3);
   });
 

--- a/packages/throttler/src/redis-store.test.ts
+++ b/packages/throttler/src/redis-store.test.ts
@@ -10,6 +10,38 @@ function createRedisClientMock(result: unknown) {
   } as unknown as Pick<Redis, 'eval'>;
 }
 
+function createRedisTimeAnchoredClient(baseNow: number) {
+  let redisNow = baseNow;
+  let entry: { count: number; resetAt: number } | undefined;
+
+  return {
+    client: {
+      eval: vi.fn(async () => {
+        const ttlMs = 60_000;
+
+        if (!entry || redisNow >= entry.resetAt) {
+          entry = {
+            count: 1,
+            resetAt: redisNow + ttlMs,
+          };
+
+          return [entry.count, entry.resetAt];
+        }
+
+        entry = {
+          count: entry.count + 1,
+          resetAt: entry.resetAt,
+        };
+
+        return [entry.count, entry.resetAt];
+      }),
+    } as unknown as Pick<Redis, 'eval'>,
+    setRedisNow(nextNow: number) {
+      redisNow = nextNow;
+    },
+  };
+}
+
 describe('RedisThrottlerStore', () => {
   it('persists the reset window at the TTL boundary with millisecond precision', async () => {
     const now = 1_710_000_000_000;
@@ -23,19 +55,47 @@ describe('RedisThrottlerStore', () => {
 
     expect(entry).toEqual({ count: 1, resetAt: now + 60_000 });
     expect(client.eval).toHaveBeenCalledWith(
-      expect.stringContaining("math.max(resetAt - now, 1)"),
+      expect.stringContaining("redis.call('TIME')"),
       1,
       'throttle:auth:127.0.0.1',
-      String(now),
       '60000',
     );
     expect(client.eval).toHaveBeenCalledWith(
       expect.stringContaining("redis.call('SET', key, cjson.encode({ count = count, resetAt = resetAt }), 'PX', ttlMsLeft)"),
       1,
       'throttle:auth:127.0.0.1',
-      String(now),
       '60000',
     );
+  });
+
+  it('anchors Redis windows to Redis server time across skewed app nodes', async () => {
+    const baseNow = 1_710_000_000_000;
+    const { client, setRedisNow } = createRedisTimeAnchoredClient(baseNow);
+    const store = new RedisThrottlerStore(client as Redis);
+
+    const first = await store.consume('throttle:auth:127.0.0.1', {
+      now: baseNow - 30_000,
+      ttlSeconds: 60,
+    });
+
+    setRedisNow(baseNow + 59_000);
+
+    const second = await store.consume('throttle:auth:127.0.0.1', {
+      now: baseNow + 30_000,
+      ttlSeconds: 60,
+    });
+
+    setRedisNow(baseNow + 60_001);
+
+    const third = await store.consume('throttle:auth:127.0.0.1', {
+      now: baseNow - 45_000,
+      ttlSeconds: 60,
+    });
+
+    expect(first).toEqual({ count: 1, resetAt: baseNow + 60_000 });
+    expect(second).toEqual({ count: 2, resetAt: baseNow + 60_000 });
+    expect(third).toEqual({ count: 1, resetAt: baseNow + 120_001 });
+    expect(client.eval).toHaveBeenCalledTimes(3);
   });
 
   it('rejects malformed consume-script responses', async () => {

--- a/packages/throttler/src/redis-store.ts
+++ b/packages/throttler/src/redis-store.ts
@@ -1,5 +1,6 @@
 import type Redis from 'ioredis';
 
+import { throttlerRetryAfterMsSymbol } from './store-internals.js';
 import type { ThrottlerConsumeInput, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
 import { validateThrottlerStoreEntry } from './validation.js';
 
@@ -29,22 +30,37 @@ const CONSUME_LUA = [
   'end',
   'local ttlMsLeft = math.max(resetAt - now, 1)',
   "redis.call('SET', key, cjson.encode({ count = count, resetAt = resetAt }), 'PX', ttlMsLeft)",
-  'return {count, resetAt}',
+  'return {count, resetAt, ttlMsLeft}',
 ].join('\n');
 
-function parseConsumeResult(result: unknown): ThrottlerStoreEntry {
+function parseConsumeResult(result: unknown, observedNow: number): ThrottlerStoreEntry {
   if (!Array.isArray(result) || result.length < 2) {
     throw new Error('Redis throttler consume script returned an invalid response.');
   }
 
   const count = Number(result[0]);
   const resetAt = Number(result[1]);
+  const retryAfterMs = result.length >= 3 ? Number(result[2]) : Number.NaN;
 
   if (!Number.isFinite(count) || !Number.isFinite(resetAt)) {
     throw new Error('Redis throttler consume script returned non-numeric counters.');
   }
 
-  return validateThrottlerStoreEntry({ count, resetAt });
+  const entry = validateThrottlerStoreEntry({
+    count,
+    resetAt: Number.isFinite(retryAfterMs) ? observedNow + retryAfterMs : resetAt,
+  });
+
+  if (Number.isFinite(retryAfterMs)) {
+    Object.defineProperty(entry, throttlerRetryAfterMsSymbol, {
+      configurable: false,
+      enumerable: false,
+      value: retryAfterMs,
+      writable: false,
+    });
+  }
+
+  return entry;
 }
 
 /**
@@ -72,6 +88,6 @@ export class RedisThrottlerStore implements ThrottlerStore {
       String(input.ttlSeconds * 1000),
     );
 
-    return parseConsumeResult(result);
+    return parseConsumeResult(result, input.now);
   }
 }

--- a/packages/throttler/src/redis-store.ts
+++ b/packages/throttler/src/redis-store.ts
@@ -33,7 +33,7 @@ const CONSUME_LUA = [
   'return {count, resetAt, ttlMsLeft}',
 ].join('\n');
 
-function parseConsumeResult(result: unknown, observedNow: number): ThrottlerStoreEntry {
+function parseConsumeResult(result: unknown): ThrottlerStoreEntry {
   if (!Array.isArray(result) || result.length < 2) {
     throw new Error('Redis throttler consume script returned an invalid response.');
   }
@@ -48,7 +48,7 @@ function parseConsumeResult(result: unknown, observedNow: number): ThrottlerStor
 
   const entry = validateThrottlerStoreEntry({
     count,
-    resetAt: Number.isFinite(retryAfterMs) ? observedNow + retryAfterMs : resetAt,
+    resetAt,
   });
 
   if (Number.isFinite(retryAfterMs)) {
@@ -88,6 +88,6 @@ export class RedisThrottlerStore implements ThrottlerStore {
       String(input.ttlSeconds * 1000),
     );
 
-    return parseConsumeResult(result, input.now);
+    return parseConsumeResult(result);
   }
 }

--- a/packages/throttler/src/redis-store.ts
+++ b/packages/throttler/src/redis-store.ts
@@ -5,8 +5,11 @@ import { validateThrottlerStoreEntry } from './validation.js';
 
 const CONSUME_LUA = [
   "local key = KEYS[1]",
-  "local now = tonumber(ARGV[1])",
-  "local ttlMs = tonumber(ARGV[2])",
+  "local ttlMs = tonumber(ARGV[1])",
+  "local time = redis.call('TIME')",
+  "local nowSeconds = tonumber(time[1])",
+  "local nowMicros = tonumber(time[2])",
+  'local now = math.floor((nowSeconds * 1000) + (nowMicros / 1000))',
   "local raw = redis.call('GET', key)",
   "local count",
   "local resetAt",
@@ -66,7 +69,6 @@ export class RedisThrottlerStore implements ThrottlerStore {
       CONSUME_LUA,
       1,
       key,
-      String(input.now),
       String(input.ttlSeconds * 1000),
     );
 

--- a/packages/throttler/src/store-internals.ts
+++ b/packages/throttler/src/store-internals.ts
@@ -1,0 +1,1 @@
+export const throttlerRetryAfterMsSymbol = Symbol('throttler.retryAfterMs');

--- a/packages/throttler/src/store-internals.ts
+++ b/packages/throttler/src/store-internals.ts
@@ -1,1 +1,4 @@
+/**
+ * Internal store-entry symbol used to carry Redis-derived retry-after milliseconds.
+ */
 export const throttlerRetryAfterMsSymbol = Symbol('throttler.retryAfterMs');


### PR DESCRIPTION
Closes #1394

## Summary
- anchor `RedisThrottlerStore` window boundaries to Redis server time so distributed nodes share one authoritative reset boundary
- add a regression test that simulates skewed application clocks while Redis time stays authoritative
- document the Redis-time behavior and ship a patch changeset for `@fluojs/throttler`

## Changes
- moved Redis throttler window anchoring into the Lua script by reading Redis `TIME` inside `RedisThrottlerStore`
- kept the public guard/store API unchanged while making Redis reset windows derive from Redis time instead of app-node local clocks
- added regression coverage for skewed application clocks and updated the package README plus `.changeset` metadata

## Testing
- `pnpm --filter @fluojs/throttler test`
- `pnpm --filter @fluojs/throttler... build`
- `pnpm --filter @fluojs/throttler typecheck`
- `lsp_diagnostics` on `packages/throttler/src/redis-store.ts`
- `lsp_diagnostics` on `packages/throttler/src/redis-store.test.ts`

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.