### PR TITLE
Resolve #1605: Align Vite plugin runtime dependencies

### DIFF
--- a/.changeset/silver-vite-boundaries.md
+++ b/.changeset/silver-vite-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/vite": patch
+---
+
+Align the Vite plugin peer dependency contract with its Babel runtime resolution and tighten transform boundaries for application TypeScript files.

--- a/.changeset/silver-vite-boundaries.md
+++ b/.changeset/silver-vite-boundaries.md
@@ -1,5 +1,7 @@
 ---
-"@fluojs/vite": patch
+"@fluojs/vite": minor
 ---
 
 Align the Vite plugin peer dependency contract with its Babel runtime resolution and tighten transform boundaries for application TypeScript files.
+
+This is a consumer-visible install contract change: `@babel/core` now requires `>=7.26.0`, `vite` now requires `>=6.2.0`, and the Babel decorator plugin/TypeScript preset are explicit peers. The minor bump is intentional for this beta package because consumers below those peer floors must update their build dependencies before upgrading.

--- a/packages/vite/README.ko.md
+++ b/packages/vite/README.ko.md
@@ -19,7 +19,7 @@ fluo 프로젝트를 위한 Vite 플러그인과 빌드 유틸리티입니다.
 npm install --save-dev @fluojs/vite vite @babel/core @babel/plugin-proposal-decorators @babel/preset-typescript
 ```
 
-`@babel/core`와 `vite`는 peer dependency입니다. `fluoDecoratorsPlugin()`이 Vite transform 시점에 decorator plugin과 TypeScript preset을 해석하므로 consuming project에는 `@babel/plugin-proposal-decorators`와 `@babel/preset-typescript`도 필요합니다.
+`@babel/core` `>=7.26.0`, `@babel/plugin-proposal-decorators` `>=7.28.0`, `@babel/preset-typescript` `>=7.27.0`, `vite` `>=6.2.0`은 peer dependency입니다. `fluoDecoratorsPlugin()`이 Vite transform 시점에 Babel decorator plugin과 TypeScript preset을 해석하기 때문입니다.
 
 ## 사용 시점
 
@@ -42,7 +42,7 @@ export default defineConfig({
 });
 ```
 
-이 플러그인은 `.ts` 애플리케이션 파일을 Babel로 변환하며 `2023-11` decorators proposal과 `@babel/preset-typescript`를 사용합니다. 경로에 `.test.`가 포함된 파일은 건너뛰므로 생성된 Vitest 테스트 파일은 계속 전용 `@fluojs/testing/vitest` transform 경로를 사용합니다.
+이 플러그인은 `.ts` 애플리케이션 파일을 Babel로 변환하며 `2023-11` decorators proposal과 `@babel/preset-typescript`를 사용합니다. declaration 파일, `.test.` 또는 `.spec.` 파일, `node_modules`, `.ts`가 아닌 파일은 건너뛰므로 생성된 Vitest 테스트 파일은 계속 전용 `@fluojs/testing/vitest` transform 경로를 사용합니다.
 
 ## 공개 API
 

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -19,7 +19,7 @@ Vite plugin and build utilities for fluo projects.
 npm install --save-dev @fluojs/vite vite @babel/core @babel/plugin-proposal-decorators @babel/preset-typescript
 ```
 
-`@babel/core` and `vite` are peer dependencies. The decorator plugin and TypeScript preset must also be available in the consuming project because `fluoDecoratorsPlugin()` resolves them when Vite transforms source files.
+`@babel/core` `>=7.26.0`, `@babel/plugin-proposal-decorators` `>=7.28.0`, `@babel/preset-typescript` `>=7.27.0`, and `vite` `>=6.2.0` are peer dependencies because `fluoDecoratorsPlugin()` resolves the Babel decorator plugin and TypeScript preset when Vite transforms source files.
 
 ## When to Use
 
@@ -42,7 +42,7 @@ export default defineConfig({
 });
 ```
 
