### PR TITLE
Resolve #1606: Fix Studio viewer focus and Quick Start drift

### DIFF
--- a/.changeset/studio-viewer-focus-contract.md
+++ b/.changeset/studio-viewer-focus-contract.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/studio": patch
+---
+
+Preserve Studio viewer focus while users search or filter loaded snapshots, and document the packaged viewer entry separately from repo-local development commands.

--- a/book/advanced/ch15-studio.ko.md
+++ b/book/advanced/ch15-studio.ko.md
@@ -130,7 +130,14 @@ Report가 raw snapshot을 대체하는 것은 아닙니다. Report는 support와
 
 ## 15.5 Using the Studio Viewer
 
-Studio Viewer는 독립 실행형 web application입니다. 모노레포 안에서 로컬로 실행하거나, install path가 제공하는 packaged viewer entry를 사용할 수 있습니다.
+Studio Viewer는 독립 실행형 web application입니다. 설치된 패키지를 사용하는 사용자는 패키징된 정적 HTML entry를 resolve해서 브라우저에서 열 수 있습니다.
+
+```bash
+pnpm add -D @fluojs/studio
+node -p "require.resolve('@fluojs/studio/viewer')"
+```
+
+출력된 경로는 패키징된 `dist/index.html` artifact를 가리킵니다. 해당 파일을 브라우저에서 연 다음 inspect artifact를 로드합니다. Studio 앱 자체를 개발하는 저장소 기여자는 대신 로컬 dev server를 실행할 수 있습니다.
 
 ```bash
 pnpm --dir packages/studio dev
@@ -145,7 +152,7 @@ Viewer가 열리면 inspect artifact를 브라우저로 drag and drop합니다. 
 - **Graph View**: 애플리케이션 dependency graph를 렌더링해 modules, providers, dependency edges를 한눈에 보게 합니다.
 - **Diagnostics Tab**: `PlatformDiagnosticIssue` 항목을 severity, message, cause, fix hints, blockers, docs links와 함께 나열합니다.
 - **Timing View**: Timing data가 있을 때 `BootstrapTimingDiagnostics`를 사용해 total bootstrap time과 phase-level cost를 보여줍니다.
-- **Filtering**: 로드된 snapshot을 변경하지 않고 query, readiness, severity filter를 적용합니다.
+- **Filtering**: 로드된 snapshot을 변경하지 않고 query, readiness, severity filter를 적용하며, view가 갱신되는 동안 활성 search 또는 filter control의 keyboard focus를 유지합니다.
 - **Mermaid Export**: Internal dependency edges와 external dependency nodes를 포함해 Studio가 소유한 `renderMermaid(snapshot)` logic으로 text diagram을 생성합니다.
 
 이 기능들은 팀에 공유 artifact review flow를 제공합니다. CLI가 파일을 내보내고, CI가 저장하고, Studio가 같은 파일을 graph, issue list, timing explanation으로 바꿉니다.

--- a/book/advanced/ch15-studio.md
+++ b/book/advanced/ch15-studio.md
@@ -130,7 +130,14 @@ A report does not replace the raw snapshot. It packages the snapshot with the ex
 
 ## 15.5 Using the Studio Viewer
 
-Studio Viewer is a standalone web application. You can run it locally inside the monorepo or use a packaged viewer entry when your install path provides one.
+Studio Viewer is a standalone web application. Installed-package users can resolve the packaged static HTML entry and open it in a browser.
+
+```bash
+pnpm add -D @fluojs/studio
+node -p "require.resolve('@fluojs/studio/viewer')"
+```
+
+The printed path points at the packaged `dist/index.html` artifact. Open that file in a browser, then load your inspect artifact. Repository contributors who are developing the Studio app itself can run the local dev server instead.
 
 ```bash
 pnpm --dir packages/studio dev
@@ -145,7 +152,7 @@ Internally, Studio uses `parseStudioPayload(rawJson)` before rendering. This kee
 - **Graph View**: Renders the application dependency graph so you can see modules, providers, and dependency edges at a glance.
 - **Diagnostics Tab**: Lists `PlatformDiagnosticIssue` entries with severity, message, cause, fix hints, blockers, and docs links when present.
 - **Timing View**: Uses `BootstrapTimingDiagnostics` to show total bootstrap time and phase-level cost when timing data is present.
