### PR TITLE
Resolve #1512: add opt-in module graph compile cache

### DIFF
--- a/.changeset/module-graph-cache.md
+++ b/.changeset/module-graph-cache.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Add an opt-in module graph compile-result cache for repeated bootstrap flows while keeping failed compilations uncached and cached graph snapshots isolated from caller mutation.

--- a/.changeset/module-graph-cache.md
+++ b/.changeset/module-graph-cache.md
@@ -1,5 +1,5 @@
 ---
-"@fluojs/runtime": patch
+"@fluojs/runtime": minor
 ---
 
 Add an opt-in module graph compile-result cache for repeated bootstrap flows while keeping failed compilations uncached and cached graph snapshots isolated from caller mutation.

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -139,6 +139,7 @@ class UsersModule {}
 - 런타임 health 모듈은 bootstrap이 ready로 표시하기 전까지 `/ready`를 HTTP 503과 `starting`으로 보고하며, 애플리케이션/컨텍스트 종료가 시작되는 즉시, 종료 시도가 실패하더라도 다시 `starting`으로 내려갑니다.
 - 시그널 기반 종료 헬퍼는 bounded drain semantics를 유지하면서 timeout/실패 상황을 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료 소유권은 주변 호스트 런타임에 남겨 둡니다.
 - 플랫폼 snapshot 생산은 런타임에 남아 있고, 그래프 보기와 Mermaid 렌더링은 CLI 및 자동화 호출자가 소비하는 Studio 소유 계약입니다.
+- 모듈 그래프 컴파일 결과 캐시는 `moduleGraphCache: true`를 통한 opt-in입니다. 캐시 항목은 root module identity, runtime provider, validation token, core metadata version, compile algorithm version으로 식별되며, 성공한 컴파일만 저장하고 호출자 mutation이 이후 bootstrap을 오염시키지 않도록 격리된 그래프 복사본을 반환합니다.
 
 ## 공개 API 개요
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -139,6 +139,7 @@ class UsersModule {}
 - Runtime health modules report `/ready` as `starting` with HTTP 503 until bootstrap marks them ready, and they return to `starting` as soon as application/context shutdown begins, including failed shutdown attempts.
 - Signal-driven shutdown helpers preserve bounded drain semantics, log timeout/failure conditions, and set `process.exitCode` when shutdown does not finish cleanly, but they leave final process termination ownership to the surrounding host runtime.
 - Platform snapshot production stays in runtime; graph viewing and Mermaid rendering are Studio-owned contracts consumed by CLI and automation callers.
+- Module graph compile-result caching is opt-in through `moduleGraphCache: true`; it keys entries by root module identity, runtime providers, validation tokens, core metadata versions, and the compile algorithm version, caches only successful compilations, and returns isolated graph copies so caller mutations cannot poison later bootstraps.
 
 ## Public API Overview
 

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -4,8 +4,9 @@ import { Global, Inject, Module, Scope as ScopeDecorator } from '@fluojs/core';
 import { defineModuleMetadata } from '@fluojs/core/internal';
 import { Controller, Convert, FromQuery, Get, RequestDto, type FrameworkRequest, type FrameworkResponse } from '@fluojs/http';
 
-import { bootstrapModule, FluoFactory } from './bootstrap.js';
+import { bootstrapApplication, bootstrapModule, FluoFactory } from './bootstrap.js';
 import { DuplicateProviderError, ModuleGraphError, ModuleInjectionMetadataError, ModuleVisibilityError } from './errors.js';
+import { clearModuleGraphCompileCacheForTesting, getModuleGraphCompileCacheSizeForTesting } from './module-graph.js';
 import type { PlatformComponent, PlatformState } from './platform-contract.js';
 import { HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL } from './tokens.js';
 import type { MicroserviceRuntime } from './types.js';
@@ -1773,6 +1774,95 @@ describe('FluoFactory.createMicroservice', () => {
     ]);
 
     await app.close();
