### PR TITLE
Resolve #1611: Align platform adapter naming docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Resolve PR verification scope
         id: resolve
@@ -252,6 +254,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -11,7 +11,7 @@ fluo는 TC39 표준 데코레이터, 명시적 의존성 경계, 메타데이터
 - NEVER use `experimentalDecorators`.
 - NEVER use `emitDecoratorMetadata`.
 - NEVER access `process.env` directly inside packages, use `@fluojs/config` at the application boundary.
-- Platform packages MUST implement the `PlatformAdapter` interface.
+- Platform packages MUST implement the repository policy seam named `PlatformAdapter`; current HTTP adapters satisfy it through `HttpApplicationAdapter` from `@fluojs/http`.
 - All public exports MUST have TSDoc.
 - Breaking changes in `1.0+` MUST trigger a major version bump.
 
@@ -59,7 +59,7 @@ fluo는 TC39 표준 데코레이터, 명시적 의존성 경계, 메타데이터
 
 - `experimentalDecorators` 또는 `emitDecoratorMetadata`를 활성화하는 것, fluo의 표준 데코레이터 기준을 깨뜨린다.
 - 패키지 코드 안에서 `process.env`를 읽는 것, environment isolation을 깨뜨리고 `@fluojs/config`를 우회한다.
-- `PlatformAdapter` 없이 플랫폼 패키지를 배포하는 것, 런타임 이식성과 conformance를 깨뜨린다.
+- 문서화된 adapter seam 없이 플랫폼 패키지를 배포하는 것(HTTP transport에서는 `HttpApplicationAdapter`), 런타임 이식성과 conformance를 깨뜨린다.
 - TSDoc 없이 공개 export를 노출하는 것, 패키지 계약과 리뷰 가능성을 약화한다.
 - major bump 없이 `1.0+`의 문서화된 동작을 변경하는 것, release governance를 위반한다.
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -11,7 +11,7 @@ fluo is a standard-first TypeScript backend framework built on TC39 standard dec
 - NEVER use `experimentalDecorators`.
 - NEVER use `emitDecoratorMetadata`.
 - NEVER access `process.env` directly inside packages, use `@fluojs/config` at the application boundary.
-- Platform packages MUST implement the `PlatformAdapter` interface.
+- Platform packages MUST implement the repository policy seam named `PlatformAdapter`; current HTTP adapters satisfy it through `HttpApplicationAdapter` from `@fluojs/http`.
 - All public exports MUST have TSDoc.
 - Breaking changes in `1.0+` MUST trigger a major version bump.
 
