### PR TITLE
Resolve #1585: Align OpenAPI default success status with HTTP contracts

### DIFF
--- a/.changeset/openapi-default-success-status.md
+++ b/.changeset/openapi-default-success-status.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/openapi": patch
+---
+
+Align implicit OpenAPI success response statuses with HTTP route defaults so undocumented POST responses are generated as 201 instead of 200.

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -78,7 +78,7 @@ fluo는 컨트롤러와 메서드를 조사하여 전체 OpenAPI 3.1.0 문서를
 HTTP 핸들러가 `@fluojs/http`의 `@Produces(...)`를 선언하면, 생성된 OpenAPI 응답은 해당 미디어 타입을 response `content` 키로 사용합니다. 예를 들어 `@ApiResponse(...)` 스키마가 있는 핸들러에 `@Produces('application/json', 'application/problem+json')`를 붙이면, `application/json`만으로 되돌아가지 않고 두 미디어 타입 모두 같은 응답 스키마로 방출합니다.
 
 ### 기본 성공 응답
-핸들러가 `@ApiResponse(...)`를 선언하지 않으면 생성된 OpenAPI 응답은 `@fluojs/http` 라우트 관례를 따릅니다. `POST` 핸들러는 기본적으로 `201`, 그 밖의 메서드는 `200`을 사용합니다. 엔드포인트가 의도적으로 다른 성공 상태를 반환해야 한다면 `@ApiResponse(...)` 또는 `@HttpCode(...)`를 사용하세요.
+핸들러가 `@ApiResponse(...)` 또는 `@HttpCode(...)`를 선언하지 않으면 OpenAPI builder는 메서드만 기준으로 한 암묵적 기본값을 적용합니다. `POST` 핸들러는 기본적으로 `201`, 그 밖의 메서드는 `200`을 사용합니다. `DELETE`와 `OPTIONS`처럼 본문이 없거나 런타임 결과에 따라 달라질 수 있는 경우에는 `@HttpCode(...)` 또는 `@ApiResponse(...)`로 의도한 성공 상태를 명시하세요.
 
 ### 통합 DTO 스키마
 `@fluojs/validation`과 원활하게 작동합니다. DTO 클래스는 자동으로 OpenAPI 컴포넌트로 변환되어 적절한 오퍼레이션에서 참조됩니다.

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -77,6 +77,9 @@ fluo는 컨트롤러와 메서드를 조사하여 전체 OpenAPI 3.1.0 문서를
 ### 응답 미디어 타입
 HTTP 핸들러가 `@fluojs/http`의 `@Produces(...)`를 선언하면, 생성된 OpenAPI 응답은 해당 미디어 타입을 response `content` 키로 사용합니다. 예를 들어 `@ApiResponse(...)` 스키마가 있는 핸들러에 `@Produces('application/json', 'application/problem+json')`를 붙이면, `application/json`만으로 되돌아가지 않고 두 미디어 타입 모두 같은 응답 스키마로 방출합니다.
 
+### 기본 성공 응답
+핸들러가 `@ApiResponse(...)`를 선언하지 않으면 생성된 OpenAPI 응답은 `@fluojs/http` 라우트 관례를 따릅니다. `POST` 핸들러는 기본적으로 `201`, 그 밖의 메서드는 `200`을 사용합니다. 엔드포인트가 의도적으로 다른 성공 상태를 반환해야 한다면 `@ApiResponse(...)` 또는 `@HttpCode(...)`를 사용하세요.
+
 ### 통합 DTO 스키마
 `@fluojs/validation`과 원활하게 작동합니다. DTO 클래스는 자동으로 OpenAPI 컴포넌트로 변환되어 적절한 오퍼레이션에서 참조됩니다.
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -78,7 +78,7 @@ fluo inspects your controllers and methods to build a complete OpenAPI 3.1.0 doc
 When an HTTP handler declares `@Produces(...)` from `@fluojs/http`, generated OpenAPI responses use those media types as the response `content` keys. For example, `@Produces('application/json', 'application/problem+json')` on a handler with an `@ApiResponse(...)` schema emits both media types with the same response schema instead of silently falling back to only `application/json`.
 
 ### Default Success Responses
-When a handler does not declare `@ApiResponse(...)`, generated OpenAPI responses follow `@fluojs/http` route conventions: `POST` handlers default to `201`, and other methods default to `200`. Use `@ApiResponse(...)` or `@HttpCode(...)` when an endpoint intentionally returns a different success status.
+When a handler does not declare `@ApiResponse(...)` or `@HttpCode(...)`, the OpenAPI builder applies method-only implicit defaults: `POST` handlers default to `201`, and other methods default to `200`. Bodyless or runtime-dependent cases such as `DELETE` and `OPTIONS` should declare the intended success status explicitly with `@HttpCode(...)` or `@ApiResponse(...)`.
 
 ### Integrated DTO Schemas
 Works seamlessly with `@fluojs/validation`. Your DTO classes are automatically converted to OpenAPI components and referenced in the appropriate operations.

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -77,6 +77,9 @@ fluo inspects your controllers and methods to build a complete OpenAPI 3.1.0 doc
 ### Response Media Types
 When an HTTP handler declares `@Produces(...)` from `@fluojs/http`, generated OpenAPI responses use those media types as the response `content` keys. For example, `@Produces('application/json', 'application/problem+json')` on a handler with an `@ApiResponse(...)` schema emits both media types with the same response schema instead of silently falling back to only `application/json`.
 
