### PR TITLE
Resolve #1429: optimize @fluojs/http dispatcher pipeline and route matching hot path

### DIFF
--- a/.changeset/bright-buses-punch.md
+++ b/.changeset/bright-buses-punch.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/http': patch
+---
+
+Improve `@fluojs/http` dispatcher and route-matching hot paths by short-circuiting empty middleware/guard/interceptor/observer chains and pre-indexing static routes for faster request matching.

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -21,7 +21,6 @@ import type {
   HandlerDescriptor,
   HandlerMapping,
   InterceptorLike,
-  InterceptorContext,
   MiddlewareContext,
   MiddlewareLike,
   RequestContext,
@@ -145,11 +144,30 @@ async function notifyObserversSafely(
   logger: DispatcherLogger | undefined,
   handler?: HandlerDescriptor,
 ): Promise<void> {
+  if (observers.length === 0) {
+    return;
+  }
+
   try {
     await notifyObservers(observers, requestContext, callback, handler);
   } catch (error) {
     logDispatchFailure(logger, 'Request observer threw an unhandled error.', error);
   }
+}
+
+function mergeInterceptors(
+  globalInterceptors: readonly InterceptorLike[],
+  routeInterceptors: readonly InterceptorLike[],
+): InterceptorLike[] {
+  if (globalInterceptors.length === 0) {
+    return routeInterceptors as InterceptorLike[];
+  }
+
+  if (routeInterceptors.length === 0) {
+    return globalInterceptors as InterceptorLike[];
+  }
+
+  return [...globalInterceptors, ...routeInterceptors];
 }
 
 async function dispatchMatchedHandler(
@@ -158,29 +176,34 @@ async function dispatchMatchedHandler(
   observers: RequestObserverLike[],
   contentNegotiation: ResolvedContentNegotiation | undefined,
   binder: Binder | undefined,
-  globalInterceptors: InterceptorLike[] | undefined,
+  globalInterceptors: readonly InterceptorLike[],
   logger: DispatcherLogger | undefined,
 ): Promise<void> {
-  const guardContext: GuardContext = {
-    handler,
-    requestContext,
-  };
-  const interceptorContext: InterceptorContext = {
-    handler,
-    requestContext,
-  };
+  const routeGuards = handler.route.guards ?? [];
+  if (routeGuards.length > 0) {
+    const guardContext: GuardContext = {
+      handler,
+      requestContext,
+    };
 
-  await runGuardChain(handler.route.guards ?? [], guardContext);
+    await runGuardChain(routeGuards, guardContext);
+  }
 
   if (requestContext.response.committed) {
     return;
   }
 
-  const interceptors = [...(globalInterceptors ?? []), ...(handler.route.interceptors ?? [])];
-
-  const result = await runInterceptorChain(interceptors, interceptorContext, async () => {
-    return invokeControllerHandler(handler, requestContext, binder);
-  });
+  const routeInterceptors = handler.route.interceptors ?? [];
+  const result = globalInterceptors.length === 0 && routeInterceptors.length === 0
+    ? await invokeControllerHandler(handler, requestContext, binder)
+    : await runInterceptorChain(
+        mergeInterceptors(globalInterceptors, routeInterceptors),
+        {
+          handler,
+          requestContext,
+        },
+        async () => invokeControllerHandler(handler, requestContext, binder),
+      );
 
   ensureRequestNotAborted(requestContext.request);
 
@@ -287,7 +310,7 @@ async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void>
         context.observers,
         context.contentNegotiation,
         context.options.binder,
-        context.options.interceptors,
+        context.options.interceptors ?? [],
         context.options.logger,
       );
     });
