### PR TITLE
Resolve #1543: Ensure decorator metadata initialization

### DIFF
--- a/.changeset/ensure-decorator-metadata.md
+++ b/.changeset/ensure-decorator-metadata.md
@@ -7,6 +7,7 @@
 "@fluojs/http": patch
 "@fluojs/microservices": patch
 "@fluojs/openapi": patch
+"@fluojs/passport": patch
 "@fluojs/queue": patch
 "@fluojs/serialization": patch
 "@fluojs/throttler": patch

--- a/.changeset/ensure-decorator-metadata.md
+++ b/.changeset/ensure-decorator-metadata.md
@@ -1,12 +1,15 @@
 ---
 "@fluojs/cqrs": patch
 "@fluojs/cron": patch
+"@fluojs/cache-manager": patch
 "@fluojs/event-bus": patch
 "@fluojs/graphql": patch
 "@fluojs/http": patch
 "@fluojs/microservices": patch
+"@fluojs/openapi": patch
 "@fluojs/queue": patch
 "@fluojs/serialization": patch
+"@fluojs/throttler": patch
 "@fluojs/validation": patch
 "@fluojs/websockets": patch
 ---

--- a/.changeset/ensure-decorator-metadata.md
+++ b/.changeset/ensure-decorator-metadata.md
@@ -1,0 +1,14 @@
+---
+"@fluojs/cqrs": patch
+"@fluojs/cron": patch
+"@fluojs/event-bus": patch
+"@fluojs/graphql": patch
+"@fluojs/http": patch
+"@fluojs/microservices": patch
+"@fluojs/queue": patch
+"@fluojs/serialization": patch
+"@fluojs/validation": patch
+"@fluojs/websockets": patch
+---
+
+Ensure first-party standard decorator modules install `Symbol.metadata` before decorated classes evaluate, preventing missing metadata bags in runtimes such as Bun.

--- a/packages/cache-manager/src/decorators.ts
+++ b/packages/cache-manager/src/decorators.ts
@@ -1,3 +1,5 @@
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
+
 import type { CacheEvictDecoratorValue, CacheKeyDecoratorValue } from './types.js';
 
 /** Shared controller metadata key used to store per-route cache metadata records. */
@@ -8,6 +10,8 @@ const cacheEvictMetadataKey = Symbol.for('fluo.cache.evict');
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecoratorContext) => void;
+
+ensureMetadataSymbol();
 
 function getMetadataBag(metadata: unknown): StandardMetadataBag {
   return metadata as StandardMetadataBag;

--- a/packages/cqrs/src/decorators.ts
+++ b/packages/cqrs/src/decorators.ts
@@ -1,4 +1,4 @@
-import { metadataSymbol } from '@fluojs/core/internal';
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
 
 import {
   commandHandlerMetadataSymbol,
@@ -19,9 +19,9 @@ import type {
 type ClassDecoratorLike = (value: Function, context: ClassDecoratorContext) => void;
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
-function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  void metadataSymbol;
+ensureMetadataSymbol();
 
+function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
   if (typeof metadata !== 'object' || metadata === null) {
     throw new Error('Decorator metadata is unavailable. Ensure standard decorators are enabled.');
   }

--- a/packages/cron/src/decorators.ts
+++ b/packages/cron/src/decorators.ts
@@ -1,4 +1,4 @@
-import { metadataSymbol } from '@fluojs/core/internal';
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
 import { Cron as CronValidator } from 'croner';
 
 import { schedulingMetadataSymbol } from './metadata.js';
@@ -15,8 +15,9 @@ type StandardMetadataBag = Record<PropertyKey, unknown>;
 type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecoratorContext) => void;
 type MethodDecoratorLike = StandardMethodDecoratorFn;
 
+ensureMetadataSymbol();
+
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 

--- a/packages/event-bus/src/decorators.ts
+++ b/packages/event-bus/src/decorators.ts
@@ -1,4 +1,4 @@
-import { metadataSymbol } from '@fluojs/core/internal';
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
 
 import type { EventHandlerMetadata, EventType } from './types.js';
 import { eventBusMetadataSymbol } from './metadata.js';
@@ -7,8 +7,9 @@ type StandardMetadataBag = Record<PropertyKey, unknown>;
 type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecoratorContext) => void;
 type MethodDecoratorLike = StandardMethodDecoratorFn;
 
+ensureMetadataSymbol();
+
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 

--- a/packages/graphql/src/decorators.ts
+++ b/packages/graphql/src/decorators.ts
@@ -1,4 +1,4 @@
-import { metadataSymbol } from '@fluojs/core/internal';
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
 
 import {
   argMetadataSymbol,
@@ -26,8 +26,9 @@ type ClassDecoratorLike = StandardClassDecoratorFn;
 type MethodDecoratorLike = StandardMethodDecoratorFn;
 type FieldDecoratorLike = StandardFieldDecoratorFn;
 
+ensureMetadataSymbol();
+
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 

--- a/packages/http/src/decorators.test.ts
+++ b/packages/http/src/decorators.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   getClassValidationRules,
@@ -447,5 +447,26 @@ describe('http decorators', () => {
         },
       },
     ]);