-The plugin transforms `.ts` application files with Babel using the `2023-11` decorators proposal and `@babel/preset-typescript`. It skips files whose path includes `.test.` so generated Vitest test files continue to use the dedicated `@fluojs/testing/vitest` transform path.
+The plugin transforms `.ts` application files with Babel using the `2023-11` decorators proposal and `@babel/preset-typescript`. It skips declaration files, `.test.` or `.spec.` files, `node_modules`, and non-`.ts` files so generated Vitest test files continue to use the dedicated `@fluojs/testing/vitest` transform path.
 
 ## Public API
 

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -42,8 +42,10 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "peerDependencies": {
-    "@babel/core": ">=7.0.0",
-    "vite": ">=5.0.0"
+    "@babel/core": ">=7.26.0",
+    "@babel/plugin-proposal-decorators": ">=7.28.0",
+    "@babel/preset-typescript": ">=7.27.0",
+    "vite": ">=6.2.0"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/vite/src/index.test.ts
+++ b/packages/vite/src/index.test.ts
@@ -3,27 +3,36 @@ import type { Plugin } from 'vite';
 
 import { fluoDecoratorsPlugin } from './index.js';
 
-function getTransform(plugin: Plugin): Extract<Plugin['transform'], (...args: never[]) => unknown> {
+function runTransform(plugin: Plugin, code: string, id: string): unknown {
   if (typeof plugin.transform !== 'function') {
     throw new Error('Expected fluoDecoratorsPlugin to expose a callable transform hook.');
   }
 
-  return plugin.transform as Extract<Plugin['transform'], (...args: never[]) => unknown>;
+  return Reflect.apply(plugin.transform, {}, [code, id]);
 }
 
 describe('fluoDecoratorsPlugin', () => {
   it('skips generated test files', async () => {
     const plugin = fluoDecoratorsPlugin();
-    const transform = getTransform(plugin);
 
-    await expect(transform.call({} as never, 'export const value: number = 1;', '/app/src/app.test.ts')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.test.ts')).resolves.toBeNull();
+  });
+
+  it('keeps the Vite transform boundary on application TypeScript files', async () => {
+    const plugin = fluoDecoratorsPlugin();
+
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.spec.ts')).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/types.d.ts')).resolves.toBeNull();
+    await expect(
+      runTransform(plugin, 'export const value: number = 1;', '/app/node_modules/dependency/index.ts'),
+    ).resolves.toBeNull();
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.tsx')).resolves.toBeNull();
   });
 
   it('transforms TypeScript files with standard decorators through Babel', async () => {
     const plugin = fluoDecoratorsPlugin();
-    const transform = getTransform(plugin);
-    const result = await transform.call(
-      {} as never,
+    const result = await runTransform(
+      plugin,
       `function logged(value: unknown, context: ClassMethodDecoratorContext) {
   context.name;
 }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,6 +1,16 @@
 import { transformAsync } from '@babel/core';
 import type { Plugin } from 'vite';
 
+function shouldTransformTypeScriptApplicationFile(id: string): boolean {
+  const [filePath] = id.split('?', 1);
+
+  if (!filePath.endsWith('.ts') || filePath.endsWith('.d.ts')) {
+    return false;
+  }
+
+  return !filePath.includes('/node_modules/') && !filePath.includes('.test.') && !filePath.includes('.spec.');
+}
+
 /**
  * Creates the Vite transform plugin used by fluo starter projects to compile
  * TC39 standard decorator syntax through Babel before Vite bundles the app.
@@ -21,14 +31,16 @@ export function fluoDecoratorsPlugin(): Plugin {
   return {
     name: 'fluo-babel-decorators',
     async transform(code: string, id: string) {
-      if (!id.endsWith('.ts') || id.includes('.test.')) {
+      if (!shouldTransformTypeScriptApplicationFile(id)) {
         return null;
       }
+
+      const [filename] = id.split('?', 1);
 
       const result = await transformAsync(code, {
         babelrc: false,
         configFile: false,
-        filename: id,
+        filename,
         plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]],
         presets: [['@babel/preset-typescript', { allowDeclareFields: true }]],
         sourceMaps: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,10 +962,16 @@ importers:
   packages/vite:
     dependencies:
       '@babel/core':
-        specifier: '>=7.0.0'
+        specifier: '>=7.26.0'
         version: 7.29.0
+      '@babel/plugin-proposal-decorators':
+        specifier: '>=7.28.0'
+        version: 7.29.0(@babel/core@7.29.0)
+      '@babel/preset-typescript':
+        specifier: '>=7.27.0'
+        version: 7.28.5(@babel/core@7.29.0)
       vite:
-        specifier: '>=5.0.0'
+        specifier: '>=6.2.0'
         version: 6.4.1(@types/node@22.19.15)(tsx@4.21.0)
     devDependencies:
       vitest:


### PR DESCRIPTION
## Summary

- Closes #1605.
- Aligns `@fluojs/vite` peer metadata with the Babel plugin/preset that `fluoDecoratorsPlugin()` resolves during Vite transforms.
- Tightens and documents the Vite plugin transform boundary for application TypeScript files.

## Changes

- Added `@babel/plugin-proposal-decorators` and `@babel/preset-typescript` as explicit peers, and raised Babel/Vite peer floors to match the repo toolchain contract.
- Skips declaration files, `.spec.` files, `node_modules`, and non-`.ts` files in the Vite transform path while preserving `.test.` skipping.
- Updated EN/KO `@fluojs/vite` README contract text and added a minor changeset.
- Release note: this is a consumer-visible peer dependency floor change (`@babel/core >=7.26.0`, `vite >=6.2.0`, plus explicit Babel plugin/preset peers). The minor bump is intentional for this beta package because consumers below those floors must update build dependencies before upgrading.

## Testing

- `lsp_diagnostics` on `packages/vite/src/index.ts`: clean
- `lsp_diagnostics` on `packages/vite/src/index.test.ts`: clean
- `pnpm --dir packages/vite test`
- `pnpm --dir packages/vite typecheck`
- `pnpm --dir packages/vite build`
- `pnpm changeset status --since=main`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; the existing `fluoDecoratorsPlugin()` TSDoc remains in place.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed.