### PR TITLE
Resolve #1534: Add runtime logger and lifecycle reporter controls

### DIFF
--- a/.changeset/runtime-logger-cli-reporter.md
+++ b/.changeset/runtime-logger-cli-reporter.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/runtime": minor
+"@fluojs/cli": minor
+---
+
+Add configurable runtime console logger modes and level filtering, and add CLI lifecycle reporter controls for quieter interactive dev output while preserving raw passthrough for CI and debugging.

--- a/book/beginner/ch02-cli-setup.md
+++ b/book/beginner/ch02-cli-setup.md
@@ -351,6 +351,10 @@ pnpm dev
 
 If you intentionally generated the project with a different package manager, use that project's matching script command. The book's documented path stays on `pnpm`.
 
+The generated `dev` script delegates to `fluo dev`. In an interactive terminal, the CLI prints concise fluo lifecycle status and keeps child-process errors visible. In CI or other non-interactive output, it falls back to raw stream passthrough so logs remain automation-friendly. If you need to debug every line from the underlying toolchain, run `fluo dev --verbose`, `fluo dev --reporter stream`, or set `FLUO_VERBOSE=1`.
+
+That CLI reporter is different from application/runtime logging. To tune logs emitted by your app after bootstrap, configure `ApplicationLogger` in code, for example with `createConsoleApplicationLogger({ mode: 'minimal', level: 'warn' })` or `createJsonApplicationLogger()` from `@fluojs/runtime/node`.
+
 On the first run, the flow looks like this. You can expect startup logs similar to the following.
 
 ```text

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -68,7 +68,7 @@ cd my-app
 pnpm dev
 ```
 
-생성된 `dev`, `build`, `start` package script는 각각 `fluo dev`, `fluo build`, `fluo start`로 위임합니다. CLI가 런타임별 lifecycle 명령을 소유하고 local toolchain binary를 실행할 때 project-local `node_modules/.bin`을 앞에 붙이며, 호출자가 명시하지 않은 경우 `dev`는 `NODE_ENV=development`, `build`/`start`는 `NODE_ENV=production`을 기본값으로 사용합니다. Cloudflare Workers의 `start`는 배포하지 않고 Wrangler remote preview를 열며, Cloudflare에 게시하려면 명시적인 deploy 명령을 사용하세요.
+생성된 `dev`, `build`, `start` package script는 각각 `fluo dev`, `fluo build`, `fluo start`로 위임합니다. CLI가 런타임별 lifecycle 명령을 소유하고 local toolchain binary를 실행할 때 project-local `node_modules/.bin`을 앞에 붙이며, 호출자가 명시하지 않은 경우 `dev`는 `NODE_ENV=development`, `build`/`start`는 `NODE_ENV=production`을 기본값으로 사용합니다. `fluo dev`는 TTY-aware lifecycle reporter를 사용합니다. Interactive terminal에서는 간결한 fluo-branded status를 보여주고, CI, non-TTY 출력, `--reporter stream`, `--verbose`, `FLUO_VERBOSE=1`에서는 디버깅과 자동화를 위해 raw child-process passthrough를 유지합니다. Cloudflare Workers의 `start`는 배포하지 않고 Wrangler remote preview를 열며, Cloudflare에 게시하려면 명시적인 deploy 명령을 사용하세요.
 
 `fluo new`는 같은 Node 기반 설치/빌드 흐름 위에서 Node.js + Fastify, Express, raw Node.js HTTP 애플리케이션 스타터를 제공합니다.
 
@@ -160,6 +160,23 @@ fluo dev --dry-run
 fluo build --dry-run
 fluo start --dry-run
 ```
+
+CLI process boundary를 조정해야 할 때는 런타임 앱 로깅이 아니라 reporter flag를 사용하세요:
+
+```bash
+# TTY에서는 pretty status, CI/non-TTY에서는 raw passthrough (기본값)
+fluo dev
+
+# child process log를 디버깅하기 위한 기존 passthrough에 가까운 출력
+fluo dev --reporter stream
+fluo dev --verbose
+FLUO_VERBOSE=1 fluo dev
+
+# child stderr와 실패는 보존하면서 wrapper/tool status는 숨김
+fluo build --reporter silent
+```
+
+런타임 애플리케이션 로그는 `ApplicationLogger`로 별도 설정합니다. 예를 들어 `@fluojs/runtime/node`의 `createConsoleApplicationLogger({ mode: 'minimal', level: 'warn' })` 또는 `createJsonApplicationLogger()`를 사용하세요.
 
 first-party package 설치 shortcut에는 `fluo add <package>`를 사용하고, CLI/latest-version 및 migration 안내는 `fluo upgrade`로 확인합니다:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,7 +68,7 @@ cd my-app
 pnpm dev
 ```
 
