### PR TITLE
Remove stale benchmark changeset ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,6 @@
     "@fluojs/example-ops-metrics-terminus",
     "@fluojs/example-realworld-api",
     "@fluojs-internal/tooling-babel",
-    "@fluojs-internal/tooling-benchmarks-http",
     "@fluojs-internal/tooling-tsconfig",
     "@fluojs-internal/tooling-vite",
     "@fluojs-internal/tooling-vitest"


### PR DESCRIPTION
## Summary

Fix the follow-up `Changesets Release` failure after #1468 by removing the benchmark package from the Changesets `ignore` list now that it is no longer part of the root pnpm workspace.

## Changes

- Removed `@fluojs-internal/tooling-benchmarks-http` from `.changeset/config.json` `ignore`.

## Testing

- `pnpm changeset status --since=main`
- `pnpm install --frozen-lockfile`

## Public export documentation

- [x] Changed public exports include a source-level summary. N/A — no public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. N/A.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. N/A.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. N/A — Changesets config only.
- [x] Intentional limitations are explicitly stated (not silently removed). N/A.
- [x] Runtime invariants are covered by regression tests. N/A — no runtime behavior changed.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. N/A.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A.