### PR TITLE
Resolve #1400: narrow GraphQL schema and resolver contracts

### DIFF
--- a/.changeset/issue-1400-graphql-schema-contract.md
+++ b/.changeset/issue-1400-graphql-schema-contract.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": minor
+---
+
+Narrow the public GraphQL contract to executable `GraphQLSchema` integration and reject the unsupported resolver `topics` option instead of silently ignoring it.

--- a/book/intermediate/ch18-graphql.ko.md
+++ b/book/intermediate/ch18-graphql.ko.md
@@ -107,7 +107,7 @@ const authorLoader = createDataLoader(async (ids: string[]) => {
 });
 ```
 
-### Using the Loader in a Resolver
+### 지원되는 Root Resolver에서 Loader 사용하기
 
 ```typescript
 class BookInput {
@@ -119,17 +119,18 @@ class BookInput {
 export class BookResolver {
   @Query({ input: BookInput })
   async book(input: BookInput) {
-    return bookService.findById(input.id);
-  }
+    const book = await bookService.findById(input.id);
+    const author = await authorLoader(context).load(book.authorId);
 
-  // Book의 'author' 필드에 대한 필드 리졸버
-  async author(book: Book, context: GraphQLContext) {
-    return authorLoader(context).load(book.authorId);
+    return {
+      ...book,
+      author,
+    };
   }
 }
 ```
 
-`authorLoader(context)`는 특정 GraphQL 실행 컨텍스트에 묶인 로더 인스턴스를 반환합니다. 따라서 배치와 캐시는 단일 요청 안에서만 공유됩니다. 이 범위를 지키면 한 사용자의 조회 결과가 다른 요청으로 새어 나가지 않으면서도 N+1 문제를 줄일 수 있습니다.
+`authorLoader(context)`는 특정 GraphQL 실행 컨텍스트에 묶인 로더 인스턴스를 반환합니다. 따라서 배치와 캐시는 단일 요청 안에서만 공유됩니다. 이 범위를 지키면 한 사용자의 조회 결과가 다른 요청으로 새어 나가지 않으면서도 N+1 문제를 줄일 수 있습니다. 현재 `@fluojs/graphql`은 런타임 field resolver 부착 대신 root operation 안에서 DataLoader를 사용하는 패턴만 문서화합니다.
 
 ## 18.5 Real-time with Subscriptions
 

--- a/book/intermediate/ch18-graphql.ko.md
+++ b/book/intermediate/ch18-graphql.ko.md
@@ -118,7 +118,7 @@ class BookInput {
 @Resolver()
 export class BookResolver {
   @Query({ input: BookInput })
-  async book(input: BookInput) {
+  async book(input: BookInput, context: GraphQLContext) {
     const book = await bookService.findById(input.id);
     const author = await authorLoader(context).load(book.authorId);
 
@@ -130,7 +130,7 @@ export class BookResolver {
 }
 ```
 
-`authorLoader(context)`는 특정 GraphQL 실행 컨텍스트에 묶인 로더 인스턴스를 반환합니다. 따라서 배치와 캐시는 단일 요청 안에서만 공유됩니다. 이 범위를 지키면 한 사용자의 조회 결과가 다른 요청으로 새어 나가지 않으면서도 N+1 문제를 줄일 수 있습니다. 현재 `@fluojs/graphql`은 런타임 field resolver 부착 대신 root operation 안에서 DataLoader를 사용하는 패턴만 문서화합니다.
+`authorLoader(context)`는 특정 GraphQL 실행 컨텍스트에 묶인 로더 인스턴스를 반환합니다. 따라서 배치와 캐시는 단일 요청 안에서만 공유됩니다. 이 범위를 지키면 한 사용자의 조회 결과가 다른 요청으로 새어 나가지 않으면서도 N+1 문제를 줄일 수 있습니다. 현재 `@fluojs/graphql`은 `context: GraphQLContext`를 명시적으로 받는 root operation 안에서 DataLoader를 사용하는 패턴만 문서화하며, 런타임 field resolver 부착은 지원하지 않습니다.
 
 ## 18.5 Real-time with Subscriptions
 

--- a/book/intermediate/ch18-graphql.md
+++ b/book/intermediate/ch18-graphql.md
@@ -107,7 +107,7 @@ const authorLoader = createDataLoader(async (ids: string[]) => {
 });
 ```
 
-### Using the Loader in a Resolver
+### Using the Loader in a Supported Root Resolver
 
 ```typescript
 class BookInput {
@@ -119,17 +119,18 @@ class BookInput {
 export class BookResolver {
   @Query({ input: BookInput })
   async book(input: BookInput) {
-    return bookService.findById(input.id);
-  }
+    const book = await bookService.findById(input.id);
+    const author = await authorLoader(context).load(book.authorId);
 
-  // Field resolver for the 'author' field on Book
-  async author(book: Book, context: GraphQLContext) {
-    return authorLoader(context).load(book.authorId);
+    return {
+      ...book,
+      author,
+    };
   }
 }
 ```
 
-`authorLoader(context)` returns a loader instance bound to a specific GraphQL execution context. Therefore, batching and caching are shared only within a single request. Keeping this scope prevents one user's lookup results from leaking into another request while still reducing the N+1 problem.
+`authorLoader(context)` returns a loader instance bound to a specific GraphQL execution context. Therefore, batching and caching are shared only within a single request. Keeping this scope prevents one user's lookup results from leaking into another request while still reducing the N+1 problem. At the moment, `@fluojs/graphql` documents DataLoader usage through root operations rather than runtime field-resolver attachment.
 
 ## 18.5 Real-time with Subscriptions
 

--- a/book/intermediate/ch18-graphql.md
+++ b/book/intermediate/ch18-graphql.md
@@ -118,7 +118,7 @@ class BookInput {
 @Resolver()
 export class BookResolver {
   @Query({ input: BookInput })
-  async book(input: BookInput) {
+  async book(input: BookInput, context: GraphQLContext) {
     const book = await bookService.findById(input.id);
     const author = await authorLoader(context).load(book.authorId);
 
@@ -130,7 +130,7 @@ export class BookResolver {
 }
 ```
 
-`authorLoader(context)` returns a loader instance bound to a specific GraphQL execution context. Therefore, batching and caching are shared only within a single request. Keeping this scope prevents one user's lookup results from leaking into another request while still reducing the N+1 problem. At the moment, `@fluojs/graphql` documents DataLoader usage through root operations rather than runtime field-resolver attachment.
+`authorLoader(context)` returns a loader instance bound to a specific GraphQL execution context. Therefore, batching and caching are shared only within a single request. Keeping this scope prevents one user's lookup results from leaking into another request while still reducing the N+1 problem. At the moment, `@fluojs/graphql` documents DataLoader usage through root operations that explicitly receive `context: GraphQLContext`, rather than runtime field-resolver attachment.
 
 ## 18.5 Real-time with Subscriptions
 

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -25,7 +25,7 @@ pnpm add @fluojs/graphql graphql graphql-yoga
 ## 사용 시점
 
 - TypeScript 데코레이터를 사용하여 타입 안전한 GraphQL API를 구축할 때 (**Code-first**).
-- 기존 GraphQL 스키마를 fluo 애플리케이션에 통합할 때 (**Schema-first**).
+- 기존의 executable `GraphQLSchema` 객체를 fluo 애플리케이션에 통합할 때.
 - GraphQL resolver 내에서 request-scoped provider를 포함한 원활한 의존성 주입이 필요할 때.
 - Request-scoped **DataLoader** 패턴을 사용하여 효율적인 데이터 페칭을 수행할 때.
 
@@ -72,6 +72,8 @@ await app.listen(3000);
 
 ### Code-first Resolvers
 fluo는 표준 데코레이터를 사용하여 GraphQL 스키마를 정의합니다. `@Resolver`, `@Query`, `@Mutation`, `@Subscription`을 사용하여 클래스 메서드를 GraphQL 작업에 매핑합니다. GraphQL 인자는 input DTO 필드에 `@Arg(...)`로 선언하고, resolver 메서드는 작업의 `input` 옵션을 통해 해당 DTO를 받습니다.
+
+현재 `@fluojs/graphql` 런타임은 root operation resolver만 지원합니다. `author(book, context)` 같은 object field resolver 패턴은 아직 런타임 계약이 아니라 `packages/graphql/field-resolver-rfc.md`에 정리된 설계 초안입니다.
 
 ### Request-Scoped DataLoaders
 내장된 DataLoader 통합을 통해 N+1 문제를 효율적으로 해결합니다. Loader는 각 GraphQL 작업마다 자동으로 격리됩니다.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -25,7 +25,7 @@ pnpm add @fluojs/graphql graphql graphql-yoga
 ## When to Use
 
 - When building type-safe GraphQL APIs using TypeScript decorators (**Code-first**).
-- When integrating existing GraphQL schemas into a fluo application (**Schema-first**).
+- When integrating an existing executable `GraphQLSchema` object into a fluo application.
 - When you need seamless dependency injection within GraphQL resolvers, including request-scoped providers.
 - When performing efficient data fetching using request-scoped **DataLoader** patterns.
 
@@ -72,6 +72,8 @@ await app.listen(3000);
 
 ### Code-first Resolvers
 fluo uses standard decorators to define your GraphQL schema. Use `@Resolver`, `@Query`, `@Mutation`, and `@Subscription` to map class methods to GraphQL operations. GraphQL arguments are declared on input DTO fields with `@Arg(...)`, then passed to the resolver method through the operation `input` option.
+
+`@fluojs/graphql` currently supports root operation resolvers only. Object field-resolver patterns such as `author(book, context)` remain design-only and are documented in `packages/graphql/field-resolver-rfc.md`, not in the runtime contract.
 
 ### Request-Scoped DataLoaders
 Efficiently solve the N+1 problem with built-in DataLoader integration. Loaders are automatically isolated per GraphQL operation.

--- a/packages/graphql/src/decorators.ts
+++ b/packages/graphql/src/decorators.ts
@@ -18,7 +18,6 @@ type StandardFieldDecoratorFn = <This, Value>(value: undefined, context: ClassFi
 export interface ResolverMethodOptions {
   fieldName?: string;
   input?: Function;
-  topics?: string | string[];
   argTypes?: Record<string, GraphqlArgType>;
   outputType?: GraphqlRootOutputType;
 }
@@ -57,12 +56,17 @@ function normalizeMethodMetadata(
     return { type };
   }
 
+  if ('topics' in fieldNameOrOptions) {
+    throw new Error(
+      'Resolver method option "topics" is not supported. GraphQL subscriptions must return an AsyncIterable directly until topic routing becomes a documented runtime feature.',
+    );
+  }
+
   return {
     argTypes: fieldNameOrOptions.argTypes,
     fieldName: fieldNameOrOptions.fieldName?.trim() || undefined,
     inputClass: fieldNameOrOptions.input,
     outputType: fieldNameOrOptions.outputType,
-    topics: fieldNameOrOptions.topics,
     type,
   };
 }
@@ -84,7 +88,6 @@ function defineStandardHandlerMetadata(metadata: unknown, propertyKey: string | 
     fieldName: handlerMetadata.fieldName,
     inputClass: handlerMetadata.inputClass,
     outputType: handlerMetadata.outputType,
-    topics: handlerMetadata.topics,
     type: handlerMetadata.type,
   });
   bag[handlerMetadataSymbol] = map;

--- a/packages/graphql/src/discovery.ts
+++ b/packages/graphql/src/discovery.ts
@@ -178,7 +178,6 @@ export function discoverResolverDescriptors(
           methodKey: entry.propertyKey,
           methodName: methodKeyToName(entry.propertyKey),
           outputType: entry.metadata.outputType,
-          topics: entry.metadata.topics,
           type: entry.metadata.type,
         };
       }),

--- a/packages/graphql/src/metadata.ts
+++ b/packages/graphql/src/metadata.ts
@@ -3,8 +3,6 @@ import { ensureSymbolMetadataPolyfill, getStandardConstructorMetadataBag, getSta
 
 import type { ArgFieldMetadata, ResolverHandlerMetadata, ResolverMetadata } from './types.js';
 
-type StandardMetadataBag = Record<PropertyKey, unknown>;
-
 void ensureSymbolMetadataPolyfill();
 
 const standardResolverMetadataKey = Symbol.for('fluo.graphql.standard.resolver');
@@ -27,7 +25,6 @@ function cloneHandlerMetadata(metadata: ResolverHandlerMetadata): ResolverHandle
     fieldName: metadata.fieldName,
     inputClass: metadata.inputClass,
     outputType: metadata.outputType,
-    topics: metadata.topics,
     type: metadata.type,
   };
 }

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -1343,7 +1343,7 @@ describe('@fluojs/graphql', () => {
     await app.close();
   });
 