+  });
+});
+
+describe('moduleGraphCache bootstrap wiring', () => {
+  it('keeps high-level application bootstrap cache usage default-off', async () => {
+    clearModuleGraphCompileCacheForTesting();
+
+    class AppService {}
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const app = await FluoFactory.create(AppModule);
+
+    expect(getModuleGraphCompileCacheSizeForTesting()).toBe(0);
+
+    await app.close();
+  });
+
+  it('passes moduleGraphCache opt-in through bootstrapApplication and FluoFactory.create', async () => {
+    clearModuleGraphCompileCacheForTesting();
+
+    class AppService {}
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const directApp = await bootstrapApplication({
+      moduleGraphCache: true,
+      rootModule: AppModule,
+    });
+
+    expect(getModuleGraphCompileCacheSizeForTesting()).toBe(1);
+
+    const factoryApp = await FluoFactory.create(AppModule, {
+      moduleGraphCache: true,
+    });
+
+    expect(getModuleGraphCompileCacheSizeForTesting()).toBe(1);
+
+    await factoryApp.close();
+    await directApp.close();
+  });
+
+  it('passes moduleGraphCache opt-in through createApplicationContext', async () => {
+    clearModuleGraphCompileCacheForTesting();
+
+    class AppService {}
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [AppService],
+    });
+
+    const context = await FluoFactory.createApplicationContext(AppModule, {
+      moduleGraphCache: true,
+    });
+
+    expect(getModuleGraphCompileCacheSizeForTesting()).toBe(1);
+
+    await context.close();
+  });
+
+  it('passes moduleGraphCache opt-in through createMicroservice context bootstrap', async () => {
+    clearModuleGraphCompileCacheForTesting();
+
+    const MICROSERVICE_TOKEN = Symbol.for('fluo.microservices.service');
+    class StubMicroserviceRuntime implements MicroserviceRuntime {
+      async listen(): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [
+        {
+          provide: MICROSERVICE_TOKEN,
+          useClass: StubMicroserviceRuntime,
+        },
+      ],
+    });
+
+    const microservice = await FluoFactory.createMicroservice(AppModule, {
+      moduleGraphCache: true,
+    });
+
+    expect(getModuleGraphCompileCacheSizeForTesting()).toBe(1);
+
+    await microservice.close();
   });
 });
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1318,6 +1318,7 @@ export async function bootstrapApplication(options: BootstrapApplicationOptions)
     const bootstrapped = bootstrapModule(options.rootModule, {
       duplicateProviderPolicy: options.duplicateProviderPolicy,
       logger,
+      moduleGraphCache: options.moduleGraphCache,
       providers: runtimeProviders,
       validationTokens: [RUNTIME_CONTAINER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER],
     });