@@ -323,12 +346,13 @@ async function handleDispatchError(context: DispatchPhaseContext, error: unknown
  */
 export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
   const contentNegotiation = resolveContentNegotiation(options.contentNegotiation);
+  const observers = options.observers ?? [];
 
   return {
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
       const phaseContext: DispatchPhaseContext = {
         contentNegotiation,
-        observers: options.observers ?? [],
+        observers,
         options,
         requestContext: createDispatchContext(createDispatchRequest(request), response, options.rootContainer),
         response,

--- a/packages/http/src/guards.ts
+++ b/packages/http/src/guards.ts
@@ -23,6 +23,10 @@ async function resolveGuard(definition: GuardLike, requestContext: RequestContex
  * @returns The run guard chain result.
  */
 export async function runGuardChain(definitions: GuardLike[], context: GuardContext): Promise<void> {
+  if (definitions.length === 0) {
+    return;
+  }
+
   for (const definition of definitions) {
     const guard = await resolveGuard(definition, context.requestContext);
     const result = await guard.canActivate(context);

--- a/packages/http/src/interceptors.ts
+++ b/packages/http/src/interceptors.ts
@@ -36,11 +36,16 @@ export async function runInterceptorChain(
   context: InterceptorContext,
   terminal: () => Promise<unknown>,
 ): Promise<unknown> {
+  if (definitions.length === 0) {
+    return terminal();
+  }
+
   let next: CallHandler = {
     handle: terminal,
   };
 
-  for (const definition of [...definitions].reverse()) {
+  for (let index = definitions.length - 1; index >= 0; index -= 1) {
+    const definition = definitions[index];
     const interceptor = await resolveInterceptor(definition, context.requestContext);
     const previous = next;
 

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -443,4 +443,90 @@ describe('handler mapping', () => {
     expect(match?.descriptor.methodName).toBe('getHealth');
     expect(match?.descriptor.route.method).toBe('GET');
   });
+
+  it('prefers ALL exact-version static routes before method-specific unversioned fallback', () => {
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { route: 'get' };
+      }
+    }
+
+    class AnyMethodController {
+      any() {
+        return { route: 'all-versioned' };
+      }
+    }
+
+    defineControllerMetadata(AnyMethodController, { basePath: '/health' });
+    defineRouteMetadata(AnyMethodController.prototype, 'any', {
+      method: 'ALL',
+      path: '/',
+      version: '2',
+    } as any);
+
+    const mapping = createHandlerMapping(
+      [
+        { controllerToken: HealthController },
+        { controllerToken: AnyMethodController },
+      ],
+      { versioning: { header: 'x-api-version', type: VersioningType.HEADER } },
+    );
+
+    const versionedMatch = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: { 'x-api-version': '2' },
+      method: 'GET',
+      params: {},
+      path: '/health',
+      query: {},
+      raw: {},
+      url: '/health',
+    });
+
+    const fallbackMatch = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/health',
+      query: {},
+      raw: {},
+      url: '/health',
+    });
+
+    expect(versionedMatch?.descriptor.methodName).toBe('any');
+    expect(versionedMatch?.descriptor.route.method).toBe('ALL');
+    expect(fallbackMatch?.descriptor.methodName).toBe('getHealth');
+    expect(fallbackMatch?.descriptor.route.method).toBe('GET');
+  });
+
+  it('normalizes incoming static paths before direct lookup', () => {
+    @Controller('//health//')
+    class HealthController {
+      @Get('///')
+      getHealth() {
+        return { route: 'get' };
+      }
+    }
+
+    const mapping = createHandlerMapping([{ controllerToken: HealthController }]);
+    const match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '///health///',
+      query: {},
+      raw: {},
+      url: '///health///',
+    });
+
+    expect(match?.descriptor.methodName).toBe('getHealth');
+    expect(match?.descriptor.route.path).toBe('/health');
+  });
 });

--- a/packages/http/src/mapping.test.ts
+++ b/packages/http/src/mapping.test.ts
@@ -401,4 +401,46 @@ describe('handler mapping', () => {
     expect(match?.descriptor.methodName).toBe('firstMatch');
     expect(match?.params).toEqual({ id: '42' });
   });