-- **Filtering**: Applies query, readiness, and severity filters without mutating the loaded snapshot.
+- **Filtering**: Applies query, readiness, and severity filters without mutating the loaded snapshot, and keeps keyboard focus in the active search or filter control while the view updates.
 - **Mermaid Export**: Produces text diagrams through Studio-owned `renderMermaid(snapshot)` logic, including internal dependency edges and external dependency nodes.
 
 These features give teams a shared artifact review flow. The CLI exports the file, CI stores it, and Studio turns the same file into a graph, issue list, and timing explanation.

--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -48,12 +48,20 @@ Studio는 fluo CLI에서 내보낸 JSON 파일을 소비합니다. 런타임은 
    fluo inspect ./src/app.module.ts --json > snapshot.json
    ```
 
-2. **Studio 실행**:
+2. **패키징된 Studio viewer 열기**:
+   ```bash
+   pnpm add -D @fluojs/studio
+   node -p "require.resolve('@fluojs/studio/viewer')"
+   ```
+
+   출력된 `dist/index.html` 경로를 브라우저에서 엽니다. 패키징된 viewer entry는 `@fluojs/studio/viewer`로 export되는 정적 HTML artifact이며, 모노레포 개발 서버를 시작하지 않습니다.
+
+   저장소 내부 Studio 개발에는 다음 명령을 사용합니다.
    ```bash
    pnpm --dir packages/studio dev
    ```
 
-3. **파일 로드**: Studio 웹 인터페이스에 `snapshot.json` 파일을 드래그 앤 드롭합니다.
+3. **파일 로드**: Studio 웹 인터페이스에 `snapshot.json` 파일을 드래그 앤 드롭합니다. Search와 filter control은 graph, diagnostics, summary가 갱신되는 동안 focus를 유지합니다.
 
 ## 주요 패턴
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -48,12 +48,20 @@ Studio consumes JSON exports from the fluo CLI. Runtime produces snapshots, the 
    fluo inspect ./src/app.module.ts --json > snapshot.json
    ```
 
-2. **Open Studio**:
+2. **Open the packaged Studio viewer**:
+   ```bash
+   pnpm add -D @fluojs/studio
+   node -p "require.resolve('@fluojs/studio/viewer')"
+   ```
+
+   Open the printed `dist/index.html` path in a browser. The packaged viewer entry is a static HTML artifact exported as `@fluojs/studio/viewer`; it does not start the monorepo development server.
+
+   For repo-local Studio development, use:
    ```bash
    pnpm --dir packages/studio dev
    ```
 
-3. **Load the file**: Drag and drop `snapshot.json` into the Studio web interface.
+3. **Load the file**: Drag and drop `snapshot.json` into the Studio web interface. Search and filter controls preserve focus while the graph, diagnostics, and summary update.
 
 ## Common Patterns
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@fluojs-internal/tooling-vite": "workspace:^",
+    "happy-dom": "^20.9.0",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -1,13 +1,15 @@
+// @vitest-environment happy-dom
+
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { PlatformShellSnapshot } from '@fluojs/runtime';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { runWorkspaceBuildClosure } from '../../../tooling/scripts/run-workspace-build-closure.mjs';
 import { applyFilters, parseStudioPayload, renderMermaid } from './contracts.js';
 import * as studio from './index.js';
 
