### PR TITLE
Update CLI scaffold dependency ranges

### DIFF
--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -222,18 +222,18 @@ describe('scaffoldBootstrapApp', () => {
 
     expect(packageJson.devDependencies?.typescript).toBe('^6.0.2');
     expect(packageJson.dependencies).toMatchObject({
-      '@fluojs/config': '^1.0.0-beta.5',
-      '@fluojs/core': '^1.0.0-beta.3',
+      '@fluojs/config': '^1.0.0-beta.7',
+      '@fluojs/core': '^1.0.0-beta.4',
       '@fluojs/di': '^1.0.0-beta.6',
-      '@fluojs/http': '^1.0.0-beta.9',
+      '@fluojs/http': '^1.0.0-beta.10',
       '@fluojs/platform-fastify': '^1.0.0-beta.8',
-      '@fluojs/runtime': '^1.0.0-beta.9',
-      '@fluojs/validation': '^1.0.0-beta.2',
+      '@fluojs/runtime': '^1.0.0-beta.11',
+      '@fluojs/validation': '^1.0.0-beta.3',
     });
     expect(packageJson.devDependencies).toMatchObject({
-      '@fluojs/cli': '^1.0.0-beta.3',
+      '@fluojs/cli': '^1.0.0-beta.7',
       '@fluojs/testing': '^1.0.0-beta.2',
-      '@fluojs/vite': '^1.0.0-beta.1',
+      '@fluojs/vite': '^1.0.0-beta.2',
     });
     expect(packageJson.scripts?.build).toBe('fluo build');
     expect(packageJson.scripts?.dev).toBe('fluo dev');

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -33,22 +33,22 @@ const PUBLISHED_RUNTIME_DEPENDENCIES = {
 } as const;
 
 const PUBLISHED_INTERNAL_DEPENDENCIES = {
-  '@fluojs/cli': '^1.0.0-beta.3',
-  '@fluojs/config': '^1.0.0-beta.5',
-  '@fluojs/core': '^1.0.0-beta.3',
+  '@fluojs/cli': '^1.0.0-beta.7',
+  '@fluojs/config': '^1.0.0-beta.7',
+  '@fluojs/core': '^1.0.0-beta.4',
   '@fluojs/di': '^1.0.0-beta.6',
-  '@fluojs/http': '^1.0.0-beta.9',
-  '@fluojs/microservices': '^1.0.0-beta.3',
+  '@fluojs/http': '^1.0.0-beta.10',
+  '@fluojs/microservices': '^1.0.0-beta.5',
   '@fluojs/platform-bun': '^1.0.0-beta.6',
   '@fluojs/platform-cloudflare-workers': '^1.0.0-beta.2',
   '@fluojs/platform-deno': '^1.0.0-beta.3',
   '@fluojs/platform-express': '^1.0.0-beta.6',
   '@fluojs/platform-fastify': '^1.0.0-beta.8',
   '@fluojs/platform-nodejs': '^1.0.0-beta.4',
-  '@fluojs/runtime': '^1.0.0-beta.9',
+  '@fluojs/runtime': '^1.0.0-beta.11',
   '@fluojs/testing': '^1.0.0-beta.2',
-  '@fluojs/validation': '^1.0.0-beta.2',
-  '@fluojs/vite': '^1.0.0-beta.1',
+  '@fluojs/validation': '^1.0.0-beta.3',
+  '@fluojs/vite': '^1.0.0-beta.2',
 } as const;
 
 


### PR DESCRIPTION
## Summary
- Update published-mode CLI scaffold internal dependency ranges to current npm latest versions.
- Include upcoming release PR #1567 versions for `@fluojs/cli`, `@fluojs/config`, and `@fluojs/microservices` so newly generated starters stay aligned after the beta release lands.
- Refresh the scaffold package.json assertion to lock the intended published dependency contract.

## Verification
- LSP diagnostics: `packages/cli/src/new/scaffold.ts`, `packages/cli/src/new/scaffold.test.ts`
- `pnpm --filter @fluojs/cli test -- src/new/scaffold.test.ts`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli build`