### PR TITLE
Resolve #1432: evaluate Express router registration fallback

### DIFF
--- a/.changeset/issue-1432-express-router-registration.md
+++ b/.changeset/issue-1432-express-router-registration.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-express': patch
+---
+
+Preserve fluo routing semantics while letting the Express adapter pre-register safe per-method router entries for explicit routes and fall back to catch-all dispatch for overlapping param shapes, `@All(...)` handlers, and normalization-sensitive requests.

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -10,6 +10,7 @@ fluo 런타임을 위한 Express 기반 HTTP 어댑터 패키지입니다.
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
+- [어댑터 계약](#어댑터-계약)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -66,6 +67,20 @@ const adapter = createExpressAdapter(
   },
 );
 ```
+
+### 안전한 fallback을 포함한 Native Route Registration
+이제 어댑터는 의미 보존이 가능한 명시적 HTTP 메서드 라우트를 Express Router에 사전 등록하면서도, 실제 요청 처리는 계속 공유 fluo dispatcher를 통해 수행합니다.
+
+덕분에 guards, interceptors, observers, body parsing, raw body 캡처, SSE, 오류 응답은 기존과 같은 framework-owned 실행 경로를 유지하면서, Express가 먼저 일부 경로 매칭 비용을 줄일 수 있습니다.
+
+문서화된 fluo semantics를 바꾸지 않기 위해 `/:id` 와 `/:slug`처럼 shape가 겹치는 파라미터 라우트, `@All(...)` 핸들러, 그리고 duplicate slash/trailing slash 정규화에 의존하는 요청은 catch-all fallback 경로에 남겨둡니다.
+
+## 어댑터 계약
+
+- **공유 dispatcher 소유권 유지**: Native Express Router 매치 이후에도 실제 요청은 공유 fluo dispatcher가 처리하므로 middleware, guards, interceptors, observers, params, error envelope 계약은 그대로 유지됩니다.
+- **안전한 fallback 범위**: `@All(...)` 핸들러와 shape가 겹치는 파라미터 라우트는 Express Router에 강제 등록하지 않고 의도적으로 catch-all fallback 경로에 둡니다.
+- **경로 정규화 parity**: duplicate slash 변형처럼 Express Router와 fluo의 정규화 방식이 다를 수 있는 요청도 fallback dispatch를 통해 fluo의 normalized route contract를 유지합니다.
+- **버저닝 parity**: Express Router가 최초 path match를 하더라도 header/media-type/custom version 선택은 계속 dispatcher가 최종 결정합니다.
 
 ## 공개 API 개요
 

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -73,12 +73,13 @@ const adapter = createExpressAdapter(
 
 덕분에 guards, interceptors, observers, body parsing, raw body 캡처, SSE, 오류 응답은 기존과 같은 framework-owned 실행 경로를 유지하면서, Express가 먼저 일부 경로 매칭 비용을 줄일 수 있습니다.
 
-문서화된 fluo semantics를 바꾸지 않기 위해 `/:id` 와 `/:slug`처럼 shape가 겹치는 파라미터 라우트, `@All(...)` 핸들러, 그리고 duplicate slash/trailing slash 정규화에 의존하는 요청은 catch-all fallback 경로에 남겨둡니다.
+문서화된 fluo semantics를 바꾸지 않기 위해 `/:id` 와 `/:slug`처럼 shape가 겹치는 파라미터 라우트, `@All(...)` 핸들러, `OPTIONS` 소유권, 그리고 duplicate slash/trailing slash 정규화에 의존하는 요청은 catch-all fallback 경로에 남겨둡니다.
 
 ## 어댑터 계약
 
 - **공유 dispatcher 소유권 유지**: Native Express Router 매치 이후에도 실제 요청은 공유 fluo dispatcher가 처리하므로 middleware, guards, interceptors, observers, params, error envelope 계약은 그대로 유지됩니다.
 - **안전한 fallback 범위**: `@All(...)` 핸들러와 shape가 겹치는 파라미터 라우트는 Express Router에 강제 등록하지 않고 의도적으로 catch-all fallback 경로에 둡니다.
+- **OPTIONS 소유권 parity**: 어댑터는 native route에 대해 Express Router가 `OPTIONS`를 자동 응답하지 못하게 막아, 미지원 메서드도 계속 fluo dispatcher semantics로 흘러가고 `@All(...)` 핸들러가 정의된 경우 `OPTIONS`도 그대로 소유할 수 있게 합니다.
 - **경로 정규화 parity**: duplicate slash 변형처럼 Express Router와 fluo의 정규화 방식이 다를 수 있는 요청도 fallback dispatch를 통해 fluo의 normalized route contract를 유지합니다.
 - **버저닝 parity**: Express Router가 최초 path match를 하더라도 header/media-type/custom version 선택은 계속 dispatcher가 최종 결정합니다.
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -10,6 +10,7 @@ Express-backed HTTP adapter for the fluo runtime.
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
+- [Adapter Contract](#adapter-contract)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -66,6 +67,20 @@ const adapter = createExpressAdapter(
   },
 );
 ```
