### PR TITLE
Resolve #1393: normalize Node content-type parsing and body-size docs

### DIFF
--- a/.changeset/issue-1393-node-content-type-body-size.md
+++ b/.changeset/issue-1393-node-content-type-body-size.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/platform-nodejs": patch
+"@fluojs/runtime": patch
+---
+
+Fix the raw Node adapter to recognize mixed-case JSON and multipart content types, and fail fast when `maxBodySize` is configured with a non-numeric value instead of byte-count input.

--- a/book/intermediate/ch21-express-node.ko.md
+++ b/book/intermediate/ch21-express-node.ko.md
@@ -93,7 +93,7 @@ async function bootstrap() {
       key: fs.readFileSync('key.pem'),
       cert: fs.readFileSync('cert.pem'),
     },
-    maxBodySize: '2mb'
+    maxBodySize: 2_097_152,
   });
 
   const app = await fluoFactory.create(AppModule, { adapter });

--- a/book/intermediate/ch21-express-node.md
+++ b/book/intermediate/ch21-express-node.md
@@ -93,7 +93,7 @@ async function bootstrap() {
       key: fs.readFileSync('key.pem'),
       cert: fs.readFileSync('cert.pem'),
     },
-    maxBodySize: '2mb'
+    maxBodySize: 2_097_152,
   });
 
   const app = await fluoFactory.create(AppModule, { adapter });

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -51,11 +51,11 @@ const adapter = createNodejsAdapter({
     key: fs.readFileSync('key.pem'),
     cert: fs.readFileSync('cert.pem'),
   },
-  maxBodySize: '1mb',
+  maxBodySize: 1_048_576,
 });
 ```
 
-`maxBodySize`는 raw Node 요청 바디가 아직 스트리밍되는 동안 바로 강제되며, 부트스트랩 시 `multipart.maxTotalSize`를 따로 재정의하지 않으면 같은 값이 멀티파트 전체 페이로드 한도의 기본값으로도 사용됩니다.
+`maxBodySize`는 바이트 수를 나타내는 숫자만 받습니다. 이 값은 raw Node 요청 바디가 아직 스트리밍되는 동안 바로 강제되며, 부트스트랩 시 `multipart.maxTotalSize`를 따로 재정의하지 않으면 같은 값이 멀티파트 전체 페이로드 한도의 기본값으로도 사용됩니다.
 
 ### 직접 애플리케이션 실행
 `runNodejsApplication`을 사용하여 graceful shutdown 및 로깅이 포함된 보일러플레이트 없는 시작이 가능합니다.
@@ -76,7 +76,7 @@ await runNodejsApplication(AppModule, {
 ## 동작 계약
 
 - `createNodejsAdapter(options)`는 Node 내장 `http` 또는 `https` 서버 primitive 위에서 fluo를 직접 실행하는 adapter-first 진입점입니다.
-- `maxBodySize`는 raw Node 요청 바이트가 아직 스트리밍되는 동안 강제되며, 부트스트랩/실행 헬퍼에서 `multipart.maxTotalSize`를 명시적으로 제공하지 않으면 멀티파트 전체 크기 한도의 기본값이 됩니다.
+- `maxBodySize`는 바이트 수를 나타내는 숫자만 받으며, raw Node 요청 바이트가 아직 스트리밍되는 동안 강제되고, 부트스트랩/실행 헬퍼에서 `multipart.maxTotalSize`를 명시적으로 제공하지 않으면 멀티파트 전체 크기 한도의 기본값이 됩니다.
 - `bootstrapNodejsApplication(module, options)`는 raw Node 어댑터가 포함된 애플리케이션을 만들지만 리스닝은 시작하지 않으므로 이후 `app.listen()`과 `app.close()` 생명주기는 호출자가 소유합니다.
 - `runNodejsApplication(module, options)`는 부트스트랩, 리스닝 시작, graceful shutdown 배선을 함께 수행합니다. 시그널 기반 종료가 타임아웃되거나 실패하면 해당 상태를 로그와 `process.exitCode`로 보고하며, 최종 프로세스 종료는 호스트 프로세스가 계속 소유합니다.
 - 고급 압축 및 shutdown 유틸리티 함수는 이 기본 platform startup surface가 아니라 `@fluojs/runtime/node` 또는 runtime 내부 seam에 남아 있습니다.

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -51,11 +51,11 @@ const adapter = createNodejsAdapter({
     key: fs.readFileSync('key.pem'),
     cert: fs.readFileSync('cert.pem'),
   },
-  maxBodySize: '1mb',
+  maxBodySize: 1_048_576,
 });
 ```
 
