### PR TITLE
Optimize HTTP safe fast paths

### DIFF
--- a/packages/http/src/dispatch/dispatch-response-policy.ts
+++ b/packages/http/src/dispatch/dispatch-response-policy.ts
@@ -82,13 +82,13 @@ function isJsonContentType(contentType: string): boolean {
  * @param contentNegotiation The content negotiation.
  * @returns The write success response result.
  */
-export async function writeSuccessResponse(
+export function writeSuccessResponse(
   handler: HandlerDescriptor,
   request: FrameworkRequest,
   response: FrameworkResponse,
   value: unknown,
   contentNegotiation: ResolvedContentNegotiation | undefined,
-): Promise<void> {
+): ReturnType<FrameworkResponse['send']> | void {
   if (response.committed) {
     return;
   }
@@ -121,14 +121,13 @@ export async function writeSuccessResponse(
   }
 
   if (!formatter && hasSimpleJsonResponseWriter(response) && canUseSimpleJsonFastPath(response, value)) {
-    await response.sendSimpleJson(value);
-    return;
+    return response.sendSimpleJson(value);
   }
 
   const responseBody = formatter
     ? formatter.format(value)
     : value;
-  await response.send(responseBody);
+  return response.send(responseBody);
 }
 
 export { resolveContentNegotiation, writeErrorResponse };

--- a/packages/http/src/dispatch/dispatch-routing-policy.test.ts
+++ b/packages/http/src/dispatch/dispatch-routing-policy.test.ts
@@ -72,6 +72,7 @@ describe('dispatch routing policy', () => {
   });
 
   it('updates request params in request context without mutating unrelated fields', () => {
+    let queryReads = 0;
     const context: RequestContext = {
       container: {
         async dispose() {
@@ -82,7 +83,16 @@ describe('dispatch routing policy', () => {
         },
       },
       metadata: {},
-      request: createRequest('/users/1', 'GET'),
+      request: Object.defineProperties(createRequest('/users/1', 'GET'), {
+        query: {
+          configurable: true,
+          enumerable: true,
+          get() {
+            queryReads += 1;
+            return {};
+          },
+        },
+      }),
       response: {
         committed: false,
         headers: {},
@@ -97,5 +107,6 @@ describe('dispatch routing policy', () => {
 
     expect(context.request.path).toBe('/users/1');
     expect(context.request.params).toEqual({ id: '1' });
+    expect(queryReads).toBe(0);
   });
 });

--- a/packages/http/src/dispatch/dispatch-routing-policy.ts
+++ b/packages/http/src/dispatch/dispatch-routing-policy.ts
@@ -25,8 +25,10 @@ export function matchHandlerOrThrow(handlerMapping: HandlerMapping, request: Fra
  * @param params The params.
  */
 export function updateRequestParams(requestContext: RequestContext, params: Readonly<Record<string, string>>): void {
-  requestContext.request = {
-    ...requestContext.request,
-    params,
-  };
+  Object.defineProperty(requestContext.request, 'params', {
+    configurable: true,
+    enumerable: true,
+    value: params,
+    writable: true,
+  });
 }

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -21,10 +21,12 @@ import {
   createCorrelationMiddleware,
   createDispatcher,
   createHandlerMapping,
+  formatFastPathStats,
   FromBody,
   FromPath,
   FromQuery,
   Get,
+  getDispatcherFastPathStats,
   getCurrentRequestContext,
   Header,
   HttpCode,
@@ -142,12 +144,12 @@ describe('dispatcher runtime', () => {
     expect(root.requestScopeDisposeCount).toBe(0);
   });
 
-  it('uses request scope when a handler declares RequestContext access', async () => {
+  it('uses fast path for handlers with RequestContext when no request-scoped dependencies exist', async () => {
     @Controller('/context-aware')
     class ContextAwareController {
       @Get('/')
       getValue(_input: undefined, ctx: RequestContext) {
-        return { hasContainer: Boolean(ctx.container) };
+        return { method: ctx.request.method };
       }
     }
 
@@ -160,9 +162,9 @@ describe('dispatcher runtime', () => {
 
     await dispatcher.dispatch(createRequest('/context-aware', 'GET'), response);
 
-    expect(response.body).toEqual({ hasContainer: true });
-    expect(root.requestScopeCreateCount).toBe(1);
-    expect(root.requestScopeDisposeCount).toBe(1);
+    expect(response.body).toEqual({ method: 'GET' });
+    expect(root.requestScopeCreateCount).toBe(0);
+    expect(root.requestScopeDisposeCount).toBe(0);
   });
 
   it('lazily promotes manual RequestContext container access to a request scope', async () => {
@@ -667,6 +669,268 @@ describe('dispatcher runtime', () => {
     expect(arrayResponse.statusCode).toBe(200);
     expect(arrayResponse.simpleJsonBody).toEqual([{ ok: true }]);
     expect(arrayResponse.body).toBeUndefined();
+  });
+
+  it('exposes automatic fast-path stats without emitting debug headers by default', async () => {
+    @Controller('/fast-path-visibility')
+    class FastPathVisibilityController {
+      @Get('/')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(FastPathVisibilityController);
+    const dispatcher = createDispatcher({
+      adapter: 'fastify',
+      handlerMapping: createHandlerMapping([{ controllerToken: FastPathVisibilityController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/fast-path-visibility'), response);
+
+    const stats = getDispatcherFastPathStats(dispatcher);
+    expect(stats?.totalRoutes).toBe(1);
+    expect(stats?.fastPathRoutes).toBe(1);
+    expect(stats?.fullPathRoutes).toBe(0);
+    expect(stats?.routes[0]?.adapter).toBe('fastify');
+    expect(stats?.routes[0]?.executionPath).toBe('fast');
+    expect(response.headers['X-Fluo-Path']).toBeUndefined();
+    expect(response.simpleJsonBody).toEqual({ ok: true });
+  });
+
+  it('emits fast-path debug headers when explicitly enabled', async () => {
+    @Controller('/fast-path-debug-header')
+    class FastPathDebugHeaderController {
+      @Get('/')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(FastPathDebugHeaderController);
+    const dispatcher = createDispatcher({
+      fastPathDebugHeaders: true,
+      handlerMapping: createHandlerMapping([{ controllerToken: FastPathDebugHeaderController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/fast-path-debug-header'), response);
+
+    expect(response.headers['X-Fluo-Path']).toBe('fast; route=GET:/fast-path-debug-header');
+    expect(response.simpleJsonBody).toEqual({ ok: true });
+  });
+
+  it('falls back to full path when route capabilities are not fast-path safe', async () => {
+    class VisibilityGuard {
+      canActivate() {
+        return true;
+      }
+    }
+
+    @Controller('/full-path-visibility')
+    class FullPathVisibilityController {
+      @UseGuards(VisibilityGuard)
+      @Get('/')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container()
+      .register(FullPathVisibilityController)
+      .register(VisibilityGuard);
+    const dispatcher = createDispatcher({
+      fastPathDebugHeaders: true,
+      handlerMapping: createHandlerMapping([{ controllerToken: FullPathVisibilityController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/full-path-visibility'), response);
+
+    const stats = getDispatcherFastPathStats(dispatcher);
+    expect(stats?.totalRoutes).toBe(1);
+    expect(stats?.fastPathRoutes).toBe(0);
+    expect(stats?.fullPathRoutes).toBe(1);
+    expect(stats?.routes[0]?.executionPath).toBe('full');
+    expect(stats?.routes[0]?.fallbackReason).toContain('guards');
+    expect(response.headers['X-Fluo-Path']).toContain('full; route=GET:/');
+    expect(response.headers['X-Fluo-Path']).toContain('guards');
+    expect(response.simpleJsonBody).toEqual({ ok: true });
+  });
+
+  it('falls back to full path when global interceptors are registered', async () => {
+    const events: string[] = [];
+
+    class VisibilityInterceptor {
+      async intercept(_context: InterceptorContext, next: { handle(): Promise<unknown> }) {
+        events.push('interceptor:before');
+        const value = await next.handle();
+        events.push('interceptor:after');
+        return value;
+      }
+    }
+
+    @Controller('/global-interceptor-visibility')
+    class GlobalInterceptorVisibilityController {
+      @Get('/')
+      getValue() {
+        events.push('handler');
+        return { ok: true };
+      }
+    }
+
+    const root = new Container()
+      .register(GlobalInterceptorVisibilityController)
+      .register(VisibilityInterceptor);
+    const dispatcher = createDispatcher({
+      fastPathDebugHeaders: true,
+      handlerMapping: createHandlerMapping([{ controllerToken: GlobalInterceptorVisibilityController }]),
+      interceptors: [VisibilityInterceptor],
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/global-interceptor-visibility'), response);
+
+    const stats = getDispatcherFastPathStats(dispatcher);
+    expect(stats?.fastPathRoutes).toBe(0);
+    expect(stats?.fullPathRoutes).toBe(1);
+    expect(stats?.routes[0]?.executionPath).toBe('full');
+    expect(stats?.routes[0]?.fallbackReason).toContain('interceptors');
+    expect(response.headers['X-Fluo-Path']).toContain('interceptors');
+    expect(response.simpleJsonBody).toEqual({ ok: true });
+    expect(events).toEqual(['interceptor:before', 'handler', 'interceptor:after']);
+  });
+
+  it('preserves matched route params on the fast path', async () => {
+    @Controller('/fast-path-params')
+    class FastPathParamsController {
+      @Get('/:id')
+      getValue() {
+        return { id: getCurrentRequestContext()?.request.params.id };
+      }
+    }
+
+    const root = new Container().register(FastPathParamsController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastPathParamsController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/fast-path-params/u-1'), response);
+
+    const stats = getDispatcherFastPathStats(dispatcher);
+    expect(stats?.routes[0]?.executionPath).toBe('fast');
+    expect(response.simpleJsonBody).toEqual({ id: 'u-1' });
+  });
+
+  it('allows fast-path handlers to read request context data without forcing full path', async () => {
+    @Controller('/fast-path-context')
+    class FastPathContextController {
+      @Get('/')
+      getValue(_input: undefined, context: RequestContext) {
+        return {
+          encoded: context.request.query['encoded'],
+          requestId: context.requestId,
+        };
+      }
+    }
+
+    const root = new Container().register(FastPathContextController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastPathContextController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    const request = createRequest('/fast-path-context', 'GET', { 'x-request-id': 'req-1' });
+    request.query = { encoded: 'hello world' };
+
+    await dispatcher.dispatch(request, response);
+
+    const stats = getDispatcherFastPathStats(dispatcher);
+    expect(stats?.routes[0]?.executionPath).toBe('fast');
+    expect(response.simpleJsonBody).toEqual({ encoded: 'hello world', requestId: 'req-1' });
+  });
+
+  it('uses adapter-snapshotted request ids without materializing headers on the fast path', async () => {
+    @Controller('/fast-path-request-id-snapshot')
+    class FastPathRequestIdSnapshotController {
+      @Get('/')
+      getValue(_input: undefined, context: RequestContext) {
+        return { requestId: context.requestId };
+      }
+    }
+
+    const root = new Container().register(FastPathRequestIdSnapshotController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastPathRequestIdSnapshotController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+    const request = createRequest('/fast-path-request-id-snapshot');
+    let headerReads = 0;
+
+    request.requestId = 'req-snapshot-1';
+    Object.defineProperty(request, 'headers', {
+      configurable: true,
+      get() {
+        headerReads += 1;
+        return { 'x-request-id': 'req-header-1' };
+      },
+    });
+
+    await dispatcher.dispatch(request, response);
+
+    expect(headerReads).toBe(0);
+    expect(response.simpleJsonBody).toEqual({ requestId: 'req-snapshot-1' });
+  });
+
+  it('does not commit a fast-path success response after request aborts during handler execution', async () => {
+    const controller = new AbortController();
+
+    @Controller('/fast-path-abort')
+    class FastPathAbortController {
+      @Get('/')
+      async getValue() {
+        controller.abort();
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(FastPathAbortController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastPathAbortController }]),
+      rootContainer: root,
+    });
+    const request = createRequest('/fast-path-abort');
+    request.signal = controller.signal;
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(request, response);
+
+    const stats = getDispatcherFastPathStats(dispatcher);
+    expect(stats?.routes[0]?.executionPath).toBe('fast');
+    expect(response.committed).toBe(false);
+    expect(response.simpleJsonBody).toBeUndefined();
+  });
+
+  it('formats empty fast-path statistics without NaN output', () => {
+    const output = formatFastPathStats({
+      fastPathRoutes: 0,
+      fullPathRoutes: 0,
+      routes: [],
+      totalRoutes: 0,
+    });
+
+    expect(output).toContain('Fast path: 0 (0.0%)');
+    expect(output).toContain('Full path: 0 (0.0%)');
+    expect(output).not.toContain('NaN');
   });
 
   it('keeps strings and binary values on the generic success writer', async () => {
@@ -1643,6 +1907,47 @@ describe('dispatcher runtime', () => {
       'middleware:after:/native/123',
       'observer:finish:123',
     ]);
+  });
+
+  it('preserves fast-path eligibility on cloned native route descriptors', async () => {
+    @Controller('/native-fast')
+    class NativeFastController {
+      @Get('/:id')
+      getById(_input: undefined, context: RequestContext) {
+        return { id: context.request.params.id };
+      }
+    }
+
+    const root = new CountingContainer().register(NativeFastController);
+    const baseMapping = createHandlerMapping([{ controllerToken: NativeFastController }]);
+    const handlerMapping = {
+      descriptors: baseMapping.descriptors,
+      match: vi.fn(() => {
+        throw new Error('native route handoff should bypass handlerMapping.match');
+      }),
+    };
+    const dispatcher = createDispatcher({
+      handlerMapping,
+      rootContainer: root,
+    });
+    const descriptor = dispatcher.describeRoutes?.()[0];
+
+    if (!descriptor) {
+      throw new Error('Expected one cloned native route descriptor.');
+    }
+
+    const request = attachFrameworkRequestNativeRouteHandoff(createRequest('/native-fast/123'), {
+      descriptor,
+      params: { id: '123' },
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(request, response);
+
+    expect(handlerMapping.match).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual({ id: '123' });
+    expect(root.requestScopeCreateCount).toBe(0);
   });
 
   it('reuses adapter-native route handoff on error paths without rematching', async () => {

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -19,6 +19,7 @@ import type {
   GuardLike,
   HandlerDescriptor,
   HandlerMapping,
+  HandlerMatch,
   InterceptorLike,
   MiddlewareContext,
   MiddlewareLike,
@@ -30,16 +31,28 @@ import type {
 import { invokeControllerHandler } from './dispatch-handler-policy.js';
 import { type ResolvedContentNegotiation, resolveContentNegotiation, writeErrorResponse, writeSuccessResponse } from './dispatch-response-policy.js';
 import { matchHandlerOrThrow, updateRequestParams } from './dispatch-routing-policy.js';
-import { readFrameworkRequestNativeRouteHandoff } from './native-route-handoff.js';
+import { attachFrameworkRequestNativeRouteHandoff, readFrameworkRequestNativeRouteHandoff } from './native-route-handoff.js';
+import {
+  compileFastPathEligibility,
+  getHandlerFastPathEligibility,
+  setHandlerFastPathEligibility,
+  type FastPathEligibility,
+  type FastPathStats,
+  FAST_PATH_STATS_SYMBOL,
+  addPathDebugHeader,
+  createFastPathStats,
+  createPathDebugInfo,
+  executeFastPath,
+  shouldUseFastPathForRequest,
+} from './fast-path/index.js';
 
-/**
- * Type definition for a global HTTP error handler function.
- */
+export type { FastPathEligibility, FastPathStats } from './fast-path/index.js';
+export { FAST_PATH_ELIGIBILITY_SYMBOL, FAST_PATH_STATS_SYMBOL } from './fast-path/index.js';
+
+/** Type definition for a global HTTP error handler function. */
 export type ErrorHandler = (error: unknown, request: FrameworkRequest, response: FrameworkResponse, requestId?: string) => Promise<boolean | void> | boolean | void;
 
-/**
- * Options for creating an HTTP {@link Dispatcher}.
- */
+/** Options for creating an HTTP {@link Dispatcher}. */
 export interface CreateDispatcherOptions {
   /** Global middleware applied to all requests. */
   appMiddleware?: MiddlewareLike[];
@@ -53,6 +66,8 @@ export interface CreateDispatcherOptions {
   interceptors?: InterceptorLike[];
   /** Global request observers for telemetry and logging. */
   observers?: RequestObserverLike[];
+  /** Emits per-response fast-path debug headers when enabled. */
+  fastPathDebugHeaders?: boolean;
   /** Optional global error handler. */
   onError?: ErrorHandler;
   /** Request-scope optimization hints supplied by runtime bootstrap. */
@@ -60,9 +75,12 @@ export interface CreateDispatcherOptions {
     /** Global DTO converters used by the default binder. */
     converterDefinitions?: readonly ConverterLike[];
   };
+  /** Logger used for non-fatal dispatcher failures. */
   logger?: DispatcherLogger;
   /** Root DI container for creating request scopes. */
   rootContainer: Container;
+  /** Human-readable adapter label included in fast-path observability output. */
+  adapter?: string;
 }
 
 interface DispatchScope {
@@ -73,6 +91,10 @@ interface DispatchScope {
 interface RequestScopeInspector {
   hasRequestScopedDependency(token: Token): boolean;
 }
+
+type FrameworkRequestWithFiles = FrameworkRequest & {
+  files?: unknown;
+};
 
 interface CompiledMiddlewareScopePlan {
   alwaysRequiresRequestScope: boolean;
@@ -91,6 +113,15 @@ interface CompiledHandlerExecutionPlan {
   routeGuards: GuardLike[];
 }
 
+interface FastPathHandlerRuntimeCache {
+  controller?: object;
+  controllerPromise?: Promise<object>;
+  method?: (this: object, input: unknown, requestContext: RequestContext) => unknown;
+}
+
+const EMPTY_NATIVE_FAST_PATH_HANDLER_EXECUTION_PLANS = new WeakMap<HandlerDescriptor, CompiledHandlerExecutionPlan>();
+const EMPTY_NATIVE_FAST_PATH_OBSERVERS: RequestObserverLike[] = [];
+
 function logDispatchFailure(
   logger: DispatcherLogger | undefined,
   message: string,
@@ -105,14 +136,42 @@ function logDispatchFailure(
 }
 
 function createDispatchRequest(request: FrameworkRequest): FrameworkRequest {
-  return {
-    ...request,
+  const dispatchRequest: FrameworkRequest = {
+    get cookies() {
+      return request.cookies;
+    },
+    get headers() {
+      return request.headers;
+    },
+    get query() {
+      return request.query;
+    },
+    body: request.body,
+    method: request.method,
     params: { ...request.params },
+    path: request.path,
+    raw: request.raw,
+    rawBody: request.rawBody,
+    requestId: request.requestId,
+    signal: request.signal,
+    url: request.url,
   };
+
+  const nativeRouteHandoff = readFrameworkRequestNativeRouteHandoff(request);
+
+  const files = (request as FrameworkRequestWithFiles).files;
+
+  if (files !== undefined) {
+    (dispatchRequest as FrameworkRequestWithFiles).files = files;
+  }
+
+  return nativeRouteHandoff
+    ? attachFrameworkRequestNativeRouteHandoff(dispatchRequest, nativeRouteHandoff)
+    : dispatchRequest;
 }
 
 function cloneHandlerDescriptor(descriptor: HandlerDescriptor): HandlerDescriptor {
-  return {
+  const cloned = {
     ...descriptor,
     metadata: {
       ...descriptor.metadata,
@@ -128,9 +187,21 @@ function cloneHandlerDescriptor(descriptor: HandlerDescriptor): HandlerDescripto
       redirect: descriptor.route.redirect ? { ...descriptor.route.redirect } : undefined,
     },
   };
+
+  const eligibility = getHandlerFastPathEligibility(descriptor);
+
+  if (eligibility) {
+    setHandlerFastPathEligibility(cloned, eligibility);
+  }
+
+  return cloned;
 }
 
 function readRequestId(request: FrameworkRequest): string | undefined {
+  if (request.requestId) {
+    return request.requestId;
+  }
+
   const raw = request.headers['x-request-id'] ?? request.headers['X-Request-Id'];
   const value = Array.isArray(raw) ? raw[0] : raw;
   const normalized = value?.trim();
@@ -156,16 +227,55 @@ function createDispatchContext(
     return context;
   }
 
-  let activeContainer = container;
+  // Wrap the container to only promote to request scope when resolve() is actually called.
+  // This allows fast-path handlers to check ctx.container without triggering scope creation.
+  let activeContainer: RequestScopeContainer = container;
+  let wrappedContainer: RequestScopeContainer | undefined;
+  let promoted = false;
+
+  const ensurePromoted = (): RequestScopeContainer => {
+    if (!promoted) {
+      activeContainer = promoteOnContainerAccess();
+      promoted = true;
+    }
+    return activeContainer;
+  };
+
+  const getWrappedContainer = (): RequestScopeContainer => {
+    if (!wrappedContainer) {
+      wrappedContainer = {
+        async resolve<T>(token: Token<T>): Promise<T> {
+          const targetContainer = ensurePromoted();
+          return targetContainer.resolve(token);
+        },
+        async dispose(): Promise<void> {
+          // If promotion never happened, this is a no-op.
+          // This prevents accidentally disposing the root container when a
+          // captured container reference is used after a singleton-only request.
+          if (!promoted) {
+            return;
+          }
+          return activeContainer.dispose();
+        },
+      };
+    }
+    return wrappedContainer;
+  };
+
   Object.defineProperty(context, 'container', {
     configurable: true,
     enumerable: true,
     get() {
-      activeContainer = promoteOnContainerAccess();
-      return activeContainer;
+      // If promotion has already occurred, return the actual container.
+      if (promoted) {
+        return activeContainer;
+      }
+      // Return the wrapped container that will promote on resolve().
+      return getWrappedContainer();
     },
     set(value: RequestScopeContainer) {
       activeContainer = value;
+      promoted = true;
     },
   });
 
@@ -317,9 +427,54 @@ function ensureRequestScope(context: DispatchPhaseContext): void {
 }
 
 function ensureRequestNotAborted(request: FrameworkRequest): void {
-  if (request.signal?.aborted) {
+  if (isRequestAborted(request)) {
     throw new RequestAbortedError();
   }
+}
+
+function isRequestAborted(request: FrameworkRequest): boolean {
+  return request.isAborted?.() ?? request.signal?.aborted === true;
+}
+
+function resolveFastPathHandlerRuntimeCache(
+  handler: HandlerDescriptor,
+  cache: WeakMap<HandlerDescriptor, FastPathHandlerRuntimeCache>,
+): FastPathHandlerRuntimeCache {
+  const cached = cache.get(handler);
+
+  if (cached) {
+    return cached;
+  }
+
+  const method = handler.controllerToken.prototype[handler.methodName] as unknown;
+
+  const compiled = {
+    method: typeof method === 'function'
+      ? method as (this: object, input: unknown, requestContext: RequestContext) => unknown
+      : undefined,
+  };
+  cache.set(handler, compiled);
+  return compiled;
+}
+
+function resolveFastPathController(
+  handler: HandlerDescriptor,
+  controllerContainer: RequestScopeContainer,
+  runtimeCache: FastPathHandlerRuntimeCache,
+): object | Promise<object> {
+  if (runtimeCache.controller) {
+    return runtimeCache.controller;
+  }
+
+  runtimeCache.controllerPromise ??= controllerContainer.resolve(handler.controllerToken as Token<object>).then((controller) => {
+    runtimeCache.controller = controller;
+    return controller;
+  });
+  return runtimeCache.controllerPromise;
+}
+
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof value === 'object' && value !== null && 'then' in value && typeof value.then === 'function';
 }
 
 function isRequestObserver(value: RequestObserverLike): value is RequestObserver {
@@ -455,9 +610,79 @@ function resolveHandlerExecutionPlan(
   return compiled;
 }
 
+async function dispatchNativeFastRoute(
+  match: HandlerMatch,
+  request: FrameworkRequest,
+  response: FrameworkResponse,
+  options: CreateDispatcherOptions,
+  contentNegotiation: ResolvedContentNegotiation | undefined,
+  fastPathRuntimeCache: WeakMap<HandlerDescriptor, FastPathHandlerRuntimeCache>,
+): Promise<boolean> {
+  const eligibility = getHandlerFastPathEligibility(match.descriptor);
+
+  if (!shouldUseFastPathForRequest(eligibility, request)) {
+    return false;
+  }
+
+  const dispatchRequest = request;
+  const dispatchScope = createRootDispatchScope(options.rootContainer);
+  let phaseContext: DispatchPhaseContext;
+  let containerPromotionOpen = true;
+  const requestContext = createDispatchContext(dispatchRequest, response, dispatchScope.container, () => {
+    if (!containerPromotionOpen) {
+      return phaseContext.dispatchScope.container;
+    }
+
+    ensureRequestScope(phaseContext);
+    return phaseContext.dispatchScope.container;
+  });
+
+  phaseContext = {
+    contentNegotiation,
+    dispatchScope,
+    fastPathRuntimeCache,
+    handlerExecutionPlans: EMPTY_NATIVE_FAST_PATH_HANDLER_EXECUTION_PLANS,
+    observers: EMPTY_NATIVE_FAST_PATH_OBSERVERS,
+    options,
+    requestContext,
+    response,
+  };
+  phaseContext.matchedHandler = match.descriptor;
+  updateRequestParams(phaseContext.requestContext, match.params);
+
+  await runWithRequestContext(phaseContext.requestContext, async () => {
+    try {
+      ensureRequestNotAborted(phaseContext.requestContext.request);
+      const fastPathSuccess = await tryFastPathExecution(match.descriptor, phaseContext);
+
+      if (!fastPathSuccess) {
+        throw new Error(`Native route ${match.descriptor.route.method}:${match.descriptor.route.path} was not fast-path executable.`);
+      }
+    } catch (error: unknown) {
+      await handleDispatchError(phaseContext, error);
+    } finally {
+      if (!phaseContext.dispatchScope.requestScoped) {
+        phaseContext.requestContext.container = phaseContext.dispatchScope.container;
+      }
+
+      containerPromotionOpen = false;
+      if (phaseContext.dispatchScope.requestScoped) {
+        try {
+          await phaseContext.dispatchScope.container.dispose();
+        } catch (error) {
+          logDispatchFailure(options.logger, 'Request-scoped container dispose threw an error.', error);
+        }
+      }
+    }
+  });
+
+  return true;
+}
+
 interface DispatchPhaseContext {
   contentNegotiation: ResolvedContentNegotiation | undefined;
   dispatchScope: DispatchScope;
+  fastPathRuntimeCache: WeakMap<HandlerDescriptor, FastPathHandlerRuntimeCache>;
   handlerExecutionPlans: WeakMap<HandlerDescriptor, CompiledHandlerExecutionPlan>;
   matchedHandler?: HandlerDescriptor;
   observers: RequestObserverLike[];
@@ -513,6 +738,50 @@ async function notifyRequestFinish(context: DispatchPhaseContext): Promise<void>
   );
 }
 
+async function tryFastPathExecution(
+  handler: HandlerDescriptor,
+  context: DispatchPhaseContext,
+): Promise<boolean> {
+  const eligibility = getHandlerFastPathEligibility(handler);
+
+  if (!eligibility || eligibility.executionPath !== 'fast') {
+    return false;
+  }
+
+  if (typeof context.dispatchScope.container.resolve !== 'function') {
+    ensureRequestScope(context);
+  }
+
+  const runtimeCache = resolveFastPathHandlerRuntimeCache(
+    handler,
+    context.fastPathRuntimeCache,
+  );
+  const controllerOrPromise = resolveFastPathController(handler, context.dispatchScope.container, runtimeCache);
+  const controller = isPromiseLike(controllerOrPromise) ? await controllerOrPromise : controllerOrPromise;
+
+  const fastPathResult = await executeFastPath({
+    binder: context.options.binder,
+    contentNegotiation: context.contentNegotiation,
+    controller,
+    controllerContainer: context.dispatchScope.container,
+    handler,
+    method: runtimeCache.method,
+    request: context.requestContext.request,
+    requestContext: context.requestContext,
+    response: context.response,
+  });
+
+  if (fastPathResult.executed) {
+    return true;
+  }
+
+  if (fastPathResult.error) {
+    throw fastPathResult.error;
+  }
+
+  return false;
+}
+
 async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void> {
   ensureRequestNotAborted(context.requestContext.request);
 
@@ -522,7 +791,7 @@ async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void>
     response: context.response,
   };
 
-  await runMiddlewareChain(context.options.appMiddleware ?? [], appMiddlewareContext, async () => {
+  const dispatchMatchedRoute = async (): Promise<void> => {
     if (context.response.committed) {
       return;
     }
@@ -531,13 +800,29 @@ async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void>
       readFrameworkRequestNativeRouteHandoff(appMiddlewareContext.request)
       ?? matchHandlerOrThrow(context.options.handlerMapping, appMiddlewareContext.request);
     context.matchedHandler = match.descriptor;
+    updateRequestParams(context.requestContext, match.params);
+
+    const eligibility = getHandlerFastPathEligibility(match.descriptor);
+
+    if (context.options.fastPathDebugHeaders === true && eligibility && !context.response.committed) {
+      const debugInfo = createPathDebugInfo(eligibility);
+      addPathDebugHeader(context.response.setHeader.bind(context.response), debugInfo);
+    }
+
+    if (shouldUseFastPathForRequest(eligibility, appMiddlewareContext.request)) {
+      const fastPathSuccess = await tryFastPathExecution(match.descriptor, context);
+
+      if (fastPathSuccess) {
+        return;
+      }
+    }
+
     const executionPlan = resolveHandlerExecutionPlan(match.descriptor, context.handlerExecutionPlans, context.options);
 
     if (handlerMayRequireRequestScope(executionPlan, appMiddlewareContext.request)) {
       ensureRequestScope(context);
     }
 
-    updateRequestParams(context.requestContext, match.params);
     await notifyHandlerMatched(context, match.descriptor);
 
     const moduleMiddlewareContext: MiddlewareContext = {
@@ -558,11 +843,20 @@ async function runDispatchPipeline(context: DispatchPhaseContext): Promise<void>
         context.options.logger,
       );
     });
-  });
+  };
+
+  const appMiddleware = context.options.appMiddleware ?? [];
+
+  if (appMiddleware.length === 0) {
+    await dispatchMatchedRoute();
+    return;
+  }
+
+  await runMiddlewareChain(appMiddleware, appMiddlewareContext, dispatchMatchedRoute);
 }
 
 async function handleDispatchError(context: DispatchPhaseContext, error: unknown): Promise<void> {
-  if (error instanceof RequestAbortedError || context.requestContext.request.signal?.aborted) {
+      if (error instanceof RequestAbortedError || isRequestAborted(context.requestContext.request)) {
     return;
   }
 
@@ -593,15 +887,27 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
   const observers = options.observers ?? [];
   const appMiddleware = options.appMiddleware ?? [];
   const dispatchStartPlan = compileDispatchStartPlan(observers, appMiddleware);
+  const fastPathRuntimeCache = new WeakMap<HandlerDescriptor, FastPathHandlerRuntimeCache>();
   const handlerExecutionPlans = new WeakMap<HandlerDescriptor, CompiledHandlerExecutionPlan>();
+  const adapter = options.adapter ?? 'default';
+  const fastPathEligibilities: FastPathEligibility[] = [];
 
   for (const descriptor of options.handlerMapping.descriptors) {
     handlerExecutionPlans.set(descriptor, compileHandlerExecutionPlan(descriptor, options));
+
+    const { eligibility } = compileFastPathEligibility(descriptor, options, adapter);
+    setHandlerFastPathEligibility(descriptor, eligibility);
+    fastPathEligibilities.push(eligibility);
   }
+
+  const fastPathStats = createFastPathStats(fastPathEligibilities);
 
   const dispatcher = {
     describeRoutes() {
       return options.handlerMapping.descriptors.map((descriptor) => cloneHandlerDescriptor(descriptor));
+    },
+    async dispatchNativeRoute(match: HandlerMatch, request: FrameworkRequest, response: FrameworkResponse): Promise<boolean> {
+      return dispatchNativeFastRoute(match, request, response, options, contentNegotiation, fastPathRuntimeCache);
     },
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
       const dispatchRequest = createDispatchRequest(request);
@@ -622,6 +928,7 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
       phaseContext = {
         contentNegotiation,
         dispatchScope,
+        fastPathRuntimeCache,
         handlerExecutionPlans,
         observers,
         options,
@@ -631,12 +938,21 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
 
       await runWithRequestContext(phaseContext.requestContext, async () => {
         try {
-          await notifyRequestStart(phaseContext);
+          if (observers.length > 0) {
+            await notifyRequestStart(phaseContext);
+          }
           await runDispatchPipeline(phaseContext);
         } catch (error: unknown) {
           await handleDispatchError(phaseContext, error);
         } finally {
-          await notifyRequestFinish(phaseContext);
+          if (observers.length > 0) {
+            await notifyRequestFinish(phaseContext);
+          }
+
+          if (!phaseContext.dispatchScope.requestScoped) {
+            phaseContext.requestContext.container = phaseContext.dispatchScope.container;
+          }
+
           containerPromotionOpen = false;
           if (phaseContext.dispatchScope.requestScoped) {
             try {
@@ -650,5 +966,19 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
     },
   };
 
+  (dispatcher as unknown as Record<symbol, FastPathStats>)[FAST_PATH_STATS_SYMBOL] = fastPathStats;
+
   return dispatcher as Dispatcher;
 }
+
+/**
+ * Reads automatic fast-path eligibility statistics attached to a dispatcher.
+ *
+ * @param dispatcher Dispatcher returned by {@link createDispatcher}.
+ * @returns Fast-path statistics when available.
+ */
+export function getDispatcherFastPathStats(dispatcher: Dispatcher): FastPathStats | undefined {
+  return (dispatcher as unknown as Record<symbol, FastPathStats | undefined>)[FAST_PATH_STATS_SYMBOL];
+}
+
+export { formatFastPathStats } from './fast-path/index.js';

--- a/packages/http/src/dispatch/fast-path/debug-visibility.ts
+++ b/packages/http/src/dispatch/fast-path/debug-visibility.ts
@@ -1,0 +1,70 @@
+import type { FastPathEligibility, FastPathStats } from './eligibility.js';
+
+const DEBUG_HEADER_NAME = 'X-Fluo-Path';
+
+interface PathDebugInfo {
+  executionPath: 'fast' | 'full';
+  fallbackReason?: string;
+  routeId: string;
+}
+
+export function createPathDebugInfo(eligibility: FastPathEligibility): PathDebugInfo {
+  return {
+    executionPath: eligibility.executionPath,
+    fallbackReason: eligibility.fallbackReason,
+    routeId: eligibility.routeId,
+  };
+}
+
+export function addPathDebugHeader(
+  setHeader: (name: string, value: string) => void,
+  info: PathDebugInfo,
+): void {
+  const value = info.executionPath === 'fast'
+    ? `fast; route=${info.routeId}`
+    : `full; route=${info.routeId}; reason=${info.fallbackReason ?? 'none'}`;
+
+  setHeader(DEBUG_HEADER_NAME, value);
+}
+
+export function createFastPathStats(eligibilities: readonly FastPathEligibility[]): FastPathStats {
+  const fastPathRoutes = eligibilities.filter((e) => e.executionPath === 'fast').length;
+
+  return {
+    fastPathRoutes,
+    fullPathRoutes: eligibilities.length - fastPathRoutes,
+    routes: eligibilities,
+    totalRoutes: eligibilities.length,
+  };
+}
+
+/**
+ * Formats dispatcher fast-path statistics for debug logs and benchmark output.
+ *
+ * @param stats Fast-path statistics returned by {@link getDispatcherFastPathStats}.
+ * @returns A human-readable route breakdown.
+ */
+export function formatFastPathStats(stats: FastPathStats): string {
+  const fastPathPercent = stats.totalRoutes === 0
+    ? '0.0'
+    : ((stats.fastPathRoutes / stats.totalRoutes) * 100).toFixed(1);
+  const fullPathPercent = stats.totalRoutes === 0
+    ? '0.0'
+    : ((stats.fullPathRoutes / stats.totalRoutes) * 100).toFixed(1);
+  const lines: string[] = [
+    '=== Fast Path Statistics ===',
+    `Total routes: ${String(stats.totalRoutes)}`,
+    `Fast path: ${String(stats.fastPathRoutes)} (${fastPathPercent}%)`,
+    `Full path: ${String(stats.fullPathRoutes)} (${fullPathPercent}%)`,
+    '',
+    'Route breakdown:',
+  ];
+
+  for (const route of stats.routes) {
+    const status = route.executionPath === 'fast' ? 'FAST' : 'FULL';
+    const reason = route.fallbackReason ? ` (${route.fallbackReason})` : '';
+    lines.push(`  [${status}] ${route.routeId}${reason}`);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/http/src/dispatch/fast-path/eligibility-checker.ts
+++ b/packages/http/src/dispatch/fast-path/eligibility-checker.ts
@@ -1,0 +1,172 @@
+import type { Container } from '@fluojs/di';
+
+import { getCompiledDtoBindingPlan } from '../../adapters/dto-binding-plan.js';
+import type {
+  Binder,
+  HandlerDescriptor,
+  MiddlewareLike,
+} from '../../types.js';
+import type { CreateDispatcherOptions } from '../dispatcher.js';
+import { type FastPathEligibility, FAST_PATH_ELIGIBILITY_SYMBOL } from './eligibility.js';
+
+interface RequestScopeInspector {
+  hasRequestScopedDependency(token: unknown): boolean;
+}
+
+interface CompiledEligibilityPlan {
+  eligibility: FastPathEligibility;
+  isEligible: boolean;
+}
+
+function hasRequestScopeInspector(container: unknown): container is RequestScopeInspector {
+  return (
+    typeof container === 'object'
+    && container !== null
+    && 'hasRequestScopedDependency' in container
+    && typeof container.hasRequestScopedDependency === 'function'
+  );
+}
+
+function requestDtoMayRequireRequestScope(handler: HandlerDescriptor, options: CreateDispatcherOptions): boolean {
+  if (!handler.route.request) {
+    return false;
+  }
+  if ((options.requestScope?.converterDefinitions ?? []).length > 0) {
+    return true;
+  }
+  if (options.binder) {
+    return true;
+  }
+  const plan = getCompiledDtoBindingPlan(handler.route.request);
+  return plan.entries.some((entry) => entry.converter !== undefined);
+}
+
+function determineRequestScopeRequirement(
+  handler: HandlerDescriptor,
+  options: CreateDispatcherOptions,
+): boolean {
+  if (handler.route.guards && handler.route.guards.length > 0) {
+    return true;
+  }
+  if (handler.route.interceptors && handler.route.interceptors.length > 0) {
+    return true;
+  }
+  if (handler.metadata.moduleMiddleware && handler.metadata.moduleMiddleware.length > 0) {
+    return true;
+  }
+  if (requestDtoMayRequireRequestScope(handler, options)) {
+    return true;
+  }
+  if (hasRequestScopeInspector(options.rootContainer)) {
+    return options.rootContainer.hasRequestScopedDependency(handler.controllerToken);
+  }
+  return true;
+}
+
+function determineMiddlewareRequirement(
+  handler: HandlerDescriptor,
+  appMiddleware: readonly MiddlewareLike[],
+): boolean {
+  if (appMiddleware.length > 0) {
+    return true;
+  }
+  const moduleMiddleware = handler.metadata.moduleMiddleware;
+  return moduleMiddleware !== undefined && moduleMiddleware.length > 0;
+}
+
+export function compileFastPathEligibility(
+  handler: HandlerDescriptor,
+  options: CreateDispatcherOptions,
+  adapter: string,
+): CompiledEligibilityPlan {
+  const routeId = `${handler.route.method}:${handler.route.path}`;
+  const hasGuard = (handler.route.guards?.length ?? 0) > 0;
+  const hasInterceptor = (handler.route.interceptors?.length ?? 0) > 0
+    || (options.interceptors?.length ?? 0) > 0;
+  const hasPipe = handler.route.request !== undefined;
+  const hasRequestScopedDI = determineRequestScopeRequirement(handler, options);
+  const hasMiddleware = determineMiddlewareRequirement(handler, options.appMiddleware ?? []);
+  const hasContentNegotiation = options.contentNegotiation?.formatters !== undefined && options.contentNegotiation.formatters.length > 0;
+
+  const eligibility: FastPathEligibility = {
+    adapter,
+    executionPath: 'full',
+    hasAdapterPluginInfluence: false,
+    hasCustomBodyParser: options.binder !== undefined,
+    hasCustomErrorFilter: options.onError !== undefined,
+    hasGlobalHook: (options.observers?.length ?? 0) > 0,
+    hasGuard,
+    hasInterceptor,
+    hasMiddleware,
+    hasPipe,
+    hasRequestScopedDI,
+    routeId,
+  };
+
+  const blockingReasons: string[] = [];
+
+  if (eligibility.hasGuard) {
+    blockingReasons.push('guards');
+  }
+  if (eligibility.hasInterceptor) {
+    blockingReasons.push('interceptors');
+  }
+  if (eligibility.hasPipe) {
+    blockingReasons.push('pipes/DTO binding');
+  }
+  if (eligibility.hasRequestScopedDI) {
+    blockingReasons.push('request-scoped DI');
+  }
+  if (eligibility.hasMiddleware) {
+    blockingReasons.push('middleware');
+  }
+  if (eligibility.hasGlobalHook) {
+    blockingReasons.push('request observers');
+  }
+  if (eligibility.hasCustomErrorFilter) {
+    blockingReasons.push('custom error filter');
+  }
+  if (eligibility.hasCustomBodyParser) {
+    blockingReasons.push('custom binder');
+  }
+  if (hasContentNegotiation) {
+    blockingReasons.push('content negotiation');
+  }
+
+  const isEligible = blockingReasons.length === 0;
+
+  if (!isEligible) {
+    eligibility.fallbackReason = `Full path required due to: ${blockingReasons.join(', ')}`;
+  } else {
+    eligibility.executionPath = 'fast';
+  }
+
+  return { eligibility, isEligible };
+}
+
+export function getHandlerFastPathEligibility(
+  handler: HandlerDescriptor,
+): FastPathEligibility | undefined {
+  return (handler as unknown as Record<symbol, FastPathEligibility | undefined>)[
+    FAST_PATH_ELIGIBILITY_SYMBOL
+  ];
+}
+
+export function setHandlerFastPathEligibility(
+  handler: HandlerDescriptor,
+  eligibility: FastPathEligibility,
+): void {
+  (handler as unknown as Record<symbol, FastPathEligibility>)[FAST_PATH_ELIGIBILITY_SYMBOL] =
+    eligibility;
+}
+
+export interface FastPathExecutorOptions {
+  binder?: Binder;
+  rootContainer: Container;
+}
+
+export interface FastPathExecutionResult {
+  executed: boolean;
+  result?: unknown;
+  error?: unknown;
+}

--- a/packages/http/src/dispatch/fast-path/eligibility.ts
+++ b/packages/http/src/dispatch/fast-path/eligibility.ts
@@ -1,0 +1,79 @@
+/**
+ * Per-route capability model used to decide whether a route can safely bypass
+ * optional framework overhead and execute through the fast path.
+ *
+ * Fast path selection is automatic and conservative: if safety cannot be proven,
+ * the route uses the full path with all framework features enabled.
+ */
+export interface FastPathEligibility {
+  /** Stable identifier for the route being analyzed. */
+  readonly routeId: string;
+
+  /** Active runtime adapter such as Fastify or Bun. */
+  readonly adapter: string;
+
+  /** Benchmark or runtime scenario associated with the route. */
+  readonly scenario?: string;
+
+  /** Whether a global hook may affect route execution. */
+  readonly hasGlobalHook: boolean;
+
+  /** Whether middleware applies to the route. */
+  readonly hasMiddleware: boolean;
+
+  /** Whether guard logic applies to the route. */
+  readonly hasGuard: boolean;
+
+  /** Whether pipe or validation logic applies to the route. */
+  readonly hasPipe: boolean;
+
+  /** Whether interceptor logic applies to the route. */
+  readonly hasInterceptor: boolean;
+
+  /** Whether request-scoped dependency resolution is needed. */
+  readonly hasRequestScopedDI: boolean;
+
+  /** Whether body parsing behavior has been customized. */
+  readonly hasCustomBodyParser: boolean;
+
+  /** Whether a custom exception filter applies. */
+  readonly hasCustomErrorFilter: boolean;
+
+  /** Whether adapter-level plugin behavior may affect execution. */
+  readonly hasAdapterPluginInfluence: boolean;
+
+  /** Resolved execution path, either 'fast' or 'full'. */
+  executionPath: 'fast' | 'full';
+
+  /** Explanation for full-path fallback when fast path is not selected. */
+  fallbackReason?: string;
+}
+
+/**
+ * Statistics collected about fast path decisions for observability.
+ */
+export interface FastPathStats {
+  /** Total number of routes analyzed. */
+  totalRoutes: number;
+
+  /** Number of routes eligible for fast path. */
+  fastPathRoutes: number;
+
+  /** Number of routes using full path. */
+  fullPathRoutes: number;
+
+  /** Per-route eligibility details. */
+  routes: ReadonlyArray<Readonly<FastPathEligibility>>;
+}
+
+/**
+ * Symbol used to attach fast path eligibility metadata to handler descriptors.
+ * @internal
+ */
+export const FAST_PATH_ELIGIBILITY_SYMBOL = Symbol('fastPathEligibility');
+
+/**
+ * Symbol used to attach fast path execution stats to dispatcher.
+ * @internal
+ */
+export const FAST_PATH_STATS_SYMBOL = Symbol('fastPathStats');

--- a/packages/http/src/dispatch/fast-path/fast-path-executor.ts
+++ b/packages/http/src/dispatch/fast-path/fast-path-executor.ts
@@ -1,0 +1,119 @@
+import type { Token } from '@fluojs/core';
+import type { RequestScopeContainer } from '@fluojs/di';
+
+import { DefaultBinder } from '../../adapters/binding.js';
+import { getCompiledDtoBindingPlan } from '../../adapters/dto-binding-plan.js';
+import { HttpDtoValidationAdapter } from '../../adapters/dto-validation-adapter.js';
+import { SseResponse } from '../../context/sse.js';
+import { RequestAbortedError } from '../../errors.js';
+import { type ResolvedContentNegotiation, writeSuccessResponse } from '../dispatch-response-policy.js';
+import type {
+  Binder,
+  FrameworkRequest,
+  FrameworkResponse,
+  HandlerDescriptor,
+  RequestContext,
+} from '../../types.js';
+import type { FastPathExecutionResult } from './eligibility-checker.js';
+
+const defaultBinder = new DefaultBinder();
+const defaultValidator = new HttpDtoValidationAdapter();
+
+type Thenable<T> = {
+  then(onFulfilled: (value: T) => unknown, onRejected?: (reason: unknown) => unknown): unknown;
+};
+
+interface ExecuteFastPathOptions {
+  binder?: Binder;
+  contentNegotiation?: ResolvedContentNegotiation;
+  controllerContainer: RequestScopeContainer;
+  controller?: object;
+  handler: HandlerDescriptor;
+  method?: (this: object, input: unknown, requestContext: RequestContext) => unknown;
+  request: FrameworkRequest;
+  requestContext: RequestContext;
+  response: FrameworkResponse;
+}
+
+export async function executeFastPath(
+  options: ExecuteFastPathOptions,
+): Promise<FastPathExecutionResult> {
+  const { binder, contentNegotiation, controllerContainer, handler, request, requestContext, response } = options;
+
+  try {
+    const controller = options.controller ?? await controllerContainer.resolve(handler.controllerToken as Token<object>);
+    const method = options.method ?? (controller as Record<string, unknown>)[handler.methodName];
+
+    if (typeof method !== 'function') {
+      return {
+        error: new Error(
+          `Controller ${handler.controllerToken.name} does not expose handler method ${handler.methodName}.`,
+        ),
+        executed: false,
+      };
+    }
+
+    const requestDto = handler.route.request;
+    let input: unknown;
+
+    if (requestDto) {
+      const bindingPlan = getCompiledDtoBindingPlan(requestDto);
+      const activeBinder = binder ?? defaultBinder;
+
+      input = await activeBinder.bind(requestDto, {
+        handler,
+        requestContext,
+      });
+
+      if (bindingPlan.needsValidation) {
+        await defaultValidator.validate(input, requestDto);
+      }
+    }
+
+    const maybeResult = method.call(controller, input, requestContext);
+    const result = isThenable(maybeResult) ? await maybeResult : maybeResult;
+
+    if (isRequestAborted(request)) {
+      throw new RequestAbortedError();
+    }
+
+    if (!(result instanceof SseResponse) && !response.committed) {
+      const writeResult = writeSuccessResponse(handler, request, response, result, contentNegotiation);
+
+      if (isThenable(writeResult)) {
+        await writeResult;
+      }
+    }
+
+    return { executed: true, result };
+  } catch (error) {
+    return { error, executed: false };
+  }
+}
+
+function isThenable<T>(value: T | Thenable<T>): value is Thenable<T> {
+  return typeof value === 'object'
+    && value !== null
+    && 'then' in value
+    && typeof value.then === 'function';
+}
+
+export function shouldUseFastPathForRequest(
+  eligibility: { executionPath: 'fast' | 'full' } | undefined,
+  request: FrameworkRequest,
+): boolean {
+  if (!eligibility) {
+    return false;
+  }
+  if (eligibility.executionPath !== 'fast') {
+    return false;
+  }
+  if (isRequestAborted(request)) {
+    return false;
+  }
+  return true;
+}
+
+function isRequestAborted(request: FrameworkRequest): boolean {
+  return request.isAborted?.() ?? request.signal?.aborted === true;
+}

--- a/packages/http/src/dispatch/fast-path/index.ts
+++ b/packages/http/src/dispatch/fast-path/index.ts
@@ -1,0 +1,15 @@
+export type { FastPathEligibility, FastPathStats } from './eligibility.js';
+export { FAST_PATH_ELIGIBILITY_SYMBOL, FAST_PATH_STATS_SYMBOL } from './eligibility.js';
+export {
+  compileFastPathEligibility,
+  getHandlerFastPathEligibility,
+  setHandlerFastPathEligibility,
+  type FastPathExecutionResult,
+} from './eligibility-checker.js';
+export { executeFastPath, shouldUseFastPathForRequest } from './fast-path-executor.js';
+export {
+  addPathDebugHeader,
+  createFastPathStats,
+  createPathDebugInfo,
+  formatFastPathStats,
+} from './debug-visibility.js';

--- a/packages/http/src/dispatch/native-route-handoff.ts
+++ b/packages/http/src/dispatch/native-route-handoff.ts
@@ -1,8 +1,8 @@
-import { normalizeRoutePath } from '../route-path.js';
 import type { FrameworkRequest, HandlerMatch } from '../types.js';
 
 const FRAMEWORK_REQUEST_NATIVE_ROUTE_HANDOFF = Symbol('fluo.http.nativeRouteHandoff');
 const RAW_REQUEST_NATIVE_ROUTE_HANDOFFS = new WeakMap<object, HandlerMatch>();
+const EMPTY_ROUTE_PARAMS: Readonly<Record<string, string>> = Object.freeze({});
 
 interface FrameworkRequestNativeRouteHandoffRecord {
   handoff: HandlerMatch;
@@ -17,8 +17,12 @@ type FrameworkRequestWithNativeRouteHandoff = FrameworkRequest & {
 function cloneNativeRouteHandoff(handoff: HandlerMatch): HandlerMatch {
   return {
     descriptor: handoff.descriptor,
-    params: { ...handoff.params },
+    params: cloneRouteParams(handoff.params),
   };
+}
+
+function cloneRouteParams(params: Readonly<Record<string, string>>): Readonly<Record<string, string>> {
+  return Object.keys(params).length === 0 ? EMPTY_ROUTE_PARAMS : { ...params };
 }
 
 /** Internal handoff payload that lets adapters skip duplicate route matching safely. */
@@ -120,5 +124,5 @@ export function readFrameworkRequestNativeRouteHandoff(
  * @returns `true` when normalization would change the incoming path.
  */
 export function isRoutePathNormalizationSensitive(path: string): boolean {
-  return normalizeRoutePath(path) !== path;
+  return (path.length > 1 && path.endsWith('/')) || path.includes('//');
 }

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -28,6 +28,13 @@ export {
   Version,
 } from './decorators.js';
 export * from './dispatch/dispatcher.js';
+export type { FastPathEligibility, FastPathStats } from './dispatch/fast-path/index.js';
+export {
+  FAST_PATH_ELIGIBILITY_SYMBOL,
+  FAST_PATH_STATS_SYMBOL,
+  formatFastPathStats,
+  getDispatcherFastPathStats,
+} from './dispatch/dispatcher.js';
 export * from './errors.js';
 export * from './exceptions.js';
 export * from './mapping.js';

--- a/packages/http/src/public-api.test.ts
+++ b/packages/http/src/public-api.test.ts
@@ -29,6 +29,10 @@ describe('@fluojs/http public API surface', () => {
     expect(httpPublicApi).toHaveProperty('UseGuards');
     expect(httpPublicApi).toHaveProperty('UseInterceptors');
     expect(httpPublicApi).toHaveProperty('createDispatcher');
+    expect(httpPublicApi).toHaveProperty('FAST_PATH_ELIGIBILITY_SYMBOL');
+    expect(httpPublicApi).toHaveProperty('FAST_PATH_STATS_SYMBOL');
+    expect(httpPublicApi).toHaveProperty('formatFastPathStats');
+    expect(httpPublicApi).toHaveProperty('getDispatcherFastPathStats');
     expect(httpPublicApi).toHaveProperty('createHandlerMapping');
     expect(httpPublicApi).toHaveProperty('forRoutes');
     expect(httpPublicApi).toHaveProperty('normalizeRoutePattern');

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -29,8 +29,12 @@ export interface FrameworkRequest {
   cookies: Readonly<Record<string, string | undefined>>;
   params: Readonly<Record<string, string>>;
   body?: unknown;
+  /** Adapter-snapshotted inbound request id used without forcing header normalization. */
+  requestId?: string;
   rawBody?: Uint8Array;
   raw: unknown;
+  /** Adapter-owned abort probe used by internal fast paths without forcing AbortSignal allocation. */
+  isAborted?: () => boolean;
   signal?: AbortSignal;
 }
 
@@ -209,6 +213,14 @@ export type VersioningOptions =
 /** Runtime dispatcher that executes the full HTTP request lifecycle. */
 export interface Dispatcher {
   dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void>;
+  /**
+   * Executes a pre-matched native route through the fast path when safe.
+   *
+   * @internal Platform adapters may use this to avoid duplicate dispatcher
+   * scaffolding for routes already selected by their native router. It returns
+   * `false` when the route must fall back to the normal dispatch lifecycle.
+   */
+  dispatchNativeRoute?(match: HandlerMatch, request: FrameworkRequest, response: FrameworkResponse): Promise<boolean>;
   /**
    * Returns the mapped route descriptors known to this dispatcher when the
    * implementation can expose them without changing dispatch behavior.

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -234,6 +234,7 @@ const DEFAULT_PORT = 3000;
 const DEFAULT_DISPATCHER_NOT_READY_MESSAGE = 'Bun adapter received a request before dispatcher binding completed.';
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 const MINIMUM_BUN_NATIVE_ROUTES_VERSION = '1.2.3';
+const EMPTY_NATIVE_ROUTE_PARAMS: Readonly<Record<string, string>> = Object.freeze({});
 const BUN_WEBSOCKET_SUPPORT_REASON =
   'Bun exposes Bun.serve() + server.upgrade() request-upgrade hosting. Use @fluojs/websockets/bun for the official raw websocket binding.';
 
@@ -251,8 +252,10 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   constructor(options: BunAdapterOptions = {}) {
     this.options = options;
     this.webRequestResponseFactory = createWebRequestResponseFactory({
+      consumeOriginalBody: true,
       maxBodySize: options.maxBodySize,
       multipart: options.multipart,
+      preferNativeJsonBodyReader: true,
       rawBody: options.rawBody,
     });
   }
@@ -433,8 +436,10 @@ export function createBunFetchHandler({
   rawBody,
 }: CreateBunFetchHandlerOptions): (request: Request) => Promise<Response> {
   const factory = createWebRequestResponseFactory({
+    consumeOriginalBody: true,
     maxBodySize,
     multipart,
+    preferNativeJsonBodyReader: true,
     rawBody,
   });
 
@@ -673,8 +678,12 @@ function createBunRouteShapeKey(path: string): string {
   return `/${segments.map((segment) => segment.startsWith(':') ? ':' : segment).join('/')}`;
 }
 
-function normalizeNativeRouteParams(params: Readonly<Record<string, string>> | undefined): Record<string, string> {
-  return params ? { ...params } : {};
+function normalizeNativeRouteParams(params: Readonly<Record<string, string>> | undefined): Readonly<Record<string, string>> {
+  if (!params || Object.keys(params).length === 0) {
+    return EMPTY_NATIVE_ROUTE_PARAMS;
+  }
+
+  return { ...params };
 }
 
 function hasNativeRouteParamSeparators(params: Readonly<Record<string, string>>): boolean {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -87,6 +87,7 @@ export type CorsInput = false | string | string[] | CorsOptions;
 const DEFAULT_MAX_BODY_SIZE = 1 * 1024 * 1024;
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 const FASTIFY_NATIVE_ROUTE_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD'] as const;
+const EMPTY_NATIVE_ROUTE_PARAMS: Readonly<Record<string, string>> = Object.freeze({});
 
 type FastifyNativeRouteMethod = (typeof FASTIFY_NATIVE_ROUTE_METHODS)[number];
 
@@ -140,6 +141,15 @@ type FastifyFrameworkRequest = FrameworkRequest & {
   materializeBody?: () => Promise<void>;
   rawBody?: Uint8Array;
 };
+
+type FastifyRequestWithMultipartProbe = FastifyRequest & {
+  isMultipart?: () => boolean;
+};
+
+interface LazyFastifyRequestSignal {
+  isAborted(): boolean;
+  signal(): AbortSignal;
+}
 
 type FastifyMultipartLikeError = Error & {
   code?: unknown;
@@ -246,14 +256,12 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
     for (const route of createFastifyNativeRoutes(descriptors)) {
       this.app.route({
         handler: async (request: FastifyRequest, reply: FastifyReply) => {
-          const requestPath = readRequestPathFromRawUrl(request.raw.url);
+          const urlParts = splitRawRequestUrl(request.raw.url ?? '/');
           const params = normalizeNativeRouteParams(request.params);
 
-          if (!isRoutePathNormalizationSensitive(requestPath) && !hasNativeRouteParamSeparators(params)) {
-            bindRawRequestNativeRouteHandoff(request.raw, {
-              descriptor: route.descriptor,
-              params,
-            });
+          if (!isRoutePathNormalizationSensitive(urlParts.path) && !hasNativeRouteParamSeparators(params)) {
+            await this.handleNativeRouteRequest(route.descriptor, params, urlParts, request, reply);
+            return;
           }
 
           await this.handleRequest(request, reply);
@@ -297,6 +305,170 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
       rawResponse: reply,
     });
   }
+
+  private async handleNativeRouteRequest(
+    descriptor: HandlerDescriptor,
+    params: Readonly<Record<string, string>>,
+    urlParts: FastifyNativeRouteUrlParts,
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ): Promise<void> {
+    if (isMultipartRequestContentType(request.raw.headers['content-type'])) {
+      bindRawRequestNativeRouteHandoff(request.raw, { descriptor, params });
+      await this.handleRequest(request, reply);
+      return;
+    }
+
+    const dispatcher = this.dispatcher;
+
+    if (!dispatcher?.dispatchNativeRoute) {
+      bindRawRequestNativeRouteHandoff(request.raw, { descriptor, params });
+      await this.handleRequest(request, reply);
+      return;
+    }
+
+    const factory = this.requestResponseFactory;
+    const frameworkResponse = factory.createResponse(reply, request);
+    const lazySignal = createLazyFastifyRequestSignal(reply, factory.createRequestSignal);
+
+    try {
+      const frameworkRequest = createNativeFastFrameworkRequest(request, lazySignal, urlParts, this.maxBodySize, this.preserveRawBody)
+        ?? await factory.createRequest(request, lazySignal.signal());
+
+      if (!isNativeFastFrameworkRequest(frameworkRequest)) {
+        await factory.materializeRequest?.(frameworkRequest);
+      }
+
+      const handled = await dispatcher.dispatchNativeRoute({ descriptor, params }, frameworkRequest, frameworkResponse);
+
+      if (!handled) {
+        bindRawRequestNativeRouteHandoff(request.raw, { descriptor, params });
+        await this.handleRequest(request, reply);
+        return;
+      }
+
+      if (!frameworkResponse.committed) {
+        await frameworkResponse.send(undefined);
+      }
+    } catch (error: unknown) {
+      if (lazySignal.isAborted() || frameworkResponse.committed) {
+        return;
+      }
+
+      await factory.writeErrorResponse(error, frameworkResponse, factory.resolveRequestId(request));
+    }
+  }
+}
+
+function createNativeFastFrameworkRequest(
+  request: FastifyRequest,
+  lazySignal: LazyFastifyRequestSignal,
+  urlParts: FastifyNativeRouteUrlParts,
+  maxBodySize: number,
+  preserveRawBody: boolean,
+): FastifyFrameworkRequest | undefined {
+  const contentType = request.headers['content-type'];
+
+  if (preserveRawBody || isFastifyMultipartRequest(request) || isMultipartRequestContentType(contentType)) {
+    return undefined;
+  }
+
+  const contentLength = Number(request.headers['content-length']);
+
+  if (Number.isFinite(contentLength) && contentLength > maxBodySize) {
+    throw new PayloadTooLargeException('Request body exceeds the size limit.');
+  }
+
+  const frameworkRequest = createDeferredFrameworkRequestShell({
+    cookieHeader: cloneHeaderValue(request.headers.cookie),
+    headersFactory: () => normalizeHeaders(cloneRequestHeaders(request.headers)),
+    method: request.method,
+    path: urlParts.path,
+    query: readSimpleQueryRecord(request.query),
+    queryFactory: () => parseQueryParamsFromSearch(urlParts.search),
+    raw: request.raw,
+    requestId: resolvePrimaryRequestIdFromHeaders(request.raw.headers),
+    signal: lazySignal.signal,
+    url: urlParts.path + urlParts.search,
+  }) as FastifyFrameworkRequest;
+
+  frameworkRequest.body = request.body;
+  frameworkRequest.isAborted = lazySignal.isAborted;
+  markNativeFastFrameworkRequest(frameworkRequest);
+  return frameworkRequest;
+}
+
+function createLazyFastifyRequestSignal(
+  reply: FastifyReply,
+  signalFactory: (reply: FastifyReply) => AbortSignal,
+): LazyFastifyRequestSignal {
+  let signal: AbortSignal | undefined;
+
+  return {
+    isAborted() {
+      return signal?.aborted ?? isFastifyReplyAborted(reply);
+    },
+    signal() {
+      if (!signal) {
+        signal = isFastifyReplyAborted(reply)
+          ? AbortSignal.abort(new Error('Response closed before response commit.'))
+          : signalFactory(reply);
+      }
+
+      return signal;
+    },
+  };
+}
+
+function isFastifyReplyAborted(reply: FastifyReply): boolean {
+  return reply.raw.destroyed && !reply.raw.writableEnded;
+}
+
+const NATIVE_FAST_FRAMEWORK_REQUEST = Symbol('fluo.fastify.nativeFastFrameworkRequest');
+
+type NativeFastFrameworkRequest = FastifyFrameworkRequest & {
+  [NATIVE_FAST_FRAMEWORK_REQUEST]?: true;
+};
+
+function markNativeFastFrameworkRequest(request: FastifyFrameworkRequest): void {
+  (request as NativeFastFrameworkRequest)[NATIVE_FAST_FRAMEWORK_REQUEST] = true;
+}
+
+function isNativeFastFrameworkRequest(request: FrameworkRequest): boolean {
+  return (request as NativeFastFrameworkRequest)[NATIVE_FAST_FRAMEWORK_REQUEST] === true;
+}
+
+function isFastifyMultipartRequest(request: FastifyRequest): boolean {
+  const probe = (request as FastifyRequestWithMultipartProbe).isMultipart;
+  return typeof probe === 'function' && probe.call(request) === true;
+}
+
+function readSimpleQueryRecord(query: unknown): Record<string, string | string[] | undefined> | undefined {
+  if (typeof query !== 'object' || query === null) {
+    return undefined;
+  }
+
+  const record = query as Record<string, unknown>;
+
+  for (const key in record) {
+    if (!Object.prototype.hasOwnProperty.call(record, key)) {
+      continue;
+    }
+
+    const value = record[key];
+
+    if (typeof value === 'string') {
+      continue;
+    }
+
+    if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+      continue;
+    }
+
+    return undefined;
+  }
+
+  return record as Record<string, string | string[] | undefined>;
 }
 
 function createFastifyRequestResponseFactory(
@@ -332,6 +504,11 @@ interface FastifyNativeRouteDefinition {
   descriptor: HandlerDescriptor;
   method: FastifyNativeRouteMethod;
   path: string;
+}
+
+interface FastifyNativeRouteUrlParts {
+  path: string;
+  search: string;
 }
 
 interface FastifyNativeRouteCandidate extends FastifyNativeRouteDefinition {
@@ -481,73 +658,86 @@ export async function runFastifyApplication(
   }, adapter);
 }
 
+class MutableFastifyFrameworkResponse implements FastifyFrameworkResponse {
+  committed: boolean;
+  headers: Record<string, string | string[]> = {};
+  raw: FastifyReply;
+  statusCode?: number;
+  statusSet = false;
+
+  private activeStream?: FrameworkResponseStream;
+
+  constructor(private readonly reply: FastifyReply) {
+    this.committed = reply.sent;
+    this.raw = reply;
+  }
+
+  get stream(): FrameworkResponseStream {
+    this.activeStream ??= createFrameworkResponseStream(this.reply);
+    return this.activeStream;
+  }
+
+  redirect(status: number, location: string): void {
+    this.setStatus(status);
+    this.setHeader('Location', location);
+    this.committed = true;
+    this.reply.redirect(location, status);
+  }
+
+  send(body: unknown): ReturnType<FrameworkResponse['send']> {
+    if (this.reply.sent) {
+      this.committed = true;
+      return;
+    }
+
+    const existingContentType = this.reply.getHeader('content-type');
+    const serialized = serializeResponseBody(body, typeof existingContentType === 'string' ? existingContentType : undefined);
+
+    if (!this.reply.hasHeader('content-type') && serialized.defaultContentType) {
+      this.reply.header('content-type', serialized.defaultContentType);
+    }
+
+    this.committed = true;
+    void this.reply.send(serialized.payload);
+  }
+
+  sendSimpleJson(body: Record<string, unknown> | unknown[]): ReturnType<FrameworkResponse['send']> {
+    if (this.reply.sent) {
+      this.committed = true;
+      return;
+    }
+
+    if (!this.reply.hasHeader('content-type')) {
+      this.reply.header('content-type', 'application/json; charset=utf-8');
+    }
+
+    this.committed = true;
+    void this.reply.send(JSON.stringify(body));
+  }
+
+  setHeader(name: string, value: string | string[]): void {
+    const lowerName = name.toLowerCase();
+
+    if (lowerName === 'set-cookie') {
+      const merged = mergeSetCookieHeader(this.reply.getHeader(name), value);
+      this.reply.header(name, merged);
+      this.headers[name] = merged;
+      return;
+    }
+
+    this.reply.header(name, value);
+    this.headers[name] = value;
+  }
+
+  setStatus(code: number): void {
+    this.reply.status(code);
+    this.statusCode = code;
+    this.statusSet = true;
+  }
+}
+
 function createFrameworkResponse(reply: FastifyReply): FastifyFrameworkResponse {
-  let activeStream: FrameworkResponseStream | undefined;
-
-  return {
-    committed: reply.sent,
-    headers: {},
-    raw: reply,
-    get stream() {
-      activeStream ??= createFrameworkResponseStream(reply);
-      return activeStream;
-    },
-    redirect(status: number, location: string) {
-      this.setStatus(status);
-      this.setHeader('Location', location);
-      this.committed = true;
-      reply.redirect(location, status);
-    },
-    async send(body: unknown) {
-      if (reply.sent) {
-        this.committed = true;
-        return;
-      }
-
-      const existingContentType = reply.getHeader('content-type');
-      const serialized = serializeResponseBody(body, typeof existingContentType === 'string' ? existingContentType : undefined);
-
-      if (!reply.hasHeader('content-type') && serialized.defaultContentType) {
-        reply.header('content-type', serialized.defaultContentType);
-      }
-
-      this.committed = true;
-      await reply.send(serialized.payload);
-    },
-    async sendSimpleJson(body: Record<string, unknown> | unknown[]) {
-      if (reply.sent) {
-        this.committed = true;
-        return;
-      }
-
-      if (!reply.hasHeader('content-type')) {
-        reply.header('content-type', 'application/json; charset=utf-8');
-      }
-
-      this.committed = true;
-      await reply.send(JSON.stringify(body));
-    },
-    setHeader(name: string, value: string | string[]) {
-      const lowerName = name.toLowerCase();
-
-      if (lowerName === 'set-cookie') {
-        const merged = mergeSetCookieHeader(reply.getHeader(name), value);
-        reply.header(name, merged);
-        this.headers[name] = merged;
-        return;
-      }
-
-      reply.header(name, value);
-      this.headers[name] = value;
-    },
-    setStatus(code: number) {
-      reply.status(code);
-      this.statusCode = code;
-      this.statusSet = true;
-    },
-    statusCode: undefined,
-    statusSet: false,
-  };
+  return new MutableFastifyFrameworkResponse(reply);
 }
 
 function createFrameworkResponseStream(reply: FastifyReply): FrameworkResponseStream {
@@ -640,7 +830,8 @@ function createDeferredFrameworkRequest(
   const querySnapshot = snapshotSimpleQueryRecord(request.query);
   const isMultipart = isMultipartRequestContentType(headerSnapshot['content-type']);
   let frameworkRequest!: FastifyFrameworkRequest;
-  const materializeBody = createMemoizedAsyncValue(async () => {
+  const needsDeferredBodyMaterialization = isMultipart || preserveRawBody;
+  const materializeBody = needsDeferredBodyMaterialization ? createMemoizedAsyncValue(async () => {
     let body = request.body;
     let files: UploadedFile[] | undefined;
 
@@ -666,7 +857,7 @@ function createDeferredFrameworkRequest(
         frameworkRequest.rawBody = rawBodyValue;
       }
     }
-  });
+  }) : undefined;
 
   frameworkRequest = createDeferredFrameworkRequestShell({
     cookieHeader: cloneHeaderValue(headerSnapshot.cookie),
@@ -677,9 +868,14 @@ function createDeferredFrameworkRequest(
     query: querySnapshot,
     queryFactory: () => parseQueryParamsFromSearch(urlParts.search),
     raw: request.raw,
+    requestId: resolvePrimaryRequestIdFromHeaders(headerSnapshot),
     signal,
     url: urlParts.path + urlParts.search,
   }) as FastifyFrameworkRequest;
+
+  if (!needsDeferredBodyMaterialization) {
+    frameworkRequest.body = request.body;
+  }
 
   const nativeRouteHandoff = consumeRawRequestNativeRouteHandoff(request.raw);
 
@@ -693,23 +889,39 @@ async function materializeFrameworkRequestBody(request: FrameworkRequest): Promi
   delete (request as FastifyFrameworkRequest).materializeBody;
 }
 
-function normalizeNativeRouteParams(params: unknown): Record<string, string> {
+function normalizeNativeRouteParams(params: unknown): Readonly<Record<string, string>> {
   if (typeof params !== 'object' || params === null) {
-    return {};
+    return EMPTY_NATIVE_ROUTE_PARAMS;
   }
 
-  return Object.fromEntries(
-    Object.entries(params).flatMap(([key, value]) =>
-      typeof value === 'string'
-        ? [[key, value] as const]
-        : value === undefined
-          ? []
-          : [[key, String(value)] as const]),
-  );
+  let normalized: Record<string, string> | undefined;
+
+  for (const key in params as Record<string, unknown>) {
+    if (!Object.prototype.hasOwnProperty.call(params, key)) {
+      continue;
+    }
+
+    const value = (params as Record<string, unknown>)[key];
+
+    if (value === undefined) {
+      continue;
+    }
+
+    normalized ??= {};
+    normalized[key] = typeof value === 'string' ? value : String(value);
+  }
+
+  return normalized ?? EMPTY_NATIVE_ROUTE_PARAMS;
 }
 
 function hasNativeRouteParamSeparators(params: Readonly<Record<string, string>>): boolean {
-  return Object.values(params).some((value) => value.includes('/'));
+  for (const key in params) {
+    if (Object.prototype.hasOwnProperty.call(params, key) && params[key]?.includes('/')) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function collectVersionSensitiveRouteKeys(descriptors: readonly HandlerDescriptor[]): Set<string> {
@@ -732,10 +944,6 @@ function collectVersionSensitiveRouteKeys(descriptors: readonly HandlerDescripto
       .filter(([, current]) => current.count > 1 || current.hasVersioned)
       .map(([routeKey]) => routeKey),
   );
-}
-
-function readRequestPathFromRawUrl(rawUrl: string | undefined): string {
-  return splitRawRequestUrl(rawUrl ?? '/').path;
 }
 
 async function parseMultipartRequest(
@@ -894,6 +1102,11 @@ function createRequestSignal(response: import('node:http').ServerResponse): Abor
 
 function resolveRequestIdFromHeaders(headers: IncomingHttpHeaders): string | undefined {
   const requestId = headers['x-request-id'] ?? headers['x-correlation-id'];
+  return Array.isArray(requestId) ? requestId[0] : requestId;
+}
+
+function resolvePrimaryRequestIdFromHeaders(headers: IncomingHttpHeaders): string | undefined {
+  const requestId = headers['x-request-id'];
   return Array.isArray(requestId) ? requestId[0] : requestId;
 }
 

--- a/packages/runtime/src/adapters/request-response-factory.test.ts
+++ b/packages/runtime/src/adapters/request-response-factory.test.ts
@@ -36,6 +36,7 @@ describe('dispatchWithRequestResponseFactory', () => {
           raw: rawRequest,
           signal,
           url: '/',
+          materializeBody: () => Promise.resolve(),
         };
       },
       createRequestSignal() {

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -41,7 +41,8 @@ export interface DeferredFrameworkRequestShellOptions<RawRequest> {
   query?: QueryRecord;
   queryFactory?: () => QueryRecord;
   raw: RawRequest;
-  signal: AbortSignal;
+  requestId?: string;
+  signal: AbortSignal | (() => AbortSignal);
   url: string;
 }
 
@@ -160,6 +161,7 @@ export function createDeferredFrameworkRequest(
     path: urlParts.path,
     queryFactory: () => parseQueryParamsFromSearch(urlParts.search),
     raw: request,
+    requestId: resolvePrimaryRequestIdFromHeaders(headers),
     signal,
     url: urlParts.path + urlParts.search,
   }) as NodeFrameworkRequest;
@@ -183,14 +185,17 @@ export function createDeferredFrameworkRequestShell<RawRequest>({
   query,
   queryFactory,
   raw,
+  requestId,
   signal,
   url,
 }: DeferredFrameworkRequestShellOptions<RawRequest>): FrameworkRequest {
+  const hasQuerySnapshot = query !== undefined;
+  const hasLazySignal = typeof signal === 'function';
   const resolveHeaders = headersFactory ? createMemoizedValue(headersFactory) : () => headers ?? {};
   const resolveCookies = createMemoizedValue(() => parseCookieHeader(cookieHeader ?? resolveHeaders().cookie));
-  const resolveQuery = createMemoizedValue(() => query ?? queryFactory?.() ?? {});
+  const resolveQuery = hasQuerySnapshot ? undefined : createMemoizedValue(() => queryFactory?.() ?? {});
 
-  const frameworkRequest: NodeFrameworkRequest = {
+  const frameworkRequest = {
     get cookies() {
       return resolveCookies();
     },
@@ -200,13 +205,34 @@ export function createDeferredFrameworkRequestShell<RawRequest>({
     method: method ?? 'GET',
     params: {},
     path,
-    get query() {
-      return resolveQuery();
-    },
+    requestId,
     raw,
-    signal,
     url,
-  };
+  } as NodeFrameworkRequest;
+
+  if (hasLazySignal) {
+    Object.defineProperty(frameworkRequest, 'signal', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return signal();
+      },
+    });
+  } else {
+    frameworkRequest.signal = signal;
+  }
+
+  if (hasQuerySnapshot) {
+    frameworkRequest.query = query;
+  } else {
+    Object.defineProperty(frameworkRequest, 'query', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return resolveQuery!();
+      },
+    });
+  }
 
   if (materializeBody) {
     frameworkRequest.materializeBody = materializeBody;
@@ -310,6 +336,11 @@ export function createRequestSignal(response: ServerResponse): AbortSignal {
  */
 export function resolveRequestIdFromHeaders(headers: IncomingHttpHeaders): string | undefined {
   const requestId = headers['x-request-id'] ?? headers['x-correlation-id'];
+  return Array.isArray(requestId) ? requestId[0] : requestId;
+}
+
+function resolvePrimaryRequestIdFromHeaders(headers: IncomingHttpHeaders): string | undefined {
+  const requestId = headers['x-request-id'];
   return Array.isArray(requestId) ? requestId[0] : requestId;
 }
 

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -39,8 +39,10 @@ const REQUEST_BODY_LIMIT_MESSAGE = 'Request body exceeds the size limit.';
  * Configures Web request parsing, multipart handling, and raw body preservation.
  */
 export interface CreateWebRequestResponseFactoryOptions {
+  consumeOriginalBody?: boolean;
   maxBodySize?: number;
   multipart?: MultipartOptions;
+  preferNativeJsonBodyReader?: boolean;
   rawBody?: boolean;
 }
 
@@ -291,6 +293,8 @@ export function createWebRequestResponseFactory(
         options.multipart,
         options.maxBodySize ?? DEFAULT_MAX_BODY_SIZE,
         options.rawBody ?? false,
+        options.preferNativeJsonBodyReader ?? false,
+        options.consumeOriginalBody ?? false,
       );
     },
     materializeRequest(request) {
@@ -382,6 +386,8 @@ function createDeferredWebFrameworkRequest(
   multipartOptions?: MultipartOptions,
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
+  preferNativeJsonBodyReader = false,
+  consumeOriginalBody = false,
 ): FrameworkRequest {
   const url = new URL(request.url);
   const requestHeaders = new Headers(request.headers);
@@ -391,15 +397,16 @@ function createDeferredWebFrameworkRequest(
   const query = createMemoizedValue(() => parseQueryString(url.search));
   const contentType = requestHeaders.get('content-type') ?? undefined;
   const isMultipart = typeof contentType === 'string' && contentType.includes('multipart/form-data');
-  const materializeBody = createMemoizedAsyncValue(async () => {
+  const hasRequestBody = request.body !== null;
+  const materializeBody = hasRequestBody ? createMemoizedAsyncValue(async () => {
     if (isMultipart) {
       const materializedRequest = request.clone();
-      const result = await parseMultipart({
-        body: materializedRequest.body,
-        headers: requestHeaders,
+      const result = await parseMultipart(createRequestWithSnapshotMetadata(
+        materializedRequest,
+        request.url,
         method,
-        url: request.url,
-      }, {
+        requestHeaders,
+      ), {
         ...multipartOptions,
         maxTotalSize: multipartOptions?.maxTotalSize ?? maxBodySize,
       });
@@ -415,13 +422,20 @@ function createDeferredWebFrameworkRequest(
       return;
     }
 
-    const bodyResult = await readWebRequestBody(request.clone(), contentType, maxBodySize, preserveRawBody);
+    const requestToRead = consumeOriginalBody ? request : request.clone();
+    const bodyResult = await readWebRequestBody(
+      requestToRead,
+      contentType,
+      maxBodySize,
+      preserveRawBody,
+      preferNativeJsonBodyReader,
+    );
     frameworkRequest.body = bodyResult.body;
 
     if (bodyResult.rawBody) {
       frameworkRequest.rawBody = bodyResult.rawBody;
     }
-  });
+  }) : undefined;
 
   const frameworkRequest: WebFrameworkRequest = {
     get cookies() {
@@ -437,16 +451,40 @@ function createDeferredWebFrameworkRequest(
       return query();
     },
     raw: request,
+    requestId: requestHeaders.get('x-request-id') ?? undefined,
     signal,
     url: url.pathname + url.search,
     materializeBody,
   };
+
+  if (!hasRequestBody) {
+    frameworkRequest.body = undefined;
+  }
 
   const nativeRouteHandoff = consumeRawRequestNativeRouteHandoff(request);
 
   return nativeRouteHandoff
     ? attachFrameworkRequestNativeRouteHandoff(frameworkRequest, nativeRouteHandoff)
     : frameworkRequest;
+}
+
+function createRequestWithSnapshotMetadata(
+  request: Request,
+  url: string,
+  method: string,
+  headers: Headers,
+): Request {
+  const init: RequestInit & { duplex?: 'half' } = {
+    headers: new Headers(headers),
+    method,
+  };
+
+  if (request.body) {
+    init.body = request.body;
+    init.duplex = 'half';
+  }
+
+  return new Request(url, init);
 }
 
 function validateWebRequestContentLength(request: Request, maxBodySize: number): void {
@@ -603,6 +641,7 @@ async function readWebRequestBody(
   contentType: string | undefined,
   maxBodySize = DEFAULT_MAX_BODY_SIZE,
   preserveRawBody = false,
+  preferNativeJsonBodyReader = false,
 ): Promise<{ body: unknown; rawBody?: Uint8Array }> {
   validateWebRequestContentLength(request, maxBodySize);
 
@@ -610,8 +649,24 @@ async function readWebRequestBody(
     return { body: undefined };
   }
 
-  const rawBody = await readByteLimitedStream(request.body, maxBodySize);
+  if (!preserveRawBody && isJsonContentType(contentType) && (preferNativeJsonBodyReader || isContentLengthWithinLimit(request, maxBodySize))) {
+    const rawBody = new Uint8Array(await request.arrayBuffer());
 
+    if (rawBody.byteLength > maxBodySize) {
+      throw new PayloadTooLargeException(REQUEST_BODY_LIMIT_MESSAGE);
+    }
+
+    return parseWebRequestRawBody(rawBody, contentType, preserveRawBody);
+  }
+
+  return parseWebRequestRawBody(await readByteLimitedStream(request.body, maxBodySize), contentType, preserveRawBody);
+}
+
+function parseWebRequestRawBody(
+  rawBody: Uint8Array,
+  contentType: string | undefined,
+  preserveRawBody: boolean,
+): { body: unknown; rawBody?: Uint8Array } {
   if (rawBody.byteLength === 0) {
     return { body: undefined };
   }
@@ -622,7 +677,7 @@ async function readWebRequestBody(
     return { body: undefined, rawBody: preserveRawBody ? rawBody : undefined };
   }
 
-  if (typeof contentType === 'string' && contentType.includes('application/json')) {
+  if (isJsonContentType(contentType)) {
     try {
       return {
         body: JSON.parse(bodyText) as unknown,
@@ -637,6 +692,17 @@ async function readWebRequestBody(
     body: bodyText,
     rawBody: preserveRawBody ? rawBody : undefined,
   };
+}
+
+function isContentLengthWithinLimit(request: Request, maxBodySize: number): boolean {
+  const contentLength = request.headers.get('content-length');
+
+  if (contentLength === null) {
+    return false;
+  }
+
+  const parsedContentLength = Number(contentLength);
+  return Number.isFinite(parsedContentLength) && parsedContentLength > 0 && parsedContentLength <= maxBodySize;
 }
 
 async function readByteLimitedStream(

--- a/tooling/benchmarks/http-comparison/README.md
+++ b/tooling/benchmarks/http-comparison/README.md
@@ -1,6 +1,6 @@
 # HTTP runtime benchmark
 
-Runs a small HTTP throughput/latency comparison between published fluo beta packages and NestJS v11 across three targets:
+Runs a small HTTP throughput/latency comparison between the local fluo worktree packages and NestJS v11 across three targets:
 
 - `Nest+Fastify`
 - `fluo+Fastify`
@@ -25,7 +25,7 @@ pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace install --froze
 pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace bench
 ```
 
-This benchmark has its own lockfile and is intentionally excluded from the root pnpm workspace. It consumes the versions that are already published to npm so repository release jobs do not need unpublished package versions before they can publish them.
+This benchmark has its own lockfile and is intentionally excluded from the root pnpm workspace. The fluo dependencies are linked to `../../../packages/*`, so build the local packages before measuring if you want benchmark results to include unpublished worktree changes.
 
 The runner starts an isolated server set for each scenario, so 1-route and 20-route scenarios register different app shapes instead of merely sending different request paths through the same route table. It warms every target for each scenario, then measures with `autocannon` at 100 connections for 40 seconds. Measurement order rotates by scenario to avoid always giving one framework the same position. Multi-route scenarios use a deterministic path cycle so every target sees the same request sequence.
 
@@ -33,6 +33,14 @@ For quick directional runs, override the defaults with environment variables:
 
 ```bash
 BENCH_WARMUP_SEC=3 BENCH_MEASURE_SEC=10 pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace bench
+```
+
+By default, the runner rebuilds the linked local fluo packages before measuring so uncommitted source changes are reflected in `dist/`. Set `BENCH_BUILD_LOCAL_FLUO_PACKAGES=0` to skip that rebuild when you have already built the packages.
+
+To collect a repeat-average for specific scenarios, set `BENCH_RUNS` and a comma-separated `BENCH_SCENARIOS` list:
+
+```bash
+BENCH_RUNS=5 BENCH_SCENARIOS=query-deterministic-1,json-body-deterministic-1 pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace bench
 ```
 
 The `fluo+Bun` target requires the `bun` CLI because `@fluojs/platform-bun` uses `globalThis.Bun.serve()` at listen time.
@@ -50,7 +58,7 @@ The report prints those counters with throughput and latency metrics.
 
 ## Scope and caveats
 
-- This measures the released npm beta surface, not unpublished workspace source changes.
+- This measures the linked local worktree package builds, not the released npm beta surface.
 - fluo uses TC39 standard decorators without `emitDecoratorMetadata`; NestJS uses legacy decorators with `emitDecoratorMetadata` through `nestjs/tsconfig.json`.
 - `fluo+Bun` is a runtime comparison, not a same-adapter comparison. Treat it as “same fluo app graph on Bun’s native server” versus the Node.js adapter targets.
 - The suite covers routing plus DTO binding on path, query, and body inputs. It does not measure validation plugins, serialization plugins, guards, pipes, database access, or production middleware.

--- a/tooling/benchmarks/http-comparison/package.json
+++ b/tooling/benchmarks/http-comparison/package.json
@@ -13,11 +13,11 @@
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p nestjs/tsconfig.json"
   },
   "dependencies": {
-    "@fluojs/core": "1.0.0-beta.2",
-    "@fluojs/http": "1.0.0-beta.4",
-    "@fluojs/platform-bun": "1.0.0-beta.4",
-    "@fluojs/platform-fastify": "1.0.0-beta.5",
-    "@fluojs/runtime": "1.0.0-beta.5",
+    "@fluojs/core": "link:../../../packages/core",
+    "@fluojs/http": "link:../../../packages/http",
+    "@fluojs/platform-bun": "link:../../../packages/platform-bun",
+    "@fluojs/platform-fastify": "link:../../../packages/platform-fastify",
+    "@fluojs/runtime": "link:../../../packages/runtime",
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-fastify": "^11.0.0",

--- a/tooling/benchmarks/http-comparison/pnpm-lock.yaml
+++ b/tooling/benchmarks/http-comparison/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       '@fluojs/core':
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2
+        specifier: link:../../../packages/core
+        version: link:../../../packages/core
       '@fluojs/http':
-        specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4
+        specifier: link:../../../packages/http
+        version: link:../../../packages/http
       '@fluojs/platform-bun':
-        specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4
+        specifier: link:../../../packages/platform-bun
+        version: link:../../../packages/platform-bun
       '@fluojs/platform-fastify':
-        specifier: 1.0.0-beta.5
-        version: 1.0.0-beta.5
+        specifier: link:../../../packages/platform-fastify
+        version: link:../../../packages/platform-fastify
       '@fluojs/runtime':
-        specifier: 1.0.0-beta.5
-        version: 1.0.0-beta.5
+        specifier: link:../../../packages/runtime
+        version: link:../../../packages/runtime
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -233,14 +233,8 @@ packages:
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
-  '@fastify/busboy@3.2.0':
-    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
-
   '@fastify/cors@11.2.0':
     resolution: {integrity: sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==}
-
-  '@fastify/deepmerge@3.2.1':
-    resolution: {integrity: sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -257,42 +251,8 @@ packages:
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
 
-  '@fastify/multipart@9.4.0':
-    resolution: {integrity: sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ==}
-
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
-
-  '@fluojs/config@1.0.0-beta.3':
-    resolution: {integrity: sha512-WxWSZKlgezpHbZuGOnGYH9D3SmMJWduyZHasufz2nuP+nJA4rLKfVOQeb3WKupzMxHGibCQkzE7/nwheidQV7w==}
-    engines: {node: '>=20.0.0'}
-
-  '@fluojs/core@1.0.0-beta.2':
-    resolution: {integrity: sha512-wesWvWH4P3vAug8bwaK3XAwVPREFRmCJPIDDshRNzPRDPdGxPEql78hnq/B4SNRsVxBGnnCcgjWYQWJtGosGZg==}
-    engines: {node: '>=20.0.0'}
-
-  '@fluojs/di@1.0.0-beta.5':
-    resolution: {integrity: sha512-2tzNQ9M+MBIkAuEB47aHnd0g9D3r9kvHZR8689LRDW3YowhlpcBzJ4BbG4lbYSmvaz9GhfCvU9Tw+4x3oqI9BA==}
-    engines: {node: '>=20.0.0'}
-
-  '@fluojs/http@1.0.0-beta.4':
-    resolution: {integrity: sha512-7GpmvpFzwho8pCFJ2OZQBti9a+6WJyy4jLusHyTvseXzKNY8N368wG3pWh1nY6TvBWj4mgCBe8jeOuVL9+RqDw==}
-    engines: {node: '>=20.0.0'}
-
-  '@fluojs/platform-bun@1.0.0-beta.4':
-    resolution: {integrity: sha512-5g9EfZ03m+Kvd6brVhtAhsKIXK6r1tUSXunNVdaJ1tU3UMx6Kh9MOfHPiD2y7+sHRdK9D8Gl/41RZ1cyw55/GQ==}
-
-  '@fluojs/platform-fastify@1.0.0-beta.5':
-    resolution: {integrity: sha512-n7l4qlg6KMjVi6fyyDO7QsGgT8q/3LmOtxhX5CutInv5ds1zB+KLU0f+4MCwVJnZOCncGZe57nECa1e6h5mInA==}
-    engines: {node: '>=20.0.0'}
-
-  '@fluojs/runtime@1.0.0-beta.5':
-    resolution: {integrity: sha512-J3/k1qo22WjlGiugIblhOPntPH7PGeH1TfHyeotbhW4x32ScfiIzYhtx54wSKE3nXrG+Quiig/zPGIKlZqE1yA==}
-    engines: {node: '>=20.0.0'}
-
-  '@fluojs/validation@1.0.0-beta.1':
-    resolution: {integrity: sha512-qmY1/+MAnzTarc+TAXWBZopnDu9uK3UZL1EKwi1Y/83jJXuzDpdFI5s7OgHzaeV3zsudgOKj+ts3MkAIQYFggA==}
-    engines: {node: '>=20.0.0'}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -359,9 +319,6 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
-
-  '@standard-schema/spec@1.1.0':
-    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
@@ -442,10 +399,6 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -503,10 +456,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -514,14 +463,6 @@ packages:
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
-
-  dotenv-expand@11.0.7:
-    resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
-    engines: {node: '>=12'}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -571,10 +512,6 @@ packages:
 
   fastify-plugin@5.1.0:
     resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
-
-  fastify-raw-body@5.0.0:
-    resolution: {integrity: sha512-2qfoaQ3BQDhZ1gtbkKZd6n0kKxJISJGM6u/skD9ljdWItAscjXrtZ1lnjr7PavmXX9j4EyCPmBDiIsLn07d5vA==}
-    engines: {node: '>= 10'}
 
   fastify@5.8.4:
     resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
@@ -646,25 +583,14 @@ packages:
   hdr-histogram-percentiles-obj@3.0.0:
     resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
 
-  http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
-
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
   hyperid@3.3.0:
     resolution: {integrity: sha512-7qhCVT4MJIoEsNcbhglhdmBKb09QtcmJNiIQGq7js/Khf5FtQQ9bzcAuloeqBeee7XD7JqDeve9KNlQya5tSGQ==}
 
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
@@ -765,10 +691,6 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
-
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
@@ -811,12 +733,6 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
@@ -828,19 +744,12 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -872,10 +781,6 @@ packages:
   toad-cache@3.7.0:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
-
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
 
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
@@ -919,10 +824,6 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-
   uuid-parse@1.1.0:
     resolution: {integrity: sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==}
 
@@ -933,10 +834,6 @@ packages:
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
-
-  validator@13.15.35:
-    resolution: {integrity: sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==}
-    engines: {node: '>= 0.10'}
 
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
@@ -1039,14 +936,10 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.20.0)
       fast-uri: 3.1.0
 
-  '@fastify/busboy@3.2.0': {}
-
   '@fastify/cors@11.2.0':
     dependencies:
       fastify-plugin: 5.1.0
       toad-cache: 3.7.0
-
-  '@fastify/deepmerge@3.2.1': {}
 
   '@fastify/error@4.2.0': {}
 
@@ -1065,62 +958,10 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  '@fastify/multipart@9.4.0':
-    dependencies:
-      '@fastify/busboy': 3.2.0
-      '@fastify/deepmerge': 3.2.1
-      '@fastify/error': 4.2.0
-      fastify-plugin: 5.1.0
-      secure-json-parse: 4.1.0
-
   '@fastify/proxy-addr@5.1.0':
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
-
-  '@fluojs/config@1.0.0-beta.3':
-    dependencies:
-      '@fluojs/core': 1.0.0-beta.2
-      dotenv: 16.6.1
-      dotenv-expand: 11.0.7
-
-  '@fluojs/core@1.0.0-beta.2': {}
-
-  '@fluojs/di@1.0.0-beta.5':
-    dependencies:
-      '@fluojs/core': 1.0.0-beta.2
-
-  '@fluojs/http@1.0.0-beta.4':
-    dependencies:
-      '@fluojs/core': 1.0.0-beta.2
-      '@fluojs/di': 1.0.0-beta.5
-      '@fluojs/validation': 1.0.0-beta.1
-
-  '@fluojs/platform-bun@1.0.0-beta.4':
-    dependencies:
-      '@fluojs/http': 1.0.0-beta.4
-      '@fluojs/runtime': 1.0.0-beta.5
-
-  '@fluojs/platform-fastify@1.0.0-beta.5':
-    dependencies:
-      '@fastify/multipart': 9.4.0
-      '@fluojs/http': 1.0.0-beta.4
-      '@fluojs/runtime': 1.0.0-beta.5
-      fastify: 5.8.5
-      fastify-raw-body: 5.0.0
-
-  '@fluojs/runtime@1.0.0-beta.5':
-    dependencies:
-      '@fluojs/config': 1.0.0-beta.3
-      '@fluojs/core': 1.0.0-beta.2
-      '@fluojs/di': 1.0.0-beta.5
-      '@fluojs/http': 1.0.0-beta.4
-
-  '@fluojs/validation@1.0.0-beta.1':
-    dependencies:
-      '@fluojs/core': 1.0.0-beta.2
-      '@standard-schema/spec': 1.1.0
-      validator: 13.15.35
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -1177,8 +1018,6 @@ snapshots:
       consola: 3.4.2
 
   '@pinojs/redact@0.4.0': {}
-
-  '@standard-schema/spec@1.1.0': {}
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -1274,8 +1113,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bytes@3.1.2: {}
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -1320,17 +1157,9 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  depd@2.0.0: {}
-
   dequal@2.0.3: {}
 
   diff@4.0.4: {}
-
-  dotenv-expand@11.0.7:
-    dependencies:
-      dotenv: 16.6.1
-
-  dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -1406,12 +1235,6 @@ snapshots:
   fast-uri@3.1.0: {}
 
   fastify-plugin@5.1.0: {}
-
-  fastify-raw-body@5.0.0:
-    dependencies:
-      fastify-plugin: 5.1.0
-      raw-body: 3.0.2
-      secure-json-parse: 2.7.0
 
   fastify@5.8.4:
     dependencies:
@@ -1527,14 +1350,6 @@ snapshots:
 
   hdr-histogram-percentiles-obj@3.0.0: {}
 
-  http-errors@2.0.1:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      toidentifier: 1.0.1
-
   http-parser-js@0.5.10: {}
 
   hyperid@3.3.0:
@@ -1543,13 +1358,7 @@ snapshots:
       uuid: 8.3.2
       uuid-parse: 1.1.0
 
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
-
   ieee754@1.2.1: {}
-
-  inherits@2.0.4: {}
 
   ipaddr.js@2.3.0: {}
 
@@ -1631,13 +1440,6 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      unpipe: 1.0.0
-
   real-require@0.2.0: {}
 
   reflect-metadata@0.2.2: {}
@@ -1666,25 +1468,17 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
-  safer-buffer@2.1.2: {}
-
-  secure-json-parse@2.7.0: {}
-
   secure-json-parse@4.1.0: {}
 
   semver@7.7.4: {}
 
   set-cookie-parser@2.7.2: {}
 
-  setprototypeof@1.2.0: {}
-
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
 
   split2@4.2.0: {}
-
-  statuses@2.0.2: {}
 
   string-width@4.2.3:
     dependencies:
@@ -1715,8 +1509,6 @@ snapshots:
   timestring@6.0.0: {}
 
   toad-cache@3.7.0: {}
-
-  toidentifier@1.0.1: {}
 
   token-types@6.1.2:
     dependencies:
@@ -1761,14 +1553,10 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  unpipe@1.0.0: {}
-
   uuid-parse@1.1.0: {}
 
   uuid@8.3.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
-
-  validator@13.15.35: {}
 
   yn@3.1.1: {}

--- a/tooling/benchmarks/http-comparison/src/run.ts
+++ b/tooling/benchmarks/http-comparison/src/run.ts
@@ -10,7 +10,16 @@ const FLUO_FASTIFY_PORT = 3001;
 const NESTJS_PORT = 3002;
 const FLUO_BUN_PORT = 3003;
 const WDIR = process.cwd();
+const REPO_ROOT = join(WDIR, '../../..');
 const FLUO_BUN_BUILD_DIR = join(WDIR, 'dist/fluo-bun');
+const LOCAL_FLUO_PACKAGES = [
+  '@fluojs/core',
+  '@fluojs/di',
+  '@fluojs/http',
+  '@fluojs/runtime',
+  '@fluojs/platform-fastify',
+  '@fluojs/platform-bun',
+] as const;
 
 type TargetName = 'nestjs-fastify' | 'fluo-fastify' | 'fluo-bun';
 type AppShape =
@@ -193,6 +202,36 @@ const SCENARIOS: readonly ScenarioConfig[] = [
 const WARMUP_SEC = readPositiveIntegerEnv('BENCH_WARMUP_SEC', 10);
 const MEASURE_SEC = readPositiveIntegerEnv('BENCH_MEASURE_SEC', 40);
 const CONNECTIONS = readPositiveIntegerEnv('BENCH_CONNECTIONS', 100);
+const RUNS = readPositiveIntegerEnv('BENCH_RUNS', 1);
+const BUILD_LOCAL_FLUO_PACKAGES = process.env.BENCH_BUILD_LOCAL_FLUO_PACKAGES !== '0';
+
+function readScenarioFilter(): Set<string> | undefined {
+  const raw = process.env.BENCH_SCENARIOS;
+  if (raw === undefined || raw.trim() === '') {
+    return undefined;
+  }
+
+  return new Set(raw.split(',').map((name) => name.trim()).filter((name) => name.length > 0));
+}
+
+function selectedScenarios(): readonly ScenarioConfig[] {
+  const filter = readScenarioFilter();
+  if (!filter) {
+    return SCENARIOS;
+  }
+
+  const selected = SCENARIOS.filter((scenario) => filter.has(scenario.name));
+  const knownNames = new Set(SCENARIOS.map((scenario) => scenario.name));
+  const unknown = [...filter].filter((name) => !knownNames.has(name));
+  if (unknown.length > 0) {
+    throw new Error(`Unknown BENCH_SCENARIOS entries: ${unknown.join(', ')}`);
+  }
+  if (selected.length === 0) {
+    throw new Error('BENCH_SCENARIOS did not select any scenarios.');
+  }
+
+  return selected;
+}
 
 function readPositiveIntegerEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -313,11 +352,6 @@ async function measure(
 
 async function runScenario(s: ScenarioConfig, index: number): Promise<ScenarioResult> {
   const processes = startTargets(s.appShape);
-  const cleanup = (): void => {
-    for (const child of processes) {
-      child.kill();
-    }
-  };
 
   await Promise.all(TARGETS.map((target) => waitForPort(target.port)));
 
@@ -351,8 +385,7 @@ async function runScenario(s: ScenarioConfig, index: number): Promise<ScenarioRe
 
     return { name: s.name, description: s.description, targets };
   } finally {
-    cleanup();
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await stopTargets(processes);
   }
 }
 
@@ -384,6 +417,7 @@ function startTargets(appShape: AppShape): ChildProcess[] {
   return TARGETS.map((target) => {
     const child = spawn(target.command, target.args, {
       cwd: WDIR,
+      detached: true,
       env: { ...process.env, BENCH_APP_SHAPE: appShape, PORT: String(target.port) },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -391,6 +425,53 @@ function startTargets(appShape: AppShape): ChildProcess[] {
     child.stderr?.on('data', (d: Buffer) => process.stderr.write(`[${target.name}] ${String(d)}`));
     return child;
   });
+}
+
+function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    let timeout: NodeJS.Timeout | undefined;
+    const settle = (): void => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+
+      child.removeListener('exit', settle);
+      resolve();
+    };
+
+    timeout = setTimeout(settle, timeoutMs);
+    child.once('exit', settle);
+  });
+}
+
+function signalTarget(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (child.exitCode !== null || child.signalCode !== null || child.pid === undefined) {
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    child.kill(signal);
+  }
+}
+
+async function stopTargets(processes: readonly ChildProcess[]): Promise<void> {
+  for (const child of processes) {
+    signalTarget(child, 'SIGTERM');
+  }
+
+  await Promise.all(processes.map((child) => waitForChildExit(child, 1_500)));
+
+  for (const child of processes) {
+    signalTarget(child, 'SIGKILL');
+  }
+
+  await Promise.all(processes.map((child) => waitForChildExit(child, 1_000)));
 }
 
 async function buildBunTarget(): Promise<void> {
@@ -406,16 +487,88 @@ async function buildBunTarget(): Promise<void> {
   ]);
 }
 
-async function main(): Promise<void> {
-  await buildBunTarget();
-
-  const results: ScenarioResult[] = [];
-  for (const [index, s] of SCENARIOS.entries()) {
-    console.log(`Scenario: ${s.name}`);
-    results.push(await runScenario(s, index));
+async function buildLocalFluoPackages(): Promise<void> {
+  if (!BUILD_LOCAL_FLUO_PACKAGES) {
+    return;
   }
 
-  printReport(results, { connections: CONNECTIONS, duration: MEASURE_SEC });
+  for (const packageName of LOCAL_FLUO_PACKAGES) {
+    process.stdout.write(`Building local ${packageName}...`);
+    await runCommand('pnpm', ['--dir', REPO_ROOT, '--filter', packageName, 'run', 'build']);
+    process.stdout.write(' done\n');
+  }
+}
+
+function average(values: readonly number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function averageResult(results: readonly Result[]): Result {
+  const first = results[0];
+  if (!first) {
+    throw new Error('Cannot average an empty result set.');
+  }
+
+  return {
+    ...first,
+    errors: Math.round(average(results.map((result) => result.errors))),
+    mismatches: Math.round(average(results.map((result) => result.mismatches))),
+    non2xx: Math.round(average(results.map((result) => result.non2xx))),
+    requests: {
+      ...first.requests,
+      average: average(results.map((result) => result.requests.average)),
+    },
+    throughput: {
+      ...first.throughput,
+      average: average(results.map((result) => result.throughput.average)),
+    },
+    timeouts: Math.round(average(results.map((result) => result.timeouts))),
+    latency: {
+      ...first.latency,
+      average: average(results.map((result) => result.latency.average)),
+      p50: average(results.map((result) => result.latency.p50)),
+      p97_5: average(results.map((result) => result.latency.p97_5)),
+      p99: average(results.map((result) => result.latency.p99)),
+    },
+  };
+}
+
+function averageScenarioResults(runs: readonly ScenarioResult[][]): ScenarioResult[] {
+  const firstRun = runs[0];
+  if (!firstRun) {
+    throw new Error('Cannot average an empty run set.');
+  }
+
+  return firstRun.map((scenario, scenarioIndex) => ({
+    description: scenario.description,
+    name: `${scenario.name} (${String(runs.length)}-run avg)`,
+    targets: scenario.targets.map((target, targetIndex) => ({
+      label: target.label,
+      result: averageResult(runs.map((run) => run[scenarioIndex]?.targets[targetIndex]?.result).filter((result): result is Result => result !== undefined)),
+    })),
+  }));
+}
+
+async function main(): Promise<void> {
+  await buildLocalFluoPackages();
+  await buildBunTarget();
+
+  const scenarios = selectedScenarios();
+  const runs: ScenarioResult[][] = [];
+  for (let run = 0; run < RUNS; run += 1) {
+    if (RUNS > 1) {
+      console.log(`Run ${String(run + 1)} of ${String(RUNS)}`);
+    }
+
+    const results: ScenarioResult[] = [];
+    for (const [index, s] of scenarios.entries()) {
+      console.log(`Scenario: ${s.name}`);
+      results.push(await runScenario(s, index + run));
+    }
+    runs.push(results);
+  }
+
+  printReport(RUNS === 1 ? runs[0] ?? [] : averageScenarioResults(runs), { connections: CONNECTIONS, duration: MEASURE_SEC });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- Add a conservative automatic HTTP fast path with diagnostics and native route handoff support.
- Optimize Fastify, Bun, Node, and Web request handling while preserving adapter/lifecycle fallback semantics.
- Update the HTTP comparison benchmark harness to use local worktree packages and support repeat averages/scenario filtering.

## Verification
- `pnpm --filter @fluojs/http run typecheck`
- `pnpm --filter @fluojs/http exec vitest run -c vitest.config.ts src/dispatch/dispatcher.test.ts src/dispatch/dispatch-routing-policy.test.ts src/public-api.test.ts`
- `pnpm --filter @fluojs/http run build`
- `pnpm --filter @fluojs/runtime run typecheck`
- `pnpm --filter @fluojs/runtime exec vitest run -c vitest.config.ts src/node/node-request.test.ts src/adapters/request-response-factory.test.ts`
- `pnpm --filter @fluojs/runtime run build`
- `pnpm --filter @fluojs/platform-fastify run typecheck`
- `pnpm --filter @fluojs/platform-fastify exec vitest run -c vitest.config.ts src/adapter.test.ts`
- `pnpm --filter @fluojs/platform-fastify run build`
- `pnpm --filter @fluojs/platform-bun run typecheck`
- `pnpm --filter @fluojs/platform-bun exec vitest run -c vitest.config.ts src/adapter.test.ts`
- `pnpm --filter @fluojs/platform-bun run build`
- `BENCH_BUILD_LOCAL_FLUO_PACKAGES=0 BENCH_RUNS=5 BENCH_SCENARIOS=query-deterministic-1,json-body-deterministic-1 BENCH_WARMUP_SEC=3 BENCH_MEASURE_SEC=10 BENCH_CONNECTIONS=100 pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace bench`

## Benchmark results
| Scenario | Target | req/s | vs Nest+Fastify |
| --- | --- | ---: | ---: |
| query-deterministic-1 | Nest+Fastify | 57,125 | baseline |
| query-deterministic-1 | fluo+Fastify | 45,741 | -19.9% |
| query-deterministic-1 | fluo+Bun | 60,321 | +5.6% |
| json-body-deterministic-1 | Nest+Fastify | 39,267 | baseline |
| json-body-deterministic-1 | fluo+Fastify | 38,102 | -3.0% |
| json-body-deterministic-1 | fluo+Bun | 51,279 | +30.6% |
