### PR TITLE
Resolve #1598: Align email cancellation diagnostics

### DIFF
--- a/.changeset/email-cancellation-diagnostics.md
+++ b/.changeset/email-cancellation-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Reject blank email recipients before transport handoff, honor aborted sends before rendering or provider delivery, and preserve lifecycle provider errors as diagnostic causes.

--- a/book/intermediate/ch16-email.ko.md
+++ b/book/intermediate/ch16-email.ko.md
@@ -151,25 +151,26 @@ NotificationsModule.forRootAsync({
 
 ```typescript
 EmailModule.forRoot({
-  template: {
-    renderer: async (name, data) => {
+  renderer: {
+    render: async ({ payload, template }) => {
       // 렌더링 로직
-      return { html: `<h1>안녕하세요 ${data.name}님</h1>` };
+      const data = payload.templateData ?? {};
+      return { html: `<h1>안녕하세요 ${String(data.name)}님</h1>`, subject: template };
     },
   },
 });
 ```
 
-렌더러를 등록하면 전송 요청에서 `templateData`를 넘겨 템플릿 기반 메일을 생성할 수 있습니다.
+렌더러를 등록하면 notification 요청에서 `template`과 `payload.templateData`를 넘겨 템플릿 기반 메일을 생성할 수 있습니다. 명시적인 `payload.text`, `payload.html`, `subject` 값은 렌더링된 fallback보다 우선합니다.
 
 ## 16.8 Status and Health Checks
 
-이메일 시스템은 네트워크, 인증, 공급자 장애의 영향을 받는 외부 의존성입니다. 트랜스포트 상태를 운영 지표로 확인하려면 `createEmailPlatformStatusSnapshot`을 사용합니다.
+이메일 시스템은 네트워크, 인증, 공급자 장애의 영향을 받는 외부 의존성입니다. 트랜스포트 상태를 운영 지표로 확인하려면 `EmailService.createPlatformStatusSnapshot()`을 사용합니다.
 
 ```typescript
-const snapshot = await createEmailPlatformStatusSnapshot(emailService);
-if (!snapshot.isReady) {
-  console.error('이메일 트랜스포트가 오프라인입니다:', snapshot.reason);
+const snapshot = emailService.createPlatformStatusSnapshot();
+if (snapshot.readiness.status !== 'ready') {
+  console.error('이메일 트랜스포트가 오프라인입니다:', snapshot.readiness.reason);
 }
 ```
 

--- a/book/intermediate/ch16-email.ko.md
+++ b/book/intermediate/ch16-email.ko.md
@@ -186,8 +186,8 @@ async sendOrderConfirmation(order: Order) {
     channel: 'email',
     recipients: [order.customerEmail],
     subject: 'FluoShop 주문 확인',
+    template: 'order-success',
     payload: {
-      template: 'order-success',
       templateData: {
         orderId: order.id,
         items: order.items,

--- a/book/intermediate/ch16-email.md
+++ b/book/intermediate/ch16-email.md
@@ -151,25 +151,26 @@ The queue adapter splits bulk notifications into individual background jobs and 
 
 ```typescript
 EmailModule.forRoot({
-  template: {
-    renderer: async (name, data) => {
+  renderer: {
+    render: async ({ payload, template }) => {
       // Rendering logic
-      return { html: `<h1>Hello, ${data.name}</h1>` };
+      const data = payload.templateData ?? {};
+      return { html: `<h1>Hello, ${String(data.name)}</h1>`, subject: template };
     },
   },
 });
 ```
 
-After registering a renderer, you can pass `templateData` in send requests to create template-based emails.
+After registering a renderer, notification requests can pass `template` and `payload.templateData` to create template-based emails. Explicit `payload.text`, `payload.html`, and `subject` values still override rendered fallbacks.
 
 ## 16.8 Status and Health Checks
 
-The Email system is an external dependency affected by network, authentication, and provider failures. Use `createEmailPlatformStatusSnapshot` to check transport status as an operational signal.
+The Email system is an external dependency affected by network, authentication, and provider failures. Use `EmailService.createPlatformStatusSnapshot()` to check transport status as an operational signal.
 
 ```typescript
-const snapshot = await createEmailPlatformStatusSnapshot(emailService);
-if (!snapshot.isReady) {
-  console.error('Email transport is offline:', snapshot.reason);
+const snapshot = emailService.createPlatformStatusSnapshot();
+if (snapshot.readiness.status !== 'ready') {
+  console.error('Email transport is offline:', snapshot.readiness.reason);
 }
 ```
 

--- a/book/intermediate/ch16-email.md
+++ b/book/intermediate/ch16-email.md
@@ -186,8 +186,8 @@ async sendOrderConfirmation(order: Order) {
     channel: 'email',
     recipients: [order.customerEmail],
     subject: 'FluoShop order confirmation',
+    template: 'order-success',
     payload: {
-      template: 'order-success',
       templateData: {
         orderId: order.id,
         items: order.items,

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -162,10 +162,13 @@ EmailModule.forRootAsync({
 Behavioral contract 메모:
 
 - `EmailService.send(...)`는 전달 전에 `defaultFrom`과 `defaultReplyTo`를 해석합니다.
+- `EmailService.send(...)`는 빈 `to` 수신자를 transport handoff 전에 거부하므로 transport가 빈 전달 대상을 받지 않습니다.
+- `EmailService.send(...)`와 `EmailService.sendNotification(...)`은 이미 abort된 `AbortSignal`을 템플릿 렌더링 또는 transport handoff 전에 반영합니다.
 - `EmailService.send(...)`는 `accepted`, `pending`, `rejected` 수신자를 분리해 보존하므로 provider의 부분 실패가 호출자에게 그대로 보입니다.
 - `EmailService.sendMany(...)`는 기본적으로 fail-fast입니다. 실패를 batch result에 수집하려면 `continueOnError: true`를 전달합니다.
 - `EmailService.createPlatformStatusSnapshot()`은 diagnostics를 위해 lifecycle, readiness, health, transport ownership details를 노출합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
+- transport `verify()`와 `close()`에서 발생한 provider error는 diagnostics를 위해 lifecycle failure의 `cause`로 보존됩니다.
 - 모듈 옵션은 provider wiring 전에 trim 및 normalize됩니다. 여기에는 sender 기본값, notification channel 이름, transport factory 소유권이 포함됩니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -162,10 +162,13 @@ EmailModule.forRootAsync({
 Behavioral contract notes:
 
 - `EmailService.send(...)` resolves `defaultFrom` and `defaultReplyTo` before delivery.
+- `EmailService.send(...)` rejects blank `to` recipients before handoff so transports never receive an empty delivery target.
+- `EmailService.send(...)` and `EmailService.sendNotification(...)` honor an already-aborted `AbortSignal` before template rendering or transport handoff.
 - `EmailService.send(...)` preserves `accepted`, `pending`, and `rejected` recipients separately so partial provider failures stay caller-visible.
 - `EmailService.sendMany(...)` is fail-fast by default; pass `continueOnError: true` to collect failures in a batch result.
 - `EmailService.createPlatformStatusSnapshot()` exposes lifecycle, readiness, health, and transport ownership details for diagnostics.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
+- Transport `verify()` and `close()` provider errors are preserved as the `cause` of lifecycle failures for diagnostics.
 - Module options are trimmed and normalized before provider wiring, including sender defaults, notification channel names, and transport factory ownership.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.
 

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -617,6 +617,38 @@ describe('EmailModule', () => {
     expect(transportState.sent).toHaveLength(0);
   });
 
+  it('aborts notification delivery after template rendering before transport handoff', async () => {
+    const controller = new AbortController();
+    const render = vi.fn(async () => {
+      controller.abort();
+
+      return { text: 'rendered' };
+    });
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      renderer: { render },
+      transport: createRecordingTransportFactory(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    await expect(
+      service.sendNotification(
+        {
+          channel: 'email',
+          payload: {},
+          recipients: ['user@example.com'],
+          template: 'welcome',
+        },
+        { signal: controller.signal },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(render).toHaveBeenCalledOnce();
+    expect(transportState.sent).toHaveLength(0);
+  });
+
   it('preserves provider errors as lifecycle failure causes', async () => {
     const initContainer = new Container();
     const initModule = EmailModule.forRoot({

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -147,7 +147,7 @@ import { EmailNotificationQueueJob, EmailNotificationsQueueWorker, createEmailNo
 import { EmailModule } from './module.js';
 import { EmailService } from './service.js';
 import { EMAIL } from './tokens.js';
-import { EmailConfigurationError } from './errors.js';
+import { EmailConfigurationError, EmailMessageValidationError } from './errors.js';
 import type { Email, EmailTransport, EmailTransportFactory, NormalizedEmailMessage } from './types.js';
 
 class PartialDeliveryTransport implements EmailTransport {
@@ -214,6 +214,31 @@ class PassiveTransport implements EmailTransport {
       pending: [],
       rejected: [],
     };
+  }
+}
+
+class FailingLifecycleTransport implements EmailTransport {
+  constructor(private readonly failurePoint: 'verify' | 'close') {}
+
+  async close(): Promise<void> {
+    if (this.failurePoint === 'close') {
+      throw new Error('provider close failed');
+    }
+  }
+
+  async send(): Promise<{ accepted: string[]; messageId: string; pending: []; rejected: [] }> {
+    return {
+      accepted: ['user@example.com'],
+      messageId: 'lifecycle-1',
+      pending: [],
+      rejected: [],
+    };
+  }
+
+  async verify(): Promise<void> {
+    if (this.failurePoint === 'verify') {
+      throw new Error('provider verify failed');
+    }
   }
 }
 
@@ -540,6 +565,93 @@ describe('EmailModule', () => {
     ).rejects.toMatchObject({
       message: 'Email transport reported an incomplete delivery (accepted=1, pending=1, rejected=1).',
       name: 'EmailDeliveryError',
+    });
+  });
+
+  it('rejects blank recipients before transport delivery', async () => {
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: createRecordingTransportFactory(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    await expect(
+      service.send({
+        subject: 'Blank recipient',
+        text: 'hello',
+        to: ['   '],
+      }),
+    ).rejects.toThrowError(new EmailMessageValidationError('Email messages require non-empty recipients in `to`.'));
+    expect(transportState.sent).toHaveLength(0);
+  });
+
+  it('aborts notification delivery before template rendering starts', async () => {
+    const controller = new AbortController();
+    const render = vi.fn(async () => ({ text: 'rendered' }));
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      renderer: { render },
+      transport: createRecordingTransportFactory(),
+    });
+
+    controller.abort();
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    await expect(
+      service.sendNotification(
+        {
+          channel: 'email',
+          payload: {},
+          recipients: ['user@example.com'],
+          template: 'welcome',
+        },
+        { signal: controller.signal },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(render).not.toHaveBeenCalled();
+    expect(transportState.sent).toHaveLength(0);
+  });
+
+  it('preserves provider errors as lifecycle failure causes', async () => {
+    const initContainer = new Container();
+    const initModule = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create: async () => new FailingLifecycleTransport('verify'),
+        ownsResources: true,
+      },
+      verifyOnModuleInit: true,
+    });
+
+    initContainer.register(...moduleProviders(initModule));
+    const initService = await initContainer.resolve(EmailService);
+
+    await expect(initService.onModuleInit()).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: 'provider verify failed' }),
+      message: 'Email transport failed to initialize.',
+    });
+
+    const shutdownContainer = new Container();
+    const shutdownModule = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create: async () => new FailingLifecycleTransport('close'),
+        ownsResources: true,
+      },
+    });
+
+    shutdownContainer.register(...moduleProviders(shutdownModule));
+    const shutdownService = await shutdownContainer.resolve(EmailService);
+    await shutdownService.send({ subject: 'Lifecycle', text: 'hello', to: ['user@example.com'] });
+
+    await expect(shutdownService.onApplicationShutdown()).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: 'provider close failed' }),
+      message: 'Email transport failed to close cleanly.',
     });
   });
 

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -50,9 +50,23 @@ function createAbortError(): Error {
   return error;
 }
 
+function assertNotAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+}
+
+function createLifecycleError(message: string, cause: unknown): Error {
+  return new Error(message, { cause });
+}
+
 function assertMessageContent(message: NormalizedEmailMessage): void {
   if (message.to.length === 0) {
     throw new EmailMessageValidationError('Email messages require at least one recipient in `to`.');
+  }
+
+  if (message.to.some((entry) => entry.address.length === 0)) {
+    throw new EmailMessageValidationError('Email messages require non-empty recipients in `to`.');
   }
 
   if (!message.from.address) {
@@ -89,9 +103,9 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
       }
 
       this.lifecycleState = 'stopped';
-    } catch {
+    } catch (error) {
       this.lifecycleState = 'failed';
-      throw new Error('Email transport failed to close cleanly.');
+      throw createLifecycleError('Email transport failed to close cleanly.', error);
     }
   }
 
@@ -106,9 +120,9 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
       }
 
       this.lifecycleState = 'ready';
-    } catch {
+    } catch (error) {
       this.lifecycleState = 'failed';
-      throw new Error('Email transport failed to initialize.');
+      throw createLifecycleError('Email transport failed to initialize.', error);
     }
   }
 
@@ -148,13 +162,12 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
    * ```
    */
   async send(message: EmailMessage, options: EmailSendOptions = {}): Promise<EmailSendResult> {
-    if (options.signal?.aborted) {
-      throw createAbortError();
-    }
+    assertNotAborted(options.signal);
 
     const transport = await this.ensureTransport();
     const normalized = this.normalizeMessage(message);
     assertMessageContent(normalized);
+    assertNotAborted(options.signal);
     const result = await transport.send(normalized, options);
 
     return {
@@ -232,7 +245,9 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     options: EmailSendOptions = {},
   ): Promise<EmailSendResult> {
     const payload = notification.payload;
-    const rendered = await this.renderNotification(notification);
+    const rendered = await this.renderNotification(notification, options.signal);
+
+    assertNotAborted(options.signal);
 
     return this.send(
       {
@@ -296,10 +311,13 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
 
   private async renderNotification(
     notification: EmailNotificationDispatchRequest,
+    signal: AbortSignal | undefined,
   ): Promise<EmailTemplateRenderResult | undefined> {
     if (!notification.template || !this.options.renderer) {
       return undefined;
     }
+
+    assertNotAborted(signal);
 
     return this.options.renderer.render({
       locale: notification.locale,


### PR DESCRIPTION
## Summary

Closes #1598.

Aligns `@fluojs/email` runtime behavior and tutorial/package docs after the notifications lifecycle fixes from #1597.

## Changes

- Reject blank `to` recipients before provider handoff and preserve provider `verify()`/`close()` errors as lifecycle failure causes.
- Honor already-aborted send signals before template rendering and before transport delivery.
- Update EN/KO package README and Chapter 16 book snippets for the current renderer and status snapshot APIs.
- Add a patch changeset for the public `@fluojs/email` behavior update.

## Testing

- `pnpm --filter @fluojs/email test`
- `pnpm --filter @fluojs/email... build`
- `pnpm --filter @fluojs/email typecheck`
- `pnpm lint` (passes; reports existing repository-wide Biome warnings outside the changed email/book files)
- LSP diagnostics: clean for changed TypeScript files (`packages/email/src/service.ts`, `packages/email/src/module.test.ts`)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; existing `EmailService` behavior docs were updated in README mirrors.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. EN/KO README and book mirrors were updated together; regression coverage lives in `packages/email/src/module.test.ts`.