### PR TITLE
Resolve #1604: Align testing harness contracts

### DIFF
--- a/.changeset/tidy-tigers-test.md
+++ b/.changeset/tidy-tigers-test.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/testing": patch
+---
+
+Preserve `createTestApp(...)` bootstrap middleware/options and align synchronous `TestingModuleRef.get(...)` singleton instances with later async resolution.

--- a/book/advanced/ch14-portability-testing.ko.md
+++ b/book/advanced/ch14-portability-testing.ko.md
@@ -148,7 +148,7 @@ export async function runPlatformConformance(options: PlatformConformanceOptions
 
 ### Conformance Testing for Library Authors
 
-커스텀 유효성 검사 파이프나 로깅 인터셉터처럼 fluo를 확장하는 라이브러리를 개발한다면 사용자에게 적합성 테스트를 제공해야 합니다. 이는 라이브러리가 fluo 생태계 안에서 예상대로 동작하고 부수 효과를 일으키지 않음을 보장합니다. 라이브러리의 구체적인 동작 요구 사항을 정의할 수 있도록 확장 가능한 `BaseLibraryConformanceHarness`를 제공합니다.
+커스텀 유효성 검사 파이프나 로깅 인터셉터처럼 fluo를 확장하는 라이브러리를 개발한다면 사용자에게 적합성 테스트를 제공해야 합니다. 이는 라이브러리가 fluo 생태계 안에서 예상대로 동작하고 부수 효과를 일으키지 않음을 보장합니다. `@fluojs/testing`은 platform, HTTP adapter, web-runtime adapter, fetch-style WebSocket 계약을 위한 구체적인 harness subpath를 배포합니다. 전용 library conformance harness가 배포되기 전까지 custom library 저자는 이 패턴을 자신의 패키지 테스트 안에서 따르세요.
 
 커스텀 파이프의 경우 적합성 스위트는 유효하지 않은 입력을 처리하는 방식과 DI 컨테이너의 메타데이터를 올바르게 전파하는지에 집중합니다. 인터셉터의 경우 실행 순서와 동기 및 비동기 결과를 모두 올바르게 처리할 수 있는지에 집중합니다. 파이프 저자가 흔히 저지르는 실수는 중첩된 객체 변환을 누락하는 것입니다. 적합성 하네스에는 복잡한 DTO의 구조적 무결성을 준수하는지 확인하는 심층 검증 시나리오가 포함되어 있습니다.
 
@@ -167,7 +167,7 @@ export function runPipeConformance(pipe: Pipe, options: PipeOptions) {
 
 이러한 자동화된 검사는 fluo의 "플러그 가능한" 특성이 안정성을 희생하지 않도록 보장합니다. 프레임워크의 모든 확장 지점에는 라이브러리 저자가 안정적인 구현을 만들도록 안내하는 적합성 영역이 있습니다. 예를 들어, 커스텀 로깅 인터셉터는 요청 바디 스트림을 실수로 소비하지 않음을 증명해야 합니다. 그렇지 않으면 후속 컨트롤러가 페이로드를 읽지 못할 수 있습니다. 라이브러리 적합성 하네스에는 인터셉터가 헤더만 관찰해야 하는 경우 기본 `ReadableStream`이 올바르게 복제되거나 그대로 유지되는지 확인하는 "스트림 무결성" 테스트가 포함되어 있습니다.
 
-`@fluojs/testing/conformance`에서 사용되는 패턴을 따르면 사용자에게 표준화된 통합 검증 방법을 제공할 수 있습니다. 이는 생태계의 신뢰성을 높이고 사용자와의 신뢰를 쌓는 데 도움이 됩니다. 테스트의 일관성은 동작의 일관성으로 이어지며, 이것이 fluo 프레임워크가 지향하는 핵심 목표입니다. 자체 도구와 라이브러리를 만들 때도 이러한 철학을 개발 프로세스의 우선순위에 두어야 합니다.
+`@fluojs/testing/platform-conformance`와 다른 배포된 harness subpath에서 사용되는 패턴을 따르면 사용자에게 표준화된 통합 검증 방법을 제공할 수 있습니다. 이는 생태계의 신뢰성을 높이고 사용자와의 신뢰를 쌓는 데 도움이 됩니다. 테스트의 일관성은 동작의 일관성으로 이어지며, 이것이 fluo 프레임워크가 지향하는 핵심 목표입니다. 자체 도구와 라이브러리를 만들 때도 이러한 철학을 개발 프로세스의 우선순위에 두어야 합니다.
 
 기본 기능 외에도 라이브러리 저자를 위한 적합성 하네스는 메모리 효율성과 성능 오버헤드도 확인합니다. 예를 들어 인증을 수행하는 미들웨어는 큰 대기 시간을 만들거나 응답이 전송된 후에도 요청 객체에 대한 참조를 유지해서는 안 됩니다. 적합성 스위트에 통합된 내부 벤치마킹 도구는 라이브러리 저자에게 추상화 비용에 대한 즉각적인 피드백을 제공합니다.
 
@@ -205,7 +205,7 @@ WebSocket 하네스에는 "백프레셔(backpressure)" 테스트도 포함되어
 13장에서 커스텀 어댑터를 구현했다면, 이제 하네스를 사용해 이를 검증해야 합니다. 이는 어댑터가 fluo 동작 계약을 준수하는지 확인하는 핵심 테스트입니다. 이식성 하네스를 통과하면 기존 비즈니스 로직을 깨뜨리지 않고 서로 다른 런타임에 어댑터를 배포할 수 있다는 근거를 얻습니다.
 
 ```typescript
-import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/portability';
+import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 import { myAdapter } from './my-adapter';
 
 const harness = createHttpAdapterPortabilityHarness({

--- a/book/advanced/ch14-portability-testing.md
+++ b/book/advanced/ch14-portability-testing.md
@@ -148,7 +148,7 @@ This lets someone writing a new adapter, such as a hypothetical `AzureFunctionsA
 
 ### Conformance Testing for Library Authors
 
-If you develop a library that extends fluo, such as a custom validation pipe or logging interceptor, you should provide conformance tests to users. This ensures the library behaves as expected inside the fluo ecosystem and does not cause side effects. An extensible `BaseLibraryConformanceHarness` is available so you can define the library's specific behavior requirements.
+If you develop a library that extends fluo, such as a custom validation pipe or logging interceptor, you should provide conformance tests to users. This ensures the library behaves as expected inside the fluo ecosystem and does not cause side effects. `@fluojs/testing` publishes concrete harness subpaths for platform, HTTP adapter, web-runtime adapter, and fetch-style WebSocket contracts; custom library authors should follow those patterns in their own package tests until a dedicated library conformance harness is published.
 
 For custom pipes, the conformance suite focuses on how invalid input is handled and whether metadata from the DI container is propagated correctly. For interceptors, it focuses on execution order and correct handling of both synchronous and asynchronous results. A common mistake by pipe authors is missing nested object transformation. The conformance harness includes deep validation scenarios that check structural integrity for complex DTOs.
 
@@ -167,7 +167,7 @@ export function runPipeConformance(pipe: Pipe, options: PipeOptions) {
 
 These automated checks ensure fluo's "pluggable" nature does not trade away stability. Every extension point in the framework has a conformance area that guides library authors toward stable implementations. For example, a custom logging interceptor must prove that it does not accidentally consume the request body stream. Otherwise, later controllers may be unable to read the payload. The library conformance harness includes a "stream integrity" test that checks whether the underlying `ReadableStream` is cloned correctly or left intact when the interceptor only needs to observe headers.
 
-By following the patterns used in `@fluojs/testing/conformance`, you can give users a standardized way to verify integrations. This improves ecosystem reliability and builds trust with users. Consistent tests lead to consistent behavior, which is the core goal of the fluo framework. When you create your own tools and libraries, you should make this philosophy a priority in your development process.
+By following the patterns used in `@fluojs/testing/platform-conformance` and the other published harness subpaths, you can give users a standardized way to verify integrations. This improves ecosystem reliability and builds trust with users. Consistent tests lead to consistent behavior, which is the core goal of the fluo framework. When you create your own tools and libraries, you should make this philosophy a priority in your development process.
 
 Beyond basic functionality, conformance harnesses for library authors also check memory efficiency and performance overhead. For example, middleware that performs authentication must not add large latency or keep references to request objects after the response has been sent. Internal benchmarking tools integrated into the conformance suite give library authors immediate feedback about the cost of their abstractions.
 
@@ -205,7 +205,7 @@ The WebSocket harness also includes "backpressure" tests. These verify that the 
 If you implemented a custom adapter in Chapter 13, you should now verify it with the harness. This is the key test that checks whether your adapter complies with the fluo Behavioral Contract. Passing the portability harness gives you evidence that the adapter can be deployed to different runtimes without breaking existing business logic.
 
 ```typescript
-import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/portability';
+import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 import { myAdapter } from './my-adapter';
 
 const harness = createHttpAdapterPortabilityHarness({

--- a/book/beginner/ch20-testing.ko.md
+++ b/book/beginner/ch20-testing.ko.md
@@ -301,8 +301,8 @@ const mailer = createDeepMock(MailService);
 mailer.send.mockResolvedValue(true);
 ```
 
-### 20.6.1 Auto-Mocking DI Tokens
-`createTestingModule`은 명시적으로 정의되지 않은 모든 프로바이더를 "자동 모의(Auto-Mock)"하도록 설정할 수도 있습니다. 이는 한두 개의 의존성만 관심 있는 큰 서비스를 테스트할 때 시간을 줄여 줍니다. Fluo는 다른 모든 의존성에 대해 깊은 모의 객체를 자동으로 주입하여, 많은 상용구 코드 없이도 클래스를 인스턴스화할 수 있게 합니다.
+### 20.6.1 명시적인 DI Token Override
+`createTestingModule`은 누락된 provider를 자동으로 mock하지 않습니다. module graph는 명시적으로 유지하고, 교체해야 하는 의존성만 `.compile()` 전에 `overrideProvider(...)`, `overrideProviders(...)`, 또는 `mockToken(...)`으로 바꾸세요. 이렇게 하면 fluo의 명시적 DI 계약과 테스트가 일치하면서도 fake가 필요한 의존성의 상용구를 줄일 수 있습니다.
 
 ### 20.6.2 The Power of Proxies in Mocking
 `createMock` 헬퍼는 ES6 Proxy를 사용하여 메서드 호출과 속성 접근을 가로챕니다. 이는 모의 객체의 모든 메서드를 일일이 정의할 필요가 없음을 의미합니다. 프록시는 모든 호출을 자동으로 처리하며, 메서드가 명시적으로 정의되지 않은 경우 기본 모의 함수를 반환합니다. 이를 통해 테스트 설정이 더 단순해지고 서비스 인터페이스 변경에도 대응하기 쉬워집니다. 서비스에 새로운 메서드를 추가하더라도, 해당 메서드를 구체적으로 검증해야 하는 테스트가 아니라면 기존의 모든 모의 객체를 업데이트할 필요가 없습니다.

--- a/book/beginner/ch20-testing.md
+++ b/book/beginner/ch20-testing.md
@@ -301,8 +301,8 @@ const mailer = createDeepMock(MailService);
 mailer.send.mockResolvedValue(true);
 ```
 
-### 20.6.1 Auto-Mocking DI Tokens
-`createTestingModule` can also be configured to auto-mock every Provider that is not explicitly defined. This saves time when testing a large service where only one or two dependencies matter. Fluo automatically injects deep mocks for every other dependency, allowing the class to be instantiated without much boilerplate.
+### 20.6.1 Explicit DI Token Overrides
+`createTestingModule` does not auto-mock missing providers. Keep the module graph explicit, then replace the dependencies that matter with `overrideProvider(...)`, `overrideProviders(...)`, or `mockToken(...)` before calling `.compile()`. This keeps tests aligned with fluo's explicit DI contract while still avoiding boilerplate for dependencies that should be faked.
 
 ### 20.6.2 The Power of Proxies in Mocking
 The `createMock` helper uses an ES6 Proxy to intercept method calls and property access. This means you do not need to define every method on the mock manually. The proxy handles every call automatically and returns a default mock function when a method is not explicitly defined. This makes test setup simpler and easier to adapt when service interfaces change. If you add a new method to a service, you do not need to update every existing mock unless a test specifically verifies that method.

--- a/docs/contracts/testing-guide.ko.md
+++ b/docs/contracts/testing-guide.ko.md
@@ -44,6 +44,8 @@ fluo의 테스트 설정은 런타임 모델과 같습니다. 표준 decorator, 
 
 수동 `FrameworkRequest`/`FrameworkResponse` stub, `makeRequest(...)`, raw `FluoFactory.create(...)`, direct `app.dispatch(...)` 테스트는 framework internal, adapter/runtime, compatibility contract에 남겨 둡니다. 이들은 기본 app-developer HTTP 경로보다 의도적으로 낮은 수준의 테스트입니다.
 
+`createTestApp(...)`은 request-facing 테스트에서 runtime HTTP bootstrap option surface를 따릅니다. 호출자가 app-level middleware를 넘기면, 테스트 헬퍼는 request-context middleware를 추가하면서 호출자의 middleware chain을 제거하지 않습니다.
+
 ## 명령어 (Commands)
 
 | 명령어 | 용도 |

--- a/docs/contracts/testing-guide.md
+++ b/docs/contracts/testing-guide.md
@@ -44,6 +44,8 @@ fluo's test setup follows its runtime model: standard decorators, explicit DI to
 
 Keep manual `FrameworkRequest`/`FrameworkResponse` stubs, `makeRequest(...)`, raw `FluoFactory.create(...)`, and direct `app.dispatch(...)` tests for framework-internal, adapter/runtime, or compatibility contracts. They are intentionally lower-level than the default app-developer HTTP path.
 
+`createTestApp(...)` follows the runtime HTTP bootstrap option surface for request-facing tests. When callers pass app-level middleware, the testing helper adds its request-context middleware without dropping the caller middleware chain.
+
 ## Commands
 
 | Command | Use |

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -114,6 +114,8 @@ await app.close();
 
 `app.request(...).send()`는 수동 `FrameworkRequest`/`FrameworkResponse` stub 없이 HTTP 의미에 가까운 테스트를 작성하게 해 주므로 애플리케이션 개발자의 기본 경로입니다. `app.dispatch(...)`, `makeRequest(...)`, raw `FluoFactory.create(...)` 테스트는 adapter/runtime contract, framework internal, 또는 low-level dispatch boundary 자체를 증명해야 하는 compatibility case에 남겨 둡니다.
 
+`createTestApp(...)`은 runtime HTTP bootstrap과 같은 application bootstrap option을 받습니다. 여기에는 `providers`, `filters`, `converters`, `interceptors`, `middleware`, `observers`, `versioning`, diagnostics option이 포함됩니다. 테스트 헬퍼는 request-context middleware를 앞에 추가하되, 호출자가 넘긴 middleware를 같은 app middleware chain 안에 보존합니다.
+
 ### 명시적 서브패스의 mock 헬퍼
 
 ```typescript

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -112,6 +112,8 @@ await app.close();
 
 `app.request(...).send()` is the preferred app-developer path because it keeps tests close to HTTP semantics without manual `FrameworkRequest`/`FrameworkResponse` stubs. Keep `app.dispatch(...)`, `makeRequest(...)`, and raw `FluoFactory.create(...)` tests for adapter/runtime contracts, framework internals, or compatibility cases where the low-level dispatch boundary itself is what the test must prove.
 
+`createTestApp(...)` accepts the same application bootstrap options as the runtime HTTP bootstrap, including `providers`, `filters`, `converters`, `interceptors`, `middleware`, `observers`, `versioning`, and diagnostics options. The testing helper prepends its request-context middleware while preserving caller-provided middleware in the same app middleware chain.
+
 ### Mock helpers from explicit subpaths
 
 ```ts

--- a/packages/testing/src/app.ts
+++ b/packages/testing/src/app.ts
@@ -10,7 +10,7 @@ import {
 } from './http.js';
 import type {
   TestApp,
-  TestingModuleOptions,
+  TestingApplicationOptions,
   TestRequestOptions,
 } from './types.js';
 
@@ -54,10 +54,10 @@ function normalizeRequestInput(
  * await app.close();
  * ```
  */
-export async function createTestApp(options: TestingModuleOptions): Promise<TestApp> {
+export async function createTestApp(options: TestingApplicationOptions): Promise<TestApp> {
   const app = await bootstrapApplication({
     ...options,
-    middleware: [createTestRequestContextMiddleware()],
+    middleware: [createTestRequestContextMiddleware(), ...(options.middleware ?? [])],
   });
 
   const request: TestApp['request'] = (

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -221,6 +221,87 @@ describe('@fluojs/testing', () => {
     expect(() => testingModule.get<string>(DISPATCH_TOKEN)).toThrow(/already resolved asynchronously/);
   });
 
+  it('promotes sync useFactory singletons after resolve() while preserving identity for get()', async () => {
+    const TOKEN = Symbol('sync-factory-token');
+    const value = { id: 'sync-factory-value' };
+
+    @Module({
+      providers: [
+        {
+          provide: TOKEN,
+          useFactory: () => value,
+        },
+      ],
+    })
+    class SyncFactoryModule {}
+
+    const testingModule = await createTestingModule({ rootModule: SyncFactoryModule }).compile();
+
+    const resolved = await testingModule.resolve<typeof value>(TOKEN);
+    const syncValue = testingModule.get<typeof value>(TOKEN);
+
+    expect(resolved).toBe(value);
+    expect(syncValue).toBe(resolved);
+  });
+
+  it('promotes classes depending on sync factories after resolve() while preserving get() identity', async () => {
+    const TOKEN = Symbol('sync-factory-dependency-token');
+    const dependency = { name: 'sync-dependency' };
+
+    @Inject(TOKEN)
+    class SyncFactoryConsumer {
+      constructor(readonly value: typeof dependency) {}
+    }
+
+    @Module({
+      providers: [
+        {
+          provide: TOKEN,
+          useFactory: () => dependency,
+        },
+        SyncFactoryConsumer,
+      ],
+    })
+    class SyncFactoryConsumerModule {}
+
+    const testingModule = await createTestingModule({ rootModule: SyncFactoryConsumerModule }).compile();
+
+    const resolved = await testingModule.resolve<SyncFactoryConsumer>(SyncFactoryConsumer);
+    const syncConsumer = testingModule.get<SyncFactoryConsumer>(SyncFactoryConsumer);
+
+    expect(resolved.value).toBe(dependency);
+    expect(syncConsumer).toBe(resolved);
+  });
+
+  it('keeps classes depending on useExisting aliases to async factories resolve-only after resolve()', async () => {
+    const SOURCE = Symbol('async-factory-source-token');
+    const ALIAS = Symbol('async-factory-alias-token');
+
+    @Inject(ALIAS)
+    class AliasAsyncConsumer {
+      constructor(readonly value: string) {}
+    }
+
+    @Module({
+      providers: [
+        {
+          provide: SOURCE,
+          useFactory: async () => 'async-aliased-value',
+        },
+        { provide: ALIAS, useExisting: SOURCE },
+        AliasAsyncConsumer,
+      ],
+    })
+    class AliasAsyncFactoryModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AliasAsyncFactoryModule }).compile();
+
+    const resolved = await testingModule.resolve<AliasAsyncConsumer>(AliasAsyncConsumer);
+
+    expect(resolved.value).toBe('async-aliased-value');
+    expect(() => testingModule.get<AliasAsyncConsumer>(AliasAsyncConsumer)).toThrow(/already resolved asynchronously/);
+  });
+
   it('treats direct function mocks in overrideProvider as useValue', async () => {
     const FUNCTION_TOKEN = Symbol('function-token');
     const mockFn = vi.fn().mockReturnValue('ok');

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -172,6 +172,55 @@ describe('@fluojs/testing', () => {
     await expect(testingModule.resolve<string>(TOKEN)).resolves.toBe('async-value');
   });
 
+  it('keeps async factory providers resolve-only after async singleton sync points', async () => {
+    const RESOLVE_TOKEN = Symbol('resolve-async-token');
+    const RESOLVE_ALL_TOKEN = Symbol('resolve-all-async-token');
+    const DISPATCH_TOKEN = Symbol('dispatch-async-token');
+
+    @Inject(DISPATCH_TOKEN)
+    @Controller('/async-singleton')
+    class AsyncSingletonController {
+      constructor(private readonly value: string) {}
+
+      @Get('/')
+      read() {
+        return { value: this.value };
+      }
+    }
+
+    @Module({
+      controllers: [AsyncSingletonController],
+      providers: [
+        {
+          provide: RESOLVE_TOKEN,
+          useFactory: async () => 'resolved-async-value',
+        },
+        {
+          provide: RESOLVE_ALL_TOKEN,
+          useFactory: async () => 'resolve-all-async-value',
+        },
+        {
+          provide: DISPATCH_TOKEN,
+          useFactory: async () => 'dispatch-async-value',
+        },
+      ],
+    })
+    class AsyncSingletonModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AsyncSingletonModule }).compile();
+
+    await expect(testingModule.resolve<string>(RESOLVE_TOKEN)).resolves.toBe('resolved-async-value');
+    expect(() => testingModule.get<string>(RESOLVE_TOKEN)).toThrow(/already resolved asynchronously/);
+
+    await expect(testingModule.resolveAll<string>([RESOLVE_ALL_TOKEN])).resolves.toEqual(['resolve-all-async-value']);
+    expect(() => testingModule.get<string>(RESOLVE_ALL_TOKEN)).toThrow(/already resolved asynchronously/);
+
+    const response = await testingModule.dispatch({ method: 'GET', path: '/async-singleton' });
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ value: 'dispatch-async-value' });
+    expect(() => testingModule.get<string>(DISPATCH_TOKEN)).toThrow(/already resolved asynchronously/);
+  });
+
   it('treats direct function mocks in overrideProvider as useValue', async () => {
     const FUNCTION_TOKEN = Symbol('function-token');
     const mockFn = vi.fn().mockReturnValue('ok');

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Inject, Module, Scope as ScopeDecorator } from '@fluojs/core';
 import { Controller, Get, Post, type RequestContext } from '@fluojs/http';
-import type { Dispatcher } from '@fluojs/http';
+import type { Dispatcher, Middleware } from '@fluojs/http';
 
 import {
   createTestApp,
@@ -76,6 +76,25 @@ describe('@fluojs/testing', () => {
 
     expect(testingModule.has(UserService)).toBe(true);
     expect(service.logger.name).toBe('logger');
+  });
+
+  it('shares singleton identity between get() and resolve()', async () => {
+    class CounterService {
+      count = 0;
+    }
+
+    @Module({ providers: [CounterService] })
+    class ServiceModule {}
+
+    const testingModule = await createTestingModule({ rootModule: ServiceModule }).compile();
+
+    const syncService = testingModule.get<CounterService>(CounterService);
+    syncService.count = 7;
+
+    const asyncService = await testingModule.resolve<CounterService>(CounterService);
+
+    expect(asyncService).toBe(syncService);
+    expect(asyncService.count).toBe(7);
   });
 
   it('overrides providers before resolution', async () => {
@@ -458,6 +477,28 @@ describe('createTestApp', () => {
     });
 
     await expect(app.close()).resolves.toBeUndefined();
+  });
+
+  it('preserves caller bootstrap middleware when adding test request context', async () => {
+    const middlewareCalls: string[] = [];
+    const callerMiddleware: Middleware = {
+      async handle(_context, next) {
+        middlewareCalls.push('caller');
+        await next();
+      },
+    };
+
+    const app = await createTestApp({
+      rootModule: AppModule,
+      middleware: [callerMiddleware],
+    });
+
+    const response = await app.request('GET', '/users/me').send();
+
+    expect(response.status).toBe(200);
+    expect(middlewareCalls).toEqual(['caller']);
+
+    await app.close();
   });
 
   it('injects principal into request context for e2e-style calls', async () => {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -201,6 +201,48 @@ function hasToken(state: SyncResolverState, token: Token): boolean {
   return lookupProvider(state.introspection, token) !== undefined || collectMultiProviders(state.introspection, token).length > 0;
 }
 
+function dependencyToken(entry: Token | ForwardRefFn | OptionalToken): Token {
+  if (isOptionalToken(entry)) {
+    return entry.token;
+  }
+
+  if (isForwardRef(entry)) {
+    return entry.forwardRef();
+  }
+
+  return entry as Token;
+}
+
+function providerGraphUsesFactory(target: ContainerIntrospection, token: Token, visited = new Set<Token>()): boolean {
+  if (visited.has(token)) {
+    return false;
+  }
+
+  visited.add(token);
+
+  try {
+    const provider = lookupProvider(target, token);
+    const multiProviders = collectMultiProviders(target, token);
+    const providers = provider ? [provider, ...multiProviders] : multiProviders;
+
+    return providers.some((candidate) => {
+      if (candidate.type === 'factory') {
+        return true;
+      }
+
+      return candidate.inject.some((entry) => providerGraphUsesFactory(target, dependencyToken(entry), visited));
+    });
+  } finally {
+    visited.delete(token);
+  }
+}
+
+function canPromoteCachedSingleton(state: SyncResolverState, token: Token): boolean {
+  const provider = lookupProvider(state.introspection, token);
+
+  return provider !== undefined && provider.scope !== 'request' && !providerGraphUsesFactory(state.introspection, token);
+}
+
 function resolveSyncDependency(entry: Token | ForwardRefFn | OptionalToken, state: SyncResolverState): unknown {
   if (isOptionalToken(entry)) {
     if (!hasToken(state, entry.token)) {
@@ -329,6 +371,10 @@ function createSyncResolver(
     get: <T>(token: Token<T>): T => resolveSyncToken(token, state) as T,
     syncFromContainer: async (): Promise<void> => {
       for (const [token, promise] of state.singletonCache) {
+        if (!canPromoteCachedSingleton(state, token)) {
+          continue;
+        }
+
         state.syncSingletonValues.set(token, await promise);
       }
     },

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -126,6 +126,7 @@ interface ContainerIntrospection {
   registrations: Map<Token, NormalizedProvider>;
   multiRegistrations: Map<Token, NormalizedProvider[]>;
   requestScopeEnabled?: boolean;
+  singletonCache: Map<Token, Promise<unknown>>;
 }
 
 function isContainerIntrospection(value: unknown): value is ContainerIntrospection {
@@ -138,12 +139,19 @@ function isContainerIntrospection(value: unknown): value is ContainerIntrospecti
     parent?: unknown;
     registrations?: unknown;
     requestScopeEnabled?: unknown;
+    singletonCache?: unknown;
   };
 
   const parentValid = candidate.parent === undefined || isContainerIntrospection(candidate.parent);
   const requestScopeValid = candidate.requestScopeEnabled === undefined || typeof candidate.requestScopeEnabled === 'boolean';
 
-  return candidate.registrations instanceof Map && candidate.multiRegistrations instanceof Map && parentValid && requestScopeValid;
+  return (
+    candidate.registrations instanceof Map &&
+    candidate.multiRegistrations instanceof Map &&
+    candidate.singletonCache instanceof Map &&
+    parentValid &&
+    requestScopeValid
+  );
 }
 
 function toContainerIntrospection(container: BootstrapResult['container']): ContainerIntrospection {
@@ -165,7 +173,12 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
 interface SyncResolverState {
   introspection: ContainerIntrospection;
   resolutionChain: Set<Token>;
-  singletonCache: Map<Token, unknown>;
+  singletonCache: Map<Token, Promise<unknown>>;
+  syncSingletonValues: Map<Token, unknown>;
+}
+
+function rootContainerIntrospection(target: ContainerIntrospection): ContainerIntrospection {
+  return target.parent ? rootContainerIntrospection(target.parent) : target;
 }
 
 function collectMultiProviders(target: ContainerIntrospection, token: Token): NormalizedProvider[] {
@@ -255,12 +268,19 @@ function resolveSyncProvider(provider: NormalizedProvider, state: SyncResolverSt
     return instantiateSyncProvider(provider, state);
   }
 
+  if (state.syncSingletonValues.has(provider.provide)) {
+    return state.syncSingletonValues.get(provider.provide);
+  }
+
   if (state.singletonCache.has(provider.provide)) {
-    return state.singletonCache.get(provider.provide);
+    throw new Error(
+      `Token ${String(provider.provide)} was already resolved asynchronously. Use resolve() instead of get() for this provider.`,
+    );
   }
 
   const instance = instantiateSyncProvider(provider, state);
-  state.singletonCache.set(provider.provide, instance);
+  state.syncSingletonValues.set(provider.provide, instance);
+  state.singletonCache.set(provider.provide, Promise.resolve(instance));
   return instance;
 }
 
@@ -292,14 +312,27 @@ function resolveSyncToken(token: Token, state: SyncResolverState): unknown {
 
 function createSyncResolver(
   container: BootstrapResult['container'],
-): <T>(token: Token<T>) => T {
+): {
+  get<T>(token: Token<T>): T;
+  syncFromContainer(): Promise<void>;
+} {
+  const introspection = toContainerIntrospection(container);
+
   const state: SyncResolverState = {
-    introspection: toContainerIntrospection(container),
+    introspection,
     resolutionChain: new Set<Token>(),
-    singletonCache: new Map<Token, unknown>(),
+    singletonCache: rootContainerIntrospection(introspection).singletonCache,
+    syncSingletonValues: new Map<Token, unknown>(),
   };
 
-  return <T>(token: Token<T>): T => resolveSyncToken(token, state) as T;
+  return {
+    get: <T>(token: Token<T>): T => resolveSyncToken(token, state) as T,
+    syncFromContainer: async (): Promise<void> => {
+      for (const [token, promise] of state.singletonCache) {
+        state.syncSingletonValues.set(token, await promise);
+      }
+    },
+  };
 }
 
 class DefaultOverrideProviderBuilder<T> implements OverrideProviderBuilder<T> {
@@ -416,13 +449,17 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
 
   private createTestingModuleRef(bootstrapped: BootstrapResult): TestingModuleRef {
     const dispatcher = createTestingDispatcher(bootstrapped);
-    const getSync = createSyncResolver(bootstrapped.container);
+    const syncResolver = createSyncResolver(bootstrapped.container);
 
     return {
       ...bootstrapped,
       has: (token) => bootstrapped.container.has(token),
-      get: (token) => getSync(token),
-      resolve: (token) => bootstrapped.container.resolve(token),
+      get: (token) => syncResolver.get(token),
+      resolve: async (token) => {
+        const value = await bootstrapped.container.resolve(token);
+        await syncResolver.syncFromContainer();
+        return value;
+      },
       resolveAll: async <T>(tokens: Token<T>[]): Promise<T[]> => {
         const results: T[] = [];
         const errors: Array<{ token: Token; error: unknown }> = [];
@@ -443,9 +480,15 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
           throw new Error(`Failed to resolve ${errors.length} of ${tokens.length} tokens:\n${summary}`);
         }
 
+        await syncResolver.syncFromContainer();
+
         return results;
       },
-      dispatch: (request: TestRequestWithOptions) => makeRequest(dispatcher, request),
+      dispatch: async (request: TestRequestWithOptions) => {
+        const response = await makeRequest(dispatcher, request);
+        await syncResolver.syncFromContainer();
+        return response;
+      },
     };
   }
 

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -171,6 +171,7 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
 }
 
 interface SyncResolverState {
+  factoryResolutionKinds: WeakMap<NormalizedProvider, 'async' | 'sync'>;
   introspection: ContainerIntrospection;
   resolutionChain: Set<Token>;
   singletonCache: Map<Token, Promise<unknown>>;
@@ -213,24 +214,69 @@ function dependencyToken(entry: Token | ForwardRefFn | OptionalToken): Token {
   return entry as Token;
 }
 
-function providerGraphUsesFactory(target: ContainerIntrospection, token: Token, visited = new Set<Token>()): boolean {
+function trackFactoryResolutionKind(
+  provider: NormalizedProvider,
+  factoryResolutionKinds: WeakMap<NormalizedProvider, 'async' | 'sync'>,
+): void {
+  if (provider.type !== 'factory' || !provider.useFactory) {
+    return;
+  }
+
+  const originalFactory = provider.useFactory;
+  provider.useFactory = (...deps: unknown[]) => {
+    const value = originalFactory(...deps);
+    factoryResolutionKinds.set(provider, isPromiseLike(value) ? 'async' : 'sync');
+    return value;
+  };
+}
+
+function installFactoryResolutionTracking(
+  target: ContainerIntrospection,
+  factoryResolutionKinds: WeakMap<NormalizedProvider, 'async' | 'sync'>,
+): void {
+  if (target.parent) {
+    installFactoryResolutionTracking(target.parent, factoryResolutionKinds);
+  }
+
+  for (const provider of target.registrations.values()) {
+    trackFactoryResolutionKind(provider, factoryResolutionKinds);
+  }
+
+  for (const providers of target.multiRegistrations.values()) {
+    for (const provider of providers) {
+      trackFactoryResolutionKind(provider, factoryResolutionKinds);
+    }
+  }
+}
+
+function providerGraphIsSyncResolvable(state: SyncResolverState, token: Token, visited = new Set<Token>()): boolean {
   if (visited.has(token)) {
-    return false;
+    return true;
   }
 
   visited.add(token);
 
   try {
-    const provider = lookupProvider(target, token);
-    const multiProviders = collectMultiProviders(target, token);
+    const provider = lookupProvider(state.introspection, token);
+    const multiProviders = collectMultiProviders(state.introspection, token);
     const providers = provider ? [provider, ...multiProviders] : multiProviders;
 
-    return providers.some((candidate) => {
+    return providers.every((candidate) => {
       if (candidate.type === 'factory') {
-        return true;
+        return state.factoryResolutionKinds.get(candidate) === 'sync';
       }
 
-      return candidate.inject.some((entry) => providerGraphUsesFactory(target, dependencyToken(entry), visited));
+      if (candidate.type === 'existing') {
+        return candidate.useExisting !== undefined && providerGraphIsSyncResolvable(state, candidate.useExisting, visited);
+      }
+
+      return candidate.inject.every((entry) => {
+        if (isOptionalToken(entry) && !hasToken(state, entry.token)) {
+          return true;
+        }
+
+        return providerGraphIsSyncResolvable(state, dependencyToken(entry), visited);
+      });
     });
   } finally {
     visited.delete(token);
@@ -240,7 +286,7 @@ function providerGraphUsesFactory(target: ContainerIntrospection, token: Token, 
 function canPromoteCachedSingleton(state: SyncResolverState, token: Token): boolean {
   const provider = lookupProvider(state.introspection, token);
 
-  return provider !== undefined && provider.scope !== 'request' && !providerGraphUsesFactory(state.introspection, token);
+  return provider !== undefined && provider.scope !== 'request' && providerGraphIsSyncResolvable(state, token);
 }
 
 function resolveSyncDependency(entry: Token | ForwardRefFn | OptionalToken, state: SyncResolverState): unknown {
@@ -359,8 +405,12 @@ function createSyncResolver(
   syncFromContainer(): Promise<void>;
 } {
   const introspection = toContainerIntrospection(container);
+  const factoryResolutionKinds = new WeakMap<NormalizedProvider, 'async' | 'sync'>();
+
+  installFactoryResolutionTracking(introspection, factoryResolutionKinds);
 
   const state: SyncResolverState = {
+    factoryResolutionKinds,
     introspection,
     resolutionChain: new Set<Token>(),
     singletonCache: rootContainerIntrospection(introspection).singletonCache,

--- a/packages/testing/src/surface.test.ts
+++ b/packages/testing/src/surface.test.ts
@@ -122,6 +122,16 @@ describe('@fluojs/testing surface', () => {
     expect(koreanReadme).toContain('원래 `rootModule`과 컴파일된 `modules[].type` identity를 보존합니다');
   });
 
+  it('documents createTestApp bootstrap option and middleware preservation in both README mirrors', () => {
+    const englishReadme = readFileSync(resolve(packageRootPath, 'README.md'), 'utf8');
+    const koreanReadme = readFileSync(resolve(packageRootPath, 'README.ko.md'), 'utf8');
+
+    expect(englishReadme).toContain('accepts the same application bootstrap options as the runtime HTTP bootstrap');
+    expect(englishReadme).toContain('preserving caller-provided middleware');
+    expect(koreanReadme).toContain('runtime HTTP bootstrap과 같은 application bootstrap option을 받습니다');
+    expect(koreanReadme).toContain('호출자가 넘긴 middleware를 같은 app middleware chain 안에 보존합니다');
+  });
+
   it('build emits the published harness subpath files without blocking the Vitest worker event loop', async () => {
     await runBuild();
 

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -2,7 +2,7 @@ import type { Mock } from 'vitest';
 
 import type { MaybePromise, Token } from '@fluojs/core';
 import type { ClassType, Container, ForwardRefFn, OptionalToken, Provider } from '@fluojs/di';
-import type { BootstrapResult, BootstrapModuleOptions, ModuleType } from '@fluojs/runtime';
+import type { BootstrapApplicationOptions, BootstrapResult, BootstrapModuleOptions, ModuleType } from '@fluojs/runtime';
 import type { Guard, Interceptor } from '@fluojs/http';
 import type { RequestBuilder, TestPrincipal, TestRequest, TestRequestWithOptions, TestResponse } from './http.js';
 
@@ -10,6 +10,13 @@ import type { RequestBuilder, TestPrincipal, TestRequest, TestRequestWithOptions
  * Bootstrap options accepted by `createTestingModule(...)`.
  */
 export interface TestingModuleOptions extends BootstrapModuleOptions {
+  rootModule: ModuleType;
+}
+
+/**
+ * Bootstrap options accepted by `createTestApp(...)`.
+ */
+export interface TestingApplicationOptions extends BootstrapApplicationOptions {
   rootModule: ModuleType;
 }
 


### PR DESCRIPTION
## Summary

Closes #1604

- Aligns `@fluojs/testing` singleton lookup and test-app bootstrap behavior with the documented runtime/testing contracts.
- Corrects testing book and package docs for explicit mocks and published harness subpaths.
- Preserves the resolve-only contract for async factory providers after `resolve(...)`, `resolveAll(...)`, and `dispatch(...)` synchronization points.

## Changes

- Shares sync `TestingModuleRef.get(...)` singleton instances with subsequent async container resolution.
- Keeps cached async factory provider graphs out of `get(...)` promotion so async providers continue to throw and require `resolve(...)` even after prior async resolution.
- Widens `createTestApp(...)` to application bootstrap options and preserves caller middleware while adding the test request context middleware.
- Adds regression coverage for singleton identity, async factory `get(...)` rejection after async sync points, caller middleware preservation, and README contract text.
- Updates EN/KO package README, testing guide, beginner testing chapter, advanced portability chapter, and adds a patch changeset for `@fluojs/testing`.

## Testing

- `node tooling/scripts/run-workspace-build-closure.mjs @fluojs/testing`
- `pnpm --filter @fluojs/testing typecheck`
- `pnpm --filter @fluojs/testing test`
- `pnpm verify:platform-consistency-governance`
- LSP diagnostics: clean for changed TypeScript files

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Follow-up note: multi-provider singleton cache parity is out of scope for this blocker because fluo DI stores multi-provider singleton entries in `multiSingletonCache`, not the `singletonCache` path that PR #1640 synchronized into `TestingModuleRef.get(...)`. This fix targets the blocked single-provider promotion path while preserving the existing multi-provider behavior for a separate contract decision.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests or marked not applicable.