### PR TITLE
Resolve #1570: Remove PrismaModule forName APIs

### DIFF
--- a/.changeset/remove-prisma-forname-aliases.md
+++ b/.changeset/remove-prisma-forname-aliases.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/prisma": major
+---
+
+Remove the `PrismaModule.forName` and `PrismaModule.forNameAsync` convenience aliases. Register named Prisma clients through `PrismaModule.forRoot({ name, ... })` or `PrismaModule.forRootAsync({ name, ... })` instead.

--- a/book/beginner/ch12-prisma.ko.md
+++ b/book/beginner/ch12-prisma.ko.md
@@ -180,7 +180,7 @@ export class AppModule {}
 트래픽이 많은 환경에서는 데이터베이스 연결을 효율적으로 관리하는 것이 중요합니다. Prisma는 대부분의 작업을 자동으로 처리하지만, 대규모 애플리케이션에서는 `new PrismaClient(...)`를 만들 때 연결 동작을 세밀하게 조정하고 싶을 수 있습니다. `PrismaModule.forRoot(...)`는 그렇게 구성된 클라이언트를 받아 fluo 안에서 수명 주기만 관리하며, 세부적인 풀·datasource 튜닝 자체는 Prisma Client 구성에 속합니다.
 
 ### Global vs. Scoped Registration
-`AppModule`에서 기본 애플리케이션 전역 Prisma Client를 등록할 때는 여전히 `forRoot`를 사용합니다. 하지만 하나의 컨테이너에서 여러 Prisma Client가 필요할 때는 추가 클라이언트마다 명시적인 이름을 부여해야 합니다. `PrismaModule.forName('analytics', { client })` 또는 `PrismaModule.forRoot({ name: 'analytics', client })`로 등록한 뒤 `@Inject(getPrismaServiceToken('analytics'))`로 대응되는 서비스를 주입하세요. 이렇게 하면 하나의 애플리케이션이 기본 트랜잭션 데이터베이스와 보조 분석 웨어하우스를 함께 사용하더라도 토큰 해석이 명시적으로 유지됩니다.
+`AppModule`에서 기본 애플리케이션 전역 Prisma Client를 등록할 때는 여전히 `forRoot`를 사용하며, 하나의 컨테이너에서 여러 Prisma Client가 필요할 때도 동일한 표준 entrypoint에 명시적인 이름을 부여합니다. `PrismaModule.forRoot({ name: 'analytics', client })`로 등록한 뒤 `@Inject(getPrismaServiceToken('analytics'))`로 대응되는 서비스를 주입하세요. 이렇게 하면 하나의 애플리케이션이 기본 트랜잭션 데이터베이스와 보조 분석 웨어하우스를 함께 사용하더라도 토큰 해석이 명시적으로 유지됩니다.
 
 ## 12.6 Using PrismaService
 

--- a/book/beginner/ch12-prisma.md
+++ b/book/beginner/ch12-prisma.md
@@ -180,7 +180,7 @@ With this registration, Fluo connects to the database automatically when the app
 In high-traffic environments, managing database connections efficiently is important. Prisma handles most of the work automatically, but for large applications you may want to tune connection behavior when you construct `new PrismaClient(...)`. `PrismaModule.forRoot(...)` receives that client and manages its lifecycle inside fluo; detailed pool or datasource tuning still belongs to the Prisma client configuration itself.
 
 ### Global vs. Scoped Registration
