### PR TITLE
Add changeset for CLI self-update installer detection

### DIFF
--- a/.changeset/cli-self-update-installer.md
+++ b/.changeset/cli-self-update-installer.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": minor
+---
+
+Update the CLI self-update flow to reuse the package manager that owns the current global install instead of always invoking pnpm.


### PR DESCRIPTION
## Summary
- Add the missing Changesets release metadata for the merged CLI self-update installer detection change from #1524.
- Mark `@fluojs/cli` as a minor prerelease bump so the next Changesets Release run can open/update the Version Packages PR.

## Verification
- Confirmed changeset file contents manually.
- `pnpm changeset status --since=HEAD~1` could not run in the isolated worktree because dependencies were not installed there; the PR only adds static release metadata.

Follow-up to #1524 / #1523.