### PR TITLE
Use direct HealthModule in CLI scaffold

### DIFF
--- a/.changeset/cli-scaffold-runtime-health-import.md
+++ b/.changeset/cli-scaffold-runtime-health-import.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Update generated `fluo new` starters to import `HealthModule` directly from `@fluojs/runtime`, call `HealthModule.forRoot()`, and omit explicit metadata symbol setup from the greeting controller scaffold.

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -213,6 +213,7 @@ describe('scaffoldBootstrapApp', () => {
     const tsconfig = readFileSync(join(targetDirectory, 'tsconfig.json'), 'utf8');
     const tsconfigBuild = readFileSync(join(targetDirectory, 'tsconfig.build.json'), 'utf8');
     const appFile = readFileSync(join(targetDirectory, 'src', 'app.ts'), 'utf8');
+    const greetingControllerFile = readFileSync(join(targetDirectory, 'src', 'greeting', 'greeting.controller.ts'), 'utf8');
     const greetingRepoFile = readFileSync(join(targetDirectory, 'src', 'greeting', 'greeting.repo.ts'), 'utf8');
     const greetingModuleFile = readFileSync(join(targetDirectory, 'src', 'greeting', 'greeting.module.ts'), 'utf8');
     const viteConfig = readFileSync(join(targetDirectory, 'vite.config.ts'), 'utf8');
@@ -243,6 +244,8 @@ describe('scaffoldBootstrapApp', () => {
     expect(appFile).toContain('GreetingModule');
     expect(appFile).not.toContain('./health/health.module');
     expect(appFile).not.toContain('createHealthModule');
+    expect(greetingControllerFile).toContain("import { Inject } from '@fluojs/core';");
+    expect(greetingControllerFile).not.toContain('ensureMetadataSymbol');
     expect(greetingRepoFile).toContain('findGreeting');
     expect(greetingRepoFile).toContain("message: 'Hello from fluo'");
     expect(greetingModuleFile).toContain('export class GreetingModule');

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -237,8 +237,8 @@ describe('scaffoldBootstrapApp', () => {
     expect(packageJson.scripts?.start).toBe('fluo start');
     expect(tsconfig).not.toContain('baseUrl');
     expect(tsconfigBuild).not.toContain('baseUrl');
-    expect(appFile).toContain("import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';");
-    expect(appFile).toContain('RuntimeHealthModule.forRoot()');
+    expect(appFile).toContain("import { HealthModule } from '@fluojs/runtime';");
+    expect(appFile).toContain('HealthModule.forRoot()');
     expect(appFile).toContain("import { GreetingModule } from './greeting/greeting.module';");
     expect(appFile).toContain('GreetingModule');
     expect(appFile).not.toContain('./health/health.module');
@@ -588,8 +588,8 @@ describe('scaffoldBootstrapApp', () => {
     expect(readDirectorySnapshot(targetDirectory)).not.toHaveProperty('.env');
     expect(readme).toContain('Cloudflare Workers runtime + Cloudflare Workers HTTP via `createCloudflareWorkerEntrypoint(...)`');
     expect(appFile).not.toContain('ConfigModule.forRoot');
-    expect(appFile).toContain("import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';");
-    expect(appFile).toContain('RuntimeHealthModule.forRoot()');
+    expect(appFile).toContain("import { HealthModule } from '@fluojs/runtime';");
+    expect(appFile).toContain('HealthModule.forRoot()');
     expect(appFile).not.toContain('createHealthModule');
     expect(workerFile).toContain('createCloudflareWorkerEntrypoint(AppModule)');
     expect(wranglerConfig).toContain('src/worker.ts');
@@ -939,13 +939,13 @@ describe('scaffoldBootstrapApp', () => {
     expect(envFile).toContain('PORT=3000');
     expect(envFile).toContain('MICROSERVICE_PORT=4000');
     expect(appFile).toContain('MicroservicesModule.forRoot');
-    expect(appFile).toContain("import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';");
-    expect(appFile).toContain('RuntimeHealthModule.forRoot()');
+    expect(appFile).toContain("import { HealthModule } from '@fluojs/runtime';");
+    expect(appFile).toContain('HealthModule.forRoot()');
     expect(appFile).not.toContain('createHealthModule');
     expect(mainFile).toContain('await app.connectMicroservice();');
     expect(mainFile).toContain('await app.startAllMicroservices();');
     expect(appTestFile).toContain('InMemoryLoopbackTransport');
-    expect(appTestFile).toContain('RuntimeHealthModule.forRoot()');
+    expect(appTestFile).toContain('HealthModule.forRoot()');
     expect(appTestFile).not.toContain('createHealthModule');
     expect(readDirectorySnapshot(targetDirectory)).not.toHaveProperty('src/microservice.ts');
   });

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -792,13 +792,11 @@ describe('GreetingService', () => {
 }
 
 function createGreetingControllerFile(importSuffix = ''): string {
-  return `import { ensureMetadataSymbol, Inject } from '@fluojs/core';
+  return `import { Inject } from '@fluojs/core';
 import { Controller, Get } from '@fluojs/http';
 
 import { GreetingService } from './greeting.service${importSuffix}';
 import { GreetingResponseDto } from './greeting.response.dto${importSuffix}';
-
-ensureMetadataSymbol();
 
 @Inject(GreetingService)
 @Controller('/greeting')

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -675,7 +675,7 @@ function createAppFile(options: BootstrapOptions): string {
 
   if (options.runtime === 'cloudflare-workers') {
     return `import { Global, Module } from '@fluojs/core';
-import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
+import { HealthModule } from '@fluojs/runtime';
 
 import { GreetingModule } from './greeting/greeting.module';
 
@@ -683,7 +683,7 @@ import { GreetingModule } from './greeting/greeting.module';
 @Module({
   imports: [
     GreetingModule,
-    RuntimeHealthModule.forRoot(),
+    HealthModule.forRoot(),
   ],
 })
 export class AppModule {}
@@ -696,7 +696,7 @@ export class AppModule {}
 
   return `import { Global, Module } from '@fluojs/core';
 import { ConfigModule } from '@fluojs/config';
-import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
+import { HealthModule } from '@fluojs/runtime';
 
 import { GreetingModule } from './greeting/greeting.module${importSuffix}';
 
@@ -708,7 +708,7 @@ import { GreetingModule } from './greeting/greeting.module${importSuffix}';
       processEnv: ${processEnvValue},
     }),
     GreetingModule,
-    RuntimeHealthModule.forRoot(),
+    HealthModule.forRoot(),
   ],
 })
 export class AppModule {}
@@ -1600,7 +1600,7 @@ function createMixedAppFile(): string {
   return `import { Global, Module } from '@fluojs/core';
 import { ConfigModule } from '@fluojs/config';
 import { MicroservicesModule, TcpMicroserviceTransport } from '@fluojs/microservices';
-import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
+import { HealthModule } from '@fluojs/runtime';
 
 import { GreetingModule } from './greeting/greeting.module';
 import { MathHandler } from './math/math.handler';
@@ -1617,7 +1617,7 @@ const microserviceHost = process.env.MICROSERVICE_HOST ?? '127.0.0.1';
       processEnv: process.env,
     }),
     GreetingModule,
-    RuntimeHealthModule.forRoot(),
+    HealthModule.forRoot(),
     MicroservicesModule.forRoot({
       transport: new TcpMicroserviceTransport({ host: microserviceHost, port: microservicePort }),
     }),
@@ -1656,7 +1656,7 @@ import {
   MicroservicesModule,
   type MicroserviceTransport,
 } from '@fluojs/microservices';
-import { FluoFactory, HealthModule as RuntimeHealthModule } from '@fluojs/runtime';
+import { FluoFactory, HealthModule } from '@fluojs/runtime';
 
 import { GreetingModule } from './greeting/greeting.module';
 import { MathHandler } from './math/math.handler';
@@ -1741,7 +1741,7 @@ describe('AppModule mixed starter', () => {
           processEnv: process.env,
         }),
         GreetingModule,
-        RuntimeHealthModule.forRoot(),
+        HealthModule.forRoot(),
         MicroservicesModule.forRoot({ transport }),
       ],
       providers: [MathHandler],

--- a/tooling/release/local-release-dry-run-matrix.test.ts
+++ b/tooling/release/local-release-dry-run-matrix.test.ts
@@ -100,7 +100,7 @@ function docsFor(publicPackageNames: string[], changelog = packageScopedChangelo
     ['packages/cli/README.md', 'canonical CLI'],
     [
       'packages/cli/src/new/scaffold.ts',
-      "import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';\nRuntimeHealthModule.forRoot()\n@Controller('/greeting')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateFastifyAdapter",
+      "import { HealthModule } from '@fluojs/runtime';\nHealthModule.forRoot()\n@Controller('/greeting')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateFastifyAdapter",
     ],
     ['packages/cli/package.json', JSON.stringify({ bin: { fluo: './bin/fluo.mjs' }, main: './dist/index.js' })],
     ['CHANGELOG.md', changelog],

--- a/tooling/release/verify-release-readiness.mjs
+++ b/tooling/release/verify-release-readiness.mjs
@@ -860,8 +860,8 @@ export function runReleaseReadinessVerification(options = {}, dependencies = {})
   assertCheck(
     checks,
     'Starter shape and runtime ownership',
-    scaffoldSource.includes("import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';") &&
-      scaffoldSource.includes('RuntimeHealthModule.forRoot()') &&
+    scaffoldSource.includes("import { HealthModule } from '@fluojs/runtime';") &&
+      scaffoldSource.includes('HealthModule.forRoot()') &&
       scaffoldSource.includes('@Controller(\'/greeting\')') &&
       scaffoldSource.includes('const app = await FluoFactory.create(AppModule, {') &&
       scaffoldSource.includes('adapter: createFastifyAdapter({ port })') &&

--- a/tooling/release/verify-release-readiness.test.ts
+++ b/tooling/release/verify-release-readiness.test.ts
@@ -53,7 +53,7 @@ function createDependencies() {
     ['packages/cli/README.md', 'canonical CLI'],
     [
       'packages/cli/src/new/scaffold.ts',
-      "import { HealthModule as RuntimeHealthModule } from '@fluojs/runtime';\nRuntimeHealthModule.forRoot()\n@Controller('/greeting')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateFastifyAdapter",
+      "import { HealthModule } from '@fluojs/runtime';\nHealthModule.forRoot()\n@Controller('/greeting')\nconst app = await FluoFactory.create(AppModule, {\nadapter: createFastifyAdapter({ port })\nawait app.listen();\ncreateFastifyAdapter",
     ],
     ['packages/cli/package.json', JSON.stringify({ bin: { fluo: './bin/fluo.mjs' }, main: './dist/index.js' })],
     ['CHANGELOG.md', changelog],


### PR DESCRIPTION
## Summary
- Update `fluo new` application and mixed starter templates to import `HealthModule` directly from `@fluojs/runtime`.
- Replace generated `RuntimeHealthModule.forRoot()` calls with `HealthModule.forRoot()` in app and mixed test scaffold output.
- Align scaffold and release readiness assertions with the direct import contract.

## Verification
- LSP diagnostics: `packages/cli/src/new/scaffold.ts`, `packages/cli/src/new/scaffold.test.ts`, `tooling/release/verify-release-readiness.mjs`, `tooling/release/verify-release-readiness.test.ts`, `tooling/release/local-release-dry-run-matrix.test.ts`
- `pnpm exec vitest run packages/cli/src/new/scaffold.test.ts tooling/release/verify-release-readiness.test.ts tooling/release/local-release-dry-run-matrix.test.ts`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli build`