-const packageDir = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(packageDir, '..', '..');
 
 function runBuild(): void {
@@ -282,12 +284,56 @@ describe('parseStudioPayload', () => {
     expect(readmeKo).toContain('공개 배포 패키지');
   });
 
-  it('keeps viewer filter controls focused across rerenders', () => {
-    const viewerSource = readFileSync(resolve(packageDir, 'src/main.ts'), 'utf8');
+  it('keeps viewer filter controls focused across search, readiness, and severity rerenders', async () => {
+    document.body.innerHTML = '<div id="app"></div>';
 
-    expect(viewerSource).toContain('captureFocusSnapshot');
-    expect(viewerSource).toContain('restoreFocusSnapshot(focusSnapshot)');
-    expect(viewerSource).toContain('renderApp({ preserveFocus: true })');
+    await import('./main.js');
+
+    const fileInput = document.querySelector<HTMLInputElement>('#file-input');
+    expect(fileInput).not.toBeNull();
+
+    Object.defineProperty(fileInput, 'files', {
+      configurable: true,
+      value: [new File([JSON.stringify(snapshotFixture)], 'snapshot.json', { type: 'application/json' })],
+    });
+    fileInput?.dispatchEvent(new Event('change', { bubbles: true }));
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('#graph-host')?.textContent).toContain('redis.default');
+    });
+
+    const searchInput = document.querySelector<HTMLInputElement>('#search');
+    expect(searchInput).not.toBeNull();
+    searchInput!.value = 'redis.default';
+    searchInput?.focus();
+    searchInput?.setSelectionRange(2, 7);
+    searchInput?.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const restoredSearchInput = document.querySelector<HTMLInputElement>('#search');
+    expect(document.activeElement).toBe(restoredSearchInput);
+    expect(restoredSearchInput?.value).toBe('redis.default');
+    expect(restoredSearchInput?.selectionStart).toBe(2);
+    expect(restoredSearchInput?.selectionEnd).toBe(7);
+
+    const readinessInput = document.querySelector<HTMLInputElement>('#readiness-ready');
+    expect(readinessInput).not.toBeNull();
+    readinessInput?.focus();
+    readinessInput!.checked = true;
+    readinessInput?.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const restoredReadinessInput = document.querySelector<HTMLInputElement>('#readiness-ready');
+    expect(document.activeElement).toBe(restoredReadinessInput);
+    expect(restoredReadinessInput?.checked).toBe(true);
+
+    const severityInput = document.querySelector<HTMLInputElement>('#severity-warning');
+    expect(severityInput).not.toBeNull();
+    severityInput?.focus();
+    severityInput!.checked = true;
+    severityInput?.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const restoredSeverityInput = document.querySelector<HTMLInputElement>('#severity-warning');
+    expect(document.activeElement).toBe(restoredSeverityInput);
+    expect(restoredSeverityInput?.checked).toBe(true);
   });
 
   it('build emits the published helper and viewer entrypoints', () => {

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -268,12 +268,26 @@ describe('parseStudioPayload', () => {
     expect(readme).toContain('@fluojs/studio/contracts');
     expect(readme).toContain('@fluojs/studio/viewer');
     expect(readme).toContain('report artifacts');
+    expect(readme).toContain('node -p "require.resolve(\'@fluojs/studio/viewer\')"');
+    expect(readme).toContain('pnpm --dir packages/studio dev');
+    expect(readme).toContain('preserve focus');
     expect(readme).toContain('intended public publish surface');
     expect(readmeKo).toContain('pnpm add @fluojs/studio');
     expect(readmeKo).toContain('@fluojs/studio/contracts');
     expect(readmeKo).toContain('@fluojs/studio/viewer');
     expect(readmeKo).toContain('report artifact');
+    expect(readmeKo).toContain('node -p "require.resolve(\'@fluojs/studio/viewer\')"');
+    expect(readmeKo).toContain('pnpm --dir packages/studio dev');
+    expect(readmeKo).toContain('focus를 유지');
     expect(readmeKo).toContain('공개 배포 패키지');
+  });
+
+  it('keeps viewer filter controls focused across rerenders', () => {
+    const viewerSource = readFileSync(resolve(packageDir, 'src/main.ts'), 'utf8');
+
+    expect(viewerSource).toContain('captureFocusSnapshot');
+    expect(viewerSource).toContain('restoreFocusSnapshot(focusSnapshot)');
+    expect(viewerSource).toContain('renderApp({ preserveFocus: true })');
   });
 
   it('build emits the published helper and viewer entrypoints', () => {

--- a/packages/studio/src/main.ts
+++ b/packages/studio/src/main.ts
@@ -20,6 +20,17 @@ interface StudioState {
   rawJson?: string;
 }
 
+interface FocusSnapshot {
+  id: string;
+  selectionEnd: number | null;
+  selectionStart: number | null;
+}
+
+interface RenderAppOptions {
+  message?: string;
+  preserveFocus?: boolean;
+}
+
 const app = document.querySelector<HTMLDivElement>('#app');
 
 if (!app) {
@@ -68,6 +79,41 @@ async function copyToClipboard(text: string): Promise<void> {
 
 function toggleValue<T extends string>(values: T[], value: T): T[] {
   return values.includes(value) ? values.filter((entry) => entry !== value) : [...values, value];
+}
+
+function isTextControl(element: Element | null): element is HTMLInputElement | HTMLTextAreaElement {
+  return element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement;
+}
+
+function captureFocusSnapshot(): FocusSnapshot | undefined {
+  const activeElement = document.activeElement;
+
+  if (!isTextControl(activeElement) || !activeElement.id) {
+    return undefined;
+  }
+
+  return {
+    id: activeElement.id,
+    selectionEnd: activeElement.selectionEnd,
+    selectionStart: activeElement.selectionStart,
+  };
+}
+
+function restoreFocusSnapshot(snapshot: FocusSnapshot | undefined): void {
+  if (!snapshot) {
+    return;
+  }
+
+  const target = document.getElementById(snapshot.id);
+  if (!isTextControl(target)) {
+    return;
+  }
+
+  target.focus({ preventScroll: true });
+
+  if (snapshot.selectionStart !== null && snapshot.selectionEnd !== null) {
+    target.setSelectionRange(snapshot.selectionStart, snapshot.selectionEnd);
+  }
 }
 
 function getSelectedComponent(snapshot: PlatformShellSnapshot | undefined, selectedId: string | undefined): PlatformSnapshot | undefined {
@@ -260,7 +306,9 @@ function renderDiagnostics(snapshot: PlatformShellSnapshot | undefined): string 
   </div>`;
 }
 
-function renderApp(message?: string): void {
+function renderApp(options: RenderAppOptions | string = {}): void {
+  const message = typeof options === 'string' ? options : options.message;
+  const focusSnapshot = typeof options === 'string' || !options.preserveFocus ? undefined : captureFocusSnapshot();
   const snapshot = state.filteredSnapshot;
   const selectedComponent = getSelectedComponent(snapshot, state.selectedComponentId);
   const mermaidText = snapshot ? renderMermaid(snapshot) : '';
@@ -303,14 +351,14 @@ function renderApp(message?: string): void {
           <div class="filter-row">
             <span>Component readiness</span>
             ${readinessOptions
-              .map((status) => `<label><input type="checkbox" data-readiness="${status}" ${state.filter.readinessStatuses.includes(status) ? 'checked' : ''}/> ${status}</label>`)
+              .map((status) => `<label><input type="checkbox" id="readiness-${status}" data-readiness="${status}" ${state.filter.readinessStatuses.includes(status) ? 'checked' : ''}/> ${status}</label>`)
               .join('')}
           </div>
 
           <div class="filter-row">
             <span>Diagnostic severity</span>
             ${severityOptions
-              .map((severity) => `<label><input type="checkbox" data-severity="${severity}" ${state.filter.severities.includes(severity) ? 'checked' : ''}/> ${severity}</label>`)
+              .map((severity) => `<label><input type="checkbox" id="severity-${severity}" data-severity="${severity}" ${state.filter.severities.includes(severity) ? 'checked' : ''}/> ${severity}</label>`)
               .join('')}
           </div>
         </div>
@@ -398,14 +446,14 @@ function renderApp(message?: string): void {
     const target = event.target as HTMLInputElement;
     state.filter.query = target.value;
     computeFilteredSnapshot();
-    renderApp();
+    renderApp({ preserveFocus: true });
   });
 
   document.querySelectorAll<HTMLInputElement>('input[data-readiness]').forEach((input) => {
     input.addEventListener('change', () => {
       state.filter.readinessStatuses = toggleValue(state.filter.readinessStatuses, input.dataset.readiness as PlatformReadinessStatus);
       computeFilteredSnapshot();
-      renderApp();
+      renderApp({ preserveFocus: true });
     });
   });
 
@@ -413,7 +461,7 @@ function renderApp(message?: string): void {
     input.addEventListener('change', () => {
       state.filter.severities = toggleValue(state.filter.severities, input.dataset.severity as PlatformDiagnosticSeverity);
       computeFilteredSnapshot();
-      renderApp();
+      renderApp({ preserveFocus: true });
     });
   });
 
@@ -459,6 +507,8 @@ function renderApp(message?: string): void {
       renderApp();
     });
   });
+
+  restoreFocusSnapshot(focusSnapshot);
 }
 
 computeFilteredSnapshot();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 6.4.1(@types/node@22.19.15)(tsx@4.21.0)
       vitest:
         specifier: ^3.0.8
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   examples/auth-jwt-passport:
     dependencies:
@@ -168,7 +168,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/cli:
     dependencies:
@@ -196,7 +196,7 @@ importers:
         version: 3.1.5
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/config:
     dependencies:
@@ -218,13 +218,13 @@ importers:
         version: link:../di
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/core:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/cqrs:
     dependencies:
@@ -243,7 +243,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/cron:
     dependencies:
@@ -265,7 +265,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/di:
     dependencies:
@@ -275,7 +275,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/discord:
     dependencies:
@@ -294,7 +294,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/drizzle:
     dependencies:
@@ -316,7 +316,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/email:
     dependencies:
@@ -344,7 +344,7 @@ importers:
         version: 8.0.0
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/event-bus:
     dependencies:
@@ -363,7 +363,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/graphql:
     dependencies:
@@ -403,7 +403,7 @@ importers:
         version: 8.18.1
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/http:
     dependencies:
@@ -419,7 +419,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/jwt:
     dependencies:
@@ -435,7 +435,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/metrics:
     dependencies:
@@ -457,7 +457,7 @@ importers:
         version: 22.19.15
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/microservices:
     dependencies:
@@ -485,7 +485,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/mongoose:
     dependencies:
@@ -507,7 +507,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/notifications:
     dependencies:
@@ -523,7 +523,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/openapi:
     dependencies:
@@ -542,7 +542,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/passport:
     dependencies:
@@ -564,7 +564,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/platform-bun:
     dependencies:
@@ -577,7 +577,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/platform-cloudflare-workers:
     dependencies:
@@ -590,7 +590,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/platform-deno:
     dependencies:
@@ -606,7 +606,7 @@ importers:
         version: link:../testing
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/platform-express:
     dependencies:
@@ -628,7 +628,7 @@ importers:
         version: 5.0.6
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/platform-fastify:
     dependencies:
@@ -653,7 +653,7 @@ importers:
         version: link:../di
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/platform-nodejs:
     dependencies:
@@ -666,7 +666,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/prisma:
     dependencies:
@@ -691,7 +691,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/queue:
     dependencies:
@@ -713,7 +713,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/redis:
     dependencies:
@@ -732,7 +732,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/runtime:
     dependencies:
@@ -754,7 +754,7 @@ importers:
         version: link:../serialization
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/serialization:
     dependencies:
@@ -767,7 +767,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/slack:
     dependencies:
@@ -786,7 +786,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/socket.io:
     dependencies:
@@ -826,7 +826,7 @@ importers:
         version: 4.8.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/studio:
     dependencies:
@@ -837,9 +837,12 @@ importers:
       '@fluojs-internal/tooling-vite':
         specifier: workspace:^
         version: link:../../tooling/vite
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/terminus:
     dependencies:
@@ -867,7 +870,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/testing:
     dependencies:
@@ -901,7 +904,7 @@ importers:
         version: link:../platform-nodejs
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/throttler:
     dependencies:
@@ -926,7 +929,7 @@ importers:
         version: 5.10.0
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/validation:
     dependencies:
@@ -951,7 +954,7 @@ importers:
         version: 1.3.1(typescript@6.0.2)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
       zod:
         specifier: ^4.1.11
         version: 4.3.6
@@ -967,7 +970,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   packages/websockets:
     dependencies:
@@ -1001,7 +1004,7 @@ importers:
         version: 8.18.1
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.19.15)(tsx@4.21.0)
+        version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)
 
   tooling/babel: {}
 
@@ -2049,6 +2052,9 @@ packages:
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/whatwg-url@13.0.0':
     resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
@@ -2534,6 +2540,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -2753,6 +2763,10 @@ packages:
   graphql@16.13.1:
     resolution: {integrity: sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3673,6 +3687,10 @@ packages:
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
   whatwg-url@14.2.0:
@@ -4761,6 +4779,8 @@ snapshots:
 
   '@types/webidl-conversions@7.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
   '@types/whatwg-url@13.0.0':
     dependencies:
       '@types/webidl-conversions': 7.0.3
@@ -5194,6 +5214,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@7.0.1: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -5519,6 +5541,18 @@ snapshots:
       tslib: 2.8.1
 
   graphql@16.13.1: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 22.19.15
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-symbols@1.1.0: {}
 
@@ -6384,7 +6418,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@22.19.15)(tsx@4.21.0):
+  vitest@3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -6411,6 +6445,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -6428,6 +6463,8 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url@14.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Closes #1606.
- Preserves Studio viewer focus while search and filter controls rerender loaded snapshot views.
- Splits packaged `@fluojs/studio/viewer` usage from repo-local Studio development commands.

## Changes

- Added focus capture/restore around Studio viewer rerenders triggered by search, readiness, and severity filters.
- Added regression coverage for the focus-preservation wiring and packaged viewer documentation contract.
- Updated `packages/studio` EN/KO README and Advanced Chapter 15 EN/KO guidance for installed-package viewer artifacts.
- Added a patch changeset for `@fluojs/studio`.

## Testing

- `lsp_diagnostics` on `packages/studio/src/main.ts`: clean
- `lsp_diagnostics` on `packages/studio/src/contracts.test.ts`: clean
- `pnpm --dir packages/studio test`
- `pnpm --dir packages/studio typecheck`
- `pnpm changeset status --since=main`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were changed; existing Studio contract helper documentation remains unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Studio now preserves focus for active search/filter controls during viewer rerenders, and installed-package users get documented `@fluojs/studio/viewer` artifact guidance separate from repo-local development.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed. EN/KO package README and book chapter mirrors were updated together.