### PR TITLE
Resolve #1617: Correct beginner CLI scaffold tree

### DIFF
--- a/book/beginner/ch02-cli-setup.ko.md
+++ b/book/beginner/ch02-cli-setup.ko.md
@@ -220,8 +220,12 @@ fluo-blog/
 ├── tsconfig.json             # TypeScript configuration
 └── src/                      # Application source
     ├── app.ts                # App assembly
-    ├── hello.controller.ts   # Default HTTP route
-    ├── hello.service.ts      # Route logic
+    ├── greeting/             # Default greeting feature slice
+    │   ├── greeting.controller.ts      # Default HTTP route
+    │   ├── greeting.module.ts          # Feature assembly
+    │   ├── greeting.repo.ts            # Response payload source
+    │   ├── greeting.response.dto.ts    # Response DTO
+    │   └── greeting.service.ts         # Route logic
     └── main.ts               # Bootstrap entrypoint
 ```
 

--- a/book/beginner/ch02-cli-setup.md
+++ b/book/beginner/ch02-cli-setup.md
@@ -220,8 +220,12 @@ fluo-blog/
 ├── tsconfig.json             # TypeScript configuration
 └── src/                      # Application source
     ├── app.ts                # App assembly
-    ├── hello.controller.ts   # Default HTTP route
-    ├── hello.service.ts      # Route logic
+    ├── greeting/             # Default greeting feature slice
+    │   ├── greeting.controller.ts      # Default HTTP route
+    │   ├── greeting.module.ts          # Feature assembly
+    │   ├── greeting.repo.ts            # Response payload source
+    │   ├── greeting.response.dto.ts    # Response DTO
+    │   └── greeting.service.ts         # Route logic
     └── main.ts               # Bootstrap entrypoint
 ```
 


### PR DESCRIPTION
## Summary

- Corrects the beginner book CLI setup project tree snippets so EN/KO now show the current `src/greeting/*` starter slice instead of stale `hello.controller.ts` / `hello.service.ts` files.
- Documents the existing scaffold shape only; no CLI runtime behavior changes are included.

Closes #1617

## Changes

- Updated `book/beginner/ch02-cli-setup.md` project tree to list `src/greeting/greeting.controller.ts`, `greeting.module.ts`, `greeting.repo.ts`, `greeting.response.dto.ts`, and `greeting.service.ts`.
- Applied the same mirrored tree correction in `book/beginner/ch02-cli-setup.ko.md`.
- Changeset/no-release decision: no changeset added because this is tutorial documentation alignment only and does not alter public package runtime behavior, package source, exports, or the generated CLI scaffold.

## Testing

- `lsp_diagnostics` on `book/beginner/ch02-cli-setup.md`: no diagnostics found.
- `lsp_diagnostics` on `book/beginner/ch02-cli-setup.ko.md`: no diagnostics found.
- `pnpm lint`: passed; existing unrelated Biome warnings/infos were reported outside the changed files, and `verify:public-export-tsdoc` passed in changed mode.

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. N/A.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. N/A.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. N/A; no new runtime contract.
- [x] Intentional limitations are explicitly stated (not silently removed). N/A.
- [x] Runtime invariants are covered by regression tests. N/A; docs-only scaffold tree correction.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. N/A; changed beginner book mirrors remain aligned.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A.

## Residual risks

- Full `pnpm verify` was not run because the change is docs-only; `pnpm lint` still surfaces pre-existing unrelated warnings/infos in package source files.