### PR TITLE
Resolve #1446: perf(http): avoid duplicate route matching for adapter-native routes

### DIFF
--- a/.changeset/fast-path-routing-1777447967.md
+++ b/.changeset/fast-path-routing-1777447967.md
@@ -1,0 +1,8 @@
+---
+"@fluojs/http": patch
+"@fluojs/runtime": patch
+"@fluojs/platform-fastify": patch
+"@fluojs/platform-express": patch
+---
+
+Add fast path for HTTP routing when adapter has already matched the route, skipping duplicate matching.


### PR DESCRIPTION
Closes #1446

## Summary
Implements a fast path in the HTTP dispatcher to skip duplicate route matching when platform adapters (Fastify/Express) have already selected a route.

## Changes
- **@fluojs/http**: Extends `Dispatcher.dispatch` to accept an optional `preMatched` `HandlerMatch` object. If provided, the dispatcher uses this directly instead of matching routes via `dispatchRoutingPolicy`.
- **@fluojs/runtime**: Updates `dispatchWithRequestResponseFactory` and `handleRequest` to accept and pass `preMatched`.
- **@fluojs/platform-fastify**: Modifies native route registration to attach descriptors and pass `preMatched` during `handleRequest`, extracting path parameters matching the fluojs descriptor format.
- **@fluojs/platform-express**: Modifies native route registration to find matching descriptors and pass `preMatched` during `handleRequest`.

## Testing
- Added regression tests in `packages/http/src/dispatch/dispatcher.test.ts` for pre-matched route dispatch logic.
- Ran `pnpm verify` successfully.

## Public export documentation
N/A - Internal dispatch mechanisms optimized, external APIs backward compatible.

## Behavioral contract
- Preserved fallback matching logic by keeping standard dispatch for edge cases (e.g., `@All`, non-URI versioning, OPTIONS/CORS). Fast path only engaged for successfully matched native routes.

## Platform consistency governance
- Ensures adapter portability semantic contracts are unweakened.