### PR TITLE
Resolve #1602: Harden Terminus health diagnostics

### DIFF
--- a/.changeset/sharp-ducks-switch.md
+++ b/.changeset/sharp-ducks-switch.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/terminus": patch
+---
+
+Reject blank health indicator result keys as down diagnostics and lazy-load Node filesystem access so root Terminus imports stay runtime-safe. Node-specific memory/disk indicators are also available from the `@fluojs/terminus/node` subpath.

--- a/book/beginner/ch18-health.ko.md
+++ b/book/beginner/ch18-health.ko.md
@@ -77,7 +77,8 @@ Fluo 생태계의 최신 상태를 유지하면 신뢰성 엔지니어링 분야
 
 ```typescript
 import { Module } from '@fluojs/core';
-import { MemoryHealthIndicator, TerminusModule } from '@fluojs/terminus';
+import { TerminusModule } from '@fluojs/terminus';
+import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 
 @Module({
   imports: [

--- a/book/beginner/ch18-health.md
+++ b/book/beginner/ch18-health.md
@@ -77,7 +77,8 @@ Register `TerminusModule` and prepare the configuration that will expose monitor
 
 ```typescript
 import { Module } from '@fluojs/core';
-import { MemoryHealthIndicator, TerminusModule } from '@fluojs/terminus';
+import { TerminusModule } from '@fluojs/terminus';
+import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 
 @Module({
   imports: [

--- a/docs/architecture/observability.ko.md
+++ b/docs/architecture/observability.ko.md
@@ -26,7 +26,7 @@
 
 - `TerminusHealthService.check()`는 등록된 indicator를 indicator result key 기준으로 집계하여 `info`, `error`, `details` 맵을 만든다.
 - `execution.indicatorTimeoutMs`는 느리거나 멈춘 indicator probe를 무기한 대기하지 않고 `down` 결과로 바꾼다.
-- 기본 제공 indicator 패키지에는 HTTP, memory, disk, Prisma, Drizzle, Redis 변형이 포함되며 Redis는 `@fluojs/terminus/redis`에서 export된다.
+- 기본 제공 indicator 패키지에는 HTTP, memory, disk, Prisma, Drizzle, Redis 변형이 포함되며 Node 전용 memory/disk indicator는 `@fluojs/terminus/node`, Redis는 `@fluojs/terminus/redis`에서 export된다.
 
 ## Readiness vs Liveness
 

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -26,7 +26,7 @@
 
 - `TerminusHealthService.check()` aggregates registered indicators into `info`, `error`, and `details` maps keyed by indicator result keys.
 - `execution.indicatorTimeoutMs` converts slow or hanging indicator probes into `down` results instead of waiting indefinitely.
-- Built-in indicator packages include HTTP, memory, disk, Prisma, Drizzle, and Redis variants, with Redis exported from `@fluojs/terminus/redis`.
+- Built-in indicator packages include HTTP, memory, disk, Prisma, Drizzle, and Redis variants, with Node-specific memory/disk indicators exported from `@fluojs/terminus/node` and Redis exported from `@fluojs/terminus/redis`.
 
 ## Readiness vs Liveness
 

--- a/examples/ops-metrics-terminus/src/app.ts
+++ b/examples/ops-metrics-terminus/src/app.ts
@@ -1,6 +1,7 @@
 import { Module } from '@fluojs/core';
 import { MetricsModule } from '@fluojs/metrics';
-import { MemoryHealthIndicator, TerminusModule } from '@fluojs/terminus';
+import { TerminusModule } from '@fluojs/terminus';
+import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 
 import { OpsModule } from './ops/ops.module';
 import { sharedRegistry } from './ops/metrics-registry';

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "paths": {
+      "@fluojs/terminus/node": ["../packages/terminus/src/node.ts"],
       "@fluojs/*": ["../packages/*/src/index.ts"]
     },
     "types": ["node"]

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -37,7 +37,8 @@ pnpm add @fluojs/terminus
 
 ```typescript
 import { Module } from '@fluojs/core';
-import { HttpHealthIndicator, MemoryHealthIndicator, TerminusModule } from '@fluojs/terminus';
+import { HttpHealthIndicator, TerminusModule } from '@fluojs/terminus';
+import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 
 @Module({
   imports: [
@@ -61,8 +62,8 @@ class AppModule {}
 - `PrismaHealthIndicator` / `DrizzleHealthIndicator`
 - `RedisHealthIndicator` (`@fluojs/terminus/redis`에서 제공)
 - `HttpHealthIndicator`
-- `MemoryHealthIndicator`
-- `DiskHealthIndicator`
+- `MemoryHealthIndicator` (`@fluojs/terminus/node`에서 제공)
+- `DiskHealthIndicator` (`@fluojs/terminus/node`에서 제공)
 
 ### DI 기반 인디케이터
 
@@ -114,6 +115,7 @@ TerminusModule.forRoot({
 - 응답 본문은 `status`, `contributors`, `info`, `error`, `details`를 포함한 구조화된 JSON 객체입니다.
 - 하나의 인디케이터가 여러 keyed entry를 반환할 수도 있으며, 이 경우 `/health`는 모든 entry를 `details`와 `contributors.up` / `contributors.down` 요약에 그대로 반영합니다.
 - 지원하지 않는 status, 빈 결과, 객체가 아닌 인디케이터 결과는 조용히 버려지지 않고 `down` 진단으로 보고됩니다.
+- Blank indicator result key는 healthy entry로 기여하지 않고 `down` 진단으로 보고됩니다.
 - 같은 실행에서 이미 보고된 key를 다른 인디케이터가 다시 사용하면, Terminus는 먼저 기록된 entry를 유지하고 데이터를 조용히 덮어쓰는 대신 결정적인 `*-duplicate-key-error` contributor를 추가합니다.
 - 플랫폼 health/readiness 실패는 `/health` 응답에서 결정적인 `fluo-platform-health`, `fluo-platform-readiness` contributor로 노출됩니다.
 - Runtime diagnostics가 있으면 `/health` response에 platform health/readiness detail을 담은 `platform` block이 포함될 수 있습니다.
@@ -143,6 +145,11 @@ TerminusModule.forRoot({
 
 - `RedisHealthIndicator`, `createRedisHealthIndicator()`, `createRedisHealthIndicatorProvider()`
   - Redis 전용 인디케이터 헬퍼는 선택적 Redis 피어가 설치되지 않은 환경에서도 루트 패키지 import가 안전하도록 전용 subpath에서 export됩니다.
+
+### `@fluojs/terminus/node`
+
+- `MemoryHealthIndicator`, `DiskHealthIndicator`, `createMemoryHealthIndicator()`, `createDiskHealthIndicator()`
+  - Node 전용 indicator helper는 non-Node runtime에서도 root package import가 안전하도록 전용 subpath에서 export됩니다.
 
 
 ### `HealthCheckError`

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -62,8 +62,8 @@ class AppModule {}
 - `PrismaHealthIndicator` / `DrizzleHealthIndicator`
 - `RedisHealthIndicator` (`@fluojs/terminus/redis`에서 제공)
 - `HttpHealthIndicator`
-- `MemoryHealthIndicator` (`@fluojs/terminus/node`에서 제공)
-- `DiskHealthIndicator` (`@fluojs/terminus/node`에서 제공)
+- `MemoryHealthIndicator` (호환성을 위해 root에서도 export되며 `@fluojs/terminus/node`에서도 제공)
+- `DiskHealthIndicator` (호환성을 위해 root에서도 export되며 `@fluojs/terminus/node`에서도 제공)
 
 ### DI 기반 인디케이터
 
@@ -149,7 +149,7 @@ TerminusModule.forRoot({
 ### `@fluojs/terminus/node`
 
 - `MemoryHealthIndicator`, `DiskHealthIndicator`, `createMemoryHealthIndicator()`, `createDiskHealthIndicator()`
-  - Node 전용 indicator helper는 non-Node runtime에서도 root package import가 안전하도록 전용 subpath에서 export됩니다.
+  - Node 전용 indicator helper는 호환성을 위해 root에서도 계속 export되며 이 전용 subpath에서도 export됩니다. Disk check의 filesystem access는 lazy-load되므로 root package import 시점에는 Node filesystem module을 load하지 않습니다.
 
 
 ### `HealthCheckError`

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -60,8 +60,8 @@ The package provides several indicators out of the box:
 - `PrismaHealthIndicator` / `DrizzleHealthIndicator`
 - `RedisHealthIndicator` (from `@fluojs/terminus/redis`)
 - `HttpHealthIndicator`
-- `MemoryHealthIndicator` (from `@fluojs/terminus/node`)
-- `DiskHealthIndicator` (from `@fluojs/terminus/node`)
+- `MemoryHealthIndicator` (root-exported for compatibility and also available from `@fluojs/terminus/node`)
+- `DiskHealthIndicator` (root-exported for compatibility and also available from `@fluojs/terminus/node`)
 
 ### DI-Backed Indicators
 
@@ -149,7 +149,7 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 ### `@fluojs/terminus/node`
 
 - `MemoryHealthIndicator`, `DiskHealthIndicator`, `createMemoryHealthIndicator()`, `createDiskHealthIndicator()`
-  - Node-specific indicator helpers are exported from the dedicated subpath so the root package stays import-safe in non-Node runtimes.
+  - Node-specific indicator helpers remain root-exported for compatibility and are also exported from this dedicated subpath. Filesystem access for disk checks is lazy-loaded so importing the root package does not load Node filesystem modules at module initialization time.
 
 
 ### `HealthCheckError`

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -35,7 +35,8 @@ Import `TerminusModule.forRoot()` to register health indicators.
 
 ```typescript
 import { Module } from '@fluojs/core';
-import { HttpHealthIndicator, MemoryHealthIndicator, TerminusModule } from '@fluojs/terminus';
+import { HttpHealthIndicator, TerminusModule } from '@fluojs/terminus';
+import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 
 @Module({
   imports: [
@@ -59,8 +60,8 @@ The package provides several indicators out of the box:
 - `PrismaHealthIndicator` / `DrizzleHealthIndicator`
 - `RedisHealthIndicator` (from `@fluojs/terminus/redis`)
 - `HttpHealthIndicator`
-- `MemoryHealthIndicator`
-- `DiskHealthIndicator`
+- `MemoryHealthIndicator` (from `@fluojs/terminus/node`)
+- `DiskHealthIndicator` (from `@fluojs/terminus/node`)
 
 ### DI-Backed Indicators
 
@@ -114,6 +115,7 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 - The response body contains a structured JSON object with `status`, `contributors`, `info`, `error`, and `details`.
 - Indicators may emit multiple keyed entries in a single check result; `/health` preserves every keyed entry in `details` and in the `contributors.up` / `contributors.down` summaries.
 - Unsupported, empty, or non-object indicator results are reported as `down` diagnostics instead of being silently discarded.
+- Blank indicator result keys are reported as `down` diagnostics instead of contributing healthy entries.
 - If an indicator reuses a key that was already reported earlier in the same run, Terminus keeps the first entry and adds a deterministic `*-duplicate-key-error` contributor instead of silently overwriting data.
 - Platform health/readiness failures are surfaced as deterministic `fluo-platform-health` and `fluo-platform-readiness` contributors in `/health` responses.
 - `/health` responses may include a `platform` block with platform health/readiness details when runtime diagnostics are available.
@@ -143,6 +145,11 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 
 - `RedisHealthIndicator`, `createRedisHealthIndicator()`, `createRedisHealthIndicatorProvider()`
   - Redis-specific indicator helpers are exported from the dedicated subpath so the root package stays import-safe without the optional Redis peer installed.
+
+### `@fluojs/terminus/node`
+
+- `MemoryHealthIndicator`, `DiskHealthIndicator`, `createMemoryHealthIndicator()`, `createDiskHealthIndicator()`
+  - Node-specific indicator helpers are exported from the dedicated subpath so the root package stays import-safe in non-Node runtimes.
 
 
 ### `HealthCheckError`

--- a/packages/terminus/package.json
+++ b/packages/terminus/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "import": "./dist/node.js"
+    },
     "./redis": {
       "types": "./dist/redis.d.ts",
       "import": "./dist/redis.js"

--- a/packages/terminus/src/health-check.test.ts
+++ b/packages/terminus/src/health-check.test.ts
@@ -189,24 +189,24 @@ describe('runHealthCheck', () => {
     });
   });
 
-  it('keeps first entries when malformed blank result keys fold to an existing indicator key', async () => {
+  it('reports blank result keys as down diagnostics instead of healthy contributors', async () => {
     const report = await runHealthCheck([
       {
         key: 'dependencies',
         check: async () => unsafeHealthIndicatorResult({
           dependencies: { status: 'up' },
-          ' ': { message: 'blank key should not overwrite', status: 'degraded' },
+          ' ': { status: 'up' },
         }),
       },
     ]);
 
     expect(report.details.dependencies).toEqual({ status: 'up' });
-    expect(report.details['dependencies-duplicate-key-error']).toEqual({
-      message: 'Indicator produced duplicate result key(s): dependencies.',
+    expect(report.details['dependencies-blank-key-error']).toEqual({
+      message: 'Indicator returned a blank result key.',
       status: 'down',
     });
     expect(report.contributors).toEqual({
-      down: ['dependencies-duplicate-key-error'],
+      down: ['dependencies-blank-key-error'],
       up: ['dependencies'],
     });
   });

--- a/packages/terminus/src/health-check.ts
+++ b/packages/terminus/src/health-check.ts
@@ -70,6 +70,34 @@ function createUnsupportedEntryMessage(entryKey: string): string {
     : 'Indicator returned an unsupported status value for an empty result key.';
 }
 
+function createBlankKeyFailureKey(indicatorKey: string, seenKeys: ReadonlySet<string>): string {
+  const baseKey = `${indicatorKey}-blank-key-error`;
+
+  if (!seenKeys.has(baseKey)) {
+    return baseKey;
+  }
+
+  let suffix = 2;
+  let candidate = `${baseKey}-${String(suffix)}`;
+
+  while (seenKeys.has(candidate)) {
+    suffix += 1;
+    candidate = `${baseKey}-${String(suffix)}`;
+  }
+
+  return candidate;
+}
+
+function createBlankKeyFailure(indicatorKey: string, seenKeys: ReadonlySet<string>): HealthCheckEntry {
+  return [
+    createBlankKeyFailureKey(indicatorKey, seenKeys),
+    {
+      message: 'Indicator returned a blank result key.',
+      status: 'down',
+    },
+  ];
+}
+
 function normalizeIndicatorResult(key: string, result: unknown): HealthCheckEntry[] {
   if (typeof result !== 'object' || result === null || Array.isArray(result)) {
     return [
@@ -95,7 +123,14 @@ function normalizeIndicatorResult(key: string, result: unknown): HealthCheckEntr
   }
 
   for (const [entryKey, entryValue] of entries) {
-    const normalizedKey = hasIndicatorStatus(entryValue) || entryKey.trim().length > 0 ? entryKey : key;
+    if (entryKey.trim().length === 0) {
+      const blankKeyFailure = createBlankKeyFailure(key, seenKeys);
+      seenKeys.add(blankKeyFailure[0]);
+      normalizedEntries.push(blankKeyFailure);
+      continue;
+    }
+
+    const normalizedKey = entryKey;
 
     if (seenKeys.has(normalizedKey)) {
       duplicateKeys.push(normalizedKey);

--- a/packages/terminus/src/indicators/disk.ts
+++ b/packages/terminus/src/indicators/disk.ts
@@ -1,5 +1,3 @@
-import { statfs } from 'node:fs/promises';
-
 import type { Provider } from '@fluojs/di';
 
 import { createDownResult, createUpResult, resolveIndicatorKey, throwHealthCheckError } from './utils.js';
@@ -17,6 +15,12 @@ const DEFAULT_DISK_FREE_RATIO_THRESHOLD = 0.1;
 
 function toNumber(value: bigint | number): number {
   return typeof value === 'bigint' ? Number(value) : value;
+}
+
+async function statFilesystem(path: string) {
+  const { statfs } = await import('node:fs/promises');
+
+  return statfs(path);
 }
 
 /**
@@ -56,7 +60,7 @@ export class DiskHealthIndicator implements HealthIndicator {
     const minFreeRatio = this.options.minFreeRatio ?? DEFAULT_DISK_FREE_RATIO_THRESHOLD;
 
     try {
-      const stats = await statfs(path);
+      const stats = await statFilesystem(path);
       const blockSize = toNumber(stats.bsize);
       const blocks = toNumber(stats.blocks);
       const availableBlocks = toNumber(stats.bavail);

--- a/packages/terminus/src/module.ts
+++ b/packages/terminus/src/module.ts
@@ -297,6 +297,8 @@ export class TerminusModule {
    *
    * @example
    * ```ts
+   * import { MemoryHealthIndicator } from '@fluojs/terminus/node';
+   *
    * TerminusModule.forRoot({
    *   indicators: [new MemoryHealthIndicator({ key: 'memory' })],
    * });

--- a/packages/terminus/src/node.ts
+++ b/packages/terminus/src/node.ts
@@ -1,0 +1,2 @@
+export * from './indicators/disk.js';
+export * from './indicators/memory.js';

--- a/packages/terminus/src/public-subpaths.test.ts
+++ b/packages/terminus/src/public-subpaths.test.ts
@@ -16,6 +16,10 @@ describe('@fluojs/terminus subpath exports', () => {
     };
 
     expect(packageJson.exports).toMatchObject({
+      './node': {
+        import: './dist/node.js',
+        types: './dist/node.d.ts',
+      },
       './redis': {
         import: './dist/redis.js',
         types: './dist/redis.d.ts',

--- a/packages/terminus/src/public-subpaths.test.ts
+++ b/packages/terminus/src/public-subpaths.test.ts
@@ -8,7 +8,7 @@ type ExportTarget = {
 };
 
 describe('@fluojs/terminus subpath exports', () => {
-  it('keeps the redis subpath aligned with emitted dist artifacts', () => {
+  it('keeps the node and redis subpaths aligned with emitted dist artifacts', () => {
     const packageJson = JSON.parse(
       readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
     ) as {

--- a/packages/terminus/src/public-surface.test.ts
+++ b/packages/terminus/src/public-surface.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import * as terminus from './index.js';
+import * as terminusNode from './node.js';
 import * as terminusRedis from './redis.js';
 
 describe('terminus public surface', () => {
@@ -9,6 +10,8 @@ describe('terminus public surface', () => {
     expect(terminus).toHaveProperty('TERMINUS_INDICATOR_PROVIDER_TOKENS');
     expect(terminus).toHaveProperty('TerminusHealthService');
     expect(terminus).not.toHaveProperty('TERMINUS_OPTIONS');
+    expect(terminus).toHaveProperty('DiskHealthIndicator');
+    expect(terminus).toHaveProperty('MemoryHealthIndicator');
     expect(terminus).not.toHaveProperty('RedisHealthIndicator');
   });
 
@@ -23,5 +26,12 @@ describe('terminus public surface', () => {
     expect(terminusRedis).toHaveProperty('RedisHealthIndicator');
     expect(terminusRedis).toHaveProperty('createRedisHealthIndicator');
     expect(terminusRedis).toHaveProperty('createRedisHealthIndicatorProvider');
+  });
+
+  it('keeps Node-specific indicators on the dedicated node subpath export', () => {
+    expect(terminusNode).toHaveProperty('DiskHealthIndicator');
+    expect(terminusNode).toHaveProperty('MemoryHealthIndicator');
+    expect(terminusNode).toHaveProperty('createDiskHealthIndicator');
+    expect(terminusNode).toHaveProperty('createMemoryHealthIndicator');
   });
 });

--- a/packages/terminus/src/root-import-runtime-safety.test.ts
+++ b/packages/terminus/src/root-import-runtime-safety.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const filesystemMockState = vi.hoisted(() => ({
+  loads: 0,
+}));
+
+describe('@fluojs/terminus root import runtime safety', () => {
+  it('does not load Node filesystem modules until disk checks run', async () => {
+    vi.resetModules();
+    vi.doMock('node:fs/promises', () => {
+      filesystemMockState.loads += 1;
+
+      return {
+        statfs: async () => {
+          throw new Error('disk check should lazy-load node filesystem modules');
+        },
+      };
+    });
+
+    const terminus = await import('./index.js');
+
+    expect(terminus).toHaveProperty('TerminusModule');
+    expect(filesystemMockState.loads).toBe(0);
+    await expect(new terminus.DiskHealthIndicator({ key: 'disk' }).check('disk')).rejects.toMatchObject({
+      causes: {
+        disk: {
+          message: 'disk check should lazy-load node filesystem modules',
+          status: 'down',
+        },
+      },
+    });
+    expect(filesystemMockState.loads).toBe(1);
+
+    vi.doUnmock('node:fs/promises');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1602

- Rejects blank Terminus indicator result keys as deterministic down diagnostics instead of allowing them to contribute healthy entries.
- Keeps root Terminus imports runtime-safe by lazy-loading Node filesystem access in the disk indicator and adds an explicit `@fluojs/terminus/node` subpath for Node-specific indicators.
- Aligns Terminus README/docs/examples and records a patch changeset for the public package behavior fix.

## Changes

- Added blank-key diagnostic normalization and regression coverage in `runHealthCheck(...)`.
- Added the `@fluojs/terminus/node` export subpath and public-surface/subpath tests.
- Updated Terminus package docs, observability docs, book snippets, and the ops metrics example to show Node-specific indicator imports.
- Added `.changeset/sharp-ducks-switch.md` for `@fluojs/terminus`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/terminus test`
- `pnpm --filter @fluojs/core --filter @fluojs/di --filter @fluojs/http --filter @fluojs/runtime --filter @fluojs/redis build` (first pass exposed missing built dependency declarations)
- `pnpm --filter @fluojs/validation --filter @fluojs/http --filter @fluojs/runtime --filter @fluojs/redis build`
- `pnpm --filter @fluojs/terminus typecheck`
- `pnpm --filter @fluojs/terminus build`
- `pnpm exec tsc -p examples/tsconfig.json --noEmit`
- `pnpm lint` (passes; existing repo-wide Biome warnings/infos are reported outside this lane)
- LSP diagnostics on changed Terminus/example TypeScript files: clean

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable: Terminus indicator behavior is covered by package regression tests rather than platform adapter conformance harnesses.