### PR TITLE
Resolve #1592: Serialize queue startup shutdown

### DIFF
--- a/.changeset/queue-lifecycle-startup-shutdown.md
+++ b/.changeset/queue-lifecycle-startup-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/queue": patch
+---
+
+Serialize queue shutdown with in-flight startup so queue-owned BullMQ workers, queues, and Redis duplicate connections are closed reliably during overlapping application lifecycle transitions.

--- a/book/intermediate/ch11-queue.ko.md
+++ b/book/intermediate/ch11-queue.ko.md
@@ -109,7 +109,7 @@ fixed backoff는 예측하기 쉽습니다. exponential backoff는 부하를 받
 
 ## 11.5 Dead-letter handling
 
-모든 retry attempt 이후에도 실패하는 job이 있습니다. 그런 job이 조용히 사라지면 안 됩니다. Queue 패키지는 해당 job을 `fluo:queue:dead-letter:<jobName>` 아래의 Redis dead-letter list로 옮깁니다. 운영자는 이 목록을 통해 무엇이 실패했는지 확인할 수 있는 durable place를 얻습니다. README는 기본 retention policy도 명시합니다. 별도 설정이 없으면 `QueueModule.forRoot()`는 job당 가장 최근 `1_000`개의 dead-letter entry를 유지합니다. 이는 운영상 중요한 기본값입니다. 무한 성장을 막으면서도 최근 실패 증거를 보존하기 때문입니다.
+모든 retry attempt 이후에도 실패하는 job이 있습니다. 그런 실패가 조용히 사라지면 안 됩니다. Queue 패키지는 `fluo:queue:dead-letter:<jobName>` 아래의 Redis dead-letter list에 dead-letter record를 append하며, BullMQ job 자체를 옮기지는 않습니다. 운영자는 이 목록을 통해 무엇이 실패했는지 확인할 수 있는 durable place를 얻습니다. README는 기본 retention policy도 명시합니다. 별도 설정이 없으면 `QueueModule.forRoot()`는 job당 가장 최근 `1_000`개의 dead-letter entry를 유지합니다. 이는 운영상 중요한 기본값입니다. 무한 성장을 막으면서도 최근 실패 증거를 보존하기 때문입니다.
 
 ### 11.5.1 What FluoShop stores in dead letters
 

--- a/book/intermediate/ch11-queue.md
+++ b/book/intermediate/ch11-queue.md
@@ -109,7 +109,7 @@ Fixed backoff is easy to predict. Exponential backoff is often safer for depende
 
 ## 11.5 Dead-letter handling
 
-Some jobs still fail after every retry attempt. Those jobs must not disappear silently. The Queue package moves them to a Redis dead-letter list under `fluo:queue:dead-letter:<jobName>`. That list gives operators a durable place to inspect what failed. The README also states the default retention policy. Without separate configuration, `QueueModule.forRoot()` keeps the most recent `1_000` dead-letter entries per job. This is an important operational default. It prevents unbounded growth while preserving recent failure evidence.
+Some jobs still fail after every retry attempt. Those failures must not disappear silently. The Queue package appends a dead-letter record to a Redis list under `fluo:queue:dead-letter:<jobName>`; it does not move the BullMQ job itself. That list gives operators a durable place to inspect what failed. The README also states the default retention policy. Without separate configuration, `QueueModule.forRoot()` keeps the most recent `1_000` dead-letter entries per job. This is an important operational default. It prevents unbounded growth while preserving recent failure evidence.
 
 ### 11.5.1 What FluoShop stores in dead letters
 

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -929,6 +929,83 @@ describe('@fluojs/queue', () => {
     expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
   });
 
