### PR TITLE
Resolve #1498: align OpenAPI public surface determinism

### DIFF
--- a/.changeset/openapi-module-determinism.md
+++ b/.changeset/openapi-module-determinism.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/openapi": patch
+---
+
+Snapshot OpenAPI module options at registration/resolution time and allow Swagger UI assets to be configured for deterministic self-hosted documentation pages.

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -89,7 +89,10 @@ HTTP 핸들러가 `@fluojs/http`의 `@Produces(...)`를 선언하면, 생성된 
 같은 scheme에 대해 여러 `@ApiSecurity()` 데코레이터를 쌓으면, 해당 scheme의 scope가 하나의 누적 OpenAPI security requirement로 병합됩니다. 따라서 라우트가 `['reports:read']`와 `['reports:write', 'reports:read']`처럼 겹치는 scope를 선언해도 OAuth 스타일 요구사항은 결정적으로 유지되며, 서로 다른 scheme은 별도 requirement로 남습니다.
 
 ### 결정적인 Swagger UI 자산
-`ui: true`를 활성화하면 생성되는 `/docs` 페이지는 정확한 `swagger-ui-dist` 버전의 자산을 참조하여 패키지 릴리스마다 동일한 동작을 유지합니다.
+`ui: true`를 활성화하면 생성되는 `/docs` 페이지는 정확한 `swagger-ui-dist` 버전의 자산을 참조하여 패키지 릴리스마다 동일한 동작을 유지합니다. 오프라인 또는 CSP 제어 환경에서 자체 호스팅 자산이 필요하면 `swaggerUiAssets.cssUrl`과 `swaggerUiAssets.jsBundleUrl`을 설정하세요. 생성된 HTML은 해당 URL을 이스케이프하며 Swagger UI 인스턴스를 `window.ui`에 노출하지 않습니다.
+
+### 모듈 옵션 결정성
+`OpenApiModule.forRoot(...)`는 등록 시점에 옵션을 스냅샷하고 freeze합니다. 등록 후 원본 options 객체, `sources`, `descriptors`, `securitySchemes`, `extraModels`, `swaggerUiAssets`를 변경해도 제공되는 OpenAPI 문서나 `/docs` HTML은 바뀌지 않습니다. `OpenApiModule.forRootAsync(...)`도 async factory가 resolve된 뒤 같은 스냅샷을 적용하며, factory 실패는 bootstrap 중 전파됩니다.
 
 ## 공개 API
 
@@ -99,6 +102,8 @@ HTTP 핸들러가 `@fluojs/http`의 `@Produces(...)`를 선언하면, 생성된 
 - `ApiBearerAuth`, `ApiSecurity`: 보안 요구사항 데코레이터.
 - `ApiExcludeEndpoint`: 특정 핸들러를 문서화에서 제외.
 - `buildOpenApiDocument`: 프로그래밍 방식의 문서 빌더 (저수준).
+- `OpenApiHandlerRegistry`: 고급 통합에서 문서 생성 전에 handler descriptor를 스냅샷하는 mutable descriptor registry.
+- `getControllerTags`, `getMethodApiMetadata`: 고급 테스트와 통합 tooling을 위한 metadata reader.
 - `OpenApiSchemaObject`: 명시적 `@ApiBody(...)` 및 `@ApiResponse(...)` 스키마를 위한 타입화된 스키마 표면입니다. OpenAPI 3.1 조합(`allOf`, `oneOf`, `anyOf`), 객체/배열 제약, examples/defaults, 읽기/쓰기/Deprecated 주석을 포함합니다.
 
 ## 관련 패키지

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -89,7 +89,10 @@ Easily document authentication requirements like Bearer tokens or API keys using
 Stacking multiple `@ApiSecurity()` decorators for the same scheme merges scopes into one cumulative OpenAPI security requirement for that scheme. This keeps OAuth-style requirements deterministic when a route declares overlapping scopes such as `['reports:read']` and `['reports:write', 'reports:read']`, while different schemes remain separate requirements.
 
 ### Deterministic Swagger UI Assets
