### PR TITLE
Resolve #1488: Support Standard Schema config validation

### DIFF
--- a/.changeset/standard-schema-config-validation.md
+++ b/.changeset/standard-schema-config-validation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/config": minor
+---
+
+Replace function-based config validation with a synchronous Standard Schema `schema` option so applications can validate and normalize config through vendor-neutral schema libraries such as Zod, Valibot, and ArkType.

--- a/book/advanced/ch07-dynamic-modules.ko.md
+++ b/book/advanced/ch07-dynamic-modules.ko.md
@@ -281,7 +281,7 @@ provider 생성을 `createQueueProviders()` (`path:packages/queue/src/module.ts:
 
 이 패턴은 module registration 과정을 감사 가능하게 만듭니다. 여러 파일에 흩어진 decorator를 추적하는 대신, 단일 helper 파일에서 전체 registration surface를 확인할 수 있습니다.
 
-이 과정을 실제로 보려면 `ConfigModule.forRoot()`가 구성 로딩 결과를 `ConfigService` provider로 감싸는 방식을 보면 됩니다. 동적 모듈은 환경 파일, 기본값, 검증 함수를 직접 전역 상태로 흘리지 않고, 제어된 factory function 안에서 service provider로 묶습니다.
+이 과정을 실제로 보려면 `ConfigModule.forRoot()`가 구성 로딩 결과를 `ConfigService` provider로 감싸는 방식을 보면 됩니다. 동적 모듈은 환경 파일, 기본값, schema validator를 직접 전역 상태로 흘리지 않고, 제어된 factory function 안에서 service provider로 묶습니다.
 
 `path:packages/config/src/module.ts:30-45`
 ```typescript

--- a/book/advanced/ch07-dynamic-modules.md
+++ b/book/advanced/ch07-dynamic-modules.md
@@ -281,7 +281,7 @@ A typical static Module helper execution flow is:
 
 This pattern makes the Module registration process auditable. Instead of tracing Decorators spread across several files, you can inspect the full registration surface in one helper file.
 
-To see this process in practice, look at how `ConfigModule.forRoot()` wraps the result of configuration loading as a `ConfigService` Provider. The Dynamic Module does not leak environment files, defaults, or validation functions into global state directly. It binds them to a service Provider inside a controlled factory function.
+To see this process in practice, look at how `ConfigModule.forRoot()` wraps the result of configuration loading as a `ConfigService` Provider. The Dynamic Module does not leak environment files, defaults, or schema validators into global state directly. It binds them to a service Provider inside a controlled factory function.
 
 `path:packages/config/src/module.ts:30-45`
 ```typescript

--- a/book/beginner/ch11-config.ko.md
+++ b/book/beginner/ch11-config.ko.md
@@ -195,20 +195,18 @@ export class ApiService {
 ```typescript
 import { z } from 'zod'; // 선택적 검증 라이브러리
 
+const ConfigSchema = z.object({
+  PORT: z.coerce.number().default(3000),
+  DATABASE_URL: z.string().url(),
+  JWT_SECRET: z.string().min(32),
+});
+
 ConfigModule.forRoot({
-  validate: (config) => {
-    const schema = z.object({
-      PORT: z.coerce.number().default(3000),
-      DATABASE_URL: z.string().url(),
-      JWT_SECRET: z.string().min(32),
-    });
-    
-    return schema.parse(config);
-  },
+  schema: ConfigSchema,
 })
 ```
 
-`forRoot` 중에 검증을 수행함으로써, Fluo는 설정이 유효하지 않은 경우 상세한 에러를 발생시키고 **부트스트랩을 중단**합니다. 이는 잘못 설정된 노드가 로드 밸런서 회전에 투입되지 않도록 보장합니다.
+`forRoot` 중에 검증을 수행함으로써, Fluo는 설정이 유효하지 않은 경우 상세한 `INVALID_CONFIG` 에러를 발생시키고 **부트스트랩을 중단**합니다. schema가 검증한 `value`가 최종 config snapshot이 되므로, `PORT`가 숫자로 변환되는 것 같은 coercion 결과도 `ConfigService`에서 관찰됩니다. Config schema는 동기식으로 검증되어야 하며, 비동기 Standard Schema 결과는 동기 config API에서 거부됩니다. 이는 잘못 설정된 노드가 로드 밸런서 회전에 투입되지 않도록 보장합니다.
 
 프로덕션 환경에서 흔히 발생하는 버그 중 하나는 애플리케이션이 "부분적으로만 유효한" 설정으로 시작되는 것입니다. 어떤 값은 있고 어떤 값은 빠진 상태로 부팅되면, 실제 요청이 들어온 뒤에야 문제가 드러나서 원인을 찾기 더 어려워집니다. `fluo`를 사용하면 부트스트랩 시점에 설정을 검증할 수 있으므로, 반쯤만 설정된 상태를 실행 중에 끌고 가지 않고 시작 단계에서 바로 막을 수 있습니다. 결국 설정 검증은 편의 기능이 아니라, 운영 환경에 잘못된 인스턴스가 들어가는 것을 막는 안전장치입니다.
 

--- a/book/beginner/ch11-config.md
+++ b/book/beginner/ch11-config.md
@@ -195,20 +195,18 @@ For important settings such as database credentials, using `getOrThrow()` is str
 ```typescript
 import { z } from 'zod'; // Optional validation library
 
+const ConfigSchema = z.object({
+  PORT: z.coerce.number().default(3000),
+  DATABASE_URL: z.string().url(),
+  JWT_SECRET: z.string().min(32),
+});
+
 ConfigModule.forRoot({
-  validate: (config) => {
-    const schema = z.object({
-      PORT: z.coerce.number().default(3000),
-      DATABASE_URL: z.string().url(),
-      JWT_SECRET: z.string().min(32),
-    });
-    
-    return schema.parse(config);
-  },
+  schema: ConfigSchema,
 })
 ```
 
-By validating during `forRoot`, Fluo raises a detailed error and **stops bootstrap** when configuration is invalid. This ensures that a misconfigured node is never put into load balancer rotation.
+By validating during `forRoot`, Fluo raises a detailed `INVALID_CONFIG` error and **stops bootstrap** when configuration is invalid. The schema's validated `value` becomes the final config snapshot, so coercions such as `PORT` becoming a number are visible through `ConfigService`. Config schemas must validate synchronously; async Standard Schema results are rejected by the synchronous config API. This ensures that a misconfigured node is never put into load balancer rotation.
 
 One common production bug is an application starting with only partially valid configuration. If it boots with some values present and others missing, the problem may appear only after a real request arrives, making the root cause harder to find. With `fluo`, you can validate configuration during bootstrap, so a half-configured state is blocked at startup instead of being carried into runtime. Configuration validation is not just a convenience. It is a safety barrier that keeps misconfigured instances out of production traffic.
 

--- a/docs/architecture/config-and-environments.ko.md
+++ b/docs/architecture/config-and-environments.ko.md
@@ -29,8 +29,8 @@
 
 | Rule | Statement | Source anchor |
 | --- | --- | --- |
-| Merge before validate | `validate` hook은 모든 설정 source가 병합된 뒤 실행됩니다. | `packages/config/src/load.ts`, `packages/config/README.md` |
-| Fail-fast startup | 초기 load 중 `validate`가 throw 하면 config load는 code `INVALID_CONFIG`를 가진 `FluoError`를 발생시킵니다. | `packages/config/src/load.ts` |
+| Merge before schema validation | `schema` validator는 모든 설정 source가 병합된 뒤 실행됩니다. | `packages/config/src/load.ts`, `packages/config/README.md` |
+| Fail-fast startup | 초기 load 중 `schema`가 issue를 보고하면 config load는 code `INVALID_CONFIG`를 가진 `FluoError`를 발생시킵니다. | `packages/config/src/load.ts` |
 | No partial snapshot | 유효하지 않은 설정은 전체가 거부됩니다. load 경로는 부분 병합 결과를 반환하지 않습니다. | `packages/config/src/load.ts` |
 | Reload keeps previous snapshot on listener failure | reload 중 listener가 실패하면 이전 스냅샷이 복원됩니다. | `packages/config/src/load.ts`, `packages/config/src/reload-module.ts` |
 | Watch reload keeps last valid snapshot on validation failure | watch 모드에서 validation이 실패하면 오류를 보고하고 현재 스냅샷은 그대로 유지됩니다. | `packages/config/src/load.ts`, `packages/config/src/load.test.ts`, `docs/architecture/dev-reload-architecture.md` |
@@ -39,20 +39,24 @@
 최소 schema 계약:
 
 ```ts
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  PORT: z.coerce.number().default(3000),
+});
+
 ConfigModule.forRoot({
   envFile: '.env',
   processEnv: {
     DATABASE_URL: process.env.DATABASE_URL,
   },
   defaults: { PORT: '3000' },
-  validate: (raw) => {
-    if (!raw.DATABASE_URL) {
-      throw new Error('DATABASE_URL is required');
-    }
-    return raw;
-  },
+  schema: EnvSchema,
 });
 ```
+
+Config schema는 동기식으로 검증되어야 합니다. Standard Schema validator가 `Promise`를 반환하면 config loader는 이를 await하지 않고 `INVALID_CONFIG`로 실패합니다.
 
 ## Access Constraints
 

--- a/docs/architecture/config-and-environments.md
+++ b/docs/architecture/config-and-environments.md
@@ -29,8 +29,8 @@ Current merge behavior:
 
 | Rule | Statement | Source anchor |
 | --- | --- | --- |
-| Merge before validate | The `validate` hook runs after all configured sources are merged. | `packages/config/src/load.ts`, `packages/config/README.md` |
-| Fail-fast startup | If `validate` throws during initial load, config loading throws `FluoError` with code `INVALID_CONFIG`. | `packages/config/src/load.ts` |
+| Merge before schema validation | The `schema` validator runs after all configured sources are merged. | `packages/config/src/load.ts`, `packages/config/README.md` |
+| Fail-fast startup | If `schema` reports issues during initial load, config loading throws `FluoError` with code `INVALID_CONFIG`. | `packages/config/src/load.ts` |
 | No partial snapshot | Invalid configuration is rejected as a whole. The load path returns no partial merged result. | `packages/config/src/load.ts` |
 | Reload keeps previous snapshot on listener failure | During reload, listener failure restores the previous snapshot. | `packages/config/src/load.ts`, `packages/config/src/reload-module.ts` |
 | Watch reload keeps last valid snapshot on validation failure | Watch-mode validation failure reports the error and keeps the current snapshot unchanged. | `packages/config/src/load.ts`, `packages/config/src/load.test.ts`, `docs/architecture/dev-reload-architecture.md` |
@@ -39,20 +39,24 @@ Current merge behavior:
 Minimal schema contract:
 
 ```ts
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  PORT: z.coerce.number().default(3000),
+});
+
 ConfigModule.forRoot({
   envFile: '.env',
   processEnv: {
     DATABASE_URL: process.env.DATABASE_URL,
   },
   defaults: { PORT: '3000' },
-  validate: (raw) => {
-    if (!raw.DATABASE_URL) {
-      throw new Error('DATABASE_URL is required');
-    }
-    return raw;
-  },
+  schema: EnvSchema,
 });
 ```
+
+Config schemas must validate synchronously. If a Standard Schema validator returns a `Promise`, config loading fails with `INVALID_CONFIG` instead of awaiting it.
 
 ## Access Constraints
 

--- a/packages/config/README.ko.md
+++ b/packages/config/README.ko.md
@@ -32,6 +32,12 @@ npm install @fluojs/config
 ```ts
 import { ConfigModule } from '@fluojs/config';
 import { Module } from '@fluojs/core';
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  PORT: z.coerce.number().default(3000),
+});
 
 @Module({
   imports: [
@@ -41,10 +47,7 @@ import { Module } from '@fluojs/core';
         DATABASE_URL: process.env.DATABASE_URL,
       },
       defaults: { PORT: '3000' },
-      validate: (config) => {
-        if (!config.DATABASE_URL) throw new Error('DATABASE_URL이 필요합니다');
-        return config;
-      },
+      schema: EnvSchema,
     }),
   ],
 })
