### PR TITLE
Refresh CLI starter beta dependency pins

### DIFF
--- a/.changeset/cli-starter-latest-beta-deps.md
+++ b/.changeset/cli-starter-latest-beta-deps.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Refresh `fluo new` starter dependency pins to the latest published beta versions of the generated `@fluojs/*` packages.

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -216,13 +216,17 @@ describe('scaffoldBootstrapApp', () => {
 
     expect(packageJson.devDependencies?.typescript).toBe('^6.0.2');
     expect(packageJson.dependencies).toMatchObject({
-      '@fluojs/http': '^1.0.0-beta.1',
-      '@fluojs/platform-fastify': '^1.0.0-beta.2',
-      '@fluojs/runtime': '^1.0.0-beta.1',
+      '@fluojs/config': '^1.0.0-beta.5',
+      '@fluojs/core': '^1.0.0-beta.3',
+      '@fluojs/di': '^1.0.0-beta.6',
+      '@fluojs/http': '^1.0.0-beta.9',
+      '@fluojs/platform-fastify': '^1.0.0-beta.8',
+      '@fluojs/runtime': '^1.0.0-beta.9',
+      '@fluojs/validation': '^1.0.0-beta.2',
     });
     expect(packageJson.devDependencies).toMatchObject({
-      '@fluojs/cli': '^1.0.0-beta.2',
-      '@fluojs/testing': '^1.0.0-beta.1',
+      '@fluojs/cli': '^1.0.0-beta.3',
+      '@fluojs/testing': '^1.0.0-beta.2',
     });
     expect(tsconfig).not.toContain('baseUrl');
     expect(tsconfigBuild).not.toContain('baseUrl');

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -33,20 +33,21 @@ const PUBLISHED_RUNTIME_DEPENDENCIES = {
 } as const;
 
 const PUBLISHED_INTERNAL_DEPENDENCIES = {
-  '@fluojs/cli': '^1.0.0-beta.2',
-  '@fluojs/config': '^1.0.0-beta.1',
-  '@fluojs/core': '^1.0.0-beta.1',
-  '@fluojs/di': '^1.0.0-beta.1',
-  '@fluojs/http': '^1.0.0-beta.1',
-  '@fluojs/microservices': '^1.0.0-beta.1',
-  '@fluojs/platform-bun': '^1.0.0-beta.1',
-  '@fluojs/platform-cloudflare-workers': '^1.0.0-beta.1',
-  '@fluojs/platform-deno': '^1.0.0-beta.1',
-  '@fluojs/platform-express': '^1.0.0-beta.1',
-  '@fluojs/platform-fastify': '^1.0.0-beta.2',
-  '@fluojs/platform-nodejs': '^1.0.0-beta.1',
-  '@fluojs/runtime': '^1.0.0-beta.1',
-  '@fluojs/testing': '^1.0.0-beta.1',
+  '@fluojs/cli': '^1.0.0-beta.3',
+  '@fluojs/config': '^1.0.0-beta.5',
+  '@fluojs/core': '^1.0.0-beta.3',
+  '@fluojs/di': '^1.0.0-beta.6',
+  '@fluojs/http': '^1.0.0-beta.9',
+  '@fluojs/microservices': '^1.0.0-beta.3',
+  '@fluojs/platform-bun': '^1.0.0-beta.6',
+  '@fluojs/platform-cloudflare-workers': '^1.0.0-beta.2',
+  '@fluojs/platform-deno': '^1.0.0-beta.3',
+  '@fluojs/platform-express': '^1.0.0-beta.6',
+  '@fluojs/platform-fastify': '^1.0.0-beta.8',
+  '@fluojs/platform-nodejs': '^1.0.0-beta.4',
+  '@fluojs/runtime': '^1.0.0-beta.9',
+  '@fluojs/testing': '^1.0.0-beta.2',
+  '@fluojs/validation': '^1.0.0-beta.2',
 } as const;
 
 


### PR DESCRIPTION
## Summary
- Refresh `fluo new` starter dependency pins to the latest published beta versions for generated `@fluojs/*` packages.
- Update scaffold expectations so generated Fastify starters include the current beta dependency set.
- Add a patch changeset for `@fluojs/cli`.

## Verification
- `node tooling/scripts/run-workspace-build-closure.mjs @fluojs/cli`
- `pnpm --filter @fluojs/cli test -- src/new/scaffold.test.ts`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm changeset status --since=origin/main`
- LSP diagnostics on `packages/cli/src/new/scaffold.ts` and `packages/cli/src/new/scaffold.test.ts`