-You still use `forRoot` for the default application-wide Prisma client in `AppModule`, but when one container needs multiple Prisma clients you must register each additional client with an explicit name. Use `PrismaModule.forName('analytics', { client })` or `PrismaModule.forRoot({ name: 'analytics', client })`, then inject the matching service with `@Inject(getPrismaServiceToken('analytics'))`. That keeps token resolution explicit when a single application talks to both a primary transactional database and a secondary analytics warehouse.
+You still use `forRoot` for the default application-wide Prisma client in `AppModule`, and when one container needs multiple Prisma clients you register each additional client with an explicit name on the same canonical entrypoint. Use `PrismaModule.forRoot({ name: 'analytics', client })`, then inject the matching service with `@Inject(getPrismaServiceToken('analytics'))`. That keeps token resolution explicit when a single application talks to both a primary transactional database and a secondary analytics warehouse.
 
 ## 12.6 Using PrismaService
 

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -83,7 +83,7 @@ export class UserRepository {
 import { Inject } from '@fluojs/core';
 import { PrismaModule, PrismaService, getPrismaServiceToken } from '@fluojs/prisma';
 
-const usersPrismaModule = PrismaModule.forName('users', { client: usersPrisma });
+const usersPrismaModule = PrismaModule.forRoot({ name: 'users', client: usersPrisma });
 const analyticsPrismaModule = PrismaModule.forRoot({ name: 'analytics', client: analyticsPrisma });
 
 @Inject(getPrismaServiceToken('users'), getPrismaServiceToken('analytics'))
@@ -176,7 +176,6 @@ defineModule(ManualPrismaModule, {
 ### `PrismaModule`
 
 - `PrismaModule.forRoot(options)` / `PrismaModule.forRootAsync(options)`
-- `PrismaModule.forName(name, options)` / `PrismaModule.forNameAsync(name, options)`
 - `forRoot(...)`와 `forRootAsync(...)`도 이름 있는/scoped 등록을 위해 `name`을 받을 수 있습니다.
 - `forRootAsync(...)`는 client와 transaction 설정을 factory에서 반환하는 DI-aware Prisma 옵션을 받습니다. 모듈 identity와 visibility가 factory 실행 전에 결정되도록 `name` 또는 `global`은 최상위 async 등록 옵션에 전달하세요.
 - `forRootAsync(...)`는 애플리케이션 컨테이너마다 옵션을 한 번 resolve하여, 별도 bootstrap 사이에서 클라이언트 라이프사이클과 요청 트랜잭션 격리를 보존합니다.

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -83,7 +83,7 @@ When one application container needs more than one Prisma client, register each 
 import { Inject } from '@fluojs/core';
 import { PrismaModule, PrismaService, getPrismaServiceToken } from '@fluojs/prisma';
 
-const usersPrismaModule = PrismaModule.forName('users', { client: usersPrisma });
+const usersPrismaModule = PrismaModule.forRoot({ name: 'users', client: usersPrisma });
 const analyticsPrismaModule = PrismaModule.forRoot({ name: 'analytics', client: analyticsPrisma });
 
 @Inject(getPrismaServiceToken('users'), getPrismaServiceToken('analytics'))
@@ -176,7 +176,6 @@ defineModule(ManualPrismaModule, {
 ### `PrismaModule`
 
 - `PrismaModule.forRoot(options)` / `PrismaModule.forRootAsync(options)`
-- `PrismaModule.forName(name, options)` / `PrismaModule.forNameAsync(name, options)`
 - `forRoot(...)` and `forRootAsync(...)` also accept `name` for named/scoped registrations.
 - `forRootAsync(...)` accepts DI-aware Prisma options whose factory returns the client and transaction settings; pass `name` or `global` on the top-level async registration so module identity and visibility are decided before the factory runs.
 - `forRootAsync(...)` resolves options once per application container, preserving client lifecycle and request transaction isolation across separate bootstraps.

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -221,7 +221,7 @@ describe('@fluojs/prisma', () => {
 
     defineModule(AppModule, {
       imports: [
-        PrismaModule.forName('users', { client: usersClient }),
+        PrismaModule.forRoot({ name: 'users', client: usersClient }),
         PrismaModule.forRoot({ name: 'analytics', client: analyticsClient }),
       ],
       providers: [MultiClientProbe],
@@ -262,8 +262,8 @@ describe('@fluojs/prisma', () => {
 
     defineModule(AppModule, {
       imports: [
-        PrismaModule.forName('users', { client: usersClient }),
-        PrismaModule.forName('analytics', { client: analyticsClient }),
+        PrismaModule.forRoot({ name: 'users', client: usersClient }),
+        PrismaModule.forRoot({ name: 'analytics', client: analyticsClient }),
       ],
     });
 
@@ -321,8 +321,9 @@ describe('@fluojs/prisma', () => {
 
     defineModule(AppModule, {
       imports: [
-        PrismaModule.forName('users', { client: usersClient }),
-        PrismaModule.forNameAsync('analytics', {
+        PrismaModule.forRoot({ name: 'users', client: usersClient }),
+        PrismaModule.forRootAsync({
+          name: 'analytics',
           useFactory: () => ({ client: analyticsClient }),
         }),
       ],

--- a/packages/prisma/src/module.ts
+++ b/packages/prisma/src/module.ts
@@ -213,27 +213,6 @@ function buildPrismaModuleAsync<
  */
 export class PrismaModule {
   /**
-   * Registers Prisma providers from static options under an explicit name.
-   *
-   * @param name Registration name used to generate isolated Prisma DI tokens.
-   * @param options Prisma module options with client handle and strict transaction mode.
-   * @returns A module definition that exports the named Prisma tokens.
-   */
-  static forName<
-    TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
-    TTransactionClient = InferPrismaTransactionClient<TClient>,
-    TTransactionOptions = InferPrismaTransactionOptions<TClient>,
-  >(
-    name: string,
-    options: Omit<PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>, 'name'>,
-  ): ModuleType {
-    return buildPrismaModule<TClient, TTransactionClient, TTransactionOptions>({
-      ...options,
-      name,
-    });
-  }
-
-  /**
    * Registers Prisma providers from static options.
    *
    * @param options Prisma module options with client handle and strict transaction mode.
@@ -247,27 +226,6 @@ export class PrismaModule {
     options: PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>,
   ): ModuleType {
     return buildPrismaModule<TClient, TTransactionClient, TTransactionOptions>(options);
-  }
-
-  /**
-   * Registers Prisma providers from an async DI factory under an explicit name.
-   *
-   * @param name Registration name used to generate isolated Prisma DI tokens.
-   * @param options Async module options that resolve Prisma client/module configuration.
-   * @returns A module definition that resolves async options once per application container.
-   */
-  static forNameAsync<
-    TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
-    TTransactionClient = InferPrismaTransactionClient<TClient>,
-    TTransactionOptions = InferPrismaTransactionOptions<TClient>,
-  >(
-    name: string,
-    options: AsyncModuleOptions<Omit<PrismaModuleOptions<TClient, TTransactionClient, TTransactionOptions>, 'global' | 'name'>>,
-  ): ModuleType {
-    return buildPrismaModuleAsync<TClient, TTransactionClient, TTransactionOptions>({
-      ...options,
-      name,
-    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #1570.

Remove the `PrismaModule.forName(...)` and `PrismaModule.forNameAsync(...)` convenience aliases so named Prisma registrations use the canonical `forRoot({ name, ... })` / `forRootAsync({ name, ... })` entrypoints.

## Changes

- Removed `forName` and `forNameAsync` from `PrismaModule`.
- Migrated named Prisma registration tests to `forRoot({ name, ... })` and `forRootAsync({ name, ... })`.
- Updated package README examples/API overview and beginner book EN/KO references.
- Added a Changeset entry for the public `@fluojs/prisma` API removal.

## Testing

- `pnpm --filter @fluojs/prisma test` — passed, 3 files / 26 tests.
- `pnpm --filter @fluojs/prisma typecheck` — passed.
- `pnpm --filter @fluojs/prisma build` — passed after building required workspace package outputs in the isolated worktree.
- `pnpm changeset status --since=origin/main` — reports `@fluojs/prisma` major bump from this changeset; also reports an existing unrelated `@fluojs/terminus` pending changeset already present on the base content.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable: no platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable: no platform conformance claims changed.