+### Default Success Responses
+When a handler does not declare `@ApiResponse(...)`, generated OpenAPI responses follow `@fluojs/http` route conventions: `POST` handlers default to `201`, and other methods default to `200`. Use `@ApiResponse(...)` or `@HttpCode(...)` when an endpoint intentionally returns a different success status.
+
 ### Integrated DTO Schemas
 Works seamlessly with `@fluojs/validation`. Your DTO classes are automatically converted to OpenAPI components and referenced in the appropriate operations.
 

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { IsArray, IsEnum, IsOptional, IsString, MinLength, ValidateNested } from '@fluojs/validation';
-import { Controller, FromBody, Get, Post, Produces, RequestDto, createHandlerMapping } from '@fluojs/http';
+import { Controller, FromBody, Get, HttpCode, Post, Produces, RequestDto, createHandlerMapping } from '@fluojs/http';
 
 import { ApiBearerAuth, ApiBody, ApiExcludeEndpoint, ApiOperation, ApiResponse, ApiSecurity } from './decorators.js';
 import { buildOpenApiDocument } from './schema-builder.js';
@@ -355,6 +355,29 @@ describe('buildOpenApiDocument', () => {
 
     expect(document.paths['/explicit-status']?.post?.responses).toEqual({
       '202': { description: 'Accepted for async processing' },
+    });
+  });
+
+  it('reflects explicit HttpCode overrides in response statuses', () => {
+    @Controller('/http-code-status')
+    class HttpCodeStatusController {
+      @HttpCode(204)
+      @Post('/')
+      create() {
+        return undefined;
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: HttpCodeStatusController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'HTTP Code Status API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/http-code-status']?.post?.responses).toEqual({
+      '204': { description: 'OK' },
     });
   });
 

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -305,6 +305,59 @@ describe('buildOpenApiDocument', () => {
     });
   });
 
+  it('aligns implicit response statuses with HTTP route defaults', () => {
+    @Controller('/implicit-status')
+    class ImplicitStatusController {
+      @Post('/')
+      create() {
+        return { created: true };
+      }
+
+      @Get('/')
+      list() {
+        return [];
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: ImplicitStatusController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Implicit Status API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/implicit-status']?.post?.responses).toEqual({
+      '201': { description: 'OK' },
+    });
+    expect(document.paths['/implicit-status']?.get?.responses).toEqual({
+      '200': { description: 'OK' },
+    });
+  });
+
+  it('keeps explicit ApiResponse statuses ahead of HTTP route defaults', () => {
+    @Controller('/explicit-status')
+    class ExplicitStatusController {
+      @ApiResponse(202, { description: 'Accepted for async processing' })
+      @Post('/')
+      create() {
+        return { accepted: true };
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: ExplicitStatusController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Explicit Status API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/explicit-status']?.post?.responses).toEqual({
+      '202': { description: 'Accepted for async processing' },
+    });
+  });
+
   it('uses controller names as default tags when @ApiTag is absent', () => {
     @Controller('/untagged')
     class UntaggedController {

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -1049,6 +1049,10 @@ function createResponseObject(
   };
 }
 
+function resolveDocumentedDefaultSuccessStatus(method: HttpMethod): number {
+  return method === 'POST' ? 201 : 200;
+}
+
 function createOperationResponses(
   descriptor: HandlerDescriptor,
   methodMeta: MethodApiMetadata | undefined,
@@ -1064,7 +1068,9 @@ function createOperationResponses(
       responses[String(response.status)] = createResponseObject(response, responseMediaTypes, componentSchemas, context);
     }
   } else {
-    responses[String(descriptor.route.successStatus ?? 200)] = { description: 'OK' };
+    responses[String(descriptor.route.successStatus ?? resolveDocumentedDefaultSuccessStatus(descriptor.route.method))] = {
+      description: 'OK',
+    };
   }
 
   if (defaultErrorResponsesPolicy === 'inject') {


### PR DESCRIPTION
## Summary

Closes #1585

Aligns `@fluojs/openapi` implicit success response generation with the document builder's supported success-status contract: undocumented `POST` operations generate `201`, other methods generate `200`, and runtime-dependent/bodyless statuses should be declared explicitly.

## Changes

- Added OpenAPI document builder default success status resolution for implicit `POST` responses.
- Added regression coverage for implicit route defaults, explicit `@ApiResponse(...)` precedence, and explicit `@HttpCode(204)` overrides.
- Narrowed the default success response contract in `packages/openapi/README.md` and `packages/openapi/README.ko.md` so it does not overclaim full `@fluojs/http` runtime route conventions.
- Added a patch changeset for `@fluojs/openapi`.

## Testing

- LSP diagnostics for `packages/openapi/src/schema-builder.test.ts` — no diagnostics
- `pnpm --filter @fluojs/openapi test` — passed (45 tests)
- `pnpm --filter @fluojs/openapi typecheck` — passed
- `pnpm --filter @fluojs/openapi build` — passed
- `pnpm lint` — passed; existing repo-wide Biome warnings were reported outside this lane, and changed-mode public export TSDoc passed

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary. (No public exports changed.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (No exported functions changed.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (Not applicable.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (Not applicable; this is OpenAPI/HTTP document generation behavior.)