### PR TITLE
Resolve #1433: add Bun routes object acceleration fallback

### DIFF
--- a/.changeset/soft-lamps-scream.md
+++ b/.changeset/soft-lamps-scream.md
@@ -1,6 +1,6 @@
 ---
-'@fluojs/http': patch
-'@fluojs/platform-bun': patch
+'@fluojs/http': minor
+'@fluojs/platform-bun': minor
 ---
 
-Preserve fluo dispatcher semantics while letting the Bun adapter pre-register safe `Bun.serve({ routes })` entries for static and parameter routes. Same-shape parameter routes and unsupported handler shapes now fall back to fetch-only dispatch instead of changing path-param behavior.
+Expose `Dispatcher.describeRoutes?.()` for adapter-side route introspection and let the Bun adapter pre-register semver-safe `Bun.serve({ routes })` entries for compatible static and parameter routes. Same-shape parameter routes, `ALL` handlers, older Bun runtimes, and other unsupported shapes continue to fall back to fetch-only dispatch so fluo path, error, and request-body semantics stay unchanged.

--- a/.changeset/soft-lamps-scream.md
+++ b/.changeset/soft-lamps-scream.md
@@ -1,0 +1,6 @@
+---
+'@fluojs/http': patch
+'@fluojs/platform-bun': patch
+---
+
+Preserve fluo dispatcher semantics while letting the Bun adapter pre-register safe `Bun.serve({ routes })` entries for static and parameter routes. Same-shape parameter routes and unsupported handler shapes now fall back to fetch-only dispatch instead of changing path-param behavior.

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -77,6 +77,25 @@ function createDispatchRequest(request: FrameworkRequest): FrameworkRequest {
   };
 }
 
