### PR TITLE
Resolve #1482: Optimize Express native fast path

### DIFF
--- a/.changeset/express-native-fast-path.md
+++ b/.changeset/express-native-fast-path.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-express": patch
+---
+
+Route semantically safe Express native matches through the shared dispatcher native fast path when eligible while preserving full dispatcher fallback, body materialization, error handling, and documented route fallback semantics.

--- a/.changeset/express-native-fast-path.md
+++ b/.changeset/express-native-fast-path.md
@@ -1,5 +1,6 @@
 ---
 "@fluojs/platform-express": patch
+"@fluojs/http": patch
 ---
 
-Route semantically safe Express native matches through the shared dispatcher native fast path when eligible while preserving full dispatcher fallback, body materialization, error handling, and documented route fallback semantics.
+Route semantically safe Express native matches through the shared dispatcher native fast path when eligible while preserving full dispatcher fallback, body materialization, error handling, and documented route fallback semantics. Synthetic dispatch requests also preserve request extension data so testing helpers can continue injecting principals into `RequestContext`.

--- a/packages/http/src/dispatch/dispatcher.ts
+++ b/packages/http/src/dispatch/dispatcher.ts
@@ -96,6 +96,10 @@ type FrameworkRequestWithFiles = FrameworkRequest & {
   files?: unknown;
 };
 
