### PR TITLE
Resolve #1515: add focused DI and module graph benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typecheck": "tsc -p tsconfig.tools.json --noEmit && tsc -p examples/tsconfig.json --noEmit && pnpm -r --filter './packages/*' --if-present run typecheck",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench:di-container": "node tooling/benchmarks/di-container/run.mjs",
     "lint": "biome lint && pnpm verify:public-export-tsdoc",
     "verify": "pnpm build && pnpm typecheck && pnpm lint && pnpm test",
     "changeset": "changeset",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "bench:di-container": "node tooling/benchmarks/di-container/run.mjs",
+    "bench:runtime-module-graph": "node tooling/benchmarks/runtime-module-graph/run.mjs",
     "lint": "biome lint && pnpm verify:public-export-tsdoc",
     "verify": "pnpm build && pnpm typecheck && pnpm lint && pnpm test",
     "changeset": "changeset",

--- a/tooling/benchmarks/README.md
+++ b/tooling/benchmarks/README.md
@@ -1,0 +1,27 @@
+# Benchmark tooling
+
+The benchmark tooling is intentionally local-only and not wired into default CI because the suites are performance evidence tools, not release gates.
+
+## Focused internal benchmarks
+
+- [`di-container`](./di-container) isolates DI provider lookup/resolution plan cache paths.
+- [`runtime-module-graph`](./runtime-module-graph) isolates repeated module graph compilation with cache-off/cache-on modes.
+
+Run both after building local packages:
+
+```bash
+pnpm build
+pnpm bench:di-container
+pnpm bench:runtime-module-graph
+```
+
+For PR smoke checks, use reduced deterministic runs:
+
+```bash
+BENCH_SMOKE=1 BENCH_WARMUP_ITERATIONS=10 pnpm bench:di-container
+BENCH_SMOKE=1 BENCH_WARMUP_ITERATIONS=10 pnpm bench:runtime-module-graph
+```
+
+## HTTP comparison benchmark
+
+The existing [`http-comparison`](./http-comparison) suite remains separate. HTTP end-to-end results should not be used as proof for DI or module graph internal wins unless a benchmark explicitly isolates those paths.

--- a/tooling/benchmarks/di-container/README.md
+++ b/tooling/benchmarks/di-container/README.md
@@ -1,0 +1,39 @@
+# DI container focused benchmark
+
+This local-only benchmark isolates `@fluojs/di` provider plan cache paths without starting HTTP servers or measuring end-to-end request handling.
+
+## Scenarios
+
+- repeated `Container.resolve(...)` for a singleton dependency chain
+- repeated `hasRequestScopedDependency(...)` for request-scoped dependency detection
+- alias-chain provider resolution
+- multi-provider token resolution
+- transient dependency-chain resolution
+
+Each scenario reports both:
+
+- `cold-plan`: prebuilt containers whose first measured lookup has not populated that container's plan cache
+- `warm-plan`: repeated lookups against a stable container after warm-up has populated reusable plans
+
+The cold/warm split is intentionally local and deterministic. It does not use HTTP throughput as evidence for DI internals.
+
+## Run
+
+Build packages first so the benchmark imports local `dist` artifacts:
+
+```bash
+pnpm build
+pnpm bench:di-container
+```
+
+Quick smoke run:
+
+```bash
+BENCH_SMOKE=1 BENCH_WARMUP_ITERATIONS=10 pnpm bench:di-container
+```
+
+Useful knobs:
+
+- `BENCH_ITERATIONS` — measured iterations per scenario, default `5000`
+- `BENCH_WARMUP_ITERATIONS` — warm-up iterations before measurement, default `1000`
+- `BENCH_OUTPUT_JSON` — optional path for raw JSON output