-Generated `dev`, `build`, and `start` package scripts delegate to `fluo dev`, `fluo build`, and `fluo start`. The CLI owns the runtime-specific lifecycle command, prepends the project-local `node_modules/.bin` when invoking local toolchain binaries, and defaults `NODE_ENV` to `development` for `dev` and `production` for `build`/`start` when the caller has not set it explicitly. Cloudflare Workers `start` opens a remote Wrangler preview instead of deploying; use an explicit deploy command when you intend to publish to Cloudflare.
+Generated `dev`, `build`, and `start` package scripts delegate to `fluo dev`, `fluo build`, and `fluo start`. The CLI owns the runtime-specific lifecycle command, prepends the project-local `node_modules/.bin` when invoking local toolchain binaries, and defaults `NODE_ENV` to `development` for `dev` and `production` for `build`/`start` when the caller has not set it explicitly. `fluo dev` uses a TTY-aware lifecycle reporter: interactive terminals get concise fluo-branded status while CI, non-TTY output, `--reporter stream`, `--verbose`, and `FLUO_VERBOSE=1` keep raw child-process passthrough available for debugging and automation. Cloudflare Workers `start` opens a remote Wrangler preview instead of deploying; use an explicit deploy command when you intend to publish to Cloudflare.
 
 `fluo new` supports Node.js + Fastify, Express, and raw Node.js HTTP application starters on the same Node-oriented install/build flow:
 
