### PR TITLE
Add isolated HTTP benchmark scenarios

### DIFF
--- a/tooling/benchmarks/http-comparison/README.md
+++ b/tooling/benchmarks/http-comparison/README.md
@@ -8,7 +8,11 @@ Runs a small HTTP throughput/latency comparison between published fluo beta pack
 
 ## Scenarios
 
-- `di-chain-random-20`: the same DI path (Controller → Service → Repository) across randomly selected 20-route families, used to expose route matching overhead.
+- `baseline`: a single no-param baseline route used to measure the adapter/framework response floor.
+- `di-chain-dto-deterministic-1`: one DTO-bound path route through Controller → Service → Repository.
+- `di-chain-dto-deterministic-20`: the same DTO-bound DI path across a deterministic 20-route cycle.
+- `di-chain-direct-param-deterministic-1`: one direct path-param route through Controller → Service → Repository.
+- `di-chain-direct-param-deterministic-20`: the same direct-param DI path across a deterministic 20-route cycle.
 
 ## Run
 
@@ -17,7 +21,13 @@ pnpm install --no-frozen-lockfile
 pnpm --filter @fluojs-internal/tooling-benchmarks-http bench
 ```
 
-The runner starts all servers, warms every target for each scenario, then measures with `autocannon` at 100 connections for 40 seconds. Measurement order rotates by scenario to avoid always giving one framework the same position.
+The runner starts an isolated server set for each scenario, so 1-route and 20-route scenarios register different app shapes instead of merely sending different request paths through the same route table. It warms every target for each scenario, then measures with `autocannon` at 100 connections for 40 seconds. Measurement order rotates by scenario to avoid always giving one framework the same position. Multi-route scenarios use a deterministic path cycle so every target sees the same request sequence.
+
+For quick directional runs, override the defaults with environment variables:
+
+```bash
+BENCH_WARMUP_SEC=3 BENCH_MEASURE_SEC=10 pnpm --filter @fluojs-internal/tooling-benchmarks-http bench
+```
 
 The `fluo+Bun` target requires the `bun` CLI because `@fluojs/platform-bun` uses `globalThis.Bun.serve()` at listen time.
 

--- a/tooling/benchmarks/http-comparison/src/fluo-bun/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo-bun/server.ts
@@ -1,9 +1,11 @@
 import { ensureMetadataSymbol, Inject, Module } from '@fluojs/core';
-import { Controller, FromPath, Get, RequestDto } from '@fluojs/http';
+import { Controller, FromPath, Get, RequestDto, type RequestContext } from '@fluojs/http';
 import { createBunAdapter } from '@fluojs/platform-bun';
 import { FluoFactory } from '@fluojs/runtime';
 
 ensureMetadataSymbol();
+
+type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20';
 
 @Controller('/baseline')
 class BaselineController {
@@ -33,126 +35,183 @@ class UsersService {
   }
 }
 
+function readPathId(context: RequestContext): string {
+  return context.request.params['id'] ?? '';
+}
+
 @Inject(UsersService)
-@Controller('/di-chain')
-class DiChainController {
+@Controller('/di-chain-one')
+class DiChainOneController {
   constructor(private readonly service: UsersService) {}
 
   @RequestDto(GetUserRequest)
-  @Get('/:id')
-  get(input: GetUserRequest): { id: string; name: string; email: string } {
+  @Get('/r01/:id')
+  getR01(input: GetUserRequest): { id: string; name: string; email: string } {
     return this.service.getUser(input.id);
   }
+}
 
-  @RequestDto(GetUserRequest)
-  @Get('/users/:id')
-  getUser(input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
-
-  @RequestDto(GetUserRequest)
-  @Get('/profiles/:id')
-  getProfile(input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
-
-  @RequestDto(GetUserRequest)
-  @Get('/settings/:id')
-  getSettings(input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
+@Inject(UsersService)
+@Controller('/di-chain')
+class DiChainTwentyController {
+  constructor(private readonly service: UsersService) {}
 
   @RequestDto(GetUserRequest)
   @Get('/r01/:id')
   getR01(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r02/:id')
   getR02(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r03/:id')
   getR03(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r04/:id')
   getR04(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r05/:id')
   getR05(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r06/:id')
   getR06(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r07/:id')
   getR07(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r08/:id')
   getR08(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r09/:id')
   getR09(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r10/:id')
   getR10(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r11/:id')
   getR11(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r12/:id')
   getR12(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r13/:id')
   getR13(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r14/:id')
   getR14(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r15/:id')
   getR15(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r16/:id')
   getR16(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r17/:id')
   getR17(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r18/:id')
   getR18(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r19/:id')
   getR19(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r20/:id')
   getR20(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
 }
 
-@Module({
-  controllers: [BaselineController, DiChainController],
-  providers: [UsersRepository, UsersService],
-})
-class AppModule {}
+@Inject(UsersService)
+@Controller('/di-chain-direct-one')
+class DirectParamOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get('/r01/:id')
+  getR01(_input: undefined, context: RequestContext): { id: string; name: string; email: string } {
+    return this.service.getUser(readPathId(context));
+  }
+}
+
+@Inject(UsersService)
+@Controller('/di-chain-direct')
+class DirectParamTwentyController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get('/r01/:id')
+  getR01(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r02/:id')
+  getR02(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r03/:id')
+  getR03(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r04/:id')
+  getR04(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r05/:id')
+  getR05(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r06/:id')
+  getR06(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r07/:id')
+  getR07(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r08/:id')
+  getR08(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r09/:id')
+  getR09(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r10/:id')
+  getR10(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r11/:id')
+  getR11(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r12/:id')
+  getR12(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r13/:id')
+  getR13(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r14/:id')
+  getR14(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r15/:id')
+  getR15(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r16/:id')
+  getR16(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r17/:id')
+  getR17(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r18/:id')
+  getR18(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r19/:id')
+  getR19(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r20/:id')
+  getR20(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+}
+
+@Module({ controllers: [BaselineController] })
+class BaselineModule {}
+
+@Module({ controllers: [DiChainOneController], providers: [UsersRepository, UsersService] })
+class DtoOneModule {}
+
+@Module({ controllers: [DiChainTwentyController], providers: [UsersRepository, UsersService] })
+class DtoTwentyModule {}
+
+@Module({ controllers: [DirectParamOneController], providers: [UsersRepository, UsersService] })
+class DirectOneModule {}
+
+@Module({ controllers: [DirectParamTwentyController], providers: [UsersRepository, UsersService] })
+class DirectTwentyModule {}
+
+function resolveAppModule(shape: AppShape) {
+  switch (shape) {
+    case 'baseline': return BaselineModule;
+    case 'dto-1': return DtoOneModule;
+    case 'dto-20': return DtoTwentyModule;
+    case 'direct-1': return DirectOneModule;
+    case 'direct-20': return DirectTwentyModule;
+  }
+}
+
+function readAppShape(): AppShape {
+  const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
+  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20') {
+    return raw;
+  }
+  throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);
+}
 
 async function main(): Promise<void> {
   const port = Number(process.env['PORT'] ?? 3003);
-
-  const app = await FluoFactory.create(AppModule, {
+  const app = await FluoFactory.create(resolveAppModule(readAppShape()), {
     adapter: createBunAdapter({ port }),
     logger: { debug() {}, error() {}, log() {}, warn() {} },
   });

--- a/tooling/benchmarks/http-comparison/src/fluo/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo/server.ts
@@ -1,7 +1,9 @@
 import { Inject, Module } from '@fluojs/core';
-import { Controller, FromPath, Get, RequestDto } from '@fluojs/http';
+import { Controller, FromPath, Get, RequestDto, type RequestContext } from '@fluojs/http';
 import { createFastifyAdapter } from '@fluojs/platform-fastify';
 import { FluoFactory } from '@fluojs/runtime';
+
+type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20';
 
 @Controller('/baseline')
 class BaselineController {
@@ -31,126 +33,183 @@ class UsersService {
   }
 }
 
+function readPathId(context: RequestContext): string {
+  return context.request.params['id'] ?? '';
+}
+
 @Inject(UsersService)
-@Controller('/di-chain')
-class DiChainController {
+@Controller('/di-chain-one')
+class DiChainOneController {
   constructor(private readonly service: UsersService) {}
 
   @RequestDto(GetUserRequest)
-  @Get('/:id')
-  get(input: GetUserRequest): { id: string; name: string; email: string } {
+  @Get('/r01/:id')
+  getR01(input: GetUserRequest): { id: string; name: string; email: string } {
     return this.service.getUser(input.id);
   }
+}
 
-  @RequestDto(GetUserRequest)
-  @Get('/users/:id')
-  getUser(input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
-
-  @RequestDto(GetUserRequest)
-  @Get('/profiles/:id')
-  getProfile(input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
-
-  @RequestDto(GetUserRequest)
-  @Get('/settings/:id')
-  getSettings(input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
+@Inject(UsersService)
+@Controller('/di-chain')
+class DiChainTwentyController {
+  constructor(private readonly service: UsersService) {}
 
   @RequestDto(GetUserRequest)
   @Get('/r01/:id')
   getR01(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r02/:id')
   getR02(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r03/:id')
   getR03(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r04/:id')
   getR04(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r05/:id')
   getR05(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r06/:id')
   getR06(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r07/:id')
   getR07(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r08/:id')
   getR08(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r09/:id')
   getR09(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r10/:id')
   getR10(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r11/:id')
   getR11(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r12/:id')
   getR12(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r13/:id')
   getR13(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r14/:id')
   getR14(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r15/:id')
   getR15(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r16/:id')
   getR16(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r17/:id')
   getR17(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r18/:id')
   getR18(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r19/:id')
   getR19(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @RequestDto(GetUserRequest)
   @Get('/r20/:id')
   getR20(input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
 }
 
-@Module({
-  controllers: [BaselineController, DiChainController],
-  providers: [UsersRepository, UsersService],
-})
-class AppModule {}
+@Inject(UsersService)
+@Controller('/di-chain-direct-one')
+class DirectParamOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get('/r01/:id')
+  getR01(_input: undefined, context: RequestContext): { id: string; name: string; email: string } {
+    return this.service.getUser(readPathId(context));
+  }
+}
+
+@Inject(UsersService)
+@Controller('/di-chain-direct')
+class DirectParamTwentyController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get('/r01/:id')
+  getR01(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r02/:id')
+  getR02(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r03/:id')
+  getR03(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r04/:id')
+  getR04(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r05/:id')
+  getR05(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r06/:id')
+  getR06(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r07/:id')
+  getR07(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r08/:id')
+  getR08(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r09/:id')
+  getR09(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r10/:id')
+  getR10(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r11/:id')
+  getR11(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r12/:id')
+  getR12(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r13/:id')
+  getR13(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r14/:id')
+  getR14(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r15/:id')
+  getR15(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r16/:id')
+  getR16(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r17/:id')
+  getR17(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r18/:id')
+  getR18(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r19/:id')
+  getR19(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+  @Get('/r20/:id')
+  getR20(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
+}
+
+@Module({ controllers: [BaselineController] })
+class BaselineModule {}
+
+@Module({ controllers: [DiChainOneController], providers: [UsersRepository, UsersService] })
+class DtoOneModule {}
+
+@Module({ controllers: [DiChainTwentyController], providers: [UsersRepository, UsersService] })
+class DtoTwentyModule {}
+
+@Module({ controllers: [DirectParamOneController], providers: [UsersRepository, UsersService] })
+class DirectOneModule {}
+
+@Module({ controllers: [DirectParamTwentyController], providers: [UsersRepository, UsersService] })
+class DirectTwentyModule {}
+
+function resolveAppModule(shape: AppShape) {
+  switch (shape) {
+    case 'baseline': return BaselineModule;
+    case 'dto-1': return DtoOneModule;
+    case 'dto-20': return DtoTwentyModule;
+    case 'direct-1': return DirectOneModule;
+    case 'direct-20': return DirectTwentyModule;
+  }
+}
+
+function readAppShape(): AppShape {
+  const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
+  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20') {
+    return raw;
+  }
+  throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);
+}
 
 async function main(): Promise<void> {
   const port = Number(process.env['PORT'] ?? 3001);
-
-  const app = await FluoFactory.create(AppModule, {
+  const app = await FluoFactory.create(resolveAppModule(readAppShape()), {
     adapter: createFastifyAdapter({ port }),
     logger: { debug() {}, error() {}, log() {}, warn() {} },
   });

--- a/tooling/benchmarks/http-comparison/src/nestjs/server.ts
+++ b/tooling/benchmarks/http-comparison/src/nestjs/server.ts
@@ -4,6 +4,8 @@ import { Controller, Get, Injectable, Module, Param } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 
+type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20';
+
 @Injectable()
 class UsersRepository {
   findOne(id: string): { id: string; name: string; email: string } {
@@ -32,102 +34,155 @@ class BaselineController {
   }
 }
 
-@Controller('di-chain')
-class DiChainController {
+@Controller('di-chain-one')
+class DiChainOneController {
   constructor(private readonly service: UsersService) {}
 
-  @Get(':id')
-  get(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
+  @Get('r01/:id')
+  getR01(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
     return this.service.getUser(input.id);
   }
+}
 
-  @Get('users/:id')
-  getUser(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
-
-  @Get('profiles/:id')
-  getProfile(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
-
-  @Get('settings/:id')
-  getSettings(@Param() input: GetUserRequest): { id: string; name: string; email: string } {
-    return this.service.getUser(input.id);
-  }
+@Controller('di-chain')
+class DiChainTwentyController {
+  constructor(private readonly service: UsersService) {}
 
   @Get('r01/:id')
   getR01(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r02/:id')
   getR02(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r03/:id')
   getR03(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r04/:id')
   getR04(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r05/:id')
   getR05(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r06/:id')
   getR06(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r07/:id')
   getR07(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r08/:id')
   getR08(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r09/:id')
   getR09(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r10/:id')
   getR10(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r11/:id')
   getR11(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r12/:id')
   getR12(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r13/:id')
   getR13(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r14/:id')
   getR14(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r15/:id')
   getR15(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r16/:id')
   getR16(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r17/:id')
   getR17(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r18/:id')
   getR18(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r19/:id')
   getR19(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
-
   @Get('r20/:id')
   getR20(@Param() input: GetUserRequest): { id: string; name: string; email: string } { return this.service.getUser(input.id); }
 }
 
-@Module({
-  controllers: [BaselineController, DiChainController],
-  providers: [UsersRepository, UsersService],
-})
-class AppModule {}
+@Controller('di-chain-direct-one')
+class DirectParamOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get('r01/:id')
+  getR01(@Param('id') id: string): { id: string; name: string; email: string } {
+    return this.service.getUser(id);
+  }
+}
+
+@Controller('di-chain-direct')
+class DirectParamTwentyController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get('r01/:id')
+  getR01(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r02/:id')
+  getR02(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r03/:id')
+  getR03(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r04/:id')
+  getR04(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r05/:id')
+  getR05(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r06/:id')
+  getR06(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r07/:id')
+  getR07(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r08/:id')
+  getR08(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r09/:id')
+  getR09(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r10/:id')
+  getR10(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r11/:id')
+  getR11(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r12/:id')
+  getR12(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r13/:id')
+  getR13(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r14/:id')
+  getR14(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r15/:id')
+  getR15(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r16/:id')
+  getR16(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r17/:id')
+  getR17(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r18/:id')
+  getR18(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r19/:id')
+  getR19(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+  @Get('r20/:id')
+  getR20(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
+}
+
+@Module({ controllers: [BaselineController] })
+class BaselineModule {}
+
+@Module({ controllers: [DiChainOneController], providers: [UsersRepository, UsersService] })
+class DtoOneModule {}
+
+@Module({ controllers: [DiChainTwentyController], providers: [UsersRepository, UsersService] })
+class DtoTwentyModule {}
+
+@Module({ controllers: [DirectParamOneController], providers: [UsersRepository, UsersService] })
+class DirectOneModule {}
+
+@Module({ controllers: [DirectParamTwentyController], providers: [UsersRepository, UsersService] })
+class DirectTwentyModule {}
+
+function resolveAppModule(shape: AppShape) {
+  switch (shape) {
+    case 'baseline': return BaselineModule;
+    case 'dto-1': return DtoOneModule;
+    case 'dto-20': return DtoTwentyModule;
+    case 'direct-1': return DirectOneModule;
+    case 'direct-20': return DirectTwentyModule;
+  }
+}
+
+function readAppShape(): AppShape {
+  const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
+  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20') {
+    return raw;
+  }
+  throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);
+}
 
 async function main(): Promise<void> {
   const port = Number(process.env['PORT'] ?? 3002);
-
   const app = await NestFactory.create<NestFastifyApplication>(
-    AppModule,
+    resolveAppModule(readAppShape()),
     new FastifyAdapter(),
     { logger: false },
   );

--- a/tooling/benchmarks/http-comparison/src/report.ts
+++ b/tooling/benchmarks/http-comparison/src/report.ts
@@ -49,13 +49,18 @@ function row(cols: string[], widths: number[]): string {
   return '  ' + cols.map((c, i) => c.padEnd(widths[i])).join('  ');
 }
 
-export function printReport(results: ScenarioResult[]): void {
+export interface ReportOptions {
+  connections: number;
+  duration: number;
+}
+
+export function printReport(results: ScenarioResult[], options: ReportOptions): void {
   const bar = '═'.repeat(112);
   const sep = '─'.repeat(108);
   const W = [22, 16, 14, 14, 18, 18];
 
   console.log('\n\n' + bar);
-  console.log('  HTTP runtime benchmark  —  NestJS vs fluo across Fastify, Express, and Bun  —  c=100 d=40s');
+  console.log(`  HTTP runtime benchmark  —  NestJS vs fluo across Fastify and Bun  —  c=${options.connections} d=${options.duration}s`);
   console.log(bar);
 
   for (const r of results) {

--- a/tooling/benchmarks/http-comparison/src/run.ts
+++ b/tooling/benchmarks/http-comparison/src/run.ts
@@ -1,5 +1,5 @@
 import autocannon, { type Result } from 'autocannon';
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { rm } from 'node:fs/promises';
 import { createConnection } from 'node:net';
 import { join } from 'node:path';
@@ -13,6 +13,7 @@ const WDIR = process.cwd();
 const FLUO_BUN_BUILD_DIR = join(WDIR, 'dist/fluo-bun');
 
 type TargetName = 'nestjs-fastify' | 'fluo-fastify' | 'fluo-bun';
+type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20';
 
 interface TargetConfig {
   name: TargetName;
@@ -47,23 +48,71 @@ const TARGETS: TargetConfig[] = [
 ];
 
 const USER_RESPONSE = JSON.stringify({ id: '1', name: 'Alice', email: 'alice@example.com' });
+const BASELINE_RESPONSE = JSON.stringify({ ok: true });
 
 function routePaths(count: number): string[] {
   return Array.from({ length: count }, (_, index) => `/di-chain/r${String(index + 1).padStart(2, '0')}/1`);
 }
 
+function directRoutePaths(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `/di-chain-direct/r${String(index + 1).padStart(2, '0')}/1`);
+}
+
 const SCENARIOS = [
   {
-    name: 'di-chain-random-20',
-    description: 'Random 20-route path DTO + 3-level DI chain',
+    name: 'baseline',
+    description: 'Single baseline route without DI-chain path param binding',
+    appShape: 'baseline',
+    path: '/baseline',
+    expectedBodies: [BASELINE_RESPONSE],
+  },
+  {
+    name: 'di-chain-dto-deterministic-1',
+    description: 'Deterministic 1-route path DTO + 3-level DI chain',
+    appShape: 'dto-1',
+    paths: ['/di-chain-one/r01/1'],
+    expectedBodies: [USER_RESPONSE],
+  },
+  {
+    name: 'di-chain-dto-deterministic-20',
+    description: 'Deterministic 20-route path DTO + 3-level DI chain',
+    appShape: 'dto-20',
     paths: routePaths(20),
+    expectedBodies: [USER_RESPONSE],
+  },
+  {
+    name: 'di-chain-direct-param-deterministic-1',
+    description: 'Deterministic 1-route direct param + 3-level DI chain',
+    appShape: 'direct-1',
+    paths: ['/di-chain-direct-one/r01/1'],
+    expectedBodies: [USER_RESPONSE],
+  },
+  {
+    name: 'di-chain-direct-param-deterministic-20',
+    description: 'Deterministic 20-route direct param + 3-level DI chain',
+    appShape: 'direct-20',
+    paths: directRoutePaths(20),
     expectedBodies: [USER_RESPONSE],
   },
 ] as const;
 
-const WARMUP_SEC = 10;
-const MEASURE_SEC = 40;
-const CONNECTIONS = 100;
+const WARMUP_SEC = readPositiveIntegerEnv('BENCH_WARMUP_SEC', 10);
+const MEASURE_SEC = readPositiveIntegerEnv('BENCH_MEASURE_SEC', 40);
+const CONNECTIONS = readPositiveIntegerEnv('BENCH_CONNECTIONS', 100);
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return fallback;
+  }
+
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got ${raw}`);
+  }
+
+  return value;
+}
 
 function waitForPort(port: number, timeoutMs = 20_000): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -98,8 +147,13 @@ function assertCleanResult(label: string, result: Result): void {
   }
 }
 