@@ -1462,6 +1463,7 @@ export class FluoFactory {
       const bootstrapped = bootstrapModule(rootModule, {
         duplicateProviderPolicy: options.duplicateProviderPolicy,
         logger,
+        moduleGraphCache: options.moduleGraphCache,
         providers: runtimeProviders,
         validationTokens: [RUNTIME_CONTAINER, COMPILED_MODULES],
       });

--- a/packages/runtime/src/module-graph.test.ts
+++ b/packages/runtime/src/module-graph.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { Inject } from '@fluojs/core';
 import { forwardRef, optional } from '@fluojs/di';
 import { defineClassDiMetadata, defineModuleMetadata } from '@fluojs/core/internal';
+import type { MiddlewareRouteConfig } from '@fluojs/http';
 
 import {
   clearModuleGraphCompileCacheForTesting,
@@ -180,6 +181,80 @@ describe('module graph cache-key prerequisites', () => {
       expect.unreachable('expected the first cached dependency to remain a forwardRef wrapper');
     }
     expect(cachedFactoryProvider.inject[1]).toEqual(optional(Metrics));
+  });
+
+  it('keeps cached useValue payload snapshots isolated from returned result mutations', () => {
+    const CONFIG_TOKEN = Symbol('config-token');
+    const originalConfig = {
+      nested: {
+        flag: 'safe',
+      },
+      list: ['first'],
+    };
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [
+        {
+          provide: CONFIG_TOKEN,
+          useValue: originalConfig,
+        },
+      ],
+    });
+
+    const firstCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });
+    const configProvider = firstCompile[0]?.definition.providers?.[0];
+    if (typeof configProvider === 'function' || configProvider === undefined || !('useValue' in configProvider)) {
+      expect.unreachable('expected a value provider with nested configuration');
+    }
+
+    const returnedConfig = configProvider.useValue as typeof originalConfig;
+    returnedConfig.nested.flag = 'poisoned';
+    returnedConfig.list.push('poisoned');
+
+    const secondCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });
+    const cachedConfigProvider = secondCompile[0]?.definition.providers?.[0];
+    if (typeof cachedConfigProvider === 'function' || cachedConfigProvider === undefined || !('useValue' in cachedConfigProvider)) {
+      expect.unreachable('expected a cached value provider with nested configuration');
+    }
+
+    expect(cachedConfigProvider.useValue).toEqual({
+      nested: {
+        flag: 'safe',
+      },
+      list: ['first'],
+    });
+  });
+
+  it('keeps cached middleware route descriptors isolated from returned result mutations', () => {
+    class AuditMiddleware {
+      handle() {}
+    }
+    const routeConfig: MiddlewareRouteConfig = {
+      middleware: AuditMiddleware,
+      routes: ['/safe'],
+    };
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      middleware: [routeConfig],
+    });
+
+    const firstCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });
+    const returnedRouteConfig = firstCompile[0]?.definition.middleware?.[0];
+    if (typeof returnedRouteConfig !== 'object' || returnedRouteConfig === null || !('routes' in returnedRouteConfig)) {
+      expect.unreachable('expected a middleware route config descriptor');
+    }
+
+    returnedRouteConfig.routes.splice(0, returnedRouteConfig.routes.length, '/poisoned');
+
+    const secondCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });
+    const cachedRouteConfig = secondCompile[0]?.definition.middleware?.[0];
+    if (typeof cachedRouteConfig !== 'object' || cachedRouteConfig === null || !('routes' in cachedRouteConfig)) {
+      expect.unreachable('expected a cached middleware route config descriptor');
+    }
+
+    expect(cachedRouteConfig.routes).toEqual(['/safe']);
   });
 
   it('keeps the module graph cache opt-in', () => {

--- a/packages/runtime/src/module-graph.test.ts
+++ b/packages/runtime/src/module-graph.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Inject } from '@fluojs/core';
+import { forwardRef, optional } from '@fluojs/di';
 import { defineClassDiMetadata, defineModuleMetadata } from '@fluojs/core/internal';
 
 import {
@@ -127,6 +128,58 @@ describe('module graph cache-key prerequisites', () => {
     expect(secondCompile[0]?.providerTokens.has(Logger)).toBe(true);
     expect(secondCompile[0]?.exportedTokens.has(Logger)).toBe(true);
     expect(secondCompile[0]?.definition.providers).toEqual([Logger]);
+  });
+
+  it('keeps cached provider descriptors and nested inject wrappers isolated from returned result mutations', () => {
+    class Logger {}
+    class Metrics {}
+    class MissingDependency {}
+    const SERVICE_TOKEN = Symbol('service-token');
+    const POISONED_TOKEN = Symbol('poisoned-token');
+    const createService = (logger: Logger) => ({ logger });
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [
+        Logger,
+        Metrics,
+        {
+          provide: SERVICE_TOKEN,
+          inject: [forwardRef(() => Logger), optional(Metrics)],
+          useFactory: createService,
+        },
+      ],
+    });
+
+    const firstCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });
+    const factoryProvider = firstCompile[0]?.definition.providers?.[2];
+    if (typeof factoryProvider === 'function' || factoryProvider === undefined || !('useFactory' in factoryProvider) || factoryProvider.inject === undefined) {
+      expect.unreachable('expected a factory provider with explicit inject metadata');
+    }
+
+    factoryProvider.provide = POISONED_TOKEN;
+    factoryProvider.inject.splice(0, factoryProvider.inject.length, forwardRef(() => MissingDependency));
+    const poisonedWrapper = factoryProvider.inject[0];
+    if (typeof poisonedWrapper === 'object' && poisonedWrapper !== null && '__forwardRef__' in poisonedWrapper) {
+      poisonedWrapper.forwardRef = () => MissingDependency;
+    }
+
+    const secondCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });
+    const cachedFactoryProvider = secondCompile[0]?.definition.providers?.[2];
+    if (typeof cachedFactoryProvider === 'function' || cachedFactoryProvider === undefined || !('useFactory' in cachedFactoryProvider) || cachedFactoryProvider.inject === undefined) {
+      expect.unreachable('expected a cached factory provider with explicit inject metadata');
+    }
+
+    expect(cachedFactoryProvider.provide).toBe(SERVICE_TOKEN);
+    expect(cachedFactoryProvider.inject).toHaveLength(2);
+    const firstWrapper = cachedFactoryProvider.inject[0];
+    if (typeof firstWrapper === 'object' && firstWrapper !== null && '__forwardRef__' in firstWrapper) {
+      expect(firstWrapper.__forwardRef__).toBe(true);
+      expect(firstWrapper.forwardRef()).toBe(Logger);
+    } else {
+      expect.unreachable('expected the first cached dependency to remain a forwardRef wrapper');
+    }
+    expect(cachedFactoryProvider.inject[1]).toEqual(optional(Metrics));
   });
 
   it('keeps the module graph cache opt-in', () => {

--- a/packages/runtime/src/module-graph.test.ts
+++ b/packages/runtime/src/module-graph.test.ts
@@ -1,11 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Inject } from '@fluojs/core';
 import { defineClassDiMetadata, defineModuleMetadata } from '@fluojs/core/internal';
 
-import { compileModuleGraph, createModuleGraphCacheKey } from './module-graph.js';
+import {
+  clearModuleGraphCompileCacheForTesting,
+  compileModuleGraph,
+  createModuleGraphCacheKey,
+  getModuleGraphCompileCacheSizeForTesting,
+} from './module-graph.js';
 
 describe('module graph cache-key prerequisites', () => {
+  beforeEach(() => {
+    clearModuleGraphCompileCacheForTesting();
+  });
+
   it('returns the same key for the same root module and options inputs', () => {
     class AppModule {}
     defineModuleMetadata(AppModule, {});
@@ -36,6 +45,13 @@ describe('module graph cache-key prerequisites', () => {
     const secondKey = createModuleGraphCacheKey(AppModule, { validationTokens: [SECOND_TOKEN] });
 
     expect(secondKey).not.toBe(firstKey);
+  });
+
+  it('includes the compile algorithm version in the cache key', () => {
+    class AppModule {}
+    defineModuleMetadata(AppModule, {});
+
+    expect(createModuleGraphCacheKey(AppModule)).toContain('algorithm:1');
   });
 
   it('changes when module metadata changes', () => {
@@ -85,14 +101,49 @@ describe('module graph cache-key prerequisites', () => {
       providers: [AppService],
     });
 
-    const cache = new Map<string, ReturnType<typeof compileModuleGraph>>();
-    const cacheKey = createModuleGraphCacheKey(AppModule);
     const compileAndStore = () => {
-      const compiled = compileModuleGraph(AppModule);
-      cache.set(cacheKey, compiled);
+      compileModuleGraph(AppModule, { moduleGraphCache: true });
     };
 
     expect(compileAndStore).toThrow('not local, not exported by an imported module');
-    expect(cache.has(cacheKey)).toBe(false);
+    expect(getModuleGraphCompileCacheSizeForTesting()).toBe(0);
+  });
+
+  it('keeps cached module graph snapshots isolated from returned result mutations', () => {
+    class Logger {}
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [Logger],
+      exports: [Logger],
+    });
+
+    const firstCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });
+    firstCompile[0]?.providerTokens.clear();
+    firstCompile[0]?.exportedTokens.clear();
+    firstCompile[0]?.definition.providers?.splice(0);
+
+    const secondCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });
+
+    expect(secondCompile[0]?.providerTokens.has(Logger)).toBe(true);
+    expect(secondCompile[0]?.exportedTokens.has(Logger)).toBe(true);
+    expect(secondCompile[0]?.definition.providers).toEqual([Logger]);
+  });
+
+  it('keeps the module graph cache opt-in', () => {
+    class Logger {}
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      providers: [Logger],
+    });
+
+    const firstCompile = compileModuleGraph(AppModule);
+    firstCompile[0]?.providerTokens.clear();
+
+    expect(getModuleGraphCompileCacheSizeForTesting()).toBe(0);
+
+    compileModuleGraph(AppModule, { moduleGraphCache: true });
+
+    expect(getModuleGraphCompileCacheSizeForTesting()).toBe(1);
+    expect(compileModuleGraph(AppModule)[0]?.providerTokens.has(Logger)).toBe(true);
   });
 });

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -161,8 +161,71 @@ function cloneModuleDefinition(definition: ModuleDefinition): ModuleDefinition {
     providers: definition.providers ? definition.providers.map((provider) => cloneProvider(provider)) : undefined,
     controllers: definition.controllers ? [...definition.controllers] : undefined,
     exports: definition.exports ? [...definition.exports] : undefined,
-    middleware: definition.middleware ? [...definition.middleware] : undefined,
+    middleware: definition.middleware ? definition.middleware.map((middleware) => cloneMutableValue(middleware)) : undefined,
   };
