### PR TITLE
Resolve #1591: Fix Socket.IO lifecycle contracts

### DIFF
--- a/.changeset/sharp-tables-fix.md
+++ b/.changeset/sharp-tables-fix.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/socket.io": patch
+---
+
+Clarify Socket.IO namespace and shutdown ownership while applying Bun payload bounds to both HTTP request bodies and WebSocket frames.

--- a/book/intermediate/ch14-socketio.md
+++ b/book/intermediate/ch14-socketio.md
@@ -53,7 +53,7 @@ import { SocketIoModule } from '@fluojs/socket.io';
 export class ChatModule {}
 ```
 
-By default, fluo keeps CORS deny by default, meaning `origin: false`. To allow cross origin browser clients, you must explicitly write the allowed origin list. The `engine` configuration maps directly to Engine.IO, letting you limit payload size for production stability. These defaults are a safer starting point because realtime browser connections often stay open for a long time.
+By default, fluo keeps CORS deny by default, meaning `origin: false`. To allow cross origin browser clients, you must explicitly write the allowed origin list. The `engine` configuration maps directly to Engine.IO, letting you limit payload size for production stability. On Bun, the adapter maps the same `engine.maxHttpBufferSize` value into both the HTTP request body limit and the WebSocket payload limit because Bun exposes those host contracts separately. These defaults are a safer starting point because realtime browser connections often stay open for a long time.
 
 ## 14.3 Room management with SocketIoRoomService
 
@@ -94,6 +94,8 @@ export class SupportChatGateway {
 ```
 
 `SocketIoRoomService` separates room logic from the gateway. With this structure, regular services that cannot access the original socket instance can still broadcast to a specific room. Realtime delivery becomes an explicit collaboration point for application services instead of being trapped inside socket handlers.
+
+Gateway paths such as `/support` are static Socket.IO namespaces owned by fluo gateway discovery. They are not dynamic child namespaces, so fluo keeps Socket.IO dynamic-child cleanup behavior out of this gateway path. If a low-level service creates dynamic namespaces through `SOCKETIO_SERVER`, that service should also own the matching cleanup policy.
 
 ## 14.4 Guarding namespaces and messages
 
