### PR TITLE
Resolve #1597: Fix notification fallback lifecycle semantics

### DIFF
--- a/.changeset/notifications-fallback-lifecycle.md
+++ b/.changeset/notifications-fallback-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/notifications": patch
+---
+
+Fix notification fallback delivery IDs so channel deliveries without external IDs use deterministic request-derived IDs, and publish failed lifecycle events for missing-channel dispatch attempts before throwing configuration errors.

--- a/book/intermediate/ch15-notifications.md
+++ b/book/intermediate/ch15-notifications.md
@@ -145,7 +145,9 @@ NotificationsModule.forRoot({
 - `notification.dispatch.requested`: When `dispatch()` is called.
 - `notification.dispatch.queued`: When a notification moves to the background queue.
 - `notification.dispatch.delivered`: When the channel confirms successful delivery.
-- `notification.dispatch.failed`: When delivery still fails after retries.
+- `notification.dispatch.failed`: When channel resolution, queue enqueue, or provider delivery fails.
+
+Channel resolution failures are permanent configuration errors: the service publishes `requested`, then `failed`, and throws `NotificationChannelNotFoundError` without enqueueing or calling a provider. Queue enqueue and provider delivery failures also publish `failed`, but retry policy should be based on the underlying queue or provider error. When a channel omits `externalId`, the service creates a deterministic fallback delivery id from the notification envelope rather than using time or random data.
 
 ## 15.7 FluoShop Context: Order Success Flow
 

--- a/packages/notifications/README.ko.md
+++ b/packages/notifications/README.ko.md
@@ -150,7 +150,7 @@ NotificationsModule.forRoot({
 - `notification.dispatch.delivered`
 - `notification.dispatch.failed`
 
-`events.publisher`가 구성되어 있으면 `publishLifecycleEvents: false`를 설정하지 않는 한 lifecycle event publication은 기본으로 켜집니다. 채널 delivery가 `externalId`를 생략하면 dispatch result가 호출자에게 안정적으로 유지되도록 deterministic fallback delivery id가 부여됩니다.
+`events.publisher`가 구성되어 있으면 `publishLifecycleEvents: false`를 설정하지 않는 한 lifecycle event publication은 기본으로 켜집니다. 채널 delivery가 `externalId`를 생략하면 시간이나 난수에 의존하지 않고 notification envelope에서 파생한 deterministic fallback delivery id가 부여되어 dispatch result가 호출자에게 안정적으로 유지됩니다. 채널 해석 실패는 `NotificationChannelNotFoundError`를 던지기 전에 `requested` 이후 `failed` 이벤트를 발행하며, 이는 영구적인 구성 오류로 취급해야 합니다. Queue enqueue와 provider delivery 실패도 `failed` 이벤트를 발행하지만, retry 여부는 underlying adapter/provider error를 기준으로 분류해야 합니다.
 
 ### 의도적인 제한 사항
 

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -150,7 +150,7 @@ Published event names:
 - `notification.dispatch.delivered`
 - `notification.dispatch.failed`
 
-If `events.publisher` is configured, lifecycle event publication defaults to on unless `publishLifecycleEvents: false` is set. Channel deliveries that omit `externalId` receive a deterministic fallback delivery id so dispatch results remain stable for callers.
+If `events.publisher` is configured, lifecycle event publication defaults to on unless `publishLifecycleEvents: false` is set. Channel deliveries that omit `externalId` receive a deterministic fallback delivery id derived from the notification envelope so dispatch results remain stable for callers without relying on time or random data. Channel resolution failures publish `requested` and then `failed` events before throwing `NotificationChannelNotFoundError`; treat those failures as permanent configuration errors. Queue enqueue and provider delivery failures also publish `failed` events, but callers should classify their retry behavior from the underlying adapter/provider error.
 
 ### Intentional limitations
 

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -291,8 +291,38 @@ describe('NotificationsModule', () => {
     ]);
   });
 
+  it('publishes requested and failed lifecycle events for direct missing-channel dispatch', async () => {
+    const publisher = new RecordingPublisher();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [],
+      events: {
+        publisher,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await expect(service.dispatch({ channel: 'discord', payload: { template: 'missing' } })).rejects.toBeInstanceOf(
+      NotificationChannelNotFoundError,
+    );
+    expect(publisher.events).toMatchObject([
+      {
+        channel: 'discord',
+        name: 'notification.dispatch.requested',
+      },
+      {
+        channel: 'discord',
+        error: { message: 'No notification channel is registered for "discord".', name: 'NotificationChannelNotFoundError' },
+        name: 'notification.dispatch.failed',
+      },
+    ]);
+  });
+
   it('validates channels before queueing a single explicit queue dispatch', async () => {
     const queue = new RecordingQueueAdapter();
+    const publisher = new RecordingPublisher();
     const container = new Container();
     const moduleType = NotificationsModule.forRoot({
       channels: [
@@ -307,6 +337,9 @@ describe('NotificationsModule', () => {
         adapter: queue,
         bulkThreshold: 50,
       },
+      events: {
+        publisher,
+      },
     });
 
     container.register(...moduleProviders(moduleType));
@@ -316,6 +349,10 @@ describe('NotificationsModule', () => {
       service.dispatch({ channel: 'discord', payload: { template: 'unknown' } }, { queue: true }),
     ).rejects.toBeInstanceOf(NotificationChannelNotFoundError);
     expect(queue.jobs).toHaveLength(0);
+    expect(publisher.events.map((event) => event.name)).toEqual([
+      'notification.dispatch.requested',
+      'notification.dispatch.failed',
+    ]);
   });
 
   it('resolves async options once and exposes the compatibility facade and channel token', async () => {
@@ -532,6 +569,7 @@ describe('NotificationsModule', () => {
 
   it('validates channels before queueing bulk deliveries', async () => {
     const queue = new RecordingQueueAdapter();
+    const publisher = new RecordingPublisher();
     const container = new Container();
     const moduleType = NotificationsModule.forRoot({
       channels: [
@@ -546,6 +584,9 @@ describe('NotificationsModule', () => {
         adapter: queue,
         bulkThreshold: 2,
       },
+      events: {
+        publisher,
+      },
     });
 
     container.register(...moduleProviders(moduleType));
@@ -558,6 +599,21 @@ describe('NotificationsModule', () => {
       ]),
     ).rejects.toBeInstanceOf(NotificationChannelNotFoundError);
     expect(queue.jobs).toHaveLength(0);
+    expect(publisher.events).toMatchObject([
+      {
+        channel: 'email',
+        name: 'notification.dispatch.requested',
+      },
+      {
+        channel: 'discord',
+        name: 'notification.dispatch.requested',
+      },
+      {
+        channel: 'discord',
+        error: { message: 'No notification channel is registered for "discord".', name: 'NotificationChannelNotFoundError' },
+        name: 'notification.dispatch.failed',
+      },
+    ]);
   });
 
   it('preserves direct delivery results when lifecycle publication fails', async () => {
@@ -615,7 +671,7 @@ describe('NotificationsModule', () => {
     );
   });
 
-  it('uses collision-resistant fallback delivery ids when channels omit external ids', async () => {
+  it('uses deterministic fallback delivery ids when channels omit external ids', async () => {
     const container = new Container();
     const moduleType = NotificationsModule.forRoot({
       channels: [
@@ -630,10 +686,14 @@ describe('NotificationsModule', () => {
 
     container.register(...moduleProviders(moduleType));
     const service = await container.resolve(NotificationsService);
-    const first = await service.dispatch({ channel: 'email', payload: { template: 'first' } });
-    const second = await service.dispatch({ channel: 'email', payload: { template: 'second' } });
+    const request = { channel: 'email', payload: { template: 'welcome', userId: 'u1' } };
+    const first = await service.dispatch(request);
+    const repeated = await service.dispatch(request);
+    const different = await service.dispatch({ channel: 'email', payload: { template: 'welcome', userId: 'u2' } });
 
-    expect(first.deliveryId).not.toBe(second.deliveryId);
+    expect(first.deliveryId).toMatch(/^fallback:email:/);
+    expect(repeated.deliveryId).toBe(first.deliveryId);
+    expect(different.deliveryId).not.toBe(first.deliveryId);
   });
 
   it('captures missing-channel failures during tolerant bulk dispatch', async () => {

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -30,7 +30,6 @@ import type {
 @Inject(NOTIFICATIONS_OPTIONS, NOTIFICATION_CHANNELS)
 export class NotificationsService implements Notifications {
   private readonly channelsByName = new Map<string, NotificationChannel>();
-  private fallbackDeliveryIdSequence = 0;
 
   constructor(
     private readonly options: NormalizedNotificationsModuleOptions,
@@ -68,7 +67,13 @@ export class NotificationsService implements Notifications {
     await this.publishLifecycleEventSafely('notification.dispatch.requested', notification, options);
 
     if (this.shouldQueueSingleDispatch(options)) {
-      this.requireChannel(notification.channel);
+      try {
+        this.requireChannel(notification.channel);
+      } catch (error) {
+        await this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error);
+        throw error;
+      }
+
       const job = this.createQueueJob(notification);
       try {
         const deliveryId = await this.requireQueueAdapter().enqueue(job);
@@ -88,7 +93,14 @@ export class NotificationsService implements Notifications {
       }
     }
 
-    const channel = this.requireChannel(notification.channel);
+    let channel: NotificationChannel;
+
+    try {
+      channel = this.requireChannel(notification.channel);
+    } catch (error) {
+      await this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error);
+      throw error;
+    }
 
     try {
       const delivery = await channel.send(notification, { signal: options.signal });
@@ -139,14 +151,21 @@ export class NotificationsService implements Notifications {
 
     if (this.shouldQueue(notifications.length, options)) {
       const queue = this.requireQueueAdapter();
-      for (const notification of notifications) {
-        this.requireChannel(notification.channel);
-      }
-      const jobs = notifications.map((notification) => this.createQueueJob(notification));
 
       for (const notification of notifications) {
         await this.publishLifecycleEventSafely('notification.dispatch.requested', notification, options);
       }
+
+      for (const notification of notifications) {
+        try {
+          this.requireChannel(notification.channel);
+        } catch (error) {
+          await this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error);
+          throw error;
+        }
+      }
+
+      const jobs = notifications.map((notification) => this.createQueueJob(notification));
 
       let ids: readonly string[];
 
@@ -254,9 +273,7 @@ export class NotificationsService implements Notifications {
       return fallback.id;
     }
 
-    this.fallbackDeliveryIdSequence = (this.fallbackDeliveryIdSequence + 1) % Number.MAX_SAFE_INTEGER;
-
-    return `${fallback.channel}:${Date.now().toString(36)}:${this.fallbackDeliveryIdSequence.toString(36)}:${Math.random().toString(36).slice(2, 10)}`;
+    return `fallback:${fallback.channel}:${stableNotificationHash(fallback)}`;
   }
 
   private requireQueueAdapter() {
@@ -332,4 +349,32 @@ export class NotificationsService implements Notifications {
       return;
     }
   }
+}
+
+function stableNotificationHash(notification: NotificationDispatchRequest): string {
+  let hash = 0x811c9dc5;
+  const input = stableStringify(notification);
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+
+  return hash.toString(36).padStart(7, '0');
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value) ?? String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`).join(',')}}`;
 }


### PR DESCRIPTION
## Summary

Closes #1597.

Fixes the `@fluojs/notifications` lifecycle contract so missing channels emit deterministic failure events and fallback delivery IDs no longer depend on time or random values.

## Changes

- Derive fallback delivery IDs from a stable notification-envelope hash when channels omit `externalId`.
- Publish `notification.dispatch.failed` for missing-channel direct, queued single, and queued bulk dispatch attempts after the corresponding `requested` event.
- Document permanent channel-resolution failures versus adapter/provider retry classification in the package README, Korean mirror, and notifications book chapter.
- Add a patch changeset for `@fluojs/notifications`.

## Testing

- `pnpm --dir packages/notifications typecheck`
- `pnpm --dir packages/notifications build`
- `pnpm --dir packages/notifications test`
- LSP diagnostics: clean for `packages/notifications/src/service.ts` and `packages/notifications/src/module.test.ts`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed; existing public export documentation remains applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed.