### PR TITLE
Resolve #1555: Use greeting starter slice

### DIFF
--- a/.changeset/greeting-scaffold.md
+++ b/.changeset/greeting-scaffold.md
@@ -1,5 +1,5 @@
 ---
-"@fluojs/cli": patch
+"@fluojs/cli": minor
 ---
 
-Replace the generated starter-owned health example slice with a greeting feature slice so operational health remains owned by `HealthModule.forRoot(...)`.
+Replace the generated starter-owned `src/health/*` example slice and `/health-info` route with a `src/greeting/*` feature slice exposed at `/greeting`. Runtime operational health remains owned by `HealthModule.forRoot(...)`, so new projects should treat `/health` and `/ready` as runtime endpoints and use the greeting slice as the starter application-structure example.

--- a/.changeset/greeting-scaffold.md
+++ b/.changeset/greeting-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Replace the generated starter-owned health example slice with a greeting feature slice so operational health remains owned by `HealthModule.forRoot(...)`.

--- a/book/beginner/ch02-cli-setup.ko.md
+++ b/book/beginner/ch02-cli-setup.ko.md
@@ -255,11 +255,11 @@ FluoBlog가 커질수록 이 조립 지점은 이후 장에서 더 많은 구성
 - 컴파일된 출력을 어떻게 실행하는지,
 - 그리고 린트나 테스트를 어떻게 연결하는지.
 
-### src/hello.controller.ts와 src/hello.service.ts
+### src/greeting/*
 
-이 두 파일은 기본 스타터가 실제로 응답 가능한 앱이라는 사실을 가장 빨리 보여 줍니다.
+greeting slice는 기본 스타터가 실제로 응답 가능한 앱이라는 사실을 가장 빨리 보여 줍니다.
 
-컨트롤러는 기본 라우트를 노출하고, 서비스는 그 라우트가 반환할 값을 제공합니다. 처음에는 이 한 쌍만 읽어도 요청이 어디로 들어와 어디서 값이 만들어지는지 바로 추적할 수 있습니다.
+컨트롤러는 스타터 라우트를 노출하고, 서비스는 use case를 위임하며, 저장소는 작은 응답 payload를 소유합니다. 처음에는 이 slice만 읽어도 요청이 어디로 들어와 어디서 값이 만들어지는지 바로 추적할 수 있습니다.
 
 ### Reading Before Editing
 
@@ -269,11 +269,11 @@ FluoBlog가 커질수록 이 조립 지점은 이후 장에서 더 많은 구성
 2. 이후 장에서 직접 바꿀 것.
 3. 어떤 파일이 어떤 책임을 가지는지.
 
-### Why the starter includes hello files
+### Why the starter includes greeting files
 
-`hello.controller.ts`와 `hello.service.ts`는 첫 실행 확인을 위한 가장 작은 예제입니다.
+`greeting.controller.ts`, `greeting.service.ts`, `greeting.repo.ts`는 첫 실행 확인을 위한 가장 작은 생성 feature slice입니다.
 
-복잡한 도메인 코드를 넣기 전에, 기본 라우트와 응답이 어디서 오는지 눈으로 확인할 수 있게 해 줍니다. 이 출발점 덕분에 이후 장에서 코드를 바꿨을 때 무엇이 새로 추가된 것인지 더 쉽게 구분할 수 있습니다.
+복잡한 도메인 코드를 넣기 전에 controller, service, repository, DTO, module이 어떻게 맞물리는지 눈으로 확인할 수 있게 해 줍니다. 이 출발점 덕분에 이후 장에서 코드를 바꿨을 때 무엇이 새로 추가된 것인지 더 쉽게 구분할 수 있습니다.
 
 ### Exploring the `node_modules` Folder (Briefly)
 
@@ -375,10 +375,10 @@ pnpm dev
 
 ```bash
 curl http://localhost:3000/health
-curl http://localhost:3000/hello
+curl http://localhost:3000/greeting
 ```
 
-`{"status":"ok"}`와 `{"message":"Hello, World!"}`가 보이면 기본 헬스 체크와 스타터 라우트가 현재 계약대로 함께 정상 동작하고 있다는 의미입니다.
+`{"status":"ok"}`와 `{"message":"Hello from fluo","framework":"fluo","project":"fluo-blog"}` 같은 greeting payload가 보이면 runtime health check와 starter feature route가 현재 계약대로 함께 정상 동작하고 있다는 의미입니다.
 
 ### What You Actually Verified
 
@@ -388,7 +388,7 @@ curl http://localhost:3000/hello
 - 의존성이 정상적으로 설치되었습니다.
 - TypeScript가 개발 모드에서 기대한 방식으로 컴파일 또는 변환되었습니다.
 - 런타임 어댑터가 정상적으로 시작되었습니다.
-- 기본 검증 라우트인 `/health`와 `/hello`에 접근할 수 있습니다.
+- 기본 검증 라우트인 runtime `/health`와 starter-owned `/greeting`에 접근할 수 있습니다.
 
 이 정도만 확인해도 이후 장을 위한 강한 기준선이 마련됩니다.
 

--- a/book/beginner/ch02-cli-setup.md
+++ b/book/beginner/ch02-cli-setup.md
@@ -255,11 +255,11 @@ This file tells you the following.
 - How to run the compiled output,
 - How linting or testing is connected.
 
-### src/hello.controller.ts and src/hello.service.ts
+### src/greeting/*
 
-These two files are the fastest proof that the default starter is an app that can actually respond.
+The greeting slice is the fastest proof that the default starter is an app that can actually respond.
 
-The Controller exposes the default route, and the service provides the value returned by that route. At the beginning, reading only this pair lets you trace where a request enters and where the returned value is created.
+The Controller exposes the starter route, the service delegates the use case, and the repository owns the tiny response payload. At the beginning, reading this slice lets you trace where a request enters and where the returned value is created.
 
 ### Reading Before Editing
 