-  it('supports schema-first mode with raw GraphQLSchema', async () => {
+  it('supports an executable GraphQLSchema instance', async () => {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         fields: {
@@ -1380,6 +1380,18 @@ describe('@fluojs/graphql', () => {
     });
 
     await app.close();
+  });
+
+  it('rejects unsupported subscription topic metadata instead of ignoring it', () => {
+    expect(() => {
+      Reflect.apply(
+        Subscription as unknown as (options: unknown) => unknown,
+        undefined,
+        [{ topics: 'NEW_NOTIFICATION' }],
+      );
+    }).toThrowError(
+      'Resolver method option "topics" is not supported. GraphQL subscriptions must return an AsyncIterable directly until topic routing becomes a documented runtime feature.',
+    );
   });
 
   it('boots the same GraphQL module repeatedly without leaking middleware registration across app instances', async () => {

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -184,7 +184,6 @@ export type GraphqlRootOutputType = GraphqlRootOutputNamedType | GraphqlListType
 export interface ResolverHandlerMetadata {
   type: ResolverHandlerType;
   fieldName?: string;
-  topics?: string | string[];
   inputClass?: Function;
   argTypes?: Record<string, GraphqlArgType>;
   outputType?: GraphqlRootOutputType;
@@ -206,7 +205,6 @@ export interface ResolverHandlerDescriptor {
   methodKey: MetadataPropertyKey;
   methodName: string;
   fieldName: string;
-  topics?: string | string[];
   inputClass?: Function;
   argFields: ArgFieldMetadata[];
   argTypes?: Record<string, GraphqlArgType>;
@@ -226,14 +224,17 @@ export interface ResolverDescriptor {
 }
 
 /**
- * Public options for `GraphqlModule.forRoot(...)` and `forRootAsync(...)`.
+ * Public options for `GraphqlModule.forRoot(...)`.
  *
  * @remarks
  * Keep README examples for end-to-end module wiring. Source hover docs here are
  * meant to clarify how each option shapes the per-request execution pipeline.
  */
 export interface GraphqlModuleOptions {
-  schema?: GraphQLSchema | string;
+  /**
+   * Provide a prebuilt executable `GraphQLSchema` when you want to own schema assembly yourself.
+   */
+  schema?: GraphQLSchema;
   resolvers?: Function[];
   context?: (ctx: GraphqlRequestContext) => Record<string, unknown>;
   graphiql?: boolean;


### PR DESCRIPTION
Closes #1400

## Summary
- narrow `@fluojs/graphql` public contract to executable `GraphQLSchema` integration instead of advertising unsupported SDL string schema-first wiring
- reject the unsupported resolver `topics` option at decorator call time so subscriptions do not silently ignore user configuration
- align package docs and Chapter 18 EN/KO examples with the supported root-resolver/DataLoader patterns

## Changes
- remove `string` from `GraphqlModuleOptions.schema` and drop public `topics` from `ResolverMethodOptions`
- remove the unused internal `topics` metadata plumbing and add a regression test that throws on unsupported topic metadata
- update `packages/graphql/README.md`, `packages/graphql/README.ko.md`, `book/intermediate/ch18-graphql.md`, and `book/intermediate/ch18-graphql.ko.md` to document root-operation-only resolver support
- add a changeset for the `@fluojs/graphql` minor release note

## Testing
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm vitest run --project packages`
- `pnpm changeset status --since main`

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Not applicable: this PR updates package/book docs and GraphQL package contracts only; it does not change governance SSOT documents or platform conformance claims.