-When `ui: true` is enabled, the generated `/docs` page references an exact `swagger-ui-dist` asset version so release behavior stays deterministic across package updates.
+When `ui: true` is enabled, the generated `/docs` page references an exact `swagger-ui-dist` asset version so release behavior stays deterministic across package updates. If your deployment requires self-hosted assets for offline or CSP-controlled environments, set `swaggerUiAssets.cssUrl` and `swaggerUiAssets.jsBundleUrl`; the generated HTML escapes those URLs and does not expose the Swagger UI instance on `window.ui`.
+
+### Module Option Determinism
+`OpenApiModule.forRoot(...)` snapshots and freezes its options at registration time. Mutating the original options object, `sources`, `descriptors`, `securitySchemes`, `extraModels`, or `swaggerUiAssets` after registration does not alter the served OpenAPI document or `/docs` HTML. `OpenApiModule.forRootAsync(...)` applies the same snapshot once the async factory resolves, and factory failures propagate during bootstrap.
 
 ## Public API
 
@@ -99,6 +102,8 @@ When `ui: true` is enabled, the generated `/docs` page references an exact `swag
 - `ApiBearerAuth`, `ApiSecurity`: Security requirement decorators.
 - `ApiExcludeEndpoint`: Omit specific handlers from documentation.
 - `buildOpenApiDocument`: Programmatic document builder (low-level).
+- `OpenApiHandlerRegistry`: Mutable descriptor registry used by advanced integrations to snapshot handler descriptors before document generation.
+- `getControllerTags`, `getMethodApiMetadata`: Metadata readers for advanced tests and integration tooling.
 - `OpenApiSchemaObject`: Typed schema surface for explicit `@ApiBody(...)` and `@ApiResponse(...)` schemas, including OpenAPI 3.1 composition (`allOf`, `oneOf`, `anyOf`), object/array constraints, examples/defaults, and read/write/deprecated annotations.
 
 ## Related Packages

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -2080,11 +2080,37 @@ describe('OpenApiModule', () => {
   });
 
   it('snapshots and freezes forRoot options before bootstrap', async () => {
+    class StableExtraModel {
+      @IsString()
+      name = '';
+    }
+
+    class MutatedExtraModel {
+      @IsString()
+      name = '';
+    }
+
     @Controller('/stable')
     class StableController {
       @ApiSecurity('apiKeyAuth')
       @Get('/')
       getStable() {
+        return { ok: true };
+      }
+    }
+
+    @Controller('/descriptor-stable')
+    class DescriptorStableController {
+      @Get('/')
+      getDescriptorStable() {
+        return { ok: true };
+      }
+    }
+
+    @Controller('/descriptor-mutated')
+    class DescriptorMutatedController {
+      @Get('/')
+      getDescriptorMutated() {
         return { ok: true };
       }
     }
@@ -2097,6 +2123,8 @@ describe('OpenApiModule', () => {
       }
     }
 
+    const descriptors = createHandlerMapping([{ controllerToken: DescriptorStableController }]).descriptors;
+    const extraModels = [StableExtraModel];
     const sources: HandlerSource[] = [{ controllerToken: StableController }];
     const securitySchemes = {
       apiKeyAuth: {
@@ -2106,6 +2134,8 @@ describe('OpenApiModule', () => {
       },
     };
     const options = {
+      descriptors,
+      extraModels,
       securitySchemes,
       sources,
       swaggerUiAssets: {
@@ -2119,6 +2149,8 @@ describe('OpenApiModule', () => {
 
     const openApiModule = OpenApiModule.forRoot(options);
 
+    descriptors.push(...createHandlerMapping([{ controllerToken: DescriptorMutatedController }]).descriptors);
+    extraModels.push(MutatedExtraModel);
     sources.push({ controllerToken: MutatedController });
     securitySchemes.apiKeyAuth.name = 'mutated-api-key';
     options.swaggerUiAssets.cssUrl = 'https://assets.example.test/mutated.css';
@@ -2127,7 +2159,7 @@ describe('OpenApiModule', () => {
     class AppModule {}
 
     defineModule(AppModule, {
-      controllers: [StableController, MutatedController],
+      controllers: [StableController, MutatedController, DescriptorStableController, DescriptorMutatedController],
       imports: [openApiModule],
     });
 
@@ -2142,6 +2174,18 @@ describe('OpenApiModule', () => {
     expect(documentResponse.body).toEqual(
       expect.objectContaining({
         components: expect.objectContaining({
+          schemas: expect.objectContaining({
+            StableExtraModel: {
+              additionalProperties: false,
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+              required: ['name'],
+              type: 'object',
+            },
+          }),
           securitySchemes: {
             apiKeyAuth: {
               in: 'header',
@@ -2158,12 +2202,83 @@ describe('OpenApiModule', () => {
           '/stable': expect.objectContaining({
             get: expect.any(Object),
           }),
+          '/descriptor-stable': expect.objectContaining({
+            get: expect.any(Object),
+          }),
         }),
       }),
     );
-    expect((documentResponse.body as { paths: Record<string, unknown> }).paths['/mutated']).toBeUndefined();
+    const document = documentResponse.body as {
+      components?: { schemas?: Record<string, unknown> };
+      paths: Record<string, unknown>;
+    };
+    expect(document.paths['/descriptor-mutated']).toBeUndefined();
+    expect(document.paths['/mutated']).toBeUndefined();
+    expect(document.components?.schemas?.MutatedExtraModel).toBeUndefined();
     expect(docsResponse.body).toEqual(expect.stringContaining('https://assets.example.test/original.css'));
     expect(docsResponse.body).not.toEqual(expect.stringContaining('https://assets.example.test/mutated.css'));
+  });
+
+  it('snapshots resolved forRootAsync options before serving docs', async () => {
+    @Controller('/async-stable')
+    class AsyncStableController {
+      @Get('/')
+      getStable() {
+        return { ok: true };
+      }
+    }
+
+    const resolvedOptions = {
+      sources: [{ controllerToken: AsyncStableController }],
+      swaggerUiAssets: {
+        cssUrl: 'https://assets.example.test/async-original.css',
+        jsBundleUrl: 'https://assets.example.test/async-original.js',
+      },
+      title: 'Async Snapshot API',
+      ui: true,
+      version: '1.0.0',
+    };
+    const openApiModule = OpenApiModule.forRootAsync({
+      useFactory: async () => resolvedOptions,
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [AsyncStableController],
+      imports: [openApiModule],
+    });
+
+    const app = registerAppForCleanup(await bootstrapApplication({ rootModule: AppModule }));
+
+    resolvedOptions.title = 'Async Mutated API';
+    resolvedOptions.swaggerUiAssets.cssUrl = 'https://assets.example.test/async-mutated.css';
+
+    const documentResponse = createResponse();
+    const docsResponse = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), documentResponse);
+    await app.dispatch(createRequest('GET', '/docs'), docsResponse);
+
+    expect(documentResponse.statusCode).toBe(200);
+    expect(documentResponse.body).toEqual(
+      expect.objectContaining({
+        info: {
+          title: 'Async Snapshot API',
+          version: '1.0.0',
+        },
+        paths: expect.objectContaining({
+          '/async-stable': expect.objectContaining({
+            get: expect.any(Object),
+          }),
+        }),
+      }),
+    );
+    expect(docsResponse.statusCode).toBe(200);
+    expect(docsResponse.body).toEqual(expect.stringContaining('Async Snapshot API'));
+    expect(docsResponse.body).toEqual(expect.stringContaining('https://assets.example.test/async-original.css'));
+    expect(docsResponse.body).not.toEqual(expect.stringContaining('Async Mutated API'));
+    expect(docsResponse.body).not.toEqual(expect.stringContaining('https://assets.example.test/async-mutated.css'));
   });
 
   it('README quick start stays executable when sources are provided explicitly', async () => {

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -7,7 +7,7 @@ import * as corePublicApi from '@fluojs/core';
 import { IsArray, IsBoolean, IsOptional, IsString, MinLength, ValidateNested } from '@fluojs/validation';
 import { IntersectionType, OmitType, PartialType, PickType } from '@fluojs/validation';
 import * as httpPublicApi from '@fluojs/http';
-import { Controller, Get, Post, Produces, Version, createHandlerMapping, type FrameworkRequest, type FrameworkResponse } from '@fluojs/http';
+import { Controller, Get, Post, Produces, Version, createHandlerMapping, type FrameworkRequest, type FrameworkResponse, type HandlerSource } from '@fluojs/http';
 import { FromBody, FromCookie, FromHeader, FromPath, FromQuery, RequestDto } from '@fluojs/http';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { bootstrapHttpAdapterApplication } from '@fluojs/runtime/internal/http-adapter';
@@ -472,6 +472,90 @@ describe('OpenApiModule', () => {
     expect(response.body).toEqual(expect.stringContaining('const specUrl = window.location.pathname.replace('));
     expect(response.body).toEqual(expect.stringContaining("url: specUrl"));
     expect(response.body).toEqual(expect.stringContaining('SwaggerUIBundle'));
+    expect(response.body).not.toEqual(expect.stringContaining('window.ui'));
+  });
+
+  it('does not serve /docs when ui is disabled', async () => {
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: HealthController }],
+      title: 'Docs Disabled API',
+      ui: false,
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [HealthController],
+      imports: [openApiModule],
+    });
+
+    const app = registerAppForCleanup(await bootstrapApplication({ rootModule: AppModule }));
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/docs'), response);
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: 'NOT_FOUND',
+          message: 'Swagger UI is disabled.',
+          status: 404,
+        }),
+      }),
+    );
+  });
+
+  it('escapes Swagger UI HTML title and asset URLs', async () => {
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      sources: [{ controllerToken: HealthController }],
+      swaggerUiAssets: {
+        cssUrl: 'https://cdn.example.test/swagger-ui.css?theme="dark"&mode=<safe>',
+        jsBundleUrl: 'https://cdn.example.test/swagger-ui-bundle.js?asset="bundle"&mode=<safe>',
+      },
+      title: '<Docs & "API">',
+      ui: true,
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [HealthController],
+      imports: [openApiModule],
+    });
+
+    const app = registerAppForCleanup(await bootstrapApplication({ rootModule: AppModule }));
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/docs'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(expect.stringContaining('&lt;Docs &amp; &quot;API&quot;&gt;'));
+    expect(response.body).toEqual(
+      expect.stringContaining('https://cdn.example.test/swagger-ui.css?theme=&quot;dark&quot;&amp;mode=&lt;safe&gt;'),
+    );
+    expect(response.body).toEqual(
+      expect.stringContaining('https://cdn.example.test/swagger-ui-bundle.js?asset=&quot;bundle&quot;&amp;mode=&lt;safe&gt;'),
+    );
+    expect(response.body).not.toEqual(expect.stringContaining('<Docs & "API">'));
   });
 
   it('serves prefix-aware Swagger UI when globalPrefix is configured', async () => {
@@ -521,11 +605,13 @@ describe('OpenApiModule', () => {
     expect(docsHtml).toContain('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui-bundle.js');
     expect(docsHtml).toContain('const specUrl = window.location.pathname.replace(');
     expect(docsHtml).toContain('url: specUrl');
+    expect(docsHtml).not.toContain('window.ui');
     expect(docsTrailingSlashResponse.status).toBe(200);
     expect(docsTrailingHtml).toContain('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui.css');
     expect(docsTrailingHtml).toContain('https://unpkg.com/swagger-ui-dist@5.32.2/swagger-ui-bundle.js');
     expect(docsTrailingHtml).toContain('const specUrl = window.location.pathname.replace(');
     expect(docsTrailingHtml).toContain('url: specUrl');
+    expect(docsTrailingHtml).not.toContain('window.ui');
     expect(specResponse.status).toBe(200);
     expect(unprefixedSpecResponse.status).toBe(404);
 
@@ -1943,6 +2029,141 @@ describe('OpenApiModule', () => {
         }),
       }),
     );
+  });
+
+  it('keeps descriptor-only registration bounded to explicit descriptors', async () => {
+    @Controller('/documented')
+    class DocumentedController {
+      @Get('/')
+      getDocumented() {
+        return { ok: true };
+      }
+    }
+
+    @Controller('/module-only')
+    class ModuleOnlyController {
+      @Get('/')
+      getModuleOnly() {
+        return { ok: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      descriptors: createHandlerMapping([{ controllerToken: DocumentedController }]).descriptors,
+      title: 'Descriptor Boundary API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [DocumentedController, ModuleOnlyController],
+      imports: [openApiModule],
+    });
+
+    const app = registerAppForCleanup(await bootstrapApplication({ rootModule: AppModule }));
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        paths: expect.objectContaining({
+          '/documented': expect.objectContaining({
+            get: expect.any(Object),
+          }),
+        }),
+      }),
+    );
+    expect((response.body as { paths: Record<string, unknown> }).paths['/module-only']).toBeUndefined();
+  });
+
+  it('snapshots and freezes forRoot options before bootstrap', async () => {
+    @Controller('/stable')
+    class StableController {
+      @ApiSecurity('apiKeyAuth')
+      @Get('/')
+      getStable() {
+        return { ok: true };
+      }
+    }
+
+    @Controller('/mutated')
+    class MutatedController {
+      @Get('/')
+      getMutated() {
+        return { ok: true };
+      }
+    }
+
+    const sources: HandlerSource[] = [{ controllerToken: StableController }];
+    const securitySchemes = {
+      apiKeyAuth: {
+        in: 'header' as const,
+        name: 'x-api-key',
+        type: 'apiKey' as const,
+      },
+    };
+    const options = {
+      securitySchemes,
+      sources,
+      swaggerUiAssets: {
+        cssUrl: 'https://assets.example.test/original.css',
+        jsBundleUrl: 'https://assets.example.test/original.js',
+      },
+      title: 'Snapshot API',
+      ui: true,
+      version: '1.0.0',
+    };
+
+    const openApiModule = OpenApiModule.forRoot(options);
+
+    sources.push({ controllerToken: MutatedController });
+    securitySchemes.apiKeyAuth.name = 'mutated-api-key';
+    options.swaggerUiAssets.cssUrl = 'https://assets.example.test/mutated.css';
+    options.title = 'Mutated API';
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [StableController, MutatedController],
+      imports: [openApiModule],
+    });
+
+    const app = registerAppForCleanup(await bootstrapApplication({ rootModule: AppModule }));
+    const documentResponse = createResponse();
+    const docsResponse = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), documentResponse);
+    await app.dispatch(createRequest('GET', '/docs'), docsResponse);
+
+    expect(documentResponse.statusCode).toBe(200);
+    expect(documentResponse.body).toEqual(
+      expect.objectContaining({
+        components: expect.objectContaining({
+          securitySchemes: {
+            apiKeyAuth: {
+              in: 'header',
+              name: 'x-api-key',
+              type: 'apiKey',
+            },
+          },
+        }),
+        info: {
+          title: 'Snapshot API',
+          version: '1.0.0',
+        },
+        paths: expect.objectContaining({
+          '/stable': expect.objectContaining({
+            get: expect.any(Object),
+          }),
+        }),
+      }),
+    );
+    expect((documentResponse.body as { paths: Record<string, unknown> }).paths['/mutated']).toBeUndefined();
+    expect(docsResponse.body).toEqual(expect.stringContaining('https://assets.example.test/original.css'));
+    expect(docsResponse.body).not.toEqual(expect.stringContaining('https://assets.example.test/mutated.css'));
   });
 
   it('README quick start stays executable when sources are provided explicitly', async () => {

--- a/packages/openapi/src/openapi-module.ts
+++ b/packages/openapi/src/openapi-module.ts
@@ -24,6 +24,14 @@ const SWAGGER_UI_CSS_URL = `${SWAGGER_UI_DIST_BASE_URL}/swagger-ui.css`;
 const SWAGGER_UI_BUNDLE_JS_URL = `${SWAGGER_UI_DIST_BASE_URL}/swagger-ui-bundle.js`;
 
 /**
+ * Asset URLs used by the generated Swagger UI HTML page.
+ */
+export interface OpenApiSwaggerUiAssetsOptions {
+  cssUrl?: string;
+  jsBundleUrl?: string;
+}
+
+/**
  * Public options for `OpenApiModule.forRoot(...)` and `OpenApiModule.forRootAsync(...)`.
  *
  * @remarks
@@ -38,6 +46,7 @@ export interface OpenApiModuleOptions {
   descriptors?: readonly HandlerDescriptor[];
   sources?: readonly HandlerSource[];
   securitySchemes?: Record<string, OpenApiSecuritySchemeObject>;
+  swaggerUiAssets?: OpenApiSwaggerUiAssetsOptions;
   extraModels?: Constructor[];
   documentTransform?: (document: OpenApiDocument) => OpenApiDocument;
 }
@@ -62,24 +71,95 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#x27;');
 }
 
-function createSwaggerUiHtml(title: string): string {
+function cloneRecord<T>(record: Record<string, T> | undefined): Record<string, T> | undefined {
+  if (!record) {
+    return undefined;
+  }
+
+  const clone: Record<string, T> = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    clone[key] = cloneSnapshotValue(value);
+  }
+
+  return clone;
+}
+
+function cloneSnapshotValue<T>(value: T): T {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => cloneSnapshotValue(entry)) as T;
+  }
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  const clone: Record<PropertyKey, unknown> = {};
+
+  for (const key of Reflect.ownKeys(value)) {
+    clone[key] = cloneSnapshotValue((value as Record<PropertyKey, unknown>)[key]);
+  }
+
+  return clone as T;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  for (const key of Reflect.ownKeys(value)) {
+    deepFreeze((value as Record<PropertyKey, unknown>)[key]);
+  }
+
+  return Object.freeze(value);
+}
+
+function snapshotOpenApiModuleOptions(options: OpenApiModuleOptions): OpenApiModuleOptions {
+  return deepFreeze({
+    defaultErrorResponsesPolicy: options.defaultErrorResponsesPolicy,
+    descriptors: options.descriptors ? cloneSnapshotValue(options.descriptors) : undefined,
+    documentTransform: options.documentTransform,
+    extraModels: options.extraModels ? [...options.extraModels] : undefined,
+    securitySchemes: cloneRecord(options.securitySchemes),
+    sources: options.sources ? cloneSnapshotValue(options.sources) : undefined,
+    swaggerUiAssets: options.swaggerUiAssets ? { ...options.swaggerUiAssets } : undefined,
+    title: options.title,
+    ui: options.ui,
+    version: options.version,
+  });
+}
+
+function resolveSwaggerUiAssets(options: OpenApiModuleOptions): Required<OpenApiSwaggerUiAssetsOptions> {
+  return {
+    cssUrl: options.swaggerUiAssets?.cssUrl ?? SWAGGER_UI_CSS_URL,
+    jsBundleUrl: options.swaggerUiAssets?.jsBundleUrl ?? SWAGGER_UI_BUNDLE_JS_URL,
+  };
+}
+
+function createSwaggerUiHtml(title: string, assets: Required<OpenApiSwaggerUiAssetsOptions>): string {
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>${escapeHtml(title)}</title>
-    <link rel="stylesheet" href="${SWAGGER_UI_CSS_URL}" />
+    <link rel="stylesheet" href="${escapeHtml(assets.cssUrl)}" />
   </head>
   <body>
     <div id="swagger-ui"></div>
-    <script src="${SWAGGER_UI_BUNDLE_JS_URL}" crossorigin></script>
+    <script src="${escapeHtml(assets.jsBundleUrl)}" crossorigin></script>
     <script>
       const specUrl = window.location.pathname.replace(/\/docs\/?$/, '/openapi.json');
-      window.ui = SwaggerUIBundle({
+      const swaggerUi = SwaggerUIBundle({
         url: specUrl,
         dom_id: '#swagger-ui'
       });
+      void swaggerUi;
     </script>
   </body>
 </html>`;