+function cloneHandlerDescriptor(descriptor: HandlerDescriptor): HandlerDescriptor {
+  return {
+    ...descriptor,
+    metadata: {
+      ...descriptor.metadata,
+      moduleMiddleware: [...descriptor.metadata.moduleMiddleware],
+      pathParams: [...descriptor.metadata.pathParams],
+    },
+    route: {
+      ...descriptor.route,
+      guards: descriptor.route.guards ? [...descriptor.route.guards] : undefined,
+      headers: descriptor.route.headers?.map((header) => ({ ...header })),
+      interceptors: descriptor.route.interceptors ? [...descriptor.route.interceptors] : undefined,
+      produces: descriptor.route.produces ? [...descriptor.route.produces] : undefined,
+      redirect: descriptor.route.redirect ? { ...descriptor.route.redirect } : undefined,
+    },
+  };
+}
+
 function readRequestId(request: FrameworkRequest): string | undefined {
   const raw = request.headers['x-request-id'] ?? request.headers['X-Request-Id'];
   const value = Array.isArray(raw) ? raw[0] : raw;
@@ -350,7 +369,7 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
 
   const dispatcher = {
     describeRoutes() {
-      return options.handlerMapping.descriptors;
+      return options.handlerMapping.descriptors.map((descriptor) => cloneHandlerDescriptor(descriptor));
     },
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
       const phaseContext: DispatchPhaseContext = {

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -209,6 +209,11 @@ export type VersioningOptions =
 /** Runtime dispatcher that executes the full HTTP request lifecycle. */
 export interface Dispatcher {
   dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void>;
+  /**
+   * Returns the mapped route descriptors known to this dispatcher when the
+   * implementation can expose them without changing dispatch behavior.
+   */
+  describeRoutes?(): readonly HandlerDescriptor[];
 }
 
 /** Logger seam used by the dispatcher for non-fatal internal failure reporting. */

--- a/packages/platform-bun/README.ko.md
+++ b/packages/platform-bun/README.ko.md
@@ -71,6 +71,11 @@ Bun.serve({
 export class MyGateway {}
 ```
 
+### 네이티브 `routes` Object 가속
+Bun `>=1.2.3`에서는 어댑터가 의미 보존이 가능한 static/param fluo route를 `Bun.serve({ routes })`에 선택적으로 등록한 뒤, 매칭된 요청도 다시 shared fluo dispatcher로 흘려보냅니다.
+
+이 방식은 raw body, multipart, SSE, error response, shutdown drain, websocket upgrade delegation을 모두 기존 shared 실행 경로에 유지합니다. same-shape param route처럼 의미가 어긋날 수 있는 경우나 `ALL` 메서드 handler처럼 안전하게 선등록할 수 없는 경우에는 의미를 바꾸지 않도록 해당 route를 fetch-only dispatch로 폴백합니다.
+
 ## 공개 API 개요
 
 - `createBunAdapter(options)`: Bun 어댑터를 위한 권장 팩토리입니다.
@@ -89,6 +94,7 @@ export class MyGateway {}
 
 - **런타임 host**: 이 패키지는 listen 시점에 `globalThis.Bun.serve()`가 필요합니다. 테스트에서는 Bun 호환 test double을 제공할 수 있지만, production 사용은 Bun 전용입니다.
 - **요청 portability**: Fetch 요청은 shared web dispatcher를 통해 변환되며 malformed cookie 값, query 배열, `rawBody: true`일 때 JSON/text raw body, SSE framing을 보존합니다.
+- **네이티브 route 가속**: Bun의 `routes` object를 사용할 수 있고 fluo route shape를 의미 보존 상태로 선등록할 수 있을 때만 Bun이 path matching을 먼저 처리하고, 이후 요청은 다시 shared dispatcher로 넘깁니다. 지원하지 않거나 모호한 route shape는 일반 `fetch` 경로로 폴백합니다.
 - **Multipart 동작**: Multipart 요청은 `rawBody`를 노출하지 않으며 multipart limit은 shared runtime parser를 통해 계속 적용됩니다.
 - **시작 target**: `hostname`, `port`, `tls`는 `Bun.serve()`로 전달됩니다. 시작 로그는 설정된 HTTP 또는 HTTPS listen URL을 보고합니다.
 - **종료 소유권**: `close()`는 새 유입을 중단하고, in-flight HTTP handler를 기다린 뒤, drain이 끝나면 adapter state를 정리하며 `runBunApplication()`이 등록한 signal listener를 제거합니다.
@@ -96,7 +102,7 @@ export class MyGateway {}
 
 ## Conformance 커버리지
 
-`packages/platform-bun/src/adapter.test.ts`는 문서화된 계약을 검증하는 package-local regression 대상입니다. 이 파일은 malformed cookie, JSON/text raw-body 보존, multipart raw-body 제외, SSE framing을 검증하는 Bun fetch-style portability assertion과 startup logging, shutdown listener cleanup, in-flight drain, timeout reporting, websocket binding delegation을 검증하는 집중 테스트를 포함합니다.
+`packages/platform-bun/src/adapter.test.ts`는 문서화된 계약을 검증하는 package-local regression 대상입니다. 이 파일은 malformed cookie, JSON/text raw-body 보존, multipart raw-body 제외, SSE framing, native-route param parity, same-shape route fallback을 검증하는 Bun fetch-style portability assertion과 startup logging, shutdown listener cleanup, in-flight drain, timeout reporting, websocket binding delegation을 검증하는 집중 테스트를 포함합니다.
 
 저장소의 더 넓은 suite도 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`에서 `createWebRuntimeHttpAdapterPortabilityHarness(...)`로 Bun을 Deno 및 Cloudflare Workers와 함께 실행해 fetch-style platform 간 shared web-runtime portability baseline을 맞춥니다.
 

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -71,6 +71,11 @@ The adapter supports Bun's native `server.upgrade()` through the `@fluojs/websoc
 export class MyGateway {}
 ```
 
+### Native `routes` Object Acceleration
+On Bun `>=1.2.3`, the adapter opportunistically registers safe static and parameterized fluo routes through `Bun.serve({ routes })` while still routing matched requests back through the shared fluo dispatcher.
+
+This keeps raw body, multipart, SSE, error responses, shutdown drain behavior, and websocket upgrade delegation on the same shared execution path. If route shape parity is unsafe, such as same-shape parameter routes with different param names or `ALL`-method handlers, the adapter falls back to fetch-only dispatch for those routes instead of changing fluo semantics.
+
 ## Public API Overview
 
 - `createBunAdapter(options)`: Recommended factory for the Bun adapter.
@@ -89,6 +94,7 @@ The adapter also exports the typed Bun integration seams used by realtime packag
 
 - **Runtime host**: This package requires `globalThis.Bun.serve()` at listen time. Tests may provide a Bun-compatible test double, but production use is Bun-only.
 - **Request portability**: Fetch requests are translated through the shared web dispatcher, preserving malformed cookie values, query arrays, JSON/text raw bodies when `rawBody: true`, and SSE framing.
+- **Native route acceleration**: When Bun's `routes` object is available and a fluo route shape is semantically safe to pre-register, the adapter lets Bun short-circuit path matching before handing the request back to the shared dispatcher. Unsupported or ambiguous route shapes fall back to the regular `fetch` path.
 - **Multipart behavior**: Multipart requests never expose `rawBody`, and multipart limits continue to flow through the shared runtime parser.
 - **Startup target**: `hostname`, `port`, and `tls` are forwarded to `Bun.serve()`. Startup logs report the configured HTTP or HTTPS listen URL.
 - **Shutdown ownership**: `close()` stops new ingress, waits for in-flight HTTP handlers, clears adapter state after drain settles, and removes signal listeners registered by `runBunApplication()`.
@@ -96,7 +102,7 @@ The adapter also exports the typed Bun integration seams used by realtime packag
 
 ## Conformance Coverage
 
-`packages/platform-bun/src/adapter.test.ts` is the package-local regression target for the documented contract. It includes Bun fetch-style portability assertions for malformed cookies, JSON/text raw-body preservation, multipart raw-body exclusion, and SSE framing, plus focused tests for startup logging, shutdown listener cleanup, in-flight drain behavior, timeout reporting, and websocket binding delegation.
+`packages/platform-bun/src/adapter.test.ts` is the package-local regression target for the documented contract. It includes Bun fetch-style portability assertions for malformed cookies, JSON/text raw-body preservation, multipart raw-body exclusion, SSE framing, native-route param parity, and same-shape route fallback, plus focused tests for startup logging, shutdown listener cleanup, in-flight drain behavior, timeout reporting, and websocket binding delegation.
 
 The broader repository suite also exercises Bun through `createWebRuntimeHttpAdapterPortabilityHarness(...)` alongside Deno and Cloudflare Workers in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`, keeping the shared web-runtime portability baseline aligned across fetch-style platforms.
 

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { Controller, Get, Post, SseResponse, type FrameworkRequest, type FrameworkResponse, type RequestContext } from '@fluojs/http';
+import { All, Controller, Get, Post, SseResponse, type FrameworkRequest, type FrameworkResponse, type RequestContext } from '@fluojs/http';
 import { defineModule, type ApplicationLogger } from '@fluojs/runtime';
 
 import {
@@ -583,6 +583,141 @@ describe('@fluojs/platform-bun', () => {
 
       expect(response?.status).toBe(200);
       await expect(response?.json()).resolves.toEqual({ firstId: '123', route: 'first' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps ALL handlers on fetch-only dispatch without native route registration', async () => {
+    const mockBun = installMockBun();
+
+    @Controller('/catch-all')
+    class CatchAllController {
+      @All('/:slug')
+      handle(_input: undefined, context: RequestContext) {
+        return {
+          method: context.request.method,
+          slug: context.request.params.slug,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [CatchAllController] });
+
+    const app = await runBunApplication(AppModule, {
+      hostname: '127.0.0.1',
+      port: 4316,
+    });
+
+    try {
+      expect(mockBun.lastOptions?.routes).toBeUndefined();
+
+      const response = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4316/catch-all/fallback-check', {
+        method: 'POST',
+      }));
+
+      expect(response?.status).toBe(200);
+      await expect(response?.json()).resolves.toEqual({
+        method: 'POST',
+        slug: 'fallback-check',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('falls back to fetch-only dispatch on Bun versions below 1.2.3', async () => {
+    const mockBun = installMockBun({ version: '1.2.2' });
+
+    @Controller('/version-gate')
+    class VersionGateController {
+      @Get('/:itemId')
+      getItem(_input: undefined, context: RequestContext) {
+        return { itemId: context.request.params.itemId };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [VersionGateController] });
+
+    const app = await runBunApplication(AppModule, {
+      hostname: '127.0.0.1',
+      port: 4317,
+    });
+
+    try {
+      expect(mockBun.lastOptions?.routes).toBeUndefined();
+
+      const response = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4317/version-gate/legacy-runtime'));
+
+      expect(response?.status).toBe(200);
+      await expect(response?.json()).resolves.toEqual({ itemId: 'legacy-runtime' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('preserves shared dispatcher error responses for both native-route and fetch-only fallback requests', async () => {
+    const mockBun = installMockBun();
+
+    @Controller('/errors')
+    class ErrorController {
+      @Get('/native')
+      nativeRoute() {
+        throw new Error('native boom');
+      }
+
+      @All('/fallback')
+      fallbackRoute() {
+        throw new Error('fallback boom');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [ErrorController] });
+
+    const app = await runBunApplication(AppModule, {
+      hostname: '127.0.0.1',
+      port: 4318,
+    });
+
+    try {
+      expect(mockBun.lastOptions?.routes).toMatchObject({
+        '/errors/native': {
+          GET: expect.any(Function),
+        },
+      });
+      expect(mockBun.lastOptions?.routes?.['/errors/fallback']).toBeUndefined();
+
+      const [nativeResponse, fallbackResponse] = await Promise.all([
+        mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4318/errors/native', {
+          headers: { 'x-request-id': 'req-bun-native-error' },
+        })),
+        mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4318/errors/fallback', {
+          headers: { 'x-request-id': 'req-bun-fallback-error' },
+          method: 'POST',
+        })),
+      ]);
+
+      expect(nativeResponse?.status).toBe(500);
+      expect(fallbackResponse?.status).toBe(500);
+      await expect(nativeResponse?.json()).resolves.toMatchObject({
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Internal server error.',
+          requestId: 'req-bun-native-error',
+          status: 500,
+        },
+      });
+      await expect(fallbackResponse?.json()).resolves.toMatchObject({
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Internal server error.',
+          requestId: 'req-bun-fallback-error',
+          status: 500,
+        },
+      });
     } finally {
       await app.close();
     }

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -26,6 +26,7 @@ type MockBun = {
   lastOptions?: BunServeOptions;
   lastServer?: MockBunServer;
   serve: ReturnType<typeof vi.fn<(options: BunServeOptions) => MockBunServer>>;
+  version: string;
 };
 
 const originalBun = (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
@@ -51,8 +52,9 @@ function createDeferred<T>() {
   return { promise, reject, resolve };
 }
 
-function installMockBun(): MockBun {
+function installMockBun(options: { version?: string } = {}): MockBun {
   const mockBun = {} as MockBun;
+  mockBun.version = options.version ?? '1.2.3';
 
   mockBun.serve = vi.fn((options: BunServeOptions) => {
     const protocol = options.tls ? 'https' : 'http';
@@ -61,7 +63,15 @@ function installMockBun(): MockBun {
     let server!: MockBunServer;
 
     server = {
-      fetch: async (request: Request): Promise<Response | undefined> => await options.fetch(request, server),
+      fetch: async (request: Request): Promise<Response | undefined> => {
+        const routed = await dispatchMockBunNativeRoute(options, request, server);
+
+        if (routed.matched) {
+          return routed.response;
+        }
+
+        return await options.fetch(request, server);
+      },
       hostname,
       port,
       stop: vi.fn<(closeActiveConnections?: boolean) => void>(),
@@ -116,6 +126,139 @@ function createMockServerWebSocket(data: unknown): BunServerWebSocket<unknown> {
       subscriptions.delete(topic);
     },
   };
+}
+
+function createMockDispatcherRoute(path: string, method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD' = 'GET') {
+  return {
+    controllerToken: class TestController {},
+    metadata: {
+      controllerPath: '',
+      effectivePath: path,
+      moduleMiddleware: [],
+      pathParams: path.split('/').filter((segment) => segment.startsWith(':')).map((segment) => segment.slice(1)),
+    },
+    methodName: 'handle',
+    route: {
+      method,
+      path,
+    },
+  };
+}
+
+async function dispatchMockBunNativeRoute(
+  options: BunServeOptions,
+  request: Request,
+  server: MockBunServer,
+): Promise<{ matched: boolean; response?: Response }> {
+  const matched = matchMockBunRoute(options.routes, new URL(request.url).pathname);
+
+  if (!matched) {
+    return { matched: false };
+  }
+
+  const routeValue = resolveMockBunRouteValue(matched.value, request.method.toUpperCase());
+
+  if (!routeValue) {
+    return { matched: false };
+  }
+
+  if (routeValue instanceof Response) {
+    return {
+      matched: true,
+      response: routeValue.clone(),
+    };
+  }
+
+  Object.defineProperty(request, 'params', {
+    configurable: true,
+    enumerable: true,
+    value: matched.params,
+  });
+
+  return {
+    matched: true,
+    response: await routeValue(request as Request & { params: Record<string, string> }, server),
+  };
+}
+
+function matchMockBunRoute(
+  routes: BunServeOptions['routes'],
+  path: string,
+): { params: Record<string, string>; value: NonNullable<BunServeOptions['routes']>[string] } | undefined {
+  if (!routes) {
+    return undefined;
+  }
+
+  const entries = Object.entries(routes);
+
+  for (const [pattern, value] of entries) {
+    if (pattern === path) {
+      return { params: {}, value };
+    }
+  }
+
+  for (const [pattern, value] of entries) {
+    if (!pattern.includes(':')) {
+      continue;
+    }
+
+    const params = matchMockBunParamRoute(pattern, path);
+
+    if (params) {
+      return { params, value };
+    }
+  }
+
+  for (const [pattern, value] of entries) {
+    if (pattern === '/*') {
+      return { params: {}, value };
+    }
+
+    if (pattern.endsWith('/*')) {
+      const prefix = pattern.slice(0, -1);
+
+      if (path.startsWith(prefix)) {
+        return { params: {}, value };
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function matchMockBunParamRoute(pattern: string, path: string): Record<string, string> | undefined {
+  const patternSegments = pattern.split('/').filter(Boolean);
+  const pathSegments = path.split('/').filter(Boolean);
+
+  if (patternSegments.length !== pathSegments.length) {
+    return undefined;
+  }
+
+  const params: Record<string, string> = {};
+
+  for (let index = 0; index < patternSegments.length; index += 1) {
+    const patternSegment = patternSegments[index];
+    const pathSegment = pathSegments[index];
+
+    if (patternSegment.startsWith(':')) {
+      params[patternSegment.slice(1)] = decodeURIComponent(pathSegment);
+      continue;
+    }
+
+    if (patternSegment !== pathSegment) {
+      return undefined;
+    }
+  }
+
+  return params;
+}
+
+function resolveMockBunRouteValue(value: NonNullable<BunServeOptions['routes']>[string], method: string) {
+  if (value instanceof Response || typeof value === 'function') {
+    return value;
+  }
+
+  return value[method as keyof typeof value];
 }
 
 function registerBunWebRuntimePortabilitySuite(): void {
@@ -349,6 +492,12 @@ describe('@fluojs/platform-bun', () => {
     });
 
     try {
+      expect(mockBun.lastOptions?.routes).toMatchObject({
+        '/webhooks/json': {
+          POST: expect.any(Function),
+        },
+      });
+
       const response = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4310/webhooks/json', {
         body: JSON.stringify({ provider: 'stripe' }),
         headers: { 'content-type': 'application/json' },
@@ -360,6 +509,80 @@ describe('@fluojs/platform-bun', () => {
         parsed: { provider: 'stripe' },
         raw: '{"provider":"stripe"}',
       });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('registers Bun native param routes without changing fluo path-param semantics', async () => {
+    const mockBun = installMockBun();
+
+    @Controller('/users')
+    class UsersController {
+      @Get('/:userId')
+      getById(_input: undefined, context: RequestContext) {
+        return { userId: context.request.params.userId };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [UsersController] });
+
+    const app = await runBunApplication(AppModule, {
+      hostname: '127.0.0.1',
+      port: 4314,
+    });
+
+    try {
+      expect(mockBun.lastOptions?.routes).toMatchObject({
+        '/users/:userId': {
+          GET: expect.any(Function),
+        },
+      });
+
+      const response = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4314/users/a%2Fb'));
+
+      expect(response?.status).toBe(200);
+      await expect(response?.json()).resolves.toEqual({ userId: 'a%2Fb' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('falls back to fetch-only dispatch for same-shape parameter routes that would change fluo matching semantics', async () => {
+    const mockBun = installMockBun();
+
+    @Controller('/items')
+    class FirstController {
+      @Get('/:firstId')
+      first(_input: undefined, context: RequestContext) {
+        return { firstId: context.request.params.firstId, route: 'first' };
+      }
+    }
+
+    @Controller('/items')
+    class SecondController {
+      @Get('/:secondId')
+      second(_input: undefined, context: RequestContext) {
+        return { route: 'second', secondId: context.request.params.secondId };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [FirstController, SecondController] });
+
+    const app = await runBunApplication(AppModule, {
+      hostname: '127.0.0.1',
+      port: 4315,
+    });
+
+    try {
+      expect(mockBun.lastOptions?.routes).toBeUndefined();
+
+      const response = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4315/items/123'));
+
+      expect(response?.status).toBe(200);
+      await expect(response?.json()).resolves.toEqual({ firstId: '123', route: 'first' });
     } finally {
       await app.close();
     }
@@ -593,6 +816,7 @@ describe('@fluojs/platform-bun', () => {
       await adapter.listen(dispatcher);
 
       const responsePromise = mockBun.lastServer!.fetch(new Request('http://127.0.0.1:3000/timeout-check'));
+      await Promise.resolve();
       const closeResultPromise = adapter.close().catch((error: unknown) => error);
 
       await vi.advanceTimersByTimeAsync(10_001);
@@ -644,6 +868,7 @@ describe('@fluojs/platform-bun', () => {
       dispatch: vi.fn(async (_request: FrameworkRequest, response: FrameworkResponse) => {
         response.setStatus(200);
       }),
+      describeRoutes: () => [createMockDispatcherRoute('/chat')],
     };
     const bindingFetch = vi.fn<BunWebSocketBinding['fetch']>(async (request, server) => {
       if (request.headers.get('upgrade')?.toLowerCase() === 'websocket') {
@@ -661,10 +886,16 @@ describe('@fluojs/platform-bun', () => {
 
     await adapter.listen(dispatcher);
 
+    expect(mockBun.lastOptions?.routes).toMatchObject({
+      '/chat': {
+        GET: expect.any(Function),
+      },
+    });
+
     const upgradeResponse = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:3000/chat', {
       headers: { upgrade: 'websocket' },
     }));
-    const httpResponse = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:3000/http'));
+    const httpResponse = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:3000/chat'));
 
     expect(mockBun.lastOptions?.websocket).toBeDefined();
     expect(upgradeResponse).toBeUndefined();

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -150,7 +150,7 @@ async function dispatchMockBunNativeRoute(
   request: Request,
   server: MockBunServer,
 ): Promise<{ matched: boolean; response?: Response }> {
-  const matched = matchMockBunRoute(options.routes, new URL(request.url).pathname);
+  const matched = matchMockBunRoute(options.routes, new URL(request.url).pathname, request.method.toUpperCase());
 
   if (!matched) {
     return { matched: false };
@@ -184,6 +184,7 @@ async function dispatchMockBunNativeRoute(
 function matchMockBunRoute(
   routes: BunServeOptions['routes'],
   path: string,
+  method: string,
 ): { params: Record<string, string>; value: NonNullable<BunServeOptions['routes']>[string] } | undefined {
   if (!routes) {
     return undefined;
@@ -193,7 +194,9 @@ function matchMockBunRoute(
 
   for (const [pattern, value] of entries) {
     if (pattern === path) {
-      return { params: {}, value };
+      return isMockBunRouteMethodSupported(value, method)
+        ? { params: {}, value }
+        : { params: {}, value: new Response(null, { status: 404 }) };
     }
   }
 
@@ -205,7 +208,9 @@ function matchMockBunRoute(
     const params = matchMockBunParamRoute(pattern, path);
 
     if (params) {
-      return { params, value };
+      return isMockBunRouteMethodSupported(value, method)
+        ? { params, value }
+        : { params, value: new Response(null, { status: 404 }) };
     }
   }
 
@@ -259,6 +264,14 @@ function resolveMockBunRouteValue(value: NonNullable<BunServeOptions['routes']>[
   }
 
   return value[method as keyof typeof value];
+}
+
+function isMockBunRouteMethodSupported(value: NonNullable<BunServeOptions['routes']>[string], method: string): boolean {
+  if (value instanceof Response || typeof value === 'function') {
+    return true;
+  }
+
+  return value[method as keyof typeof value] !== undefined;
 }
 
 function registerBunWebRuntimePortabilitySuite(): void {
@@ -544,6 +557,52 @@ describe('@fluojs/platform-bun', () => {
 
       expect(response?.status).toBe(200);
       await expect(response?.json()).resolves.toEqual({ userId: 'a%2Fb' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('preserves shared dispatcher method-miss semantics for Bun native routes', async () => {
+    const mockBun = installMockBun();
+
+    @Controller('/users')
+    class UsersController {
+      @Get('/:userId')
+      getById(_input: undefined, context: RequestContext) {
+        return { userId: context.request.params.userId };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [UsersController] });
+
+    const app = await runBunApplication(AppModule, {
+      hostname: '127.0.0.1',
+      port: 4319,
+    });
+
+    try {
+      expect(mockBun.lastOptions?.routes).toMatchObject({
+        '/users/:userId': {
+          GET: expect.any(Function),
+          POST: expect.any(Function),
+        },
+      });
+
+      const response = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4319/users/123', {
+        headers: { 'x-request-id': 'req-bun-method-miss' },
+        method: 'POST',
+      }));
+
+      expect(response?.status).toBe(404);
+      await expect(response?.json()).resolves.toMatchObject({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'No handler registered for POST /users/123.',
+          requestId: 'req-bun-method-miss',
+          status: 404,
+        },
+      });
     } finally {
       await app.close();
     }

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -1,7 +1,9 @@
 import type {
   CorsOptions,
   Dispatcher,
+  HandlerDescriptor,
   HttpApplicationAdapter,
+  HttpMethod,
   MiddlewareLike,
   SecurityHeadersOptions,
 } from '@fluojs/http';
@@ -34,9 +36,20 @@ declare module '@fluojs/http' {
 
 type BunGlobal = {
   serve(options: BunServeOptions): BunServerLike;
+  version?: string;
 };
 
 type BunHostname = string;
+type BunRequestLike = Request & {
+  params?: Readonly<Record<string, string>>;
+};
+type BunRouteHandler = (
+  request: BunRequestLike,
+  server: BunServerLike,
+) => Response | Promise<Response> | undefined | Promise<Response | undefined>;
+type BunRouteMethod = Exclude<HttpMethod, 'ALL'>;
+type BunRouteMethodMap = Partial<Record<BunRouteMethod, BunRouteHandler | Response>>;
+type BunRouteValue = BunRouteHandler | Response | BunRouteMethodMap;
 
 /** Shutdown signal names that `runBunApplication()` can register. */
 export type BunApplicationSignal = 'SIGINT' | 'SIGTERM';
@@ -114,6 +127,7 @@ export interface BunServeOptions {
   idleTimeout?: number;
   maxRequestBodySize?: number;
   port?: number;
+  routes?: Record<string, BunRouteValue>;
   tls?: BunTlsOptions;
   websocket?: BunWebSocketHandler;
 }
@@ -215,6 +229,7 @@ export interface RunBunApplicationOptions extends BootstrapBunApplicationOptions
 const DEFAULT_PORT = 3000;
 const DEFAULT_DISPATCHER_NOT_READY_MESSAGE = 'Bun adapter received a request before dispatcher binding completed.';
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+const MINIMUM_BUN_NATIVE_ROUTES_VERSION = '1.2.3';
 const BUN_WEBSOCKET_SUPPORT_REASON =
   'Bun exposes Bun.serve() + server.upgrade() request-upgrade hosting. Use @fluojs/websockets/bun for the official raw websocket binding.';
 
@@ -280,28 +295,30 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
 
     const bun = requireBunGlobal();
     const realtimeBinding = this.realtimeBinding;
+    const handleRequest: BunRouteHandler = async (request, server) => {
+      if (this.server === undefined) {
+        this.server = server;
+      }
+
+      if (realtimeBinding) {
+        const handled = await realtimeBinding.fetch(request, server);
+
+        if (handled !== undefined || isWebSocketUpgradeRequest(request)) {
+          return handled;
+        }
+      }
+
+      return await this.dispatchHttpRequest(request);
+    };
 
     this.server = bun.serve({
       development: this.options.development,
-      fetch: async (request, server) => {
-        if (this.server === undefined) {
-          this.server = server;
-        }
-
-        if (realtimeBinding) {
-          const handled = await realtimeBinding.fetch(request, server);
-
-          if (handled !== undefined || isWebSocketUpgradeRequest(request)) {
-            return handled;
-          }
-        }
-
-        return await this.dispatchHttpRequest(request);
-      },
+      fetch: handleRequest,
       hostname: this.options.hostname,
       idleTimeout: realtimeBinding?.idleTimeout ?? this.options.idleTimeout,
       maxRequestBodySize: realtimeBinding?.maxRequestBodySize ?? this.options.maxBodySize,
       port: resolvePort(this.options.port),
+      routes: createBunNativeRoutes(dispatcher, handleRequest, bun),
       tls: this.options.tls,
       websocket: realtimeBinding?.websocket,
     });
@@ -499,6 +516,117 @@ function resolvePort(port: number | undefined): number {
   return typeof port === 'number' && Number.isFinite(port) ? port : DEFAULT_PORT;
 }
 
+function createBunNativeRoutes(
+  dispatcher: Dispatcher,
+  handleRequest: BunRouteHandler,
+  bun: BunGlobal,
+): Record<string, BunRouteValue> | undefined {
+  if (!supportsBunNativeRoutes(bun)) {
+    return undefined;
+  }
+
+  const descriptors = dispatcher.describeRoutes?.();
+
+  if (!descriptors || descriptors.length === 0) {
+    return undefined;
+  }
+
+  const unsafeShapes = collectUnsafeNativeRouteShapes(descriptors);
+  const routes = new Map<string, BunRouteMethodMap>();
+
+  for (const descriptor of descriptors) {
+    const method = toBunRouteMethod(descriptor.route.method);
+
+    if (!method) {
+      continue;
+    }
+
+    if (unsafeShapes.has(`${method}:${createBunRouteShapeKey(descriptor.route.path)}`)) {
+      continue;
+    }
+
+    const routeHandlers = routes.get(descriptor.route.path) ?? {};
+    routeHandlers[method] ??= handleRequest;
+    routes.set(descriptor.route.path, routeHandlers);
+  }
+
+  return routes.size > 0 ? Object.fromEntries(routes) : undefined;
+}
+
+function supportsBunNativeRoutes(bun: BunGlobal): boolean {
+  return compareBunVersions(bun.version, MINIMUM_BUN_NATIVE_ROUTES_VERSION) >= 0;
+}
+
+function compareBunVersions(left: string | undefined, right: string): number {
+  if (typeof left !== 'string') {
+    return -1;
+  }
+
+  const leftSegments = parseBunVersionSegments(left);
+  const rightSegments = parseBunVersionSegments(right);
+  const length = Math.max(leftSegments.length, rightSegments.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftValue = leftSegments[index] ?? 0;
+    const rightValue = rightSegments[index] ?? 0;
+
+    if (leftValue === rightValue) {
+      continue;
+    }
+
+    return leftValue > rightValue ? 1 : -1;
+  }
+
+  return 0;
+}
+
+function parseBunVersionSegments(version: string): number[] {
+  return version.match(/\d+/g)?.map((segment) => Number.parseInt(segment, 10)) ?? [];
+}
+
+function collectUnsafeNativeRouteShapes(descriptors: readonly HandlerDescriptor[]): Set<string> {
+  const signatures = new Map<string, Set<string>>();
+  const unsafe = new Set<string>();
+
+  for (const descriptor of descriptors) {
+    const shapeKey = createBunRouteShapeKey(descriptor.route.path);
+    const paramSignature = descriptor.metadata.pathParams.join(',');
+
+    if (descriptor.route.method === 'ALL') {
+      for (const method of bunRouteMethods) {
+        unsafe.add(`${method}:${shapeKey}`);
+      }
+
+      continue;
+    }
+
+    const key = `${descriptor.route.method}:${shapeKey}`;
+    const current = signatures.get(key) ?? new Set<string>();
+    current.add(paramSignature);
+    signatures.set(key, current);
+
+    if (current.size > 1) {
+      unsafe.add(key);
+    }
+  }
+
+  return unsafe;
+}
+
+function createBunRouteShapeKey(path: string): string {
+  const segments = path.split('/').filter(Boolean);
+
+  if (segments.length === 0) {
+    return '/';
+  }
+
+  return `/${segments.map((segment) => segment.startsWith(':') ? ':' : segment).join('/')}`;
+}
+
+function toBunRouteMethod(method: HttpMethod): BunRouteMethod | undefined {
+  return method === 'ALL' ? undefined : method;
+}
+
 function closeBunServerWithDrain(
   server: BunServerLike,
   stopActiveConnections: boolean | undefined,
@@ -558,6 +686,8 @@ function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number)
 function isWebSocketUpgradeRequest(request: Request): boolean {
   return request.headers.get('upgrade')?.toLowerCase() === 'websocket';
 }
+
+const bunRouteMethods: readonly BunRouteMethod[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'];
 
 interface Deferred<T> {
   promise: Promise<T>;

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -546,7 +546,11 @@ function createBunNativeRoutes(
     }
 
     const routeHandlers = routes.get(descriptor.route.path) ?? {};
-    routeHandlers[method] ??= handleRequest;
+
+    for (const bunRouteMethod of bunRouteMethods) {
+      routeHandlers[bunRouteMethod] ??= handleRequest;
+    }
+
     routes.set(descriptor.route.path, routeHandlers);
   }
 

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -259,6 +259,23 @@ function onceDisconnected(socket: ClientSocket): Promise<string> {
   });
 }
 
+async function waitForExpectation(assertion: () => void, timeoutMs = 250): Promise<void> {
+  const startedAt = Date.now();
+
+  while (true) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+}
+
 interface SupportedSocketIoAdapterScenario {
   createAdapter: (options: { port: number; shutdownTimeoutMs?: number }) => ReturnType<typeof createNodejsAdapter>;
   name: string;
@@ -469,10 +486,10 @@ describe('@fluojs/socket.io', () => {
     socket.disconnect();
 
     expect(await disconnected).toBe('io client disconnect');
-    await new Promise((resolve) => setTimeout(resolve, 25));
-
-    expect(state.disconnectCount).toBe(1);
-    expect(state.disconnectReason).toBe('client namespace disconnect');
+    await waitForExpectation(() => {
+      expect(state.disconnectCount).toBe(1);
+      expect(state.disconnectReason).toBe('client namespace disconnect');
+    });
 
     await app.close();
   });


### PR DESCRIPTION
Closes #1433

## Summary

Add a Bun `routes` object acceleration path for `@fluojs/platform-bun` only when fluo's dispatch semantics can be preserved, and close the remaining merge blockers with governed semver and regression evidence.

## Changes

- expose cloned dispatcher route descriptions so platform adapters can inspect mapped routes without mutating runtime dispatch state
- pre-register safe Bun static/param routes on Bun `>=1.2.3`, but keep matched requests on the shared fluo dispatcher path so raw body, multipart, SSE, error responses, websocket upgrades, and shutdown drain behavior remain unchanged
- fall back to fetch-only dispatch for unsupported shapes, including same-shape param routes, `ALL` handlers, and Bun `<1.2.3`, and document the behavior in `packages/platform-bun/README.md` / `README.ko.md`
- reclassify `.changeset/soft-lamps-scream.md` to `minor` for `@fluojs/http` and `@fluojs/platform-bun` because this PR adds backward-compatible public capability (`Dispatcher.describeRoutes?.()` plus documented Bun native-route support)
- add regression coverage for `ALL` fallback registration, Bun `<1.2.3` version gating, and shared dispatcher error preservation across both native-route and fetch-only fallback paths

## Testing

- `pnpm --filter @fluojs/platform-bun typecheck`
- `pnpm --filter @fluojs/platform-bun test`
- `pnpm verify:release-readiness`
- `pnpm changeset status --since=main`
- `lsp_diagnostics` clean for changed TypeScript file:
  - `packages/platform-bun/src/adapter.test.ts`

New executable regression evidence in `packages/platform-bun/src/adapter.test.ts` now covers:
- `ALL` handler fallback staying off native Bun route registration while preserving dispatcher params/method semantics
- Bun `<1.2.3` version gate fallback staying on fetch-only dispatch
- shared `INTERNAL_SERVER_ERROR` response preservation for both native-route and fetch-only fallback requests

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Parity evidence added in `packages/platform-bun/src/adapter.test.ts` covers:
- native route registration preserving encoded path-param semantics
- same-shape param route fallback to fetch-only dispatch
- `ALL` handler fallback staying fetch-only
- Bun `<1.2.3` version-gate fallback
- raw body / multipart / SSE parity through the accelerated path
- shared error serialization parity across native-route and fallback dispatch
- websocket upgrade delegation remaining ahead of HTTP dispatch

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Governed release-readiness evidence:
- `.github/workflows/ci.yml` runs `Verify release readiness` only on `push` to `refs/heads/main` (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`), so the skipped PR check is expected for PR #1441.
- This branch was validated with the repo-local canonical gate instead: `pnpm verify:release-readiness` passed locally without writing draft artifacts.
- `pnpm changeset status --since=main` now reports `@fluojs/http` and `@fluojs/platform-bun` under the `minor` bucket.

## Residual risks

- Bun native routing stays intentionally scoped to Bun `>=1.2.3`; older runtimes continue on fetch-only dispatch.
- Ambiguous same-shape param tables and `ALL` handlers intentionally skip native registration, so some applications will retain the existing Bun fetch-only routing path until Bun-safe semantics can be widened.