--- a/tooling/benchmarks/di-container/run.mjs
+++ b/tooling/benchmarks/di-container/run.mjs
@@ -1,0 +1,284 @@
+import { performance } from 'node:perf_hooks';
+import { writeFile } from 'node:fs/promises';
+
+import { defineClassDiMetadata } from '../../../packages/core/dist/internal.js';
+import { Container, Scope } from '../../../packages/di/dist/index.js';
+
+const DEFAULT_ITERATIONS = 5_000;
+const SMOKE_ITERATIONS = 250;
+const warmupIterations = Number(process.env.BENCH_WARMUP_ITERATIONS ?? 1_000);
+const measuredIterations = Number(process.env.BENCH_ITERATIONS ?? DEFAULT_ITERATIONS);
+const outputJson = process.env.BENCH_OUTPUT_JSON;
+
+function assertPositiveInteger(name, value) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+}
+
+function defineInject(target, inject, scope) {
+  defineClassDiMetadata(target, {
+    inject,
+    ...(scope ? { scope } : {}),
+  });
+}
+
+function createDependencyChain(prefix, depth, scope) {
+  const providers = [];
+  let previousToken;
+
+  for (let index = 0; index < depth; index += 1) {
+    const dependency = previousToken;
+    const ProviderClass = class {
+      constructor(value) {
+        this.value = value;
+      }
+    };
+
+    Object.defineProperty(ProviderClass, 'name', { value: `${prefix}Provider${index}` });
+    defineInject(ProviderClass, dependency ? [dependency] : [], scope);
+    providers.push(ProviderClass);
+    previousToken = ProviderClass;
+  }
+
+  return { providers, leaf: previousToken };
+}
+
+function createColdPlanContainers(count, factory) {
+  return Array.from({ length: count }, (_unused, index) => factory(index));
+}
+
+function coldSlotCount(iterations) {
+  return iterations + warmupIterations;
+}
+
+function createSingletonChainScenario(mode, iterations) {
+  if (mode === 'cold-plan') {
+    const containers = createColdPlanContainers(coldSlotCount(iterations), () => {
+      const chain = createDependencyChain('ColdSingletonChain', 12);
+      const container = new Container().register(...chain.providers);
+
+      return { container, token: chain.leaf };
+    });
+
+    let index = 0;
+
+    return async () => {
+      const entry = containers[index];
+      index = (index + 1) % containers.length;
+      await entry.container.resolve(entry.token);
+    };
+  }
+
+  const chain = createDependencyChain('WarmSingletonChain', 12);
+  const container = new Container().register(...chain.providers);
+
+  return async () => {
+    await container.resolve(chain.leaf);
+  };
+}
+
+function createRequestScopeScenario(mode, iterations) {
+  const makeEntry = (prefix) => {
+    class RequestContext {}
+    class RequestRepository {
+      constructor(context) {
+        this.context = context;
+      }
+    }
+    class RequestService {
+      constructor(repository) {
+        this.repository = repository;
+      }
+    }
+
+    Object.defineProperty(RequestContext, 'name', { value: `${prefix}Context` });
+    Object.defineProperty(RequestRepository, 'name', { value: `${prefix}Repository` });
+    Object.defineProperty(RequestService, 'name', { value: `${prefix}Service` });
+    defineInject(RequestContext, [], Scope.REQUEST);
+    defineInject(RequestRepository, [RequestContext], Scope.REQUEST);
+    defineInject(RequestService, [RequestRepository], Scope.REQUEST);
+
+    const container = new Container().register(RequestContext, RequestRepository, RequestService);
+
+    return { container, token: RequestService };
+  };
+
+  if (mode === 'cold-plan') {
+    const entries = createColdPlanContainers(coldSlotCount(iterations), (index) => makeEntry(`ColdRequest${index}`));
+    let index = 0;
+
+    return async () => {
+      const entry = entries[index];
+      index = (index + 1) % entries.length;
+      entry.container.hasRequestScopedDependency(entry.token);
+    };
+  }
+
+  const entry = makeEntry('WarmRequest');
+
+  return async () => {
+    entry.container.hasRequestScopedDependency(entry.token);
+  };
+}
+
+function createAliasChainScenario(mode, iterations) {
+  const makeEntry = (prefix) => {
+    const aliasTokens = Array.from({ length: 8 }, (_unused, index) => Symbol(`${prefix}.alias.${index}`));
+    class AliasTarget {}
+    Object.defineProperty(AliasTarget, 'name', { value: `${prefix}AliasTarget` });
+
+    const providers = [AliasTarget];
+    providers.push({ provide: aliasTokens[0], useExisting: AliasTarget });
+    for (let index = 1; index < aliasTokens.length; index += 1) {
+      providers.push({ provide: aliasTokens[index], useExisting: aliasTokens[index - 1] });
+    }
+
+    const container = new Container().register(...providers);
+
+    return { container, token: aliasTokens.at(-1) };
+  };
+
+  if (mode === 'cold-plan') {
+    const entries = createColdPlanContainers(coldSlotCount(iterations), (index) => makeEntry(`ColdAlias${index}`));
+    let index = 0;
+
+    return async () => {
+      const entry = entries[index];
+      index = (index + 1) % entries.length;
+      await entry.container.resolve(entry.token);
+    };
+  }
+
+  const entry = makeEntry('WarmAlias');
+
+  return async () => {
+    await entry.container.resolve(entry.token);
+  };
+}
+
+function createMultiProviderScenario(mode, iterations) {
+  const makeEntry = (prefix) => {
+    const token = Symbol(`${prefix}.multi`);
+    const providers = [];
+
+    for (let index = 0; index < 16; index += 1) {
+      class Contribution {}
+      Object.defineProperty(Contribution, 'name', { value: `${prefix}Contribution${index}` });
+      providers.push({ provide: token, useClass: Contribution, multi: true });
+    }
+
+    const container = new Container().register(...providers);
+
+    return { container, token };
+  };
+
+  if (mode === 'cold-plan') {
+    const entries = createColdPlanContainers(coldSlotCount(iterations), (index) => makeEntry(`ColdMulti${index}`));
+    let index = 0;
+
+    return async () => {
+      const entry = entries[index];
+      index = (index + 1) % entries.length;
+      await entry.container.resolve(entry.token);
+    };
+  }
+
+  const entry = makeEntry('WarmMulti');
+
+  return async () => {
+    await entry.container.resolve(entry.token);
+  };
+}
+
+function createTransientScenario(mode, iterations) {
+  if (mode === 'cold-plan') {
+    const entries = createColdPlanContainers(coldSlotCount(iterations), () => {
+      const chain = createDependencyChain('ColdTransientChain', 8, Scope.TRANSIENT);
+      const container = new Container().register(...chain.providers);
+
+      return { container, token: chain.leaf };
+    });
+    let index = 0;
+
+    return async () => {
+      const entry = entries[index];
+      index = (index + 1) % entries.length;
+      await entry.container.resolve(entry.token);
+    };
+  }
+
+  const chain = createDependencyChain('WarmTransientChain', 8, Scope.TRANSIENT);
+  const container = new Container().register(...chain.providers);
+
+  return async () => {
+    await container.resolve(chain.leaf);
+  };
+}
+
+async function runBenchmark({ name, mode, iterations, createRun }) {
+  const run = createRun(mode, iterations);
+
+  for (let index = 0; index < warmupIterations; index += 1) {
+    await run();
+  }
+
+  const started = performance.now();
+  for (let index = 0; index < iterations; index += 1) {
+    await run();
+  }
+  const durationMs = performance.now() - started;
+
+  return {
+    hz: iterations / (durationMs / 1_000),
+    iterations,
+    mode,
+    name,
+    totalMs: durationMs,
+    usPerIteration: (durationMs * 1_000) / iterations,
+  };
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value);
+}
+
+function printResults(results) {
+  const maxNameLength = Math.max(...results.map((result) => `${result.name} ${result.mode}`.length));
+  console.log('DI container focused benchmark');
+  console.log(`iterations=${results[0]?.iterations ?? 0} warmup=${warmupIterations}`);
+  console.log('HTTP stack is not involved; results isolate Container plan lookup/resolution paths.');
+  console.log('');
+  for (const result of results) {
+    const label = `${result.name} ${result.mode}`.padEnd(maxNameLength);
+    console.log(`${label}  ${formatNumber(result.usPerIteration)} us/op  ${formatNumber(result.hz)} ops/sec`);
+  }
+}
+
+async function main() {
+  const iterations = process.env.BENCH_SMOKE === '1' ? SMOKE_ITERATIONS : measuredIterations;
+  assertPositiveInteger('BENCH_ITERATIONS', iterations);
+  assertPositiveInteger('BENCH_WARMUP_ITERATIONS', warmupIterations);
+
+  const scenarios = [
+    { name: 'resolve singleton dependency chain', createRun: createSingletonChainScenario },
+    { name: 'hasRequestScopedDependency chain', createRun: createRequestScopeScenario },
+    { name: 'resolve alias chain', createRun: createAliasChainScenario },
+    { name: 'resolve multi-provider token', createRun: createMultiProviderScenario },
+    { name: 'resolve transient dependency chain', createRun: createTransientScenario },
+  ];
+  const results = [];
+
+  for (const scenario of scenarios) {
+    results.push(await runBenchmark({ ...scenario, mode: 'cold-plan', iterations }));
+    results.push(await runBenchmark({ ...scenario, mode: 'warm-plan', iterations }));
+  }
+
+  printResults(results);
+
+  if (outputJson) {
+    await writeFile(outputJson, `${JSON.stringify({ generatedAt: new Date().toISOString(), results }, null, 2)}\n`);
+  }
+}
+
+await main();

