### PR TITLE
Resolve #1601: Reject metrics platform telemetry gauge collisions

### DIFF
--- a/.changeset/strict-platform-gauges.md
+++ b/.changeset/strict-platform-gauges.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/metrics": patch
+---
+
+Reject app-owned platform telemetry gauge name collisions in shared registries and reuse only framework-owned gauges with the expected label schema.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -109,11 +109,11 @@ new Counter({
 class AppModule {}
 ```
 
-여러 `MetricsModule` 인스턴스가 같은 Registry를 의도적으로 공유하는 경우, 내장 HTTP 메트릭은 기존 `http_requests_total`, `http_errors_total`, `http_request_duration_seconds` collector를 재사용합니다. 애플리케이션이 직접 등록한 중복 메트릭 이름은 Prometheus Registry 규칙대로 계속 빠르게 실패합니다.
+여러 `MetricsModule` 인스턴스가 같은 Registry를 의도적으로 공유하는 경우, 내장 HTTP 메트릭은 기존 `http_requests_total`, `http_errors_total`, `http_request_duration_seconds` collector를 재사용합니다. 내장 플랫폼 텔레메트리 Gauge도 같은 ownership 규칙을 따릅니다. 모듈이 만든 `fluo_component_ready`, `fluo_component_health`, `fluo_metrics_registry_mode` Gauge는 framework ownership과 label schema가 일치할 때만 재사용합니다. 애플리케이션이 직접 등록한 중복 메트릭 이름은 Prometheus Registry 규칙대로 계속 빠르게 실패합니다.
 
 ### 중복 메트릭 이름은 계속 빠르게 실패합니다
 
-Prometheus 메트릭 이름은 하나의 Registry 안에서 고유해야 합니다. 공유 Registry 모드는 애플리케이션 메트릭의 중복 이름을 조용히 덮어쓰지 않고 이 동작을 유지합니다.
+Prometheus 메트릭 이름은 하나의 Registry 안에서 고유해야 합니다. 공유 Registry 모드는 애플리케이션 메트릭의 중복 이름을 조용히 덮어쓰지 않고 이 동작을 유지합니다. 애플리케이션이 내장 HTTP collector 또는 플랫폼 텔레메트리 Gauge 이름을 미리 등록한 경우, `MetricsModule.forRoot()`는 app-owned collector를 재사용하지 않고 충돌을 거부합니다.
 
 ### 런타임 플랫폼 텔레메트리
 
@@ -168,7 +168,7 @@ MetricsModule.forRoot({
 - `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`로 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 끌 수 있습니다.
 - `endpointMiddleware`는 스크레이프 엔드포인트에만 route-scoped middleware를 바인딩합니다.
 - HTTP 메트릭은 `http: true` 또는 `http` 옵션 객체를 전달한 경우에만 설치되며, 설치된 뒤에는 기본적으로 템플릿 기반 경로 라벨 정규화를 사용합니다.
-- 내장 HTTP collector는 같은 Registry를 공유하는 모듈 인스턴스 사이에서 재사용되며, 커스텀 애플리케이션 메트릭 이름 충돌은 Prometheus의 중복 이름 실패 동작을 유지합니다.
+- 내장 HTTP collector와 플랫폼 텔레메트리 Gauge는 같은 Registry를 공유하는 모듈 인스턴스 사이에서 framework-owned이고 예상 label schema를 가진 경우에만 재사용되며, 커스텀 애플리케이션 메트릭 이름 충돌은 Prometheus의 중복 이름 실패 동작을 유지합니다.
 - raw path 라벨은 `allowUnsafeRawPathLabelMode: true`를 명시한 bounded internal route에서만 사용해야 합니다.
 - 플랫폼 텔레메트리는 `PLATFORM_SHELL`이 실제로 누락된 경우에만 생략되며, 그 외 resolve 실패는 스크레이프를 실패시킵니다.
 - 직전 성공 스크레이프에서 노출된 플랫폼 텔레메트리 시리즈는 `PLATFORM_SHELL`을 사용할 수 없게 된 스크레이프에서 제거됩니다.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -109,11 +109,11 @@ new Counter({
 class AppModule {}
 ```
 
-When multiple metrics module instances intentionally share the same registry, built-in HTTP metrics reuse the existing `http_requests_total`, `http_errors_total`, and `http_request_duration_seconds` collectors instead of registering duplicate framework metrics. Application-defined duplicate names still fail fast.
+When multiple metrics module instances intentionally share the same registry, built-in HTTP metrics reuse the existing `http_requests_total`, `http_errors_total`, and `http_request_duration_seconds` collectors instead of registering duplicate framework metrics. Built-in platform telemetry gauges follow the same ownership rule: module-created `fluo_component_ready`, `fluo_component_health`, and `fluo_metrics_registry_mode` gauges are reused only when their framework ownership and label schema match. Application-defined duplicate names still fail fast.
 
 ### Duplicate metric names still fail fast
 
-Prometheus metric names must stay unique inside a registry. Shared-registry mode keeps that behavior intact instead of silently shadowing metrics.
+Prometheus metric names must stay unique inside a registry. Shared-registry mode keeps that behavior intact instead of silently shadowing metrics. If an application predefines a built-in HTTP collector or platform telemetry gauge name, `MetricsModule.forRoot()` rejects the collision instead of reusing an app-owned collector.
 
 ### Runtime platform telemetry
 
@@ -168,7 +168,7 @@ MetricsModule.forRoot({
 - `defaultMetrics` defaults to `true`, and `defaultMetrics: false` disables Prometheus default process and Node.js collectors for that registry.
 - `endpointMiddleware` binds route-scoped middleware only to the scrape endpoint.
 - HTTP metrics are installed only when `http: true` or an `http` options object is provided, and then default to template-normalized path labels.
-- Built-in HTTP collectors are reused when module instances share one registry; custom application metric name collisions keep Prometheus' duplicate-name failure behavior.
+- Built-in HTTP collectors and platform telemetry gauges are reused when module instances share one registry only if they are framework-owned and have the expected label schema; custom application metric name collisions keep Prometheus' duplicate-name failure behavior.
 - Raw path labels require `allowUnsafeRawPathLabelMode: true` and should stay limited to bounded internal routes.
 - Platform telemetry is omitted only when `PLATFORM_SHELL` is genuinely missing; other resolution failures fail the scrape.
 - Stale platform telemetry series are removed when `PLATFORM_SHELL` becomes unavailable after the last successful scrape.

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -7,7 +7,7 @@ import {
   type Next,
 } from '@fluojs/http';
 import { bootstrapApplication, defineModule, PLATFORM_SHELL, type PlatformComponent } from '@fluojs/runtime';
-import { Counter, Histogram, Registry } from 'prom-client';
+import { Counter, Gauge, Histogram, Registry } from 'prom-client';
 import { describe, expect, it } from 'vitest';
 import { METER_PROVIDER } from './providers/meter-provider.js';
 import { MetricsModule } from './metrics-module.js';
@@ -436,6 +436,65 @@ describe('MetricsModule', () => {
     expect(metricsText).toContain('fluo_metrics_registry_mode{mode="shared"} 1');
 
     await app.close();
+  });
+
+  it('reuses framework-owned platform telemetry gauges when module instances share one registry', async () => {
+    const sharedRegistry = new Registry();
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [
+        MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-a', registry: sharedRegistry }),
+        MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-b', registry: sharedRegistry }),
+      ],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const firstResponse = createResponse();
+    await app.dispatch(createRequest('/metrics-a'), firstResponse);
+    expect(firstResponse.statusCode).toBe(200);
+
+    const secondResponse = createResponse();
+    await app.dispatch(createRequest('/metrics-b'), secondResponse);
+    expect(secondResponse.statusCode).toBe(200);
+
+    const metricsText = await sharedRegistry.metrics();
+    expect(metricsText).toContain('fluo_metrics_registry_mode{mode="shared"} 1');
+    expect(metricsText).toContain('fluo_component_ready{component_id="runtime.shell"');
+    expect(metricsText).toContain('fluo_component_health{component_id="runtime.shell"');
+
+    await app.close();
+  });
+
+  it('throws when an app predefines a built-in platform telemetry gauge name', () => {
+    const sharedRegistry = new Registry();
+
+    new Gauge({
+      help: 'Application-defined platform readiness',
+      labelNames: ['component_id'],
+      name: 'fluo_component_ready',
+      registers: [sharedRegistry],
+    });
+
+    expect(() => MetricsModule.forRoot({ defaultMetrics: false, registry: sharedRegistry })).toThrow(
+      'Metric name "fluo_component_ready" is already registered by the application. Built-in platform telemetry requires framework-owned gauges.',
+    );
+  });
+
+  it('validates framework-owned platform telemetry gauge label schemas before reuse', () => {
+    const sharedRegistry = new Registry();
+
+    MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-a', registry: sharedRegistry });
+    const readinessGauge = sharedRegistry.getSingleMetric('fluo_component_ready') as Gauge<string> & { labelNames: string[] };
+    readinessGauge.labelNames = ['component_id'];
+
+    expect(() => MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-b', registry: sharedRegistry })).toThrow(
+      'Metric name "fluo_component_ready" is already registered with labels [component_id]. Built-in platform telemetry requires labels [component_id,component_kind,operation,result,env,instance].',
+    );
   });
 
   it('exports runtime component readiness and health metrics with shared labels', async () => {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -140,6 +140,7 @@ type RuntimeTelemetryComponent = {
 
 const PLATFORM_COMPONENT_LABELS = ['component_id', 'component_kind', 'operation', 'result', 'env', 'instance'] as const;
 const REGISTRY_MODE_LABELS = ['mode'] as const;
+const FRAMEWORK_PLATFORM_GAUGES = new WeakSet<Gauge<string>>();
 const HEALTH_STATUSES = ['healthy', 'unhealthy', 'degraded'] as const satisfies readonly PlatformHealthStatus[];
 const READINESS_STATUSES = ['ready', 'not-ready', 'degraded'] as const satisfies readonly PlatformReadinessStatus[];
 const PLATFORM_SHELL_TOKEN_NAME = 'PLATFORM_SHELL';
@@ -164,15 +165,41 @@ function getOrCreateGauge(
   const existing = registry.getSingleMetric(config.name);
 
   if (existing instanceof Gauge) {
+    if (!FRAMEWORK_PLATFORM_GAUGES.has(existing)) {
+      throw new Error(
+        `Metric name "${config.name}" is already registered by the application. Built-in platform telemetry requires framework-owned gauges.`,
+      );
+    }
+
+    assertGaugeLabelSchema(existing, config);
     return existing;
   }
 
-  return new Gauge({
+  const gauge = new Gauge({
     help: config.help,
     labelNames: [...config.labelNames],
     name: config.name,
     registers: [registry],
   });
+  FRAMEWORK_PLATFORM_GAUGES.add(gauge);
+  return gauge;
+}
+
+function assertGaugeLabelSchema(
+  gauge: Gauge<string>,
+  config: {
+    labelNames: readonly string[];
+    name: string;
+  },
+): void {
+  const registeredLabels = ((gauge as Gauge<string> & { labelNames?: string[] }).labelNames ?? []).join(',');
+  const expectedLabels = config.labelNames.join(',');
+
+  if (registeredLabels !== expectedLabels) {
+    throw new Error(
+      `Metric name "${config.name}" is already registered with labels [${registeredLabels}]. Built-in platform telemetry requires labels [${expectedLabels}].`,
+    );
+  }
 }
 
 class RuntimePlatformTelemetry {


### PR DESCRIPTION
## Summary

- Closes #1601.
- Hardens `@fluojs/metrics` shared-registry platform telemetry so built-in gauges are reused only when framework-owned and label-compatible.
- Documents the shared-registry ownership contract in EN/KO README mirrors and adds a patch changeset.

## Changes

- Track module-created platform telemetry gauges in a framework-owned `WeakSet`.
- Reject app-owned `fluo_component_ready`, `fluo_component_health`, and `fluo_metrics_registry_mode` gauge collisions instead of silently reusing them.
- Validate framework-owned gauge label schemas before reuse across multiple `MetricsModule.forRoot()` calls.
- Add regression coverage for shared-registry reuse, app-owned collisions, and label-schema mismatch.

## Testing

- `pnpm install --frozen-lockfile` — completed to hydrate the fresh worktree dependencies; lockfile unchanged.
- `pnpm --filter @fluojs/metrics test` — passed (3 files, 40 tests).
- `pnpm --filter @fluojs/metrics... build && pnpm --filter @fluojs/metrics typecheck` — passed.
- LSP diagnostics on changed TS files — clean after dependency hydration/build.
- `pnpm lint` — completed; changed-mode public export TSDoc passed, while Biome reported existing warnings in unrelated packages.

## Public export documentation

- [x] Changed public exports include a source-level summary. No public export signatures were added or changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No exported function signatures changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. Only package README mirrors changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. No platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. No platform conformance claims changed.