### PR TITLE
Resolve #1596: Fix Microservices shutdown cleanup gaps

### DIFF
--- a/.changeset/fair-apples-listen.md
+++ b/.changeset/fair-apples-listen.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/microservices": patch
+---
+
+Fix TCP shutdown guards and gRPC streaming AbortSignal cleanup so closing microservice transports reject new work and release stream abort listeners reliably.

--- a/book/intermediate/ch01-microservices-intro.md
+++ b/book/intermediate/ch01-microservices-intro.md
@@ -88,7 +88,7 @@ Using fluo's microservices Module gives you the following strategic advantages. 
 
 - **Developer Velocity**: You can focus on business logic without worrying about socket management or broker-specific APIs.
 - **Operational Flexibility**: You can start with simple TCP in development, then upgrade to a durable broker in production without changing handlers.
-- **Safety Defaults**: fluo includes defenses for problems common in ad hoc implementations, such as protection against oversized packets, the 1 MiB TCP limit, safe resource cleanup, and delivery confusion prevention.
+- **Safety Defaults**: fluo includes defenses for problems common in ad hoc implementations, such as protection against oversized packets, the 1 MiB TCP limit, OS-assigned TCP test ports, guarded shutdown sends, gRPC stream abort-listener cleanup, and delivery confusion prevention.
 - **Team Consistency**: Shared conventions reduce coordination costs across teams. When every service uses the same handler style, developers can move across domains smoothly.
 
 ## 1.4 Deep Dive into the Microservice Module

--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -91,6 +91,8 @@ await microservice.listen();
 - RabbitMQ 요청-응답은 기본적으로 인스턴스별 response queue를 사용합니다. 공유 reply topology를 의도적으로 운영할 때만 `responseQueue`를 명시적으로 지정하세요.
 - caller-owned broker collaborator는 shutdown 중에도 caller-owned로 유지됩니다. NATS, Kafka, RabbitMQ transport는 subscription/consumer를 분리하고 in-flight 요청을 reject하지만, 애플리케이션이 넘긴 client, producer, consumer, publisher, 외부 connection 객체를 close/disconnect하지 않습니다.
 - `AbortSignal`을 받는 요청-응답 transport는 이미 abort된 send를 publish 전에 reject하고, 나중에 abort된 in-flight send도 reject합니다. `close()`가 시작된 뒤에는 shutdown 중인 lifecycle에 새 작업을 publish하지 않고 `send()`/`emit()`을 reject합니다.
