### PR TITLE
Resolve #1431: make runtime request/response normalization lazier

### DIFF
--- a/.changeset/runtime-normalization-lazy-hotpath.md
+++ b/.changeset/runtime-normalization-lazy-hotpath.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Reduce request/response normalization overhead for common adapter hot paths by skipping empty-body materialization and deferring stream/compression helper setup until requests actually use them.

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -122,6 +122,11 @@ export function createDeferredFrameworkRequest(
       return;
     }
 
+    if (!hasNodeRequestBody(request)) {
+      frameworkRequest.body = undefined;
+      return;
+    }
+
     const bodyResult = await readRequestBody(request, headers['content-type'], maxBodySize, preserveRawBody);
     frameworkRequest.body = bodyResult.body;
 
@@ -148,6 +153,24 @@ export function createDeferredFrameworkRequest(
   };
 
   return frameworkRequest;
+}
+
+function hasNodeRequestBody(request: IncomingMessage): boolean {
+  const contentLength = request.headers['content-length'];
+  const transferEncoding = request.headers['transfer-encoding'];
+  const primaryContentLength = Array.isArray(contentLength) ? contentLength[0] : contentLength;
+
+  if (transferEncoding !== undefined) {
+    return true;
+  }
+
+  if (primaryContentLength === undefined) {
+    return true;
+  }
+
+  const parsedContentLength = Number(primaryContentLength);
+
+  return !Number.isFinite(parsedContentLength) || parsedContentLength !== 0;
 }
 
 /**

--- a/packages/runtime/src/node/internal-node-response.ts
+++ b/packages/runtime/src/node/internal-node-response.ts
@@ -14,6 +14,8 @@ import {
  */
 export type MutableFrameworkResponse = FrameworkResponse & { statusSet?: boolean };
 