-`maxBodySize` is enforced while the raw Node request body is still streaming, and the same limit becomes the default total multipart payload cap unless you override `multipart.maxTotalSize` during bootstrap.
+`maxBodySize` accepts a byte count number. It is enforced while the raw Node request body is still streaming, and the same limit becomes the default total multipart payload cap unless you override `multipart.maxTotalSize` during bootstrap.
 
 ### Direct Application Execution
 You can use `runNodejsApplication` for a zero-boilerplate startup that includes graceful shutdown and logging.
@@ -76,7 +76,7 @@ await runNodejsApplication(AppModule, {
 ## Behavioral Contracts
 
 - `createNodejsAdapter(options)` is the adapter-first entrypoint for running fluo directly on Node's built-in `http` or `https` server primitives.
-- `maxBodySize` is enforced while raw Node request bytes are still streaming, and it becomes the default multipart total-size cap unless `multipart.maxTotalSize` is explicitly provided through the bootstrap/run helpers.
+- `maxBodySize` accepts a byte count number, is enforced while raw Node request bytes are still streaming, and becomes the default multipart total-size cap unless `multipart.maxTotalSize` is explicitly provided through the bootstrap/run helpers.
 - `bootstrapNodejsApplication(module, options)` creates an application with the raw Node adapter but does not start listening, so the caller owns the subsequent `app.listen()` and `app.close()` lifecycle.
 - `runNodejsApplication(module, options)` bootstraps, starts, and wires graceful shutdown. When signal-driven shutdown times out or fails, it logs the condition and sets `process.exitCode`; final process termination remains owned by the host process.
 - Advanced compression and shutdown utility functions remain on `@fluojs/runtime/node` or internal runtime seams rather than this primary platform startup surface.

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'node:net';
-import { Controller, FromBody, Get, Post, RequestDto } from '@fluojs/http';
+import { Controller, FromBody, Get, Post, RequestDto, type RequestContext } from '@fluojs/http';
 import { defineModule, FluoFactory } from '@fluojs/runtime';
 import {
   type BootstrapNodeApplicationOptions,
@@ -47,6 +47,15 @@ async function findAvailablePort(): Promise<number> {
     });
   });
 }