@@ -59,7 +59,7 @@ Canonical package and runtime coverage lives in [`docs/reference/package-surface
 
 - Enabling `experimentalDecorators` or `emitDecoratorMetadata`, this violates fluo's standard-decorator baseline.
 - Reading `process.env` inside package code, this breaks environment isolation and bypasses `@fluojs/config`.
-- Shipping a platform package without `PlatformAdapter`, this breaks runtime portability and conformance.
+- Shipping a platform package without the documented adapter seam (`HttpApplicationAdapter` for HTTP transports), this breaks runtime portability and conformance.
 - Exposing public exports without TSDoc, this weakens package contracts and reviewability.
 - Changing documented behavior in `1.0+` without a major bump, this violates release governance.
 

--- a/docs/architecture/architecture-overview.ko.md
+++ b/docs/architecture/architecture-overview.ko.md
@@ -35,8 +35,8 @@
 | Rule 1 | Core 패키지는 transport adapter나 feature 패키지에 의존하면 안 된다. |
 | Rule 2 | Transport 패키지는 core 계약에는 의존할 수 있지만, core 계층이 소유한 decorator, DI, config primitive를 다시 정의하면 안 된다. |
 | Rule 3 | Feature 패키지는 core 패키지와 자신이 확장하는 문서화된 transport 표면에 의존할 수 있다. |
-| Rule 4 | Feature 패키지는 `@fluojs/config`, runtime lifecycle contract, `PlatformAdapter` 접점을 우회하기 위해 hosting environment API에 직접 접근하면 안 된다. |
-| Rule 5 | Platform 패키지는 `PlatformAdapter` 인터페이스를 구현해야 하며, HTTP runtime이 정의한 요청 phase 순서를 보존해야 한다. |
+| Rule 4 | Feature 패키지는 `@fluojs/config`, runtime lifecycle contract, 문서화된 adapter seam을 우회하기 위해 hosting environment API에 직접 접근하면 안 된다. |
+| Rule 5 | Platform 패키지는 저장소 정책상 `PlatformAdapter`라고 부르는 접점(HTTP transport에서는 `HttpApplicationAdapter`)을 구현해야 하며, HTTP runtime이 정의한 요청 phase 순서를 보존해야 한다. |
 | Rule 6 | 패키지 간 통합은 암시적 reflection이나 ambient global이 아니라 export된 module contract, provider token, 문서화된 metadata를 통해 흘러야 한다. |
 
 ## Constraints

--- a/docs/architecture/architecture-overview.md
+++ b/docs/architecture/architecture-overview.md
@@ -35,8 +35,8 @@
 | Rule 1 | Core packages MUST NOT depend on transport adapters or feature packages. |
 | Rule 2 | Transport packages MAY depend on core contracts, but transport packages MUST NOT redefine decorator, DI, or config primitives owned by the core layer. |
 | Rule 3 | Feature packages MAY depend on core packages and the documented transport surface that they extend. |
-| Rule 4 | Feature packages MUST NOT access hosting-environment APIs as a substitute for `@fluojs/config`, runtime lifecycle contracts, or `PlatformAdapter` seams. |
-| Rule 5 | Platform packages MUST implement the `PlatformAdapter` interface and MUST preserve the request-phase ordering defined by the HTTP runtime. |
+| Rule 4 | Feature packages MUST NOT access hosting-environment APIs as a substitute for `@fluojs/config`, runtime lifecycle contracts, or documented adapter seams. |
+| Rule 5 | Platform packages MUST implement the repository policy seam named `PlatformAdapter` (`HttpApplicationAdapter` for HTTP transports) and MUST preserve the request-phase ordering defined by the HTTP runtime. |
 | Rule 6 | Cross-package integration MUST flow through exported module contracts, provider tokens, and documented metadata rather than implicit reflection or ambient globals. |
 
 ## Constraints

--- a/docs/architecture/platform-consistency-design.ko.md
+++ b/docs/architecture/platform-consistency-design.ko.md
@@ -2,13 +2,13 @@
 
 <p><a href="./platform-consistency-design.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
-이 문서는 fluo transport 패키지가 사용하는 현재 플랫폼 어댑터 계약을 정의한다. 저장소 가이드는 이 접점을 `PlatformAdapter`로 부르며, 현재 transport 중심 코드는 `@fluojs/http`의 `HttpApplicationAdapter`와 `@fluojs/runtime`의 `PlatformShell`로 이 계약을 노출한다.
+이 문서는 fluo transport 패키지가 사용하는 현재 플랫폼 어댑터 계약을 정의한다. 저장소 가이드는 이 정책 접점을 `PlatformAdapter`로 부르며, 현재 transport 중심 코드는 `@fluojs/http`의 `HttpApplicationAdapter`와 `@fluojs/runtime`의 `PlatformShell`로 이 계약을 노출한다.
 
-## PlatformAdapter Interface
+## Platform Adapter Seam
 
 | Contract area | Current source | Requirement |
 | --- | --- | --- |
-| Package identity | `docs/reference/package-surface.ko.md`는 `@fluojs/platform-*`를 `PlatformAdapter`를 구현하는 어댑터 전용으로 예약한다. | Platform 패키지는 하나의 hosting environment 또는 protocol을 위한 런타임 어댑터 접점을 제공해야 한다. |
+| Package identity | `docs/reference/package-surface.ko.md`는 `@fluojs/platform-*`를 문서화된 adapter seam을 구현하는 어댑터 전용으로 예약한다. | Platform 패키지는 하나의 hosting environment 또는 protocol을 위한 런타임 어댑터 접점을 제공해야 한다. |
 | HTTP transport seam | `packages/http/src/adapter.ts`는 `HttpApplicationAdapter`를 정의한다. | 어댑터는 `listen(dispatcher)`로 dispatcher를 host transport에 연결하고, `close(signal?)`로 transport resource를 해제해야 한다. |
 | Request contract | `packages/http/src/types.ts`는 `FrameworkRequest`와 `FrameworkResponse`를 정의한다. | 어댑터는 dispatch 전에 host-native request와 response를 framework contract로 정규화해야 한다. |
 | Runtime shell integration | `packages/runtime/src/bootstrap.ts`는 `HTTP_APPLICATION_ADAPTER`와 `PLATFORM_SHELL`을 등록한다. | 어댑터는 module compilation, lifecycle hook 순서, dispatcher 생성 순서를 바꾸지 않고 runtime bootstrap에 참여해야 한다. |

--- a/docs/architecture/platform-consistency-design.md
+++ b/docs/architecture/platform-consistency-design.md
@@ -2,13 +2,13 @@
 
 <p><strong><kbd>English</kbd></strong> <a href="./platform-consistency-design.ko.md"><kbd>한국어</kbd></a></p>
 
-This document defines the current platform adapter contract used by fluo transport packages. Repository guidance names this seam `PlatformAdapter`, while the current transport-facing code exposes `HttpApplicationAdapter` in `@fluojs/http` and platform component orchestration through `PlatformShell` in `@fluojs/runtime`.
+This document defines the current platform adapter contract used by fluo transport packages. Repository guidance names this policy seam `PlatformAdapter`, while the current transport-facing code exposes `HttpApplicationAdapter` in `@fluojs/http` and platform component orchestration through `PlatformShell` in `@fluojs/runtime`.
 
-## PlatformAdapter Interface
+## Platform Adapter Seam
 
 | Contract area | Current source | Requirement |
 | --- | --- | --- |
-| Package identity | `docs/reference/package-surface.md` reserves `@fluojs/platform-*` for adapters implementing `PlatformAdapter`. | Platform packages MUST provide the runtime-facing adapter seam for one hosting environment or protocol. |
+| Package identity | `docs/reference/package-surface.md` reserves `@fluojs/platform-*` for adapters implementing the documented adapter seam. | Platform packages MUST provide the runtime-facing adapter seam for one hosting environment or protocol. |
 | HTTP transport seam | `packages/http/src/adapter.ts` defines `HttpApplicationAdapter`. | An adapter MUST bind the dispatcher to the host transport through `listen(dispatcher)` and release transport resources through `close(signal?)`. |
 | Request contract | `packages/http/src/types.ts` defines `FrameworkRequest` and `FrameworkResponse`. | An adapter MUST normalize host-native request and response objects to the framework contracts before dispatch. |
 | Runtime shell integration | `packages/runtime/src/bootstrap.ts` registers `HTTP_APPLICATION_ADAPTER` and `PLATFORM_SHELL`. | An adapter MUST participate in runtime bootstrap without changing module compilation, lifecycle hook order, or dispatcher creation order. |

--- a/docs/contracts/platform-conformance-authoring-checklist.ko.md
+++ b/docs/contracts/platform-conformance-authoring-checklist.ko.md
@@ -37,7 +37,7 @@
 
 ## Package Contract Requirements
 
-- [ ] MUST: 공식 플랫폼 패키지는 `PlatformAdapter` 인터페이스를 구현합니다.
+- [ ] MUST: 공식 플랫폼 패키지는 저장소 정책상 `PlatformAdapter`라고 부르는 접점을 구현합니다. HTTP 플랫폼 패키지는 `@fluojs/http`의 `HttpApplicationAdapter`로 이 접점을 충족합니다.
 - [ ] MUST: 타입이 있는 구성을 노출하고 bootstrap 중 입력을 검증합니다.
 - [ ] MUST: 패키지 동작과 문서에서 health와 readiness를 구분합니다.
 - [ ] MUST: 호출자에게 보이는 실패 상태에 대해 안정적인 diagnostic code를 제공합니다.

--- a/docs/contracts/platform-conformance-authoring-checklist.md
+++ b/docs/contracts/platform-conformance-authoring-checklist.md
@@ -37,7 +37,7 @@ Use this checklist when authoring or changing official platform-facing packages 
 
 ## Package Contract Requirements
 
-- [ ] MUST: Implement the `PlatformAdapter` interface for official platform packages.
+- [ ] MUST: Implement the repository policy seam named `PlatformAdapter`; HTTP platform packages satisfy that seam through `HttpApplicationAdapter` from `@fluojs/http`.
 - [ ] MUST: Expose typed configuration and validate inputs during bootstrap.
 - [ ] MUST: Distinguish health from readiness in package behavior and package docs.
 - [ ] MUST: Emit stable diagnostic codes for caller-visible failure states.

--- a/docs/guides/anti-patterns.ko.md
+++ b/docs/guides/anti-patterns.ko.md
@@ -101,17 +101,17 @@ export class FastifyLikePlatform {
 ### ✅ Correct
 
 ```ts
-import type { PlatformAdapter } from '@fluojs/runtime';
+import type { Dispatcher, HttpApplicationAdapter } from '@fluojs/http';
 
-export class FastifyPlatformAdapter implements PlatformAdapter {
-  readonly name = '@fluojs/platform-fastify';
+export class FastifyPlatformAdapter implements HttpApplicationAdapter {
+  #server: FastifyServer | undefined;
 
-  async listen(app: FluoRuntimeApplication): Promise<void> {
-    await app.start();
+  async listen(dispatcher: Dispatcher): Promise<void> {
+    this.#server = await startFastifyServer(dispatcher);
   }
 
-  async close(app: FluoRuntimeApplication): Promise<void> {
-    await app.close();
+  async close(_signal?: string): Promise<void> {
+    await this.#server?.close();
   }
 }
 ```

--- a/docs/guides/anti-patterns.md
+++ b/docs/guides/anti-patterns.md
@@ -101,17 +101,17 @@ export class FastifyLikePlatform {
 ### ✅ Correct
 
 ```ts
-import type { PlatformAdapter } from '@fluojs/runtime';
+import type { Dispatcher, HttpApplicationAdapter } from '@fluojs/http';
 
-export class FastifyPlatformAdapter implements PlatformAdapter {
-  readonly name = '@fluojs/platform-fastify';
+export class FastifyPlatformAdapter implements HttpApplicationAdapter {
+  #server: FastifyServer | undefined;
 
-  async listen(app: FluoRuntimeApplication): Promise<void> {
-    await app.start();
+  async listen(dispatcher: Dispatcher): Promise<void> {
+    this.#server = await startFastifyServer(dispatcher);
   }
 
-  async close(app: FluoRuntimeApplication): Promise<void> {
-    await app.close();
+  async close(_signal?: string): Promise<void> {
+    await this.#server?.close();
   }
 }
 ```

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -36,7 +36,7 @@
 - **`@fluojs/runtime`**: 애플리케이션 부트스트랩, 모듈 오케스트레이션, 플랫폼 셸 등록, 플랫폼 snapshot 생산. 공개 런타임 헬퍼는 `@fluojs/runtime/node`와 `@fluojs/runtime/web`에서 제공됩니다.
 
 ### adapters
-- **`platform-*`**: `PlatformAdapter` 인터페이스를 구현합니다. 추상 HTTP 호출을 런타임별 리스너에 연결합니다.
+- **`platform-*`**: 저장소 정책상 `PlatformAdapter`라고 부르는 접점을 구현합니다. HTTP 런타임 패키지는 `@fluojs/http`의 `HttpApplicationAdapter`로 이를 충족합니다. 추상 HTTP 호출을 런타임별 리스너에 연결합니다.
 - **`@fluojs/socket.io`**: 업스트림 Socket.IO 시맨틱을 미러링하는 전용 전송 브랜드 어댑터.
 
 ### features
@@ -67,7 +67,7 @@
 이 경계는 graph semantics를 `@fluojs/cli` 밖에 둡니다. CLI는 `@fluojs/studio/contracts`를 찾아 `renderMermaid(snapshot)`을 호출할 수 있지만, 내부 dependency edge와 외부 dependency node를 Mermaid output으로 바꾸는 방식은 Studio가 정의합니다. 지속 보관할 artifact가 필요한 소비자는 raw snapshot에는 `fluo inspect --json --output <path>`, standalone timing diagnostics에는 `fluo inspect --timing --output <path>`, snapshot-plus-timing envelope에는 `fluo inspect --json --timing --output <path>`, support report에는 `fluo inspect --report --output <path>`를 사용해야 합니다.
 
 ## 명명 규칙
-- **`platform-*`**: `PlatformAdapter`를 구현하는 런타임/프로토콜 어댑터 전용.
+- **`platform-*`**: 문서화된 adapter seam(HTTP transport에서는 `HttpApplicationAdapter`)을 구현하는 런타임/프로토콜 어댑터 전용.
 - **`*service`**: 비즈니스 로직의 구체적 구현.
 - **`*module`**: 패키지 런타임 초기화의 진입점.
 

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -36,7 +36,7 @@
 - **`@fluojs/runtime`**: Application bootstrap, module orchestration, platform shell registration, and platform snapshot production. Public runtime helpers are exposed through `@fluojs/runtime/node` and `@fluojs/runtime/web`.
 
 ### adapters
-- **`platform-*`**: Implement the `PlatformAdapter` interface. They bridge abstract HTTP calls to runtime-specific listeners.
+- **`platform-*`**: Implement the repository policy seam named `PlatformAdapter`; HTTP runtime packages do so through `HttpApplicationAdapter` from `@fluojs/http`. They bridge abstract HTTP calls to runtime-specific listeners.
 - **`@fluojs/socket.io`**: A dedicated transport-brand adapter that mirrors upstream Socket.IO semantics.
 
 ### features
@@ -67,7 +67,7 @@ Runtime packages remain the source of inspection snapshots and timing diagnostic
 This boundary keeps graph semantics out of `@fluojs/cli`: the CLI may locate `@fluojs/studio/contracts` and call `renderMermaid(snapshot)`, but Studio defines how internal dependency edges and external dependency nodes become Mermaid output. Consumers that need a persistent artifact should use `fluo inspect --json --output <path>` for raw snapshots, `fluo inspect --timing --output <path>` for standalone timing diagnostics, `fluo inspect --json --timing --output <path>` for snapshot-plus-timing envelopes, or `fluo inspect --report --output <path>` for support reports.
 
 ## naming conventions
-- **`platform-*`**: Reserved for runtime/protocol adapters implementing `PlatformAdapter`.
+- **`platform-*`**: Reserved for runtime/protocol adapters that implement the documented adapter seam (`HttpApplicationAdapter` for HTTP transports).
 - **`*service`**: Concrete implementation of business logic.
 - **`*module`**: Entry point for a package's runtime initialization.
 

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -271,6 +271,8 @@ describe('platform consistency governance docs', () => {
     expect(ciWorkflow).toContain('build-and-typecheck:');
     expect(ciWorkflow).toContain("if: github.event_name == 'pull_request'");
     expect(ciWorkflow).toContain('verify-platform-consistency-governance');
+    expect(ciWorkflow).toMatch(/resolve-pr-verification-scope:[\s\S]*?- name: Checkout[\s\S]*?fetch-depth: 0/u);
+    expect(ciWorkflow).toMatch(/verify-platform-consistency-governance:[\s\S]*?- name: Checkout[\s\S]*?fetch-depth: 0/u);
   });
 
   it('keeps Changesets release automation bound to main pushes and token-backed npm publish', () => {

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -80,28 +80,51 @@ function run(command, args, options = {}) {
   return result;
 }
 
-function changedFilesFromGit() {
-  const preferredBase = process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'origin/main';
-  const mergeBaseResult = run('git', ['merge-base', 'HEAD', preferredBase], { allowFailure: true });
+export function changedFilesFromGit(runCommand = run, env = process.env) {
+  const preferredBase = env.GITHUB_BASE_REF ? `origin/${env.GITHUB_BASE_REF}` : 'origin/main';
+  const mergeBaseResult = runCommand('git', ['merge-base', 'HEAD', preferredBase], { allowFailure: true });
 
   if (mergeBaseResult.status === 0 && mergeBaseResult.stdout.trim().length > 0) {
     const mergeBase = mergeBaseResult.stdout.trim();
-    const diffResult = run('git', ['diff', '--name-only', `${mergeBase}...HEAD`]);
-    return diffResult.stdout
+    const diffResult = runCommand('git', ['diff', '--name-only', `${mergeBase}...HEAD`], { allowFailure: true });
+
+    if (diffResult.status !== 0) {
+      throw new Error(
+        'Platform consistency governance check failed: unable to compute changed files from git diff. Ensure CI fetches full history before running pnpm verify:platform-consistency-governance.',
+      );
+    }
+
+    const changedFiles = diffResult.stdout
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean);
+
+    for (const args of [
+      ['diff', '--name-only'],
+      ['diff', '--name-only', '--cached'],
+      ['ls-files', '--others', '--exclude-standard'],
+    ]) {
+      const workingTreeResult = runCommand('git', args, { allowFailure: true });
+      if (workingTreeResult.status !== 0) {
+        throw new Error(
+          'Platform consistency governance check failed: unable to compute working tree changed files. Ensure git status is readable before running pnpm verify:platform-consistency-governance.',
+        );
+      }
+
+      changedFiles.push(
+        ...workingTreeResult.stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean),
+      );
+    }
+
+    return [...new Set(changedFiles)].sort((left, right) => left.localeCompare(right));
   }
 
-  const fallbackDiff = run('git', ['diff', '--name-only', 'HEAD~1...HEAD'], { allowFailure: true });
-  if (fallbackDiff.status === 0) {
-    return fallbackDiff.stdout
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean);
-  }
-
-  return [];
+  throw new Error(
+    `Platform consistency governance check failed: unable to compute merge-base with ${preferredBase}. Ensure CI fetches full history before running pnpm verify:platform-consistency-governance.`,
+  );
 }
 
 function normalizeHeading(line) {
@@ -500,7 +523,7 @@ function enforceSsotMirrorStructure() {
   }
 }
 
-function enforceContractCompanionUpdates(changedFiles) {
+export function enforceContractCompanionUpdates(changedFiles) {
   const touchedContractGate = changedFiles.some((path) => contractGateTriggers.has(path));
 
   if (!touchedContractGate) {

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -9,6 +9,16 @@ import {
   parsePackageNamesFromFamilyTable,
 } from './verify-platform-consistency-governance.mjs';
 
+type GitResult = { status: number; stdout: string };
+type RunCommand = (command: string, args: string[], options?: { allowFailure?: boolean }) => GitResult;
+
+async function loadGovernanceInternals() {
+  return (await import('./verify-platform-consistency-governance.mjs')) as unknown as {
+    changedFilesFromGit: (runCommand?: RunCommand, env?: { GITHUB_BASE_REF?: string }) => string[];
+    enforceContractCompanionUpdates: (changedFiles: string[]) => void;
+  };
+}
+
 describe('isGovernedPackageSourcePath', () => {
   it('includes ordinary package source files', () => {
     expect(isGovernedPackageSourcePath('packages/core/src/module.ts')).toBe(true);
@@ -148,6 +158,98 @@ describe('officialTransportDocsPackages', () => {
     };
 
     expect(governanceModule.getOfficialTransportDocsPackages()).toContain('@fluojs/socket.io');
+  });
+});
+
+describe('changedFilesFromGit', () => {
+  it('fails closed when merge-base cannot be computed', async () => {
+    const { changedFilesFromGit } = await loadGovernanceInternals();
+    const runCommand = () => ({ status: 1, stdout: '' });
+
+    expect(() => changedFilesFromGit(runCommand, { GITHUB_BASE_REF: 'main' })).toThrowError(
+      /unable to compute merge-base with origin\/main/,
+    );
+  });
+
+  it('fails closed when diff cannot be computed after merge-base resolves', async () => {
+    const { changedFilesFromGit } = await loadGovernanceInternals();
+    const results: GitResult[] = [
+      { status: 0, stdout: 'abc123\n' },
+      { status: 1, stdout: '' },
+    ];
+    const runCommand = () => results.shift() ?? { status: 1, stdout: '' };
+
+    expect(() => changedFilesFromGit(runCommand, { GITHUB_BASE_REF: 'main' })).toThrowError(
+      /unable to compute changed files from git diff/,
+    );
+  });
+
+  it('returns changed files from the merge-base diff', async () => {
+    const { changedFilesFromGit } = await loadGovernanceInternals();
+    const calls: string[][] = [];
+    const results: GitResult[] = [
+      { status: 0, stdout: 'abc123\n' },
+      { status: 0, stdout: 'docs/CONTEXT.md\n.github/workflows/ci.yml\n' },
+      { status: 0, stdout: 'tooling/governance/verify-platform-consistency-governance.mjs\n' },
+      { status: 0, stdout: 'tooling/governance/verify-platform-consistency-governance.test.ts\n' },
+      { status: 0, stdout: 'packages/testing/src/conformance/platform-consistency-governance-docs.test.ts\n' },
+    ];
+    const runCommand = (_command: string, args: string[]) => {
+      calls.push(args);
+      return results.shift() ?? { status: 1, stdout: '' };
+    };
+
+    expect(changedFilesFromGit(runCommand, { GITHUB_BASE_REF: 'main' })).toEqual([
+      '.github/workflows/ci.yml',
+      'docs/CONTEXT.md',
+      'packages/testing/src/conformance/platform-consistency-governance-docs.test.ts',
+      'tooling/governance/verify-platform-consistency-governance.mjs',
+      'tooling/governance/verify-platform-consistency-governance.test.ts',
+    ]);
+    expect(calls).toEqual([
+      ['merge-base', 'HEAD', 'origin/main'],
+      ['diff', '--name-only', 'abc123...HEAD'],
+      ['diff', '--name-only'],
+      ['diff', '--name-only', '--cached'],
+      ['ls-files', '--others', '--exclude-standard'],
+    ]);
+  });
+});
+
+describe('enforceContractCompanionUpdates', () => {
+  it('requires discoverability, tooling or CI, and regression test updates for contract-governing docs', async () => {
+    const { enforceContractCompanionUpdates } = await loadGovernanceInternals();
+
+    expect(() => enforceContractCompanionUpdates(['docs/reference/package-surface.md'])).toThrowError(
+      /docs\/CONTEXT\.md and docs\/CONTEXT\.ko\.md/,
+    );
+
+    expect(() =>
+      enforceContractCompanionUpdates([
+        'docs/reference/package-surface.md',
+        'docs/CONTEXT.md',
+        'docs/CONTEXT.ko.md',
+      ]),
+    ).toThrowError(/CI\/tooling enforcement updates/);
+
+    expect(() =>
+      enforceContractCompanionUpdates([
+        'docs/reference/package-surface.md',
+        'docs/CONTEXT.md',
+        'docs/CONTEXT.ko.md',
+        '.github/workflows/ci.yml',
+      ]),
+    ).toThrowError(/regression test updates/);
+
+    expect(() =>
+      enforceContractCompanionUpdates([
+        'docs/reference/package-surface.md',
+        'docs/CONTEXT.md',
+        'docs/CONTEXT.ko.md',
+        '.github/workflows/ci.yml',
+        'tooling/governance/verify-platform-consistency-governance.test.ts',
+      ]),
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #1611

Align the platform adapter contract wording so docs describe `PlatformAdapter` as the repository policy seam and `HttpApplicationAdapter` as the concrete HTTP transport contract currently implemented by platform packages. Also harden the platform governance verifier so contract-doc companion gates cannot be bypassed when PR diff detection lacks enough Git history.

## Changes

- Updated platform conformance, architecture, package-surface, AI context, and anti-pattern docs in English and Korean.
- Replaced the misleading `PlatformAdapter` code sample with an `HttpApplicationAdapter` example.
- Reviewed affected package README mirrors for `@fluojs/platform-fastify` and `@fluojs/platform-bun`; no runtime adapter contract changes were needed.
- Added full-history checkout for PR scope resolution and platform governance verification.
- Changed `verify-platform-consistency-governance` to fail closed when merge-base or diff detection fails, and added regression coverage for companion enforcement.

## Testing

- `lsp_diagnostics` on changed docs/tooling/test files: 0 diagnostics.
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts`: 15 tests passed.
- `pnpm vitest run packages/testing/src/conformance/platform-consistency-governance-docs.test.ts`: 12 tests passed.
- `pnpm verify:platform-consistency-governance`: passed.
- `pnpm build`: passed.
- `pnpm typecheck`: passed after build artifacts were available.
- `pnpm lint`: passed with pre-existing warnings in unrelated package source/tests; `verify:public-export-tsdoc` passed in changed mode.

## Public export documentation

- [x] No public package exports changed; source-level TSDoc is not applicable.
- [x] No exported functions changed in published package source; `@param` / `@returns` updates are not applicable.
- [x] README/package examples remain aligned with the documented adapter seam.

## Behavioral contract

- [x] No documented runtime behavioral contracts were removed without migration notes.
- [x] No new runtime behavioral contracts were introduced; adapter naming changes are documentation/platform naming alignment.
- [x] Governance behavior was intentionally tightened: diff detection now fails closed instead of treating unknown changed files as empty.
- [x] Runtime regression tests are not applicable because no runtime adapter behavior changed; governance regression tests were added for the changed contract gate.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Companion docs/index references were aligned across `docs/CONTEXT`, architecture, reference, guide, and contract docs.
- [x] CI/tooling enforcement was updated so the governance verifier receives full history and cannot silently bypass companion checks on diff failure.
- [x] Package README alignment claims were reviewed against `packages/platform-fastify/README.md`, `packages/platform-fastify/README.ko.md`, `packages/platform-bun/README.md`, and `packages/platform-bun/README.ko.md`; existing conformance evidence remains `packages/platform-fastify/src/adapter.test.ts`, `packages/platform-bun/src/adapter.test.ts`, and `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`.

## Release impact

No changeset: this PR does not change public package runtime behavior, public package APIs, or package release contents. The added CI/tooling/test changes only harden repository governance verification.