### PR TITLE
Resolve #1541: Patch Dependabot dependency alerts

### DIFF
--- a/tooling/benchmarks/http-comparison/package.json
+++ b/tooling/benchmarks/http-comparison/package.json
@@ -26,7 +26,7 @@
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-fastify": "^11.0.0",
-    "fastify": "^5.0.0",
+    "fastify": "^5.8.5",
     "reflect-metadata": "^0.2.0"
   },
   "devDependencies": {
@@ -36,5 +36,10 @@
     "ts-node": "^10.0.0",
     "tsx": "^4.0.0",
     "typescript": "~5.8.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "fastify": "5.8.5"
+    }
   }
 }

--- a/tooling/benchmarks/http-comparison/pnpm-lock.yaml
+++ b/tooling/benchmarks/http-comparison/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fastify: 5.8.5
+
 importers:
 
   .:
@@ -42,7 +45,7 @@ importers:
         specifier: ^11.0.0
         version: 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))
       fastify:
-        specifier: ^5.0.0
+        specifier: 5.8.5
         version: 5.8.5
       reflect-metadata:
         specifier: ^0.2.0
@@ -584,9 +587,6 @@ packages:
   fastify-raw-body@5.0.0:
     resolution: {integrity: sha512-2qfoaQ3BQDhZ1gtbkKZd6n0kKxJISJGM6u/skD9ljdWItAscjXrtZ1lnjr7PavmXX9j4EyCPmBDiIsLn07d5vA==}
     engines: {node: '>= 10'}
-
-  fastify@5.8.4:
-    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
 
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
@@ -1173,7 +1173,7 @@ snapshots:
       '@nestjs/common': 11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       fast-querystring: 1.1.2
-      fastify: 5.8.4
+      fastify: 5.8.5
       fastify-plugin: 5.1.0
       find-my-way: 9.5.0
       light-my-request: 6.6.0
@@ -1421,24 +1421,6 @@ snapshots:
       fastify-plugin: 5.1.0
       raw-body: 3.0.2
       secure-json-parse: 2.7.0
-
-  fastify@5.8.4:
-    dependencies:
-      '@fastify/ajv-compiler': 4.0.5
-      '@fastify/error': 4.2.0
-      '@fastify/fast-json-stringify-compiler': 5.0.3
-      '@fastify/proxy-addr': 5.1.0
-      abstract-logging: 2.0.1
-      avvio: 9.2.0
-      fast-json-stringify: 6.3.0
-      find-my-way: 9.5.0
-      light-my-request: 6.6.0
-      pino: 10.3.1
-      process-warning: 5.0.0
-      rfdc: 1.4.1
-      secure-json-parse: 4.1.0
-      semver: 7.7.4
-      toad-cache: 3.7.0
 
   fastify@5.8.5:
     dependencies:


### PR DESCRIPTION
## Summary

Patch the open Dependabot dependency alerts by ensuring default-branch dependency sources and lockfiles resolve to non-vulnerable versions for `fastify` and `protobufjs`.

Closes #1541

## Changes

- Added an isolated `pnpm.overrides.fastify` pin in `tooling/benchmarks/http-comparison` so `@nestjs/platform-fastify` resolves `fastify` to `5.8.5` instead of `5.8.4`.
- Raised the benchmark suite's direct `fastify` range to `^5.8.5` and refreshed its nested `pnpm-lock.yaml`.
- Confirmed the root lockfile already resolves `protobufjs` to `7.5.5` and `packages/platform-fastify` already declares `fastify` `^5.8.5`.
- No changeset: this is a dependency/security lockfile and internal benchmark install refresh only; it does not change public `@fluojs/*` package behavior or exported API.

## Testing

- `pnpm install --lockfile-only --frozen-lockfile`
- `pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace install --lockfile-only --frozen-lockfile`
- `pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace install --frozen-lockfile`
- `pnpm --dir tooling/benchmarks/http-comparison --ignore-workspace run typecheck`
- `git grep -n -E 'fastify@(5\\.[3-7]\\.|5\\.8\\.[0-4])|fastify: 5\\.[3-7]\\.|fastify: 5\\.8\\.[0-4]|protobufjs@([0-6]\\.|7\\.[0-4]\\.|7\\.5\\.[0-4])|protobufjs: ([0-6]\\.|7\\.[0-4]\\.|7\\.5\\.[0-4])' -- ':**/pnpm-lock.yaml'` (no matches)
- `pnpm install --frozen-lockfile`
- `pnpm --filter "@fluojs/platform-fastify" test` (35 tests passed)
- LSP diagnostics: no diagnostics for changed `package.json` / `pnpm-lock.yaml`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. Not applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. Not applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. Not applicable; no runtime behavior change.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. Existing platform-fastify tests still pass.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. Not applicable; no governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable.