### PR TITLE
Add HTTP runtime benchmark comparison

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -45,7 +45,9 @@
     "includes": [
       "packages/*/src/**/*.ts",
       "tooling/**/*.ts",
-      "tooling/**/*.mjs"
+      "tooling/**/*.mjs",
+      "!tooling/benchmarks/http-comparison/src/nestjs/**/*.ts",
+      "!tooling/benchmarks/http-comparison/src/nestjs-express/**/*.ts"
     ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,6 +980,67 @@ importers:
 
   tooling/babel: {}
 
+  tooling/benchmarks/http-comparison:
+    dependencies:
+      '@fluojs/core':
+        specifier: 1.0.0-beta.2
+        version: 1.0.0-beta.2
+      '@fluojs/http':
+        specifier: 1.0.0-beta.3
+        version: 1.0.0-beta.3
+      '@fluojs/platform-bun':
+        specifier: 1.0.0-beta.3
+        version: 1.0.0-beta.3
+      '@fluojs/platform-express':
+        specifier: 1.0.0-beta.3
+        version: 1.0.0-beta.3
+      '@fluojs/platform-fastify':
+        specifier: 1.0.0-beta.4
+        version: 1.0.0-beta.4
+      '@fluojs/runtime':
+        specifier: 1.0.0-beta.4
+        version: 1.0.0-beta.4
+      '@nestjs/common':
+        specifier: ^11.0.0
+        version: 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.0.0
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/platform-express':
+        specifier: ^11.0.0
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+      '@nestjs/platform-fastify':
+        specifier: ^11.0.0
+        version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.5
+      reflect-metadata:
+        specifier: ^0.2.0
+        version: 0.2.2
+    devDependencies:
+      '@types/autocannon':
+        specifier: ^7.12.7
+        version: 7.12.7
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      autocannon:
+        specifier: ^7.0.0
+        version: 7.15.0
+      ts-node:
+        specifier: ^10.0.0
+        version: 10.9.2(@types/node@22.19.15)(typescript@5.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+
   tooling/tsconfig: {}
 
   tooling/vite: {}
@@ -993,6 +1054,9 @@ packages:
 
   '@ark/util@0.56.0':
     resolution: {integrity: sha512-BghfRC8b9pNs3vBoDJhcta0/c1J1rsoS1+HgVUreMFPdhz/CRAKReAu57YEllNaSy98rWAdY1gE+gFup7OXpgA==}
+
+  '@assemblyscript/loader@0.19.23':
+    resolution: {integrity: sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==}
 
   '@babel/cli@7.28.6':
     resolution: {integrity: sha512-6EUNcuBbNkj08Oj4gAZ+BUU8yLCgKzgVX4gaTh09Ya2C8ICM4P+G30g4m3akRxSYAp3A/gnWchrNst7px4/nUQ==}
@@ -1199,6 +1263,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
+
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
 
@@ -1265,6 +1332,14 @@ packages:
 
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@envelop/core@5.5.1':
     resolution: {integrity: sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==}
@@ -1596,6 +1671,9 @@ packages:
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
 
+  '@fastify/cors@11.2.0':
+    resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
+
   '@fastify/deepmerge@3.2.1':
     resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
 
@@ -1604,6 +1682,9 @@ packages:
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
     resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/formbody@8.0.2':
+    resolution: {integrity: sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==}
 
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
@@ -1616,6 +1697,41 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fluojs/config@1.0.0-beta.3':
+    resolution: {integrity: sha512-WxWSZKlgezpHbZuGOnGYH9D3SmMJWduyZHasufz2nuP+nJA4rLKfVOQeb3WKupzMxHGibCQkzE7/nwheidQV7w==}
+    engines: {node: '>=20.0.0'}
+
+  '@fluojs/core@1.0.0-beta.2':
+    resolution: {integrity: sha512-wesWvWH4P3vAug8bwaK3XAwVPREFRmCJPIDDshRNzPRDPdGxPEql78hnq/B4SNRsVxBGnnCcgjWYQWJtGosGZg==}
+    engines: {node: '>=20.0.0'}
+
+  '@fluojs/di@1.0.0-beta.4':
+    resolution: {integrity: sha512-LKh/rmcrAIvdIAaPhF0+ke4ACo2piKsV58eiZs9S0D2IDcqL3QXg3UN8id2GpsxmJ54cFRGid+GaGaJGpQl3ew==}
+    engines: {node: '>=20.0.0'}
+
+  '@fluojs/http@1.0.0-beta.3':
+    resolution: {integrity: sha512-qRhfbg6Z782/WY9lMvApl9BBXcW8Vm+NsSKx/M0guy8Md5TFKgvz/6A2ipYD2TdSAN9mTMEycQ2OBmLZMenA/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@fluojs/platform-bun@1.0.0-beta.3':
+    resolution: {integrity: sha512-eOSL5kAYnlsgBVbkNNcAjwowSoPa8M2SrqWMJLGAqvyWj2ynOvEGlPwugM8UaLDv9ZpnWlyTOa3X4n1VBnb/OQ==}
+
+  '@fluojs/platform-express@1.0.0-beta.3':
+    resolution: {integrity: sha512-CaKqQu9IwdeDx13kEENbLdD/TwfpMFngs0lDa2UNwBo/+7UDIt4LGLeznJmioS2Jxg9rm2dHFPA0WuQ48Gy/eA==}
+    engines: {node: '>=20.0.0'}
+
+  '@fluojs/platform-fastify@1.0.0-beta.4':
+    resolution: {integrity: sha512-lTm7T+L5AujKXEk8fqlJEnmOtcimRVsEU99by6nkLthUJihBQxAmuYchYHCe/xyDq+UGe4PmVuR2FB0Vu45wwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@fluojs/runtime@1.0.0-beta.4':
+    resolution: {integrity: sha512-dLOedEWGYs0qBLa5xBiYQbvOe0tBYwWGZp9/O0a5Cp1uwH8hWhMkgPgVZqPcRg53TSgZuSqmGQItTEMhxRTvaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@fluojs/validation@1.0.0-beta.1':
+    resolution: {integrity: sha512-qmY1/+MAnzTarc+TAXWBZopnDu9uK3UZL1EKwi1Y/83jJXuzDpdFI5s7OgHzaeV3zsudgOKj+ts3MkAIQYFggA==}
+    engines: {node: '>=20.0.0'}
 
   '@graphql-tools/executor@1.5.1':
     resolution: {integrity: sha512-n94Qcu875Mji9GQ52n5UbgOTxlgvFJicBPYD+FRks9HKIQpdNPjkkrKZUYNG51XKa+bf03rxNflm4+wXhoHHrA==}
@@ -1704,8 +1820,15 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1746,6 +1869,56 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@nestjs/common@11.1.19':
+    resolution: {integrity: sha512-qeiTt2tv+e5QyDKqG8HlVZb2wx64FEaSGFJouqTSRs+kG44iTfl3xlz1XqVped+rihx4hmjWgL5gkhtdK3E6+Q==}
+    peerDependencies:
+      class-transformer: '>=0.4.1'
+      class-validator: '>=0.13.2'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+
+  '@nestjs/core@11.1.19':
+    resolution: {integrity: sha512-6nJkWa2efrYi+XlU686J9y5L7OvxpLVjT0T/sxRKE7Jvpffiihelup4WSvLvRhdHDjj/5SuoWEwqReXAaaeHmw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/microservices': ^11.0.0
+      '@nestjs/platform-express': ^11.0.0
+      '@nestjs/websockets': ^11.0.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      '@nestjs/microservices':
+        optional: true
+      '@nestjs/platform-express':
+        optional: true
+      '@nestjs/websockets':
+        optional: true
+
+  '@nestjs/platform-express@11.1.19':
+    resolution: {integrity: sha512-Vpdv8jyCQdThfoTx+UTn+DRYr6H6X02YUqcpZ3qP6G3ZUwtVp7eS+hoQPGd4UuCnlnFG8Wqr2J9bGEzQdi1rIg==}
+    peerDependencies:
+      '@nestjs/common': ^11.0.0
+      '@nestjs/core': ^11.0.0
+
+  '@nestjs/platform-fastify@11.1.19':
+    resolution: {integrity: sha512-PdldJPw+xu8JM7VNE2FY+ty+qoxDMW7326h/z0MtfZvKj84FE6zuqpcSXen1CYjtyP8og+x/5XrJbKKKDNabtQ==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0 || ^9.0.0
+      '@fastify/view': ^10.0.0 || ^11.0.0
+      '@nestjs/common': ^11.0.0
+      '@nestjs/core': ^11.0.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      '@fastify/view':
+        optional: true
+
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
 
@@ -1760,6 +1933,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nuxt/opencollective@0.4.1':
+    resolution: {integrity: sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==}
+    engines: {node: ^14.18.0 || >=16.10.0, npm: '>=5.10.0'}
+    hasBin: true
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -1952,6 +2130,28 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/autocannon@7.12.7':
+    resolution: {integrity: sha512-Pd4nPf7wRpacULa6D/EC9x3CwzFQXwA0z5WFuik/fvJjW44V3WzBTM3jtt8nSBoflUNgswPiMCtgrr1bwnAcMg==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -2098,6 +2298,15 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2125,6 +2334,12 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  append-field@1.0.0:
+    resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -2148,9 +2363,16 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  autocannon@7.15.0:
+    resolution: {integrity: sha512-NaP2rQyA+tcubOJMFv2+oeW9jv2pq/t+LM6BL3cfJic0HEfscEcnWgAyU5YovE/oTHUzAgTliGdLPR+RQAWUbg==}
+    hasBin: true
 
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
@@ -2213,11 +2435,18 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bullmq@5.71.0:
     resolution: {integrity: sha512-aeNWh4drsafSKnAJeiNH/nZP/5O8ZdtdMbnOPZmpjXj7NZUP5YC901U3bIH41iZValm7d1i3c34ojv7q31m30w==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2242,6 +2471,13 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  char-spinner@1.0.1:
+    resolution: {integrity: sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==}
+
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
@@ -2252,6 +2488,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2268,6 +2508,14 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
@@ -2281,6 +2529,10 @@ packages:
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
@@ -2309,6 +2561,9 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
@@ -2316,6 +2571,9 @@ packages:
   croner@8.1.2:
     resolution: {integrity: sha512-ypfPFcAXHuAZRCzo3vJL6ltENzniTjwe/qsLleH1V2/7SRDjgvRQyrLmumFTLmjFax4IuSxfGXEn79fozXcJog==}
     engines: {node: '>=18.0'}
+
+  cross-argv@2.0.0:
+    resolution: {integrity: sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==}
 
   cross-inspect@1.0.1:
     resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
@@ -2344,6 +2602,10 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -2363,6 +2625,10 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -2524,6 +2790,10 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -2588,6 +2858,9 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fast-string-truncated-width@1.2.1:
     resolution: {integrity: sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==}
 
@@ -2611,6 +2884,9 @@ packages:
     resolution: {integrity: sha512-2qfoaQ3BQDhZ1gtbkKZd6n0kKxJISJGM6u/skD9ljdWItAscjXrtZ1lnjr7PavmXX9j4EyCPmBDiIsLn07d5vA==}
     engines: {node: '>= 10'}
 
+  fastify@5.8.4:
+    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
+
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
@@ -2625,6 +2901,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
 
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
@@ -2644,6 +2924,10 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2729,13 +3013,31 @@ packages:
     resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  has-async-hooks@1.0.0:
+    resolution: {integrity: sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hdr-histogram-js@3.0.1:
+    resolution: {integrity: sha512-l3GSdZL1Jr1C0kyb461tUjEdrRPZr8Qry7jByltf5JGrA0xvqOSrxRBfcrJqqV/AMEtqqhHhC6w8HW0gn76tRQ==}
+    engines: {node: '>=14'}
+
+  hdr-histogram-percentiles-obj@3.0.0:
+    resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -2744,9 +3046,15 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
+
+  hyperid@3.3.0:
+    resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2820,6 +3128,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  iterare@1.2.1:
+    resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
+    engines: {node: '>=6'}
+
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
@@ -2868,6 +3180,10 @@ packages:
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
+  load-esm@1.0.3:
+    resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
+    engines: {node: '>=13.2.0'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -2875,8 +3191,17 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.chunk@4.2.0:
+    resolution: {integrity: sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
@@ -2907,9 +3232,19 @@ packages:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
 
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  manage-path@2.0.0:
+    resolution: {integrity: sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -3021,6 +3356,10 @@ packages:
   msgpackr@1.11.5:
     resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
 
+  multer@2.1.1:
+    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+    engines: {node: '>= 10.16.0'}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -3080,6 +3419,10 @@ packages:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
+  on-net-listen@1.1.2:
+    resolution: {integrity: sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==}
+    engines: {node: '>=9.4.0 || ^8.9.4'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3109,6 +3452,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3125,8 +3471,8 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-to-regexp@8.4.1:
-    resolution: {integrity: sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -3173,6 +3519,10 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  pretty-bytes@5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -3185,6 +3535,10 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
 
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
@@ -3251,6 +3605,12 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
+  reinterval@1.1.0:
+    resolution: {integrity: sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -3270,6 +3630,9 @@ packages:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
 
+  retimer@3.0.0:
+    resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3288,6 +3651,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -3437,6 +3803,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3455,6 +3825,17 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
+  subarg@1.0.0:
+    resolution: {integrity: sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
@@ -3465,6 +3846,10 @@ packages:
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
+
+  timestring@6.0.0:
+    resolution: {integrity: sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==}
+    engines: {node: '>=8'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3500,12 +3885,30 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3515,6 +3918,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -3522,10 +3929,23 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uid@2.0.2:
+    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
+    engines: {node: '>=8'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3550,9 +3970,19 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  uuid-parse@1.1.0:
+    resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
+
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   valibot@1.3.1:
     resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
@@ -3729,6 +4159,10 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -3739,6 +4173,8 @@ snapshots:
       '@ark/util': 0.56.0
 
   '@ark/util@0.56.0': {}
+
+  '@assemblyscript/loader@0.19.23': {}
 
   '@babel/cli@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -3991,6 +4427,8 @@ snapshots:
   '@biomejs/cli-win32-x64@2.4.10':
     optional: true
 
+  '@borewit/text-codec@0.2.2': {}
+
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
       '@changesets/config': 3.1.4
@@ -4160,6 +4598,13 @@ snapshots:
       fast-string-width: 1.1.0
       fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
+
+  '@colors/colors@1.5.0':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@envelop/core@5.5.1':
     dependencies:
@@ -4342,6 +4787,11 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
+  '@fastify/cors@11.2.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.0
+
   '@fastify/deepmerge@3.2.1': {}
 
   '@fastify/error@4.2.0': {}
@@ -4349,6 +4799,11 @@ snapshots:
   '@fastify/fast-json-stringify-compiler@5.0.3':
     dependencies:
       fast-json-stringify: 6.3.0
+
+  '@fastify/formbody@8.0.2':
+    dependencies:
+      fast-querystring: 1.1.2
+      fastify-plugin: 5.1.0
 
   '@fastify/forwarded@3.0.1': {}
 
@@ -4368,6 +4823,58 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fluojs/config@1.0.0-beta.3':
+    dependencies:
+      '@fluojs/core': 1.0.0-beta.2
+      dotenv: 16.6.1
+      dotenv-expand: 11.0.7
+
+  '@fluojs/core@1.0.0-beta.2': {}
+
+  '@fluojs/di@1.0.0-beta.4':
+    dependencies:
+      '@fluojs/core': 1.0.0-beta.2
+
+  '@fluojs/http@1.0.0-beta.3':
+    dependencies:
+      '@fluojs/core': 1.0.0-beta.2
+      '@fluojs/di': 1.0.0-beta.4
+      '@fluojs/validation': 1.0.0-beta.1
+
+  '@fluojs/platform-bun@1.0.0-beta.3':
+    dependencies:
+      '@fluojs/http': 1.0.0-beta.3
+      '@fluojs/runtime': 1.0.0-beta.4
+
+  '@fluojs/platform-express@1.0.0-beta.3':
+    dependencies:
+      '@fluojs/http': 1.0.0-beta.3
+      '@fluojs/runtime': 1.0.0-beta.4
+      express: 5.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fluojs/platform-fastify@1.0.0-beta.4':
+    dependencies:
+      '@fastify/multipart': 9.4.0
+      '@fluojs/http': 1.0.0-beta.3
+      '@fluojs/runtime': 1.0.0-beta.4
+      fastify: 5.8.5
+      fastify-raw-body: 5.0.0
+
+  '@fluojs/runtime@1.0.0-beta.4':
+    dependencies:
+      '@fluojs/config': 1.0.0-beta.3
+      '@fluojs/core': 1.0.0-beta.2
+      '@fluojs/di': 1.0.0-beta.4
+      '@fluojs/http': 1.0.0-beta.3
+
+  '@fluojs/validation@1.0.0-beta.1':
+    dependencies:
+      '@fluojs/core': 1.0.0-beta.2
+      '@standard-schema/spec': 1.1.0
+      validator: 13.15.26
 
   '@graphql-tools/executor@1.5.1(graphql@16.13.1)':
     dependencies:
@@ -4470,7 +4977,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@lukeed/csprng@1.1.0': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4510,6 +5024,59 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
+  '@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      file-type: 21.3.4
+      iterare: 1.2.1
+      load-esm: 1.0.3
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nuxt/opencollective': 0.4.1
+      fast-safe-stringify: 2.1.1
+      iterare: 1.2.1
+      path-to-regexp: 8.4.2
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    optionalDependencies:
+      '@nestjs/platform-express': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)
+
+  '@nestjs/platform-express@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
+    dependencies:
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cors: 2.8.6
+      express: 5.2.1
+      multer: 2.1.1
+      path-to-regexp: 8.4.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@nestjs/platform-fastify@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)':
+    dependencies:
+      '@fastify/cors': 11.2.0
+      '@fastify/formbody': 8.0.2
+      '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      fast-querystring: 1.1.2
+      fastify: 5.8.4
+      fastify-plugin: 5.1.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      path-to-regexp: 8.4.2
+      reusify: 1.1.0
+      tslib: 2.8.1
+
   '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     optional: true
 
@@ -4524,6 +5091,10 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@nuxt/opencollective@0.4.1':
+    dependencies:
+      consola: 3.4.2
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -4644,6 +5215,27 @@ snapshots:
   '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@tsconfig/node10@1.0.12': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/autocannon@7.12.7':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4835,6 +5427,12 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -4860,6 +5458,10 @@ snapshots:
       picomatch: 2.3.1
     optional: true
 
+  append-field@1.0.0: {}
+
+  arg@4.1.3: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -4882,7 +5484,35 @@ snapshots:
 
   async@3.2.6: {}
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
+
+  autocannon@7.15.0:
+    dependencies:
+      chalk: 4.1.2
+      char-spinner: 1.0.1
+      cli-table3: 0.6.5
+      color-support: 1.1.3
+      cross-argv: 2.0.0
+      form-data: 4.0.5
+      has-async-hooks: 1.0.0
+      hdr-histogram-js: 3.0.1
+      hdr-histogram-percentiles-obj: 3.0.0
+      http-parser-js: 0.5.10
+      hyperid: 3.3.0
+      lodash.chunk: 4.2.0
+      lodash.clonedeep: 4.5.0
+      lodash.flatten: 4.4.0
+      manage-path: 2.0.0
+      on-net-listen: 1.1.2
+      pretty-bytes: 5.6.0
+      progress: 2.0.3
+      reinterval: 1.1.0
+      retimer: 3.0.0
+      semver: 7.7.4
+      subarg: 1.0.0
+      timestring: 6.0.0
 
   avvio@9.2.0:
     dependencies:
@@ -4959,6 +5589,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -4975,6 +5610,10 @@ snapshots:
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
 
   bytes@3.1.2: {}
 
@@ -5000,6 +5639,13 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  char-spinner@1.0.1: {}
+
   chardet@2.1.1: {}
 
   check-error@2.1.3: {}
@@ -5017,6 +5663,12 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -5031,6 +5683,12 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-support@1.1.3: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@6.2.1: {}
 
   commist@3.2.0: {}
@@ -5043,6 +5701,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       typedarray: 0.0.6
+
+  consola@3.4.2: {}
 
   content-disposition@1.0.1: {}
 
@@ -5061,11 +5721,15 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  create-require@1.1.1: {}
+
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.7.2
 
   croner@8.1.2: {}
+
+  cross-argv@2.0.0: {}
 
   cross-inspect@1.0.1:
     dependencies:
@@ -5087,6 +5751,8 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  delayed-stream@1.0.0: {}
+
   denque@2.1.0: {}
 
   depd@2.0.0: {}
@@ -5097,6 +5763,8 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  diff@4.0.4: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -5178,6 +5846,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -5315,6 +5990,8 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
+  fast-safe-stringify@2.1.1: {}
+
   fast-string-truncated-width@1.2.1: {}
 
   fast-string-width@1.1.0:
@@ -5339,6 +6016,24 @@ snapshots:
       fastify-plugin: 5.1.0
       raw-body: 3.0.2
       secure-json-parse: 2.7.0
+
+  fastify@5.8.4:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.0
 
   fastify@5.8.5:
     dependencies:
@@ -5365,6 +6060,15 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   filelist@1.0.6:
     dependencies:
@@ -5395,6 +6099,14 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   forwarded@0.2.0: {}
 
@@ -5495,11 +6207,27 @@ snapshots:
 
   graphql@16.13.1: {}
 
+  has-async-hooks@1.0.0: {}
+
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hdr-histogram-js@3.0.1:
+    dependencies:
+      '@assemblyscript/loader': 0.19.23
+      base64-js: 1.5.1
+      pako: 1.0.11
+
+  hdr-histogram-percentiles-obj@3.0.0: {}
 
   help-me@5.0.0: {}
 
@@ -5511,7 +6239,15 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-parser-js@0.5.10: {}
+
   human-id@4.1.3: {}
+
+  hyperid@3.3.0:
+    dependencies:
+      buffer: 5.7.1
+      uuid: 8.3.2
+      uuid-parse: 1.1.0
 
   iconv-lite@0.7.2:
     dependencies:
@@ -5587,6 +6323,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  iterare@1.2.1: {}
+
   jake@10.9.4:
     dependencies:
       async: 3.2.6
@@ -5630,13 +6368,21 @@ snapshots:
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
 
+  load-esm@1.0.3: {}
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.chunk@4.2.0: {}
+
+  lodash.clonedeep@4.5.0: {}
+
   lodash.defaults@4.2.0: {}
+
+  lodash.flatten@4.4.0: {}
 
   lodash.isarguments@3.1.0: {}
 
@@ -5663,7 +6409,13 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
 
+  make-error@1.3.6: {}
+
+  manage-path@2.0.0: {}
+
   math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
 
@@ -5785,6 +6537,13 @@ snapshots:
     optionalDependencies:
       msgpackr-extract: 3.0.3
 
+  multer@2.1.1:
+    dependencies:
+      append-field: 1.0.0
+      busboy: 1.6.0
+      concat-stream: 2.0.0
+      type-is: 1.6.18
+
   nanoid@3.3.11: {}
 
   negotiator@0.6.3: {}
@@ -5826,6 +6585,8 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
+  on-net-listen@1.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -5852,6 +6613,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  pako@1.0.11: {}
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -5860,7 +6623,7 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-to-regexp@8.4.1: {}
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -5904,6 +6667,8 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  pretty-bytes@5.6.0: {}
+
   process-nextick-args@2.0.1: {}
 
   process-warning@4.0.1: {}
@@ -5911,6 +6676,8 @@ snapshots:
   process-warning@5.0.0: {}
 
   process@0.11.10: {}
+
+  progress@2.0.3: {}
 
   prom-client@15.1.3:
     dependencies:
@@ -5992,6 +6759,10 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  reflect-metadata@0.2.2: {}
+
+  reinterval@1.1.0: {}
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -6001,6 +6772,8 @@ snapshots:
   resolve-pkg-maps@1.0.0: {}
 
   ret@0.5.0: {}
+
+  retimer@3.0.0: {}
 
   reusify@1.1.0: {}
 
@@ -6043,13 +6816,17 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.4.1
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-buffer@5.2.1: {}
 
@@ -6221,6 +6998,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  streamsearch@1.1.0: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -6241,6 +7020,18 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  subarg@1.0.0:
+    dependencies:
+      minimist: 1.2.8
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
@@ -6250,6 +7041,8 @@ snapshots:
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
+
+  timestring@6.0.0: {}
 
   tinybench@2.9.0: {}
 
@@ -6274,11 +7067,35 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   tr46@0.0.3: {}
 
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  ts-node@10.9.2(@types/node@22.19.15)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.15
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
 
   tslib@2.8.1: {}
 
@@ -6289,6 +7106,11 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -6297,7 +7119,15 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typescript@5.8.3: {}
+
   typescript@6.0.2: {}
+
+  uid@2.0.2:
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
+  uint8array-extras@1.5.0: {}
 
   undici-types@6.21.0: {}
 
@@ -6315,7 +7145,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  uuid-parse@1.1.0: {}
+
   uuid@11.1.0: {}
+
+  uuid@8.3.2: {}
+
+  v8-compile-cache-lib@3.0.1: {}
 
   valibot@1.3.1(typescript@6.0.2):
     optionalDependencies:
@@ -6479,5 +7315,7 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yn@3.1.1: {}
 
   zod@4.3.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - packages/*
   - tooling/*
+  - tooling/benchmarks/*
   - examples/*

--- a/tooling/benchmarks/http-comparison/README.md
+++ b/tooling/benchmarks/http-comparison/README.md
@@ -1,0 +1,45 @@
+# HTTP runtime benchmark
+
+Runs a small HTTP throughput/latency comparison between published fluo beta packages and NestJS v11 across five targets:
+
+- `Nest+Fastify`
+- `Nest+Express`
+- `fluo+Fastify`
+- `fluo+Express`
+- `fluo+Bun`
+
+## Scenarios
+
+- `baseline`: pure controller routing with an identical `{ "ok": true }` JSON response.
+- `di-chain`: controller → service → repository constructor injection with an identical user JSON response.
+- `di-chain-random-3`, `di-chain-random-5`, `di-chain-random-20`: the same DI path across randomly selected route families, used to expose route matching overhead as route count increases.
+
+## Run
+
+```bash
+pnpm install --no-frozen-lockfile
+pnpm --filter @fluojs-internal/tooling-benchmarks-http bench
+```
+
+The runner starts all servers, warms every target for each scenario, then measures with `autocannon` at 100 connections for 40 seconds. Measurement order rotates by scenario to avoid always giving one framework the same position.
+
+The `fluo+Bun` target requires the `bun` CLI because `@fluojs/platform-bun` uses `globalThis.Bun.serve()` at listen time.
+
+## Correctness gates
+
+Each warm-up and measured run validates the expected response body and fails on:
+
+- connection errors
+- timeouts
+- non-2xx responses
+- body mismatches
+
+The report prints those counters with throughput and latency metrics.
+
+## Scope and caveats
+
+- This measures the released npm beta surface, not unpublished workspace source changes.
+- fluo uses TC39 standard decorators without `emitDecoratorMetadata`; NestJS uses legacy decorators with `emitDecoratorMetadata` through `nestjs/tsconfig.json`.
+- Fastify and Express adapter comparisons should be read as framework-plus-adapter measurements, not pure framework-core measurements.
+- `fluo+Bun` is a runtime comparison, not a same-adapter comparison. Treat it as “same fluo app graph on Bun’s native server” versus the Node.js adapter targets.
+- The suite only covers routing and one constructor-DI path. It does not measure validation, serialization plugins, guards, pipes, database access, or production middleware.

--- a/tooling/benchmarks/http-comparison/nestjs/tsconfig.json
+++ b/tooling/benchmarks/http-comparison/nestjs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["../src/nestjs/**/*", "../src/nestjs-express/**/*"]
+}

--- a/tooling/benchmarks/http-comparison/package.json
+++ b/tooling/benchmarks/http-comparison/package.json
@@ -11,7 +11,8 @@
     "bench:fluo": "tsx src/fluo/server.ts",
     "bench:fluo:express": "tsx src/fluo-express/server.ts",
     "bench:nestjs": "ts-node --transpile-only --project nestjs/tsconfig.json src/nestjs/server.ts",
-    "bench:nestjs:express": "ts-node --transpile-only --project nestjs/tsconfig.json src/nestjs-express/server.ts"
+    "bench:nestjs:express": "ts-node --transpile-only --project nestjs/tsconfig.json src/nestjs-express/server.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p nestjs/tsconfig.json"
   },
   "dependencies": {
     "@fluojs/core": "1.0.0-beta.2",

--- a/tooling/benchmarks/http-comparison/package.json
+++ b/tooling/benchmarks/http-comparison/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@fluojs-internal/tooling-benchmarks-http",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "HTTP throughput/latency benchmark: NestJS vs fluo across Fastify, Express, and Bun",
+  "scripts": {
+    "bench": "tsx src/run.ts",
+    "build:fluo:bun": "tsc src/fluo-bun/server.ts --target ES2022 --module ESNext --moduleResolution Bundler --strict --skipLibCheck --outDir dist/fluo-bun",
+    "bench:fluo:bun": "pnpm run build:fluo:bun && bun run dist/fluo-bun/server.js",
+    "bench:fluo": "tsx src/fluo/server.ts",
+    "bench:fluo:express": "tsx src/fluo-express/server.ts",
+    "bench:nestjs": "ts-node --transpile-only --project nestjs/tsconfig.json src/nestjs/server.ts",
+    "bench:nestjs:express": "ts-node --transpile-only --project nestjs/tsconfig.json src/nestjs-express/server.ts"
+  },
+  "dependencies": {
+    "@fluojs/core": "1.0.0-beta.2",
+    "@fluojs/http": "1.0.0-beta.3",
+    "@fluojs/platform-bun": "1.0.0-beta.3",
+    "@fluojs/platform-express": "1.0.0-beta.3",
+    "@fluojs/platform-fastify": "1.0.0-beta.4",
+    "@fluojs/runtime": "1.0.0-beta.4",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/platform-fastify": "^11.0.0",
+    "express": "^5.2.1",
+    "fastify": "^5.0.0",
+    "reflect-metadata": "^0.2.0"
+  },
+  "devDependencies": {
+    "@types/autocannon": "^7.12.7",
+    "@types/node": "^22.0.0",
+    "autocannon": "^7.0.0",
+    "ts-node": "^10.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "~5.8.3"
+  }
+}

--- a/tooling/benchmarks/http-comparison/src/fluo-bun/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo-bun/server.ts
@@ -1,0 +1,167 @@
+import { ensureMetadataSymbol, Inject, Module } from '@fluojs/core';
+import { Controller, FromPath, Get, RequestDto } from '@fluojs/http';
+import { createBunAdapter } from '@fluojs/platform-bun';
+import { FluoFactory } from '@fluojs/runtime';
+
+ensureMetadataSymbol();
+
+@Controller('/baseline')
+class BaselineController {
+  @Get('/')
+  health(): { ok: boolean } {
+    return { ok: true };
+  }
+}
+
+class UsersRepository {
+  findOne(id: string): { id: string; name: string; email: string } {
+    return { id, name: 'Alice', email: 'alice@example.com' };
+  }
+}
+
+class GetUserRequest {
+  @FromPath('id')
+  id = '';
+}
+
+@Inject(UsersRepository)
+class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+
+  getUser(id: string): { id: string; name: string; email: string } {
+    return this.repo.findOne(id);
+  }
+}
+
+@Inject(UsersService)
+@Controller('/di-chain')
+class DiChainController {
+  constructor(private readonly service: UsersService) {}
+
+  @RequestDto(GetUserRequest)
+  @Get('/:id')
+  get(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/users/:id')
+  getUser(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/profiles/:id')
+  getProfile(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/settings/:id')
+  getSettings(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r01/:id')
+  getR01(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r02/:id')
+  getR02(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r03/:id')
+  getR03(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r04/:id')
+  getR04(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r05/:id')
+  getR05(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r06/:id')
+  getR06(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r07/:id')
+  getR07(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r08/:id')
+  getR08(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r09/:id')
+  getR09(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r10/:id')
+  getR10(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r11/:id')
+  getR11(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r12/:id')
+  getR12(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r13/:id')
+  getR13(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r14/:id')
+  getR14(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r15/:id')
+  getR15(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r16/:id')
+  getR16(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r17/:id')
+  getR17(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r18/:id')
+  getR18(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r19/:id')
+  getR19(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r20/:id')
+  getR20(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+}
+
+@Module({
+  controllers: [BaselineController, DiChainController],
+  providers: [UsersRepository, UsersService],
+})
+class AppModule {}
+
+async function main(): Promise<void> {
+  const port = Number(process.env['PORT'] ?? 3003);
+
+  const app = await FluoFactory.create(AppModule, {
+    adapter: createBunAdapter({ port }),
+    logger: { debug() {}, error() {}, log() {}, warn() {} },
+  });
+
+  await app.listen();
+  process.stdout.write(`fluo+Bun listening on :${port}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[fluo-bun] fatal: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/tooling/benchmarks/http-comparison/src/fluo-express/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo-express/server.ts
@@ -1,0 +1,165 @@
+import { Inject, Module } from '@fluojs/core';
+import { Controller, FromPath, Get, RequestDto } from '@fluojs/http';
+import { createExpressAdapter } from '@fluojs/platform-express';
+import { FluoFactory } from '@fluojs/runtime';
+
+@Controller('/baseline')
+class BaselineController {
+  @Get('/')
+  health(): { ok: boolean } {
+    return { ok: true };
+  }
+}
+
+class UsersRepository {
+  findOne(id: string): { id: string; name: string; email: string } {
+    return { id, name: 'Alice', email: 'alice@example.com' };
+  }
+}
+
+class GetUserRequest {
+  @FromPath('id')
+  id = '';
+}
+
+@Inject(UsersRepository)
+class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+
+  getUser(id: string): { id: string; name: string; email: string } {
+    return this.repo.findOne(id);
+  }
+}
+
+@Inject(UsersService)
+@Controller('/di-chain')
+class DiChainController {
+  constructor(private readonly service: UsersService) {}
+
+  @RequestDto(GetUserRequest)
+  @Get('/:id')
+  get(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/users/:id')
+  getUser(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/profiles/:id')
+  getProfile(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/settings/:id')
+  getSettings(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r01/:id')
+  getR01(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r02/:id')
+  getR02(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r03/:id')
+  getR03(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r04/:id')
+  getR04(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r05/:id')
+  getR05(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r06/:id')
+  getR06(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r07/:id')
+  getR07(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r08/:id')
+  getR08(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r09/:id')
+  getR09(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r10/:id')
+  getR10(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r11/:id')
+  getR11(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r12/:id')
+  getR12(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r13/:id')
+  getR13(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r14/:id')
+  getR14(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r15/:id')
+  getR15(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r16/:id')
+  getR16(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r17/:id')
+  getR17(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r18/:id')
+  getR18(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r19/:id')
+  getR19(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r20/:id')
+  getR20(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+}
+
+@Module({
+  controllers: [BaselineController, DiChainController],
+  providers: [UsersRepository, UsersService],
+})
+class AppModule {}
+
+async function main(): Promise<void> {
+  const port = Number(process.env['PORT'] ?? 3005);
+
+  const app = await FluoFactory.create(AppModule, {
+    adapter: createExpressAdapter({ port }),
+    logger: { debug() {}, error() {}, log() {}, warn() {} },
+  });
+
+  await app.listen();
+  process.stdout.write(`fluo+Express listening on :${port}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[fluo-express] fatal: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/tooling/benchmarks/http-comparison/src/fluo/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo/server.ts
@@ -1,0 +1,165 @@
+import { Inject, Module } from '@fluojs/core';
+import { Controller, FromPath, Get, RequestDto } from '@fluojs/http';
+import { createFastifyAdapter } from '@fluojs/platform-fastify';
+import { FluoFactory } from '@fluojs/runtime';
+
+@Controller('/baseline')
+class BaselineController {
+  @Get('/')
+  health(): { ok: boolean } {
+    return { ok: true };
+  }
+}
+
+class UsersRepository {
+  findOne(id: string): { id: string; name: string; email: string } {
+    return { id, name: 'Alice', email: 'alice@example.com' };
+  }
+}
+
+class GetUserRequest {
+  @FromPath('id')
+  id = '';
+}
+
+@Inject(UsersRepository)
+class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+
+  getUser(id: string): { id: string; name: string; email: string } {
+    return this.repo.findOne(id);
+  }
+}
+
+@Inject(UsersService)
+@Controller('/di-chain')
+class DiChainController {
+  constructor(private readonly service: UsersService) {}
+
+  @RequestDto(GetUserRequest)
+  @Get('/:id')
+  get(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/users/:id')
+  getUser(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/profiles/:id')
+  getProfile(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/settings/:id')
+  getSettings(input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r01/:id')
+  getR01(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r02/:id')
+  getR02(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r03/:id')
+  getR03(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r04/:id')
+  getR04(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r05/:id')
+  getR05(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r06/:id')
+  getR06(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r07/:id')
+  getR07(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r08/:id')
+  getR08(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r09/:id')
+  getR09(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r10/:id')
+  getR10(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r11/:id')
+  getR11(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r12/:id')
+  getR12(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r13/:id')
+  getR13(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r14/:id')
+  getR14(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r15/:id')
+  getR15(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r16/:id')
+  getR16(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r17/:id')
+  getR17(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r18/:id')
+  getR18(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r19/:id')
+  getR19(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @RequestDto(GetUserRequest)
+  @Get('/r20/:id')
+  getR20(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+}
+
+@Module({
+  controllers: [BaselineController, DiChainController],
+  providers: [UsersRepository, UsersService],
+})
+class AppModule {}
+
+async function main(): Promise<void> {
+  const port = Number(process.env['PORT'] ?? 3001);
+
+  const app = await FluoFactory.create(AppModule, {
+    adapter: createFastifyAdapter({ port }),
+    logger: { debug() {}, error() {}, log() {}, warn() {} },
+  });
+
+  await app.listen();
+  process.stdout.write(`fluo listening on :${port}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[fluo] fatal: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/tooling/benchmarks/http-comparison/src/nestjs-express/package.json
+++ b/tooling/benchmarks/http-comparison/src/nestjs-express/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/tooling/benchmarks/http-comparison/src/nestjs-express/server.ts
+++ b/tooling/benchmarks/http-comparison/src/nestjs-express/server.ts
@@ -1,0 +1,141 @@
+import 'reflect-metadata';
+
+import { Controller, Get, Injectable, Module, Param } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+
+@Injectable()
+class UsersRepository {
+  findOne(id: string): { id: string; name: string; email: string } {
+    return { id, name: 'Alice', email: 'alice@example.com' };
+  }
+}
+
+@Injectable()
+class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+
+  getUser(id: string): { id: string; name: string; email: string } {
+    return this.repo.findOne(id);
+  }
+}
+
+class GetUserRequest {
+  id = '';
+}
+
+@Controller('baseline')
+class BaselineController {
+  @Get()
+  health(): { ok: boolean } {
+    return { ok: true };
+  }
+}
+
+@Controller('di-chain')
+class DiChainController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get(':id')
+  get(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @Get('users/:id')
+  getUser(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @Get('profiles/:id')
+  getProfile(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @Get('settings/:id')
+  getSettings(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @Get('r01/:id')
+  getR01(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r02/:id')
+  getR02(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r03/:id')
+  getR03(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r04/:id')
+  getR04(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r05/:id')
+  getR05(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r06/:id')
+  getR06(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r07/:id')
+  getR07(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r08/:id')
+  getR08(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r09/:id')
+  getR09(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r10/:id')
+  getR10(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r11/:id')
+  getR11(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r12/:id')
+  getR12(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r13/:id')
+  getR13(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r14/:id')
+  getR14(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r15/:id')
+  getR15(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r16/:id')
+  getR16(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r17/:id')
+  getR17(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r18/:id')
+  getR18(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r19/:id')
+  getR19(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r20/:id')
+  getR20(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+}
+
+@Module({
+  controllers: [BaselineController, DiChainController],
+  providers: [UsersRepository, UsersService],
+})
+class AppModule {}
+
+async function main(): Promise<void> {
+  const port = Number(process.env['PORT'] ?? 3004);
+
+  const app = await NestFactory.create<NestExpressApplication>(
+    AppModule,
+    { logger: false },
+  );
+
+  await app.listen(port, '0.0.0.0');
+  process.stdout.write(`NestJS+Express listening on :${port}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[nestjs-express] fatal: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/tooling/benchmarks/http-comparison/src/nestjs/package.json
+++ b/tooling/benchmarks/http-comparison/src/nestjs/package.json
@@ -1,0 +1,1 @@
+{ "type": "commonjs" }

--- a/tooling/benchmarks/http-comparison/src/nestjs/server.ts
+++ b/tooling/benchmarks/http-comparison/src/nestjs/server.ts
@@ -1,0 +1,142 @@
+import 'reflect-metadata';
+
+import { Controller, Get, Injectable, Module, Param } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+
+@Injectable()
+class UsersRepository {
+  findOne(id: string): { id: string; name: string; email: string } {
+    return { id, name: 'Alice', email: 'alice@example.com' };
+  }
+}
+
+@Injectable()
+class UsersService {
+  constructor(private readonly repo: UsersRepository) {}
+
+  getUser(id: string): { id: string; name: string; email: string } {
+    return this.repo.findOne(id);
+  }
+}
+
+class GetUserRequest {
+  id = '';
+}
+
+@Controller('baseline')
+class BaselineController {
+  @Get()
+  health(): { ok: boolean } {
+    return { ok: true };
+  }
+}
+
+@Controller('di-chain')
+class DiChainController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get(':id')
+  get(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @Get('users/:id')
+  getUser(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @Get('profiles/:id')
+  getProfile(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @Get('settings/:id')
+  getSettings(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+    return this.service.getUser(input.id);
+  }
+
+  @Get('r01/:id')
+  getR01(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r02/:id')
+  getR02(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r03/:id')
+  getR03(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r04/:id')
+  getR04(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r05/:id')
+  getR05(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r06/:id')
+  getR06(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r07/:id')
+  getR07(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r08/:id')
+  getR08(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r09/:id')
+  getR09(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r10/:id')
+  getR10(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r11/:id')
+  getR11(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r12/:id')
+  getR12(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r13/:id')
+  getR13(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r14/:id')
+  getR14(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r15/:id')
+  getR15(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r16/:id')
+  getR16(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r17/:id')
+  getR17(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r18/:id')
+  getR18(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r19/:id')
+  getR19(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+
+  @Get('r20/:id')
+  getR20(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
+}
+
+@Module({
+  controllers: [BaselineController, DiChainController],
+  providers: [UsersRepository, UsersService],
+})
+class AppModule {}
+
+async function main(): Promise<void> {
+  const port = Number(process.env['PORT'] ?? 3002);
+
+  const app = await NestFactory.create<NestFastifyApplication>(
+    AppModule,
+    new FastifyAdapter(),
+    { logger: false },
+  );
+
+  await app.listen(port, '0.0.0.0');
+  process.stdout.write(`NestJS listening on :${port}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[nestjs] fatal: ${String(err)}\n`);
+  process.exit(1);
+});

--- a/tooling/benchmarks/http-comparison/src/report.ts
+++ b/tooling/benchmarks/http-comparison/src/report.ts
@@ -1,0 +1,95 @@
+import type { Result } from 'autocannon';
+
+export interface TargetResult {
+  label: string;
+  result: Result;
+}
+
+export interface ScenarioResult {
+  name: string;
+  description: string;
+  targets: TargetResult[];
+}
+
+function throughputDelta(value: number, baseline: number): string {
+  if (baseline === 0) return 'N/A';
+  const v = ((value - baseline) / baseline) * 100;
+  const s = (v >= 0 ? '+' : '') + v.toFixed(1) + '%';
+  const better = v > 1;
+  const worse = v < -1;
+  return better ? `\x1b[32m${s}\x1b[0m` : worse ? `\x1b[31m${s}\x1b[0m` : `\x1b[33m${s}\x1b[0m`;
+}
+
+function latencyDelta(value: number, baseline: number): string {
+  if (baseline === 0) return 'N/A';
+  const v = ((value - baseline) / baseline) * 100;
+  const s = (v >= 0 ? '+' : '') + v.toFixed(1) + '%';
+  const better = v < -1;
+  const worse = v > 1;
+  return better ? `\x1b[32m${s}\x1b[0m` : worse ? `\x1b[31m${s}\x1b[0m` : `\x1b[33m${s}\x1b[0m`;
+}
+
+function countDelta(value: number, baseline: number): string {
+  if (baseline === 0) {
+    return value === 0 ? '0' : `+${value}`;
+  }
+
+  const v = ((value - baseline) / baseline) * 100;
+  const s = (v >= 0 ? '+' : '') + v.toFixed(1) + '%';
+  const better = value < baseline;
+  const worse = value > baseline;
+  return better ? `\x1b[32m${s}\x1b[0m` : worse ? `\x1b[31m${s}\x1b[0m` : `\x1b[33m${s}\x1b[0m`;
+}
+
+function n(v: number, d = 0): string {
+  return v.toLocaleString('en-US', { maximumFractionDigits: d });
+}
+
+function row(cols: string[], widths: number[]): string {
+  return '  ' + cols.map((c, i) => c.padEnd(widths[i])).join('  ');
+}
+
+export function printReport(results: ScenarioResult[]): void {
+  const bar = '═'.repeat(112);
+  const sep = '─'.repeat(108);
+  const W = [22, 16, 14, 14, 18, 18];
+
+  console.log('\n\n' + bar);
+  console.log('  HTTP runtime benchmark  —  NestJS vs fluo across Fastify, Express, and Bun  —  c=100 d=40s');
+  console.log(bar);
+
+  for (const r of results) {
+    const baseline = r.targets.find((target) => target.label === 'Nest+Fastify') ?? r.targets[0];
+
+    console.log(`\n  ${r.name.toUpperCase()}  —  ${r.description}`);
+    console.log('  ' + sep);
+    console.log(row(['Target', 'req/s', 'MB/s', 'p50 ms', 'p97.5 ms', 'Δ req/s vs Nest'], W));
+    console.log('  ' + sep);
+    for (const target of r.targets) {
+      console.log(row([
+        target.label,
+        n(target.result.requests.average),
+        n(target.result.throughput.average / 1_048_576, 2),
+        n(target.result.latency.p50, 2),
+        n(target.result.latency.p97_5, 2),
+        throughputDelta(target.result.requests.average, baseline.result.requests.average),
+      ], W));
+    }
+
+    console.log('  ' + sep);
+    console.log(row(['Target', 'p99 ms', 'errors', 'timeouts', 'non-2xx', 'mismatches'], W));
+    console.log('  ' + sep);
+    for (const target of r.targets) {
+      console.log(row([
+        target.label,
+        `${n(target.result.latency.p99, 2)} (${latencyDelta(target.result.latency.p99, baseline.result.latency.p99)})`,
+        `${target.result.errors} (${countDelta(target.result.errors, baseline.result.errors)})`,
+        String(target.result.timeouts),
+        String(target.result.non2xx),
+        String(target.result.mismatches),
+      ], W));
+    }
+  }
+
+  console.log('\n' + bar + '\n');
+}

--- a/tooling/benchmarks/http-comparison/src/run.ts
+++ b/tooling/benchmarks/http-comparison/src/run.ts
@@ -272,7 +272,11 @@ async function main(): Promise<void> {
     return child;
   });
 
-  const cleanup = (): void => { processes.forEach((child) => child.kill()); };
+  const cleanup = (): void => {
+    for (const child of processes) {
+      child.kill();
+    }
+  };
   process.on('exit', cleanup);
   process.on('SIGINT', () => { cleanup(); process.exit(130); });
 

--- a/tooling/benchmarks/http-comparison/src/run.ts
+++ b/tooling/benchmarks/http-comparison/src/run.ts
@@ -1,0 +1,299 @@
+import autocannon, { type Result } from 'autocannon';
+import { spawn } from 'node:child_process';
+import { rm } from 'node:fs/promises';
+import { createConnection } from 'node:net';
+import { join } from 'node:path';
+
+import { printReport, type ScenarioResult, type TargetResult } from './report';
+
+const FLUO_FASTIFY_PORT = 3001;
+const NESTJS_PORT = 3002;
+const FLUO_BUN_PORT = 3003;
+const NESTJS_EXPRESS_PORT = 3004;
+const FLUO_EXPRESS_PORT = 3005;
+const WDIR = process.cwd();
+const FLUO_BUN_BUILD_DIR = join(WDIR, 'dist/fluo-bun');
+
+type TargetName = 'nestjs-fastify' | 'fluo-fastify' | 'fluo-bun' | 'nestjs-express' | 'fluo-express';
+
+interface TargetConfig {
+  name: TargetName;
+  label: string;
+  port: number;
+  command: string;
+  args: string[];
+}
+
+const TARGETS: TargetConfig[] = [
+  {
+    name: 'nestjs-fastify',
+    label: 'Nest+Fastify',
+    port: NESTJS_PORT,
+    command: 'ts-node',
+    args: ['--transpile-only', '--project', 'nestjs/tsconfig.json', 'src/nestjs/server.ts'],
+  },
+  {
+    name: 'nestjs-express',
+    label: 'Nest+Express',
+    port: NESTJS_EXPRESS_PORT,
+    command: 'ts-node',
+    args: ['--transpile-only', '--project', 'nestjs/tsconfig.json', 'src/nestjs-express/server.ts'],
+  },
+  {
+    name: 'fluo-fastify',
+    label: 'fluo+Fastify',
+    port: FLUO_FASTIFY_PORT,
+    command: 'tsx',
+    args: ['src/fluo/server.ts'],
+  },
+  {
+    name: 'fluo-express',
+    label: 'fluo+Express',
+    port: FLUO_EXPRESS_PORT,
+    command: 'tsx',
+    args: ['src/fluo-express/server.ts'],
+  },
+  {
+    name: 'fluo-bun',
+    label: 'fluo+Bun',
+    port: FLUO_BUN_PORT,
+    command: 'bun',
+    args: ['run', 'dist/fluo-bun/server.js'],
+  },
+];
+
+const USER_RESPONSE = JSON.stringify({ id: '1', name: 'Alice', email: 'alice@example.com' });
+
+function routePaths(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `/di-chain/r${String(index + 1).padStart(2, '0')}/1`);
+}
+
+const SCENARIOS = [
+  {
+    name: 'baseline',
+    description: 'Pure routing — no DI',
+    path: '/baseline',
+    expectedBodies: [JSON.stringify({ ok: true })],
+  },
+  {
+    name: 'di-chain',
+    description: 'Path DTO + 3-level DI chain  (Controller → Service → Repository)',
+    path: '/di-chain/1',
+    expectedBodies: [USER_RESPONSE],
+  },
+  {
+    name: 'di-chain-random-3',
+    description: 'Random 3-route path DTO + 3-level DI chain',
+    paths: routePaths(3),
+    expectedBodies: [USER_RESPONSE],
+  },
+  {
+    name: 'di-chain-random-5',
+    description: 'Random 5-route path DTO + 3-level DI chain',
+    paths: routePaths(5),
+    expectedBodies: [USER_RESPONSE],
+  },
+  {
+    name: 'di-chain-random-20',
+    description: 'Random 20-route path DTO + 3-level DI chain',
+    paths: routePaths(20),
+    expectedBodies: [USER_RESPONSE],
+  },
+] as const;
+
+const WARMUP_SEC = 10;
+const MEASURE_SEC = 40;
+const CONNECTIONS = 100;
+
+function waitForPort(port: number, timeoutMs = 20_000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const attempt = (): void => {
+      const sock = createConnection({ port, host: '127.0.0.1' });
+      sock.on('connect', () => { sock.destroy(); resolve(); });
+      sock.on('error', () => {
+        sock.destroy();
+        if (Date.now() > deadline) {
+          reject(new Error(`port ${port} not ready within ${timeoutMs}ms`));
+        } else {
+          setTimeout(attempt, 300);
+        }
+      });
+    };
+    attempt();
+  });
+}
+
+function assertCleanResult(label: string, result: Result): void {
+  const failures = [
+    ['errors', result.errors],
+    ['timeouts', result.timeouts],
+    ['non2xx', result.non2xx],
+    ['mismatches', result.mismatches],
+  ].filter(([, count]) => count !== 0);
+
+  if (failures.length > 0) {
+    const details = failures.map(([name, count]) => `${name}=${count}`).join(', ');
+    throw new Error(`${label} returned invalid benchmark traffic: ${details}`);
+  }
+}
+
+function randomPath(paths: readonly string[]): string {
+  return paths[Math.floor(Math.random() * paths.length)] ?? paths[0] ?? '/';
+}
+
+function shoot(
+  url: string,
+  duration: number,
+  expectedBodies: readonly string[],
+  label: string,
+  paths?: readonly string[],
+): Promise<Result> {
+  return new Promise((resolve, reject) => {
+    autocannon({
+      url,
+      connections: CONNECTIONS,
+      duration,
+      verifyBody: (body) => expectedBodies.includes(String(body)),
+      bailout: 1,
+      ...(paths
+        ? {
+            requests: [{
+              setupRequest(request) {
+                request.path = randomPath(paths);
+                return request;
+              },
+            }],
+          }
+        : {}),
+    }, (err, result) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      assertCleanResult(label, result!);
+      resolve(result!);
+    });
+  });
+}
+
+async function measure(
+  label: string,
+  url: string,
+  expectedBodies: readonly string[],
+  paths?: readonly string[],
+): Promise<Result> {
+  process.stdout.write(`  measuring ${label.padEnd(6)} (${MEASURE_SEC}s)...`);
+  const result = await shoot(url, MEASURE_SEC, expectedBodies, label, paths);
+  process.stdout.write(' done\n');
+  return result;
+}
+
+async function runScenario(s: (typeof SCENARIOS)[number], index: number): Promise<ScenarioResult> {
+  const scenarioTargets = rotationFor(index).map((target) => ({
+    target,
+    url: `http://127.0.0.1:${target.port}${'path' in s ? s.path : ''}`,
+  }));
+
+  process.stdout.write(`  [${s.name}] warm-up (${WARMUP_SEC}s)...`);
+  await Promise.all(scenarioTargets.map(({ target, url }) => (
+    shoot(url, WARMUP_SEC, s.expectedBodies, `${s.name}/${target.label} warm-up`, 'paths' in s ? s.paths : undefined)
+  )));
+  process.stdout.write(' done\n');
+
+  const measured: TargetResult[] = [];
+  for (const { target, url } of scenarioTargets) {
+    measured.push({
+      label: target.label,
+      result: await measure(target.label, url, s.expectedBodies, 'paths' in s ? s.paths : undefined),
+    });
+  }
+
+  const targets = TARGETS.map((target) => {
+    const result = measured.find((item) => item.label === target.label);
+    if (!result) {
+      throw new Error(`missing result for ${target.label}`);
+    }
+    return result;
+  });
+
+  return { name: s.name, description: s.description, targets };
+}
+
+function rotationFor(index: number): TargetConfig[] {
+  const offset = index % TARGETS.length;
+  return [...TARGETS.slice(offset), ...TARGETS.slice(0, offset)];
+}
+
+function runCommand(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: WDIR,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`${command} ${args.join(' ')} failed with ${signal ?? `exit code ${code}`}`));
+    });
+  });
+}
+
+async function buildBunTarget(): Promise<void> {
+  await rm(FLUO_BUN_BUILD_DIR, { force: true, recursive: true });
+  await runCommand('tsc', [
+    'src/fluo-bun/server.ts',
+    '--target', 'ES2022',
+    '--module', 'ESNext',
+    '--moduleResolution', 'Bundler',
+    '--strict',
+    '--skipLibCheck',
+    '--outDir', 'dist/fluo-bun',
+  ]);
+}
+
+async function main(): Promise<void> {
+  await buildBunTarget();
+
+  const processes = TARGETS.map((target) => {
+    const child = spawn(target.command, target.args, {
+      cwd: WDIR,
+      env: { ...process.env, PORT: String(target.port) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stderr?.on('data', (d: Buffer) => process.stderr.write(`[${target.name}] ${String(d)}`));
+    return child;
+  });
+
+  const cleanup = (): void => { processes.forEach((child) => child.kill()); };
+  process.on('exit', cleanup);
+  process.on('SIGINT', () => { cleanup(); process.exit(130); });
+
+  try {
+    console.log('\nWaiting for servers...');
+    await Promise.all(TARGETS.map((target) => waitForPort(target.port)));
+    console.log('All servers ready\n');
+
+    const results: ScenarioResult[] = [];
+    for (const [index, s] of SCENARIOS.entries()) {
+      console.log(`Scenario: ${s.name}`);
+      results.push(await runScenario(s, index));
+    }
+
+    printReport(results);
+  } finally {
+    cleanup();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tooling/benchmarks/http-comparison/tsconfig.json
+++ b/tooling/benchmarks/http-comparison/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/fluo/**/*", "src/fluo-express/**/*", "src/fluo-bun/**/*", "src/run.ts", "src/report.ts"]
+}

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -9,5 +9,8 @@
     "vitest.config.ts",
     "tooling/**/*.ts",
     "tooling/**/*.d.mts"
+  ],
+  "exclude": [
+    "tooling/benchmarks/http-comparison/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Add an isolated HTTP benchmark workspace package for published fluo beta packages versus NestJS v11.
- Cover Nest+Fastify, Nest+Express, fluo+Fastify, fluo+Express, and fluo+Bun targets with baseline, DI-chain, and random-route scenarios.
- Document scope, caveats, correctness gates, and runner usage.

## Verification
- pnpm install --no-frozen-lockfile
- pnpm exec tsc --noEmit -p tsconfig.json
- pnpm exec tsc --noEmit -p nestjs/tsconfig.json
- pnpm run build:fluo:bun
- Smoke tested all five targets for /baseline, /di-chain/1, /di-chain/r01/1, /di-chain/r05/1, /di-chain/r20/1
- pnpm bench

## Benchmark notes
- All measured scenarios completed with errors=0, timeouts=0, non-2xx=0, mismatches=0.
- fluo+Bun was closest to Nest+Fastify, while Express-backed targets were substantially slower for this workload.