@@ -78,7 +81,9 @@ class MyService {
 
 ### 부트스트랩 전 검증
 
-`validate` 함수는 모든 소스가 합쳐진 뒤 실행되며, 에러를 던지면 부트스트랩이 즉시 중단됩니다.
+`schema` 옵션은 Zod, Valibot, ArkType 같은 동기식 [Standard Schema](https://standardschema.dev/schema) 호환 validator를 받습니다. 스키마는 모든 소스가 합쳐진 뒤 실행되고, 검증된 `value`가 최종 config snapshot이 됩니다. schema issue가 보고되면 bootstrap/load/reload는 `INVALID_CONFIG`로 실패합니다.
+
+`@fluojs/config`의 load와 reload API는 동기식입니다. 비동기 Standard Schema 결과는 `INVALID_CONFIG`로 거부되므로 config 검증에는 동기 스키마를 사용하세요.
 
 ### 런타임 접근과 리로드 비용 모델
 
@@ -103,7 +108,7 @@ class MyService {
 ## 관련 패키지
 
 - `@fluojs/runtime`: 부트스트랩 중 `loadConfig()`를 호출합니다.
-- `@fluojs/validation`: `validate` 함수 안에서 스키마 기반 검증을 조합할 수 있습니다.
+- Standard Schema validator: Zod, Valibot, ArkType 및 호환 schema 라이브러리를 `schema` 옵션으로 전달할 수 있습니다.
 
 ## 예제 소스
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -35,6 +35,12 @@ The `ConfigModule` handles loading and validating your configuration during boot
 ```typescript
 import { Module } from '@fluojs/core';
 import { ConfigModule } from '@fluojs/config';
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  PORT: z.coerce.number().default(3000),
+});
 
 @Module({
   imports: [
@@ -44,10 +50,7 @@ import { ConfigModule } from '@fluojs/config';
         DATABASE_URL: process.env.DATABASE_URL,
       },
       defaults: { PORT: '3000' },
-      validate: (config) => {
-        if (!config.DATABASE_URL) throw new Error('DATABASE_URL is required');
-        return config;
-      },
+      schema: EnvSchema,
     }),
   ],
 })
@@ -83,7 +86,9 @@ Configuration is merged in the following order (highest precedence wins):
 Plain objects are deep-merged by key. Arrays and primitive values from higher-precedence sources completely replace lower-precedence ones.
 
 ### Validation
-The `validate` function runs after all sources are merged but before the application starts. If it throws, the application bootstrap fails immediately.
+The `schema` option accepts a synchronous [Standard Schema](https://standardschema.dev/schema)-compatible validator such as Zod, Valibot, or ArkType. The schema runs after all sources are merged but before the application starts. Its validated `value` becomes the final config snapshot, and reported issues fail bootstrap/load/reload with `INVALID_CONFIG`.
+
+`@fluojs/config` keeps loading and reload APIs synchronous. Async Standard Schema results are rejected with `INVALID_CONFIG`; use a synchronous schema for config validation.
 
 ### Runtime Access and Reload Cost Model
 `ConfigService.get('a.b.c')` resolves dot-path keys by walking each path segment, so lookup cost is proportional to path depth. When `get()`, `getOrThrow()`, or `snapshot()` returns an object-like value, the returned value is a detached clone; clone cost is proportional to the returned subtree size so caller mutations cannot affect the active config snapshot.
@@ -107,7 +112,7 @@ The `validate` function runs after all sources are merged but before the applica
 ## Related Packages
 
 - **`@fluojs/runtime`**: Calls `loadConfig` internally during application bootstrap.
-- **`@fluojs/validation`**: Can be used within the `validate` function for schema-based validation.
+- **Standard Schema validators**: Zod, Valibot, ArkType, and other compatible schema libraries can be passed through the `schema` option.
 
 ## Example Sources
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@fluojs/core": "workspace:^",
+    "@standard-schema/spec": "^1.1.0",
     "dotenv": "^16.0.0",
     "dotenv-expand": "^11.0.0"
   },

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -246,14 +246,36 @@ describe('loadConfig', () => {
     expect(error).toMatchObject({ meta: { issues: ['PORT: PORT must be numeric'] } });
   });
 
-  it('rejects malformed Standard Schema config results', () => {
-    const malformedSchema: ConfigSchema = {
+  it('preserves Standard Schema object path key segments in INVALID_CONFIG issues', () => {
+    const schema: ConfigSchema = {
       '~standard': {
-        validate: () => ({ issues: 'bad-result' }) as never,
+        validate: () => ({
+          issues: [
+            {
+              message: 'DATABASE_URL must be a URL',
+              path: [{ key: 'database' }, { key: 'url' }],
+            },
+          ],
+        }),
         vendor: 'test',
         version: 1,
       },
     };
+
+    const error = expectInvalidConfigFailure(() =>
+      loadConfig({
+        schema,
+      }),
+    );
+
+    expect(error).toMatchObject({ meta: { issues: ['database.url: DATABASE_URL must be a URL'] } });
+  });
+
+  it('rejects malformed Standard Schema config results', () => {
+    const malformedSchema = createPortSchema();
+    Object.defineProperty(malformedSchema['~standard'], 'validate', {
+      value: () => ({ issues: 'bad-result' }),
+    });
 
     const error = expectInvalidConfigFailure(() =>
       loadConfig({

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createConfigReloader, loadConfig } from './load.js';
 import { ConfigModule } from './module.js';
 import { ConfigService, replaceConfigServiceSnapshot } from './service.js';
+import type { ConfigDictionary, ConfigSchema } from './types.js';
 
 const watchCallbacks = vi.hoisted(() => new Set<() => void>());
 
@@ -32,6 +33,54 @@ function emitWatchChange(): void {
   for (const callback of [...watchCallbacks]) {
     callback();
   }
+}
+
+function isConfigDictionary(value: unknown): value is ConfigDictionary {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function createPortSchema(): ConfigSchema {
+  return {
+    '~standard': {
+      validate: (value) => {
+        if (!isConfigDictionary(value)) {
+          return { issues: [{ message: 'config must be an object' }] };
+        }
+
+        const port = value.PORT;
+
+        if (typeof port !== 'string' || !/^\d+$/.test(port)) {
+          return { issues: [{ message: 'PORT must be numeric', path: ['PORT'] }] };
+        }
+
+        return { value: { ...value, PORT: Number(port) } };
+      },
+      vendor: 'test',
+      version: 1,
+    },
+  };
+}
+
+function expectInvalidConfigFailure(action: () => void): unknown {
+  try {
+    action();
+  } catch (error: unknown) {
+    expect(error).toMatchObject({
+      code: 'INVALID_CONFIG',
+      message: 'Invalid configuration.',
+    });
+    return error;
+  }
+
+  throw new Error('Expected action to fail with INVALID_CONFIG.');
+}
+
+function getErrorCause(error: unknown): unknown {
+  if (typeof error === 'object' && error !== null && 'cause' in error) {
+    return error.cause;
+  }
+
+  return undefined;
 }
 
 beforeEach(() => {
@@ -177,14 +226,64 @@ describe('loadConfig', () => {
     });
   });
 
-  it('fails when validation rejects the merged config', () => {
-    expect(() =>
+  it('uses a Standard Schema value as the final config snapshot', () => {
+    const loaded = loadConfig({
+      defaults: { PORT: '3000' },
+      schema: createPortSchema(),
+    });
+
+    expect(loaded.PORT).toBe(3000);
+  });
+
+  it('fails with INVALID_CONFIG when Standard Schema reports issues', () => {
+    const error = expectInvalidConfigFailure(() =>
       loadConfig({
-        validate: () => {
-          throw new Error('PORT is required');
-        },
+        defaults: { PORT: 'not-a-number' },
+        schema: createPortSchema(),
       }),
-    ).toThrow('Invalid configuration.');
+    );
+
+    expect(error).toMatchObject({ meta: { issues: ['PORT: PORT must be numeric'] } });
+  });
+
+  it('rejects malformed Standard Schema config results', () => {
+    const malformedSchema: ConfigSchema = {
+      '~standard': {
+        validate: () => ({ issues: 'bad-result' }) as never,
+        vendor: 'test',
+        version: 1,
+      },
+    };
+
+    const error = expectInvalidConfigFailure(() =>
+      loadConfig({
+        schema: malformedSchema,
+      }),
+    );
+
+    expect(getErrorCause(error)).toMatchObject({
+      message: 'Standard Schema config validator returned a malformed result.',
+    });
+  });
+
+  it('rejects async Standard Schema config results', () => {
+    const asyncSchema: ConfigSchema = {
+      '~standard': {
+        validate: async () => ({ value: { PORT: 3000 } }),
+        vendor: 'test',
+        version: 1,
+      },
+    };
+
+    const error = expectInvalidConfigFailure(() =>
+      loadConfig({
+        schema: asyncSchema,
+      }),
+    );
+
+    expect(getErrorCause(error)).toMatchObject({
+      message: 'Config schemas must validate synchronously. Async Standard Schema validation is not supported by the synchronous config API.',
+    });
   });
 
   it('parses multiline values from env files using dotenv', () => {
@@ -250,7 +349,7 @@ describe('loadConfig', () => {
     try {
       const updates: Array<{ port: string; reason: string }> = [];
       const subscription = reloader.subscribe((snapshot, reason) => {
-        const port = snapshot['PORT'];
+        const port = snapshot.PORT;
         if (typeof port === 'string') {
           updates.push({ port, reason });
         }
@@ -354,20 +453,12 @@ describe('loadConfig', () => {
       cwd,
       envFile: envPath,
       processEnv: {},
-      validate: (raw) => {
-        const port = raw['PORT'];
-
-        if (typeof port !== 'string' || !/^\d+$/.test(port)) {
-          throw new Error('PORT must be numeric');
-        }
-
-        return raw;
-      },
+      schema: createPortSchema(),
       watch: true,
     });
 
     try {
-      const updates: string[] = [];
+      const updates: number[] = [];
       const errors: string[] = [];
       const updateSubscription = reloader.subscribe((snapshot, reason) => {
         if (reason !== 'watch') {
@@ -375,7 +466,7 @@ describe('loadConfig', () => {
         }
 
         const port = snapshot['PORT'];
-        if (typeof port === 'string') {
+        if (typeof port === 'number') {
           updates.push(port);
         }
       });
@@ -391,12 +482,12 @@ describe('loadConfig', () => {
       writeFileSync(envPath, 'PORT=oops\n');
       emitWatchChange();
       await waitForCondition(() => errors.length > 0);
-      expect(reloader.current()['PORT']).toBe('4000');
+      expect(reloader.current().PORT).toBe(4000);
 
       writeFileSync(envPath, 'PORT=4300\n');
       emitWatchChange();
-      await waitForCondition(() => updates.includes('4300'));
-      expect(reloader.current()['PORT']).toBe('4300');
+      await waitForCondition(() => updates.includes(4300));
+      expect(reloader.current().PORT).toBe(4300);
 
       updateSubscription.unsubscribe();
       errorSubscription.unsubscribe();
@@ -770,6 +861,20 @@ describe('ConfigModule', () => {
     expect(service?.getOrThrow('PORT')).toBe('4000');
     expect(service?.snapshot()['PORT']).toBe('4000');
     expect(parseCalls).toBe(1);
+  });
+
+  it('uses Standard Schema validation through ConfigModule.forRoot', () => {
+    const moduleRef = ConfigModule.forRoot({
+      defaults: { PORT: '4000' },
+      schema: createPortSchema(),
+    });
+    const providers = getModuleMetadata(moduleRef)?.providers as
+      | Array<{ provide?: unknown; useFactory?: () => unknown }>
+      | undefined;
+    const configProvider = providers?.find((provider) => provider.provide === ConfigService);
+    const service = configProvider?.useFactory?.() as ConfigService | undefined;
+
+    expect(service?.get('PORT')).toBe(4000);
   });
 
   it('uses the provided processEnv snapshot through ConfigService registration', () => {

--- a/packages/config/src/load.test.ts
+++ b/packages/config/src/load.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createConfigReloader, loadConfig } from './load.js';
 import { ConfigModule } from './module.js';
 import { ConfigService, replaceConfigServiceSnapshot } from './service.js';
-import type { ConfigDictionary, ConfigSchema } from './types.js';
+import type { ConfigDictionary, ConfigLoadOptions, ConfigSchema } from './types.js';
 
 const watchCallbacks = vi.hoisted(() => new Set<() => void>());
 
@@ -283,6 +283,18 @@ describe('loadConfig', () => {
 
     expect(getErrorCause(error)).toMatchObject({
       message: 'Config schemas must validate synchronously. Async Standard Schema validation is not supported by the synchronous config API.',
+    });
+  });
+
+  it('rejects legacy function-based validate options instead of silently ignoring them', () => {
+    const legacyOptions: ConfigLoadOptions & { validate: (raw: ConfigDictionary) => ConfigDictionary } = {
+      validate: (raw) => raw,
+    };
+
+    const error = expectInvalidConfigFailure(() => loadConfig(legacyOptions));
+
+    expect(getErrorCause(error)).toMatchObject({
+      message: 'The legacy `validate` option was removed. Use `schema` with a synchronous Standard Schema validator instead.',
     });
   });
 

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -71,7 +71,18 @@ function sanitizeProcessEnv(processEnv: NodeJS.ProcessEnv): Record<string, strin
   );
 }
 
+function rejectLegacyValidateOption(options: ConfigLoadOptions): void {
+  if ('validate' in options) {
+    throw new FluoError('Invalid configuration.', {
+      code: 'INVALID_CONFIG',
+      cause: new Error('The legacy `validate` option was removed. Use `schema` with a synchronous Standard Schema validator instead.'),
+    });
+  }
+}
+
 function normalizeLoadOptions(options: ConfigLoadOptions): NormalizedLoadOptions {
+  rejectLegacyValidateOption(options);
+
   const cwd = options.cwd ?? process.cwd();
   const envFile = options.envFilePath ?? options.envFile ?? join(cwd, '.env');
   const defaults = options.defaults ?? {};

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -32,6 +32,10 @@ type ConfigSchemaIssue = {
   readonly path?: readonly unknown[];
 };
 
+type ConfigSchemaPathKeySegment = {
+  readonly key: string | number | symbol;
+};
+
 type ConfigSchemaFailureResult = {
   readonly issues: readonly ConfigSchemaIssue[];
 };
@@ -185,10 +189,30 @@ function isConfigSchemaSuccessResult(value: unknown): value is ConfigSchemaSucce
   return typeof value === 'object' && value !== null && 'value' in value && isPlainObject(value.value);
 }
 
+function isConfigSchemaPathKeySegment(value: unknown): value is ConfigSchemaPathKeySegment {
+  if (typeof value !== 'object' || value === null || !('key' in value)) {
+    return false;
+  }
+
+  return typeof value.key === 'string' || typeof value.key === 'number' || typeof value.key === 'symbol';
+}
+
+function formatConfigSchemaPathSegment(segment: unknown): string | undefined {
+  if (typeof segment === 'string' || typeof segment === 'number') {
+    return String(segment);
+  }
+
+  if (isConfigSchemaPathKeySegment(segment)) {
+    return String(segment.key);
+  }
+
+  return undefined;
+}
+
 function formatConfigSchemaIssue(issue: ConfigSchemaIssue): string {
   const path = issue.path
-    ?.filter((segment): segment is string | number => typeof segment === 'string' || typeof segment === 'number')
-    .map((segment) => String(segment))
+    ?.map(formatConfigSchemaPathSegment)
+    .filter((segment): segment is string => segment !== undefined)
     .join('.');
 
   return path && path.length > 0 ? `${path}: ${issue.message}` : issue.message;

--- a/packages/config/src/load.ts
+++ b/packages/config/src/load.ts
@@ -15,6 +15,7 @@ import type {
   ConfigReloadListener,
   ConfigReloadReason,
   ConfigReloadSubscription,
+  ConfigSchema,
 } from './types.js';
 
 interface NormalizedLoadOptions {
@@ -23,8 +24,21 @@ interface NormalizedLoadOptions {
   safeProcessEnv: Record<string, string>;
   runtimeOverrides: ConfigDictionary;
   parse?: (content: string) => Record<string, string>;
-  validate?: (raw: ConfigDictionary) => ConfigDictionary;
+  schema?: ConfigSchema;
 }
+
+type ConfigSchemaIssue = {
+  readonly message: string;
+  readonly path?: readonly unknown[];
+};
+
+type ConfigSchemaFailureResult = {
+  readonly issues: readonly ConfigSchemaIssue[];
+};
+
+type ConfigSchemaSuccessResult = {
+  readonly value: ConfigDictionary;
+};
 
 const reloadFailureReasons = new WeakMap<object, ConfigReloadReason>();
 
@@ -71,7 +85,7 @@ function normalizeLoadOptions(options: ConfigLoadOptions): NormalizedLoadOptions
     parse: options.parse,
     runtimeOverrides,
     safeProcessEnv,
-    validate: options.validate,
+    schema: options.schema,
   };
 }
 
@@ -135,14 +149,83 @@ function buildMergedConfig(options: NormalizedLoadOptions): ConfigDictionary {
   );
 }
 
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' || typeof value === 'function')
+    && value !== null
+    && 'then' in value
+    && typeof value.then === 'function'
+  );
+}
+
+function isConfigSchemaIssue(value: unknown): value is ConfigSchemaIssue {
+  return typeof value === 'object' && value !== null && 'message' in value && typeof value.message === 'string';
+}
+
+function isConfigSchemaFailureResult(value: unknown): value is ConfigSchemaFailureResult {
+  if (typeof value !== 'object' || value === null || !('issues' in value)) {
+    return false;
+  }
+
+  return Array.isArray(value.issues) && value.issues.every(isConfigSchemaIssue);
+}
+
+function isConfigSchemaSuccessResult(value: unknown): value is ConfigSchemaSuccessResult {
+  return typeof value === 'object' && value !== null && 'value' in value && isPlainObject(value.value);
+}
+
+function formatConfigSchemaIssue(issue: ConfigSchemaIssue): string {
+  const path = issue.path
+    ?.filter((segment): segment is string | number => typeof segment === 'string' || typeof segment === 'number')
+    .map((segment) => String(segment))
+    .join('.');
+
+  return path && path.length > 0 ? `${path}: ${issue.message}` : issue.message;
+}
+
+function createInvalidConfigError(cause: unknown, issues?: readonly ConfigSchemaIssue[]): FluoError {
+  return new FluoError('Invalid configuration.', {
+    code: 'INVALID_CONFIG',
+    cause,
+    meta: issues ? { issues: issues.map(formatConfigSchemaIssue) } : undefined,
+  });
+}
+
+function isInvalidConfigError(error: unknown): error is FluoError {
+  return error instanceof FluoError && error.code === 'INVALID_CONFIG';
+}
+
+function readConfigSchemaResult(result: unknown): ConfigDictionary {
+  if (isConfigSchemaFailureResult(result)) {
+    throw createInvalidConfigError(new Error('Standard Schema config validation failed.'), result.issues);
+  }
+
+  if (!isConfigSchemaSuccessResult(result)) {
+    throw createInvalidConfigError(new Error('Standard Schema config validator returned a malformed result.'));
+  }
+
+  return result.value;
+}
+
 function validateConfig(options: NormalizedLoadOptions, merged: ConfigDictionary): ConfigDictionary {
+  if (!options.schema) {
+    return merged;
+  }
+
   try {
-    return options.validate ? options.validate(merged) : merged;
+    const result = options.schema['~standard'].validate(merged);
+
+    if (isPromiseLike(result)) {
+      throw new Error('Config schemas must validate synchronously. Async Standard Schema validation is not supported by the synchronous config API.');
+    }
+
+    return readConfigSchemaResult(result);
   } catch (error: unknown) {
-    throw new FluoError('Invalid configuration.', {
-      code: 'INVALID_CONFIG',
-      cause: error,
-    });
+    if (isInvalidConfigError(error)) {
+      throw error;
+    }
+
+    throw createInvalidConfigError(error);
   }
 }
 
@@ -279,7 +362,7 @@ function closeReloader(
 /**
  * Creates a stateful config reloader that mirrors `loadConfig(...)` semantics and optionally watches the env file.
  *
- * @param options Configuration loading options, including optional watch mode and validation hooks.
+ * @param options Configuration loading options, including optional watch mode and a synchronous Standard Schema validator.
  * @returns A reloader that exposes the current snapshot, manual reload, subscriptions, and cleanup.
  * @throws {FluoError} When the initial config load or validation fails.
  *
@@ -333,7 +416,7 @@ export function createConfigReloader(options: ConfigLoadOptions): ConfigReloader
  *
  * Merge precedence stays aligned with the package README contract: `defaults` < env file < `processEnv` < `runtimeOverrides`.
  *
- * @param options Configuration loading options for source precedence, parsing, and validation.
+ * @param options Configuration loading options for source precedence, parsing, and synchronous schema validation.
  * @returns A detached normalized configuration dictionary for the current load.
  * @throws {FluoError} When validation throws or the config cannot be normalized.
  */

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,7 +1,17 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
 /**
  * Plain JSON-like object used as the normalized configuration snapshot shape.
  */
 export type ConfigDictionary = Record<string, unknown>;
+
+/**
+ * Standard Schema v1-compatible config validator accepted by `@fluojs/config` loaders.
+ *
+ * @typeParam Input Raw merged config shape consumed by the schema validator.
+ * @typeParam Output Normalized config shape produced by the schema validator.
+ */
+export type ConfigSchema<Input = unknown, Output extends ConfigDictionary = ConfigDictionary> = StandardSchemaV1<Input, Output>;
 
 /**
  * Nested dot-path key helper.
@@ -33,7 +43,7 @@ export interface ConfigModuleOptions {
   envFile?: string;
   envFilePath?: string;
   processEnv?: NodeJS.ProcessEnv;
-  validate?: (raw: ConfigDictionary) => ConfigDictionary;
+  schema?: ConfigSchema;
   defaults?: ConfigDictionary;
   /** Supply a custom file parser (e.g. for YAML or TOML). Receives raw file content,
    *  returns a flat key-value record. Defaults to dotenv parsing. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@fluojs/core':
         specifier: workspace:^
         version: link:../core
+      '@standard-schema/spec':
+        specifier: ^1.1.0
+        version: 1.1.0
       dotenv:
         specifier: ^16.0.0
         version: 16.6.1


### PR DESCRIPTION
## Summary

Closes #1488

Add Standard Schema-only validation support to `@fluojs/config` so merged config can be validated and normalized through a vendor-neutral `schema` option while preserving the package's synchronous load/reload API.

## Changes

- Replaced the function-based `validate` option with a `schema` option typed through `@standard-schema/spec`.
- Centralized config schema validation in `loadConfig(...)`, so `ConfigModule.forRoot(...)` and `createConfigReloader(...)` share the same path.
- Uses successful schema `value` results as the final config snapshot, converts schema issues into `INVALID_CONFIG`, rejects malformed results, and rejects async schema validation results.
- Updated `@fluojs/config` README EN/KO, config architecture docs EN/KO, beginner config chapter EN/KO, and dynamic-module wording.
- Added a Changeset for the public `@fluojs/config` API change.

## Testing

- `pnpm --filter @fluojs/config test` — 50 tests passed.
- `pnpm --filter @fluojs/config typecheck` — passed.
- `pnpm --filter @fluojs/config build` — passed.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm changeset status --since=main` — reports `@fluojs/config` minor bump.
- `pnpm lint` — public export TSDoc check passed; Biome reported existing warning-level diagnostics.
- `pnpm verify:release-readiness` — passed after installing worktree workspace links.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.