### PR TITLE
Resolve #1589: Fix Mongoose transaction shutdown

### DIFF
--- a/.changeset/mongoose-ambient-session-shutdown.md
+++ b/.changeset/mongoose-ambient-session-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/mongoose": patch
+---
+
+Preserve Mongoose connection.transaction ambient session scope while tracking active sessions through shutdown so dispose hooks wait for transaction cleanup.

--- a/book/intermediate/ch19-mongoose.md
+++ b/book/intermediate/ch19-mongoose.md
@@ -23,7 +23,7 @@ This chapter covers how to integrate FluoShop's document-oriented data model int
 Mongoose is a widely used modeling layer for working with MongoDB in the Node.js ecosystem. Using the fluo-specific integration package gives you these benefits.
 
 - **Lifecycle Management**: It registers the provided connection in the application lifecycle and, when you supply `dispose(connection)`, runs that cleanup only after request-scoped transactions have drained during shutdown.
-- **Session Awareness**: The `MongooseConnection` service tracks MongoDB sessions across the call stack to preserve transaction boundaries.
+- **Session Awareness**: The `MongooseConnection` service tracks MongoDB sessions across the call stack and through shutdown cleanup to preserve transaction boundaries.
 - **Request-Scoped Transactions**: `MongooseTransactionInterceptor` can wrap an entire HTTP request in a MongoDB transaction.
 
 ## 19.2 Installation and Setup
@@ -79,11 +79,13 @@ export class ProductRepository {
 }
 ```
 
-The `conn.current()` method always returns the registered Mongoose connection. Transaction state is tracked separately through `conn.currentSession()`, so repository methods that participate in a transaction still need to pass that session into Mongoose model operations explicitly.
+The `conn.current()` method always returns the registered Mongoose connection. Transaction state is tracked separately through `conn.currentSession()`, so repository methods that participate in a transaction still need to pass that session into Mongoose model operations explicitly. Fluo does not overwrite existing Mongoose operation options; an explicit `{ session }` stays under the repository's control.
 
 ## 19.5 Transaction Management
 
 MongoDB transactions require an active **session**. Fluo reduces the caller's burden by grouping session creation, execution, and cleanup into one transaction wrapper.
+
+When the provided Mongoose connection exposes `connection.transaction(...)`, fluo delegates the transaction boundary to that API so Mongoose's own ambient-session scope and cleanup semantics remain intact. Otherwise it falls back to `startSession()`, `startTransaction()`, `commitTransaction()` / `abortTransaction()`, and `endSession()` directly. In both modes, `dispose(connection)` waits until active request transactions and session cleanup settle during application shutdown.
 
 ### Manual Transactions
 

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -56,13 +56,14 @@ class AppModule {}
 
 `MongooseModule`은 `MongooseConnection`을 fluo 애플리케이션 라이프사이클에 등록합니다. 이 패키지는 원본 Mongoose 연결을 직접 생성하거나 소유하지 않습니다. 애플리케이션 종료 시 외부 연결을 닫아야 한다면 `dispose` 훅을 전달하세요.
 
-종료 과정은 요청 트랜잭션 정리 순서를 보존합니다.
+종료 과정은 트랜잭션 정리 순서를 보존합니다.
 
 1. 열려 있는 요청 범위 트랜잭션은 `Application shutdown interrupted an open request transaction.` 오류로 abort됩니다.
-2. 해당 Mongoose 세션은 `abortTransaction()`과 `endSession()` 정리를 끝냅니다.
-3. 설정한 `dispose(connection)` 훅은 활성 요청 트랜잭션이 모두 settled된 뒤에만 실행됩니다.
+2. 활성 ambient session은 transaction callback과 session cleanup이 settle될 때까지 추적됩니다.
+3. 해당 Mongoose 세션은 `abortTransaction()`과 `endSession()` 정리를 끝냅니다.
+4. 설정한 `dispose(connection)` 훅은 활성 요청 트랜잭션과 ambient session scope가 모두 settled된 뒤에만 실행됩니다.
 
-`createMongoosePlatformStatusSnapshot(...)`은 트래픽 처리 중에는 `ready`, 요청 트랜잭션 drain 중에는 `shutting-down`, dispose 훅 완료 뒤에는 `stopped`를 보고합니다. 상태 details에는 `sessionStrategy`, `transactionContext: 'als'`, 리소스 소유권, strict/session 지원 진단이 포함됩니다. 수동 `transaction()`도 요청 범위 트랜잭션과 같은 명시적 세션 계약을 사용하므로, 트랜잭션에 참여해야 하는 Mongoose 모델 작업에는 repository 코드가 `conn.currentSession()`을 전달해야 합니다.
+`createMongoosePlatformStatusSnapshot(...)`은 트래픽 처리 중에는 `ready`, 요청 트랜잭션 drain 중에는 `shutting-down`, dispose 훅 완료 뒤에는 `stopped`를 보고합니다. 상태 details에는 `sessionStrategy`, `transactionContext: 'als'`, 활성 요청/session 개수, 리소스 소유권, strict/session 지원 진단이 포함됩니다. 수동 `transaction()`도 요청 범위 트랜잭션과 같은 명시적 세션 계약을 사용하므로, 트랜잭션에 참여해야 하는 Mongoose 모델 작업에는 repository 코드가 `conn.currentSession()`을 전달해야 합니다. 감싼 Mongoose 연결이 `connection.transaction(...)`을 노출하면 fluo는 Mongoose 자체 ambient-session scope를 보존하기 위해 그 API에 transaction boundary를 위임하면서도 같은 session을 `currentSession()`으로 노출합니다.
 
 ## 공통 패턴
 
@@ -98,6 +99,8 @@ await this.conn.transaction(async () => {
 ```
 
 감싼 연결이 `startSession()`을 구현하지 않으면 트랜잭션은 기본적으로 직접 실행으로 fallback합니다. fallback 대신 예외를 던지려면 `strictTransactions: true`를 설정합니다. 이때 오류 메시지는 `Transaction not supported: Mongoose connection does not implement startSession.`입니다.
