### PR TITLE
Resolve #1615: Add Terminus regression coverage

### DIFF
--- a/packages/terminus/src/indicators/http.test.ts
+++ b/packages/terminus/src/indicators/http.test.ts
@@ -59,4 +59,40 @@ describe('HttpHealthIndicator', () => {
       name: 'HealthCheckError',
     } satisfies Partial<HealthCheckError>);
   });
+
+  it('aborts timed out HTTP probes and reports the timeout as down', async () => {
+    let observedSignal: AbortSignal | undefined;
+    const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation((_input, init) => {
+      observedSignal = init?.signal ?? undefined;
+
+      return new Promise<Response>((_resolve, reject) => {
+        observedSignal?.addEventListener('abort', () => {
+          reject(observedSignal?.reason instanceof Error ? observedSignal.reason : new Error('HTTP probe aborted.'));
+        }, { once: true });
+      });
+    });
+
+    const indicator = new HttpHealthIndicator({
+      timeoutMs: 5,
+      url: 'https://example.com/slow-health',
+    });
+
+    await expect(indicator.check('upstream')).rejects.toMatchObject({
+      causes: {
+        upstream: {
+          message: 'HTTP health check timed out after 5ms.',
+          status: 'down',
+        },
+      },
+      message: 'HTTP health check failed.',
+      name: 'HealthCheckError',
+    } satisfies Partial<HealthCheckError>);
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com/slow-health', expect.objectContaining({
+      method: 'GET',
+      signal: observedSignal,
+    }));
+    expect(observedSignal?.aborted).toBe(true);
+    expect(observedSignal?.reason).toEqual(new Error('HTTP health check timed out after 5ms.'));
+  });
 });

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, it } from 'vitest';
-
 import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
 import { getRedisClientToken, REDIS_CLIENT } from '@fluojs/redis';
 import { bootstrapApplication, defineModule, type PlatformComponent } from '@fluojs/runtime';
+import { describe, expect, it } from 'vitest';
 
 import { MemoryHealthIndicator } from './indicators/memory.js';
 import { createRedisHealthIndicatorProvider, RedisHealthIndicator } from './indicators/redis.js';
@@ -98,6 +97,53 @@ describe('TerminusModule.forRoot', () => {
 
     expect(readyResponse.statusCode).toBe(200);
     expect(readyResponse.body).toEqual({ status: 'ready' });
+
+    await app.close();
+  });
+
+  it('mounts /health and /ready under the configured custom path', async () => {
+    const indicators: HealthIndicator[] = [new MemoryHealthIndicator({ key: 'database' })];
+    const terminusModule = TerminusModule.forRoot({
+      indicators,
+      path: '/internal',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [terminusModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    const customHealthResponse = createResponse();
+    await app.dispatch(createRequest('/internal/health'), customHealthResponse);
+
+    expect(customHealthResponse.statusCode).toBe(200);
+    expect(customHealthResponse.body).toMatchObject({
+      details: {
+        database: {
+          status: 'up',
+        },
+      },
+      status: 'ok',
+    });
+
+    const customReadyResponse = createResponse();
+    await app.dispatch(createRequest('/internal/ready'), customReadyResponse);
+
+    expect(customReadyResponse.statusCode).toBe(200);
+    expect(customReadyResponse.body).toEqual({ status: 'ready' });
+
+    const defaultHealthResponse = createResponse();
+    await app.dispatch(createRequest('/health'), defaultHealthResponse);
+
+    expect(defaultHealthResponse.statusCode).toBe(404);
+
+    const defaultReadyResponse = createResponse();
+    await app.dispatch(createRequest('/ready'), defaultReadyResponse);
+
+    expect(defaultReadyResponse.statusCode).toBe(404);
 
     await app.close();
   });


### PR DESCRIPTION
## Summary

Closes #1615.

Adds regression coverage for the existing `@fluojs/terminus` custom path and HTTP timeout contracts without changing runtime behavior.

## Changes

- Added `TerminusModule.forRoot({ path })` coverage proving `/health` and `/ready` mount beneath the configured prefix and the unprefixed routes are not registered.
- Added `HttpHealthIndicator` coverage proving timed-out probes abort the underlying `fetch` signal and surface a deterministic down result.
- Changeset decision: no changeset because this is tests-only coverage for existing documented behavior, with no public API or runtime behavior change.
- Docs decision: no README changes because the existing README/README.ko contract already documents `path` and timeout semantics; this PR pins them with regression tests.

## Testing

- `pnpm --filter @fluojs/terminus... build`
- `pnpm exec biome check "packages/terminus/src/module.test.ts" "packages/terminus/src/indicators/http.test.ts"`
- `pnpm --filter @fluojs/terminus typecheck`
- `pnpm --filter @fluojs/terminus test`
- LSP diagnostics: clean for changed files

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No new behavior was introduced; this PR adds regression tests for existing `path` and HTTP timeout/abort behavior.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs or package README files changed.