### PR TITLE
Resolve #1392: close fetch-style sockets on shutdown

### DIFF
--- a/.changeset/eight-cougars-film.md
+++ b/.changeset/eight-cougars-film.md
@@ -2,4 +2,4 @@
 '@fluojs/websockets': patch
 ---
 
-Close active Bun, Deno, and Cloudflare Workers websocket clients during application shutdown so `@OnDisconnect()` cleanup runs consistently before teardown completes.
+Close active Bun, Deno, and Cloudflare Workers websocket clients during application shutdown and wait up to `shutdown.timeoutMs` for `@OnDisconnect()` cleanup to drain before teardown completes.

--- a/.changeset/eight-cougars-film.md
+++ b/.changeset/eight-cougars-film.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/websockets': patch
+---
+
+Close active Bun, Deno, and Cloudflare Workers websocket clients during application shutdown so `@OnDisconnect()` cleanup runs consistently before teardown completes.

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -222,6 +222,31 @@ describe('platform consistency governance docs', () => {
     expect(packageChooserKo).toContain('@fluojs/email/node');
   });
 
+  it('keeps the websockets README shutdown contract scoped to fetch-style runtimes with linked regression evidence', () => {
+    const websocketsReadme = readFileSync(resolve(repoRoot, 'packages/websockets/README.md'), 'utf8');
+    const websocketsReadmeKo = readFileSync(resolve(repoRoot, 'packages/websockets/README.ko.md'), 'utf8');
+
+    expect(websocketsReadme).toContain('@fluojs/websockets/bun');
+    expect(websocketsReadme).toContain('@fluojs/websockets/deno');
+    expect(websocketsReadme).toContain('@fluojs/websockets/cloudflare-workers');
+    expect(websocketsReadme).toContain('close tracked websocket clients during application shutdown');
+    expect(websocketsReadme).toContain('bounded chance to finish within `shutdown.timeoutMs`');
+    expect(websocketsReadme).not.toContain('Across Node.js, Bun, Deno, and Cloudflare Workers');
+    expect(websocketsReadme).toContain('packages/websockets/src/bun/bun.test.ts');
+    expect(websocketsReadme).toContain('packages/websockets/src/deno/deno.test.ts');
+    expect(websocketsReadme).toContain('packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts');
+
+    expect(websocketsReadmeKo).toContain('@fluojs/websockets/bun');
+    expect(websocketsReadmeKo).toContain('@fluojs/websockets/deno');
+    expect(websocketsReadmeKo).toContain('@fluojs/websockets/cloudflare-workers');
+    expect(websocketsReadmeKo).toContain('애플리케이션 shutdown 시 추적 중인 websocket 클라이언트를 닫고');
+    expect(websocketsReadmeKo).toContain('`shutdown.timeoutMs` 범위 안에서 `@OnDisconnect()` cleanup');
+    expect(websocketsReadmeKo).not.toContain('Node.js, Bun, Deno, Cloudflare Workers 전반에서');
+    expect(websocketsReadmeKo).toContain('packages/websockets/src/bun/bun.test.ts');
+    expect(websocketsReadmeKo).toContain('packages/websockets/src/deno/deno.test.ts');
+    expect(websocketsReadmeKo).toContain('packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts');
+  });
+
   it('keeps PR CI governance-gated while reserving release-readiness for main pushes', () => {
     const ciWorkflow = readFileSync(resolve(repoRoot, '.github/workflows/ci.yml'), 'utf8');
     const vitestConfig = readFileSync(resolve(repoRoot, 'vitest.config.ts'), 'utf8');

--- a/packages/websockets/README.ko.md
+++ b/packages/websockets/README.ko.md
@@ -101,7 +101,7 @@ WebSocketModule.forRoot({
 });
 ```
 
-옵션을 생략하면 `@fluojs/websockets`는 동시 연결 수와 인바운드 페이로드 크기에 대해 기본 제한값을 적용합니다. 또한 server-backed Node 리스너는 `heartbeat.enabled`를 명시적으로 `false`로 두지 않는 한 heartbeat 타이머를 활성화합니다.
+옵션을 생략하면 `@fluojs/websockets`는 동시 연결 수와 인바운드 페이로드 크기에 대해 기본 제한값을 적용합니다. 또한 server-backed Node 리스너는 `heartbeat.enabled`를 명시적으로 `false`로 두지 않는 한 heartbeat 타이머를 활성화합니다. Node.js, Bun, Deno, Cloudflare Workers 전반에서 애플리케이션 shutdown 시 추적 중인 websocket 클라이언트를 닫고 `shutdown.timeoutMs` 범위 안에서 `@OnDisconnect()` cleanup이 마무리될 기회를 제공합니다.
 
 ## 공개 API 개요
 

--- a/packages/websockets/README.ko.md
+++ b/packages/websockets/README.ko.md
@@ -101,7 +101,7 @@ WebSocketModule.forRoot({
 });
 ```
 
-옵션을 생략하면 `@fluojs/websockets`는 동시 연결 수와 인바운드 페이로드 크기에 대해 기본 제한값을 적용합니다. 또한 server-backed Node 리스너는 `heartbeat.enabled`를 명시적으로 `false`로 두지 않는 한 heartbeat 타이머를 활성화합니다. Node.js, Bun, Deno, Cloudflare Workers 전반에서 애플리케이션 shutdown 시 추적 중인 websocket 클라이언트를 닫고 `shutdown.timeoutMs` 범위 안에서 `@OnDisconnect()` cleanup이 마무리될 기회를 제공합니다.
+옵션을 생략하면 `@fluojs/websockets`는 동시 연결 수와 인바운드 페이로드 크기에 대해 기본 제한값을 적용합니다. 또한 server-backed Node 리스너는 `heartbeat.enabled`를 명시적으로 `false`로 두지 않는 한 heartbeat 타이머를 활성화합니다. 공식 fetch-style 런타임 모듈(`@fluojs/websockets/bun`, `@fluojs/websockets/deno`, `@fluojs/websockets/cloudflare-workers`)은 애플리케이션 shutdown 시 추적 중인 websocket 클라이언트를 닫고 `shutdown.timeoutMs` 범위 안에서 `@OnDisconnect()` cleanup이 마무리될 수 있도록 bounded 기회를 제공합니다.
 
 ## 공개 API 개요
 
@@ -131,3 +131,5 @@ WebSocketModule.forRoot({
 - `packages/websockets/src/public-surface.test.ts`
 - `packages/websockets/src/node/node.test.ts`
 - `packages/websockets/src/bun/bun.test.ts`
+- `packages/websockets/src/deno/deno.test.ts`
+- `packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts`

--- a/packages/websockets/README.md
+++ b/packages/websockets/README.md
@@ -101,7 +101,7 @@ WebSocketModule.forRoot({
 });
 ```
 
-When omitted, `@fluojs/websockets` now applies bounded defaults for concurrent connections and inbound payload size. Server-backed Node listeners also enable heartbeat timers unless you explicitly set `heartbeat.enabled` to `false`. Across Node.js, Bun, Deno, and Cloudflare Workers, application shutdown closes tracked websocket clients and gives `@OnDisconnect()` cleanup a chance to finish within `shutdown.timeoutMs`.
+When omitted, `@fluojs/websockets` now applies bounded defaults for concurrent connections and inbound payload size. Server-backed Node listeners also enable heartbeat timers unless you explicitly set `heartbeat.enabled` to `false`. The official fetch-style runtime modules (`@fluojs/websockets/bun`, `@fluojs/websockets/deno`, and `@fluojs/websockets/cloudflare-workers`) close tracked websocket clients during application shutdown and give `@OnDisconnect()` cleanup a bounded chance to finish within `shutdown.timeoutMs`.
 
 ## Public API Overview
 
@@ -131,3 +131,5 @@ Use the runtime subpaths when you want an explicit runtime binding instead of th
 - `packages/websockets/src/public-surface.test.ts`
 - `packages/websockets/src/node/node.test.ts`
 - `packages/websockets/src/bun/bun.test.ts`
+- `packages/websockets/src/deno/deno.test.ts`
+- `packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts`

--- a/packages/websockets/README.md
+++ b/packages/websockets/README.md
@@ -101,7 +101,7 @@ WebSocketModule.forRoot({
 });
 ```
 
-When omitted, `@fluojs/websockets` now applies bounded defaults for concurrent connections and inbound payload size. Server-backed Node listeners also enable heartbeat timers unless you explicitly set `heartbeat.enabled` to `false`.
+When omitted, `@fluojs/websockets` now applies bounded defaults for concurrent connections and inbound payload size. Server-backed Node listeners also enable heartbeat timers unless you explicitly set `heartbeat.enabled` to `false`. Across Node.js, Bun, Deno, and Cloudflare Workers, application shutdown closes tracked websocket clients and gives `@OnDisconnect()` cleanup a chance to finish within `shutdown.timeoutMs`.
 
 ## Public API Overview
 

--- a/packages/websockets/src/bun/bun-service.ts
+++ b/packages/websockets/src/bun/bun-service.ts
@@ -38,16 +38,22 @@ interface ConnectionHandlerState {
   bufferedDisconnect: BufferedDisconnectEvent | undefined;
   bufferedMessages: BunWebSocketMessage[];
   bufferedMessagesStartIndex: number;
+  connectLifecycleSettled: boolean;
+  connectLifecyclePromise: Promise<void>;
   descriptors: readonly WebSocketGatewayDescriptor[];
+  disconnectLifecycleSettled: boolean;
+  disconnectLifecyclePromise: Promise<void>;
   enqueuedMessageCount: number;
   handlerQueue: Promise<void>;
   handlersReady: boolean;
   processingMessageQueue: boolean;
-  queuedMessages: BunWebSocketMessage[];
-  queuedMessagesStartIndex: number;
-  request: Request;
-  resolved: ResolvedGatewayInstance[];
-  socketId: string;
+    queuedMessages: BunWebSocketMessage[];
+    queuedMessagesStartIndex: number;
+    request: Request;
+    resolveConnectLifecycle: () => void;
+    resolveDisconnectLifecycle: () => void;
+    resolved: ResolvedGatewayInstance[];
+    socketId: string;
 }
 
 interface BunSocketData {
@@ -131,6 +137,15 @@ function resolveMessageByteLength(message: BunWebSocketMessage): number {
 
 function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
+}
+
+function createCompletionSignal(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
 }
 
 /**
@@ -307,20 +322,35 @@ export class BunWebSocketGatewayLifecycleService
     this.socketRegistry.set(state.socketId, socket);
     this.socketStates.set(state.socketId, state);
 
-    await this.resolveConnectionGateways(state);
-    await this.runConnectHandlers(state, socket);
-    await this.finalizeConnectionBinding(state, socket);
+    try {
+      await this.resolveConnectionGateways(state);
+      await this.runConnectHandlers(state, socket);
+      await this.finalizeConnectionBinding(state, socket);
+    } finally {
+      if (!state.handlersReady && state.bufferedDisconnect) {
+        this.settleDisconnectLifecycle(state);
+      }
+
+      this.settleConnectLifecycle(state);
+    }
   }
 
   private createConnectionHandlerState(
     request: Request,
     descriptors: readonly WebSocketGatewayDescriptor[],
   ): ConnectionHandlerState {
+    const connectLifecycle = createCompletionSignal();
+    const disconnectLifecycle = createCompletionSignal();
+
     return {
       bufferedDisconnect: undefined,
       bufferedMessages: [],
       bufferedMessagesStartIndex: 0,
+      connectLifecycleSettled: false,
+      connectLifecyclePromise: connectLifecycle.promise,
       descriptors,
+      disconnectLifecycleSettled: false,
+      disconnectLifecyclePromise: disconnectLifecycle.promise,
       enqueuedMessageCount: 0,
       handlerQueue: Promise.resolve(),
       handlersReady: false,
@@ -328,9 +358,29 @@ export class BunWebSocketGatewayLifecycleService
       queuedMessages: [],
       queuedMessagesStartIndex: 0,
       request,
+      resolveConnectLifecycle: connectLifecycle.resolve,
+      resolveDisconnectLifecycle: disconnectLifecycle.resolve,
       resolved: [],
       socketId: crypto.randomUUID(),
     };
+  }
+
+  private settleConnectLifecycle(state: ConnectionHandlerState): void {
+    if (state.connectLifecycleSettled) {
+      return;
+    }
+
+    state.connectLifecycleSettled = true;
+    state.resolveConnectLifecycle();
+  }
+
+  private settleDisconnectLifecycle(state: ConnectionHandlerState): void {
+    if (state.disconnectLifecycleSettled) {
+      return;
+    }
+
+    state.disconnectLifecycleSettled = true;
+    state.resolveDisconnectLifecycle();
   }
 
   private getBufferedMessageCount(state: ConnectionHandlerState): number {
@@ -533,6 +583,9 @@ export class BunWebSocketGatewayLifecycleService
       })
       .catch((error) => {
         this.logger.error('WebSocket gateway disconnect dispatch failed.', error, LIFECYCLE_LOG_CONTEXT);
+      })
+      .finally(() => {
+        this.settleDisconnectLifecycle(state);
       });
   }
 
@@ -797,7 +850,10 @@ export class BunWebSocketGatewayLifecycleService
         reject(new Error(`Timed out while closing Bun websocket connections after ${String(timeoutMs)}ms.`));
       }, timeoutMs);
 
-      Promise.all(states.map(async (state) => await state.handlerQueue))
+      Promise.all(states.map(async (state) => {
+        await state.connectLifecyclePromise;
+        await state.disconnectLifecyclePromise;
+      }))
         .then(() => {
           if (settled) {
             return;

--- a/packages/websockets/src/bun/bun-service.ts
+++ b/packages/websockets/src/bun/bun-service.ts
@@ -155,6 +155,8 @@ function createCompletionSignal(): { promise: Promise<void>; resolve: () => void
 export class BunWebSocketGatewayLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
 {
+  private isShuttingDown = false;
+  private readonly pendingUpgradeOperations = new Set<Promise<void>>();
   private pendingUpgradeReservations = 0;
   private readonly roomSockets = new Map<string, Set<string>>();
   private shutdownPromise: Promise<void> | undefined;
@@ -217,7 +219,9 @@ export class BunWebSocketGatewayLifecycleService
     const descriptorsByPath = this.groupDescriptorsByPath(descriptors);
 
     return {
-      fetch: (request, server) => this.handleUpgradeRequest(request, server, descriptorsByPath),
+      fetch: (request, server) => this.trackPendingUpgradeOperation(
+        this.handleUpgradeRequest(request, server, descriptorsByPath),
+      ),
       websocket: {
         backpressureLimit: this.resolveBackpressureLimit(),
         close: (socket, code, reason) => {
@@ -235,7 +239,7 @@ export class BunWebSocketGatewayLifecycleService
           this.handleSocketMessage(socket, message);
         },
         open: (socket) => {
-          void this.bindConnectionHandlers(socket).catch((error) => {
+          void this.trackPendingUpgradeOperation(this.bindConnectionHandlers(socket)).catch((error) => {
             this.unregisterSocket(socket.data.state.socketId);
             this.logger.error('WebSocket gateway open lifecycle failed.', error, LIFECYCLE_LOG_CONTEXT);
             socket.close(1011, 'Internal server error');
@@ -297,6 +301,11 @@ export class BunWebSocketGatewayLifecycleService
       });
     }
 
+    if (this.isShuttingDown) {
+      this.releaseUpgradeReservation();
+      return new Response('WebSocket server is shutting down.', { status: 503 });
+    }
+
     const state = this.createConnectionHandlerState(request, [...descriptors]);
     let upgraded = false;
 
@@ -326,6 +335,11 @@ export class BunWebSocketGatewayLifecycleService
       await this.resolveConnectionGateways(state);
       await this.runConnectHandlers(state, socket);
       await this.finalizeConnectionBinding(state, socket);
+
+      if (this.isShuttingDown && socket.readyState === 1) {
+        socket.close(1001, 'Server shutting down');
+        await state.disconnectLifecyclePromise;
+      }
     } finally {
       if (!state.handlersReady && state.bufferedDisconnect) {
         this.settleDisconnectLifecycle(state);
@@ -655,6 +669,13 @@ export class BunWebSocketGatewayLifecycleService
     request: Request,
     path: string,
   ): Promise<WebSocketUpgradeRejection | undefined> {
+    if (this.isShuttingDown) {
+      return {
+        body: 'WebSocket server is shutting down.',
+        status: 503,
+      };
+    }
+
     if (!this.tryReserveUpgradeSlot()) {
       return {
         body: 'WebSocket connection limit exceeded.',
@@ -795,6 +816,8 @@ export class BunWebSocketGatewayLifecycleService
   }
 
   private async runShutdownLifecycle(): Promise<void> {
+    this.isShuttingDown = true;
+
     if (hasBunWebSocketBindingHost(this.adapter)) {
       const bunAdapter = this.adapter as HttpApplicationAdapter & BunWebSocketBindingHost;
       bunAdapter.configureWebSocketBinding(undefined);
@@ -802,6 +825,7 @@ export class BunWebSocketGatewayLifecycleService
 
     const shutdownTimeoutMs = this.resolveShutdownTimeoutMs();
 
+    await this.awaitPendingUpgradeOperations(shutdownTimeoutMs);
     await this.closeActiveSockets(shutdownTimeoutMs);
 
     this.pendingUpgradeReservations = 0;
@@ -809,6 +833,65 @@ export class BunWebSocketGatewayLifecycleService
     this.socketRooms.clear();
     this.socketStates.clear();
     this.roomSockets.clear();
+  }
+
+  private trackPendingUpgradeOperation<T>(operation: Promise<T>): Promise<T> {
+    let trackedOperation: Promise<void> | undefined;
+
+    trackedOperation = operation
+      .then(() => undefined, () => undefined)
+      .finally(() => {
+        if (trackedOperation) {
+          this.pendingUpgradeOperations.delete(trackedOperation);
+        }
+      });
+
+    this.pendingUpgradeOperations.add(trackedOperation);
+    return operation;
+  }
+
+  private async awaitPendingUpgradeOperations(timeoutMs: number): Promise<void> {
+    if (this.pendingUpgradeOperations.size === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(new Error(`Timed out while waiting for in-flight Bun websocket upgrades after ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+
+      Promise.all([...this.pendingUpgradeOperations])
+        .then(() => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        })
+        .catch((error) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          reject(error);
+        });
+    }).catch((error) => {
+      this.logger.error(
+        `Failed to wait for in-flight Bun websocket upgrades within ${String(timeoutMs)}ms.`,
+        error,
+        LIFECYCLE_LOG_CONTEXT,
+      );
+    });
   }
 
   private async closeActiveSockets(timeoutMs: number): Promise<void> {

--- a/packages/websockets/src/bun/bun-service.ts
+++ b/packages/websockets/src/bun/bun-service.ts
@@ -57,6 +57,7 @@ interface BunSocketData {
 const DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET = 256;
 const DEFAULT_MAX_WEBSOCKET_CONNECTIONS = 1_000;
 const DEFAULT_MAX_WEBSOCKET_PAYLOAD_BYTES = 1_048_576;
+const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LIFECYCLE_LOG_CONTEXT = 'WebSocketGatewayLifecycleService';
 
 type FetchStyleRealtimeCapability = {
@@ -144,6 +145,7 @@ export class BunWebSocketGatewayLifecycleService
   private shutdownPromise: Promise<void> | undefined;
   private readonly socketRegistry = new Map<string, BunServerWebSocket<BunSocketData>>();
   private readonly socketRooms = new Map<string, Set<string>>();
+  private readonly socketStates = new Map<string, ConnectionHandlerState>();
 
   constructor(
     private readonly runtimeContainer: Container,
@@ -303,6 +305,7 @@ export class BunWebSocketGatewayLifecycleService
 
     this.releaseUpgradeReservation();
     this.socketRegistry.set(state.socketId, socket);
+    this.socketStates.set(state.socketId, state);
 
     await this.resolveConnectionGateways(state);
     await this.runConnectHandlers(state, socket);
@@ -718,6 +721,16 @@ export class BunWebSocketGatewayLifecycleService
     return Math.max(1, Math.ceil(configured / 1000));
   }
 
+  private resolveShutdownTimeoutMs(): number {
+    const configured = this.moduleOptions.shutdown?.timeoutMs;
+
+    if (typeof configured !== 'number' || !Number.isFinite(configured) || configured <= 0) {
+      return DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS;
+    }
+
+    return Math.floor(configured);
+  }
+
   private async shutdown(): Promise<void> {
     if (this.shutdownPromise) {
       await this.shutdownPromise;
@@ -734,10 +747,82 @@ export class BunWebSocketGatewayLifecycleService
       bunAdapter.configureWebSocketBinding(undefined);
     }
 
+    const shutdownTimeoutMs = this.resolveShutdownTimeoutMs();
+
+    await this.closeActiveSockets(shutdownTimeoutMs);
+
     this.pendingUpgradeReservations = 0;
     this.socketRegistry.clear();
     this.socketRooms.clear();
+    this.socketStates.clear();
     this.roomSockets.clear();
+  }
+
+  private async closeActiveSockets(timeoutMs: number): Promise<void> {
+    const activeSockets = [...this.socketRegistry.entries()];
+
+    if (activeSockets.length === 0) {
+      return;
+    }
+
+    const activeStates = activeSockets
+      .map(([socketId]) => this.socketStates.get(socketId))
+      .filter((state): state is ConnectionHandlerState => state !== undefined);
+
+    for (const [, socket] of activeSockets) {
+      if (socket.readyState === 1) {
+        socket.close(1001, 'Server shutting down');
+      }
+    }
+
+    await this.awaitHandlerQueueDrain(activeStates, timeoutMs);
+  }
+
+  private async awaitHandlerQueueDrain(
+    states: readonly ConnectionHandlerState[],
+    timeoutMs: number,
+  ): Promise<void> {
+    if (states.length === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(new Error(`Timed out while closing Bun websocket connections after ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+
+      Promise.all(states.map(async (state) => await state.handlerQueue))
+        .then(() => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        })
+        .catch((error) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          reject(error);
+        });
+    }).catch((error) => {
+      this.logger.error(
+        `Failed to close Bun websocket connections within ${String(timeoutMs)}ms.`,
+        error,
+        LIFECYCLE_LOG_CONTEXT,
+      );
+    });
   }
 
   joinRoom(socketId: string, room: string): void {
@@ -813,6 +898,7 @@ export class BunWebSocketGatewayLifecycleService
 
   private unregisterSocket(socketId: string): void {
     this.socketRegistry.delete(socketId);
+    this.socketStates.delete(socketId);
 
     const rooms = this.socketRooms.get(socketId);
     if (rooms) {

--- a/packages/websockets/src/bun/bun-service.ts
+++ b/packages/websockets/src/bun/bun-service.ts
@@ -46,10 +46,13 @@ interface ConnectionHandlerState {
   enqueuedMessageCount: number;
   handlerQueue: Promise<void>;
   handlersReady: boolean;
+  openRegistrationSettled: boolean;
+  openRegistrationPromise: Promise<void>;
   processingMessageQueue: boolean;
     queuedMessages: BunWebSocketMessage[];
     queuedMessagesStartIndex: number;
     request: Request;
+    resolveOpenRegistration: () => void;
     resolveConnectLifecycle: () => void;
     resolveDisconnectLifecycle: () => void;
     resolved: ResolvedGatewayInstance[];
@@ -307,16 +310,19 @@ export class BunWebSocketGatewayLifecycleService
     }
 
     const state = this.createConnectionHandlerState(request, [...descriptors]);
+    void this.trackPendingUpgradeOperation(state.openRegistrationPromise);
     let upgraded = false;
 
     try {
       upgraded = server.upgrade(request, { data: { state } });
     } catch (error) {
+      this.settleOpenRegistration(state);
       this.releaseUpgradeReservation();
       throw error;
     }
 
     if (!upgraded) {
+      this.settleOpenRegistration(state);
       this.releaseUpgradeReservation();
       return new Response(null, { status: 400 });
     }
@@ -330,6 +336,7 @@ export class BunWebSocketGatewayLifecycleService
     this.releaseUpgradeReservation();
     this.socketRegistry.set(state.socketId, socket);
     this.socketStates.set(state.socketId, state);
+    this.settleOpenRegistration(state);
 
     try {
       await this.resolveConnectionGateways(state);
@@ -355,6 +362,7 @@ export class BunWebSocketGatewayLifecycleService
   ): ConnectionHandlerState {
     const connectLifecycle = createCompletionSignal();
     const disconnectLifecycle = createCompletionSignal();
+    const openRegistration = createCompletionSignal();
 
     return {
       bufferedDisconnect: undefined,
@@ -368,15 +376,27 @@ export class BunWebSocketGatewayLifecycleService
       enqueuedMessageCount: 0,
       handlerQueue: Promise.resolve(),
       handlersReady: false,
+      openRegistrationSettled: false,
+      openRegistrationPromise: openRegistration.promise,
       processingMessageQueue: false,
       queuedMessages: [],
       queuedMessagesStartIndex: 0,
       request,
+      resolveOpenRegistration: openRegistration.resolve,
       resolveConnectLifecycle: connectLifecycle.resolve,
       resolveDisconnectLifecycle: disconnectLifecycle.resolve,
       resolved: [],
       socketId: crypto.randomUUID(),
     };
+  }
+
+  private settleOpenRegistration(state: ConnectionHandlerState): void {
+    if (state.openRegistrationSettled) {
+      return;
+    }
+
+    state.openRegistrationSettled = true;
+    state.resolveOpenRegistration();
   }
 
   private settleConnectLifecycle(state: ConnectionHandlerState): void {

--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -546,6 +546,122 @@ describe('@fluojs/websockets/bun', () => {
     expect(state.disconnectCount).toBe(1);
   });
 
+  it('waits for asynchronous Bun disconnect cleanup before finishing shutdown', async () => {
+    const adapter = new TestBunAdapter();
+    const connected = createDeferred<void>();
+    const disconnectGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-async-disconnect' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      async onDisconnect() {
+        await disconnectGate.promise;
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('http://127.0.0.1:3000/shutdown-async-disconnect', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    await connected.promise;
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.disconnectCount).toBe(0);
+
+    disconnectGate.resolve();
+    await closePromise;
+
+    expect(state.disconnectCount).toBe(1);
+  });
+
+  it('bounds Bun disconnect cleanup waits by shutdown.timeoutMs', async () => {
+    const adapter = new TestBunAdapter();
+    const connected = createDeferred<void>();
+    const disconnectGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-disconnect-timeout' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      async onDisconnect() {
+        await disconnectGate.promise;
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({ shutdown: { timeoutMs: 1 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('http://127.0.0.1:3000/shutdown-disconnect-timeout', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    await connected.promise;
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await closePromise;
+
+    expect(closed).toBe(true);
+    expect(state.disconnectCount).toBe(0);
+  });
+
   it('waits for in-flight Bun connect handlers to replay buffered disconnects during shutdown', async () => {
     const adapter = new TestBunAdapter();
     const connectGate = createDeferred<void>();

--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -59,6 +59,7 @@ class TestBunAdapter implements HttpApplicationAdapter, BunWebSocketBindingHost 
 }
 
 class TestBunServer implements BunServerLike {
+  closeDeliveryPromise?: Promise<void>;
   lastSocket?: MockSocket;
 
   constructor(private readonly binding?: BunWebSocketBinding<unknown>) {}
@@ -96,7 +97,12 @@ class TestBunServer implements BunServerLike {
 
     let socket!: MockSocket;
     socket = createMockSocket(options?.data, (code, reason) => {
-      void Promise.resolve(this.binding?.websocket.close?.(socket, code ?? 1000, reason ?? ''));
+      const deliver = () => Promise.resolve(this.binding?.websocket.close?.(socket, code ?? 1000, reason ?? ''));
+      if (this.closeDeliveryPromise) {
+        return this.closeDeliveryPromise.then(deliver);
+      }
+
+      return deliver();
     });
     this.lastSocket = socket;
     void Promise.resolve(this.binding.websocket.open?.(socket));
@@ -474,6 +480,130 @@ describe('@fluojs/websockets/bun', () => {
     expect(state.connectCount).toBe(1);
     expect(state.disconnectCount).toBe(1);
     expect((Reflect.get(service, 'socketRegistry') as Map<string, MockSocket>).size).toBe(0);
+  });
+
+  it('waits for asynchronously delivered Bun close events during shutdown', async () => {
+    const adapter = new TestBunAdapter();
+    const connected = createDeferred<void>();
+    const closeGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-async-close' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('http://127.0.0.1:3000/shutdown-async-close', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    if (!server) {
+      throw new Error('Expected Bun test server to be available after websocket upgrade.');
+    }
+
+    await connected.promise;
+    server.closeDeliveryPromise = closeGate.promise;
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.disconnectCount).toBe(0);
+
+    closeGate.resolve();
+    await closePromise;
+
+    expect(state.disconnectCount).toBe(1);
+  });
+
+  it('waits for in-flight Bun connect handlers to replay buffered disconnects during shutdown', async () => {
+    const adapter = new TestBunAdapter();
+    const connectGate = createDeferred<void>();
+
+    class GatewayState {
+      connectCount = 0;
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-connect-in-flight' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      async onConnect() {
+        await connectGate.promise;
+        this.state.connectCount += 1;
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('http://127.0.0.1:3000/shutdown-connect-in-flight', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.connectCount).toBe(0);
+    expect(state.disconnectCount).toBe(0);
+
+    connectGate.resolve();
+    await closePromise;
+
+    expect(state.connectCount).toBe(1);
+    expect(state.disconnectCount).toBe(1);
   });
 
   it('closes Bun sockets when inbound payloads exceed the configured limit', async () => {

--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -22,6 +22,9 @@ type MockSocket = BunServerWebSocket<unknown> & {
   sentMessages: string[];
 };
 
+const WEBSOCKET_CLOSED_READY_STATE = 3;
+const WEBSOCKET_OPEN_READY_STATE = 1;
+
 class TestBunAdapter implements HttpApplicationAdapter, BunWebSocketBindingHost {
   private binding?: BunWebSocketBinding<unknown>;
   private server?: TestBunServer;
@@ -91,18 +94,31 @@ class TestBunServer implements BunServerLike {
       return false;
     }
 
-    const socket = createMockSocket(options?.data);
+    let socket!: MockSocket;
+    socket = createMockSocket(options?.data, (code, reason) => {
+      void Promise.resolve(this.binding?.websocket.close?.(socket, code ?? 1000, reason ?? ''));
+    });
     this.lastSocket = socket;
     void Promise.resolve(this.binding.websocket.open?.(socket));
     return true;
   }
 }
 
-function createMockSocket(data: unknown): MockSocket {
+function createMockSocket(
+  data: unknown,
+  onClose?: (code?: number, reason?: string) => void,
+): MockSocket {
   const subscriptions = new Set<string>();
+  let readyState = WEBSOCKET_OPEN_READY_STATE;
   const socket: MockSocket = {
     close(code?: number, reason?: string) {
+      if (readyState === WEBSOCKET_CLOSED_READY_STATE) {
+        return;
+      }
+
+      readyState = WEBSOCKET_CLOSED_READY_STATE;
       socket.closeCalls.push({ code, reason });
+      onClose?.(code, reason);
     },
     closeCalls: [],
     cork(callback: (target: BunServerWebSocket<unknown>) => void) {
@@ -113,7 +129,9 @@ function createMockSocket(data: unknown): MockSocket {
       return subscriptions.has(topic);
     },
     publish() {},
-    readyState: 1,
+    get readyState() {
+      return readyState;
+    },
     remoteAddress: '127.0.0.1',
     send(message: BunWebSocketMessage) {
       if (typeof message === 'string') {
@@ -392,6 +410,70 @@ describe('@fluojs/websockets/bun', () => {
     expect(await firstUpgradePromise).toBeUndefined();
 
     await app.close();
+  });
+
+  it('closes Bun sockets and runs disconnect cleanup during application shutdown', async () => {
+    const adapter = new TestBunAdapter();
+    const connected = createDeferred<void>();
+
+    class GatewayState {
+      connectCount = 0;
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        this.state.connectCount += 1;
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({
+        shutdown: { timeoutMs: 200 },
+      })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    const service = await app.container.resolve(BunWebSocketGatewayLifecycleService);
+    await app.listen();
+
+    const server = adapter.getServer();
+    const upgradeResponse = await server?.fetch(new Request('http://127.0.0.1:3000/shutdown', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    await flushAsyncWork();
+
+    const socket = server?.lastSocket;
+    expect(upgradeResponse).toBeUndefined();
+
+    if (!socket) {
+      throw new Error('Expected Bun test socket to be available after websocket upgrade.');
+    }
+
+    await connected.promise;
+    await app.close();
+    await flushAsyncWork();
+
+    expect(socket.closeCalls).toEqual([{ code: 1001, reason: 'Server shutting down' }]);
+    expect(socket.readyState).toBe(WEBSOCKET_CLOSED_READY_STATE);
+    expect(state.connectCount).toBe(1);
+    expect(state.disconnectCount).toBe(1);
+    expect((Reflect.get(service, 'socketRegistry') as Map<string, MockSocket>).size).toBe(0);
   });
 
   it('closes Bun sockets when inbound payloads exceed the configured limit', async () => {

--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -61,6 +61,7 @@ class TestBunAdapter implements HttpApplicationAdapter, BunWebSocketBindingHost 
 class TestBunServer implements BunServerLike {
   closeDeliveryPromise?: Promise<void>;
   lastSocket?: MockSocket;
+  openDeliveryPromise?: Promise<void>;
 
   constructor(private readonly binding?: BunWebSocketBinding<unknown>) {}
 
@@ -105,7 +106,15 @@ class TestBunServer implements BunServerLike {
       return deliver();
     });
     this.lastSocket = socket;
-    void Promise.resolve(this.binding.websocket.open?.(socket));
+
+    const deliverOpen = () => Promise.resolve(this.binding?.websocket.open?.(socket));
+
+    if (this.openDeliveryPromise) {
+      void this.openDeliveryPromise.then(deliverOpen);
+    } else {
+      void deliverOpen();
+    }
+
     return true;
   }
 }
@@ -766,6 +775,85 @@ describe('@fluojs/websockets/bun', () => {
 
     expect(state.connectCount).toBe(1);
     expect(state.disconnectCount).toBe(1);
+  });
+
+  it('keeps shutdown pending across the Bun upgrade-success before open-callback race', async () => {
+    const adapter = new TestBunAdapter();
+    const openGate = createDeferred<void>();
+
+    class GatewayState {
+      connectCount = 0;
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-open-race' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        this.state.connectCount += 1;
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    const service = await app.container.resolve(BunWebSocketGatewayLifecycleService);
+    await app.listen();
+
+    const server = adapter.getServer();
+
+    if (!server) {
+      throw new Error('Expected Bun test server to be available after application listen.');
+    }
+
+    server.openDeliveryPromise = openGate.promise;
+
+    const upgradeResponse = await server.fetch(new Request('http://127.0.0.1:3000/shutdown-open-race', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    const socket = server.lastSocket;
+
+    expect(upgradeResponse).toBeUndefined();
+
+    if (!socket) {
+      throw new Error('Expected Bun test socket to be available after websocket upgrade.');
+    }
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(socket.closeCalls).toEqual([]);
+    expect((Reflect.get(service, 'socketRegistry') as Map<string, MockSocket>).size).toBe(0);
+
+    openGate.resolve();
+    await closePromise;
+    await flushAsyncWork();
+
+    expect(closed).toBe(true);
+    expect(socket.closeCalls).toEqual([{ code: 1001, reason: 'Server shutting down' }]);
+    expect(socket.readyState).toBe(WEBSOCKET_CLOSED_READY_STATE);
+    expect(state.connectCount).toBe(1);
+    expect(state.disconnectCount).toBe(1);
+    expect((Reflect.get(service, 'socketRegistry') as Map<string, MockSocket>).size).toBe(0);
   });
 
   it('closes Bun sockets when inbound payloads exceed the configured limit', async () => {

--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -418,6 +418,52 @@ describe('@fluojs/websockets/bun', () => {
     await app.close();
   });
 
+  it('rejects in-flight Bun upgrades once shutdown begins during an async guard', async () => {
+    const adapter = new TestBunAdapter();
+    const guardGate = createDeferred<void>();
+
+    @WebSocketGateway({ path: '/shutdown-guard-race' })
+    class GuardedGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({
+        upgrade: {
+          async guard() {
+            await guardGate.promise;
+            return true;
+          },
+        },
+      })],
+      providers: [GuardedGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    await app.listen();
+
+    const server = adapter.getServer();
+    const upgradePromise = server?.fetch(new Request('http://127.0.0.1:3000/shutdown-guard-race', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    await flushAsyncWork();
+
+    const closePromise = app.close();
+
+    guardGate.resolve();
+
+    const response = await upgradePromise;
+
+    expect(response?.status).toBe(503);
+    expect(await response?.text()).toBe('WebSocket server is shutting down.');
+    expect(server?.lastSocket).toBeUndefined();
+
+    await closePromise;
+  });
+
   it('closes Bun sockets and runs disconnect cleanup during application shutdown', async () => {
     const adapter = new TestBunAdapter();
     const connected = createDeferred<void>();

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
@@ -33,7 +33,11 @@ interface ConnectionHandlerState {
   bufferedDisconnect: BufferedDisconnectEvent | undefined;
   bufferedMessages: CloudflareWorkerWebSocketMessage[];
   bufferedMessagesStartIndex: number;
+  connectLifecycleSettled: boolean;
+  connectLifecyclePromise: Promise<void>;
   descriptors: readonly WebSocketGatewayDescriptor[];
+  disconnectLifecycleSettled: boolean;
+  disconnectLifecyclePromise: Promise<void>;
   enqueuedMessageCount: number;
   handlerQueue: Promise<void>;
   handlersReady: boolean;
@@ -41,6 +45,8 @@ interface ConnectionHandlerState {
   queuedMessages: CloudflareWorkerWebSocketMessage[];
   queuedMessagesStartIndex: number;
   request: Request;
+  resolveConnectLifecycle: () => void;
+  resolveDisconnectLifecycle: () => void;
   resolved: ResolvedGatewayInstance[];
   socketId: string;
 }
@@ -127,6 +133,15 @@ function resolveMessageByteLength(message: CloudflareWorkerWebSocketMessage): nu
   }
 
   return message.byteLength;
+}
+
+function createCompletionSignal(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
 }
 
 /**
@@ -277,20 +292,35 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
     this.socketStates.set(state.socketId, state);
     this.attachConnectionListeners(state, socket, request);
 
-    await this.resolveConnectionGateways(state);
-    await this.runConnectHandlers(state, socket);
-    await this.finalizeConnectionBinding(state, socket, request);
+    try {
+      await this.resolveConnectionGateways(state);
+      await this.runConnectHandlers(state, socket);
+      await this.finalizeConnectionBinding(state, socket, request);
+    } finally {
+      if (!state.handlersReady && state.bufferedDisconnect) {
+        this.settleDisconnectLifecycle(state);
+      }
+
+      this.settleConnectLifecycle(state);
+    }
   }
 
   private createConnectionHandlerState(
     request: Request,
     descriptors: readonly WebSocketGatewayDescriptor[],
   ): ConnectionHandlerState {
+    const connectLifecycle = createCompletionSignal();
+    const disconnectLifecycle = createCompletionSignal();
+
     return {
       bufferedDisconnect: undefined,
       bufferedMessages: [],
       bufferedMessagesStartIndex: 0,
+      connectLifecycleSettled: false,
+      connectLifecyclePromise: connectLifecycle.promise,
       descriptors,
+      disconnectLifecycleSettled: false,
+      disconnectLifecyclePromise: disconnectLifecycle.promise,
       enqueuedMessageCount: 0,
       handlerQueue: Promise.resolve(),
       handlersReady: false,
@@ -298,9 +328,29 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
       queuedMessages: [],
       queuedMessagesStartIndex: 0,
       request,
+      resolveConnectLifecycle: connectLifecycle.resolve,
+      resolveDisconnectLifecycle: disconnectLifecycle.resolve,
       resolved: [],
       socketId: crypto.randomUUID(),
     };
+  }
+
+  private settleConnectLifecycle(state: ConnectionHandlerState): void {
+    if (state.connectLifecycleSettled) {
+      return;
+    }
+
+    state.connectLifecycleSettled = true;
+    state.resolveConnectLifecycle();
+  }
+
+  private settleDisconnectLifecycle(state: ConnectionHandlerState): void {
+    if (state.disconnectLifecycleSettled) {
+      return;
+    }
+
+    state.disconnectLifecycleSettled = true;
+    state.resolveDisconnectLifecycle();
   }
 
   private attachConnectionListeners(
@@ -530,6 +580,9 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
       })
       .catch((error) => {
         this.logger.error('WebSocket gateway disconnect dispatch failed.', error, LIFECYCLE_LOG_CONTEXT);
+      })
+      .finally(() => {
+        this.settleDisconnectLifecycle(state);
       });
   }
 
@@ -788,7 +841,10 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
         reject(new Error(`Timed out while closing Cloudflare Worker websocket connections after ${String(timeoutMs)}ms.`));
       }, timeoutMs);
 
-      Promise.all(states.map(async (state) => await state.handlerQueue))
+      Promise.all(states.map(async (state) => {
+        await state.connectLifecyclePromise;
+        await state.disconnectLifecyclePromise;
+      }))
         .then(() => {
           if (settled) {
             return;

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
@@ -151,6 +151,8 @@ function createCompletionSignal(): { promise: Promise<void>; resolve: () => void
 export class CloudflareWorkersWebSocketGatewayLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
 {
+  private isShuttingDown = false;
+  private readonly pendingUpgradeOperations = new Set<Promise<void>>();
   private pendingUpgradeReservations = 0;
   private readonly roomSockets = new Map<string, Set<string>>();
   private shutdownPromise: Promise<void> | undefined;
@@ -212,53 +214,66 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
     const descriptorsByPath = this.groupDescriptorsByPath(descriptors);
 
     return {
-      fetch: async (request, host) => {
-        if (!isWebSocketUpgradeRequest(request)) {
-          return new Response(null, { status: 426 });
-        }
-
-        let targetPath: string;
-
-        try {
-          targetPath = normalizeGatewayPath(new URL(request.url).pathname);
-        } catch {
-          return new Response(null, { status: 400 });
-        }
-
-        const matchedDescriptors = descriptorsByPath.get(targetPath);
-
-        if (!matchedDescriptors) {
-          return new Response(null, { status: 404 });
-        }
-
-        const rejection = await this.resolveUpgradeRejection(request, targetPath);
-
-        if (rejection) {
-          return new Response(rejection.body ?? null, {
-            headers: rejection.headers,
-            status: rejection.status,
-          });
-        }
-
-        let response: Response;
-        let serverSocket: CloudflareWorkerWebSocket;
-
-        try {
-          ({ response, serverSocket } = host.upgrade(request));
-        } catch (error) {
-          this.releaseUpgradeReservation();
-          throw error;
-        }
-
-        serverSocket.accept();
-        void this.bindConnectionHandlers(serverSocket, request, matchedDescriptors).catch((error) => {
-          this.unregisterSocket(this.findSocketId(serverSocket));
-          this.logger.error('WebSocket gateway open lifecycle failed.', error, LIFECYCLE_LOG_CONTEXT);
-          serverSocket.close(1011, 'Internal server error');
-        });
-        return response;
-      },
+      fetch: (request, host) => this.trackPendingUpgradeOperation(
+        this.handleUpgradeRequest(request, host, descriptorsByPath),
+      ),
     };
+  }
+
+  private async handleUpgradeRequest(
+    request: Request,
+    host: import('./cloudflare-workers-types.js').CloudflareWorkerWebSocketUpgradeHost,
+    descriptorsByPath: ReadonlyMap<string, readonly WebSocketGatewayDescriptor[]>,
+  ): Promise<Response> {
+    if (!isWebSocketUpgradeRequest(request)) {
+      return new Response(null, { status: 426 });
+    }
+
+    let targetPath: string;
+
+    try {
+      targetPath = normalizeGatewayPath(new URL(request.url).pathname);
+    } catch {
+      return new Response(null, { status: 400 });
+    }
+
+    const matchedDescriptors = descriptorsByPath.get(targetPath);
+
+    if (!matchedDescriptors) {
+      return new Response(null, { status: 404 });
+    }
+
+    const rejection = await this.resolveUpgradeRejection(request, targetPath);
+
+    if (rejection) {
+      return new Response(rejection.body ?? null, {
+        headers: rejection.headers,
+        status: rejection.status,
+      });
+    }
+
+    if (this.isShuttingDown) {
+      this.releaseUpgradeReservation();
+      return new Response('WebSocket server is shutting down.', { status: 503 });
+    }
+
+    let response: Response;
+    let serverSocket: CloudflareWorkerWebSocket;
+
+    try {
+      ({ response, serverSocket } = host.upgrade(request));
+    } catch (error) {
+      this.releaseUpgradeReservation();
+      throw error;
+    }
+
+    serverSocket.accept();
+    void this.trackPendingUpgradeOperation(this.bindConnectionHandlers(serverSocket, request, matchedDescriptors)).catch((error) => {
+      this.unregisterSocket(this.findSocketId(serverSocket));
+      this.logger.error('WebSocket gateway open lifecycle failed.', error, LIFECYCLE_LOG_CONTEXT);
+      serverSocket.close(1011, 'Internal server error');
+    });
+    return response;
   }
 
   private groupDescriptorsByPath(
@@ -296,6 +311,11 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
       await this.resolveConnectionGateways(state);
       await this.runConnectHandlers(state, socket);
       await this.finalizeConnectionBinding(state, socket, request);
+
+      if (this.isShuttingDown && socket.readyState === WEBSOCKET_OPEN_READY_STATE) {
+        socket.close(1001, 'Server shutting down');
+        await state.disconnectLifecyclePromise;
+      }
     } finally {
       if (!state.handlersReady && state.bufferedDisconnect) {
         this.settleDisconnectLifecycle(state);
@@ -661,6 +681,13 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
     request: Request,
     path: string,
   ): Promise<WebSocketUpgradeRejection | undefined> {
+    if (this.isShuttingDown) {
+      return {
+        body: 'WebSocket server is shutting down.',
+        status: 503,
+      };
+    }
+
     if (!this.tryReserveUpgradeSlot()) {
       return {
         body: 'WebSocket connection limit exceeded.',
@@ -787,12 +814,15 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
   }
 
   private async runShutdownLifecycle(): Promise<void> {
+    this.isShuttingDown = true;
+
     if (hasCloudflareWorkerWebSocketBindingHost(this.adapter)) {
       this.adapter.configureWebSocketBinding(undefined);
     }
 
     const shutdownTimeoutMs = this.resolveShutdownTimeoutMs();
 
+    await this.awaitPendingUpgradeOperations(shutdownTimeoutMs);
     await this.closeActiveSockets(shutdownTimeoutMs);
 
     this.pendingUpgradeReservations = 0;
@@ -800,6 +830,75 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
     this.socketRooms.clear();
     this.socketStates.clear();
     this.roomSockets.clear();
+  }
+
+  private trackPendingUpgradeOperation<TArgs extends unknown[], TResult>(
+    operation: (...args: TArgs) => Promise<TResult>,
+  ): (...args: TArgs) => Promise<TResult>;
+  private trackPendingUpgradeOperation<TResult>(operation: Promise<TResult>): Promise<TResult>;
+  private trackPendingUpgradeOperation<TArgs extends unknown[], TResult>(
+    operation: Promise<TResult> | ((...args: TArgs) => Promise<TResult>),
+  ): Promise<TResult> | ((...args: TArgs) => Promise<TResult>) {
+    if (typeof operation === 'function') {
+      return (...args: TArgs) => this.trackPendingUpgradeOperation(operation(...args));
+    }
+
+    let trackedOperation: Promise<void> | undefined;
+
+    trackedOperation = operation
+      .then(() => undefined, () => undefined)
+      .finally(() => {
+        if (trackedOperation) {
+          this.pendingUpgradeOperations.delete(trackedOperation);
+        }
+      });
+
+    this.pendingUpgradeOperations.add(trackedOperation);
+    return operation;
+  }
+
+  private async awaitPendingUpgradeOperations(timeoutMs: number): Promise<void> {
+    if (this.pendingUpgradeOperations.size === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(new Error(`Timed out while waiting for in-flight Cloudflare Worker websocket upgrades after ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+
+      Promise.all([...this.pendingUpgradeOperations])
+        .then(() => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        })
+        .catch((error) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          reject(error);
+        });
+    }).catch((error) => {
+      this.logger.error(
+        `Failed to wait for in-flight Cloudflare Worker websocket upgrades within ${String(timeoutMs)}ms.`,
+        error,
+        LIFECYCLE_LOG_CONTEXT,
+      );
+    });
   }
 
   private async closeActiveSockets(timeoutMs: number): Promise<void> {

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
@@ -48,6 +48,7 @@ interface ConnectionHandlerState {
 const DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET = 256;
 const DEFAULT_MAX_WEBSOCKET_CONNECTIONS = 1_000;
 const DEFAULT_MAX_WEBSOCKET_PAYLOAD_BYTES = 1_048_576;
+const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LIFECYCLE_LOG_CONTEXT = 'WebSocketGatewayLifecycleService';
 const WEBSOCKET_OPEN_READY_STATE = 1;
 
@@ -140,6 +141,7 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
   private shutdownPromise: Promise<void> | undefined;
   private readonly socketRegistry = new Map<string, CloudflareWorkerWebSocket>();
   private readonly socketRooms = new Map<string, Set<string>>();
+  private readonly socketStates = new Map<string, ConnectionHandlerState>();
 
   constructor(
     private readonly runtimeContainer: Container,
@@ -272,6 +274,7 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
 
     this.releaseUpgradeReservation();
     this.socketRegistry.set(state.socketId, socket);
+    this.socketStates.set(state.socketId, state);
     this.attachConnectionListeners(state, socket, request);
 
     await this.resolveConnectionGateways(state);
@@ -710,6 +713,16 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
     return configured;
   }
 
+  private resolveShutdownTimeoutMs(): number {
+    const configured = this.moduleOptions.shutdown?.timeoutMs;
+
+    if (typeof configured !== 'number' || !Number.isFinite(configured) || configured <= 0) {
+      return DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS;
+    }
+
+    return Math.floor(configured);
+  }
+
   private async shutdown(): Promise<void> {
     if (this.shutdownPromise) {
       await this.shutdownPromise;
@@ -725,10 +738,82 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
       this.adapter.configureWebSocketBinding(undefined);
     }
 
+    const shutdownTimeoutMs = this.resolveShutdownTimeoutMs();
+
+    await this.closeActiveSockets(shutdownTimeoutMs);
+
     this.pendingUpgradeReservations = 0;
     this.socketRegistry.clear();
     this.socketRooms.clear();
+    this.socketStates.clear();
     this.roomSockets.clear();
+  }
+
+  private async closeActiveSockets(timeoutMs: number): Promise<void> {
+    const activeSockets = [...this.socketRegistry.entries()];
+
+    if (activeSockets.length === 0) {
+      return;
+    }
+
+    const activeStates = activeSockets
+      .map(([socketId]) => this.socketStates.get(socketId))
+      .filter((state): state is ConnectionHandlerState => state !== undefined);
+
+    for (const [, socket] of activeSockets) {
+      if (socket.readyState === WEBSOCKET_OPEN_READY_STATE) {
+        socket.close(1001, 'Server shutting down');
+      }
+    }
+
+    await this.awaitHandlerQueueDrain(activeStates, timeoutMs);
+  }
+
+  private async awaitHandlerQueueDrain(
+    states: readonly ConnectionHandlerState[],
+    timeoutMs: number,
+  ): Promise<void> {
+    if (states.length === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(new Error(`Timed out while closing Cloudflare Worker websocket connections after ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+
+      Promise.all(states.map(async (state) => await state.handlerQueue))
+        .then(() => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        })
+        .catch((error) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          reject(error);
+        });
+    }).catch((error) => {
+      this.logger.error(
+        `Failed to close Cloudflare Worker websocket connections within ${String(timeoutMs)}ms.`,
+        error,
+        LIFECYCLE_LOG_CONTEXT,
+      );
+    });
   }
 
   joinRoom(socketId: string, room: string): void {
@@ -808,6 +893,7 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
     }
 
     this.socketRegistry.delete(socketId);
+    this.socketStates.delete(socketId);
 
     const rooms = this.socketRooms.get(socketId);
     if (rooms) {

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -33,6 +33,7 @@ class MockWorkerSocket implements CloudflareWorkerWebSocket {
     message: [],
   };
   #readyState: number = WEBSOCKET_OPEN_READY_STATE;
+  #closeDeliveryPromise?: Promise<void>;
   accepted = false;
   readonly sentMessages: string[] = [];
 
@@ -74,9 +75,22 @@ class MockWorkerSocket implements CloudflareWorkerWebSocket {
       reason: { value: reason ?? '' },
     });
 
-    for (const listener of this.#listeners.close) {
-      listener(event);
+    const dispatch = () => {
+      for (const listener of this.#listeners.close) {
+        listener(event);
+      }
+    };
+
+    if (this.#closeDeliveryPromise) {
+      void this.#closeDeliveryPromise.then(dispatch);
+      return;
     }
+
+    dispatch();
+  }
+
+  delayCloseUntil(promise: Promise<void>): void {
+    this.#closeDeliveryPromise = promise;
   }
 
   emitMessage(data: CloudflareWorkerWebSocketMessage): void {
@@ -511,6 +525,132 @@ describe('@fluojs/websockets/cloudflare-workers', () => {
     expect(state.connectCount).toBe(1);
     expect(state.disconnectCount).toBe(1);
     expect((Reflect.get(service, 'socketRegistry') as Map<string, MockWorkerSocket>).size).toBe(0);
+  });
+
+  it('waits for asynchronously delivered Worker close events during shutdown', async () => {
+    const adapter = new TestWorkerAdapter();
+    const connected = createDeferred<void>();
+    const closeGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-async-close' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('https://worker.test/shutdown-async-close', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    const socket = server?.lastSocket;
+
+    if (!socket) {
+      throw new Error('Expected Worker test socket to be available after websocket upgrade.');
+    }
+
+    await connected.promise;
+    socket.delayCloseUntil(closeGate.promise);
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.disconnectCount).toBe(0);
+
+    closeGate.resolve();
+    await closePromise;
+
+    expect(state.disconnectCount).toBe(1);
+  });
+
+  it('waits for in-flight Worker connect handlers to replay buffered disconnects during shutdown', async () => {
+    const adapter = new TestWorkerAdapter();
+    const connectGate = createDeferred<void>();
+
+    class GatewayState {
+      connectCount = 0;
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-connect-in-flight' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      async onConnect() {
+        await connectGate.promise;
+        this.state.connectCount += 1;
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('https://worker.test/shutdown-connect-in-flight', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.connectCount).toBe(0);
+    expect(state.disconnectCount).toBe(0);
+
+    connectGate.resolve();
+    await closePromise;
+
+    expect(state.connectCount).toBe(1);
+    expect(state.disconnectCount).toBe(1);
   });
 
   it('closes Worker sockets when string payloads exceed the configured limit', async () => {

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -593,6 +593,122 @@ describe('@fluojs/websockets/cloudflare-workers', () => {
     expect(state.disconnectCount).toBe(1);
   });
 
+  it('waits for asynchronous Worker disconnect cleanup before finishing shutdown', async () => {
+    const adapter = new TestWorkerAdapter();
+    const connected = createDeferred<void>();
+    const disconnectGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-async-disconnect' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      async onDisconnect() {
+        await disconnectGate.promise;
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('https://worker.test/shutdown-async-disconnect', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    await connected.promise;
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.disconnectCount).toBe(0);
+
+    disconnectGate.resolve();
+    await closePromise;
+
+    expect(state.disconnectCount).toBe(1);
+  });
+
+  it('bounds Worker disconnect cleanup waits by shutdown.timeoutMs', async () => {
+    const adapter = new TestWorkerAdapter();
+    const connected = createDeferred<void>();
+    const disconnectGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-disconnect-timeout' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      async onDisconnect() {
+        await disconnectGate.promise;
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot({ shutdown: { timeoutMs: 1 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('https://worker.test/shutdown-disconnect-timeout', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    await connected.promise;
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await closePromise;
+
+    expect(closed).toBe(true);
+    expect(state.disconnectCount).toBe(0);
+  });
+
   it('waits for in-flight Worker connect handlers to replay buffered disconnects during shutdown', async () => {
     const adapter = new TestWorkerAdapter();
     const connectGate = createDeferred<void>();

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -450,6 +450,69 @@ describe('@fluojs/websockets/cloudflare-workers', () => {
     await app.close();
   });
 
+  it('closes Worker sockets and runs disconnect cleanup during application shutdown', async () => {
+    const adapter = new TestWorkerAdapter();
+    const connected = createDeferred<void>();
+
+    class GatewayState {
+      connectCount = 0;
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        this.state.connectCount += 1;
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot({
+        shutdown: { timeoutMs: 200 },
+      })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    const service = await app.container.resolve(CloudflareWorkersWebSocketGatewayLifecycleService);
+    await app.listen();
+
+    const server = adapter.getServer();
+    const upgradeResponse = await server?.fetch(new Request('https://worker.test/shutdown', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    await flushAsyncWork();
+
+    const socket = server?.lastSocket;
+    expect(upgradeResponse?.status).toBe(200);
+
+    if (!socket) {
+      throw new Error('Expected Worker test socket to be available after websocket upgrade.');
+    }
+
+    await connected.promise;
+    await app.close();
+    await flushAsyncWork();
+
+    expect(socket.readyState).toBe(WEBSOCKET_CLOSED_READY_STATE);
+    expect(state.connectCount).toBe(1);
+    expect(state.disconnectCount).toBe(1);
+    expect((Reflect.get(service, 'socketRegistry') as Map<string, MockWorkerSocket>).size).toBe(0);
+  });
+
   it('closes Worker sockets when string payloads exceed the configured limit', async () => {
     const adapter = new TestWorkerAdapter();
 

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers.test.ts
@@ -464,6 +464,52 @@ describe('@fluojs/websockets/cloudflare-workers', () => {
     await app.close();
   });
 
+  it('rejects in-flight Worker upgrades once shutdown begins during an async guard', async () => {
+    const adapter = new TestWorkerAdapter();
+    const guardGate = createDeferred<void>();
+
+    @WebSocketGateway({ path: '/shutdown-guard-race' })
+    class GuardedGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CloudflareWorkersWebSocketModule.forRoot({
+        upgrade: {
+          async guard() {
+            await guardGate.promise;
+            return true;
+          },
+        },
+      })],
+      providers: [GuardedGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    await app.listen();
+
+    const server = adapter.getServer();
+    const upgradePromise = server?.fetch(new Request('https://worker.test/shutdown-guard-race', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    await flushAsyncWork();
+
+    const closePromise = app.close();
+
+    guardGate.resolve();
+
+    const response = await upgradePromise;
+
+    expect(response?.status).toBe(503);
+    expect(await response?.text()).toBe('WebSocket server is shutting down.');
+    expect(server?.lastSocket).toBeUndefined();
+
+    await closePromise;
+  });
+
   it('closes Worker sockets and runs disconnect cleanup during application shutdown', async () => {
     const adapter = new TestWorkerAdapter();
     const connected = createDeferred<void>();

--- a/packages/websockets/src/deno/deno-service.ts
+++ b/packages/websockets/src/deno/deno-service.ts
@@ -33,7 +33,11 @@ interface ConnectionHandlerState {
   bufferedDisconnect: BufferedDisconnectEvent | undefined;
   bufferedMessages: DenoWebSocketMessage[];
   bufferedMessagesStartIndex: number;
+  connectLifecycleSettled: boolean;
+  connectLifecyclePromise: Promise<void>;
   descriptors: readonly WebSocketGatewayDescriptor[];
+  disconnectLifecycleSettled: boolean;
+  disconnectLifecyclePromise: Promise<void>;
   enqueuedMessageCount: number;
   handlerQueue: Promise<void>;
   handlersReady: boolean;
@@ -41,6 +45,8 @@ interface ConnectionHandlerState {
   queuedMessages: DenoWebSocketMessage[];
   queuedMessagesStartIndex: number;
   request: Request;
+  resolveConnectLifecycle: () => void;
+  resolveDisconnectLifecycle: () => void;
   resolved: ResolvedGatewayInstance[];
   socketId: string;
 }
@@ -123,6 +129,15 @@ function resolveMessageByteLength(message: DenoWebSocketMessage): number {
   }
 
   return message.size;
+}
+
+function createCompletionSignal(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
 }
 
 /**
@@ -272,20 +287,35 @@ export class DenoWebSocketGatewayLifecycleService
     this.socketStates.set(state.socketId, state);
     this.attachConnectionListeners(state, socket, request);
 
-    await this.resolveConnectionGateways(state);
-    await this.runConnectHandlers(state, socket);
-    await this.finalizeConnectionBinding(state, socket, request);
+    try {
+      await this.resolveConnectionGateways(state);
+      await this.runConnectHandlers(state, socket);
+      await this.finalizeConnectionBinding(state, socket, request);
+    } finally {
+      if (!state.handlersReady && state.bufferedDisconnect) {
+        this.settleDisconnectLifecycle(state);
+      }
+
+      this.settleConnectLifecycle(state);
+    }
   }
 
   private createConnectionHandlerState(
     request: Request,
     descriptors: readonly WebSocketGatewayDescriptor[],
   ): ConnectionHandlerState {
+    const connectLifecycle = createCompletionSignal();
+    const disconnectLifecycle = createCompletionSignal();
+
     return {
       bufferedDisconnect: undefined,
       bufferedMessages: [],
       bufferedMessagesStartIndex: 0,
+      connectLifecycleSettled: false,
+      connectLifecyclePromise: connectLifecycle.promise,
       descriptors,
+      disconnectLifecycleSettled: false,
+      disconnectLifecyclePromise: disconnectLifecycle.promise,
       enqueuedMessageCount: 0,
       handlerQueue: Promise.resolve(),
       handlersReady: false,
@@ -293,9 +323,29 @@ export class DenoWebSocketGatewayLifecycleService
       queuedMessages: [],
       queuedMessagesStartIndex: 0,
       request,
+      resolveConnectLifecycle: connectLifecycle.resolve,
+      resolveDisconnectLifecycle: disconnectLifecycle.resolve,
       resolved: [],
       socketId: crypto.randomUUID(),
     };
+  }
+
+  private settleConnectLifecycle(state: ConnectionHandlerState): void {
+    if (state.connectLifecycleSettled) {
+      return;
+    }
+
+    state.connectLifecycleSettled = true;
+    state.resolveConnectLifecycle();
+  }
+
+  private settleDisconnectLifecycle(state: ConnectionHandlerState): void {
+    if (state.disconnectLifecycleSettled) {
+      return;
+    }
+
+    state.disconnectLifecycleSettled = true;
+    state.resolveDisconnectLifecycle();
   }
 
   private attachConnectionListeners(
@@ -522,6 +572,9 @@ export class DenoWebSocketGatewayLifecycleService
       })
       .catch((error) => {
         this.logger.error('WebSocket gateway disconnect dispatch failed.', error, LIFECYCLE_LOG_CONTEXT);
+      })
+      .finally(() => {
+        this.settleDisconnectLifecycle(state);
       });
   }
 
@@ -780,7 +833,10 @@ export class DenoWebSocketGatewayLifecycleService
         reject(new Error(`Timed out while closing Deno websocket connections after ${String(timeoutMs)}ms.`));
       }, timeoutMs);
 
-      Promise.all(states.map(async (state) => await state.handlerQueue))
+      Promise.all(states.map(async (state) => {
+        await state.connectLifecyclePromise;
+        await state.disconnectLifecyclePromise;
+      }))
         .then(() => {
           if (settled) {
             return;

--- a/packages/websockets/src/deno/deno-service.ts
+++ b/packages/websockets/src/deno/deno-service.ts
@@ -147,6 +147,8 @@ function createCompletionSignal(): { promise: Promise<void>; resolve: () => void
 export class DenoWebSocketGatewayLifecycleService
   implements OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy, WebSocketRoomService
 {
+  private isShuttingDown = false;
+  private readonly pendingUpgradeOperations = new Set<Promise<void>>();
   private pendingUpgradeReservations = 0;
   private readonly roomSockets = new Map<string, Set<string>>();
   private shutdownPromise: Promise<void> | undefined;
@@ -208,52 +210,67 @@ export class DenoWebSocketGatewayLifecycleService
     const descriptorsByPath = this.groupDescriptorsByPath(descriptors);
 
     return {
-      fetch: async (request, host) => {
-        if (!isWebSocketUpgradeRequest(request)) {
-          return new Response(null, { status: 426 });
-        }
-
-        let targetPath: string;
-
-        try {
-          targetPath = normalizeGatewayPath(new URL(request.url).pathname);
-        } catch {
-          return new Response(null, { status: 400 });
-        }
-
-        const descriptors = descriptorsByPath.get(targetPath);
-
-        if (!descriptors) {
-          return new Response(null, { status: 404 });
-        }
-
-        const rejection = await this.resolveUpgradeRejection(request, targetPath);
-
-        if (rejection) {
-          return new Response(rejection.body ?? null, {
-            headers: rejection.headers,
-            status: rejection.status,
-          });
-        }
-
-        let response: Response;
-        let socket: DenoServerWebSocket;
-
-        try {
-          ({ response, socket } = host.upgrade(request));
-        } catch (error) {
-          this.releaseUpgradeReservation();
-          throw error;
-        }
-
-        void this.bindConnectionHandlers(socket, request, descriptors).catch((error) => {
-          this.unregisterSocket(this.findSocketId(socket));
-          this.logger.error('WebSocket gateway open lifecycle failed.', error, LIFECYCLE_LOG_CONTEXT);
-          socket.close(1011, 'Internal server error');
-        });
-        return response;
-      },
+      fetch: (request, host) => this.trackPendingUpgradeOperation(
+        this.handleUpgradeRequest(request, host, descriptorsByPath),
+      ),
     };
+  }
+
+  private async handleUpgradeRequest(
+    request: Request,
+    host: DenoWebSocketBindingHost extends { configureWebSocketBinding(binding: DenoWebSocketBinding<infer TSocket> | undefined): void }
+      ? import('./deno-types.js').DenoWebSocketUpgradeHost<TSocket>
+      : never,
+    descriptorsByPath: ReadonlyMap<string, readonly WebSocketGatewayDescriptor[]>,
+  ): Promise<Response> {
+    if (!isWebSocketUpgradeRequest(request)) {
+      return new Response(null, { status: 426 });
+    }
+
+    let targetPath: string;
+
+    try {
+      targetPath = normalizeGatewayPath(new URL(request.url).pathname);
+    } catch {
+      return new Response(null, { status: 400 });
+    }
+
+    const descriptors = descriptorsByPath.get(targetPath);
+
+    if (!descriptors) {
+      return new Response(null, { status: 404 });
+    }
+
+    const rejection = await this.resolveUpgradeRejection(request, targetPath);
+
+    if (rejection) {
+      return new Response(rejection.body ?? null, {
+        headers: rejection.headers,
+        status: rejection.status,
+      });
+    }
+
+    if (this.isShuttingDown) {
+      this.releaseUpgradeReservation();
+      return new Response('WebSocket server is shutting down.', { status: 503 });
+    }
+
+    let response: Response;
+    let socket: DenoServerWebSocket;
+
+    try {
+      ({ response, socket } = host.upgrade(request));
+    } catch (error) {
+      this.releaseUpgradeReservation();
+      throw error;
+    }
+
+    void this.trackPendingUpgradeOperation(this.bindConnectionHandlers(socket, request, descriptors)).catch((error) => {
+      this.unregisterSocket(this.findSocketId(socket));
+      this.logger.error('WebSocket gateway open lifecycle failed.', error, LIFECYCLE_LOG_CONTEXT);
+      socket.close(1011, 'Internal server error');
+    });
+    return response;
   }
 
   private groupDescriptorsByPath(
@@ -291,6 +308,11 @@ export class DenoWebSocketGatewayLifecycleService
       await this.resolveConnectionGateways(state);
       await this.runConnectHandlers(state, socket);
       await this.finalizeConnectionBinding(state, socket, request);
+
+      if (this.isShuttingDown && socket.readyState === WEBSOCKET_OPEN_READY_STATE) {
+        socket.close(1001, 'Server shutting down');
+        await state.disconnectLifecyclePromise;
+      }
     } finally {
       if (!state.handlersReady && state.bufferedDisconnect) {
         this.settleDisconnectLifecycle(state);
@@ -653,6 +675,13 @@ export class DenoWebSocketGatewayLifecycleService
     request: Request,
     path: string,
   ): Promise<WebSocketUpgradeRejection | undefined> {
+    if (this.isShuttingDown) {
+      return {
+        body: 'WebSocket server is shutting down.',
+        status: 503,
+      };
+    }
+
     if (!this.tryReserveUpgradeSlot()) {
       return {
         body: 'WebSocket connection limit exceeded.',
@@ -779,12 +808,15 @@ export class DenoWebSocketGatewayLifecycleService
   }
 
   private async runShutdownLifecycle(): Promise<void> {
+    this.isShuttingDown = true;
+
     if (hasDenoWebSocketBindingHost(this.adapter)) {
       this.adapter.configureWebSocketBinding(undefined);
     }
 
     const shutdownTimeoutMs = this.resolveShutdownTimeoutMs();
 
+    await this.awaitPendingUpgradeOperations(shutdownTimeoutMs);
     await this.closeActiveSockets(shutdownTimeoutMs);
 
     this.pendingUpgradeReservations = 0;
@@ -792,6 +824,75 @@ export class DenoWebSocketGatewayLifecycleService
     this.socketRooms.clear();
     this.socketStates.clear();
     this.roomSockets.clear();
+  }
+
+  private trackPendingUpgradeOperation<TArgs extends unknown[], TResult>(
+    operation: (...args: TArgs) => Promise<TResult>,
+  ): (...args: TArgs) => Promise<TResult>;
+  private trackPendingUpgradeOperation<TResult>(operation: Promise<TResult>): Promise<TResult>;
+  private trackPendingUpgradeOperation<TArgs extends unknown[], TResult>(
+    operation: Promise<TResult> | ((...args: TArgs) => Promise<TResult>),
+  ): Promise<TResult> | ((...args: TArgs) => Promise<TResult>) {
+    if (typeof operation === 'function') {
+      return (...args: TArgs) => this.trackPendingUpgradeOperation(operation(...args));
+    }
+
+    let trackedOperation: Promise<void> | undefined;
+
+    trackedOperation = operation
+      .then(() => undefined, () => undefined)
+      .finally(() => {
+        if (trackedOperation) {
+          this.pendingUpgradeOperations.delete(trackedOperation);
+        }
+      });
+
+    this.pendingUpgradeOperations.add(trackedOperation);
+    return operation;
+  }
+
+  private async awaitPendingUpgradeOperations(timeoutMs: number): Promise<void> {
+    if (this.pendingUpgradeOperations.size === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(new Error(`Timed out while waiting for in-flight Deno websocket upgrades after ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+
+      Promise.all([...this.pendingUpgradeOperations])
+        .then(() => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        })
+        .catch((error) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          reject(error);
+        });
+    }).catch((error) => {
+      this.logger.error(
+        `Failed to wait for in-flight Deno websocket upgrades within ${String(timeoutMs)}ms.`,
+        error,
+        LIFECYCLE_LOG_CONTEXT,
+      );
+    });
   }
 
   private async closeActiveSockets(timeoutMs: number): Promise<void> {

--- a/packages/websockets/src/deno/deno-service.ts
+++ b/packages/websockets/src/deno/deno-service.ts
@@ -48,6 +48,7 @@ interface ConnectionHandlerState {
 const DEFAULT_MAX_PENDING_MESSAGES_PER_SOCKET = 256;
 const DEFAULT_MAX_WEBSOCKET_CONNECTIONS = 1_000;
 const DEFAULT_MAX_WEBSOCKET_PAYLOAD_BYTES = 1_048_576;
+const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LIFECYCLE_LOG_CONTEXT = 'WebSocketGatewayLifecycleService';
 const WEBSOCKET_OPEN_READY_STATE = 1;
 
@@ -136,6 +137,7 @@ export class DenoWebSocketGatewayLifecycleService
   private shutdownPromise: Promise<void> | undefined;
   private readonly socketRegistry = new Map<string, DenoServerWebSocket>();
   private readonly socketRooms = new Map<string, Set<string>>();
+  private readonly socketStates = new Map<string, ConnectionHandlerState>();
 
   constructor(
     private readonly runtimeContainer: Container,
@@ -267,6 +269,7 @@ export class DenoWebSocketGatewayLifecycleService
 
     this.releaseUpgradeReservation();
     this.socketRegistry.set(state.socketId, socket);
+    this.socketStates.set(state.socketId, state);
     this.attachConnectionListeners(state, socket, request);
 
     await this.resolveConnectionGateways(state);
@@ -702,6 +705,16 @@ export class DenoWebSocketGatewayLifecycleService
     return configured;
   }
 
+  private resolveShutdownTimeoutMs(): number {
+    const configured = this.moduleOptions.shutdown?.timeoutMs;
+
+    if (typeof configured !== 'number' || !Number.isFinite(configured) || configured <= 0) {
+      return DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS;
+    }
+
+    return Math.floor(configured);
+  }
+
   private async shutdown(): Promise<void> {
     if (this.shutdownPromise) {
       await this.shutdownPromise;
@@ -717,10 +730,82 @@ export class DenoWebSocketGatewayLifecycleService
       this.adapter.configureWebSocketBinding(undefined);
     }
 
+    const shutdownTimeoutMs = this.resolveShutdownTimeoutMs();
+
+    await this.closeActiveSockets(shutdownTimeoutMs);
+
     this.pendingUpgradeReservations = 0;
     this.socketRegistry.clear();
     this.socketRooms.clear();
+    this.socketStates.clear();
     this.roomSockets.clear();
+  }
+
+  private async closeActiveSockets(timeoutMs: number): Promise<void> {
+    const activeSockets = [...this.socketRegistry.entries()];
+
+    if (activeSockets.length === 0) {
+      return;
+    }
+
+    const activeStates = activeSockets
+      .map(([socketId]) => this.socketStates.get(socketId))
+      .filter((state): state is ConnectionHandlerState => state !== undefined);
+
+    for (const [, socket] of activeSockets) {
+      if (socket.readyState === WEBSOCKET_OPEN_READY_STATE) {
+        socket.close(1001, 'Server shutting down');
+      }
+    }
+
+    await this.awaitHandlerQueueDrain(activeStates, timeoutMs);
+  }
+
+  private async awaitHandlerQueueDrain(
+    states: readonly ConnectionHandlerState[],
+    timeoutMs: number,
+  ): Promise<void> {
+    if (states.length === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        reject(new Error(`Timed out while closing Deno websocket connections after ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
+
+      Promise.all(states.map(async (state) => await state.handlerQueue))
+        .then(() => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        })
+        .catch((error) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timeout);
+          reject(error);
+        });
+    }).catch((error) => {
+      this.logger.error(
+        `Failed to close Deno websocket connections within ${String(timeoutMs)}ms.`,
+        error,
+        LIFECYCLE_LOG_CONTEXT,
+      );
+    });
   }
 
   joinRoom(socketId: string, room: string): void {
@@ -800,6 +885,7 @@ export class DenoWebSocketGatewayLifecycleService
     }
 
     this.socketRegistry.delete(socketId);
+    this.socketStates.delete(socketId);
 
     const rooms = this.socketRooms.get(socketId);
     if (rooms) {

--- a/packages/websockets/src/deno/deno.test.ts
+++ b/packages/websockets/src/deno/deno.test.ts
@@ -33,6 +33,7 @@ class MockDenoSocket implements DenoServerWebSocket {
     message: [],
   };
   #readyState: number = WEBSOCKET_OPEN_READY_STATE;
+  #closeDeliveryPromise?: Promise<void>;
 
   readonly sentMessages: string[] = [];
 
@@ -70,9 +71,22 @@ class MockDenoSocket implements DenoServerWebSocket {
       reason: { value: reason ?? '' },
     });
 
-    for (const listener of this.#listeners.close) {
-      listener(event);
+    const dispatch = () => {
+      for (const listener of this.#listeners.close) {
+        listener(event);
+      }
+    };
+
+    if (this.#closeDeliveryPromise) {
+      void this.#closeDeliveryPromise.then(dispatch);
+      return;
     }
+
+    dispatch();
+  }
+
+  delayCloseUntil(promise: Promise<void>): void {
+    this.#closeDeliveryPromise = promise;
   }
 
   emitError(): void {
@@ -513,6 +527,132 @@ describe('@fluojs/websockets/deno', () => {
     expect(state.connectCount).toBe(1);
     expect(state.disconnectCount).toBe(1);
     expect((Reflect.get(service, 'socketRegistry') as Map<string, MockDenoSocket>).size).toBe(0);
+  });
+
+  it('waits for asynchronously delivered Deno close events during shutdown', async () => {
+    const adapter = new TestDenoAdapter();
+    const connected = createDeferred<void>();
+    const closeGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-async-close' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DenoWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('https://runtime.test/shutdown-async-close', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    const socket = server?.lastSocket;
+
+    if (!socket) {
+      throw new Error('Expected Deno test socket to be available after websocket upgrade.');
+    }
+
+    await connected.promise;
+    socket.delayCloseUntil(closeGate.promise);
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.disconnectCount).toBe(0);
+
+    closeGate.resolve();
+    await closePromise;
+
+    expect(state.disconnectCount).toBe(1);
+  });
+
+  it('waits for in-flight Deno connect handlers to replay buffered disconnects during shutdown', async () => {
+    const adapter = new TestDenoAdapter();
+    const connectGate = createDeferred<void>();
+
+    class GatewayState {
+      connectCount = 0;
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-connect-in-flight' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      async onConnect() {
+        await connectGate.promise;
+        this.state.connectCount += 1;
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DenoWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('https://runtime.test/shutdown-connect-in-flight', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.connectCount).toBe(0);
+    expect(state.disconnectCount).toBe(0);
+
+    connectGate.resolve();
+    await closePromise;
+
+    expect(state.connectCount).toBe(1);
+    expect(state.disconnectCount).toBe(1);
   });
 
   it('closes Deno sockets when string payloads exceed the configured limit', async () => {

--- a/packages/websockets/src/deno/deno.test.ts
+++ b/packages/websockets/src/deno/deno.test.ts
@@ -595,6 +595,122 @@ describe('@fluojs/websockets/deno', () => {
     expect(state.disconnectCount).toBe(1);
   });
 
+  it('waits for asynchronous Deno disconnect cleanup before finishing shutdown', async () => {
+    const adapter = new TestDenoAdapter();
+    const connected = createDeferred<void>();
+    const disconnectGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-async-disconnect' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      async onDisconnect() {
+        await disconnectGate.promise;
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DenoWebSocketModule.forRoot({ shutdown: { timeoutMs: 200 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('https://runtime.test/shutdown-async-disconnect', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    await connected.promise;
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await flushAsyncWork();
+
+    expect(closed).toBe(false);
+    expect(state.disconnectCount).toBe(0);
+
+    disconnectGate.resolve();
+    await closePromise;
+
+    expect(state.disconnectCount).toBe(1);
+  });
+
+  it('bounds Deno disconnect cleanup waits by shutdown.timeoutMs', async () => {
+    const adapter = new TestDenoAdapter();
+    const connected = createDeferred<void>();
+    const disconnectGate = createDeferred<void>();
+
+    class GatewayState {
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown-disconnect-timeout' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      async onDisconnect() {
+        await disconnectGate.promise;
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DenoWebSocketModule.forRoot({ shutdown: { timeoutMs: 1 } })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('https://runtime.test/shutdown-disconnect-timeout', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    await connected.promise;
+
+    let closed = false;
+    const closePromise = app.close().then(() => {
+      closed = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await closePromise;
+
+    expect(closed).toBe(true);
+    expect(state.disconnectCount).toBe(0);
+  });
+
   it('waits for in-flight Deno connect handlers to replay buffered disconnects during shutdown', async () => {
     const adapter = new TestDenoAdapter();
     const connectGate = createDeferred<void>();

--- a/packages/websockets/src/deno/deno.test.ts
+++ b/packages/websockets/src/deno/deno.test.ts
@@ -452,6 +452,69 @@ describe('@fluojs/websockets/deno', () => {
     await app.close();
   });
 
+  it('closes Deno sockets and runs disconnect cleanup during application shutdown', async () => {
+    const adapter = new TestDenoAdapter();
+    const connected = createDeferred<void>();
+
+    class GatewayState {
+      connectCount = 0;
+      disconnectCount = 0;
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/shutdown' })
+    class ShutdownGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      onConnect() {
+        this.state.connectCount += 1;
+        connected.resolve();
+      }
+
+      @OnDisconnect()
+      onDisconnect() {
+        this.state.disconnectCount += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DenoWebSocketModule.forRoot({
+        shutdown: { timeoutMs: 200 },
+      })],
+      providers: [GatewayState, ShutdownGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    const service = await app.container.resolve(DenoWebSocketGatewayLifecycleService);
+    await app.listen();
+
+    const server = adapter.getServer();
+    const upgradeResponse = await server?.fetch(new Request('https://runtime.test/shutdown', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    await flushAsyncWork();
+
+    const socket = server?.lastSocket;
+    expect(upgradeResponse?.status).toBe(200);
+
+    if (!socket) {
+      throw new Error('Expected Deno test socket to be available after websocket upgrade.');
+    }
+
+    await connected.promise;
+    await app.close();
+    await flushAsyncWork();
+
+    expect(socket.readyState).toBe(WEBSOCKET_CLOSED_READY_STATE);
+    expect(state.connectCount).toBe(1);
+    expect(state.disconnectCount).toBe(1);
+    expect((Reflect.get(service, 'socketRegistry') as Map<string, MockDenoSocket>).size).toBe(0);
+  });
+
   it('closes Deno sockets when string payloads exceed the configured limit', async () => {
     const adapter = new TestDenoAdapter();
 

--- a/packages/websockets/src/deno/deno.test.ts
+++ b/packages/websockets/src/deno/deno.test.ts
@@ -466,6 +466,52 @@ describe('@fluojs/websockets/deno', () => {
     await app.close();
   });
 
+  it('rejects in-flight Deno upgrades once shutdown begins during an async guard', async () => {
+    const adapter = new TestDenoAdapter();
+    const guardGate = createDeferred<void>();
+
+    @WebSocketGateway({ path: '/shutdown-guard-race' })
+    class GuardedGateway {
+      @OnMessage('ping')
+      onPing() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DenoWebSocketModule.forRoot({
+        upgrade: {
+          async guard() {
+            await guardGate.promise;
+            return true;
+          },
+        },
+      })],
+      providers: [GuardedGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    await app.listen();
+
+    const server = adapter.getServer();
+    const upgradePromise = server?.fetch(new Request('https://runtime.test/shutdown-guard-race', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    await flushAsyncWork();
+
+    const closePromise = app.close();
+
+    guardGate.resolve();
+
+    const response = await upgradePromise;
+
+    expect(response?.status).toBe(503);
+    expect(await response?.text()).toBe('WebSocket server is shutting down.');
+    expect(server?.lastSocket).toBeUndefined();
+
+    await closePromise;
+  });
+
   it('closes Deno sockets and runs disconnect cleanup during application shutdown', async () => {
     const adapter = new TestDenoAdapter();
     const connected = createDeferred<void>();


### PR DESCRIPTION
Closes #1392

## Summary
- Close active websocket clients during application shutdown for Bun, Deno, and Cloudflare Workers.
- Wait for fetch-style disconnect cleanup to drain within `shutdown.timeoutMs` before clearing runtime tracking state.
- Document the fetch-style runtime shutdown guarantee and include a patch changeset for `@fluojs/websockets`.

## Changes
- Added fetch-style shutdown lifecycle handling that snapshots tracked sockets, closes open connections, and waits for disconnect handler queues before clearing registries.
- Added Bun, Deno, and Cloudflare Workers regression tests that assert shutdown closes active sockets and runs `@OnDisconnect()` cleanup.
- Narrowed `packages/websockets/README.md` and `packages/websockets/README.ko.md` to the official fetch-style runtime modules (`@fluojs/websockets/bun`, `@fluojs/websockets/deno`, `@fluojs/websockets/cloudflare-workers`) and linked the package example sources to the Bun/Deno/Workers regression files.
- Added governed README evidence in `packages/testing/src/conformance/platform-consistency-governance-docs.test.ts` so the public shutdown contract stays bound to the documented runtime scope and regression-source links.
- Added `.changeset/eight-cougars-film.md` for the public package behavior fix.

## Testing
- `pnpm exec vitest run packages/testing/src/conformance/platform-consistency-governance-docs.test.ts`
- `pnpm verify:release-readiness`
- Local `pnpm verify:release-readiness` passed in the PR worktree. The CI `Verify release readiness` job is expected to be skipped for this PR because `.github/workflows/ci.yml` gates that job to `github.event_name == 'push' && github.ref == 'refs/heads/main'`.

## Public export documentation
- No public exports changed in this PR.
- README scenario documentation was updated to reflect the shutdown lifecycle guarantee for the official fetch-style runtime modules only.

## Behavioral contract
- No documented behavioral contracts were removed without migration notes.
- The affected package README now documents that the official fetch-style runtime modules close tracked websocket clients during shutdown and give `@OnDisconnect()` cleanup bounded time within `shutdown.timeoutMs`.
- Runtime invariants remain covered by the Bun/Deno/Workers regression tests, and the governed docs test now locks the README scope and evidence links to those runtime-specific suites.

## Platform consistency governance (SSOT)
- No governance SSOT documents changed.
- The README alignment claim is now scoped to the fetch-style runtime modules actually covered by the public shutdown regression suites.
- Governed evidence now lives in `packages/testing/src/conformance/platform-consistency-governance-docs.test.ts`.