@@ -139,6 +141,8 @@ export class ScalingService {
 ```
 
 This boundary lets fluo provide a decorator based surface without blocking the extension points of the underlying library. Most code can use fluo's declarative gateways, while operational exceptions stay gathered around the raw server boundary.
+
+The managed Socket.IO lifecycle owns shutdown for the raw server it exposes. Application shutdown delegates client disconnects and the underlying HTTP server close to Socket.IO's `io.close(...)`, so low-level services should avoid adding a second manual disconnect or HTTP close path for the same managed instance.
 
 ## 14.6 Bun engine details
 

--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -105,13 +105,17 @@ SocketIoModule.forRoot({
 
 `cors`를 생략하면 `@fluojs/socket.io`는 `{ credentials: false, origin: false }`를 기본값으로 사용하므로 cross-origin 노출은 명시적 opt-in이 필요합니다. `engine.maxHttpBufferSize`를 생략하면 어댑터가 1 MiB Engine.IO payload 상한을 적용합니다. 기본값에는 `buffer.maxPendingMessagesPerSocket: 128`, `buffer.overflowPolicy: 'drop-oldest'`, `shutdown.timeoutMs: 5000`도 포함됩니다.
 
+정적 `@WebSocketGateway({ path })` namespace는 fluo gateway discovery가 소유하며 Socket.IO dynamic child namespace로 취급하지 않습니다. 어댑터는 이러한 정적 namespace에 대해 Socket.IO의 `cleanupEmptyChildNamespaces` 동작을 비활성화합니다. 애플리케이션 코드가 raw `SOCKETIO_SERVER` 접근으로 dynamic child namespace를 만들면 해당 소유권과 cleanup 정책은 애플리케이션 수준 Socket.IO 통합이 담당합니다.
+
+애플리케이션 종료 중 `@fluojs/socket.io`는 client disconnect와 underlying HTTP server close를 Socket.IO의 `io.close(...)` lifecycle에 위임합니다. 동일한 managed server 주변에 별도의 manual socket-disconnect 또는 HTTP-server-close 경로를 추가하지 마세요.
+
 ### Guard 계약
 
 `auth.connection`은 namespace connect handler가 실행되기 전에 `SocketIoConnectionGuardContext`를 받습니다. `auth.message`는 message handler가 실행되기 전에 `SocketIoMessageGuardContext`를 받습니다. Guard는 `true`, `false`, 또는 `message`, optional `data`, optional `disconnect`를 가진 `SocketIoGuardRejection`을 반환할 수 있으며, message rejection은 `{ error, data }` 형태의 ACK payload를 사용합니다.
 
 ### Bun 전용 참고
 
-Bun path는 `@socket.io/bun-engine`을 통해 Socket.IO를 지원하지만 static CORS shape가 필요합니다. CORS delegate function과 `cors.origin` array 안의 boolean entry는 지원하지 않습니다. `@WebSocketGateway({ serverBacked })`는 Bun에서 지원하지 않습니다.
+Bun path는 `@socket.io/bun-engine`을 통해 Socket.IO를 지원하지만 static CORS shape가 필요합니다. CORS delegate function과 `cors.origin` array 안의 boolean entry는 지원하지 않습니다. `@WebSocketGateway({ serverBacked })`는 Bun에서 지원하지 않습니다. Bun의 HTTP request body limit(`maxRequestBodySize`)과 WebSocket frame limit(`websocket.maxPayloadLength`)은 별도 host contract입니다. 어댑터는 polling request와 websocket frame이 같은 inbound payload bound를 따르도록 두 값을 모두 `engine.maxHttpBufferSize`에서 매핑합니다.
 
 ### 모듈 등록
 `SocketIoModule.forRoot(...)`로 Socket.IO를 등록합니다.

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -107,13 +107,17 @@ SocketIoModule.forRoot({
 
 When `cors` is omitted, `@fluojs/socket.io` defaults to `{ credentials: false, origin: false }` so cross-origin exposure stays opt-in. When `engine.maxHttpBufferSize` is omitted, the adapter applies a bounded 1 MiB Engine.IO payload limit. Defaults also include `buffer.maxPendingMessagesPerSocket: 128`, `buffer.overflowPolicy: 'drop-oldest'`, and `shutdown.timeoutMs: 5000`.
 
+Static `@WebSocketGateway({ path })` namespaces are owned by fluo's gateway discovery and are not treated as Socket.IO dynamic child namespaces. The adapter keeps Socket.IO's `cleanupEmptyChildNamespaces` behavior disabled for those static namespaces; if application code creates dynamic child namespaces through raw `SOCKETIO_SERVER` access, that ownership and cleanup policy stays with the application-level Socket.IO integration.
+
+During application shutdown, `@fluojs/socket.io` delegates client disconnects and the underlying HTTP server close to Socket.IO's `io.close(...)` lifecycle. Do not add a second manual socket-disconnect or HTTP-server-close path around the same managed server.
+
 ### Guard contracts
 
 `auth.connection` receives `SocketIoConnectionGuardContext` before namespace connect handlers run. `auth.message` receives `SocketIoMessageGuardContext` before message handlers run. Guards can return `true`, `false`, or a `SocketIoGuardRejection` with `message`, optional `data`, and optional `disconnect`; message rejections use ACK payloads shaped as `{ error, data }`.
 
 ### Bun-specific notes
 
-The Bun path supports Socket.IO through `@socket.io/bun-engine`, but it requires static CORS shapes: no CORS delegate functions and no boolean entries inside `cors.origin` arrays. `@WebSocketGateway({ serverBacked })` is not supported on Bun.
+The Bun path supports Socket.IO through `@socket.io/bun-engine`, but it requires static CORS shapes: no CORS delegate functions and no boolean entries inside `cors.origin` arrays. `@WebSocketGateway({ serverBacked })` is not supported on Bun. Bun's HTTP request body limit (`maxRequestBodySize`) and WebSocket frame limit (`websocket.maxPayloadLength`) are separate host contracts; the adapter maps both from `engine.maxHttpBufferSize` so polling requests and websocket frames share the configured inbound payload bound.
 
 ### Module registration
 Register Socket.IO with `SocketIoModule.forRoot(...)`.

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -103,6 +103,12 @@ interface BunEngineCorsOptions {
   origin?: boolean | RegExp | string | Array<RegExp | string>;
 }
 
+interface BunEngineOptions {
+  cors?: BunEngineCorsOptions;
+  maxHttpBufferSize?: number;
+  path: string;
+}
+
 interface BunRealtimeBindingHost {
   configureRealtimeBinding(binding: BunRealtimeBinding | undefined): void;
 }
@@ -490,6 +496,8 @@ export class SocketIoLifecycleService
 
     options.maxHttpBufferSize = this.resolveMaxHttpBufferSize();
 
+    options.cleanupEmptyChildNamespaces = false;
+
     if (this.moduleOptions.transports !== undefined) {
       options.transports = this.moduleOptions.transports;
     }
@@ -497,11 +505,9 @@ export class SocketIoLifecycleService
     return options;
   }
 
-  private createBunEngineOptions() {
-    const options: {
-      cors?: BunEngineCorsOptions;
-      path: string;
-    } = {
+  private createBunEngineOptions(): BunEngineOptions {
+    const options: BunEngineOptions = {
+      maxHttpBufferSize: this.resolveMaxHttpBufferSize(),
       path: DEFAULT_SOCKETIO_ENGINE_PATH,
     };
 
@@ -549,10 +555,10 @@ export class SocketIoLifecycleService
         return await engine.handleRequest(request, server as never);
       },
       idleTimeout: handler.idleTimeout,
-      maxRequestBodySize: handler.maxRequestBodySize,
+      maxRequestBodySize: this.resolveMaxHttpBufferSize(),
       websocket: {
         close: handler.websocket.close as BunRealtimeBinding['websocket']['close'],
-        maxPayloadLength: handler.websocket.maxPayloadLength,
+        maxPayloadLength: this.resolveMaxHttpBufferSize(),
         message: handler.websocket.message as BunRealtimeBinding['websocket']['message'],
         open: handler.websocket.open as BunRealtimeBinding['websocket']['open'],
       },

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -509,16 +509,92 @@ describe('@fluojs/socket.io', () => {
     );
 
     const serverOptions = Reflect.get(service, 'createServerOptions').call(service) as {
+      cleanupEmptyChildNamespaces?: boolean;
       cors?: unknown;
       maxHttpBufferSize?: number;
     };
     const bunOptions = Reflect.get(service, 'createBunEngineOptions').call(service) as {
       cors?: unknown;
+      maxHttpBufferSize?: number;
     };
 
     expect(serverOptions.cors).toEqual({ credentials: false, origin: false });
+    expect(serverOptions.cleanupEmptyChildNamespaces).toBe(false);
     expect(serverOptions.maxHttpBufferSize).toBe(1_048_576);
     expect(bunOptions.cors).toEqual({ credentials: false, origin: false });
+    expect(bunOptions.maxHttpBufferSize).toBe(1_048_576);
+  });
+
+  it('maps Bun HTTP request-body and websocket payload limits from the engine payload bound', () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getRealtimeCapability() {
+          return createServerBackedHttpAdapterRealtimeCapability({});
+        },
+      } as never,
+      {
+        engine: {
+          maxHttpBufferSize: 256,
+        },
+      },
+    );
+    const engine = {
+      handler() {
+        return {
+          idleTimeout: 120,
+          maxRequestBodySize: 999,
+          websocket: {
+            close() {},
+            maxPayloadLength: 999,
+            message() {},
+            open() {},
+          },
+        };
+      },
+      handleRequest() {
+        return new Response();
+      },
+    };
+    const binding = Reflect.get(service, 'createBunSocketIoBinding').call(service, engine) as {
+      maxRequestBodySize?: number;
+      websocket: { maxPayloadLength?: number };
+    };
+
+    expect(binding.maxRequestBodySize).toBe(256);
+    expect(binding.websocket.maxPayloadLength).toBe(256);
+  });
+
+  it('delegates Socket.IO shutdown ownership to io.close without separately disconnecting clients', async () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getRealtimeCapability() {
+          return createServerBackedHttpAdapterRealtimeCapability({});
+        },
+      } as never,
+      {},
+    );
+    const calls: string[] = [];
+    const io = {
+      close(callback: () => void) {
+        calls.push('close');
+        callback();
+      },
+      disconnectSockets() {
+        calls.push('disconnectSockets');
+      },
+    };
+
+    await Reflect.get(service, 'closeServerWithTimeout').call(service, io, 100);
+
+    expect(calls).toEqual(['close']);
   });
 
   it('rejects incomplete server-like bridge objects before constructing Socket.IO', () => {


### PR DESCRIPTION
## Summary

Closes #1591

- @fluojs/socket.io의 정적 namespace 소유권, shutdown 소유권, Bun payload limit 계약을 명확히 맞췄습니다.
- Bun host의 HTTP request body limit과 WebSocket payload limit을 `engine.maxHttpBufferSize`에서 함께 파생하도록 회귀 방어를 추가했습니다.

## Changes

- Socket.IO server options에서 static gateway namespace를 dynamic child namespace cleanup 대상으로 보지 않도록 `cleanupEmptyChildNamespaces: false`를 명시했습니다.
- Bun realtime binding의 `maxRequestBodySize`와 `websocket.maxPayloadLength`를 adapter의 Engine.IO payload bound와 동기화했습니다.
- `packages/socket.io/README.md`, `packages/socket.io/README.ko.md`, `book/intermediate/ch14-socketio.md`에 namespace/shutdown/Bun payload 계약을 문서화했습니다.
- `@fluojs/socket.io` patch changeset을 추가했습니다.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm build`
- LSP diagnostics: `packages/socket.io/src/adapter.ts`, `packages/socket.io/src/module.test.ts` clean
- `pnpm --dir packages/socket.io typecheck`
- `pnpm --dir packages/socket.io test` (33 passed)
- `pnpm changeset status --since=main`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

변경된 공개 export shape는 없고 기존 `SocketIoLifecycleService` 내부 lifecycle behavior와 문서/테스트를 갱신했습니다.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

정적 gateway namespace는 fluo gateway discovery가 소유하고, dynamic child namespace cleanup은 raw `SOCKETIO_SERVER` 사용자가 소유한다는 경계를 명시했습니다. Shutdown은 `io.close(...)`가 client disconnect와 HTTP server close를 소유한다는 계약을 테스트로 고정했습니다.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Governance docs는 변경하지 않았습니다. Package README EN/KO mirror와 tutorial-facing book 문서만 동기화했습니다.