+
+### Native Route Registration with Safe Fallback
+The adapter now pre-registers semantically safe Express Router handlers for explicit HTTP methods and still dispatches those requests through the shared fluo dispatcher.
+
+This keeps guards, interceptors, observers, body parsing, raw body capture, SSE, and error responses on the same framework-owned execution path while allowing Express to short-circuit some path matching work first.
+
+To avoid changing documented fluo semantics, overlapping same-shape param routes such as `/:id` and `/:slug`, `@All(...)` handlers, and requests that rely on fluo's duplicate-slash/trailing-slash normalization stay on the catch-all fallback path.
+
+## Adapter Contract
+
+- **Shared dispatcher ownership**: Native Express Router matches still hand off to the shared fluo dispatcher, so middleware, guards, interceptors, observers, params, and error envelopes remain framework-defined.
+- **Safe fallback scope**: `@All(...)` handlers and overlapping same-shape param routes intentionally stay on the catch-all fallback path instead of being force-registered through Express Router.
+- **Path normalization parity**: Requests that Express Router does not normalize the same way as fluo, such as duplicate-slash variants, still resolve through fallback dispatch so fluo's normalized route contract is preserved.
+- **Versioning parity**: Header/media-type/custom version selection remains dispatcher-owned even when Express Router handles the initial path match.
 
 ## Public API Overview
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -73,12 +73,13 @@ The adapter now pre-registers semantically safe Express Router handlers for expl
 
 This keeps guards, interceptors, observers, body parsing, raw body capture, SSE, and error responses on the same framework-owned execution path while allowing Express to short-circuit some path matching work first.
 
-To avoid changing documented fluo semantics, overlapping same-shape param routes such as `/:id` and `/:slug`, `@All(...)` handlers, and requests that rely on fluo's duplicate-slash/trailing-slash normalization stay on the catch-all fallback path.
+To avoid changing documented fluo semantics, overlapping same-shape param routes such as `/:id` and `/:slug`, `@All(...)` handlers, `OPTIONS` ownership, and requests that rely on fluo's duplicate-slash/trailing-slash normalization stay on the catch-all fallback path.
 
 ## Adapter Contract
 
 - **Shared dispatcher ownership**: Native Express Router matches still hand off to the shared fluo dispatcher, so middleware, guards, interceptors, observers, params, and error envelopes remain framework-defined.
 - **Safe fallback scope**: `@All(...)` handlers and overlapping same-shape param routes intentionally stay on the catch-all fallback path instead of being force-registered through Express Router.
