### PR TITLE
Resolve #1499: Fix GraphQL stream teardown

### DIFF
--- a/.changeset/graphql-stream-teardown.md
+++ b/.changeset/graphql-stream-teardown.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Restore GraphQL's patched instance helper on shutdown and cancel streaming GraphQL response bodies when downstream streams close or error, preventing long-lived subscription resources from leaking.

--- a/book/intermediate/ch18-graphql.ko.md
+++ b/book/intermediate/ch18-graphql.ko.md
@@ -152,7 +152,7 @@ export class NotificationResolver {
 
 ### Enabling WebSockets
 
-양방향 실시간 통신이 필요하거나 클라이언트 환경이 WebSocket 중심일 때는 WebSocket 트랜스포트를 활성화합니다. 기본 SSE 경로로 충분한지 먼저 판단하고, 실제로 양방향 메시징이 필요한 경우에만 WebSocket을 선택하는 편이 운영 경계를 단순하게 유지합니다.
+양방향 실시간 통신이 필요하거나 클라이언트 환경이 WebSocket 중심일 때는 WebSocket 트랜스포트를 활성화합니다. 기본 SSE 경로로 충분한지 먼저 판단하고, 실제로 양방향 메시징이 필요한 경우에만 WebSocket을 선택하는 편이 운영 경계를 단순하게 유지합니다. WebSocket 트랜스포트는 Node HTTP adapter처럼 upgrade listener를 지원하는 Node HTTP/S 서버를 노출하는 adapter가 필요합니다. 해당 서버 표면이 없는 런타임에서는 기본 SSE 구독 경로를 유지해야 합니다.
 
 ```typescript
 GraphqlModule.forRoot({

--- a/book/intermediate/ch18-graphql.md
+++ b/book/intermediate/ch18-graphql.md
@@ -152,7 +152,7 @@ export class NotificationResolver {
 
 ### Enabling WebSockets
 
-Enable the WebSocket transport when you need bidirectional realtime communication or when the client environment is WebSocket-centered. Check whether the default SSE path is enough first, then choose WebSockets only when bidirectional messaging is actually needed so the operational boundary stays simpler.
+Enable the WebSocket transport when you need bidirectional realtime communication or when the client environment is WebSocket-centered. Check whether the default SSE path is enough first, then choose WebSockets only when bidirectional messaging is actually needed so the operational boundary stays simpler. The WebSocket transport requires an adapter that exposes a Node HTTP/S server with upgrade listeners, such as the Node HTTP adapter; runtimes without that server surface should keep the default SSE subscription path.
 
 ```typescript
 GraphqlModule.forRoot({

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -133,7 +133,7 @@ class RequestResolver {
 ### 프로토콜 지원
 - **HTTP**: 표준 GET/POST 쿼리 및 뮤테이션.
 - **SSE**: Server-Sent Events를 통한 구독(기본값).
-- **WebSockets**: 실시간 구독을 위한 선택적 `graphql-ws` 지원.
+- **WebSockets**: 활성 adapter가 upgrade listener를 지원하는 Node HTTP/S 서버를 노출할 때(예: Node HTTP adapter) 사용할 수 있는 선택적 `graphql-ws` 실시간 구독 지원.
 
 ```typescript
 GraphqlModule.forRoot({
@@ -154,6 +154,7 @@ GraphqlModule.forRoot({
 
 - `graphiql`을 명시적으로 켜거나 `introspection: true`를 설정하지 않으면 스키마 introspection은 기본적으로 비활성화됩니다.
 - 문서 depth, field complexity, aggregate query cost에 대한 request validation budget이 기본적으로 보수적인 값으로 활성화됩니다.
+- Streaming GraphQL 응답은 downstream response stream이 닫히거나 오류를 내면 upstream fetch body를 cancel하므로 SSE subscription 리소스를 즉시 해제합니다.
 - WebSocket 구독 경로에는 별도의 전송 budget이 기본 적용됩니다: 동시 연결 `100`, 최대 payload 크기 `64 KiB`, 연결당 활성 operation `25`개입니다.
 - 무제한 WebSocket 동작이 정말 필요할 때만 `subscriptions.websocket.limits = false`를 사용하고, 그 경우에도 동일한 수준의 외부 제어 수단을 마련해야 합니다.
 - 무제한 동작이 꼭 필요할 때만 `limits: false`를 사용하고, 그 경우에는 외부 제어 수단을 함께 두어야 합니다.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -133,7 +133,7 @@ class RequestResolver {
 ### Protocol Support
 - **HTTP**: Standard GET/POST queries and mutations.
 - **SSE**: Subscriptions over Server-Sent Events (default).
-- **WebSockets**: Optional `graphql-ws` support for real-time subscriptions.
+- **WebSockets**: Optional `graphql-ws` support for real-time subscriptions when the active adapter exposes a Node HTTP/S server with upgrade listeners (for example, the Node HTTP adapter).
 
 ```typescript
 GraphqlModule.forRoot({
@@ -154,6 +154,7 @@ GraphqlModule.forRoot({
 
 - Schema introspection is disabled by default unless you explicitly enable `graphiql` or set `introspection: true`.
 - Request validation budgets are enabled by default with conservative limits for document depth, field complexity, and aggregate query cost.
+- Streaming GraphQL responses cancel the upstream fetch body when the downstream response stream closes or errors, so SSE subscription resources are released promptly.
 - WebSocket subscriptions use separate transport budgets by default: `100` concurrent connections, `64 KiB` maximum payload size, and `25` active operations per connection.
 - Set `subscriptions.websocket.limits = false` only when you intentionally need unbounded websocket behavior and can enforce equivalent controls elsewhere.
 - Pass `limits: false` only when you intentionally need unbounded behavior and can compensate with external controls.

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { createServer } from 'node:net';
 
 import { describe, expect, it } from 'vitest';
@@ -12,6 +13,10 @@ import { GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType } fro
 import { Arg, Mutation, Query, Resolver, Subscription } from './decorators.js';
 import { GraphqlModule } from './module.js';
 import { GRAPHQL_OPERATION_CONTAINER, listOf } from './types.js';
+
+type GraphqlInstanceOf = (value: unknown, constructor: { prototype?: { [Symbol.toStringTag]?: string } }) => boolean;
+
+const runtimeRequire = createRequire(import.meta.url);
 
 async function findAvailablePort(): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
@@ -1432,6 +1437,37 @@ describe('@fluojs/graphql', () => {
       },
     });
     await secondApp.close();
+  });
+
+  it('restores the GraphQL instanceOf helper when the application shuts down', async () => {
+    const instanceOfModule = runtimeRequire('graphql/jsutils/instanceOf.js') as {
+      instanceOf: GraphqlInstanceOf;
+    };
+    const originalInstanceOf = instanceOfModule.instanceOf;
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [GraphqlResolver],
+        }),
+      ],
+      providers: [ResolverState, GraphqlResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    expect(instanceOfModule.instanceOf).not.toBe(originalInstanceOf);
+
+    await app.close();
+
+    expect(instanceOfModule.instanceOf).toBe(originalInstanceOf);
   });
 
   it('keeps internal operation container when custom context includes reserved symbol key', async () => {

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -170,7 +170,8 @@ interface GraphqlDeps {
 
 const graphqlRequestContextStorage = new AsyncLocalStorage<GraphqlRequestContext>();
 const runtimeRequire = createRequire(import.meta.url);
-let graphqlInstanceOfPatched = false;
+let graphqlInstanceOfPatchRefCount = 0;
+let restoreGraphqlInstanceOfPatch: (() => void) | undefined;
 const allowedCrossRealmGraphqlObjects = new WeakSet<object>();
 
 /**
@@ -252,19 +253,21 @@ function isAllowedCrossRealmGraphqlObject(
   return allowedCrossRealmGraphqlObjects.has(value) && getCrossRealmGraphqlTag(value, constructor) !== undefined;
 }
 
-function patchGraphqlInstanceOf(): void {
-  if (graphqlInstanceOfPatched) {
-    return;
-  }
-
+function installGraphqlInstanceOfPatch(): () => void {
   const instanceOfModule = runtimeRequire('graphql/jsutils/instanceOf.js') as {
     instanceOf: GraphqlInstanceOf;
   };
-  const originalInstanceOf = instanceOfModule.instanceOf;
 
-  instanceOfModule.instanceOf = (value, constructor) => {
+  if (restoreGraphqlInstanceOfPatch) {
+    graphqlInstanceOfPatchRefCount += 1;
+    return releaseGraphqlInstanceOfPatch;
+  }
+
+  const patchedFrom = instanceOfModule.instanceOf;
+
+  const patchedInstanceOf: GraphqlInstanceOf = (value, constructor) => {
     try {
-      if (originalInstanceOf(value, constructor)) {
+      if (patchedFrom(value, constructor)) {
         return true;
       }
     } catch (error) {
@@ -277,8 +280,33 @@ function patchGraphqlInstanceOf(): void {
 
     return isAllowedCrossRealmGraphqlObject(value, constructor);
   };
+  instanceOfModule.instanceOf = patchedInstanceOf;
 
-  graphqlInstanceOfPatched = true;
+  graphqlInstanceOfPatchRefCount = 1;
+  restoreGraphqlInstanceOfPatch = () => {
+    if (instanceOfModule.instanceOf !== patchedInstanceOf) {
+      return;
+    }
+
+    instanceOfModule.instanceOf = patchedFrom;
+  };
+
+  return releaseGraphqlInstanceOfPatch;
+}
+
+function releaseGraphqlInstanceOfPatch(): void {
+  if (graphqlInstanceOfPatchRefCount === 0) {
+    return;
+  }
+
+  graphqlInstanceOfPatchRefCount -= 1;
+
+  if (graphqlInstanceOfPatchRefCount > 0) {
+    return;
+  }
+
+  restoreGraphqlInstanceOfPatch?.();
+  restoreGraphqlInstanceOfPatch = undefined;
 }
 
 async function loadGraphqlDeps(): Promise<GraphqlDeps> {
@@ -317,6 +345,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   private websocketUpgradeListener: NodeUpgradeListener | undefined;
   private websocketUpgradeServer: NodeUpgradeServer | undefined;
   private executeGraphqlOperation: ((args: ExecutionArgs) => OperationResult) | undefined;
+  private releaseGraphqlInstanceOfPatch: (() => void) | undefined;
   private subscribeGraphqlOperation: ((args: ExecutionArgs) => OperationResult) | undefined;
   private yoga: YogaLike | undefined;
 
@@ -418,6 +447,8 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     this.middlewareRegistered = false;
     this.executeGraphqlOperation = undefined;
     this.graphQLErrorConstructor = undefined;
+    this.releaseGraphqlInstanceOfPatch?.();
+    this.releaseGraphqlInstanceOfPatch = undefined;
     this.subscribeGraphqlOperation = undefined;
     this.yoga = undefined;
   }
@@ -446,7 +477,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   }
 
   private resolveSchema(deps: GraphqlDeps): GraphQLSchemaType {
-    patchGraphqlInstanceOf();
+    this.releaseGraphqlInstanceOfPatch ??= installGraphqlInstanceOfPatch();
 
     return resolveSchema(deps, this.options.schema, () => this.createCodeFirstSchema(deps), markAllowedCrossRealmGraphqlObjects);
   }

--- a/packages/graphql/src/transport/transport.test.ts
+++ b/packages/graphql/src/transport/transport.test.ts
@@ -161,4 +161,41 @@ describe('writeFetchResponse', () => {
 
     expect(cancel).toHaveBeenCalledOnce();
   });
+
+  it('cancels and settles a pending upstream read when the downstream stream closes', async () => {
+    const cancel = vi.fn(async () => {});
+    const fetchResponse = new Response(new ReadableStream<Uint8Array>({
+      cancel,
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+      status: 200,
+    });
+    const frameworkResponse = createFrameworkResponseMock();
+    const stream = frameworkResponse.stream;
+    let closeListener: (() => void) | undefined;
+    const removeCloseListener = vi.fn();
+
+    if (!stream) {
+      throw new Error('Expected stream mock to exist.');
+    }
+
+    stream.onClose = vi.fn((listener: () => void) => {
+      closeListener = listener;
+      return removeCloseListener;
+    });
+
+    const writePromise = writeFetchResponse(fetchResponse, frameworkResponse);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    Reflect.set(stream, 'closed', true);
+    closeListener?.();
+
+    await expect(writePromise).resolves.toBeUndefined();
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(removeCloseListener).toHaveBeenCalledOnce();
+    expect(stream.close).not.toHaveBeenCalled();
+    expect(frameworkResponse.writes).toEqual([]);
+  });
 });

--- a/packages/graphql/src/transport/transport.test.ts
+++ b/packages/graphql/src/transport/transport.test.ts
@@ -96,4 +96,69 @@ describe('writeFetchResponse', () => {
     expect(frameworkResponse.stream?.close).toHaveBeenCalledOnce();
     expect(frameworkResponse.writes.map((chunk: Uint8Array) => Buffer.from(chunk).toString('utf8'))).toEqual(['chunk-1', 'chunk-2']);
   });
+
+  it('cancels the upstream fetch body when the downstream stream closes during a write', async () => {
+    const cancel = vi.fn();
+    const fetchResponse = new Response(new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk-1'));
+        controller.enqueue(new TextEncoder().encode('chunk-2'));
+      },
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+      status: 200,
+    });
+    const frameworkResponse = createFrameworkResponseMock();
+    const stream = frameworkResponse.stream;
+
+    if (!stream) {
+      throw new Error('Expected stream mock to exist.');
+    }
+
+    vi.mocked(stream.write).mockImplementationOnce((chunk: string | Uint8Array) => {
+      frameworkResponse.writes.push(typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk);
+      Reflect.set(stream, 'closed', true);
+      return true;
+    });
+
+    await writeFetchResponse(fetchResponse, frameworkResponse);
+
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(stream.close).not.toHaveBeenCalled();
+    expect(frameworkResponse.writes.map((chunk: Uint8Array) => Buffer.from(chunk).toString('utf8'))).toEqual(['chunk-1']);
+  });
+
+  it('cancels the upstream fetch body when downstream backpressure errors', async () => {
+    const cancel = vi.fn();
+    const fetchResponse = new Response(new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('chunk-1'));
+        controller.enqueue(new TextEncoder().encode('chunk-2'));
+      },
+    }), {
+      headers: { 'content-type': 'text/event-stream' },
+      status: 200,
+    });
+    const frameworkResponse = createFrameworkResponseMock();
+    const stream = frameworkResponse.stream;
+    const downstreamError = new Error('downstream closed with error');
+
+    if (!stream) {
+      throw new Error('Expected stream mock to exist.');
+    }
+    const waitForDrain = stream.waitForDrain;
+
+    if (!waitForDrain) {
+      throw new Error('Expected waitForDrain mock to exist.');
+    }
+
+    vi.mocked(stream.write).mockReturnValueOnce(false);
+    vi.mocked(waitForDrain).mockRejectedValueOnce(downstreamError);
+
+    await expect(writeFetchResponse(fetchResponse, frameworkResponse)).rejects.toBe(downstreamError);
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/graphql/src/transport/transport.ts
+++ b/packages/graphql/src/transport/transport.ts
@@ -119,24 +119,38 @@ function readSetCookieValues(headers: Headers): string[] {
 async function writeFetchResponseStream(body: ReadableStream<Uint8Array>, stream: FrameworkResponseStream): Promise<void> {
   const reader = body.getReader();
   let readerDone = false;
-  let cancelReader: (() => void) | undefined;
+  let cancelPromise: Promise<void> | undefined;
+  let notifyCancellation: (() => void) | undefined;
+  const cancellationStarted = new Promise<void>((resolve) => {
+    notifyCancellation = resolve;
+  });
   const removeCloseListener = stream.onClose?.(() => {
     if (!readerDone) {
-      cancelReader?.();
+      void cancelUnreadBody().catch(() => {});
     }
   });
 
-  const cancelUnreadBody = async (): Promise<void> => {
-    if (readerDone) {
-      return;
+  const cancelUnreadBody = (): Promise<void> => {
+    if (!cancelPromise) {
+      readerDone = true;
+      notifyCancellation?.();
+      cancelPromise = reader.cancel();
     }
 
-    readerDone = true;
-    await reader.cancel();
+    return cancelPromise;
   };
 
-  cancelReader = () => {
-    void cancelUnreadBody();
+  const readNextChunk = async (): Promise<ReadableStreamReadResult<Uint8Array>> => {
+    const readPromise = reader.read();
+    readPromise.catch(() => {});
+
+    return await Promise.race([
+      readPromise,
+      cancellationStarted.then(async () => {
+        await cancelPromise;
+        return { done: true, value: undefined } as ReadableStreamReadDoneResult<Uint8Array>;
+      }),
+    ]);
   };
 
   try {
@@ -146,7 +160,7 @@ async function writeFetchResponseStream(body: ReadableStream<Uint8Array>, stream
         break;
       }
 
-      const { done, value } = await reader.read();
+      const { done, value } = await readNextChunk();
 
       if (done) {
         readerDone = true;

--- a/packages/graphql/src/transport/transport.ts
+++ b/packages/graphql/src/transport/transport.ts
@@ -116,6 +116,66 @@ function readSetCookieValues(headers: Headers): string[] {
   return values;
 }
 
+async function writeFetchResponseStream(body: ReadableStream<Uint8Array>, stream: FrameworkResponseStream): Promise<void> {
+  const reader = body.getReader();
+  let readerDone = false;
+  let cancelReader: (() => void) | undefined;
+  const removeCloseListener = stream.onClose?.(() => {
+    if (!readerDone) {
+      cancelReader?.();
+    }
+  });
+
+  const cancelUnreadBody = async (): Promise<void> => {
+    if (readerDone) {
+      return;
+    }
+
+    readerDone = true;
+    await reader.cancel();
+  };
+
+  cancelReader = () => {
+    void cancelUnreadBody();
+  };
+
+  try {
+    while (true) {
+      if (stream.closed) {
+        await cancelUnreadBody();
+        break;
+      }
+
+      const { done, value } = await reader.read();
+
+      if (done) {
+        readerDone = true;
+        break;
+      }
+
+      if (stream.closed) {
+        await cancelUnreadBody();
+        break;
+      }
+
+      const canContinue = stream.write(value);
+
+      if (!canContinue && !stream.closed) {
+        await stream.waitForDrain?.();
+      }
+    }
+  } catch (error) {
+    await cancelUnreadBody();
+    throw error;
+  } finally {
+    removeCloseListener?.();
+  }
+
+  if (!stream.closed) {
+    stream.close();
+  }
+}
+
 /**
  * Write fetch response.
  *
@@ -146,29 +206,7 @@ export async function writeFetchResponse(fetchResponse: Response, frameworkRespo
     frameworkResponse.committed = true;
     stream.flush?.();
 
-    const reader = fetchResponse.body.getReader();
-
-    while (true) {
-      const { done, value } = await reader.read();
-
-      if (done) {
-        break;
-      }
-
-      if (stream.closed) {
-        break;
-      }
-
-      const canContinue = stream.write(value);
-
-      if (!canContinue && !stream.closed) {
-        await stream.waitForDrain?.();
-      }
-    }
-
-    if (!stream.closed) {
-      stream.close();
-    }
+    await writeFetchResponseStream(fetchResponse.body, stream);
 
     return;
   }


### PR DESCRIPTION
## Summary

Fixes GraphQL lifecycle leaks from issue #1499 by making the `graphql/jsutils/instanceOf.js` compatibility patch reversible and by cancelling upstream streaming response bodies when downstream streams close or error.

Closes #1499

## Changes

- Ref-counts and restores the GraphQL `instanceOf` helper patch during `GraphqlLifecycleService` shutdown.
- Cancels unread fetch response bodies when GraphQL streaming/SSE responses detect downstream close or backpressure errors.
- Documents WebSocket's Node HTTP/S upgrade-server requirement and the stream cancellation contract in package README/book EN/KO docs.
- Adds a patch changeset for `@fluojs/graphql` because public package lifecycle behavior changes.

## Testing

- `pnpm install --offline`
- `pnpm --filter @fluojs/core --filter @fluojs/di --filter @fluojs/http --filter @fluojs/runtime --filter @fluojs/validation build`
- `pnpm --filter @fluojs/graphql typecheck`
- `pnpm --filter @fluojs/graphql test` (78 tests passed)
- LSP diagnostics clean for changed TypeScript files.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed; existing documentation remains applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Regression coverage includes GraphQL patch restoration and upstream stream cancellation on downstream close/error.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs or conformance claims changed; EN/KO package README and book updates were kept aligned.