### PR TITLE
Resolve #1470: cache dispatcher execution plans

### DIFF
--- a/.changeset/issue-1470-dispatcher-execution-plan-cache.md
+++ b/.changeset/issue-1470-dispatcher-execution-plan-cache.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/http': patch
+---
+
+Reduce singleton-route dispatcher overhead by caching stable execution plans while preserving lazy request-scope promotion, route-matched middleware behavior, observer callbacks, and request-scoped DI isolation.

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -1,13 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { Inject, Scope as ScopeDecorator } from '@fluojs/core';
 import { Container } from '@fluojs/di';
-
+import { IntersectionType, IsNumber, IsString, MinLength, OmitType, PartialType, PickType, ValidateNested } from '@fluojs/validation';
+import { describe, expect, it, vi } from 'vitest';
 import type {
   CallHandler,
-  GuardContext,
   FrameworkRequest,
   FrameworkResponse,
+  GuardContext,
   InterceptorContext,
   Middleware,
   MiddlewareContext,
@@ -16,32 +15,29 @@ import type {
   RequestObservationContext,
 } from '../index.js';
 import {
+  type assertRequestContext,
+  Controller,
   Convert,
-  FromBody,
-  FromPath,
-  FromQuery,
   createCorrelationMiddleware,
   createDispatcher,
   createHandlerMapping,
-  Controller,
+  FromBody,
+  FromPath,
+  FromQuery,
   Get,
+  getCurrentRequestContext,
+  Header,
+  HttpCode,
   Post,
   Produces,
+  Redirect,
   RequestDto,
   SseResponse,
-  HttpCode,
-  Header,
-  Redirect,
   UseGuards,
   UseInterceptors,
-  type assertRequestContext,
-  getCurrentRequestContext,
 } from '../index.js';
-import { IsNumber, IsString, MinLength, ValidateNested } from '@fluojs/validation';
-
-import { IntersectionType, OmitType, PartialType, PickType } from '@fluojs/validation';
-import { attachFrameworkRequestNativeRouteHandoff } from './native-route-handoff.js';
 import { forRoutes, runMiddlewareChain } from '../middleware/middleware.js';
+import { attachFrameworkRequestNativeRouteHandoff } from './native-route-handoff.js';
 
 function createResponse(): FrameworkResponse & { body?: unknown } {
   return {
@@ -321,6 +317,161 @@ describe('dispatcher runtime', () => {
 
     expect(firstResponse.body).toEqual({ store: 1 });
     expect(secondResponse.body).toEqual({ store: 2 });
+    expect(root.requestScopeCreateCount).toBe(2);
+    expect(root.requestScopeDisposeCount).toBe(2);
+  });
+
+  it('uses request scope when DTO converters resolve request-scoped providers', async () => {
+    let created = 0;
+
+    @ScopeDecorator('request')
+    class RequestStore {
+      readonly id = ++created;
+    }
+
+    @Inject(RequestStore)
+    @ScopeDecorator('request')
+    class ScopedConverter {
+      constructor(private readonly store: RequestStore) {}
+
+      convert(value: unknown) {
+        return `${String(value)}:${this.store.id}`;
+      }
+    }
+
+    class ScopedDto {
+      @Convert(ScopedConverter)
+      @FromPath('id')
+      id!: string;
+    }
+
+    @Controller('/converter-scope')
+    class ConverterScopeController {
+      @Get('/:id')
+      @RequestDto(ScopedDto)
+      getValue(input: ScopedDto) {
+        return { id: input.id };
+      }
+    }
+
+    const root = new CountingContainer().register(RequestStore, ScopedConverter, ConverterScopeController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ConverterScopeController }]),
+      rootContainer: root,
+    });
+
+    const firstResponse = createResponse();
+    await dispatcher.dispatch(createRequest('/converter-scope/one', 'GET'), firstResponse);
+
+    const secondResponse = createResponse();
+    await dispatcher.dispatch(createRequest('/converter-scope/two', 'GET'), secondResponse);
+
+    expect(firstResponse.body).toEqual({ id: 'one:1' });
+    expect(secondResponse.body).toEqual({ id: 'two:2' });
+    expect(root.requestScopeCreateCount).toBe(2);
+    expect(root.requestScopeDisposeCount).toBe(2);
+  });
+
+  it('promotes to request scope only when route-matched middleware is active', async () => {
+    const events: string[] = [];
+    let created = 0;
+
+    @ScopeDecorator('request')
+    class RequestStore {
+      readonly id = ++created;
+    }
+
+    @Inject(RequestStore)
+    @ScopeDecorator('request')
+    class ScopedMiddleware implements Middleware {
+      constructor(private readonly store: RequestStore) {}
+
+      async handle(context: MiddlewareContext, next: Next) {
+        events.push(`middleware:${context.request.path}:${this.store.id}`);
+        await next();
+      }
+    }
+
+    @Controller('/middleware-scope')
+    class MiddlewareScopeController {
+      @Get('/active')
+      getActive() {
+        return { ok: 'active' };
+      }
+
+      @Get('/inactive')
+      getInactive() {
+        return { ok: 'inactive' };
+      }
+    }
+
+    const root = new CountingContainer().register(RequestStore, ScopedMiddleware, MiddlewareScopeController);
+    const dispatcher = createDispatcher({
+      appMiddleware: [forRoutes(ScopedMiddleware, '/middleware-scope/active')],
+      handlerMapping: createHandlerMapping([{ controllerToken: MiddlewareScopeController }]),
+      rootContainer: root,
+    });
+
+    const inactiveResponse = createResponse();
+    await dispatcher.dispatch(createRequest('/middleware-scope/inactive', 'GET'), inactiveResponse);
+
+    const activeResponse = createResponse();
+    await dispatcher.dispatch(createRequest('/middleware-scope/active', 'GET'), activeResponse);
+
+    expect(inactiveResponse.body).toEqual({ ok: 'inactive' });
+    expect(activeResponse.body).toEqual({ ok: 'active' });
+    expect(events).toEqual(['middleware:/middleware-scope/active:1']);
+    expect(root.requestScopeCreateCount).toBe(1);
+    expect(root.requestScopeDisposeCount).toBe(1);
+  });
+
+  it('uses isolated request scopes for observer callbacks on singleton routes', async () => {
+    const events: string[] = [];
+    let created = 0;
+
+    @ScopeDecorator('request')
+    class RequestStore {
+      readonly id = ++created;
+    }
+
+    @Inject(RequestStore)
+    @ScopeDecorator('request')
+    class ScopedObserver {
+      constructor(private readonly store: RequestStore) {}
+
+      onRequestFinish() {
+        events.push(`finish:${this.store.id}`);
+      }
+
+      onRequestStart() {
+        events.push(`start:${this.store.id}`);
+      }
+    }
+
+    @Controller('/observer-scope')
+    class ObserverScopeController {
+      @Get('/')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new CountingContainer().register(RequestStore, ScopedObserver, ObserverScopeController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ObserverScopeController }]),
+      observers: [ScopedObserver],
+      rootContainer: root,
+    });
+
+    const firstResponse = createResponse();
+    await dispatcher.dispatch(createRequest('/observer-scope', 'GET'), firstResponse);
+
+    const secondResponse = createResponse();
+    await dispatcher.dispatch(createRequest('/observer-scope', 'GET'), secondResponse);
+
+    expect(firstResponse.body).toEqual({ ok: true });
+    expect(secondResponse.body).toEqual({ ok: true });
+    expect(events).toEqual(['start:1', 'finish:1', 'start:2', 'finish:2']);
     expect(root.requestScopeCreateCount).toBe(2);
     expect(root.requestScopeDisposeCount).toBe(2);
   });

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -1,17 +1,12 @@
 import type { Token } from '@fluojs/core';
 import type { Container, RequestScopeContainer } from '@fluojs/di';
