### PR TITLE
Resolve #1434: add Fastify native route registration parity coverage

### DIFF
--- a/.changeset/issue-1434-fastify-native-route-registration.md
+++ b/.changeset/issue-1434-fastify-native-route-registration.md
@@ -1,0 +1,8 @@
+---
+"@fluojs/http": patch
+"@fluojs/platform-fastify": patch
+---
+
+Improve `@fluojs/platform-fastify` request dispatch by registering Fastify-native per-route handlers when fluo route metadata can be translated safely, while keeping wildcard fallback behavior for unmatched requests.
+
+Preserve fluo route semantics for params, versioning, middleware/guard/interceptor/observer lifecycle, error handling, SSE, multipart, raw body, and streaming with regression coverage for native route selection.

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -348,7 +348,10 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
   const contentNegotiation = resolveContentNegotiation(options.contentNegotiation);
   const observers = options.observers ?? [];
 
-  return {
+  const dispatcher = {
+    describeRoutes() {
+      return options.handlerMapping.descriptors;
+    },
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
       const phaseContext: DispatchPhaseContext = {
         contentNegotiation,
@@ -375,4 +378,6 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
       });
     },
   };
+
+  return dispatcher as Dispatcher;
 }

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -125,6 +125,11 @@ await bootstrapFastifyApplication(AppModule, {
 });
 ```
 
+### 네이티브 라우트 등록과 안전한 폴백
+fluo 라우트 메타데이터를 Fastify 경로로 그대로 옮길 수 있는 경우, 어댑터는 모든 요청을 단일 와일드카드 라우트로 보내는 대신 Fastify 네이티브 per-route 핸들러를 등록합니다. 이 네이티브 핸들러도 최종적으로는 공통 fluo dispatcher로 위임하므로 params, versioning, middleware, guards, interceptors, observers, SSE, multipart, raw body, streaming, error handling 의미론은 그대로 유지됩니다.
+
+어댑터는 매칭되지 않은 경로와 이식성에 민감한 경우를 위해 와일드카드 fallback 라우트를 계속 유지하며, Fastify의 trailing slash / duplicate slash 정규화를 켜서 네이티브 선택 경로도 fluo의 문서화된 route path 계약과 맞추어 동작하도록 합니다.
+
 ## 성능
 
 fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어댑터보다 훨씬 뛰어난 성능을 발휘합니다.

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -128,6 +128,8 @@ await bootstrapFastifyApplication(AppModule, {
 ### 네이티브 라우트 등록과 안전한 폴백
 fluo 라우트 메타데이터를 Fastify 경로로 그대로 옮길 수 있는 경우, 어댑터는 모든 요청을 단일 와일드카드 라우트로 보내는 대신 Fastify 네이티브 per-route 핸들러를 등록합니다. 이 네이티브 핸들러도 최종적으로는 공통 fluo dispatcher로 위임하므로 params, versioning, middleware, guards, interceptors, observers, SSE, multipart, raw body, streaming, error handling 의미론은 그대로 유지됩니다.
 
+여러 라우트가 같은 method와 정규화된 param shape를 공유하는 경우(예: `/:id` 와 `/:slug`), 어댑터는 해당 shape를 의도적으로 와일드카드 fallback 경로에 남겨 둡니다. 이렇게 해서 Fastify 등록 단계에서 부팅 실패가 나거나 fluo의 등록 순서 기반 매칭 의미론이 좁아지지 않도록 보장합니다.
+
 어댑터는 매칭되지 않은 경로와 이식성에 민감한 경우를 위해 와일드카드 fallback 라우트를 계속 유지하며, Fastify의 trailing slash / duplicate slash 정규화를 켜서 네이티브 선택 경로도 fluo의 문서화된 route path 계약과 맞추어 동작하도록 합니다.
 
 ## 성능

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -125,6 +125,11 @@ await bootstrapFastifyApplication(AppModule, {
 });
 ```
 