+
+type MultipartRequestWithFiles = RequestContext['request'] & {
+  files?: Array<{
+    fieldname: string;
+    mimetype: string;
+    originalname: string;
+    size: number;
+  }>;
+};
 
 describe('@fluojs/platform-nodejs', () => {
   it('re-exports the existing Node compatibility helpers through the platform package', () => {
@@ -159,6 +168,118 @@ describe('@fluojs/platform-nodejs', () => {
           message: 'Request body exceeds the size limit.',
           status: 413,
         },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('parses mixed-case JSON content-type headers through the public Node adapter request path', async () => {
+    class JsonBody {
+      @FromBody()
+      ok!: boolean;
+    }
+
+    @Controller('/echo')
+    class EchoController {
+      @Post('/json')
+      @RequestDto(JsonBody)
+      echo(input: JsonBody, ctx: RequestContext) {
+        return {
+          dto: input,
+          requestBody: ctx.request.body,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [EchoController] });
+
+    const port = await findAvailablePort();
+    const app = await FluoFactory.create(AppModule, {
+      adapter: createNodejsAdapter({ port }),
+    });
+
+    try {
+      await app.listen();
+
+      const response = await fetch(`http://127.0.0.1:${String(port)}/echo/json`, {
+        body: JSON.stringify({ ok: true }),
+        headers: {
+          'content-type': 'Application/Json; Charset=UTF-8',
+        },
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(201);
+      await expect(response.json()).resolves.toEqual({
+        dto: { ok: true },
+        requestBody: { ok: true },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('parses mixed-case multipart content-type headers through the public Node adapter request path', async () => {
+    @Controller('/uploads')
+    class UploadController {
+      @Post('/')
+      upload(_input: undefined, ctx: RequestContext) {
+        const request = ctx.request as MultipartRequestWithFiles;
+
+        return {
+          body: ctx.request.body,
+          files: request.files?.map((file: NonNullable<MultipartRequestWithFiles['files']>[number]) => ({
+            fieldname: file.fieldname,
+            mimetype: file.mimetype,
+            originalname: file.originalname,
+            size: file.size,
+          })) ?? [],
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [UploadController] });
+
+    const port = await findAvailablePort();
+    const app = await FluoFactory.create(AppModule, {
+      adapter: createNodejsAdapter({ port }),
+    });
+
+    try {
+      await app.listen();
+
+      const form = new FormData();
+      form.append('name', 'Ada');
+      form.append('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
+
+      const request = new Request(`http://127.0.0.1:${String(port)}/uploads`, {
+        body: form,
+        method: 'POST',
+      });
+      const response = await fetch(request.url, {
+        body: await request.arrayBuffer(),
+        headers: {
+          'content-type': request.headers
+            .get('content-type')
+            ?.replace('multipart/form-data', 'Multipart/Form-Data') ?? '',
+        },
+        method: request.method,
+      });
+
+      expect(response.status).toBe(201);
+      await expect(response.json()).resolves.toEqual({
+        body: { name: 'Ada' },
+        files: [
+          {
+            fieldname: 'payload',
+            mimetype: 'text/plain',
+            originalname: 'payload.txt',
+            size: 5,
+          },
+        ],
       });
     } finally {
       await app.close();

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -123,6 +123,7 @@ class UsersModule {}
 ## 동작 계약
 
 - 요청 바디 파싱은 Web 표준 요청과 Node 기반 요청 모두에서 바이트가 스트리밍되는 동안 `maxBodySize`를 강제합니다.
+- `@fluojs/runtime/node`에서는 Node 요청 바디 파싱 전에 primary `content-type` media type을 normalize한 뒤 JSON 및 멀티파트 여부를 판단하므로, 대소문자가 섞인 JSON/멀티파트 헤더도 문서화된 파서 동작을 그대로 유지합니다.
 - Node 기반 및 Web 표준 요청 wrapper는 바디 파싱 전에 저비용 요청 metadata를 snapshot으로 고정한 뒤 dispatch 경계에서 `body`/`rawBody`를 한 번 materialize하므로 userland는 계속 동기 parsed 값을 관찰합니다.
 - Node 기반 쿠키/쿼리 값과 Web 표준 헤더는 요청 wrapper가 생성되는 시점에 snapshot으로 고정된 뒤 요청별로 lazy하게 normalize되고 memoize됩니다. 이후 upstream 객체가 변경되어도 `FrameworkRequest` view는 바뀌지 않습니다.
 - `ApplicationContext.get()`과 `Application.get()`은 bootstrap 시점에 알려진 직접 root singleton class/factory provider 조회만 memoize하며, alias, request, transient, 종료 이후, multi-provider, `container.override()` 해석 의미는 그대로 유지합니다.
@@ -131,6 +132,7 @@ class UsersModule {}
 - 애플리케이션 또는 컨텍스트 bootstrap이 런타임 리소스나 lifecycle instance 생성 이후 실패하면 fluo는 readiness를 초기화하고, 등록된 runtime cleanup callback을 실행하며, 그 시점까지 해석된 instance의 shutdown hook을 `bootstrap-failed`로 호출하고, 컨테이너를 dispose하고, cleanup 실패를 로그로 남긴 뒤 원래 bootstrap error를 다시 던집니다.
 - Bootstrap은 독립적인 singleton lifecycle provider를 병렬로 해석한 뒤 lifecycle hook은 결정적인 provider 순서대로 실행합니다.
 - 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다.
+- `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, `runNodeApplication(...)`는 `maxBodySize`를 0 이상의 정수 바이트 수로만 받으며, 값이 잘못되면 어댑터 생성/부트스트랩 단계에서 즉시 실패합니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.
 - 런타임 health 모듈은 bootstrap이 ready로 표시하기 전까지 `/ready`를 HTTP 503과 `starting`으로 보고하며, 애플리케이션/컨텍스트 종료가 시작되는 즉시, 종료 시도가 실패하더라도 다시 `starting`으로 내려갑니다.
 - 시그널 기반 종료 헬퍼는 bounded drain semantics를 유지하면서 timeout/실패 상황을 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료 소유권은 주변 호스트 런타임에 남겨 둡니다.
@@ -170,9 +172,18 @@ import {
 } from '@fluojs/runtime/node';
 ```
 
+```typescript
+const adapter = createNodeHttpAdapter({
+  port: 3000,
+  maxBodySize: 1_048_576,
+});
+```
+
+공개 Node 런타임 surface에서 `maxBodySize`는 바이트 수를 나타내는 숫자만 허용합니다. `'1mb'` 같은 값은 나중에 암묵 변환되지 않고 어댑터 생성 시점에 즉시 거부됩니다.
+
 - `createConsoleApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 컬러 콘솔 로거.
 - `createJsonApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 구조화된 JSON 로거.
-- `createNodeHttpAdapter()`: 어댑터 우선 런타임 구성을 위한 raw Node `http`/`https` 어댑터 팩토리.
+- `createNodeHttpAdapter()`: 어댑터 우선 런타임 구성을 위한 raw Node `http`/`https` 어댑터 팩토리입니다. primary Node 요청 `content-type`을 JSON/멀티파트 판별 전에 normalize하며, `maxBodySize`는 숫자 바이트 수만 받습니다.
 - `bootstrapNodeApplication()` / `runNodeApplication()`: 호환 패키지와 직접 Node 런타임 흐름에서 사용하는 Node 전용 부트스트랩 헬퍼.
 - `createNodeShutdownSignalRegistration()`, `defaultNodeShutdownSignals()`, `registerShutdownSignals()`: 호스트가 명시적으로 시그널 wiring을 제어할 때 쓰는 종료 등록 헬퍼.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -123,6 +123,7 @@ class UsersModule {}
 ## Behavioral Contracts
 
 - Request body parsing enforces `maxBodySize` while bytes are still streaming for both Web-standard and Node-backed requests.
+- On `@fluojs/runtime/node`, Node request body parsing normalizes the primary `content-type` media type before JSON and multipart detection, so mixed-case JSON and multipart headers preserve the documented parser behavior.
 - Node-backed and Web-standard request wrappers snapshot cheap request metadata before body parsing, then materialize `body`/`rawBody` once at the dispatch boundary so userland continues to observe synchronous parsed values.
 - Node-backed cookies/query values and Web-standard headers are snapshotted when the request wrapper is created, then lazily normalized and memoized per request; later upstream object mutations do not change the `FrameworkRequest` view.
 - `ApplicationContext.get()` and `Application.get()` memoize only direct root singleton class/factory provider lookups known at bootstrap, while preserving alias, request, transient, post-close, multi-provider, and `container.override()` resolution semantics.
@@ -131,6 +132,7 @@ class UsersModule {}
 - If application or context bootstrap fails after runtime resources or lifecycle instances have been created, fluo resets readiness, runs registered runtime cleanup callbacks, invokes shutdown hooks for instances resolved so far with `bootstrap-failed`, disposes the container, logs cleanup failures, and rethrows the original bootstrap error.
 - Bootstrap resolves independent singleton lifecycle providers concurrently, then runs lifecycle hooks in deterministic provider order.
 - Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it.
+- `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, and `runNodeApplication(...)` accept `maxBodySize` only as a non-negative integer byte count and fail fast during adapter creation/bootstrap when the value is invalid.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.
 - Runtime health modules report `/ready` as `starting` with HTTP 503 until bootstrap marks them ready, and they return to `starting` as soon as application/context shutdown begins, including failed shutdown attempts.
 - Signal-driven shutdown helpers preserve bounded drain semantics, log timeout/failure conditions, and set `process.exitCode` when shutdown does not finish cleanly, but they leave final process termination ownership to the surrounding host runtime.
@@ -170,9 +172,18 @@ import {
 } from '@fluojs/runtime/node';
 ```
 
+```typescript
+const adapter = createNodeHttpAdapter({
+  port: 3000,
+  maxBodySize: 1_048_576,
+});
+```
+
+For the public Node runtime surface, `maxBodySize` is a byte-count number only. Values such as `'1mb'` are rejected immediately during adapter creation instead of being coerced later.
+
 - `createConsoleApplicationLogger()`: Colorized console logger using `process.stdout`/`process.stderr`.
 - `createJsonApplicationLogger()`: Structured JSON logger using `process.stdout`/`process.stderr`.
-- `createNodeHttpAdapter()`: Raw Node `http`/`https` adapter factory for adapter-first runtime setup.
+- `createNodeHttpAdapter()`: Raw Node `http`/`https` adapter factory for adapter-first runtime setup. The helper normalizes the primary Node request `content-type` before JSON/multipart detection and accepts `maxBodySize` only as numeric bytes.
 - `bootstrapNodeApplication()` / `runNodeApplication()`: Node-specific bootstrap helpers used by compatibility packages and direct Node runtime flows.
 - `createNodeShutdownSignalRegistration()`, `defaultNodeShutdownSignals()`, `registerShutdownSignals()`: Shutdown registration helpers for hosts that need explicit signal wiring.
 

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -101,8 +101,8 @@ export function createDeferredFrameworkRequest(
   const searchParams = new URLSearchParams(url.searchParams);
   const cookies = createMemoizedValue(() => parseCookieHeader(cookieHeader));
   const query = createMemoizedValue(() => parseQueryParams(searchParams));
-  const contentType = readPrimaryHeaderValue(headers['content-type']);
-  const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
+  const contentType = normalizePrimaryContentType(headers['content-type']);
+  const isMultipart = contentType === 'multipart/form-data';
   const materializeBody = createMemoizedAsyncValue(async () => {
     if (isMultipart) {
       const result = await parseMultipart(
@@ -281,6 +281,19 @@ function readPrimaryHeaderValue(headerValue: string | string[] | undefined): str
   return headerValue;
 }
 
+function normalizePrimaryContentType(headerValue: string | string[] | undefined): string | undefined {
+  const primaryHeaderValue = readPrimaryHeaderValue(headerValue);
+
+  if (typeof primaryHeaderValue !== 'string') {
+    return undefined;
+  }
+
+  const [mediaType] = primaryHeaderValue.split(';', 1);
+  const normalizedMediaType = mediaType?.trim().toLowerCase();
+
+  return normalizedMediaType && normalizedMediaType.length > 0 ? normalizedMediaType : undefined;
+}
+
 function decodeCookieValue(raw: string): string {
   try {
     return decodeURIComponent(raw);
@@ -344,9 +357,9 @@ async function readRequestBody(
     return { body: undefined, rawBody: preserveRawBody ? rawBody : undefined };
   }
 
-  const primaryContentType = Array.isArray(contentType) ? contentType[0] : contentType;
+  const primaryContentType = normalizePrimaryContentType(contentType);
 
-  if (typeof primaryContentType === 'string' && primaryContentType.includes('application/json')) {
+  if (primaryContentType === 'application/json') {
     try {
       return {
         body: JSON.parse(bodyText) as unknown,

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -139,11 +139,11 @@ export class NodeHttpApplicationAdapter implements HttpApplicationAdapter {
     private readonly host: string | undefined,
     private readonly retryDelayMs = 150,
     private readonly retryLimit = 20,
-    private readonly compression = false,
+    compression = false,
     private readonly httpsOptions: HttpsServerOptions | undefined,
-    private readonly multipartOptions?: MultipartOptions,
-    private readonly maxBodySize = 1 * 1024 * 1024,
-    private readonly preserveRawBody = false,
+    multipartOptions?: MultipartOptions,
+    maxBodySize = 1 * 1024 * 1024,
+    preserveRawBody = false,
     private readonly shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
   ) {
     this.requestResponseFactory = createNodeRequestResponseFactory(
@@ -276,7 +276,7 @@ export function createNodeHttpAdapter(options: NodeHttpAdapterOptions = {}, comp
     compression,
     options.https,
     multipartOptions,
-    options.maxBodySize,
+    resolveNodeMaxBodySize(options.maxBodySize),
     options.rawBody,
     options.shutdownTimeoutMs,
   );
@@ -462,4 +462,16 @@ function resolveNodePort(value: number | undefined): number {
   }
 
   return port;
+}
+
+function resolveNodeMaxBodySize(value: number | undefined): number {
+  const maxBodySize = value ?? 1 * 1024 * 1024;
+
+  if (!Number.isInteger(maxBodySize) || maxBodySize < 0) {
+    throw new Error(
+      `Invalid maxBodySize value: ${String(value ?? 1 * 1024 * 1024)}. Expected a non-negative integer number of bytes.`,
+    );
+  }
+
+  return maxBodySize;
 }

--- a/packages/runtime/src/node/node-request.test.ts
+++ b/packages/runtime/src/node/node-request.test.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -29,18 +30,23 @@ function createIncomingMessage(options: {
     chunks.push(typeof options.body === 'string' ? Buffer.from(options.body, 'utf8') : options.body);
   }
 
-  return {
-    destroy: options.destroy,
-    headers: options.headers,
-    method: options.method ?? 'GET',
-    pause: options.pause,
-    async *[Symbol.asyncIterator]() {
-      for (const chunk of chunks) {
-        yield chunk;
-      }
-    },
-    url: options.url ?? '/',
-  } as unknown as IncomingMessage;
+  const stream = Readable.from(chunks) as Readable & IncomingMessage;
+  const originalDestroy = stream.destroy.bind(stream);
+  const originalPause = stream.pause.bind(stream);
+
+  stream.destroy = (...args) => {
+    options.destroy?.();
+    return originalDestroy(...args);
+  };
+  stream.pause = () => {
+    options.pause?.();
+    return originalPause();
+  };
+  stream.headers = options.headers;
+  stream.method = options.method ?? 'GET';
+  stream.url = options.url ?? '/';
+
+  return stream;
 }
 
 describe('node request adapter', () => {
@@ -138,6 +144,55 @@ describe('node request adapter', () => {
     const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
 
     expect(frameworkRequest.body).toEqual({ ok: true });
+  });
+
+  it('parses JSON bodies when the primary content-type uses mixed-case media types', async () => {
+    const request = createIncomingMessage({
+      body: '{"ok":true}',
+      headers: {
+        'content-type': 'Application/Json; Charset=UTF-8',
+      },
+      method: 'POST',
+      url: '/body',
+    });
+
+    const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+
+    expect(frameworkRequest.body).toEqual({ ok: true });
+  });
+
+  it('parses multipart bodies when the primary content-type uses mixed-case media types', async () => {
+    const form = new FormData();
+    form.append('name', 'Ada');
+    form.append('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
+
+    const multipartRequest = new Request('http://localhost/uploads', {
+      body: form,
+      method: 'POST',
+    });
+    const requestBody = Buffer.from(await multipartRequest.arrayBuffer());
+
+    const request = createIncomingMessage({
+      body: requestBody,
+      headers: {
+        'content-type': multipartRequest.headers.get('content-type')?.replace('multipart/form-data', 'Multipart/Form-Data'),
+      },
+      method: 'POST',
+      url: '/uploads',
+    });
+
+    const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+
+    expect(frameworkRequest.body).toEqual({ name: 'Ada' });
+    expect(frameworkRequest.files).toEqual([
+      {
+        buffer: Buffer.from('hello'),
+        fieldname: 'payload',
+        mimetype: 'text/plain',
+        originalname: 'payload.txt',
+        size: 5,
+      },
+    ]);
   });
 
   it('creates the request shell before materializing body and rawBody', async () => {

--- a/packages/runtime/src/node/node.test.ts
+++ b/packages/runtime/src/node/node.test.ts
@@ -52,4 +52,10 @@ describe('createNodeHttpAdapter', () => {
     expect(publicNodeApi).not.toHaveProperty('compressNodeResponse');
     expect(publicNodeApi).not.toHaveProperty('createNodeResponseCompression');
   });
+
+  it('fails fast when maxBodySize is not provided as numeric bytes', () => {
+    expect(() => Function.prototype.call.call(publicNodeApi.createNodeHttpAdapter, undefined, { maxBodySize: '1mb' })).toThrow(
+      'Invalid maxBodySize value: 1mb. Expected a non-negative integer number of bytes.',
+    );
+  });
 });


### PR DESCRIPTION
Closes #1393

## Summary
- normalize raw Node request content-type detection before JSON and multipart parsing so mixed-case media types keep the documented behavior
- fail fast when `maxBodySize` is configured with a non-numeric value and align public Node adapter docs/examples to numeric byte counts

## Changes
- lowercased the primary Node request media type before JSON and multipart detection
- added regression coverage for mixed-case JSON and multipart headers plus invalid non-numeric `maxBodySize`
- updated `packages/platform-nodejs` README mirrors, intermediate Node adapter book chapters, and added a patch changeset for `@fluojs/runtime` and `@fluojs/platform-nodejs`

## Testing
- ✅ `pnpm exec vitest run packages/runtime/src/node/node-request.test.ts packages/runtime/src/node/node.test.ts`
- ⚠️ `pnpm --filter @fluojs/runtime typecheck`
- ⚠️ `pnpm --filter @fluojs/platform-nodejs typecheck`
- ⚠️ `pnpm --filter @fluojs/runtime build && pnpm --filter @fluojs/platform-nodejs build`
- ✅ `pnpm exec biome lint packages/runtime/src/node/internal-node-request.ts packages/runtime/src/node/internal-node.ts packages/runtime/src/node/node-request.test.ts packages/runtime/src/node/node.test.ts packages/platform-nodejs/README.md packages/platform-nodejs/README.ko.md book/intermediate/ch21-express-node.md book/intermediate/ch21-express-node.ko.md`

Typecheck/build attempts in the dedicated worktree still hit existing `TS2307` workspace-resolution failures for `@fluojs/*` package imports, so the targeted regression tests are the passing verification evidence attached to this PR.

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed in this PR.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

This PR changes package/book docs and runtime parsing behavior, but does not alter governance docs or add new platform conformance claims.