@@ -132,7 +212,7 @@ export class OpenApiModule {
   static forRoot(options: OpenApiModuleOptions): ModuleType {
     return this.createModule({
       scope: 'singleton',
-      useValue: options,
+      useValue: snapshotOpenApiModuleOptions(options),
     });
   }
 
@@ -157,7 +237,7 @@ export class OpenApiModule {
     return this.createModule({
       inject: options.inject,
       scope: 'singleton',
-      useFactory: options.useFactory,
+      useFactory: async (...deps: unknown[]) => snapshotOpenApiModuleOptions(await options.useFactory(...deps)),
     });
   }
 
@@ -186,7 +266,7 @@ export class OpenApiModule {
 
         context.response.setHeader('content-type', 'text/html; charset=utf-8');
 
-        return createSwaggerUiHtml(this.options.title);
+        return createSwaggerUiHtml(this.options.title, resolveSwaggerUiAssets(this.options));
       }
     }
 

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -305,6 +305,27 @@ describe('buildOpenApiDocument', () => {
     });
   });
 
+  it('uses controller names as default tags when @ApiTag is absent', () => {
+    @Controller('/untagged')
+    class UntaggedController {
+      @Get('/')
+      getUntagged() {
+        return { ok: true };
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: UntaggedController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Default Tags API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/untagged']?.get?.tags).toEqual(['UntaggedController']);
+    expect(document.paths['/untagged']?.get?.operationId).toBe('UntaggedController_getUntagged_get_untagged');
+  });
+
   it('merges stacked same-scheme ApiSecurity scopes into a cumulative requirement', () => {
     @Controller('/reports')
     class ReportsController {


### PR DESCRIPTION
## Summary

Closes #1498

Aligns `@fluojs/openapi` public documentation and module determinism so the generated OpenAPI document and `/docs` HTML do not drift after registration.

## Changes

- Snapshot and freeze `OpenApiModule` options for `forRoot(...)` and resolved `forRootAsync(...)` options.
- Add configurable Swagger UI asset URLs, escape generated HTML values, and avoid assigning the UI instance to `window.ui`.
- Add regressions for `/docs` with `ui: false`, default tags, descriptor-only boundaries, async factory failure propagation, HTML escaping, Swagger UI determinism, `forRoot(...)` post-registration mutation of `sources` / `descriptors` / `securitySchemes` / `extraModels` / `swaggerUiAssets`, and resolved `forRootAsync(...)` option mutation after bootstrap.
- Document supported root-barrel metadata helpers/registry plus module determinism in EN/KO OpenAPI READMEs.
- Add a patch changeset for the user-facing OpenAPI module behavior update.

## Testing

- `pnpm --filter @fluojs/openapi... build` — passed
- `pnpm --filter @fluojs/openapi typecheck` — passed after dependency build
- `pnpm --filter @fluojs/openapi test` — passed (42 tests)
- `pnpm exec biome lint packages/openapi/src/openapi-module.ts packages/openapi/src/openapi-module.test.ts packages/openapi/src/schema-builder.test.ts packages/openapi/README.md packages/openapi/README.ko.md .changeset/openapi-module-determinism.md` — passed
- LSP diagnostics — clean for changed TypeScript files

Notes:
- Async factory failure propagation is covered directly by `propagates async option factory errors during bootstrap`.
- Resolved async option snapshot behavior is covered directly by `snapshots resolved forRootAsync options before serving docs`.
- README-claimed `descriptors` and `extraModels` mutation immutability is covered directly by `snapshots and freezes forRoot options before bootstrap`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Release

Patch changeset included: `.changeset/openapi-module-determinism.md`.

## Remaining risks

- Swagger UI still loads from the pinned `unpkg.com` default unless applications configure self-hosted `swaggerUiAssets` URLs.