### PR TITLE
Add changeset for HTTP safe fast path

### DIFF
--- a/.changeset/http-safe-fast-path.md
+++ b/.changeset/http-safe-fast-path.md
@@ -1,0 +1,8 @@
+---
+"@fluojs/http": patch
+"@fluojs/runtime": patch
+"@fluojs/platform-fastify": patch
+"@fluojs/platform-bun": patch
+---
+
+Add conservative HTTP fast-path execution and native route handoff optimizations for singleton-safe routes while preserving middleware, guards, pipes, interceptors, error handling, adapter fallback, raw-body, multipart, streaming, abort, and request-scope behavior.


### PR DESCRIPTION
## Summary
- Add the missing Changesets release note for the HTTP safe fast-path work merged in #1479.
- Mark `@fluojs/http`, `@fluojs/runtime`, `@fluojs/platform-fastify`, and `@fluojs/platform-bun` for patch bumps.

## Verification
- `pnpm changeset status --since=main`