-
-import { readFrameworkRequestNativeRouteHandoff } from './native-route-handoff.js';
-import { invokeControllerHandler } from './dispatch-handler-policy.js';
-import { resolveContentNegotiation, writeErrorResponse, writeSuccessResponse, type ResolvedContentNegotiation } from './dispatch-response-policy.js';
-import { matchHandlerOrThrow, updateRequestParams } from './dispatch-routing-policy.js';
 import { getCompiledDtoBindingPlan } from '../adapters/dto-binding-plan.js';
+import { createRequestContext, runWithRequestContext } from '../context/request-context.js';
+import { SseResponse } from '../context/sse.js';
 import { RequestAbortedError } from '../errors.js';
 import { runGuardChain } from '../guards.js';
 import { runInterceptorChain } from '../interceptors.js';
 import { isMiddlewareRouteConfig, matchRoutePattern, runMiddlewareChain } from '../middleware/middleware.js';
-import { createRequestContext, runWithRequestContext } from '../context/request-context.js';
-import { SseResponse } from '../context/sse.js';
 import type {
   Binder,
   ContentNegotiationOptions,
@@ -21,6 +16,7 @@ import type {
   FrameworkRequest,
   FrameworkResponse,
   GuardContext,
+  GuardLike,
   HandlerDescriptor,
   HandlerMapping,
   InterceptorLike,
@@ -31,6 +27,10 @@ import type {
   RequestObserver,
   RequestObserverLike,
 } from '../types.js';
+import { invokeControllerHandler } from './dispatch-handler-policy.js';
+import { type ResolvedContentNegotiation, resolveContentNegotiation, writeErrorResponse, writeSuccessResponse } from './dispatch-response-policy.js';
+import { matchHandlerOrThrow, updateRequestParams } from './dispatch-routing-policy.js';
+import { readFrameworkRequestNativeRouteHandoff } from './native-route-handoff.js';
 
 /**
  * Type definition for a global HTTP error handler function.
@@ -72,6 +72,23 @@ interface DispatchScope {
 
 interface RequestScopeInspector {
   hasRequestScopedDependency(token: Token): boolean;
+}
+
+interface CompiledMiddlewareScopePlan {
+  alwaysRequiresRequestScope: boolean;
+  conditionalDefinitions: MiddlewareLike[];
+}
+
+interface CompiledDispatchStartPlan {
+  requestScope: CompiledMiddlewareScopePlan;
+  requiresRequestScope: boolean;
+}
+
+interface CompiledHandlerExecutionPlan {
+  mergedInterceptors: InterceptorLike[];
+  requestScope: CompiledMiddlewareScopePlan;
+  requiresRequestScope: boolean;
+  routeGuards: GuardLike[];
 }
 
 function logDispatchFailure(
@@ -182,6 +199,33 @@ function activeMiddlewareMayRequireRequestScope(
   });
 }
 
+function compileMiddlewareScopePlan(definitions: readonly MiddlewareLike[]): CompiledMiddlewareScopePlan {
+  const conditionalDefinitions: MiddlewareLike[] = [];
+
+  for (const definition of definitions) {
+    if (!isMiddlewareRouteConfig(definition) || definition.routes.length === 0) {
+      return {
+        alwaysRequiresRequestScope: true,
+        conditionalDefinitions: [],
+      };
+    }
+
+    conditionalDefinitions.push(definition);
+  }
+
+  return {
+    alwaysRequiresRequestScope: false,
+    conditionalDefinitions,
+  };
+}
+
+function compiledMiddlewareMayRequireRequestScope(
+  plan: CompiledMiddlewareScopePlan,
+  request: FrameworkRequest,
+): boolean {
+  return plan.alwaysRequiresRequestScope || activeMiddlewareMayRequireRequestScope(plan.conditionalDefinitions, request);
+}
+
 function requestDtoMayRequireRequestScope(handler: HandlerDescriptor, options: CreateDispatcherOptions): boolean {
   if (!handler.route.request) {
     return false;
@@ -213,42 +257,54 @@ function hasRequestScopeInspector(container: unknown): container is RequestScope
     && typeof container.hasRequestScopedDependency === 'function';
 }
 
-function handlerMayRequireRequestScope(
+function compileHandlerExecutionPlan(
   handler: HandlerDescriptor,
-  request: FrameworkRequest,
   options: CreateDispatcherOptions,
+): CompiledHandlerExecutionPlan {
+  const routeGuards = handler.route.guards ?? [];
+  const requestScope = compileMiddlewareScopePlan(handler.metadata.moduleMiddleware);
+  const mergedInterceptors = mergeInterceptors(options.interceptors ?? [], handler.route.interceptors ?? []);
+
+  return {
+    mergedInterceptors,
+    requestScope,
+    requiresRequestScope:
+      routeGuards.length > 0
+      || mergedInterceptors.length > 0
+      || requestScope.alwaysRequiresRequestScope
+      || requestDtoMayRequireRequestScope(handler, options)
+      || handlerMethodMayUseRequestContext(handler)
+      || (hasRequestScopeInspector(options.rootContainer)
+        ? options.rootContainer.hasRequestScopedDependency(handler.controllerToken)
+        : true),
+    routeGuards,
+  };
+}
+
+function handlerMayRequireRequestScope(
+  plan: CompiledHandlerExecutionPlan,
+  request: FrameworkRequest,
 ): boolean {
-  if (handler.route.guards && handler.route.guards.length > 0) {
-    return true;
-  }
+  return plan.requiresRequestScope || compiledMiddlewareMayRequireRequestScope(plan.requestScope, request);
+}
 
-  if ((options.interceptors ?? []).length > 0 || (handler.route.interceptors ?? []).length > 0) {
-    return true;
-  }
+function compileDispatchStartPlan(
+  observers: readonly RequestObserverLike[],
+  appMiddleware: readonly MiddlewareLike[],
+): CompiledDispatchStartPlan {
+  const requestScope = compileMiddlewareScopePlan(appMiddleware);
 
-  if (activeMiddlewareMayRequireRequestScope(handler.metadata.moduleMiddleware, request)) {
-    return true;
-  }
-
-  if (requestDtoMayRequireRequestScope(handler, options)) {
-    return true;
-  }
-
-  if (handlerMethodMayUseRequestContext(handler)) {
-    return true;
-  }
-
-  return hasRequestScopeInspector(options.rootContainer)
-    ? options.rootContainer.hasRequestScopedDependency(handler.controllerToken)
-    : true;
+  return {
+    requestScope,
+    requiresRequestScope: observers.length > 0 || requestScope.alwaysRequiresRequestScope,
+  };
 }
 
 function dispatchStartMayRequireRequestScope(
+  plan: CompiledDispatchStartPlan,
   request: FrameworkRequest,
-  observers: readonly RequestObserverLike[],
-  options: CreateDispatcherOptions,
 ): boolean {
-  return observers.length > 0 || activeMiddlewareMayRequireRequestScope(options.appMiddleware ?? [], request);
+  return plan.requiresRequestScope || compiledMiddlewareMayRequireRequestScope(plan.requestScope, request);
 }
 
 function ensureRequestScope(context: DispatchPhaseContext): void {
@@ -333,15 +389,15 @@ function mergeInterceptors(
 
 async function dispatchMatchedHandler(
   handler: HandlerDescriptor,
+  executionPlan: CompiledHandlerExecutionPlan,
   requestContext: RequestContext,
   controllerContainer: RequestScopeContainer,
   observers: RequestObserverLike[],
   contentNegotiation: ResolvedContentNegotiation | undefined,
   binder: Binder | undefined,
-  globalInterceptors: readonly InterceptorLike[],
   logger: DispatcherLogger | undefined,
 ): Promise<void> {
-  const routeGuards = handler.route.guards ?? [];
+  const routeGuards = executionPlan.routeGuards;
   if (routeGuards.length > 0) {
     const guardContext: GuardContext = {
       handler,
@@ -355,11 +411,10 @@ async function dispatchMatchedHandler(
     return;
   }
 
-  const routeInterceptors = handler.route.interceptors ?? [];
-  const result = globalInterceptors.length === 0 && routeInterceptors.length === 0
+  const result = executionPlan.mergedInterceptors.length === 0
     ? await invokeControllerHandler(handler, requestContext, binder, controllerContainer)
     : await runInterceptorChain(
-        mergeInterceptors(globalInterceptors, routeInterceptors),
+        executionPlan.mergedInterceptors,
         {
           handler,
           requestContext,
@@ -384,9 +439,26 @@ async function dispatchMatchedHandler(
   );
 }
 
+function resolveHandlerExecutionPlan(
+  handler: HandlerDescriptor,
+  executionPlans: WeakMap<HandlerDescriptor, CompiledHandlerExecutionPlan>,
+  options: CreateDispatcherOptions,
+): CompiledHandlerExecutionPlan {
+  const cached = executionPlans.get(handler);
+
+  if (cached) {
+    return cached;
+  }
+
+  const compiled = compileHandlerExecutionPlan(handler, options);
+  executionPlans.set(handler, compiled);
+  return compiled;
+}
+
 interface DispatchPhaseContext {
   contentNegotiation: ResolvedContentNegotiation | undefined;
   dispatchScope: DispatchScope;
+  handlerExecutionPlans: WeakMap<HandlerDescriptor, CompiledHandlerExecutionPlan>;
   matchedHandler?: HandlerDescriptor;
   observers: RequestObserverLike[];
   options: CreateDispatcherOptions;
@@ -459,8 +531,9 @@ async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void>
       readFrameworkRequestNativeRouteHandoff(appMiddlewareContext.request)
       ?? matchHandlerOrThrow(context.options.handlerMapping, appMiddlewareContext.request);
     context.matchedHandler = match.descriptor;
+    const executionPlan = resolveHandlerExecutionPlan(match.descriptor, context.handlerExecutionPlans, context.options);
 
-    if (handlerMayRequireRequestScope(match.descriptor, appMiddlewareContext.request, context.options)) {
+    if (handlerMayRequireRequestScope(executionPlan, appMiddlewareContext.request)) {
       ensureRequestScope(context);
     }
 
@@ -476,12 +549,12 @@ async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void>
     await runMiddlewareChain(match.descriptor.metadata.moduleMiddleware ?? [], moduleMiddlewareContext, async () => {
       await dispatchMatchedHandler(
         match.descriptor,
+        executionPlan,
         context.requestContext,
         context.dispatchScope.container,
         context.observers,
         context.contentNegotiation,
         context.options.binder,
-        context.options.interceptors ?? [],
         context.options.logger,
       );
     });
@@ -518,6 +591,13 @@ async function handleDispatchError(context: DispatchPhaseContext, error: unknown
 export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
   const contentNegotiation = resolveContentNegotiation(options.contentNegotiation);
   const observers = options.observers ?? [];
+  const appMiddleware = options.appMiddleware ?? [];
+  const dispatchStartPlan = compileDispatchStartPlan(observers, appMiddleware);
+  const handlerExecutionPlans = new WeakMap<HandlerDescriptor, CompiledHandlerExecutionPlan>();
+
+  for (const descriptor of options.handlerMapping.descriptors) {
+    handlerExecutionPlans.set(descriptor, compileHandlerExecutionPlan(descriptor, options));
+  }
 
   const dispatcher = {
     describeRoutes() {
@@ -525,7 +605,7 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
     },
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
       const dispatchRequest = createDispatchRequest(request);
-      const dispatchScope = dispatchStartMayRequireRequestScope(dispatchRequest, observers, options)
+      const dispatchScope = dispatchStartMayRequireRequestScope(dispatchStartPlan, dispatchRequest)
         ? createRequestDispatchScope(options.rootContainer)
         : createRootDispatchScope(options.rootContainer);
       let phaseContext: DispatchPhaseContext;
@@ -542,6 +622,7 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
       phaseContext = {
         contentNegotiation,
         dispatchScope,
+        handlerExecutionPlans,
         observers,
         options,
         requestContext,


### PR DESCRIPTION
Closes #1470

## Summary
- Cache stable dispatcher execution plans for singleton-only and other static handler paths.
- Preserve lazy request-scope promotion, request-scoped provider isolation, middleware route matching, observer callbacks, AsyncLocalStorage request context behavior, and native route handoff behavior.

## Changes
- Precompile per-handler request-scope and interceptor plans at dispatcher creation time and reuse them during dispatch.
- Keep route-matched middleware on a conservative dynamic request-scope path so request rewrites and middleware filtering stay behaviorally identical.
- Add regressions for the singleton-only fast path, request-scoped controller routes, converter-triggered request scope, middleware-triggered request scope, and observer-triggered request scope.
- Add a patch changeset for `@fluojs/http`.

## Testing
- `pnpm exec vitest run packages/http/src/dispatch/dispatcher.test.ts`
- `pnpm exec tsc -p packages/http/tsconfig.build.json --noEmit`
- `pnpm -r --filter @fluojs/core --filter @fluojs/di --filter @fluojs/validation --filter @fluojs/http build`
- `pnpm --filter @fluojs/runtime build`
- `pnpm exec biome check "packages/http/src/dispatch/dispatcher.ts" "packages/http/src/dispatch/dispatcher.test.ts" ".changeset/issue-1470-dispatcher-execution-plan-cache.md"`

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No public exports changed in this PR.
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new public behavioral contracts were introduced; the existing dispatcher/request-context contract is preserved.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] No governance SSOT docs changed in this PR.
- [x] No platform contract docs changed, so no companion governance updates were required.
- [x] No package README alignment/conformance claims changed in this PR.