@@ -160,6 +160,23 @@ fluo dev --dry-run
 fluo build --dry-run
 fluo start --dry-run
 ```
+
+Use reporter flags when you need to tune the CLI process boundary rather than runtime app logging:
+
+```bash
+# Pretty status in TTY, raw passthrough in CI/non-TTY (default)
+fluo dev
+
+# Current passthrough-like output for debugging child process logs
+fluo dev --reporter stream
+fluo dev --verbose
+FLUO_VERBOSE=1 fluo dev
+
+# Suppress wrapper/tool status while keeping child stderr and failures visible
+fluo build --reporter silent
+```
+
+Runtime application logs are configured separately through `ApplicationLogger`, for example `createConsoleApplicationLogger({ mode: 'minimal', level: 'warn' })` or `createJsonApplicationLogger()` from `@fluojs/runtime/node`.
 
 Use `fluo add <package>` for first-party package installation shortcuts and `fluo upgrade` for CLI/latest-version and migration guidance:
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1512,8 +1512,36 @@ void bootstrap();
     expect(spawned).toEqual([{ stdio: 'pipe' }]);
     expect(stdoutBuffer.join('')).toContain('[fluo] dev node lifecycle starting');
     expect(stdoutBuffer.join('')).not.toContain('child stdout');
+    expect(stderrBuffer.join('')).toContain('[fluo] child stdout before failure:');
+    expect(stderrBuffer.join('')).toContain('child stdout');
     expect(stderrBuffer.join('')).toContain('child stderr');
     expect(stderrBuffer.join('')).toContain('[fluo] dev lifecycle failed with exit code 1');
+  });
+
+  it('flushes only bounded child stdout on non-verbose pretty reporter failures', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    writeFileSync(join(workspaceDirectory, 'package.json'), JSON.stringify({ name: 'test-app', scripts: { dev: 'fluo dev' } }, null, 2));
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['dev'], {
+      cwd: workspaceDirectory,
+      env: {},
+      spawnCommand: async (_command, _args, options) => {
+        options.stdout?.write(`start-${'x'.repeat(20_000)}-end`);
+        return 9;
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { isTTY: true, write: () => undefined },
+    });
+
+    const stderrOutput = stderrBuffer.join('');
+
+    expect(exitCode).toBe(9);
+    expect(stderrOutput).toContain('[fluo] child stdout before failure:');
+    expect(stderrOutput).toContain('-end');
+    expect(stderrOutput).not.toContain('start-');
+    expect(stderrOutput.length).toBeLessThan(17_000);
   });
 
   it('keeps raw stream output for CI and explicit verbose dev runs', async () => {
@@ -1569,6 +1597,8 @@ void bootstrap();
 
     expect(exitCode).toBe(2);
     expect(stdoutBuffer.join('')).toBe('');
+    expect(stderrBuffer.join('')).toContain('[fluo] child stdout before failure:');
+    expect(stderrBuffer.join('')).toContain('child stdout');
     expect(stderrBuffer.join('')).toContain('child stderr');
     expect(stderrBuffer.join('')).toContain('[fluo] build lifecycle failed with exit code 2');
   });

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1484,6 +1484,93 @@ void bootstrap();
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Would run: node --env-file=.env --watch --watch-preserve-output --import tsx src/main.ts --port 4000');
     expect(stdoutBuffer.join('')).toContain('NODE_ENV: development');
+    expect(stdoutBuffer.join('')).toContain('Reporter: stream');
+  });
+
+  it('uses a TTY-aware pretty reporter for fluo dev without hiding child errors', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    writeFileSync(join(workspaceDirectory, 'package.json'), JSON.stringify({ name: 'test-app', scripts: { dev: 'fluo dev' } }, null, 2));
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const spawned: Array<{ stdio: string }> = [];
+
+    const exitCode = await runCli(['dev'], {
+      cwd: workspaceDirectory,
+      env: {},
+      spawnCommand: async (_command, _args, options) => {
+        spawned.push({ stdio: options.stdio });
+        options.stdout?.write('child stdout\n');
+        options.stderr?.write('child stderr\n');
+        return 1;
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { isTTY: true, write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(spawned).toEqual([{ stdio: 'pipe' }]);
+    expect(stdoutBuffer.join('')).toContain('[fluo] dev node lifecycle starting');
+    expect(stdoutBuffer.join('')).not.toContain('child stdout');
+    expect(stderrBuffer.join('')).toContain('child stderr');
+    expect(stderrBuffer.join('')).toContain('[fluo] dev lifecycle failed with exit code 1');
+  });
+
+  it('keeps raw stream output for CI and explicit verbose dev runs', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    writeFileSync(join(workspaceDirectory, 'package.json'), JSON.stringify({ name: 'test-app', scripts: { dev: 'fluo dev' } }, null, 2));
+    const modes: string[] = [];
+
+    await runCli(['dev'], {
+      ci: true,
+      cwd: workspaceDirectory,
+      env: {},
+      spawnCommand: async (_command, _args, options) => {
+        modes.push(options.stdio);
+        return 0;
+      },
+      stderr: { write: () => undefined },
+      stdout: { isTTY: true, write: () => undefined },
+    });
+
+    await runCli(['dev', '--verbose'], {
+      cwd: workspaceDirectory,
+      env: {},
+      spawnCommand: async (_command, _args, options) => {
+        modes.push(options.stdio);
+        return 0;
+      },
+      stderr: { write: () => undefined },
+      stdout: { isTTY: true, write: () => undefined },
+    });
+
+    expect(modes).toEqual(['inherit', 'inherit']);
+  });
+
+  it('supports a silent lifecycle reporter that preserves child stderr and failures', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    writeFileSync(join(workspaceDirectory, 'package.json'), JSON.stringify({ name: 'test-app', scripts: { build: 'fluo build' } }, null, 2));
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['build', '--reporter', 'silent'], {
+      cwd: workspaceDirectory,
+      env: {},
+      spawnCommand: async (_command, _args, options) => {
+        options.stdout?.write('child stdout\n');
+        options.stderr?.write('child stderr\n');
+        return 2;
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(2);
+    expect(stdoutBuffer.join('')).toBe('');
+    expect(stderrBuffer.join('')).toContain('child stderr');
+    expect(stderrBuffer.join('')).toContain('[fluo] build lifecycle failed with exit code 2');
   });
 
   it('runs the production lifecycle directly while preserving explicit NODE_ENV', async () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -1542,6 +1542,45 @@ void bootstrap();
     expect(stderrOutput).toContain('-end');
     expect(stderrOutput).not.toContain('start-');
     expect(stderrOutput.length).toBeLessThan(17_000);
+  });
+
+  it('drains default spawned child stdout before flushing pretty reporter failures', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const binDirectory = join(workspaceDirectory, 'node_modules', '.bin');
+    mkdirSync(binDirectory, { recursive: true });
+    writeFileSync(join(workspaceDirectory, 'package.json'), JSON.stringify({ name: 'test-app', scripts: { dev: 'fluo dev' } }, null, 2));
+
+    const nodeBin = join(binDirectory, 'node');
+    writeFileSync(
+      nodeBin,
+      `#!/bin/sh
+printf 'default spawn stdout before failure\n'
+printf 'default spawn stderr before failure\n' >&2
+exit 7
+`,
+    );
+    chmodSync(nodeBin, 0o755);
+
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['dev'], {
+      cwd: workspaceDirectory,
+      env: { PATH: process.env.PATH },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { isTTY: true, write: (message) => stdoutBuffer.push(message) },
+    });
+
+    const stderrOutput = stderrBuffer.join('');
+
+    expect(exitCode).toBe(7);
+    expect(stdoutBuffer.join('')).toContain('[fluo] dev node lifecycle starting');
+    expect(stdoutBuffer.join('')).not.toContain('default spawn stdout before failure');
+    expect(stderrOutput).toContain('[fluo] child stdout before failure:');
+    expect(stderrOutput).toContain('default spawn stdout before failure');
+    expect(stderrOutput).toContain('default spawn stderr before failure');
+    expect(stderrOutput.indexOf('default spawn stdout before failure')).toBeLessThan(stderrOutput.indexOf('[fluo] dev lifecycle failed with exit code 7'));
   });
 
   it('keeps raw stream output for CI and explicit verbose dev runs', async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,7 +31,7 @@ export interface CliRuntimeOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   fetchDistTags?: (packageName: string) => Promise<Record<string, string> | undefined>;
-  spawnCommand?: (command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv; stdio: 'inherit' }) => Promise<number>;
+  spawnCommand?: (command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv; stderr?: CliStream; stdio: 'inherit' | 'pipe'; stdout?: CliStream }) => Promise<number>;
   stderr?: CliStream;
   stdin?: CliReadableStream;
   stdout?: CliStream;

--- a/packages/cli/src/commands/scripts.ts
+++ b/packages/cli/src/commands/scripts.ts
@@ -34,6 +34,7 @@ type ProjectRuntime = 'bun' | 'cloudflare-workers' | 'deno' | 'node';
 type ProjectRunnerStep = { args: string[]; command: string };
 
 const EMPTY_ENV: NodeJS.ProcessEnv = {};
+const FAILURE_STDOUT_BUFFER_LIMIT = 16_384;
 
 function isRecord(value: unknown): value is JsonRecord {
   return typeof value === 'object' && value !== null;
@@ -273,16 +274,59 @@ function renderStep(step: ProjectRunnerStep): string {
   return `${step.command} ${step.args.join(' ')}`.trim();
 }
 
-function createReporterStreams(mode: EffectiveLifecycleReporterMode, verbose: boolean, stdout: CliStream, stderr: CliStream): { stderr?: CliStream; stdio: 'inherit' | 'pipe'; stdout?: CliStream } {
+function createBoundedBufferStream(limit: number): CliStream & { flush(target: CliStream): void; hasContent(): boolean } {
+  let buffer = '';
+
+  return {
+    flush(target) {
+      if (buffer.length > 0) {
+        target.write(buffer);
+      }
+    },
+    hasContent() {
+      return buffer.length > 0;
+    },
+    write(message) {
+      buffer += message;
+      if (buffer.length > limit) {
+        buffer = buffer.slice(buffer.length - limit);
+      }
+    },
+  };
+}
+
+function createReporterStreams(
+  mode: EffectiveLifecycleReporterMode,
+  verbose: boolean,
+  stdout: CliStream,
+  stderr: CliStream,
+): { flushBufferedStdoutOnFailure(): void; stderr?: CliStream; stdio: 'inherit' | 'pipe'; stdout?: CliStream } {
   if (mode === 'stream') {
-    return { stdio: 'inherit' };
+    return { flushBufferedStdoutOnFailure() {}, stdio: 'inherit' };
   }
 
   if (mode === 'silent' || mode === 'pretty') {
-    return { stderr, stdio: 'pipe', ...(verbose ? { stdout } : {}) };
+    if (verbose) {
+      return { flushBufferedStdoutOnFailure() {}, stderr, stdio: 'pipe', stdout };
+    }
+
+    const bufferedStdout = createBoundedBufferStream(FAILURE_STDOUT_BUFFER_LIMIT);
+
+    return {
+      flushBufferedStdoutOnFailure() {
+        if (bufferedStdout.hasContent()) {
+          stderr.write('[fluo] child stdout before failure:\n');
+          bufferedStdout.flush(stderr);
+          stderr.write('\n');
+        }
+      },
+      stderr,
+      stdio: 'pipe',
+      stdout: bufferedStdout,
+    };
   }
 
-  return { stdio: 'inherit' };
+  return { flushBufferedStdoutOnFailure() {}, stdio: 'inherit' };
 }
 
 /**
@@ -362,11 +406,13 @@ export async function runScriptCommand(command: ScriptCommand, argv: string[], r
 
   if (reporterMode === 'pretty') {
     if (exitCode === 0) {
-      stdout.write(`[fluo] ${command} lifecycle ready\n`);
+      stdout.write(`[fluo] ${command} lifecycle completed\n`);
     } else {
+      reporterStreams.flushBufferedStdoutOnFailure();
       stderr.write(`[fluo] ${command} lifecycle failed with exit code ${exitCode}\n`);
     }
   } else if (reporterMode === 'silent' && exitCode !== 0) {
+    reporterStreams.flushBufferedStdoutOnFailure();
     stderr.write(`[fluo] ${command} lifecycle failed with exit code ${exitCode}\n`);
   }
 

--- a/packages/cli/src/commands/scripts.ts
+++ b/packages/cli/src/commands/scripts.ts
@@ -4,13 +4,27 @@ import { delimiter, dirname, join, resolve } from 'node:path';
 import { SUPPORTED_PACKAGE_MANAGERS } from './package-manager.js';
 
 type CliStream = {
+  isTTY?: boolean;
   write(message: string): unknown;
 };
 
+type LifecycleReporterMode = 'auto' | 'silent' | 'stream';
+type EffectiveLifecycleReporterMode = 'pretty' | 'silent' | 'stream';
+
+type SpawnCommandOptions = {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  stderr?: CliStream;
+  stdio: 'inherit' | 'pipe';
+  stdout?: CliStream;
+};
+
 type ScriptRuntimeOptions = {
+  ci?: boolean;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
-  spawnCommand?: (command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv; stdio: 'inherit' }) => Promise<number>;
+  spawnCommand?: (command: string, args: string[], options: SpawnCommandOptions) => Promise<number>;
+  stderr?: CliStream;
   stdout?: CliStream;
 };
 
@@ -105,9 +119,13 @@ function withProjectLocalBin(env: NodeJS.ProcessEnv, projectDirectory: string): 
   };
 }
 
-function defaultSpawnCommand(command: string, args: string[], options: { cwd: string; env: NodeJS.ProcessEnv; stdio: 'inherit' }): Promise<number> {
+function defaultSpawnCommand(command: string, args: string[], options: SpawnCommandOptions): Promise<number> {
   return new Promise((resolveExitCode, reject) => {
     const child = spawn(command, args, options);
+    if (options.stdio === 'pipe') {
+      child.stdout?.on('data', (chunk) => options.stdout?.write(String(chunk)));
+      child.stderr?.on('data', (chunk) => options.stderr?.write(String(chunk)));
+    }
     child.on('error', reject);
     child.on('exit', (code) => resolveExitCode(code ?? 1));
   });
@@ -158,7 +176,7 @@ function buildProjectRunner(command: ScriptCommand, runtime: ProjectRuntime, pas
 async function runProjectRunnerSteps(
   steps: ProjectRunnerStep[],
   runtime: Required<Pick<ScriptRuntimeOptions, 'spawnCommand'>>,
-  options: { cwd: string; env: NodeJS.ProcessEnv; stdio: 'inherit' },
+  options: SpawnCommandOptions,
 ): Promise<number> {
   for (const step of steps) {
     const exitCode = await runtime.spawnCommand(step.command, step.args, options);
@@ -170,9 +188,11 @@ async function runProjectRunnerSteps(
   return 0;
 }
 
-function parseScriptArgs(argv: string[]): { dryRun: boolean; packageManager?: string; passThrough: string[] } {
+function parseScriptArgs(argv: string[]): { dryRun: boolean; packageManager?: string; passThrough: string[]; reporter: LifecycleReporterMode; verbose: boolean } {
   let dryRun = false;
   let packageManager: string | undefined;
+  let reporter: LifecycleReporterMode = 'auto';
+  let verbose = false;
   const passThrough: string[] = [];
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -180,6 +200,24 @@ function parseScriptArgs(argv: string[]): { dryRun: boolean; packageManager?: st
 
     if (arg === '--dry-run') {
       dryRun = true;
+      continue;
+    }
+
+    if (arg === '--verbose') {
+      verbose = true;
+      continue;
+    }
+
+    if (arg === '--reporter') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error('Expected --reporter to have a value.');
+      }
+      if (!(value === 'auto' || value === 'stream' || value === 'silent')) {
+        throw new Error(`Invalid --reporter value "${value}". Use one of: auto, stream, silent.`);
+      }
+      reporter = value;
+      index += 1;
       continue;
     }
 
@@ -204,9 +242,55 @@ function parseScriptArgs(argv: string[]): { dryRun: boolean; packageManager?: st
     passThrough.push(arg);
   }
 
-  return { dryRun, packageManager, passThrough };
+  return { dryRun, packageManager, passThrough, reporter, verbose };
 }
 
+function isEnabledEnvironmentFlag(value: string | undefined): boolean {
+  return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
+function resolveReporterMode(command: ScriptCommand, parsed: { reporter: LifecycleReporterMode; verbose: boolean }, runtime: ScriptRuntimeOptions): EffectiveLifecycleReporterMode {
+  if (parsed.reporter !== 'auto') {
+    return parsed.reporter;
+  }
+
+  if (parsed.verbose || isEnabledEnvironmentFlag(runtime.env?.FLUO_VERBOSE)) {
+    return 'stream';
+  }
+
+  if (runtime.ci || isEnabledEnvironmentFlag(runtime.env?.CI) || isEnabledEnvironmentFlag(runtime.env?.GITHUB_ACTIONS)) {
+    return 'stream';
+  }
+
+  if (command !== 'dev') {
+    return 'stream';
+  }
+
+  return (runtime.stdout ?? process.stdout).isTTY ? 'pretty' : 'stream';
+}
+
+function renderStep(step: ProjectRunnerStep): string {
+  return `${step.command} ${step.args.join(' ')}`.trim();
+}
+
+function createReporterStreams(mode: EffectiveLifecycleReporterMode, verbose: boolean, stdout: CliStream, stderr: CliStream): { stderr?: CliStream; stdio: 'inherit' | 'pipe'; stdout?: CliStream } {
+  if (mode === 'stream') {
+    return { stdio: 'inherit' };
+  }
+
+  if (mode === 'silent' || mode === 'pretty') {
+    return { stderr, stdio: 'pipe', ...(verbose ? { stdout } : {}) };
+  }
+
+  return { stdio: 'inherit' };
+}
+
+/**
+ * Renders lifecycle command help text.
+ *
+ * @param command Lifecycle command whose help text should be rendered.
+ * @returns Human-readable lifecycle command usage text.
+ */
 export function scriptUsage(command: ScriptCommand): string {
   const nodeEnv = command === 'dev' ? 'development' : 'production';
   return [
@@ -216,10 +300,20 @@ export function scriptUsage(command: ScriptCommand): string {
     '',
     'Options',
     '  --dry-run                              Print the command without running it.',
+    '  --reporter <auto|stream|silent>        Choose lifecycle reporter output mode (default: auto).',
+    '  --verbose                             Expose raw child process output; also honored by FLUO_VERBOSE=1.',
     `  --help                                 Show help for the ${command} command.`,
   ].join('\n');
 }
 
+/**
+ * Runs one generated-project lifecycle command through the CLI-owned runtime command matrix.
+ *
+ * @param command Lifecycle command to run.
+ * @param argv Command-specific arguments after the lifecycle command name.
+ * @param runtime Runtime dependencies used by tests, sandboxes, and embedders.
+ * @returns Process-style exit code from the lifecycle command.
+ */
 export async function runScriptCommand(command: ScriptCommand, argv: string[], runtime: ScriptRuntimeOptions = {}): Promise<number> {
   if (argv.includes('--help') || argv.includes('-h')) {
     (runtime.stdout ?? process.stdout).write(`${scriptUsage(command)}\n`);
@@ -228,6 +322,7 @@ export async function runScriptCommand(command: ScriptCommand, argv: string[], r
 
   const env = runtime.env ?? EMPTY_ENV;
   const stdout = runtime.stdout ?? process.stdout;
+  const stderr = runtime.stderr ?? process.stderr;
   const project = findProjectManifest(runtime.cwd ?? process.cwd());
   if (!project) {
     throw new Error(`Unable to find package.json for fluo ${command}.`);
@@ -239,6 +334,8 @@ export async function runScriptCommand(command: ScriptCommand, argv: string[], r
   const defaultNodeEnv = command === 'dev' ? 'development' : 'production';
   const childEnv = withProjectLocalBin(withDefaultNodeEnv(env, defaultNodeEnv), project.directory);
   const runnerSteps = buildProjectRunner(command, projectRuntime, parsed.passThrough);
+  const reporterMode = resolveReporterMode(command, parsed, { ...runtime, env, stdout });
+  const verbose = parsed.verbose || isEnabledEnvironmentFlag(env.FLUO_VERBOSE);
 
   if (parsed.dryRun) {
     for (const step of runnerSteps) {
@@ -247,12 +344,31 @@ export async function runScriptCommand(command: ScriptCommand, argv: string[], r
     stdout.write(`Project: ${project.path}\n`);
     stdout.write(`Runtime: ${projectRuntime}\n`);
     stdout.write(`NODE_ENV: ${childEnv.NODE_ENV ?? ''}\n`);
+    stdout.write(`Reporter: ${reporterMode}\n`);
     return 0;
   }
 
-  return runProjectRunnerSteps(runnerSteps, { spawnCommand: runtime.spawnCommand ?? defaultSpawnCommand }, {
+  if (reporterMode === 'pretty') {
+    stdout.write(`[fluo] ${command} ${projectRuntime} lifecycle starting\n`);
+    stdout.write(`[fluo] ${runnerSteps.map(renderStep).join(' && ')}\n`);
+  }
+
+  const reporterStreams = createReporterStreams(reporterMode, verbose, stdout, stderr);
+  const exitCode = await runProjectRunnerSteps(runnerSteps, { spawnCommand: runtime.spawnCommand ?? defaultSpawnCommand }, {
     cwd: project.directory,
     env: childEnv,
-    stdio: 'inherit',
+    ...reporterStreams,
   });
+
+  if (reporterMode === 'pretty') {
+    if (exitCode === 0) {
+      stdout.write(`[fluo] ${command} lifecycle ready\n`);
+    } else {
+      stderr.write(`[fluo] ${command} lifecycle failed with exit code ${exitCode}\n`);
+    }
+  } else if (reporterMode === 'silent' && exitCode !== 0) {
+    stderr.write(`[fluo] ${command} lifecycle failed with exit code ${exitCode}\n`);
+  }
+
+  return exitCode;
 }

--- a/packages/cli/src/commands/scripts.ts
+++ b/packages/cli/src/commands/scripts.ts
@@ -128,7 +128,7 @@ function defaultSpawnCommand(command: string, args: string[], options: SpawnComm
       child.stderr?.on('data', (chunk) => options.stderr?.write(String(chunk)));
     }
     child.on('error', reject);
-    child.on('exit', (code) => resolveExitCode(code ?? 1));
+    child.on('close', (code) => resolveExitCode(code ?? 1));
   });
 }
 

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -184,11 +184,22 @@ const adapter = createNodeHttpAdapter({
 
 공개 Node 런타임 surface에서 `maxBodySize`는 바이트 수를 나타내는 숫자만 허용합니다. `'1mb'` 같은 값은 나중에 암묵 변환되지 않고 어댑터 생성 시점에 즉시 거부됩니다.
 
-- `createConsoleApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 컬러 콘솔 로거.
+- `createConsoleApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 컬러 콘솔 로거입니다. 기본값은 기존 pretty 형식을 유지합니다. 더 간결한 `[fluo] LEVEL [context] message` 줄을 원하면 `{ mode: 'minimal' }`, 런타임 로거 출력을 숨기려면 `{ mode: 'silent' }`, 낮은 심각도 메시지를 걸러내려면 `{ level: 'warn' }` 같은 threshold, 결정적인 비컬러 출력을 원하면 `{ color: false }`를 전달하세요.
 - `createJsonApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 구조화된 JSON 로거.
 - `createNodeHttpAdapter()`: 어댑터 우선 런타임 구성을 위한 raw Node `http`/`https` 어댑터 팩토리입니다. primary Node 요청 `content-type`을 JSON/멀티파트 판별 전에 normalize하며, `maxBodySize`는 숫자 바이트 수만 받습니다.
 - `bootstrapNodeApplication()` / `runNodeApplication()`: 호환 패키지와 직접 Node 런타임 흐름에서 사용하는 Node 전용 부트스트랩 헬퍼.
 - `createNodeShutdownSignalRegistration()`, `defaultNodeShutdownSignals()`, `registerShutdownSignals()`: 호스트가 명시적으로 시그널 wiring을 제어할 때 쓰는 종료 등록 헬퍼.