--- a/tooling/benchmarks/runtime-module-graph/README.md
+++ b/tooling/benchmarks/runtime-module-graph/README.md
@@ -1,0 +1,37 @@
+# Runtime module graph focused benchmark
+
+This local-only benchmark isolates repeated `compileModuleGraph(...)` work for `@fluojs/runtime`. It does not start HTTP adapters and does not use HTTP throughput as evidence for module-graph cache behavior.
+
+## Scenarios
+
+- `small-root` — compact root module with a few imported feature modules
+- `wide-imports` — root module importing a wider set of deterministic feature modules
+- `runtime-providers` — same compile path with bootstrap runtime providers included in the cache key
+- `validation-tokens` — same compile path with validation tokens included in the cache key
+- `metadata-invalidation` — repeatedly changes DI metadata so cache-key invalidation and failed-compile non-caching stay exercised
+
+Each stable scenario reports:
+
+- `cache-off`: repeated compile with `moduleGraphCache` omitted
+- `cache-on`: repeated compile with `moduleGraphCache: true`
+
+## Run
+
+Build packages first so the benchmark imports local `dist` artifacts:
+
+```bash
+pnpm build
+pnpm bench:runtime-module-graph
+```
+
+Quick smoke run:
+
+```bash
+BENCH_SMOKE=1 BENCH_WARMUP_ITERATIONS=10 pnpm bench:runtime-module-graph
+```
+
+Useful knobs:
+
+- `BENCH_ITERATIONS` — measured iterations per scenario, default `2000`
+- `BENCH_WARMUP_ITERATIONS` — warm-up iterations before measurement, default `200`
+- `BENCH_OUTPUT_JSON` — optional path for raw JSON output