+
+Fluo는 Mongoose operation option을 다시 쓰지 않습니다. 모델 호출이 명시적인 `{ session }`을 전달하면 그 option은 그대로 유지되며, 생략한 경우 fluo가 session을 자동 부착한다고 가정하면 안 됩니다. 같은 session에서 병렬 작업이나 중첩 transaction 기대치는 보수적으로 유지하세요. 중첩된 `MongooseConnection.transaction(...)` 호출은 같은 session에 두 번째 MongoDB transaction을 여는 대신 활성 boundary를 재사용합니다.
 
 ### 요청 범위 트랜잭션
 

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -54,13 +54,14 @@ class AppModule {}
 
 `MongooseModule` registers `MongooseConnection` with the fluo application lifecycle. The package does not create or own the raw Mongoose connection for you; pass a `dispose` hook when the application should close that external connection during shutdown.
 
-Shutdown preserves request transaction cleanup order:
+Shutdown preserves transaction cleanup order:
 
 1. Open request-scoped transactions are aborted with `Application shutdown interrupted an open request transaction.`
-2. Their Mongoose sessions finish `abortTransaction()` and `endSession()` cleanup.
-3. The configured `dispose(connection)` hook runs only after active request transactions have settled.
+2. Active ambient sessions are tracked until their transaction callback and session cleanup settle.
+3. Their Mongoose sessions finish `abortTransaction()` and `endSession()` cleanup.
+4. The configured `dispose(connection)` hook runs only after active request transactions and ambient session scopes have settled.
 
-`createMongoosePlatformStatusSnapshot(...)` reports `ready` while serving traffic, `shutting-down` while request transactions are draining, and `stopped` after the dispose hook completes. The status details include `sessionStrategy`, `transactionContext: 'als'`, resource ownership, and strict/session support diagnostics. Manual `transaction()` calls still use the same explicit-session contract as request-scoped transactions: repository code must pass `conn.currentSession()` into Mongoose model operations that participate in the transaction.
+`createMongoosePlatformStatusSnapshot(...)` reports `ready` while serving traffic, `shutting-down` while request transactions are draining, and `stopped` after the dispose hook completes. The status details include `sessionStrategy`, `transactionContext: 'als'`, active request/session counts, resource ownership, and strict/session support diagnostics. Manual `transaction()` calls still use the same explicit-session contract as request-scoped transactions: repository code must pass `conn.currentSession()` into Mongoose model operations that participate in the transaction. If the wrapped Mongoose connection exposes `connection.transaction(...)`, fluo delegates the transaction boundary to that API so Mongoose's own ambient-session scope is preserved while still exposing the same session through `currentSession()`.
 
 ## Common Patterns
 