+
+런타임 애플리케이션 로깅은 CLI lifecycle reporting과 별개입니다. 애플리케이션/런타임 자체가 내는 로그를 바꾸고 싶을 때 `ApplicationLogger`를 설정하세요:
+
+```typescript
+import { createConsoleApplicationLogger, createJsonApplicationLogger } from '@fluojs/runtime/node';
+
+const minimalLogger = createConsoleApplicationLogger({ mode: 'minimal', level: 'warn' });
+const jsonLogger = createJsonApplicationLogger();
+```
+
+개발 명령의 raw child-process 출력이 필요하면 대신 `fluo dev --verbose` 같은 CLI reporter flag를 사용하세요.
 
 더 저수준의 Node compression internals는 공개 `@fluojs/runtime/node` 계약이 아니라 `@fluojs/runtime/internal-node` seam 뒤에 둡니다.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -184,11 +184,22 @@ const adapter = createNodeHttpAdapter({
 
 For the public Node runtime surface, `maxBodySize` is a byte-count number only. Values such as `'1mb'` are rejected immediately during adapter creation instead of being coerced later.
 
-- `createConsoleApplicationLogger()`: Colorized console logger using `process.stdout`/`process.stderr`.
+- `createConsoleApplicationLogger()`: Colorized console logger using `process.stdout`/`process.stderr`. The default remains the historical pretty format. Pass `{ mode: 'minimal' }` for concise `[fluo] LEVEL [context] message` lines, `{ mode: 'silent' }` to suppress runtime logger output, `{ level: 'warn' }` or another threshold to filter lower-severity messages, and `{ color: false }` when you need deterministic non-colored output.
 - `createJsonApplicationLogger()`: Structured JSON logger using `process.stdout`/`process.stderr`.
 - `createNodeHttpAdapter()`: Raw Node `http`/`https` adapter factory for adapter-first runtime setup. The helper normalizes the primary Node request `content-type` before JSON/multipart detection and accepts `maxBodySize` only as numeric bytes.
 - `bootstrapNodeApplication()` / `runNodeApplication()`: Node-specific bootstrap helpers used by compatibility packages and direct Node runtime flows.
 - `createNodeShutdownSignalRegistration()`, `defaultNodeShutdownSignals()`, `registerShutdownSignals()`: Shutdown registration helpers for hosts that need explicit signal wiring.
+
+Runtime app logging is separate from CLI lifecycle reporting. Configure `ApplicationLogger` when you want to change logs emitted by the application/runtime itself:
+
+```typescript
+import { createConsoleApplicationLogger, createJsonApplicationLogger } from '@fluojs/runtime/node';
+
+const minimalLogger = createConsoleApplicationLogger({ mode: 'minimal', level: 'warn' });
+const jsonLogger = createJsonApplicationLogger();
+```
+
+Use CLI reporter flags such as `fluo dev --verbose` when you need raw child-process output from the development command instead.
 
 Lower-level Node compression internals stay behind the `@fluojs/runtime/internal-node` seam rather than the public `@fluojs/runtime/node` contract.
 

--- a/packages/runtime/src/logging/json-logger.test.ts
+++ b/packages/runtime/src/logging/json-logger.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createJsonApplicationLogger } from './json-logger.js';
+
+describe('createJsonApplicationLogger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps structured JSON output stable while console logger options evolve', () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const logger = createJsonApplicationLogger();
+    const error = new Error('boom');
+
+    logger.log('Application started', 'Bootstrap');
+    logger.error('Application failed', error, 'Bootstrap');
+
+    const logEntry = JSON.parse(String(stdout.mock.calls[0]?.[0])) as { context: string; level: string; message: string; timestamp: string };
+    const errorEntry = JSON.parse(String(stderr.mock.calls[0]?.[0])) as { context: string; error: { message: string; name: string }; level: string; message: string };
+
+    expect(logEntry).toMatchObject({ context: 'Bootstrap', level: 'log', message: 'Application started' });
+    expect(logEntry.timestamp).toEqual(expect.any(String));
+    expect(errorEntry).toMatchObject({
+      context: 'Bootstrap',
+      error: { message: 'boom', name: 'Error' },
+      level: 'error',
+      message: 'Application failed',
+    });
+  });
+});