+  });
+
+  it('installs Symbol.metadata when the HTTP decorator module is imported', async () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Symbol, 'metadata');
+
+    vi.resetModules();
+    delete (Symbol as typeof Symbol & { metadata?: symbol }).metadata;
+
+    try {
+      const decoratorModuleSpecifier = './decorators.js?http-ensure-metadata';
+      await import(/* @vite-ignore */ decoratorModuleSpecifier);
+
+      expect(typeof (Symbol as typeof Symbol & { metadata?: symbol }).metadata).toBe('symbol');
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(Symbol, 'metadata', originalDescriptor);
+      } else {
+        delete (Symbol as typeof Symbol & { metadata?: symbol }).metadata;
+      }
+      vi.resetModules();
+    }
   });
 });

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -4,8 +4,8 @@ import {
   type MetadataSource,
 } from '@fluojs/core';
 import {
+  ensureMetadataSymbol,
   getStandardMetadataBag as readStandardMetadataBag,
-  metadataSymbol,
   type ControllerMetadata,
   type DtoFieldBindingMetadata,
 } from '@fluojs/core/internal';
@@ -25,6 +25,8 @@ type FieldDecoratorLike = StandardFieldDecoratorFn;
 const standardControllerMetadataKey = Symbol.for('fluo.standard.controller');
 const standardRouteMetadataKey = Symbol.for('fluo.standard.route');
 const standardDtoBindingMetadataKey = Symbol.for('fluo.standard.dto-binding');
+
+ensureMetadataSymbol();
 
 interface StandardRouteMetadataRecord {
   guards?: GuardLike[];
@@ -68,7 +70,6 @@ function mergeUnique<T>(existing: T[] | undefined, values: T[]): T[] {
 }
 
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 

--- a/packages/microservices/src/decorators.ts
+++ b/packages/microservices/src/decorators.ts
@@ -1,4 +1,4 @@
-import { metadataSymbol } from '@fluojs/core/internal';
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
 
 import { microserviceMetadataSymbol } from './metadata.js';
 import type { HandlerKind, HandlerMetadata, Pattern } from './types.js';
@@ -6,8 +6,9 @@ import type { HandlerKind, HandlerMetadata, Pattern } from './types.js';
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 type MethodDecoratorLike = (value: Function, context: ClassMethodDecoratorContext) => void;
 
+ensureMetadataSymbol();
+
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -1,5 +1,5 @@
 import { type Constructor, type MetadataPropertyKey } from '@fluojs/core';
-import { getStandardMetadataBag } from '@fluojs/core/internal';
+import { ensureMetadataSymbol, getStandardMetadataBag } from '@fluojs/core/internal';
 import type { OpenApiSchemaObject } from './schema-builder.js';
 
 /**
@@ -110,6 +110,8 @@ const openApiMethodSecurityRequirementsKey = Symbol.for('fluo.openapi.method-sec
 const openApiMethodExcludeEndpointKey = Symbol.for('fluo.openapi.method-exclude-endpoint');
 
 type MetadataBag = Record<PropertyKey, unknown>;
+
+ensureMetadataSymbol();
 
 function getMetadataBag(target: object): MetadataBag | undefined {
   return getStandardMetadataBag(target);

--- a/packages/passport/src/decorators.ts
+++ b/packages/passport/src/decorators.ts
@@ -1,3 +1,4 @@
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
 import { UseGuards } from '@fluojs/http';
 
 import { AuthGuard } from './guard.js';
@@ -13,6 +14,8 @@ type RequirementPatch = AuthRequirement;
 
 const standardClassRequirementKey = Symbol.for('fluo.passport.standard.class-auth');
 const standardMethodRequirementKey = Symbol.for('fluo.passport.standard.method-auth');
+
+ensureMetadataSymbol();
 
 function isStandardClassContext(context: unknown): context is ClassDecoratorContext {
   return typeof context === 'object' && context !== null && 'kind' in context && context.kind === 'class';

--- a/packages/passport/src/metadata.test.ts
+++ b/packages/passport/src/metadata.test.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@fluojs/http';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { RequireScopes, UseAuth } from './decorators.js';
 import { getAuthRequirement } from './metadata.js';
@@ -67,5 +67,26 @@ describe('auth metadata scope merge', () => {
 
     expect(secondClassRequirement).toBe(firstClassRequirement);
     expect(secondMethodRequirement).toBe(firstMethodRequirement);
+  });
+
+  it('installs Symbol.metadata when the passport decorator module is imported', async () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(Symbol, 'metadata');
+
+    vi.resetModules();
+    delete (Symbol as typeof Symbol & { metadata?: symbol }).metadata;
+
+    try {
+      const decoratorModuleSpecifier = './decorators.js?passport-ensure-metadata';
+      await import(/* @vite-ignore */ decoratorModuleSpecifier);
+
+      expect(typeof (Symbol as typeof Symbol & { metadata?: symbol }).metadata).toBe('symbol');
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(Symbol, 'metadata', originalDescriptor);
+      } else {
+        delete (Symbol as typeof Symbol & { metadata?: symbol }).metadata;
+      }
+      vi.resetModules();
+    }
   });
 });

