### PR TITLE
Resolve #1403: remove release-gate test flakes

### DIFF
--- a/packages/jwt/src/signing/jwks.test.ts
+++ b/packages/jwt/src/signing/jwks.test.ts
@@ -25,6 +25,7 @@ describe('JwksClient', () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it('fetches keys from jwks uri and finds key by kid', async () => {
@@ -71,6 +72,9 @@ describe('JwksClient', () => {
   });
 
   it('refetches after ttl expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
     const { publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
     const jwk = publicKey.export({ format: 'jwk' });
     const fetchMock = vi.fn(async () =>
@@ -83,7 +87,7 @@ describe('JwksClient', () => {
 
     const client = new JwksClient('https://example.test/.well-known/jwks.json', 1);
     await client.getSigningKey('key-1');
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.002Z'));
     await client.getSigningKey('key-1');
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -114,6 +118,7 @@ describe('DefaultJwtVerifier with jwksUri', () => {
   afterEach(() => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it('verifies RS256 token using jwksUri option', async () => {

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { createServer } from 'node:net';
+import type { AddressInfo } from 'node:net';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -10,7 +10,8 @@ import * as httpPublicApi from '@fluojs/http';
 import { Controller, Get, Post, Produces, Version, createHandlerMapping, type FrameworkRequest, type FrameworkResponse } from '@fluojs/http';
 import { FromBody, FromCookie, FromHeader, FromPath, FromQuery, RequestDto } from '@fluojs/http';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
-import { bootstrapNodeApplication } from '@fluojs/runtime/node';
+import { bootstrapHttpAdapterApplication } from '@fluojs/runtime/internal/http-adapter';
+import { createNodeHttpAdapter } from '@fluojs/runtime/node';
 
 import {
   ApiBearerAuth,
@@ -158,29 +159,24 @@ function expectExamplesToUsePublicExports(markdownPath: string): void {
   }
 }
 
-async function findAvailablePort(): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
-    const server = createServer();
+function hasAddressMethod(value: unknown): value is { address(): AddressInfo | string | null } {
+  return typeof value === 'object' && value !== null && 'address' in value && typeof value.address === 'function';
+}
 
-    server.once('error', reject);
-    server.listen(0, () => {
-      const address = server.address();
+function resolveAssignedPort(adapter: { getServer?: () => unknown }): number {
+  const server = adapter.getServer?.();
 
-      if (!address || typeof address === 'string') {
-        reject(new Error('Failed to resolve an available port.'));
-        return;
-      }
+  if (!hasAddressMethod(server)) {
+    throw new Error('Expected the OpenAPI test adapter to expose an addressable server.');
+  }
 
-      server.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
+  const address = server.address();
 
-        resolve(address.port);
-      });
-    });
-  });
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected the OpenAPI test adapter to expose an assigned TCP port.');
+  }
+
+  return address.port;
 }
 
 describe('OpenApiModule', () => {
@@ -502,14 +498,14 @@ describe('OpenApiModule', () => {
       imports: [openApiModule],
     });
 
-    const port = await findAvailablePort();
-    const app = registerAppForCleanup(await bootstrapNodeApplication(AppModule, {
+    const adapter = createNodeHttpAdapter({ port: 0 });
+    const app = registerAppForCleanup(await bootstrapHttpAdapterApplication(AppModule, {
       cors: false,
       globalPrefix: '/api',
-      port,
-    }));
+    }, adapter));
 
     await app.listen();
+    const port = resolveAssignedPort(adapter);
 
     const [docsResponse, docsTrailingSlashResponse, specResponse, unprefixedSpecResponse] = await Promise.all([
       fetchForTest(`http://127.0.0.1:${String(port)}/api/docs`),

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -618,7 +618,7 @@ describe('@fluojs/platform-express', () => {
     });
 
     const signal = 'SIGTERM' as const;
-    const listenersBefore = process.listeners(signal).length;
+    const listenersBefore = new Set(process.listeners(signal));
     const port = await findAvailablePort();
     const app = await runExpressApplication(AppModule, {
       cors: false,
@@ -627,11 +627,14 @@ describe('@fluojs/platform-express', () => {
       shutdownSignals: [signal],
     });
 
-    expect(process.listeners(signal).length).toBe(listenersBefore + 1);
+    const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
+    expect(registeredListeners.length).toBeGreaterThan(0);
 
     await app.close();
 
-    expect(process.listeners(signal).length).toBe(listenersBefore);
+    for (const listener of registeredListeners) {
+      expect(process.listeners(signal)).not.toContain(listener);
+    }
   });
 
   it('does not leak global-prefix path rewrites to request observers', async () => {
@@ -1242,7 +1245,7 @@ describe('@fluojs/platform-express', () => {
       });
     };
 
-    const adapter = new ExpressHttpApplicationAdapter(3000, '127.0.0.1', 20, 20, undefined, undefined, 1024, false, 1_000);
+    const adapter = new ExpressHttpApplicationAdapter(port, '127.0.0.1', 20, 20, undefined, undefined, 1024, false, 1_000);
     const dispatcher = {
       async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
         response.setStatus(200);
@@ -1259,13 +1262,12 @@ describe('@fluojs/platform-express', () => {
 
       await listenPromise;
 
-      const response = await fetch('http://127.0.0.1:3000/retry-check');
+      const response = await fetch(`http://127.0.0.1:${String(port)}/retry-check`);
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toEqual({ ok: true });
-
-      await adapter.close();
     } finally {
+      await adapter.close();
       await closeBlocker();
     }
   });

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1050,7 +1050,7 @@ describe('@fluojs/platform-fastify', () => {
     });
 
     const signal = 'SIGTERM' as const;
-    const listenersBefore = process.listeners(signal).length;
+    const listenersBefore = new Set(process.listeners(signal));
     const port = await findAvailablePort();
     const app = await runFastifyApplication(AppModule, {
       cors: false,
@@ -1059,11 +1059,14 @@ describe('@fluojs/platform-fastify', () => {
       shutdownSignals: [signal],
     });
 
-    expect(process.listeners(signal).length).toBe(listenersBefore + 1);
+    const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
+    expect(registeredListeners.length).toBeGreaterThan(0);
 
     await app.close();
 
-    expect(process.listeners(signal).length).toBe(listenersBefore);
+    for (const listener of registeredListeners) {
+      expect(process.listeners(signal)).not.toContain(listener);
+    }
   });
 
   it('does not leak global-prefix path rewrites to request observers', async () => {

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -645,7 +645,7 @@ export class HttpAdapterPortabilityHarness<
     });
 
     const signal = 'SIGTERM' as const;
-    const listenersBefore = process.listeners(signal).length;
+    const listenersBefore = new Set(process.listeners(signal));
     const port = await findAvailablePort();
     const app = await this.options.run(AppModule, {
       cors: false,
@@ -655,14 +655,17 @@ export class HttpAdapterPortabilityHarness<
     } as TRunOptions);
 
     try {
-      if (process.listeners(signal).length !== listenersBefore + 1) {
+      const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
+
+      if (registeredListeners.length === 0) {
         throw new Error(`${this.options.name} adapter did not register the expected shutdown listener.`);
       }
     } finally {
       await closeSilently(app);
     }
 
-    if (process.listeners(signal).length !== listenersBefore) {
+    const leakedListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
+    if (leakedListeners.length > 0) {
       throw new Error(`${this.options.name} adapter leaked shutdown signal listeners after close().`);
     }
   }

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -653,10 +653,9 @@ export class HttpAdapterPortabilityHarness<
       port,
       shutdownSignals: [signal],
     } as TRunOptions);
+    const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
 
     try {
-      const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
-
       if (registeredListeners.length === 0) {
         throw new Error(`${this.options.name} adapter did not register the expected shutdown listener.`);
       }
@@ -664,7 +663,8 @@ export class HttpAdapterPortabilityHarness<
       await closeSilently(app);
     }
 
-    const leakedListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
+    const remainingListeners = process.listeners(signal);
+    const leakedListeners = registeredListeners.filter((listener) => remainingListeners.includes(listener));
     if (leakedListeners.length > 0) {
       throw new Error(`${this.options.name} adapter leaked shutdown signal listeners after close().`);
     }

--- a/packages/websockets/src/node/node.test.ts
+++ b/packages/websockets/src/node/node.test.ts
@@ -76,6 +76,18 @@ function onceClosed(socket: WebSocket): Promise<void> {
   });
 }
 
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
 describe('@fluojs/websockets/node', () => {
   it('exposes the explicit Node-only websocket seam', () => {
     expect(nodePublicApi).toHaveProperty('NodeWebSocketModule');
@@ -98,6 +110,8 @@ describe('@fluojs/websockets/node', () => {
   });
 
   it('preserves Node-backed websocket behavior through the explicit node seam', async () => {
+    const disconnected = createDeferred<void>();
+
     class GatewayState {
       connectCount = 0;
       disconnectCount = 0;
@@ -123,6 +137,7 @@ describe('@fluojs/websockets/node', () => {
       @OnDisconnect()
       onDisconnect() {
         this.state.disconnectCount += 1;
+        disconnected.resolve();
       }
     }
 
@@ -149,8 +164,7 @@ describe('@fluojs/websockets/node', () => {
     expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
 
     socket.close();
-    await onceClosed(socket);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await Promise.all([onceClosed(socket), disconnected.promise]);
 
     expect(state.connectCount).toBe(1);
     expect(state.messages).toEqual([{ value: 'hello' }]);


### PR DESCRIPTION
## Summary

- Closes #1403.
- Removes nondeterministic release-gate test waits and port/listener assumptions across OpenAPI, JWT, platform adapters, `@fluojs/testing`, and WebSockets.

## Changes

- Use a real OS-assigned Node adapter port for the OpenAPI global-prefix docs test instead of probing and reusing a closed port.
- Replace the JWT JWKS TTL wall-clock sleep with Vitest fake time.
- Track shutdown signal listener identity in Fastify, Express, and the shared HTTP adapter portability harness instead of asserting absolute process-global listener counts.
- Use the same dynamic port in the Express `EADDRINUSE` retry test for the blocker, adapter, and request target.
- Wait for the Node WebSocket `@OnDisconnect()` completion signal rather than sleeping after socket close.

## Testing

- `pnpm test -- --project packages packages/openapi/src/openapi-module.test.ts`
- `pnpm test` — 197 files / 2264 tests passed
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` — completed with existing repository warnings; `verify:public-export-tsdoc` passed in changed mode
- LSP diagnostics: clean for all changed files
- Review work: goal, QA, code quality, security, and context-mining reviews all passed

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed. `packages/testing/src/portability/http-adapter-portability.ts` is published as `@fluojs/testing/http-adapter-portability`, but this PR only makes its internal release-gate shutdown-listener assertion deterministic; it does not change the exported API shape or documented consumer behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This is a test and testing-harness determinism change. Runtime/package behavior is preserved, so no package README update or changeset is required.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed.