### PR TITLE
Resolve #1523: align CLI self-update installer detection

### DIFF
--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -30,12 +30,12 @@ pnpm dlx @fluojs/cli new my-app
 ## 릴리스 계약
 
 - `@fluojs/cli`는 intended publish surface에 포함되는 공개 패키지입니다.
-- 지원되는 설치 경로는 전역 패키지(`pnpm add -g @fluojs/cli`)와 무설치 실행 경로(`pnpm dlx @fluojs/cli ...`)입니다.
+- 지원되는 설치 경로는 전역 패키지(`npm install -g @fluojs/cli`, `pnpm add -g @fluojs/cli`, `bun add -g @fluojs/cli`, `yarn global add @fluojs/cli`)와 무설치 실행 경로(`pnpm dlx @fluojs/cli ...`)입니다.
 - 배포되는 `fluo` bin은 `package.json`에 선언된 dist 빌드 CLI 엔트리포인트를 기준으로 동작합니다.
 
 ## 업데이트 확인
 
-`fluo`가 interactive TTY에서 실행되면 로컬 캐시를 사용해 공개 npm `latest` dist-tag의 `@fluojs/cli` 버전을 확인하므로 매 invocation마다 registry를 호출하지 않습니다. 더 새로운 버전이 있으면 CLI가 설치 여부를 묻습니다. 거절하면 현재 설치된 버전으로 기존 명령을 계속 실행하고, 승인하면 `pnpm add -g @fluojs/cli@<latest>`를 실행한 뒤 같은 인자로 업데이트된 `fluo` 바이너리를 다시 시작합니다.
+`fluo`가 interactive TTY에서 실행되면 로컬 캐시를 사용해 공개 npm `latest` dist-tag의 `@fluojs/cli` 버전을 확인하므로 매 invocation마다 registry를 호출하지 않습니다. 더 새로운 버전이 있으면 CLI가 설치 여부를 묻습니다. 거절하면 현재 설치된 버전으로 기존 명령을 계속 실행하고, 승인하면 현재 설치를 소유한 것으로 보이는 package manager의 전역 업데이트 명령(`npm install -g`, `pnpm add -g`, `bun add -g`, `yarn global add`)을 사용한 뒤 같은 인자로 업데이트된 `fluo` 바이너리를 다시 시작합니다. 설치 도구를 추론할 수 없으면 Node.js 기본 전역 설치 경로를 소유하는 npm 기준으로 `npm install -g @fluojs/cli@<latest>`를 fallback으로 사용합니다.
 
 업데이트 확인은 CI, non-TTY 출력, npm-script context, 업데이트 후 재실행 context, registry/network 실패, 명시적 opt-out 경로에서는 건너뜁니다. 한 번만 끄려면 `--no-update-check`(또는 compatibility alias `--no-update-notifier`)를 사용하고, 자동화에서 절대 prompt가 뜨면 안 되는 경우에는 `FLUO_NO_UPDATE_CHECK=1`을 설정하세요.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,12 +30,12 @@ pnpm dlx @fluojs/cli new my-app
 ## Release Contract
 
 - `@fluojs/cli` is a public package in the intended publish surface.
-- The supported install paths are the global package (`pnpm add -g @fluojs/cli`) and the no-install runner (`pnpm dlx @fluojs/cli ...`).
+- The supported install paths are the global package (`npm install -g @fluojs/cli`, `pnpm add -g @fluojs/cli`, `bun add -g @fluojs/cli`, or `yarn global add @fluojs/cli`) and the no-install runner (`pnpm dlx @fluojs/cli ...`).
 - The published `fluo` bin is backed by the dist-built CLI entrypoint declared in `package.json`.
 
 ## Update Checks
 
-When `fluo` runs in an interactive TTY, it checks the public npm `latest` dist-tag for `@fluojs/cli` using a local cache so every invocation does not hit the registry. If a newer version is available, the CLI asks whether to install it. Declining continues the current command with the installed version; accepting runs `pnpm add -g @fluojs/cli@<latest>` and then restarts `fluo` with the same arguments under the updated binary.
+When `fluo` runs in an interactive TTY, it checks the public npm `latest` dist-tag for `@fluojs/cli` using a local cache so every invocation does not hit the registry. If a newer version is available, the CLI asks whether to install it. Declining continues the current command with the installed version; accepting updates the global CLI with the package manager that appears to own the current installation (`npm install -g`, `pnpm add -g`, `bun add -g`, or `yarn global add`) and then restarts `fluo` with the same arguments under the updated binary. If the installer cannot be inferred, the CLI falls back to `npm install -g @fluojs/cli@<latest>` because npm owns the default Node.js global installation path.
 
 The update check is skipped in CI, non-TTY output, npm-script contexts, rerun-after-update contexts, registry/network failures, and explicit opt-out paths. Use `--no-update-check` (or the compatibility alias `--no-update-notifier`) for one invocation, or set `FLUO_NO_UPDATE_CHECK=1` when automation must never prompt.
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -151,11 +151,157 @@ describe('CLI command runner', () => {
     });
 
     expect(exitCode).toBe(42);
-    expect(installCommands).toEqual(['pnpm add -g @fluojs/cli@1.0.0-beta.2']);
+    expect(installCommands).toEqual(['npm install -g @fluojs/cli@1.0.0-beta.2']);
     expect(rerunArgv).toEqual([['help', 'new']]);
     expect(rerunEnvValues).toEqual(['1']);
     expect(stderrBuffer.join('')).toContain('Updated @fluojs/cli to 1.0.0-beta.2. Restarting fluo...');
     expect(stdoutBuffer.join('')).toBe('');
+  });
+
+  it.each([
+    ['bun', 'bun add -g @fluojs/cli@1.0.0-beta.2'],
+    ['npm', 'npm install -g @fluojs/cli@1.0.0-beta.2'],
+    ['pnpm', 'pnpm add -g @fluojs/cli@1.0.0-beta.2'],
+    ['yarn', 'yarn global add @fluojs/cli@1.0.0-beta.2'],
+  ] as const)('uses %s for accepted CLI updates when that installer is detected', async (packageManager, expectedCommand) => {
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const installCommands: string[] = [];
+
+    const exitCode = await runCli(['help'], {
+      env: {
+        ...updateCheckEnv,
+        npm_config_user_agent: `${packageManager}/1.0.0 node/v20.0.0 darwin arm64`,
+      },
+      stderr: createTtyBufferStream(stderrBuffer),
+      stdin: { isTTY: true },
+      stdout: createTtyBufferStream(stdoutBuffer),
+      updateCheck: {
+        cacheFile: createUpdateCacheFile(),
+        currentVersion: '1.0.0-beta.1',
+        fetchLatestVersion: async () => '1.0.0-beta.2',
+        installPackage: async (installCommand) => {
+          installCommands.push(installCommand.display);
+          return 0;
+        },
+        prompt: {
+          confirm: async () => true,
+        },
+        rerunCli: async () => 0,
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(installCommands).toEqual([expectedCommand]);
+    expect(stderrBuffer.join('')).toContain(`Installing @fluojs/cli@1.0.0-beta.2 with \`${expectedCommand}\``);
+  });
+
+  it.each([
+    ['bun', '/Users/example/.bun/bin/bun', 'bun add -g @fluojs/cli@1.0.0-beta.2'],
+    ['npm', '/Users/example/.nvm/versions/node/v20.0.0/lib/node_modules/npm/bin/npm-cli.js', 'npm install -g @fluojs/cli@1.0.0-beta.2'],
+    ['pnpm', '/Users/example/Library/pnpm/pnpm.cjs', 'pnpm add -g @fluojs/cli@1.0.0-beta.2'],
+    ['yarn', '/Users/example/.yarn/bin/yarn.js', 'yarn global add @fluojs/cli@1.0.0-beta.2'],
+  ] as const)('uses %s for accepted CLI updates when npm_execpath points at that installer', async (_packageManager, npmExecPath, expectedCommand) => {
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const installCommands: string[] = [];
+
+    const exitCode = await runCli(['help'], {
+      env: {
+        ...updateCheckEnv,
+        npm_execpath: npmExecPath,
+      },
+      stderr: createTtyBufferStream(stderrBuffer),
+      stdin: { isTTY: true },
+      stdout: createTtyBufferStream(stdoutBuffer),
+      updateCheck: {
+        cacheFile: createUpdateCacheFile(),
+        currentVersion: '1.0.0-beta.1',
+        fetchLatestVersion: async () => '1.0.0-beta.2',
+        installPackage: async (installCommand) => {
+          installCommands.push(installCommand.display);
+          return 0;
+        },
+        prompt: {
+          confirm: async () => true,
+        },
+        rerunCli: async () => 0,
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(installCommands).toEqual([expectedCommand]);
+  });
+
+  it.each([
+    ['bun', '/Users/example/.bun/install/global/node_modules/@fluojs/cli', 'bun add -g @fluojs/cli@1.0.0-beta.2'],
+    ['npm', '/Users/example/.nvm/versions/node/v20.0.0/lib/node_modules/@fluojs/cli', 'npm install -g @fluojs/cli@1.0.0-beta.2'],
+    ['pnpm', '/Users/example/Library/pnpm/global/5/node_modules/.pnpm/@fluojs+cli@1.0.0-beta.1/node_modules/@fluojs/cli', 'pnpm add -g @fluojs/cli@1.0.0-beta.2'],
+    ['pnpm', '/Users/example/Library/pnpm/global/5/node_modules/@fluojs/cli', 'pnpm add -g @fluojs/cli@1.0.0-beta.2'],
+    ['yarn', '/Users/example/.config/yarn/global/node_modules/@fluojs/cli', 'yarn global add @fluojs/cli@1.0.0-beta.2'],
+  ] as const)('uses the package root as the install-owner signal for %s global installs', async (_packageManager, packageRoot, expectedCommand) => {
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const installCommands: string[] = [];
+
+    const exitCode = await runCli(['help'], {
+      env: updateCheckEnv,
+      stderr: createTtyBufferStream(stderrBuffer),
+      stdin: { isTTY: true },
+      stdout: createTtyBufferStream(stdoutBuffer),
+      updateCheck: {
+        cacheFile: createUpdateCacheFile(),
+        currentVersion: '1.0.0-beta.1',
+        env: undefined,
+        fetchLatestVersion: async () => '1.0.0-beta.2',
+        installPackage: async (installCommand) => {
+          installCommands.push(installCommand.display);
+          return 0;
+        },
+        packageRoot,
+        prompt: {
+          confirm: async () => true,
+        },
+        rerunCli: async () => 0,
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(installCommands).toEqual([expectedCommand]);
+  });
+
+  it('prefers the package root install-owner signal over launcher package-manager hints', async () => {
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const installCommands: string[] = [];
+
+    const exitCode = await runCli(['help'], {
+      env: {
+        ...updateCheckEnv,
+        npm_config_user_agent: 'npm/10.0.0 node/v20.0.0 darwin arm64',
+        npm_execpath: '/Users/example/.nvm/versions/node/v20.0.0/lib/node_modules/npm/bin/npm-cli.js',
+      },
+      stderr: createTtyBufferStream(stderrBuffer),
+      stdin: { isTTY: true },
+      stdout: createTtyBufferStream(stdoutBuffer),
+      updateCheck: {
+        cacheFile: createUpdateCacheFile(),
+        currentVersion: '1.0.0-beta.1',
+        fetchLatestVersion: async () => '1.0.0-beta.2',
+        installPackage: async (installCommand) => {
+          installCommands.push(installCommand.display);
+          return 0;
+        },
+        packageRoot: '/Users/example/Library/pnpm/global/5/node_modules/@fluojs/cli',
+        prompt: {
+          confirm: async () => true,
+        },
+        rerunCli: async () => 0,
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(installCommands).toEqual(['pnpm add -g @fluojs/cli@1.0.0-beta.2']);
   });
 
   it('continues the original CLI command when the accepted update install fails', async () => {

--- a/packages/cli/src/update-check.ts
+++ b/packages/cli/src/update-check.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join, sep } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import { fileURLToPath } from 'node:url';
 
@@ -47,6 +47,9 @@ export type UpdateInstallCommand = {
   display: string;
 };
 
+/** Package manager that can install the CLI globally. */
+export type UpdatePackageManager = 'bun' | 'npm' | 'pnpm' | 'yarn';
+
 /**
  * Defines the update command runtime type.
  */
@@ -76,6 +79,8 @@ export interface CliUpdateCheckRuntimeOptions {
   interactive?: boolean;
   now?: () => Date;
   packageName?: string;
+  packageManager?: UpdatePackageManager;
+  packageRoot?: string;
   prompt?: UpdatePrompter;
   rerunCli?: (argv: string[], runtime: UpdateCommandRuntime) => Promise<number>;
   skip?: boolean;
@@ -88,6 +93,7 @@ const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_PACKAGE_NAME = '@fluojs/cli';
 const DEFAULT_REGISTRY_TIMEOUT_MS = 5_000;
 const UPDATE_CHECK_FLAGS = new Set(['--no-update-check', '--no-update-notifier']);
+const UPDATE_PACKAGE_MANAGERS = new Set<UpdatePackageManager>(['bun', 'npm', 'pnpm', 'yarn']);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -347,13 +353,120 @@ async function readOwnPackageVersion(): Promise<string | undefined> {
   }
 }
 
-function resolveInstallCommand(packageName: string, latestVersion: string): UpdateInstallCommand {
+function normalizePathForDetection(path: string | undefined): string {
+  return (path ?? '').replaceAll('\\', '/').toLowerCase();
+}
+
+function parsePackageManagerName(value: string | undefined): UpdatePackageManager | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (UPDATE_PACKAGE_MANAGERS.has(normalized as UpdatePackageManager)) {
+    return normalized as UpdatePackageManager;
+  }
+
+  return undefined;
+}
+
+function parsePackageManagerFromUserAgent(userAgent: string | undefined): UpdatePackageManager | undefined {
+  const name = userAgent?.split(' ')[0]?.split('/')[0];
+
+  return parsePackageManagerName(name);
+}
+
+function parsePackageManagerFromExecPath(execPath: string | undefined): UpdatePackageManager | undefined {
+  const executableName = basename(execPath ?? '', '.cmd').toLowerCase();
+  const packageManager = parsePackageManagerName(executableName.replace(/\.(?:cjs|mjs|js)$/, ''));
+  if (packageManager) {
+    return packageManager;
+  }
+
+  const normalizedPath = normalizePathForDetection(execPath);
+  if (normalizedPath.includes('/pnpm/')) {
+    return 'pnpm';
+  }
+
+  if (normalizedPath.includes('/yarn/')) {
+    return 'yarn';
+  }
+
+  if (normalizedPath.includes('/bun/')) {
+    return 'bun';
+  }
+
+  if (normalizedPath.includes('/npm/')) {
+    return 'npm';
+  }
+
+  return undefined;
+}
+
+function parsePackageManagerFromPackageRoot(packageRoot: string): UpdatePackageManager | undefined {
+  const normalizedPath = normalizePathForDetection(`${sep}${packageRoot}${sep}`);
+  if (normalizedPath.includes('/.pnpm/') || normalizedPath.includes('/pnpm/global/')) {
+    return 'pnpm';
+  }
+
+  if (normalizedPath.includes('/.bun/install/global/') || normalizedPath.includes('/bun/install/global/')) {
+    return 'bun';
+  }
+
+  if (normalizedPath.includes('/.config/yarn/global/') || normalizedPath.includes('/yarn/global/')) {
+    return 'yarn';
+  }
+
+  if (normalizedPath.includes('/node_modules/')) {
+    return 'npm';
+  }
+
+  return undefined;
+}
+
+function resolveUpdatePackageManager(env: NodeJS.ProcessEnv, packageRoot: string): UpdatePackageManager {
+  return parsePackageManagerName(env.FLUO_UPDATE_PACKAGE_MANAGER)
+    ?? parsePackageManagerFromPackageRoot(packageRoot)
+    ?? parsePackageManagerFromUserAgent(env.npm_config_user_agent)
+    ?? parsePackageManagerFromExecPath(env.npm_execpath)
+    ?? 'npm';
+}
+
+function resolveInstallCommand(
+  packageName: string,
+  latestVersion: string,
+  packageManager: UpdatePackageManager,
+): UpdateInstallCommand {
   const packageSpecifier = `${packageName}@${latestVersion}`;
 
+  if (packageManager === 'bun') {
+    return {
+      args: ['add', '-g', packageSpecifier],
+      command: 'bun',
+      display: `bun add -g ${packageSpecifier}`,
+    };
+  }
+
+  if (packageManager === 'pnpm') {
+    return {
+      args: ['add', '-g', packageSpecifier],
+      command: 'pnpm',
+      display: `pnpm add -g ${packageSpecifier}`,
+    };
+  }
+
+  if (packageManager === 'yarn') {
+    return {
+      args: ['global', 'add', packageSpecifier],
+      command: 'yarn',
+      display: `yarn global add ${packageSpecifier}`,
+    };
+  }
+
   return {
-    args: ['add', '-g', packageSpecifier],
-    command: 'pnpm',
-    display: `pnpm add -g ${packageSpecifier}`,
+    args: ['install', '-g', packageSpecifier],
+    command: 'npm',
+    display: `npm install -g ${packageSpecifier}`,
   };
 }
 
@@ -472,6 +585,7 @@ export async function runCliUpdateCheck(argv: string[], options: CliUpdateCheckR
   const cacheFile = options.cacheFile ?? resolveCacheFile(env);
   const cacheTtlMs = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
   const currentVersion = options.currentVersion ?? await readOwnPackageVersion();
+  const packageRoot = options.packageRoot ?? dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
 
   if (!currentVersion) {
     return { action: 'continue' };
@@ -498,7 +612,8 @@ export async function runCliUpdateCheck(argv: string[], options: CliUpdateCheckR
     return { action: 'continue' };
   }
 
-  const installCommand = resolveInstallCommand(packageName, latestVersion);
+  const packageManager = options.packageManager ?? resolveUpdatePackageManager(env, packageRoot);
+  const installCommand = resolveInstallCommand(packageName, latestVersion, packageManager);
   stderr.write(`Installing ${packageName}@${latestVersion} with \`${installCommand.display}\`...\n`);
 
   const commandRuntime = { env, stderr };


### PR DESCRIPTION
## Summary
- Detect the CLI self-update installer from the current global install owner instead of hard-coding pnpm.
- Support npm, pnpm, bun, and Yarn global update commands with npm as the final fallback.
- Update CLI docs in English and Korean to describe the expanded global install/update contract.

## Verification
- LSP diagnostics on modified TypeScript files
- node tooling/scripts/run-workspace-build-closure.mjs @fluojs/cli
- pnpm --filter @fluojs/cli typecheck
- pnpm --filter @fluojs/cli test -- src/cli.test.ts

Closes #1523