### PR TITLE
Resolve #1448: add simple JSON response fast path

### DIFF
--- a/.changeset/simple-json-response-fast-path.md
+++ b/.changeset/simple-json-response-fast-path.md
@@ -1,0 +1,9 @@
+---
+"@fluojs/http": patch
+"@fluojs/runtime": patch
+"@fluojs/platform-bun": patch
+"@fluojs/platform-express": patch
+"@fluojs/platform-fastify": patch
+---
+
+Add a conservative fast path for successful object and array JSON responses while preserving existing formatter, streaming, redirect, binary, string, header, status, and error semantics.

--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -10,6 +10,12 @@ import type {
   HandlerDescriptor,
 } from '../types.js';
 
+type SimpleJsonResponseBody = Record<string, unknown> | unknown[];
+
+type SimpleJsonFrameworkResponse = FrameworkResponse & {
+  sendSimpleJson(body: SimpleJsonResponseBody): ReturnType<FrameworkResponse['send']>;
+};
+
 function resolveDefaultSuccessStatus(handler: HandlerDescriptor, value: unknown): number {
   switch (handler.route.method) {
     case 'POST':
@@ -20,6 +26,50 @@ function resolveDefaultSuccessStatus(handler: HandlerDescriptor, value: unknown)
     default:
       return 200;
   }
+}
+
+function canUseSimpleJsonFastPath(
+  response: FrameworkResponse,
+  value: unknown,
+): value is SimpleJsonResponseBody {
+  return isSimpleJsonResponseBody(value)
+    && !isResponseBodyForbidden(response.statusCode)
+    && hasJsonCompatibleContentType(response);
+}
+
+function hasSimpleJsonResponseWriter(response: FrameworkResponse): response is SimpleJsonFrameworkResponse {
+  return typeof (response as { sendSimpleJson?: unknown }).sendSimpleJson === 'function';
+}
+
+function isSimpleJsonResponseBody(value: unknown): value is SimpleJsonResponseBody {
+  if (Array.isArray(value)) {
+    return true;
+  }
+
+  return typeof value === 'object'
+    && value !== null
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function isResponseBodyForbidden(status: number | undefined): boolean {
+  return status === 204 || status === 205 || status === 304;
+}
+
+function hasJsonCompatibleContentType(response: FrameworkResponse): boolean {
+  const contentType = readHeader(response.headers, 'content-type');
+  return contentType === undefined || isJsonContentType(contentType);
+}
+
+function readHeader(headers: FrameworkResponse['headers'], name: string): string | undefined {
+  const lowerName = name.toLowerCase();
+  const entry = Object.entries(headers).find(([headerName]) => headerName.toLowerCase() === lowerName);
+  const value = entry?.[1];
+
+  return typeof value === 'string' ? value : undefined;
+}
+
+function isJsonContentType(contentType: string): boolean {
+  return contentType.toLowerCase().includes('application/json') || contentType.toLowerCase().endsWith('+json');
 }
 
 /**
@@ -68,6 +118,11 @@ export async function writeSuccessResponse(
     response.setStatus(handler.route.successStatus);
   } else if (response.statusSet !== true) {
     response.setStatus(resolveDefaultSuccessStatus(handler, value));
+  }
+
+  if (!formatter && hasSimpleJsonResponseWriter(response) && canUseSimpleJsonFastPath(response, value)) {
+    await response.sendSimpleJson(value);
+    return;
   }
 
   const responseBody = formatter

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -66,6 +66,20 @@ function createResponse(): FrameworkResponse & { body?: unknown } {
   };
 }
 
+function createFastPathResponse(): FrameworkResponse & {
+  body?: unknown;
+  simpleJsonBody?: Record<string, unknown> | unknown[];
+  sendSimpleJson(body: Record<string, unknown> | unknown[]): void;
+} {
+  return {
+    ...createResponse(),
+    sendSimpleJson(body) {
+      this.simpleJsonBody = body;
+      this.committed = true;
+    },
+  };
+}
+
 function createRequest(
   path: string,
   method = 'GET',
@@ -106,6 +120,127 @@ describe('dispatcher runtime', () => {
     expect(response.statusCode).toBe(200);
     expect(response.body).toEqual({ ok: true });
     expect(response.headers['Content-Type']).toBeUndefined();
+  });
+
+  it('uses the simple JSON fast writer for successful object and array responses', async () => {
+    @Controller('/fast-json')
+    class FastJsonController {
+      @Get('/object')
+      getObject() {
+        return { ok: true };
+      }
+
+      @Get('/array')
+      getArray() {
+        return [{ ok: true }];
+      }
+    }
+
+    const root = new Container().register(FastJsonController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastJsonController }]),
+      rootContainer: root,
+    });
+    const objectResponse = createFastPathResponse();
+    const arrayResponse = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/fast-json/object'), objectResponse);
+    await dispatcher.dispatch(createRequest('/fast-json/array'), arrayResponse);
+
+    expect(objectResponse.statusCode).toBe(200);
+    expect(objectResponse.simpleJsonBody).toEqual({ ok: true });
+    expect(objectResponse.body).toBeUndefined();
+    expect(arrayResponse.statusCode).toBe(200);
+    expect(arrayResponse.simpleJsonBody).toEqual([{ ok: true }]);
+    expect(arrayResponse.body).toBeUndefined();
+  });
+
+  it('keeps strings and binary values on the generic success writer', async () => {
+    @Controller('/generic-values')
+    class GenericValuesController {
+      @Get('/string')
+      getString() {
+        return 'plain';
+      }
+
+      @Get('/bytes')
+      getBytes() {
+        return Uint8Array.from([1, 2, 3]);
+      }
+
+      @Get('/buffer')
+      getBuffer() {
+        return Uint8Array.from([4, 5, 6]).buffer;
+      }
+    }
+
+    const root = new Container().register(GenericValuesController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: GenericValuesController }]),
+      rootContainer: root,
+    });
+    const stringResponse = createFastPathResponse();
+    const bytesResponse = createFastPathResponse();
+    const bufferResponse = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/generic-values/string'), stringResponse);
+    await dispatcher.dispatch(createRequest('/generic-values/bytes'), bytesResponse);
+    await dispatcher.dispatch(createRequest('/generic-values/buffer'), bufferResponse);
+
+    expect(stringResponse.simpleJsonBody).toBeUndefined();
+    expect(stringResponse.body).toBe('plain');
+    expect(bytesResponse.simpleJsonBody).toBeUndefined();
+    expect(bytesResponse.body).toEqual(Uint8Array.from([1, 2, 3]));
+    expect(bufferResponse.simpleJsonBody).toBeUndefined();
+    expect(bufferResponse.body).toBeInstanceOf(ArrayBuffer);
+  });
+
+  it('preserves explicit success headers and status on the simple JSON fast path', async () => {
+    @Controller('/fast-json-contract')
+    class FastJsonContractController {
+      @Header('X-Contract', 'preserved')
+      @HttpCode(202)
+      @Get('/headers')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(FastJsonContractController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastJsonContractController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/fast-json-contract/headers'), response);
+
+    expect(response.statusCode).toBe(202);
+    expect(response.headers['X-Contract']).toBe('preserved');
+    expect(response.simpleJsonBody).toEqual({ ok: true });
+  });
+
+  it('skips the simple JSON fast path for explicit non-JSON content types', async () => {
+    @Controller('/fast-json-contract')
+    class FastJsonContractController {
+      @Header('Content-Type', 'application/vnd.custom')
+      @Get('/custom-type')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(FastJsonContractController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastJsonContractController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/fast-json-contract/custom-type'), response);
+
+    expect(response.simpleJsonBody).toBeUndefined();
+    expect(response.body).toEqual({ ok: true });
   });
 
   it('selects formatter by Accept header when content negotiation is configured', async () => {

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { All, Controller, createDispatcher, createHandlerMapping, Get, Post, SseResponse, Version, VersioningType, type FrameworkRequest, type FrameworkResponse, type RequestContext } from '@fluojs/http';
+import { All, Controller, createDispatcher, createHandlerMapping, Get, Header, HttpCode, Post, Redirect, SseResponse, Version, VersioningType, type FrameworkRequest, type FrameworkResponse, type RequestContext } from '@fluojs/http';
 import { defineModule, type ApplicationLogger } from '@fluojs/runtime';
 
 import {
@@ -479,6 +479,105 @@ describe('@fluojs/platform-bun', () => {
     expect(response.status).toBe(202);
     expect(response.headers.get('x-runtime')).toBe('bun');
     await expect(response.text()).resolves.toBe('');
+  });
+
+  it('preserves response parity for simple JSON and non-fast-path responses', async () => {
+    @Controller('/responses')
+    class ResponsesController {
+      @Get('/object')
+      getObject() {
+        return { ok: true };
+      }
+
+      @Get('/array')
+      getArray() {
+        return [{ ok: true }];
+      }
+
+      @Get('/string')
+      getString() {
+        return 'plain';
+      }
+
+      @Get('/bytes')
+      getBytes() {
+        return Uint8Array.from([65, 66]);
+      }
+
+      @Get('/buffer')
+      getBuffer() {
+        return Uint8Array.from([67, 68]).buffer;
+      }
+
+      @Header('X-Contract', 'preserved')
+      @HttpCode(202)
+      @Get('/headers')
+      getHeaders() {
+        return { ok: true };
+      }
+
+      @Redirect('/responses/object', 302)
+      @Get('/redirect')
+      getRedirect() {
+        return { ignored: true };
+      }
+
+      @Get('/error')
+      getError() {
+        throw new Error('bun response parity error');
+      }
+    }
+
+    const fetch = createBunFetchHandler({
+      dispatcher: createDispatcher({
+        handlerMapping: createHandlerMapping([{ controllerToken: ResponsesController }]),
+        rootContainer: {
+          createRequestScope() {
+            return {
+              async dispose() {},
+              resolve() {
+                return new ResponsesController();
+              },
+            };
+          },
+        } as never,
+      }),
+    });
+    const responseFor = (path: string) => fetch(new Request(`https://runtime.test${path}`));
+
+    const objectResponse = await responseFor('/responses/object');
+    const arrayResponse = await responseFor('/responses/array');
+    const stringResponse = await responseFor('/responses/string');
+    const bytesResponse = await responseFor('/responses/bytes');
+    const bufferResponse = await responseFor('/responses/buffer');
+    const headerResponse = await responseFor('/responses/headers');
+    const redirectResponse = await responseFor('/responses/redirect');
+    const errorResponse = await responseFor('/responses/error');
+
+    expect(objectResponse.status).toBe(200);
+    expect(objectResponse.headers.get('content-type')).toContain('application/json');
+    await expect(objectResponse.json()).resolves.toEqual({ ok: true });
+    expect(arrayResponse.status).toBe(200);
+    expect(arrayResponse.headers.get('content-type')).toContain('application/json');
+    await expect(arrayResponse.json()).resolves.toEqual([{ ok: true }]);
+    expect(stringResponse.headers.get('content-type')).toContain('text/plain');
+    await expect(stringResponse.text()).resolves.toBe('plain');
+    expect(bytesResponse.headers.get('content-type')).toContain('application/octet-stream');
+    await expect(bytesResponse.text()).resolves.toBe('AB');
+    expect(bufferResponse.headers.get('content-type')).toContain('application/octet-stream');
+    await expect(bufferResponse.text()).resolves.toBe('CD');
+    expect(headerResponse.status).toBe(202);
+    expect(headerResponse.headers.get('x-contract')).toBe('preserved');
+    await expect(headerResponse.json()).resolves.toEqual({ ok: true });
+    expect(redirectResponse.status).toBe(302);
+    expect(redirectResponse.headers.get('location')).toBe('/responses/object');
+    expect(errorResponse.status).toBe(500);
+    await expect(errorResponse.json()).resolves.toMatchObject({
+      error: {
+        code: 'INTERNAL_SERVER_ERROR',
+        status: 500,
+      },
+    });
   });
 
   it('bridges rawBody-preserving app requests through Bun.serve()', async () => {

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -157,6 +157,10 @@ function isExpressResponse(value: unknown): value is ExpressResponse {
   return typeof value === 'object' && value !== null && 'emit' in value;
 }
 
+interface ExpressJsonSettingsHost {
+  set(name: 'json replacer', value: (key: string, value: unknown) => unknown): void;
+}
+
 const TEST_TLS_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDBbj6DdMPNvDMr
 yNUM0dreceSBINfH+VDV750R3X57mdoqebUgjKOXjbjR7JRkloJ4PEgAic+840rq
@@ -347,6 +351,44 @@ describe('@fluojs/platform-express', () => {
           status: 500,
         },
       });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps the simple JSON fast path off Express json replacer serialization', async () => {
+    @Controller('/serializer')
+    class SerializerController {
+      @Get('/object')
+      getObject() {
+        return { keep: 'generic-json-stringify' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [SerializerController] });
+
+    const port = await findAvailablePort();
+    const adapter = createExpressAdapter({ port });
+    const expressApp = Reflect.get(adapter, 'app') as ExpressJsonSettingsHost;
+    let replacerCalls = 0;
+
+    expressApp.set('json replacer', () => {
+      replacerCalls += 1;
+      return 'express-native-serializer';
+    });
+
+    const app = await fluoFactory.create(AppModule, { adapter });
+
+    await app.listen();
+
+    try {
+      const response = await requestHttp({ path: '/serializer/object', port });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers.get('content-type')).toContain('application/json');
+      expect(response.body).toBe(JSON.stringify({ keep: 'generic-json-stringify' }));
+      expect(replacerCalls).toBe(0);
     } finally {
       await app.close();
     }

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -17,7 +17,10 @@ import {
   createDispatcher,
   createHandlerMapping,
   Get,
+  Header,
+  HttpCode,
   Post,
+  Redirect,
   SseResponse,
   UseGuards,
   UseInterceptors,
@@ -251,6 +254,102 @@ describe('@fluojs/platform-express', () => {
     it('removes registered shutdown signal listeners after close', async () => {
       await expressPortabilityHarness.assertRemovesShutdownSignalListenersAfterClose();
     });
+  });
+
+  it('preserves response parity for simple JSON and non-fast-path responses', async () => {
+    @Controller('/responses')
+    class ResponsesController {
+      @Get('/object')
+      getObject() {
+        return { ok: true };
+      }
+
+      @Get('/array')
+      getArray() {
+        return [{ ok: true }];
+      }
+
+      @Get('/string')
+      getString() {
+        return 'plain';
+      }
+
+      @Get('/bytes')
+      getBytes() {
+        return Uint8Array.from([65, 66]);
+      }
+
+      @Get('/buffer')
+      getBuffer() {
+        return Uint8Array.from([67, 68]).buffer;
+      }
+
+      @Header('X-Contract', 'preserved')
+      @HttpCode(202)
+      @Get('/headers')
+      getHeaders() {
+        return { ok: true };
+      }
+
+      @Redirect('/responses/object', 302)
+      @Get('/redirect')
+      getRedirect() {
+        return { ignored: true };
+      }
+
+      @Get('/error')
+      getError() {
+        throw new Error('express response parity error');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [ResponsesController] });
+
+    const port = await findAvailablePort();
+    const app = await fluoFactory.create(AppModule, {
+      adapter: createExpressAdapter({ port }),
+    });
+
+    await app.listen();
+
+    try {
+      const objectResponse = await requestHttp({ path: '/responses/object', port });
+      const arrayResponse = await requestHttp({ path: '/responses/array', port });
+      const stringResponse = await requestHttp({ path: '/responses/string', port });
+      const bytesResponse = await requestHttp({ path: '/responses/bytes', port });
+      const bufferResponse = await requestHttp({ path: '/responses/buffer', port });
+      const headerResponse = await requestHttp({ path: '/responses/headers', port });
+      const redirectResponse = await requestHttp({ path: '/responses/redirect', port });
+      const errorResponse = await requestHttp({ path: '/responses/error', port });
+
+      expect(objectResponse.statusCode).toBe(200);
+      expect(objectResponse.headers.get('content-type')).toContain('application/json');
+      expect(JSON.parse(objectResponse.body)).toEqual({ ok: true });
+      expect(arrayResponse.statusCode).toBe(200);
+      expect(arrayResponse.headers.get('content-type')).toContain('application/json');
+      expect(JSON.parse(arrayResponse.body)).toEqual([{ ok: true }]);
+      expect(stringResponse.headers.get('content-type')).toContain('text/plain');
+      expect(stringResponse.body).toBe('plain');
+      expect(bytesResponse.headers.get('content-type')).toContain('application/octet-stream');
+      expect(bytesResponse.body).toBe('AB');
+      expect(bufferResponse.headers.get('content-type')).toContain('application/octet-stream');
+      expect(bufferResponse.body).toBe('CD');
+      expect(headerResponse.statusCode).toBe(202);
+      expect(headerResponse.headers.get('x-contract')).toBe('preserved');
+      expect(JSON.parse(headerResponse.body)).toEqual({ ok: true });
+      expect(redirectResponse.statusCode).toBe(302);
+      expect(redirectResponse.headers.get('location')).toBe('/responses/object');
+      expect(errorResponse.statusCode).toBe(500);
+      expect(JSON.parse(errorResponse.body)).toMatchObject({
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          status: 500,
+        },
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('uses the runtime default port instead of process.env.PORT', async () => {

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -541,8 +541,14 @@ function createFrameworkResponse(response: ExpressResponse): ExpressFrameworkRes
         return;
       }
 
+      const serialized = serializeResponseBody(body);
+
+      if (!response.hasHeader('content-type') && serialized.defaultContentType) {
+        response.setHeader('content-type', serialized.defaultContentType);
+      }
+
       this.committed = true;
-      response.json(body);
+      response.send(serialized.payload);
     },
     setHeader(name: string, value: string | string[]) {
       const lowerName = name.toLowerCase();

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -32,7 +32,6 @@ import {
   type FrameworkResponseStream,
   type HandlerDescriptor,
   type HttpApplicationAdapter,
-  type HttpMethod,
   type MiddlewareLike,
   type SecurityHeadersOptions,
 } from '@fluojs/http';
@@ -155,6 +154,7 @@ interface ExpressNativeRouteCandidate {
 
 type ExpressFrameworkResponse = FrameworkResponse & {
   raw: ExpressResponse;
+  sendSimpleJson(body: Record<string, unknown> | unknown[]): ReturnType<FrameworkResponse['send']>;
   statusSet?: boolean;
 };
 
@@ -534,6 +534,15 @@ function createFrameworkResponse(response: ExpressResponse): ExpressFrameworkRes
 
       this.committed = true;
       response.send(serialized.payload);
+    },
+    async sendSimpleJson(body: Record<string, unknown> | unknown[]) {
+      if (response.writableEnded) {
+        this.committed = true;
+        return;
+      }
+
+      this.committed = true;
+      response.json(body);
     },
     setHeader(name: string, value: string | string[]) {
       const lowerName = name.toLowerCase();

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -190,6 +190,10 @@ fHFvqyh6pXZV7XKcPxCTNuIw2rpw2WqY5/H+lTmUFmSXieFZAAMRueGH8Y5trCHU
 JNCDpGwh8us=
 -----END CERTIFICATE-----`;
 
+interface FastifyReplySerializerHost {
+  setReplySerializer(serializer: (payload: unknown, statusCode: number) => string): void;
+}
+
 describe('@fluojs/platform-fastify', () => {
   it('uses the runtime default port instead of process.env.PORT', async () => {
     const previousPort = process.env.PORT;
@@ -331,6 +335,44 @@ describe('@fluojs/platform-fastify', () => {
           status: 500,
         },
       });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps the simple JSON fast path off Fastify reply serialization overrides', async () => {
+    @Controller('/serializer')
+    class SerializerController {
+      @Get('/object')
+      getObject() {
+        return { keep: 'generic-json-stringify' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [SerializerController] });
+
+    const port = await findAvailablePort();
+    const adapter = createFastifyAdapter({ port });
+    const fastifyApp = Reflect.get(adapter, 'app') as FastifyReplySerializerHost;
+    let serializerCalls = 0;
+
+    fastifyApp.setReplySerializer(() => {
+      serializerCalls += 1;
+      return JSON.stringify({ keep: 'fastify-native-serializer' });
+    });
+
+    const app = await fluoFactory.create(AppModule, { adapter });
+
+    await app.listen();
+
+    try {
+      const response = await requestHttp({ path: '/serializer/object', port });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain('application/json');
+      expect(response.body).toBe(JSON.stringify({ keep: 'generic-json-stringify' }));
+      expect(serializerCalls).toBe(0);
     } finally {
       await app.close();
     }

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -12,7 +12,10 @@ import {
   createDispatcher,
   createHandlerMapping,
   Get,
+  Header,
+  HttpCode,
   Post,
+  Redirect,
   SseResponse,
   UseGuards,
   UseInterceptors,
@@ -234,6 +237,102 @@ describe('@fluojs/platform-fastify', () => {
       });
     } finally {
       await adapter.close();
+    }
+  });
+
+  it('preserves response parity for simple JSON and non-fast-path responses', async () => {
+    @Controller('/responses')
+    class ResponsesController {
+      @Get('/object')
+      getObject() {
+        return { ok: true };
+      }
+
+      @Get('/array')
+      getArray() {
+        return [{ ok: true }];
+      }
+
+      @Get('/string')
+      getString() {
+        return 'plain';
+      }
+
+      @Get('/bytes')
+      getBytes() {
+        return Uint8Array.from([65, 66]);
+      }
+
+      @Get('/buffer')
+      getBuffer() {
+        return Uint8Array.from([67, 68]).buffer;
+      }
+
+      @Header('X-Contract', 'preserved')
+      @HttpCode(202)
+      @Get('/headers')
+      getHeaders() {
+        return { ok: true };
+      }
+
+      @Redirect('/responses/object', 302)
+      @Get('/redirect')
+      getRedirect() {
+        return { ignored: true };
+      }
+
+      @Get('/error')
+      getError() {
+        throw new Error('fastify response parity error');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [ResponsesController] });
+
+    const port = await findAvailablePort();
+    const app = await fluoFactory.create(AppModule, {
+      adapter: createFastifyAdapter({ port }),
+    });
+
+    await app.listen();
+
+    try {
+      const objectResponse = await requestHttp({ path: '/responses/object', port });
+      const arrayResponse = await requestHttp({ path: '/responses/array', port });
+      const stringResponse = await requestHttp({ path: '/responses/string', port });
+      const bytesResponse = await requestHttp({ path: '/responses/bytes', port });
+      const bufferResponse = await requestHttp({ path: '/responses/buffer', port });
+      const headerResponse = await requestHttp({ path: '/responses/headers', port });
+      const redirectResponse = await requestHttp({ path: '/responses/redirect', port });
+      const errorResponse = await requestHttp({ path: '/responses/error', port });
+
+      expect(objectResponse.statusCode).toBe(200);
+      expect(objectResponse.headers['content-type']).toContain('application/json');
+      expect(JSON.parse(objectResponse.body)).toEqual({ ok: true });
+      expect(arrayResponse.statusCode).toBe(200);
+      expect(arrayResponse.headers['content-type']).toContain('application/json');
+      expect(JSON.parse(arrayResponse.body)).toEqual([{ ok: true }]);
+      expect(stringResponse.headers['content-type']).toContain('text/plain');
+      expect(stringResponse.body).toBe('plain');
+      expect(bytesResponse.headers['content-type']).toContain('application/octet-stream');
+      expect(bytesResponse.body).toBe('AB');
+      expect(bufferResponse.headers['content-type']).toContain('application/octet-stream');
+      expect(bufferResponse.body).toBe('CD');
+      expect(headerResponse.statusCode).toBe(202);
+      expect(headerResponse.headers['x-contract']).toBe('preserved');
+      expect(JSON.parse(headerResponse.body)).toEqual({ ok: true });
+      expect(redirectResponse.statusCode).toBe(302);
+      expect(redirectResponse.headers.location).toBe('/responses/object');
+      expect(errorResponse.statusCode).toBe(500);
+      expect(JSON.parse(errorResponse.body)).toMatchObject({
+        error: {
+          code: 'INTERNAL_SERVER_ERROR',
+          status: 500,
+        },
+      });
+    } finally {
+      await app.close();
     }
   });
 

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -497,12 +497,14 @@ function createFrameworkResponse(reply: FastifyReply): FastifyFrameworkResponse 
         return;
       }
 
-      if (!reply.hasHeader('content-type')) {
-        reply.header('content-type', 'application/json; charset=utf-8');
+      const serialized = serializeResponseBody(body);
+
+      if (!reply.hasHeader('content-type') && serialized.defaultContentType) {
+        reply.header('content-type', serialized.defaultContentType);
       }
 
       this.committed = true;
-      await reply.send(body);
+      await reply.send(serialized.payload);
     },
     setHeader(name: string, value: string | string[]) {
       const lowerName = name.toLowerCase();

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -122,6 +122,7 @@ interface FastifyListenTarget {
 
 type FastifyFrameworkResponse = FrameworkResponse & {
   raw: FastifyReply;
+  sendSimpleJson(body: Record<string, unknown> | unknown[]): ReturnType<FrameworkResponse['send']>;
   statusSet?: boolean;
 };
 
@@ -489,6 +490,19 @@ function createFrameworkResponse(reply: FastifyReply): FastifyFrameworkResponse 
 
       this.committed = true;
       await reply.send(serialized.payload);
+    },
+    async sendSimpleJson(body: Record<string, unknown> | unknown[]) {
+      if (reply.sent) {
+        this.committed = true;
+        return;
+      }
+
+      if (!reply.hasHeader('content-type')) {
+        reply.header('content-type', 'application/json; charset=utf-8');
+      }
+
+      this.committed = true;
+      await reply.send(body);
     },
     setHeader(name: string, value: string | string[]) {
       const lowerName = name.toLowerCase();

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -9,6 +9,67 @@ import {
 } from './web.js';
 
 describe('dispatchWebRequest', () => {
+  it('serializes simple JSON responses while preserving non-JSON response semantics', async () => {
+    const responseFor = (path: string) => dispatchWebRequest({
+      dispatcher: {
+        async dispatch(_request: FrameworkRequest, frameworkResponse: FrameworkResponse) {
+          switch (path) {
+            case '/object':
+              await frameworkResponse.send({ ok: true });
+              return;
+            case '/array':
+              await frameworkResponse.send([{ ok: true }]);
+              return;
+            case '/string':
+              await frameworkResponse.send('plain');
+              return;
+            case '/bytes':
+              await frameworkResponse.send(Uint8Array.from([65, 66]));
+              return;
+            case '/buffer':
+              await frameworkResponse.send(Uint8Array.from([67, 68]).buffer);
+              return;
+            case '/headers':
+              frameworkResponse.setStatus(202);
+              frameworkResponse.setHeader('x-contract', 'preserved');
+              await frameworkResponse.send({ ok: true });
+              return;
+            case '/redirect':
+              frameworkResponse.redirect(302, '/next');
+              return;
+            default:
+              throw new Error(`Unhandled path ${path}`);
+          }
+        },
+      },
+      request: new Request(`https://runtime.test${path}`),
+    });
+
+    const objectResponse = await responseFor('/object');
+    const arrayResponse = await responseFor('/array');
+    const stringResponse = await responseFor('/string');
+    const bytesResponse = await responseFor('/bytes');
+    const bufferResponse = await responseFor('/buffer');
+    const headerResponse = await responseFor('/headers');
+    const redirectResponse = await responseFor('/redirect');
+
+    expect(objectResponse.headers.get('content-type')).toContain('application/json');
+    await expect(objectResponse.json()).resolves.toEqual({ ok: true });
+    expect(arrayResponse.headers.get('content-type')).toContain('application/json');
+    await expect(arrayResponse.json()).resolves.toEqual([{ ok: true }]);
+    expect(stringResponse.headers.get('content-type')).toContain('text/plain');
+    await expect(stringResponse.text()).resolves.toBe('plain');
+    expect(bytesResponse.headers.get('content-type')).toContain('application/octet-stream');
+    await expect(bytesResponse.text()).resolves.toBe('AB');
+    expect(bufferResponse.headers.get('content-type')).toContain('application/octet-stream');
+    await expect(bufferResponse.text()).resolves.toBe('CD');
+    expect(headerResponse.status).toBe(202);
+    expect(headerResponse.headers.get('x-contract')).toBe('preserved');
+    await expect(headerResponse.json()).resolves.toEqual({ ok: true });
+    expect(redirectResponse.status).toBe(302);
+    expect(redirectResponse.headers.get('location')).toBe('/next');
+  });
+
   it('translates Web Request semantics into the framework request contract', async () => {
     const response = await dispatchWebRequest({
       dispatcher: {

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -207,6 +207,20 @@ class MutableWebFrameworkResponse implements WebFrameworkResponse {
     this.committed = true;
   }
 
+  async sendSimpleJson(body: Record<string, unknown> | unknown[]): Promise<void> {
+    if (this.finalizedResponse) {
+      this.committed = true;
+      return;
+    }
+
+    if (!hasHeader(this.headers, 'content-type')) {
+      this.setHeader('Content-Type', 'application/json; charset=utf-8');
+    }
+
+    this.responseBody = JSON.stringify(body);
+    this.committed = true;
+  }
+
   setHeader(name: string, value: string | string[]): void {
     const existingHeaderName = findHeaderName(this.headers, name) ?? name;
 

--- a/tooling/benchmarks/http-dispatch-hot-path.mjs
+++ b/tooling/benchmarks/http-dispatch-hot-path.mjs
@@ -23,6 +23,8 @@ function resetResponse(response) {
   response.body = undefined;
   response.committed = false;
   response.headers = {};
+  response.payload = undefined;
+  response.simpleJsonBody = undefined;
   response.statusCode = undefined;
   response.statusSet = false;
 }
@@ -39,6 +41,70 @@ function createResponse() {
     },
     send(body) {
       this.body = body;
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+function createJsonStringifyResponse() {
+  return {
+    committed: false,
+    headers: {},
+    payload: undefined,
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body) {
+      if (typeof body === 'object' && body !== null) {
+        this.headers['Content-Type'] = 'application/json; charset=utf-8';
+        this.payload = JSON.stringify(body);
+      } else {
+        this.payload = body;
+      }
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+function createSimpleJsonFastResponse() {
+  return {
+    committed: false,
+    headers: {},
+    payload: undefined,
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body) {
+      this.payload = typeof body === 'object' && body !== null
+        ? JSON.stringify(body)
+        : body;
+      this.committed = true;
+    },
+    sendSimpleJson(body) {
+      this.headers['Content-Type'] = 'application/json; charset=utf-8';
+      this.payload = JSON.stringify(body);
       this.committed = true;
     },
     setHeader(name, value) {
@@ -175,6 +241,8 @@ function buildDispatchBenchmarks() {
 
   const emptyPipelineRequest = createRequest('/health');
   const emptyPipelineResponse = createResponse();
+  const genericJsonPipelineResponse = createJsonStringifyResponse();
+  const simpleJsonFastPipelineResponse = createSimpleJsonFastResponse();
   const preMatchedPipelineRequest = createRequest('/health');
   const preMatchedPipelineResponse = createResponse();
 
@@ -221,6 +289,8 @@ function buildDispatchBenchmarks() {
 
   const chainRequest = createRequest('/chain');
   const chainResponse = createResponse();
+  const genericJsonChainResponse = createJsonStringifyResponse();
+  const simpleJsonFastChainResponse = createSimpleJsonFastResponse();
 
   class AllowGuard {
     canActivate() {
@@ -302,6 +372,22 @@ function buildDispatchBenchmarks() {
     },
     {
       iterations: 20000,
+      name: 'dispatch static GET /health (generic JSON.stringify writer baseline)',
+      async run() {
+        resetResponse(genericJsonPipelineResponse);
+        await emptyPipelineDispatcher.dispatch(emptyPipelineRequest, genericJsonPipelineResponse);
+      },
+    },
+    {
+      iterations: 20000,
+      name: 'dispatch static GET /health (simple JSON fast writer)',
+      async run() {
+        resetResponse(simpleJsonFastPipelineResponse);
+        await emptyPipelineDispatcher.dispatch(emptyPipelineRequest, simpleJsonFastPipelineResponse);
+      },
+    },
+    {
+      iterations: 20000,
       name: 'dispatch pre-matched native handoff GET /health (empty pipeline)',
       async run() {
         resetResponse(preMatchedPipelineResponse);
@@ -318,6 +404,22 @@ function buildDispatchBenchmarks() {
       async run() {
         resetResponse(chainResponse);
         await chainDispatcher.dispatch(chainRequest, chainResponse);
+      },
+    },
+    {
+      iterations: 20000,
+      name: 'dispatch singleton chain GET /chain (generic JSON.stringify writer baseline)',
+      async run() {
+        resetResponse(genericJsonChainResponse);
+        await chainDispatcher.dispatch(chainRequest, genericJsonChainResponse);
+      },
+    },
+    {
+      iterations: 20000,
+      name: 'dispatch singleton chain GET /chain (simple JSON fast writer)',
+      async run() {
+        resetResponse(simpleJsonFastChainResponse);
+        await chainDispatcher.dispatch(chainRequest, simpleJsonFastChainResponse);
       },
     },
     {
@@ -364,7 +466,7 @@ async function main() {
 
   process.stdout.write(`${JSON.stringify({
     benchmark: 'http-dispatch-hot-path',
-    note: 'Route matching and dispatcher hot-path scenarios measured against built dist artifacts on the current branch.',
+    note: 'Route matching, generic JSON.stringify response baseline, and simple JSON fast-writer dispatcher scenarios measured against built dist artifacts on the current branch.',
     results,
   }, null, 2)}\n`);
 }


### PR DESCRIPTION
## Summary

Closes #1448.

Adds a conservative fast path for simple successful JSON object/array responses while keeping formatter-driven, streaming, redirect, binary, string, explicit header/status, and error semantics on their existing paths. Fix-back update: Express/Fastify fast-path writers now preserve the previous generic `JSON.stringify(...)` payload semantics instead of newly activating adapter-native JSON serializer overrides.

## Changes

- Added dispatcher-level eligibility for object/array JSON fast responses only when no content-negotiation formatter overrides the response and the response content type is absent or JSON-compatible.
- Updated Express/Fastify `sendSimpleJson(...)` to serialize through the same framework-owned `JSON.stringify(...)` payload path used by the previous generic writer, then send that serialized string payload.
- Added Express regression coverage proving an Express `json replacer` is not invoked by the simple JSON fast path and the emitted payload remains `JSON.stringify(...)` output.
- Added Fastify regression coverage proving `setReplySerializer(...)` is not invoked by the simple JSON fast path and the emitted payload remains `JSON.stringify(...)` output.
- Added workspace-source dispatcher benchmark scenarios comparing generic `JSON.stringify` writer baseline with the simple JSON fast writer on the current PR branch `dist` artifacts.
- Added a Changesets patch entry for @fluojs/http, @fluojs/runtime, @fluojs/platform-fastify, @fluojs/platform-express, and @fluojs/platform-bun.

## Testing

- LSP diagnostics on modified TypeScript files (`packages/platform-express/src/adapter.ts`, `packages/platform-express/src/adapter.test.ts`, `packages/platform-fastify/src/adapter.ts`, `packages/platform-fastify/src/adapter.test.ts`) → no diagnostics.
- `pnpm exec vitest run packages/platform-express/src/adapter.test.ts packages/platform-fastify/src/adapter.test.ts` → 2 files / 68 tests passed.
- `pnpm build` → passed.
- `pnpm typecheck` → passed.
- `pnpm exec vitest run packages/http/src/dispatch/dispatcher.test.ts packages/runtime/src/web.test.ts packages/platform-fastify/src/adapter.test.ts packages/platform-express/src/adapter.test.ts packages/platform-bun/src/adapter.test.ts` → 5 files / 146 tests passed.
- `pnpm lint` → `verify:public-export-tsdoc` passed; Biome reported existing repo-wide warnings outside this PR's changed files.
- `node tooling/benchmarks/http-dto-binding-plan.mjs` → path DTO + request converter DI chain: 211,062.67 ops/sec, 4.74 us/op; 32-field body DTO schema: 81,336.01 ops/sec, 12.29 us/op.
- `node tooling/benchmarks/http-dispatch-hot-path.mjs` → route-match static 2,581,713.92 ops/sec; route-match param 1,339,964.29 ops/sec; route-match mixed 1,124,003.59 ops/sec; static dispatch empty pipeline 215,002.71 ops/sec; static generic `JSON.stringify` writer baseline 260,153.58 ops/sec; static simple JSON fast writer 257,942.34 ops/sec; pre-matched native handoff 239,672.85 ops/sec; singleton chain dispatch 249,300.4 ops/sec; singleton chain generic `JSON.stringify` writer baseline 252,013.22 ops/sec; singleton chain simple JSON fast writer 269,023.31 ops/sec; decorated dispatch 76,120.04 ops/sec.
- Full `tooling/benchmarks/http-comparison` was not used as PR-branch evidence because its own README and package manifest scope it to released npm beta packages (`@fluojs/*` version dependencies), not unpublished workspace source changes. The workspace-source benchmarks above measure the current PR branch built `dist` artifacts directly and cover the #1448 baseline/DI-chain-relevant dispatcher and DTO paths.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; existing public export documentation remains unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This remains an internal performance fast path with preserved runtime semantics. Express/Fastify regression tests now explicitly prove native serializer overrides are not newly invoked when no fluo content-negotiation formatter override exists, and the payload remains the previous generic `JSON.stringify(...)` output.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs or README conformance claims changed.