+type FrameworkResponseCompressionFactory = () => FrameworkResponseCompression | undefined;
+
 function createFrameworkResponseStream(response: ServerResponse): FrameworkResponseStream {
   return {
     close() {
@@ -66,8 +68,26 @@ function createFrameworkResponseStream(response: ServerResponse): FrameworkRespo
  */
 export function createFrameworkResponse(
   response: ServerResponse,
-  compression?: FrameworkResponseCompression,
+  compression?: FrameworkResponseCompression | FrameworkResponseCompressionFactory,
 ): MutableFrameworkResponse {
+  let activeStream: FrameworkResponseStream | undefined;
+  const resolveCompression = (() => {
+    const factory = typeof compression === 'function'
+      ? compression as FrameworkResponseCompressionFactory
+      : () => compression;
+    let resolved = false;
+    let value: FrameworkResponseCompression | undefined;
+
+    return () => {
+      if (!resolved) {
+        value = factory();
+        resolved = true;
+      }
+
+      return value;
+    };
+  })();
+
   const mergeSetCookieHeader = (
     current: string | string[] | number | undefined,
     incoming: string | string[],
@@ -92,7 +112,10 @@ export function createFrameworkResponse(
     committed: response.headersSent || response.writableEnded,
     headers: {},
     raw: response,
-    stream: createFrameworkResponseStream(response),
+    get stream() {
+      activeStream ??= createFrameworkResponseStream(response);
+      return activeStream;
+    },
     redirect(status: number, location: string) {
       this.setStatus(status);
       this.setHeader('Location', location);
@@ -118,11 +141,12 @@ export function createFrameworkResponse(
       const payload = typeof serialized.payload === 'string'
         ? Buffer.from(serialized.payload, 'utf8')
         : serialized.payload;
+      const activeCompression = resolveCompression();
 
-      if (compression) {
+      if (activeCompression) {
         this.committed = true;
 
-        return Promise.resolve(compression.write(payload, { contentType }))
+        return Promise.resolve(activeCompression.write(payload, { contentType }))
           .then((handled) => {
             if (!handled && !response.writableEnded) {
               response.end(payload);

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -242,7 +242,7 @@ function createNodeRequestResponseFactory(
       return createFrameworkResponse(
         response,
         compression
-          ? createNodeResponseCompression(response, request.headers['accept-encoding'] as string | undefined)
+          ? () => createNodeResponseCompression(response, request.headers['accept-encoding'] as string | undefined)
           : undefined,
       );
     },

--- a/packages/runtime/src/node/node-request.test.ts
+++ b/packages/runtime/src/node/node-request.test.ts
@@ -174,6 +174,29 @@ describe('node request adapter', () => {
     expect(Buffer.from(frameworkRequest.rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
   });
 
+  it('skips request stream reads when headers indicate no request body', async () => {
+    let chunksRead = 0;
+    const request = {
+      headers: {
+        'content-length': '0',
+      },
+      method: 'GET',
+      async *[Symbol.asyncIterator]() {
+        chunksRead += 1;
+        yield Buffer.from('unexpected', 'utf8');
+      },
+      url: '/empty',
+    } as unknown as IncomingMessage;
+
+    const frameworkRequest = createDeferredFrameworkRequest(request, new AbortController().signal);
+
+    await materializeFrameworkRequestBody(frameworkRequest);
+    await materializeFrameworkRequestBody(frameworkRequest);
+
+    expect(chunksRead).toBe(0);
+    expect(frameworkRequest.body).toBeUndefined();
+  });
+
   it('destroys the raw Node request stream when maxBodySize is exceeded', async () => {
     let destroyed = false;
     let paused = false;

--- a/packages/runtime/src/node/node-response.test.ts
+++ b/packages/runtime/src/node/node-response.test.ts
@@ -88,6 +88,23 @@ describe('createFrameworkResponse', () => {
     expect(frameworkResponse.committed).toBe(true);
   });
 
+  it('defers compression helper creation until send is called', async () => {
+    const rawResponse = createMockServerResponse();
+    const endSpy = vi.fn();
+    rawResponse.end = endSpy as typeof rawResponse.end;
+    const compression = { write: vi.fn().mockResolvedValue(false) };
+    const compressionFactory = vi.fn(() => compression);
+    const frameworkResponse = createFrameworkResponse(rawResponse, compressionFactory);
+
+    expect(compressionFactory).not.toHaveBeenCalled();
+
+    await frameworkResponse.send('hello');
+
+    expect(compressionFactory).toHaveBeenCalledOnce();
+    expect(compression.write).toHaveBeenCalledOnce();
+    expect(endSpy).toHaveBeenCalledWith(Buffer.from('hello', 'utf8'));
+  });
+
   it('settles waitForDrain when the response closes before drain', async () => {
     const rawResponse = createMockServerResponse();
     const frameworkResponse = createFrameworkResponse(rawResponse);

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -211,6 +211,28 @@ describe('createWebFrameworkRequest', () => {
     expect(Buffer.from(frameworkRequest.rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
   });
 
+  it('skips clone-based body materialization for bodyless requests', async () => {
+    const request = new Request('https://runtime.test/empty?tag=one');
+    const originalClone = request.clone.bind(request);
+    let cloneCalls = 0;
+
+    Object.defineProperty(request, 'clone', {
+      value: () => {
+        cloneCalls += 1;
+        return originalClone();
+      },
+    });
+
+    const factory = createWebRequestResponseFactory();
+    const frameworkRequest = await factory.createRequest(request, new AbortController().signal);
+
+    await factory.materializeRequest?.(frameworkRequest);
+    await factory.materializeRequest?.(frameworkRequest);
+
+    expect(cloneCalls).toBe(0);
+    expect(frameworkRequest.body).toBeUndefined();
+  });
+
   it('uses creation-time metadata when materializing deferred multipart bodies', async () => {
     const formData = new FormData();
     formData.set('title', 'before');

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -166,13 +166,13 @@ class MutableWebFrameworkResponse implements WebFrameworkResponse {
   statusSet?: boolean;
 
   private finalizedResponse?: Response;
-  private readonly responseStream = new WebResponseStream(() => {
-    this.streamActive = true;
-  });
+  private responseStream?: WebResponseStream;
   private responseBody?: string | Uint8Array;
   private streamActive = false;
 
-  stream: WebFrameworkResponseStream = this.responseStream;
+  get stream(): WebFrameworkResponseStream {
+    return this.getOrCreateResponseStream();
+  }
 
   redirect(status: number, location: string): void {
     this.setStatus(status);
@@ -230,13 +230,21 @@ class MutableWebFrameworkResponse implements WebFrameworkResponse {
         : this.responseBody;
 
       this.finalizedResponse = this.streamActive
-        ? new Response(this.responseStream.readable, init)
+        ? new Response(this.getOrCreateResponseStream().readable, init)
         : new Response(responseBody ?? '', init);
       this.raw = this.finalizedResponse;
       this.committed = true;
     }
 
     return this.finalizedResponse;
+  }
+
+  private getOrCreateResponseStream(): WebResponseStream {
+    this.responseStream ??= new WebResponseStream(() => {
+      this.streamActive = true;
+    });
+
+    return this.responseStream;
   }
 }
 
@@ -375,6 +383,13 @@ function createDeferredWebFrameworkRequest(
       return;
     }
 
+    validateWebRequestContentLength(request, maxBodySize);
+
+    if (!request.body) {
+      frameworkRequest.body = undefined;
+      return;
+    }
+
     const bodyResult = await readWebRequestBody(request.clone(), contentType, maxBodySize, preserveRawBody);
     frameworkRequest.body = bodyResult.body;
 
@@ -403,6 +418,20 @@ function createDeferredWebFrameworkRequest(
   };
 
   return frameworkRequest;
+}
+
+function validateWebRequestContentLength(request: Request, maxBodySize: number): void {
+  const contentLength = request.headers.get('content-length');
+
+  if (contentLength === null) {
+    return;
+  }
+
+  const parsedContentLength = Number(contentLength);
+
+  if (Number.isFinite(parsedContentLength) && parsedContentLength > maxBodySize) {
+    throw new PayloadTooLargeException(REQUEST_BODY_LIMIT_MESSAGE);
+  }
 }
 
 /**
@@ -507,15 +536,7 @@ async function readWebRequestBody(
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
 ): Promise<{ body: unknown; rawBody?: Uint8Array }> {
-  const contentLength = request.headers.get('content-length');
-
-  if (contentLength !== null) {
-    const parsedContentLength = Number(contentLength);
-
-    if (Number.isFinite(parsedContentLength) && parsedContentLength > maxBodySize) {
-      throw new PayloadTooLargeException(REQUEST_BODY_LIMIT_MESSAGE);
-    }
-  }
+  validateWebRequestContentLength(request, maxBodySize);
 
   if (!request.body) {
     return { body: undefined };


### PR DESCRIPTION
Closes #1431

## Summary

Reduce `@fluojs/runtime` request/response normalization overhead on common adapter hot paths without changing observable `FrameworkRequest` / `FrameworkResponse` behavior.

## Changes

- skip clone/stream body materialization when Web requests have no body and when Node requests explicitly advertise `content-length: 0`
- defer Node compression helper setup and Web/Node stream wrapper allocation until response streaming or body writing actually uses them
- add regression coverage for empty-body request materialization and lazy response helper setup
- add a patch changeset for `@fluojs/runtime`

## Testing

- `pnpm vitest run packages/runtime/src/web.test.ts packages/runtime/src/node/node-request.test.ts packages/runtime/src/node/node-response.test.ts packages/runtime/src/adapters/request-response-factory.test.ts`
- `pnpm --filter @fluojs/runtime test`
- `pnpm build`
- `pnpm typecheck`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.