@@ -269,11 +269,11 @@ Before changing anything, spend a few minutes reading the generated files. That 
 2. What you will change yourself in later chapters.
 3. Which file owns which responsibility.
 
-### Why the starter includes hello files
+### Why the starter includes greeting files
 
-`hello.controller.ts` and `hello.service.ts` are the smallest example for verifying the first run.
+`greeting.controller.ts`, `greeting.service.ts`, and `greeting.repo.ts` are the smallest generated feature slice for verifying the first run.
 
-Before adding complex domain code, they let you see where the default route and response come from. This starting point makes it easier to tell what was newly added when you change code in later chapters.
+Before adding complex domain code, they let you see how a controller, service, repository, DTO, and module fit together. This starting point makes it easier to tell what was newly added when you change code in later chapters.
 
 ### Exploring the `node_modules` Folder (Briefly)
 
@@ -375,10 +375,10 @@ After the server starts, send a real request once.
 
 ```bash
 curl http://localhost:3000/health
-curl http://localhost:3000/hello
+curl http://localhost:3000/greeting
 ```
 
-If you see `{"status":"ok"}` and `{"message":"Hello, World!"}`, the default health check and starter route are both working correctly according to the current contract.
+If you see `{"status":"ok"}` and a greeting payload such as `{"message":"Hello from fluo","framework":"fluo","project":"fluo-blog"}`, the runtime health check and starter feature route are both working correctly according to the current contract.
 
 ### What You Actually Verified
 
@@ -388,7 +388,7 @@ When the first run succeeds, it is easy to underestimate what that request prove
 - Dependencies were installed correctly.
 - TypeScript compiled or transformed as expected in development mode.
 - The runtime adapter started correctly.
-- The default verification routes, `/health` and `/hello`, are reachable.
+- The default verification routes, runtime `/health` and starter-owned `/greeting`, are reachable.
 
 That is enough to give you a strong baseline for the chapters that follow.
 

--- a/docs/getting-started/quick-start.ko.md
+++ b/docs/getting-started/quick-start.ko.md
@@ -121,14 +121,14 @@ Server listening on http://localhost:3000
 
 ```bash
 curl http://localhost:3000/health
-curl http://localhost:3000/hello
+curl http://localhost:3000/greeting
 ```
 
 예상 출력:
 
 ```text
 {"status":"ok"}
-{"message":"Hello, World!"}
+{"message":"Hello from fluo","framework":"fluo","project":"my-fluo-app"}
 ```
 
 ## Invariants
@@ -136,6 +136,6 @@ curl http://localhost:3000/hello
 - `tsconfig.json`에서 `experimentalDecorators`는 비활성화 상태를 유지합니다.
 - `tsconfig.json`에서 `emitDecoratorMetadata`는 비활성화 상태를 유지합니다.
 - 기본 생성 애플리케이션은 `fluo dev`로 위임되는 `pnpm dev` 중 포트 `3000`에서 리슨하며, 생성된 build/start script도 각각 `fluo build`, `fluo start`로 위임됩니다.
-- 기본 생성 애플리케이션은 `/health`와 `/hello`를 노출합니다.
+- 기본 생성 애플리케이션은 runtime `/health`와 starter-owned `/greeting`을 노출합니다.
 - `fluo new` 스타터 변형은 CLI README와 지원 매트릭스에 문서화된 유지보수 대상 스타터 매트릭스에 맞춰집니다.
 - `fluo new --print-plan`은 읽기 전용 preview 경로입니다. 프로젝트 파일 작성, dependency 설치, git 초기화 없이 starter plan과 dependency 세트를 해석합니다.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -121,14 +121,14 @@ Default verification endpoints:
 
 ```bash
 curl http://localhost:3000/health
-curl http://localhost:3000/hello
+curl http://localhost:3000/greeting
 ```
 
 Expected output:
 
 ```text
 {"status":"ok"}
-{"message":"Hello, World!"}
+{"message":"Hello from fluo","framework":"fluo","project":"my-fluo-app"}
 ```
 
 ## Invariants
@@ -136,6 +136,6 @@ Expected output:
 - `tsconfig.json` keeps `experimentalDecorators` disabled.
 - `tsconfig.json` keeps `emitDecoratorMetadata` disabled.
 - The default generated application listens on port `3000` during `pnpm dev`, which delegates to `fluo dev`; generated build/start scripts likewise delegate to `fluo build` and `fluo start`.
-- The default generated application exposes `/health` and `/hello`.
+- The default generated application exposes runtime `/health` plus starter-owned `/greeting`.
 - `fluo new` starter variants map to the maintained starter matrix documented in the CLI README and the support matrix.
 - `fluo new --print-plan` is a read-only preview path. It resolves the starter plan and dependency sets without writing project files, running dependency installation, or initializing git.

--- a/examples/minimal/README.ko.md
+++ b/examples/minimal/README.ko.md
@@ -2,7 +2,7 @@
 
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
-가장 작은 실행 가능한 fluo 애플리케이션입니다. 이 예제는 `fluo new`의 기본/명시적 HTTP v2 스타터가 생성하는 것과 동일한 시작 경로를 따르되, 필수 요소만 남겼습니다.
+가장 작은 실행 가능한 fluo 애플리케이션입니다. 이 예제는 `fluo new`의 기본/명시적 HTTP v2 스타터와 같은 bootstrap 경로를 따르되, 더 작은 `/hello` 경로만 남겼습니다.
 
 ## 이 예제가 보여주는 것
 
@@ -41,7 +41,7 @@ examples/minimal/
 
 ## 스타터 스캐폴드와의 관계
 
