### PR TITLE
Resolve #1447: precompile HTTP DTO binding plans

### DIFF
--- a/.changeset/calm-hats-hammer.md
+++ b/.changeset/calm-hats-hammer.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/http': patch
+---
+
+Reduce `@RequestDto()` binding overhead by reusing compiled HTTP DTO binding plans while preserving request-scoped converter resolution and existing validation/binding error contracts.

--- a/packages/http/src/adapters/binding.test.ts
+++ b/packages/http/src/adapters/binding.test.ts
@@ -483,6 +483,51 @@ describe('HttpDtoValidationAdapter', () => {
     });
   });
 
+  it('preserves symbol-backed bound fields while filtering unbound validation properties', async () => {
+    const sessionToken = Symbol('sessionToken');
+
+    class SymbolBackedRequest {
+      @FromBody('session')
+      @MinLength(4, { code: 'SESSION_REQUIRED', message: 'session token is required' })
+      [sessionToken] = '';
+
+      @MinLength(1, { code: 'UNBOUND_REQUIRED', message: 'unbound hint is required' })
+      unboundHint = '';
+    }
+
+    const validator = new HttpDtoValidationAdapter();
+
+    await expect(
+      validator.validate(
+        Object.assign(new SymbolBackedRequest(), {
+          [sessionToken]: 'abcd',
+          unboundHint: '',
+        }),
+        SymbolBackedRequest,
+      ),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      validator.validate(
+        Object.assign(new SymbolBackedRequest(), {
+          [sessionToken]: '',
+          unboundHint: '',
+        }),
+        SymbolBackedRequest,
+      ),
+    ).rejects.toMatchObject({
+      details: [
+        {
+          code: 'SESSION_REQUIRED',
+          field: String(sessionToken),
+          message: 'session token is required',
+          source: 'body',
+        },
+      ],
+      status: 400,
+    });
+  });
+
   it('supports nested DTO validation, each semantics, and nested field paths', async () => {
     class AddressDto {
       @MinLength(1, { code: 'REQUIRED_CITY', message: 'city is required' })

--- a/packages/http/src/adapters/binding.test.ts
+++ b/packages/http/src/adapters/binding.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import type { Token } from '@fluojs/core';
 
 import {
   Convert,
   FromBody,
-  FromQuery,
+  FromCookie,
+  FromHeader,
   FromPath,
+  FromQuery,
   Optional,
 } from '../decorators.js';
 import {
@@ -16,8 +19,8 @@ import {
   ValidateIf,
   ValidateNested,
 } from '@fluojs/validation';
-import { BadRequestException } from '../exceptions.js';
 import { DefaultBinder } from './binding.js';
+import { getCompiledDtoBindingPlan } from './dto-binding-plan.js';
 import { HttpDtoValidationAdapter } from './dto-validation-adapter.js';
 import type { ArgumentResolverContext, FrameworkRequest, FrameworkResponse } from '../types.js';
 
@@ -60,7 +63,12 @@ function createResponse(): FrameworkResponse {
   };
 }
 
-function createContext(request: FrameworkRequest): ArgumentResolverContext {
+function createContext(
+  request: FrameworkRequest,
+  resolve: <T>(token: Token<T>) => Promise<T> = async () => {
+    throw new Error('not used');
+  },
+): ArgumentResolverContext {
   return {
     handler: {
       controllerToken: class ExampleController {},
@@ -82,8 +90,8 @@ function createContext(request: FrameworkRequest): ArgumentResolverContext {
         async dispose() {
           return undefined;
         },
-        resolve() {
-          throw new Error('not used');
+        async resolve(token) {
+          return resolve(token);
         },
       },
       metadata: {},
@@ -141,7 +149,55 @@ describe('DefaultBinder', () => {
           }),
         ),
       ),
-    ).rejects.toBeInstanceOf(BadRequestException);
+    ).rejects.toMatchObject({
+      details: [
+        {
+          code: 'DANGEROUS_KEY',
+          field: '__proto__',
+          message: 'Dangerous body key __proto__ is not allowed.',
+          source: 'body',
+        },
+        {
+          code: 'UNKNOWN_FIELD',
+          field: 'extra',
+          message: 'Unknown body field extra.',
+          source: 'body',
+        },
+      ],
+      status: 400,
+    });
+  });
+
+  it('binds header and cookie fields while preserving symbol property keys', async () => {
+    const sessionToken = Symbol('sessionToken');
+
+    class AuthenticatedRequest {
+      @FromHeader('x-request-id')
+      requestId = '';
+
+      @FromCookie('session')
+      [sessionToken] = '';
+
+      @FromBody('nickname')
+      @Optional()
+      nickname?: string;
+    }
+
+    const binder = new DefaultBinder();
+    const bound = (await binder.bind(
+      AuthenticatedRequest,
+      createContext(
+        createRequest({
+          body: {},
+          cookies: { session: 'cookie-123' },
+          headers: { 'x-request-id': 'req-123' },
+        }),
+      ),
+    )) as AuthenticatedRequest;
+
+    expect(bound.requestId).toBe('req-123');
+    expect(bound[sessionToken]).toBe('cookie-123');
+    expect(bound.nickname).toBeUndefined();
   });
 
   it('preserves single-element arrays for query bindings', async () => {
@@ -233,6 +289,39 @@ describe('DefaultBinder', () => {
 
     expect(bound.name).toBe('field:global:Ada');
   });
+
+  it('reuses compiled DTO binding plans without reusing request-scoped converters', async () => {
+    const requestScopedConverter = Symbol('requestScopedConverter');
+
+    class SearchUsersRequest {
+      @FromQuery('id')
+      id = '';
+    }
+
+    const binder = new DefaultBinder([requestScopedConverter]);
+    const plan = getCompiledDtoBindingPlan(SearchUsersRequest);
+
+    expect(getCompiledDtoBindingPlan(SearchUsersRequest)).toBe(plan);
+
+    const resolveCalls: string[] = [];
+    const createRequestScopedContext = (prefix: string) =>
+      createContext(createRequest({ query: { id: '42' } }), async <T>(token: Token<T>) => {
+        expect(token).toBe(requestScopedConverter);
+        resolveCalls.push(prefix);
+        return {
+          convert(value: unknown) {
+            return `${prefix}:${String(value)}`;
+          },
+        } as T;
+      });
+
+    const first = (await binder.bind(SearchUsersRequest, createRequestScopedContext('first'))) as SearchUsersRequest;
+    const second = (await binder.bind(SearchUsersRequest, createRequestScopedContext('second'))) as SearchUsersRequest;
+
+    expect(first.id).toBe('first:42');
+    expect(second.id).toBe('second:42');
+    expect(resolveCalls).toEqual(['first', 'second']);
+  });
 });
 
 describe('HttpDtoValidationAdapter', () => {
@@ -302,7 +391,7 @@ describe('HttpDtoValidationAdapter', () => {
   it('supports conditional and optional validator decorators', async () => {
     class PasswordResetRequest {
       @FromBody('password')
-      @ValidateIf((dto) => Boolean((dto as { enabled?: boolean }).enabled))
+      @ValidateIf((dto: unknown) => Boolean((dto as PasswordResetRequest).enabled))
       @MinLength(8, { message: 'password must have length at least 8' })
       password = '';
 

--- a/packages/http/src/adapters/binding.ts
+++ b/packages/http/src/adapters/binding.ts
@@ -1,9 +1,9 @@
-import { InvariantError, type Constructor, type MetadataPropertyKey, type MetadataSource, type Token } from '@fluojs/core';
-import { getDtoBindingSchema } from '@fluojs/core/internal';
+import { InvariantError, type Constructor, type Token } from '@fluojs/core';
 
 import { BadRequestException, type HttpExceptionDetail } from '../exceptions.js';
 import { toInputErrorDetail } from '../input-error-detail.js';
 import type { ArgumentResolverContext, Binder, Converter, ConverterLike, ConverterTarget, FrameworkRequest } from '../types.js';
+import { getCompiledDtoBindingPlan } from './dto-binding-plan.js';
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
@@ -15,50 +15,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   const prototype = Object.getPrototypeOf(value);
 
   return prototype === Object.prototype || prototype === null;
-}
-
-function toFieldName(propertyKey: MetadataPropertyKey): string {
-  return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
-}
-
-function resolveSourceKey(propertyKey: MetadataPropertyKey, key?: string): string {
-  return key ?? toFieldName(propertyKey);
-}
-
-function readHeader(request: FrameworkRequest, key: string): string | string[] | undefined {
-  return request.headers[key.toLowerCase()] ?? request.headers[key];
-}
-
-function readSourceValue(
-  request: FrameworkRequest,
-  source: MetadataSource,
-  propertyKey: MetadataPropertyKey,
-  key?: string,
-): unknown {
-  const resolvedKey = resolveSourceKey(propertyKey, key);
-
-  switch (source) {
-    case 'path':
-      return request.params[resolvedKey];
-    case 'query':
-      return request.query[resolvedKey];
-    case 'header':
-      return readHeader(request, resolvedKey);
-    case 'cookie':
-      return request.cookies[resolvedKey];
-    case 'body': {
-      if (!isPlainObject(request.body)) {
-        if (request.body !== undefined && request.body !== null) {
-          throw new BadRequestException('Request body must be a plain object.', {
-            details: [toInputErrorDetail({ code: 'INVALID_BODY', message: 'Request body must be a plain object.', source: 'body' })],
-          });
-        }
-        return undefined;
-      }
-
-      return request.body[resolvedKey];
-    }
-  }
 }
 
 function validateBodyKeys(
@@ -166,42 +122,31 @@ export class DefaultBinder implements Binder {
   constructor(private readonly converters: readonly ConverterLike[] = []) {}
 
   async bind(dto: Constructor, context: ArgumentResolverContext): Promise<unknown> {
-    const schema = getDtoBindingSchema(dto);
-    type BindingSchemaEntry = (typeof schema)[number];
+    const plan = getCompiledDtoBindingPlan(dto);
     const value = new dto() as Record<string | symbol, unknown>;
     const converterCache = new Map<unknown, Converter>();
-    const bodyKeys = new Set<string>(
-      schema
-        .filter((entry: BindingSchemaEntry) => entry.metadata.source === 'body')
-        .map((entry: BindingSchemaEntry) => resolveSourceKey(entry.propertyKey, entry.metadata.key)),
-    );
     const globalConverters = (
       await Promise.all(this.converters.map((converter) => resolveConverter(converter, context, converterCache)))
     ).filter((converter): converter is Converter => Boolean(converter));
 
-    validateBodyKeys(context.requestContext.request, bodyKeys);
+    validateBodyKeys(context.requestContext.request, plan.bodyKeys);
 
     const details: HttpExceptionDetail[] = [];
 
-    for (const entry of schema) {
-      const rawValue = readSourceValue(
-        context.requestContext.request,
-        entry.metadata.source,
-        entry.propertyKey,
-        entry.metadata.key,
-      );
+    for (const entry of plan.entries) {
+      const rawValue = entry.read(context.requestContext.request);
 
       if (rawValue === undefined) {
-        if (entry.metadata.optional) {
+        if (entry.optional) {
           continue;
         }
 
         details.push(
           toInputErrorDetail({
             code: 'MISSING_FIELD',
-            field: toFieldName(entry.propertyKey),
-            message: `Missing required ${entry.metadata.source} field ${resolveSourceKey(entry.propertyKey, entry.metadata.key)}.`,
-            source: entry.metadata.source,
+            field: entry.fieldName,
+            message: `Missing required ${entry.source} field ${entry.sourceKey}.`,
+            source: entry.source,
           }),
         );
         continue;
@@ -210,10 +155,10 @@ export class DefaultBinder implements Binder {
       const target: ConverterTarget = {
         dto,
         handler: context.handler,
-        key: resolveSourceKey(entry.propertyKey, entry.metadata.key),
+        key: entry.sourceKey,
         propertyKey: entry.propertyKey,
         requestContext: context.requestContext,
-        source: entry.metadata.source,
+        source: entry.source,
       };
 
       let convertedValue: unknown = rawValue;
@@ -222,7 +167,7 @@ export class DefaultBinder implements Binder {
         convertedValue = await converter.convert(convertedValue, target);
       }
 
-      const fieldConverter = await resolveConverter(entry.metadata.converter, context, converterCache);
+      const fieldConverter = await resolveConverter(entry.converter, context, converterCache);
 
       if (fieldConverter) {
         convertedValue = await fieldConverter.convert(convertedValue, target);

--- a/packages/http/src/adapters/dto-binding-plan.ts
+++ b/packages/http/src/adapters/dto-binding-plan.ts
@@ -1,0 +1,81 @@
+import { type Constructor, type MetadataPropertyKey, type MetadataSource } from '@fluojs/core';
+import { getDtoBindingSchema, type DtoBindingSchemaEntry, type DtoFieldBindingMetadata } from '@fluojs/core/internal';
+
+import type { FrameworkRequest } from '../types.js';
+
+function toFieldName(propertyKey: MetadataPropertyKey): string {
+  return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
+}
+
+function resolveSourceKey(propertyKey: MetadataPropertyKey, key?: string): string {
+  return key ?? toFieldName(propertyKey);
+}
+
+function readHeader(request: FrameworkRequest, key: string): string | string[] | undefined {
+  return request.headers[key.toLowerCase()] ?? request.headers[key];
+}
+
+export interface CompiledDtoBindingPlanEntry {
+  readonly converter?: DtoFieldBindingMetadata['converter'];
+  readonly fieldName: string;
+  readonly optional: boolean;
+  readonly propertyKey: MetadataPropertyKey;
+  readonly read: (request: FrameworkRequest) => unknown;
+  readonly source: MetadataSource;
+  readonly sourceKey: string;
+}
+
+export interface CompiledDtoBindingPlan {
+  readonly bodyKeys: ReadonlySet<string>;
+  readonly entries: readonly CompiledDtoBindingPlanEntry[];
+  readonly propertyKeys: readonly MetadataPropertyKey[];
+}
+
+const dtoBindingPlanCache = new WeakMap<Constructor, CompiledDtoBindingPlan>();
+
+function createSourceReader(source: MetadataSource, sourceKey: string): (request: FrameworkRequest) => unknown {
+  switch (source) {
+    case 'path':
+      return (request) => request.params[sourceKey];
+    case 'query':
+      return (request) => request.query[sourceKey];
+    case 'header':
+      return (request) => readHeader(request, sourceKey);
+    case 'cookie':
+      return (request) => request.cookies[sourceKey];
+    case 'body':
+      return (request) => (request.body as Record<string, unknown> | undefined)?.[sourceKey];
+    default:
+      return () => undefined;
+  }
+}
+
+export function getCompiledDtoBindingPlan(dto: Constructor): CompiledDtoBindingPlan {
+  const cached = dtoBindingPlanCache.get(dto);
+
+  if (cached) {
+    return cached;
+  }
+
+  const entries = getDtoBindingSchema(dto).map((entry: DtoBindingSchemaEntry) => {
+    const sourceKey = resolveSourceKey(entry.propertyKey, entry.metadata.key);
+
+    return {
+      ...(entry.metadata.converter === undefined ? {} : { converter: entry.metadata.converter }),
+      fieldName: toFieldName(entry.propertyKey),
+      optional: entry.metadata.optional === true,
+      propertyKey: entry.propertyKey,
+      read: createSourceReader(entry.metadata.source, sourceKey),
+      source: entry.metadata.source,
+      sourceKey,
+    } satisfies CompiledDtoBindingPlanEntry;
+  });
+  const next: CompiledDtoBindingPlan = {
+    bodyKeys: new Set(entries.filter((entry: CompiledDtoBindingPlanEntry) => entry.source === 'body').map((entry: CompiledDtoBindingPlanEntry) => entry.sourceKey)),
+    entries,
+    propertyKeys: entries.map((entry: CompiledDtoBindingPlanEntry) => entry.propertyKey),
+  };
+
+  dtoBindingPlanCache.set(dto, next);
+  return next;
+}

--- a/packages/http/src/adapters/dto-validation-adapter.ts
+++ b/packages/http/src/adapters/dto-validation-adapter.ts
@@ -1,10 +1,10 @@
 import { type Constructor } from '@fluojs/core';
-import { getDtoBindingSchema } from '@fluojs/core/internal';
 import { DefaultValidator as BaseDefaultValidator, DtoValidationError } from '@fluojs/validation';
 
 import { BadRequestException } from '../exceptions.js';
 import { toInputErrorDetail } from '../input-error-detail.js';
 import type { ValidationIssue, Validator } from '../types.js';
+import { getCompiledDtoBindingPlan } from './dto-binding-plan.js';
 
 /**
  * Represents the http dto validation adapter.
@@ -26,9 +26,9 @@ export class HttpDtoValidationAdapter implements Validator {
     const source = value as Record<PropertyKey, unknown>;
     const filtered: Record<PropertyKey, unknown> = Object.create(Object.getPrototypeOf(value));
 
-    for (const binding of getDtoBindingSchema(target)) {
-      if (Object.hasOwn(source, binding.propertyKey)) {
-        filtered[binding.propertyKey] = source[binding.propertyKey];
+    for (const propertyKey of getCompiledDtoBindingPlan(target).propertyKeys) {
+      if (Object.hasOwn(source, propertyKey)) {
+        filtered[propertyKey] = source[propertyKey];
       }
     }
 

--- a/tooling/benchmarks/http-dto-binding-plan.mjs
+++ b/tooling/benchmarks/http-dto-binding-plan.mjs
@@ -1,0 +1,200 @@
+import { performance } from 'node:perf_hooks';
+
+import { defineDtoFieldBindingMetadata } from '../../packages/core/dist/internal.js';
+import { Container } from '../../packages/di/dist/index.js';
+import { DefaultBinder } from '../../packages/http/dist/internal.js';
+
+function createRequest(overrides = {}) {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'POST',
+    params: {},
+    path: '/benchmarks',
+    query: {},
+    raw: {},
+    url: '/benchmarks',
+    ...overrides,
+  };
+}
+
+function createResponse() {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+function createContext(request, container) {
+  return {
+    handler: {
+      controllerToken: class BenchmarkController {},
+      metadata: {
+        controllerPath: '/benchmarks',
+        effectivePath: '/benchmarks/:tenantId/:userId',
+        moduleMiddleware: [],
+        pathParams: ['tenantId', 'userId'],
+      },
+      methodName: 'run',
+      route: {
+        method: 'POST',
+        path: '/benchmarks/:tenantId/:userId',
+        request: undefined,
+      },
+    },
+    requestContext: {
+      container,
+      metadata: {},
+      request,
+      response: createResponse(),
+    },
+  };
+}
+
+function bindField(dto, propertyKey, source, key = propertyKey) {
+  defineDtoFieldBindingMetadata(dto.prototype, propertyKey, {
+    key: String(key),
+    source,
+  });
+}
+
+const REQUEST_CONVERTER = Symbol('REQUEST_CONVERTER');
+
+class RequestScopedStringConverter {
+  convert(value) {
+    return typeof value === 'string' ? value.trim() : value;
+  }
+}
+
+class PathDtoWithDiChain {
+  tenantId = '';
+  userId = '';
+  include = '';
+  traceId = '';
+  session = '';
+  displayName = '';
+}
+
+defineDtoFieldBindingMetadata(PathDtoWithDiChain.prototype, 'tenantId', {
+  converter: REQUEST_CONVERTER,
+  key: 'tenantId',
+  source: 'path',
+});
+bindField(PathDtoWithDiChain, 'userId', 'path', 'userId');
+bindField(PathDtoWithDiChain, 'include', 'query', 'include');
+bindField(PathDtoWithDiChain, 'traceId', 'header', 'x-trace-id');
+bindField(PathDtoWithDiChain, 'session', 'cookie', 'session');
+bindField(PathDtoWithDiChain, 'displayName', 'body', 'displayName');
+
+class LargeDtoSchema {}
+
+for (let index = 0; index < 32; index += 1) {
+  const propertyKey = `field${index}`;
+  LargeDtoSchema.prototype[propertyKey] = '';
+  bindField(LargeDtoSchema, propertyKey, 'body', propertyKey);
+}
+
+function createPathDtoScenario() {
+  const binder = new DefaultBinder([REQUEST_CONVERTER]);
+  const rootContainer = new Container().register(RequestScopedStringConverter, {
+    provide: REQUEST_CONVERTER,
+    scope: 'request',
+    useClass: RequestScopedStringConverter,
+  });
+  const container = rootContainer.createRequestScope();
+  const context = createContext(
+    createRequest({
+      body: { displayName: ' Ada ' },
+      cookies: { session: 'cookie-123' },
+      headers: { 'x-trace-id': 'trace-123' },
+      params: { tenantId: ' tenant-1 ', userId: 'user-42' },
+      query: { include: 'profile' },
+    }),
+    container,
+  );
+
+  return {
+    iterations: 50000,
+    name: 'bind path DTO + request converter DI chain',
+    async run() {
+      await binder.bind(PathDtoWithDiChain, context);
+    },
+  };
+}
+
+function createLargeDtoScenario() {
+  const binder = new DefaultBinder();
+  const body = {};
+
+  for (let index = 0; index < 32; index += 1) {
+    body[`field${index}`] = `value-${index}`;
+  }
+
+  const context = createContext(createRequest({ body }), new Container());
+
+  return {
+    iterations: 50000,
+    name: 'bind 32-field body DTO schema',
+    async run() {
+      await binder.bind(LargeDtoSchema, context);
+    },
+  };
+}
+
+async function measureScenario({ iterations, name, run }) {
+  const warmupIterations = Math.min(1000, Math.max(100, Math.floor(iterations / 20)));
+
+  for (let iteration = 0; iteration < warmupIterations; iteration += 1) {
+    await run();
+  }
+
+  const startedAt = performance.now();
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    await run();
+  }
+
+  const durationMs = performance.now() - startedAt;
+
+  return {
+    durationMs: Number(durationMs.toFixed(2)),
+    iterations,
+    name,
+    opsPerSecond: Number(((iterations / durationMs) * 1000).toFixed(2)),
+    usPerOperation: Number(((durationMs * 1000) / iterations).toFixed(2)),
+  };
+}
+
+async function main() {
+  const results = [];
+
+  for (const scenario of [createPathDtoScenario(), createLargeDtoScenario()]) {
+    results.push(await measureScenario(scenario));
+  }
+
+  process.stdout.write(`${JSON.stringify({
+    benchmark: 'http-dto-binding-plan',
+    note: 'DTO binding hot-path scenarios measured against built dist artifacts on the current branch.',
+    results,
+  }, null, 2)}\n`);
+}
+
+void main();


### PR DESCRIPTION
Closes #1447

## Summary

Reduce `@RequestDto()` request-time binding overhead by compiling reusable HTTP DTO binding plans once per DTO and reusing them across requests.

## Changes

- added a cached `dto-binding-plan` helper that precomputes source readers, required field metadata, body key sets, and bound property lists for HTTP DTOs
- updated `DefaultBinder` and `HttpDtoValidationAdapter` to reuse compiled plans while keeping converter resolution request-scoped
- added regression coverage for header/cookie bindings, symbol-backed properties, detailed dangerous/unknown body errors, and plan reuse without cross-request converter caching
- added a patch changeset for `@fluojs/http`

## Testing

- `pnpm --filter @fluojs/core --filter @fluojs/di --filter @fluojs/validation --filter @fluojs/http build`
- `pnpm --filter @fluojs/http build`
- `pnpm exec tsc -p packages/http/tsconfig.build.json --noEmit`
- `pnpm --filter @fluojs/http test`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary. No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No public exports changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. No public export docs changed.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. No new caller-visible contract was added.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. No governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable.

## Benchmark evidence for #1447

Command run after rebuilding `@fluojs/core`, `@fluojs/di`, `@fluojs/validation`, and `@fluojs/http`:

```bash
node tooling/benchmarks/http-dto-binding-plan.mjs
```

Results on this branch:

```json
{
  "benchmark": "http-dto-binding-plan",
  "note": "DTO binding hot-path scenarios measured against built dist artifacts on the current branch.",
  "results": [
    {
      "durationMs": 131.78,
      "iterations": 50000,
      "name": "bind path DTO + request converter DI chain",
      "opsPerSecond": 379408.73,
      "usPerOperation": 2.64
    },
    {
      "durationMs": 320.52,
      "iterations": 50000,
      "name": "bind 32-field body DTO schema",
      "opsPerSecond": 155996.73,
      "usPerOperation": 6.41
    }
  ]
}
```

Additional regression evidence: `packages/http/src/adapters/binding.test.ts` now covers symbol-backed bound properties through `HttpDtoValidationAdapter` filtering while unbound validation-only fields remain ignored.