+- **OPTIONS ownership parity**: The adapter prevents Express Router from auto-answering `OPTIONS` for native routes, so unsupported methods still fall through to fluo dispatcher semantics and `@All(...)` handlers can continue to own `OPTIONS` when defined.
 - **Path normalization parity**: Requests that Express Router does not normalize the same way as fluo, such as duplicate-slash variants, still resolve through fallback dispatch so fluo's normalized route contract is preserved.
 - **Versioning parity**: Header/media-type/custom version selection remains dispatcher-owned even when Express Router handles the initial path match.
 

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -745,13 +745,9 @@ describe('@fluojs/platform-express', () => {
     await app.listen();
 
     try {
-      const router = Reflect.get(adapter, 'router') as { stack?: Array<{ route?: { methods: Record<string, boolean>; path: string } }> };
-      const nativeRoutes = (router.stack ?? [])
-        .flatMap((layer) => layer.route
-          ? Object.keys(layer.route.methods)
-            .filter((method) => layer.route?.methods[method])
-            .map((method) => `${method.toUpperCase()}:${layer.route?.path}`)
-          : []);
+      const router = Reflect.get(adapter, 'router');
+      const nativeRoutes = (Reflect.get(router, '__fluoNativeRoutes') as Array<{ methods: string[]; path: string }>)
+        .flatMap((route) => route.methods.map((method) => `${method}:${route.path}`));
 
       expect(nativeRoutes).toContain('GET:/users/:id');
       expect(nativeRoutes).toContain('GET:/versions');
@@ -809,6 +805,30 @@ describe('@fluojs/platform-express', () => {
       });
       expect(allResponse.statusCode).toBe(200);
       expect(JSON.parse(allResponse.body)).toEqual({ method: 'PATCH', route: 'all' });
+
+      const optionsFallbackResponse = await requestHttp({
+        method: 'OPTIONS',
+        path: '/fallback',
+        port,
+      });
+      expect(optionsFallbackResponse.statusCode).toBe(200);
+      expect(optionsFallbackResponse.headers.get('allow')).toBeNull();
+      expect(JSON.parse(optionsFallbackResponse.body)).toEqual({ method: 'OPTIONS', route: 'all' });
+
+      const unsupportedOptionsResponse = await requestHttp({
+        method: 'OPTIONS',
+        path: '/users/123',
+        port,
+      });
+      expect(unsupportedOptionsResponse.statusCode).toBe(404);
+      expect(unsupportedOptionsResponse.headers.get('allow')).toBeNull();
+      expect(JSON.parse(unsupportedOptionsResponse.body)).toEqual({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'No handler registered for OPTIONS /users/123.',
+          status: 404,
+        },
+      });
 
       lifecycle.length = 0;
       const errorResponse = await requestHttp({
@@ -890,19 +910,15 @@ describe('@fluojs/platform-express', () => {
     await app.listen();
 
     try {
-      const router = Reflect.get(adapter, 'router') as { stack?: Array<{ route?: { methods: Record<string, boolean>; path: string } }> };
-      const nativeRoutes = (router.stack ?? [])
-        .flatMap((layer) => layer.route
-          ? Object.keys(layer.route.methods)
-            .filter((method) => layer.route?.methods[method])
-            .map((method) => `${method.toUpperCase()}:${layer.route?.path}`)
-          : []);
+      const router = Reflect.get(adapter, 'router');
+      const nativeRoutes = (Reflect.get(router, '__fluoNativeRoutes') as Array<{ methods: string[]; path: string }>)
+        .flatMap((route) => route.methods.map((method) => `${method}:${route.path}`));
 
       expect(nativeRoutes).not.toContain('GET:/matches/:id');
       expect(nativeRoutes).not.toContain('GET:/matches/:slug');
       expect(nativeRoutes).not.toContain('PATCH:/catch-all/:slug');
 
-      const [shapeConflictResponse, fallbackResponse] = await Promise.all([
+      const [shapeConflictResponse, fallbackResponse, optionsFallbackResponse] = await Promise.all([
         requestHttp({
           method: 'GET',
           path: '/matches/42',
@@ -910,6 +926,11 @@ describe('@fluojs/platform-express', () => {
         }),
         requestHttp({
           method: 'PATCH',
+          path: '/catch-all/fallback-check',
+          port,
+        }),
+        requestHttp({
+          method: 'OPTIONS',
           path: '/catch-all/fallback-check',
           port,
         }),
@@ -925,6 +946,14 @@ describe('@fluojs/platform-express', () => {
       expect(fallbackResponse.statusCode).toBe(200);
       expect(JSON.parse(fallbackResponse.body)).toEqual({
         method: 'PATCH',
+        route: 'all',
+        slug: 'fallback-check',
+      });
+
+      expect(optionsFallbackResponse.statusCode).toBe(200);
+      expect(optionsFallbackResponse.headers.get('allow')).toBeNull();
+      expect(JSON.parse(optionsFallbackResponse.body)).toEqual({
+        method: 'OPTIONS',
         route: 'all',
         slug: 'fallback-check',
       });

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -8,17 +8,29 @@ import { createServer as createNetServer } from 'node:net';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  All,
+  type CallHandler,
   Controller,
   Get,
   Post,
   SseResponse,
+  UseGuards,
+  UseInterceptors,
+  Version,
+  VersioningType,
   type FrameworkRequest,
   type FrameworkResponse,
+  type GuardContext,
+  type InterceptorContext,
+  type MiddlewareContext,
+  type RequestObservationContext,
   type RequestContext,
+  type RequestObserver,
 } from '@fluojs/http';
 import {
   createHealthModule,
   defineModule,
+  fluoFactory,
   type ApplicationLogger,
 } from '@fluojs/runtime';
 
@@ -88,6 +100,46 @@ async function requestHttps(url: string): Promise<{ body: string; statusCode: nu
     });
 
     request.on('error', reject);
+    request.end();
+  });
+}
+
+async function requestHttp(options: {
+  body?: string;
+  headers?: Record<string, string>;
+  method?: string;
+  path: string;
+  port: number;
+}): Promise<{ body: string; headers: Headers; statusCode: number }> {
+  return await new Promise((resolve, reject) => {
+    const request = httpRequest({
+      headers: options.headers,
+      host: '127.0.0.1',
+      method: options.method,
+      path: options.path,
+      port: options.port,
+    }, (response) => {
+      const chunks: Buffer[] = [];
+
+      response.on('data', (chunk) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      response.on('end', () => {
+        resolve({
+          body: Buffer.concat(chunks).toString('utf8'),
+          headers: new Headers(response.headers as Record<string, string>),
+          statusCode: response.statusCode ?? 0,
+        });
+      });
+      response.on('error', reject);
+    });
+
+    request.on('error', reject);
+
+    if (options.body) {
+      request.write(options.body);
+    }
+
     request.end();
   });
 }
@@ -580,6 +632,305 @@ describe('@fluojs/platform-express', () => {
     expect(body).toContain('data: {"ready":true}');
 
     await app.close();
+  });
+
+  it('registers native Express router routes while preserving fluo matching, versioning, lifecycle, and fallback semantics', async () => {
+    const lifecycle: string[] = [];
+
+    const appMiddleware = {
+      async handle(context: MiddlewareContext, next: () => Promise<void>) {
+        lifecycle.push(`middleware:before:${context.request.method}`);
+        await next();
+        lifecycle.push(`middleware:after:${context.request.method}`);
+      },
+    };
+
+    const guard = {
+      canActivate(context: GuardContext) {
+        lifecycle.push(`guard:${context.handler.route.path}:${context.requestContext.request.params.id ?? '-'}`);
+        return true;
+      },
+    };
+
+    const interceptor = {
+      async intercept(context: InterceptorContext, next: CallHandler) {
+        lifecycle.push(`interceptor:before:${context.handler.route.path}`);
+        const result = await next.handle();
+        lifecycle.push(`interceptor:after:${context.handler.route.path}`);
+        return result;
+      },
+    };
+
+    const observer: RequestObserver = {
+      onHandlerMatched(context: RequestObservationContext) {
+        lifecycle.push(`observer:matched:${context.handler?.route.method}:${context.handler?.route.path}`);
+      },
+      onRequestError(_context: RequestObservationContext, error: unknown) {
+        lifecycle.push(`observer:error:${error instanceof Error ? error.message : String(error)}`);
+      },
+      onRequestFinish(context: RequestObservationContext) {
+        lifecycle.push(`observer:finish:${context.requestContext.request.method}`);
+      },
+      onRequestStart(context: RequestObservationContext) {
+        lifecycle.push(`observer:start:${context.requestContext.request.method}`);
+      },
+      onRequestSuccess(_context: RequestObservationContext, value: unknown) {
+        lifecycle.push(`observer:success:${typeof value === 'object' && value && 'route' in value ? String((value as { route: string }).route) : typeof value}`);
+      },
+    };
+
+    @Controller('/users')
+    class UsersController {
+      @Get('/:id')
+      @UseGuards(guard)
+      @UseInterceptors(interceptor)
+      getUser(_input: undefined, context: RequestContext) {
+        const queryTag = context.request.query.tag;
+
+        return {
+          id: context.request.params.id,
+          queryTag,
+          route: 'user',
+        };
+      }
+    }
+
+    @Controller('/versions')
+    class VersionedController {
+      @Get('/')
+      @Version('1')
+      v1() {
+        return { route: 'version', version: '1' };
+      }
+
+      @Get('/')
+      latest() {
+        return { route: 'version', version: 'latest' };
+      }
+    }
+
+    @Controller('/errors')
+    class ErrorsController {
+      @Get('/')
+      explode() {
+        throw new Error('native route boom');
+      }
+    }
+
+    @Controller('/fallback')
+    class FallbackController {
+      @All('/')
+      handle(_input: undefined, context: RequestContext) {
+        return { method: context.request.method, route: 'all' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [UsersController, VersionedController, ErrorsController, FallbackController],
+    });
+
+    const port = await findAvailablePort();
+    const adapter = createExpressAdapter({ port }) as ExpressHttpApplicationAdapter;
+    const app = await fluoFactory.create(AppModule, {
+      adapter,
+      middleware: [appMiddleware],
+      observers: [observer],
+      versioning: {
+        header: 'x-api-version',
+        type: VersioningType.HEADER,
+      },
+    });
+
+    await app.listen();
+
+    try {
+      const router = Reflect.get(adapter, 'router') as { stack?: Array<{ route?: { methods: Record<string, boolean>; path: string } }> };
+      const nativeRoutes = (router.stack ?? [])
+        .flatMap((layer) => layer.route
+          ? Object.keys(layer.route.methods)
+            .filter((method) => layer.route?.methods[method])
+            .map((method) => `${method.toUpperCase()}:${layer.route?.path}`)
+          : []);
+
+      expect(nativeRoutes).toContain('GET:/users/:id');
+      expect(nativeRoutes).toContain('GET:/versions');
+      expect(nativeRoutes).toContain('GET:/errors');
+      expect(nativeRoutes).not.toContain('PATCH:/fallback');
+
+      lifecycle.length = 0;
+      const userResponse = await requestHttp({
+        method: 'GET',
+        path: '/users///123/?tag=a&tag=b',
+        port,
+      });
+
+      expect(userResponse.statusCode).toBe(200);
+      expect(JSON.parse(userResponse.body)).toEqual({
+        id: '123',
+        queryTag: ['a', 'b'],
+        route: 'user',
+      });
+      expect(lifecycle).toContain('observer:matched:GET:/users/:id');
+      expect(lifecycle).toContain('guard:/users/:id:123');
+      expect(lifecycle).toContain('interceptor:before:/users/:id');
+      expect(lifecycle).toContain('interceptor:after:/users/:id');
+      expect(lifecycle).toContain('observer:success:user');
+      expect(lifecycle.indexOf('observer:start:GET')).toBeLessThan(lifecycle.indexOf('middleware:before:GET'));
+      expect(lifecycle.indexOf('middleware:before:GET')).toBeLessThan(lifecycle.indexOf('observer:matched:GET:/users/:id'));
+      expect(lifecycle.indexOf('observer:matched:GET:/users/:id')).toBeLessThan(lifecycle.indexOf('guard:/users/:id:123'));
+      expect(lifecycle.indexOf('guard:/users/:id:123')).toBeLessThan(lifecycle.indexOf('interceptor:before:/users/:id'));
+      expect(lifecycle.indexOf('interceptor:before:/users/:id')).toBeLessThan(lifecycle.indexOf('interceptor:after:/users/:id'));
+      expect(lifecycle.indexOf('interceptor:after:/users/:id')).toBeLessThan(lifecycle.indexOf('observer:success:user'));
+      expect(lifecycle.indexOf('observer:success:user')).toBeLessThan(lifecycle.indexOf('middleware:after:GET'));
+      expect(lifecycle.indexOf('middleware:after:GET')).toBeLessThan(lifecycle.indexOf('observer:finish:GET'));
+
+      const versionedResponse = await requestHttp({
+        headers: { 'x-api-version': '1' },
+        method: 'GET',
+        path: '/versions/',
+        port,
+      });
+      expect(versionedResponse.statusCode).toBe(200);
+      expect(JSON.parse(versionedResponse.body)).toEqual({ route: 'version', version: '1' });
+
+      const unversionedResponse = await requestHttp({
+        method: 'GET',
+        path: '/versions',
+        port,
+      });
+      expect(unversionedResponse.statusCode).toBe(200);
+      expect(JSON.parse(unversionedResponse.body)).toEqual({ route: 'version', version: 'latest' });
+
+      const allResponse = await requestHttp({
+        method: 'PATCH',
+        path: '/fallback',
+        port,
+      });
+      expect(allResponse.statusCode).toBe(200);
+      expect(JSON.parse(allResponse.body)).toEqual({ method: 'PATCH', route: 'all' });
+
+      lifecycle.length = 0;
+      const errorResponse = await requestHttp({
+        method: 'GET',
+        path: '/errors',
+        port,
+      });
+      expect(errorResponse.statusCode).toBe(500);
+      expect(JSON.parse(errorResponse.body)).toEqual({
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Internal server error.',
+          status: 500,
+        },
+      });
+      expect(lifecycle).toContain('observer:error:native route boom');
+
+      const missingResponse = await requestHttp({
+        method: 'GET',
+        path: '/missing',
+        port,
+      });
+      expect(missingResponse.statusCode).toBe(404);
+      expect(JSON.parse(missingResponse.body)).toEqual({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'No handler registered for GET /missing.',
+          status: 404,
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('falls back to dispatcher-only routing for overlapping same-shape param routes and ALL handlers', async () => {
+    @Controller('/matches')
+    class MatchesController {
+      @Get('/:id')
+      firstMatch(_input: undefined, context: RequestContext) {
+        return {
+          paramName: 'id',
+          route: 'first',
+          value: context.request.params.id,
+        };
+      }
+
+      @Get('/:slug')
+      secondMatch(_input: undefined, context: RequestContext) {
+        return {
+          paramName: 'slug',
+          route: 'second',
+          value: context.request.params.slug,
+        };
+      }
+    }
+
+    @Controller('/catch-all')
+    class CatchAllController {
+      @All('/:slug')
+      catchAll(_input: undefined, context: RequestContext) {
+        return {
+          method: context.request.method,
+          route: 'all',
+          slug: context.request.params.slug,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [MatchesController, CatchAllController],
+    });
+
+    const port = await findAvailablePort();
+    const adapter = createExpressAdapter({ port }) as ExpressHttpApplicationAdapter;
+    const app = await fluoFactory.create(AppModule, { adapter });
+
+    await app.listen();
+
+    try {
+      const router = Reflect.get(adapter, 'router') as { stack?: Array<{ route?: { methods: Record<string, boolean>; path: string } }> };
+      const nativeRoutes = (router.stack ?? [])
+        .flatMap((layer) => layer.route
+          ? Object.keys(layer.route.methods)
+            .filter((method) => layer.route?.methods[method])
+            .map((method) => `${method.toUpperCase()}:${layer.route?.path}`)
+          : []);
+
+      expect(nativeRoutes).not.toContain('GET:/matches/:id');
+      expect(nativeRoutes).not.toContain('GET:/matches/:slug');
+      expect(nativeRoutes).not.toContain('PATCH:/catch-all/:slug');
+
+      const [shapeConflictResponse, fallbackResponse] = await Promise.all([
+        requestHttp({
+          method: 'GET',
+          path: '/matches/42',
+          port,
+        }),
+        requestHttp({
+          method: 'PATCH',
+          path: '/catch-all/fallback-check',
+          port,
+        }),
+      ]);
+
+      expect(shapeConflictResponse.statusCode).toBe(200);
+      expect(JSON.parse(shapeConflictResponse.body)).toEqual({
+        paramName: 'id',
+        route: 'first',
+        value: '42',
+      });
+
+      expect(fallbackResponse.statusCode).toBe(200);
+      expect(JSON.parse(fallbackResponse.body)).toEqual({
+        method: 'PATCH',
+        route: 'all',
+        slug: 'fallback-check',
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('supports https startup and reports the https listen URL', async () => {

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -90,7 +90,7 @@ export type CorsInput = false | string | string[] | CorsOptions;
 
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
-const EXPRESS_NATIVE_ROUTE_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'] as const;
+const EXPRESS_NATIVE_ROUTE_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'] as const;
 
 type ExpressNativeRouteMethod = (typeof EXPRESS_NATIVE_ROUTE_METHODS)[number];
 
@@ -135,11 +135,13 @@ interface ExpressListenTarget {
 type ExpressServer = ReturnType<typeof createHttpServer> | ReturnType<typeof createHttpsServer>;
 
 interface ExpressNativeRouteDefinition {
-  method: ExpressNativeRouteMethod;
+  methods: readonly ExpressNativeRouteMethod[];
   path: string;
 }
 
-interface ExpressNativeRouteCandidate extends ExpressNativeRouteDefinition {
+interface ExpressNativeRouteCandidate {
+  method: ExpressNativeRouteMethod;
+  path: string;
   shapeKey: string;
 }
 
@@ -266,8 +268,16 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
       return;
     }
 
-    for (const route of createExpressNativeRoutes(resolveDispatcherRouteDescriptors(dispatcher))) {
-      this.router[route.method.toLowerCase() as Lowercase<ExpressNativeRouteMethod>](route.path, (request, response) => {
+    const nativeRoutes = createExpressNativeRoutes(resolveDispatcherRouteDescriptors(dispatcher));
+    Reflect.set(this.router, '__fluoNativeRoutes', nativeRoutes);
+
+    for (const route of nativeRoutes) {
+      this.router.all(route.path, (request, response, next) => {
+        if (!route.methods.includes(request.method.toUpperCase() as ExpressNativeRouteMethod)) {
+          next();
+          return;
+        }
+
         void this.handleRequest(request, response);
       });
     }
@@ -302,9 +312,27 @@ function createExpressNativeRoutes(descriptors: readonly HandlerDescriptor[]): E
     registerExpressNativeRouteCandidate(candidates, shapePaths, descriptor.route.method, descriptor.route.path);
   }
 
-  return [...candidates.values()]
-    .filter((candidate) => shapePaths.get(candidate.shapeKey)?.size === 1)
-    .map(({ method, path }) => ({ method, path }));
+  const routesByPath = new Map<string, Set<ExpressNativeRouteMethod>>();
+
+  for (const candidate of candidates.values()) {
+    if (shapePaths.get(candidate.shapeKey)?.size !== 1) {
+      continue;
+    }
+
+    let methods = routesByPath.get(candidate.path);
+
+    if (!methods) {
+      methods = new Set<ExpressNativeRouteMethod>();
+      routesByPath.set(candidate.path, methods);
+    }
+
+    methods.add(candidate.method);
+  }
+
+  return [...routesByPath.entries()].map(([path, methods]) => ({
+    methods: [...methods],
+    path,
+  }));
 }
 
 function registerExpressNativeRouteCandidate(

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -30,7 +30,9 @@ import {
   type FrameworkRequest,
   type FrameworkResponse,
   type FrameworkResponseStream,
+  type HandlerDescriptor,
   type HttpApplicationAdapter,
+  type HttpMethod,
   type MiddlewareLike,
   type SecurityHeadersOptions,
 } from '@fluojs/http';
@@ -88,6 +90,13 @@ export type CorsInput = false | string | string[] | CorsOptions;
 
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+const EXPRESS_NATIVE_ROUTE_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'] as const;
+
+type ExpressNativeRouteMethod = (typeof EXPRESS_NATIVE_ROUTE_METHODS)[number];
+
+type RouteDescribingDispatcher = Dispatcher & {
+  describeRoutes?: () => readonly HandlerDescriptor[];
+};
 
 /**
  * Describes the bootstrap express application options contract.
@@ -125,6 +134,15 @@ interface ExpressListenTarget {
 
 type ExpressServer = ReturnType<typeof createHttpServer> | ReturnType<typeof createHttpsServer>;
 
+interface ExpressNativeRouteDefinition {
+  method: ExpressNativeRouteMethod;
+  path: string;
+}
+
+interface ExpressNativeRouteCandidate extends ExpressNativeRouteDefinition {
+  shapeKey: string;
+}
+
 type ExpressFrameworkResponse = FrameworkResponse & {
   raw: ExpressResponse;
   statusSet?: boolean;
@@ -144,11 +162,13 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
   private closeInFlight?: Promise<void>;
   private dispatcher?: Dispatcher;
   private readonly app: Express;
+  private nativeRoutesReady = false;
   private readonly requestResponseFactory: RequestResponseFactory<
     ExpressRequest,
     ExpressResponse,
     ExpressFrameworkResponse
   >;
+  private readonly router = express.Router();
   private readonly server: ExpressServer;
   private readonly sockets = new Set<Socket>();
 
@@ -170,6 +190,7 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
       this.preserveRawBody,
     );
     this.server = createExpressServer(this.httpsOptions, this.app);
+    this.app.use(this.router);
     this.app.use((request: ExpressRequest, response: ExpressResponse) => {
       void this.handleRequest(request, response);
     });
@@ -195,6 +216,7 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
 
   async listen(dispatcher: Dispatcher): Promise<void> {
     this.dispatcher = dispatcher;
+    this.registerNativeRoutes(dispatcher);
     await this.listenWithRetry();
   }
 
@@ -239,6 +261,20 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
     }
   }
 
+  private registerNativeRoutes(dispatcher: Dispatcher): void {
+    if (this.nativeRoutesReady) {
+      return;
+    }
+
+    for (const route of createExpressNativeRoutes(resolveDispatcherRouteDescriptors(dispatcher))) {
+      this.router[route.method.toLowerCase() as Lowercase<ExpressNativeRouteMethod>](route.path, (request, response) => {
+        void this.handleRequest(request, response);
+      });
+    }
+
+    this.nativeRoutesReady = true;
+  }
+
   private async handleRequest(request: ExpressRequest, response: ExpressResponse): Promise<void> {
     await dispatchWithRequestResponseFactory({
       dispatcher: this.dispatcher,
@@ -248,6 +284,68 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
       rawResponse: response,
     });
   }
+}
+
+function resolveDispatcherRouteDescriptors(dispatcher: Dispatcher): readonly HandlerDescriptor[] {
+  return (dispatcher as RouteDescribingDispatcher).describeRoutes?.() ?? [];
+}
+
+function createExpressNativeRoutes(descriptors: readonly HandlerDescriptor[]): ExpressNativeRouteDefinition[] {
+  const candidates = new Map<string, ExpressNativeRouteCandidate>();
+  const shapePaths = new Map<string, Set<string>>();
+
+  for (const descriptor of descriptors) {
+    if (descriptor.route.method === 'ALL') {
+      continue;
+    }
+
+    registerExpressNativeRouteCandidate(candidates, shapePaths, descriptor.route.method, descriptor.route.path);
+  }
+
+  return [...candidates.values()]
+    .filter((candidate) => shapePaths.get(candidate.shapeKey)?.size === 1)
+    .map(({ method, path }) => ({ method, path }));
+}
+
+function registerExpressNativeRouteCandidate(
+  candidates: Map<string, ExpressNativeRouteCandidate>,
+  shapePaths: Map<string, Set<string>>,
+  method: HttpMethod,
+  path: string,
+): void {
+  if (!EXPRESS_NATIVE_ROUTE_METHODS.includes(method as ExpressNativeRouteMethod)) {
+    return;
+  }
+
+  const nativeMethod = method as ExpressNativeRouteMethod;
+  const routeKey = `${nativeMethod}:${path}`;
+  const shapeKey = `${nativeMethod}:${canonicalizeExpressRouteShape(path)}`;
+
+  if (!candidates.has(routeKey)) {
+    candidates.set(routeKey, {
+      method: nativeMethod,
+      path,
+      shapeKey,
+    });
+  }
+
+  let paths = shapePaths.get(shapeKey);
+
+  if (!paths) {
+    paths = new Set<string>();
+    shapePaths.set(shapeKey, paths);
+  }
+
+  paths.add(path);
+}
+
+function canonicalizeExpressRouteShape(path: string): string {
+  const segments = path
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => segment.startsWith(':') ? ':' : segment);
+
+  return segments.length === 0 ? '/' : `/${segments.join('/')}`;
 }
 
 function createExpressRequestResponseFactory(


### PR DESCRIPTION
## Summary

Closes #1432

Evaluate Express Router registration for fluo routes and enable only the subset that can preserve existing dispatcher-owned semantics.

## Changes

- add Express Router native route registration for explicit HTTP methods while keeping the shared dispatcher as the only execution path
- keep overlapping same-shape param routes and `@All(...)` handlers on catch-all fallback dispatch to preserve route-order and method-fallback semantics
- add parity tests for lifecycle ordering, versioned routes, duplicate-slash normalization fallback, error envelopes, same-shape fallback, and ALL-handler fallback
- document the new Express adapter fallback contract in `packages/platform-express/README.md` and `packages/platform-express/README.ko.md`
- add a patch changeset for `@fluojs/platform-express`

## Testing

- `pnpm --filter @fluojs/platform-express build`
- `pnpm --filter @fluojs/platform-express typecheck`
- `pnpm --filter @fluojs/platform-express test`
- `pnpm lint`
- `pnpm test -- --runInBand packages/platform-express/src/adapter.test.ts`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Residual risk / follow-up evidence

- this PR proves semantic parity for the guarded Express Router subset, but it does not yet include throughput benchmarks against the pure catch-all adapter path
- benchmark follow-up should compare static, param, mixed, and large route tables before deciding whether to broaden or tune native registration further