### PR TITLE
Resolve #1613: clarify runtime diagnostics ownership

### DIFF
--- a/book/intermediate/ch21-express-node.ko.md
+++ b/book/intermediate/ch21-express-node.ko.md
@@ -11,6 +11,7 @@
 - 어댑터 교체 뒤에도 비즈니스 로직을 그대로 유지하는 이식성 원칙을 확인합니다.
 - 플랫폼 네이티브 요청과 응답 객체에 접근해야 하는 상황을 살펴봅니다.
 - Express 미들웨어와 Node.js 스트림을 fluo 흐름에 맞게 연결하는 방법을 익힙니다.
+- 런타임이 소유하는 diagnostic snapshot과 Studio가 소유하는 graph 및 Mermaid 표현을 구분합니다.
 - FluoShop을 Express 기반 실행 환경으로 옮길 때 점검할 항목을 정리합니다.
 
 ## Prerequisites
@@ -148,6 +149,12 @@ async download(_input: undefined, ctx: RequestContext) {
 }
 ```
 
+### 21.3.3 Runtime diagnostics snapshots vs Studio rendering
+
+어댑터 선택은 diagnostics 소유권을 바꾸지 않습니다. `@fluojs/runtime`과 platform shell은 readiness, health, component graph data, structured diagnostic issue를 포함한 기계 읽기 가능한 `PlatformShellSnapshot`을 생산합니다. `fluo inspect`는 CLI, CI, support workflow를 위해 런타임이 생산한 snapshot을 JSON 또는 report artifact로 내보냅니다.
+
+시각적 표현은 다른 곳의 책임입니다. Graph view나 Mermaid 출력이 필요하면 CLI는 렌더링을 `@fluojs/studio`에 위임합니다. Studio는 runtime snapshot을 parsing/filtering하고, viewer behavior를 소유하며, snapshot-to-Mermaid 계약을 소유합니다. 이 분리는 Express 및 raw Node.js adapter가 HTTP 실행에 집중하고, runtime은 진실한 diagnostics data에 집중하며, CLI나 adapter package가 Studio rendering semantics를 중복하지 않게 합니다.
+
 ## 21.4 Conclusion
 
 이식성은 선호하는 도구를 포기하라는 뜻이 아닙니다. fluo의 어댑터 시스템은 비즈니스 로직을 웹 엔진에서 분리하면서도, 필요할 때 하부 플랫폼의 성능과 생태계에 접근할 수 있게 합니다. 다음 장에서는 같은 로직을 유지한 채 FluoShop을 Bun 런타임으로 옮기는 흐름을 살펴봅니다.
@@ -226,4 +233,5 @@ await runExpressApplication(AppModule, {
 - `@fluojs/platform-nodejs`는 최소한의 프레임워크 없는 HTTP 레이어를 제공합니다.
 - 대부분의 fluo 코드(컨트롤러, 프로바이더, 모듈)는 어떤 어댑터가 실행 중인지 전혀 알 필요가 없습니다.
 - 플랫폼 전용 기능이 필요한 경우에만 `getInstance()`로 하부 엔진에 접근하세요.
+- Runtime은 diagnostic snapshot과 issue 생산을 소유하고, Studio는 해당 artifact의 graph viewing 및 Mermaid rendering을 소유합니다.
 - 크로스 플랫폼 호환성을 유지하려면 fluo의 추상화(예: `MiddlewareConsumer`)를 먼저 검토하세요.

--- a/book/intermediate/ch21-express-node.md
+++ b/book/intermediate/ch21-express-node.md
@@ -11,6 +11,7 @@ This chapter explains how to choose between the Express and raw Node.js adapters
 - Confirm the portability principle that keeps business logic unchanged after swapping adapters.
 - Review situations where you need access to platform-native request and response objects.
 - Learn how to connect Express middleware and Node.js streams to the fluo flow.
+- Distinguish runtime-owned diagnostic snapshots from Studio-owned graph and Mermaid presentation.
 - Summarize the checklist for moving FluoShop to an Express-based runtime environment.
 
 ## Prerequisites
@@ -148,6 +149,12 @@ async download(_input: undefined, ctx: RequestContext) {
 }
 ```
 