--- a/packages/queue/src/decorators.ts
+++ b/packages/queue/src/decorators.ts
@@ -1,4 +1,4 @@
-import { metadataSymbol } from '@fluojs/core/internal';
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
 
 import { queueWorkerMetadataSymbol } from './metadata.js';
 import type { QueueJobType, QueueWorkerMetadata, QueueWorkerOptions } from './types.js';
@@ -6,8 +6,9 @@ import type { QueueJobType, QueueWorkerMetadata, QueueWorkerOptions } from './ty
 type ClassDecoratorLike = (value: Function, context: ClassDecoratorContext) => void;
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
+ensureMetadataSymbol();
+
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 

--- a/packages/serialization/src/metadata.ts
+++ b/packages/serialization/src/metadata.ts
@@ -1,5 +1,5 @@
 import { type MetadataPropertyKey } from '@fluojs/core';
-import { getOwnStandardConstructorMetadataBag, metadataSymbol } from '@fluojs/core/internal';
+import { ensureMetadataSymbol, getOwnStandardConstructorMetadataBag } from '@fluojs/core/internal';
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
@@ -27,12 +27,13 @@ export interface SerializationFieldMetadata {
 const standardSerializationClassMetadataKey = Symbol.for('fluo.standard.serialization.class');
 const standardSerializationFieldMetadataKey = Symbol.for('fluo.standard.serialization.field');
 
+ensureMetadataSymbol();
+
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
   if (metadata === null || metadata === undefined) {
     throw new Error('Decorator metadata is not available. Ensure your environment supports TC39 decorator metadata (Stage 3).');
   }
 
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 

--- a/packages/throttler/src/decorators.ts
+++ b/packages/throttler/src/decorators.ts
@@ -1,3 +1,5 @@
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
+
 import type { ThrottlerHandlerOptions } from './types.js';
 import { validateThrottleOptions } from './validation.js';
 
@@ -12,6 +14,8 @@ type StandardMetadataBag = Record<PropertyKey, unknown>;
 type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecoratorContext) => void;
 type StandardClassDecoratorFn = (value: Function, context: ClassDecoratorContext) => void;
 type ClassOrMethodDecoratorLike = StandardClassDecoratorFn & StandardMethodDecoratorFn;
