### PR TITLE
Resolve #1564: Document node scaffold logger defaults

### DIFF
--- a/.changeset/node-scaffold-logger-guidance.md
+++ b/.changeset/node-scaffold-logger-guidance.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Clarify generated Node.js starter logging defaults and point JSON-log opt-ins to the runtime logger factory.

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -379,6 +379,10 @@ describe('scaffoldBootstrapApp', () => {
     expect(readme).not.toContain('@fluojs/platform-nodejs');
     expect(mainFile).toContain('// The generated starter wires the selected first-class fluo new application path:');
     expect(mainFile).toContain('// Node.js runtime + Fastify HTTP via createFastifyAdapter(...).');
+    expect(mainFile).toContain('// Application logging defaults to the pretty console logger when logger is omitted.');
+    expect(mainFile).toContain("// import { createJsonApplicationLogger } from '@fluojs/runtime/node';");
+    expect(mainFile).toContain('// Then pass `logger: createJsonApplicationLogger()` to FluoFactory.create(...).');
+    expect(mainFile).not.toContain('logger: createJsonApplicationLogger(),');
     expect(mainFile).not.toContain('Bun');
     expect(mainFile).not.toContain('Deno');
     expect(mainFile).not.toContain('Cloudflare');

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -894,6 +894,14 @@ export default {
   const portExpression = options.runtime === 'bun'
     ? "Bun.env.PORT ?? '3000'"
     : "process.env.PORT ?? '3000'";
+  const loggerGuidance = options.runtime === 'node'
+    ? `
+// Application logging defaults to the pretty console logger when logger is omitted.
+// JSON logs are opt-in:
+// import { createJsonApplicationLogger } from '@fluojs/runtime/node';
+// Then pass \`logger: createJsonApplicationLogger()\` to FluoFactory.create(...).
+`
+    : '';
 
   return `import { ${starter.adapterFactory} } from '${starter.packageName}';
 import { FluoFactory } from '@fluojs/runtime';
@@ -902,6 +910,7 @@ import { AppModule } from './app';
 
 // The generated starter wires the selected first-class fluo new application path:
 // ${starter.runtimeLabel} + ${starter.platformLabel} via ${starter.adapterFactory}(...).
+${loggerGuidance}
 
 const parsedPort = Number.parseInt(${portExpression}, 10);
 const port = Number.isFinite(parsedPort) ? parsedPort : 3000;


### PR DESCRIPTION
## Summary

Closes #1564

Clarifies that generated Node.js starters use the runtime's default pretty console application logger when the `logger` option is omitted, while JSON logging is an explicit opt-in.

## Changes

- Added Node-only logger guidance to the generated `src/main.ts` scaffold comments.
- Documented the supported JSON opt-in via `createJsonApplicationLogger` from `@fluojs/runtime/node` without wiring it by default.
- Added scaffold test coverage and a patch changeset for `@fluojs/cli`.

## Testing

- `lsp_diagnostics` on `packages/cli/src/new/scaffold.ts`: clean
- `lsp_diagnostics` on `packages/cli/src/new/scaffold.test.ts`: clean
- `pnpm build`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli test -- src/new/scaffold.test.ts`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. N/A.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. N/A.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. N/A; this is generated starter inline guidance and preserves existing default behavior.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. N/A.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A.