### PR TITLE
Resolve #1514: prepare module graph cache prerequisites

### DIFF
--- a/packages/core/src/metadata.test.ts
+++ b/packages/core/src/metadata.test.ts
@@ -17,8 +17,10 @@ import {
   getInheritedClassDiMetadata,
   getInjectionSchema,
   getModuleMetadata,
+  getModuleMetadataVersion,
   getOwnClassDiMetadata,
   getRouteMetadata,
+  getClassDiMetadataVersion,
 } from './metadata.js';
 import {
   getOwnStandardConstructorMetadataBag,
@@ -89,6 +91,24 @@ describe('metadata helpers', () => {
       middleware: ['LoggingMiddleware'],
       providers: ['LoggerProvider'],
     });
+  });
+
+  it('increments module metadata version after each module metadata write', () => {
+    class ExampleModule {}
+
+    const initialVersion = getModuleMetadataVersion();
+
+    defineModuleMetadata(ExampleModule, {
+      providers: ['LoggerProvider'],
+    });
+    const firstWriteVersion = getModuleMetadataVersion();
+
+    defineModuleMetadata(ExampleModule, {
+      exports: ['LoggerProvider'],
+    });
+
+    expect(firstWriteVersion).toBeGreaterThan(initialVersion);
+    expect(getModuleMetadataVersion()).toBeGreaterThan(firstWriteVersion);
   });
 
   it('preserves explicit global false across partial module metadata writes', () => {
@@ -723,6 +743,24 @@ describe('metadata helpers', () => {
       inject: ['LOGGER'],
       scope: 'request',
     });
+  });
+
+  it('increments class DI metadata version after each class DI metadata write', () => {
+    class ExampleService {}
+
+    const initialVersion = getClassDiMetadataVersion();
+
+    defineClassDiMetadata(ExampleService, {
+      inject: ['LOGGER'],
+    });
+    const firstWriteVersion = getClassDiMetadataVersion();
+
+    defineClassDiMetadata(ExampleService, {
+      scope: 'request',
+    });
+
+    expect(firstWriteVersion).toBeGreaterThan(initialVersion);
+    expect(getClassDiMetadataVersion()).toBeGreaterThan(firstWriteVersion);
   });
 
   it('returns a frozen stable own class DI metadata snapshot', () => {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,7 +1,13 @@
-export { getClassDiMetadata, getInheritedClassDiMetadata, getOwnClassDiMetadata, defineClassDiMetadata } from './metadata/class-di.js';
+export {
+  getClassDiMetadata,
+  getClassDiMetadataVersion,
+  getInheritedClassDiMetadata,
+  getOwnClassDiMetadata,
+  defineClassDiMetadata,
+} from './metadata/class-di.js';
 export { defineControllerMetadata, defineRouteMetadata, getControllerMetadata, getRouteMetadata } from './metadata/controller-route.js';
 export { defineInjectionMetadata, getInjectionSchema } from './metadata/injection.js';
-export { defineModuleMetadata, getModuleMetadata } from './metadata/module.js';
+export { defineModuleMetadata, getModuleMetadata, getModuleMetadataVersion } from './metadata/module.js';
 export {
   ensureMetadataSymbol,
   getOwnStandardConstructorMetadataBag,

--- a/packages/core/src/metadata/class-di.ts
+++ b/packages/core/src/metadata/class-di.ts
@@ -96,3 +96,12 @@ export function getInheritedClassDiMetadata(target: Function): ClassDiMetadata |
 export function getClassDiMetadata(target: Function): ClassDiMetadata | undefined {
   return getInheritedClassDiMetadata(target);
 }
+
+/**
+ * Reads the process-local class-DI metadata write version.
+ *
+ * @returns Monotonically increasing version bumped after each class-DI metadata write.
+ */
+export function getClassDiMetadataVersion(): number {
+  return classDiMetadataVersion;
+}

--- a/packages/core/src/metadata/module.ts
+++ b/packages/core/src/metadata/module.ts
@@ -2,6 +2,7 @@ import { cloneCollection, cloneMutableValue } from './shared.js';
 import type { ModuleMetadata } from './types.js';
 
 const moduleMetadataStore = new WeakMap<Function, ModuleMetadata>();
+let moduleMetadataVersion = 0;
 
 function isValueProvider(provider: unknown): provider is { useValue: unknown } {
   return typeof provider === 'object' && provider !== null && 'useValue' in provider;
@@ -110,6 +111,7 @@ export function defineModuleMetadata(target: Function, metadata: ModuleMetadata)
     middleware: metadata.middleware ?? existing?.middleware,
     providers: metadata.providers ?? existing?.providers,
   })));
