### PR TITLE
Resolve #1676: Track nested Drizzle request shutdown

### DIFF
--- a/.changeset/drizzle-nested-request-shutdown.md
+++ b/.changeset/drizzle-nested-request-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/drizzle": patch
+---
+
+Track nested request transactions opened inside manual Drizzle transaction boundaries during shutdown so they abort and drain before disposal.

--- a/apps/docs/content/docs/guides/persistence.ko.mdx
+++ b/apps/docs/content/docs/guides/persistence.ko.mdx
@@ -136,7 +136,7 @@ export class UserRepository {
 }
 ```
 
-`DrizzleTransactionInterceptor`는 HTTP request를 `DrizzleDatabase.requestTransaction(...)`으로 감쌉니다. Shutdown 중에는 active request transaction을 abort/settle한 뒤 configured `dispose(database)` hook을 실행합니다.
+`DrizzleTransactionInterceptor`는 HTTP request를 `DrizzleDatabase.requestTransaction(...)`으로 감쌉니다. Shutdown 중에는 active request transaction을 abort/settle한 뒤 configured `dispose(database)` hook을 실행합니다. 기존 manual transaction boundary 안의 중첩 `requestTransaction(...)` 호출도 별도 Drizzle transaction을 열지 않고 같은 shutdown tracking에 참여합니다.
 
 ## Mongoose
 

--- a/apps/docs/content/docs/guides/persistence.mdx
+++ b/apps/docs/content/docs/guides/persistence.mdx
@@ -136,7 +136,7 @@ export class UserRepository {
 }
 ```
 
-`DrizzleTransactionInterceptor` wraps HTTP requests with `DrizzleDatabase.requestTransaction(...)`. During shutdown, active request transactions are aborted and settled before the configured `dispose(database)` hook runs.
+`DrizzleTransactionInterceptor` wraps HTTP requests with `DrizzleDatabase.requestTransaction(...)`. During shutdown, active request transactions are aborted and settled before the configured `dispose(database)` hook runs. Nested `requestTransaction(...)` calls inside existing manual transaction boundaries participate in the same shutdown tracking without opening another Drizzle transaction.
 
 ## Mongoose
 

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -107,6 +107,7 @@ class UsersController {}
 ### 종료와 상태 계약
 
 `DrizzleTransactionInterceptor`는 각 HTTP 요청을 `DrizzleDatabase.requestTransaction(...)`으로 실행합니다. 애플리케이션 종료 중에는 `DrizzleDatabase`가 아직 활성 상태인 요청 트랜잭션을 abort하고, 해당 transaction callback이 settle되거나 rollback될 때까지 기다린 뒤 선택적 `dispose(database)` hook을 실행합니다. 이 순서는 pool이나 외부 관리 리소스를 닫기 전에 driver가 rollback/cleanup 작업을 끝낼 수 있게 보장합니다.
+기존 수동 transaction boundary 안에서 열린 중첩 `requestTransaction(...)` 호출도 shutdown tracking에 참여하므로, 두 번째 Drizzle transaction을 열지 않으면서 shutdown이 해당 호출을 abort하고 drain한 뒤 `dispose(database)`를 실행합니다.
 종료가 시작된 뒤 새 `requestTransaction(...)` 호출은 거부되므로, 종료 boundary를 지난 뒤 시작되는 늦은 요청 트랜잭션보다 dispose가 먼저 실행되는 상황을 방지합니다.
 요청 callback이 완료된 뒤 underlying Drizzle transaction runner가 commit 또는 rollback을 끝내기 전에 request signal이 abort되면, `requestTransaction(...)`은 먼저 해당 runner가 settle될 때까지 기다린 다음 abort reason으로 reject합니다. 이 동작은 Drizzle cleanup을 request cancellation과 직렬화하면서, 완료된 callback 결과를 반환하는 대신 늦은 request abort를 caller에게 드러냅니다.
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -107,6 +107,7 @@ class UsersController {}
 ### Shutdown and status contracts
 
 `DrizzleTransactionInterceptor` runs each HTTP request through `DrizzleDatabase.requestTransaction(...)`. During application shutdown, `DrizzleDatabase` aborts any still-active request transaction, waits for its transaction callback to settle or roll back, and only then runs the optional `dispose(database)` hook. This ordering lets drivers finish rollback/cleanup work before pools or externally managed resources are closed.
