### PR TITLE
Resolve #1511: cache DI provider resolution plans

### DIFF
--- a/.changeset/di-plan-cache.md
+++ b/.changeset/di-plan-cache.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/di": patch
+---
+
+Cache DI provider resolution plans so repeated resolves and request-scope checks avoid redundant provider graph traversal without caching transient or request-scoped instances.

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -1181,6 +1181,91 @@ describe('Container', () => {
 
       expect(container.hasRequestScopedDependency(Consumer)).toBe(false);
     });
+
+    it('invalidates child request-scope verdict plans when parent registrations change', () => {
+      const OPTIONAL_STORE = Symbol('OptionalStore');
+
+      class RequestStore {}
+      class SingletonStore {}
+      class Consumer {
+        constructor(readonly store: RequestStore | SingletonStore | undefined) {}
+      }
+
+      const root = new Container().register({
+        provide: Consumer,
+        useClass: Consumer,
+        inject: [optional(OPTIONAL_STORE)],
+      });
+      const child = root.createRequestScope();
+
+      expect(child.hasRequestScopedDependency(Consumer)).toBe(false);
+
+      root.register({ provide: OPTIONAL_STORE, scope: Scope.REQUEST, useClass: RequestStore });
+
+      expect(child.hasRequestScopedDependency(Consumer)).toBe(true);
+
+      root.override({ provide: OPTIONAL_STORE, useClass: SingletonStore });
+
+      expect(child.hasRequestScopedDependency(Consumer)).toBe(false);
+    });
+
+    it('invalidates alias request-scope plans when useExisting tokens are overridden', () => {
+      const REQUEST_STORE = Symbol('RequestStore');
+      const STORE_ALIAS = Symbol('StoreAlias');
+
+      class RequestStore {}
+      class Consumer {
+        constructor(readonly store: RequestStore | string) {}
+      }
+
+      const container = new Container().register(
+        { provide: REQUEST_STORE, scope: Scope.REQUEST, useClass: RequestStore },
+        { provide: STORE_ALIAS, useExisting: REQUEST_STORE },
+        { provide: Consumer, useClass: Consumer, inject: [STORE_ALIAS] },
+      );
+
+      expect(container.hasRequestScopedDependency(Consumer)).toBe(true);
+
+      container.override({ provide: STORE_ALIAS, useValue: 'singleton-store' });
+
+      expect(container.hasRequestScopedDependency(Consumer)).toBe(false);
+    });
+  });
+
+  describe('provider resolution plan caching', () => {
+    it('invalidates child multi-provider plans when parent multi providers change', async () => {
+      const PLUGINS = Symbol('Plugins');
+
+      const root = new Container().register({ provide: PLUGINS, useValue: 'root-a', multi: true });
+      const child = root.createRequestScope();
+
+      await expect(child.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a']);
+
+      root.register({ provide: PLUGINS, useValue: 'root-b', multi: true });
+
+      await expect(child.resolve<string[]>(PLUGINS)).resolves.toEqual(['root-a', 'root-b']);
+    });
+
+    it('keeps transient providers uncached while reusing the provider plan', async () => {
+      let created = 0;
+
+      class TransientService {
+        readonly id = ++created;
+      }
+
+      const container = new Container().register({
+        provide: TransientService,
+        scope: Scope.TRANSIENT,
+        useClass: TransientService,
+      });
+
+      const first = await container.resolve(TransientService);
+      const second = await container.resolve(TransientService);
+
+      expect(first).not.toBe(second);
+      expect(first.id).toBe(1);
+      expect(second.id).toBe(2);
+    });
   });
 
   describe('dispose', () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -25,6 +25,11 @@ import { Scope, isForwardRef, isOptionalToken } from './types.js';
 
 type ObjectProvider = ClassProvider | ExistingProvider | FactoryProvider | ValueProvider;
 
+interface CachedResolutionPlan<T> {
+  readonly lineageRevision: string;
+  readonly value: T;
+}
+
 function isClassConstructor(value: Provider): value is ClassType {
   return typeof value === 'function';
 }
@@ -169,10 +174,15 @@ export class Container {
   private readonly staleDisposalErrors: unknown[] = [];
   private readonly singletonCache: Map<Token, Promise<unknown>>;
   private readonly forwardRefTokenCache = new WeakMap<ForwardRefFn, Token>();
+  private readonly providerLookupPlanCache = new Map<Token, CachedResolutionPlan<NormalizedProvider | undefined>>();
+  private readonly multiProviderPlanCache = new Map<Token, CachedResolutionPlan<readonly NormalizedProvider[]>>();
+  private readonly requestScopeVerdictPlanCache = new Map<Token, CachedResolutionPlan<boolean>>();
+  private readonly effectiveProviderPlanCache = new Map<Token, CachedResolutionPlan<NormalizedProvider | undefined>>();
   private childScopes: Set<Container> | undefined;
   private disposePromise: Promise<void> | undefined;
   private disposed = false;
   private trackedByRoot = false;
+  private graphRevision = 0;
 
   constructor(
     private readonly parent?: Container,
@@ -221,6 +231,7 @@ export class Container {
 
         if (existing) {
           existing.push(normalized);
+          this.advanceGraphRevision();
           continue;
         }
 
@@ -228,6 +239,8 @@ export class Container {
       } else {
         this.registrations.set(normalized.provide, normalized);
       }
+
+      this.advanceGraphRevision();
     }
 
     return this;
@@ -266,11 +279,13 @@ export class Container {
       if (normalized.multi) {
         this.multiRegistrations.set(normalized.provide, [normalized]);
         this.multiOverriddenTokens.add(normalized.provide);
+        this.advanceGraphRevision();
         continue;
       }
 
       this.multiOverriddenTokens.add(normalized.provide);
       this.registrations.set(normalized.provide, normalized);
+      this.advanceGraphRevision();
     }
 
     return this;
@@ -293,7 +308,17 @@ export class Container {
    * @returns `true` when the provider graph contains request-scoped dependencies or is cyclic.
    */
   hasRequestScopedDependency(token: Token): boolean {
-    return this.providerGraphRequiresRequestScope(token, new Set<Token>());
+    const cached = this.readCachedPlan(this.requestScopeVerdictPlanCache, token);
+
+    if (cached) {
+      return cached.value;
+    }
+
+    return this.writePlanCache(
+      this.requestScopeVerdictPlanCache,
+      token,
+      this.providerGraphRequiresRequestScope(token, new Set<Token>()),
+    );
   }
 
   /**
@@ -347,6 +372,7 @@ export class Container {
     }
 
     this.disposed = true;
+    this.advanceGraphRevision();
     this.disposePromise = this.disposeAll();
 
     try {
@@ -446,19 +472,25 @@ export class Container {
   }
 
   private collectMultiProviders(token: Token): NormalizedProvider[] {
+    const cached = this.readCachedPlan(this.multiProviderPlanCache, token);
+
+    if (cached) {
+      return [...cached.value];
+    }
+
     const local = this.multiRegistrations.get(token);
+    let providers: readonly NormalizedProvider[];
 
     if (this.multiOverriddenTokens.has(token)) {
-      return local ?? [];
+      providers = Object.freeze([...(local ?? [])]);
+    } else {
+      const fromParent = this.parent ? this.parent.collectMultiProviders(token) : [];
+
+      providers = Object.freeze(local ? [...fromParent, ...local] : [...fromParent]);
     }
 
-    const fromParent = this.parent ? this.parent.collectMultiProviders(token) : [];
-
-    if (local) {
-      return [...fromParent, ...local];
-    }
-
-    return fromParent;
+    this.writePlanCache(this.multiProviderPlanCache, token, providers);
+    return [...providers];
   }
 
   private providerGraphRequiresRequestScope(token: Token, visited: Set<Token>): boolean {
@@ -781,13 +813,16 @@ export class Container {
   }
 
   private lookupProvider(token: Token): NormalizedProvider | undefined {
-    const local = this.registrations.get(token);
+    const cached = this.readCachedPlan(this.providerLookupPlanCache, token);
 
-    if (local) {
-      return local;
+    if (cached) {
+      return cached.value;
     }
 
-    return this.parent?.lookupProvider(token);
+    const local = this.registrations.get(token);
+    const provider = local ?? this.parent?.lookupProvider(token);
+
+    return this.writePlanCache(this.providerLookupPlanCache, token, provider);
   }
 
   /**
@@ -926,11 +961,50 @@ export class Container {
     if (this.parent) {
       this.requestCache?.clear();
       this.multiRequestCache?.clear();
+      this.clearResolutionPlanCaches();
       return;
     }
 
     this.singletonCache.clear();
     this.multiSingletonCache.clear();
+    this.clearResolutionPlanCaches();
+  }
+
+  private currentLineageRevision(): string {
+    const parentRevision = this.parent?.currentLineageRevision();
+
+    return parentRevision ? `${parentRevision}/${this.graphRevision}` : String(this.graphRevision);
+  }
+
+  private readCachedPlan<T>(cache: Map<Token, CachedResolutionPlan<T>>, token: Token): CachedResolutionPlan<T> | undefined {
+    const cached = cache.get(token);
+
+    if (!cached || cached.lineageRevision !== this.currentLineageRevision()) {
+      return undefined;
+    }
+
+    return cached;
+  }
+
+  private writePlanCache<T>(cache: Map<Token, CachedResolutionPlan<T>>, token: Token, value: T): T {
+    cache.set(token, {
+      lineageRevision: this.currentLineageRevision(),
+      value,
+    });
+
+    return value;
+  }
+
+  private advanceGraphRevision(): void {
+    this.graphRevision += 1;
+    this.clearResolutionPlanCaches();
+  }
+
+  private clearResolutionPlanCaches(): void {
+    this.providerLookupPlanCache.clear();
+    this.multiProviderPlanCache.clear();
+    this.requestScopeVerdictPlanCache.clear();
+    this.effectiveProviderPlanCache.clear();
   }
 
   private async waitForStaleDisposalTasks(): Promise<void> {
@@ -1092,6 +1166,16 @@ export class Container {
     visited = new Set<Token>(),
     chain: Token[] = [],
   ): NormalizedProvider | undefined {
+    const cacheable = visited.size === 0 && chain.length === 0;
+
+    if (cacheable) {
+      const cached = this.readCachedPlan(this.effectiveProviderPlanCache, token);
+
+      if (cached) {
+        return cached.value;
+      }
+    }
+
     let currentToken = token;
 
     while (true) {
@@ -1104,10 +1188,18 @@ export class Container {
       const provider = this.lookupProvider(currentToken);
 
       if (!provider) {
+        if (cacheable) {
+          return this.writePlanCache(this.effectiveProviderPlanCache, token, undefined);
+        }
+
         return undefined;
       }
 
       if (provider.type !== 'existing' || provider.useExisting === undefined) {
+        if (cacheable) {
+          return this.writePlanCache(this.effectiveProviderPlanCache, token, provider);
+        }
+
         return provider;
       }
 


### PR DESCRIPTION
## Summary

Closes #1511.

Implements performance-only provider resolution plan caching for `@fluojs/di` while preserving lifecycle semantics and the DI cache regression contracts added by #1513.

## Changes

- Added monotonic container graph revisions and parent-lineage-aware plan keys for DI resolution plans.
- Cached immutable provider lookup, multi-provider aggregation, alias/effective-provider, and request-scope verdict plans.
- Invalidated plan caches on `register(...)`, `override(...)`, disposal cache clearing, and parent-lineage revision changes.
- Added regressions proving parent registration changes invalidate child plans, alias overrides invalidate request-scope verdicts, multi-provider order updates remain visible, and transient instances are not cached.
- Added a patch changeset for `@fluojs/di`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/di test` — 93 tests passed
- `pnpm --filter @fluojs/core build && pnpm --filter @fluojs/di typecheck` — passed
- `pnpm --filter @fluojs/di build` — passed
- `pnpm exec biome lint packages/di/src/container.ts packages/di/src/container.test.ts && pnpm verify:public-export-tsdoc` — passed; existing informational lint notes remain in unchanged `container.test.ts` lines 1790-1791
- `pnpm lint` — completed public export TSDoc successfully; repo-wide Biome reported pre-existing warnings/infos outside this PR plus existing informational notes in `packages/di/src/container.test.ts`
- `pnpm --filter @fluojs/runtime test` — 17 files / 208 tests passed
- `pnpm --filter @fluojs/http test` — 15 files / 177 tests passed
- `pnpm --filter @fluojs/testing test` — 7 files / 128 tests passed
- LSP diagnostics on changed DI files — no diagnostics found

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public export signatures were changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This is intended as performance-only plan caching. It does not cache provider instances beyond the existing singleton/request caches and does not cache transient/request values, active resolution chains, or active token sets.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract or governance docs were changed.