+  moduleMetadataVersion += 1;
 }
 
 /**
@@ -120,4 +122,13 @@ export function defineModuleMetadata(target: Function, metadata: ModuleMetadata)
  */
 export function getModuleMetadata(target: Function): ModuleMetadata | undefined {
   return moduleMetadataStore.get(target);
+}
+
+/**
+ * Reads the process-local module metadata write version.
+ *
+ * @returns Monotonically increasing version bumped after each module metadata write.
+ */
+export function getModuleMetadataVersion(): number {
+  return moduleMetadataVersion;
 }

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -17,9 +17,11 @@ describe('@fluojs/core public API surface', () => {
   it('does not expose internal metadata helpers on the root barrel', () => {
     expect(corePublicApi).not.toHaveProperty('defineModuleMetadata');
     expect(corePublicApi).not.toHaveProperty('getModuleMetadata');
+    expect(corePublicApi).not.toHaveProperty('getModuleMetadataVersion');
     expect(corePublicApi).not.toHaveProperty('defineControllerMetadata');
     expect(corePublicApi).not.toHaveProperty('getControllerMetadata');
     expect(corePublicApi).not.toHaveProperty('getClassDiMetadata');
+    expect(corePublicApi).not.toHaveProperty('getClassDiMetadataVersion');
     expect(corePublicApi).not.toHaveProperty('metadataSymbol');
     expect(corePublicApi).not.toHaveProperty('ensureSymbolMetadataPolyfill');
     expect(corePublicApi).not.toHaveProperty('cloneWithFallback');
@@ -29,9 +31,11 @@ describe('@fluojs/core public API surface', () => {
   it('keeps internal metadata helpers available from the internal subpath', () => {
     expect(coreInternalApi).toHaveProperty('defineModuleMetadata');
     expect(coreInternalApi).toHaveProperty('getModuleMetadata');
+    expect(coreInternalApi).toHaveProperty('getModuleMetadataVersion');
     expect(coreInternalApi).toHaveProperty('defineControllerMetadata');
     expect(coreInternalApi).toHaveProperty('getControllerMetadata');
     expect(coreInternalApi).toHaveProperty('getClassDiMetadata');
+    expect(coreInternalApi).toHaveProperty('getClassDiMetadataVersion');
     expect(coreInternalApi).toHaveProperty('metadataSymbol');
     expect(coreInternalApi).toHaveProperty('ensureSymbolMetadataPolyfill');
     expect(coreInternalApi).toHaveProperty('cloneWithFallback');

--- a/packages/runtime/src/module-graph.test.ts
+++ b/packages/runtime/src/module-graph.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { Inject } from '@fluojs/core';
+import { defineClassDiMetadata, defineModuleMetadata } from '@fluojs/core/internal';
+
+import { compileModuleGraph, createModuleGraphCacheKey } from './module-graph.js';
+
+describe('module graph cache-key prerequisites', () => {
+  it('returns the same key for the same root module and options inputs', () => {
+    class AppModule {}
+    defineModuleMetadata(AppModule, {});
+
+    expect(createModuleGraphCacheKey(AppModule)).toBe(createModuleGraphCacheKey(AppModule));
+  });
+
+  it('changes when runtime providers change', () => {
+    class Logger {}
+    class Metrics {}
+    class AppModule {}
+    defineModuleMetadata(AppModule, {});
+
+    const loggerKey = createModuleGraphCacheKey(AppModule, { providers: [Logger] });
+    const metricsKey = createModuleGraphCacheKey(AppModule, { providers: [Metrics] });
+
+    expect(metricsKey).not.toBe(loggerKey);
+  });
+
+  it('changes when validation tokens change', () => {
+    const FIRST_TOKEN = Symbol('first-validation-token');
+    const SECOND_TOKEN = Symbol('second-validation-token');
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {});
+
+    const firstKey = createModuleGraphCacheKey(AppModule, { validationTokens: [FIRST_TOKEN] });
+    const secondKey = createModuleGraphCacheKey(AppModule, { validationTokens: [SECOND_TOKEN] });
+
+    expect(secondKey).not.toBe(firstKey);
+  });
+
+  it('changes when module metadata changes', () => {
+    class Logger {}
+    class AppModule {}
+    defineModuleMetadata(AppModule, {});
+    const emptyKey = createModuleGraphCacheKey(AppModule);
+
+    defineModuleMetadata(AppModule, {
+      providers: [Logger],
+    });
+
+    expect(createModuleGraphCacheKey(AppModule)).not.toBe(emptyKey);
+  });
+
+  it('changes when class-DI metadata changes', () => {
+    class Logger {}
+
+    @Inject(Logger)
+    class AppService {
+      constructor(readonly logger: Logger) {}
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [Logger, AppService],
+    });
+    const initialKey = createModuleGraphCacheKey(AppModule);
+
+    defineClassDiMetadata(AppService, {
+      scope: 'request',
+    });
+
+    expect(createModuleGraphCacheKey(AppModule)).not.toBe(initialKey);
+  });
+
+  it('does not cache failed module graph compilation as a successful reusable result', () => {
+    class MissingDependency {}
+
+    @Inject(MissingDependency)
+    class AppService {
+      constructor(readonly missingDependency: MissingDependency) {}
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const cache = new Map<string, ReturnType<typeof compileModuleGraph>>();
+    const cacheKey = createModuleGraphCacheKey(AppModule);
+    const compileAndStore = () => {
+      const compiled = compileModuleGraph(AppModule);
+      cache.set(cacheKey, compiled);
+    };
+
+    expect(compileAndStore).toThrow('not local, not exported by an imported module');
+    expect(cache.has(cacheKey)).toBe(false);
+  });
+});

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -1,6 +1,12 @@
 import type { Provider } from '@fluojs/di';
 import type { Token } from '@fluojs/core';
-import { getClassDiMetadata, getModuleMetadata, getOwnClassDiMetadata } from '@fluojs/core/internal';
+import {
+  getClassDiMetadata,
+  getClassDiMetadataVersion,
+  getModuleMetadata,
+  getModuleMetadataVersion,
+  getOwnClassDiMetadata,
+} from '@fluojs/core/internal';
 import type { MiddlewareLike } from '@fluojs/http';
 
 import { ModuleGraphError, ModuleInjectionMetadataError, ModuleVisibilityError } from './errors.js';
@@ -28,6 +34,108 @@ type OptionalToken = { __optional__: true; token: Token };
 type ClassDiMetadataView = {
   inject?: readonly InjectionToken[];
 };
+
+const objectTokenIds = new WeakMap<Function, number>();
+const symbolTokenIds = new Map<symbol, number>();
+let nextTokenId = 0;
+
+function getFunctionTokenId(token: Function): number {
+  const existing = objectTokenIds.get(token);
+
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  nextTokenId += 1;
+  objectTokenIds.set(token, nextTokenId);
+
+  return nextTokenId;
+}
+
+function getSymbolTokenId(token: symbol): number {
+  const existing = symbolTokenIds.get(token);
+
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  nextTokenId += 1;
+  symbolTokenIds.set(token, nextTokenId);
+
+  return nextTokenId;
+}
+
+function describeTokenForCacheKey(token: Token): string {
+  if (typeof token === 'function') {
+    return `fn:${getFunctionTokenId(token)}`;
+  }
+
+  if (typeof token === 'symbol') {
+    return `sym:${getSymbolTokenId(token)}`;
+  }
+
+  return `str:${JSON.stringify(token)}`;
+}
+
+function describeInjectionTokenForCacheKey(token: InjectionToken): string {
+  if (isForwardRef(token)) {
+    return `forward:${describeTokenForCacheKey(token.forwardRef())}`;
+  }
+
+  if (isOptionalToken(token)) {
+    return `optional:${describeTokenForCacheKey(token.token)}`;
+  }
+
+  return describeTokenForCacheKey(token);
+}
+
+function describeProviderForCacheKey(provider: Provider): string {
+  if (typeof provider === 'function') {
+    return `class:${describeTokenForCacheKey(provider)}`;
+  }
+
+  const provide = describeTokenForCacheKey(provider.provide);
+  const multi = 'multi' in provider && provider.multi === true ? 'multi' : 'single';
+
+  if ('useClass' in provider) {
+    const inject = provider.inject?.map(describeInjectionTokenForCacheKey).join(',') ?? '';
+
+    return `useClass:${provide}:${describeTokenForCacheKey(provider.useClass)}:${provider.scope ?? ''}:${multi}:${inject}`;
+  }
+
+  if ('useFactory' in provider) {
+    const inject = provider.inject?.map(describeInjectionTokenForCacheKey).join(',') ?? '';
+    const resolverClass = provider.resolverClass ? describeTokenForCacheKey(provider.resolverClass) : '';
+
+    return `useFactory:${provide}:${getFunctionTokenId(provider.useFactory)}:${resolverClass}:${provider.scope ?? ''}:${multi}:${inject}`;
+  }
+
+  if ('useExisting' in provider) {
+    return `useExisting:${provide}:${describeTokenForCacheKey(provider.useExisting)}`;
+  }
+
+  return `useValue:${provide}:${multi}`;
+}
+
+/**
+ * Builds the prerequisite key for future module graph compile caching.
+ *
+ * @param rootModule Root module that would be compiled.
+ * @param options Bootstrap options that influence graph validation.
+ * @returns Process-local key that changes when metadata or runtime validation inputs change.
+ */
+export function createModuleGraphCacheKey(rootModule: ModuleType, options: BootstrapModuleOptions = {}): string {
+  const runtimeProviders = (options.providers ?? []).map(describeProviderForCacheKey).join('|');
+  const validationTokens = (options.validationTokens ?? []).map(describeTokenForCacheKey).join('|');
+
+  return [
+    `root:${describeTokenForCacheKey(rootModule)}`,
+    `module:${getModuleMetadataVersion()}`,
+    `class-di:${getClassDiMetadataVersion()}`,
+    `runtime:${runtimeProviders}`,
+    `validation:${validationTokens}`,
+  ].join(';');
+}
 
 function getEffectiveClassDiMetadata(target: Function): ClassDiMetadataView | undefined {
   const metadata = getClassDiMetadata(target);


### PR DESCRIPTION
## Summary

Prepares the internal metadata-version and module-graph cache-key prerequisites needed before the opt-in module graph compile cache work in #1512.

Closes #1514

## Changes

- Added internal-only module metadata version tracking and exposed the existing class-DI metadata version through `@fluojs/core/internal` only.
- Added public root-barrel regression checks to keep metadata version helpers off the application-facing `@fluojs/core` API.
- Added focused module graph cache-key prerequisite coverage for stable inputs, runtime providers, validation tokens, metadata version bumps, class-DI version bumps, and failed compilation non-caching expectations.

## Testing

- `pnpm --filter @fluojs/core test` — passed: 5 files / 55 tests.
- `pnpm --filter @fluojs/runtime test` — passed: 17 files / 208 tests.
- `pnpm --filter @fluojs/core typecheck` — passed.
- Initial `pnpm --filter @fluojs/runtime typecheck` failed because the fresh worktree had no built dependency declarations; after `pnpm --filter @fluojs/runtime... build`, `pnpm --filter @fluojs/runtime typecheck` passed.
- `pnpm --filter @fluojs/runtime... build` — passed.
- `pnpm lint` — completed with existing Biome warnings outside this change set; `verify:public-export-tsdoc` passed in changed mode.
- LSP diagnostics on changed runtime files after dependency build — clean.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No application-facing root-barrel exports were added; new metadata version helpers remain under `@fluojs/core/internal`, with explicit public API regression coverage.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This is prerequisite/internal metadata and test coverage only. It does not implement the #1512 module graph compile cache and does not change documented runtime behavior, so no changeset is included.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Not applicable: no platform contract docs or package README conformance claims changed.