### PR TITLE
Fix Bun starter test environment

### DIFF
--- a/.changeset/bun-starter-types.md
+++ b/.changeset/bun-starter-types.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Include Bun globals in generated Bun starter TypeScript configuration so pnpm typecheck succeeds when the starter references `Bun.env`.

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -424,19 +424,30 @@ describe('scaffoldBootstrapApp', () => {
 
     const packageJson = JSON.parse(readFileSync(join(targetDirectory, 'package.json'), 'utf8')) as {
       dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
       scripts?: Record<string, string>;
     };
     const readme = readFileSync(join(targetDirectory, 'README.md'), 'utf8');
+    const appFile = readFileSync(join(targetDirectory, 'src', 'app.ts'), 'utf8');
     const mainFile = readFileSync(join(targetDirectory, 'src', 'main.ts'), 'utf8');
+    const tsconfig = JSON.parse(readFileSync(join(targetDirectory, 'tsconfig.json'), 'utf8')) as {
+      compilerOptions?: { types?: string[] };
+    };
 
     expect(packageJson.dependencies).toMatchObject({
       '@fluojs/platform-bun': expect.any(String),
       '@fluojs/runtime': expect.any(String),
     });
+    expect(packageJson.devDependencies).toMatchObject({
+      '@types/bun': '^1.2.5',
+    });
     expect(packageJson.scripts?.build).toBe('fluo build');
     expect(packageJson.scripts?.dev).toBe('fluo dev');
     expect(packageJson.scripts?.start).toBe('fluo start');
+    expect(tsconfig.compilerOptions?.types).toEqual(['node', 'bun']);
     expect(readme).toContain('Bun runtime + Bun native HTTP via `createBunAdapter(...)`');
+    expect(appFile).toContain('processEnv: process.env');
+    expect(appFile).not.toContain('Bun.env');
     expect(mainFile).toContain("import { createBunAdapter } from '@fluojs/platform-bun';");
     expect(mainFile).toContain("Bun.env.PORT ?? '3000'");
   });

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -236,6 +236,13 @@ function createPublishedDevDependencies(bootstrapPlan: ResolvedBootstrapPlan): R
     return {};
   }
 
+  if (bootstrapPlan.profile.id === 'application-bun-bun-http') {
+    return {
+      ...PUBLISHED_DEV_DEPENDENCIES,
+      '@types/bun': '^1.2.5',
+    };
+  }
+
   if (bootstrapPlan.profile.id === 'application-cloudflare-workers-cloudflare-workers-http') {
     return {
       ...PUBLISHED_DEV_DEPENDENCIES,
@@ -300,7 +307,11 @@ function createProjectPackageJson(
   );
 }
 
-function createProjectTsconfig(): string {
+function createProjectTsconfig(bootstrapPlan: ResolvedBootstrapPlan): string {
+  const types = bootstrapPlan.profile.id === 'application-bun-bun-http'
+    ? ['node', 'bun']
+    : ['node'];
+
   return `{
   "compilerOptions": {
     "target": "ES2022",
@@ -314,7 +325,7 @@ function createProjectTsconfig(): string {
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "rootDir": "src",
-    "types": ["node"]
+    "types": ${JSON.stringify(types)}
   },
   "include": ["src/**/*.ts"]
 }
@@ -681,9 +692,7 @@ export class AppModule {}
 `;
   }
 
-  const processEnvValue = options.runtime === 'bun'
-    ? 'Bun.env'
-    : options.runtime === 'deno'
+  const processEnvValue = options.runtime === 'deno'
       ? 'Deno.env.toObject()'
       : 'process.env';
 
@@ -2036,7 +2045,7 @@ function emitSharedScaffoldFiles(
 
   if (bootstrapPlan.profile.id !== 'application-deno-deno-http') {
     sharedFiles.push(
-      { content: createProjectTsconfig(), path: 'tsconfig.json' },
+      { content: createProjectTsconfig(bootstrapPlan), path: 'tsconfig.json' },
       { content: createProjectTsconfigBuild(), path: 'tsconfig.build.json' },
       { content: createBabelConfig(), path: 'babel.config.cjs' },
       { content: createViteConfig(), path: 'vite.config.ts' },


### PR DESCRIPTION
## Summary
- Add Bun type support to generated Bun starters so `Bun.env` entrypoint usage typechecks under pnpm/tsc.
- Keep generated `src/app.ts` Node/Vitest-safe by using `process.env` for ConfigModule while leaving Bun-only `Bun.env.PORT` in `src/main.ts`.
- Add scaffold regression coverage and a CLI patch changeset.

## Verification
- LSP diagnostics: clean for `packages/cli/src/new/scaffold.ts` and `packages/cli/src/new/scaffold.test.ts`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli test -- src/new/scaffold.test.ts`
- `pnpm --filter @fluojs/cli build`
- Generated Bun starter: `pnpm install && pnpm typecheck && pnpm build && pnpm test`
- `pnpm changeset status`

## Notes
- This fixes the generated Bun starter failures where `tsc` could not find the `Bun` global and Vitest/Node threw `ReferenceError: Bun is not defined` while importing `src/app.ts`.