### PR TITLE
Resolve #1588: Harden Drizzle request transaction shutdown boundaries

### DIFF
--- a/.changeset/drizzle-request-shutdown-boundary.md
+++ b/.changeset/drizzle-request-shutdown-boundary.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/drizzle": patch
+---
+
+Reject late request transactions after Drizzle shutdown begins and preserve abort errors until the active transaction lifecycle settles.

--- a/.changeset/drizzle-request-shutdown-boundary.md
+++ b/.changeset/drizzle-request-shutdown-boundary.md
@@ -2,4 +2,4 @@
 "@fluojs/drizzle": patch
 ---
 
-Reject late request transactions after Drizzle shutdown begins and preserve abort errors until the active transaction lifecycle settles.
+Reject late request transactions after Drizzle shutdown begins and preserve request abort errors until the active Drizzle transaction lifecycle settles, so commit/rollback cleanup is not interrupted before the caller sees the abort reason.

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -107,6 +107,7 @@ class UsersController {}
 ### 종료와 상태 계약
 
 `DrizzleTransactionInterceptor`는 각 HTTP 요청을 `DrizzleDatabase.requestTransaction(...)`으로 실행합니다. 애플리케이션 종료 중에는 `DrizzleDatabase`가 아직 활성 상태인 요청 트랜잭션을 abort하고, 해당 transaction callback이 settle되거나 rollback될 때까지 기다린 뒤 선택적 `dispose(database)` hook을 실행합니다. 이 순서는 pool이나 외부 관리 리소스를 닫기 전에 driver가 rollback/cleanup 작업을 끝낼 수 있게 보장합니다.
+종료가 시작된 뒤 새 `requestTransaction(...)` 호출은 거부되므로, 종료 boundary를 지난 뒤 시작되는 늦은 요청 트랜잭션보다 dispose가 먼저 실행되는 상황을 방지합니다.
 
 `createDrizzlePlatformStatusSnapshot(...)`과 `DrizzleDatabase.createPlatformStatusSnapshot()`은 같은 계약을 진단 surface에 노출합니다.
 

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -108,6 +108,7 @@ class UsersController {}
 
 `DrizzleTransactionInterceptor`는 각 HTTP 요청을 `DrizzleDatabase.requestTransaction(...)`으로 실행합니다. 애플리케이션 종료 중에는 `DrizzleDatabase`가 아직 활성 상태인 요청 트랜잭션을 abort하고, 해당 transaction callback이 settle되거나 rollback될 때까지 기다린 뒤 선택적 `dispose(database)` hook을 실행합니다. 이 순서는 pool이나 외부 관리 리소스를 닫기 전에 driver가 rollback/cleanup 작업을 끝낼 수 있게 보장합니다.
 종료가 시작된 뒤 새 `requestTransaction(...)` 호출은 거부되므로, 종료 boundary를 지난 뒤 시작되는 늦은 요청 트랜잭션보다 dispose가 먼저 실행되는 상황을 방지합니다.
+요청 callback이 완료된 뒤 underlying Drizzle transaction runner가 commit 또는 rollback을 끝내기 전에 request signal이 abort되면, `requestTransaction(...)`은 먼저 해당 runner가 settle될 때까지 기다린 다음 abort reason으로 reject합니다. 이 동작은 Drizzle cleanup을 request cancellation과 직렬화하면서, 완료된 callback 결과를 반환하는 대신 늦은 request abort를 caller에게 드러냅니다.
 
 `createDrizzlePlatformStatusSnapshot(...)`과 `DrizzleDatabase.createPlatformStatusSnapshot()`은 같은 계약을 진단 surface에 노출합니다.
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -108,6 +108,7 @@ class UsersController {}
 
 `DrizzleTransactionInterceptor` runs each HTTP request through `DrizzleDatabase.requestTransaction(...)`. During application shutdown, `DrizzleDatabase` aborts any still-active request transaction, waits for its transaction callback to settle or roll back, and only then runs the optional `dispose(database)` hook. This ordering lets drivers finish rollback/cleanup work before pools or externally managed resources are closed.
 New `requestTransaction(...)` calls are rejected once shutdown begins, so disposal cannot overtake a late request transaction that starts after the shutdown boundary is crossed.
+If the request signal aborts after the request callback has completed but before the underlying Drizzle transaction runner finishes committing or rolling back, `requestTransaction(...)` waits for that runner to settle first and then rejects with the abort reason. This keeps Drizzle cleanup serialized with request cancellation while making the late request abort visible to the caller instead of returning the completed callback result.
 
 `createDrizzlePlatformStatusSnapshot(...)` and `DrizzleDatabase.createPlatformStatusSnapshot()` expose the same contract to diagnostics surfaces:
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -107,6 +107,7 @@ class UsersController {}
 ### Shutdown and status contracts
 
 `DrizzleTransactionInterceptor` runs each HTTP request through `DrizzleDatabase.requestTransaction(...)`. During application shutdown, `DrizzleDatabase` aborts any still-active request transaction, waits for its transaction callback to settle or roll back, and only then runs the optional `dispose(database)` hook. This ordering lets drivers finish rollback/cleanup work before pools or externally managed resources are closed.
+New `requestTransaction(...)` calls are rejected once shutdown begins, so disposal cannot overtake a late request transaction that starts after the shutdown boundary is crossed.
 
 `createDrizzlePlatformStatusSnapshot(...)` and `DrizzleDatabase.createPlatformStatusSnapshot()` expose the same contract to diagnostics surfaces:
 

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 import {
+  createAbortError,
   createRequestAbortContext,
   raceWithAbort,
   trackActiveRequestTransaction,
@@ -19,6 +20,7 @@ import type {
 const TRANSACTION_NOT_SUPPORTED_ERROR = 'Transaction not supported: Drizzle database does not implement transaction.';
 const NESTED_TRANSACTION_OPTIONS_NOT_SUPPORTED_ERROR =
   'Nested Drizzle transaction options are not supported because the active transaction context is reused.';
+const REQUEST_TRANSACTION_UNAVAILABLE_ERROR = 'Drizzle request transactions are not available during shutdown.';
 
 type ActiveRequestTransaction = {
   abort(reason?: unknown): void;
@@ -181,14 +183,20 @@ export class DrizzleDatabase<
     options: TTransactionOptions | undefined,
     signal?: AbortSignal,
   ): Promise<T> {
+    this.assertRequestTransactionsAvailable();
+
     const abortContext = createRequestAbortContext(signal);
     const active = this.trackActiveRequestTransaction(abortContext.controller);
 
     try {
-      return await transactionRunner(
+      const result = await transactionRunner<T>(
         (transactionDatabase) => this.transactions.run(transactionDatabase, () => raceWithAbort(fn, abortContext.signal)),
         options,
       );
+
+      this.throwIfRequestAborted(abortContext.signal);
+
+      return result;
     } finally {
       abortContext.cleanup();
       this.untrackActiveRequestTransaction(active);
@@ -196,14 +204,32 @@ export class DrizzleDatabase<
   }
 
   private async executeRequestFallback<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    this.assertRequestTransactionsAvailable();
+
     const abortContext = createRequestAbortContext(signal);
     const active = this.trackActiveRequestTransaction(abortContext.controller);
 
     try {
-      return await raceWithAbort(fn, abortContext.signal);
+      const result = await raceWithAbort(fn, abortContext.signal);
+
+      this.throwIfRequestAborted(abortContext.signal);
+
+      return result;
     } finally {
       abortContext.cleanup();
       this.untrackActiveRequestTransaction(active);
+    }
+  }
+
+  private assertRequestTransactionsAvailable(): void {
+    if (this.lifecycleState !== 'ready') {
+      throw new Error(REQUEST_TRANSACTION_UNAVAILABLE_ERROR);
+    }
+  }
+
+  private throwIfRequestAborted(signal: AbortSignal): void {
+    if (signal.aborted) {
+      throw createAbortError(signal.reason);
     }
   }
 

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -206,7 +206,7 @@ describe('@fluojs/drizzle', () => {
 
     const shutdownPromise = app.close();
 
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(events).toContain('transaction:rollback:pending');
     expect(events).not.toContain('dispose');
 
@@ -221,6 +221,118 @@ describe('@fluojs/drizzle', () => {
       'transaction:rollback:done',
       'transaction:end',
       'dispose',
+    ]);
+  });
+
+  it('rejects new request transactions once shutdown begins', async () => {
+    const events: string[] = [];
+    const transactionDatabase = {};
+    let releaseRollback!: () => void;
+    const rollbackBarrier = new Promise<void>((resolve) => {
+      releaseRollback = resolve;
+    });
+    const database = {
+      async transaction<T>(callback: (value: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        events.push('transaction:start');
+
+        try {
+          return await callback(transactionDatabase);
+        } catch (error) {
+          events.push('transaction:rollback:pending');
+          await rollbackBarrier;
+          events.push('transaction:rollback:done');
+          throw error;
+        } finally {
+          events.push('transaction:end');
+        }
+      },
+    };
+
+    const drizzleModule = DrizzleModule.forRoot<typeof database, typeof transactionDatabase>({
+      database,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [drizzleModule],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+    const drizzle = await app.container.resolve(DrizzleDatabase<typeof database, typeof transactionDatabase>);
+    const openTransaction = drizzle.requestTransaction(async () => new Promise<never>(() => undefined));
+    const shutdownPromise = app.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(events).toContain('transaction:rollback:pending');
+
+    await expect(drizzle.requestTransaction(async () => 'late-request')).rejects.toThrow(
+      'Drizzle request transactions are not available during shutdown.',
+    );
+
+    releaseRollback();
+
+    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+    await shutdownPromise;
+
+    expect(events).toEqual([
+      'transaction:start',
+      'transaction:rollback:pending',
+      'transaction:rollback:done',
+      'transaction:end',
+      'dispose',
+    ]);
+  });
+
+  it('waits for transaction runner settlement before reporting late request aborts', async () => {
+    const events: string[] = [];
+    const transactionDatabase = {};
+    let releaseCommit!: () => void;
+    const commitBarrier = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    const database = {
+      async transaction<T>(callback: (value: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        events.push('transaction:start');
+        const result = await callback(transactionDatabase);
+        events.push('transaction:commit:pending');
+        await commitBarrier;
+        events.push('transaction:commit:done');
+        return result;
+      },
+    };
+    const drizzle = new DrizzleDatabase<typeof database, typeof transactionDatabase>(database);
+    const controller = new AbortController();
+
+    const requestTransaction = drizzle.requestTransaction(
+      async () => {
+        events.push('request:done');
+        return 'committed-result';
+      },
+      controller.signal,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(events).toEqual(['transaction:start', 'request:done', 'transaction:commit:pending']);
+
+    controller.abort(new Error('client aborted during transaction settlement'));
+
+    await Promise.resolve();
+    expect(events).not.toContain('transaction:commit:done');
+
+    releaseCommit();
+
+    await expect(requestTransaction).rejects.toThrow('client aborted during transaction settlement');
+    expect(events).toEqual([
+      'transaction:start',
+      'request:done',
+      'transaction:commit:pending',
+      'transaction:commit:done',
     ]);
   });
 


### PR DESCRIPTION
## Summary

Closes #1588.

Hardens `@fluojs/drizzle` request transaction abort/shutdown behavior so active transaction lifecycle settlement remains serialized with request aborts and application disposal.

## Changes

- Rejects new `DrizzleDatabase.requestTransaction(...)` calls once Drizzle shutdown has begun.
- Preserves late abort errors until the underlying transaction runner has settled.
- Adds regression tests for shutdown-boundary rejection and abort-during-transaction-settlement paths.
- Documents the shutdown-boundary contract in `packages/drizzle/README.md` and `packages/drizzle/README.ko.md`.
- Adds a patch Changeset for `@fluojs/drizzle`.

## Testing

- `pnpm install --frozen-lockfile` — passed
- `pnpm --filter @fluojs/drizzle... build` — passed
- `pnpm --filter @fluojs/drizzle test` — passed (3 files, 23 tests)
- `pnpm --filter @fluojs/drizzle typecheck` — passed
- `lsp_diagnostics packages/drizzle` — 0 diagnostics

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or removed; existing public method documentation remains intact.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs changed; package README EN/KO mirrors were updated together with regression tests.