### PR TITLE
Resolve #1607: Add Redis contract coverage

### DIFF
--- a/.changeset/redis-driver-boundary.md
+++ b/.changeset/redis-driver-boundary.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/redis": patch
+---
+
+Declare `ioredis` as an explicit peer driver for `@fluojs/redis` while preserving the documented install command and runtime behavior.

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -45,10 +45,13 @@
   "dependencies": {
     "@fluojs/core": "workspace:^",
     "@fluojs/di": "workspace:^",
-    "@fluojs/runtime": "workspace:^",
+    "@fluojs/runtime": "workspace:^"
+  },
+  "peerDependencies": {
     "ioredis": "^5.10.0"
   },
   "devDependencies": {
+    "ioredis": "^5.10.0",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -1,8 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { Inject } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 interface MockRedisInstance {
   options: Record<string, unknown>;
@@ -21,6 +20,7 @@ const mockRedisState = vi.hoisted(() => ({
   events: [] as string[],
   instances: [] as MockRedisInstance[],
   quitError: undefined as Error | undefined,
+  setCalls: [] as Array<{ args: unknown[]; key: string; value: string }>,
 }));
 
 vi.mock('ioredis', () => ({
@@ -66,7 +66,8 @@ vi.mock('ioredis', () => ({
       return this.storage.get(key) ?? null;
     }
 
-    async set(key: string, value: string, ..._args: unknown[]): Promise<'OK'> {
+    async set(key: string, value: string, ...args: unknown[]): Promise<'OK'> {
+      mockRedisState.setCalls.push({ args, key, value });
       this.storage.set(key, value);
       return 'OK';
     }
@@ -79,11 +80,12 @@ vi.mock('ioredis', () => ({
 }));
 
 import {
-  getRedisClientToken,
-  getRedisServiceToken,
-  RedisModule,
   createRedisPlatformStatusSnapshot,
+  getRedisClientToken,
+  getRedisComponentId,
+  getRedisServiceToken,
   REDIS_CLIENT,
+  RedisModule,
   RedisService,
 } from './index.js';
 
@@ -94,6 +96,7 @@ describe('@fluojs/redis', () => {
     mockRedisState.events.length = 0;
     mockRedisState.instances.length = 0;
     mockRedisState.quitError = undefined;
+    mockRedisState.setCalls.length = 0;
   });
 
   it('fails bootstrap when connect throws and disconnects wait-state client', async () => {
@@ -267,6 +270,20 @@ describe('@fluojs/redis', () => {
     expect(Symbol.keyFor(cacheServiceToken as symbol)).toBeUndefined();
   });
 
+  it.each([
+    ['client token helper', () => getRedisClientToken('   ')],
+    ['service token helper', () => getRedisServiceToken('\t')],
+    ['component id helper', () => getRedisComponentId('\n')],
+  ])('rejects blank Redis names through the %s', (_caseName, createToken) => {
+    expect(createToken).toThrow('Redis client name must be a non-empty string.');
+  });
+
+  it('normalizes named Redis helper lookups by trimming names', () => {
+    expect(getRedisClientToken(' cache ')).toBe(getRedisClientToken('cache'));
+    expect(getRedisServiceToken(' cache ')).toBe(getRedisServiceToken('cache'));
+    expect(getRedisComponentId(' cache ')).toBe('redis.cache');
+  });
+
   it('falls back to disconnect when quit fails during shutdown', async () => {
     mockRedisState.quitError = new Error('quit failed');
 
@@ -313,7 +330,15 @@ describe('@fluojs/redis', () => {
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
   });
 
-  it('disconnects directly on shutdown when client is still waiting', async () => {
+  it.each([
+    ['connect', ['connect', 'quit']],
+    ['connecting', ['connect', 'quit']],
+    ['ready', ['connect', 'quit']],
+    ['reconnecting', ['connect', 'quit']],
+    ['wait', ['connect', 'disconnect']],
+    ['close', ['connect', 'disconnect']],
+    ['end', ['connect']],
+  ])('routes shutdown for %s Redis status through the documented lifecycle branch', async (status, expectedEvents) => {
     class AppModule {}
     defineModule(AppModule, {
       imports: [RedisModule.forRoot({ host: '127.0.0.1', port: 6379 })],
@@ -327,10 +352,10 @@ describe('@fluojs/redis', () => {
       throw new Error('Expected a Redis instance to be created.');
     }
 
-    instance.status = 'wait';
+    instance.status = status;
 
     await expect(app.close()).resolves.toBeUndefined();
-    expect(mockRedisState.events).toEqual(['connect', 'disconnect']);
+    expect(mockRedisState.events).toEqual(expectedEvents);
   });
 
   it('skips shutdown work when client is already closed', async () => {
@@ -381,6 +406,44 @@ describe('@fluojs/redis', () => {
 
     await cacheFacade.redisService.del('user:1');
     await expect(cacheFacade.redisService.get('user:1')).resolves.toBeNull();
+
+    await app.close();
+  });
+
+  it.each([
+    ['positive TTL', 60, ['EX', 60]],
+    ['fractional positive TTL', 0.5, ['EX', 0.5]],
+    ['zero TTL', 0, []],
+    ['negative TTL', -1, []],
+    ['omitted TTL', undefined, []],
+  ])('serializes values and forwards %s using the documented RedisService.set args', async (_caseName, ttlSeconds, expectedArgs) => {
+    @Inject(RedisService)
+    class CacheFacade {
+      constructor(readonly redisService: RedisService) {}
+    }
+
+    class FeatureModule {}
+    defineModule(FeatureModule, {
+      providers: [CacheFacade],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [RedisModule.forRoot({ host: '127.0.0.1', port: 6379 }), FeatureModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const cacheFacade = await app.container.resolve(CacheFacade);
+
+    await cacheFacade.redisService.set('ttl:key', { ttl: ttlSeconds ?? null }, ttlSeconds);
+
+    expect(mockRedisState.setCalls).toEqual([
+      {
+        args: expectedArgs,
+        key: 'ttl:key',
+        value: JSON.stringify({ ttl: ttlSeconds ?? null }),
+      },
+    ]);
 
     await app.close();
   });
@@ -443,17 +506,23 @@ describe('@fluojs/redis', () => {
     await app.close();
   });
 
-  it('reports ownership/readiness/health semantics in platform snapshot shape', () => {
-    const snapshot = createRedisPlatformStatusSnapshot({
-      status: 'ready',
-    });
+  it.each([
+    ['ready', { critical: true, status: 'ready' }, { status: 'healthy' }],
+    ['wait', { critical: true, reason: 'Redis client is still in lazyConnect wait state.', status: 'not-ready' }, { reason: 'Redis client is wait.', status: 'degraded' }],
+    ['connect', { critical: true, reason: 'Redis client is connect.', status: 'degraded' }, { reason: 'Redis client is connect.', status: 'degraded' }],
+    ['connecting', { critical: true, reason: 'Redis client is connecting.', status: 'degraded' }, { reason: 'Redis client is connecting.', status: 'degraded' }],
+    ['reconnecting', { critical: true, reason: 'Redis client is reconnecting.', status: 'degraded' }, { reason: 'Redis client is reconnecting.', status: 'degraded' }],
+    ['close', { critical: true, reason: 'Redis client is close.', status: 'not-ready' }, { reason: 'Redis client is close.', status: 'unhealthy' }],
+    ['end', { critical: true, reason: 'Redis client is end.', status: 'not-ready' }, { reason: 'Redis client is end.', status: 'unhealthy' }],
+  ] as const)('reports ownership/readiness/health semantics for %s platform snapshots', (status, readiness, health) => {
+    const snapshot = createRedisPlatformStatusSnapshot({ status });
 
     expect(snapshot.ownership).toEqual({ externallyManaged: false, ownsResources: true });
-    expect(snapshot.readiness).toEqual({ critical: true, status: 'ready' });
-    expect(snapshot.health).toEqual({ status: 'healthy' });
+    expect(snapshot.readiness).toEqual(readiness);
+    expect(snapshot.health).toEqual(health);
     expect(snapshot.details).toMatchObject({
       componentId: undefined,
-      connectionState: 'ready',
+      connectionState: status,
       lazyConnect: true,
     });
   });
@@ -482,21 +551,4 @@ describe('@fluojs/redis', () => {
     expect(namedSnapshot.ownership).toEqual({ externallyManaged: false, ownsResources: true });
   });
 
-  it('separates wait-state readiness from health', () => {
-    const snapshot = createRedisPlatformStatusSnapshot({
-      status: 'wait',
-    });
-
-    expect(snapshot.readiness.status).toBe('not-ready');
-    expect(snapshot.health.status).toBe('degraded');
-  });
-
-  it('marks closed redis client as unhealthy and not-ready', () => {
-    const snapshot = createRedisPlatformStatusSnapshot({
-      status: 'end',
-    });
-
-    expect(snapshot.readiness.status).toBe('not-ready');
-    expect(snapshot.health.status).toBe('unhealthy');
-  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,10 +726,10 @@ importers:
       '@fluojs/runtime':
         specifier: workspace:^
         version: link:../runtime
+    devDependencies:
       ioredis:
         specifier: ^5.10.0
         version: 5.10.0
-    devDependencies:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)


### PR DESCRIPTION
## Summary

- Adds Redis regression coverage for documented TTL forwarding, lifecycle shutdown routing, named-client normalization, and status snapshot branches.
- Aligns `@fluojs/redis` package metadata with the documented explicit `ioredis` driver install boundary.

Closes #1607

## Changes

- Expanded `packages/redis/src/module.test.ts` with table-driven coverage for `RedisService.set()` TTL args, lifecycle status routing, name helper normalization/rejection, and platform snapshot health/readiness states.
- Moved `ioredis` from `dependencies` to required `peerDependencies` plus `devDependencies` for package-local build/test usage.
- Added a patch changeset for the public package metadata boundary change.

## Testing

- `pnpm --filter @fluojs/redis test` ✅
- `pnpm -r build` ✅
- LSP diagnostics on changed files ✅

Note: `pnpm --filter @fluojs/redis typecheck` initially failed before workspace dependency `dist` artifacts existed in the fresh worktree; the subsequent recursive build completed successfully and includes the Redis package TypeScript build.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The existing EN/KO README contract already documents explicit `ioredis` installation, TTL behavior, lifecycle ownership, named-client normalization, and status snapshot helpers; this PR pins those contracts with tests and metadata alignment without changing runtime behavior.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs or platform conformance claims were changed.