### PR TITLE
Resolve #1587: Align Passport JWT module wiring and docs

### DIFF
--- a/.changeset/align-passport-jwt-docs.md
+++ b/.changeset/align-passport-jwt-docs.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/passport": patch
+---
+
+Align JWT and cookie-auth documentation with the runtime wiring contract, and reject malformed non-string cookie access tokens before verification.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -34,23 +34,46 @@ npm install @fluojs/passport
 사용할 전략을 정의하고 `PassportModule.forRoot(...)`를 통해 등록합니다.
 
 ```typescript
-import { Module } from '@fluojs/core';
-import { PassportModule } from '@fluojs/passport';
-import { MyJwtStrategy } from './jwt.strategy';
+import { Inject, Module } from '@fluojs/core';
+import type { GuardContext } from '@fluojs/http';
+import { DefaultJwtVerifier, JwtModule } from '@fluojs/jwt';
+import { AuthenticationRequiredError, PassportModule, type AuthStrategy } from '@fluojs/passport';
+
+@Inject(DefaultJwtVerifier)
+export class BearerJwtStrategy implements AuthStrategy {
+  constructor(private readonly verifier: DefaultJwtVerifier) {}
+
+  async authenticate(context: GuardContext) {
+    const authorization = context.requestContext.request.headers.authorization;
+    const [scheme, token] = typeof authorization === 'string' ? authorization.split(' ') : [];
+
+    if (scheme !== 'Bearer' || !token) {
+      throw new AuthenticationRequiredError('Bearer access token is required.');
+    }
+
+    return this.verifier.verifyAccessToken(token);
+  }
+}
 
 @Module({
   imports: [
+    JwtModule.forRoot({
+      algorithms: ['HS256'],
+      audience: 'my-app',
+      issuer: 'my-api',
+      secret: 'your-secure-secret',
+    }),
     PassportModule.forRoot(
       { defaultStrategy: 'jwt' },
-      [{ name: 'jwt', token: MyJwtStrategy }]
+      [{ name: 'jwt', token: BearerJwtStrategy }],
     ),
   ],
-  providers: [MyJwtStrategy],
+  providers: [BearerJwtStrategy],
 })
 export class AuthModule {}
 ```
 
-전략 등록은 `PassportModule.forRoot(...)`로 구성합니다.
+JWT 기반 passport 전략에는 두 가지 module wiring이 모두 필요합니다. `JwtModule.forRoot(...)`는 `DefaultJwtVerifier`를 등록하고, `PassportModule.forRoot(...)`는 `@UseAuth('jwt')`가 resolve할 named strategy를 등록합니다. `DefaultJwtVerifier.verifyAccessToken(...)` 결과를 반환하면 `AuthGuard`가 `requestContext.principal`에 기록하는 정규화 principal 계약(`subject`, `claims`, `issuer`, `audience`, `roles`, `scopes`)이 보존됩니다.
 
 ### 2. 라우트 보호
 
@@ -91,6 +114,7 @@ HTTP 쿠키에서 인증 정보를 읽는 애플리케이션이라면 `CookieAut
 
 ```typescript
 import { Module } from '@fluojs/core';
