### PR TITLE
Resolve #1660: Correct runtime portability harness API

### DIFF
--- a/book/advanced/ch14-portability-testing.ko.md
+++ b/book/advanced/ch14-portability-testing.ko.md
@@ -205,6 +205,7 @@ WebSocket 하네스에는 "백프레셔(backpressure)" 테스트도 포함되어
 13장에서 커스텀 어댑터를 구현했다면, 이제 하네스를 사용해 이를 검증해야 합니다. 이는 어댑터가 fluo 동작 계약을 준수하는지 확인하는 핵심 테스트입니다. 이식성 하네스를 통과하면 기존 비즈니스 로직을 깨뜨리지 않고 서로 다른 런타임에 어댑터를 배포할 수 있다는 근거를 얻습니다.
 
 ```typescript
+import { FluoFactory } from '@fluojs/runtime';
 import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 import { myAdapter } from './my-adapter';
 

--- a/book/advanced/ch14-portability-testing.ko.md
+++ b/book/advanced/ch14-portability-testing.ko.md
@@ -215,7 +215,9 @@ const harness = createHttpAdapterPortabilityHarness({
     return app;
   },
   run: async (module, opts) => {
-    return await FluoFactory.run(module, { adapter: myAdapter(opts) });
+    const app = await FluoFactory.create(module, { adapter: myAdapter(opts) });
+    await app.listen();
+    return app;
   }
 });
 

--- a/book/advanced/ch14-portability-testing.md
+++ b/book/advanced/ch14-portability-testing.md
@@ -215,7 +215,9 @@ const harness = createHttpAdapterPortabilityHarness({
     return app;
   },
   run: async (module, opts) => {
-    return await FluoFactory.run(module, { adapter: myAdapter(opts) });
+    const app = await FluoFactory.create(module, { adapter: myAdapter(opts) });
+    await app.listen();
+    return app;
   }
 });
 

--- a/book/advanced/ch14-portability-testing.md
+++ b/book/advanced/ch14-portability-testing.md
@@ -205,6 +205,7 @@ The WebSocket harness also includes "backpressure" tests. These verify that the 
 If you implemented a custom adapter in Chapter 13, you should now verify it with the harness. This is the key test that checks whether your adapter complies with the fluo Behavioral Contract. Passing the portability harness gives you evidence that the adapter can be deployed to different runtimes without breaking existing business logic.
 
 ```typescript
+import { FluoFactory } from '@fluojs/runtime';
 import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 import { myAdapter } from './my-adapter';
 


### PR DESCRIPTION
## Summary

- Corrects the advanced book portability harness example so it uses the documented `FluoFactory.create(...)` plus `app.listen()` runtime flow instead of the non-existent `FluoFactory.run(...)` root API.
- Keeps the English and Korean Chapter 14 mirrors aligned for the docs/book-only correction.

Closes #1660

## Changes

- Updated `book/advanced/ch14-portability-testing.md` custom adapter harness example.
- Updated `book/advanced/ch14-portability-testing.ko.md` with the same code flow.
- No runtime source or public API changes; no changeset is included because this is a book-only correction.

## Testing

- LSP diagnostics: no diagnostics for changed EN/KO markdown files.
- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm lint` — completed repository lint/TSDoc checks; existing Biome warnings/infos were reported outside the changed book files, and `verify:public-export-tsdoc` passed.
- `pnpm exec biome lint book/advanced/ch14-portability-testing.md book/advanced/ch14-portability-testing.ko.md` — Biome reported the book markdown paths are ignored, so no markdown files were processed by that command.

## Public export documentation

- [x] No public exports changed.
- [x] No exported functions changed.
- [x] README/source example roles are unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed.
- [x] No new runtime behavioral contracts were introduced.
- [x] Runtime API remains unchanged; the docs now point to the existing documented `FluoFactory.create(...)` / `app.listen()` flow.
- [x] Regression tests are not required for this docs/book-only correction.

## Platform consistency governance (SSOT)

- [x] English/Korean book mirrors remain synchronized for the changed example.
- [x] Platform contract docs were not changed.
- [x] Package README alignment/conformance claims were not changed.