+Nested `requestTransaction(...)` calls opened inside an existing manual transaction boundary also join shutdown tracking, so shutdown aborts and drains them before `dispose(database)` runs without opening a second Drizzle transaction.
 New `requestTransaction(...)` calls are rejected once shutdown begins, so disposal cannot overtake a late request transaction that starts after the shutdown boundary is crossed.
 If the request signal aborts after the request callback has completed but before the underlying Drizzle transaction runner finishes committing or rolling back, `requestTransaction(...)` waits for that runner to settle first and then rejects with the abort reason. This keeps Drizzle cleanup serialized with request cancellation while making the late request abort visible to the caller instead of returning the completed callback result.
 

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -41,6 +41,12 @@ type DrizzleRuntimeOptions = {
   strictTransactions: boolean;
 };
 
+type TransactionContext<TTransactionDatabase> = {
+  database: TTransactionDatabase;
+  deferredRequestTransactionHandles?: Set<ActiveRequestTransactionHandle>;
+  requestAbortSignal?: AbortSignal;
+};
+
 /**
  * Transaction-aware Drizzle wrapper that integrates request scoping and shutdown handling with the Fluo runtime.
  *
@@ -55,7 +61,7 @@ export class DrizzleDatabase<
   TTransactionOptions = unknown,
 > implements DrizzleHandleProvider<TDatabase, TTransactionDatabase, TTransactionOptions>, OnApplicationShutdown
 {
-  private readonly transactions = new AsyncLocalStorage<TTransactionDatabase>();
+  private readonly transactions = new AsyncLocalStorage<TransactionContext<TTransactionDatabase>>();
   private readonly activeRequestTransactions = new Set<ActiveRequestTransaction>();
   private lifecycleState: 'ready' | 'shutting-down' | 'stopped' = 'ready';
 
@@ -76,7 +82,7 @@ export class DrizzleDatabase<
    * @returns The transaction-scoped database inside an active boundary, or the root database outside one.
    */
   current(): TDatabase | TTransactionDatabase {
-    return this.transactions.getStore() ?? this.database;
+    return this.transactions.getStore()?.database ?? this.database;
   }
 
   /** Aborts active request transactions, waits for settlement, then runs the optional dispose hook. */
@@ -154,8 +160,8 @@ export class DrizzleDatabase<
         throw new Error(NESTED_TRANSACTION_OPTIONS_NOT_SUPPORTED_ERROR);
       }
 
-      if (requestScoped && signal) {
-        return raceWithAbort(fn, signal);
+      if (requestScoped) {
+        return this.executeNestedRequestTransaction(current, fn, signal);
       }
 
       return fn();
@@ -171,7 +177,22 @@ export class DrizzleDatabase<
     }
 
     if (!requestScoped) {
-      return transactionRunner((transactionDatabase) => this.transactions.run(transactionDatabase, fn), options);
+      const deferredRequestTransactionHandles = new Set<ActiveRequestTransactionHandle>();
+
+      try {
+        return await transactionRunner(
+          (transactionDatabase) =>
+            this.transactions.run(
+              { database: transactionDatabase, deferredRequestTransactionHandles },
+              fn,
+            ),
+          options,
+        );
+      } finally {
+        for (const handle of deferredRequestTransactionHandles) {
+          this.untrackActiveRequestTransaction(handle);
+        }
+      }
     }
 
     return this.executeRequestTransaction(transactionRunner, fn, options, signal);