+import { JwtModule } from '@fluojs/jwt';
 import {
   CookieAuthModule,
   CookieAuthStrategy,
@@ -101,6 +125,10 @@ import {
 @Module({
   imports: [
     CookieAuthModule.forRoot(),
+    JwtModule.forRoot({
+      algorithms: ['HS256'],
+      secret: 'your-secure-secret',
+    }),
     PassportModule.forRoot(
       { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
       [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
@@ -110,9 +138,11 @@ import {
 export class AuthModule {}
 ```
 
-애플리케이션 모듈에서 cookie-auth 지원이 필요하면 `CookieAuthModule.forRoot(...)`를 `PassportModule.forRoot(...)`와 함께 import 하세요.
+애플리케이션 모듈에서 cookie-auth 지원이 필요하면 `CookieAuthModule.forRoot(...)`, `JwtModule.forRoot(...)`, `PassportModule.forRoot(...)`를 함께 import 하세요. Cookie preset은 `CookieAuthStrategy`와 cookie option을 제공하고, JWT 검증은 여전히 `@fluojs/jwt`에서 오며, passport registry는 여전히 `PassportModule.forRoot(...)`에서 옵니다.
 
 `CookieAuthStrategy`는 `@fluojs/jwt`가 정규화한 JWT principal 계약을 보존하며, `subject`, `claims`, `issuer`, `audience`, `roles`, `scopes`를 그대로 전달합니다.
+
+Cookie access token은 비어 있지 않은 문자열이어야 합니다. `requireAccessToken: false`일 때만 누락된 cookie가 `{ authenticated: false }`로 resolve될 수 있으며, 존재하지만 malformed인 cookie 값은 JWT 검증 전에 항상 인증 실패로 처리됩니다.
 
 보호된 라우트는 계속 `@UseAuth(...)`를 사용해야 합니다. `requireAccessToken: false`를 설정해도 쿠키가 없을 때는 익명 principal이 아니라 명시적인 미인증 결과를 반환하므로, 보호된 라우트는 요청을 계속 거부합니다.
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -34,23 +34,46 @@ npm install @fluojs/passport
 Define your strategies and register them using `PassportModule.forRoot(...)`.
 
 ```typescript
-import { Module } from '@fluojs/core';
-import { PassportModule } from '@fluojs/passport';
-import { MyJwtStrategy } from './jwt.strategy';
+import { Inject, Module } from '@fluojs/core';
+import type { GuardContext } from '@fluojs/http';
+import { DefaultJwtVerifier, JwtModule } from '@fluojs/jwt';
+import { AuthenticationRequiredError, PassportModule, type AuthStrategy } from '@fluojs/passport';
+
+@Inject(DefaultJwtVerifier)
+export class BearerJwtStrategy implements AuthStrategy {
+  constructor(private readonly verifier: DefaultJwtVerifier) {}
+
+  async authenticate(context: GuardContext) {
+    const authorization = context.requestContext.request.headers.authorization;
+    const [scheme, token] = typeof authorization === 'string' ? authorization.split(' ') : [];
+
+    if (scheme !== 'Bearer' || !token) {
+      throw new AuthenticationRequiredError('Bearer access token is required.');
+    }
+
+    return this.verifier.verifyAccessToken(token);
+  }
+}
 
 @Module({
   imports: [
+    JwtModule.forRoot({
+      algorithms: ['HS256'],
+      audience: 'my-app',
+      issuer: 'my-api',
+      secret: 'your-secure-secret',
+    }),
     PassportModule.forRoot(
       { defaultStrategy: 'jwt' },
-      [{ name: 'jwt', token: MyJwtStrategy }]
+      [{ name: 'jwt', token: BearerJwtStrategy }],
     ),
   ],
-  providers: [MyJwtStrategy],
+  providers: [BearerJwtStrategy],
 })
 export class AuthModule {}
 ```
 
-Register strategies through `PassportModule.forRoot(...)`.
+JWT-based passport strategies require both pieces of module wiring: `JwtModule.forRoot(...)` registers `DefaultJwtVerifier`, and `PassportModule.forRoot(...)` registers the named strategy that `@UseAuth('jwt')` resolves. Returning the `DefaultJwtVerifier.verifyAccessToken(...)` result preserves the normalized principal contract (`subject`, `claims`, `issuer`, `audience`, `roles`, and `scopes`) that `AuthGuard` writes to `requestContext.principal`.
 
 ### 2. Protect Routes
 
@@ -91,6 +114,7 @@ Use `CookieAuthModule.forRoot(...)` when your app authenticates requests from HT
 
 ```typescript
 import { Module } from '@fluojs/core';
+import { JwtModule } from '@fluojs/jwt';
 import {
   CookieAuthModule,
   CookieAuthStrategy,
@@ -101,6 +125,10 @@ import {
 @Module({
   imports: [
     CookieAuthModule.forRoot(),
+    JwtModule.forRoot({
+      algorithms: ['HS256'],
+      secret: 'your-secure-secret',
+    }),
     PassportModule.forRoot(
       { defaultStrategy: COOKIE_AUTH_STRATEGY_NAME },
       [{ name: COOKIE_AUTH_STRATEGY_NAME, token: CookieAuthStrategy }],
@@ -110,9 +138,11 @@ import {
 export class AuthModule {}
 ```
 
-Import `CookieAuthModule.forRoot(...)` alongside `PassportModule.forRoot(...)` when you want cookie-auth support in an application module.
+Import `CookieAuthModule.forRoot(...)`, `JwtModule.forRoot(...)`, and `PassportModule.forRoot(...)` together when you want cookie-auth support in an application module. The cookie preset provides `CookieAuthStrategy` and cookie options; JWT verification still comes from `@fluojs/jwt`, and the passport registry still comes from `PassportModule.forRoot(...)`.
 
 `CookieAuthStrategy` preserves the normalized JWT principal contract from `@fluojs/jwt`, including `subject`, `claims`, `issuer`, `audience`, `roles`, and `scopes`.
+
+Cookie access tokens must be non-empty strings. Missing cookies can resolve to `{ authenticated: false }` only when `requireAccessToken: false`; malformed present cookie values always fail authentication before JWT verification.
 
 Protected routes must keep using `@UseAuth(...)`. If you configure `requireAccessToken: false`, a missing cookie resolves to an explicit unauthenticated result instead of an anonymous principal, so protected routes still reject the request.
 

--- a/packages/passport/src/cookie/cookie-auth.test.ts
+++ b/packages/passport/src/cookie/cookie-auth.test.ts
@@ -130,6 +130,15 @@ describe('CookieAuthStrategy', () => {
       await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
     });
 
+    it('throws AuthenticationRequiredError for malformed non-string access token cookies', async () => {
+      const verifier = createMockVerifier();
+      const strategy = new CookieAuthStrategy(verifier, { requireAccessToken: false });
+      const context = createGuardContext({ access_token: ['not-a-cookie-string'] as unknown as string });
+
+      await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
+      expect(verifier.verifyAccessToken).not.toHaveBeenCalled();
+    });
+
     it('handles non-Error verification failures gracefully', async () => {
       const verifier = createMockVerifier({
         verifyAccessToken: vi.fn().mockRejectedValue('string error'),
@@ -225,7 +234,7 @@ describe('CookieManager', () => {
         this.setHeader('Location', location);
         this.committed = true;
       },
-      send(body: unknown) {
+      send(_body: unknown) {
         this.committed = true;
       },
     };

--- a/packages/passport/src/cookie/cookie-auth.ts
+++ b/packages/passport/src/cookie/cookie-auth.ts
@@ -9,6 +9,10 @@ const unauthenticatedCookieAuthResult: AuthOptionalResult = {
   authenticated: false,
 };
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
 /**
  * Provides cookie-auth strategy options through dependency injection.
  */
@@ -79,12 +83,16 @@ export class CookieAuthStrategy implements AuthStrategy {
 
     const accessToken = cookies[this.options.accessTokenCookieName];
 
-    if (!accessToken) {
+    if (accessToken === undefined || accessToken === '') {
       if (this.options.requireAccessToken) {
         throw new AuthenticationRequiredError('Access token cookie is required.');
       }
 
       return unauthenticatedCookieAuthResult;
+    }
+
+    if (!isNonEmptyString(accessToken)) {
+      throw new AuthenticationRequiredError('Access token cookie must be a non-empty string.');
     }
 
     try {


### PR DESCRIPTION
## Summary

Closes #1587

- Align `@fluojs/passport` JWT and cookie-auth examples with the runtime module wiring contract.
- Preserve the normalized principal contract documented across `@fluojs/jwt`, `@fluojs/passport`, and `@fluojs/http`.

## Changes

- Document that JWT-based Passport strategies require `JwtModule.forRoot(...)` plus `PassportModule.forRoot(...)`.
- Update EN/KO cookie-auth docs to include `JwtModule.forRoot(...)`, Passport registry wiring, principal preservation, and malformed cookie behavior.
- Reject malformed non-string cookie access-token values before JWT verification and cover that path with a regression test.
- Add a patch changeset for `@fluojs/passport`.

## Testing

- `pnpm install` (worktree dependency bootstrap)
- `pnpm build` (workspace build)
- `pnpm --dir packages/passport typecheck`
- `pnpm --dir packages/passport test` — 8 files / 86 tests passed
- LSP diagnostics on changed TS files: clean

## Public export documentation

- [x] No public exports were added or removed.
- [x] Changed public runtime behavior is documented in package README examples/contract text.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New/clarified behavioral contracts are documented in `packages/passport/README.md` and `packages/passport/README.ko.md`.
- [x] Intentional limitations are explicitly stated: missing optional cookies may be unauthenticated, malformed present cookie values fail authentication.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean package README mirror content remains synchronized for the changed auth docs.
- [x] No platform contract docs changed.
- [x] No package README platform conformance claims changed.