### PR TITLE
Resolve #1591: Fix Socket.IO namespace, shutdown, and Bun payload limits

### DIFF
--- a/.changeset/fix-socketio-contracts.md
+++ b/.changeset/fix-socketio-contracts.md
@@ -1,0 +1,8 @@
+---
+"@fluojs/socket.io": patch
+---
+
+Fix namespace, shutdown, and payload limit behavioral contract risks:
+- Set `cleanupEmptyChildNamespaces: false` to ensure Socket.IO v4 defaults don't prematurely clean up statically defined gateway namespaces.
+- Detach the underlying HTTP server from the Socket.IO instance before calling `io.close()` during shutdown to prevent Socket.IO from aggressively shutting down the shared HTTP server.
+- Forward `engine.maxHttpBufferSize` to the Bun engine binding so both HTTP body limits and WebSocket payload limits are correctly bounded under `@fluojs/platform-bun`.

--- a/.changeset/fix-socketio-contracts.md
+++ b/.changeset/fix-socketio-contracts.md
@@ -4,5 +4,5 @@
 
 Fix namespace, shutdown, and payload limit behavioral contract risks:
 - Set `cleanupEmptyChildNamespaces: false` to ensure Socket.IO v4 defaults don't prematurely clean up statically defined gateway namespaces.
-- Detach the underlying HTTP server from the Socket.IO instance before calling `io.close()` during shutdown to prevent Socket.IO from aggressively shutting down the shared HTTP server.
+- Detach the underlying HTTP server from the Socket.IO instance before calling `io.close()` during shutdown so Socket.IO cleans up clients without closing adapter-owned/shared HTTP listeners.
 - Forward `engine.maxHttpBufferSize` to the Bun engine binding so both HTTP body limits and WebSocket payload limits are correctly bounded under `@fluojs/platform-bun`.

--- a/book/intermediate/ch14-socketio.md
+++ b/book/intermediate/ch14-socketio.md
@@ -53,7 +53,7 @@ import { SocketIoModule } from '@fluojs/socket.io';
 export class ChatModule {}
 ```
 
-By default, fluo keeps CORS deny by default, meaning `origin: false`. To allow cross origin browser clients, you must explicitly write the allowed origin list. The `engine` configuration maps directly to Engine.IO, letting you limit payload size for production stability. These defaults are a safer starting point because realtime browser connections often stay open for a long time.
+By default, fluo keeps CORS deny by default, meaning `origin: false`. To allow cross origin browser clients, you must explicitly write the allowed origin list. The `engine` configuration maps directly to Engine.IO, letting you limit payload size for production stability. On Bun, the adapter maps the same `engine.maxHttpBufferSize` value into both the HTTP request body limit and the WebSocket payload limit because Bun exposes those host contracts separately. These defaults are a safer starting point because realtime browser connections often stay open for a long time.
 
 ## 14.3 Room management with SocketIoRoomService
 
@@ -94,6 +94,8 @@ export class SupportChatGateway {
 ```
 
 `SocketIoRoomService` separates room logic from the gateway. With this structure, regular services that cannot access the original socket instance can still broadcast to a specific room. Realtime delivery becomes an explicit collaboration point for application services instead of being trapped inside socket handlers.
+
+Gateway paths such as `/support` are static Socket.IO namespaces owned by fluo gateway discovery. They are not dynamic child namespaces, so fluo keeps Socket.IO dynamic-child cleanup behavior out of this gateway path. If a low-level service creates dynamic namespaces through `SOCKETIO_SERVER`, that service should also own the matching cleanup policy.
 
 ## 14.4 Guarding namespaces and messages
 
