### PR TITLE
Resolve #1599: Stop retrying permanent Slack webhook failures

### DIFF
--- a/.changeset/slack-permanent-webhook-failures.md
+++ b/.changeset/slack-permanent-webhook-failures.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Stop retrying permanent Slack webhook failures such as 403 and 404 while preserving bounded retries for transient webhook statuses.

--- a/book/intermediate/ch17-slack-discord.md
+++ b/book/intermediate/ch17-slack-discord.md
@@ -196,7 +196,7 @@ async alertOps(event: OrderPlacedEvent) {
 The built-in webhook transports are designed around failure patterns seen in production environments.
 
 - **Automatic retry**: Transient `408`, `429`, and `5xx` errors are retried with exponential backoff.
-- **Explicit errors**: Permanent failures, such as 404 or 403, are surfaced as `SlackTransportError` or `DiscordTransportError` so the application level can handle them.
+- **Explicit errors**: Permanent failures, such as 404 or 403, are not retried and are surfaced as `SlackTransportError` or `DiscordTransportError` so the application level can handle them.
 
 ## 17.8 Status Snapshots
 

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -196,7 +196,7 @@ await slack.send({
 
 Behavioral contract 메모:
 
-- 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 실패를 호출자에게 에러를 노출하기 전에 bounded exponential backoff로 재시도합니다.
+- 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 실패를 호출자에게 에러를 노출하기 전에 bounded exponential backoff로 재시도하며, `403` 또는 `404` 같은 영구 실패는 재시도 없이 즉시 노출합니다.
 - 호출자에게 보이는 `SlackTransportError` 메시지는 기본적으로 raw upstream response body를 포함하지 않습니다.
 
 ### 의도적인 제한 사항

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -196,7 +196,7 @@ For richer API integrations such as `chat.postMessage`, implement the exported `
 
 Behavioral contract notes:
 
-- The built-in webhook transport retries transient `408`, `429`, and `5xx` failures with bounded exponential backoff before surfacing an error.
+- The built-in webhook transport retries transient `408`, `429`, and `5xx` failures with bounded exponential backoff before surfacing an error; permanent failures such as `403` or `404` are surfaced immediately without retry.
 - Caller-visible `SlackTransportError` messages omit raw upstream response bodies by default.
 
 ### Intentional limitations

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -513,6 +513,36 @@ describe('SlackModule', () => {
     }
   });
 
+  it.each([403, 404])('does not retry permanent webhook status %i failures', async (status) => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi.fn<SlackFetchLike>().mockResolvedValue({
+        ok: false,
+        status,
+        statusText: status === 403 ? 'Forbidden' : 'Not Found',
+        async text() {
+          return 'permanent upstream failure';
+        },
+      });
+      const transport = createSlackWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+      });
+
+      await expect(
+        transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Permanent failure' }, {}),
+      ).rejects.toThrowError(
+        new SlackTransportError(
+          `Slack webhook delivery failed with status ${String(status)} ${status === 403 ? 'Forbidden' : 'Not Found'} after 1 attempt(s). Upstream response body was omitted from the caller-visible error.`,
+        ),
+      );
+      expect(fetchLike).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('sanitizes webhook failure errors after bounded retries', async () => {
     vi.useFakeTimers();
 

--- a/packages/slack/src/webhook.ts
+++ b/packages/slack/src/webhook.ts
@@ -155,13 +155,13 @@ export function createSlackWebhookTransport(options: SlackWebhookTransportOption
             throw error;
           }
 
+          if (error instanceof SlackTransportError) {
+            throw error;
+          }
+
           if (attempt < DEFAULT_RETRY_ATTEMPTS) {
             await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
             continue;
-          }
-
-          if (error instanceof SlackTransportError) {
-            throw error;
           }
 
           throw new SlackTransportError(createTransportFailureMessage(attempt));


### PR DESCRIPTION
## Summary

Closes #1599.

## Changes

- Stop the built-in Slack webhook transport from retrying caller-visible permanent `SlackTransportError` responses such as 403 and 404.
- Add 403/404 no-retry regression coverage while preserving transient 408/429/5xx retry behavior.
- Align Slack README, Korean README, book tutorial contract text, and Changesets release note.

## Testing

- `pnpm build`
- `pnpm --filter @fluojs/slack typecheck`
- `pnpm --filter @fluojs/slack test`
- LSP diagnostics: clean for changed Slack source/test files after workspace build

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.