+### 21.3.3 Runtime diagnostics snapshots vs Studio rendering
+
+Adapter choice does not change who owns diagnostics. `@fluojs/runtime` and the platform shell produce the machine-readable `PlatformShellSnapshot`, including readiness, health, component graph data, and structured diagnostic issues. `fluo inspect` exports that runtime-produced snapshot as JSON or as a report artifact for CLI, CI, and support workflows.
+
+Visual presentation belongs elsewhere. When you request a graph view or Mermaid output, the CLI delegates rendering to `@fluojs/studio`. Studio parses and filters the runtime snapshot, owns viewer behavior, and owns the snapshot-to-Mermaid contract. This keeps Express and raw Node.js adapters focused on HTTP execution, keeps runtime focused on truthful diagnostics data, and prevents CLI or adapter packages from duplicating Studio rendering semantics.
+
 ## 21.4 Conclusion
 
 Portability does not mean giving up the tools you prefer. fluo's adapter system separates business logic from the web engine while still letting you access the performance and ecosystem of the underlying platform when needed. In the next chapter, we'll look at the flow for moving FluoShop to the Bun runtime while keeping the same logic.
@@ -226,4 +233,5 @@ This helper helps clean up active connections before the process exits. In deplo
 - `@fluojs/platform-nodejs` provides a minimal HTTP layer without a framework.
 - Most fluo code (Controllers, Providers, Modules) does not need to know which adapter is running at all.
 - Access the underlying engine with `getInstance()` only when you need platform-specific features.
+- Runtime owns diagnostic snapshot and issue production; Studio owns graph viewing and Mermaid rendering of those artifacts.
 - To maintain cross-platform compatibility, review fluo abstractions first, such as `MiddlewareConsumer`.

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -27,7 +27,7 @@ npm install @fluojs/runtime
 - **fluo 애플리케이션 부트스트랩**: 모듈을 실행 중인 HTTP 서버나 마이크로서비스로 변환할 때.
 - **DI 및 라이프사이클 오케스트레이션**: 모듈 그래프 컴파일, 프로바이더 연결 및 애플리케이션 훅(`onModuleInit`, `onApplicationBootstrap`)을 관리할 때.
 - **독립형 컨텍스트 생성**: HTTP 서버는 필요 없지만 DI가 필요한 CLI task, script 또는 worker를 실행할 때.
-- **진단 및 검사**: CLI 내보내기와 Studio 소유 그래프 보기/렌더링을 위한 기계 읽기 가능한 플랫폼 snapshot을 생산할 때.
+- **진단 및 검사**: CLI 내보내기를 위한 기계 읽기 가능한 플랫폼 snapshot과 diagnostic issue를 생산하되, 그래프 보기와 Mermaid 표현은 Studio에 맡길 때.
 
 ## 퀵 스타트
 
@@ -138,7 +138,7 @@ class UsersModule {}
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.
 - 런타임 health 모듈은 bootstrap이 ready로 표시하기 전까지 `/ready`를 HTTP 503과 `starting`으로 보고하며, 애플리케이션/컨텍스트 종료가 시작되는 즉시, 종료 시도가 실패하더라도 다시 `starting`으로 내려갑니다.
 - 시그널 기반 종료 헬퍼는 bounded drain semantics를 유지하면서 timeout/실패 상황을 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료 소유권은 주변 호스트 런타임에 남겨 둡니다.
-- 플랫폼 snapshot 생산은 런타임에 남아 있고, 그래프 보기와 Mermaid 렌더링은 CLI 및 자동화 호출자가 소비하는 Studio 소유 계약입니다.
+- 플랫폼 snapshot 및 diagnostic issue 생산은 런타임에 남아 있고, 그래프 보기, filtering 표현, Mermaid 렌더링은 CLI 및 자동화 호출자가 소비하는 Studio 소유 계약입니다.
 - 모듈 그래프 컴파일 결과 캐시는 `moduleGraphCache: true`를 통한 opt-in입니다. 캐시 항목은 root module identity, runtime provider, validation token, core metadata version, compile algorithm version으로 식별되며, 성공한 컴파일만 저장하고 호출자 mutation이 이후 bootstrap을 오염시키지 않도록 격리된 그래프 복사본을 반환합니다.
 
 ## 공개 API 개요
@@ -153,7 +153,7 @@ class UsersModule {}
 - `defineModule(cls, metadata)`: 프로그래밍 방식의 모듈 정의 헬퍼입니다.
 - `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다.
 - `bootstrapModule(...)`: 저수준 module graph bootstrap helper입니다.
-- `createBootstrapTimingDiagnostics(...)`, `createRuntimeDiagnosticsGraph(...)`: CLI/support tooling을 위한 runtime diagnostics helper입니다.
+- `createBootstrapTimingDiagnostics(...)`, `createRuntimeDiagnosticsGraph(...)`: CLI/support tooling을 위한 runtime 소유 diagnostics snapshot helper입니다. 이 helper들은 기계 읽기 가능한 데이터를 생산하며, Studio가 viewer parsing, graph presentation, Mermaid rendering을 소유합니다.
 - `createRequestAbortContext(...)`, `trackActiveRequestTransaction(...)`, `untrackActiveRequestTransaction(...)`: runtime-aware integration이 사용하는 request abort 및 active transaction helper입니다.
 
 ## 플랫폼 전용 서브경로
@@ -215,7 +215,7 @@ const jsonLogger = createJsonApplicationLogger();
 - [@fluojs/di](../di): 의존성 주입(DI) 컨테이너 구현체.
 - [@fluojs/http](../http): HTTP 라우팅, 컨트롤러 및 디스패처.
 - [@fluojs/platform-nodejs](../platform-nodejs): 공식 Node.js HTTP 어댑터.
-- [@fluojs/studio](../studio): 런타임이 생산한 snapshot을 위한 뷰어 및 렌더링 헬퍼.
+- [@fluojs/studio](../studio): 런타임이 생산한 snapshot과 diagnostic issue를 위한 viewer, filtering, rendering helper.
 
 ## 예제 소스
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -27,7 +27,7 @@ Use this package when you need to:
 - **Bootstrap a fluo application**: Convert your modules into a running HTTP server or microservice.
 - **Orchestrate DI and Lifecycle**: Manage module-graph compilation, provider wiring, and application hooks (`onModuleInit`, `onApplicationBootstrap`).
 - **Create Standalone Contexts**: Run CLI tasks, scripts, or workers that need DI but not an HTTP server.
-- **Diagnostic Inspection**: Produce machine-readable platform snapshots for CLI export and Studio-owned graph viewing/rendering.
+- **Diagnostic Inspection**: Produce machine-readable platform snapshots and diagnostic issues for CLI export while leaving graph viewing and Mermaid presentation to Studio.
 
 ## Quick Start
 
@@ -138,7 +138,7 @@ class UsersModule {}
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.
 - Runtime health modules report `/ready` as `starting` with HTTP 503 until bootstrap marks them ready, and they return to `starting` as soon as application/context shutdown begins, including failed shutdown attempts.
 - Signal-driven shutdown helpers preserve bounded drain semantics, log timeout/failure conditions, and set `process.exitCode` when shutdown does not finish cleanly, but they leave final process termination ownership to the surrounding host runtime.
-- Platform snapshot production stays in runtime; graph viewing and Mermaid rendering are Studio-owned contracts consumed by CLI and automation callers.
+- Platform snapshot and diagnostic issue production stay in runtime; graph viewing, filtering presentation, and Mermaid rendering are Studio-owned contracts consumed by CLI and automation callers.
 - Module graph compile-result caching is opt-in through `moduleGraphCache: true`; it keys entries by root module identity, runtime providers, validation tokens, core metadata versions, and the compile algorithm version, caches only successful compilations, and returns isolated graph copies so caller mutations cannot poison later bootstraps.
 
 ## Public API Overview
@@ -153,7 +153,7 @@ class UsersModule {}
 - `defineModule(cls, metadata)`: Programmatic module definition helper.
 - `bootstrapApplication(options)`: Lower-level async bootstrap function.
 - `bootstrapModule(...)`: Lower-level module graph bootstrap helper.
-- `createBootstrapTimingDiagnostics(...)`, `createRuntimeDiagnosticsGraph(...)`: Runtime diagnostics helpers for CLI/support tooling.
+- `createBootstrapTimingDiagnostics(...)`, `createRuntimeDiagnosticsGraph(...)`: Runtime-owned diagnostics snapshot helpers for CLI/support tooling. They produce machine-readable data; Studio owns viewer parsing, graph presentation, and Mermaid rendering.
 - `createRequestAbortContext(...)`, `trackActiveRequestTransaction(...)`, `untrackActiveRequestTransaction(...)`: Request abort and active transaction helpers used by runtime-aware integrations.
 
 ## Platform-Specific Subpaths
@@ -215,7 +215,7 @@ Lower-level Node compression internals stay behind the `@fluojs/runtime/internal
 - [@fluojs/di](../di): Dependency injection container implementation.
 - [@fluojs/http](../http): HTTP routing, controllers, and dispatcher.
 - [@fluojs/platform-nodejs](../platform-nodejs): Official Node.js HTTP adapter.