+### Native Route Registration with Safe Fallback
+When fluo route metadata can be translated directly, the adapter registers Fastify-native per-route handlers instead of sending every request through a single wildcard route. Those native handlers still hand off to the shared fluo dispatcher, so params, versioning, middleware, guards, interceptors, observers, SSE, multipart, raw body, streaming, and error handling keep the same framework-level semantics.
+
+The adapter keeps a wildcard fallback route for unmatched paths and portability-sensitive cases, and enables Fastify trailing-slash / duplicate-slash normalization so native selection stays aligned with fluo's documented route path contract.
+
 ## Performance
 
 fluo's Fastify adapter significantly outperforms the raw Node.js adapter in high-concurrency scenarios.

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -128,6 +128,8 @@ await bootstrapFastifyApplication(AppModule, {
 ### Native Route Registration with Safe Fallback
 When fluo route metadata can be translated directly, the adapter registers Fastify-native per-route handlers instead of sending every request through a single wildcard route. Those native handlers still hand off to the shared fluo dispatcher, so params, versioning, middleware, guards, interceptors, observers, SSE, multipart, raw body, streaming, and error handling keep the same framework-level semantics.
 
+When multiple routes share the same method and normalized param shape (for example `/:id` and `/:slug`), the adapter intentionally leaves that shape on the wildcard fallback path so Fastify registration cannot boot-fail or narrow fluo's registration-order matching semantics.
+
 The adapter keeps a wildcard fallback route for unmatched paths and portability-sensitive cases, and enables Fastify trailing-slash / duplicate-slash normalization so native selection stays aligned with fluo's documented route path contract.
 
 ## Performance

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -545,6 +545,64 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('falls back to wildcard dispatch for overlapping same-shape param routes without changing fluo route order semantics', async () => {
+    @Controller('/matches')
+    class MatchesController {
+      @Get('/:id')
+      firstMatch(_input: undefined, context: RequestContext) {
+        return {
+          paramName: 'id',
+          route: 'first',
+          value: context.request.params.id,
+        };
+      }
+
+      @Get('/:slug')
+      secondMatch(_input: undefined, context: RequestContext) {
+        return {
+          paramName: 'slug',
+          route: 'second',
+          value: context.request.params.slug,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [MatchesController],
+    });
+
+    const port = await findAvailablePort();
+    const adapter = createFastifyAdapter({ port }) as FastifyHttpApplicationAdapter;
+    const app = await fluoFactory.create(AppModule, { adapter });
+
+    await app.listen();
+
+    try {
+      const fastifyApp = (adapter as unknown as Record<'app', {
+        hasRoute: (options: { method: string; url: string }) => boolean;
+      }>).app;
+
+      expect(fastifyApp.hasRoute({ method: 'GET', url: '/matches/:id' })).toBe(false);
+      expect(fastifyApp.hasRoute({ method: 'GET', url: '/matches/:slug' })).toBe(false);
+
+      const response = await requestHttp({
+        method: 'GET',
+        path: '/matches/42',
+        port,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({
+        paramName: 'id',
+        route: 'first',
+        value: '42',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('settles stream drain waits when the response stream closes before drain', async () => {
     const drainSettled = createDeferred<void>();
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1,11 +1,30 @@
+import type { IncomingHttpHeaders } from 'node:http';
 import { request as httpRequest } from 'node:http';
 import { createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { Controller, Get, Post, SseResponse, type FrameworkRequest, type RequestContext } from '@fluojs/http';
-import { createHealthModule, defineModule, type ApplicationLogger } from '@fluojs/runtime';
+import {
+  All,
+  Controller,
+  Get,
+  Post,
+  SseResponse,
+  UseGuards,
+  UseInterceptors,
+  Version,
+  VersioningType,
+  type CallHandler,
+  type FrameworkRequest,
+  type GuardContext,
+  type InterceptorContext,
+  type MiddlewareContext,
+  type RequestObservationContext,
+  type RequestContext,
+  type RequestObserver,
+} from '@fluojs/http';
+import { createHealthModule, defineModule, fluoFactory, type ApplicationLogger } from '@fluojs/runtime';
 
 import {
   bootstrapFastifyApplication,
@@ -73,6 +92,46 @@ async function requestHttps(url: string): Promise<{ body: string; statusCode: nu
     });
 
     request.on('error', reject);
+    request.end();
+  });
+}
+
+async function requestHttp(options: {
+  body?: string;
+  headers?: IncomingHttpHeaders;
+  method?: string;
+  path: string;
+  port: number;
+}): Promise<{ body: string; headers: IncomingHttpHeaders; statusCode: number }> {
+  return await new Promise((resolve, reject) => {
+    const request = httpRequest({
+      headers: options.headers,
+      host: '127.0.0.1',
+      method: options.method,
+      path: options.path,
+      port: options.port,
+    }, (response) => {
+      const chunks: Buffer[] = [];
+
+      response.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      response.on('end', () => {
+        resolve({
+          body: Buffer.concat(chunks).toString('utf8'),
+          headers: response.headers,
+          statusCode: response.statusCode ?? 0,
+        });
+      });
+      response.on('error', reject);
+    });
+
+    request.on('error', reject);
+
+    if (options.body) {
+      request.write(options.body);
+    }
+
     request.end();
   });
 }
@@ -277,6 +336,213 @@ describe('@fluojs/platform-fastify', () => {
     expect(body).toContain('data: {"ready":true}');
 
     await app.close();
+  });
+
+  it('registers native Fastify routes while preserving fluo matching, versioning, lifecycle, and fallback semantics', async () => {
+    const lifecycle: string[] = [];
+
+    const appMiddleware = {
+      async handle(context: MiddlewareContext, next: () => Promise<void>) {
+        lifecycle.push(`middleware:before:${context.request.method}`);
+        await next();
+        lifecycle.push(`middleware:after:${context.request.method}`);
+      },
+    };
+
+    const guard = {
+      canActivate(context: GuardContext) {
+        lifecycle.push(`guard:${context.handler.route.path}:${context.requestContext.request.params.id ?? '-'}`);
+        return true;
+      },
+    };
+
+    const interceptor = {
+      async intercept(context: InterceptorContext, next: CallHandler) {
+        lifecycle.push(`interceptor:before:${context.handler.route.path}`);
+        const result = await next.handle();
+        lifecycle.push(`interceptor:after:${context.handler.route.path}`);
+        return result;
+      },
+    };
+
+    const observer: RequestObserver = {
+      onHandlerMatched(context: RequestObservationContext) {
+        lifecycle.push(`observer:matched:${context.handler?.route.method}:${context.handler?.route.path}`);
+      },
+      onRequestError(_context: RequestObservationContext, error: unknown) {
+        lifecycle.push(`observer:error:${error instanceof Error ? error.message : String(error)}`);
+      },
+      onRequestFinish(context: RequestObservationContext) {
+        lifecycle.push(`observer:finish:${context.requestContext.request.method}`);
+      },
+      onRequestStart(context: RequestObservationContext) {
+        lifecycle.push(`observer:start:${context.requestContext.request.method}`);
+      },
+      onRequestSuccess(_context: RequestObservationContext, value: unknown) {
+        lifecycle.push(`observer:success:${typeof value === 'object' && value && 'route' in value ? String((value as { route: string }).route) : typeof value}`);
+      },
+    };
+
+    @Controller('/users')
+    class UsersController {
+      @Get('/:id')
+      @UseGuards(guard)
+      @UseInterceptors(interceptor)
+      getUser(_input: undefined, context: RequestContext) {
+        const queryTag = context.request.query.tag;
+
+        return {
+          id: context.request.params.id,
+          queryTag,
+          route: 'user',
+        };
+      }
+    }
+
+    @Controller('/versions')
+    class VersionedController {
+      @Get('/')
+      @Version('1')
+      v1() {
+        return { route: 'version', version: '1' };
+      }
+
+      @Get('/')
+      latest() {
+        return { route: 'version', version: 'latest' };
+      }
+    }
+
+    @Controller('/errors')
+    class ErrorsController {
+      @Get('/')
+      explode() {
+        throw new Error('native route boom');
+      }
+    }
+
+    @Controller('/fallback')
+    class FallbackController {
+      @All('/')
+      handle(_input: undefined, context: RequestContext) {
+        return { method: context.request.method, route: 'all' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UsersController, VersionedController, ErrorsController, FallbackController],
+    });
+
+    const port = await findAvailablePort();
+    const adapter = createFastifyAdapter({ port }) as FastifyHttpApplicationAdapter;
+    const app = await fluoFactory.create(AppModule, {
+      adapter,
+      middleware: [appMiddleware],
+      observers: [observer],
+      versioning: {
+        header: 'x-api-version',
+        type: VersioningType.HEADER,
+      },
+    });
+
+    await app.listen();
+
+    try {
+      const fastifyApp = (adapter as unknown as Record<'app', {
+        hasRoute: (options: { method: string; url: string }) => boolean;
+        printRoutes: () => string;
+      }>).app;
+
+      expect(fastifyApp.hasRoute({ method: 'GET', url: '/users/:id' })).toBe(true);
+      expect(fastifyApp.hasRoute({ method: 'PATCH', url: '/fallback' })).toBe(true);
+      expect(fastifyApp.hasRoute({ method: 'GET', url: '/versions' })).toBe(true);
+      expect(fastifyApp.printRoutes()).toContain('*');
+
+      lifecycle.length = 0;
+      const userResponse = await requestHttp({
+        method: 'GET',
+        path: '/users///123/?tag=a&tag=b',
+        port,
+      });
+
+      expect(userResponse.statusCode).toBe(200);
+      expect(JSON.parse(userResponse.body)).toEqual({
+        id: '123',
+        queryTag: ['a', 'b'],
+        route: 'user',
+      });
+      expect(lifecycle).toContain('observer:matched:GET:/users/:id');
+      expect(lifecycle).toContain('guard:/users/:id:123');
+      expect(lifecycle).toContain('interceptor:before:/users/:id');
+      expect(lifecycle).toContain('interceptor:after:/users/:id');
+      expect(lifecycle).toContain('observer:success:user');
+      expect(lifecycle.indexOf('observer:start:GET')).toBeLessThan(lifecycle.indexOf('middleware:before:GET'));
+      expect(lifecycle.indexOf('middleware:before:GET')).toBeLessThan(lifecycle.indexOf('observer:matched:GET:/users/:id'));
+      expect(lifecycle.indexOf('observer:matched:GET:/users/:id')).toBeLessThan(lifecycle.indexOf('guard:/users/:id:123'));
+      expect(lifecycle.indexOf('guard:/users/:id:123')).toBeLessThan(lifecycle.indexOf('interceptor:before:/users/:id'));
+      expect(lifecycle.indexOf('interceptor:before:/users/:id')).toBeLessThan(lifecycle.indexOf('interceptor:after:/users/:id'));
+      expect(lifecycle.indexOf('interceptor:after:/users/:id')).toBeLessThan(lifecycle.indexOf('observer:success:user'));
+      expect(lifecycle.indexOf('observer:success:user')).toBeLessThan(lifecycle.indexOf('middleware:after:GET'));
+      expect(lifecycle.indexOf('middleware:after:GET')).toBeLessThan(lifecycle.indexOf('observer:finish:GET'));
+
+      const versionedResponse = await requestHttp({
+        headers: { 'x-api-version': '1' },
+        method: 'GET',
+        path: '/versions/',
+        port,
+      });
+      expect(versionedResponse.statusCode).toBe(200);
+      expect(JSON.parse(versionedResponse.body)).toEqual({ route: 'version', version: '1' });
+
+      const unversionedResponse = await requestHttp({
+        method: 'GET',
+        path: '/versions',
+        port,
+      });
+      expect(unversionedResponse.statusCode).toBe(200);
+      expect(JSON.parse(unversionedResponse.body)).toEqual({ route: 'version', version: 'latest' });
+
+      const allResponse = await requestHttp({
+        method: 'PATCH',
+        path: '/fallback',
+        port,
+      });
+      expect(allResponse.statusCode).toBe(200);
+      expect(JSON.parse(allResponse.body)).toEqual({ method: 'PATCH', route: 'all' });
+
+      lifecycle.length = 0;
+      const errorResponse = await requestHttp({
+        method: 'GET',
+        path: '/errors',
+        port,
+      });
+      expect(errorResponse.statusCode).toBe(500);
+      expect(JSON.parse(errorResponse.body)).toEqual({
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Internal server error.',
+          status: 500,
+        },
+      });
+      expect(lifecycle).toContain('observer:error:native route boom');
+
+      const missingResponse = await requestHttp({
+        method: 'GET',
+        path: '/missing',
+        port,
+      });
+      expect(missingResponse.statusCode).toBe(404);
+      expect(JSON.parse(missingResponse.body)).toEqual({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'No handler registered for GET /missing.',
+          status: 404,
+        },
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('settles stream drain waits when the response stream closes before drain', async () => {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -10,6 +10,7 @@ import {
   createServerBackedHttpAdapterRealtimeCapability,
   createErrorResponse,
   HttpException,
+  type HandlerDescriptor,
   InternalServerErrorException,
   PayloadTooLargeException,
   type CorsOptions,
@@ -70,6 +71,13 @@ export type CorsInput = false | string | string[] | CorsOptions;
 
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+const FASTIFY_NATIVE_ROUTE_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'] as const;
+
+type FastifyNativeRouteMethod = (typeof FASTIFY_NATIVE_ROUTE_METHODS)[number];
+
+type RouteDescribingDispatcher = Dispatcher & {
+  describeRoutes?: () => readonly HandlerDescriptor[];
+};
 
 /**
  * Bootstrap options for creating a Fastify-backed application without
@@ -166,7 +174,7 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
 
   async listen(dispatcher: Dispatcher): Promise<void> {
     this.dispatcher = dispatcher;
-    await this.registerPluginsAndRoute();
+    await this.registerPluginsAndRoutes(dispatcher);
     await this.listenWithRetry();
   }
 
@@ -195,7 +203,7 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
     await waitForCloseWithTimeout(closeInFlight, this.shutdownTimeoutMs);
   }
 
-  private async registerPluginsAndRoute(): Promise<void> {
+  private async registerPluginsAndRoutes(dispatcher: Dispatcher): Promise<void> {
     if (this.pluginsReady) {
       return;
     }
@@ -211,11 +219,28 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
       });
     }
 
+    this.registerNativeRoutes(resolveDispatcherRouteDescriptors(dispatcher));
+    this.registerWildcardFallbackRoute();
+
+    this.pluginsReady = true;
+  }
+
+  private registerNativeRoutes(descriptors: readonly HandlerDescriptor[]): void {
+    for (const route of createFastifyNativeRoutes(descriptors)) {
+      this.app.route({
+        handler: async (request: FastifyRequest, reply: FastifyReply) => {
+          await this.handleRequest(request, reply);
+        },
+        method: route.method,
+        url: route.path,
+      });
+    }
+  }
+
+  private registerWildcardFallbackRoute(): void {
     this.app.all('*', async (request: FastifyRequest, reply: FastifyReply) => {
       await this.handleRequest(request, reply);
     });
-
-    this.pluginsReady = true;
   }
 
   private async listenWithRetry(): Promise<void> {
@@ -271,6 +296,49 @@ function createFastifyRequestResponseFactory(
       await response.send(createErrorResponse(httpError, requestId));
     },
   };
+}
+
+interface FastifyNativeRouteDefinition {
+  method: FastifyNativeRouteMethod;
+  path: string;
+}
+
+function resolveDispatcherRouteDescriptors(dispatcher: Dispatcher): readonly HandlerDescriptor[] {
+  return (dispatcher as RouteDescribingDispatcher).describeRoutes?.() ?? [];
+}
+
+function createFastifyNativeRoutes(descriptors: readonly HandlerDescriptor[]): FastifyNativeRouteDefinition[] {
+  const registrations = new Map<string, FastifyNativeRouteDefinition>();
+
+  for (const descriptor of descriptors) {
+    const path = descriptor.route.path;
+
+    if (descriptor.route.method === 'ALL') {
+      for (const method of FASTIFY_NATIVE_ROUTE_METHODS) {
+        const key = `${method}:${path}`;
+
+        if (!registrations.has(key)) {
+          registrations.set(key, {
+            method,
+            path,
+          });
+        }
+      }
+
+      continue;
+    }
+
+    const key = `${descriptor.route.method}:${path}`;
+
+    if (!registrations.has(key)) {
+      registrations.set(key, {
+        method: descriptor.route.method,
+        path,
+      });
+    }
+  }
+
+  return [...registrations.values()];
 }
 
 /**
@@ -725,14 +793,24 @@ function createFastifyApp(
   if (httpsOptions) {
     return fastify({
       bodyLimit: maxBodySize,
+      exposeHeadRoutes: false,
       https: httpsOptions,
       logger: false,
+      routerOptions: {
+        ignoreDuplicateSlashes: true,
+        ignoreTrailingSlash: true,
+      },
     } as Parameters<typeof fastify>[0]);
   }
 
   return fastify({
     bodyLimit: maxBodySize,
+    exposeHeadRoutes: false,
     logger: false,
+    routerOptions: {
+      ignoreDuplicateSlashes: true,
+      ignoreTrailingSlash: true,
+    },
   });
 }
 

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -303,42 +303,71 @@ interface FastifyNativeRouteDefinition {
   path: string;
 }
 
+interface FastifyNativeRouteCandidate extends FastifyNativeRouteDefinition {
+  shapeKey: string;
+}
+
 function resolveDispatcherRouteDescriptors(dispatcher: Dispatcher): readonly HandlerDescriptor[] {
   return (dispatcher as RouteDescribingDispatcher).describeRoutes?.() ?? [];
 }
 
 function createFastifyNativeRoutes(descriptors: readonly HandlerDescriptor[]): FastifyNativeRouteDefinition[] {
-  const registrations = new Map<string, FastifyNativeRouteDefinition>();
+  const candidates = new Map<string, FastifyNativeRouteCandidate>();
+  const shapePaths = new Map<string, Set<string>>();
 
   for (const descriptor of descriptors) {
     const path = descriptor.route.path;
 
     if (descriptor.route.method === 'ALL') {
       for (const method of FASTIFY_NATIVE_ROUTE_METHODS) {
-        const key = `${method}:${path}`;
-
-        if (!registrations.has(key)) {
-          registrations.set(key, {
-            method,
-            path,
-          });
-        }
+        registerFastifyNativeRouteCandidate(candidates, shapePaths, method, path);
       }
 
       continue;
     }
 
-    const key = `${descriptor.route.method}:${path}`;
-
-    if (!registrations.has(key)) {
-      registrations.set(key, {
-        method: descriptor.route.method,
-        path,
-      });
-    }
+    registerFastifyNativeRouteCandidate(candidates, shapePaths, descriptor.route.method, path);
   }
 
-  return [...registrations.values()];
+  return [...candidates.values()]
+    .filter((candidate) => shapePaths.get(candidate.shapeKey)?.size === 1)
+    .map(({ method, path }) => ({ method, path }));
+}
+
+function registerFastifyNativeRouteCandidate(
+  candidates: Map<string, FastifyNativeRouteCandidate>,
+  shapePaths: Map<string, Set<string>>,
+  method: FastifyNativeRouteMethod,
+  path: string,
+): void {
+  const routeKey = `${method}:${path}`;
+  const shapeKey = `${method}:${canonicalizeFastifyRouteShape(path)}`;
+
+  if (!candidates.has(routeKey)) {
+    candidates.set(routeKey, {
+      method,
+      path,
+      shapeKey,
+    });
+  }
+
+  let paths = shapePaths.get(shapeKey);
+
+  if (!paths) {
+    paths = new Set<string>();
+    shapePaths.set(shapeKey, paths);
+  }
+
+  paths.add(path);
+}
+
+function canonicalizeFastifyRouteShape(path: string): string {
+  const segments = path
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => segment.startsWith(':') ? ':' : segment);
+
+  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
 }
 
 /**


### PR DESCRIPTION
Closes #1434

## Summary

Preserve fluo route-selection semantics when `@fluojs/platform-fastify` pre-registers Fastify-native routes, including overlapping same-shape param routes such as `/:id` and `/:slug`.

## Changes

- skip Fastify-native registration for method/path-shape collisions so overlapping param-shape routes fall back to the wildcard dispatcher instead of boot-failing or narrowing fluo's registration-order matching semantics
- add regression coverage proving `/:id` vs `/:slug` still resolves through fluo fallback dispatch with first-registration semantics preserved
- document the same-shape param fallback contract in `packages/platform-fastify/README.md` and `packages/platform-fastify/README.ko.md`

## Testing

- `pnpm --filter @fluojs/platform-fastify test`
- `pnpm --filter @fluojs/platform-fastify typecheck`
- `pnpm --filter @fluojs/platform-fastify build`
- `pnpm vitest run --project packages packages/testing/src/portability/http-adapter-portability.test.ts --testNamePattern="fastify adapter portability"`
- `lsp_diagnostics` clean for `packages/platform-fastify/src`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Fastify adapter portability claims are backed by `packages/testing/src/portability/http-adapter-portability.test.ts` via `createHttpAdapterPortabilityHarness(...)`.