### PR TITLE
Resolve #1609: Export throttler consume input

### DIFF
--- a/.changeset/throttler-consume-input-surface.md
+++ b/.changeset/throttler-consume-input-surface.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/throttler": patch
+---
+
+Export `ThrottlerConsumeInput` from the root package surface so custom store implementations can type their consume contract directly.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -138,6 +138,7 @@ ThrottlerModule.forRoot({
 - `createMemoryThrottlerStore()`: 간단한 메모리 내 저장소를 생성합니다 (기본값).
 - `RedisThrottlerStore`: Redis용 저장소 어댑터입니다.
 - `ThrottlerStore`: custom store를 위한 공개 계약입니다.
+- `ThrottlerConsumeInput`: custom store가 guard의 현재 시간과 TTL window를 공유할 수 있도록 `ThrottlerStore.consume(key, input)`에 전달되는 공개 입력 shape입니다.
 
 ### status와 diagnostics
 - `createThrottlerPlatformStatusSnapshot(...)`: 플랫폼 status snapshot을 생성합니다.

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -138,6 +138,7 @@ ThrottlerModule.forRoot({
 - `createMemoryThrottlerStore()`: Creates a simple in-memory store (default).
 - `RedisThrottlerStore`: Store adapter for Redis.
 - `ThrottlerStore`: Public contract for custom stores.
+- `ThrottlerConsumeInput`: Public input shape passed to `ThrottlerStore.consume(key, input)` so custom stores can share the guard's current time and TTL window.
 
 ### Status and diagnostics
 - `createThrottlerPlatformStatusSnapshot(...)`: Creates a platform status snapshot.

--- a/packages/throttler/src/index.ts
+++ b/packages/throttler/src/index.ts
@@ -5,4 +5,10 @@ export * from './module.js';
 export * from './status.js';
 export { createMemoryThrottlerStore } from './store.js';
 export { THROTTLER_OPTIONS } from './tokens.js';
-export type { ThrottlerHandlerOptions, ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
+export type {
+  ThrottlerConsumeInput,
+  ThrottlerHandlerOptions,
+  ThrottlerModuleOptions,
+  ThrottlerStore,
+  ThrottlerStoreEntry,
+} from './types.js';

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -16,7 +16,7 @@ import type {
   ThrottlerModuleOptions,
   ThrottlerStore,
   ThrottlerStoreEntry,
-} from './types.js';
+} from './index.js';
 
 function createRequestContext(
   options:
@@ -104,6 +104,18 @@ describe('@fluojs/throttler public entrypoints', () => {
     expect(throttlerExports).not.toHaveProperty('createThrottlerProviders');
     expect(throttlerExports.ThrottlerModule).toBe(ThrottlerModule);
     expect(typeof throttlerExports.ThrottlerModule.forRoot).toBe('function');
+  });
+
+  it('keeps the low-level consume input type available from the root barrel', () => {
+    const consume: ThrottlerStore['consume'] = (_key: string, input: ThrottlerConsumeInput): ThrottlerStoreEntry => ({
+      count: input.ttlSeconds,
+      resetAt: input.now + input.ttlSeconds * 1000,
+    });
+
+    expect(consume('client', { now: 1000, ttlSeconds: 60 })).toEqual({
+      count: 60,
+      resetAt: 61_000,
+    });
   });
 });
 

--- a/packages/throttler/src/types.ts
+++ b/packages/throttler/src/types.ts
@@ -11,8 +11,8 @@ export interface ThrottlerStoreEntry {
 /**
  * Public input passed to a `ThrottlerStore` when consuming a request slot.
  *
- * @remarks Custom stores receive this shape from `ThrottlerGuard.consume(...)`
- * calls so they can anchor the current window to the guard's clock and the
+ * @remarks `ThrottlerGuard` passes this shape to `ThrottlerStore.consume(...)`
+ * so custom stores can anchor the current window to the guard's clock and the
  * resolved module or route-level TTL.
  */
 export interface ThrottlerConsumeInput {

--- a/packages/throttler/src/types.ts
+++ b/packages/throttler/src/types.ts
@@ -9,10 +9,16 @@ export interface ThrottlerStoreEntry {
 }
 
 /**
- * Input passed to a `ThrottlerStore` when consuming a request slot.
+ * Public input passed to a `ThrottlerStore` when consuming a request slot.
+ *
+ * @remarks Custom stores receive this shape from `ThrottlerGuard.consume(...)`
+ * calls so they can anchor the current window to the guard's clock and the
+ * resolved module or route-level TTL.
  */
 export interface ThrottlerConsumeInput {
+  /** Current epoch time in milliseconds for the consume operation. */
   now: number;
+  /** Rate-limit window length in seconds. */
   ttlSeconds: number;
 }
 


### PR DESCRIPTION
## Summary

- Closes #1609.
- Exports the `ThrottlerConsumeInput` type from `@fluojs/throttler`'s root surface so custom stores can type the low-level consume contract directly.
- Documents the contract decision in the EN/KO throttler READMEs and records a patch changeset for the public package-surface addition.

## Changes

- Added `ThrottlerConsumeInput` to the root `packages/throttler/src/index.ts` type exports.
- Expanded source TSDoc for `ThrottlerConsumeInput` and its fields.
- Added a public entrypoint regression test that imports the low-level consume input type from the root barrel.
- Updated `packages/throttler/README.md` and `packages/throttler/README.ko.md` public API overview entries.
- Added `.changeset/throttler-consume-input-surface.md` as a patch release note for `@fluojs/throttler`.

## Testing

- `pnpm install --offline --frozen-lockfile` (worktree dependency links only)
- `pnpm --filter @fluojs/validation --filter @fluojs/http --filter @fluojs/runtime --filter @fluojs/throttler build`
- `pnpm --filter @fluojs/throttler typecheck`
- `pnpm --filter @fluojs/throttler test`
- `pnpm verify:public-export-tsdoc`
- LSP diagnostics: clean for `packages/throttler/src`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed; the platform checklist is not otherwise applicable.