+
+ensureMetadataSymbol();
 
 function getMetadataBag(metadata: unknown): StandardMetadataBag {
   return metadata as StandardMetadataBag;

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -3,7 +3,7 @@ import {
   type MetadataPropertyKey,
 } from '@fluojs/core';
 import {
-  metadataSymbol,
+  ensureMetadataSymbol,
   type ClassValidationRule,
   type CustomClassValidator,
   type CustomFieldValidator,
@@ -23,12 +23,13 @@ type ValidateClassInput = CustomClassValidator | StandardSchemaV1Like;
 const standardDtoValidationMetadataKey = Symbol.for('fluo.standard.dto-validation');
 const standardClassValidationMetadataKey = Symbol.for('fluo.standard.class-validation');
 
+ensureMetadataSymbol();
+
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
   if (metadata === null || metadata === undefined) {
     throw new Error('Decorator metadata is not available. Ensure your environment supports TC39 decorator metadata (Stage 3).');
   }
 
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 

--- a/packages/websockets/src/decorators.ts
+++ b/packages/websockets/src/decorators.ts
@@ -1,4 +1,4 @@
-import { metadataSymbol } from '@fluojs/core/internal';
+import { ensureMetadataSymbol } from '@fluojs/core/internal';
 
 import { webSocketGatewayMetadataSymbol, webSocketHandlerMetadataSymbol } from './metadata.js';
 import type { WebSocketEventMap, WebSocketGatewayHandlerMetadata, WebSocketGatewayOptions } from './types.js';
@@ -9,8 +9,9 @@ type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecorator
 type ClassDecoratorLike = StandardClassDecoratorFn;
 type MethodDecoratorLike = StandardMethodDecoratorFn;
 
+ensureMetadataSymbol();
+
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  void metadataSymbol;
   return metadata as StandardMetadataBag;
 }
 


### PR DESCRIPTION
## Summary

Resolve #1543 by ensuring first-party standard decorator modules install `Symbol.metadata` before decorated classes evaluate. This prevents Bun/TC39 decorator runs from reaching route/metadata helpers with `context.metadata === undefined`.

Closes #1543.

## Changes

- Replace passive `metadataSymbol` references with top-level `ensureMetadataSymbol()` calls in first-party decorator modules.
- Add HTTP and passport regression tests proving decorator modules install `Symbol.metadata` when imported after the symbol is absent.
- Extend the fix to the same metadata-bag pattern in cache-manager, throttler, OpenAPI, and passport decorators.
- Add a patch changeset for all affected public decorator packages.

## Testing

- `pnpm build`
- `pnpm --filter @fluojs/http --filter @fluojs/validation --filter @fluojs/serialization --filter @fluojs/cqrs --filter @fluojs/cron --filter @fluojs/event-bus --filter @fluojs/queue --filter @fluojs/graphql --filter @fluojs/websockets --filter @fluojs/microservices typecheck`
- `pnpm --filter @fluojs/http --filter @fluojs/validation --filter @fluojs/serialization --filter @fluojs/cqrs --filter @fluojs/cron --filter @fluojs/event-bus --filter @fluojs/queue --filter @fluojs/graphql --filter @fluojs/websockets --filter @fluojs/microservices --filter @fluojs/cache-manager --filter @fluojs/throttler --filter @fluojs/openapi typecheck`
- `pnpm --filter @fluojs/passport typecheck`
- `pnpm --filter @fluojs/http --filter @fluojs/validation --filter @fluojs/serialization --filter @fluojs/cqrs --filter @fluojs/cron --filter @fluojs/event-bus --filter @fluojs/queue --filter @fluojs/graphql --filter @fluojs/websockets --filter @fluojs/microservices test`
- `pnpm --filter @fluojs/http --filter @fluojs/validation --filter @fluojs/serialization --filter @fluojs/cqrs --filter @fluojs/cron --filter @fluojs/event-bus --filter @fluojs/queue --filter @fluojs/graphql --filter @fluojs/websockets --filter @fluojs/microservices --filter @fluojs/cache-manager --filter @fluojs/throttler --filter @fluojs/openapi test` (13 package suites passed)
- `pnpm --filter @fluojs/passport test` (8 files / 85 tests passed)
- LSP diagnostics: clean on all modified source/test files
- CLI generated starter smoke: `pnpm --filter @fluojs/cli sandbox:create`, generated starter `pnpm build`, generated starter `pnpm dev -- --reporter stream` reached `fluo application successfully started`, and generated starter `PORT=31943 pnpm start -- --reporter stream` reached `fluo application successfully started` with no decorator metadata crash.
- Oracle review: PASS, no blockers

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary. No public exports were added or removed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No exported signatures changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. No example contract changed.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. No new behavior surface was introduced; this restores documented standard decorator portability.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. HTTP and passport decorator imports now have regression coverage for `Symbol.metadata` initialization.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. No governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. No platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. No README conformance claims changed.