### PR TITLE
Support Bun legacy HTTP decorator metadata

### DIFF
--- a/.changeset/bun-legacy-http-decorators.md
+++ b/.changeset/bun-legacy-http-decorators.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/core": patch
+"@fluojs/http": patch
+---
+
+Support Bun legacy decorator bundle output for HTTP route metadata while preserving the TC39 standard decorator metadata path.

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -47,7 +47,7 @@ export interface RouteRedirect {
  * Describes the route metadata contract.
  */
 export interface RouteMetadata {
-  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD';
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'ALL';
   path: string;
   request?: new (...args: never[]) => unknown;
   guards?: MetadataCollection;

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -125,6 +125,12 @@ Framework integration이 명시적인 request context boundary나 typed per-requ
 
 Dispatcher는 adapter와 diagnostics를 위해 `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`, `formatFastPathStats(...)`, `getDispatcherFastPathStats(...)`로 fast-path observability를 노출합니다.
 
+### Bun decorator bundling compatibility
+
+Fluo의 HTTP 데코레이터는 TC39 표준 데코레이터이며, runtime 또는 compiler가 표준 decorator context를 제공하면 계속 `context.metadata`를 통해 metadata를 기록합니다. Bun이 legacy TypeScript decorator transform으로 애플리케이션을 번들링하는 경우에도 controller, route, DTO binding, guard/interceptor, header, redirect, versioning, status, request DTO, `@Produces(...)` metadata를 Fluo 내부 metadata store에 기록하여 생성된 Bun bundle의 route mapping 동작을 보존합니다.
+
+이 호환 경로는 Bun bundle output을 위한 실행 fallback입니다. 애플리케이션 소스는 계속 Fluo 표준 데코레이터를 사용해야 하며, `emitDecoratorMetadata`를 켜거나 `reflect-metadata`에 의존해서는 안 됩니다.
+
 ## 요청 정리와 런타임 이식성
 
 디스패처는 활성 dispatch 동안에만 `AsyncLocalStorage`로 `RequestContext`를 바인딩합니다. 요청이 controller graph, middleware, guard, interceptor, observer, DTO converter, custom binder 또는 수동 `getCurrentRequestContext()` / `assertRequestContext()` container 접근을 통해 request-scoped DI를 사용할 수 있으면, 디스패처는 요청 observer가 끝난 뒤 `finally` 경로에서 isolated request-scoped DI 컨테이너를 생성하고 dispose합니다. Singleton-only route는 `RequestContext.container`가 접근되기 전까지 이 컨테이너 lifecycle을 건너뛰어 baseline 경로의 불필요한 per-request allocation을 피하면서도, graph가 모호하거나 request-scoped이면 request-scoped provider isolation을 유지합니다. 따라서 공개 `RequestContext.container` 읽기는 request-scoped provider resolve에 항상 안전합니다. singleton-only fast path는 내부 dispatcher 최적화일 뿐, 공개 context가 root container를 노출한다는 약속이 아닙니다.

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -127,6 +127,12 @@ Use `runWithRequestContext(...)`, `assertRequestContext()`, `createRequestContex
 
 The dispatcher exposes fast-path observability for adapters and diagnostics through `FAST_PATH_ELIGIBILITY_SYMBOL`, `FAST_PATH_STATS_SYMBOL`, `formatFastPathStats(...)`, and `getDispatcherFastPathStats(...)`.
 
+### Bun decorator bundling compatibility
+
+Fluo's HTTP decorators are standard TC39 decorators and continue to record metadata through `context.metadata` when the runtime or compiler provides the standard decorator context. When Bun bundles an application through its legacy TypeScript decorator transform, the same controller, route, DTO binding, guard/interceptor, header, redirect, versioning, status, request DTO, and `@Produces(...)` metadata is recorded through Fluo's internal metadata stores so generated Bun bundles preserve route mapping behavior.
+
+This compatibility path is an execution fallback for Bun bundle output; application source should still use Fluo's standard decorators and should not enable `emitDecoratorMetadata` or rely on `reflect-metadata`.
+
 ## Request Cleanup and Portability
 
 The dispatcher binds `RequestContext` with `AsyncLocalStorage` for the active dispatch only. When a request may use request-scoped DI through its controller graph, middleware, guards, interceptors, observers, DTO converters, a custom binder, or manual `getCurrentRequestContext()` / `assertRequestContext()` container access, the dispatcher creates and disposes an isolated request-scoped DI container from its `finally` path after request observers finish. Singleton-only routes skip that container lifecycle until `RequestContext.container` is accessed, so the baseline path avoids unnecessary per-request allocation while preserving request-scoped provider isolation whenever the graph is ambiguous or request-scoped. Public `RequestContext.container` reads are therefore always safe for resolving request-scoped providers; the singleton-only fast path is an internal dispatcher optimization, not a promise that the public context exposes the root container.

--- a/packages/http/src/decorators.test.ts
+++ b/packages/http/src/decorators.test.ts
@@ -15,12 +15,15 @@ import {
   FromPath,
   FromQuery,
   Get,
+  Header,
   Optional,
   Produces,
   RequestDto,
   HttpCode,
+  Redirect,
   UseGuards,
   UseInterceptors,
+  Version,
   getRouteProducesMetadata,
 } from './decorators.js';
 import { InvalidRoutePathError } from './errors.js';
@@ -32,6 +35,10 @@ class NoopTestConverter {
     return value;
   }
 }
+
+type LegacyClassDecoratorFn = (target: Function) => void;
+type LegacyMethodDecoratorFn = (target: object, propertyKey: string | symbol, descriptor: PropertyDescriptor) => void;
+type LegacyFieldDecoratorFn = (target: object, propertyKey: string | symbol) => void;
 
 describe('http decorators', () => {
   it('writes controller and route metadata using decorator syntax', () => {
@@ -140,6 +147,101 @@ describe('http decorators', () => {
     ]);
 
     expect(getClassValidationRules(ExampleController)).toHaveLength(1);
+  });
+
+  it('writes controller, route, and dto metadata when invoked by legacy decorator transforms', () => {
+    class ClassGuard {
+      canActivate() {}
+    }
+
+    class MethodGuard {
+      canActivate() {}
+    }
+
+    class ClassInterceptor {
+      intercept(_context: unknown, next: { handle(): Promise<unknown> }) {
+        return next.handle();
+      }
+    }
+
+    class MethodInterceptor {
+      intercept(_context: unknown, next: { handle(): Promise<unknown> }) {
+        return next.handle();
+      }
+    }
+
+    class LegacyRequest {
+      id = '';
+      note?: string;
+    }
+
+    (Optional() as unknown as LegacyFieldDecoratorFn)(LegacyRequest.prototype, 'note');
+    (Convert(NoopTestConverter) as unknown as LegacyFieldDecoratorFn)(LegacyRequest.prototype, 'note');
+    (FromBody('note') as unknown as LegacyFieldDecoratorFn)(LegacyRequest.prototype, 'note');
+    (FromPath('id') as unknown as LegacyFieldDecoratorFn)(LegacyRequest.prototype, 'id');
+
+    class LegacyController {
+      getUser() {
+        return { ok: true };
+      }
+    }
+
+    const getUserDescriptor = Object.getOwnPropertyDescriptor(LegacyController.prototype, 'getUser') ?? {};
+
+    (UseInterceptors(MethodInterceptor) as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+    (UseGuards(MethodGuard) as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+    (Redirect('/users/1', 302) as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+    (Header('x-test', 'legacy') as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+    (Get('/:id') as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+    (Produces('application/json') as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+    (Version('1') as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+    (HttpCode(202) as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+    (RequestDto(LegacyRequest) as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUser', getUserDescriptor);
+
+    (UseInterceptors(ClassInterceptor) as unknown as LegacyClassDecoratorFn)(LegacyController);
+    (UseGuards(ClassGuard) as unknown as LegacyClassDecoratorFn)(LegacyController);
+    (Version('2') as unknown as LegacyClassDecoratorFn)(LegacyController);
+    (Controller('/legacy') as unknown as LegacyClassDecoratorFn)(LegacyController);
+
+    expect(getControllerMetadata(LegacyController)).toEqual({
+      basePath: '/legacy',
+      guards: [ClassGuard],
+      interceptors: [ClassInterceptor],
+      version: '2',
+    });
+
+    expect(getRouteMetadata(LegacyController.prototype, 'getUser')).toEqual({
+      guards: [MethodGuard],
+      headers: [{ name: 'x-test', value: 'legacy' }],
+      interceptors: [MethodInterceptor],
+      method: 'GET',
+      path: '/:id',
+      redirect: { url: '/users/1', statusCode: 302 },
+      request: LegacyRequest,
+      successStatus: 202,
+      version: '1',
+    });
+    expect(getRouteProducesMetadata(LegacyController, 'getUser')).toEqual(['application/json']);
+
+    expect(getDtoBindingSchema(LegacyRequest)).toEqual([
+      {
+        propertyKey: 'note',
+        metadata: {
+          converter: NoopTestConverter,
+          key: 'note',
+          optional: true,
+          source: 'body',
+        },
+      },
+      {
+        propertyKey: 'id',
+        metadata: {
+          key: 'id',
+          optional: undefined,
+          source: 'path',
+        },
+      },
+    ]);
   });
 
   it('stores handler-level produced media types', () => {

--- a/packages/http/src/decorators.test.ts
+++ b/packages/http/src/decorators.test.ts
@@ -37,7 +37,7 @@ class NoopTestConverter {
 }
 
 type LegacyClassDecoratorFn = (target: Function) => void;
-type LegacyMethodDecoratorFn = (target: object, propertyKey: string | symbol, descriptor: PropertyDescriptor) => void;
+type LegacyMethodDecoratorFn = (target: object, propertyKey: string | symbol, descriptor?: PropertyDescriptor) => void;
 type LegacyFieldDecoratorFn = (target: object, propertyKey: string | symbol) => void;
 
 describe('http decorators', () => {
@@ -184,6 +184,10 @@ describe('http decorators', () => {
       getUser() {
         return { ok: true };
       }
+
+      getUserWithoutDescriptor() {
+        return { ok: true };
+      }
     }
 
     const getUserDescriptor = Object.getOwnPropertyDescriptor(LegacyController.prototype, 'getUser') ?? {};
@@ -222,6 +226,23 @@ describe('http decorators', () => {
       version: '1',
     });
     expect(getRouteProducesMetadata(LegacyController, 'getUser')).toEqual(['application/json']);
+
+    (Get('/without-descriptor') as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUserWithoutDescriptor');
+    (Produces('application/json') as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUserWithoutDescriptor');
+    (Version('1') as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUserWithoutDescriptor');
+    (HttpCode(204) as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUserWithoutDescriptor');
+    (RequestDto(LegacyRequest) as unknown as LegacyMethodDecoratorFn)(LegacyController.prototype, 'getUserWithoutDescriptor');
+
+    expect(getRouteMetadata(LegacyController.prototype, 'getUserWithoutDescriptor')).toEqual({
+      guards: undefined,
+      interceptors: undefined,
+      method: 'GET',
+      path: '/without-descriptor',
+      request: LegacyRequest,
+      successStatus: 204,
+      version: '1',
+    });
+    expect(getRouteProducesMetadata(LegacyController, 'getUserWithoutDescriptor')).toEqual(['application/json']);
 
     expect(getDtoBindingSchema(LegacyRequest)).toEqual([
       {

--- a/packages/http/src/decorators.ts
+++ b/packages/http/src/decorators.ts
@@ -4,10 +4,17 @@ import {
   type MetadataSource,
 } from '@fluojs/core';
 import {
+  defineControllerMetadata,
+  defineDtoFieldBindingMetadata,
+  defineRouteMetadata,
   ensureMetadataSymbol,
+  getControllerMetadata,
+  getDtoFieldBindingMetadata,
+  getRouteMetadata,
   getStandardMetadataBag as readStandardMetadataBag,
   type ControllerMetadata,
   type DtoFieldBindingMetadata,
+  type RouteMetadata,
 } from '@fluojs/core/internal';
 
 import { validateRoutePath } from './route-path.js';
@@ -17,6 +24,9 @@ type StandardMetadataBag = Record<PropertyKey, unknown>;
 type StandardClassDecoratorFn = (value: Function, context: ClassDecoratorContext) => void;
 type StandardMethodDecoratorFn = (value: Function, context: ClassMethodDecoratorContext) => void;
 type StandardFieldDecoratorFn = <This, Value>(value: undefined, context: ClassFieldDecoratorContext<This, Value>) => void;
+type LegacyClassDecoratorFn = (target: Function) => void;
+type LegacyMethodDecoratorFn = (target: object, propertyKey: MetadataPropertyKey, descriptor?: PropertyDescriptor) => void;
+type LegacyFieldDecoratorFn = (target: object, propertyKey: MetadataPropertyKey) => void;
 type ClassDecoratorLike = StandardClassDecoratorFn;
 type MethodDecoratorLike = StandardMethodDecoratorFn;
 type ClassOrMethodDecoratorLike = StandardClassDecoratorFn & StandardMethodDecoratorFn;
@@ -25,6 +35,9 @@ type FieldDecoratorLike = StandardFieldDecoratorFn;
 const standardControllerMetadataKey = Symbol.for('fluo.standard.controller');
 const standardRouteMetadataKey = Symbol.for('fluo.standard.route');
 const standardDtoBindingMetadataKey = Symbol.for('fluo.standard.dto-binding');
+
+const legacyRouteMetadataStore = new WeakMap<object, Map<MetadataPropertyKey, StandardRouteMetadataRecord>>();
+const legacyDtoBindingMetadataStore = new WeakMap<object, Map<MetadataPropertyKey, Partial<DtoFieldBindingMetadata>>>();
 
 ensureMetadataSymbol();
 
@@ -70,7 +83,149 @@ function mergeUnique<T>(existing: T[] | undefined, values: T[]): T[] {
 }
 
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  return metadata as StandardMetadataBag;
+  return typeof metadata === 'object' && metadata !== null ? metadata as StandardMetadataBag : {};
+}
+
+function isStandardDecoratorContext(value: unknown): value is ClassDecoratorContext | ClassMethodDecoratorContext | ClassFieldDecoratorContext {
+  return typeof value === 'object' && value !== null && 'kind' in value && 'name' in value;
+}
+
+function isMetadataPropertyKey(value: unknown): value is MetadataPropertyKey {
+  return typeof value === 'string' || typeof value === 'symbol';
+}
+
+function getLegacyRouteRecord(target: object, propertyKey: MetadataPropertyKey): StandardRouteMetadataRecord {
+  let routeMap = legacyRouteMetadataStore.get(target);
+
+  if (!routeMap) {
+    routeMap = new Map<MetadataPropertyKey, StandardRouteMetadataRecord>();
+    legacyRouteMetadataStore.set(target, routeMap);
+  }
+
+  let record = routeMap.get(propertyKey);
+
+  if (!record) {
+    record = {};
+    routeMap.set(propertyKey, record);
+  }
+
+  return record;
+}
+
+function flushLegacyRouteMetadata(target: object, propertyKey: MetadataPropertyKey, record: StandardRouteMetadataRecord): void {
+  if (!record.method || record.path === undefined) {
+    return;
+  }
+
+  const existing = getRouteMetadata(target, propertyKey);
+  const metadata: RouteMetadata = {
+    guards: mergeUnique(existing?.guards as GuardLike[] | undefined, record.guards ?? []),
+    headers: record.headers ?? existing?.headers,
+    interceptors: mergeUnique(existing?.interceptors as InterceptorLike[] | undefined, record.interceptors ?? []),
+    method: record.method as RouteMetadata['method'],
+    path: record.path,
+    redirect: record.redirect ?? existing?.redirect,
+    request: record.request ?? existing?.request,
+    successStatus: record.successStatus ?? existing?.successStatus,
+    version: record.version ?? existing?.version,
+  };
+
+  defineRouteMetadata(target, propertyKey, metadata);
+}
+
+function mergeLegacyRouteMetadata(
+  target: object,
+  propertyKey: MetadataPropertyKey,
+  partial: Partial<StandardRouteMetadataRecord>,
+): void {
+  const record = getLegacyRouteRecord(target, propertyKey);
+  Object.assign(record, partial);
+  flushLegacyRouteMetadata(target, propertyKey, record);
+}
+
+function defineLegacyControllerMetadata(target: Function, partial: Partial<ControllerMetadata>): void {
+  const existing = getControllerMetadata(target);
+
+  defineControllerMetadata(target, {
+    basePath: partial.basePath ?? existing?.basePath ?? '',
+    guards: partial.guards ?? existing?.guards,
+    interceptors: partial.interceptors ?? existing?.interceptors,
+    version: partial.version ?? existing?.version,
+  });
+}
+
+function getLegacyDtoBindingRecord(target: object, propertyKey: MetadataPropertyKey): Partial<DtoFieldBindingMetadata> {
+  let bindingMap = legacyDtoBindingMetadataStore.get(target);
+
+  if (!bindingMap) {
+    bindingMap = new Map<MetadataPropertyKey, Partial<DtoFieldBindingMetadata>>();
+    legacyDtoBindingMetadataStore.set(target, bindingMap);
+  }
+
+  let record = bindingMap.get(propertyKey);
+
+  if (!record) {
+    record = {};
+    bindingMap.set(propertyKey, record);
+  }
+
+  return record;
+}
+
+function mergeLegacyDtoBinding(
+  target: object,
+  propertyKey: MetadataPropertyKey,
+  partial: Partial<DtoFieldBindingMetadata>,
+): void {
+  const record = getLegacyDtoBindingRecord(target, propertyKey);
+  Object.assign(record, partial);
+
+  const source = record.source ?? getDtoFieldBindingMetadata(target, propertyKey)?.source;
+
+  if (!source) {
+    return;
+  }
+
+  defineDtoFieldBindingMetadata(target, propertyKey, {
+    converter: record.converter,
+    key: record.key,
+    optional: record.optional,
+    source,
+  });
+}
+
+function appendLegacyRouteHeader(target: object, propertyKey: MetadataPropertyKey, name: string, value: string): void {
+  const record = getLegacyRouteRecord(target, propertyKey);
+  record.headers = [...(record.headers ?? []), { name, value }];
+  flushLegacyRouteMetadata(target, propertyKey, record);
+}
+
+function appendLegacyControllerGuards(target: Function, guards: GuardLike[]): void {
+  const existing = getControllerMetadata(target);
+
+  defineLegacyControllerMetadata(target, {
+    guards: mergeUnique(existing?.guards as GuardLike[] | undefined, guards),
+  });
+}
+
+function appendLegacyControllerInterceptors(target: Function, interceptors: InterceptorLike[]): void {
+  const existing = getControllerMetadata(target);
+
+  defineLegacyControllerMetadata(target, {
+    interceptors: mergeUnique(existing?.interceptors as InterceptorLike[] | undefined, interceptors),
+  });
+}
+
+function appendLegacyRouteGuards(target: object, propertyKey: MetadataPropertyKey, guards: GuardLike[]): void {
+  const record = getLegacyRouteRecord(target, propertyKey);
+  record.guards = mergeUnique(record.guards, guards);
+  flushLegacyRouteMetadata(target, propertyKey, record);
+}
+
+function appendLegacyRouteInterceptors(target: object, propertyKey: MetadataPropertyKey, interceptors: InterceptorLike[]): void {
+  const record = getLegacyRouteRecord(target, propertyKey);
+  record.interceptors = mergeUnique(record.interceptors, interceptors);
+  flushLegacyRouteMetadata(target, propertyKey, record);
 }
 
 function getStandardControllerRecord(metadata: unknown): Partial<ControllerMetadata> {
@@ -141,36 +296,62 @@ function createRouteDecorator(method: HttpMethod) {
   return (path: string): MethodDecoratorLike => {
     validateRoutePath(path, `@${method}() path`);
 
-    const decorator = (_value: Function, context: ClassMethodDecoratorContext) => {
-      const route = getStandardRouteRecord(context.metadata, context.name);
-      route.method = method;
-      route.path = path;
+    const decorator = (valueOrTarget: Function | object, contextOrPropertyKey: ClassMethodDecoratorContext | MetadataPropertyKey) => {
+      if (isStandardDecoratorContext(contextOrPropertyKey)) {
+        const route = getStandardRouteRecord(contextOrPropertyKey.metadata, contextOrPropertyKey.name);
+        route.method = method;
+        route.path = path;
+        return;
+      }
+
+      if (isMetadataPropertyKey(contextOrPropertyKey)) {
+        mergeLegacyRouteMetadata(valueOrTarget, contextOrPropertyKey, { method, path });
+      }
     };
 
-    return decorator as MethodDecoratorLike;
+    return decorator as MethodDecoratorLike & LegacyMethodDecoratorFn;
   };
 }
 
 function createRouteValueDecorator<T>(apply: (record: StandardRouteMetadataRecord, value: T) => void) {
   return (value: T): MethodDecoratorLike => {
-    const decorator = (_target: Function, context: ClassMethodDecoratorContext) => {
-      apply(getStandardRouteRecord(context.metadata, context.name), value);
+    const decorator = (valueOrTarget: Function | object, contextOrPropertyKey: ClassMethodDecoratorContext | MetadataPropertyKey) => {
+      if (isStandardDecoratorContext(contextOrPropertyKey)) {
+        apply(getStandardRouteRecord(contextOrPropertyKey.metadata, contextOrPropertyKey.name), value);
+        return;
+      }
+
+      if (isMetadataPropertyKey(contextOrPropertyKey)) {
+        const record = getLegacyRouteRecord(valueOrTarget, contextOrPropertyKey);
+        apply(record, value);
+        flushLegacyRouteMetadata(valueOrTarget, contextOrPropertyKey, record);
+      }
     };
 
-    return decorator as MethodDecoratorLike;
+    return decorator as MethodDecoratorLike & LegacyMethodDecoratorFn;
   };
 }
 
 function createDtoFieldDecorator(source: MetadataSource) {
   return (key?: string): FieldDecoratorLike => {
-    const decorator = <This, Value>(_value: undefined, context: ClassFieldDecoratorContext<This, Value>) => {
-      mergeStandardDtoBinding(context.metadata, context.name, {
-        key,
-        source,
-      });
+    const decorator = <This, Value>(valueOrTarget: undefined | object, contextOrPropertyKey: ClassFieldDecoratorContext<This, Value> | MetadataPropertyKey) => {
+      if (isStandardDecoratorContext(contextOrPropertyKey)) {
+        mergeStandardDtoBinding(contextOrPropertyKey.metadata, contextOrPropertyKey.name, {
+          key,
+          source,
+        });
+        return;
+      }
+
+      if (isMetadataPropertyKey(contextOrPropertyKey) && valueOrTarget && typeof valueOrTarget === 'object') {
+        mergeLegacyDtoBinding(valueOrTarget, contextOrPropertyKey, {
+          key,
+          source,
+        });
+      }
     };
 
-    return decorator as FieldDecoratorLike;
+    return decorator as FieldDecoratorLike & LegacyFieldDecoratorFn;
   };
 }
 
@@ -183,11 +364,16 @@ function createDtoFieldDecorator(source: MetadataSource) {
 export function Controller(basePath = ''): ClassDecoratorLike {
   validateRoutePath(basePath, '@Controller() base path');
 
-  const decorator = (_target: Function, context: ClassDecoratorContext) => {
-    getStandardControllerRecord(context.metadata).basePath = basePath;
+  const decorator = (target: Function, context?: ClassDecoratorContext) => {
+    if (isStandardDecoratorContext(context)) {
+      getStandardControllerRecord(context.metadata).basePath = basePath;
+      return;
+    }
+
+    defineLegacyControllerMetadata(target, { basePath });
   };
 
-  return decorator as ClassDecoratorLike;
+  return decorator as ClassDecoratorLike & LegacyClassDecoratorFn;
 }
 
 /**
@@ -197,16 +383,28 @@ export function Controller(basePath = ''): ClassDecoratorLike {
  * @returns A decorator that applies version metadata at class or method scope.
  */
 export function Version(version: string): ClassOrMethodDecoratorLike {
-  const decorator = (_target: Function, context: ClassDecoratorContext | ClassMethodDecoratorContext) => {
-    if (context.kind === 'class') {
-      getStandardControllerRecord(context.metadata).version = version;
+  const decorator = (target: Function | object, contextOrPropertyKey?: ClassDecoratorContext | ClassMethodDecoratorContext | MetadataPropertyKey) => {
+    if (isStandardDecoratorContext(contextOrPropertyKey)) {
+      if (contextOrPropertyKey.kind === 'class') {
+        getStandardControllerRecord(contextOrPropertyKey.metadata).version = version;
+        return;
+      }
+
+      getStandardRouteRecord(contextOrPropertyKey.metadata, contextOrPropertyKey.name).version = version;
       return;
     }
 
-    getStandardRouteRecord(context.metadata, context.name).version = version;
+    if (isMetadataPropertyKey(contextOrPropertyKey)) {
+      mergeLegacyRouteMetadata(target, contextOrPropertyKey, { version });
+      return;
+    }
+
+    if (typeof target === 'function') {
+      defineLegacyControllerMetadata(target, { version });
+    }
   };
 
-  return decorator as ClassOrMethodDecoratorLike;
+  return decorator as ClassOrMethodDecoratorLike & LegacyClassDecoratorFn & LegacyMethodDecoratorFn;
 }
 
 /**
@@ -308,7 +506,7 @@ export const HttpCode = createRouteValueDecorator<number>((record, status) => {
 export function getRouteProducesMetadata(controllerToken: Constructor, propertyKey: MetadataPropertyKey): string[] | undefined {
   const bag = readStandardMetadataBag(controllerToken);
   const routeMap = bag?.[standardRouteMetadataKey] as Map<MetadataPropertyKey, StandardRouteMetadataRecord> | undefined;
-  const produces = routeMap?.get(propertyKey)?.produces;
+  const produces = routeMap?.get(propertyKey)?.produces ?? legacyRouteMetadataStore.get(controllerToken.prototype)?.get(propertyKey)?.produces;
 
   return produces ? [...produces] : undefined;
 }
@@ -355,11 +553,18 @@ export const FromBody = createDtoFieldDecorator('body');
  * @returns A field decorator that marks the DTO binding as optional.
  */
 export function Optional(): FieldDecoratorLike {
-  const decorator = <This, Value>(_value: undefined, context: ClassFieldDecoratorContext<This, Value>) => {
-    mergeStandardDtoBinding(context.metadata, context.name, { optional: true });
+  const decorator = <This, Value>(valueOrTarget: undefined | object, contextOrPropertyKey: ClassFieldDecoratorContext<This, Value> | MetadataPropertyKey) => {
+    if (isStandardDecoratorContext(contextOrPropertyKey)) {
+      mergeStandardDtoBinding(contextOrPropertyKey.metadata, contextOrPropertyKey.name, { optional: true });
+      return;
+    }
+
+    if (isMetadataPropertyKey(contextOrPropertyKey) && valueOrTarget && typeof valueOrTarget === 'object') {
+      mergeLegacyDtoBinding(valueOrTarget, contextOrPropertyKey, { optional: true });
+    }
   };
 
-  return decorator as FieldDecoratorLike;
+  return decorator as FieldDecoratorLike & LegacyFieldDecoratorFn;
 }
 
 /**
@@ -369,11 +574,18 @@ export function Optional(): FieldDecoratorLike {
  * @returns A field decorator that stores converter metadata for the DTO field.
  */
 export function Convert(converter: ConverterLike): FieldDecoratorLike {
-  const decorator = <This, Value>(_value: undefined, context: ClassFieldDecoratorContext<This, Value>) => {
-    mergeStandardDtoBinding(context.metadata, context.name, { converter });
+  const decorator = <This, Value>(valueOrTarget: undefined | object, contextOrPropertyKey: ClassFieldDecoratorContext<This, Value> | MetadataPropertyKey) => {
+    if (isStandardDecoratorContext(contextOrPropertyKey)) {
+      mergeStandardDtoBinding(contextOrPropertyKey.metadata, contextOrPropertyKey.name, { converter });
+      return;
+    }
+
+    if (isMetadataPropertyKey(contextOrPropertyKey) && valueOrTarget && typeof valueOrTarget === 'object') {
+      mergeLegacyDtoBinding(valueOrTarget, contextOrPropertyKey, { converter });
+    }
   };
 
-  return decorator as FieldDecoratorLike;
+  return decorator as FieldDecoratorLike & LegacyFieldDecoratorFn;
 }
 
 /**
@@ -384,12 +596,19 @@ export function Convert(converter: ConverterLike): FieldDecoratorLike {
  * @returns A method decorator that appends route-level response-header metadata.
  */
 export function Header(name: string, value: string): MethodDecoratorLike {
-  const decorator = (_target: Function, context: ClassMethodDecoratorContext) => {
-    const route = getStandardRouteRecord(context.metadata, context.name);
-    route.headers = [...(route.headers ?? []), { name, value }];
+  const decorator = (valueOrTarget: Function | object, contextOrPropertyKey: ClassMethodDecoratorContext | MetadataPropertyKey) => {
+    if (isStandardDecoratorContext(contextOrPropertyKey)) {
+      const route = getStandardRouteRecord(contextOrPropertyKey.metadata, contextOrPropertyKey.name);
+      route.headers = [...(route.headers ?? []), { name, value }];
+      return;
+    }
+
+    if (isMetadataPropertyKey(contextOrPropertyKey)) {
+      appendLegacyRouteHeader(valueOrTarget, contextOrPropertyKey, name, value);
+    }
   };
 
-  return decorator as MethodDecoratorLike;
+  return decorator as MethodDecoratorLike & LegacyMethodDecoratorFn;
 }
 
 /**
@@ -400,11 +619,18 @@ export function Header(name: string, value: string): MethodDecoratorLike {
  * @returns A method decorator that writes redirect metadata for the route.
  */
 export function Redirect(url: string, statusCode?: number): MethodDecoratorLike {
-  const decorator = (_target: Function, context: ClassMethodDecoratorContext) => {
-    getStandardRouteRecord(context.metadata, context.name).redirect = { url, statusCode };
+  const decorator = (valueOrTarget: Function | object, contextOrPropertyKey: ClassMethodDecoratorContext | MetadataPropertyKey) => {
+    if (isStandardDecoratorContext(contextOrPropertyKey)) {
+      getStandardRouteRecord(contextOrPropertyKey.metadata, contextOrPropertyKey.name).redirect = { url, statusCode };
+      return;
+    }
+
+    if (isMetadataPropertyKey(contextOrPropertyKey)) {
+      mergeLegacyRouteMetadata(valueOrTarget, contextOrPropertyKey, { redirect: { url, statusCode } });
+    }
   };
 
-  return decorator as MethodDecoratorLike;
+  return decorator as MethodDecoratorLike & LegacyMethodDecoratorFn;
 }
 
 /**
@@ -414,18 +640,30 @@ export function Redirect(url: string, statusCode?: number): MethodDecoratorLike 
  * @returns A decorator applicable to classes and methods.
  */
 export function UseGuards(...guards: GuardLike[]): ClassOrMethodDecoratorLike {
-  const decorator = (_target: Function, context: ClassDecoratorContext | ClassMethodDecoratorContext) => {
-    if (context.kind === 'class') {
-      const controller = getStandardControllerRecord(context.metadata);
-      controller.guards = mergeUnique(controller.guards as GuardLike[] | undefined, guards);
+  const decorator = (target: Function | object, contextOrPropertyKey?: ClassDecoratorContext | ClassMethodDecoratorContext | MetadataPropertyKey) => {
+    if (isStandardDecoratorContext(contextOrPropertyKey)) {
+      if (contextOrPropertyKey.kind === 'class') {
+        const controller = getStandardControllerRecord(contextOrPropertyKey.metadata);
+        controller.guards = mergeUnique(controller.guards as GuardLike[] | undefined, guards);
+        return;
+      }
+
+      const route = getStandardRouteRecord(contextOrPropertyKey.metadata, contextOrPropertyKey.name);
+      route.guards = mergeUnique(route.guards, guards);
       return;
     }
 
-    const route = getStandardRouteRecord(context.metadata, context.name);
-    route.guards = mergeUnique(route.guards, guards);
+    if (isMetadataPropertyKey(contextOrPropertyKey)) {
+      appendLegacyRouteGuards(target, contextOrPropertyKey, guards);
+      return;
+    }
+
+    if (typeof target === 'function') {
+      appendLegacyControllerGuards(target, guards);
+    }
   };
 
-  return decorator as ClassOrMethodDecoratorLike;
+  return decorator as ClassOrMethodDecoratorLike & LegacyClassDecoratorFn & LegacyMethodDecoratorFn;
 }
 
 /**
@@ -435,16 +673,28 @@ export function UseGuards(...guards: GuardLike[]): ClassOrMethodDecoratorLike {
  * @returns A decorator applicable to classes and methods.
  */
 export function UseInterceptors(...interceptors: InterceptorLike[]): ClassOrMethodDecoratorLike {
-  const decorator = (_target: Function, context: ClassDecoratorContext | ClassMethodDecoratorContext) => {
-    if (context.kind === 'class') {
-      const controller = getStandardControllerRecord(context.metadata);
-      controller.interceptors = mergeUnique(controller.interceptors as InterceptorLike[] | undefined, interceptors);
+  const decorator = (target: Function | object, contextOrPropertyKey?: ClassDecoratorContext | ClassMethodDecoratorContext | MetadataPropertyKey) => {
+    if (isStandardDecoratorContext(contextOrPropertyKey)) {
+      if (contextOrPropertyKey.kind === 'class') {
+        const controller = getStandardControllerRecord(contextOrPropertyKey.metadata);
+        controller.interceptors = mergeUnique(controller.interceptors as InterceptorLike[] | undefined, interceptors);
+        return;
+      }
+
+      const route = getStandardRouteRecord(contextOrPropertyKey.metadata, contextOrPropertyKey.name);
+      route.interceptors = mergeUnique(route.interceptors, interceptors);
       return;
     }
 
-    const route = getStandardRouteRecord(context.metadata, context.name);
-    route.interceptors = mergeUnique(route.interceptors, interceptors);
+    if (isMetadataPropertyKey(contextOrPropertyKey)) {
+      appendLegacyRouteInterceptors(target, contextOrPropertyKey, interceptors);
+      return;
+    }
+
+    if (typeof target === 'function') {
+      appendLegacyControllerInterceptors(target, interceptors);
+    }
   };
 
-  return decorator as ClassOrMethodDecoratorLike;
+  return decorator as ClassOrMethodDecoratorLike & LegacyClassDecoratorFn & LegacyMethodDecoratorFn;
 }


### PR DESCRIPTION
## Summary
- Support Bun's legacy decorator transform shape for HTTP controller, route, DTO binding, guard/interceptor, header, redirect, version, status, request DTO, and produces metadata.
- Preserve the TC39 standard decorator metadata path while writing Bun legacy calls into the core explicit metadata stores.
- Add regression coverage for legacy decorator invocation and descriptorless method decorator calls, and align core route metadata with the existing `ALL` route method.

## Changes
- Document the Bun decorator bundling compatibility contract in `packages/http/README.md` and `packages/http/README.ko.md`.
- Add a patch changeset for `@fluojs/core` and `@fluojs/http`.

## Testing
- LSP diagnostics clean for modified TypeScript files
- `pnpm --filter @fluojs/http test -- src/decorators.test.ts`
- `pnpm --filter @fluojs/http typecheck`
- `pnpm --filter @fluojs/core typecheck`
- `pnpm --filter @fluojs/core build && pnpm --filter @fluojs/http build`
- `pnpm changeset status --since main`
- `pnpm verify:release-readiness`
- Packed fixture with Bun 1.3.6: `pnpm install && bun build ./main.ts --outfile ./dist.js --target bun && bun ./dist.js` → `bun legacy metadata ok`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.