### PR TITLE
Resolve #1494: Fix DI disposal failure handling

### DIFF
--- a/.changeset/di-disposal-scope-guards.md
+++ b/.changeset/di-disposal-scope-guards.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/di": patch
+---
+
+Preserve DI shutdown progress when request-scope child disposal fails, aggregate child/root disposal failures, and reject singleton dependency graphs that reach request scope through transient or factory providers.

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -76,6 +76,8 @@ const service = await container.resolve(UserService);
 - **request**: `createRequestScope()`마다 새로 생성됩니다.
 - **transient**: resolve할 때마다 새 인스턴스를 만듭니다.
 
+dispose 중에는 루트 컨테이너가 먼저 살아 있는 request scope 자식을 정리한 뒤, 자식 dispose 중 하나 이상이 실패하더라도 루트가 소유한 singleton 정리를 계속 수행합니다. 자식/루트 dispose 실패가 여러 개 발생하면 `dispose()`는 모든 shutdown 실패를 확인할 수 있도록 `AggregateError`로 보고합니다.
+
 ### request scope 분리
 
 ```ts
@@ -91,7 +93,7 @@ provider 객체는 등록 시점에 검증됩니다. 모든 객체 provider는 n
 
 컨테이너는 순환 의존성을 자동으로 감지하고 `CircularDependencyError`를 발생시켜 무한 루프를 방지합니다. 여기에는 직접 참조(A→A), 이중 노드(A→B→A), 깊은 순환(A→B→C→A)이 모두 포함됩니다.
 
-순환 의존성을 해결하려면 `forwardRef()`를 사용하여 의존성 토큰의 해석을 지연시키세요.
+선언 순서 때문에 아직 정의되지 않은 토큰을 참조해야 한다면 `forwardRef()`를 사용하세요. `forwardRef()`는 선언 순서 문제를 위해 토큰 조회를 지연할 뿐이며, 실제 생성자 순환을 해소하지는 않습니다. 그런 순환은 여전히 `CircularDependencyError`로 거부됩니다.
 
 ```typescript
 import { forwardRef } from '@fluojs/di';

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -101,12 +101,13 @@ import { Inject } from '@fluojs/core';
 
 @Inject(forwardRef(() => ServiceB))
 class ServiceA {
-  constructor(private serviceB: any) {}
+  constructor(private readonly serviceB: ServiceB) {}
 }
 
-@Inject(forwardRef(() => ServiceA))
 class ServiceB {
-  constructor(private serviceA: any) {}
+  getStatus() {
+    return 'ready';
+  }
 }
 ```
 
@@ -133,7 +134,7 @@ const service = await container.resolve(DataService);
 ## 문제 해결
 
 ### CircularDependencyError
-의존성 그래프에서 순환이 감지될 때 발생합니다. 생성자 주입 항목을 확인하고 필요한 경우 `forwardRef()`를 사용하여 순환을 끊으세요.
+의존성 그래프에서 순환이 감지될 때 발생합니다. 생성자 주입 항목을 확인하고 공유 상태 추출, 중재자 도입, 수명 주기 경계 변경 등으로 순환을 제거하세요. `forwardRef()`는 선언 순서 문제를 위해 토큰 조회만 지연하며, 실제 생성자 순환을 끊지는 않습니다.
 
 ### 토큰을 찾을 수 없음 (Token Not Found)
 필요한 모든 provider가 컨테이너에 등록되어 있는지 확인하세요. `createRequestScope()`를 사용하는 경우 자식 컨테이너는 부모의 토큰을 해석할 수 있지만, 그 반대는 불가능합니다.

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -75,6 +75,8 @@ fluo DI supports three main provider shapes:
 - **Request**: Instance is created once per `createRequestScope()` call.
 - **Transient**: A new instance is created every time it is resolved.
 
+During disposal, the root container first tears down live request-scope children and then continues with root-owned singleton cleanup even if one or more child disposals fail. When multiple child/root disposals fail, `dispose()` reports an `AggregateError` so callers can inspect every shutdown failure without losing cleanup progress.
+
 ### Request Scoping
 Isolated containers can be created to handle per-request state without polluting the root container.
 
@@ -91,7 +93,7 @@ Provider objects are validated at registration time: every object provider must 
 
 The container automatically detects circular dependencies and throws a `CircularDependencyError` to prevent infinite loops. This includes direct (A→A), two-node (A→B→A), and deep (A→B→C→A) cycles.
 
-To resolve a circular dependency, use `forwardRef()` to defer the resolution of the dependent token.
+Use `forwardRef()` when a token is referenced before its declaration. It defers token lookup for declaration-order issues, but it does not make true constructor cycles resolvable; those cycles are still rejected with `CircularDependencyError`.
 
 ```typescript
 import { forwardRef } from '@fluojs/di';

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -101,12 +101,13 @@ import { Inject } from '@fluojs/core';
 
 @Inject(forwardRef(() => ServiceB))
 class ServiceA {
-  constructor(private serviceB: any) {}
+  constructor(private readonly serviceB: ServiceB) {}
 }
 