@@ -91,6 +92,8 @@ await this.conn.transaction(async () => {
 ```
 
 If the wrapped connection does not implement `startSession()`, transactions fall back to direct execution by default. Set `strictTransactions: true` to throw `Transaction not supported: Mongoose connection does not implement startSession.` instead of falling back.
+
+Fluo never rewrites Mongoose operation options. If a model call passes an explicit `{ session }`, that option is left intact; if it omits one, repositories should not assume fluo will attach a session for them. Keep same-session parallel work and nested transaction expectations conservative: nested `MongooseConnection.transaction(...)` calls reuse the active boundary rather than opening a second MongoDB transaction on the same session.
 
 ### Request-scoped transactions
 

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -29,6 +29,14 @@ type ActiveRequestTransactionHandle = {
   settle(): void;
 };
 
+type ActiveSessionScope = {
+  settled: Promise<void>;
+};
+
+type ActiveSessionScopeHandle = {
+  settle(): void;
+};
+
 type MongooseRuntimeOptions = {
   strictTransactions: boolean;
 };
@@ -61,6 +69,7 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
 {
   private readonly sessions = new AsyncLocalStorage<MongooseSessionLike>();
   private readonly activeRequestTransactions = new Set<ActiveRequestTransaction>();
+  private readonly activeSessions = new Set<ActiveSessionScope>();
   private lifecycleState: 'ready' | 'shutting-down' | 'stopped' = 'ready';
 
   constructor(
@@ -105,7 +114,10 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
       transaction.abort(new Error('Application shutdown interrupted an open request transaction.'));
     }
 
-    await Promise.allSettled(Array.from(this.activeRequestTransactions, (transaction) => transaction.settled));
+    await Promise.allSettled([
+      ...Array.from(this.activeRequestTransactions, (transaction) => transaction.settled),
+      ...Array.from(this.activeSessions, (session) => session.settled),
+    ]);
 
     if (this.dispose) {
       await this.dispose(this.connection);
@@ -118,9 +130,11 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
   createPlatformStatusSnapshot() {
     return createMongoosePlatformStatusSnapshot({
       activeRequestTransactions: this.activeRequestTransactions.size,
-      hasActiveSession: this.sessions.getStore() !== undefined,
+      activeSessions: this.activeSessions.size,
+      hasActiveSession: this.activeSessions.size > 0,
       lifecycleState: this.lifecycleState,
       strictTransactions: this.connectionOptions.strictTransactions,
+      supportsConnectionTransaction: typeof this.connection.transaction === 'function',
       supportsStartSession: typeof this.connection.startSession === 'function',
     });
   }
@@ -144,18 +158,16 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
       return fn();
     }
 
+    if (typeof this.connection.transaction === 'function') {
+      return this.runConnectionTransaction(fn);
+    }
+
     const session = await this.resolveSession();
     if (!session) {
       return fn();
     }
 
-    try {
-      return await this.sessions.run(session, () =>
-        executeSessionTransaction(session, () => this.sessions.run(session, fn)),
-      );
-    } finally {
-      await session.endSession();
-    }
+    return this.runManualSessionTransaction(session, fn);
   }
 
   /**
@@ -181,29 +193,69 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
 
     const abortContext = createRequestAbortContext(signal);
     const active = this.trackActiveRequestTransaction(abortContext.controller);
-    let acquiredSession: MongooseSessionLike | undefined;
 
     try {
+      if (typeof this.connection.transaction === 'function') {
+        return await this.runConnectionTransaction(() => raceWithAbort(fn, abortContext.signal));
+      }
+
       const resolvedSession = await this.resolveSession();
       if (!resolvedSession) {
         return await raceWithAbort(fn, abortContext.signal);
       }
 
-      acquiredSession = resolvedSession;
-      return await this.sessions.run(resolvedSession, () =>
-        executeSessionTransaction(resolvedSession, () =>
-          this.sessions.run(resolvedSession, () => raceWithAbort(fn, abortContext.signal)),
-        ),
-      );
+      return await this.runManualSessionTransaction(resolvedSession, () => raceWithAbort(fn, abortContext.signal));
     } finally {
       abortContext.cleanup();
 
+      this.untrackActiveRequestTransaction(active);
+    }
+  }
+
+  private async runManualSessionTransaction<T>(session: MongooseSessionLike, fn: () => Promise<T>): Promise<T> {
+    const activeSession = this.trackActiveSession();
+
+    try {
+      return await this.sessions.run(session, () => executeSessionTransaction(session, fn));
+    } finally {
       try {
-        await acquiredSession?.endSession();
+        await session.endSession();
       } finally {
-        this.untrackActiveRequestTransaction(active);
+        activeSession.settle();
       }
     }
+  }
+
+  private async runConnectionTransaction<T>(fn: () => Promise<T>): Promise<T> {
+    const activeSession = this.trackActiveSession();
+
+    try {
+      if (typeof this.connection.transaction !== 'function') {
+        throw new Error('Mongoose connection transaction resolver initialization failed.');
+      }
+
+      return await this.connection.transaction((session) => this.sessions.run(session, fn));
+    } finally {
+      activeSession.settle();
+    }
+  }
+
+  private trackActiveSession(): ActiveSessionScopeHandle {
+    let settle!: () => void;
+    const active: ActiveSessionScope = {
+      settled: new Promise<void>((resolve) => {
+        settle = resolve;
+      }),
+    };
+
+    this.activeSessions.add(active);
+
+    return {
+      settle: () => {
+        this.activeSessions.delete(active);
+        settle();
+      },
+    };
   }
 
   private trackActiveRequestTransaction(controller: AbortController): ActiveRequestTransactionHandle {

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -573,6 +573,140 @@ describe('@fluojs/mongoose', () => {
     expect(sessionCalls).toBe(1);
   });
 
+  it('uses Mongoose connection.transaction when available without overriding explicit session flow', async () => {
+    const events: string[] = [];
+    const session = createFakeSession(events);
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+      async transaction(fn) {
+        events.push('connection:transaction:start');
+        try {
+          return await fn(session);
+        } finally {
+          events.push('connection:transaction:end');
+          await session.endSession();
+        }
+      },
+    };
+
+    const mongoose = new MongooseConnection<typeof connection>(connection);
+
+    await expect(
+      mongoose.transaction(async () => {
+        events.push(`session:${mongoose.currentSession() === session}`);
+        return 'ok';
+      }),
+    ).resolves.toBe('ok');
+
+    expect(events).toEqual([
+      'connection:transaction:start',
+      'session:true',
+      'connection:transaction:end',
+      'session:end',
+    ]);
+    expect(events).not.toContain('connection:startSession');
+  });
+
+  it('waits for connection.transaction request session cleanup before dispose on shutdown', async () => {
+    const events: string[] = [];
+    let resolveEndSessionStarted!: () => void;
+    let resolveEndSession!: () => void;
+    const endSessionStarted = new Promise<void>((resolve) => {
+      resolveEndSessionStarted = resolve;
+    });
+    const endSessionDeferred = new Promise<void>((resolve) => {
+      resolveEndSession = resolve;
+    });
+
+    const session: MongooseSessionLike = {
+      abortTransaction() {
+        events.push('transaction:abort');
+      },
+      commitTransaction() {
+        events.push('transaction:commit');
+      },
+      async endSession() {
+        events.push('session:end:start');
+        resolveEndSessionStarted();
+        await endSessionDeferred;
+        events.push('session:end:done');
+      },
+      startTransaction() {
+        events.push('transaction:start');
+      },
+    };
+
+    const connection: MongooseConnectionLike = {
+      async transaction(fn) {
+        events.push('connection:transaction:start');
+        await session.startTransaction();
+        try {
+          const result = await fn(session);
+          await session.commitTransaction();
+          return result;
+        } catch (error) {
+          await session.abortTransaction();
+          throw error;
+        } finally {
+          await session.endSession();
+        }
+      },
+    };
+
+    const mongooseModule = MongooseModule.forRoot<typeof connection>({
+      connection,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [mongooseModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
+
+    const openTransaction = mongoose.requestTransaction(async () => new Promise<never>(() => undefined));
+    const closePromise = app.close();
+
+    await endSessionStarted;
+
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 1,
+        activeSessions: 1,
+        lifecycleState: 'shutting-down',
+      },
+    });
+    expect(events).toEqual([
+      'connection:transaction:start',
+      'transaction:start',
+      'transaction:abort',
+      'session:end:start',
+    ]);
+
+    resolveEndSession();
+
+    await closePromise;
+    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+
+    expect(events).toEqual([
+      'connection:transaction:start',
+      'transaction:start',
+      'transaction:abort',
+      'session:end:start',
+      'session:end:done',
+      'dispose',
+    ]);
+  });
+
   it('handles transaction abort on error', async () => {
     const events: string[] = [];
     const session = createFakeSession(events);
@@ -715,9 +849,11 @@ describe('@fluojs/mongoose', () => {
   it('reports ownership/readiness/health semantics in platform snapshot shape', () => {
     const snapshot = createMongoosePlatformStatusSnapshot({
       activeRequestTransactions: 1,
+      activeSessions: 0,
       hasActiveSession: false,
       lifecycleState: 'ready',
       strictTransactions: false,
+      supportsConnectionTransaction: false,
       supportsStartSession: true,
     });
 
@@ -734,9 +870,11 @@ describe('@fluojs/mongoose', () => {
   it('marks strict transaction mismatch as not-ready', () => {
     const snapshot = createMongoosePlatformStatusSnapshot({
       activeRequestTransactions: 0,
+      activeSessions: 0,
       hasActiveSession: false,
       lifecycleState: 'ready',
       strictTransactions: true,
+      supportsConnectionTransaction: false,
       supportsStartSession: false,
     });
 
@@ -748,9 +886,11 @@ describe('@fluojs/mongoose', () => {
   it('marks shutdown state as not-ready and degraded health', () => {
     const snapshot = createMongoosePlatformStatusSnapshot({
       activeRequestTransactions: 0,
+      activeSessions: 0,
       hasActiveSession: false,
       lifecycleState: 'shutting-down',
       strictTransactions: false,
+      supportsConnectionTransaction: false,
       supportsStartSession: true,
     });
 

--- a/packages/mongoose/src/status.ts
+++ b/packages/mongoose/src/status.ts
@@ -8,9 +8,11 @@ type MongoosePlatformLifecycleState = 'ready' | 'shutting-down' | 'stopped';
 
 type MongoosePlatformStatusSnapshotInput = {
   activeRequestTransactions: number;
+  activeSessions: number;
   hasActiveSession: boolean;
   lifecycleState: MongoosePlatformLifecycleState;
   strictTransactions: boolean;
+  supportsConnectionTransaction: boolean;
   supportsStartSession: boolean;
 };
 
@@ -31,7 +33,7 @@ function createReadiness(input: MongoosePlatformStatusSnapshotInput): PlatformRe
     };
   }
 
-  if (input.strictTransactions && !input.supportsStartSession) {
+  if (input.strictTransactions && !input.supportsStartSession && !input.supportsConnectionTransaction) {
     return {
       critical: true,
       reason: 'Mongoose strictTransactions is enabled but connection.startSession is unavailable.',
@@ -77,10 +79,12 @@ export function createMongoosePlatformStatusSnapshot(
   return {
     details: {
       activeRequestTransactions: input.activeRequestTransactions,
+      activeSessions: input.activeSessions,
       hasActiveSession: input.hasActiveSession,
       lifecycleState: input.lifecycleState,
-      sessionStrategy: input.supportsStartSession ? 'explicit-session' : 'none',
+      sessionStrategy: input.supportsStartSession || input.supportsConnectionTransaction ? 'explicit-session' : 'none',
       strictTransactions: input.strictTransactions,
+      supportsConnectionTransaction: input.supportsConnectionTransaction,
       supportsStartSession: input.supportsStartSession,
       transactionContext: 'als',
     },

--- a/packages/mongoose/src/types.ts
+++ b/packages/mongoose/src/types.ts
@@ -8,6 +8,7 @@ import type { MaybePromise } from '@fluojs/core';
  */
 export interface MongooseConnectionLike {
   startSession?(): Promise<MongooseSessionLike>;
+  transaction?<T>(fn: (session: MongooseSessionLike) => Promise<T>): Promise<T>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes @fluojs/mongoose transaction shutdown handling so active session scopes are tracked until transaction cleanup completes.
- Preserves Mongoose connection.transaction ambient-session behavior while keeping fluo's explicit currentSession() contract documented.

Closes #1589

## Changes

- Delegate to Mongoose connection.transaction(...) when available and expose its session through MongooseConnection.currentSession().
- Track active session scopes in platform status and wait for request/session settlement before dispose(connection).
- Add regression coverage for connection.transaction delegation and shutdown cleanup ordering.
- Update package README EN/KO and book chapter guidance for explicit sessions, nested transaction limits, and shutdown behavior.
- Add a patch changeset for @fluojs/mongoose.

## Testing

- LSP diagnostics: packages/mongoose/src/connection.ts, status.ts, types.ts, module.test.ts clean.
- pnpm --dir packages/mongoose test
- pnpm --dir packages/mongoose typecheck
- pnpm --dir packages/mongoose build
- pnpm exec biome lint packages/mongoose/src/connection.ts packages/mongoose/src/status.ts packages/mongoose/src/types.ts packages/mongoose/src/module.test.ts
- Note: full pnpm lint was also attempted and is blocked by pre-existing unrelated lint findings under packages/config, packages/core, packages/cqrs, and packages/cron; changed-file lint passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.