-이 예제는 `fluo new` HTTP 스타터 출력의 의도적인 부분 집합입니다. config, health 모듈, 생성된 테스트, 빌드 도구가 포함된 전체 스타터 경험을 원한다면 기본 명령 또는 명시적 v2 HTTP 계약을 사용하세요.
+이 예제는 전체 `fluo new` HTTP 스타터 출력보다 의도적으로 작습니다. config, runtime health endpoint, 생성된 greeting feature slice, 생성된 테스트, 빌드 도구가 포함된 전체 스타터 경험을 원한다면 기본 명령 또는 명시적 HTTP v2 계약을 사용하세요.
 
 ```sh
 pnpm add -g @fluojs/cli

--- a/examples/minimal/README.md
+++ b/examples/minimal/README.md
@@ -2,7 +2,7 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./README.ko.md"><kbd>한국어</kbd></a></p>
 
-The smallest runnable fluo application. This example follows the exact same startup path that `fluo new` generates for the default and explicit HTTP v2 starter, stripped down to the essentials.
+The smallest runnable fluo application. This example follows the same bootstrap path that `fluo new` generates for the default and explicit HTTP v2 starter, stripped down to a smaller `/hello` route.
 
 ## what this example demonstrates
 
@@ -41,7 +41,7 @@ examples/minimal/
 
 ## relationship to the starter scaffold
 
-This example is intentionally a subset of the `fluo new` HTTP starter output. If you want the full starter experience with config, health module, generated tests, and build tooling, run either the default command or the explicit v2 HTTP contract:
+This example is intentionally smaller than the full `fluo new` HTTP starter output. If you want the complete starter experience with config, runtime health endpoints, the generated greeting feature slice, generated tests, and build tooling, run either the default command or the explicit HTTP v2 contract:
 
 ```sh
 pnpm add -g @fluojs/cli

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -3414,13 +3414,13 @@ exit 7
     expect(readFileSync(join(projectDirectory, '.gitignore'), 'utf8')).toContain('.env');
     expect(readFileSync(join(projectDirectory, '.env'), 'utf8')).toContain('PORT=3000');
     expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
-    expect(existsSync(join(projectDirectory, 'src', 'health', 'health.repo.ts'))).toBe(true);
-    expect(existsSync(join(projectDirectory, 'src', 'health', 'health.repo.test.ts'))).toBe(true);
-    expect(existsSync(join(projectDirectory, 'src', 'health', 'health.service.ts'))).toBe(true);
-    expect(existsSync(join(projectDirectory, 'src', 'health', 'health.service.test.ts'))).toBe(true);
-    expect(existsSync(join(projectDirectory, 'src', 'health', 'health.response.dto.ts'))).toBe(true);
-    expect(existsSync(join(projectDirectory, 'src', 'health', 'health.controller.ts'))).toBe(true);
-    expect(existsSync(join(projectDirectory, 'src', 'health', 'health.controller.test.ts'))).toBe(true);
+    expect(existsSync(join(projectDirectory, 'src', 'greeting', 'greeting.repo.ts'))).toBe(true);
+    expect(existsSync(join(projectDirectory, 'src', 'greeting', 'greeting.repo.test.ts'))).toBe(true);
+    expect(existsSync(join(projectDirectory, 'src', 'greeting', 'greeting.service.ts'))).toBe(true);
+    expect(existsSync(join(projectDirectory, 'src', 'greeting', 'greeting.service.test.ts'))).toBe(true);
+    expect(existsSync(join(projectDirectory, 'src', 'greeting', 'greeting.response.dto.ts'))).toBe(true);
+    expect(existsSync(join(projectDirectory, 'src', 'greeting', 'greeting.controller.ts'))).toBe(true);
+    expect(existsSync(join(projectDirectory, 'src', 'greeting', 'greeting.controller.test.ts'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'app.test.ts'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'app.e2e.test.ts'))).toBe(true);
     expect(readmeContent).toContain('Starter contract: `src/main.ts` wires the selected first-class application starter: Node.js runtime + Fastify HTTP via `createFastifyAdapter(...)`');
@@ -3435,10 +3435,10 @@ exit 7
     expect(mainContent).toContain('await app.listen();');
     expect(appTestContent).toContain("createRequest('/health')");
     expect(appTestContent).toContain("createRequest('/ready')");
-    expect(appTestContent).toContain("createRequest('/health-info/')");
+    expect(appTestContent).toContain("createRequest('/greeting/')");
     expect(appE2eTestContent).toContain("path: '/health'");
     expect(appE2eTestContent).toContain("path: '/ready'");
-    expect(appE2eTestContent).toContain("path: '/health-info/'");
+    expect(appE2eTestContent).toContain("path: '/greeting/'");
 
   }, 90000);
 
@@ -3677,7 +3677,7 @@ exit 7
     });
 
     expect(exitCode).toBe(0);