@@ -190,7 +211,11 @@ export class DrizzleDatabase<
 
     try {
       const result = await transactionRunner<T>(
-        (transactionDatabase) => this.transactions.run(transactionDatabase, () => raceWithAbort(fn, abortContext.signal)),
+        (transactionDatabase) =>
+          this.transactions.run(
+            { database: transactionDatabase, requestAbortSignal: abortContext.signal },
+            () => raceWithAbort(fn, abortContext.signal),
+          ),
         options,
       );
 
@@ -200,6 +225,43 @@ export class DrizzleDatabase<
     } finally {
       abortContext.cleanup();
       this.untrackActiveRequestTransaction(active);
+    }
+  }
+
+  private async executeNestedRequestTransaction<T>(
+    current: TransactionContext<TTransactionDatabase>,
+    fn: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    if (current.requestAbortSignal) {
+      if (signal) {
+        return raceWithAbort(fn, signal);
+      }
+
+      return fn();
+    }
+
+    this.assertRequestTransactionsAvailable();
+
+    const abortContext = createRequestAbortContext(signal);
+    const active = this.trackActiveRequestTransaction(abortContext.controller);
+    current.deferredRequestTransactionHandles?.add(active);
+
+    try {
+      const result = await this.transactions.run(
+        { database: current.database, requestAbortSignal: abortContext.signal },
+        () => raceWithAbort(fn, abortContext.signal),
+      );
+
+      this.throwIfRequestAborted(abortContext.signal);
+
+      return result;
+    } finally {
+      abortContext.cleanup();
+
+      if (!current.deferredRequestTransactionHandles) {
+        this.untrackActiveRequestTransaction(active);
+      }
     }
   }
 

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -553,6 +553,60 @@ describe('@fluojs/drizzle', () => {
     expect(transactionCalls).toBe(1);
   });
 
+  it('tracks nested request transactions during shutdown when an explicit transaction is already active', async () => {
+    const events: string[] = [];
+    const transactionDatabase = {};
+    const database = {
+      async transaction<T>(callback: (value: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        events.push('transaction:start');
+
+        try {
+          return await callback(transactionDatabase);
+        } catch (error) {
+          events.push('transaction:rollback');
+          throw error;
+        } finally {
+          events.push('transaction:end');
+        }
+      },
+    };
+
+    const drizzleModule = DrizzleModule.forRoot<typeof database, typeof transactionDatabase>({
+      database,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [drizzleModule],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+    const drizzle = await app.container.resolve(DrizzleDatabase<typeof database, typeof transactionDatabase>);
+
+    const openTransaction = drizzle.transaction(async () =>
+      drizzle.requestTransaction(async () => new Promise<never>(() => undefined)),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(drizzle.createPlatformStatusSnapshot().details.activeRequestTransactions).toBe(1);
+
+    await app.close();
+
+    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+    expect(events).toEqual([
+      'transaction:start',
+      'transaction:rollback',
+      'transaction:end',
+      'dispose',
+    ]);
+  });
+
   it('forwards transaction options for explicit and request-scoped transactions', async () => {
     const optionsCalls: Array<{ isolationLevel: string } | undefined> = [];
     const transactionDatabase = { kind: 'transaction' };


### PR DESCRIPTION
## Summary

Closes #1676.

Fixes Drizzle request transaction shutdown tracking for nested `requestTransaction(...)` calls opened inside an existing manual transaction boundary.

## Changes

- Keep nested request transactions visible in `activeRequestTransactions` until the enclosing Drizzle transaction runner settles.
- Preserve single-boundary nested transaction behavior while allowing shutdown abort/drain semantics to cover nested request scopes.
- Document the nested shutdown tracking contract in `@fluojs/drizzle` README EN/KO and persistence docs EN/KO.
- Add a patch changeset for `@fluojs/drizzle`.

## Testing

- `pnpm --filter @fluojs/drizzle... build`
- `pnpm --filter @fluojs/drizzle build`
- `pnpm --filter @fluojs/drizzle typecheck`
- `pnpm --filter @fluojs/drizzle test`
- `pnpm docs:sync-check`
- LSP diagnostics: `packages/drizzle/src` clean after dependency build.

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or conformance claims were changed; docs parity was checked with `pnpm docs:sync-check`.