+
+  it('prefers method-specific static routes before ALL fallbacks on the same path', () => {
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { route: 'get' };
+      }
+    }
+
+    class AnyMethodController {
+      any() {
+        return { route: 'all' };
+      }
+    }
+
+    defineControllerMetadata(AnyMethodController, { basePath: '/health' });
+    defineRouteMetadata(AnyMethodController.prototype, 'any', {
+      method: 'ALL',
+      path: '/',
+    } as any);
+
+    const mapping = createHandlerMapping([
+      { controllerToken: AnyMethodController },
+      { controllerToken: HealthController },
+    ]);
+
+    const match = mapping.match({
+      body: undefined,
+      cookies: {},
+      headers: {},
+      method: 'GET',
+      params: {},
+      path: '/health',
+      query: {},
+      raw: {},
+      url: '/health',
+    });
+
+    expect(match?.descriptor.methodName).toBe('getHealth');
+    expect(match?.descriptor.route.method).toBe('GET');
+  });
 });

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -242,36 +242,38 @@ function buildDescriptorIndex(descriptors: HandlerDescriptor[]): CompiledDescrip
 }
 
 function findStaticMatch(
-  descriptors: readonly HandlerDescriptor[] | undefined,
+  descriptorBuckets: readonly (readonly HandlerDescriptor[] | undefined)[],
   requestVersion: string | undefined,
   versioning: ResolvedVersioning,
 ): HandlerMatch | undefined {
-  if (!descriptors) {
-    return undefined;
-  }
-
   let firstUnversionedMatch: HandlerMatch | undefined;
 
-  for (const descriptor of descriptors) {
-    if (versioning.type === VersioningType.URI) {
-      return {
-        descriptor,
-        params: {},
-      };
+  for (const descriptors of descriptorBuckets) {
+    if (!descriptors || descriptors.length === 0) {
+      continue;
     }
 
-    if (matchesRouteVersion(descriptor, requestVersion)) {
-      return {
-        descriptor,
-        params: {},
-      };
-    }
+    for (const descriptor of descriptors) {
+      if (versioning.type === VersioningType.URI) {
+        return {
+          descriptor,
+          params: {},
+        };
+      }
 
-    if (descriptor.route.version === undefined && !firstUnversionedMatch) {
-      firstUnversionedMatch = {
-        descriptor,
-        params: {},
-      };
+      if (matchesRouteVersion(descriptor, requestVersion)) {
+        return {
+          descriptor,
+          params: {},
+        };
+      }
+
+      if (descriptor.route.version === undefined && !firstUnversionedMatch) {
+        firstUnversionedMatch = {
+          descriptor,
+          params: {},
+        };
+      }
     }
   }
 
@@ -392,9 +394,11 @@ export function createHandlerMapping(sources: HandlerSource[], options?: CreateH
       const normalizedPath = normalizeRoutePath(request.path);
       const methodStaticDescriptors = descriptorIndex.static.get(method)?.get(normalizedPath);
       const allStaticDescriptors = descriptorIndex.static.get('ALL' as HttpMethod)?.get(normalizedPath);
-      const directStaticMatch =
-        findStaticMatch(methodStaticDescriptors, requestVersion, versioning)
-        ?? findStaticMatch(allStaticDescriptors, requestVersion, versioning);
+      const directStaticMatch = findStaticMatch(
+        [methodStaticDescriptors, allStaticDescriptors],
+        requestVersion,
+        versioning,
+      );
 
       if (directStaticMatch) {
         return directStaticMatch;

--- a/packages/http/src/mapping.ts
+++ b/packages/http/src/mapping.ts
@@ -3,7 +3,7 @@ import { getControllerMetadata, getRouteMetadata } from '@fluojs/core/internal';
 
 import { getRouteProducesMetadata } from './decorators.js';
 import { RouteConflictError } from './errors.js';
-import { extractRoutePathParams, matchRoutePath, normalizeRoutePath, parseRoutePath, type RoutePathSegment } from './route-path.js';
+import { extractRoutePathParams, normalizeRoutePath, parseRoutePath, type RoutePathSegment } from './route-path.js';
 import { VersioningType } from './types.js';
 import type {
   FrameworkRequest,
@@ -32,7 +32,13 @@ type IndexedDescriptor = {
   segments: readonly RoutePathSegment[];
 };
 
-type DescriptorIndex = Map<HttpMethod, Map<number, IndexedDescriptor[]>>;
+type StaticDescriptorIndex = Map<HttpMethod, Map<string, HandlerDescriptor[]>>;
+type ParamDescriptorIndex = Map<HttpMethod, Map<number, IndexedDescriptor[]>>;
+
+interface CompiledDescriptorIndex {
+  param: ParamDescriptorIndex;
+  static: StaticDescriptorIndex;
+}
 
 function joinPaths(basePath: string, routePath: string): string {
   return normalizeRoutePath(`${basePath}/${routePath}`);
@@ -186,22 +192,38 @@ function getControllerMethodNames(controllerToken: Constructor): MetadataPropert
   return Object.getOwnPropertyNames(controllerToken.prototype).filter((propertyKey) => propertyKey !== 'constructor');
 }
 
-function splitIncomingPathSegments(path: string): string[] {
-  return normalizeRoutePath(path).split('/').filter(Boolean);
-}
-
-function buildDescriptorIndex(descriptors: HandlerDescriptor[]): DescriptorIndex {
-  const index: DescriptorIndex = new Map();
+function buildDescriptorIndex(descriptors: HandlerDescriptor[]): CompiledDescriptorIndex {
+  const staticIndex: StaticDescriptorIndex = new Map();
+  const paramIndex: ParamDescriptorIndex = new Map();
 
   for (const descriptor of descriptors) {
     const method = descriptor.route.method;
     const segments = parseRoutePath(descriptor.route.path, `Registered ${descriptor.route.method} route path`);
-    const segmentCount = segments.length;
 
-    let methodMap = index.get(method);
+    if (segments.every((segment) => segment.kind === 'literal')) {
+      let methodMap = staticIndex.get(method);
+      if (!methodMap) {
+        methodMap = new Map();
+        staticIndex.set(method, methodMap);
+      }
+
+      const path = descriptor.route.path;
+      const bucket = methodMap.get(path);
+
+      if (bucket) {
+        bucket.push(descriptor);
+      } else {
+        methodMap.set(path, [descriptor]);
+      }
+
+      continue;
+    }
+
+    const segmentCount = segments.length;
+    let methodMap = paramIndex.get(method);
     if (!methodMap) {
       methodMap = new Map();
-      index.set(method, methodMap);
+      paramIndex.set(method, methodMap);
     }
 
     let bucket = methodMap.get(segmentCount);
@@ -210,13 +232,79 @@ function buildDescriptorIndex(descriptors: HandlerDescriptor[]): DescriptorIndex
       methodMap.set(segmentCount, bucket);
     }
 
-    bucket.push({
-      descriptor,
-      segments,
-    });
+    bucket.push({ descriptor, segments });
   }
 
-  return index;
+  return {
+    param: paramIndex,
+    static: staticIndex,
+  };
+}
+
+function findStaticMatch(
+  descriptors: readonly HandlerDescriptor[] | undefined,
+  requestVersion: string | undefined,
+  versioning: ResolvedVersioning,
+): HandlerMatch | undefined {
+  if (!descriptors) {
+    return undefined;
+  }
+
+  let firstUnversionedMatch: HandlerMatch | undefined;
+
+  for (const descriptor of descriptors) {
+    if (versioning.type === VersioningType.URI) {
+      return {
+        descriptor,
+        params: {},
+      };
+    }
+
+    if (matchesRouteVersion(descriptor, requestVersion)) {
+      return {
+        descriptor,
+        params: {},
+      };
+    }
+
+    if (descriptor.route.version === undefined && !firstUnversionedMatch) {
+      firstUnversionedMatch = {
+        descriptor,
+        params: {},
+      };
+    }
+  }
+
+  return firstUnversionedMatch;
+}
+
+function matchParameterizedRoute(
+  candidate: IndexedDescriptor,
+  incomingSegments: readonly string[],
+): Readonly<Record<string, string>> | undefined {
+  const { segments } = candidate;
+
+  if (segments.length !== incomingSegments.length) {
+    return undefined;
+  }
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    if (segment.kind === 'literal' && segment.value !== incomingSegments[index]) {
+      return undefined;
+    }
+  }
+
+  const params: Record<string, string> = {};
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const segment = segments[index];
+    if (segment.kind === 'param') {
+      params[segment.name] = incomingSegments[index];
+    }
+  }
+
+  return params;
 }
 
 function createHandlerDescriptors(source: HandlerSource, versioning: ResolvedVersioning): HandlerDescriptor[] {
@@ -301,15 +389,26 @@ export function createHandlerMapping(sources: HandlerSource[], options?: CreateH
     match(request: FrameworkRequest): HandlerMatch | undefined {
       const method = request.method.toUpperCase() as HttpMethod;
       const requestVersion = versioning.type === VersioningType.URI ? undefined : resolveRequestVersion(request, versioning);
-      const incomingSegments = splitIncomingPathSegments(request.path);
+      const normalizedPath = normalizeRoutePath(request.path);
+      const methodStaticDescriptors = descriptorIndex.static.get(method)?.get(normalizedPath);
+      const allStaticDescriptors = descriptorIndex.static.get('ALL' as HttpMethod)?.get(normalizedPath);
+      const directStaticMatch =
+        findStaticMatch(methodStaticDescriptors, requestVersion, versioning)
+        ?? findStaticMatch(allStaticDescriptors, requestVersion, versioning);
+
+      if (directStaticMatch) {
+        return directStaticMatch;
+      }
+
+      const incomingSegments = normalizedPath.split('/').filter(Boolean);
       const candidates = [
-        ...(descriptorIndex.get(method)?.get(incomingSegments.length) ?? []),
-        ...(descriptorIndex.get('ALL' as HttpMethod)?.get(incomingSegments.length) ?? []),
+        ...(descriptorIndex.param.get(method)?.get(incomingSegments.length) ?? []),
+        ...(descriptorIndex.param.get('ALL' as HttpMethod)?.get(incomingSegments.length) ?? []),
       ];
       let firstUnversionedMatch: HandlerMatch | undefined;
 
       for (const candidate of candidates) {
-        const params = matchRoutePath(candidate.segments, incomingSegments);
+        const params = matchParameterizedRoute(candidate, incomingSegments);
 
         if (!params) {
           continue;

--- a/packages/http/src/middleware/middleware.ts
+++ b/packages/http/src/middleware/middleware.ts
@@ -118,7 +118,18 @@ export async function runMiddlewareChain(
   context: MiddlewareContext,
   terminal: Next,
 ): Promise<void> {
+  if (definitions.length === 0) {
+    await terminal();
+    return;
+  }
+
   const middlewareChain = await resolveActiveMiddlewareDefinitions(definitions, context);
+
+  if (middlewareChain.length === 0) {
+    await terminal();
+    return;
+  }
+
   const composed = middlewareChain.reduceRight<Next>(
     (next, middleware) => deferNext(async () => {
       await middleware.handle(context, next);

--- a/tooling/benchmarks/http-dispatch-hot-path.mjs
+++ b/tooling/benchmarks/http-dispatch-hot-path.mjs
@@ -1,0 +1,355 @@
+import { performance } from 'node:perf_hooks';
+
+import { defineClassDiMetadata, defineControllerMetadata, defineRouteMetadata } from '../../packages/core/dist/internal.js';
+import { Container } from '../../packages/di/dist/index.js';
+import { createDispatcher, createHandlerMapping } from '../../packages/http/dist/index.js';
+
+function createRequest(path, method = 'GET', headers = {}) {
+  return {
+    body: undefined,
+    cookies: {},
+    headers,
+    method,
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function resetResponse(response) {
+  response.body = undefined;
+  response.committed = false;
+  response.headers = {};
+  response.statusCode = undefined;
+  response.statusSet = false;
+}
+
+function createResponse() {
+  return {
+    body: undefined,
+    committed: false,
+    headers: {},
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+function registerRoute(controllerToken, { basePath, method, methodName, path, guards, interceptors }) {
+  defineControllerMetadata(controllerToken, { basePath });
+  defineRouteMetadata(controllerToken.prototype, methodName, {
+    guards,
+    interceptors,
+    method,
+    path,
+  });
+}
+
+function buildRouteMatchBenchmarks() {
+  class StaticController {
+    health() {
+      return { ok: true };
+    }
+  }
+
+  class ParamController {
+    getUser() {
+      return { ok: true };
+    }
+  }
+
+  class MixedController {
+    getItem() {
+      return { ok: true };
+    }
+  }
+
+  registerRoute(StaticController, {
+    basePath: '/health',
+    method: 'GET',
+    methodName: 'health',
+    path: '/',
+  });
+  registerRoute(ParamController, {
+    basePath: '/users',
+    method: 'GET',
+    methodName: 'getUser',
+    path: '/:id',
+  });
+  registerRoute(MixedController, {
+    basePath: '/reports',
+    method: 'GET',
+    methodName: 'getItem',
+    path: '/:reportId/items/:itemId',
+  });
+
+  const extraSources = [];
+  for (let index = 0; index < 40; index += 1) {
+    class ExtraController {
+      value() {
+        return index;
+      }
+    }
+
+    registerRoute(ExtraController, {
+      basePath: `/extra-${index}`,
+      method: 'GET',
+      methodName: 'value',
+      path: index % 2 === 0 ? '/fixed' : '/:id',
+    });
+
+    extraSources.push({ controllerToken: ExtraController });
+  }
+
+  const mapping = createHandlerMapping([
+    { controllerToken: StaticController },
+    { controllerToken: ParamController },
+    { controllerToken: MixedController },
+    ...extraSources,
+  ]);
+
+  return [
+    {
+      iterations: 200000,
+      name: 'route-match static GET /health',
+      run() {
+        mapping.match(createRequest('/health'));
+      },
+    },
+    {
+      iterations: 200000,
+      name: 'route-match param GET /users/42',
+      run() {
+        mapping.match(createRequest('/users/42'));
+      },
+    },
+    {
+      iterations: 200000,
+      name: 'route-match mixed GET /reports/monthly/items/42',
+      run() {
+        mapping.match(createRequest('/reports/monthly/items/42'));
+      },
+    },
+  ];
+}
+
+function buildDispatchBenchmarks() {
+  class HealthController {
+    health() {
+      return { ok: true };
+    }
+  }
+
+  registerRoute(HealthController, {
+    basePath: '/health',
+    method: 'GET',
+    methodName: 'health',
+    path: '/',
+  });
+
+  const emptyPipelineRoot = new Container().register(HealthController);
+  const emptyPipelineDispatcher = createDispatcher({
+    handlerMapping: createHandlerMapping([{ controllerToken: HealthController }]),
+    rootContainer: emptyPipelineRoot,
+  });
+
+  const emptyPipelineRequest = createRequest('/health');
+  const emptyPipelineResponse = createResponse();
+
+  class Repository {
+    read() {
+      return { ok: true };
+    }
+  }
+
+  class Service {
+    constructor(repository) {
+      this.repository = repository;
+    }
+
+    read() {
+      return this.repository.read();
+    }
+  }
+
+  class ChainController {
+    constructor(service) {
+      this.service = service;
+    }
+
+    health() {
+      return this.service.read();
+    }
+  }
+
+  defineClassDiMetadata(Service, { inject: [Repository] });
+  defineClassDiMetadata(ChainController, { inject: [Service] });
+  registerRoute(ChainController, {
+    basePath: '/chain',
+    method: 'GET',
+    methodName: 'health',
+    path: '/',
+  });
+
+  const chainRoot = new Container().register(Repository).register(Service).register(ChainController);
+  const chainDispatcher = createDispatcher({
+    handlerMapping: createHandlerMapping([{ controllerToken: ChainController }]),
+    rootContainer: chainRoot,
+  });
+
+  const chainRequest = createRequest('/chain');
+  const chainResponse = createResponse();
+
+  class AllowGuard {
+    canActivate() {
+      return true;
+    }
+  }
+
+  class RouteInterceptor {
+    async intercept(_context, next) {
+      return next.handle();
+    }
+  }
+
+  class DecoratedController {
+    health() {
+      return { ok: true };
+    }
+  }
+
+  registerRoute(DecoratedController, {
+    basePath: '/decorated',
+    guards: [AllowGuard],
+    interceptors: [RouteInterceptor],
+    method: 'GET',
+    methodName: 'health',
+    path: '/',
+  });
+
+  const moduleMiddleware = {
+    async handle(_context, next) {
+      await next();
+    },
+  };
+
+  const decoratedRoot = new Container().register(AllowGuard).register(RouteInterceptor).register(DecoratedController);
+  const decoratedDispatcher = createDispatcher({
+    appMiddleware: [
+      {
+        async handle(_context, next) {
+          await next();
+        },
+      },
+    ],
+    handlerMapping: createHandlerMapping([
+      {
+        controllerToken: DecoratedController,
+        moduleMiddleware: [moduleMiddleware],
+      },
+    ]),
+    interceptors: [
+      {
+        async intercept(_context, next) {
+          return next.handle();
+        },
+      },
+    ],
+    observers: [
+      {
+        onHandlerMatched() {},
+        onRequestFinish() {},
+        onRequestStart() {},
+        onRequestSuccess() {},
+      },
+    ],
+    rootContainer: decoratedRoot,
+  });
+
+  const decoratedRequest = createRequest('/decorated');
+  const decoratedResponse = createResponse();
+
+  return [
+    {
+      iterations: 20000,
+      name: 'dispatch static GET /health (empty pipeline)',
+      async run() {
+        resetResponse(emptyPipelineResponse);
+        await emptyPipelineDispatcher.dispatch(emptyPipelineRequest, emptyPipelineResponse);
+      },
+    },
+    {
+      iterations: 20000,
+      name: 'dispatch singleton chain GET /chain',
+      async run() {
+        resetResponse(chainResponse);
+        await chainDispatcher.dispatch(chainRequest, chainResponse);
+      },
+    },
+    {
+      iterations: 20000,
+      name: 'dispatch decorated GET /decorated',
+      async run() {
+        resetResponse(decoratedResponse);
+        await decoratedDispatcher.dispatch(decoratedRequest, decoratedResponse);
+      },
+    },
+  ];
+}
+
+async function measureScenario({ iterations, name, run }) {
+  const warmupIterations = Math.min(1000, Math.max(100, Math.floor(iterations / 20)));
+
+  for (let iteration = 0; iteration < warmupIterations; iteration += 1) {
+    await run();
+  }
+
+  const startedAt = performance.now();
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    await run();
+  }
+
+  const durationMs = performance.now() - startedAt;
+
+  return {
+    durationMs: Number(durationMs.toFixed(2)),
+    iterations,
+    name,
+    opsPerSecond: Number(((iterations / durationMs) * 1000).toFixed(2)),
+    usPerOperation: Number(((durationMs * 1000) / iterations).toFixed(2)),
+  };
+}
+
+async function main() {
+  const results = [];
+
+  for (const scenario of [...buildRouteMatchBenchmarks(), ...buildDispatchBenchmarks()]) {
+    results.push(await measureScenario(scenario));
+  }
+
+  process.stdout.write(`${JSON.stringify({
+    benchmark: 'http-dispatch-hot-path',
+    note: 'Route matching and dispatcher hot-path scenarios measured against built dist artifacts on the current branch.',
+    results,
+  }, null, 2)}\n`);
+}
+
+void main();


### PR DESCRIPTION
## Summary

- Pre-index `@fluojs/http` static routes so the hottest GET path avoids segment splitting and broad candidate scans.
- Skip empty observer, middleware, guard, and interceptor stages without changing request lifecycle, error, or versioning semantics.
- Add a scoped hot-path benchmark artifact plus a patch changeset for the public package update.

Closes #1429

## Changes

- Add static route lookup buckets ahead of parameterized matching in `packages/http/src/mapping.ts` and keep method/`ALL` plus version fallback behavior intact.
- Defer param object allocation until a parameterized route fully matches, and add a regression test covering method-specific static routing precedence.
- Short-circuit empty observer, middleware, guard, and interceptor chains in the dispatcher/runtime helpers while preserving wrapping order when chains are present.
- Add `tooling/benchmarks/http-dispatch-hot-path.mjs` to capture route-matching and dispatcher baseline numbers for static, param, mixed, and decorated request paths.
- Add `.changeset/bright-buses-punch.md` for the `@fluojs/http` patch release intent.

## Testing

- `pnpm verify`
- `pnpm --dir packages/http typecheck`
- `node tooling/benchmarks/http-dispatch-hot-path.mjs`
  - `route-match static GET /health`: 4,485,272.89 ops/s (`0.22 us/op`)
  - `route-match param GET /users/42`: 1,798,646.75 ops/s (`0.56 us/op`)
  - `route-match mixed GET /reports/monthly/items/42`: 1,581,089.12 ops/s (`0.63 us/op`)
  - `dispatch static GET /health (empty pipeline)`: 182,398.54 ops/s (`5.48 us/op`)
  - `dispatch singleton chain GET /chain`: 188,029.79 ops/s (`5.32 us/op`)
  - `dispatch decorated GET /decorated`: 74,622.71 ops/s (`13.4 us/op`)

## Public export documentation

- [x] No public export signatures changed in `packages/http/src`.
- [x] No new `@param` / `@returns` source TSDoc requirements were introduced.
- [x] README contract text remains accurate because the change is internal-only performance work.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new public behavioral contracts were introduced that require README updates.
- [x] Intentional limitations around route normalization and version selection remain unchanged.
- [x] Runtime invariants stay covered by the existing dispatcher/mapping suites plus the new static route precedence regression.

## Platform consistency governance (SSOT)

- [x] No governed English/Korean docs changed.
- [x] No platform contract or README conformance claims changed.
- [x] No additional SSOT/tooling sync work was required for this scoped runtime optimization.