--- a/packages/runtime/src/logging/logger.test.ts
+++ b/packages/runtime/src/logging/logger.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createConsoleApplicationLogger } from './logger.js';
+
+describe('createConsoleApplicationLogger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps the default pretty console format compatible', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    createConsoleApplicationLogger({ color: false }).log('Application started', 'Bootstrap');
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]?.[0]).toMatch(/^\[fluo\] \d+ - .+ LOG \[Bootstrap\] Application started$/);
+  });
+
+  it('filters messages below the configured level', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const logger = createConsoleApplicationLogger({ color: false, level: 'warn' });
+
+    logger.debug('debug');
+    logger.log('log');
+    logger.warn('warn');
+    logger.error('error');
+
+    expect(debug).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports minimal output without timestamp and process metadata', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    createConsoleApplicationLogger({ color: false, mode: 'minimal' }).warn('Retrying connection', 'Worker');
+
+    expect(warn).toHaveBeenCalledWith('[fluo] WARN [Worker] Retrying connection');
+  });
+
+  it('suppresses every method in silent mode including error objects', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const logger = createConsoleApplicationLogger({ mode: 'silent' });
+
+    logger.debug('debug');
+    logger.log('log');
+    logger.warn('warn');
+    logger.error('error', new Error('boom'));
+
+    expect(debug).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/runtime/src/logging/logger.ts
+++ b/packages/runtime/src/logging/logger.ts
@@ -1,10 +1,38 @@
 import type { ApplicationLogger } from '../types.js';
 
+/** Severity threshold accepted by `createConsoleApplicationLogger(...)`. */
+export type ConsoleApplicationLoggerLevel = 'debug' | 'error' | 'log' | 'warn';
+/** Console formatting mode accepted by `createConsoleApplicationLogger(...)`. */
+export type ConsoleApplicationLoggerMode = 'minimal' | 'pretty' | 'silent';
+
+/** Options used to tune the Node console logger without replacing the runtime logger contract. */
+export interface ConsoleApplicationLoggerOptions {
+  /**
+   * Controls console formatting.
+   *
+   * - `pretty` keeps the historical timestamp, pid, level, context, and message format.
+   * - `minimal` writes only `[fluo] LEVEL [context] message`.
+   * - `silent` suppresses all logger methods.
+   */
+  mode?: ConsoleApplicationLoggerMode;
+  /** Lowest severity emitted by the logger. Defaults to `debug`, preserving existing output. */
+  level?: ConsoleApplicationLoggerLevel;
+  /** Override TTY-aware ANSI color detection. */
+  color?: boolean;
+}
+
 const RESET = '\u001B[0m';
 const BRIGHT_GREEN = '\u001B[32m';
 const BRIGHT_RED = '\u001B[31m';
 const BRIGHT_YELLOW = '\u001B[33m';
 const DIM = '\u001B[2m';
+
+const LEVEL_PRIORITY: Record<ConsoleApplicationLoggerLevel, number> = {
+  debug: 10,
+  log: 20,
+  warn: 30,
+  error: 40,
+};
 
 function colorize(value: string, color: string, enabled: boolean): string {
   return enabled ? `${color}${value}${RESET}` : value;
@@ -21,28 +49,65 @@ function formatLog(level: 'DEBUG' | 'ERROR' | 'LOG' | 'WARN', context: string, m
   return `${prefix} ${pid} - ${timestamp} ${levelLabel} ${contextLabel} ${message}`;
 }
 
+function formatMinimalLog(level: 'DEBUG' | 'ERROR' | 'LOG' | 'WARN', context: string, message: string, color: boolean): string {
+  const prefix = colorize('[fluo]', BRIGHT_GREEN, color);
+  const levelColor = level === 'ERROR' || level === 'WARN' ? BRIGHT_RED : BRIGHT_GREEN;
+  const levelLabel = colorize(level, levelColor, color);
+  const contextLabel = colorize(`[${context}]`, BRIGHT_YELLOW, color);
+
+  return `${prefix} ${levelLabel} ${contextLabel} ${message}`;
+}
+
+function shouldLog(currentLevel: ConsoleApplicationLoggerLevel, configuredLevel: ConsoleApplicationLoggerLevel): boolean {
+  return LEVEL_PRIORITY[currentLevel] >= LEVEL_PRIORITY[configuredLevel];
+}
+
 /**
  * Create console application logger.
  *
+ * @param options Console logger mode, severity threshold, and color override.
  * @returns The create console application logger result.
  */
-export function createConsoleApplicationLogger(): ApplicationLogger {
+export function createConsoleApplicationLogger(options: ConsoleApplicationLoggerOptions = {}): ApplicationLogger {
+  const mode = options.mode ?? 'pretty';
+  const level = options.level ?? 'debug';
+  const format = mode === 'minimal' ? formatMinimalLog : formatLog;
+
+  if (mode === 'silent') {
+    return {
+      debug() {},
+      error() {},
+      log() {},
+      warn() {},
+    };
+  }
+
   return {
     debug(message, context = 'fluo') {
-      console.debug(formatLog('DEBUG', context, message, Boolean(process.stdout.isTTY)));
+      if (shouldLog('debug', level)) {
+        console.debug(format('DEBUG', context, message, options.color ?? Boolean(process.stdout.isTTY)));
+      }
     },
     error(message, error, context = 'fluo') {
-      console.error(formatLog('ERROR', context, message, Boolean(process.stderr.isTTY)));
+      if (!shouldLog('error', level)) {
+        return;
+      }
+
+      console.error(format('ERROR', context, message, options.color ?? Boolean(process.stderr.isTTY)));
 
       if (error) {
         console.error(error);
       }
     },
     log(message, context = 'fluo') {
-      console.log(formatLog('LOG', context, message, Boolean(process.stdout.isTTY)));
+      if (shouldLog('log', level)) {
+        console.log(format('LOG', context, message, options.color ?? Boolean(process.stdout.isTTY)));
+      }
     },
     warn(message, context = 'fluo') {
-      console.warn(formatLog('WARN', context, message, Boolean(process.stderr.isTTY)));
+      if (shouldLog('warn', level)) {
+        console.warn(format('WARN', context, message, options.color ?? Boolean(process.stderr.isTTY)));
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary

- Closes #1534
- Adds runtime console logger mode/level controls while keeping default pretty console formatting and JSON logger behavior stable.
- Adds a CLI lifecycle reporter boundary for `fluo dev` so TTY sessions get concise fluo status while CI/non-TTY/debugging can keep raw passthrough.

## Changes

- Extended `createConsoleApplicationLogger(...)` with `mode`, `level`, and `color` options.
- Added lifecycle reporter parsing for `--reporter auto|stream|silent`, `--verbose`, and `FLUO_VERBOSE=1` while preserving the `spawnCommand` test seam through equivalent stream-aware options.
- Updated runtime/CLI docs, Korean README mirrors, beginner CLI setup docs, and added a Changeset for `@fluojs/runtime` and `@fluojs/cli`.

## Testing

- `pnpm install --frozen-lockfile` (pass)
- `pnpm exec vitest run packages/runtime/src/logging/logger.test.ts packages/runtime/src/logging/json-logger.test.ts packages/cli/src/cli.test.ts` (pass: 3 files, 143 tests)
- `pnpm build` (pass)
- `pnpm typecheck` (pass)
- `pnpm exec biome lint packages/runtime/src/logging/logger.ts packages/runtime/src/logging/logger.test.ts packages/runtime/src/logging/json-logger.test.ts packages/cli/src/commands/scripts.ts packages/cli/src/cli.ts packages/cli/src/cli.test.ts` (pass)
- `pnpm verify:public-export-tsdoc` (pass)
- LSP diagnostics on changed runtime/CLI source files (pass)

Note: an initial direct `pnpm typecheck` before `pnpm build` failed because workspace package declarations were not built in the fresh worktree; rerunning after `pnpm build` passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; runtime/CLI README mirrors were updated together.