### PR TITLE
Resolve #1471: optimize Web runtime request materialization

### DIFF
--- a/.changeset/lucky-pears-mix.md
+++ b/.changeset/lucky-pears-mix.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/runtime': patch
+---
+
+Optimize Web runtime request materialization so fetch-style adapters avoid extra request cloning and eager query/header snapshots while preserving rawBody, multipart, and portability semantics.

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -103,6 +103,26 @@ describe('dispatchWebRequest', () => {
     expect(await response.text()).toBe('');
   });
 
+  it('preserves query decoding semantics for repeated, empty, and plus-separated values', async () => {
+    const response = await dispatchWebRequest({
+      dispatcher: {
+        async dispatch(request: FrameworkRequest, frameworkResponse: FrameworkResponse) {
+          expect(request.query).toEqual({
+            empty: '',
+            encoded: 'hello world',
+            flag: '',
+            plain: 'ok',
+            tag: ['one', 'two'],
+          });
+          await frameworkResponse.send({ ok: true });
+        },
+      },
+      request: new Request('https://runtime.test/query?tag=one&tag=two&empty=&flag&encoded=hello+world&plain=ok'),
+    });
+
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
   it('serializes framework errors into a Web Response', async () => {
     const response = await dispatchWebRequest({
       dispatcher: {
@@ -287,7 +307,7 @@ describe('createWebFrameworkRequest', () => {
     expect(secondHeaders['x-runtime']).toBe('before');
   });
 
-  it('creates the request shell before materializing body and rawBody', async () => {
+  it('creates the request shell before materializing body and rawBody without cloning the request', async () => {
     let pulls = 0;
     const request = new Request('https://runtime.test/body?tag=one', {
       body: new ReadableStream<Uint8Array>({
@@ -323,7 +343,7 @@ describe('createWebFrameworkRequest', () => {
     await factory.materializeRequest?.(frameworkRequest);
     await factory.materializeRequest?.(frameworkRequest);
 
-    expect(cloneCalls).toBe(1);
+    expect(cloneCalls).toBe(0);
     expect(pulls).toBe(1);
     expect(frameworkRequest.body).toEqual({ ok: true });
     expect(Buffer.from(frameworkRequest.rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
@@ -369,5 +389,31 @@ describe('createWebFrameworkRequest', () => {
     expect(frameworkRequest.body).toEqual({ title: 'before' });
     expect(frameworkRequest.headers['content-type']).toContain('multipart/form-data');
     expect(frameworkRequest.headers['x-runtime']).toBeUndefined();
+  });
+
+  it('materializes deferred multipart bodies without cloning the request stream', async () => {
+    const formData = new FormData();
+    formData.set('title', 'before');
+    const request = new Request('https://runtime.test/upload', {
+      body: formData,
+      method: 'POST',
+    });
+    const originalClone = request.clone.bind(request);
+    let cloneCalls = 0;
+
+    Object.defineProperty(request, 'clone', {
+      value: () => {
+        cloneCalls += 1;
+        return originalClone();
+      },
+    });
+
+    const factory = createWebRequestResponseFactory();
+    const frameworkRequest = await factory.createRequest(request, new AbortController().signal);
+
+    await factory.materializeRequest?.(frameworkRequest);
+
+    expect(cloneCalls).toBe(0);
+    expect(frameworkRequest.body).toEqual({ title: 'before' });
   });
 });

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -123,6 +123,23 @@ describe('dispatchWebRequest', () => {
     await expect(response.json()).resolves.toEqual({ ok: true });
   });
 
+  it('matches URLSearchParams semantics for malformed percent-encoded query values', async () => {
+    const response = await dispatchWebRequest({
+      dispatcher: {
+        async dispatch(request: FrameworkRequest, frameworkResponse: FrameworkResponse) {
+          expect(request.query).toEqual({
+            bad: '�%A',
+            ok: 'hello world',
+          });
+          await frameworkResponse.send({ ok: true });
+        },
+      },
+      request: new Request('https://runtime.test/query?bad=%E0%A4%A&ok=hello+world'),
+    });
+
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
   it('serializes framework errors into a Web Response', async () => {
     const response = await dispatchWebRequest({
       dispatcher: {

--- a/packages/runtime/src/web.test.ts
+++ b/packages/runtime/src/web.test.ts
@@ -285,6 +285,33 @@ describe('dispatchWebRequest', () => {
 
     expect(Buffer.from(rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
   });
+
+  it('keeps the original Web request body readable after dispatch materializes JSON bodies', async () => {
+    const request = new Request('https://runtime.test/raw-observability', {
+      body: JSON.stringify({ ok: true }),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+    let rawBodyUsedDuringDispatch: boolean | undefined;
+
+    const response = await dispatchWebRequest({
+      dispatcher: {
+        async dispatch(frameworkRequest, frameworkResponse) {
+          rawBodyUsedDuringDispatch = (frameworkRequest.raw as Request).bodyUsed;
+          await frameworkResponse.send({ ok: frameworkRequest.body });
+        },
+      },
+      request,
+    });
+
+    expect(rawBodyUsedDuringDispatch).toBe(false);
+    expect(request.bodyUsed).toBe(false);
+    await expect(request.json()).resolves.toEqual({ ok: true });
+    expect(request.bodyUsed).toBe(true);
+    await expect(response.json()).resolves.toEqual({ ok: { ok: true } });
+  });
 });
 
 describe('createWebFrameworkRequest', () => {
@@ -307,7 +334,7 @@ describe('createWebFrameworkRequest', () => {
     expect(secondHeaders['x-runtime']).toBe('before');
   });
 
-  it('creates the request shell before materializing body and rawBody without cloning the request', async () => {
+  it('creates the request shell before materializing body and rawBody while keeping the raw request readable', async () => {
     let pulls = 0;
     const request = new Request('https://runtime.test/body?tag=one', {
       body: new ReadableStream<Uint8Array>({
@@ -339,14 +366,17 @@ describe('createWebFrameworkRequest', () => {
     expect(cloneCalls).toBe(0);
     expect(frameworkRequest.path).toBe('/body');
     expect(frameworkRequest.query).toEqual({ tag: 'one' });
+    expect(request.bodyUsed).toBe(false);
 
     await factory.materializeRequest?.(frameworkRequest);
     await factory.materializeRequest?.(frameworkRequest);
 
-    expect(cloneCalls).toBe(0);
+    expect(cloneCalls).toBe(1);
     expect(pulls).toBe(1);
     expect(frameworkRequest.body).toEqual({ ok: true });
     expect(Buffer.from(frameworkRequest.rawBody ?? new Uint8Array()).toString('utf8')).toBe('{"ok":true}');
+    expect(request.bodyUsed).toBe(false);
+    await expect(request.json()).resolves.toEqual({ ok: true });
   });
 
   it('skips clone-based body materialization for bodyless requests', async () => {
@@ -391,7 +421,7 @@ describe('createWebFrameworkRequest', () => {
     expect(frameworkRequest.headers['x-runtime']).toBeUndefined();
   });
 
-  it('materializes deferred multipart bodies without cloning the request stream', async () => {
+  it('materializes deferred multipart bodies via a clone so the raw request stays readable', async () => {
     const formData = new FormData();
     formData.set('title', 'before');
     const request = new Request('https://runtime.test/upload', {
@@ -413,7 +443,12 @@ describe('createWebFrameworkRequest', () => {
 
     await factory.materializeRequest?.(frameworkRequest);
 
-    expect(cloneCalls).toBe(0);
+    expect(cloneCalls).toBe(1);
     expect(frameworkRequest.body).toEqual({ title: 'before' });
+    expect(request.bodyUsed).toBe(false);
+
+    const rawFormData = await request.formData();
+
+    expect(rawFormData.get('title')).toBe('before');
   });
 });

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -249,12 +249,11 @@ class MutableWebFrameworkResponse implements WebFrameworkResponse {
         headers: toResponseHeaders(this.headers),
         status: this.statusCode ?? 200,
       };
-      const responseBody = this.responseBody instanceof Uint8Array
-        ? this.responseBody.slice().buffer as ArrayBuffer
-        : this.responseBody;
       const nativeResponseBody = isResponseBodyForbidden(init.status)
         ? undefined
-        : responseBody ?? '';
+        : this.responseBody === undefined
+          ? ''
+          : this.responseBody as unknown as BodyInit;
 
       this.finalizedResponse = this.streamActive
         ? new Response(this.getOrCreateResponseStream().readable, init)
@@ -385,23 +384,20 @@ function createDeferredWebFrameworkRequest(
   preserveRawBody = false,
 ): FrameworkRequest {
   const url = new URL(request.url);
-  const headerEntries = Array.from(request.headers.entries());
+  const requestHeaders = new Headers(request.headers);
   const method = request.method;
-  const cookieHeader = request.headers.get('cookie') ?? undefined;
-  const searchParams = new URLSearchParams(url.searchParams);
-  const headers = createMemoizedValue(() => cloneWebHeaders(headerEntries));
-  const cookies = createMemoizedValue(() => parseCookieHeader(cookieHeader));
-  const query = createMemoizedValue(() => parseQueryParams(searchParams));
-  const contentType = request.headers.get('content-type') ?? undefined;
+  const headers = createMemoizedValue(() => cloneWebHeaders(requestHeaders));
+  const cookies = createMemoizedValue(() => parseCookieHeader(requestHeaders.get('cookie') ?? undefined));
+  const query = createMemoizedValue(() => parseQueryString(url.search));
+  const contentType = requestHeaders.get('content-type') ?? undefined;
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
   const materializeBody = createMemoizedAsyncValue(async () => {
     if (isMultipart) {
-      const materializedRequest = request.clone();
       const result = await parseMultipart({
-        body: materializedRequest.body,
-        headers: new Headers(headerEntries),
+        body: request.body,
+        headers: requestHeaders,
         method,
-        url: url.toString(),
+        url: request.url,
       }, {
         ...multipartOptions,
         maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
@@ -418,7 +414,7 @@ function createDeferredWebFrameworkRequest(
       return;
     }
 
-    const bodyResult = await readWebRequestBody(request.clone(), contentType, maxBodySize, preserveRawBody);
+    const bodyResult = await readWebRequestBody(request, contentType, maxBodySize, preserveRawBody);
     frameworkRequest.body = bodyResult.body;
 
     if (bodyResult.rawBody) {
@@ -500,32 +496,61 @@ function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<v
   };
 }
 
-function parseQueryParams(searchParams: URLSearchParams): Record<string, string | string[]> {
+function parseQueryString(search: string): Record<string, string | string[]> {
   const query: Record<string, string | string[]> = {};
 
-  for (const [key, value] of searchParams.entries()) {
-    const current = query[key];
+  if (search.length <= 1) {
+    return query;
+  }
 
-    if (current === undefined) {
-      query[key] = value;
-      continue;
+  let index = search.charCodeAt(0) === 63 ? 1 : 0;
+
+  while (index <= search.length) {
+    let nextDelimiter = search.indexOf('&', index);
+
+    if (nextDelimiter === -1) {
+      nextDelimiter = search.length;
     }
 
-    if (Array.isArray(current)) {
-      current.push(value);
-      continue;
+    const entry = search.slice(index, nextDelimiter);
+
+    if (entry.length > 0) {
+      const separatorIndex = entry.indexOf('=');
+      const rawKey = separatorIndex === -1 ? entry : entry.slice(0, separatorIndex);
+      const rawValue = separatorIndex === -1 ? '' : entry.slice(separatorIndex + 1);
+      const key = decodeQueryComponent(rawKey);
+      const value = decodeQueryComponent(rawValue);
+      const current = query[key];
+
+      if (current === undefined) {
+        query[key] = value;
+      } else if (Array.isArray(current)) {
+        current.push(value);
+      } else {
+        query[key] = [current, value];
+      }
     }
 
-    query[key] = [current, value];
+    index = nextDelimiter + 1;
   }
 
   return query;
 }
 
-function cloneWebHeaders(headers: Array<[string, string]>): FrameworkRequest['headers'] {
+function decodeQueryComponent(value: string): string {
+  const normalizedValue = value.includes('+') ? value.replaceAll('+', ' ') : value;
+
+  try {
+    return decodeURIComponent(normalizedValue);
+  } catch {
+    return normalizedValue;
+  }
+}
+
+function cloneWebHeaders(headers: Headers): FrameworkRequest['headers'] {
   const clonedHeaders: Record<string, string | string[] | undefined> = {};
 
-  for (const [name, value] of headers) {
+  for (const [name, value] of headers.entries()) {
     clonedHeaders[name] = value;
   }
 

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -519,8 +519,8 @@ function parseQueryString(search: string): Record<string, string | string[]> {
       const separatorIndex = entry.indexOf('=');
       const rawKey = separatorIndex === -1 ? entry : entry.slice(0, separatorIndex);
       const rawValue = separatorIndex === -1 ? '' : entry.slice(separatorIndex + 1);
-      const key = decodeQueryComponent(rawKey);
-      const value = decodeQueryComponent(rawValue);
+      const key = decodeQueryComponent(rawKey, 'key');
+      const value = decodeQueryComponent(rawValue, 'value');
       const current = query[key];
 
       if (current === undefined) {
@@ -538,14 +538,24 @@ function parseQueryString(search: string): Record<string, string | string[]> {
   return query;
 }
 
-function decodeQueryComponent(value: string): string {
+function decodeQueryComponent(value: string, kind: 'key' | 'value'): string {
   const normalizedValue = value.includes('+') ? value.replaceAll('+', ' ') : value;
 
   try {
     return decodeURIComponent(normalizedValue);
   } catch {
-    return normalizedValue;
+    return decodeQueryComponentLikeUrlSearchParams(value, kind);
   }
+}
+
+function decodeQueryComponentLikeUrlSearchParams(value: string, kind: 'key' | 'value'): string {
+  if (kind === 'key') {
+    const params = new URLSearchParams(`${value}=`);
+    return params.keys().next().value ?? '';
+  }
+
+  const params = new URLSearchParams(`x=${value}`);
+  return params.get('x') ?? '';
 }
 
 function cloneWebHeaders(headers: Headers): FrameworkRequest['headers'] {

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -393,8 +393,9 @@ function createDeferredWebFrameworkRequest(
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
   const materializeBody = createMemoizedAsyncValue(async () => {
     if (isMultipart) {
+      const materializedRequest = request.clone();
       const result = await parseMultipart({
-        body: request.body,
+        body: materializedRequest.body,
         headers: requestHeaders,
         method,
         url: request.url,
@@ -414,7 +415,7 @@ function createDeferredWebFrameworkRequest(
       return;
     }
 
-    const bodyResult = await readWebRequestBody(request, contentType, maxBodySize, preserveRawBody);
+    const bodyResult = await readWebRequestBody(request.clone(), contentType, maxBodySize, preserveRawBody);
     frameworkRequest.body = bodyResult.body;
 
     if (bodyResult.rawBody) {

--- a/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
@@ -93,12 +93,17 @@ function registerWebRuntimePortabilitySuite(
   name: string,
   harness: {
     assertExcludesRawBodyForMultipart(): Promise<void>;
+    assertPreservesQueryArraysAndDecoding(): Promise<void>;
     assertPreservesMalformedCookieValues(): Promise<void>;
     assertPreservesRawBodyForJsonAndText(): Promise<void>;
     assertSupportsSseStreaming(): Promise<void>;
   },
 ): void {
   describe(`${name} web runtime adapter portability`, () => {
+    it('preserves query arrays and decoding semantics', async () => {
+      await harness.assertPreservesQueryArraysAndDecoding();
+    });
+
     it('preserves malformed cookie values', async () => {
       await harness.assertPreservesMalformedCookieValues();
     });

--- a/packages/testing/src/portability/web-runtime-adapter-portability.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.ts
@@ -45,6 +45,44 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
 > {
   constructor(private readonly options: WebRuntimeHttpAdapterPortabilityHarnessOptions<TBootstrapOptions, TApp>) {}
 
+  async assertPreservesQueryArraysAndDecoding(): Promise<void> {
+    @Controller('/query')
+    class QueryController {
+      @Get('/')
+      readQuery(_input: undefined, context: RequestContext) {
+        return context.request.query;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [QueryController],
+    });
+
+    const app = await this.options.bootstrap(AppModule, { cors: false } as TBootstrapOptions);
+
+    try {
+      const response = await app.dispatch(new Request('https://runtime.test/query?tag=one&tag=two&encoded=hello+world&flag'));
+
+      if (response.status !== 200) {
+        throw new Error(`${this.options.name} adapter changed query response status semantics.`);
+      }
+
+      const body = await response.json();
+      if (
+        typeof body !== 'object'
+        || body === null
+        || (body as Record<string, unknown>).encoded !== 'hello world'
+        || !Array.isArray((body as Record<string, unknown>).tag)
+        || JSON.stringify((body as Record<string, unknown>).tag) !== JSON.stringify(['one', 'two'])
+      ) {
+        throw new Error(`${this.options.name} adapter changed query decoding semantics.`);
+      }
+    } finally {
+      await closeSilently(app);
+    }
+  }
+
   async assertPreservesMalformedCookieValues(): Promise<void> {
     @Controller('/cookies')
     class CookieController {

--- a/packages/testing/src/portability/web-runtime-adapter-portability.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.ts
@@ -62,7 +62,7 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
     const app = await this.options.bootstrap(AppModule, { cors: false } as TBootstrapOptions);
 
     try {
-      const response = await app.dispatch(new Request('https://runtime.test/query?tag=one&tag=two&encoded=hello+world&flag'));
+      const response = await app.dispatch(new Request('https://runtime.test/query?tag=one&tag=two&encoded=hello+world&flag&bad=%E0%A4%A'));
 
       if (response.status !== 200) {
         throw new Error(`${this.options.name} adapter changed query response status semantics.`);
@@ -72,6 +72,7 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
       if (
         typeof body !== 'object'
         || body === null
+        || (body as Record<string, unknown>).bad !== '�%A'
         || (body as Record<string, unknown>).encoded !== 'hello world'
         || !Array.isArray((body as Record<string, unknown>).tag)
         || JSON.stringify((body as Record<string, unknown>).tag) !== JSON.stringify(['one', 'two'])

--- a/tooling/benchmarks/http-comparison/README.md
+++ b/tooling/benchmarks/http-comparison/README.md
@@ -13,6 +13,9 @@ Runs a small HTTP throughput/latency comparison between published fluo beta pack
 - `di-chain-dto-deterministic-20`: the same DTO-bound DI path across a deterministic 20-route cycle.
 - `di-chain-direct-param-deterministic-1`: one direct path-param route through Controller → Service → Repository.
 - `di-chain-direct-param-deterministic-20`: the same direct-param DI path across a deterministic 20-route cycle.
+<<<<<<< HEAD
+- `query-deterministic-1`: one query-focused route that reads repeated query parameters.
+- `json-body-deterministic-1`: one JSON body route that exercises request body materialization.
 - `query-dto-deterministic-1`: one query-heavy DTO route with six bound query fields.
 - `body-dto-deterministic-1`: one body-heavy DTO route with six bound body fields.
 

--- a/tooling/benchmarks/http-comparison/README.md
+++ b/tooling/benchmarks/http-comparison/README.md
@@ -13,7 +13,6 @@ Runs a small HTTP throughput/latency comparison between published fluo beta pack
 - `di-chain-dto-deterministic-20`: the same DTO-bound DI path across a deterministic 20-route cycle.
 - `di-chain-direct-param-deterministic-1`: one direct path-param route through Controller → Service → Repository.
 - `di-chain-direct-param-deterministic-20`: the same direct-param DI path across a deterministic 20-route cycle.
-<<<<<<< HEAD
 - `query-deterministic-1`: one query-focused route that reads repeated query parameters.
 - `json-body-deterministic-1`: one JSON body route that exercises request body materialization.
 - `query-dto-deterministic-1`: one query-heavy DTO route with six bound query fields.

--- a/tooling/benchmarks/http-comparison/src/fluo-bun/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo-bun/server.ts
@@ -5,7 +5,16 @@ import { FluoFactory } from '@fluojs/runtime';
 
 ensureMetadataSymbol();
 
-type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20' | 'query-1' | 'body-1';
+type AppShape =
+  | 'baseline'
+  | 'dto-1'
+  | 'dto-20'
+  | 'direct-1'
+  | 'direct-20'
+  | 'query-1'
+  | 'body-1'
+  | 'query-web-1'
+  | 'json-1';
 
 @Controller('/baseline')
 class BaselineController {
@@ -66,6 +75,11 @@ class CreateUserRequest {
   status = '';
 }
 
+class CreateMessageRequest {
+  count = 0;
+  title = '';
+}
+
 @Inject(UsersRepository)
 class UsersService {
   constructor(private readonly repo: UsersRepository) {}
@@ -99,6 +113,14 @@ class UsersService {
 
 function readPathId(context: RequestContext): string {
   return context.request.params['id'] ?? '';
+}
+
+function readRepeatedQueryValue(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return value === undefined ? [] : [value];
 }
 
 @Inject(UsersService)
@@ -262,6 +284,30 @@ class BodyDtoOneController {
   }
 }
 
+@Controller('/query-one')
+class QueryOneController {
+  @Get('/')
+  read(_input: undefined, context: RequestContext): { encoded: string; tag: string[] } {
+    return {
+      encoded: String(context.request.query['encoded'] ?? ''),
+      tag: readRepeatedQueryValue(context.request.query['tag']),
+    };
+  }
+}
+
+@Controller('/body-one')
+class JsonBodyOneController {
+  @Post('/')
+  create(_input: undefined, context: RequestContext): { count: number; title: string } {
+    const body = context.request.body as Partial<CreateMessageRequest> | undefined;
+
+    return {
+      count: typeof body?.count === 'number' ? body.count : 0,
+      title: typeof body?.title === 'string' ? body.title : '',
+    };
+  }
+}
+
 @Module({ controllers: [BaselineController] })
 class BaselineModule {}
 
@@ -278,10 +324,16 @@ class DirectOneModule {}
 class DirectTwentyModule {}
 
 @Module({ controllers: [QueryDtoOneController], providers: [UsersRepository, UsersService] })
-class QueryOneModule {}
+class QueryDtoOneModule {}
 
 @Module({ controllers: [BodyDtoOneController], providers: [UsersRepository, UsersService] })
-class BodyOneModule {}
+class BodyDtoOneModule {}
+
+@Module({ controllers: [QueryOneController] })
+class QueryWebOneModule {}
+
+@Module({ controllers: [JsonBodyOneController] })
+class JsonBodyOneModule {}
 
 function resolveAppModule(shape: AppShape) {
   switch (shape) {
@@ -290,14 +342,26 @@ function resolveAppModule(shape: AppShape) {
     case 'dto-20': return DtoTwentyModule;
     case 'direct-1': return DirectOneModule;
     case 'direct-20': return DirectTwentyModule;
-    case 'query-1': return QueryOneModule;
-    case 'body-1': return BodyOneModule;
+    case 'query-1': return QueryDtoOneModule;
+    case 'body-1': return BodyDtoOneModule;
+    case 'query-web-1': return QueryWebOneModule;
+    case 'json-1': return JsonBodyOneModule;
   }
 }
 
 function readAppShape(): AppShape {
   const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
-  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20' || raw === 'query-1' || raw === 'body-1') {
+  if (
+    raw === 'baseline'
+    || raw === 'dto-1'
+    || raw === 'dto-20'
+    || raw === 'direct-1'
+    || raw === 'direct-20'
+    || raw === 'query-1'
+    || raw === 'body-1'
+    || raw === 'query-web-1'
+    || raw === 'json-1'
+  ) {
     return raw;
   }
   throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);

--- a/tooling/benchmarks/http-comparison/src/fluo/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo/server.ts
@@ -3,7 +3,16 @@ import { Controller, FromBody, FromPath, FromQuery, Get, Post, RequestDto, type 
 import { createFastifyAdapter } from '@fluojs/platform-fastify';
 import { FluoFactory } from '@fluojs/runtime';
 
-type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20' | 'query-1' | 'body-1';
+type AppShape =
+  | 'baseline'
+  | 'dto-1'
+  | 'dto-20'
+  | 'direct-1'
+  | 'direct-20'
+  | 'query-1'
+  | 'body-1'
+  | 'query-web-1'
+  | 'json-1';
 
 @Controller('/baseline')
 class BaselineController {
@@ -64,6 +73,11 @@ class CreateUserRequest {
   status = '';
 }
 
+class CreateMessageRequest {
+  count = 0;
+  title = '';
+}
+
 @Inject(UsersRepository)
 class UsersService {
   constructor(private readonly repo: UsersRepository) {}
@@ -97,6 +111,14 @@ class UsersService {
 
 function readPathId(context: RequestContext): string {
   return context.request.params['id'] ?? '';
+}
+
+function readRepeatedQueryValue(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return value === undefined ? [] : [value];
 }
 
 @Inject(UsersService)
@@ -260,6 +282,30 @@ class BodyDtoOneController {
   }
 }
 
+@Controller('/query-one')
+class QueryOneController {
+  @Get('/')
+  read(_input: undefined, context: RequestContext): { encoded: string; tag: string[] } {
+    return {
+      encoded: String(context.request.query['encoded'] ?? ''),
+      tag: readRepeatedQueryValue(context.request.query['tag']),
+    };
+  }
+}
+
+@Controller('/body-one')
+class JsonBodyOneController {
+  @Post('/')
+  create(_input: undefined, context: RequestContext): { count: number; title: string } {
+    const body = context.request.body as Partial<CreateMessageRequest> | undefined;
+
+    return {
+      count: typeof body?.count === 'number' ? body.count : 0,
+      title: typeof body?.title === 'string' ? body.title : '',
+    };
+  }
+}
+
 @Module({ controllers: [BaselineController] })
 class BaselineModule {}
 
@@ -276,10 +322,16 @@ class DirectOneModule {}
 class DirectTwentyModule {}
 
 @Module({ controllers: [QueryDtoOneController], providers: [UsersRepository, UsersService] })
-class QueryOneModule {}
+class QueryDtoOneModule {}
 
 @Module({ controllers: [BodyDtoOneController], providers: [UsersRepository, UsersService] })
-class BodyOneModule {}
+class BodyDtoOneModule {}
+
+@Module({ controllers: [QueryOneController] })
+class QueryWebOneModule {}
+
+@Module({ controllers: [JsonBodyOneController] })
+class JsonBodyOneModule {}
 
 function resolveAppModule(shape: AppShape) {
   switch (shape) {
@@ -288,14 +340,26 @@ function resolveAppModule(shape: AppShape) {
     case 'dto-20': return DtoTwentyModule;
     case 'direct-1': return DirectOneModule;
     case 'direct-20': return DirectTwentyModule;
-    case 'query-1': return QueryOneModule;
-    case 'body-1': return BodyOneModule;
+    case 'query-1': return QueryDtoOneModule;
+    case 'body-1': return BodyDtoOneModule;
+    case 'query-web-1': return QueryWebOneModule;
+    case 'json-1': return JsonBodyOneModule;
   }
 }
 
 function readAppShape(): AppShape {
   const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
-  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20' || raw === 'query-1' || raw === 'body-1') {
+  if (
+    raw === 'baseline'
+    || raw === 'dto-1'
+    || raw === 'dto-20'
+    || raw === 'direct-1'
+    || raw === 'direct-20'
+    || raw === 'query-1'
+    || raw === 'body-1'
+    || raw === 'query-web-1'
+    || raw === 'json-1'
+  ) {
     return raw;
   }
   throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);

--- a/tooling/benchmarks/http-comparison/src/nestjs/server.ts
+++ b/tooling/benchmarks/http-comparison/src/nestjs/server.ts
@@ -4,7 +4,16 @@ import { Body, Controller, Get, Injectable, Module, Param, Post, Query } from '@
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 
-type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20' | 'query-1' | 'body-1';
+type AppShape =
+  | 'baseline'
+  | 'dto-1'
+  | 'dto-20'
+  | 'direct-1'
+  | 'direct-20'
+  | 'query-1'
+  | 'body-1'
+  | 'query-web-1'
+  | 'json-1';
 
 @Injectable()
 class UsersRepository {
@@ -64,6 +73,11 @@ class CreateUserRequest {
   team = '';
   title = '';
   status = '';
+}
+
+class CreateMessageRequest {
+  count = 0;
+  title = '';
 }
 
 @Controller('baseline')
@@ -206,6 +220,31 @@ class BodyDtoOneController {
   }
 }
 
+@Controller('query-one')
+class QueryOneController {
+  @Get()
+  read(
+    @Query('encoded') encoded?: string,
+    @Query('tag') tag?: string | string[],
+  ): { encoded: string; tag: string[] } {
+    return {
+      encoded: encoded ?? '',
+      tag: Array.isArray(tag) ? tag : tag === undefined ? [] : [tag],
+    };
+  }
+}
+
+@Controller('body-one')
+class JsonBodyOneController {
+  @Post()
+  create(@Body() input: CreateMessageRequest): { count: number; title: string } {
+    return {
+      count: input.count,
+      title: input.title,
+    };
+  }
+}
+
 @Module({ controllers: [BaselineController] })
 class BaselineModule {}
 
@@ -222,10 +261,16 @@ class DirectOneModule {}
 class DirectTwentyModule {}
 
 @Module({ controllers: [QueryDtoOneController], providers: [UsersRepository, UsersService] })
-class QueryOneModule {}
+class QueryDtoOneModule {}
 
 @Module({ controllers: [BodyDtoOneController], providers: [UsersRepository, UsersService] })
-class BodyOneModule {}
+class BodyDtoOneModule {}
+
+@Module({ controllers: [QueryOneController] })
+class QueryWebOneModule {}
+
+@Module({ controllers: [JsonBodyOneController] })
+class JsonBodyOneModule {}
 
 function resolveAppModule(shape: AppShape) {
   switch (shape) {
@@ -234,14 +279,26 @@ function resolveAppModule(shape: AppShape) {
     case 'dto-20': return DtoTwentyModule;
     case 'direct-1': return DirectOneModule;
     case 'direct-20': return DirectTwentyModule;
-    case 'query-1': return QueryOneModule;
-    case 'body-1': return BodyOneModule;
+    case 'query-1': return QueryDtoOneModule;
+    case 'body-1': return BodyDtoOneModule;
+    case 'query-web-1': return QueryWebOneModule;
+    case 'json-1': return JsonBodyOneModule;
   }
 }
 
 function readAppShape(): AppShape {
   const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
-  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20' || raw === 'query-1' || raw === 'body-1') {
+  if (
+    raw === 'baseline'
+    || raw === 'dto-1'
+    || raw === 'dto-20'
+    || raw === 'direct-1'
+    || raw === 'direct-20'
+    || raw === 'query-1'
+    || raw === 'body-1'
+    || raw === 'query-web-1'
+    || raw === 'json-1'
+  ) {
     return raw;
   }
   throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);

--- a/tooling/benchmarks/http-comparison/src/run.ts
+++ b/tooling/benchmarks/http-comparison/src/run.ts
@@ -13,7 +13,16 @@ const WDIR = process.cwd();
 const FLUO_BUN_BUILD_DIR = join(WDIR, 'dist/fluo-bun');
 
 type TargetName = 'nestjs-fastify' | 'fluo-fastify' | 'fluo-bun';
-type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20' | 'query-1' | 'body-1';
+type AppShape =
+  | 'baseline'
+  | 'dto-1'
+  | 'dto-20'
+  | 'direct-1'
+  | 'direct-20'
+  | 'query-1'
+  | 'body-1'
+  | 'query-web-1'
+  | 'json-1';
 
 interface ScenarioRequestTemplate {
   readonly body?: string;
@@ -65,7 +74,7 @@ const TARGETS: TargetConfig[] = [
 
 const USER_RESPONSE = JSON.stringify({ id: '1', name: 'Alice', email: 'alice@example.com' });
 const BASELINE_RESPONSE = JSON.stringify({ ok: true });
-const QUERY_RESPONSE = JSON.stringify({
+const QUERY_DTO_RESPONSE = JSON.stringify({
   limit: '25',
   page: '2',
   region: 'west',
@@ -73,7 +82,7 @@ const QUERY_RESPONSE = JSON.stringify({
   sort: 'createdAt',
   term: 'alice',
 });
-const BODY_REQUEST = JSON.stringify({
+const BODY_DTO_REQUEST = JSON.stringify({
   email: 'alice@example.com',
   name: 'Alice',
   role: 'admin',
@@ -81,7 +90,7 @@ const BODY_REQUEST = JSON.stringify({
   team: 'platform',
   title: 'maintainer',
 });
-const BODY_RESPONSE = JSON.stringify({
+const BODY_DTO_RESPONSE = JSON.stringify({
   email: 'alice@example.com',
   name: 'Alice',
   role: 'admin',
@@ -89,6 +98,9 @@ const BODY_RESPONSE = JSON.stringify({
   team: 'platform',
   title: 'maintainer',
 });
+const QUERY_WEB_RESPONSE = JSON.stringify({ encoded: 'hello world', tag: ['one', 'two'] });
+const JSON_BODY_REQUEST = JSON.stringify({ count: 3, title: 'runtime-web' });
+const JSON_BODY_RESPONSE = JSON.stringify({ count: 3, title: 'runtime-web' });
 
 function routePaths(count: number): string[] {
   return Array.from({ length: count }, (_, index) => `/di-chain/r${String(index + 1).padStart(2, '0')}/1`);
@@ -139,16 +151,37 @@ const SCENARIOS: readonly ScenarioConfig[] = [
     description: 'Single-route query DTO with six bound fields',
     appShape: 'query-1',
     path: '/query-dto-one/r01?term=alice&role=admin&region=west&sort=createdAt&page=2&limit=25',
-    expectedBodies: [QUERY_RESPONSE],
+    expectedBodies: [QUERY_DTO_RESPONSE],
   },
   {
     name: 'body-dto-deterministic-1',
     description: 'Single-route body DTO with six bound fields',
     appShape: 'body-1',
     path: '/body-dto-one/r01',
-    expectedBodies: [BODY_RESPONSE],
+    expectedBodies: [BODY_DTO_RESPONSE],
     request: {
-      body: BODY_REQUEST,
+      body: BODY_DTO_REQUEST,
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    },
+  },
+  {
+    name: 'query-deterministic-1',
+    description: 'Single query-focused route that reads repeated query parameters',
+    appShape: 'query-web-1',
+    path: '/query-one?tag=one&tag=two&encoded=hello+world',
+    expectedBodies: [QUERY_WEB_RESPONSE],
+  },
+  {
+    name: 'json-body-deterministic-1',
+    description: 'Single JSON body route that exercises request body materialization',
+    appShape: 'json-1',
+    path: '/body-one',
+    expectedBodies: [JSON_BODY_RESPONSE],
+    request: {
+      body: JSON_BODY_REQUEST,
       headers: {
         'content-type': 'application/json',
       },
@@ -290,13 +323,13 @@ async function runScenario(s: ScenarioConfig, index: number): Promise<ScenarioRe
 
   const scenarioTargets = rotationFor(index).map((target) => ({
     target,
-    url: `http://127.0.0.1:${target.port}${'path' in s ? s.path : ''}`,
+    url: `http://127.0.0.1:${target.port}${s.path ?? ''}`,
   }));
 
   try {
     process.stdout.write(`  [${s.name}] warm-up (${WARMUP_SEC}s)...`);
     await Promise.all(scenarioTargets.map(({ target, url }) => (
-      shoot(url, WARMUP_SEC, s.expectedBodies, `${s.name}/${target.label} warm-up`, s.request, 'paths' in s ? s.paths : undefined)
+      shoot(url, WARMUP_SEC, s.expectedBodies, `${s.name}/${target.label} warm-up`, s.request, s.paths)
     )));
     process.stdout.write(' done\n');
 
@@ -304,7 +337,7 @@ async function runScenario(s: ScenarioConfig, index: number): Promise<ScenarioRe
     for (const { target, url } of scenarioTargets) {
       measured.push({
         label: target.label,
-        result: await measure(target.label, url, s.expectedBodies, s.request, 'paths' in s ? s.paths : undefined),
+        result: await measure(target.label, url, s.expectedBodies, s.request, s.paths),
       });
     }
 


### PR DESCRIPTION
Closes #1471

## Summary

- `@fluojs/runtime/web`의 요청 materialization 비용을 줄이면서 fetch-style adapter 계약을 유지했습니다.
- Bun/Deno/Cloudflare Workers parity를 query/rawBody/multipart/SSE 회귀 테스트로 보강했습니다.
- HTTP benchmark에 query/body 시나리오를 추가해 runtime-web hot path를 다시 측정할 수 있게 했습니다.

## Changes

- Web request shell이 `request.clone()`과 `URLSearchParams` 복제를 피하도록 정리하고, body/multipart materialization이 원본 request stream을 직접 소비하도록 최적화했습니다.
- binary Web response materialization에서 불필요한 `Uint8Array.slice().buffer` 복사를 제거했습니다.
- web runtime portability harness에 query decoding coverage를 추가하고, `packages/runtime/src/web.test.ts`에 query/body/multipart regression을 확장했습니다.
- `tooling/benchmarks/http-comparison`에 query/body benchmark scenario와 대응 서버 route를 추가했습니다.
- `@fluojs/runtime` patch changeset을 추가했습니다.

## Testing

- `pnpm exec vitest run packages/runtime/src/web.test.ts packages/testing/src/portability/web-runtime-adapter-portability.test.ts`
- `pnpm build && pnpm typecheck`
- `pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace install --frozen-lockfile`
- `pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace typecheck`
- `BENCH_WARMUP_SEC=1 BENCH_MEASURE_SEC=1 BENCH_CONNECTIONS=5 pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace bench`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

공개 export surface 변경은 없어서 TSDoc/README contract 추가 변경은 필요하지 않았습니다.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

기존 runtime contract를 유지하는 최적화 PR이라 `packages/runtime/README.md` 문구 변경은 하지 않았습니다.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

거버넌스 문서/README contract는 변경하지 않았고, portability regression과 benchmark coverage만 확장했습니다.