-    expect(readFileSync(join(workspaceDirectory, "starter'app", 'src', 'health', 'health.repo.ts'), 'utf8')).toContain('service: "starter\'app"');
+    expect(readFileSync(join(workspaceDirectory, "starter'app", 'src', 'greeting', 'greeting.repo.ts'), 'utf8')).toContain('project: "starter\'app"');
   });
 
   it('prints generate usage for an unknown schematic', async () => {

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -213,6 +213,8 @@ describe('scaffoldBootstrapApp', () => {
     const tsconfig = readFileSync(join(targetDirectory, 'tsconfig.json'), 'utf8');
     const tsconfigBuild = readFileSync(join(targetDirectory, 'tsconfig.build.json'), 'utf8');
     const appFile = readFileSync(join(targetDirectory, 'src', 'app.ts'), 'utf8');
+    const greetingRepoFile = readFileSync(join(targetDirectory, 'src', 'greeting', 'greeting.repo.ts'), 'utf8');
+    const greetingModuleFile = readFileSync(join(targetDirectory, 'src', 'greeting', 'greeting.module.ts'), 'utf8');
     const viteConfig = readFileSync(join(targetDirectory, 'vite.config.ts'), 'utf8');
     const vitestConfig = readFileSync(join(targetDirectory, 'vitest.config.ts'), 'utf8');
 
@@ -237,7 +239,13 @@ describe('scaffoldBootstrapApp', () => {
     expect(tsconfigBuild).not.toContain('baseUrl');
     expect(appFile).toContain("import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';");
     expect(appFile).toContain('RuntimeHealthModule.forRoot()');
+    expect(appFile).toContain("import { GreetingModule } from './greeting/greeting.module';");
+    expect(appFile).toContain('GreetingModule');
+    expect(appFile).not.toContain('./health/health.module');
     expect(appFile).not.toContain('createHealthModule');
+    expect(greetingRepoFile).toContain('findGreeting');
+    expect(greetingRepoFile).toContain("message: 'Hello from fluo'");
+    expect(greetingModuleFile).toContain('export class GreetingModule');
     expect(viteConfig).toContain("import { defineConfig } from 'vite';");
     expect(viteConfig).not.toContain('baseUrl');
     expect(vitestConfig).toContain("import { fluoBabelDecoratorsPlugin } from '@fluojs/testing/vitest';");
@@ -533,7 +541,7 @@ describe('scaffoldBootstrapApp', () => {
     expect(packageJson.devDependencies).not.toHaveProperty('vitest');
     expect(readme).toContain('Deno runtime + Deno native HTTP via `runDenoApplication(...)`');
     expect(appFile).toContain("Deno.env.toObject()");
-    expect(appFile).toContain("'./health/health.module.ts'");
+    expect(appFile).toContain("'./greeting/greeting.module.ts'");
     expect(mainFile).toContain("import { AppModule } from './app.ts';");
     expect(appTestFile).toContain('Deno.test');
   });

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -448,7 +448,7 @@ function createHttpProjectReadme(options: BootstrapOptions): string {
       : `- CORS: defaults to allowOrigin '*'; pass a \`cors\` option to \`FluoFactory.create(..., { cors, adapter: ${starter.adapterFactory}(...) })\` to restrict origins`;
   const testingSection = options.runtime === 'deno'
     ? `## Official generated testing templates\n\n- \`src/app.test.ts\` — Deno-native integration-style dispatch verification for the generated runtime + starter routes.\n\nUse this test when you need confidence that the generated Deno entrypoint and module graph still agree on the same HTTP contract.`
-    : `## Official generated testing templates\n\n- \`src/health/*.test.ts\` — unit templates for the starter-owned health slice.\n- \`src/app.test.ts\` — integration-style dispatch template for runtime + starter routes.\n- \`src/app.e2e.test.ts\` — e2e-style template powered by \`createTestApp\` from \`@fluojs/testing\`.\n- \`${createExecCommand(options.packageManager, 'fluo g repo User')}\` also adds:\n  - \`src/users/user.repo.test.ts\` (unit template)\n  - \`src/users/user.repo.slice.test.ts\` (slice/integration template via \`createTestingModule\`)\n\nUse unit templates for fast logic checks. Use slice/e2e templates when you need module wiring and route-level confidence.`;
+    : `## Official generated testing templates\n\n- \`src/greeting/*.test.ts\` — unit templates for the starter-owned greeting slice.\n- \`src/app.test.ts\` — integration-style dispatch template for runtime + starter routes.\n- \`src/app.e2e.test.ts\` — e2e-style template powered by \`createTestApp\` from \`@fluojs/testing\`.\n- \`${createExecCommand(options.packageManager, 'fluo g repo User')}\` also adds:\n  - \`src/users/user.repo.test.ts\` (unit template)\n  - \`src/users/user.repo.slice.test.ts\` (slice/integration template via \`createTestingModule\`)\n\nUse unit templates for fast logic checks. Use slice/e2e templates when you need module wiring and route-level confidence.`;
 
   return `# ${options.projectName}
 
@@ -677,12 +677,12 @@ function createAppFile(options: BootstrapOptions): string {
     return `import { Global, Module } from '@fluojs/core';
 import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
 
-import { HealthModule } from './health/health.module';
+import { GreetingModule } from './greeting/greeting.module';
 
 @Global()
 @Module({
   imports: [
-    HealthModule,
+    GreetingModule,
     RuntimeHealthModule.forRoot(),
   ],
 })
@@ -698,7 +698,7 @@ export class AppModule {}
 import { ConfigModule } from '@fluojs/config';
 import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
 
-import { HealthModule } from './health/health.module${importSuffix}';
+import { GreetingModule } from './greeting/greeting.module${importSuffix}';
 
 @Global()
 @Module({
@@ -707,7 +707,7 @@ import { HealthModule } from './health/health.module${importSuffix}';
       envFile: '.env',
       processEnv: ${processEnvValue},
     }),
-    HealthModule,
+    GreetingModule,
     RuntimeHealthModule.forRoot(),
   ],
 })
@@ -715,134 +715,136 @@ export class AppModule {}
 `;
 }
 
-function createHealthResponseDtoFile(): string {
-  return `export class HealthResponseDto {
-  ok!: boolean;
-  service!: string;
+function createGreetingResponseDtoFile(): string {
+  return `export class GreetingResponseDto {
+  message!: string;
+  framework!: 'fluo';
+  project!: string;
 }
 `;
 }
 
-function createHealthRepoFile(projectName: string, importSuffix = ''): string {
-  return `import type { HealthResponseDto } from './health.response.dto${importSuffix}';
+function createGreetingRepoFile(projectName: string, importSuffix = ''): string {
+  return `import type { GreetingResponseDto } from './greeting.response.dto${importSuffix}';
 
-export class HealthRepo {
-  findHealth(): HealthResponseDto {
+export class GreetingRepo {
+  findGreeting(): GreetingResponseDto {
     return {
-      ok: true,
-      service: ${JSON.stringify(projectName)},
+      message: 'Hello from fluo',
+      framework: 'fluo',
+      project: ${JSON.stringify(projectName)},
     };
   }
 }
 `;
 }
 
-function createHealthRepoTestFile(): string {
+function createGreetingRepoTestFile(): string {
   return `import { describe, expect, it } from 'vitest';
 
-import { HealthRepo } from './health.repo';
+import { GreetingRepo } from './greeting.repo';
 
-describe('HealthRepo', () => {
-  it('returns health data', () => {
-    const repo = new HealthRepo();
-    expect(repo.findHealth()).toEqual({ ok: true, service: expect.any(String) });
+describe('GreetingRepo', () => {
+  it('returns greeting data', () => {
+    const repo = new GreetingRepo();
+    expect(repo.findGreeting()).toEqual({ message: 'Hello from fluo', framework: 'fluo', project: expect.any(String) });
   });
 });
 `;
 }
 
-function createHealthServiceFile(importSuffix = ''): string {
+function createGreetingServiceFile(importSuffix = ''): string {
   return `import { Inject } from '@fluojs/core';
-import type { HealthResponseDto } from './health.response.dto${importSuffix}';
+import type { GreetingResponseDto } from './greeting.response.dto${importSuffix}';
 
-import { HealthRepo } from './health.repo${importSuffix}';
+import { GreetingRepo } from './greeting.repo${importSuffix}';
 
-@Inject(HealthRepo)
-export class HealthService {
-  constructor(private readonly repo: HealthRepo) {}
+@Inject(GreetingRepo)
+export class GreetingService {
+  constructor(private readonly repo: GreetingRepo) {}
 
-  getHealth(): HealthResponseDto {
-    return this.repo.findHealth();
+  getGreeting(): GreetingResponseDto {
+    return this.repo.findGreeting();
   }
 }
 `;
 }
 
-function createHealthServiceTestFile(): string {
+function createGreetingServiceTestFile(): string {
   return `import { describe, expect, it } from 'vitest';
 
-import { HealthService } from './health.service';
-import { HealthRepo } from './health.repo';
+import { GreetingService } from './greeting.service';
+import { GreetingRepo } from './greeting.repo';
 
-class FakeHealthRepo {
-  findHealth() {
-    return { ok: true, service: 'test' };
+class FakeGreetingRepo {
+  findGreeting() {
+    return { message: 'Hello from fluo', framework: 'fluo' as const, project: 'test' };
   }
 }
 
-describe('HealthService', () => {
+describe('GreetingService', () => {
   it('delegates to the repo', () => {
-    const service = new HealthService(new FakeHealthRepo() as HealthRepo);
-    expect(service.getHealth()).toEqual({ ok: true, service: 'test' });
+    const service = new GreetingService(new FakeGreetingRepo() as GreetingRepo);
+    expect(service.getGreeting()).toEqual({ message: 'Hello from fluo', framework: 'fluo', project: 'test' });
   });
 });
 `;
 }
 
-function createHealthControllerFile(importSuffix = ''): string {
+function createGreetingControllerFile(importSuffix = ''): string {
   return `import { ensureMetadataSymbol, Inject } from '@fluojs/core';
 import { Controller, Get } from '@fluojs/http';
 
-import { HealthService } from './health.service${importSuffix}';
-import { HealthResponseDto } from './health.response.dto${importSuffix}';
+import { GreetingService } from './greeting.service${importSuffix}';
+import { GreetingResponseDto } from './greeting.response.dto${importSuffix}';
 
 ensureMetadataSymbol();
 
-@Inject(HealthService)
-@Controller('/health-info')
-export class HealthController {
-  constructor(private readonly service: HealthService) {}
+@Inject(GreetingService)
+@Controller('/greeting')
+export class GreetingController {
+  constructor(private readonly service: GreetingService) {}
 
   @Get('/')
-  getHealth(): HealthResponseDto {
-    return this.service.getHealth();
+  getGreeting(): GreetingResponseDto {
+    return this.service.getGreeting();
   }
 }
 `;
 }
 
-function createHealthControllerTestFile(): string {
+function createGreetingControllerTestFile(): string {
   return `import { describe, expect, it } from 'vitest';
 
-import { HealthController } from './health.controller';
+import { GreetingController } from './greeting.controller';
 
-class FakeHealthService {
-  getHealth() {
-    return { ok: true, service: 'test' };
+class FakeGreetingService {
+  getGreeting() {
+    return { message: 'Hello from fluo', framework: 'fluo' as const, project: 'test' };
   }
 }
 
-describe('HealthController', () => {
+describe('GreetingController', () => {
   it('delegates to the service', () => {
-    const controller = new HealthController(new FakeHealthService() as never);
-    expect(controller.getHealth()).toEqual({ ok: true, service: 'test' });
+    const controller = new GreetingController(new FakeGreetingService() as never);
+    expect(controller.getGreeting()).toEqual({ message: 'Hello from fluo', framework: 'fluo', project: 'test' });
   });
 });
 `;
 }
 
-function createHealthModuleFile(importSuffix = ''): string {
+function createGreetingModuleFile(importSuffix = ''): string {
   return `import { Module } from '@fluojs/core';
 
-import { HealthController } from './health.controller${importSuffix}';
-import { HealthRepo } from './health.repo${importSuffix}';
-import { HealthService } from './health.service${importSuffix}';
+import { GreetingController } from './greeting.controller${importSuffix}';
+import { GreetingRepo } from './greeting.repo${importSuffix}';
+import { GreetingService } from './greeting.service${importSuffix}';
 
 @Module({
-  controllers: [HealthController],
-  providers: [HealthRepo, HealthService],
+  controllers: [GreetingController],
+  providers: [GreetingRepo, GreetingService],
 })
-export class HealthModule {}
+export class GreetingModule {}
 `;
 }
 
@@ -1581,12 +1583,12 @@ Generated by @fluojs/cli.
 
 - \`src/app.ts\` — shared application module with config, runtime health endpoints, and the TCP microservice registration.
 - \`src/main.ts\` — Fastify HTTP bootstrap that also starts the attached TCP microservice.
-- \`src/health/*\` — starter-owned HTTP health slice.
+- \`src/greeting/*\` — starter-owned HTTP greeting slice.
 - \`src/math/*\` — starter-owned message handler slice that proves the microservice half of the topology.
 
 ## Official generated testing templates
 
-- \`src/health/*.test.ts\` — unit templates for the HTTP slice.
+- \`src/greeting/*.test.ts\` — unit templates for the HTTP slice.
 - \`src/math/math.handler.test.ts\` — unit template for the microservice handler.
 - \`src/app.test.ts\` — hybrid verification template covering HTTP dispatch plus in-memory message routing with the same shared module contract.
 
@@ -1600,7 +1602,7 @@ import { ConfigModule } from '@fluojs/config';
 import { MicroservicesModule, TcpMicroserviceTransport } from '@fluojs/microservices';
 import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
 
-import { HealthModule } from './health/health.module';
+import { GreetingModule } from './greeting/greeting.module';
 import { MathHandler } from './math/math.handler';
 
 const parsedMicroservicePort = Number.parseInt(process.env.MICROSERVICE_PORT ?? '4000', 10);
@@ -1614,7 +1616,7 @@ const microserviceHost = process.env.MICROSERVICE_HOST ?? '127.0.0.1';
       envFile: '.env',
       processEnv: process.env,
     }),
-    HealthModule,
+    GreetingModule,
     RuntimeHealthModule.forRoot(),
     MicroservicesModule.forRoot({
       transport: new TcpMicroserviceTransport({ host: microserviceHost, port: microservicePort }),
@@ -1656,7 +1658,7 @@ import {
 } from '@fluojs/microservices';
 import { FluoFactory, HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
 
-import { HealthModule } from './health/health.module';
+import { GreetingModule } from './greeting/greeting.module';
 import { MathHandler } from './math/math.handler';
 
 type TransportHandler = Parameters<MicroserviceTransport['listen']>[0];
@@ -1738,7 +1740,7 @@ describe('AppModule mixed starter', () => {
           envFile: '.env',
           processEnv: process.env,
         }),
-        HealthModule,
+        GreetingModule,
         RuntimeHealthModule.forRoot(),
         MicroservicesModule.forRoot({ transport }),
       ],
@@ -1747,13 +1749,13 @@ describe('AppModule mixed starter', () => {
     class TestAppModule {}
 
     const app = await FluoFactory.create(TestAppModule, {});
-    const healthResponse = createResponse();
+    const greetingResponse = createResponse();
 
     const microservice = await app.connectMicroservice();
 
-    await Promise.all([app.startAllMicroservices(), app.dispatch(createRequest('/health-info/'), healthResponse)]);
+    await Promise.all([app.startAllMicroservices(), app.dispatch(createRequest('/greeting/'), greetingResponse)]);
 
-    expect(healthResponse.body).toEqual({ ok: true, service: expect.any(String) });
+    expect(greetingResponse.body).toEqual({ message: 'Hello from fluo', framework: 'fluo', project: expect.any(String) });
     await expect(transport.send('math.sum', { a: 20, b: 22 })).resolves.toBe(42);
     expect(microservice.state).toBe('ready');
 
@@ -1825,13 +1827,13 @@ describe('AppModule', () => {
     await app.close();
   });
 
-  it('dispatches the health-info route', async () => {
+  it('dispatches the greeting route', async () => {
     const app = await FluoFactory.create(AppModule, {});
     const response = createResponse();
 
-    await app.dispatch(createRequest('/health-info/'), response);
+    await app.dispatch(createRequest('/greeting/'), response);
 
-    expect(response.body).toEqual({ ok: true, service: expect.any(String) });
+    expect(response.body).toEqual({ message: 'Hello from fluo', framework: 'fluo', project: expect.any(String) });
 
     await app.close();
   });
@@ -1858,8 +1860,8 @@ describe('AppModule e2e', () => {
       body: { status: 'ready' },
       status: 200,
     });
-    await expect(app.dispatch({ method: 'GET', path: '/health-info/' })).resolves.toMatchObject({
-      body: { ok: true, service: expect.any(String) },
+    await expect(app.dispatch({ method: 'GET', path: '/greeting/' })).resolves.toMatchObject({
+      body: { message: 'Hello from fluo', framework: 'fluo', project: expect.any(String) },
       status: 200,
     });
 
@@ -1919,7 +1921,7 @@ Deno.test('AppModule dispatches the generated Deno starter routes', async () => 
 
   await app.dispatch({ body: undefined, cookies: {}, headers: {}, method: 'GET', params: {}, path: '/health', query: {}, raw: {}, url: '/health' }, healthResponse as never);
   await app.dispatch({ body: undefined, cookies: {}, headers: {}, method: 'GET', params: {}, path: '/ready', query: {}, raw: {}, url: '/ready' }, readyResponse as never);
-  await app.dispatch({ body: undefined, cookies: {}, headers: {}, method: 'GET', params: {}, path: '/health-info/', query: {}, raw: {}, url: '/health-info/' }, infoResponse as never);
+  await app.dispatch({ body: undefined, cookies: {}, headers: {}, method: 'GET', params: {}, path: '/greeting/', query: {}, raw: {}, url: '/greeting/' }, infoResponse as never);
 
   if (JSON.stringify(healthResponse.body) !== JSON.stringify({ status: 'ok' })) {
     throw new Error('Expected /health to return status ok.');
@@ -1930,12 +1932,12 @@ Deno.test('AppModule dispatches the generated Deno starter routes', async () => 
   }
 
   if (typeof infoResponse.body !== 'object' || infoResponse.body === null) {
-    throw new Error('Expected /health-info/ to return an object body.');
+    throw new Error('Expected /greeting/ to return an object body.');
   }
 
-  const infoBody = infoResponse.body as { ok?: unknown; service?: unknown };
-  if (infoBody.ok !== true || typeof infoBody.service !== 'string') {
-    throw new Error('Expected /health-info/ to return the generated service payload.');
+  const infoBody = infoResponse.body as { framework?: unknown; message?: unknown; project?: unknown };
+  if (infoBody.message !== 'Hello from fluo' || infoBody.framework !== 'fluo' || typeof infoBody.project !== 'string') {
+    throw new Error('Expected /greeting/ to return the generated service payload.');
   }
 
   await app.close();
@@ -2063,11 +2065,11 @@ function emitApplicationScaffoldFiles(options: BootstrapOptions): ScaffoldFile[]
   const files: ScaffoldFile[] = [
     { content: createAppFile(options), path: 'src/app.ts' },
     { content: createMainFile(options), path: entrypointPath },
-    { content: createHealthResponseDtoFile(), path: 'src/health/health.response.dto.ts' },
-    { content: createHealthRepoFile(options.projectName, importSuffix), path: 'src/health/health.repo.ts' },
-    { content: createHealthServiceFile(importSuffix), path: 'src/health/health.service.ts' },
-    { content: createHealthControllerFile(importSuffix), path: 'src/health/health.controller.ts' },
-    { content: createHealthModuleFile(importSuffix), path: 'src/health/health.module.ts' },
+    { content: createGreetingResponseDtoFile(), path: 'src/greeting/greeting.response.dto.ts' },
+    { content: createGreetingRepoFile(options.projectName, importSuffix), path: 'src/greeting/greeting.repo.ts' },
+    { content: createGreetingServiceFile(importSuffix), path: 'src/greeting/greeting.service.ts' },
+    { content: createGreetingControllerFile(importSuffix), path: 'src/greeting/greeting.controller.ts' },
+    { content: createGreetingModuleFile(importSuffix), path: 'src/greeting/greeting.module.ts' },
   ];
 
   if (options.runtime === 'deno') {
@@ -2076,9 +2078,9 @@ function emitApplicationScaffoldFiles(options: BootstrapOptions): ScaffoldFile[]
   }
 
   files.push(
-    { content: createHealthRepoTestFile(), path: 'src/health/health.repo.test.ts' },
-    { content: createHealthServiceTestFile(), path: 'src/health/health.service.test.ts' },
-    { content: createHealthControllerTestFile(), path: 'src/health/health.controller.test.ts' },
+    { content: createGreetingRepoTestFile(), path: 'src/greeting/greeting.repo.test.ts' },
+    { content: createGreetingServiceTestFile(), path: 'src/greeting/greeting.service.test.ts' },
+    { content: createGreetingControllerTestFile(), path: 'src/greeting/greeting.controller.test.ts' },
     { content: createAppTestFile(importSuffix), path: 'src/app.test.ts' },
     { content: createAppE2eTestFile(importSuffix), path: 'src/app.e2e.test.ts' },
   );
@@ -2140,14 +2142,14 @@ function emitScaffoldFilesForRecipe(options: BootstrapOptions, recipeId: Starter
     return [
       { content: createMixedAppFile(), path: 'src/app.ts' },
       { content: createMixedMainFile(), path: 'src/main.ts' },
-      { content: createHealthResponseDtoFile(), path: 'src/health/health.response.dto.ts' },
-      { content: createHealthRepoFile(options.projectName), path: 'src/health/health.repo.ts' },
-      { content: createHealthRepoTestFile(), path: 'src/health/health.repo.test.ts' },
-      { content: createHealthServiceFile(), path: 'src/health/health.service.ts' },
-      { content: createHealthServiceTestFile(), path: 'src/health/health.service.test.ts' },
-      { content: createHealthControllerFile(), path: 'src/health/health.controller.ts' },
-      { content: createHealthControllerTestFile(), path: 'src/health/health.controller.test.ts' },
-      { content: createHealthModuleFile(), path: 'src/health/health.module.ts' },
+      { content: createGreetingResponseDtoFile(), path: 'src/greeting/greeting.response.dto.ts' },
+      { content: createGreetingRepoFile(options.projectName), path: 'src/greeting/greeting.repo.ts' },
+      { content: createGreetingRepoTestFile(), path: 'src/greeting/greeting.repo.test.ts' },
+      { content: createGreetingServiceFile(), path: 'src/greeting/greeting.service.ts' },
+      { content: createGreetingServiceTestFile(), path: 'src/greeting/greeting.service.test.ts' },
+      { content: createGreetingControllerFile(), path: 'src/greeting/greeting.controller.ts' },
+      { content: createGreetingControllerTestFile(), path: 'src/greeting/greeting.controller.test.ts' },
+      { content: createGreetingModuleFile(), path: 'src/greeting/greeting.module.ts' },
       { content: createMathHandlerFile({ transport: 'tcp' }), path: 'src/math/math.handler.ts' },
       { content: createMathHandlerTestFile({ transport: 'tcp' }), path: 'src/math/math.handler.test.ts' },
       { content: createMixedAppTestFile(), path: 'src/app.test.ts' },

--- a/tooling/release/local-release-dry-run-matrix.test.ts
+++ b/tooling/release/local-release-dry-run-matrix.test.ts
@@ -100,7 +100,7 @@ function docsFor(publicPackageNames: string[], changelog = packageScopedChangelo
     ['packages/cli/README.md', 'canonical CLI'],
     [
       'packages/cli/src/new/scaffold.ts',
-      "import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';\nRuntimeHealthModule.forRoot()\n@Controller('/health-info')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateFastifyAdapter",
+      "import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';\nRuntimeHealthModule.forRoot()\n@Controller('/greeting')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateFastifyAdapter",
     ],
     ['packages/cli/package.json', JSON.stringify({ bin: { fluo: './bin/fluo.mjs' }, main: './dist/index.js' })],
     ['CHANGELOG.md', changelog],

--- a/tooling/release/release-readiness-summary.ko.md
+++ b/tooling/release/release-readiness-summary.ko.md
@@ -4,7 +4,7 @@
 
 - [x] Canonical bootstrap docs — The quick start guide documents the public `pnpm add -g @fluojs/cli` + `fluo new` path.
 - [x] Repo-local smoke path docs — The repo-local sandbox path is documented in CONTRIBUTING.md as monorepo verification support.
-- [x] Starter shape and runtime ownership — The generated starter uses runtime-owned bootstrap helpers plus a starter-owned health module, without default metrics or OpenAPI surfaces.
+- [x] Starter shape and runtime ownership — The generated starter uses runtime-owned bootstrap helpers plus a starter-owned greeting module, without default metrics or OpenAPI surfaces.
 - [x] Generic-first bootstrap contract — Bootstrap docs and scaffold source no longer encode ORM/DB prompts, support tiers, or starter-time ORM adapter injection.
 - [x] Toolchain contract lock — The toolchain contract matrix documents the generated app baseline plus the canonical fluo command surfaces.
 - [x] Manifest benchmark evidence — Release governance documents the canonical publish surface and the automated release gates.

--- a/tooling/release/release-readiness-summary.md
+++ b/tooling/release/release-readiness-summary.md
@@ -4,7 +4,7 @@
 
 - [x] Canonical bootstrap docs — The quick start guide documents the public `pnpm add -g @fluojs/cli` + `fluo new` path.
 - [x] Repo-local smoke path docs — The repo-local sandbox path is documented in CONTRIBUTING.md as monorepo verification support.
-- [x] Starter shape and runtime ownership — The generated starter uses runtime-owned bootstrap helpers plus a starter-owned health module, without default metrics or OpenAPI surfaces.
+- [x] Starter shape and runtime ownership — The generated starter uses runtime-owned bootstrap helpers plus a starter-owned greeting module, without default metrics or OpenAPI surfaces.
 - [x] Generic-first bootstrap contract — Bootstrap docs and scaffold source no longer encode ORM/DB prompts, support tiers, or starter-time ORM adapter injection.
 - [x] Toolchain contract lock — The toolchain contract matrix documents the generated app baseline plus the canonical fluo command surfaces.
 - [x] Manifest benchmark evidence — Release governance documents the canonical publish surface and the automated release gates.

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -862,7 +862,7 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
     'Starter shape and runtime ownership',
     scaffoldSource.includes("import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';") &&
       scaffoldSource.includes('RuntimeHealthModule.forRoot()') &&
-      scaffoldSource.includes('@Controller(\'/health-info\')') &&
+      scaffoldSource.includes('@Controller(\'/greeting\')') &&
       scaffoldSource.includes('const app = await FluoFactory.create(AppModule, {') &&
       scaffoldSource.includes('adapter: createFastifyAdapter({ port })') &&
       scaffoldSource.includes('await app.listen();') &&
@@ -871,7 +871,7 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
       !scaffoldSource.includes('MetricsModule.forRoot') &&
       !scaffoldSource.includes('OpenApiModule.forRoot') &&
       !scaffoldSource.includes('src/node-http-adapter.ts'),
-    'The generated starter uses runtime-owned bootstrap helpers plus a starter-owned health module, without default metrics or OpenAPI surfaces.',
+    'The generated starter uses runtime-owned bootstrap helpers plus a starter-owned greeting module, without default metrics or OpenAPI surfaces.',
   );
   assertCheck(
     checks,

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -53,7 +53,7 @@ function createDependencies() {
     ['packages/cli/README.md', 'canonical CLI'],
     [
       'packages/cli/src/new/scaffold.ts',
-      "import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';\nRuntimeHealthModule.forRoot()\n@Controller('/health-info')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateFastifyAdapter",
+      "import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';\nRuntimeHealthModule.forRoot()\n@Controller('/greeting')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateFastifyAdapter",
     ],
     ['packages/cli/package.json', JSON.stringify({ bin: { fluo: './bin/fluo.mjs' }, main: './dist/index.js' })],
     ['CHANGELOG.md', changelog],


### PR DESCRIPTION
## Summary

Closes #1555.

Replace the `fluo new` starter-owned health example slice with a small greeting feature slice so operational health remains owned by `HealthModule.forRoot(...)`.

## Changes

- Generate `src/greeting/*` (`GreetingModule`, controller, service, repo, response DTO, tests) instead of starter-owned `src/health/*`.
- Route the example feature at `GET /greeting` while preserving runtime `/health` and `/ready` via `RuntimeHealthModule.forRoot()`.
- Update scaffold tests, CLI e2e assertions, release readiness checks, quick-start/book docs, minimal example notes, and add a CLI minor changeset.

## Testing

- LSP diagnostics on changed TS/MJS files: no diagnostics.
- `pnpm build`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm exec vitest run packages/cli/src/new/scaffold.test.ts packages/cli/src/cli.test.ts`
- `pnpm exec vitest run --project tooling tooling/release/verify-release-readiness.test.ts tooling/release/local-release-dry-run-matrix.test.ts`
- `pnpm exec vitest run --project packages packages/cli/src/runtime-matrix-docs-contract.test.ts`
- `pnpm verify:release-readiness`
- Read-only post-implementation review: no blocking findings.
- Oracle final review: no blocking findings.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary. (No public exports changed.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (No public exports changed.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (Generated starter docs/examples updated.)

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (Generated starter README/docs describe greeting slice and runtime health split.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (No platform contract docs changed.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (No package README conformance claims changed.)