### PR TITLE
Preserve Bun lifecycle colors

### DIFF
--- a/.changeset/bun-lifecycle-color-tty.md
+++ b/.changeset/bun-lifecycle-color-tty.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Preserve Bun app terminal color detection when `fluo dev` or `fluo start` pipes child output through the CLI lifecycle reporter.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -2269,6 +2269,35 @@ void bootstrap();
     await expect(runPromise).resolves.toBe(0);
   });
 
+  it('preserves app child TTY color detection in the Bun dev runner when pretty mode requests it', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(join(workspaceDirectory, 'src', 'main.ts'), '');
+    const children: Array<{ args: string[]; child: ChildProcess; command: string }> = [];
+
+    const runPromise = runNodeRestartRunner({
+      env: { FLUO_DEV_PRETTY_TTY_COLOR: '1' },
+      projectDirectory: workspaceDirectory,
+      runtime: 'bun',
+      signalTarget: createSignalTarget().target,
+      spawnChild: (command, args) => {
+        const child = createMockChild();
+        children.push({ args, child, command });
+        return child;
+      },
+      watchTarget: () => ({ close() {} }) as never,
+    });
+
+    expect(children[0]?.command).toBe('bun');
+    expect(children[0]?.args[0]).toBe('--preload');
+    expect(children[0]?.args[1]?.endsWith('preserve-color-tty.js')).toBe(true);
+    expect(children[0]?.args.slice(2)).toEqual(['src/main.ts']);
+
+    children[0]?.child.emit('close', 0);
+    await expect(runPromise).resolves.toBe(0);
+  });
+
   it('prefixes multiline child output in explicit non-verbose pretty reporter runs', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);
@@ -2492,6 +2521,37 @@ exit 7
     expect(spawned[0]?.forceColor).toBe('1');
     expect(spawned[0]?.prettyTtyColor).toBe('1');
     expect(spawned[0]?.args[0]).toBe('--import');
+    expect(spawned[0]?.args[1]?.endsWith('preserve-color-tty.js')).toBe(true);
+    expect(spawned[0]?.args.slice(2)).toEqual(['dist/main.js']);
+  });
+
+  it('preserves TTY color detection for direct Bun app lifecycle runs', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    writeFileSync(
+      join(workspaceDirectory, 'package.json'),
+      JSON.stringify({ dependencies: { '@fluojs/platform-bun': '^1.0.0' }, name: 'test-app', scripts: { start: 'fluo start' } }, null, 2),
+    );
+    const spawned: Array<{ args: string[]; command: string; forceColor?: string; prettyTtyColor?: string; stdio: string }> = [];
+
+    const exitCode = await runCli(['start'], {
+      cwd: workspaceDirectory,
+      env: {},
+      spawnCommand: async (command, args, options) => {
+        spawned.push({ args, command, forceColor: options.env.FORCE_COLOR, prettyTtyColor: options.env.FLUO_DEV_PRETTY_TTY_COLOR, stdio: options.stdio });
+        return 0;
+      },
+      stderr: { isTTY: true, write: () => undefined },
+      stdout: { isTTY: true, write: () => undefined },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0]?.command).toBe('bun');
+    expect(spawned[0]?.stdio).toBe('pipe');
+    expect(spawned[0]?.forceColor).toBe('1');
+    expect(spawned[0]?.prettyTtyColor).toBe('1');
+    expect(spawned[0]?.args[0]).toBe('--preload');
     expect(spawned[0]?.args[1]?.endsWith('preserve-color-tty.js')).toBe(true);
     expect(spawned[0]?.args.slice(2)).toEqual(['dist/main.js']);
   });

--- a/packages/cli/src/commands/scripts.ts
+++ b/packages/cli/src/commands/scripts.ts
@@ -229,17 +229,21 @@ async function runProjectRunnerSteps(
   return 0;
 }
 