+type FrameworkRequestWithPrincipal = FrameworkRequest & {
+  principal?: unknown;
+};
+
 interface CompiledMiddlewareScopePlan {
   alwaysRequiresRequestScope: boolean;
   conditionalDefinitions: MiddlewareLike[];
@@ -160,9 +164,14 @@ function createDispatchRequest(request: FrameworkRequest): FrameworkRequest {
   const nativeRouteHandoff = readFrameworkRequestNativeRouteHandoff(request);
 
   const files = (request as FrameworkRequestWithFiles).files;
+  const principal = (request as FrameworkRequestWithPrincipal).principal;
 
   if (files !== undefined) {
     (dispatchRequest as FrameworkRequestWithFiles).files = files;
+  }
+
+  if (principal !== undefined) {
+    (dispatchRequest as FrameworkRequestWithPrincipal).principal = principal;
   }
 
   return nativeRouteHandoff

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -73,7 +73,7 @@ const adapter = createExpressAdapter(
 ### 안전한 fallback을 포함한 Native Route Registration
 이제 어댑터는 의미 보존이 가능한 명시적 HTTP 메서드 라우트를 Express Router에 사전 등록하면서도, 실제 요청 처리는 계속 공유 fluo dispatcher를 통해 수행합니다.
 
-의미 보존이 가능한 unversioned route에서는 Express가 미리 고른 descriptor와 params를 공유 dispatcher에 전달하므로 duplicate route matching을 건너뛰면서도 guards, interceptors, observers, body parsing, raw body 캡처, SSE, 오류 응답은 기존과 같은 framework-owned 실행 경로를 유지합니다.
+의미 보존이 가능한 unversioned route에서는 Express가 미리 고른 descriptor와 params를 공유 dispatcher에 전달하므로 singleton-safe handler는 dispatcher fast path에서 완료될 수 있고 그 밖의 handler는 duplicate route matching 없이 fallback되며, guards, interceptors, observers, body parsing, raw body 캡처, SSE, 오류 응답은 기존과 같은 framework-owned 실행 경로를 유지합니다.
 
 어댑터가 native handoff를 붙인 뒤 app middleware가 framework request의 method 또는 path를 rewrite하면 dispatcher는 그 handoff를 stale로 보고 원래 Express match를 재사용하지 않고 rewrite된 요청을 다시 매칭합니다.
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -73,7 +73,7 @@ const adapter = createExpressAdapter(
 ### Native Route Registration with Safe Fallback
 The adapter now pre-registers semantically safe Express Router handlers for explicit HTTP methods and still dispatches those requests through the shared fluo dispatcher.
 
-For semantically safe unversioned routes, Express hands the pre-matched descriptor and params to the shared dispatcher so duplicate route matching is skipped while guards, interceptors, observers, body parsing, raw body capture, SSE, and error responses stay on the same framework-owned execution path.
+For semantically safe unversioned routes, Express hands the pre-matched descriptor and params to the shared dispatcher so eligible singleton-safe handlers can complete on the dispatcher fast path and other handlers can fall back without duplicate route matching, while guards, interceptors, observers, body parsing, raw body capture, SSE, and error responses stay on the same framework-owned execution path.
 
 If app middleware rewrites the framework request method or path after the adapter attaches a native handoff, the dispatcher treats that handoff as stale and rematches the rewritten request instead of reusing the original Express match.
 

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -1379,6 +1379,7 @@ describe('@fluojs/platform-express', () => {
       },
       rootContainer: root,
     });
+    const nativeDispatch = vi.spyOn(dispatcher, 'dispatchNativeRoute');
     const port = await findAvailablePort();
     const adapter = createExpressAdapter({ port }) as ExpressHttpApplicationAdapter;
 
@@ -1393,6 +1394,56 @@ describe('@fluojs/platform-express', () => {
 
       expect(response.statusCode).toBe(200);
       expect(JSON.parse(response.body)).toEqual({ id: '123' });
+      expect(nativeDispatch).toHaveBeenCalledTimes(1);
+      expect(nativeDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ params: { id: '123' } }),
+        expect.objectContaining({ path: '/native/123' }),
+        expect.any(Object),
+      );
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it('falls back to full dispatch when native Express routes are not fast-path executable', async () => {
+    @Controller('/native-fallback')
+    class NativeFallbackController {
+      @Get('/:id')
+      getById(_input: undefined, context: RequestContext) {
+        return { id: context.request.params.id, route: 'fallback' };
+      }
+    }
+
+    const root = new Container().register(NativeFallbackController);
+    const baseMapping = createHandlerMapping([{ controllerToken: NativeFallbackController }]);
+    const dispatcher = createDispatcher({
+      handlerMapping: {
+        descriptors: baseMapping.descriptors,
+        match: vi.fn(() => {
+          throw new Error('Express native fallback should reuse framework handoff before rematching.');
+        }),
+      },
+      rootContainer: root,
+    });
+    const nativeDispatch = vi.fn(async () => false);
+    dispatcher.dispatchNativeRoute = nativeDispatch;
+    const fullDispatch = vi.spyOn(dispatcher, 'dispatch');
+    const port = await findAvailablePort();
+    const adapter = createExpressAdapter({ port }) as ExpressHttpApplicationAdapter;
+
+    await adapter.listen(dispatcher);
+
+    try {
+      const response = await requestHttp({
+        method: 'GET',
+        path: '/native-fallback/abc',
+        port,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ id: 'abc', route: 'fallback' });
+      expect(nativeDispatch).toHaveBeenCalledTimes(1);
+      expect(fullDispatch).toHaveBeenCalledTimes(1);
     } finally {
       await adapter.close();
     }

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -1449,6 +1449,48 @@ describe('@fluojs/platform-express', () => {
     }
   });
 
+  it('preserves raw handoff fallback when dispatchers do not expose native route dispatch', async () => {
+    @Controller('/native-legacy')
+    class NativeLegacyController {
+      @Get('/:id')
+      getById(_input: undefined, context: RequestContext) {
+        return { id: context.request.params.id, route: 'legacy' };
+      }
+    }
+
+    const root = new Container().register(NativeLegacyController);
+    const baseMapping = createHandlerMapping([{ controllerToken: NativeLegacyController }]);
+    const dispatcher = createDispatcher({
+      handlerMapping: {
+        descriptors: baseMapping.descriptors,
+        match: vi.fn(() => {
+          throw new Error('Express legacy native fallback should reuse raw handoff before rematching.');
+        }),
+      },
+      rootContainer: root,
+    });
+    dispatcher.dispatchNativeRoute = undefined;
+    const fullDispatch = vi.spyOn(dispatcher, 'dispatch');
+    const port = await findAvailablePort();
+    const adapter = createExpressAdapter({ port }) as ExpressHttpApplicationAdapter;
+
+    await adapter.listen(dispatcher);
+
+    try {
+      const response = await requestHttp({
+        method: 'GET',
+        path: '/native-legacy/xyz',
+        port,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({ id: 'xyz', route: 'legacy' });
+      expect(fullDispatch).toHaveBeenCalledTimes(1);
+    } finally {
+      await adapter.close();
+    }
+  });
+
   it('supports https startup and reports the https listen URL', async () => {
     const loggerEvents: string[] = [];
     const logger: ApplicationLogger = {

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -302,10 +302,8 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
         const params = normalizeNativeRouteParams(request.params);
 
         if (descriptor && !isRoutePathNormalizationSensitive(requestPath) && !hasNativeRouteParamSeparators(params)) {
-          bindRawRequestNativeRouteHandoff(request, {
-            descriptor,
-            params,
-          });
+          void this.handleNativeRouteRequest(descriptor, params, request, response);
+          return;
         }
 
         void this.handleRequest(request, response);
@@ -323,6 +321,50 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
       rawRequest: request,
       rawResponse: response,
     });
+  }
+
+  private async handleNativeRouteRequest(
+    descriptor: HandlerDescriptor,
+    params: Readonly<Record<string, string>>,
+    request: ExpressRequest,
+    response: ExpressResponse,
+  ): Promise<void> {
+    const dispatcher = this.dispatcher;
+
+    if (!dispatcher?.dispatchNativeRoute) {
+      bindRawRequestNativeRouteHandoff(request, { descriptor, params });
+      await this.handleRequest(request, response);
+      return;
+    }
+
+    const factory = this.requestResponseFactory;
+    const frameworkResponse = factory.createResponse(response, request);
+    const signal = factory.createRequestSignal(response);
+
+    try {
+      const frameworkRequest = attachFrameworkRequestNativeRouteHandoff(
+        await factory.createRequest(request, signal),
+        { descriptor, params },
+      );
+
+      await factory.materializeRequest?.(frameworkRequest);
+
+      const handled = await dispatcher.dispatchNativeRoute({ descriptor, params }, frameworkRequest, frameworkResponse);
+
+      if (!handled && !frameworkResponse.committed) {
+        await dispatcher.dispatch(frameworkRequest, frameworkResponse);
+      }
+
+      if (!frameworkResponse.committed) {
+        await frameworkResponse.send(undefined);
+      }
+    } catch (error: unknown) {
+      if (signal.aborted || frameworkResponse.committed) {
+        return;
+      }
+
+      await factory.writeErrorResponse(error, frameworkResponse, factory.resolveRequestId(request));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #1482

Optimize `@fluojs/platform-express` native route handling so semantically safe Express matches can enter the shared dispatcher native fast path without changing the documented adapter contract. This also preserves synthetic request extension data in the shared dispatcher clone path so `@fluojs/testing` principal injection keeps working through helper dispatch.

## Changes

- Route safe Express native matches through `dispatcher.dispatchNativeRoute(...)` when available.
- Preserve full dispatcher fallback on non-fast-path handlers without duplicate route matching.
- Keep legacy raw handoff fallback for dispatchers that do not expose native dispatch support.
- Preserve synthetic request `principal` extension data while cloning dispatcher requests for middleware.
- Document the fast-path/fallback behavior in English and Korean package READMEs.
- Add a patch changeset for `@fluojs/platform-express` and `@fluojs/http`.

## Testing

- `pnpm --filter @fluojs/testing exec vitest run -c vitest.config.ts src/module.test.ts` — 48 passed
- `pnpm --filter @fluojs/http exec vitest run -c vitest.config.ts src/dispatch/dispatcher.test.ts` — 62 passed
- `pnpm --filter @fluojs/platform-express exec vitest run -c vitest.config.ts src/adapter.test.ts` — 40 passed
- `pnpm --filter @fluojs/platform-express run typecheck`
- `pnpm --filter @fluojs/platform-express run build`
- `pnpm --filter @fluojs/runtime run typecheck`
- `pnpm --filter @fluojs/http run typecheck`
- `pnpm --filter @fluojs/testing run typecheck`
- `pnpm changeset status`
- `GIT_MASTER=1 git diff --check`
- LSP diagnostics for `packages/platform-express/src` and `packages/http/src/dispatch/dispatcher.ts` — 0 diagnostics
- GitHub CI run `25176329625` — all checks passed, including `Test`, `Build and typecheck`, and `Verify`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or removed; this changes internal adapter dispatch behavior and internal dispatcher request cloning.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The Express adapter still preserves guards, interceptors, observers, body parsing, raw body capture, SSE, error responses, normalization-sensitive fallback, and documented route fallback semantics. The testing helper principal contract is preserved by retaining synthetic request extension data before middleware execution.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs changed; package README mirrors and adapter/testing regression tests cover the contract update.