-@Inject(forwardRef(() => ServiceA))
 class ServiceB {
-  constructor(private serviceA: any) {}
+  getStatus() {
+    return 'ready';
+  }
 }
 ```
 
@@ -133,7 +134,7 @@ const service = await container.resolve(DataService);
 ## Troubleshooting
 
 ### CircularDependencyError
-Thrown when the container detects a cycle in the dependency graph. Check your constructor injections and use `forwardRef()` where necessary to break the cycle.
+Thrown when the container detects a cycle in the dependency graph. Check your constructor injections and remove the cycle by extracting shared state, introducing a mediator, or changing the lifetime boundary. `forwardRef()` only defers token lookup for declaration-order issues; it does not break true constructor cycles.
 
 ### Token Not Found
 Ensure all required providers are registered in the container. If you use `createRequestScope()`, the child container can resolve tokens from the parent, but not vice versa.

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -250,6 +250,44 @@ describe('Container', () => {
 
       await expect(container.resolve(SingletonService)).rejects.toThrow(ScopeMismatchError);
     });
+
+    it('throws ScopeMismatchError when a singleton depends on a transient chain that reaches request scope', async () => {
+      class RequestDep {}
+
+      class TransientDep {
+        constructor(readonly dep: RequestDep) {}
+      }
+
+      class SingletonService {
+        constructor(readonly dep: TransientDep) {}
+      }
+
+      const container = new Container().register(
+        { provide: RequestDep, scope: Scope.REQUEST, useClass: RequestDep },
+        { provide: TransientDep, scope: Scope.TRANSIENT, useClass: TransientDep, inject: [RequestDep] },
+        { provide: SingletonService, useClass: SingletonService, inject: [TransientDep] },
+      );
+
+      await expect(container.resolve(SingletonService)).rejects.toThrow(ScopeMismatchError);
+    });
+
+    it('throws ScopeMismatchError when a singleton depends on a factory chain that reaches request scope', async () => {
+      const FACTORY_TOKEN = Symbol('FactoryDep');
+
+      class RequestDep {}
+
+      class SingletonService {
+        constructor(readonly dep: unknown) {}
+      }
+
+      const container = new Container().register(
+        { provide: RequestDep, scope: Scope.REQUEST, useClass: RequestDep },
+        { provide: FACTORY_TOKEN, scope: Scope.TRANSIENT, useFactory: (dep: unknown) => dep, inject: [RequestDep] },
+        { provide: SingletonService, useClass: SingletonService, inject: [FACTORY_TOKEN] },
+      );
+
+      await expect(container.resolve(SingletonService)).rejects.toThrow(ScopeMismatchError);
+    });
   });
 
   describe('circular dependency detection', () => {
@@ -1186,6 +1224,72 @@ describe('Container', () => {
 
       await expect(container.dispose()).rejects.toThrow('first failed');
       expect(events).toEqual(['second', 'first']);
+    });
+
+    it('continues root disposal after request-scope child disposal fails', async () => {
+      const events: string[] = [];
+
+      class RootService {
+        onDestroy() {
+          events.push('root');
+        }
+      }
+
+      class RequestService {
+        onDestroy() {
+          events.push('request');
+          throw new Error('request failed');
+        }
+      }
+
+      const root = new Container().register(
+        RootService,
+        { provide: RequestService, scope: Scope.REQUEST, useClass: RequestService },
+      );
+      const requestScope = root.createRequestScope();
+
+      await root.resolve(RootService);
+      await requestScope.resolve(RequestService);
+
+      await expect(root.dispose()).rejects.toThrow('request failed');
+      expect(events).toEqual(['request', 'root']);
+    });
+
+    it('aggregates request-scope child and root disposal failures', async () => {
+      const events: string[] = [];
+
+      class RootService {
+        onDestroy() {
+          events.push('root');
+          throw new Error('root failed');
+        }
+      }
+
+      class RequestService {
+        onDestroy() {
+          events.push('request');
+          throw new Error('request failed');
+        }
+      }
+
+      const root = new Container().register(
+        RootService,
+        { provide: RequestService, scope: Scope.REQUEST, useClass: RequestService },
+      );
+      const requestScope = root.createRequestScope();
+
+      await root.resolve(RootService);
+      await requestScope.resolve(RequestService);
+
+      const error = await root.dispose().catch((value: unknown) => value);
+
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors).toHaveLength(2);
+      expect((error as AggregateError).errors.map((failure) => (failure as Error).message)).toEqual([
+        'request failed',
+        'root failed',
+      ]);
+      expect(events).toEqual(['request', 'root']);
     });
 
     it('disposes stale overridden singleton instances immediately and exactly once', async () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -358,14 +358,29 @@ export class Container {
   }
 
   private async disposeAll(): Promise<void> {
+    const errors: unknown[] = [];
+
     try {
       // Dispose all live request-scope children first (root only)
       if (!this.parent && this.childScopes && this.childScopes.size > 0) {
-        await Promise.all(Array.from(this.childScopes).map((child) => child.dispose()));
+        const childResults = await Promise.allSettled(Array.from(this.childScopes).map((child) => child.dispose()));
+
+        for (const result of childResults) {
+          if (result.status === 'rejected') {
+            this.collectDisposalError(result.reason, errors);
+          }
+        }
+
         this.childScopes.clear();
       }
 
-      await this.disposeCache(this.disposalCacheEntries());
+      try {
+        await this.disposeCache(this.disposalCacheEntries());
+      } catch (error) {
+        this.collectDisposalError(error, errors);
+      }
+
+      this.throwDisposalErrors(errors);
     } finally {
       if (this.parent && this.trackedByRoot) {
         this.root().childScopes?.delete(this);
@@ -954,6 +969,15 @@ export class Container {
     }
   }
 
+  private collectDisposalError(error: unknown, errors: unknown[]): void {
+    if (error instanceof AggregateError) {
+      errors.push(...error.errors);
+      return;
+    }
+
+    errors.push(error);
+  }
+
   private isDisposable(value: unknown): value is Disposable {
     return typeof value === 'object' && value !== null && 'onDestroy' in value && typeof value.onDestroy === 'function';
   }
@@ -994,20 +1018,72 @@ export class Container {
       return;
     }
 
-    for (const depEntry of provider.inject) {
-      const depToken = this.resolveProviderDependencyToken(depEntry);
-      const effectiveProvider = this.resolveEffectiveProvider(depToken);
+    const requestScopedDependency = this.findRequestScopedDependency(provider.inject, new Set<Token>([provider.provide]));
 
-      if (effectiveProvider?.scope === 'request') {
-        throw new ScopeMismatchError(
-          `Singleton provider ${formatTokenName(provider.provide)} depends on request-scoped provider ${formatTokenName(depToken)}.`,
-          {
-            token: provider.provide,
-            scope: 'singleton',
-            hint: `Singleton providers cannot depend on request-scoped providers. Either change ${formatTokenName(depToken)} to singleton/transient scope, or change ${formatTokenName(provider.provide)} to request scope.`,
-          },
-        );
+    if (requestScopedDependency) {
+      throw new ScopeMismatchError(
+        `Singleton provider ${formatTokenName(provider.provide)} depends on request-scoped provider ${formatTokenName(requestScopedDependency)}.`,
+        {
+          token: provider.provide,
+          scope: 'singleton',
+          hint: `Singleton providers cannot depend on request-scoped providers. Either change ${formatTokenName(requestScopedDependency)} to singleton/transient scope, or change ${formatTokenName(provider.provide)} to request scope.`,
+        },
+      );
+    }
+  }
+
+  private findRequestScopedDependency(
+    depEntries: readonly (Token | ForwardRefFn | OptionalToken)[],
+    visited: Set<Token>,
+  ): Token | undefined {
+    for (const depEntry of depEntries) {
+      const depToken = this.resolveProviderDependencyToken(depEntry);
+
+      if (isOptionalToken(depEntry) && !this.has(depToken)) {
+        continue;
       }
+
+      const requestScopedToken = this.findRequestScopedDependencyToken(depToken, visited);
+
+      if (requestScopedToken) {
+        return requestScopedToken;
+      }
+    }
+
+    return undefined;
+  }
+
+  private findRequestScopedDependencyToken(token: Token, visited: Set<Token>): Token | undefined {
+    if (visited.has(token)) {
+      return undefined;
+    }
+
+    visited.add(token);
+
+    try {
+      const provider = this.resolveEffectiveProvider(token);
+
+      if (provider) {
+        if (provider.scope === Scope.REQUEST) {
+          return provider.provide;
+        }
+
+        return this.findRequestScopedDependency(provider.inject, visited);
+      }
+
+      if (typeof token !== 'function') {
+        return undefined;
+      }
+
+      const metadata = getClassDiMetadata(token);
+
+      if (metadata?.scope === Scope.REQUEST) {
+        return token;
+      }
+
+      return this.findRequestScopedDependency(metadata?.inject ?? [], visited);
+    } finally {
+      visited.delete(token);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #1494.

Fixes DI shutdown and scope enforcement gaps so disposal continues through request-scope child failures and singleton graphs cannot indirectly depend on request-scoped providers through transient/factory links.

## Changes

- Continue root cache disposal after live request-scope child disposal failures and aggregate child/root failures with `AggregateError`.
- Extend singleton scope validation to traverse transient/factory dependency chains while preserving existing cycle detection behavior.
- Clarify DI README disposal and `forwardRef()` contracts in English and Korean.
- Add a patch changeset for `@fluojs/di` because this public runtime behavior strengthens the documented shutdown/scope contract.

## Testing

- `pnpm --filter @fluojs/di test` — 84 tests passed.
- `pnpm --filter @fluojs/di typecheck` — passed.
- `pnpm --filter @fluojs/di build` — passed.
- LSP diagnostics for `packages/di/src/container.ts` and `packages/di/src/container.test.ts` — clean.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; implementation changes are internal to `Container` and README contract wording was updated.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Regression coverage includes child-disposal continuation, child/root failure aggregation, and singleton-to-transient/factory-to-request scope rejection.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform package conformance claims changed.