+}
+
+function cloneMutableValue<T>(value: T, clones = new WeakMap<object, unknown>()): T {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  const existing = clones.get(value);
+  if (existing !== undefined) {
+    return existing as T;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value) as T;
+  }
+
+  if (value instanceof RegExp) {
+    return new RegExp(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    const clonedArray: unknown[] = [];
+    clones.set(value, clonedArray);
+
+    for (const item of value) {
+      clonedArray.push(cloneMutableValue(item, clones));
+    }
+
+    return clonedArray as T;
+  }
+
+  if (value instanceof Map) {
+    const clonedMap = new Map<unknown, unknown>();
+    clones.set(value, clonedMap);
+
+    for (const [key, entryValue] of value) {
+      clonedMap.set(cloneMutableValue(key, clones), cloneMutableValue(entryValue, clones));
+    }
+
+    return clonedMap as T;
+  }
+
+  if (value instanceof Set) {
+    const clonedSet = new Set<unknown>();
+    clones.set(value, clonedSet);
+
+    for (const entryValue of value) {
+      clonedSet.add(cloneMutableValue(entryValue, clones));
+    }
+
+    return clonedSet as T;
+  }
+
+  const source = value as Record<PropertyKey, unknown>;
+  const prototype = Object.getPrototypeOf(value) as object | null;
+  const clonedObject = Object.create(prototype) as Record<PropertyKey, unknown>;
+  clones.set(value, clonedObject);
+
+  for (const key of Reflect.ownKeys(source)) {
+    clonedObject[key] = cloneMutableValue(source[key], clones);
+  }
+
+  return clonedObject as T;
 }
 
 function cloneInjectionToken(token: InjectionToken): InjectionToken {
@@ -202,6 +265,13 @@ function cloneProvider(provider: Provider): Provider {
     };
   }
 
