### PR TITLE
Optimize HTTP DTO fast path

### DIFF
--- a/.changeset/http-dto-fast-path.md
+++ b/.changeset/http-dto-fast-path.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/http": patch
+---
+
+Allow simple `@RequestDto` routes to use the shared dispatcher fast path while preserving binding, validation, request-scope, middleware, guard, and interceptor behavior.

--- a/packages/http/src/adapters/dto-validation-adapter.ts
+++ b/packages/http/src/adapters/dto-validation-adapter.ts
@@ -18,10 +18,6 @@ export class HttpDtoValidationAdapter implements Validator {
     });
   }
 
-  private getValidationValue(value: unknown, target: Constructor): unknown {
-    return getCompiledDtoBindingPlan(target).toValidationValue(value);
-  }
-
   async validate(value: unknown, target: Constructor): Promise<void> {
     try {
       const plan = getCompiledDtoBindingPlan(target);
@@ -30,7 +26,7 @@ export class HttpDtoValidationAdapter implements Validator {
         return;
       }
 
-      await this.validator.validate(this.getValidationValue(value, target), target);
+      await this.validator.validate(plan.toValidationValue(value), target);
     } catch (error: unknown) {
       if (error instanceof DtoValidationError) {
         this.throwBadRequestForValidationError(error);

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -167,6 +167,37 @@ describe('dispatcher runtime', () => {
     expect(root.requestScopeDisposeCount).toBe(0);
   });
 
+  it('uses fast path for simple RequestDto handlers without request-scoped dependencies', async () => {
+    class FastPathDtoRequest {
+      @FromPath('id')
+      id = '';
+    }
+
+    @Controller('/fast-path-dto')
+    class FastPathDtoController {
+      @RequestDto(FastPathDtoRequest)
+      @Get('/:id')
+      getValue(input: FastPathDtoRequest) {
+        return { id: input.id };
+      }
+    }
+
+    const root = new CountingContainer().register(FastPathDtoController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: FastPathDtoController }]),
+      rootContainer: root,
+    });
+    const response = createFastPathResponse();
+
+    await dispatcher.dispatch(createRequest('/fast-path-dto/u-1'), response);
+
+    const stats = getDispatcherFastPathStats(dispatcher);
+    expect(stats?.routes[0]?.executionPath).toBe('fast');
+    expect(response.simpleJsonBody).toEqual({ id: 'u-1' });
+    expect(root.requestScopeCreateCount).toBe(0);
+    expect(root.requestScopeDisposeCount).toBe(0);
+  });
+
   it('lazily promotes manual RequestContext container access to a request scope', async () => {
     let created = 0;
 

--- a/packages/http/src/dispatch/fast-path/eligibility-checker.ts
+++ b/packages/http/src/dispatch/fast-path/eligibility-checker.ts
@@ -111,9 +111,6 @@ export function compileFastPathEligibility(
   if (eligibility.hasInterceptor) {
     blockingReasons.push('interceptors');
   }
-  if (eligibility.hasPipe) {
-    blockingReasons.push('pipes/DTO binding');
-  }
   if (eligibility.hasRequestScopedDI) {
     blockingReasons.push('request-scoped DI');
   }


### PR DESCRIPTION
## Summary

Improve `@fluojs/http` DTO-heavy request throughput by letting simple `@RequestDto` routes use the existing shared dispatcher fast path while preserving binding, validation, request-scope, middleware, guard, and interceptor behavior.

## Changes

- Allow DTO routes to remain fast-path eligible when all other safety blockers are absent.
- Reuse the already-loaded compiled DTO binding plan during HTTP DTO validation.
- Add regression coverage for simple `RequestDto` fast-path execution without request-scope container creation.
- Add a patch changeset for `@fluojs/http` so the next beta release can publish the improvement.

## Testing

- `pnpm --filter @fluojs/http test` — 172 passed
- `pnpm --filter @fluojs/http typecheck`
- `pnpm --filter @fluojs/platform-fastify test` — 35 passed
- `pnpm --filter @fluojs/platform-bun test` — 27 passed
- `pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace typecheck`
- `pnpm build`
- `pnpm typecheck`
- `pnpm changeset status --since=main`
- `pnpm verify:release-readiness`

Benchmark spot-checks:

| Scenario | fluo+Fastify req/s | Nest+Fastify req/s | Δ vs Nest | Correctness |
|---|---:|---:|---:|---|
| `di-chain-dto-deterministic-20` | 49,562 | 52,931 | -6.4% | 0 errors/timeouts/non-2xx/mismatches |
| `body-dto-deterministic-1` | 34,596 | 34,731 | -0.4% | 0 errors/timeouts/non-2xx/mismatches |
| `di-chain-direct-param-deterministic-20` | 49,852 | 48,129 | +3.6% | 0 errors/timeouts/non-2xx/mismatches |

## Public export documentation

No public exports changed; this PR only adjusts internal dispatcher eligibility and validation-plan reuse.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

The public DTO contract is preserved: binding still constructs DTO instances, preserves validation semantics, and keeps request-scoped converter/custom binder cases on the safe path.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

No platform contract docs changed. The shared `@fluojs/http` improvement is covered by HTTP, Fastify, and Bun tests plus benchmark evidence.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.