### PR TITLE
Resolve #1612: Add platform runtime edge conformance coverage

### DIFF
--- a/.changeset/platform-runtime-edge-coverage.md
+++ b/.changeset/platform-runtime-edge-coverage.md
@@ -1,0 +1,8 @@
+---
+'@fluojs/platform-cloudflare-workers': patch
+'@fluojs/platform-deno': patch
+'@fluojs/platform-express': patch
+'@fluojs/platform-nodejs': patch
+---
+
+Document and test platform runtime edge contracts for native-route rematching, shutdown and body-size boundaries, Node.js portability harness coverage, and edge runtime conformance parity.

--- a/packages/platform-cloudflare-workers/README.ko.md
+++ b/packages/platform-cloudflare-workers/README.ko.md
@@ -10,6 +10,7 @@
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
+- [Conformance 커버리지](#conformance-커버리지)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -90,6 +91,12 @@ const adapter = createCloudflareWorkerAdapter({
 - `close()`는 shutdown 중 새 요청에 JSON `503` response를 반환하고, active request가 끝나지 않으면 10초 뒤 timeout됩니다.
 - Multipart request는 `rawBody`를 보존하지 않습니다.
 - Worker `env` 객체는 fetch entrypoint boundary를 통과하며, package-level config resolution은 application이 소유합니다.
+
+## Conformance 커버리지
+
+`packages/platform-cloudflare-workers/src/adapter.test.ts`는 문서화된 Worker 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, `executionContext.waitUntil(...)` 등록, websocket upgrade binding, lazy entrypoint 재사용, shutdown gating, close 중 JSON `503` response, bounded 10초 close timeout을 검증합니다.
+
+공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Cloudflare Workers를 Bun 및 Deno와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트의 README parity assertion은 이 edge-runtime 커버리지 문서가 한국어 mirror와 계속 동기화되도록 확인합니다.
 
 ## 공개 API 개요
 

--- a/packages/platform-cloudflare-workers/README.md
+++ b/packages/platform-cloudflare-workers/README.md
@@ -10,6 +10,7 @@ Cloudflare Workers HTTP adapter for the fluo runtime, optimized for the edge.
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
+- [Conformance Coverage](#conformance-coverage)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -90,6 +91,12 @@ const adapter = createCloudflareWorkerAdapter({
 - `close()` returns JSON `503` responses for new requests during shutdown and times out after 10 seconds if active requests never settle.
 - Multipart requests do not preserve `rawBody`.
 - The Worker `env` object is passed through the fetch entrypoint boundary; package-level config resolution remains application-owned.
+
+## Conformance Coverage
+
+`packages/platform-cloudflare-workers/src/adapter.test.ts` is the package-local regression target for the documented Worker contract. It covers shared Web dispatch delegation, `executionContext.waitUntil(...)` registration, websocket upgrade binding, lazy entrypoint reuse, shutdown gating, JSON `503` responses while closing, and the bounded 10-second close timeout.
+
+The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Cloudflare Workers beside Bun and Deno for malformed cookie preservation, query decoding, JSON/text raw-body capture, multipart raw-body exclusion, and SSE framing. The README parity assertion in the package test keeps these documented edge-runtime coverage claims synchronized with the Korean mirror.
 
 ## Public API Overview
 

--- a/packages/platform-cloudflare-workers/src/adapter.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -91,6 +93,20 @@ afterEach(() => {
 });
 
 describe('@fluojs/platform-cloudflare-workers', () => {
+  it('keeps edge runtime README conformance coverage aligned across English and Korean docs', () => {
+    const englishReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+    const koreanReadme = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');
+
+    for (const readme of [englishReadme, koreanReadme]) {
+      expect(readme).toContain('Cloudflare Workers');
+      expect(readme).toContain('executionContext.waitUntil(...)');
+      expect(readme).toContain('10');
+      expect(readme).toContain('503');
+      expect(readme).toContain('packages/platform-cloudflare-workers/src/adapter.test.ts');
+      expect(readme).toContain('packages/testing/src/portability/web-runtime-adapter-portability.test.ts');
+    }
+  });
+
   it('delegates Worker fetch handling to the shared web adapter core', async () => {
     const adapter = createCloudflareWorkerAdapter({ rawBody: true });
     const dispatcher = {

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -11,6 +11,7 @@
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
 - [HTTPS와 런타임 이식성](#https와-런타임-이식성)
+- [Conformance 커버리지](#conformance-커버리지)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -85,6 +86,12 @@ await runDenoApplication(AppModule, {
 `hostname`은 Deno 네이티브 옵션 이름으로 유지됩니다. 공유 HTTP 어댑터 테스트와 교차 런타임 설정 헬퍼를 위해 `host`도 이식성 alias로 허용하며, 둘 다 제공하면 `hostname`이 우선합니다.
 
 Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve`, `upgradeWebSocket` seam, `rawBody`, `maxBodySize`, `multipart`, `shutdownSignals`가 포함됩니다. `runDenoApplication(...)`은 기본적으로 `SIGINT`/`SIGTERM`을 연결하고, `shutdownSignals: false`는 signal registration을 끕니다. Close는 active request drain을 최대 10초 기다립니다. `handle(...)`은 `listen()`이 dispatcher를 bind하기 전에는 JSON `500`, shutdown 진행 중에는 JSON `503`을 반환합니다.
+
+## Conformance 커버리지
+
+`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, HTTPS startup forwarding, `SIGINT`/`SIGTERM` signal listener 등록과 정리, websocket upgrade binding, listen 전 `500` 처리, shutdown 중 `503` 처리, in-flight request drain, bounded 10초 close timeout을 검증합니다.
+
+공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Deno를 Bun 및 Cloudflare Workers와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트의 README parity assertion은 이 edge-runtime 커버리지 문서가 한국어 mirror와 계속 동기화되도록 확인합니다.
 
 ## 공개 API 개요
 

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -11,6 +11,7 @@ Deno-backed HTTP adapter for the fluo runtime, built on native `Deno.serve`.
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
 - [HTTPS and Runtime Portability](#https-and-runtime-portability)
+- [Conformance Coverage](#conformance-coverage)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -85,6 +86,12 @@ await runDenoApplication(AppModule, {
 `hostname` remains the Deno-native option name. The adapter also accepts `host` as a portability alias for shared HTTP adapter tests and cross-runtime configuration helpers; when both are provided, `hostname` wins.
 
 Advanced options include injectable `serve` and `upgradeWebSocket` seams for tests or non-hosted runtimes, `rawBody`, `maxBodySize`, `multipart`, and `shutdownSignals`. `runDenoApplication(...)` wires `SIGINT`/`SIGTERM` by default, `shutdownSignals: false` disables signal registration, and close waits up to 10 seconds for active requests to drain. `handle(...)` returns a JSON `500` before `listen()` binds the dispatcher and a JSON `503` while shutdown is in progress.
+
+## Conformance Coverage
+
+`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, HTTPS startup forwarding, `SIGINT`/`SIGTERM` signal listener registration and cleanup, websocket upgrade binding, pre-listen `500` handling, shutdown `503` handling, in-flight request drain, and the bounded 10-second close timeout.
+
+The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Deno beside Bun and Cloudflare Workers for malformed cookie preservation, query decoding, JSON/text raw-body capture, multipart raw-body exclusion, and SSE framing. The README parity assertion in the package test keeps these documented edge-runtime coverage claims synchronized with the Korean mirror.
 
 ## Public API Overview
 

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createServer as createHttpsServer } from 'node:https';
 
@@ -310,6 +311,20 @@ function createMockDenoSocket(): DenoServerWebSocket {
 }
 
 describe('@fluojs/platform-deno', () => {
+  it('keeps edge runtime README conformance coverage aligned across English and Korean docs', () => {
+    const englishReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+    const koreanReadme = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');
+
+    for (const readme of [englishReadme, koreanReadme]) {
+      expect(readme).toContain('Deno.serve');
+      expect(readme).toContain('SIGINT');
+      expect(readme).toContain('SIGTERM');
+      expect(readme).toContain('10');
+      expect(readme).toContain('packages/platform-deno/src/adapter.test.ts');
+      expect(readme).toContain('packages/testing/src/portability/web-runtime-adapter-portability.test.ts');
+    }
+  });
+
   it('dispatches requests through the shared Web request/response core', async () => {
     @Controller('/hooks')
     class WebhookController {

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -791,6 +791,55 @@ describe('@fluojs/platform-express', () => {
     await app.close();
   });
 
+  it('accepts raw bodies at maxBodySize and rejects the first byte over the Express limit', async () => {
+    @Controller('/body-limit')
+    class BodyLimitController {
+      @Post('/')
+      echo(_input: undefined, context: RequestContext) {
+        return context.request.body;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [BodyLimitController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      maxBodySize: 8,
+      port,
+    });
+
+    await app.listen();
+
+    try {
+      const boundaryResponse = await fetch(`http://127.0.0.1:${String(port)}/body-limit`, {
+        body: '12345678',
+        headers: { 'content-type': 'text/plain' },
+        method: 'POST',
+      });
+      const overflowResponse = await fetch(`http://127.0.0.1:${String(port)}/body-limit`, {
+        body: '123456789',
+        headers: { 'content-type': 'text/plain' },
+        method: 'POST',
+      });
+
+      expect(boundaryResponse.status).toBe(201);
+      await expect(boundaryResponse.text()).resolves.toBe('12345678');
+      expect(overflowResponse.status).toBe(413);
+      await expect(overflowResponse.json()).resolves.toMatchObject({
+        error: {
+          code: 'PAYLOAD_TOO_LARGE',
+          message: 'Request body exceeds the size limit.',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
   it('accepts a cors string and merges framework defaults', async () => {
     @Controller('/ping')
     class PingController {
@@ -1446,6 +1495,73 @@ describe('@fluojs/platform-express', () => {
       expect(fullDispatch).toHaveBeenCalledTimes(1);
     } finally {
       await adapter.close();
+    }
+  });
+
+  it('rematches a native Express handoff when middleware rewrites the framework path', async () => {
+    const lifecycle: string[] = [];
+    const rewriteMiddleware = {
+      async handle(context: MiddlewareContext, next: () => Promise<void>) {
+        lifecycle.push(`middleware:${context.request.path}`);
+
+        if (context.request.path === '/rewrite-source/42') {
+          context.request.path = '/rewrite-target/42';
+          context.request.url = '/rewrite-target/42';
+        }
+
+        await next();
+      },
+    };
+
+    @Controller('/rewrite-source')
+    class RewriteSourceController {
+      @Get('/:id')
+      source(_input: undefined, context: RequestContext) {
+        return { id: context.request.params.id, route: 'source' };
+      }
+    }
+
+    @Controller('/rewrite-target')
+    class RewriteTargetController {
+      @Get('/:id')
+      target(_input: undefined, context: RequestContext) {
+        lifecycle.push(`target:${context.request.params.id}`);
+        return { id: context.request.params.id, path: context.request.path, route: 'target' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [RewriteSourceController, RewriteTargetController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await fluoFactory.create(AppModule, {
+      adapter: createExpressAdapter({ port }),
+      middleware: [rewriteMiddleware],
+    });
+
+    await app.listen();
+
+    try {
+      const response = await requestHttp({
+        method: 'GET',
+        path: '/rewrite-source/42',
+        port,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({
+        id: '42',
+        path: '/rewrite-target/42',
+        route: 'target',
+      });
+      expect(lifecycle).toEqual([
+        'middleware:/rewrite-source/42',
+        'target:42',
+      ]);
+    } finally {
+      await app.close();
     }
   });
 

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -115,6 +115,42 @@ describe('@fluojs/platform-nodejs', () => {
     }
   });
 
+  it('removes registered shutdown signal listeners after close through the platform run helper', async () => {
+    @Controller('/health')
+    class HealthController {
+      @Get('/')
+      getHealth() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [HealthController] });
+
+    const signal = 'SIGTERM' as const;
+    const listenersBefore = new Set(process.listeners(signal));
+    const port = await findAvailablePort();
+    const app = await runNodejsApplication(AppModule, {
+      logger: {
+        debug() {},
+        error() {},
+        log() {},
+        warn() {},
+      },
+      port,
+      shutdownSignals: [signal],
+    });
+    const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
+
+    expect(registeredListeners.length).toBeGreaterThan(0);
+
+    await app.close();
+
+    for (const listener of registeredListeners) {
+      expect(process.listeners(signal)).not.toContain(listener);
+    }
+  });
+
   it('preserves benchmark-style simple query and JSON body routes through the public Node adapter path', async () => {
     @Controller('/')
     class BenchmarkController {
@@ -191,6 +227,11 @@ describe('@fluojs/platform-nodejs', () => {
 
     @Controller('/echo')
     class EchoController {
+      @Post('/raw')
+      raw(_input: undefined, context: RequestContext) {
+        return context.request.body;
+      }
+
       @Post('/')
       @RequestDto(EchoBody)
       echo(input: EchoBody) {
@@ -208,6 +249,17 @@ describe('@fluojs/platform-nodejs', () => {
 
     try {
       await app.listen();
+
+      const boundaryResponse = await fetch(`http://127.0.0.1:${String(port)}/echo/raw`, {
+        body: '12345678',
+        headers: {
+          'content-type': 'text/plain',
+        },
+        method: 'POST',
+      });
+
+      expect(boundaryResponse.status).toBe(201);
+      await expect(boundaryResponse.text()).resolves.toBe('12345678');
 
       const response = await fetch(`http://127.0.0.1:${String(port)}/echo`, {
         body: '0123456789',


### PR DESCRIPTION
## Summary
- Add Express native route handoff coverage for rewrite/rematch behavior and body-size boundary handling.
- Add Node.js platform-package coverage for shutdown listener cleanup and exact raw-body size acceptance.
- Document and assert Cloudflare Workers/Deno conformance coverage parity across English and Korean READMEs, with a patch changeset for affected platform packages.

## Verification
- pnpm exec vitest run packages/platform-express/src/adapter.test.ts packages/platform-nodejs/src/index.test.ts packages/platform-cloudflare-workers/src/adapter.test.ts packages/platform-deno/src/adapter.test.ts
- pnpm build
- pnpm typecheck
- pnpm verify:release-readiness

## Notes
- pnpm lint still reports pre-existing unrelated Biome issues outside this lane.
- Closes #1612