--- a/tooling/benchmarks/runtime-module-graph/run.mjs
+++ b/tooling/benchmarks/runtime-module-graph/run.mjs
@@ -1,0 +1,221 @@
+import { performance } from 'node:perf_hooks';
+import { writeFile } from 'node:fs/promises';
+
+import { defineClassDiMetadata, defineModuleMetadata } from '../../../packages/core/dist/internal.js';
+import { compileModuleGraph, clearModuleGraphCompileCacheForTesting, getModuleGraphCompileCacheSizeForTesting } from '../../../packages/runtime/dist/module-graph.js';
+
+const DEFAULT_ITERATIONS = 2_000;
+const SMOKE_ITERATIONS = 100;
+const warmupIterations = Number(process.env.BENCH_WARMUP_ITERATIONS ?? 200);
+const measuredIterations = Number(process.env.BENCH_ITERATIONS ?? DEFAULT_ITERATIONS);
+const outputJson = process.env.BENCH_OUTPUT_JSON;
+
+function assertPositiveInteger(name, value) {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+}
+
+function defineInject(target, inject) {
+  defineClassDiMetadata(target, { inject });
+}
+
+function createProvider(name, dependency) {
+  const ProviderClass = class {
+    constructor(value) {
+      this.value = value;
+    }
+  };
+
+  Object.defineProperty(ProviderClass, 'name', { value: name });
+  defineInject(ProviderClass, dependency ? [dependency] : []);
+
+  return ProviderClass;
+}
+
+function createModule(name, metadata) {
+  const ModuleClass = class {};
+  Object.defineProperty(ModuleClass, 'name', { value: name });
+  defineModuleMetadata(ModuleClass, metadata);
+
+  return ModuleClass;
+}
+
+function createLeafModule(prefix, providerCount) {
+  const providers = [];
+  for (let index = 0; index < providerCount; index += 1) {
+    providers.push(createProvider(`${prefix}Provider${index}`, providers[index - 1]));
+  }
+
+  const moduleType = createModule(`${prefix}Module`, {
+    providers,
+    exports: providers.slice(-2),
+  });
+
+  return { moduleType, exported: providers.at(-1) };
+}
+
+function createRootGraph(prefix, options) {
+  const imports = [];
+  const importedTokens = [];
+
+  for (let index = 0; index < options.importCount; index += 1) {
+    const leaf = createLeafModule(`${prefix}Feature${index}`, options.providersPerImport);
+    imports.push(leaf.moduleType);
+    importedTokens.push(leaf.exported);
+  }
+
+  const rootProviders = [];
+  for (let index = 0; index < options.rootProviderCount; index += 1) {
+    const dependency = index === 0 ? importedTokens[index % importedTokens.length] : rootProviders[index - 1];
+    rootProviders.push(createProvider(`${prefix}RootProvider${index}`, dependency));
+  }
+
+  const controller = createProvider(`${prefix}Controller`, rootProviders.at(-1));
+  const rootModule = createModule(`${prefix}RootModule`, {
+    imports,
+    providers: rootProviders,
+    controllers: [controller],
+  });
+
+  return { rootModule, rootProviders };
+}
+
+function createRuntimeProviders(prefix, count) {
+  return Array.from({ length: count }, (_unused, index) => ({
+    provide: Symbol(`${prefix}.runtime.${index}`),
+    useValue: { index, prefix },
+  }));
+}
+
+function createValidationTokens(prefix, count) {
+  return Array.from({ length: count }, (_unused, index) => Symbol(`${prefix}.validation.${index}`));
+}
+
+function createScenarioGraph(name) {
+  if (name === 'small-root') {
+    return {
+      ...createRootGraph('SmallGraph', { importCount: 2, providersPerImport: 4, rootProviderCount: 6 }),
+      options: {},
+    };
+  }
+
+  if (name === 'wide-imports') {
+    return {
+      ...createRootGraph('WideGraph', { importCount: 8, providersPerImport: 5, rootProviderCount: 8 }),
+      options: {},
+    };
+  }
+
+  if (name === 'runtime-providers') {
+    return {
+      ...createRootGraph('RuntimeProviderGraph', { importCount: 5, providersPerImport: 5, rootProviderCount: 8 }),
+      options: { providers: createRuntimeProviders('RuntimeProviderGraph', 16) },
+    };
+  }
+
+  return {
+    ...createRootGraph('ValidationTokenGraph', { importCount: 5, providersPerImport: 5, rootProviderCount: 8 }),
+    options: { validationTokens: createValidationTokens('ValidationTokenGraph', 16) },
+  };
+}
+
+function mutateMetadataForInvalidation(rootProvider) {
+  const token = Symbol(`metadata-invalidation-${performance.now()}`);
+  defineInject(rootProvider, [token]);
+}
+
+async function runBenchmark({ name, mode, iterations, run }) {
+  for (let index = 0; index < warmupIterations; index += 1) {
+    run(index);
+  }
+
+  const started = performance.now();
+  for (let index = 0; index < iterations; index += 1) {
+    run(index);
+  }
+  const durationMs = performance.now() - started;
+
+  return {
+    cacheSize: getModuleGraphCompileCacheSizeForTesting(),
+    hz: iterations / (durationMs / 1_000),
+    iterations,
+    mode,
+    name,
+    totalMs: durationMs,
+    usPerIteration: (durationMs * 1_000) / iterations,
+  };
+}
+
+function formatNumber(value) {
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value);
+}
+
+function printResults(results) {
+  const maxNameLength = Math.max(...results.map((result) => `${result.name} ${result.mode}`.length));
+  console.log('Runtime module graph focused benchmark');
+  console.log(`iterations=${results[0]?.iterations ?? 0} warmup=${warmupIterations}`);
+  console.log('HTTP stack is not involved; results isolate compileModuleGraph(...) repeated bootstrap inputs.');
+  console.log('');
+  for (const result of results) {
+    const label = `${result.name} ${result.mode}`.padEnd(maxNameLength);
+    console.log(`${label}  ${formatNumber(result.usPerIteration)} us/op  ${formatNumber(result.hz)} ops/sec  cacheSize=${result.cacheSize}`);
+  }
+}
+
+async function main() {
+  const iterations = process.env.BENCH_SMOKE === '1' ? SMOKE_ITERATIONS : measuredIterations;
+  assertPositiveInteger('BENCH_ITERATIONS', iterations);
+  assertPositiveInteger('BENCH_WARMUP_ITERATIONS', warmupIterations);
+
+  const scenarioNames = ['small-root', 'wide-imports', 'runtime-providers', 'validation-tokens'];
+  const results = [];
+
+  for (const name of scenarioNames) {
+    const graph = createScenarioGraph(name);
+
+    clearModuleGraphCompileCacheForTesting();
+    results.push(await runBenchmark({
+      name,
+      mode: 'cache-off',
+      iterations,
+      run: () => compileModuleGraph(graph.rootModule, graph.options),
+    }));
+
+    clearModuleGraphCompileCacheForTesting();
+    results.push(await runBenchmark({
+      name,
+      mode: 'cache-on',
+      iterations,
+      run: () => compileModuleGraph(graph.rootModule, { ...graph.options, moduleGraphCache: true }),
+    }));
+  }
+
+  const invalidationGraph = createScenarioGraph('validation-tokens');
+  clearModuleGraphCompileCacheForTesting();
+  results.push(await runBenchmark({
+    name: 'metadata-invalidation',
+    mode: 'cache-on-changing-metadata',
+    iterations,
+    run: (index) => {
+      if (index % 25 === 0) {
+        mutateMetadataForInvalidation(invalidationGraph.rootProviders[0]);
+      }
+      try {
+        compileModuleGraph(invalidationGraph.rootModule, { ...invalidationGraph.options, moduleGraphCache: true });
+      } catch (error) {
+        if (!(error instanceof Error) || !error.message.includes('cannot access token')) {
+          throw error;
+        }
+      }
+    },
+  }));
+
+  printResults(results);
+
+  if (outputJson) {
+    await writeFile(outputJson, `${JSON.stringify({ generatedAt: new Date().toISOString(), results }, null, 2)}\n`);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary

Closes #1515

Adds local-only, focused benchmark tooling for the foundation cache work so DI provider resolution and runtime module graph compilation can be measured without relying on HTTP end-to-end throughput.

## Changes

- Added `tooling/benchmarks/di-container` with deterministic cold-plan vs warm-plan DI scenarios for `resolve(...)`, `hasRequestScopedDependency(...)`, alias chains, multi providers, and transient chains.
- Added `tooling/benchmarks/runtime-module-graph` with cache-off vs cache-on repeated `compileModuleGraph(...)` scenarios covering root/import size, runtime providers, validation tokens, and metadata invalidation.
- Added root scripts `pnpm bench:di-container` and `pnpm bench:runtime-module-graph`, plus benchmark docs that keep the existing HTTP comparison suite separate.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `BENCH_SMOKE=1 BENCH_WARMUP_ITERATIONS=10 pnpm bench:di-container`
- `BENCH_SMOKE=1 BENCH_WARMUP_ITERATIONS=10 pnpm bench:runtime-module-graph`
- `pnpm typecheck`
- `pnpm lint` (Biome reported existing repository warnings; `verify:public-export-tsdoc` passed)
- `pnpm exec biome lint package.json tooling/benchmarks/README.md tooling/benchmarks/di-container/run.mjs tooling/benchmarks/di-container/README.md tooling/benchmarks/runtime-module-graph/run.mjs tooling/benchmarks/runtime-module-graph/README.md`
- LSP diagnostics clean for `package.json`, `tooling/benchmarks/di-container/run.mjs`, and `tooling/benchmarks/runtime-module-graph/run.mjs`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. Not applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. Not applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. Not applicable; tooling-only benchmark addition.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. Not applicable; no runtime behavior changed.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. Not applicable.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable.