### PR TITLE
Resolve #1584: Harden validation root handling

### DIFF
--- a/.changeset/empty-masks-drum.md
+++ b/.changeset/empty-masks-drum.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/validation": patch
+---
+
+Return deterministic validation errors for malformed validation roots and document nested DTO instance preservation during materialization.

--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -64,10 +64,17 @@ try {
 - **`materialize<T>(value, target)`**: **입력 처리**에 가장 적합합니다. plain 객체를 받아 대상 클래스의 인스턴스를 생성하고, 값을 복사하며, 중첩된 DTO를 재귀적으로 처리한 후 모든 검증 규칙을 실행합니다.
 - **`validate(instance, target)`**: **기존 루트 객체 확인**에 적합합니다. 이미 생성된 루트 값에 대해 검증 규칙을 실행하며, plain 객체인 `@ValidateNested(...)` 값은 중첩 DTO 규칙을 실행하기 위해 임시로 실체화할 수 있습니다. 이 임시 실체화는 호출자가 넘긴 속성 값을 대체하지 않습니다.
 
+`validate()`는 문자열, 배열, `null`, `undefined` 같은 잘못된 루트 값을 field 또는
+class rule이 실행되기 전에 deterministic `DtoValidationError`로 거부합니다. 이미
+생성된 대상 DTO 인스턴스와 plain 루트 객체는 허용하므로 request-pipeline binder가
+준비한 DTO payload를 scalar coercion 없이 검증할 수 있습니다.
+
 `materialize()`는 plain 입력 객체의 안전한 own enumerable 속성을 복사하고,
 DTO 바인딩 메타데이터를 적용한 뒤 `@ValidateNested(...)` 필드를 재귀적으로
 실체화합니다. 어떤 요청 소스를 선택하고 스칼라 값을 변환할지는 transport 또는
 binder가 검증 전에 담당한다는 request-pipeline 계약을 유지합니다.
+선언된 중첩 DTO의 인스턴스인 기존 중첩 값은 그대로 보존하고, plain 중첩 값만
+해당 필드 또는 collection entry 단위로 실체화합니다.
 `materialize()`에 넘기는 루트 값은 plain 객체이거나 대상 DTO 인스턴스여야 합니다.
 문자열, 배열, `null` 같은 잘못된 루트 값은 대상 DTO 생성자나 필드 initializer가
 실행되기 전에 거부됩니다.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -66,10 +66,19 @@ try {
   temporarily materialize plain nested `@ValidateNested(...)` values to run their
   nested DTO rules without replacing the caller's properties
 
+`validate()` rejects malformed roots such as strings, arrays, `null`, and
+`undefined` with a deterministic `DtoValidationError` before field or class rules
+run. It accepts already-created target DTO instances and plain root objects so
+request-pipeline binders can validate their prepared DTO payloads without scalar
+coercion.
+
 `materialize()` copies safe own enumerable properties from plain input objects,
 applies DTO binding metadata, and recursively hydrates `@ValidateNested(...)`
 fields. It preserves the request-pipeline contract that transports or binders own
 source selection and scalar conversion before validation runs.
+Existing nested values that are already instances of the declared nested DTO are
+preserved; plain nested values are hydrated only for the affected nested field or
+collection entry.
 The root value passed to `materialize()` must already be a plain object or an
 instance of the target DTO; malformed roots such as strings, arrays, and `null`
 are rejected before the target DTO constructor or field initializers run.

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -96,6 +96,30 @@ describe('DefaultValidator', () => {
     expect(result.email).toBe('hello@example.com');
   });
 
+  it('validate rejects malformed roots with deterministic validation issues', async () => {
+    let conditionRuns = 0;
+
+    class RootDto {
+      @ValidateIf(() => {
+        conditionRuns += 1;
+        return true;
+      })
+      @IsString()
+      name = '';
+    }
+
+    const validator = new DefaultValidator();
+    const malformedRoots: unknown[] = [undefined, null, 'unsafe-string-input', ['unsafe-array-input']];
+
+    for (const malformedRoot of malformedRoots) {
+      await expect(validator.validate(malformedRoot, RootDto)).rejects.toMatchObject({
+        issues: [{ code: 'INVALID_DTO', message: 'DTO root value must be a plain object.' }],
+      });
+    }
+
+    expect(conditionRuns).toBe(0);
+  });
+
   it('rejects malformed materialize roots before constructor and initializer side effects run', async () => {
     let constructorRuns = 0;
     let initializerRuns = 0;
@@ -153,6 +177,35 @@ describe('DefaultValidator', () => {
     expect(result).toBeInstanceOf(CreateOrderDto);
     expect(result.address).toBeInstanceOf(AddressDto);
     expect(result.previousAddresses[0]).toBeInstanceOf(AddressDto);
+  });
+
+  it('materialize preserves nested DTO instances while hydrating plain nested values', async () => {
+    class AddressDto {
+      @MinLength(1)
+      city = '';
+    }
+
+    class CreateOrderDto {
+      @ValidateNested(() => AddressDto)
+      currentAddress = new AddressDto();
+
+      @ValidateNested(() => AddressDto, { each: true })
+      previousAddresses: AddressDto[] = [];
+    }
+
+    const existingAddress = Object.assign(new AddressDto(), { city: 'Seoul' });
+    const validator = new DefaultValidator();
+    const result = await validator.materialize<CreateOrderDto>(
+      {
+        currentAddress: existingAddress,
+        previousAddresses: [existingAddress, { city: 'Busan' }],
+      },
+      CreateOrderDto,
+    );
+
+    expect(result.currentAddress).toBe(existingAddress);
+    expect(result.previousAddresses[0]).toBe(existingAddress);
+    expect(result.previousAddresses[1]).toBeInstanceOf(AddressDto);
   });
 
   it('materialize recursively hydrates nested Set and Map DTO collections', async () => {

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -583,6 +583,14 @@ function buildInvalidRootIssue(): ValidationIssue {
   };
 }
 
+function assertValidRootValue(value: unknown, target: Constructor): void {
+  if (value instanceof target || isPlainObject(value)) {
+    return;
+  }
+
+  throw new DtoValidationError('Validation failed.', [buildInvalidRootIssue()]);
+}
+
 function getRuleValues(value: unknown): unknown[] {
   return getIterableValues(value) ?? [value];
 }
@@ -805,15 +813,15 @@ async function collectValidationIssuesInternal<T>(
  */
 export class DefaultValidator implements Validator {
   async validate(value: unknown, target: Constructor): Promise<void> {
+    assertValidRootValue(value, target);
+
     const issues = await collectValidationIssues(target, value);
     if (issues.length === 0) return;
     throw new DtoValidationError('Validation failed.', issues);
   }
 
   async materialize<T>(value: unknown, target: Constructor<T>): Promise<T> {
-    if (!(value instanceof target) && !isPlainObject(value)) {
-      throw new DtoValidationError('Validation failed.', [buildInvalidRootIssue()]);
-    }
+    assertValidRootValue(value, target);
 
     const instance = createNestedDtoInstance(target, value, { active: new WeakSet<object>() });
     const issues = await collectValidationIssues(target, instance);


### PR DESCRIPTION
## Summary

- Closes #1584.
- Hardens `@fluojs/validation` so malformed `validate()` roots return deterministic `DtoValidationError` issues instead of surfacing raw runtime errors.
- Documents validation root behavior and nested DTO instance preservation in the package README mirrors.

## Changes

- Added a shared root assertion for `DefaultValidator.validate()` and `materialize()`.
- Added regression coverage for malformed `validate()` roots and nested DTO instance preservation during materialization.
- Added a patch changeset for the public `@fluojs/validation` behavior fix.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/core build && pnpm --filter @fluojs/validation typecheck && pnpm --filter @fluojs/validation test && pnpm --filter @fluojs/validation build`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Not applicable: this PR does not change platform contract docs or platform conformance claims.