### PR TITLE
Resolve #1661: Reduce runtime peer internals

### DIFF
--- a/.changeset/runtime-peer-internal-seams.md
+++ b/.changeset/runtime-peer-internal-seams.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Reduce runtime coupling to peer package internal subpaths by isolating the remaining core/http integration points behind runtime-owned seams.

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { Global, Inject, Module, Scope as ScopeDecorator } from '@fluojs/core';
-import { defineModuleMetadata } from '@fluojs/core/internal';
 import { Controller, Convert, FromQuery, Get, RequestDto, type FrameworkRequest, type FrameworkResponse } from '@fluojs/http';
 
 import { bootstrapApplication, bootstrapModule, FluoFactory } from './bootstrap.js';
 import { DuplicateProviderError, ModuleGraphError, ModuleInjectionMetadataError, ModuleVisibilityError } from './errors.js';
+import { defineRuntimeModuleMetadata } from './internal/core-metadata.js';
 import { clearModuleGraphCompileCacheForTesting, getModuleGraphCompileCacheSizeForTesting } from './module-graph.js';
 import type { PlatformComponent, PlatformState } from './platform-contract.js';
 import { HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL } from './tokens.js';
@@ -64,7 +64,7 @@ describe('bootstrapModule', () => {
     class Logger {}
 
     class SharedModule {}
-    defineModuleMetadata(SharedModule, {
+    defineRuntimeModuleMetadata(SharedModule, {
       exports: [Logger],
       providers: [Logger],
     });
@@ -75,7 +75,7 @@ describe('bootstrapModule', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       imports: [SharedModule],
       providers: [AppService],
     });
@@ -92,13 +92,13 @@ describe('bootstrapModule', () => {
     class Logger {}
 
     class SharedModule {}
-    defineModuleMetadata(SharedModule, {
+    defineRuntimeModuleMetadata(SharedModule, {
       exports: [Logger],
       providers: [Logger],
     });
 
     class ReExportModule {}
-    defineModuleMetadata(ReExportModule, {
+    defineRuntimeModuleMetadata(ReExportModule, {
       exports: [Logger],
       imports: [SharedModule],
     });
@@ -109,7 +109,7 @@ describe('bootstrapModule', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       imports: [ReExportModule],
       providers: [AppService],
     });
@@ -128,7 +128,7 @@ describe('bootstrapModule', () => {
     class InternalRepository {}
 
     class DataModule {}
-    defineModuleMetadata(DataModule, {
+    defineRuntimeModuleMetadata(DataModule, {
       providers: [InternalRepository],
     });
 
@@ -136,7 +136,7 @@ describe('bootstrapModule', () => {
     class BillingService {}
 
     class BillingModule {}
-    defineModuleMetadata(BillingModule, {
+    defineRuntimeModuleMetadata(BillingModule, {
       imports: [DataModule],
       providers: [BillingService],
     });
@@ -152,7 +152,7 @@ describe('bootstrapModule', () => {
     }
 
     class BillingModule {}
-    defineModuleMetadata(BillingModule, {
+    defineRuntimeModuleMetadata(BillingModule, {
       providers: [Logger, BillingService],
     });
 
@@ -172,7 +172,7 @@ describe('bootstrapModule', () => {
     }
 
     class BillingModule {}
-    defineModuleMetadata(BillingModule, {
+    defineRuntimeModuleMetadata(BillingModule, {
       providers: [
         Logger,
         Metrics,
@@ -196,7 +196,7 @@ describe('bootstrapModule', () => {
     }
 
     class BillingModule {}
-    defineModuleMetadata(BillingModule, {
+    defineRuntimeModuleMetadata(BillingModule, {
       controllers: [BillingController],
       providers: [Logger],
     });
@@ -213,7 +213,7 @@ describe('bootstrapModule', () => {
     }
 
     class BillingModule {}
-    defineModuleMetadata(BillingModule, {
+    defineRuntimeModuleMetadata(BillingModule, {
       providers: [
         Logger,
         {
@@ -238,7 +238,7 @@ describe('bootstrapModule', () => {
     class BillingService extends BaseBillingService {}
 
     class BillingModule {}
-    defineModuleMetadata(BillingModule, {
+    defineRuntimeModuleMetadata(BillingModule, {
       providers: [Logger, BillingService],
     });
 
@@ -264,7 +264,7 @@ describe('bootstrapModule', () => {
     }
 
     class BillingModule {}
-    defineModuleMetadata(BillingModule, {
+    defineRuntimeModuleMetadata(BillingModule, {
       providers: [Logger, Metrics, BillingService],
     });
 
@@ -298,7 +298,7 @@ describe('bootstrapModule', () => {
     class BillingModule {}
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       imports: [RootModule, BillingModule],
     });
 
@@ -315,7 +315,7 @@ describe('bootstrapModule middleware DI registration', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       middleware: [LoggingMiddleware],
     });
 
@@ -333,7 +333,7 @@ describe('bootstrapModule middleware DI registration', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       middleware: [{ middleware: AuthMiddleware, routes: ['/users'] }],
     });
 
@@ -349,7 +349,7 @@ describe('bootstrapModule middleware DI registration', () => {
     };
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       middleware: [factoryMiddleware],
     });
 
@@ -364,7 +364,7 @@ describe('bootstrapModule middleware DI registration', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       middleware: [LoggingMiddleware],
       providers: [LoggingMiddleware],
     });
@@ -378,19 +378,19 @@ describe('bootstrapModule duplicate provider detection', () => {
     class SharedService {}
 
     class ModuleA {}
-    defineModuleMetadata(ModuleA, {
+    defineRuntimeModuleMetadata(ModuleA, {
       providers: [SharedService],
       exports: [SharedService],
     });
 
     class ModuleB {}
-    defineModuleMetadata(ModuleB, {
+    defineRuntimeModuleMetadata(ModuleB, {
       providers: [SharedService],
       exports: [SharedService],
     });
 
     class RootModule {}
-    defineModuleMetadata(RootModule, {
+    defineRuntimeModuleMetadata(RootModule, {
       imports: [ModuleA, ModuleB],
     });
 
@@ -406,17 +406,17 @@ describe('bootstrapModule duplicate provider detection', () => {
     const SHARED = Symbol('shared-token');
 
     class ModuleA {}
-    defineModuleMetadata(ModuleA, {
+    defineRuntimeModuleMetadata(ModuleA, {
       providers: [{ provide: SHARED, useValue: 'from-a' }],
     });
 
     class ModuleB {}
-    defineModuleMetadata(ModuleB, {
+    defineRuntimeModuleMetadata(ModuleB, {
       providers: [{ provide: SHARED, useValue: 'from-b' }],
     });
 
     class RootModule {}
-    defineModuleMetadata(RootModule, {
+    defineRuntimeModuleMetadata(RootModule, {
       imports: [ModuleA, ModuleB],
     });
 
@@ -432,19 +432,19 @@ describe('bootstrapModule duplicate provider detection', () => {
     class SharedService {}
 
     class ModuleA {}
-    defineModuleMetadata(ModuleA, {
+    defineRuntimeModuleMetadata(ModuleA, {
       providers: [SharedService],
       exports: [SharedService],
     });
 
     class ModuleB {}
-    defineModuleMetadata(ModuleB, {
+    defineRuntimeModuleMetadata(ModuleB, {
       providers: [SharedService],
       exports: [SharedService],
     });
 
     class RootModule {}
-    defineModuleMetadata(RootModule, {
+    defineRuntimeModuleMetadata(RootModule, {
       imports: [ModuleA, ModuleB],
     });
 
@@ -459,19 +459,19 @@ describe('bootstrapModule duplicate provider detection', () => {
     class SharedService {}
 
     class ModuleA {}
-    defineModuleMetadata(ModuleA, {
+    defineRuntimeModuleMetadata(ModuleA, {
       providers: [SharedService],
       exports: [SharedService],
     });
 
     class ModuleB {}
-    defineModuleMetadata(ModuleB, {
+    defineRuntimeModuleMetadata(ModuleB, {
       providers: [SharedService],
       exports: [SharedService],
     });
 
     class RootModule {}
-    defineModuleMetadata(RootModule, {
+    defineRuntimeModuleMetadata(RootModule, {
       imports: [ModuleA, ModuleB],
     });
 
@@ -483,19 +483,19 @@ describe('bootstrapModule duplicate provider detection', () => {
     class SharedService {}
 
     class ModuleA {}
-    defineModuleMetadata(ModuleA, {
+    defineRuntimeModuleMetadata(ModuleA, {
       providers: [SharedService],
       exports: [SharedService],
     });
 
     class ModuleB {}
-    defineModuleMetadata(ModuleB, {
+    defineRuntimeModuleMetadata(ModuleB, {
       providers: [SharedService],
       exports: [SharedService],
     });
 
     class RootModule {}
-    defineModuleMetadata(RootModule, {
+    defineRuntimeModuleMetadata(RootModule, {
       imports: [ModuleA, ModuleB],
     });
 
@@ -510,17 +510,17 @@ describe('bootstrapModule duplicate provider detection', () => {
     const SHARED = Symbol('shared-token');
 
     class ModuleA {}
-    defineModuleMetadata(ModuleA, {
+    defineRuntimeModuleMetadata(ModuleA, {
       providers: [{ provide: SHARED, useValue: 'from-a' }],
     });
 
     class ModuleB {}
-    defineModuleMetadata(ModuleB, {
+    defineRuntimeModuleMetadata(ModuleB, {
       providers: [{ provide: SHARED, useValue: 'from-b' }],
     });
 
     class RootModule {}
-    defineModuleMetadata(RootModule, {
+    defineRuntimeModuleMetadata(RootModule, {
       imports: [ModuleA, ModuleB],
     });
 
@@ -536,7 +536,7 @@ describe('bootstrapModule duplicate provider detection', () => {
     class SharedService {}
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [SharedService],
     });
 
@@ -562,7 +562,7 @@ describe('bootstrapModule requiredConstructorParameters fix', () => {
     class ZeroDependencyService {}
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [ZeroDependencyService],
     });
 
@@ -581,7 +581,7 @@ describe('bootstrapModule requiredConstructorParameters fix', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [Logger, AppService],
     });
 
@@ -597,7 +597,7 @@ describe('bootstrapModule requiredConstructorParameters fix', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [Logger, LegacyAppService],
     });
 
@@ -612,7 +612,7 @@ describe('FluoFactory.createApplicationContext', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -630,7 +630,7 @@ describe('FluoFactory.createApplicationContext', () => {
     class AppService {}
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -651,7 +651,7 @@ describe('FluoFactory.createApplicationContext', () => {
     class AppService {}
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -684,7 +684,7 @@ describe('FluoFactory.createApplicationContext', () => {
       let resolutionCount = 0;
 
       class AppModule {}
-      defineModuleMetadata(AppModule, {
+      defineRuntimeModuleMetadata(AppModule, {
         providers: [
           {
             provide: CACHE_TOKEN,
@@ -722,7 +722,7 @@ describe('FluoFactory.createApplicationContext', () => {
       let resolutionCount = 0;
 
       class AppModule {}
-      defineModuleMetadata(AppModule, {});
+      defineRuntimeModuleMetadata(AppModule, {});
 
       const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
@@ -758,7 +758,7 @@ describe('FluoFactory.createApplicationContext', () => {
     const secondContribution = { id: 'second' };
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           multi: true,
@@ -796,7 +796,7 @@ describe('FluoFactory.createApplicationContext', () => {
     const runtimeContribution = { id: 'runtime' };
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           multi: true,
@@ -837,7 +837,7 @@ describe('FluoFactory.createApplicationContext', () => {
     const firstCanResolve = createDeferred<void>();
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: FIRST,
@@ -887,7 +887,7 @@ describe('FluoFactory.createApplicationContext', () => {
     const FAILING = Symbol('failing');
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: SUCCESS,
@@ -947,7 +947,7 @@ describe('FluoFactory.createApplicationContext', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -971,7 +971,7 @@ describe('FluoFactory.createApplicationContext', () => {
     const LIFECYCLE_VALUE = Symbol('lifecycle-value');
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: LIFECYCLE_VALUE,
@@ -1015,7 +1015,7 @@ describe('FluoFactory.createApplicationContext', () => {
       const LIFECYCLE_VALUE = Symbol('lifecycle-value');
 
       class AppModule {}
-      defineModuleMetadata(AppModule, {
+      defineRuntimeModuleMetadata(AppModule, {
         providers: [
           {
             provide: LIFECYCLE_VALUE,
@@ -1080,7 +1080,7 @@ describe('FluoFactory.createApplicationContext', () => {
       const LIFECYCLE_VALUE = Symbol('runtime-lifecycle-value');
 
       class AppModule {}
-      defineModuleMetadata(AppModule, {});
+      defineRuntimeModuleMetadata(AppModule, {});
 
       const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
@@ -1144,7 +1144,7 @@ describe('FluoFactory.createApplicationContext', () => {
       const LIFECYCLE_VALUE = Symbol('lifecycle-value');
 
       class AppModule {}
-      defineModuleMetadata(AppModule, {
+      defineRuntimeModuleMetadata(AppModule, {
         providers: [
           {
             provide: LIFECYCLE_VALUE,
@@ -1191,7 +1191,7 @@ describe('FluoFactory.createApplicationContext', () => {
       const LIFECYCLE_VALUE = Symbol('runtime-lifecycle-value-without-hooks');
 
       class AppModule {}
-      defineModuleMetadata(AppModule, {});
+      defineRuntimeModuleMetadata(AppModule, {});
 
       const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
@@ -1232,7 +1232,7 @@ describe('FluoFactory.createApplicationContext', () => {
 
   it('does not collect bootstrap timing diagnostics by default', async () => {
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     const context = await FluoFactory.createApplicationContext(AppModule);
 
@@ -1243,7 +1243,7 @@ describe('FluoFactory.createApplicationContext', () => {
 
   it('collects bootstrap timing diagnostics when enabled', async () => {
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     const context = await FluoFactory.createApplicationContext(AppModule, {
       diagnostics: {
@@ -1266,7 +1266,7 @@ describe('FluoFactory.createApplicationContext', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -1403,7 +1403,7 @@ describe('runtime platform shell enforcement', () => {
     const queue = createComponent('queue.default', events);
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     const app = await FluoFactory.create(AppModule, {
       platform: {
@@ -1431,7 +1431,7 @@ describe('runtime platform shell enforcement', () => {
     const queue = createComponent('queue.default', events);
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     await expect(
       FluoFactory.create(AppModule, {
@@ -1451,7 +1451,7 @@ describe('runtime platform shell enforcement', () => {
     };
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     const app = await FluoFactory.create(AppModule, {
       adapter,
@@ -1477,7 +1477,7 @@ describe('FluoFactory.createMicroservice', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: MICROSERVICE_TOKEN,
@@ -1520,7 +1520,7 @@ describe('FluoFactory.createMicroservice', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         CleanupHook,
         {
@@ -1552,7 +1552,7 @@ describe('FluoFactory.createMicroservice', () => {
     const MICROSERVICE_TOKEN = Symbol.for('fluo.microservices.service');
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: MICROSERVICE_TOKEN,
@@ -1580,7 +1580,7 @@ describe('FluoFactory.createMicroservice', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         CleanupHook,
         {
@@ -1611,7 +1611,7 @@ describe('FluoFactory.createMicroservice', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: MICROSERVICE_TOKEN,
@@ -1646,7 +1646,7 @@ describe('FluoFactory.createMicroservice', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: MICROSERVICE_TOKEN,
@@ -1687,7 +1687,7 @@ describe('FluoFactory.createMicroservice', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         LifecycleHook,
         {
@@ -1746,7 +1746,7 @@ describe('FluoFactory.createMicroservice', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: FIRST_MICROSERVICE_TOKEN,
@@ -1783,7 +1783,7 @@ describe('moduleGraphCache bootstrap wiring', () => {
 
     class AppService {}
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -1799,7 +1799,7 @@ describe('moduleGraphCache bootstrap wiring', () => {
 
     class AppService {}
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -1825,7 +1825,7 @@ describe('moduleGraphCache bootstrap wiring', () => {
 
     class AppService {}
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -1847,7 +1847,7 @@ describe('moduleGraphCache bootstrap wiring', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: MICROSERVICE_TOKEN,
@@ -1872,7 +1872,7 @@ describe('Recovery-oriented error context (runtime)', () => {
       class InternalRepository {}
 
       class DataModule {}
-      defineModuleMetadata(DataModule, {
+      defineRuntimeModuleMetadata(DataModule, {
         providers: [InternalRepository],
       });
 
@@ -1880,7 +1880,7 @@ describe('Recovery-oriented error context (runtime)', () => {
       class BillingService {}
 
       class BillingModule {}
-      defineModuleMetadata(BillingModule, {
+      defineRuntimeModuleMetadata(BillingModule, {
         imports: [DataModule],
         providers: [BillingService],
       });
@@ -1903,7 +1903,7 @@ describe('Recovery-oriented error context (runtime)', () => {
       class InternalRepository {}
 
       class DataModule {}
-      defineModuleMetadata(DataModule, {
+      defineRuntimeModuleMetadata(DataModule, {
         providers: [InternalRepository],
       });
 
@@ -1911,7 +1911,7 @@ describe('Recovery-oriented error context (runtime)', () => {
       class BillingController {}
 
       class BillingModule {}
-      defineModuleMetadata(BillingModule, {
+      defineRuntimeModuleMetadata(BillingModule, {
         imports: [DataModule],
         controllers: [BillingController],
       });
@@ -1933,7 +1933,7 @@ describe('Recovery-oriented error context (runtime)', () => {
       class InternalRepository {}
 
       class DataModule {}
-      defineModuleMetadata(DataModule, {
+      defineRuntimeModuleMetadata(DataModule, {
         providers: [InternalRepository],
       });
 
@@ -1941,7 +1941,7 @@ describe('Recovery-oriented error context (runtime)', () => {
       class BillingService {}
 
       class BillingModule {}
-      defineModuleMetadata(BillingModule, {
+      defineRuntimeModuleMetadata(BillingModule, {
         imports: [DataModule],
         providers: [BillingService],
       });
@@ -1964,10 +1964,10 @@ describe('Recovery-oriented error context (runtime)', () => {
     it('includes module name and hint for circular module imports', () => {
       class ModuleA {}
       class ModuleB {}
-      defineModuleMetadata(ModuleA, {
+      defineRuntimeModuleMetadata(ModuleA, {
         imports: [ModuleB],
       });
-      defineModuleMetadata(ModuleB, {
+      defineRuntimeModuleMetadata(ModuleB, {
         imports: [ModuleA],
       });
 
@@ -1988,10 +1988,10 @@ describe('Recovery-oriented error context (runtime)', () => {
     it('provides machine-readable meta on ModuleGraphError', () => {
       class ModuleA {}
       class ModuleB {}
-      defineModuleMetadata(ModuleA, {
+      defineRuntimeModuleMetadata(ModuleA, {
         imports: [ModuleB],
       });
-      defineModuleMetadata(ModuleB, {
+      defineRuntimeModuleMetadata(ModuleB, {
         imports: [ModuleA],
       });
 
@@ -2016,7 +2016,7 @@ describe('Recovery-oriented error context (runtime)', () => {
       }
 
       class BillingModule {}
-      defineModuleMetadata(BillingModule, {
+      defineRuntimeModuleMetadata(BillingModule, {
         providers: [Logger, BillingService],
       });
 
@@ -2041,7 +2041,7 @@ describe('Recovery-oriented error context (runtime)', () => {
       }
 
       class BillingModule {}
-      defineModuleMetadata(BillingModule, {
+      defineRuntimeModuleMetadata(BillingModule, {
         providers: [Logger, BillingService],
       });
 
@@ -2063,19 +2063,19 @@ describe('Recovery-oriented error context (runtime)', () => {
       class SharedService {}
 
       class ModuleA {}
-      defineModuleMetadata(ModuleA, {
+      defineRuntimeModuleMetadata(ModuleA, {
         providers: [SharedService],
         exports: [SharedService],
       });
 
       class ModuleB {}
-      defineModuleMetadata(ModuleB, {
+      defineRuntimeModuleMetadata(ModuleB, {
         providers: [SharedService],
         exports: [SharedService],
       });
 
       class RootModule {}
-      defineModuleMetadata(RootModule, {
+      defineRuntimeModuleMetadata(RootModule, {
         imports: [ModuleA, ModuleB],
       });
 
@@ -2097,19 +2097,19 @@ describe('Recovery-oriented error context (runtime)', () => {
       class SharedService {}
 
       class ModuleA {}
-      defineModuleMetadata(ModuleA, {
+      defineRuntimeModuleMetadata(ModuleA, {
         providers: [SharedService],
         exports: [SharedService],
       });
 
       class ModuleB {}
-      defineModuleMetadata(ModuleB, {
+      defineRuntimeModuleMetadata(ModuleB, {
         providers: [SharedService],
         exports: [SharedService],
       });
 
       class RootModule {}
-      defineModuleMetadata(RootModule, {
+      defineRuntimeModuleMetadata(RootModule, {
         imports: [ModuleA, ModuleB],
       });
 
@@ -2132,12 +2132,12 @@ describe('Recovery-oriented error context (runtime)', () => {
       class NonExistentService {}
 
       class BadModule {}
-      defineModuleMetadata(BadModule, {
+      defineRuntimeModuleMetadata(BadModule, {
         exports: [NonExistentService],
       });
 
       class AppModule {}
-      defineModuleMetadata(AppModule, {
+      defineRuntimeModuleMetadata(AppModule, {
         imports: [BadModule],
       });
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1,7 +1,5 @@
 import { Container, type Provider } from '@fluojs/di';
-import { DefaultBinder } from '@fluojs/http/internal';
 import { InvariantError, type Token } from '@fluojs/core';
-import { defineModuleMetadata, getClassDiMetadata } from '@fluojs/core/internal';
 import {
   createDispatcher,
   createHandlerMapping,
@@ -14,6 +12,8 @@ import {
 
 import { DuplicateProviderError } from './errors.js';
 import { createBootstrapTimingDiagnostics, type BootstrapTimingPhase } from './health/diagnostics.js';
+import { defineRuntimeModuleMetadata, getRuntimeClassDiMetadata } from './internal/core-metadata.js';
+import { RuntimeDefaultBinder } from './internal/http-runtime.js';
 import { createConsoleApplicationLogger } from './logging/logger.js';
 import { compileModuleGraph, providerToken } from './module-graph.js';
 import { createRuntimePlatformShell, type RuntimePlatformShell } from './platform-shell.js';
@@ -70,7 +70,7 @@ async function runExceptionFilters(
 
 function providerScope(provider: Provider): 'singleton' | 'request' | 'transient' {
   if (typeof provider === 'function') {
-    return getClassDiMetadata(provider)?.scope ?? 'singleton';
+    return getRuntimeClassDiMetadata(provider)?.scope ?? 'singleton';
   }
 
   if ('useValue' in provider) {
@@ -78,11 +78,11 @@ function providerScope(provider: Provider): 'singleton' | 'request' | 'transient
   }
 
   if ('useClass' in provider) {
-    return provider.scope ?? getClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
+    return provider.scope ?? getRuntimeClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
   }
 
   if ('useFactory' in provider) {
-    return provider.scope ?? (provider.resolverClass ? getClassDiMetadata(provider.resolverClass)?.scope : undefined) ?? 'singleton';
+    return provider.scope ?? (provider.resolverClass ? getRuntimeClassDiMetadata(provider.resolverClass)?.scope : undefined) ?? 'singleton';
   }
 
   return 'singleton';
@@ -487,7 +487,7 @@ function registerModuleMiddleware(container: Container, modules: CompiledModule[
  * @returns The same `moduleType` reference for fluent helper composition.
  */
 export function defineModule<T extends ModuleType>(moduleType: T, definition: ModuleDefinition): T {
-  defineModuleMetadata(moduleType, definition);
+  defineRuntimeModuleMetadata(moduleType, definition);
 
   return moduleType;
 }
@@ -1254,7 +1254,7 @@ function createRuntimeDispatcherOptions(
   };
 
   if (converters.length > 0) {
-    dispatcherOptions.binder = new DefaultBinder(converters);
+    dispatcherOptions.binder = new RuntimeDefaultBinder(converters);
   }
 
   if (errorHandler) {

--- a/packages/runtime/src/health/diagnostics.test.ts
+++ b/packages/runtime/src/health/diagnostics.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { Scope } from '@fluojs/core';
-import { defineModuleMetadata } from '@fluojs/core/internal';
 
+import { defineRuntimeModuleMetadata } from '../internal/core-metadata.js';
 import { compileModuleGraph } from '../module-graph.js';
 import {
   createBootstrapTimingDiagnostics,
@@ -23,7 +23,7 @@ describe('runtime diagnostics graph export', () => {
     class UsersController {}
 
     class SharedModule {}
-    defineModuleMetadata(SharedModule, {
+    defineRuntimeModuleMetadata(SharedModule, {
       exports: [LoggerService, FACTORY_TOKEN],
       providers: [
         LoggerService,
@@ -37,7 +37,7 @@ describe('runtime diagnostics graph export', () => {
     });
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       controllers: [UsersController],
       exports: [VALUE_TOKEN],
       imports: [SharedModule],
@@ -88,10 +88,10 @@ describe('runtime diagnostics graph export', () => {
 
   it('renders module-level Mermaid output', () => {
     class SharedModule {}
-    defineModuleMetadata(SharedModule, {});
+    defineRuntimeModuleMetadata(SharedModule, {});
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       imports: [SharedModule],
     });
 

--- a/packages/runtime/src/health/diagnostics.ts
+++ b/packages/runtime/src/health/diagnostics.ts
@@ -1,7 +1,7 @@
 import { type Token } from '@fluojs/core';
-import { getClassDiMetadata } from '@fluojs/core/internal';
 import type { Provider, Scope } from '@fluojs/di';
 
+import { getRuntimeClassDiMetadata } from '../internal/core-metadata.js';
 import type { CompiledModule, ModuleType } from '../types.js';
 
 /**
@@ -125,7 +125,7 @@ function providerShape(provider: Provider): RuntimeDiagnosticsProvider['type'] {
 
 function providerScope(provider: Provider): Scope {
   if (typeof provider === 'function') {
-    return getClassDiMetadata(provider)?.scope ?? 'singleton';
+    return getRuntimeClassDiMetadata(provider)?.scope ?? 'singleton';
   }
 
   if ('useValue' in provider || 'useExisting' in provider) {
@@ -133,11 +133,11 @@ function providerScope(provider: Provider): Scope {
   }
 
   if ('useFactory' in provider) {
-    return provider.scope ?? (provider.resolverClass ? getClassDiMetadata(provider.resolverClass)?.scope : undefined) ?? 'singleton';
+    return provider.scope ?? (provider.resolverClass ? getRuntimeClassDiMetadata(provider.resolverClass)?.scope : undefined) ?? 'singleton';
   }
 
   if ('useClass' in provider) {
-    return provider.scope ?? getClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
+    return provider.scope ?? getRuntimeClassDiMetadata(provider.useClass)?.scope ?? 'singleton';
   }
 
   return 'singleton';

--- a/packages/runtime/src/internal-peer-dependencies.test.ts
+++ b/packages/runtime/src/internal-peer-dependencies.test.ts
@@ -1,0 +1,53 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const RUNTIME_SRC_DIR = dirname(fileURLToPath(import.meta.url));
+const CORE_INTERNAL_IMPORT = '@fluojs/core' + '/internal';
+const HTTP_INTERNAL_IMPORT = '@fluojs/http' + '/internal';
+
+async function collectTypeScriptFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const absolutePath = resolve(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await collectTypeScriptFiles(absolutePath)));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.ts')) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+describe('runtime peer package internal dependencies', () => {
+  it('keeps peer internal imports isolated behind runtime-owned seams', async () => {
+    const files = await collectTypeScriptFiles(RUNTIME_SRC_DIR);
+    const importHits: Array<{ file: string; specifier: string }> = [];
+
+    for (const file of files) {
+      const source = await readFile(file, 'utf8');
+      for (const specifier of [CORE_INTERNAL_IMPORT, HTTP_INTERNAL_IMPORT]) {
+        if (source.includes(specifier)) {
+          importHits.push({
+            file: relative(RUNTIME_SRC_DIR, file),
+            specifier,
+          });
+        }
+      }
+    }
+
+    expect(importHits).toEqual([
+      { file: 'internal/core-metadata.ts', specifier: CORE_INTERNAL_IMPORT },
+      { file: 'internal/http-runtime.ts', specifier: HTTP_INTERNAL_IMPORT },
+    ]);
+  });
+});

--- a/packages/runtime/src/internal-peer-dependencies.test.ts
+++ b/packages/runtime/src/internal-peer-dependencies.test.ts
@@ -45,7 +45,10 @@ describe('runtime peer package internal dependencies', () => {
       }
     }
 
-    expect(importHits).toEqual([
+    expect([...importHits].sort((left, right) => {
+      const fileOrder = left.file.localeCompare(right.file);
+      return fileOrder === 0 ? left.specifier.localeCompare(right.specifier) : fileOrder;
+    })).toEqual([
       { file: 'internal/core-metadata.ts', specifier: CORE_INTERNAL_IMPORT },
       { file: 'internal/http-runtime.ts', specifier: HTTP_INTERNAL_IMPORT },
     ]);

--- a/packages/runtime/src/internal/core-metadata.ts
+++ b/packages/runtime/src/internal/core-metadata.ts
@@ -1,0 +1,83 @@
+import type { Token } from '@fluojs/core';
+import {
+  defineClassDiMetadata as definePeerClassDiMetadata,
+  defineModuleMetadata as definePeerModuleMetadata,
+  getClassDiMetadata as getPeerClassDiMetadata,
+  getClassDiMetadataVersion as getPeerClassDiMetadataVersion,
+  getModuleMetadata as getPeerModuleMetadata,
+  getModuleMetadataVersion as getPeerModuleMetadataVersion,
+  getOwnClassDiMetadata as getPeerOwnClassDiMetadata,
+} from '@fluojs/core/internal';
+import type { Scope } from '@fluojs/di';
+
+import type { ModuleDefinition } from '../types.js';
+
+/** Runtime-local view of DI forward references consumed by module graph compilation. */
+export type RuntimeForwardRef = { __forwardRef__: true; forwardRef: () => Token };
+/** Runtime-local view of optional DI tokens consumed by module graph compilation. */
+export type RuntimeOptionalToken = { __optional__: true; token: Token };
+/** Runtime-local union for DI dependency metadata consumed by module graph compilation. */
+export type RuntimeInjectionToken = Token | RuntimeForwardRef | RuntimeOptionalToken;
+
+/** Runtime-local class DI metadata view used for provider scope and dependency validation. */
+export interface RuntimeClassDiMetadata {
+  inject?: readonly RuntimeInjectionToken[];
+  scope?: Scope;
+}
+
+/** Runtime-local writable class DI metadata shape used by explicit metadata-version tests. */
+export interface RuntimeWritableClassDiMetadata {
+  inject?: Token[];
+  scope?: Scope;
+}
+
+/** Runtime-local module metadata view used while compiling application module graphs. */
+export type RuntimeModuleMetadata = Pick<
+  ModuleDefinition,
+  'controllers' | 'exports' | 'global' | 'imports' | 'middleware' | 'providers'
+>;
+
+/** Runtime-local writable module metadata shape used by decorators, tests, and dynamic module normalization. */
+export interface RuntimeWritableModuleMetadata {
+  controllers?: unknown[];
+  exports?: unknown[];
+  global?: boolean;
+  imports?: unknown[];
+  middleware?: unknown[];
+  providers?: unknown[];
+}
+
+/** Runtime-owned seam for writing module metadata during dynamic module normalization. */
+export function defineRuntimeModuleMetadata(target: Function, metadata: RuntimeWritableModuleMetadata): void {
+  definePeerModuleMetadata(target, metadata);
+}
+
+/** Runtime-owned seam for tests that need to mutate class DI metadata versions explicitly. */
+export function defineRuntimeClassDiMetadata(target: Function, metadata: RuntimeWritableClassDiMetadata): void {
+  definePeerClassDiMetadata(target, metadata);
+}
+
+/** Runtime-owned seam for reading class DI metadata without spreading peer internal imports. */
+export function getRuntimeClassDiMetadata(target: Function): RuntimeClassDiMetadata | undefined {
+  return getPeerClassDiMetadata(target) as RuntimeClassDiMetadata | undefined;
+}
+
+/** Runtime-owned seam for reading own class DI metadata without spreading peer internal imports. */
+export function getOwnRuntimeClassDiMetadata(target: Function): RuntimeClassDiMetadata | undefined {
+  return getPeerOwnClassDiMetadata(target) as RuntimeClassDiMetadata | undefined;
+}
+
+/** Runtime-owned seam for module metadata versioning used by compile-cache keys. */
+export function getRuntimeModuleMetadataVersion(): number {
+  return getPeerModuleMetadataVersion();
+}
+
+/** Runtime-owned seam for class DI metadata versioning used by compile-cache keys. */
+export function getRuntimeClassDiMetadataVersion(): number {
+  return getPeerClassDiMetadataVersion();
+}
+
+/** Runtime-owned seam for reading module metadata during graph compilation. */
+export function getRuntimeModuleMetadata(target: Function): RuntimeModuleMetadata {
+  return getPeerModuleMetadata(target) as RuntimeModuleMetadata;
+}

--- a/packages/runtime/src/internal/core-metadata.ts
+++ b/packages/runtime/src/internal/core-metadata.ts
@@ -47,37 +47,70 @@ export interface RuntimeWritableModuleMetadata {
   providers?: unknown[];
 }
 
-/** Runtime-owned seam for writing module metadata during dynamic module normalization. */
+/**
+ * Writes runtime-visible module metadata through the runtime-owned core metadata seam.
+ *
+ * @param target Module constructor that should receive the metadata snapshot.
+ * @param metadata Module metadata used by decorators, tests, or dynamic module normalization.
+ */
 export function defineRuntimeModuleMetadata(target: Function, metadata: RuntimeWritableModuleMetadata): void {
   definePeerModuleMetadata(target, metadata);
 }
 
-/** Runtime-owned seam for tests that need to mutate class DI metadata versions explicitly. */
+/**
+ * Writes runtime-visible class DI metadata through the runtime-owned core metadata seam.
+ *
+ * @param target Class constructor that should receive DI metadata.
+ * @param metadata DI metadata used by explicit runtime metadata-version tests.
+ */
 export function defineRuntimeClassDiMetadata(target: Function, metadata: RuntimeWritableClassDiMetadata): void {
   definePeerClassDiMetadata(target, metadata);
 }
 
-/** Runtime-owned seam for reading class DI metadata without spreading peer internal imports. */
+/**
+ * Reads runtime-visible class DI metadata without spreading peer internal imports.
+ *
+ * @param target Class constructor whose effective DI metadata should be read.
+ * @returns The effective class DI metadata when present.
+ */
 export function getRuntimeClassDiMetadata(target: Function): RuntimeClassDiMetadata | undefined {
   return getPeerClassDiMetadata(target) as RuntimeClassDiMetadata | undefined;
 }
 
-/** Runtime-owned seam for reading own class DI metadata without spreading peer internal imports. */
+/**
+ * Reads own runtime-visible class DI metadata without inherited metadata fallback.
+ *
+ * @param target Class constructor whose own DI metadata should be read.
+ * @returns The own class DI metadata when present.
+ */
 export function getOwnRuntimeClassDiMetadata(target: Function): RuntimeClassDiMetadata | undefined {
   return getPeerOwnClassDiMetadata(target) as RuntimeClassDiMetadata | undefined;
 }
 
-/** Runtime-owned seam for module metadata versioning used by compile-cache keys. */
+/**
+ * Reads the current module metadata version for runtime compile-cache keys.
+ *
+ * @returns Monotonic module metadata version maintained by the core metadata store.
+ */
 export function getRuntimeModuleMetadataVersion(): number {
   return getPeerModuleMetadataVersion();
 }
 
-/** Runtime-owned seam for class DI metadata versioning used by compile-cache keys. */
+/**
+ * Reads the current class DI metadata version for runtime compile-cache keys.
+ *
+ * @returns Monotonic class DI metadata version maintained by the core metadata store.
+ */
 export function getRuntimeClassDiMetadataVersion(): number {
   return getPeerClassDiMetadataVersion();
 }
 
-/** Runtime-owned seam for reading module metadata during graph compilation. */
+/**
+ * Reads runtime-visible module metadata during graph compilation.
+ *
+ * @param target Module constructor whose metadata should be read.
+ * @returns Module metadata normalized by the core metadata store.
+ */
 export function getRuntimeModuleMetadata(target: Function): RuntimeModuleMetadata {
   return getPeerModuleMetadata(target) as RuntimeModuleMetadata;
 }

--- a/packages/runtime/src/internal/http-runtime.ts
+++ b/packages/runtime/src/internal/http-runtime.ts
@@ -1,0 +1,11 @@
+import { DefaultBinder } from '@fluojs/http/internal';
+import {
+  attachFrameworkRequestNativeRouteHandoff,
+  consumeRawRequestNativeRouteHandoff,
+} from '@fluojs/http/internal';
+
+export { DefaultBinder as RuntimeDefaultBinder };
+export {
+  attachFrameworkRequestNativeRouteHandoff as attachRuntimeFrameworkRequestNativeRouteHandoff,
+  consumeRawRequestNativeRouteHandoff as consumeRuntimeRawRequestNativeRouteHandoff,
+};

--- a/packages/runtime/src/module-graph.test.ts
+++ b/packages/runtime/src/module-graph.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Inject } from '@fluojs/core';
 import { forwardRef, optional } from '@fluojs/di';
-import { defineClassDiMetadata, defineModuleMetadata } from '@fluojs/core/internal';
 import type { MiddlewareRouteConfig } from '@fluojs/http';
 
+import { defineRuntimeClassDiMetadata, defineRuntimeModuleMetadata } from './internal/core-metadata.js';
 import {
   clearModuleGraphCompileCacheForTesting,
   compileModuleGraph,
@@ -19,7 +19,7 @@ describe('module graph cache-key prerequisites', () => {
 
   it('returns the same key for the same root module and options inputs', () => {
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     expect(createModuleGraphCacheKey(AppModule)).toBe(createModuleGraphCacheKey(AppModule));
   });
@@ -28,7 +28,7 @@ describe('module graph cache-key prerequisites', () => {
     class Logger {}
     class Metrics {}
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     const loggerKey = createModuleGraphCacheKey(AppModule, { providers: [Logger] });
     const metricsKey = createModuleGraphCacheKey(AppModule, { providers: [Metrics] });
@@ -41,7 +41,7 @@ describe('module graph cache-key prerequisites', () => {
     const SECOND_TOKEN = Symbol('second-validation-token');
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     const firstKey = createModuleGraphCacheKey(AppModule, { validationTokens: [FIRST_TOKEN] });
     const secondKey = createModuleGraphCacheKey(AppModule, { validationTokens: [SECOND_TOKEN] });
@@ -51,7 +51,7 @@ describe('module graph cache-key prerequisites', () => {
 
   it('includes the compile algorithm version in the cache key', () => {
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
 
     expect(createModuleGraphCacheKey(AppModule)).toContain('algorithm:1');
   });
@@ -59,10 +59,10 @@ describe('module graph cache-key prerequisites', () => {
   it('changes when module metadata changes', () => {
     class Logger {}
     class AppModule {}
-    defineModuleMetadata(AppModule, {});
+    defineRuntimeModuleMetadata(AppModule, {});
     const emptyKey = createModuleGraphCacheKey(AppModule);
 
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [Logger],
     });
 
@@ -78,12 +78,12 @@ describe('module graph cache-key prerequisites', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [Logger, AppService],
     });
     const initialKey = createModuleGraphCacheKey(AppModule);
 
-    defineClassDiMetadata(AppService, {
+    defineRuntimeClassDiMetadata(AppService, {
       scope: 'request',
     });
 
@@ -99,7 +99,7 @@ describe('module graph cache-key prerequisites', () => {
     }
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [AppService],
     });
 
@@ -114,7 +114,7 @@ describe('module graph cache-key prerequisites', () => {
   it('keeps cached module graph snapshots isolated from returned result mutations', () => {
     class Logger {}
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [Logger],
       exports: [Logger],
     });
@@ -140,7 +140,7 @@ describe('module graph cache-key prerequisites', () => {
     const createService = (logger: Logger) => ({ logger });
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         Logger,
         Metrics,
@@ -193,7 +193,7 @@ describe('module graph cache-key prerequisites', () => {
     };
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [
         {
           provide: CONFIG_TOKEN,
@@ -236,7 +236,7 @@ describe('module graph cache-key prerequisites', () => {
     };
 
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       middleware: [routeConfig],
     });
 
@@ -260,7 +260,7 @@ describe('module graph cache-key prerequisites', () => {
   it('keeps the module graph cache opt-in', () => {
     class Logger {}
     class AppModule {}
-    defineModuleMetadata(AppModule, {
+    defineRuntimeModuleMetadata(AppModule, {
       providers: [Logger],
     });
 

--- a/packages/runtime/src/module-graph.ts
+++ b/packages/runtime/src/module-graph.ts
@@ -1,13 +1,14 @@
-import type { Provider } from '@fluojs/di';
 import type { Token } from '@fluojs/core';
-import {
-  getClassDiMetadata,
-  getClassDiMetadataVersion,
-  getModuleMetadata,
-  getModuleMetadataVersion,
-  getOwnClassDiMetadata,
-} from '@fluojs/core/internal';
+import type { Provider } from '@fluojs/di';
 import type { MiddlewareLike } from '@fluojs/http';
+
+import {
+  getRuntimeClassDiMetadata,
+  getRuntimeClassDiMetadataVersion,
+  getOwnRuntimeClassDiMetadata,
+  getRuntimeModuleMetadata,
+  getRuntimeModuleMetadataVersion,
+} from './internal/core-metadata.js';
 
 import { ModuleGraphError, ModuleInjectionMetadataError, ModuleVisibilityError } from './errors.js';
 import type { BootstrapModuleOptions, CompiledModule, ModuleDefinition, ModuleType } from './types.js';
@@ -146,8 +147,8 @@ export function createModuleGraphCacheKey(rootModule: ModuleType, options: Boots
 
   return [
     `root:${describeTokenForCacheKey(rootModule)}`,
-    `module:${getModuleMetadataVersion()}`,
-    `class-di:${getClassDiMetadataVersion()}`,
+    `module:${getRuntimeModuleMetadataVersion()}`,
+    `class-di:${getRuntimeClassDiMetadataVersion()}`,
     `algorithm:${MODULE_GRAPH_COMPILE_ALGORITHM_VERSION}`,
     `runtime:${runtimeProviders}`,
     `validation:${validationTokens}`,
@@ -380,7 +381,7 @@ function createModuleGraphCacheSnapshot(modules: readonly CompiledModule[]): rea
 }
 
 function getEffectiveClassDiMetadata(target: Function): ClassDiMetadataView | undefined {
-  const metadata = getClassDiMetadata(target);
+  const metadata = getRuntimeClassDiMetadata(target);
 
   if (!metadata) {
     return undefined;
@@ -443,7 +444,7 @@ function mergeRuntimeTokenSets(providers: Provider[] = [], validationTokens: rea
 }
 
 function requiredConstructorParameters(target: Function): number {
-  if (getOwnClassDiMetadata(target)?.inject !== undefined) {
+  if (getOwnRuntimeClassDiMetadata(target)?.inject !== undefined) {
     return 0;
   }
 
@@ -517,7 +518,7 @@ function validateControllerInjectionMetadata(controller: ModuleType, scope: stri
   );
 }
 
-function normalizeModuleDefinition(rawDefinition: ReturnType<typeof getModuleMetadata>): ModuleDefinition {
+function normalizeModuleDefinition(rawDefinition: ReturnType<typeof getRuntimeModuleMetadata>): ModuleDefinition {
   if (!rawDefinition) {
     return {};
   }
@@ -560,7 +561,7 @@ function compileModule(
 
   visiting.add(moduleType);
 
-  const definition = normalizeModuleDefinition(getModuleMetadata(moduleType));
+  const definition = normalizeModuleDefinition(getRuntimeModuleMetadata(moduleType));
 
   for (const imported of definition.imports ?? []) {
     compileModule(imported, runtimeProviderTokens, compiled, visiting, ordered);

--- a/packages/runtime/src/web.ts
+++ b/packages/runtime/src/web.ts
@@ -8,11 +8,11 @@ import {
   type FrameworkRequest,
   type FrameworkResponse,
 } from '@fluojs/http';
-import {
-  attachFrameworkRequestNativeRouteHandoff,
-  consumeRawRequestNativeRouteHandoff,
-} from '@fluojs/http/internal';
 
+import {
+  attachRuntimeFrameworkRequestNativeRouteHandoff,
+  consumeRuntimeRawRequestNativeRouteHandoff,
+} from './internal/http-runtime.js';
 import {
   parseMultipart,
   type MultipartOptions,
@@ -461,10 +461,10 @@ function createDeferredWebFrameworkRequest(
     frameworkRequest.body = undefined;
   }
 
-  const nativeRouteHandoff = consumeRawRequestNativeRouteHandoff(request);
+  const nativeRouteHandoff = consumeRuntimeRawRequestNativeRouteHandoff(request);
 
   return nativeRouteHandoff
-    ? attachFrameworkRequestNativeRouteHandoff(frameworkRequest, nativeRouteHandoff)
+    ? attachRuntimeFrameworkRequestNativeRouteHandoff(frameworkRequest, nativeRouteHandoff)
     : frameworkRequest;
 }
 


### PR DESCRIPTION
## Summary

Closes #1661.

- Reduces `@fluojs/runtime` direct coupling to peer package internal subpaths by isolating the remaining `@fluojs/core/internal` and `@fluojs/http/internal` usage behind runtime-owned seams.
- Preserves runtime public behavior and package export maps while adding regression coverage that keeps peer-internal imports centralized.

## Changes

- Added runtime-owned internal wrappers for core metadata reads/writes and HTTP runtime-only helpers.
- Updated runtime bootstrap, module graph, diagnostics, web dispatch, and tests to consume those wrappers instead of importing peer internals directly.
- Added `internal-peer-dependencies.test.ts` to ensure only the runtime seam files import peer internal subpaths.
- Added a patch changeset for `@fluojs/runtime` because the public package artifact changes while behavior remains preserved.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --dir packages/runtime typecheck`
- `pnpm --dir packages/runtime build`
- `pnpm --dir packages/runtime test`
- `pnpm lint` (completed; existing Biome warnings remain in unrelated `packages/config`/`packages/core` files while `verify:public-export-tsdoc` passed)
- LSP diagnostics: clean for changed runtime source/test files

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public runtime API or export-map surface changed; new exported symbols are runtime-internal source seams and are not re-exported from package entrypoints.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This is a contract-preserving refactor. Runtime README behavior and documented runtime invariants are unchanged.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or package README conformance claims changed.