+  it('waits for in-flight startup before closing queue-owned resources during shutdown', async () => {
+    const releaseStartup = createDeferred<void>();
+    const loggerEvents: string[] = [];
+
+    class SlowStartupJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(SlowStartupJob)
+    class SlowStartupWorker {
+      async handle(_job: SlowStartupJob): Promise<void> {}
+    }
+
+    class AppModule {}
+
+    const redis = new MockRedisClient();
+    const originalDuplicate = redis.duplicate.bind(redis);
+    let duplicateCount = 0;
+    redis.duplicate = (options: MockRedisDuplicateOptions = {}): MockRedisConnection => {
+      duplicateCount += 1;
+      const connection = originalDuplicate(options);
+      const originalConnect = connection.connect;
+
+      connection.connect = async () => {
+        if (duplicateCount === 1) {
+          await releaseStartup.promise;
+        }
+
+        await originalConnect();
+      };
+
+      return connection;
+    };
+
+    const container = {
+      has: (token: unknown) => token === REDIS_CLIENT,
+      resolve: async (token: unknown) => {
+        if (token === REDIS_CLIENT) {
+          return redis;
+        }
+
+        return new SlowStartupWorker();
+      },
+    };
+    const service = new QueueLifecycleService(
+      {
+        defaultAttempts: 1,
+        defaultConcurrency: 1,
+        defaultDeadLetterMaxEntries: 1_000,
+      },
+      container as never,
+      [
+        {
+          definition: { providers: [SlowStartupWorker] },
+          type: AppModule,
+        },
+      ] as never,
+      createLogger(loggerEvents),
+    );
+
+    const startupPromise = service.onApplicationBootstrap();
+    await Promise.resolve();
+
+    const shutdownPromise = service.onApplicationShutdown();
+    await Promise.resolve();
+
+    releaseStartup.resolve();
+
+    await startupPromise;
+    await shutdownPromise;
+
+    expect(bullmqState.workers.get('SlowStartupJob')?.closeCalls).toBe(1);
+    expect(bullmqState.queues.get('SlowStartupJob')?.closeCalls).toBe(1);
+    expect(redis.duplicates).toHaveLength(2);
+    expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
+  });
+
   it('returns deterministic state-aware errors for enqueue after shutdown', async () => {
     class ShutdownStateJob {
       constructor(public readonly value: string) {}

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -1006,6 +1006,78 @@ describe('@fluojs/queue', () => {
     expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
   });
 
+  it('keeps shutdown terminal when in-flight startup fails during shutdown', async () => {
+    const releaseStartup = createDeferred<void>();
+    const loggerEvents: string[] = [];
+
+    class FailingStartupOverlapJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(FailingStartupOverlapJob)
+    class FailingStartupOverlapWorker {
+      async handle(_job: FailingStartupOverlapJob): Promise<void> {}
+    }
+
+    class AppModule {}
+
+    const redis = new MockRedisClient();
+    const originalDuplicate = redis.duplicate.bind(redis);
+    redis.duplicate = (options: MockRedisDuplicateOptions = {}): MockRedisConnection => {
+      const connection = originalDuplicate(options);
+      const originalConnect = connection.connect;
+
+      connection.connect = async () => {
+        await releaseStartup.promise;
+        await originalConnect();
+      };
+
+      return connection;
+    };
+
+    const container = {
+      has: (token: unknown) => token === REDIS_CLIENT,
+      resolve: async (token: unknown) => {
+        if (token === REDIS_CLIENT) {
+          return redis;
+        }
+
+        return new FailingStartupOverlapWorker();
+      },
+    };
+    const service = new QueueLifecycleService(
+      {
+        defaultAttempts: 1,
+        defaultConcurrency: 1,
+        defaultDeadLetterMaxEntries: 1_000,
+      },
+      container as never,
+      [
+        {
+          definition: { providers: [FailingStartupOverlapWorker] },
+          type: AppModule,
+        },
+      ] as never,
+      createLogger(loggerEvents),
+    );
+
+    const startupPromise = service.onApplicationBootstrap();
+    await Promise.resolve();
+
+    const shutdownPromise = service.onApplicationShutdown();
+    await Promise.resolve();
+
+    releaseStartup.reject(new Error('startup overlap failed'));
+
+    await expect(startupPromise).rejects.toThrow('startup overlap failed');
+    await shutdownPromise;
+
+    expect(service.createPlatformStatusSnapshot().details).toMatchObject({ lifecycleState: 'stopped' });
+    expect(redis.duplicates).toHaveLength(1);
+    expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
+    await expect(service.enqueue(new FailingStartupOverlapJob('after-stop'))).rejects.toThrow('Queue lifecycle state is stopped.');
+  });
+
   it('returns deterministic state-aware errors for enqueue after shutdown', async () => {
     class ShutdownStateJob {
       constructor(public readonly value: string) {}

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -2,12 +2,12 @@ import { Inject } from '@fluojs/core';
 import { cloneWithFallback } from '@fluojs/core/internal';
 import type { Container } from '@fluojs/di';
 import { getRedisClientToken, getRedisComponentId } from '@fluojs/redis';
-import {
-  type ApplicationLogger,
-  type CompiledModule,
-  type OnApplicationBootstrap,
-  type OnApplicationShutdown,
-  type OnModuleDestroy,
+import type {
+  ApplicationLogger,
+  CompiledModule,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+  OnModuleDestroy,
 } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 import { Queue as BullQueue, Worker as BullWorker, type ConnectionOptions, type JobsOptions, type Job as BullJob } from 'bullmq';
@@ -471,13 +471,32 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     this.lifecycleState = 'stopping';
 
     this.shutdownPromise = (async () => {
+      await this.waitForInFlightStartup();
+
       await this.closeInitializedResources();
       await this.deadLetterManager.drainPendingWrites();
       this.lifecycleState = 'stopped';
+      this.redisClient = undefined;
       this.startPromise = undefined;
     })();
 
     await this.shutdownPromise;
+  }
+
+  private async waitForInFlightStartup(): Promise<void> {
+    const startup = this.startPromise;
+
+    if (!startup) {
+      return;
+    }
+
+    try {
+      await startup;
+    } catch {
+      // ensureStarted() owns startup rollback and preserves the original
+      // bootstrap error. Shutdown still continues so partially registered
+      // resources cannot outlive the application lifecycle.
+    }
   }
 
   private async closeInitializedResources(): Promise<void> {

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -171,6 +171,10 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   async enqueue<TJob extends object>(job: TJob): Promise<string> {
     await this.ensureStarted();
 
+    if (this.lifecycleState !== 'started') {
+      throw new Error(`Queue lifecycle state is ${this.lifecycleState}.`);
+    }
+
     const descriptor = this.descriptorsByJobType.get(job.constructor as QueueJobType);
 
     if (!descriptor) {
@@ -241,12 +245,16 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     }
 
     await this.initializeWorkers(redis);
-    this.lifecycleState = 'started';
+    if (this.lifecycleState === 'starting') {
+      this.lifecycleState = 'started';
+    }
   }
 
   private async handleStartupFailure(): Promise<void> {
     await this.closeInitializedResources();
-    this.lifecycleState = 'idle';
+    if (this.lifecycleState === 'starting') {
+      this.lifecycleState = 'idle';
+    }
     this.redisClient = undefined;
     this.startPromise = undefined;
   }


### PR DESCRIPTION
## Summary

- Closes #1592.
- Serializes `@fluojs/queue` shutdown with in-flight startup so queue-owned BullMQ resources are closed after startup finishes.
- Aligns queue book DLQ wording with the package contract that dead-letter records are appended rather than BullMQ jobs moved.

## Changes

- Added a shutdown wait path for `startPromise` before closing workers, queues, and duplicate Redis connections.
- Added regressions covering shutdown during delayed startup connection creation and startup failure overlap.
- Added a patch changeset for `@fluojs/queue` and updated EN/KO chapter 11 DLQ wording.

## Testing

- `pnpm install --frozen-lockfile` — passed.
- `pnpm --filter @fluojs/queue test` — passed: 3 files, 26 tests.
- `pnpm build` — passed.
- `pnpm --filter @fluojs/queue typecheck` — passed after workspace build.
- `pnpm exec biome lint "packages/queue/src/service.ts" "packages/queue/src/module.test.ts" "book/intermediate/ch11-queue.md" "book/intermediate/ch11-queue.ko.md"` — passed.
- LSP diagnostics for `packages/queue/src` — 0 diagnostics after dependency install.

Note: `pnpm lint --changed=origin/main` is not a supported repo script path here: it runs full `biome lint` and then forwards `--changed=origin/main` to `verify-public-export-tsdoc`, which rejects that option. Full `biome lint` also reports pre-existing unrelated diagnostics outside this PR, so targeted changed-file lint is listed above.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; the existing `QueueLifecycleService` public surface is preserved.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The queue README already documents lifecycle-managed execution, retry/backoff, and DLQ append semantics. This PR preserves that public contract and adds startup/shutdown overlap regressions.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs or package conformance claims changed.
