### PR TITLE
Resolve #1513: add DI resolution cache regression coverage

### DIFF
--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -516,6 +516,28 @@ describe('Container', () => {
       expect(first).not.toBe(second);
     });
 
+    it('resolves transient dependency graphs against the latest override', async () => {
+      const CONFIG = Symbol('Config');
+
+      class Consumer {
+        constructor(readonly config: string) {}
+      }
+
+      const container = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: Consumer, scope: Scope.TRANSIENT, useClass: Consumer, inject: [CONFIG] },
+      );
+
+      const beforeOverride = await container.resolve<Consumer>(Consumer);
+
+      container.override({ provide: CONFIG, useValue: 'after-override' });
+
+      const afterOverride = await container.resolve<Consumer>(Consumer);
+
+      expect(beforeOverride.config).toBe('before-override');
+      expect(afterOverride.config).toBe('after-override');
+    });
+
     it('replaces existing multi providers when overriding a token', async () => {
       const token = Symbol('plugins');
       const container = new Container().register(
@@ -698,6 +720,35 @@ describe('Container', () => {
 
       expect(instance.logger).toBeInstanceOf(Logger);
     });
+
+    it('rechecks optional dependencies for transient providers after register()', async () => {
+      const LOGGER = Symbol('Logger');
+
+      class Logger {
+        readonly name = 'registered-later';
+      }
+
+      class MyService {
+        constructor(public logger: Logger | undefined) {}
+      }
+
+      const container = new Container().register({
+        provide: MyService,
+        scope: Scope.TRANSIENT,
+        useClass: MyService,
+        inject: [optional(LOGGER)],
+      });
+
+      const beforeRegister = await container.resolve<MyService>(MyService);
+
+      container.register({ provide: LOGGER, useClass: Logger });
+
+      const afterRegister = await container.resolve<MyService>(MyService);
+
+      expect(beforeRegister.logger).toBeUndefined();
+      expect(afterRegister.logger).toBeInstanceOf(Logger);
+      expect(afterRegister.logger?.name).toBe('registered-later');
+    });
   });
 
   describe('useExisting provider (alias)', () => {
@@ -821,6 +872,30 @@ describe('Container', () => {
       expect(first).toBe(second);
       expect(createTarget).toHaveBeenCalledTimes(1);
     });
+
+    it('keeps alias chains pointed at the latest overridden target for transient consumers', async () => {
+      const CONFIG = Symbol('Config');
+      const CONFIG_ALIAS = Symbol('ConfigAlias');
+
+      class Consumer {
+        constructor(readonly config: string) {}
+      }
+
+      const container = new Container().register(
+        { provide: CONFIG, useValue: 'initial' },
+        { provide: CONFIG_ALIAS, useExisting: CONFIG },
+        { provide: Consumer, scope: Scope.TRANSIENT, useClass: Consumer, inject: [CONFIG_ALIAS] },
+      );
+
+      const initial = await container.resolve<Consumer>(Consumer);
+
+      container.override({ provide: CONFIG, useValue: 'overridden' });
+
+      const overridden = await container.resolve<Consumer>(Consumer);
+
+      expect(initial.config).toBe('initial');
+      expect(overridden.config).toBe('overridden');
+    });
   });
 
   describe('has()', () => {
@@ -874,6 +949,22 @@ describe('Container', () => {
       expect(plugins).toHaveLength(2);
       expect(plugins[0]).toBeInstanceOf(PluginA);
       expect(plugins[1]).toBeInstanceOf(PluginB);
+    });
+
+    it('preserves multi-provider order across repeated resolutions and replacement', async () => {
+      const PLUGINS = Symbol('Plugins');
+      const container = new Container().register(
+        { provide: PLUGINS, useValue: 'a', multi: true },
+        { provide: PLUGINS, useValue: 'b', multi: true },
+        { provide: PLUGINS, useValue: 'c', multi: true },
+      );
+
+      await expect(container.resolve<string[]>(PLUGINS)).resolves.toEqual(['a', 'b', 'c']);
+      await expect(container.resolve<string[]>(PLUGINS)).resolves.toEqual(['a', 'b', 'c']);
+
+      container.override({ provide: PLUGINS, useValue: 'replacement', multi: true });
+
+      await expect(container.resolve<string[]>(PLUGINS)).resolves.toEqual(['replacement']);
     });
 
     it('collects parent and child multi providers without overriding parent registrations', async () => {
@@ -1061,6 +1152,32 @@ describe('Container', () => {
         useClass: Consumer,
         inject: [optional(OPTIONAL_STORE)],
       });
+
+      expect(container.hasRequestScopedDependency(Consumer)).toBe(false);
+    });
+
+    it('reflects register() and override() changes across repeated inspections', () => {
+      const OPTIONAL_STORE = Symbol('OptionalStore');
+
+      class RequestStore {}
+      class SingletonStore {}
+      class Consumer {
+        constructor(readonly store: RequestStore | SingletonStore | undefined) {}
+      }
+
+      const container = new Container().register({
+        provide: Consumer,
+        useClass: Consumer,
+        inject: [optional(OPTIONAL_STORE)],
+      });
+
+      expect(container.hasRequestScopedDependency(Consumer)).toBe(false);
+
+      container.register({ provide: OPTIONAL_STORE, scope: Scope.REQUEST, useClass: RequestStore });
+
+      expect(container.hasRequestScopedDependency(Consumer)).toBe(true);
+
+      container.override({ provide: OPTIONAL_STORE, useClass: SingletonStore });
 
       expect(container.hasRequestScopedDependency(Consumer)).toBe(false);
     });

--- a/packages/http/src/dispatch/dispatcher.test.ts
+++ b/packages/http/src/dispatch/dispatcher.test.ts
@@ -198,6 +198,81 @@ describe('dispatcher runtime', () => {
     expect(root.requestScopeDisposeCount).toBe(0);
   });
 
+  it('keeps singleton-only routes on the fast path across repeated dispatches with unrelated request providers', async () => {
+    @ScopeDecorator('request')
+    class UnusedRequestStore {}
+
+    @Controller('/cached-singleton-only')
+    class CachedSingletonOnlyController {
+      @Get('/')
+      getValue() {
+        return { ok: true };
+      }
+    }
+
+    const root = new CountingContainer().register(UnusedRequestStore, CachedSingletonOnlyController);
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: CachedSingletonOnlyController }]),
+      rootContainer: root,
+    });
+
+    const firstResponse = createFastPathResponse();
+    await dispatcher.dispatch(createRequest('/cached-singleton-only', 'GET'), firstResponse);
+
+    const secondResponse = createFastPathResponse();
+    await dispatcher.dispatch(createRequest('/cached-singleton-only', 'GET'), secondResponse);
+
+    const stats = getDispatcherFastPathStats(dispatcher);
+    expect(stats?.routes[0]?.executionPath).toBe('fast');
+    expect(firstResponse.simpleJsonBody).toEqual({ ok: true });
+    expect(secondResponse.simpleJsonBody).toEqual({ ok: true });
+    expect(root.requestScopeCreateCount).toBe(0);
+    expect(root.requestScopeDisposeCount).toBe(0);
+  });
+
+  it('promotes alias-based request-scoped controller dependencies before dispatch plan reuse', async () => {
+    const STORE_ALIAS = Symbol('StoreAlias');
+    let created = 0;
+
+    @ScopeDecorator('request')
+    class RequestStore {
+      readonly id = ++created;
+    }
+
+    @Inject(STORE_ALIAS)
+    @ScopeDecorator('request')
+    @Controller('/alias-request-scope')
+    class AliasRequestScopeController {
+      constructor(private readonly store: RequestStore) {}
+
+      @Get('/')
+      getValue() {
+        return { store: this.store.id };
+      }
+    }
+
+    const root = new CountingContainer().register(
+      RequestStore,
+      { provide: STORE_ALIAS, useExisting: RequestStore },
+      AliasRequestScopeController,
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: AliasRequestScopeController }]),
+      rootContainer: root,
+    });
+
+    const firstResponse = createResponse();
+    await dispatcher.dispatch(createRequest('/alias-request-scope', 'GET'), firstResponse);
+
+    const secondResponse = createResponse();
+    await dispatcher.dispatch(createRequest('/alias-request-scope', 'GET'), secondResponse);
+
+    expect(firstResponse.body).toEqual({ store: 1 });
+    expect(secondResponse.body).toEqual({ store: 2 });
+    expect(root.requestScopeCreateCount).toBe(2);
+    expect(root.requestScopeDisposeCount).toBe(2);
+  });
+
   it('lazily promotes manual RequestContext container access to a request scope', async () => {
     let created = 0;
 

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { Inject, Module } from '@fluojs/core';
+import { Inject, Module, Scope as ScopeDecorator } from '@fluojs/core';
 import { Controller, Get, Post, type RequestContext } from '@fluojs/http';
 import type { Dispatcher } from '@fluojs/http';
 
@@ -268,6 +268,90 @@ describe('@fluojs/testing', () => {
     const consumer = await testingModule.resolve<ConsumerService>(ConsumerService);
     expect(consumer.value).toBe('fake');
     expect(factoryCallCount).toBe(0);
+  });
+
+  it('applies overrides through aliases across repeated transient resolutions', async () => {
+    const REAL_CONFIG = Symbol('real-config');
+    const CONFIG_ALIAS = Symbol('config-alias');
+
+    class ConsumerService {
+      constructor(readonly value: string) {}
+    }
+
+    @Module({
+      providers: [
+        { provide: REAL_CONFIG, useValue: 'real' },
+        { provide: CONFIG_ALIAS, useExisting: REAL_CONFIG },
+        { provide: ConsumerService, scope: 'transient', useClass: ConsumerService, inject: [CONFIG_ALIAS] },
+      ],
+    })
+    class ServiceModule {}
+
+    const testingModule = await createTestingModule({ rootModule: ServiceModule })
+      .overrideProvider(REAL_CONFIG, 'fake')
+      .compile();
+
+    const first = await testingModule.resolve<ConsumerService>(ConsumerService);
+    const second = await testingModule.resolve<ConsumerService>(ConsumerService);
+
+    expect(first).not.toBe(second);
+    expect(first.value).toBe('fake');
+    expect(second.value).toBe('fake');
+  });
+
+  it('keeps testing-module overrides from materializing replaced request-scoped factories', async () => {
+    const REQUEST_TOKEN = Symbol('request-token');
+    let realFactoryCallCount = 0;
+
+    class ConsumerService {
+      constructor(readonly value: string) {}
+    }
+
+    @Module({
+      providers: [
+        {
+          provide: REQUEST_TOKEN,
+          scope: 'request',
+          useFactory: () => {
+            realFactoryCallCount += 1;
+            return 'real-request';
+          },
+        },
+        { provide: ConsumerService, useClass: ConsumerService, inject: [REQUEST_TOKEN] },
+      ],
+    })
+    class ServiceModule {}
+
+    const testingModule = await createTestingModule({ rootModule: ServiceModule })
+      .overrideProvider(REQUEST_TOKEN, 'fake-request')
+      .compile();
+
+    const consumer = await testingModule.resolve<ConsumerService>(ConsumerService);
+
+    expect(consumer.value).toBe('fake-request');
+    expect(realFactoryCallCount).toBe(0);
+  });
+
+  it('preserves request-scoped testing module provider isolation when no override is applied', async () => {
+    let created = 0;
+
+    @ScopeDecorator('request')
+    class RequestStore {
+      readonly id = ++created;
+    }
+
+    @Inject(RequestStore)
+    @ScopeDecorator('request')
+    class ConsumerService {
+      constructor(readonly store: RequestStore) {}
+    }
+
+    @Module({ providers: [RequestStore, ConsumerService] })
+    class ServiceModule {}
+
+    const testingModule = await createTestingModule({ rootModule: ServiceModule }).compile();
+
+    await expect(testingModule.resolve<ConsumerService>(ConsumerService)).rejects.toThrow('outside request scope');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds test-only regression coverage for DI provider resolution semantics before resolution-plan caching work lands.

Closes #1513

## Changes

- Extends `@fluojs/di` container tests for repeated resolution with overrides, late optional dependency registration, alias chains, multi-provider order/replacement, and `hasRequestScopedDependency(...)` register/override changes.
- Extends HTTP dispatcher tests to pin singleton fast-path behavior and alias-backed request-scoped controller promotion across repeated dispatches.
- Extends `@fluojs/testing` module tests for override behavior through aliases, request-scoped provider override replacement, and request-scope isolation without overrides.

## Testing

- `./node_modules/.bin/vitest run packages/di/src/container.test.ts packages/http/src/dispatch/dispatcher.test.ts packages/testing/src/module.test.ts` — 3 files / 205 tests passed.
- `pnpm --filter @fluojs/di typecheck && pnpm --filter @fluojs/http typecheck && pnpm --filter @fluojs/testing typecheck` — passed.
- LSP diagnostics on changed files — clean.
- Full `pnpm typecheck` was attempted after `pnpm install --frozen-lockfile --offline`, but existing unrelated package ordering/path issues failed in `@fluojs/cron` (`@fluojs/redis`) and `@fluojs/cqrs` (`@fluojs/event-bus`); changed-package typechecks passed.

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Test-only change; no README/changeset required.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Not applicable: no platform/governance docs or package README claims changed.