+  if ('useValue' in provider) {
+    return {
+      ...provider,
+      useValue: cloneMutableValue(provider.useValue),
+    };
+  }
+
   return { ...provider };
 }
 
@@ -228,6 +298,34 @@ function freezeInjectionToken(token: InjectionToken): InjectionToken {
   return token;
 }
 
+function freezeMutableValue<T>(value: T, frozen = new WeakSet<object>()): T {
+  if (typeof value !== 'object' || value === null || frozen.has(value)) {
+    return value;
+  }
+
+  frozen.add(value);
+
+  if (value instanceof Map) {
+    for (const [key, entryValue] of value) {
+      freezeMutableValue(key, frozen);
+      freezeMutableValue(entryValue, frozen);
+    }
+  } else if (value instanceof Set) {
+    for (const entryValue of value) {
+      freezeMutableValue(entryValue, frozen);
+    }
+  } else {
+    const source = value as Record<PropertyKey, unknown>;
+    for (const key of Reflect.ownKeys(source)) {
+      freezeMutableValue(source[key], frozen);
+    }
+  }
+
+  Object.freeze(value);
+
+  return value;
+}
+
 function freezeProvider(provider: Provider): Provider {
   if (typeof provider === 'function') {
     return provider;
@@ -240,7 +338,19 @@ function freezeProvider(provider: Provider): Provider {
     Object.freeze(provider.inject);
   }
 
+  if ('useValue' in provider) {
+    freezeMutableValue(provider.useValue);
+  }
+
   return Object.freeze(provider);
+}
+
+function freezeMiddleware(middleware: MiddlewareLike): MiddlewareLike {
+  if (typeof middleware === 'object' && middleware !== null) {
+    freezeMutableValue(middleware);
+  }
+
+  return middleware;
 }
 
 function freezeModuleDefinition(definition: ModuleDefinition): ModuleDefinition {
@@ -251,6 +361,9 @@ function freezeModuleDefinition(definition: ModuleDefinition): ModuleDefinition 
   definition.providers && Object.freeze(definition.providers);
   definition.controllers && Object.freeze(definition.controllers);
   definition.exports && Object.freeze(definition.exports);
+  for (const middleware of definition.middleware ?? []) {
+    freezeMiddleware(middleware);
+  }
   definition.middleware && Object.freeze(definition.middleware);
 
   return Object.freeze(definition);

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -38,6 +38,22 @@ type ClassDiMetadataView = {
 const objectTokenIds = new WeakMap<Function, number>();
 const symbolTokenIds = new Map<symbol, number>();
 let nextTokenId = 0;
+const MODULE_GRAPH_COMPILE_ALGORITHM_VERSION = 1;
+const moduleGraphCompileCache = new Map<string, readonly CompiledModule[]>();
+
+/** Clears the process-local module graph compile cache for isolated regression tests. */
+export function clearModuleGraphCompileCacheForTesting(): void {
+  moduleGraphCompileCache.clear();
+}
+
+/**
+ * Reads the current process-local module graph compile cache size for tests.
+ *
+ * @returns Number of successful compile snapshots currently retained in the cache.
+ */
+export function getModuleGraphCompileCacheSizeForTesting(): number {
+  return moduleGraphCompileCache.size;
+}
 
 function getFunctionTokenId(token: Function): number {
   const existing = objectTokenIds.get(token);
@@ -118,7 +134,7 @@ function describeProviderForCacheKey(provider: Provider): string {
 }
 
 /**
- * Builds the prerequisite key for future module graph compile caching.
+ * Builds the key used for opt-in module graph compile caching.
  *
  * @param rootModule Root module that would be compiled.
  * @param options Bootstrap options that influence graph validation.
@@ -132,9 +148,46 @@ export function createModuleGraphCacheKey(rootModule: ModuleType, options: Boots
     `root:${describeTokenForCacheKey(rootModule)}`,
     `module:${getModuleMetadataVersion()}`,
     `class-di:${getClassDiMetadataVersion()}`,
+    `algorithm:${MODULE_GRAPH_COMPILE_ALGORITHM_VERSION}`,
     `runtime:${runtimeProviders}`,
     `validation:${validationTokens}`,
   ].join(';');
+}
+
+function cloneModuleDefinition(definition: ModuleDefinition): ModuleDefinition {
+  return {
+    global: definition.global,
+    imports: definition.imports ? [...definition.imports] : undefined,
+    providers: definition.providers ? [...definition.providers] : undefined,
+    controllers: definition.controllers ? [...definition.controllers] : undefined,
+    exports: definition.exports ? [...definition.exports] : undefined,
+    middleware: definition.middleware ? [...definition.middleware] : undefined,
+  };
+}
+
+function cloneCompiledModule(compiledModule: CompiledModule): CompiledModule {
+  return {
+    type: compiledModule.type,
+    definition: cloneModuleDefinition(compiledModule.definition),
+    accessibleTokens: new Set(compiledModule.accessibleTokens),
+    exportedTokens: new Set(compiledModule.exportedTokens),
+    importedExportedTokens: new Set(compiledModule.importedExportedTokens),
+    providerTokens: new Set(compiledModule.providerTokens),
+  };
+}
+
+function cloneCompiledModules(modules: readonly CompiledModule[]): CompiledModule[] {
+  return modules.map((compiledModule) => cloneCompiledModule(compiledModule));
+}
+
+function freezeCompiledModule(compiledModule: CompiledModule): CompiledModule {
+  Object.freeze(compiledModule.definition);
+
+  return Object.freeze(compiledModule);
+}
+
+function createModuleGraphCacheSnapshot(modules: readonly CompiledModule[]): readonly CompiledModule[] {
+  return Object.freeze(cloneCompiledModules(modules).map((compiledModule) => freezeCompiledModule(compiledModule)));
 }
 
 function getEffectiveClassDiMetadata(target: Function): ClassDiMetadataView | undefined {
@@ -533,12 +586,31 @@ function validateCompiledModules(
  * @returns Compiled modules in dependency order after visibility and injection validation succeed.
  */
 export function compileModuleGraph(rootModule: ModuleType, options: BootstrapModuleOptions = {}): CompiledModule[] {
+  const cacheKey = options.moduleGraphCache === true
+    ? createModuleGraphCacheKey(rootModule, options)
+    : undefined;
+
+  if (cacheKey !== undefined) {
+    const cachedModules = moduleGraphCompileCache.get(cacheKey);
+
+    if (cachedModules !== undefined) {
+      return cloneCompiledModules(cachedModules);
+    }
+  }
+
   const ordered: CompiledModule[] = [];
   const runtimeProviders = options.providers ?? [];
   const runtimeProviderTokens = mergeRuntimeTokenSets(runtimeProviders, options.validationTokens ?? []);
 
   compileModule(rootModule, runtimeProviderTokens, new Map(), new Set(), ordered);
   validateCompiledModules(ordered, runtimeProviders, runtimeProviderTokens);
+
+  if (cacheKey !== undefined) {
+    const cacheSnapshot = createModuleGraphCacheSnapshot(ordered);
+    moduleGraphCompileCache.set(cacheKey, cacheSnapshot);
+
+    return cloneCompiledModules(cacheSnapshot);
+  }
 
   return ordered;
 }

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -158,11 +158,51 @@ function cloneModuleDefinition(definition: ModuleDefinition): ModuleDefinition {
   return {
     global: definition.global,
     imports: definition.imports ? [...definition.imports] : undefined,
-    providers: definition.providers ? [...definition.providers] : undefined,
+    providers: definition.providers ? definition.providers.map((provider) => cloneProvider(provider)) : undefined,
     controllers: definition.controllers ? [...definition.controllers] : undefined,
     exports: definition.exports ? [...definition.exports] : undefined,
     middleware: definition.middleware ? [...definition.middleware] : undefined,
   };
+}
+
+function cloneInjectionToken(token: InjectionToken): InjectionToken {
+  if (isForwardRef(token)) {
+    return {
+      __forwardRef__: true,
+      forwardRef: token.forwardRef,
+    };
+  }
+
+  if (isOptionalToken(token)) {
+    return {
+      __optional__: true,
+      token: token.token,
+    };
+  }
+
+  return token;
+}
+
+function cloneProvider(provider: Provider): Provider {
+  if (typeof provider === 'function') {
+    return provider;
+  }
+
+  if ('useClass' in provider) {
+    return {
+      ...provider,
+      ...(provider.inject ? { inject: provider.inject.map((token) => cloneInjectionToken(token)) } : {}),
+    };
+  }
+
+  if ('useFactory' in provider) {
+    return {
+      ...provider,
+      ...(provider.inject ? { inject: provider.inject.map((token) => cloneInjectionToken(token)) } : {}),
+    };
+  }
+
+  return { ...provider };
 }
 
 function cloneCompiledModule(compiledModule: CompiledModule): CompiledModule {
@@ -180,8 +220,44 @@ function cloneCompiledModules(modules: readonly CompiledModule[]): CompiledModul
   return modules.map((compiledModule) => cloneCompiledModule(compiledModule));
 }
 
+function freezeInjectionToken(token: InjectionToken): InjectionToken {
+  if (isForwardRef(token) || isOptionalToken(token)) {
+    Object.freeze(token);
+  }
+
+  return token;
+}
+
+function freezeProvider(provider: Provider): Provider {
+  if (typeof provider === 'function') {
+    return provider;
+  }
+
+  if ('inject' in provider && provider.inject) {
+    for (const token of provider.inject) {
+      freezeInjectionToken(token);
+    }
+    Object.freeze(provider.inject);
+  }
+
+  return Object.freeze(provider);
+}
+
+function freezeModuleDefinition(definition: ModuleDefinition): ModuleDefinition {
+  definition.imports && Object.freeze(definition.imports);
+  for (const provider of definition.providers ?? []) {
+    freezeProvider(provider);
+  }
+  definition.providers && Object.freeze(definition.providers);
+  definition.controllers && Object.freeze(definition.controllers);
+  definition.exports && Object.freeze(definition.exports);
+  definition.middleware && Object.freeze(definition.middleware);
+
+  return Object.freeze(definition);
+}
+
 function freezeCompiledModule(compiledModule: CompiledModule): CompiledModule {
-  Object.freeze(compiledModule.definition);
+  freezeModuleDefinition(compiledModule.definition);
 
   return Object.freeze(compiledModule);
 }

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -34,6 +34,15 @@ export interface ModuleDefinition {
 export interface BootstrapModuleOptions {
   duplicateProviderPolicy?: 'warn' | 'throw' | 'ignore';
   logger?: ApplicationLogger;
+  /**
+   * Opts this bootstrap into the process-local module graph compile result cache.
+   *
+   * The cache is disabled by default. When enabled, successful graph compiles are
+   * keyed by root module identity, runtime provider inputs, validation tokens,
+   * core metadata write versions, and the runtime compile algorithm version.
+   * Failed compilations are never cached.
+   */
+  moduleGraphCache?: boolean;
   providers?: Provider[];
   validationTokens?: Token[];
 }
@@ -120,6 +129,12 @@ export interface ExceptionFilterHandler {
 /** High-level bootstrap options for creating an HTTP application shell. */
 export interface BootstrapApplicationOptions {
   adapter?: HttpApplicationAdapter;
+  /**
+   * Enables the opt-in process-local module graph compile result cache for this
+   * bootstrap. The default is `false`, so each bootstrap compiles a fresh graph
+   * unless callers explicitly request cache reuse.
+   */
+  moduleGraphCache?: boolean;
   /**
    * Policy for duplicate provider tokens across modules.
    *


### PR DESCRIPTION
## Summary

Implements an opt-in `moduleGraphCache` runtime bootstrap option for repeated bootstrap/module graph compilation flows.

Closes #1512

## Changes

- Adds process-local module graph compile-result caching behind `moduleGraphCache: true` and leaves default bootstrap behavior uncached.
- Includes root module identity, runtime providers, validation tokens, module metadata version, class-DI metadata version, and compile algorithm version in cache identity.
- Stores only successful compile snapshots and returns isolated graph copies; cached provider descriptors plus nested `inject`/wrapper objects are cloned so caller mutation cannot poison later cache hits.
- Wires and covers the option through `bootstrapApplication`, `FluoFactory.create(...)`, `createApplicationContext(...)`, and microservice context bootstrap.
- Documents the new behavioral contract in `packages/runtime/README.md` and `README.ko.md`, with a minor changeset for `@fluojs/runtime`.

## Testing

- LSP diagnostics clean for `packages/runtime/src/module-graph.ts`, `packages/runtime/src/module-graph.test.ts`, and `packages/runtime/src/bootstrap.test.ts`.
- `pnpm --filter @fluojs/runtime test -- src/module-graph.test.ts src/bootstrap.test.ts` (runtime package suite: 17 files, 216 tests passed)
- `pnpm --filter @fluojs/runtime typecheck`
- `pnpm --filter @fluojs/runtime build`
- `pnpm exec biome lint packages/runtime/src/module-graph.ts packages/runtime/src/module-graph.test.ts packages/runtime/src/bootstrap.test.ts .changeset/module-graph-cache.md`
- `pnpm verify:public-export-tsdoc`
- `pnpm exec changeset status --since=main`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or conformance claims changed.