+- TCP는 테스트와 ephemeral listener를 위해 `port: 0`을 허용하고, listen 중에는 OS가 할당한 포트로 outbound `send()`/`emit()`을 라우팅합니다.
+- gRPC shutdown은 가능하면 server-level `tryShutdown()`을 사용하고, graceful shutdown을 제공하지 않는 런타임에서만 `forceShutdown()`으로 fallback합니다. Active unary/streaming call의 AbortSignal 취소는 call-level `cancel()` 또는 stream end 경로를 사용하며, stream이 end/error/early return으로 끝나면 abort listener를 제거합니다.
 - transport logger를 통해 이벤트 핸들러 실패를 기록하는 경로(`RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `MqttMicroserviceTransport`, gRPC event emit)는 끝까지 logger-driven observability를 유지합니다. transport logger를 주입하지 않으면 fluo는 해당 실패를 raw `console.error` fallback으로 복제하지 않습니다.
 
 ## 공통 패턴

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -88,6 +88,8 @@ Microservice handlers fully support fluo's DI scopes. Request-scoped providers a
 - RabbitMQ request/reply uses an instance-scoped response queue by default. Pass `responseQueue` explicitly only when you intentionally own and coordinate a shared reply topology.
 - Caller-owned broker collaborators stay caller-owned during shutdown. NATS, Kafka, and RabbitMQ transports detach their subscriptions/consumers and reject in-flight requests, but they do not close or disconnect the client, producer, consumer, publisher, or external connection objects supplied by the application.
 - Request-response transports that accept `AbortSignal` reject already-aborted sends before publishing and reject in-flight sends on later abort. Once `close()` starts, transports reject new `send()`/`emit()` calls instead of publishing work into a shutting-down lifecycle.
+- TCP accepts `port: 0` for tests and ephemeral listeners, then routes outbound `send()`/`emit()` calls through the OS-assigned port while the transport is listening.
+- gRPC shutdown uses server-level `tryShutdown()` when available and falls back to `forceShutdown()` only for runtimes without graceful shutdown support. AbortSignal cancellation for active unary or streaming calls uses the call-level `cancel()`/stream end path and removes abort listeners when streams end, error, or are returned early.
 - Event-handler failures that flow through the transport logger (`RedisPubSubMicroserviceTransport`, `RedisStreamsMicroserviceTransport`, `NatsMicroserviceTransport`, `MqttMicroserviceTransport`, and gRPC event emits) remain logger-driven. If you do not inject a transport logger, fluo does not mirror those failures through a raw `console.error` fallback.
 
 ## Common Patterns

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -329,7 +329,7 @@ describe('@fluojs/microservices', () => {
   });
 
   it('handles TCP transport send and receive', async () => {
-    const port = 39001;
+    const port = 0;
     const transport = new TcpMicroserviceTransport({ port });
 
     class Handler {
@@ -637,7 +637,6 @@ describe('@fluojs/microservices', () => {
     };
 
     class LoggerAwareTransport implements MicroserviceTransport {
-      private handler: TransportHandler | undefined;
       private logger: MicroserviceTransportLogger | undefined;
 
       setLogger(loggerInstance: MicroserviceTransportLogger): void {
@@ -653,7 +652,7 @@ describe('@fluojs/microservices', () => {
       }
 
       async listen(handler: TransportHandler): Promise<void> {
-        this.handler = handler;
+        void handler;
       }
 
       async send(): Promise<unknown> {

--- a/packages/microservices/src/transports/grpc-transport.test.ts
+++ b/packages/microservices/src/transports/grpc-transport.test.ts
@@ -140,25 +140,6 @@ class FakeReadableStream {
   }
 }
 
-class FakeDuplexStream extends FakeReadableStream {
-  private ended = false;
-  readonly written: unknown[] = [];
-
-  write(data: unknown): boolean {
-    if (!this.ended) {
-      this.written.push(data);
-    }
-
-    return true;
-  }
-
-  end(): void {
-    if (!this.ended) {
-      this.ended = true;
-    }
-  }
-}
-
 function createBidiStreamPair(): { clientStream: FakeBidiHalf; serverStream: FakeBidiHalf } {
   const clientStream = new FakeBidiHalf();
   const serverStream = new FakeBidiHalf();
@@ -931,6 +912,50 @@ describe('GrpcMicroserviceTransport', () => {
     await transport.close();
   });
 
+  it('serverStream() removes AbortSignal listener when the stream ends', async () => {
+    const { transport } = createGrpcTransport();
+
+    transport.listenServerStreaming(async (_pattern, _payload, writer) => {
+      writer.write({ value: 'done' });
+      writer.end();
+    });
+
+    await transport.listen(async () => undefined);
+
+    const controller = new AbortController();
+    const removeEventListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+    const results: unknown[] = [];
+
+    for await (const item of transport.serverStream('MathService.StreamData', {}, controller.signal)) {
+      results.push(item);
+    }
+
+    expect(results).toEqual([{ value: 'done' }]);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+
+    await transport.close();
+  });
+
+  it('serverStream() removes AbortSignal listener when iterator return() cancels the call', async () => {
+    const { transport } = createGrpcTransport();
+
+    transport.listenServerStreaming(async (_pattern, _payload, writer) => {
+      writer.write({ value: 'first' });
+    });
+
+    await transport.listen(async () => undefined);
+
+    const controller = new AbortController();
+    const removeEventListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+    const iterator = transport.serverStream('MathService.StreamData', {}, controller.signal)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({ value: { value: 'first' }, done: false });
+    await expect(iterator.return?.()).resolves.toEqual({ value: undefined, done: true });
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+
+    await transport.close();
+  });
+
   it('server-stream handler throw surfaces as an error on the client iterator, not a clean EOF', async () => {
     const { transport } = createGrpcTransport();
 
@@ -1042,6 +1067,35 @@ describe('GrpcMicroserviceTransport', () => {
     await transport.close();
   });
 
+  it('clientStream() removes AbortSignal listener when the response resolves', async () => {
+    const { transport } = createGrpcTransport();
+
+    transport.listenClientStreaming(async (_pattern, reader) => {
+      let sum = 0;
+
+      for await (const item of reader) {
+        sum += (item as { value: number }).value;
+      }
+
+      return { total: sum };
+    });
+
+    await transport.listen(async () => undefined);
+
+    const controller = new AbortController();
+    const removeEventListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+    const { writer, result } = transport.clientStream('MathService.StreamAll', controller.signal);
+
+    writer.write({ value: 1 });
+    writer.write({ value: 2 });
+    writer.end();
+
+    await expect(result).resolves.toEqual({ total: 3 });
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+
+    await transport.close();
+  });
+
   it('clientStream() throws when transport is not listening', () => {
     const { transport } = createGrpcTransport();
 
@@ -1130,6 +1184,38 @@ describe('GrpcMicroserviceTransport', () => {
       { pattern: 'MathService.StreamBidi', doubled: 4 },
       { pattern: 'MathService.StreamBidi', doubled: 6 },
     ]);
+
+    await transport.close();
+  });
+
+  it('bidiStream() removes AbortSignal listeners when the reader completes', async () => {
+    const { transport } = createGrpcTransport();
+
+    transport.listenBidiStreaming(async (_pattern, reader, writer) => {
+      for await (const item of reader) {
+        writer.write(item);
+      }
+
+      writer.end();
+    });
+
+    await transport.listen(async () => undefined);
+
+    const controller = new AbortController();
+    const removeEventListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+    const { reader, writer } = transport.bidiStream('MathService.StreamBidi', controller.signal);
+
+    writer.write({ value: 1 });
+    writer.end();
+
+    const results: unknown[] = [];
+
+    for await (const item of reader) {
+      results.push(item);
+    }
+
+    expect(results).toEqual([{ value: 1 }]);
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
 
     await transport.close();
   });

--- a/packages/microservices/src/transports/grpc-transport.ts
+++ b/packages/microservices/src/transports/grpc-transport.ts
@@ -34,10 +34,12 @@ interface GrpcClientLike {
 interface GrpcReadableStreamLike {
   cancel?(): void;
   destroy?(err?: Error): void;
+  off?(event: string, listener: (...args: unknown[]) => void): this;
   on(event: 'data', listener: (data: unknown) => void): this;
   on(event: 'end', listener: () => void): this;
   on(event: 'error', listener: (err: Error) => void): this;
   on(event: string, listener: (...args: unknown[]) => void): this;
+  removeListener?(event: string, listener: (...args: unknown[]) => void): this;
 }
 
 interface GrpcDuplexStreamLike extends GrpcReadableStreamLike {
@@ -763,6 +765,17 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
         let error: Error | undefined;
         let waiting: { resolve: (result: IteratorResult<unknown>) => void; reject: (err: Error) => void } | undefined;
         let stream: GrpcReadableStreamLike | undefined;
+        let removeAbortListener: (() => void) | undefined;
+
+        const cleanupAbortListener = () => {
+          removeAbortListener?.();
+          removeAbortListener = undefined;
+        };
+
+        const finish = () => {
+          done = true;
+          cleanupAbortListener();
+        };
 
         const startStream = () => {
           if (stream) {
@@ -789,7 +802,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
           });
 
           stream.on('end', () => {
-            done = true;
+            finish();
 
             if (waiting) {
               const w = waiting;
@@ -799,7 +812,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
           });
 
           stream.on('error', (err: Error) => {
-            done = true;
+            finish();
 
             if (signal?.aborted) {
               error = new Error('gRPC server stream aborted.');
@@ -816,14 +829,14 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
 
           if (signal) {
             if (signal.aborted) {
-              done = true;
+              finish();
               error = new Error('gRPC server stream aborted.');
               stream.cancel?.();
               return;
             }
 
             const onAbort = () => {
-              done = true;
+              finish();
               error = new Error('gRPC server stream aborted.');
               stream?.cancel?.();
 
@@ -835,6 +848,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
             };
 
             signal.addEventListener('abort', onAbort, { once: true });
+            removeAbortListener = () => signal.removeEventListener('abort', onAbort);
           }
         };
 
@@ -862,7 +876,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
           },
 
           return(): Promise<IteratorResult<unknown>> {
-            done = true;
+            finish();
             stream?.cancel?.();
             return Promise.resolve({ value: undefined, done: true });
           },
@@ -885,6 +899,12 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
     const metadata = this.createMetadata(grpcKinds.message);
     let callStream: GrpcWritableStreamLike | undefined;
     let ended = false;
+    let cleanupAbortListener: (() => void) | undefined;
+
+    const cleanup = () => {
+      cleanupAbortListener?.();
+      cleanupAbortListener = undefined;
+    };
 
     const result = new Promise<unknown>((resolve, reject) => {
       if (signal?.aborted) {
@@ -899,6 +919,8 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
         runtime.client,
         metadata,
         (error: { code?: number; message?: string } | null, response: unknown) => {
+          cleanup();
+
           if (error) {
             if (signal?.aborted) {
               reject(new Error('gRPC client stream aborted.'));
@@ -927,6 +949,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
         };
 
         signal.addEventListener('abort', onAbort, { once: true });
+        cleanupAbortListener = () => signal.removeEventListener('abort', onAbort);
       }
     });
 
@@ -976,6 +999,7 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
     );
 
     let writerEnded = false;
+    let cleanupAbortListener: (() => void) | undefined;
 
     if (signal) {
       if (signal.aborted) {
@@ -991,10 +1015,11 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
         };
 
         signal.addEventListener('abort', onAbort, { once: true });
+        cleanupAbortListener = () => signal.removeEventListener('abort', onAbort);
       }
     }
 
-    const reader = grpcReadableToAsyncIterable(duplexStream, signal);
+    const reader = grpcReadableToAsyncIterable(duplexStream, signal, cleanupAbortListener);
 
     const writer: ServerStreamWriter = {
       write(data: unknown): void {
@@ -1281,13 +1306,29 @@ export class GrpcMicroserviceTransport implements MicroserviceTransport {
   }
 }
 
-function grpcReadableToAsyncIterable(stream: GrpcReadableStreamLike, signal?: AbortSignal): AsyncIterable<unknown> {
+function grpcReadableToAsyncIterable(
+  stream: GrpcReadableStreamLike,
+  signal?: AbortSignal,
+  externalAbortCleanup?: () => void,
+): AsyncIterable<unknown> {
   return {
     [Symbol.asyncIterator](): AsyncIterator<unknown> {
       const buffer: unknown[] = [];
       let done = false;
       let error: Error | undefined;
       let waiting: { resolve: (result: IteratorResult<unknown>) => void; reject: (err: Error) => void } | undefined;
+      let removeAbortListener: (() => void) | undefined;
+
+      const cleanupAbortListeners = () => {
+        removeAbortListener?.();
+        removeAbortListener = undefined;
+        externalAbortCleanup?.();
+      };
+
+      const finish = () => {
+        done = true;
+        cleanupAbortListeners();
+      };
 
       stream.on('data', (data: unknown) => {
         if (waiting) {
@@ -1300,7 +1341,7 @@ function grpcReadableToAsyncIterable(stream: GrpcReadableStreamLike, signal?: Ab
       });
 
       stream.on('end', () => {
-        done = true;
+        finish();
 
         if (waiting) {
           const w = waiting;
@@ -1310,7 +1351,7 @@ function grpcReadableToAsyncIterable(stream: GrpcReadableStreamLike, signal?: Ab
       });
 
       stream.on('error', (err: Error) => {
-        done = true;
+        finish();
 
         if (signal?.aborted) {
           error = new Error('gRPC stream aborted.');
@@ -1327,12 +1368,12 @@ function grpcReadableToAsyncIterable(stream: GrpcReadableStreamLike, signal?: Ab
 
       if (signal) {
         if (signal.aborted) {
-          done = true;
+          finish();
           error = new Error('gRPC stream aborted.');
           stream.cancel?.();
         } else {
           const onAbort = () => {
-            done = true;
+            finish();
             error = new Error('gRPC stream aborted.');
             stream.cancel?.();
 
@@ -1344,6 +1385,7 @@ function grpcReadableToAsyncIterable(stream: GrpcReadableStreamLike, signal?: Ab
           };
 
           signal.addEventListener('abort', onAbort, { once: true });
+          removeAbortListener = () => signal.removeEventListener('abort', onAbort);
         }
       }
 
@@ -1367,7 +1409,7 @@ function grpcReadableToAsyncIterable(stream: GrpcReadableStreamLike, signal?: Ab
         },
 
         return(): Promise<IteratorResult<unknown>> {
-          done = true;
+          finish();
           stream.cancel?.();
           return Promise.resolve({ value: undefined, done: true });
         },

--- a/packages/microservices/src/transports/tcp-transport.test.ts
+++ b/packages/microservices/src/transports/tcp-transport.test.ts
@@ -1,14 +1,27 @@
 import { Socket } from 'node:net';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { TcpMicroserviceTransport } from './tcp-transport.js';
 
 describe('TcpMicroserviceTransport', () => {
+  const transports: TcpMicroserviceTransport[] = [];
+
+  afterEach(async () => {
+    await Promise.allSettled(transports.map((transport) => transport.close()));
+    transports.length = 0;
+  });
+
+  const createTransport = (options: ConstructorParameters<typeof TcpMicroserviceTransport>[0]) => {
+    const transport = new TcpMicroserviceTransport(options);
+    transports.push(transport);
+    return transport;
+  };
+
   it('closes sockets that exceed the inbound frame buffer cap', async () => {
     const port = 0;
     const handler = vi.fn(async () => undefined);
-    const transport = new TcpMicroserviceTransport({ port, requestTimeoutMs: 1_000 });
+    const transport = createTransport({ port, requestTimeoutMs: 1_000 });
 
     await transport.listen(handler);
 
@@ -26,12 +39,11 @@ describe('TcpMicroserviceTransport', () => {
 
     expect(handler).not.toHaveBeenCalled();
 
-    await transport.close();
   });
 
   it('removes abort listener after a request completes normally', async () => {
     const port = 0;
-    const transport = new TcpMicroserviceTransport({ port, requestTimeoutMs: 1_000 });
+    const transport = createTransport({ port, requestTimeoutMs: 1_000 });
 
     await transport.listen(async () => 'ok');
 
@@ -42,11 +54,10 @@ describe('TcpMicroserviceTransport', () => {
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
 
-    await transport.close();
   });
 
   it('rejects send and emit after close() stops the listener', async () => {
-    const transport = new TcpMicroserviceTransport({ port: 0, requestTimeoutMs: 1_000 });
+    const transport = createTransport({ port: 0, requestTimeoutMs: 1_000 });
 
     await transport.listen(async () => 'ok');
     await transport.close();
@@ -57,5 +68,24 @@ describe('TcpMicroserviceTransport', () => {
     await expect(transport.emit('closed.event', {})).rejects.toThrow(
       'TcpMicroserviceTransport is closing. Wait for close() to complete before emit().',
     );
+  });
+
+  it('keeps the closing guard when listen() races with close()', async () => {
+    const transport = createTransport({ port: 0, requestTimeoutMs: 1_000 });
+
+    await transport.listen(async () => 'ok');
+
+    const closePromise = transport.close();
+    await expect(transport.listen(async () => 'reopened')).rejects.toThrow(
+      'TcpMicroserviceTransport is closing. Wait for close() to complete before listen().',
+    );
+    await expect(transport.send('closing.pattern', {})).rejects.toThrow(
+      'TcpMicroserviceTransport is closing. Wait for close() to complete before send().',
+    );
+    await expect(transport.emit('closing.event', {})).rejects.toThrow(
+      'TcpMicroserviceTransport is closing. Wait for close() to complete before emit().',
+    );
+
+    await closePromise;
   });
 });

--- a/packages/microservices/src/transports/tcp-transport.test.ts
+++ b/packages/microservices/src/transports/tcp-transport.test.ts
@@ -6,7 +6,7 @@ import { TcpMicroserviceTransport } from './tcp-transport.js';
 
 describe('TcpMicroserviceTransport', () => {
   it('closes sockets that exceed the inbound frame buffer cap', async () => {
-    const port = 40_000 + Math.floor(Math.random() * 10_000);
+    const port = 0;
     const handler = vi.fn(async () => undefined);
     const transport = new TcpMicroserviceTransport({ port, requestTimeoutMs: 1_000 });
 
@@ -17,7 +17,7 @@ describe('TcpMicroserviceTransport', () => {
 
       socket.once('close', () => resolve());
       socket.once('error', () => resolve());
-      socket.connect(port, '127.0.0.1', () => {
+      socket.connect((transport as unknown as { boundPort: number }).boundPort, '127.0.0.1', () => {
         socket.write('x'.repeat(1_048_577));
       });
 
@@ -30,7 +30,7 @@ describe('TcpMicroserviceTransport', () => {
   });
 
   it('removes abort listener after a request completes normally', async () => {
-    const port = 40_000 + Math.floor(Math.random() * 10_000);
+    const port = 0;
     const transport = new TcpMicroserviceTransport({ port, requestTimeoutMs: 1_000 });
 
     await transport.listen(async () => 'ok');
@@ -43,5 +43,19 @@ describe('TcpMicroserviceTransport', () => {
     expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
 
     await transport.close();
+  });
+
+  it('rejects send and emit after close() stops the listener', async () => {
+    const transport = new TcpMicroserviceTransport({ port: 0, requestTimeoutMs: 1_000 });
+
+    await transport.listen(async () => 'ok');
+    await transport.close();
+
+    await expect(transport.send('closed.pattern', {})).rejects.toThrow(
+      'TcpMicroserviceTransport is closing. Wait for close() to complete before send().',
+    );
+    await expect(transport.emit('closed.event', {})).rejects.toThrow(
+      'TcpMicroserviceTransport is closing. Wait for close() to complete before emit().',
+    );
   });
 });

--- a/packages/microservices/src/transports/tcp-transport.ts
+++ b/packages/microservices/src/transports/tcp-transport.ts
@@ -24,6 +24,8 @@ const DEFAULT_MAX_FRAME_BYTES = 1_048_576;
  * simple first-party microservice setups where both sides can share the same framing contract.
  */
 export class TcpMicroserviceTransport implements MicroserviceTransport {
+  private boundPort: number | undefined;
+  private closing = false;
   private handler: TransportHandler | undefined;
   private listenPromise: Promise<void> | undefined;
   private readonly sockets = new Set<Socket>();
@@ -54,6 +56,7 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once the TCP server is listening.
    */
   async listen(handler: TransportHandler): Promise<void> {
+    this.closing = false;
     this.handler = handler;
 
     if (this.server.listening) {
@@ -69,6 +72,7 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
       this.server.once('error', reject);
       this.server.listen(this.options.port, this.host, () => {
         this.server.off('error', reject);
+        this.boundPort = this.resolveBoundPort();
         resolve();
       });
     });
@@ -88,6 +92,7 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves after the event frame is written.
    */
   async emit(pattern: string, payload: unknown): Promise<void> {
+    this.assertAcceptingOutbound('emit');
     await this.sendWirePacket({ kind: 'event', pattern, payload });
   }
 
@@ -100,6 +105,7 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
    * @returns The remote handler response payload.
    */
   async send(pattern: string, payload: unknown, signal?: AbortSignal): Promise<unknown> {
+    this.assertAcceptingOutbound('send');
     const requestId = randomRequestId();
     return await this.sendWirePacket({ kind: 'message', pattern, payload, requestId }, signal);
   }
@@ -110,6 +116,8 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once the server is fully closed.
    */
   async close(): Promise<void> {
+    this.closing = true;
+
     if (this.listenPromise) {
       await this.listenPromise;
     }
@@ -121,6 +129,7 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
     this.sockets.clear();
 
     if (!this.server.listening) {
+      this.boundPort = undefined;
       return;
     }
 
@@ -134,6 +143,8 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
         resolve();
       });
     });
+
+    this.boundPort = undefined;
   }
 
   private async handleInboundPacket(socket: Socket, packet: TransportPacket): Promise<void> {
@@ -261,8 +272,36 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
       }
 
       socket.once('error', fail);
-      socket.connect(this.options.port, this.host);
+      socket.connect(this.resolveConnectPort(), this.host);
     });
+  }
+
+  private assertAcceptingOutbound(operation: 'emit' | 'send'): void {
+    if (this.closing) {
+      throw new Error(`TcpMicroserviceTransport is closing. Wait for close() to complete before ${operation}().`);
+    }
+
+    if (!this.server.listening || typeof this.boundPort !== 'number') {
+      throw new Error(`TcpMicroserviceTransport is not listening. Call listen() before ${operation}().`);
+    }
+  }
+
+  private resolveConnectPort(): number {
+    if (typeof this.boundPort === 'number') {
+      return this.boundPort;
+    }
+
+    return this.options.port;
+  }
+
+  private resolveBoundPort(): number {
+    const address = this.server.address();
+
+    if (address && typeof address === 'object') {
+      return address.port;
+    }
+
+    return this.options.port;
   }
 
   private bindSocketParser<TPacket>(socket: Socket, onPacket: (packet: TPacket) => void): void {

--- a/packages/microservices/src/transports/tcp-transport.ts
+++ b/packages/microservices/src/transports/tcp-transport.ts
@@ -56,7 +56,10 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once the TCP server is listening.
    */
   async listen(handler: TransportHandler): Promise<void> {
-    this.closing = false;
+    if (this.closing) {
+      throw new Error('TcpMicroserviceTransport is closing. Wait for close() to complete before listen().');
+    }
+
     this.handler = handler;
 
     if (this.server.listening) {
@@ -272,6 +275,13 @@ export class TcpMicroserviceTransport implements MicroserviceTransport {
       }
 
       socket.once('error', fail);
+      try {
+        this.assertAcceptingOutbound(packet.kind === 'event' ? 'emit' : 'send');
+      } catch (error) {
+        fail(error);
+        return;
+      }
+
       socket.connect(this.resolveConnectPort(), this.host);
     });
   }


### PR DESCRIPTION
## Summary

- Closes #1596.
- Fixes @fluojs/microservices TCP shutdown guards and OS-assigned test port support.
- Cleans up gRPC streaming AbortSignal listeners while preserving server-level tryShutdown()/forceShutdown() semantics and call-level cancellation.

## Changes

- TCP now rejects outbound send()/emit() when close() has started or the listener is stopped, and routes port: 0 listeners through the OS-assigned port.
- gRPC server-stream, client-stream, and bidi-stream paths remove AbortSignal listeners on end/error/return and keep active stream cancellation scoped to call.cancel()/stream end.
- Replaced flaky fixed TCP test ports with OS-assigned ports and added regression coverage for shutdown and stream cleanup.
- Updated @fluojs/microservices README/README.ko, the intermediate microservices chapter, and added a patch changeset.

## Testing

- LSP diagnostics: no errors on changed TypeScript files.
- pnpm install --frozen-lockfile
- pnpm build
- pnpm --dir packages/microservices typecheck
- pnpm --dir packages/microservices test
- pnpm exec biome lint packages/microservices/src/transports/tcp-transport.ts packages/microservices/src/transports/grpc-transport.ts packages/microservices/src/transports/tcp-transport.test.ts packages/microservices/src/transports/grpc-transport.test.ts packages/microservices/src/module.test.ts

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

No new public exports were added; existing exported transport APIs retain their documented TSDoc surface.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.

No platform/governance docs changed; package README EN/KO contract notes are synchronized and backed by microservices transport regression tests.