-function randomPath(paths: readonly string[]): string {
-  return paths[Math.floor(Math.random() * paths.length)] ?? paths[0] ?? '/';
+function createDeterministicPathSequence(paths: readonly string[]): () => string {
+  let index = 0;
+  return () => {
+    const path = paths[index % paths.length] ?? paths[0] ?? '/';
+    index += 1;
+    return path;
+  };
 }
 
 function shoot(
@@ -110,6 +164,8 @@ function shoot(
   paths?: readonly string[],
 ): Promise<Result> {
   return new Promise((resolve, reject) => {
+    const nextPath = paths ? createDeterministicPathSequence(paths) : undefined;
+
     autocannon({
       url,
       connections: CONNECTIONS,
@@ -120,7 +176,7 @@ function shoot(
         ? {
             requests: [{
               setupRequest(request) {
-                request.path = randomPath(paths);
+                request.path = nextPath?.() ?? request.path;
                 return request;
               },
             }],
@@ -151,34 +207,48 @@ async function measure(
 }
 
 async function runScenario(s: (typeof SCENARIOS)[number], index: number): Promise<ScenarioResult> {
+  const processes = startTargets(s.appShape);
+  const cleanup = (): void => {
+    for (const child of processes) {
+      child.kill();
+    }
+  };
+
+  await Promise.all(TARGETS.map((target) => waitForPort(target.port)));
+
   const scenarioTargets = rotationFor(index).map((target) => ({
     target,
     url: `http://127.0.0.1:${target.port}${'path' in s ? s.path : ''}`,
   }));
 
-  process.stdout.write(`  [${s.name}] warm-up (${WARMUP_SEC}s)...`);
-  await Promise.all(scenarioTargets.map(({ target, url }) => (
-    shoot(url, WARMUP_SEC, s.expectedBodies, `${s.name}/${target.label} warm-up`, 'paths' in s ? s.paths : undefined)
-  )));
-  process.stdout.write(' done\n');
+  try {
+    process.stdout.write(`  [${s.name}] warm-up (${WARMUP_SEC}s)...`);
+    await Promise.all(scenarioTargets.map(({ target, url }) => (
+      shoot(url, WARMUP_SEC, s.expectedBodies, `${s.name}/${target.label} warm-up`, 'paths' in s ? s.paths : undefined)
+    )));
+    process.stdout.write(' done\n');
 
-  const measured: TargetResult[] = [];
-  for (const { target, url } of scenarioTargets) {
-    measured.push({
-      label: target.label,
-      result: await measure(target.label, url, s.expectedBodies, 'paths' in s ? s.paths : undefined),
-    });
-  }
-
-  const targets = TARGETS.map((target) => {
-    const result = measured.find((item) => item.label === target.label);
-    if (!result) {
-      throw new Error(`missing result for ${target.label}`);
+    const measured: TargetResult[] = [];
+    for (const { target, url } of scenarioTargets) {
+      measured.push({
+        label: target.label,
+        result: await measure(target.label, url, s.expectedBodies, 'paths' in s ? s.paths : undefined),
+      });
     }
-    return result;
-  });
 
-  return { name: s.name, description: s.description, targets };
+    const targets = TARGETS.map((target) => {
+      const result = measured.find((item) => item.label === target.label);
+      if (!result) {
+        throw new Error(`missing result for ${target.label}`);
+      }
+      return result;
+    });
+
+    return { name: s.name, description: s.description, targets };
+  } finally {
+    cleanup();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
 }
 
 function rotationFor(index: number): TargetConfig[] {
@@ -205,6 +275,19 @@ function runCommand(command: string, args: string[]): Promise<void> {
   });
 }
 
+function startTargets(appShape: AppShape): ChildProcess[] {
+  return TARGETS.map((target) => {
+    const child = spawn(target.command, target.args, {
+      cwd: WDIR,
+      env: { ...process.env, BENCH_APP_SHAPE: appShape, PORT: String(target.port) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stderr?.on('data', (d: Buffer) => process.stderr.write(`[${target.name}] ${String(d)}`));
+    return child;
+  });
+}
+
 async function buildBunTarget(): Promise<void> {
   await rm(FLUO_BUN_BUILD_DIR, { force: true, recursive: true });
   await runCommand('tsc', [
@@ -221,40 +304,13 @@ async function buildBunTarget(): Promise<void> {
 async function main(): Promise<void> {
   await buildBunTarget();
 
-  const processes = TARGETS.map((target) => {
-    const child = spawn(target.command, target.args, {
-      cwd: WDIR,
-      env: { ...process.env, PORT: String(target.port) },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    child.stderr?.on('data', (d: Buffer) => process.stderr.write(`[${target.name}] ${String(d)}`));
-    return child;
-  });
-
-  const cleanup = (): void => {
-    for (const child of processes) {
-      child.kill();
-    }
-  };
-  process.on('exit', cleanup);
-  process.on('SIGINT', () => { cleanup(); process.exit(130); });
-
-  try {
-    console.log('\nWaiting for servers...');
-    await Promise.all(TARGETS.map((target) => waitForPort(target.port)));
-    console.log('All servers ready\n');
-
-    const results: ScenarioResult[] = [];
-    for (const [index, s] of SCENARIOS.entries()) {
-      console.log(`Scenario: ${s.name}`);
-      results.push(await runScenario(s, index));
-    }
-
-    printReport(results);
-  } finally {
-    cleanup();
+  const results: ScenarioResult[] = [];
+  for (const [index, s] of SCENARIOS.entries()) {
+    console.log(`Scenario: ${s.name}`);
+    results.push(await runScenario(s, index));
   }
+
+  printReport(results, { connections: CONNECTIONS, duration: MEASURE_SEC });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Add isolated benchmark app shapes for baseline, DTO-bound, and direct-param HTTP comparisons across Nest+Fastify, fluo+Fastify, and fluo+Bun.
- Replace random request path selection with deterministic path cycling so each target sees the same route sequence.
- Update report metadata and benchmark docs for scenario-specific server startup and env-overridable durations.

## Verification
- pnpm --filter @fluojs-internal/tooling-benchmarks-http typecheck
- BENCH_WARMUP_SEC=3 BENCH_MEASURE_SEC=10 pnpm bench
- BENCH_WARMUP_SEC=5 BENCH_MEASURE_SEC=20 pnpm bench