### PR TITLE
Resolve #1472: reuse Node-backed request shells across adapters

### DIFF
--- a/.changeset/green-tables-relate.md
+++ b/.changeset/green-tables-relate.md
@@ -1,0 +1,8 @@
+---
+'@fluojs/platform-express': patch
+'@fluojs/platform-fastify': patch
+'@fluojs/platform-nodejs': patch
+'@fluojs/runtime': patch
+---
+
+Optimize Node-backed request shell creation so Express, Fastify, and raw Node adapters reuse host-parsed request data where possible without changing query, body, raw body, multipart, or native route handoff behavior.

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -5,7 +5,7 @@ import {
 import { request as httpsRequest } from 'node:https';
 import { createServer as createNetServer } from 'node:net';
 
-import type { Response as ExpressResponse } from 'express';
+import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -412,6 +412,70 @@ describe('@fluojs/platform-express', () => {
       expect(JSON.parse(bodyResponse.body)).toEqual({
         body: { ok: true, source: 'express' },
       });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('falls back to raw URL parsing when Express host query values are unsafe or non-simple', async () => {
+    @Controller('/query-fallback')
+    class QueryFallbackController {
+      @Get('/undefined')
+      readUndefined(_input: undefined, context: RequestContext) {
+        return context.request.query;
+      }
+
+      @Get('/object')
+      readObject(_input: undefined, context: RequestContext) {
+        return context.request.query;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [QueryFallbackController] });
+
+    const port = await findAvailablePort();
+    const adapter = createExpressAdapter({ port }) as ExpressHttpApplicationAdapter;
+    const router = (adapter as unknown as {
+      router: {
+        use: (handler: (request: ExpressRequest, response: ExpressResponse, next: () => void) => void) => void;
+      };
+    }).router;
+
+    router.use((request, _response, next) => {
+      const mutableQuery = request.query as Record<string, unknown>;
+
+      if (request.originalUrl.startsWith('/query-fallback/undefined')) {
+        mutableQuery.flag = undefined;
+      } else if (request.originalUrl.startsWith('/query-fallback/object')) {
+        mutableQuery.nested = { unsafe: 'true' };
+      }
+
+      next();
+    });
+
+    const app = await fluoFactory.create(AppModule, { adapter });
+
+    await app.listen();
+
+    try {
+      const undefinedResponse = await requestHttp({
+        method: 'GET',
+        path: '/query-fallback/undefined?flag',
+        port,
+      });
+
+      expect(undefinedResponse.statusCode).toBe(200);
+      expect(JSON.parse(undefinedResponse.body)).toEqual({ flag: '' });
+
+      const objectResponse = await requestHttp({
+        method: 'GET',
+        path: '/query-fallback/object?nested=1',
+        port,
+      });
+
+      expect(objectResponse.statusCode).toBe(200);
+      expect(JSON.parse(objectResponse.body)).toEqual({ nested: '1' });
     } finally {
       await app.close();
     }

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -356,6 +356,67 @@ describe('@fluojs/platform-express', () => {
     }
   });
 
+  it('preserves benchmark-style simple query and JSON body routes on the native request path', async () => {
+    @Controller('/')
+    class BenchmarkController {
+      @Get('/query-one')
+      readQuery(_input: undefined, context: RequestContext) {
+        return {
+          encoded: context.request.query.encoded,
+          tag: context.request.query.tag,
+        };
+      }
+
+      @Post('/body-one')
+      readBody(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [BenchmarkController] });
+
+    const port = await findAvailablePort();
+    const app = await fluoFactory.create(AppModule, {
+      adapter: createExpressAdapter({ port }),
+    });
+
+    await app.listen();
+
+    try {
+      const queryResponse = await requestHttp({
+        method: 'GET',
+        path: '/query-one?tag=one&tag=two&encoded=hello+world',
+        port,
+      });
+
+      expect(queryResponse.statusCode).toBe(200);
+      expect(JSON.parse(queryResponse.body)).toEqual({
+        encoded: 'hello world',
+        tag: ['one', 'two'],
+      });
+
+      const bodyResponse = await requestHttp({
+        body: JSON.stringify({ ok: true, source: 'express' }),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        path: '/body-one',
+        port,
+      });
+
+      expect(bodyResponse.statusCode).toBe(201);
+      expect(JSON.parse(bodyResponse.body)).toEqual({
+        body: { ok: true, source: 'express' },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('keeps the simple JSON fast path off Express json replacer serialization', async () => {
     @Controller('/serializer')
     class SerializerController {

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -1,7 +1,6 @@
 import type {
   IncomingHttpHeaders,
   IncomingMessage,
-  ServerResponse,
 } from 'node:http';
 import { createServer as createHttpServer } from 'node:http';
 import {
@@ -10,7 +9,6 @@ import {
 } from 'node:https';
 import type { AddressInfo, Socket } from 'node:net';
 import { Readable } from 'node:stream';
-import { URL } from 'node:url';
 
 import express, {
   type Express,
@@ -53,6 +51,18 @@ import {
   createNodeShutdownSignalRegistration,
   defaultNodeShutdownSignals,
 } from '@fluojs/runtime/node';
+import {
+  cloneRequestHeaders,
+  createDeferredFrameworkRequestShell,
+  createMemoizedAsyncValue,
+  createRequestSignal,
+  normalizePrimaryContentType,
+  parseQueryParamsFromSearch,
+  resolveAbsoluteRequestUrl,
+  resolveRequestIdFromHeaders,
+  snapshotSimpleQueryRecord,
+  splitRawRequestUrl,
+} from '@fluojs/runtime/internal-node';
 import { parseMultipart } from '@fluojs/runtime/web';
 import {
   bootstrapHttpAdapterApplication,
@@ -287,7 +297,7 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
         }
 
         const nativeMethod = request.method.toUpperCase() as ExpressNativeRouteMethod;
-        const requestPath = new URL(request.originalUrl || request.url || '/', 'http://localhost').pathname;
+        const requestPath = splitRawRequestUrl(request.originalUrl || request.url || '/').path;
         const descriptor = route.descriptorsByMethod[nativeMethod];
         const params = normalizeNativeRouteParams(request.params);
 
@@ -433,6 +443,9 @@ function createExpressRequestResponseFactory(
     },
     createResponse(response: ExpressResponse) {
       return createFrameworkResponse(response);
+    },
+    async materializeRequest(request: FrameworkRequest) {
+      await materializeFrameworkRequestBody(request);
     },
     resolveRequestId(request: ExpressRequest) {
       return resolveRequestIdFromHeaders(request.headers);
@@ -624,48 +637,51 @@ async function createFrameworkRequest(
   preserveRawBody = false,
 ): Promise<FrameworkRequest> {
   const rawUrl = request.originalUrl || request.url || '/';
-  const url = new URL(rawUrl, 'http://localhost');
-  const headers = normalizeHeaders(request.headers);
-  const contentType = readPrimaryHeaderValue(headers['content-type']);
-  const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
+  const urlParts = splitRawRequestUrl(rawUrl);
+  const headers = normalizeHeaders(cloneRequestHeaders(request.headers));
+  const querySnapshot = snapshotSimpleQueryRecord(request.query);
+  const contentType = normalizePrimaryContentType(headers['content-type']);
+  const isMultipart = contentType === 'multipart/form-data';
+  let frameworkRequest!: FrameworkRequest & {
+    files?: UploadedFile[];
+    materializeBody?: () => Promise<void>;
+    rawBody?: Uint8Array;
+  };
+  const materializeBody = createMemoizedAsyncValue(async () => {
+    if (isMultipart) {
+      const parsed = await parseMultipartRequest(request, {
+        ...multipartOptions,
+        maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
+      });
+      frameworkRequest.body = parsed.fields;
+      frameworkRequest.files = parsed.files;
+      return;
+    }
 
-  let body: unknown;
-  let files: UploadedFile[] | undefined;
-  let rawBody: Uint8Array | undefined;
-
-  if (isMultipart) {
-    const parsed = await parseMultipartRequest(request, {
-      ...multipartOptions,
-      maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
-    });
-    body = parsed.fields;
-    files = parsed.files;
-  } else {
     const bodyResult = await readRequestBody(request, headers['content-type'], maxBodySize, preserveRawBody);
-    body = bodyResult.body;
-    rawBody = bodyResult.rawBody;
-  }
+    frameworkRequest.body = bodyResult.body;
 
-  const frameworkRequest: FrameworkRequest & { files?: UploadedFile[]; rawBody?: Uint8Array } = {
-    body,
-    cookies: parseCookieHeader(Array.isArray(headers.cookie) ? headers.cookie[0] : headers.cookie),
+    if (bodyResult.rawBody) {
+      frameworkRequest.rawBody = bodyResult.rawBody;
+    }
+  });
+
+  frameworkRequest = createDeferredFrameworkRequestShell({
+    cookieHeader: headers.cookie,
     headers,
+    materializeBody,
     method: request.method,
-    params: {},
-    path: url.pathname,
-    query: parseQueryParams(url.searchParams),
+    path: urlParts.path,
+    query: querySnapshot,
+    queryFactory: () => parseQueryParamsFromSearch(urlParts.search),
     raw: request,
     signal,
-    url: url.pathname + url.search,
+    url: urlParts.path + urlParts.search,
+  }) as FrameworkRequest & {
+    files?: UploadedFile[];
+    materializeBody?: () => Promise<void>;
+    rawBody?: Uint8Array;
   };
-
-  if (files) {
-    frameworkRequest.files = files;
-  }
-
-  if (rawBody) {
-    frameworkRequest.rawBody = rawBody;
-  }
 
   const nativeRouteHandoff = consumeRawRequestNativeRouteHandoff(request);
 
@@ -725,7 +741,7 @@ async function parseMultipartRequest(
         body: Readable.toWeb(request),
         headers: normalizeHeaders(request.headers),
         method: request.method,
-        url: new URL(request.url ?? '/', 'http://localhost').toString(),
+        url: resolveAbsoluteRequestUrl(request.url),
       },
       options,
     );
@@ -797,78 +813,6 @@ function normalizeHeaders(headers: IncomingHttpHeaders): Record<string, string |
   }
 
   return normalized;
-}
-
-function parseQueryParams(searchParams: URLSearchParams): Record<string, string | string[]> {
-  const query: Record<string, string | string[]> = {};
-
-  for (const [key, value] of searchParams.entries()) {
-    const current = query[key];
-
-    if (current === undefined) {
-      query[key] = value;
-      continue;
-    }
-
-    if (Array.isArray(current)) {
-      current.push(value);
-      continue;
-    }
-
-    query[key] = [current, value];
-  }
-
-  return query;
-}
-
-function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
-  if (!cookieHeader) {
-    return {};
-  }
-
-  return Object.fromEntries(
-    cookieHeader
-      .split(';')
-      .map((pair) => pair.trim())
-      .filter(Boolean)
-      .map((pair) => {
-        const index = pair.indexOf('=');
-
-        if (index === -1) {
-          return [pair.trim(), ''] as [string, string];
-        }
-
-        const rawValue = pair.slice(index + 1).trim();
-
-        try {
-          return [pair.slice(0, index).trim(), decodeURIComponent(rawValue)] as [string, string];
-        } catch {
-          return [pair.slice(0, index).trim(), rawValue] as [string, string];
-        }
-      }),
-  );
-}
-
-function createRequestSignal(response: ServerResponse): AbortSignal {
-  const controller = new AbortController();
-  const abort = (reason: string) => {
-    if (!controller.signal.aborted) {
-      controller.abort(new Error(reason));
-    }
-  };
-
-  response.once('close', () => {
-    if (!response.writableEnded) {
-      abort('Response closed before response commit.');
-    }
-  });
-
-  return controller.signal;
-}
-
-function resolveRequestIdFromHeaders(headers: IncomingHttpHeaders): string | undefined {
-  const requestId = headers['x-request-id'] ?? headers['x-correlation-id'];
-  return Array.isArray(requestId) ? requestId[0] : requestId;
 }
 
 function createExpressServer(httpsOptions: HttpsServerOptions | undefined, app: Express): ExpressServer {
@@ -1094,9 +1038,9 @@ async function readRequestBody(
     return { body: undefined, rawBody: preserveRawBody ? rawBody : undefined };
   }
 
-  const primaryContentType = readPrimaryHeaderValue(contentType);
+  const primaryContentType = normalizePrimaryContentType(contentType);
 
-  if (typeof primaryContentType === 'string' && primaryContentType.includes('application/json')) {
+  if (primaryContentType === 'application/json') {
     try {
       return {
         body: JSON.parse(bodyText) as unknown,
@@ -1107,7 +1051,7 @@ async function readRequestBody(
     }
   }
 
-  if (typeof primaryContentType === 'string' && primaryContentType.includes('application/x-www-form-urlencoded')) {
+  if (primaryContentType === 'application/x-www-form-urlencoded') {
     return {
       body: parseUrlEncodedBody(bodyText),
       rawBody: preserveRawBody ? rawBody : undefined,
@@ -1131,12 +1075,9 @@ function parseUrlEncodedBody(bodyText: string): Record<string, string | string[]
   return fields;
 }
 
-function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {
-  if (Array.isArray(headerValue)) {
-    return headerValue[0];
-  }
-
-  return headerValue;
+async function materializeFrameworkRequestBody(request: FrameworkRequest): Promise<void> {
+  await (request as { materializeBody?: () => Promise<void> }).materializeBody?.();
+  delete (request as { materializeBody?: () => Promise<void> }).materializeBody;
 }
 
 function setMultiValue(target: Record<string, string | string[]>, key: string, value: string): void {

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -3,6 +3,8 @@ import { request as httpRequest } from 'node:http';
 import { createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
 
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import { Container } from '@fluojs/di';
@@ -397,6 +399,75 @@ describe('@fluojs/platform-fastify', () => {
       expect(JSON.parse(bodyResponse.body)).toEqual({
         body: { ok: true, source: 'fastify' },
       });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('falls back to raw URL parsing when Fastify host query values are unsafe or non-simple', async () => {
+    @Controller('/query-fallback')
+    class QueryFallbackController {
+      @Get('/undefined')
+      readUndefined(_input: undefined, context: RequestContext) {
+        return context.request.query;
+      }
+
+      @Get('/object')
+      readObject(_input: undefined, context: RequestContext) {
+        return context.request.query;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [QueryFallbackController] });
+
+    const port = await findAvailablePort();
+    const adapter = createFastifyAdapter({ port }) as FastifyHttpApplicationAdapter;
+    const fastifyApp = (adapter as unknown as {
+      app: {
+        addHook: (
+          name: 'preHandler',
+          hook: (
+            request: FastifyRequest & { query: Record<string, unknown> },
+            reply: FastifyReply,
+          ) => Promise<void>,
+        ) => void;
+      };
+    }).app;
+
+    fastifyApp.addHook('preHandler', async (request, _reply) => {
+      if (request.raw.url?.startsWith('/query-fallback/undefined')) {
+        request.query = { flag: undefined };
+        return;
+      }
+
+      if (request.raw.url?.startsWith('/query-fallback/object')) {
+        request.query = { nested: { unsafe: true } };
+      }
+    });
+
+    const app = await fluoFactory.create(AppModule, { adapter });
+
+    await app.listen();
+
+    try {
+      const undefinedResponse = await requestHttp({
+        method: 'GET',
+        path: '/query-fallback/undefined?flag',
+        port,
+      });
+
+      expect(undefinedResponse.statusCode).toBe(200);
+      expect(JSON.parse(undefinedResponse.body)).toEqual({ flag: '' });
+
+      const objectResponse = await requestHttp({
+        method: 'GET',
+        path: '/query-fallback/object?nested=1',
+        port,
+      });
+
+      expect(objectResponse.statusCode).toBe(200);
+      expect(JSON.parse(objectResponse.body)).toEqual({ nested: '1' });
     } finally {
       await app.close();
     }

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -23,8 +23,9 @@ import {
   VersioningType,
   type CallHandler,
   type Dispatcher,
-  type FrameworkRequest,
-  type GuardContext,
+    type FrameworkRequest,
+    type FrameworkResponse,
+    type GuardContext,
   type InterceptorContext,
   type MiddlewareContext,
   type RequestObservationContext,
@@ -340,6 +341,67 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('preserves benchmark-style simple query and JSON body routes on the native request path', async () => {
+    @Controller('/')
+    class BenchmarkController {
+      @Get('/query-one')
+      readQuery(_input: undefined, context: RequestContext) {
+        return {
+          encoded: context.request.query.encoded,
+          tag: context.request.query.tag,
+        };
+      }
+
+      @Post('/body-one')
+      readBody(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [BenchmarkController] });
+
+    const port = await findAvailablePort();
+    const app = await fluoFactory.create(AppModule, {
+      adapter: createFastifyAdapter({ port }),
+    });
+
+    await app.listen();
+
+    try {
+      const queryResponse = await requestHttp({
+        method: 'GET',
+        path: '/query-one?tag=one&tag=two&encoded=hello+world',
+        port,
+      });
+
+      expect(queryResponse.statusCode).toBe(200);
+      expect(JSON.parse(queryResponse.body)).toEqual({
+        encoded: 'hello world',
+        tag: ['one', 'two'],
+      });
+
+      const bodyResponse = await requestHttp({
+        body: JSON.stringify({ ok: true, source: 'fastify' }),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+        path: '/body-one',
+        port,
+      });
+
+      expect(bodyResponse.statusCode).toBe(201);
+      expect(JSON.parse(bodyResponse.body)).toEqual({
+        body: { ok: true, source: 'fastify' },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('keeps the simple JSON fast path off Fastify reply serialization overrides', async () => {
     @Controller('/serializer')
     class SerializerController {
@@ -460,7 +522,7 @@ describe('@fluojs/platform-fastify', () => {
     });
 
     const dispatcher: Dispatcher = {
-      async dispatch(request, response) {
+      async dispatch(request: FrameworkRequest, response: FrameworkResponse) {
         response.setStatus(201);
         await response.send({
           rawBytes: Array.from(request.rawBody ?? new Uint8Array()),

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -41,6 +41,15 @@ import {
   defaultNodeShutdownSignals,
 } from '@fluojs/runtime/node';
 import {
+  cloneHeaderValue,
+  createDeferredFrameworkRequestShell,
+  createMemoizedAsyncValue,
+  createMemoizedValue,
+  parseQueryParamsFromSearch,
+  snapshotSimpleQueryRecord,
+  splitRawRequestUrl,
+} from '@fluojs/runtime/internal-node';
+import {
   bootstrapHttpAdapterApplication,
   runHttpAdapterApplication,
 } from '@fluojs/runtime/internal/http-adapter';
@@ -131,8 +140,6 @@ type FastifyFrameworkRequest = FrameworkRequest & {
   materializeBody?: () => Promise<void>;
   rawBody?: Uint8Array;
 };
-
-type MemoizedValue<T> = () => T;
 
 type FastifyMultipartLikeError = Error & {
   code?: unknown;
@@ -630,10 +637,9 @@ function createDeferredFrameworkRequest(
   const urlParts = splitRawRequestUrl(rawUrl);
   const headerSnapshot = cloneRequestHeaders(request.headers);
   const headers = createMemoizedValue(() => normalizeHeaders(headerSnapshot));
-  const cookieHeader = cloneHeaderValue(headerSnapshot.cookie);
-  const cookies = createMemoizedValue(() => parseCookieHeader(cookieHeader));
-  const query = createMemoizedValue(() => parseQueryParamsFromSearch(urlParts.search));
+  const querySnapshot = snapshotSimpleQueryRecord(request.query);
   const isMultipart = isMultipartRequestContentType(headerSnapshot['content-type']);
+  let frameworkRequest!: FastifyFrameworkRequest;
   const materializeBody = createMemoizedAsyncValue(async () => {
     let body = request.body;
     let files: UploadedFile[] | undefined;
@@ -662,24 +668,18 @@ function createDeferredFrameworkRequest(
     }
   });
 
-  const frameworkRequest: FastifyFrameworkRequest = {
-    get cookies() {
-      return cookies();
-    },
-    get headers() {
-      return headers();
-    },
+  frameworkRequest = createDeferredFrameworkRequestShell({
+    cookieHeader: cloneHeaderValue(headerSnapshot.cookie),
+    headersFactory: headers,
+    materializeBody,
     method: request.method,
-    params: {},
     path: urlParts.path,
-    get query() {
-      return query();
-    },
+    query: querySnapshot,
+    queryFactory: () => parseQueryParamsFromSearch(urlParts.search),
     raw: request.raw,
     signal,
     url: urlParts.path + urlParts.search,
-    materializeBody,
-  };
+  }) as FastifyFrameworkRequest;
 
   const nativeRouteHandoff = consumeRawRequestNativeRouteHandoff(request.raw);
 
@@ -853,116 +853,10 @@ function normalizeHeaders(headers: IncomingHttpHeaders): Record<string, string |
   return normalized;
 }
 
-function parseQueryParamsFromSearch(search: string): Record<string, string | string[]> {
-  return parseQueryParams(new URLSearchParams(search));
-}
-
-function parseQueryParams(searchParams: URLSearchParams): Record<string, string | string[]> {
-  const query: Record<string, string | string[]> = {};
-
-  for (const [key, value] of searchParams.entries()) {
-    const current = query[key];
-
-    if (current === undefined) {
-      query[key] = value;
-      continue;
-    }
-
-    if (Array.isArray(current)) {
-      current.push(value);
-      continue;
-    }
-
-    query[key] = [current, value];
-  }
-
-  return query;
-}
-
-function parseCookieHeader(cookieHeader: string | string[] | undefined): Record<string, string> {
-  const normalizedCookieHeader = Array.isArray(cookieHeader) ? cookieHeader.join('; ') : cookieHeader;
-
-  if (!normalizedCookieHeader) {
-    return {};
-  }
-
-  return Object.fromEntries(
-    normalizedCookieHeader
-      .split(';')
-      .map((pair) => pair.trim())
-      .filter(Boolean)
-      .map((pair) => {
-        const index = pair.indexOf('=');
-
-        if (index === -1) {
-          return [pair.trim(), ''] as [string, string];
-        }
-
-        const rawValue = pair.slice(index + 1).trim();
-
-        try {
-          return [pair.slice(0, index).trim(), decodeURIComponent(rawValue)] as [string, string];
-        } catch {
-          return [pair.slice(0, index).trim(), rawValue] as [string, string];
-        }
-      }),
-  );
-}
-
-function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
-  let initialized = false;
-  let value: T;
-
-  return () => {
-    if (!initialized) {
-      value = factory();
-      initialized = true;
-    }
-
-    return value;
-  };
-}
-
-function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<void> {
-  let promise: Promise<void> | undefined;
-
-  return () => {
-    promise ??= factory();
-    return promise;
-  };
-}
-
-function cloneHeaderValue<T extends string | string[] | undefined>(value: T): T {
-  return (Array.isArray(value) ? [...value] : value) as T;
-}
-
 function cloneRequestHeaders(headers: FastifyRequest['headers']): IncomingHttpHeaders {
   return Object.fromEntries(
     Object.entries(headers).map(([name, value]) => [name, cloneHeaderValue(value)]),
   );
-}
-
-function splitRawRequestUrl(rawUrl: string): { path: string; search: string } {
-  if (rawUrl.startsWith('http://') || rawUrl.startsWith('https://')) {
-    const url = new URL(rawUrl);
-    return { path: url.pathname, search: url.search };
-  }
-
-  const queryStart = rawUrl.indexOf('?');
-  const hashStart = rawUrl.indexOf('#');
-  const pathEndCandidates = [queryStart, hashStart].filter((index) => index >= 0);
-  const pathEnd = pathEndCandidates.length > 0 ? Math.min(...pathEndCandidates) : rawUrl.length;
-  const path = rawUrl.slice(0, pathEnd) || '/';
-
-  if (queryStart === -1) {
-    return { path, search: '' };
-  }
-
-  const searchEnd = hashStart >= 0 && hashStart > queryStart ? hashStart : rawUrl.length;
-  return {
-    path,
-    search: rawUrl.slice(queryStart, searchEnd),
-  };
 }
 
 function setMultiValue(target: Record<string, string | string[]>, key: string, value: string): void {

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -115,6 +115,61 @@ describe('@fluojs/platform-nodejs', () => {
     }
   });
 
+  it('preserves benchmark-style simple query and JSON body routes through the public Node adapter path', async () => {
+    @Controller('/')
+    class BenchmarkController {
+      @Get('/query-one')
+      readQuery(_input: undefined, context: RequestContext) {
+        return {
+          encoded: context.request.query.encoded,
+          tag: context.request.query.tag,
+        };
+      }
+
+      @Post('/body-one')
+      readBody(_input: undefined, context: RequestContext) {
+        return {
+          body: context.request.body,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [BenchmarkController] });
+
+    const port = await findAvailablePort();
+    const app = await FluoFactory.create(AppModule, {
+      adapter: createNodejsAdapter({ port }),
+    });
+
+    try {
+      await app.listen();
+
+      const queryResponse = await fetch(`http://127.0.0.1:${String(port)}/query-one?tag=one&tag=two&encoded=hello+world`);
+
+      expect(queryResponse.status).toBe(200);
+      await expect(queryResponse.json()).resolves.toEqual({
+        encoded: 'hello world',
+        tag: ['one', 'two'],
+      });
+
+      const bodyResponse = await fetch(`http://127.0.0.1:${String(port)}/body-one`, {
+        body: JSON.stringify({ ok: true, source: 'node' }),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      });
+
+      expect(bodyResponse.status).toBe(201);
+      await expect(bodyResponse.json()).resolves.toEqual({
+        body: { ok: true, source: 'node' },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('exposes a server-backed realtime capability on the raw Node adapter', async () => {
     const adapter = createNodejsAdapter();
 

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -28,6 +28,9 @@ type MemoizedValue<T> = () => T;
 
 type QueryRecord = Record<string, string | string[] | undefined>;
 
+/**
+ * Options for creating a deferred framework request shell from a Node-backed adapter.
+ */
 export interface DeferredFrameworkRequestShellOptions<RawRequest> {
   cookieHeader?: string | string[] | undefined;
   headers?: FrameworkRequest['headers'];
@@ -164,6 +167,12 @@ export function createDeferredFrameworkRequest(
   return frameworkRequest;
 }
 
+/**
+ * Creates a framework request shell from already-snapshotted Node adapter metadata.
+ *
+ * @param options - Raw request, metadata factories, and deferred body materialization hooks.
+ * @returns A framework request with lazy headers, cookies, query values, and optional body materialization.
+ */
 export function createDeferredFrameworkRequestShell<RawRequest>({
   cookieHeader,
   headers,
@@ -235,6 +244,12 @@ export async function materializeFrameworkRequestBody(request: FrameworkRequest)
   delete (request as NodeFrameworkRequest).materializeBody;
 }
 
+/**
+ * Creates a synchronous memoized value resolver.
+ *
+ * @param factory - Function that computes the value on first access.
+ * @returns A stable resolver that returns the cached value after the first call.
+ */
 export function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
   let initialized = false;
   let value: T;
@@ -249,6 +264,12 @@ export function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
   };
 }
 
+/**
+ * Creates an async memoized side-effect resolver.
+ *
+ * @param factory - Async function to run at most once.
+ * @returns A resolver that returns the same in-flight or completed promise for every call.
+ */
 export function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<void> {
   let promise: Promise<void> | undefined;
 
@@ -292,6 +313,12 @@ export function resolveRequestIdFromHeaders(headers: IncomingHttpHeaders): strin
   return Array.isArray(requestId) ? requestId[0] : requestId;
 }
 
+/**
+ * Parses a raw URL search string into the framework query shape.
+ *
+ * @param search - Raw search string, with or without a leading question mark.
+ * @returns Query values where repeated keys become string arrays.
+ */
 export function parseQueryParamsFromSearch(search: string): Record<string, string | string[]> {
   return parseQueryParams(new URLSearchParams(search));
 }
@@ -318,6 +345,12 @@ function parseQueryParams(searchParams: URLSearchParams): Record<string, string 
   return query;
 }
 
+/**
+ * Snapshots host-parsed query values when they already match framework semantics.
+ *
+ * @param query - Host query object exposed by a Node-backed adapter.
+ * @returns A cloned query record when all values are strings or string arrays; otherwise `undefined` for raw URL fallback.
+ */
 export function snapshotSimpleQueryRecord(query: unknown): QueryRecord | undefined {
   if (typeof query !== 'object' || query === null) {
     return undefined;
@@ -342,16 +375,34 @@ export function snapshotSimpleQueryRecord(query: unknown): QueryRecord | undefin
   return snapshot;
 }
 
+/**
+ * Clones Node request headers into the framework header record shape.
+ *
+ * @param headers - Raw Node incoming headers.
+ * @returns A shallow header snapshot with array values cloned.
+ */
 export function cloneRequestHeaders(headers: IncomingHttpHeaders): FrameworkRequest['headers'] {
   const clonedEntries = Object.entries(headers).map(([name, value]) => [name, cloneHeaderValue(value)]);
 
   return Object.fromEntries(clonedEntries);
 }
 
+/**
+ * Clones a single Node header value when it is array-backed.
+ *
+ * @param value - Header value to snapshot.
+ * @returns The original scalar value or a cloned array value.
+ */
 export function cloneHeaderValue<T extends string | string[] | undefined>(value: T): T {
   return (Array.isArray(value) ? [...value] : value) as T;
 }
 
+/**
+ * Reads the primary value from a Node header value.
+ *
+ * @param headerValue - Header value that may contain multiple entries.
+ * @returns The first header value when present.
+ */
 export function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {
   if (Array.isArray(headerValue)) {
     return headerValue[0];
@@ -360,6 +411,12 @@ export function readPrimaryHeaderValue(headerValue: string | string[] | undefine
   return headerValue;
 }
 
+/**
+ * Normalizes a Node content-type header to its primary media type.
+ *
+ * @param headerValue - Raw content-type header value.
+ * @returns Lowercase primary media type without parameters, or `undefined` when absent.
+ */
 export function normalizePrimaryContentType(headerValue: string | string[] | undefined): string | undefined {
   const primaryHeaderValue = readPrimaryHeaderValue(headerValue);
 
@@ -381,6 +438,12 @@ function decodeCookieValue(raw: string): string {
   }
 }
 
+/**
+ * Parses a Node cookie header into framework cookie values.
+ *
+ * @param cookieHeader - Raw cookie header value or values.
+ * @returns Cookie name/value pairs with percent-decoded values when possible.
+ */
 export function parseCookieHeader(cookieHeader: string | string[] | undefined): Record<string, string> {
   const normalizedCookieHeader = Array.isArray(cookieHeader) ? cookieHeader.join('; ') : cookieHeader;
 
@@ -455,6 +518,12 @@ async function readRequestBody(
   };
 }
 
+/**
+ * Splits a raw Node request URL into path and search components.
+ *
+ * @param rawUrl - Raw request URL, absolute URL, or undefined value from Node.
+ * @returns The pathname and search string used by framework request matching and query parsing.
+ */
 export function splitRawRequestUrl(rawUrl: string | undefined): { path: string; search: string } {
   const resolvedRawUrl = rawUrl ?? '/';
 
@@ -480,6 +549,12 @@ export function splitRawRequestUrl(rawUrl: string | undefined): { path: string; 
   };
 }
 
+/**
+ * Resolves a raw Node request URL into an absolute URL string.
+ *
+ * @param rawUrl - Raw request URL, absolute URL, or undefined value from Node.
+ * @returns An absolute URL suitable for Web-standard parsers.
+ */
 export function resolveAbsoluteRequestUrl(rawUrl: string | undefined): string {
   const resolvedRawUrl = rawUrl ?? '/';
 

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -326,7 +326,7 @@ export function snapshotSimpleQueryRecord(query: unknown): QueryRecord | undefin
   const snapshot: QueryRecord = {};
 
   for (const [key, value] of Object.entries(query)) {
-    if (typeof value === 'string' || value === undefined) {
+    if (typeof value === 'string') {
       snapshot[key] = value;
       continue;
     }

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -26,6 +26,22 @@ type NodeFrameworkRequest = FrameworkRequest & {
 
 type MemoizedValue<T> = () => T;
 
+type QueryRecord = Record<string, string | string[] | undefined>;
+
+export interface DeferredFrameworkRequestShellOptions<RawRequest> {
+  cookieHeader?: string | string[] | undefined;
+  headers?: FrameworkRequest['headers'];
+  headersFactory?: () => FrameworkRequest['headers'];
+  materializeBody?: () => Promise<void>;
+  method?: string;
+  path: string;
+  query?: QueryRecord;
+  queryFactory?: () => QueryRecord;
+  raw: RawRequest;
+  signal: AbortSignal;
+  url: string;
+}
+
 /**
  * HTTP payload-size error that closes the underlying Node request stream after the response commits.
  */
@@ -95,14 +111,12 @@ export function createDeferredFrameworkRequest(
   maxBodySize = 1 * 1024 * 1024,
   preserveRawBody = false,
 ): FrameworkRequest {
-  const url = new URL(request.url ?? '/', 'http://localhost');
+  const rawUrl = request.url ?? '/';
+  const urlParts = splitRawRequestUrl(rawUrl);
   const headers = cloneRequestHeaders(request.headers);
-  const cookieHeader = cloneHeaderValue(headers.cookie);
-  const searchParams = new URLSearchParams(url.searchParams);
-  const cookies = createMemoizedValue(() => parseCookieHeader(cookieHeader));
-  const query = createMemoizedValue(() => parseQueryParams(searchParams));
   const contentType = normalizePrimaryContentType(headers['content-type']);
   const isMultipart = contentType === 'multipart/form-data';
+  let frameworkRequest!: NodeFrameworkRequest;
   const materializeBody = createMemoizedAsyncValue(async () => {
     if (isMultipart) {
       const result = await parseMultipart(
@@ -110,7 +124,7 @@ export function createDeferredFrameworkRequest(
           body: Readable.toWeb(request),
           headers,
           method: request.method,
-          url: url.toString(),
+          url: resolveAbsoluteRequestUrl(rawUrl),
         },
         {
           ...multipartOptions,
@@ -135,22 +149,59 @@ export function createDeferredFrameworkRequest(
     }
   });
 
-  const frameworkRequest: NodeFrameworkRequest = {
-    get cookies() {
-      return cookies();
-    },
+  frameworkRequest = createDeferredFrameworkRequestShell({
+    cookieHeader: cloneHeaderValue(headers.cookie),
     headers,
-    method: request.method ?? 'GET',
-    params: {},
-    path: url.pathname,
-    get query() {
-      return query();
-    },
+    materializeBody,
+    method: request.method,
+    path: urlParts.path,
+    queryFactory: () => parseQueryParamsFromSearch(urlParts.search),
     raw: request,
     signal,
-    url: url.pathname + url.search,
-    materializeBody,
+    url: urlParts.path + urlParts.search,
+  }) as NodeFrameworkRequest;
+
+  return frameworkRequest;
+}
+
+export function createDeferredFrameworkRequestShell<RawRequest>({
+  cookieHeader,
+  headers,
+  headersFactory,
+  materializeBody,
+  method,
+  path,
+  query,
+  queryFactory,
+  raw,
+  signal,
+  url,
+}: DeferredFrameworkRequestShellOptions<RawRequest>): FrameworkRequest {
+  const resolveHeaders = headersFactory ? createMemoizedValue(headersFactory) : () => headers ?? {};
+  const resolveCookies = createMemoizedValue(() => parseCookieHeader(cookieHeader ?? resolveHeaders().cookie));
+  const resolveQuery = createMemoizedValue(() => query ?? queryFactory?.() ?? {});
+
+  const frameworkRequest: NodeFrameworkRequest = {
+    get cookies() {
+      return resolveCookies();
+    },
+    get headers() {
+      return resolveHeaders();
+    },
+    method: method ?? 'GET',
+    params: {},
+    path,
+    get query() {
+      return resolveQuery();
+    },
+    raw,
+    signal,
+    url,
   };
+
+  if (materializeBody) {
+    frameworkRequest.materializeBody = materializeBody;
+  }
 
   return frameworkRequest;
 }
@@ -184,7 +235,7 @@ export async function materializeFrameworkRequestBody(request: FrameworkRequest)
   delete (request as NodeFrameworkRequest).materializeBody;
 }
 
-function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
+export function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
   let initialized = false;
   let value: T;
 
@@ -198,7 +249,7 @@ function createMemoizedValue<T>(factory: () => T): MemoizedValue<T> {
   };
 }
 
-function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<void> {
+export function createMemoizedAsyncValue(factory: () => Promise<void>): () => Promise<void> {
   let promise: Promise<void> | undefined;
 
   return () => {
@@ -241,6 +292,10 @@ export function resolveRequestIdFromHeaders(headers: IncomingHttpHeaders): strin
   return Array.isArray(requestId) ? requestId[0] : requestId;
 }
 
+export function parseQueryParamsFromSearch(search: string): Record<string, string | string[]> {
+  return parseQueryParams(new URLSearchParams(search));
+}
+
 function parseQueryParams(searchParams: URLSearchParams): Record<string, string | string[]> {
   const query: Record<string, string | string[]> = {};
 
@@ -263,17 +318,41 @@ function parseQueryParams(searchParams: URLSearchParams): Record<string, string 
   return query;
 }
 
-function cloneRequestHeaders(headers: IncomingHttpHeaders): FrameworkRequest['headers'] {
+export function snapshotSimpleQueryRecord(query: unknown): QueryRecord | undefined {
+  if (typeof query !== 'object' || query === null) {
+    return undefined;
+  }
+
+  const snapshot: QueryRecord = {};
+
+  for (const [key, value] of Object.entries(query)) {
+    if (typeof value === 'string' || value === undefined) {
+      snapshot[key] = value;
+      continue;
+    }
+
+    if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+      snapshot[key] = [...value];
+      continue;
+    }
+
+    return undefined;
+  }
+
+  return snapshot;
+}
+
+export function cloneRequestHeaders(headers: IncomingHttpHeaders): FrameworkRequest['headers'] {
   const clonedEntries = Object.entries(headers).map(([name, value]) => [name, cloneHeaderValue(value)]);
 
   return Object.fromEntries(clonedEntries);
 }
 
-function cloneHeaderValue<T extends string | string[] | undefined>(value: T): T {
+export function cloneHeaderValue<T extends string | string[] | undefined>(value: T): T {
   return (Array.isArray(value) ? [...value] : value) as T;
 }
 
-function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {
+export function readPrimaryHeaderValue(headerValue: string | string[] | undefined): string | undefined {
   if (Array.isArray(headerValue)) {
     return headerValue[0];
   }
@@ -281,7 +360,7 @@ function readPrimaryHeaderValue(headerValue: string | string[] | undefined): str
   return headerValue;
 }
 
-function normalizePrimaryContentType(headerValue: string | string[] | undefined): string | undefined {
+export function normalizePrimaryContentType(headerValue: string | string[] | undefined): string | undefined {
   const primaryHeaderValue = readPrimaryHeaderValue(headerValue);
 
   if (typeof primaryHeaderValue !== 'string') {
@@ -302,7 +381,7 @@ function decodeCookieValue(raw: string): string {
   }
 }
 
-function parseCookieHeader(cookieHeader: string | string[] | undefined): Record<string, string> {
+export function parseCookieHeader(cookieHeader: string | string[] | undefined): Record<string, string> {
   const normalizedCookieHeader = Array.isArray(cookieHeader) ? cookieHeader.join('; ') : cookieHeader;
 
   if (!normalizedCookieHeader) {
@@ -374,4 +453,39 @@ async function readRequestBody(
     body: bodyText,
     rawBody: preserveRawBody ? rawBody : undefined,
   };
+}
+
+export function splitRawRequestUrl(rawUrl: string | undefined): { path: string; search: string } {
+  const resolvedRawUrl = rawUrl ?? '/';
+
+  if (resolvedRawUrl.startsWith('http://') || resolvedRawUrl.startsWith('https://')) {
+    const url = new URL(resolvedRawUrl);
+    return { path: url.pathname, search: url.search };
+  }
+
+  const queryStart = resolvedRawUrl.indexOf('?');
+  const hashStart = resolvedRawUrl.indexOf('#');
+  const pathEndCandidates = [queryStart, hashStart].filter((index) => index >= 0);
+  const pathEnd = pathEndCandidates.length > 0 ? Math.min(...pathEndCandidates) : resolvedRawUrl.length;
+  const path = resolvedRawUrl.slice(0, pathEnd) || '/';
+
+  if (queryStart === -1) {
+    return { path, search: '' };
+  }
+
+  const searchEnd = hashStart >= 0 && hashStart > queryStart ? hashStart : resolvedRawUrl.length;
+  return {
+    path,
+    search: resolvedRawUrl.slice(queryStart, searchEnd),
+  };
+}
+
+export function resolveAbsoluteRequestUrl(rawUrl: string | undefined): string {
+  const resolvedRawUrl = rawUrl ?? '/';
+
+  if (resolvedRawUrl.startsWith('http://') || resolvedRawUrl.startsWith('https://')) {
+    return resolvedRawUrl;
+  }
+
+  return new URL(resolvedRawUrl, 'http://localhost').toString();
 }

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -20,11 +20,23 @@ import {
   compressNodeResponse,
 } from './internal-node-compression.js';
 import {
+  cloneHeaderValue,
+  cloneRequestHeaders,
+  createDeferredFrameworkRequestShell,
   createDeferredFrameworkRequest,
+  createMemoizedAsyncValue,
+  createMemoizedValue,
   NodeRequestPayloadTooLargeException,
+  normalizePrimaryContentType,
+  parseCookieHeader,
+  parseQueryParamsFromSearch,
   createRequestSignal,
   materializeFrameworkRequestBody,
+  readPrimaryHeaderValue,
+  resolveAbsoluteRequestUrl,
   resolveRequestIdFromHeaders,
+  snapshotSimpleQueryRecord,
+  splitRawRequestUrl,
 } from './internal-node-request.js';
 import {
   createFrameworkResponse,
@@ -321,11 +333,25 @@ export async function runNodeApplication(
 }
 
 export {
+  cloneHeaderValue,
+  cloneRequestHeaders,
   compressNodeResponse,
+  createDeferredFrameworkRequestShell,
+  createMemoizedAsyncValue,
+  createMemoizedValue,
+  createRequestSignal,
   createNodeResponseCompression,
   createNodeShutdownSignalRegistration,
   defaultNodeShutdownSignals,
+  normalizePrimaryContentType,
+  parseCookieHeader,
+  parseQueryParamsFromSearch,
+  readPrimaryHeaderValue,
   registerShutdownSignals,
+  resolveAbsoluteRequestUrl,
+  resolveRequestIdFromHeaders,
+  snapshotSimpleQueryRecord,
+  splitRawRequestUrl,
 };
 
 function createNodeServer(


### PR DESCRIPTION
Closes #1472

## Summary
- optimize Node-backed request shell creation by sharing deferred runtime helpers and reusing host-parsed request metadata where semantics stay identical
- preserve Fastify/Express native route handoff safety, middleware rewrite fallback, multipart/raw body behavior, and route normalization parity while falling back to raw URL parsing when host query data is unsafe
- add adapter-level regression coverage for benchmark-style simple query and JSON body routes plus unsafe host-query fallback cases across Fastify, Express, and raw Node

## Changes
- add shared `@fluojs/runtime/internal-node` request-shell helpers for deferred materialization, raw URL splitting, absolute URL resolution, and safe host query snapshots
- make `snapshotSimpleQueryRecord(...)` reject present `undefined` and other non-simple host query values so adapters preserve raw URL semantics such as `?flag` -> `''`
- update `packages/platform-fastify/src/adapter.ts` to reuse safe `request.query` snapshots before falling back to raw URL parsing
- update `packages/platform-express/src/adapter.ts` to build deferred request shells, reuse safe host query snapshots, and defer JSON/body parsing to dispatch materialization
- add regression coverage in `packages/platform-fastify/src/adapter.test.ts`, `packages/platform-express/src/adapter.test.ts`, and `packages/platform-nodejs/src/index.test.ts`
- add a patch changeset for `@fluojs/runtime`, `@fluojs/platform-fastify`, `@fluojs/platform-express`, and `@fluojs/platform-nodejs`

## Testing
- `pnpm --filter @fluojs/runtime test`
- `pnpm --filter @fluojs/platform-fastify --filter @fluojs/platform-express --filter @fluojs/platform-nodejs test`
- `pnpm build`
- `pnpm typecheck`
- regression evidence:
  - `packages/platform-fastify/src/adapter.test.ts` covers simple query/JSON body routes and unsafe host-query fallback (`?flag` -> `''`)
  - `packages/platform-express/src/adapter.test.ts` covers simple query/JSON body routes and unsafe host-query fallback (`?flag` -> `''`)
  - `packages/platform-nodejs/src/index.test.ts` covers simple query/JSON body benchmark-style routes

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Behavior remains contract-preserving; no new package README behavioral contract was introduced.

## Platform consistency governance (SSOT)
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.