### PR TITLE
Resolve #1599: Stop retrying permanent Slack webhook failures

### DIFF
--- a/.changeset/fix-slack-webhook-retry.md
+++ b/.changeset/fix-slack-webhook-retry.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/slack": patch
+---
+
+Stop retrying permanent Slack webhook HTTP failures (such as 403, 404).
+
+Previously, the built-in webhook transport would mistakenly retry all errors if the attempt count had not been exhausted, ignoring the intent to only retry transient (408, 429, 5xx) failures. Now, non-transient HTTP errors correctly throw `SlackTransportError` immediately, aligning with the documented behavioral contract.

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -545,6 +545,52 @@ describe('SlackModule', () => {
     }
   });
 
+  it('rethrows permanent webhook failures (like 403) without retrying', async () => {
+    const fetchLike = vi.fn<SlackFetchLike>().mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      async text() {
+        return 'invalid_token';
+      },
+    });
+    const transport = createSlackWebhookTransport({
+      fetch: fetchLike,
+      webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+    });
+
+    const pending = transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Permanent failure path' }, {});
+    await expect(pending).rejects.toThrowError(
+      new SlackTransportError(
+        'Slack webhook delivery failed with status 403 Forbidden after 1 attempt(s). Upstream response body was omitted from the caller-visible error.',
+      ),
+    );
+    expect(fetchLike).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows permanent webhook failures (like 404) without retrying', async () => {
+    const fetchLike = vi.fn<SlackFetchLike>().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      async text() {
+        return 'channel_not_found';
+      },
+    });
+    const transport = createSlackWebhookTransport({
+      fetch: fetchLike,
+      webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+    });
+
+    const pending = transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Permanent failure path' }, {});
+    await expect(pending).rejects.toThrowError(
+      new SlackTransportError(
+        'Slack webhook delivery failed with status 404 Not Found after 1 attempt(s). Upstream response body was omitted from the caller-visible error.',
+      ),
+    );
+    expect(fetchLike).toHaveBeenCalledTimes(1);
+  });
+
   it('accepts custom provider-backed transports without bootstrap verification', async () => {
     const transport = new PassiveTransport();
     const container = new Container();

--- a/packages/slack/src/webhook.ts
+++ b/packages/slack/src/webhook.ts
@@ -155,13 +155,13 @@ export function createSlackWebhookTransport(options: SlackWebhookTransportOption
             throw error;
           }
 
+          if (error instanceof SlackTransportError) {
+            throw error;
+          }
+
           if (attempt < DEFAULT_RETRY_ATTEMPTS) {
             await waitForRetry(DEFAULT_RETRY_DELAY_MS * 2 ** (attempt - 1), context.signal);
             continue;
-          }
-
-          if (error instanceof SlackTransportError) {
-            throw error;
           }
 
           throw new SlackTransportError(createTransportFailureMessage(attempt));


### PR DESCRIPTION
## Summary

This PR fixes a bug where permanent Slack webhook HTTP failures (like 403 and 404) were being retried despite the behavioral contract restricting retries to transient errors (408, 429, 5xx).

Closes #1599

## Changes

- Moved the explicit `SlackTransportError` re-throw condition above the retry loop in `createSlackWebhookTransport`'s error handling.
- Added regression tests for permanent webhook failures (403 Forbidden and 404 Not Found) to ensure they are immediately rejected without delay.
- Added a patch changeset for `@fluojs/slack`.

## Testing

- Validated using `@fluojs/slack` local package test suite (`pnpm test` inside `packages/slack`) which exercises both the retry and permanent failure paths.
- Verified across the workspace with `pnpm verify`.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.