-- [@fluojs/studio](../studio): Viewer and rendering helpers for runtime-produced snapshots.
+- [@fluojs/studio](../studio): Viewer, filtering, and rendering helpers for runtime-produced snapshots and diagnostic issues.
 
 ## Example Sources
 


### PR DESCRIPTION
## Summary

Closes #1613

Clarifies the diagnostics ownership boundary for `@fluojs/runtime`, Studio, CLI export, and book learning material without changing runtime behavior.

## Changes

- Updated `packages/runtime/README.md` and `packages/runtime/README.ko.md` to state that runtime owns machine-readable platform snapshots and diagnostic issue production.
- Updated `book/intermediate/ch21-express-node.md` and `.ko.md` to clarify that Express/Node adapter choice does not affect diagnostics ownership.
- Documented that Studio owns viewer parsing/presentation, filtering presentation, graph viewing, and Mermaid rendering while CLI exports/delegates artifacts.
- No changeset added: docs-only clarification that preserves current behavior and does not alter public runtime/API behavior or package release output.

## Testing

- `lsp_diagnostics` on changed Markdown files: no diagnostics found.
- `pnpm verify:platform-consistency-governance`: passed.
- `pnpm exec biome lint ...changed markdown files`: not applicable; Biome ignored these Markdown paths.
- `pnpm verify:release-readiness`: after `pnpm install --frozen-lockfile`, build/typecheck/lint/test portions progressed and test suites reported passing, but the command failed in the existing CLI sandbox matrix with `Expected the starter scaffold to include src/app.e2e.test.ts.` No source behavior was changed in this PR.

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. N/A.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. N/A; package README prose only.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. N/A; this clarifies ownership of existing diagnostics contracts.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. N/A for docs-only behavior-preserving clarification.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. N/A; changed package/book EN/KO mirrors stay aligned.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A.

## Residual risks

- `pnpm verify:release-readiness` remains blocked by the existing CLI sandbox expectation around `src/app.e2e.test.ts`; this appears unrelated to the documentation-only changes here.