### PR TITLE
Resolve #1586: Tighten cache Redis TTL and HTTP edge contracts

### DIFF
--- a/.changeset/gentle-redis-caches.md
+++ b/.changeset/gentle-redis-caches.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cache-manager": patch
+---
+
+Tighten Redis fractional TTL freshness and HTTP response cacheability boundaries so cache-manager avoids replaying expired Redis entries or non-success GET responses.

--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -121,6 +121,8 @@ CacheModule.forRoot({
 
 내장 `RedisStore`는 엔트리를 `JSON.stringify(...)`로 저장합니다. 따라서 캐시 값은 JSON 호환 형태여야 합니다. 일반 객체, 배열, 문자열, 숫자, 불리언, `null`은 안정적으로 round-trip 되지만, `Date`는 JSON 결과(예: ISO 문자열)로 돌아오고, 함수/`undefined`/`symbol`은 유지되지 않으며, `bigint`나 순환 그래프처럼 직렬화 불가능한 값은 캐싱 전에 정규화해야 합니다.
 
+양수 Redis TTL 값은 초 단위로 받으며 소수도 허용됩니다. Redis `EX`는 정수 초를 사용하므로 Redis 만료 시간은 다음 정수 초로 올림하지만, fluo는 저장된 엔트리 안에 밀리초 정밀도의 만료 timestamp도 기록하고 해당 timestamp에 도달하면 값을 만료된 것으로 처리합니다. Redis 만료를 의도적으로 사용하지 않으려면 `ttl: 0`을 사용하세요.
+
 Redis reset 소유권은 기본값이 `fluo:cache:`인 `keyPrefix`로 제한됩니다. Redis 기반 저장소에서 `CacheService.reset()`은 해당 prefix 아래의 키만 삭제하므로, cache prefix 밖의 애플리케이션 소유 Redis 데이터는 유지됩니다. 의도적으로 빈 `keyPrefix`를 설정하면 reset은 `*`를 scan하지 않고 현재 `RedisStore` 인스턴스가 쓴 키로만 제한됩니다. 재시작 이후나 여러 프로세스에 걸친 캐시 엔트리까지 reset해야 한다면 비어 있지 않은 애플리케이션 전용 prefix를 사용하세요.
 
 ### 쿼리 매개변수 기반 캐싱
@@ -137,6 +139,8 @@ CacheModule.forRoot({
 ```
 
 완전히 다른 키 전략이 필요하다면 `httpKeyStrategy`에 함수를 전달하거나, literal key 또는 key factory를 받는 `@CacheKey(...)`를 사용하세요.
+
+HTTP 인터셉터는 나중에 재사용할 수 있는 값이 있는 성공한, 아직 commit되지 않은 GET 핸들러 결과만 캐싱합니다. `undefined`, `SseResponse` 스트림, 이미 commit된 응답, 그리고 status code가 `2xx` 범위를 벗어난 응답은 건너뛰므로 redirect와 error 응답은 cache hit로 저장되지 않습니다.
 
 ### 캐시 소유권과 reset 범위
 

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -121,6 +121,8 @@ CacheModule.forRoot({
 
 The built-in `RedisStore` persists entries with `JSON.stringify(...)`. Cache values therefore need to be JSON-compatible: plain objects, arrays, strings, numbers, booleans, and `null` round-trip cleanly, while values such as `Date` come back as JSON output (for example ISO strings), functions/`undefined`/symbols do not survive, and non-serializable values like `bigint` or cyclic graphs should be normalized before caching.
 
+Positive Redis TTL values are accepted in seconds and may be fractional. Redis expiry is rounded up to the next whole second because Redis `EX` uses integer seconds, while fluo also records the millisecond-precision expiry timestamp in the stored entry and treats the value as expired once that timestamp is reached. Use `ttl: 0` when you intentionally want no Redis expiry.
+
 Redis reset ownership is scoped by `keyPrefix`, which defaults to `fluo:cache:`. `CacheService.reset()` deletes only keys under that prefix for Redis-backed stores, so application-owned Redis data outside the cache prefix is preserved. If you intentionally configure an empty `keyPrefix`, reset is limited to keys written by the current `RedisStore` instance instead of scanning `*`; use a non-empty, application-specific prefix when you need reset to cover cache entries across restarts or multiple processes.
 
 ### Query-Sensitive Caching
@@ -137,6 +139,8 @@ CacheModule.forRoot({
 ```
 
 For fully custom keying, pass a function as `httpKeyStrategy` or use `@CacheKey(...)` with either a literal key or a key factory.
+
+The HTTP interceptor caches only successful, uncommitted GET handler results with a value that can be replayed later. It skips `undefined`, `SseResponse` streams, already committed responses, and responses whose status code is outside the `2xx` range, so redirects and error responses are not stored as cache hits.
 
 ### Cache Ownership and Reset Scope
 

--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -1,11 +1,10 @@
+import { type CallHandler, type HttpMethod, type InterceptorContext, type Principal, type RequestContext, SseResponse } from '@fluojs/http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-
-import { SseResponse, type CallHandler, type HttpMethod, type InterceptorContext, type Principal, type RequestContext } from '@fluojs/http';
 
 import { CacheEvict, CacheKey, CacheTTL } from './decorators.js';
 import { CacheInterceptor } from './interceptor.js';
-import { MemoryStore } from './stores/memory-store.js';
 import { CacheService } from './service.js';
+import { MemoryStore } from './stores/memory-store.js';
 import type { NormalizedCacheModuleOptions } from './types.js';
 
 const cacheOptions: NormalizedCacheModuleOptions = {
@@ -91,6 +90,7 @@ function createContext(
   requestContext: RequestContext,
   requestMethod: HttpMethod = 'GET',
   effectivePath = requestContext.request.path,
+  routeOverrides: Partial<InterceptorContext['handler']['route']> = {},
 ): InterceptorContext {
   return {
     handler: {
@@ -107,6 +107,7 @@ function createContext(
       route: {
         method: requestMethod,
         path: requestContext.request.path,
+        ...routeOverrides,
       },
     },
     requestContext,
@@ -335,6 +336,80 @@ describe('CacheInterceptor', () => {
 
     expect(next.handle).toHaveBeenCalledTimes(2);
     await expect(cacheService.get('/products')).resolves.toBeUndefined();
+  });
+
+  it('does not cache GET handlers whose route metadata redirects later in dispatch', async () => {
+    class ProductController {
+      @CacheTTL(120)
+      detail() {}
+    }
+
+    const { interceptor, cacheService } = createInterceptor({ ttl: 120 });
+    const firstContext = createContext(
+      ProductController,
+      'detail',
+      createRequestContext('GET', '/products/old', '/products/old'),
+      'GET',
+      '/products/old',
+      { redirect: { url: '/products/new', statusCode: 302 } },
+    );
+    const secondContext = createContext(
+      ProductController,
+      'detail',
+      createRequestContext('GET', '/products/old', '/products/old'),
+      'GET',
+      '/products/old',
+      { redirect: { url: '/products/new', statusCode: 302 } },
+    );
+    const next: CallHandler = {
+      handle: vi
+        .fn<CallHandler['handle']>()
+        .mockResolvedValueOnce({ redirect: 'first' })
+        .mockResolvedValueOnce({ redirect: 'second' }),
+    };
+
+    await expect(interceptor.intercept(firstContext, next)).resolves.toEqual({ redirect: 'first' });
+    await expect(interceptor.intercept(secondContext, next)).resolves.toEqual({ redirect: 'second' });
+
+    expect(next.handle).toHaveBeenCalledTimes(2);
+    await expect(cacheService.get('/products/old')).resolves.toBeUndefined();
+  });
+
+  it('does not cache GET handlers whose route metadata applies a non-success status later in dispatch', async () => {
+    class ProductController {
+      @CacheTTL(120)
+      missing() {}
+    }
+
+    const { interceptor, cacheService } = createInterceptor({ ttl: 120 });
+    const firstContext = createContext(
+      ProductController,
+      'missing',
+      createRequestContext('GET', '/products/missing', '/products/missing'),
+      'GET',
+      '/products/missing',
+      { successStatus: 404 },
+    );
+    const secondContext = createContext(
+      ProductController,
+      'missing',
+      createRequestContext('GET', '/products/missing', '/products/missing'),
+      'GET',
+      '/products/missing',
+      { successStatus: 404 },
+    );
+    const next: CallHandler = {
+      handle: vi
+        .fn<CallHandler['handle']>()
+        .mockResolvedValueOnce({ error: 'not-found' })
+        .mockResolvedValueOnce({ error: 'still-not-found' }),
+    };
+
+    await expect(interceptor.intercept(firstContext, next)).resolves.toEqual({ error: 'not-found' });
+    await expect(interceptor.intercept(secondContext, next)).resolves.toEqual({ error: 'still-not-found' });
+
+    expect(next.handle).toHaveBeenCalledTimes(2);
+    await expect(cacheService.get('/products/missing')).resolves.toBeUndefined();
   });
 
   it('does not fail successful non-GET handlers when cache eviction fails', async () => {

--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -310,6 +310,33 @@ describe('CacheInterceptor', () => {
     await expect(cacheService.get('/events')).resolves.toBeUndefined();
   });
 
+  it('does not cache non-success HTTP responses returned by GET handlers', async () => {
+    class ProductController {
+      @CacheTTL(120)
+      list() {}
+    }
+
+    const { interceptor, cacheService } = createInterceptor({ ttl: 120 });
+    const firstRequestContext = createRequestContext('GET', '/products', '/products');
+    const secondRequestContext = createRequestContext('GET', '/products', '/products');
+    firstRequestContext.response.statusCode = 500;
+    secondRequestContext.response.statusCode = 500;
+    const firstContext = createContext(ProductController, 'list', firstRequestContext);
+    const secondContext = createContext(ProductController, 'list', secondRequestContext);
+    const next: CallHandler = {
+      handle: vi
+        .fn<CallHandler['handle']>()
+        .mockResolvedValueOnce({ error: 'temporary' })
+        .mockResolvedValueOnce({ error: 'still-temporary' }),
+    };
+
+    await expect(interceptor.intercept(firstContext, next)).resolves.toEqual({ error: 'temporary' });
+    await expect(interceptor.intercept(secondContext, next)).resolves.toEqual({ error: 'still-temporary' });
+
+    expect(next.handle).toHaveBeenCalledTimes(2);
+    await expect(cacheService.get('/products')).resolves.toBeUndefined();
+  });
+
   it('does not fail successful non-GET handlers when cache eviction fails', async () => {
     class ProductController {
       @CacheEvict('GET:/products')

--- a/packages/cache-manager/src/interceptor.test.ts
+++ b/packages/cache-manager/src/interceptor.test.ts
@@ -375,6 +375,32 @@ describe('CacheInterceptor', () => {
     await expect(cacheService.get('/products/old')).resolves.toBeUndefined();
   });
 
+  it('does not return pre-existing cache hits for GET handlers whose route metadata redirects later in dispatch', async () => {
+    class ProductController {
+      @CacheTTL(120)
+      detail() {}
+    }
+
+    const { interceptor, cacheService } = createInterceptor({ ttl: 120 });
+    await cacheService.set('/products/old', { stale: 'redirect-cache-hit' }, 120);
+    const context = createContext(
+      ProductController,
+      'detail',
+      createRequestContext('GET', '/products/old', '/products/old'),
+      'GET',
+      '/products/old',
+      { redirect: { url: '/products/new', statusCode: 302 } },
+    );
+    const next: CallHandler = {
+      handle: vi.fn<CallHandler['handle']>().mockResolvedValue({ redirect: 'handler' }),
+    };
+
+    await expect(interceptor.intercept(context, next)).resolves.toEqual({ redirect: 'handler' });
+
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    await expect(cacheService.get('/products/old')).resolves.toEqual({ stale: 'redirect-cache-hit' });
+  });
+
   it('does not cache GET handlers whose route metadata applies a non-success status later in dispatch', async () => {
     class ProductController {
       @CacheTTL(120)
@@ -410,6 +436,32 @@ describe('CacheInterceptor', () => {
 
     expect(next.handle).toHaveBeenCalledTimes(2);
     await expect(cacheService.get('/products/missing')).resolves.toBeUndefined();
+  });
+
+  it('does not return pre-existing cache hits for GET handlers with route-level non-success status metadata', async () => {
+    class ProductController {
+      @CacheTTL(120)
+      missing() {}
+    }
+
+    const { interceptor, cacheService } = createInterceptor({ ttl: 120 });
+    await cacheService.set('/products/missing', { stale: 'not-found-cache-hit' }, 120);
+    const context = createContext(
+      ProductController,
+      'missing',
+      createRequestContext('GET', '/products/missing', '/products/missing'),
+      'GET',
+      '/products/missing',
+      { successStatus: 404 },
+    );
+    const next: CallHandler = {
+      handle: vi.fn<CallHandler['handle']>().mockResolvedValue({ error: 'handler-not-found' }),
+    };
+
+    await expect(interceptor.intercept(context, next)).resolves.toEqual({ error: 'handler-not-found' });
+
+    expect(next.handle).toHaveBeenCalledTimes(1);
+    await expect(cacheService.get('/products/missing')).resolves.toEqual({ stale: 'not-found-cache-hit' });
   });
 
   it('does not fail successful non-GET handlers when cache eviction fails', async () => {

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -219,8 +219,9 @@ export class CacheInterceptor implements Interceptor {
     const keyMetadata = metadataBag ? getCacheKeyMetadata(metadataBag) : undefined;
     const key = await resolveCacheKeyValue(keyMetadata, context, this.options.httpKeyStrategy, this.options.principalScopeResolver);
     const ttl = normalizeTtl(metadataBag ? getCacheTtlMetadata(metadataBag) : undefined, this.options.ttl);
+    const cacheableRoute = this.shouldCacheRoute(context);
 
-    if (ttl !== undefined) {
+    if (ttl !== undefined && cacheableRoute) {
       const cached = await this.safeGet(key);
 
       if (cached !== undefined) {
@@ -230,7 +231,7 @@ export class CacheInterceptor implements Interceptor {
 
     const value = await next.handle();
 
-    if (ttl !== undefined && this.shouldCacheValue(context, value)) {
+    if (ttl !== undefined && cacheableRoute && this.shouldCacheValue(context, value)) {
       await this.safeSet(key, value, ttl);
     }
 
@@ -276,19 +277,20 @@ export class CacheInterceptor implements Interceptor {
     return normalizeEvictKeys(metadata);
   }
 
-  private shouldCacheValue(context: InterceptorContext, value: unknown): boolean {
-    const statusCode = context.requestContext.response.statusCode;
+  private shouldCacheRoute(context: InterceptorContext): boolean {
     const route = context.handler.route;
-
-    if (value === undefined) {
-      return false;
-    }
 
     if (route.redirect) {
       return false;
     }
 
-    if (typeof route.successStatus === 'number' && !isSuccessStatusCode(route.successStatus)) {
+    return typeof route.successStatus !== 'number' || isSuccessStatusCode(route.successStatus);
+  }
+
+  private shouldCacheValue(context: InterceptorContext, value: unknown): boolean {
+    const statusCode = context.requestContext.response.statusCode;
+
+    if (value === undefined) {
       return false;
     }
 

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -1,6 +1,6 @@
 import { Inject } from '@fluojs/core';
 import { getStandardMetadataBag } from '@fluojs/core/internal';
-import { SseResponse, type CallHandler, type Interceptor, type InterceptorContext } from '@fluojs/http';
+import { type CallHandler, type Interceptor, type InterceptorContext, SseResponse } from '@fluojs/http';
 
 import { cacheRouteMetadataKey, getCacheEvictMetadata, getCacheKeyMetadata, getCacheTtlMetadata } from './decorators.js';
 import { CacheService } from './service.js';
@@ -121,6 +121,10 @@ function normalizeEvictKeys(value: string | readonly string[]): string[] {
   }
 
   return [];
+}
+
+function isSuccessStatusCode(statusCode: number): boolean {
+  return statusCode >= 200 && statusCode < 300;
 }
 
 async function resolveCacheKeyValue(
@@ -274,12 +278,21 @@ export class CacheInterceptor implements Interceptor {
 
   private shouldCacheValue(context: InterceptorContext, value: unknown): boolean {
     const statusCode = context.requestContext.response.statusCode;
+    const route = context.handler.route;
 
     if (value === undefined) {
       return false;
     }
 
-    if (typeof statusCode === 'number' && (statusCode < 200 || statusCode >= 300)) {
+    if (route.redirect) {
+      return false;
+    }
+
+    if (typeof route.successStatus === 'number' && !isSuccessStatusCode(route.successStatus)) {
+      return false;
+    }
+
+    if (typeof statusCode === 'number' && !isSuccessStatusCode(statusCode)) {
       return false;
     }
 

--- a/packages/cache-manager/src/interceptor.ts
+++ b/packages/cache-manager/src/interceptor.ts
@@ -273,7 +273,13 @@ export class CacheInterceptor implements Interceptor {
   }
 
   private shouldCacheValue(context: InterceptorContext, value: unknown): boolean {
+    const statusCode = context.requestContext.response.statusCode;
+
     if (value === undefined) {
+      return false;
+    }
+
+    if (typeof statusCode === 'number' && (statusCode < 200 || statusCode >= 300)) {
       return false;
     }
 

--- a/packages/cache-manager/src/stores/redis-store.test.ts
+++ b/packages/cache-manager/src/stores/redis-store.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-
-import { RedisStore } from './redis-store.js';
 import type { RedisCompatibleClient } from '../types.js';
+import { RedisStore } from './redis-store.js';
 
 class MockRedisClient implements RedisCompatibleClient {
   readonly deletedKeys: string[][] = [];
@@ -157,7 +156,32 @@ describe('RedisStore', () => {
     vi.setSystemTime(new Date('2026-03-24T00:00:00.250Z'));
 
     await expect(store.get('short')).resolves.toBeUndefined();
-    expect(client.deletedKeys).toContainEqual(['cache:short']);
+    expect(client.deletedKeys).not.toContainEqual(['cache:short']);
+  });
+
+  it('does not delete a fresh Redis value written while an expired entry is being read', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-24T00:00:00.500Z'));
+
+    class RefreshingRedisClient extends MockRedisClient {
+      async get(key: string): Promise<string | null> {
+        const raw = await super.get(key);
+        this.storage.set(key, JSON.stringify({ value: { fresh: true } }));
+        return raw;
+      }
+    }
+
+    const client = new RefreshingRedisClient();
+    const store = new RedisStore(client, { keyPrefix: 'cache:' });
+    client.storage.set('cache:short', JSON.stringify({
+      expiresAt: Date.parse('2026-03-24T00:00:00.250Z'),
+      value: { stale: true },
+    }));
+
+    await expect(store.get('short')).resolves.toBeUndefined();
+
+    expect(client.deletedKeys).toEqual([]);
+    expect(client.storage.get('cache:short')).toBe(JSON.stringify({ value: { fresh: true } }));
   });
 
   it('round-trips values using JSON serialization semantics', async () => {

--- a/packages/cache-manager/src/stores/redis-store.test.ts
+++ b/packages/cache-manager/src/stores/redis-store.test.ts
@@ -138,6 +138,28 @@ describe('RedisStore', () => {
     });
   });
 
+  it('rounds fractional positive TTLs up for Redis expiry while enforcing millisecond freshness', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-24T00:00:00.000Z'));
+
+    const client = new MockRedisClient();
+    const store = new RedisStore(client, { keyPrefix: 'cache:' });
+
+    await store.set('short', { fresh: true }, 0.25);
+
+    expect(client.setCalls[0]?.args).toEqual(['EX', 1]);
+    expect(JSON.parse(client.setCalls[0]?.value ?? '{}')).toEqual({
+      expiresAt: Date.parse('2026-03-24T00:00:00.250Z'),
+      value: { fresh: true },
+    });
+    await expect(store.get('short')).resolves.toEqual({ fresh: true });
+
+    vi.setSystemTime(new Date('2026-03-24T00:00:00.250Z'));
+
+    await expect(store.get('short')).resolves.toBeUndefined();
+    expect(client.deletedKeys).toContainEqual(['cache:short']);
+  });
+
   it('round-trips values using JSON serialization semantics', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-24T00:00:00.000Z'));

--- a/packages/cache-manager/src/stores/redis-store.ts
+++ b/packages/cache-manager/src/stores/redis-store.ts
@@ -52,6 +52,14 @@ function normalizeScanResponse(result: [string | number, string[]]): { cursor: s
   };
 }
 
+function normalizePositiveTtlMilliseconds(ttlSeconds: number): number {
+  return Math.max(1, Math.ceil(ttlSeconds * 1000));
+}
+
+function normalizeRedisExpirySeconds(ttlSeconds: number): number {
+  return Math.max(1, Math.ceil(ttlSeconds));
+}
+
 /**
  * Cache store implementation backed by a Redis-compatible client.
  */
@@ -86,6 +94,11 @@ export class RedisStore implements CacheStore {
       return undefined;
     }
 
+    if (decoded.expiresAt !== undefined && decoded.expiresAt <= Date.now()) {
+      await this.del(key);
+      return undefined;
+    }
+
     return decoded.value as T;
   }
 
@@ -97,9 +110,9 @@ export class RedisStore implements CacheStore {
     };
 
     if (ttlSeconds > 0) {
-      const ttlMilliseconds = Math.max(1, Math.floor(ttlSeconds * 1000));
+      const ttlMilliseconds = normalizePositiveTtlMilliseconds(ttlSeconds);
       entry.expiresAt = now + ttlMilliseconds;
-      const ttlSecondsRounded = Math.max(1, Math.ceil(ttlMilliseconds / 1000));
+      const ttlSecondsRounded = normalizeRedisExpirySeconds(ttlSeconds);
       await this.client.set(redisKey, JSON.stringify(entry), 'EX', ttlSecondsRounded);
       this.trackOwnedKey(redisKey);
       return;

--- a/packages/cache-manager/src/stores/redis-store.ts
+++ b/packages/cache-manager/src/stores/redis-store.ts
@@ -95,7 +95,6 @@ export class RedisStore implements CacheStore {
     }
 
     if (decoded.expiresAt !== undefined && decoded.expiresAt <= Date.now()) {
-      await this.del(key);
       return undefined;
     }
 


### PR DESCRIPTION
## Summary

Closes #1586

Tightens `@fluojs/cache-manager` Redis TTL and HTTP cacheability contracts so fractional Redis TTLs and non-success GET responses have explicit, tested behavior.

## Changes

- Enforce Redis entry `expiresAt` on read and delete stale entries when Redis `EX` granularity is coarser than fractional TTL freshness.
- Round positive Redis TTLs up for integer-second Redis `EX` while preserving millisecond freshness in the serialized cache entry.
- Skip HTTP response caching for non-2xx GET responses, while preserving existing skips for `undefined`, SSE streams, and committed responses.
- Align `README.md` / `README.ko.md` and add a patch changeset for `@fluojs/cache-manager`.

## Testing

- [x] LSP diagnostics clean for changed TypeScript files.
- [x] `pnpm --filter @fluojs/cache-manager... build`
- [x] `pnpm --filter @fluojs/cache-manager test` (9 files / 110 tests)
- [x] `pnpm --filter @fluojs/cache-manager typecheck`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. N/A.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. N/A; package README EN/KO alignment updated.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A.