### PR TITLE
Resolve #1608: Pin inherited serialization metadata

### DIFF
--- a/.changeset/pin-serialization-inheritance.md
+++ b/.changeset/pin-serialization-inheritance.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/serialization": patch
+---
+
+Preserve inherited excludeExtraneous serialization metadata when derived DTOs use class-level Expose without options.

--- a/packages/serialization/README.ko.md
+++ b/packages/serialization/README.ko.md
@@ -109,6 +109,8 @@ fluo의 직렬화 엔진은 활성 순환 참조를 자동으로 감지하고 `u
 
 기반 클래스에 선언한 직렬화 메타데이터는 파생 DTO에도 상속됩니다. 공통 필드에 적용한 `@Expose()`, `@Exclude()`, `@Transform()` 규칙은 서브클래스 인스턴스를 직렬화할 때도 그대로 반영됩니다.
 
+Class-level `excludeExtraneous`도 일반 상속 규칙을 따릅니다. 파생 클래스에 option 없는 `@Expose()`를 붙여도 가장 가까운 상속 설정이 유지되므로, expose-only 기반 DTO는 subclass에서도 expose-only 상태를 유지합니다. 일반 enumerable field를 다시 포함하려는 의도가 있을 때만 파생 클래스에 `@Expose({ excludeExtraneous: false })`를 명시하세요. 이 경우에도 상속된 field-level `@Exclude()` metadata는 계속 적용됩니다.
+
 Decorated metadata가 없는 class instance도 재귀적으로 순회하므로, parent object에 serialization metadata가 없어도 decorated nested descendant는 반영됩니다.
 
 ### 일반 객체 안전성

--- a/packages/serialization/README.md
+++ b/packages/serialization/README.md
@@ -109,6 +109,8 @@ The serializer cuts active cyclic references safely instead of recursing forever
 
 Serialization metadata declared on a base class is inherited by derived DTOs. `@Expose()`, `@Exclude()`, and `@Transform()` rules applied to shared base fields still take effect when you serialize subclass instances.
 
+Class-level `excludeExtraneous` also follows normal inheritance. A derived class with `@Expose()` and no options keeps the nearest inherited setting, so an expose-only base DTO remains expose-only in subclasses. Use `@Expose({ excludeExtraneous: false })` on the derived class only when you intentionally want to re-enable ordinary enumerable fields while still honoring inherited field-level `@Exclude()` metadata.
+
 Undecorated class instances are still traversed recursively, so decorated nested descendants are respected even when the parent object has no serialization metadata.
 
 ### Plain-object safety

--- a/packages/serialization/src/decorators/expose.ts
+++ b/packages/serialization/src/decorators/expose.ts
@@ -42,9 +42,11 @@ export function Expose(options?: ExposeClassOptions): ClassOrFieldDecoratorLike 
     context: ClassDecoratorContext | ClassFieldDecoratorContext<unknown, unknown>,
   ) => {
     if (context.kind === 'class') {
-      updateClassSerializationOptions(context.metadata, {
-        excludeExtraneous: options?.excludeExtraneous,
-      });
+      if (Object.prototype.hasOwnProperty.call(options ?? {}, 'excludeExtraneous')) {
+        updateClassSerializationOptions(context.metadata, {
+          excludeExtraneous: options?.excludeExtraneous,
+        });
+      }
       return;
     }
 

--- a/packages/serialization/src/serialize.test.ts
+++ b/packages/serialization/src/serialize.test.ts
@@ -284,6 +284,50 @@ describe('serialize', () => {
     });
   });
 
+  it('preserves inherited excludeExtraneous when derived classes use class-level Expose without options', () => {
+    @Expose({ excludeExtraneous: true })
+    class BaseView {
+      @Expose()
+      id = 'u-1';
+
+      inheritedInternal = 'hidden-base';
+    }
+
+    @Expose()
+    class DerivedView extends BaseView {
+      @Expose()
+      role = 'admin';
+
+      derivedInternal = 'hidden-derived';
+    }
+
+    expect(serialize(new DerivedView())).toEqual({
+      id: 'u-1',
+      role: 'admin',
+    });
+  });
+
+  it('lets derived classes explicitly override inherited excludeExtraneous with false', () => {
+    @Expose({ excludeExtraneous: true })
+    class BaseView {
+      @Expose()
+      id = 'u-1';
+
+      @Exclude()
+      inheritedSecret = 'hidden';
+    }
+
+    @Expose({ excludeExtraneous: false })
+    class DerivedView extends BaseView {
+      role = 'admin';
+    }
+
+    expect(serialize(new DerivedView())).toEqual({
+      id: 'u-1',
+      role: 'admin',
+    });
+  });
+
   it('merges base and derived transforms for the same field in declaration order', () => {
     class BaseView {
       @Transform((value) => String(value).trim())


### PR DESCRIPTION
## Summary

Pins the inherited serialization metadata contract for `@fluojs/serialization` so class-level `@Expose()` without options does not accidentally clear inherited `excludeExtraneous` behavior.

Closes #1608

## Changes

- Preserves inherited `excludeExtraneous` unless a derived class explicitly sets `@Expose({ excludeExtraneous: false })`.
- Adds regression tests for inherited expose-only DTO behavior and explicit derived override behavior.
- Clarifies EN/KO serialization README inheritance behavior and adds a patch changeset for `@fluojs/serialization`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/serialization test` (26 tests passed)
- `pnpm build`
- `pnpm --filter @fluojs/serialization typecheck`
- LSP diagnostics clean for changed TypeScript files after dependency build

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; existing public decorator behavior is clarified in package README docs.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed; only the `@fluojs/serialization` package README pair was updated.