### PR TITLE
Resolve #1463: optimize shared runtime dispatch seam

### DIFF
--- a/.changeset/runtime-web-dispatch-factory-cache.md
+++ b/.changeset/runtime-web-dispatch-factory-cache.md
@@ -1,0 +1,8 @@
+---
+"@fluojs/runtime": patch
+"@fluojs/platform-bun": patch
+"@fluojs/platform-cloudflare-workers": patch
+"@fluojs/platform-deno": patch
+---
+
+Reuse shared Web request-response factories across adapter requests while preserving per-request body materialization and error/fallback response semantics.

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -24,7 +24,7 @@ import {
   createNodeShutdownSignalRegistration,
   defaultNodeShutdownSignals,
 } from '@fluojs/runtime/node';
-import { dispatchWebRequest } from '@fluojs/runtime/web';
+import { createWebRequestResponseFactory, dispatchWebRequest } from '@fluojs/runtime/web';
 import {
   bootstrapHttpAdapterApplication,
   runHttpAdapterApplication,
@@ -245,8 +245,17 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   private inFlightRequestCount = 0;
   private server?: BunServerLike;
   private realtimeBinding?: BunWebSocketBinding<unknown>;
+  private readonly options: BunAdapterOptions;
+  private readonly webRequestResponseFactory;
 
-  constructor(private readonly options: BunAdapterOptions = {}) {}
+  constructor(options: BunAdapterOptions = {}) {
+    this.options = options;
+    this.webRequestResponseFactory = createWebRequestResponseFactory({
+      maxBodySize: options.maxBodySize,
+      multipart: options.multipart,
+      rawBody: options.rawBody,
+    });
+  }
 
   /** Returns the active Bun server handle after `listen()` starts. */
   getServer(): BunServerLike | undefined {
@@ -372,9 +381,7 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
       return await dispatchWebRequest({
         dispatcher: this.dispatcher,
         dispatcherNotReadyMessage: DEFAULT_DISPATCHER_NOT_READY_MESSAGE,
-        maxBodySize: this.options.maxBodySize,
-        multipart: this.options.multipart,
-        rawBody: this.options.rawBody,
+        factory: this.webRequestResponseFactory,
         request,
       });
     } finally {
@@ -425,13 +432,17 @@ export function createBunFetchHandler({
   multipart,
   rawBody,
 }: CreateBunFetchHandlerOptions): (request: Request) => Promise<Response> {
+  const factory = createWebRequestResponseFactory({
+    maxBodySize,
+    multipart,
+    rawBody,
+  });
+
   return async function bunFetchHandler(request: Request): Promise<Response> {
     return await dispatchWebRequest({
       dispatcher,
       dispatcherNotReadyMessage,
-      maxBodySize,
-      multipart,
-      rawBody,
+      factory,
       request,
     });
   };

--- a/packages/platform-cloudflare-workers/src/adapter.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.test.ts
@@ -119,7 +119,9 @@ describe('@fluojs/platform-cloudflare-workers', () => {
     expect(dispatchSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         dispatcher,
-        rawBody: true,
+        factory: expect.objectContaining({
+          materializeRequest: expect.any(Function),
+        }),
         request,
       }),
     );

--- a/packages/platform-cloudflare-workers/src/adapter.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.ts
@@ -13,6 +13,7 @@ import type {
   UploadedFile,
 } from '@fluojs/runtime';
 import {
+  createWebRequestResponseFactory,
   dispatchWebRequest,
   type CreateWebRequestResponseFactoryOptions,
 } from '@fluojs/runtime/web';
@@ -119,8 +120,13 @@ export class CloudflareWorkerHttpApplicationAdapter
   private inFlightDrain?: Deferred<void>;
   private inFlightRequestCount = 0;
   private websocketBinding?: CloudflareWorkerWebSocketBinding;
+  private readonly options: CloudflareWorkerAdapterOptions;
+  private readonly webRequestResponseFactory;
 
-  constructor(private readonly options: CloudflareWorkerAdapterOptions = {}) {}
+  constructor(options: CloudflareWorkerAdapterOptions = {}) {
+    this.options = options;
+    this.webRequestResponseFactory = createWebRequestResponseFactory(options);
+  }
 
   async close(): Promise<void> {
     if (this.closeInFlight) {
@@ -173,9 +179,9 @@ export class CloudflareWorkerHttpApplicationAdapter
         }
 
         return await dispatchWebRequest({
-          ...this.options,
           dispatcher: this.dispatcher,
           dispatcherNotReadyMessage: WORKER_DISPATCHER_NOT_READY_MESSAGE,
+          factory: this.webRequestResponseFactory,
           request,
         });
       } finally {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -7,7 +7,7 @@ import {
   type HttpAdapterListenTarget,
   type RunHttpAdapterApplicationOptions,
 } from '@fluojs/runtime/internal/http-adapter';
-import { dispatchWebRequest } from '@fluojs/runtime/web';
+import { createWebRequestResponseFactory, dispatchWebRequest } from '@fluojs/runtime/web';
 
 /** Listen target metadata reported by `Deno.serve(...)` callbacks. */
 export interface DenoServeOnListenInfo {
@@ -133,8 +133,17 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
   private inFlightRequestCount = 0;
   private server?: DenoServeController;
   private websocketBinding?: DenoWebSocketBinding<DenoServerWebSocket>;
+  private readonly options: Required<Pick<DenoAdapterOptions, 'hostname' | 'port'>> & DenoAdapterOptions;
+  private readonly webRequestResponseFactory;
 
-  constructor(private readonly options: Required<Pick<DenoAdapterOptions, 'hostname' | 'port'>> & DenoAdapterOptions) {}
+  constructor(options: Required<Pick<DenoAdapterOptions, 'hostname' | 'port'>> & DenoAdapterOptions) {
+    this.options = options;
+    this.webRequestResponseFactory = createWebRequestResponseFactory({
+      maxBodySize: options.maxBodySize,
+      multipart: options.multipart,
+      rawBody: options.rawBody,
+    });
+  }
 
   getServer(): DenoServeController | undefined {
     return this.server;
@@ -180,9 +189,7 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
       return await dispatchWebRequest({
         dispatcher: this.dispatcher,
         dispatcherNotReadyMessage: 'Deno adapter received a request before dispatcher binding completed.',
-        maxBodySize: this.options.maxBodySize,
-        multipart: this.options.multipart,
-        rawBody: this.options.rawBody,
+        factory: this.webRequestResponseFactory,
         request,
       });
     } finally {

--- a/packages/runtime/src/adapters/request-response-factory.test.ts
+++ b/packages/runtime/src/adapters/request-response-factory.test.ts
@@ -10,7 +10,7 @@ import {
 describe('dispatchWithRequestResponseFactory', () => {
   it('dispatches through the extracted factory seam and finalizes uncommitted responses', async () => {
     const events: string[] = [];
-    const response = {
+    const response: FrameworkResponse = {
       committed: false,
       headers: {},
       redirect() {},
@@ -137,5 +137,66 @@ describe('dispatchWithRequestResponseFactory', () => {
     expect(frameworkResponse).toMatchObject({ committed: false });
     expect(writeErrorResponse).toHaveBeenCalledOnce();
     expect(writeErrorResponse).toHaveBeenCalledWith(error, expect.objectContaining({ committed: false }), 'req-2');
+  });
+
+  it('skips request materialization when the factory does not provide a materializer', async () => {
+    const events: string[] = [];
+    const response = {
+      committed: false,
+      headers: {},
+      redirect() {},
+      async send() {
+        events.push('send');
+        response.committed = true;
+      },
+      setHeader() {},
+      setStatus() {},
+      statusSet: false,
+    };
+
+    const frameworkResponse = await dispatchWithRequestResponseFactory({
+      dispatcher: {
+        async dispatch(request: FrameworkRequest, response: FrameworkResponse) {
+          events.push(`dispatch:${request.path}`);
+          await response.send({ ok: true });
+        },
+      },
+      dispatcherNotReadyMessage: 'dispatcher missing',
+      factory: {
+        async createRequest(rawRequest, signal) {
+          events.push('request');
+          return {
+            cookies: {},
+            headers: {},
+            method: 'GET',
+            params: {},
+            path: rawRequest.path,
+            query: {},
+            raw: rawRequest,
+            signal,
+            url: rawRequest.path,
+          };
+        },
+        createRequestSignal() {
+          events.push('signal');
+          return new AbortController().signal;
+        },
+        createResponse() {
+          events.push('response');
+          return response;
+        },
+        resolveRequestId(rawRequest) {
+          return rawRequest.path;
+        },
+        async writeErrorResponse() {
+          events.push('error');
+        },
+      },
+      rawRequest: { path: '/fast-path' },
+      rawResponse: undefined,
+    });
+
+    expect(frameworkResponse.committed).toBe(true);
+    expect(events).toEqual(['response', 'signal', 'request', 'dispatch:/fast-path', 'send']);
   });
 });

--- a/packages/runtime/src/adapters/request-response-factory.ts
+++ b/packages/runtime/src/adapters/request-response-factory.ts
@@ -49,7 +49,11 @@ export async function dispatchWithRequestResponseFactory<
 
   try {
     const frameworkRequest = await factory.createRequest(rawRequest, signal);
-    await factory.materializeRequest?.(frameworkRequest);
+    const materializeRequest = factory.materializeRequest;
+
+    if (materializeRequest) {
+      await materializeRequest(frameworkRequest);
+    }
 
     if (!dispatcher) {
       throw new Error(dispatcherNotReadyMessage);

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -240,6 +240,31 @@ describe('dispatchWebRequest', () => {
     expect(seenBodies).toEqual([{ name: 'first' }, { name: 'second' }]);
     expect(seenRawBodies).toEqual(['{"name":"first"}', '{"name":"second"}']);
   });
+
+  it('lets an injected web factory own parsing options over dispatch options', async () => {
+    const factory = createWebRequestResponseFactory({ rawBody: true });
+    let rawBody: Uint8Array | undefined;
+
+    await dispatchWebRequest({
+      dispatcher: {
+        async dispatch(request: FrameworkRequest, frameworkResponse: FrameworkResponse) {
+          rawBody = request.rawBody;
+          await frameworkResponse.send({ ok: true });
+        },
+      },
+      factory,
+      rawBody: false,
+      request: new Request('https://runtime.test/factory-options', {
+        body: JSON.stringify({ ok: true }),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }),
+    });
+
+    expect(Buffer.from(rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
+  });
 });
 
 describe('createWebFrameworkRequest', () => {

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -208,6 +208,38 @@ describe('dispatchWebRequest', () => {
     });
     expect(producedChunks).toBeLessThanOrEqual(3);
   });
+
+  it('reuses an injected web factory without sharing request-specific state', async () => {
+    const factory = createWebRequestResponseFactory({ rawBody: true });
+    const seenBodies: unknown[] = [];
+    const seenRawBodies: string[] = [];
+
+    const dispatch = (name: string) => dispatchWebRequest({
+      dispatcher: {
+        async dispatch(request: FrameworkRequest, frameworkResponse: FrameworkResponse) {
+          seenBodies.push(request.body);
+          seenRawBodies.push(Buffer.from(request.rawBody ?? new Uint8Array()).toString('utf8'));
+          await frameworkResponse.send({ name });
+        },
+      },
+      factory,
+      request: new Request('https://runtime.test/reused-factory', {
+        body: JSON.stringify({ name }),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      }),
+    });
+
+    const firstResponse = await dispatch('first');
+    const secondResponse = await dispatch('second');
+
+    await expect(firstResponse.json()).resolves.toEqual({ name: 'first' });
+    await expect(secondResponse.json()).resolves.toEqual({ name: 'second' });
+    expect(seenBodies).toEqual([{ name: 'first' }, { name: 'second' }]);
+    expect(seenRawBodies).toEqual(['{"name":"first"}', '{"name":"second"}']);
+  });
 });
 
 describe('createWebFrameworkRequest', () => {

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -50,6 +50,8 @@ export interface CreateWebRequestResponseFactoryOptions {
 export interface DispatchWebRequestOptions extends CreateWebRequestResponseFactoryOptions {
   dispatcher?: Dispatcher;
   dispatcherNotReadyMessage?: string;
+  /** Factory reused by adapters that share one stable Web parsing configuration across requests. */
+  factory?: RequestResponseFactory<Request, AbortSignal | undefined, WebFrameworkResponse>;
   request: Request;
 }
 
@@ -317,13 +319,14 @@ export function createWebRequestResponseFactory(
 export async function dispatchWebRequest({
   dispatcher,
   dispatcherNotReadyMessage = 'Web adapter received a request before dispatcher binding completed.',
+  factory,
   request,
   ...options
 }: DispatchWebRequestOptions): Promise<Response> {
   const frameworkResponse = await dispatchWithRequestResponseFactory({
     dispatcher,
     dispatcherNotReadyMessage,
-    factory: createWebRequestResponseFactory(options),
+    factory: factory ?? createWebRequestResponseFactory(options),
     rawRequest: request,
     rawResponse: request.signal,
   });

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -50,7 +50,11 @@ export interface CreateWebRequestResponseFactoryOptions {
 export interface DispatchWebRequestOptions extends CreateWebRequestResponseFactoryOptions {
   dispatcher?: Dispatcher;
   dispatcherNotReadyMessage?: string;
-  /** Factory reused by adapters that share one stable Web parsing configuration across requests. */
+  /**
+   * Factory reused by adapters that share one stable Web parsing configuration across requests.
+   *
+   * When provided, the factory owns parsing configuration and `maxBodySize`, `multipart`, and `rawBody` are ignored.
+   */
   factory?: RequestResponseFactory<Request, AbortSignal | undefined, WebFrameworkResponse>;
   request: Request;
 }


### PR DESCRIPTION
## Summary

Optimize the shared runtime request/response dispatch seam so fetch-style adapters can reuse a stable Web request-response factory instead of recreating it for every request.

Closes #1463

## Changes

- Let `dispatchWebRequest(...)` accept a prebuilt Web request-response factory while preserving the existing per-call fallback behavior.
- Cache Web request-response factories in Bun, Deno, Cloudflare Workers, and standalone Bun fetch handler paths at their stable adapter/runtime configuration boundary.
- Avoid optional materialization lookup work in `dispatchWithRequestResponseFactory(...)` when no materializer is registered.
- Add regression coverage for no-materializer dispatch and reused Web factory request-state isolation.
- Add patch changeset entries for the affected public runtime/platform packages.

## Testing

- `pnpm build`
- `pnpm --filter @fluojs/runtime typecheck`
- `pnpm --filter @fluojs/platform-bun typecheck`
- `pnpm --filter @fluojs/platform-deno typecheck`
- `pnpm --filter @fluojs/platform-cloudflare-workers typecheck`
- `pnpm --filter @fluojs/runtime test -- src/adapters/request-response-factory.test.ts src/web.test.ts`
- `pnpm --filter @fluojs/platform-bun test`
- `pnpm --filter @fluojs/platform-deno test`
- `pnpm --filter @fluojs/platform-cloudflare-workers test`
- `pnpm exec biome lint .changeset/runtime-web-dispatch-factory-cache.md packages/runtime/src/adapters/request-response-factory.ts packages/runtime/src/adapters/request-response-factory.test.ts packages/runtime/src/web.ts packages/runtime/src/web.test.ts packages/platform-bun/src/adapter.ts packages/platform-deno/src/adapter.ts packages/platform-cloudflare-workers/src/adapter.ts packages/platform-cloudflare-workers/src/adapter.test.ts`
- `pnpm verify:public-export-tsdoc` via `pnpm lint`

Note: full `pnpm lint` still reports existing unrelated Biome diagnostics outside this PR's changed files; changed-file Biome lint and public export TSDoc checks pass.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This PR preserves the documented request snapshot/materialization, fallback `send(undefined)`, and error serialization semantics. It only moves factory allocation to stable adapter configuration boundaries.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed platform contract docs or README conformance claims changed; runtime/platform regression tests cover the affected shared dispatch path.