### PR TITLE
Resolve #1473: optimize RequestDto binding and validation hot path

### DIFF
--- a/.changeset/issue-1473-request-dto-hot-path.md
+++ b/.changeset/issue-1473-request-dto-hot-path.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/http': patch
+---
+
+Improve `@RequestDto` request-pipeline throughput by skipping unnecessary validation work for DTOs without validation rules and by reducing per-request binding overhead on the common no-converter path.

--- a/packages/http/src/adapters/binding.test.ts
+++ b/packages/http/src/adapters/binding.test.ts
@@ -509,7 +509,7 @@ describe('HttpDtoValidationAdapter', () => {
     expect(validateSpy).not.toHaveBeenCalled();
   });
 
-  it('reuses the bound DTO instance when every validated property is request-bound', async () => {
+  it('reuses the bound DTO instance for simple bound-field validation rules', async () => {
     class SearchRequest {
       @FromQuery('q')
       @IsString()
@@ -528,6 +528,29 @@ describe('HttpDtoValidationAdapter', () => {
     expect(validateSpy).toHaveBeenCalledOnce();
     expect(validateSpy.mock.calls[0]?.[0]).toBe(input);
     expect(validateSpy.mock.calls[0]?.[1]).toBe(SearchRequest);
+  });
+
+  it('filters unbound DTO state before running ValidateIf rules', async () => {
+    class SearchRequest {
+      @FromQuery('q')
+      @ValidateIf((dto: unknown) => Boolean((dto as SearchRequest).enabled))
+      @MinLength(2, { code: 'QUERY_TOO_SHORT', message: 'q must have length at least 2' })
+      query = '';
+
+      enabled = false;
+    }
+
+    const validateSpy = vi.spyOn(BaseDefaultValidator.prototype, 'validate');
+    const validator = new HttpDtoValidationAdapter();
+    const input = Object.assign(new SearchRequest(), {
+      enabled: true,
+      query: '',
+    });
+
+    await expect(validator.validate(input, SearchRequest)).resolves.toBeUndefined();
+
+    expect(validateSpy).toHaveBeenCalledOnce();
+    expect(validateSpy.mock.calls[0]?.[0]).not.toBe(input);
   });
 
   it('preserves symbol-backed bound fields while filtering unbound validation properties', async () => {

--- a/packages/http/src/adapters/binding.test.ts
+++ b/packages/http/src/adapters/binding.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Token } from '@fluojs/core';
 
 import {
@@ -12,6 +12,7 @@ import {
 } from '../decorators.js';
 import {
   ArrayMinSize,
+  DefaultValidator as BaseDefaultValidator,
   IsEmail,
   IsOptional,
   IsString,
@@ -38,6 +39,10 @@ function createRequest(overrides: Partial<FrameworkRequest> = {}): FrameworkRequ
     ...overrides,
   };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function createResponse(): FrameworkResponse {
   return {
@@ -481,6 +486,48 @@ describe('HttpDtoValidationAdapter', () => {
       ],
       status: 400,
     });
+  });
+
+  it('skips validation engine work when a RequestDto has no validation rules', async () => {
+    class SearchRequest {
+      @FromQuery('q')
+      query = '';
+    }
+
+    const validateSpy = vi.spyOn(BaseDefaultValidator.prototype, 'validate');
+    const validator = new HttpDtoValidationAdapter();
+
+    await expect(
+      validator.validate(
+        Object.assign(new SearchRequest(), {
+          query: 'fluo',
+        }),
+        SearchRequest,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('reuses the bound DTO instance when every validated property is request-bound', async () => {
+    class SearchRequest {
+      @FromQuery('q')
+      @IsString()
+      @MinLength(1, { code: 'QUERY_REQUIRED', message: 'q is required' })
+      query = '';
+    }
+
+    const validateSpy = vi.spyOn(BaseDefaultValidator.prototype, 'validate');
+    const validator = new HttpDtoValidationAdapter();
+    const input = Object.assign(new SearchRequest(), {
+      query: 'fluo',
+    });
+
+    await expect(validator.validate(input, SearchRequest)).resolves.toBeUndefined();
+
+    expect(validateSpy).toHaveBeenCalledOnce();
+    expect(validateSpy.mock.calls[0]?.[0]).toBe(input);
+    expect(validateSpy.mock.calls[0]?.[1]).toBe(SearchRequest);
   });
 
   it('preserves symbol-backed bound fields while filtering unbound validation properties', async () => {

--- a/packages/http/src/adapters/binding.ts
+++ b/packages/http/src/adapters/binding.ts
@@ -6,6 +6,7 @@ import type { ArgumentResolverContext, Binder, Converter, ConverterLike, Convert
 import { getCompiledDtoBindingPlan } from './dto-binding-plan.js';
 
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const NO_CONVERTERS: readonly Converter[] = [];
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== 'object' || value === null) {
@@ -123,18 +124,56 @@ export class DefaultBinder implements Binder {
 
   async bind(dto: Constructor, context: ArgumentResolverContext): Promise<unknown> {
     const plan = getCompiledDtoBindingPlan(dto);
+    const request = context.requestContext.request;
     const value = new dto() as Record<string | symbol, unknown>;
-    const converterCache = new Map<unknown, Converter>();
-    const globalConverters = (
-      await Promise.all(this.converters.map((converter) => resolveConverter(converter, context, converterCache)))
-    ).filter((converter): converter is Converter => Boolean(converter));
 
-    validateBodyKeys(context.requestContext.request, plan.bodyKeys);
+    if (request.body !== undefined && request.body !== null) {
+      validateBodyKeys(request, plan.bodyKeys);
+    }
 
     const details: HttpExceptionDetail[] = [];
 
+    if (this.converters.length === 0 && !plan.hasFieldConverters) {
+      for (const entry of plan.entries) {
+        const rawValue = entry.read(request);
+
+        if (rawValue === undefined) {
+          if (entry.optional) {
+            continue;
+          }
+
+          details.push(
+            toInputErrorDetail({
+              code: 'MISSING_FIELD',
+              field: entry.fieldName,
+              message: `Missing required ${entry.source} field ${entry.sourceKey}.`,
+              source: entry.source,
+            }),
+          );
+          continue;
+        }
+
+        value[entry.propertyKey] = rawValue;
+      }
+
+      if (details.length > 0) {
+        throw new BadRequestException('Request binding failed.', {
+          details,
+        });
+      }
+
+      return value;
+    }
+
+    const converterCache = new Map<unknown, Converter>();
+    const globalConverters = this.converters.length === 0
+      ? NO_CONVERTERS
+      : (
+          await Promise.all(this.converters.map((converter) => resolveConverter(converter, context, converterCache)))
+        ).filter((converter): converter is Converter => Boolean(converter));
+
     for (const entry of plan.entries) {
-      const rawValue = entry.read(context.requestContext.request);
+      const rawValue = entry.read(request);
 
       if (rawValue === undefined) {
         if (entry.optional) {
@@ -167,10 +206,12 @@ export class DefaultBinder implements Binder {
         convertedValue = await converter.convert(convertedValue, target);
       }
 
-      const fieldConverter = await resolveConverter(entry.converter, context, converterCache);
+      if (entry.converter !== undefined) {
+        const fieldConverter = await resolveConverter(entry.converter, context, converterCache);
 
-      if (fieldConverter) {
-        convertedValue = await fieldConverter.convert(convertedValue, target);
+        if (fieldConverter) {
+          convertedValue = await fieldConverter.convert(convertedValue, target);
+        }
       }
 
       value[entry.propertyKey] = convertedValue;

--- a/packages/http/src/adapters/dto-binding-plan.ts
+++ b/packages/http/src/adapters/dto-binding-plan.ts
@@ -5,6 +5,7 @@ import {
   getDtoValidationSchema,
   type DtoBindingSchemaEntry,
   type DtoFieldBindingMetadata,
+  type DtoFieldValidationRule,
 } from '@fluojs/core/internal';
 
 import type { FrameworkRequest } from '../types.js';
@@ -84,6 +85,10 @@ function createValidationValueFilter(
   };
 }
 
+function isDtoAwareValidationRule(rule: DtoFieldValidationRule): boolean {
+  return rule.kind === 'custom' || rule.kind === 'validateIf';
+}
+
 export function getCompiledDtoBindingPlan(dto: Constructor): CompiledDtoBindingPlan {
   const cached = dtoBindingPlanCache.get(dto);
 
@@ -106,10 +111,15 @@ export function getCompiledDtoBindingPlan(dto: Constructor): CompiledDtoBindingP
   });
   const propertyKeys = entries.map((entry: CompiledDtoBindingPlanEntry) => entry.propertyKey);
   const boundPropertyKeys = new Set(propertyKeys);
-  const validationPropertyKeys = getDtoValidationSchema(dto).map((entry: { propertyKey: MetadataPropertyKey }) => entry.propertyKey);
+  const validationSchema = getDtoValidationSchema(dto);
+  const validationPropertyKeys = validationSchema.map((entry: { propertyKey: MetadataPropertyKey }) => entry.propertyKey);
   const hasClassValidationRules = getClassValidationRules(dto).length > 0;
+  const hasDtoAwareValidationRules = validationSchema.some((entry: { rules: readonly DtoFieldValidationRule[] }) =>
+    entry.rules.some((rule: DtoFieldValidationRule) => isDtoAwareValidationRule(rule))
+  );
   const needsValidation = hasClassValidationRules || validationPropertyKeys.length > 0;
   const requiresValidationFilter = hasClassValidationRules
+    || hasDtoAwareValidationRules
     || validationPropertyKeys.some((propertyKey: MetadataPropertyKey) => !boundPropertyKeys.has(propertyKey));
 
   const next: CompiledDtoBindingPlan = {

--- a/packages/http/src/adapters/dto-binding-plan.ts
+++ b/packages/http/src/adapters/dto-binding-plan.ts
@@ -1,5 +1,11 @@
 import { type Constructor, type MetadataPropertyKey, type MetadataSource } from '@fluojs/core';
-import { getDtoBindingSchema, type DtoBindingSchemaEntry, type DtoFieldBindingMetadata } from '@fluojs/core/internal';
+import {
+  getClassValidationRules,
+  getDtoBindingSchema,
+  getDtoValidationSchema,
+  type DtoBindingSchemaEntry,
+  type DtoFieldBindingMetadata,
+} from '@fluojs/core/internal';
 
 import type { FrameworkRequest } from '../types.js';
 
@@ -28,7 +34,10 @@ export interface CompiledDtoBindingPlanEntry {
 export interface CompiledDtoBindingPlan {
   readonly bodyKeys: ReadonlySet<string>;
   readonly entries: readonly CompiledDtoBindingPlanEntry[];
+  readonly hasFieldConverters: boolean;
+  readonly needsValidation: boolean;
   readonly propertyKeys: readonly MetadataPropertyKey[];
+  readonly toValidationValue: (value: unknown) => unknown;
 }
 
 const dtoBindingPlanCache = new WeakMap<Constructor, CompiledDtoBindingPlan>();
@@ -48,6 +57,31 @@ function createSourceReader(source: MetadataSource, sourceKey: string): (request
     default:
       return () => undefined;
   }
+}
+
+function identityValidationValue(value: unknown): unknown {
+  return value;
+}
+
+function createValidationValueFilter(
+  propertyKeys: readonly MetadataPropertyKey[],
+): (value: unknown) => unknown {
+  return (value: unknown): unknown => {
+    if (typeof value !== 'object' || value === null) {
+      return value;
+    }
+
+    const source = value as Record<PropertyKey, unknown>;
+    const filtered: Record<PropertyKey, unknown> = Object.create(Object.getPrototypeOf(value));
+
+    for (const propertyKey of propertyKeys) {
+      if (Object.hasOwn(source, propertyKey)) {
+        filtered[propertyKey] = source[propertyKey];
+      }
+    }
+
+    return filtered;
+  };
 }
 
 export function getCompiledDtoBindingPlan(dto: Constructor): CompiledDtoBindingPlan {
@@ -70,10 +104,21 @@ export function getCompiledDtoBindingPlan(dto: Constructor): CompiledDtoBindingP
       sourceKey,
     } satisfies CompiledDtoBindingPlanEntry;
   });
+  const propertyKeys = entries.map((entry: CompiledDtoBindingPlanEntry) => entry.propertyKey);
+  const boundPropertyKeys = new Set(propertyKeys);
+  const validationPropertyKeys = getDtoValidationSchema(dto).map((entry: { propertyKey: MetadataPropertyKey }) => entry.propertyKey);
+  const hasClassValidationRules = getClassValidationRules(dto).length > 0;
+  const needsValidation = hasClassValidationRules || validationPropertyKeys.length > 0;
+  const requiresValidationFilter = hasClassValidationRules
+    || validationPropertyKeys.some((propertyKey: MetadataPropertyKey) => !boundPropertyKeys.has(propertyKey));
+
   const next: CompiledDtoBindingPlan = {
     bodyKeys: new Set(entries.filter((entry: CompiledDtoBindingPlanEntry) => entry.source === 'body').map((entry: CompiledDtoBindingPlanEntry) => entry.sourceKey)),
     entries,
-    propertyKeys: entries.map((entry: CompiledDtoBindingPlanEntry) => entry.propertyKey),
+    hasFieldConverters: entries.some((entry: CompiledDtoBindingPlanEntry) => entry.converter !== undefined),
+    needsValidation,
+    propertyKeys,
+    toValidationValue: requiresValidationFilter ? createValidationValueFilter(propertyKeys) : identityValidationValue,
   };
 
   dtoBindingPlanCache.set(dto, next);

--- a/packages/http/src/adapters/dto-validation-adapter.ts
+++ b/packages/http/src/adapters/dto-validation-adapter.ts
@@ -18,27 +18,19 @@ export class HttpDtoValidationAdapter implements Validator {
     });
   }
 
-  private filterUnboundRequestDtoFields(value: unknown, target: Constructor): unknown {
-    if (typeof value !== 'object' || value === null) {
-      return value;
-    }
-
-    const source = value as Record<PropertyKey, unknown>;
-    const filtered: Record<PropertyKey, unknown> = Object.create(Object.getPrototypeOf(value));
-
-    for (const propertyKey of getCompiledDtoBindingPlan(target).propertyKeys) {
-      if (Object.hasOwn(source, propertyKey)) {
-        filtered[propertyKey] = source[propertyKey];
-      }
-    }
-
-    return filtered;
+  private getValidationValue(value: unknown, target: Constructor): unknown {
+    return getCompiledDtoBindingPlan(target).toValidationValue(value);
   }
 
   async validate(value: unknown, target: Constructor): Promise<void> {
     try {
-      const filteredValue = this.filterUnboundRequestDtoFields(value, target);
-      await this.validator.validate(filteredValue, target);
+      const plan = getCompiledDtoBindingPlan(target);
+
+      if (!plan.needsValidation) {
+        return;
+      }
+
+      await this.validator.validate(this.getValidationValue(value, target), target);
     } catch (error: unknown) {
       if (error instanceof DtoValidationError) {
         this.throwBadRequestForValidationError(error);

--- a/packages/http/src/dispatch/dispatch-handler-policy.test.ts
+++ b/packages/http/src/dispatch/dispatch-handler-policy.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { MinLength } from '@fluojs/validation';
+
+import { FromQuery, RequestDto } from '../decorators.js';
+import { HttpDtoValidationAdapter } from '../adapters/dto-validation-adapter.js';
+import { invokeControllerHandler } from './dispatch-handler-policy.js';
+import type { FrameworkRequest, FrameworkResponse, HandlerDescriptor } from '../types.js';
+
+function createRequest(overrides: Partial<FrameworkRequest> = {}): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path: '/search',
+    query: {},
+    raw: {},
+    url: '/search',
+    ...overrides,
+  };
+}
+
+function createResponse(): FrameworkResponse {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status, location) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send() {
+      this.committed = true;
+    },
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    setStatus(code) {
+      this.statusCode = code;
+      this.statusSet = true;
+    },
+    statusCode: undefined,
+    statusSet: false,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('invokeControllerHandler', () => {
+  it('skips dto validation when the RequestDto has no validation rules', async () => {
+    class SearchRequest {
+      @FromQuery('q')
+      query = '';
+    }
+
+    class SearchController {
+      @RequestDto(SearchRequest)
+      search(input: SearchRequest) {
+        return input.query;
+      }
+    }
+
+    const controller = new SearchController();
+    const validateSpy = vi.spyOn(HttpDtoValidationAdapter.prototype, 'validate');
+    const result = await invokeControllerHandler(
+      {
+        controllerToken: SearchController,
+        metadata: {
+          controllerPath: '/search',
+          effectivePath: '/search',
+          moduleMiddleware: [],
+          pathParams: [],
+        },
+        methodName: 'search',
+        route: {
+          method: 'GET',
+          path: '/search',
+          request: SearchRequest,
+        },
+      } satisfies HandlerDescriptor,
+      {
+        container: {
+          async dispose() {
+            return undefined;
+          },
+          async resolve<T>() {
+            return controller as T;
+          },
+        },
+        metadata: {},
+        request: createRequest({ query: { q: 'fluo' } }),
+        response: createResponse(),
+      },
+    );
+
+    expect(result).toBe('fluo');
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps validation enabled when the RequestDto declares validation rules', async () => {
+    class SearchRequest {
+      @FromQuery('q')
+      @MinLength(1, { code: 'QUERY_REQUIRED', message: 'q is required' })
+      query = '';
+    }
+
+    class SearchController {
+      @RequestDto(SearchRequest)
+      search(input: SearchRequest) {
+        return input.query;
+      }
+    }
+
+    const controller = new SearchController();
+    const validateSpy = vi.spyOn(HttpDtoValidationAdapter.prototype, 'validate');
+
+    await invokeControllerHandler(
+      {
+        controllerToken: SearchController,
+        metadata: {
+          controllerPath: '/search',
+          effectivePath: '/search',
+          moduleMiddleware: [],
+          pathParams: [],
+        },
+        methodName: 'search',
+        route: {
+          method: 'GET',
+          path: '/search',
+          request: SearchRequest,
+        },
+      } satisfies HandlerDescriptor,
+      {
+        container: {
+          async dispose() {
+            return undefined;
+          },
+          async resolve<T>() {
+            return controller as T;
+          },
+        },
+        metadata: {},
+        request: createRequest({ query: { q: 'fluo' } }),
+        response: createResponse(),
+      },
+    );
+
+    expect(validateSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/http/src/dispatch/dispatch-handler-policy.ts
+++ b/packages/http/src/dispatch/dispatch-handler-policy.ts
@@ -2,6 +2,7 @@ import { InvariantError, type Token } from '@fluojs/core';
 import type { RequestScopeContainer } from '@fluojs/di';
 
 import { DefaultBinder } from '../adapters/binding.js';
+import { getCompiledDtoBindingPlan } from '../adapters/dto-binding-plan.js';
 import { HttpDtoValidationAdapter } from '../adapters/dto-validation-adapter.js';
 import type { ArgumentResolverContext, Binder, HandlerDescriptor, RequestContext } from '../types.js';
 
@@ -36,12 +37,13 @@ export async function invokeControllerHandler(
     handler,
     requestContext,
   };
-  const input = handler.route.request
-    ? await binder.bind(handler.route.request, argumentResolverContext)
+  const requestDto = handler.route.request;
+  const input = requestDto
+    ? await binder.bind(requestDto, argumentResolverContext)
     : undefined;
 
-  if (handler.route.request) {
-    await defaultValidator.validate(input, handler.route.request);
+  if (requestDto && getCompiledDtoBindingPlan(requestDto).needsValidation) {
+    await defaultValidator.validate(input, requestDto);
   }
 
   return method.call(controller, input, requestContext);

--- a/tooling/benchmarks/http-comparison/README.md
+++ b/tooling/benchmarks/http-comparison/README.md
@@ -13,6 +13,8 @@ Runs a small HTTP throughput/latency comparison between published fluo beta pack
 - `di-chain-dto-deterministic-20`: the same DTO-bound DI path across a deterministic 20-route cycle.
 - `di-chain-direct-param-deterministic-1`: one direct path-param route through Controller → Service → Repository.
 - `di-chain-direct-param-deterministic-20`: the same direct-param DI path across a deterministic 20-route cycle.
+- `query-dto-deterministic-1`: one query-heavy DTO route with six bound query fields.
+- `body-dto-deterministic-1`: one body-heavy DTO route with six bound body fields.
 
 ## Run
 
@@ -49,4 +51,4 @@ The report prints those counters with throughput and latency metrics.
 - This measures the released npm beta surface, not unpublished workspace source changes.
 - fluo uses TC39 standard decorators without `emitDecoratorMetadata`; NestJS uses legacy decorators with `emitDecoratorMetadata` through `nestjs/tsconfig.json`.
 - `fluo+Bun` is a runtime comparison, not a same-adapter comparison. Treat it as “same fluo app graph on Bun’s native server” versus the Node.js adapter targets.
-- The suite only covers routing and one constructor-DI path. It does not measure validation, serialization plugins, guards, pipes, database access, or production middleware.
+- The suite covers routing plus DTO binding on path, query, and body inputs. It does not measure validation plugins, serialization plugins, guards, pipes, database access, or production middleware.

--- a/tooling/benchmarks/http-comparison/src/fluo-bun/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo-bun/server.ts
@@ -1,11 +1,11 @@
 import { ensureMetadataSymbol, Inject, Module } from '@fluojs/core';
-import { Controller, FromPath, Get, RequestDto, type RequestContext } from '@fluojs/http';
+import { Controller, FromBody, FromPath, FromQuery, Get, Post, RequestDto, type RequestContext } from '@fluojs/http';
 import { createBunAdapter } from '@fluojs/platform-bun';
 import { FluoFactory } from '@fluojs/runtime';
 
 ensureMetadataSymbol();
 
-type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20';
+type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20' | 'query-1' | 'body-1';
 
 @Controller('/baseline')
 class BaselineController {
@@ -26,12 +26,74 @@ class GetUserRequest {
   id = '';
 }
 
+class SearchUsersRequest {
+  @FromQuery('term')
+  term = '';
+
+  @FromQuery('role')
+  role = '';
+
+  @FromQuery('region')
+  region = '';
+
+  @FromQuery('sort')
+  sort = '';
+
+  @FromQuery('page')
+  page = '';
+
+  @FromQuery('limit')
+  limit = '';
+}
+
+class CreateUserRequest {
+  @FromBody('name')
+  name = '';
+
+  @FromBody('email')
+  email = '';
+
+  @FromBody('role')
+  role = '';
+
+  @FromBody('team')
+  team = '';
+
+  @FromBody('title')
+  title = '';
+
+  @FromBody('status')
+  status = '';
+}
+
 @Inject(UsersRepository)
 class UsersService {
   constructor(private readonly repo: UsersRepository) {}
 
   getUser(id: string): { id: string; name: string; email: string } {
     return this.repo.findOne(id);
+  }
+
+  searchUsers(input: SearchUsersRequest) {
+    return {
+      limit: input.limit,
+      page: input.page,
+      region: input.region,
+      role: input.role,
+      sort: input.sort,
+      term: input.term,
+    };
+  }
+
+  createUser(input: CreateUserRequest) {
+    return {
+      email: input.email,
+      name: input.name,
+      role: input.role,
+      status: input.status,
+      team: input.team,
+      title: input.title,
+    };
   }
 }
 
@@ -176,6 +238,30 @@ class DirectParamTwentyController {
   getR20(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
 }
 
+@Inject(UsersService)
+@Controller('/query-dto-one')
+class QueryDtoOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @RequestDto(SearchUsersRequest)
+  @Get('/r01')
+  getR01(input: SearchUsersRequest) {
+    return this.service.searchUsers(input);
+  }
+}
+
+@Inject(UsersService)
+@Controller('/body-dto-one')
+class BodyDtoOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @RequestDto(CreateUserRequest)
+  @Post('/r01')
+  createR01(input: CreateUserRequest) {
+    return this.service.createUser(input);
+  }
+}
+
 @Module({ controllers: [BaselineController] })
 class BaselineModule {}
 
@@ -191,6 +277,12 @@ class DirectOneModule {}
 @Module({ controllers: [DirectParamTwentyController], providers: [UsersRepository, UsersService] })
 class DirectTwentyModule {}
 
+@Module({ controllers: [QueryDtoOneController], providers: [UsersRepository, UsersService] })
+class QueryOneModule {}
+
+@Module({ controllers: [BodyDtoOneController], providers: [UsersRepository, UsersService] })
+class BodyOneModule {}
+
 function resolveAppModule(shape: AppShape) {
   switch (shape) {
     case 'baseline': return BaselineModule;
@@ -198,12 +290,14 @@ function resolveAppModule(shape: AppShape) {
     case 'dto-20': return DtoTwentyModule;
     case 'direct-1': return DirectOneModule;
     case 'direct-20': return DirectTwentyModule;
+    case 'query-1': return QueryOneModule;
+    case 'body-1': return BodyOneModule;
   }
 }
 
 function readAppShape(): AppShape {
   const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
-  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20') {
+  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20' || raw === 'query-1' || raw === 'body-1') {
     return raw;
   }
   throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);

--- a/tooling/benchmarks/http-comparison/src/fluo/server.ts
+++ b/tooling/benchmarks/http-comparison/src/fluo/server.ts
@@ -1,9 +1,9 @@
 import { Inject, Module } from '@fluojs/core';
-import { Controller, FromPath, Get, RequestDto, type RequestContext } from '@fluojs/http';
+import { Controller, FromBody, FromPath, FromQuery, Get, Post, RequestDto, type RequestContext } from '@fluojs/http';
 import { createFastifyAdapter } from '@fluojs/platform-fastify';
 import { FluoFactory } from '@fluojs/runtime';
 
-type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20';
+type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20' | 'query-1' | 'body-1';
 
 @Controller('/baseline')
 class BaselineController {
@@ -24,12 +24,74 @@ class GetUserRequest {
   id = '';
 }
 
+class SearchUsersRequest {
+  @FromQuery('term')
+  term = '';
+
+  @FromQuery('role')
+  role = '';
+
+  @FromQuery('region')
+  region = '';
+
+  @FromQuery('sort')
+  sort = '';
+
+  @FromQuery('page')
+  page = '';
+
+  @FromQuery('limit')
+  limit = '';
+}
+
+class CreateUserRequest {
+  @FromBody('name')
+  name = '';
+
+  @FromBody('email')
+  email = '';
+
+  @FromBody('role')
+  role = '';
+
+  @FromBody('team')
+  team = '';
+
+  @FromBody('title')
+  title = '';
+
+  @FromBody('status')
+  status = '';
+}
+
 @Inject(UsersRepository)
 class UsersService {
   constructor(private readonly repo: UsersRepository) {}
 
   getUser(id: string): { id: string; name: string; email: string } {
     return this.repo.findOne(id);
+  }
+
+  searchUsers(input: SearchUsersRequest) {
+    return {
+      limit: input.limit,
+      page: input.page,
+      region: input.region,
+      role: input.role,
+      sort: input.sort,
+      term: input.term,
+    };
+  }
+
+  createUser(input: CreateUserRequest) {
+    return {
+      email: input.email,
+      name: input.name,
+      role: input.role,
+      status: input.status,
+      team: input.team,
+      title: input.title,
+    };
   }
 }
 
@@ -174,6 +236,30 @@ class DirectParamTwentyController {
   getR20(_input: undefined, context: RequestContext): { id: string; name: string; email: string } { return this.service.getUser(readPathId(context)); }
 }
 
+@Inject(UsersService)
+@Controller('/query-dto-one')
+class QueryDtoOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @RequestDto(SearchUsersRequest)
+  @Get('/r01')
+  getR01(input: SearchUsersRequest) {
+    return this.service.searchUsers(input);
+  }
+}
+
+@Inject(UsersService)
+@Controller('/body-dto-one')
+class BodyDtoOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @RequestDto(CreateUserRequest)
+  @Post('/r01')
+  createR01(input: CreateUserRequest) {
+    return this.service.createUser(input);
+  }
+}
+
 @Module({ controllers: [BaselineController] })
 class BaselineModule {}
 
@@ -189,6 +275,12 @@ class DirectOneModule {}
 @Module({ controllers: [DirectParamTwentyController], providers: [UsersRepository, UsersService] })
 class DirectTwentyModule {}
 
+@Module({ controllers: [QueryDtoOneController], providers: [UsersRepository, UsersService] })
+class QueryOneModule {}
+
+@Module({ controllers: [BodyDtoOneController], providers: [UsersRepository, UsersService] })
+class BodyOneModule {}
+
 function resolveAppModule(shape: AppShape) {
   switch (shape) {
     case 'baseline': return BaselineModule;
@@ -196,12 +288,14 @@ function resolveAppModule(shape: AppShape) {
     case 'dto-20': return DtoTwentyModule;
     case 'direct-1': return DirectOneModule;
     case 'direct-20': return DirectTwentyModule;
+    case 'query-1': return QueryOneModule;
+    case 'body-1': return BodyOneModule;
   }
 }
 
 function readAppShape(): AppShape {
   const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
-  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20') {
+  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20' || raw === 'query-1' || raw === 'body-1') {
     return raw;
   }
   throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);

--- a/tooling/benchmarks/http-comparison/src/nestjs/server.ts
+++ b/tooling/benchmarks/http-comparison/src/nestjs/server.ts
@@ -1,10 +1,10 @@
 import 'reflect-metadata';
 
-import { Controller, Get, Injectable, Module, Param } from '@nestjs/common';
+import { Body, Controller, Get, Injectable, Module, Param, Post, Query } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 
-type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20';
+type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20' | 'query-1' | 'body-1';
 
 @Injectable()
 class UsersRepository {
@@ -20,10 +20,50 @@ class UsersService {
   getUser(id: string): { id: string; name: string; email: string } {
     return this.repo.findOne(id);
   }
+
+  searchUsers(input: SearchUsersRequest) {
+    return {
+      limit: input.limit,
+      page: input.page,
+      region: input.region,
+      role: input.role,
+      sort: input.sort,
+      term: input.term,
+    };
+  }
+
+  createUser(input: CreateUserRequest) {
+    return {
+      email: input.email,
+      name: input.name,
+      role: input.role,
+      status: input.status,
+      team: input.team,
+      title: input.title,
+    };
+  }
 }
 
 class GetUserRequest {
   id = '';
+}
+
+class SearchUsersRequest {
+  term = '';
+  role = '';
+  region = '';
+  sort = '';
+  page = '';
+  limit = '';
+}
+
+class CreateUserRequest {
+  name = '';
+  email = '';
+  role = '';
+  team = '';
+  title = '';
+  status = '';
 }
 
 @Controller('baseline')
@@ -146,6 +186,26 @@ class DirectParamTwentyController {
   getR20(@Param('id') id: string): { id: string; name: string; email: string } { return this.service.getUser(id); }
 }
 
+@Controller('query-dto-one')
+class QueryDtoOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @Get('r01')
+  getR01(@Query() input: SearchUsersRequest) {
+    return this.service.searchUsers(input);
+  }
+}
+
+@Controller('body-dto-one')
+class BodyDtoOneController {
+  constructor(private readonly service: UsersService) {}
+
+  @Post('r01')
+  createR01(@Body() input: CreateUserRequest) {
+    return this.service.createUser(input);
+  }
+}
+
 @Module({ controllers: [BaselineController] })
 class BaselineModule {}
 
@@ -161,6 +221,12 @@ class DirectOneModule {}
 @Module({ controllers: [DirectParamTwentyController], providers: [UsersRepository, UsersService] })
 class DirectTwentyModule {}
 
+@Module({ controllers: [QueryDtoOneController], providers: [UsersRepository, UsersService] })
+class QueryOneModule {}
+
+@Module({ controllers: [BodyDtoOneController], providers: [UsersRepository, UsersService] })
+class BodyOneModule {}
+
 function resolveAppModule(shape: AppShape) {
   switch (shape) {
     case 'baseline': return BaselineModule;
@@ -168,12 +234,14 @@ function resolveAppModule(shape: AppShape) {
     case 'dto-20': return DtoTwentyModule;
     case 'direct-1': return DirectOneModule;
     case 'direct-20': return DirectTwentyModule;
+    case 'query-1': return QueryOneModule;
+    case 'body-1': return BodyOneModule;
   }
 }
 
 function readAppShape(): AppShape {
   const raw = process.env['BENCH_APP_SHAPE'] ?? 'dto-20';
-  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20') {
+  if (raw === 'baseline' || raw === 'dto-1' || raw === 'dto-20' || raw === 'direct-1' || raw === 'direct-20' || raw === 'query-1' || raw === 'body-1') {
     return raw;
   }
   throw new Error(`Unsupported BENCH_APP_SHAPE: ${raw}`);

--- a/tooling/benchmarks/http-comparison/src/run.ts
+++ b/tooling/benchmarks/http-comparison/src/run.ts
@@ -1,4 +1,4 @@
-import autocannon, { type Result } from 'autocannon';
+import autocannon, { type Request as AutocannonRequest, type Result } from 'autocannon';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { rm } from 'node:fs/promises';
 import { createConnection } from 'node:net';
@@ -13,7 +13,13 @@ const WDIR = process.cwd();
 const FLUO_BUN_BUILD_DIR = join(WDIR, 'dist/fluo-bun');
 
 type TargetName = 'nestjs-fastify' | 'fluo-fastify' | 'fluo-bun';
-type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20';
+type AppShape = 'baseline' | 'dto-1' | 'dto-20' | 'direct-1' | 'direct-20' | 'query-1' | 'body-1';
+
+interface ScenarioRequestTemplate {
+  readonly body?: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly method?: 'GET' | 'POST';
+}
 
 interface TargetConfig {
   name: TargetName;
@@ -21,6 +27,16 @@ interface TargetConfig {
   port: number;
   command: string;
   args: string[];
+}
+
+interface ScenarioConfig {
+  readonly appShape: AppShape;
+  readonly description: string;
+  readonly expectedBodies: readonly string[];
+  readonly name: string;
+  readonly path?: string;
+  readonly paths?: readonly string[];
+  readonly request?: ScenarioRequestTemplate;
 }
 
 const TARGETS: TargetConfig[] = [
@@ -49,6 +65,30 @@ const TARGETS: TargetConfig[] = [
 
 const USER_RESPONSE = JSON.stringify({ id: '1', name: 'Alice', email: 'alice@example.com' });
 const BASELINE_RESPONSE = JSON.stringify({ ok: true });
+const QUERY_RESPONSE = JSON.stringify({
+  limit: '25',
+  page: '2',
+  region: 'west',
+  role: 'admin',
+  sort: 'createdAt',
+  term: 'alice',
+});
+const BODY_REQUEST = JSON.stringify({
+  email: 'alice@example.com',
+  name: 'Alice',
+  role: 'admin',
+  status: 'active',
+  team: 'platform',
+  title: 'maintainer',
+});
+const BODY_RESPONSE = JSON.stringify({
+  email: 'alice@example.com',
+  name: 'Alice',
+  role: 'admin',
+  status: 'active',
+  team: 'platform',
+  title: 'maintainer',
+});
 
 function routePaths(count: number): string[] {
   return Array.from({ length: count }, (_, index) => `/di-chain/r${String(index + 1).padStart(2, '0')}/1`);
@@ -58,7 +98,7 @@ function directRoutePaths(count: number): string[] {
   return Array.from({ length: count }, (_, index) => `/di-chain-direct/r${String(index + 1).padStart(2, '0')}/1`);
 }
 
-const SCENARIOS = [
+const SCENARIOS: readonly ScenarioConfig[] = [
   {
     name: 'baseline',
     description: 'Single baseline route without DI-chain path param binding',
@@ -94,7 +134,28 @@ const SCENARIOS = [
     paths: directRoutePaths(20),
     expectedBodies: [USER_RESPONSE],
   },
-] as const;
+  {
+    name: 'query-dto-deterministic-1',
+    description: 'Single-route query DTO with six bound fields',
+    appShape: 'query-1',
+    path: '/query-dto-one/r01?term=alice&role=admin&region=west&sort=createdAt&page=2&limit=25',
+    expectedBodies: [QUERY_RESPONSE],
+  },
+  {
+    name: 'body-dto-deterministic-1',
+    description: 'Single-route body DTO with six bound fields',
+    appShape: 'body-1',
+    path: '/body-dto-one/r01',
+    expectedBodies: [BODY_RESPONSE],
+    request: {
+      body: BODY_REQUEST,
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    },
+  },
+];
 
 const WARMUP_SEC = readPositiveIntegerEnv('BENCH_WARMUP_SEC', 10);
 const MEASURE_SEC = readPositiveIntegerEnv('BENCH_MEASURE_SEC', 40);
@@ -161,28 +222,38 @@ function shoot(
   duration: number,
   expectedBodies: readonly string[],
   label: string,
+  requestTemplate: ScenarioRequestTemplate = {},
   paths?: readonly string[],
 ): Promise<Result> {
   return new Promise((resolve, reject) => {
     const nextPath = paths ? createDeterministicPathSequence(paths) : undefined;
+    const hasCustomRequest = nextPath !== undefined
+      || requestTemplate.method !== undefined
+      || requestTemplate.body !== undefined
+      || requestTemplate.headers !== undefined;
 
     autocannon({
       url,
       connections: CONNECTIONS,
       duration,
-      verifyBody: (body) => expectedBodies.includes(String(body)),
+      verifyBody: (body: unknown) => expectedBodies.includes(String(body)),
       bailout: 1,
-      ...(paths
+      ...(hasCustomRequest
         ? {
             requests: [{
-              setupRequest(request) {
+              setupRequest(request: AutocannonRequest, _context: object) {
                 request.path = nextPath?.() ?? request.path;
+                request.method = requestTemplate.method ?? request.method;
+                request.body = requestTemplate.body ?? request.body;
+                request.headers = requestTemplate.headers
+                  ? { ...(request.headers ?? {}), ...requestTemplate.headers }
+                  : request.headers;
                 return request;
               },
             }],
           }
         : {}),
-    }, (err, result) => {
+    }, (err: Error | null, result: Result | undefined) => {
       if (err) {
         reject(err);
         return;
@@ -198,15 +269,16 @@ async function measure(
   label: string,
   url: string,
   expectedBodies: readonly string[],
+  requestTemplate: ScenarioRequestTemplate = {},
   paths?: readonly string[],
 ): Promise<Result> {
   process.stdout.write(`  measuring ${label.padEnd(6)} (${MEASURE_SEC}s)...`);
-  const result = await shoot(url, MEASURE_SEC, expectedBodies, label, paths);
+  const result = await shoot(url, MEASURE_SEC, expectedBodies, label, requestTemplate, paths);
   process.stdout.write(' done\n');
   return result;
 }
 
-async function runScenario(s: (typeof SCENARIOS)[number], index: number): Promise<ScenarioResult> {
+async function runScenario(s: ScenarioConfig, index: number): Promise<ScenarioResult> {
   const processes = startTargets(s.appShape);
   const cleanup = (): void => {
     for (const child of processes) {
@@ -224,7 +296,7 @@ async function runScenario(s: (typeof SCENARIOS)[number], index: number): Promis
   try {
     process.stdout.write(`  [${s.name}] warm-up (${WARMUP_SEC}s)...`);
     await Promise.all(scenarioTargets.map(({ target, url }) => (
-      shoot(url, WARMUP_SEC, s.expectedBodies, `${s.name}/${target.label} warm-up`, 'paths' in s ? s.paths : undefined)
+      shoot(url, WARMUP_SEC, s.expectedBodies, `${s.name}/${target.label} warm-up`, s.request, 'paths' in s ? s.paths : undefined)
     )));
     process.stdout.write(' done\n');
 
@@ -232,7 +304,7 @@ async function runScenario(s: (typeof SCENARIOS)[number], index: number): Promis
     for (const { target, url } of scenarioTargets) {
       measured.push({
         label: target.label,
-        result: await measure(target.label, url, s.expectedBodies, 'paths' in s ? s.paths : undefined),
+        result: await measure(target.label, url, s.expectedBodies, s.request, 'paths' in s ? s.paths : undefined),
       });
     }
 
@@ -264,7 +336,7 @@ function runCommand(command: string, args: string[]): Promise<void> {
     });
 
     child.on('error', reject);
-    child.on('exit', (code, signal) => {
+    child.on('exit', (code: number | null, signal: NodeJS.Signals | null) => {
       if (code === 0) {
         resolve();
         return;


### PR DESCRIPTION
Closes #1473

## Summary

Optimize the shared `@RequestDto` request pipeline so DTO-heavy routes spend less work per request while preserving existing binding and validation contracts.

## Changes

- precompile additional RequestDto execution metadata so binding can skip converter setup and reuse validation-safe inputs on the common fast path
- skip validation engine work for DTOs without validation rules and add dispatch-level regressions for no-op validation behavior
- extend the HTTP comparison benchmark with query-heavy and body-heavy DTO scenarios across fluo Fastify, fluo Bun, and Nest Fastify
- add a patch changeset for `@fluojs/http`

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm --filter @fluojs/http test`
- `pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace install --frozen-lockfile`
- `pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace typecheck`
- `BENCH_WARMUP_SEC=1 BENCH_MEASURE_SEC=1 pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace bench`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Behavior is preserved for `@RequestDto`, binding sources, converter ordering, validation filtering, unknown-field rejection, dangerous-key rejection, and optional field handling. No README contract text changed because the optimization is behavior-preserving.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed docs or platform contract docs changed in this PR.