### PR TITLE
Add CLI version command

### DIFF
--- a/.changeset/cli-version-command.md
+++ b/.changeset/cli-version-command.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Add `fluo version`, `fluo --version`, and `fluo -v` so users can inspect the installed CLI version without triggering update checks.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -7,6 +7,7 @@ fluo 공식 CLI — 새 애플리케이션 부트스트랩, 컴포넌트 생성,
 ## 목차
 
 - [설치](#설치)
+- [버전 확인](#버전-확인)
 - [업데이트 확인](#업데이트-확인)
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
@@ -32,6 +33,16 @@ pnpm dlx @fluojs/cli new my-app
 - `@fluojs/cli`는 intended publish surface에 포함되는 공개 패키지입니다.
 - 지원되는 설치 경로는 전역 패키지(`npm install -g @fluojs/cli`, `pnpm add -g @fluojs/cli`, `bun add -g @fluojs/cli`, `yarn global add @fluojs/cli`)와 무설치 실행 경로(`pnpm dlx @fluojs/cli ...`)입니다.
 - 배포되는 `fluo` bin은 `package.json`에 선언된 dist 빌드 CLI 엔트리포인트를 기준으로 동작합니다.
+
+## 버전 확인
+
+Interactive update check를 실행하지 않고 설치된 CLI 버전을 확인합니다:
+
+```bash
+fluo version
+fluo --version
+fluo -v
+```
 
 ## 업데이트 확인
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,6 +7,7 @@ The canonical CLI for fluo — bootstrap new applications, generate components, 
 ## Table of Contents
 
 - [Installation](#installation)
+- [Version Inspection](#version-inspection)
 - [Update Checks](#update-checks)
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
@@ -32,6 +33,16 @@ pnpm dlx @fluojs/cli new my-app
 - `@fluojs/cli` is a public package in the intended publish surface.
 - The supported install paths are the global package (`npm install -g @fluojs/cli`, `pnpm add -g @fluojs/cli`, `bun add -g @fluojs/cli`, or `yarn global add @fluojs/cli`) and the no-install runner (`pnpm dlx @fluojs/cli ...`).
 - The published `fluo` bin is backed by the dist-built CLI entrypoint declared in `package.json`.
+
+## Version Inspection
+
+Check the installed CLI version without triggering the interactive update check:
+
+```bash
+fluo version
+fluo --version
+fluo -v
+```
 
 ## Update Checks
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1356,11 +1356,55 @@ void bootstrap();
 
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Usage: fluo <command> [options]');
-    expect(stdoutBuffer.join('')).toContain('| Command  | Aliases | Description');
+    expect(stdoutBuffer.join('')).toContain('| Command  | Aliases');
     expect(stdoutBuffer.join('')).toContain('| new      | create');
     expect(stdoutBuffer.join('')).toContain('| generate | g');
+    expect(stdoutBuffer.join('')).toContain('| version  | --version, -v');
     expect(stdoutBuffer.join('')).toContain("Run 'fluo help <command>'");
     expect(stdoutBuffer.join('')).toContain('Docs: https://github.com/fluojs/fluo/tree/main/docs/getting-started/quick-start.md');
+  });
+
+  it('prints the installed CLI version without running the update check', async () => {
+    const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+    const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as { version: string };
+    const stdoutBuffer: string[] = [];
+    let fetchCount = 0;
+
+    const exitCode = await runCli(['--version'], {
+      env: updateCheckEnv,
+      stderr: createTtyBufferStream([]),
+      stdin: { isTTY: true },
+      stdout: createTtyBufferStream(stdoutBuffer),
+      updateCheck: {
+        cacheFile: createUpdateCacheFile(),
+        currentVersion: '0.0.0',
+        fetchLatestVersion: async (): Promise<string> => {
+          fetchCount += 1;
+          return '999.0.0';
+        },
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fetchCount).toBe(0);
+    expect(stdoutBuffer.join('')).toBe(`${manifest.version}\n`);
+  });
+
+  it('supports the version command and short version flag', async () => {
+    const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+    const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8')) as { version: string };
+
+    for (const argv of [['version'], ['-v']]) {
+      const stdoutBuffer: string[] = [];
+
+      const exitCode = await runCli(argv, {
+        stderr: { write: () => undefined },
+        stdout: { write: (message) => stdoutBuffer.push(message) },
+      });
+
+      expect(exitCode).toBe(0);
+      expect(stdoutBuffer.join('')).toBe(`${manifest.version}\n`);
+    }
   });
 
   it('prints `new` usage for `new --help`', async () => {
@@ -2143,6 +2187,7 @@ void bootstrap();
     expect(output).toContain('Generate a schematic');
     expect(output).toContain('Inspect runtime platform snapshot/diagnostics');
     expect(output).toContain('dry-run by default');
+    expect(output).toContain('Print the installed fluo CLI version');
     expect(output).toContain('Show top-level or command-specific help');
   });
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -102,6 +102,7 @@ const TOP_LEVEL_COMMAND_HELP: TopLevelCommandHelpEntry[] = [
   { aliases: ['g'], command: 'generate', description: 'Generate a schematic inside an existing fluo application.' },
   { aliases: [], command: 'inspect', description: 'Inspect runtime platform snapshot/diagnostics and emit timing optionally.' },
   { aliases: [], command: 'migrate', description: 'Run NestJS-to-fluo codemods (dry-run by default).' },
+  { aliases: ['--version', '-v'], command: 'version', description: 'Print the installed fluo CLI version.' },
   { aliases: [], command: 'help', description: 'Show top-level or command-specific help.' },
 ];
 
@@ -111,6 +112,21 @@ function normalizeGeneratorKind(value: string | undefined): GeneratorKind | unde
 
 function isHelpFlag(value: string | undefined): boolean {
   return value === '--help' || value === '-h';
+}
+
+function isVersionCommand(value: string | undefined): boolean {
+  return value === 'version' || value === '--version' || value === '-v';
+}
+
+function readCliVersion(): string {
+  const packageJsonPath = fileURLToPath(new URL('../package.json', import.meta.url));
+  const manifest: unknown = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+  if (typeof manifest !== 'object' || manifest === null || !('version' in manifest) || typeof manifest.version !== 'string') {
+    throw new Error('Unable to determine the installed fluo CLI version.');
+  }
+
+  return manifest.version;
 }
 
 function generateUsage(): string {
@@ -339,6 +355,11 @@ export async function runCli(
   const commandArgv = updateFlagResult.argv;
 
   try {
+    if (isVersionCommand(commandArgv[0])) {
+      stdout.write(`${readCliVersion()}\n`);
+      return 0;
+    }
+
     const updateCheckOptions = runtime.updateCheck === false ? undefined : runtime.updateCheck;
     const updateCheckResult = await runCliUpdateCheck(commandArgv, {
       ...updateCheckOptions,


### PR DESCRIPTION
## Summary
- Add `fluo version`, `fluo --version`, and `fluo -v` to print the installed CLI version.
- Bypass the interactive update check for version inspection so users can debug stale installs/cache safely.
- Document the version inspection commands in EN/KO README files and add a patch changeset.

## Verification
- `pnpm --filter @fluojs/cli test -- src/cli.test.ts`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm changeset status --since=origin/main`
- `pnpm --filter @fluojs/cli exec tsx src/cli.ts --version`
- LSP diagnostics on `packages/cli/src/cli.ts` and `packages/cli/src/cli.test.ts`