@@ -139,6 +141,8 @@ export class ScalingService {
 ```
 
 This boundary lets fluo provide a decorator based surface without blocking the extension points of the underlying library. Most code can use fluo's declarative gateways, while operational exceptions stay gathered around the raw server boundary.
+
+During shutdown, Socket.IO owns cleanup for connected Socket.IO clients. The underlying HTTP server still belongs to the platform adapter or shared HTTP server integration that supplied it, so fluo detaches that server reference before `io.close(...)` and leaves HTTP listener shutdown to the platform owner.
 
 ## 14.6 Bun engine details
 

--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -105,13 +105,17 @@ SocketIoModule.forRoot({
 
 `cors`를 생략하면 `@fluojs/socket.io`는 `{ credentials: false, origin: false }`를 기본값으로 사용하므로 cross-origin 노출은 명시적 opt-in이 필요합니다. `engine.maxHttpBufferSize`를 생략하면 어댑터가 1 MiB Engine.IO payload 상한을 적용합니다. 기본값에는 `buffer.maxPendingMessagesPerSocket: 128`, `buffer.overflowPolicy: 'drop-oldest'`, `shutdown.timeoutMs: 5000`도 포함됩니다.
 
+정적 `@WebSocketGateway({ path })` namespace는 fluo gateway discovery가 소유하며 Socket.IO dynamic child namespace로 취급하지 않습니다. 어댑터는 이러한 정적 namespace에 대해 Socket.IO의 `cleanupEmptyChildNamespaces` 동작을 비활성화합니다. 애플리케이션 코드가 raw `SOCKETIO_SERVER` 접근으로 dynamic child namespace를 만들면 해당 소유권과 cleanup 정책은 애플리케이션 수준 Socket.IO 통합이 담당합니다.
+
+애플리케이션 종료 중 Socket.IO client 정리는 Socket.IO가 소유하지만 underlying HTTP server는 이를 제공한 platform adapter 또는 shared HTTP server 통합이 계속 소유합니다. 어댑터는 `io.close(...)` 전에 해당 HTTP server 참조를 분리하므로 client cleanup은 실행되지만 Socket.IO가 adapter-owned/shared HTTP listener를 닫지는 않습니다. 동일한 managed Socket.IO instance 주변에 별도의 manual socket-disconnect 경로를 추가하지 마세요.
+
 ### Guard 계약
 
 `auth.connection`은 namespace connect handler가 실행되기 전에 `SocketIoConnectionGuardContext`를 받습니다. `auth.message`는 message handler가 실행되기 전에 `SocketIoMessageGuardContext`를 받습니다. Guard는 `true`, `false`, 또는 `message`, optional `data`, optional `disconnect`를 가진 `SocketIoGuardRejection`을 반환할 수 있으며, message rejection은 `{ error, data }` 형태의 ACK payload를 사용합니다.
 
 ### Bun 전용 참고
 
-Bun path는 `@socket.io/bun-engine`을 통해 Socket.IO를 지원하지만 static CORS shape가 필요합니다. CORS delegate function과 `cors.origin` array 안의 boolean entry는 지원하지 않습니다. `@WebSocketGateway({ serverBacked })`는 Bun에서 지원하지 않습니다.
+Bun path는 `@socket.io/bun-engine`을 통해 Socket.IO를 지원하지만 static CORS shape가 필요합니다. CORS delegate function과 `cors.origin` array 안의 boolean entry는 지원하지 않습니다. `@WebSocketGateway({ serverBacked })`는 Bun에서 지원하지 않습니다. Bun의 HTTP request body limit(`maxRequestBodySize`)과 WebSocket frame limit(`websocket.maxPayloadLength`)은 별도 host contract입니다. 어댑터는 polling request와 websocket frame이 같은 inbound payload bound를 따르도록 두 값을 모두 `engine.maxHttpBufferSize`에서 매핑합니다.
 
 ### 모듈 등록
 `SocketIoModule.forRoot(...)`로 Socket.IO를 등록합니다.

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -107,13 +107,17 @@ SocketIoModule.forRoot({
 
 When `cors` is omitted, `@fluojs/socket.io` defaults to `{ credentials: false, origin: false }` so cross-origin exposure stays opt-in. When `engine.maxHttpBufferSize` is omitted, the adapter applies a bounded 1 MiB Engine.IO payload limit. Defaults also include `buffer.maxPendingMessagesPerSocket: 128`, `buffer.overflowPolicy: 'drop-oldest'`, and `shutdown.timeoutMs: 5000`.
 
+Static `@WebSocketGateway({ path })` namespaces are owned by fluo's gateway discovery and are not treated as Socket.IO dynamic child namespaces. The adapter keeps Socket.IO's `cleanupEmptyChildNamespaces` behavior disabled for those static namespaces. If application code creates dynamic child namespaces through raw `SOCKETIO_SERVER` access, that ownership and cleanup policy stays with the application-level Socket.IO integration.
+
+During application shutdown, Socket.IO owns cleanup for connected Socket.IO clients, but the underlying HTTP server remains owned by the platform adapter or shared HTTP server integration that supplied it. The adapter detaches that HTTP server reference before `io.close(...)`, so client cleanup still runs while Socket.IO does not close adapter-owned/shared HTTP listeners. Do not add a second manual socket-disconnect path around the same managed Socket.IO instance.
+
 ### Guard contracts
 
 `auth.connection` receives `SocketIoConnectionGuardContext` before namespace connect handlers run. `auth.message` receives `SocketIoMessageGuardContext` before message handlers run. Guards can return `true`, `false`, or a `SocketIoGuardRejection` with `message`, optional `data`, and optional `disconnect`; message rejections use ACK payloads shaped as `{ error, data }`.
 
 ### Bun-specific notes
 
-The Bun path supports Socket.IO through `@socket.io/bun-engine`, but it requires static CORS shapes: no CORS delegate functions and no boolean entries inside `cors.origin` arrays. `@WebSocketGateway({ serverBacked })` is not supported on Bun.
+The Bun path supports Socket.IO through `@socket.io/bun-engine`, but it requires static CORS shapes: no CORS delegate functions and no boolean entries inside `cors.origin` arrays. `@WebSocketGateway({ serverBacked })` is not supported on Bun. Bun's HTTP request body limit (`maxRequestBodySize`) and WebSocket frame limit (`websocket.maxPayloadLength`) are separate host contracts; the adapter maps both from `engine.maxHttpBufferSize` so polling requests and websocket frames share the configured inbound payload bound.
 
 ### Module registration
 Register Socket.IO with `SocketIoModule.forRoot(...)`.

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -103,6 +103,12 @@ interface BunEngineCorsOptions {
   origin?: boolean | RegExp | string | Array<RegExp | string>;
 }
 
+interface BunEngineOptions {
+  cors?: BunEngineCorsOptions;
+  maxHttpBufferSize?: number;
+  path: string;
+}
+
 interface BunRealtimeBindingHost {
   configureRealtimeBinding(binding: BunRealtimeBinding | undefined): void;
 }
@@ -499,12 +505,8 @@ export class SocketIoLifecycleService
     return options;
   }
 
-  private createBunEngineOptions() {
-    const options: {
-      cors?: BunEngineCorsOptions;
-      maxHttpBufferSize?: number;
-      path: string;
-    } = {
+  private createBunEngineOptions(): BunEngineOptions {
+    const options: BunEngineOptions = {
       path: DEFAULT_SOCKETIO_ENGINE_PATH,
     };
 
@@ -541,6 +543,7 @@ export class SocketIoLifecycleService
 
   private createBunSocketIoBinding(engine: BunEngineServer): BunRealtimeBinding {
     const handler = engine.handler();
+    const maxHttpBufferSize = this.resolveMaxHttpBufferSize();
 
     return {
       fetch: async (request, server) => {
@@ -553,10 +556,10 @@ export class SocketIoLifecycleService
         return await engine.handleRequest(request, server as never);
       },
       idleTimeout: handler.idleTimeout,
-      maxRequestBodySize: handler.maxRequestBodySize,
+      maxRequestBodySize: maxHttpBufferSize,
       websocket: {
         close: handler.websocket.close as BunRealtimeBinding['websocket']['close'],
-        maxPayloadLength: handler.websocket.maxPayloadLength,
+        maxPayloadLength: maxHttpBufferSize,
         message: handler.websocket.message as BunRealtimeBinding['websocket']['message'],
         open: handler.websocket.open as BunRealtimeBinding['websocket']['open'],
       },
@@ -1161,8 +1164,8 @@ export class SocketIoLifecycleService
         reject(new Error(`Timed out while closing Socket.IO server after ${String(timeoutMs)}ms.`));
       }, timeoutMs);
 
-      // Prevent Socket.IO from stealing the HTTP server shutdown
-      (io as any).httpServer = undefined;
+      // Socket.IO owns client cleanup; the shared HTTP server remains owned by the platform adapter.
+      (io as Omit<Server, 'httpServer'> & { httpServer?: unknown }).httpServer = undefined;
 
       io.close(() => {
         if (settled) {

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -484,7 +484,9 @@ export class SocketIoLifecycleService
   }
 
   private createServerOptions(): Partial<ServerOptions> {
-    const options: Partial<ServerOptions> = {};
+    const options: Partial<ServerOptions> = {
+      cleanupEmptyChildNamespaces: false,
+    };
 
     options.cors = this.resolveCorsOptions();
 
@@ -500,12 +502,14 @@ export class SocketIoLifecycleService
   private createBunEngineOptions() {
     const options: {
       cors?: BunEngineCorsOptions;
+      maxHttpBufferSize?: number;
       path: string;
     } = {
       path: DEFAULT_SOCKETIO_ENGINE_PATH,
     };
 
     options.cors = normalizeCorsForBunEngine(this.resolveCorsOptions());
+    options.maxHttpBufferSize = this.resolveMaxHttpBufferSize();
 
     return options;
   }
@@ -1156,6 +1160,9 @@ export class SocketIoLifecycleService
         settled = true;
         reject(new Error(`Timed out while closing Socket.IO server after ${String(timeoutMs)}ms.`));
       }, timeoutMs);
+
+      // Prevent Socket.IO from stealing the HTTP server shutdown
+      (io as any).httpServer = undefined;
 
       io.close(() => {
         if (settled) {

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -494,7 +494,7 @@ describe('@fluojs/socket.io', () => {
     await app.close();
   });
 
-  it('uses safe deny-by-default CORS and bounded engine defaults when options are omitted', () => {
+  it('uses safe CORS, bounded engine defaults, and static namespace cleanup ownership when options are omitted', () => {
     const service = new SocketIoLifecycleService(
       {} as never,
       [] as never,
@@ -509,16 +509,107 @@ describe('@fluojs/socket.io', () => {
     );
 
     const serverOptions = Reflect.get(service, 'createServerOptions').call(service) as {
+      cleanupEmptyChildNamespaces?: boolean;
       cors?: unknown;
       maxHttpBufferSize?: number;
     };
     const bunOptions = Reflect.get(service, 'createBunEngineOptions').call(service) as {
       cors?: unknown;
+      maxHttpBufferSize?: number;
     };
 
     expect(serverOptions.cors).toEqual({ credentials: false, origin: false });
+    expect(serverOptions.cleanupEmptyChildNamespaces).toBe(false);
     expect(serverOptions.maxHttpBufferSize).toBe(1_048_576);
     expect(bunOptions.cors).toEqual({ credentials: false, origin: false });
+    expect(bunOptions.maxHttpBufferSize).toBe(1_048_576);
+  });
+
+  it('maps Bun HTTP request-body and websocket payload limits from the engine payload bound', () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getRealtimeCapability() {
+          return createServerBackedHttpAdapterRealtimeCapability({});
+        },
+      } as never,
+      {
+        engine: {
+          maxHttpBufferSize: 256,
+        },
+      },
+    );
+    const engine = {
+      handler() {
+        return {
+          idleTimeout: 120,
+          maxRequestBodySize: 999,
+          websocket: {
+            close() {},
+            maxPayloadLength: 999,
+            message() {},
+            open() {},
+          },
+        };
+      },
+      handleRequest() {
+        return new Response();
+      },
+    };
+    const binding = Reflect.get(service, 'createBunSocketIoBinding').call(service, engine) as {
+      maxRequestBodySize?: number;
+      websocket: { maxPayloadLength?: number };
+    };
+
+    expect(binding.maxRequestBodySize).toBe(256);
+    expect(binding.websocket.maxPayloadLength).toBe(256);
+  });
+
+  it('lets io.close clean clients without closing the adapter-owned shared HTTP server', async () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getRealtimeCapability() {
+          return createServerBackedHttpAdapterRealtimeCapability({});
+        },
+      } as never,
+      {},
+    );
+    const calls: string[] = [];
+    const sharedHttpServer = {
+      close() {
+        calls.push('http-close');
+      },
+      emit() {
+        return true;
+      },
+      listeners() {
+        return [];
+      },
+      on() {
+        return this;
+      },
+      removeAllListeners() {
+        return this;
+      },
+    };
+    const io = {
+      httpServer: sharedHttpServer,
+      close(this: { httpServer?: unknown }, callback: () => void) {
+        calls.push(this.httpServer === undefined ? 'client-cleanup' : 'http-server-still-attached');
+        callback();
+      },
+    } as unknown as SocketIoServer;
+
+    await Reflect.get(service, 'closeServerWithTimeout').call(service, io, 100);
+
+    expect(calls).toEqual(['client-cleanup']);
   });
 
   it('rejects incomplete server-like bridge objects before constructing Socket.IO', () => {

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -842,6 +842,60 @@ describe('@fluojs/socket.io', () => {
     await app.close();
   });
 
+  it('disconnects Bun-style sockets when inbound payloads exceed the configured engine limit', async () => {
+    const port = await findAvailablePort();
+    const adapter = new TestBunSocketIoAdapter(port);
+
+    class GatewayState {
+      messages: unknown[] = [];
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/bun-payload-limit' })
+    class PayloadGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnMessage('ping')
+      onPing(payload: unknown) {
+        this.state.messages.push(payload);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({
+        engine: {
+          maxHttpBufferSize: 32,
+        },
+        transports: ['polling'],
+      })],
+      providers: [GatewayState, PayloadGateway],
+    });
+
+    const app = await bootstrapApplication({
+      adapter,
+      rootModule: AppModule,
+    });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+
+    await app.listen();
+
+    const socket = createClient(`http://127.0.0.1:${String(port)}/bun-payload-limit`, {
+      reconnection: false,
+      transports: ['polling'],
+    });
+    await onceConnected(socket);
+
+    const disconnected = onceDisconnected(socket);
+    socket.emit('ping', 'x'.repeat(256));
+
+    expect(['transport close', 'transport error']).toContain(await disconnected);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(state.messages).toEqual([]);
+
+    await app.close();
+  });
+
   for (const scenario of supportedSocketIoAdapterScenarios) {
     it(`boots a real ${scenario.name} app and handles connect, message, room broadcast, and disconnect`, async () => {
     class GatewayState {


### PR DESCRIPTION
## Summary

This PR addresses the P1 contract/runtime risks in `@fluojs/socket.io` identified in the package audit. It clarifies namespace ownership, prevents Socket.IO from aggressively shutting down the shared HTTP server, and properly enforces Bun payload limits.

Closes #1591.

## Changes

- Set `cleanupEmptyChildNamespaces: false` in Socket.IO server options to ensure statically defined gateway namespaces are not prematurely cleaned up.
- Detach the underlying HTTP server from the Socket.IO instance before calling `io.close()` during shutdown to prevent Socket.IO from shutting down the shared HTTP server.
- Forward `engine.maxHttpBufferSize` to the Bun engine binding so both HTTP body limits and WebSocket payload limits are correctly bounded under `@fluojs/platform-bun`.
- Added a regression test specifically for testing Bun payload limits using the `TestBunSocketIoAdapter`.

## Testing

- Verified with `pnpm verify` (build, lint, typecheck, tests).
- Added `disconnects Bun-style sockets when inbound payloads exceed the configured engine limit` regression test in `module.test.ts`.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.