-function withPipedNodeColorTtyImport(steps: ProjectRunnerStep[], env: NodeJS.ProcessEnv): ProjectRunnerStep[] {
+function withPipedAppColorTtyBootstrap(steps: ProjectRunnerStep[], env: NodeJS.ProcessEnv): ProjectRunnerStep[] {
   if (env[PRETTY_TTY_COLOR_ENV] !== '1') {
     return steps;
   }
 
   return steps.map((step) => {
-    if (step.command !== 'node' || step.mode === 'fluo-restart') {
-      return step;
+    if (step.command === 'node' && step.mode !== 'fluo-restart') {
+      return { ...step, args: ['--import', getPreserveColorTtyImport(), ...step.args] };
     }
 
-    return { ...step, args: ['--import', getPreserveColorTtyImport(), ...step.args] };
+    if (step.command === 'bun' && step.args[0] === 'dist/main.js') {
+      return { ...step, args: ['--preload', getPreserveColorTtyImport(), ...step.args] };
+    }
+
+    return step;
   });
 }
 
@@ -492,7 +496,7 @@ export async function runScriptCommand(command: ScriptCommand, argv: string[], r
   const reporterMode = resolveReporterMode(parsed, { ...runtime, env, stdout });
   const verbose = parsed.verbose || isEnabledEnvironmentFlag(env.FLUO_VERBOSE);
   const childEnv = withPipedReporterColorEnv(withProjectLocalBin(withDefaultNodeEnv(env, defaultNodeEnv), project.directory), reporterMode, stdout, stderr);
-  const colorAwareRunnerSteps = withPipedNodeColorTtyImport(runnerSteps, childEnv);
+  const colorAwareRunnerSteps = withPipedAppColorTtyBootstrap(runnerSteps, childEnv);
 
   if (command === 'dev' && (reporterMode === 'pretty' || verbose)) {
     childEnv[SHOW_NODE_RESTART_NOTICE_ENV] = '1';

--- a/packages/cli/src/dev-runner/node-restart-runner.ts
+++ b/packages/cli/src/dev-runner/node-restart-runner.ts
@@ -187,10 +187,16 @@ function buildNodeAppArgs(env: NodeJS.ProcessEnv, appArgs: string[]): string[] {
   return ['--env-file=.env', ...colorTtyImport, '--import', 'tsx', 'src/main.ts', ...appArgs];
 }
 
+function buildBunAppArgs(env: NodeJS.ProcessEnv, appArgs: string[]): string[] {
+  const colorTtyPreload = env[PRETTY_TTY_COLOR_ENV] === '1' ? ['--preload', getPreserveColorTtyImport()] : [];
+
+  return [...colorTtyPreload, 'src/main.ts', ...appArgs];
+}
+
 function buildAppCommand(runtime: DevRunnerRuntime, env: NodeJS.ProcessEnv, appArgs: string[]): { args: string[]; command: string } {
   switch (runtime) {
     case 'bun':
-      return { command: 'bun', args: ['src/main.ts', ...appArgs] };
+      return { command: 'bun', args: buildBunAppArgs(env, appArgs) };
     case 'cloudflare-workers':
       return { command: 'wrangler', args: ['dev', '--show-interactive-dev-session=false', ...appArgs] };
     case 'deno':


### PR DESCRIPTION
## Summary
- Preload the CLI TTY color shim for Bun app children when `fluo dev` runs through the restart runner with piped TTY output.
- Apply the same Bun preload for direct `fluo start` lifecycle runs so Bun color detection matches Node under the CLI reporter boundary.
- Add CLI regression tests plus a CLI patch changeset.

## Verification
- LSP diagnostics: `packages/cli/src/commands/scripts.ts`, `packages/cli/src/dev-runner/node-restart-runner.ts`, `packages/cli/src/cli.test.ts`
- `pnpm exec vitest run packages/cli/src/cli.test.ts`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli build`
- `bun --preload ./packages/cli/dist/dev-runner/preserve-color-tty.js -e "if (process.stdout.isTTY !== true || process.stderr.isTTY !== true) process.exit(1)"`

## Notes
- This keeps the existing lifecycle model: `fluo dev` uses the Node-based CLI supervisor and spawns Bun as the app runtime.
- Production deployments that run `fluo start` still require the CLI runtime prerequisites; running `bun dist/main.js` directly remains the Bun-only path.