### PR TITLE
Resolve #1462: optimize Fastify adapter hot path

### DIFF
--- a/.changeset/fastify-adapter-hot-path.md
+++ b/.changeset/fastify-adapter-hot-path.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-fastify": patch
+---
+
+Reduce Fastify adapter request and response hot-path overhead while preserving request headers, query, cookie, raw-body, multipart, streaming, and abort behavior.

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1334,6 +1334,60 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('preserves request header passthrough on native and fallback dispatch paths', async () => {
+    @Controller('/headers')
+    class HeaderController {
+      @Get('/native')
+      getNative(_input: undefined, context: RequestContext) {
+        return {
+          requestId: context.request.headers['x-request-id'],
+        };
+      }
+
+      @All('/fallback')
+      getFallback(_input: undefined, context: RequestContext) {
+        return {
+          requestId: context.request.headers['x-request-id'],
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [HeaderController] });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    try {
+      const [nativeResponse, fallbackResponse] = await Promise.all([
+        requestHttp({
+          headers: { 'x-request-id': 'native-req' },
+          method: 'GET',
+          path: '/headers/native',
+          port,
+        }),
+        requestHttp({
+          headers: { 'x-request-id': 'fallback-req' },
+          method: 'PATCH',
+          path: '/headers/fallback',
+          port,
+        }),
+      ]);
+
+      expect(nativeResponse.statusCode).toBe(200);
+      expect(JSON.parse(nativeResponse.body)).toEqual({ requestId: 'native-req' });
+      expect(fallbackResponse.statusCode).toBe(200);
+      expect(JSON.parse(fallbackResponse.body)).toEqual({ requestId: 'fallback-req' });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('supports https startup and reports the https listen URL', async () => {
     const loggerEvents: string[] = [];
     const logger: ApplicationLogger = {

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1388,6 +1388,55 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('snapshots request headers before middleware can mutate raw headers', async () => {
+    const mutatingMiddleware = {
+      async handle(context: MiddlewareContext, next: () => Promise<void>) {
+        const rawRequest = context.request.raw as { headers?: Record<string, string | string[] | undefined> };
+
+        if (rawRequest.headers) {
+          rawRequest.headers['x-request-id'] = 'mutated-after-wrapper-create';
+        }
+
+        await next();
+      },
+    };
+
+    @Controller('/snapshot')
+    class SnapshotController {
+      @Get('/headers')
+      getHeaders(_input: undefined, context: RequestContext) {
+        return {
+          requestId: context.request.headers['x-request-id'],
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [SnapshotController] });
+
+    const port = await findAvailablePort();
+    const app = await fluoFactory.create(AppModule, {
+      adapter: createFastifyAdapter({ port }),
+      middleware: [mutatingMiddleware],
+    });
+
+    await app.listen();
+
+    try {
+      const response = await requestHttp({
+        headers: { 'x-request-id': 'original-at-wrapper-create' },
+        method: 'GET',
+        path: '/snapshot/headers',
+        port,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ requestId: 'original-at-wrapper-create' });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('supports https startup and reports the https listen URL', async () => {
     const loggerEvents: string[] = [];
     const logger: ApplicationLogger = {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -126,6 +126,14 @@ type FastifyFrameworkResponse = FrameworkResponse & {
   statusSet?: boolean;
 };
 
+type FastifyFrameworkRequest = FrameworkRequest & {
+  files?: UploadedFile[];
+  materializeBody?: () => Promise<void>;
+  rawBody?: Uint8Array;
+};
+
+type MemoizedValue<T> = () => T;
+
 type FastifyMultipartLikeError = Error & {
   code?: unknown;
   statusCode?: unknown;
@@ -299,6 +307,9 @@ function createFastifyRequestResponseFactory(
     createResponse(reply: FastifyReply) {
       return createFrameworkResponse(reply);
     },
+    async materializeRequest(request: FrameworkRequest) {
+      await materializeFrameworkRequestBody(request);
+    },
     resolveRequestId(request: FastifyRequest) {
       return resolveRequestIdFromHeaders(request.raw.headers);
     },
@@ -464,11 +475,16 @@ export async function runFastifyApplication(
 }
 
 function createFrameworkResponse(reply: FastifyReply): FastifyFrameworkResponse {
+  let activeStream: FrameworkResponseStream | undefined;
+
   return {
     committed: reply.sent,
     headers: {},
     raw: reply,
-    stream: createFrameworkResponseStream(reply),
+    get stream() {
+      activeStream ??= createFrameworkResponseStream(reply);
+      return activeStream;
+    },
     redirect(status: number, location: string) {
       this.setStatus(status);
       this.setHeader('Location', location);
@@ -497,14 +513,12 @@ function createFrameworkResponse(reply: FastifyReply): FastifyFrameworkResponse 
         return;
       }
 
-      const serialized = serializeResponseBody(body);
-
-      if (!reply.hasHeader('content-type') && serialized.defaultContentType) {
-        reply.header('content-type', serialized.defaultContentType);
+      if (!reply.hasHeader('content-type')) {
+        reply.header('content-type', 'application/json; charset=utf-8');
       }
 
       this.committed = true;
-      await reply.send(serialized.payload);
+      await reply.send(JSON.stringify(body));
     },
     setHeader(name: string, value: string | string[]) {
       const lowerName = name.toLowerCase();
@@ -602,54 +616,80 @@ async function createFrameworkRequest(
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
+  return createDeferredFrameworkRequest(request, signal, multipartOptions, maxBodySize, preserveRawBody);
+}
+
+function createDeferredFrameworkRequest(
+  request: FastifyRequest,
+  signal: AbortSignal,
+  multipartOptions?: MultipartOptions,
+  maxBodySize = DEFAULT_MAX_BODY_SIZE,
+  preserveRawBody = false,
+): FrameworkRequest {
   const rawUrl = request.raw.url ?? '/';
-  const url = new URL(rawUrl, 'http://localhost');
-  const headers = normalizeHeaders(request.headers);
-  const contentType = headers['content-type'];
-  const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
+  const urlParts = splitRawRequestUrl(rawUrl);
+  const headers = createMemoizedValue(() => normalizeHeaders(request.raw.headers));
+  const cookieHeader = cloneHeaderValue(request.raw.headers.cookie);
+  const cookies = createMemoizedValue(() => parseCookieHeader(cookieHeader));
+  const query = createMemoizedValue(() => parseQueryParamsFromSearch(urlParts.search));
+  const isMultipart = isMultipartRequestContentType(request.raw.headers['content-type']);
+  const materializeBody = createMemoizedAsyncValue(async () => {
+    let body = request.body;
+    let files: UploadedFile[] | undefined;
 
-  let body = request.body;
-  let files: UploadedFile[] | undefined;
+    if (isMultipart) {
+      const parsed = await parseMultipartRequest(request, {
+        ...multipartOptions,
+        maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
+      });
+      body = parsed.fields;
+      files = parsed.files;
+    }
 
-  if (isMultipart) {
-    const parsed = await parseMultipartRequest(request, {
-      ...multipartOptions,
-      maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
-    });
-    body = parsed.fields;
-    files = parsed.files;
-  }
+    frameworkRequest.body = body;
 
-  const frameworkRequest: FrameworkRequest = {
-    body,
-    cookies: parseCookieHeader(Array.isArray(headers.cookie) ? headers.cookie[0] : headers.cookie),
-    headers,
+    if (files) {
+      frameworkRequest.files = files;
+    }
+
+    if (preserveRawBody && !isMultipart) {
+      const rawBodyValue = (request as FastifyRequest & { rawBody?: Buffer }).rawBody;
+
+      if (rawBodyValue !== undefined) {
+        frameworkRequest.rawBody = rawBodyValue;
+      }
+    }
+  });
+
+  const frameworkRequest: FastifyFrameworkRequest = {
+    get cookies() {
+      return cookies();
+    },
+    get headers() {
+      return headers();
+    },
     method: request.method,
     params: {},
-    path: url.pathname,
-    query: parseQueryParams(url.searchParams),
+    path: urlParts.path,
+    get query() {
+      return query();
+    },
     raw: request.raw,
     signal,
-    url: url.pathname + url.search,
+    url: urlParts.path + urlParts.search,
+    materializeBody,
   };
-
-  if (files) {
-    frameworkRequest.files = files;
-  }
-
-  if (preserveRawBody && !isMultipart) {
-    const rawBodyValue = (request as FastifyRequest & { rawBody?: Buffer }).rawBody;
-
-    if (rawBodyValue !== undefined) {
-      frameworkRequest.rawBody = rawBodyValue;
-    }
-  }
 
   const nativeRouteHandoff = consumeRawRequestNativeRouteHandoff(request.raw);
 
   return nativeRouteHandoff
     ? attachFrameworkRequestNativeRouteHandoff(frameworkRequest, nativeRouteHandoff)
     : frameworkRequest;
+}
+
+async function materializeFrameworkRequestBody(request: FrameworkRequest): Promise<void> {
+  await (request as FastifyFrameworkRequest).materializeBody?.();
+  delete (request as FastifyFrameworkRequest).materializeBody;
 }
 
 function normalizeNativeRouteParams(params: unknown): Record<string, string> {
@@ -694,7 +734,7 @@ function collectVersionSensitiveRouteKeys(descriptors: readonly HandlerDescripto
 }
 
 function readRequestPathFromRawUrl(rawUrl: string | undefined): string {
-  return new URL(rawUrl ?? '/', 'http://localhost').pathname;
+  return splitRawRequestUrl(rawUrl ?? '/').path;
 }
 
 async function parseMultipartRequest(
@@ -787,7 +827,7 @@ export function isFastifyMultipartTooLargeError(error: unknown): boolean {
   return error.message.includes('toobig') || error.message.includes('File too large');
 }
 
-function normalizeHeaders(headers: FastifyRequest['headers']): Record<string, string | string[] | undefined> {
+function normalizeHeaders(headers: IncomingHttpHeaders): Record<string, string | string[] | undefined> {
   const normalized: Record<string, string | string[] | undefined> = {};
 
   for (const [name, value] of Object.entries(headers)) {
@@ -812,6 +852,10 @@ function normalizeHeaders(headers: FastifyRequest['headers']): Record<string, st
   return normalized;
 }
 
+function parseQueryParamsFromSearch(search: string): Record<string, string | string[]> {
+  return parseQueryParams(new URLSearchParams(search));
+}
+
 function parseQueryParams(searchParams: URLSearchParams): Record<string, string | string[]> {
   const query: Record<string, string | string[]> = {};
 
@@ -834,13 +878,15 @@ function parseQueryParams(searchParams: URLSearchParams): Record<string, string 
   return query;
 }
 
-function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
-  if (!cookieHeader) {
+function parseCookieHeader(cookieHeader: string | string[] | undefined): Record<string, string> {
+  const normalizedCookieHeader = Array.isArray(cookieHeader) ? cookieHeader.join('; ') : cookieHeader;
+
+  if (!normalizedCookieHeader) {
     return {};
   }
 
   return Object.fromEntries(
-    cookieHeader
+    normalizedCookieHeader
       .split(';')
       .map((pair) => pair.trim())
       .filter(Boolean)
@@ -860,6 +906,56 @@ function parseCookieHeader(cookieHeader: string | undefined): Record<string, str
         }
       }),
   );
+}
+
+function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
+  let initialized = false;
+  let value: T;
+
+  return () => {
+    if (!initialized) {
+      value = factory();
+      initialized = true;
+    }
+
+    return value;
+  };
+}
+
+function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<void> {
+  let promise: Promise<void> | undefined;
+
+  return () => {
+    promise ??= factory();
+    return promise;
+  };
+}
+
+function cloneHeaderValue<T extends string | string[] | undefined>(value: T): T {
+  return (Array.isArray(value) ? [...value] : value) as T;
+}
+
+function splitRawRequestUrl(rawUrl: string): { path: string; search: string } {
+  if (rawUrl.startsWith('http://') || rawUrl.startsWith('https://')) {
+    const url = new URL(rawUrl);
+    return { path: url.pathname, search: url.search };
+  }
+
+  const queryStart = rawUrl.indexOf('?');
+  const hashStart = rawUrl.indexOf('#');
+  const pathEndCandidates = [queryStart, hashStart].filter((index) => index >= 0);
+  const pathEnd = pathEndCandidates.length > 0 ? Math.min(...pathEndCandidates) : rawUrl.length;
+  const path = rawUrl.slice(0, pathEnd) || '/';
+
+  if (queryStart === -1) {
+    return { path, search: '' };
+  }
+
+  const searchEnd = hashStart >= 0 && hashStart > queryStart ? hashStart : rawUrl.length;
+  return {
+    path,
+    search: rawUrl.slice(queryStart, searchEnd),
+  };
 }
 
 function setMultiValue(target: Record<string, string | string[]>, key: string, value: string): void {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -628,11 +628,12 @@ function createDeferredFrameworkRequest(
 ): FrameworkRequest {
   const rawUrl = request.raw.url ?? '/';
   const urlParts = splitRawRequestUrl(rawUrl);
-  const headers = createMemoizedValue(() => normalizeHeaders(request.raw.headers));
-  const cookieHeader = cloneHeaderValue(request.raw.headers.cookie);
+  const headerSnapshot = cloneRequestHeaders(request.headers);
+  const headers = createMemoizedValue(() => normalizeHeaders(headerSnapshot));
+  const cookieHeader = cloneHeaderValue(headerSnapshot.cookie);
   const cookies = createMemoizedValue(() => parseCookieHeader(cookieHeader));
   const query = createMemoizedValue(() => parseQueryParamsFromSearch(urlParts.search));
-  const isMultipart = isMultipartRequestContentType(request.raw.headers['content-type']);
+  const isMultipart = isMultipartRequestContentType(headerSnapshot['content-type']);
   const materializeBody = createMemoizedAsyncValue(async () => {
     let body = request.body;
     let files: UploadedFile[] | undefined;
@@ -933,6 +934,12 @@ function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<v
 
 function cloneHeaderValue<T extends string | string[] | undefined>(value: T): T {
   return (Array.isArray(value) ? [...value] : value) as T;
+}
+
+function cloneRequestHeaders(headers: FastifyRequest['headers']): IncomingHttpHeaders {
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [name, cloneHeaderValue(value)]),
+  );
 }
 
 function splitRawRequestUrl(rawUrl: string): { path: string; search: string } {


### PR DESCRIPTION
## Summary

Closes #1462

- Reduces Fastify adapter request hot-path work by creating a cheap framework request shell and deferring body/materialization through the shared factory seam.
- Keeps headers, query, cookies, multipart/raw body, native route handoff, streaming, redirects, and abort behavior covered by existing and added regression tests.
- Adds a patch changeset for the public `@fluojs/platform-fastify` performance improvement.

## Changes

- Split Fastify request creation into shell creation plus `materializeRequest(...)`, matching the Node/Web deferred request pattern.
- Lazily normalize headers, query params, and cookies, and avoid `new URL(...)` on the normal relative URL path.
- Lazily create Fastify response stream wrappers and simplify the simple JSON response path.
- Added native-route and wildcard fallback request-header passthrough coverage.

## Testing

- `pnpm build`
- `pnpm --filter @fluojs/platform-fastify typecheck`
- `pnpm --filter @fluojs/platform-fastify test`
- `pnpm lint` *(completed; repo-wide Biome reported existing warnings/infos outside this PR, while `verify:public-export-tsdoc` passed in changed mode)*
- LSP diagnostics: no diagnostics for `packages/platform-fastify/src/adapter.ts` and `packages/platform-fastify/src/adapter.test.ts`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.