### PR TITLE
Resolve #1684: Align notifications lifecycle and queue semantics

### DIFF
--- a/.changeset/fair-owls-report.md
+++ b/.changeset/fair-owls-report.md
@@ -1,5 +1,5 @@
 ---
-"@fluojs/notifications": patch
+"@fluojs/notifications": minor
 ---
 
 Preserve failed lifecycle publication visibility and add deterministic queue job idempotency keys for notification dispatch.

--- a/.changeset/fair-owls-report.md
+++ b/.changeset/fair-owls-report.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/notifications": patch
+---
+
+Preserve failed lifecycle publication visibility and add deterministic queue job idempotency keys for notification dispatch.

--- a/book/intermediate/ch15-notifications.ko.md
+++ b/book/intermediate/ch15-notifications.ko.md
@@ -120,7 +120,7 @@ NotificationsModule.forRoot({
 });
 ```
 
-`bulkThreshold`에 도달하거나 옵션을 통해 명시적으로 요청된 경우, service는 직접 전송 대신 queue adapter를 사용합니다.
+`bulkThreshold`에 도달하거나 옵션을 통해 명시적으로 요청된 경우, service는 직접 전송 대신 queue adapter를 사용합니다. 각 queued job은 안정적인 idempotency key를 포함합니다. `notification.id`가 있으면 그 값을 보존하고, 없으면 notification envelope에서 key를 파생하므로 idempotent enqueue를 지원하는 queue backend가 반복 요청을 중복 제거할 수 있습니다.
 
 ## 15.6 Lifecycle Events
 
@@ -145,7 +145,11 @@ NotificationsModule.forRoot({
 - `notification.dispatch.requested`: `dispatch()`가 호출되었을 때.
 - `notification.dispatch.queued`: 알림이 백그라운드 큐로 이동했을 때.
 - `notification.dispatch.delivered`: 채널이 성공적인 전송을 확인했을 때.
-- `notification.dispatch.failed`: 재시도 후에도 전송이 실패했을 때.
+- `notification.dispatch.failed`: 채널 해석, queue enqueue, provider delivery가 실패했을 때.
+
+채널 해석 실패는 영구적인 구성 오류입니다. 서비스는 `requested` 다음 `failed`를 발행하고, queue에 넣거나 provider를 호출하지 않은 채 `NotificationChannelNotFoundError`를 던집니다. Queue enqueue와 provider delivery 실패도 `failed`를 발행하지만, retry 정책은 underlying queue/provider error를 기준으로 판단해야 합니다. 채널이 `externalId`를 생략하면 서비스는 시간이나 난수가 아니라 notification envelope에서 deterministic fallback delivery id를 만듭니다.
+
+성공 이벤트 publication failure는 이미 완료된 delivery를 애플리케이션 실패로 바꾸지 않도록 best-effort입니다. 반면 `notification.dispatch.failed` publication failure는 다르게 처리됩니다. 호출자는 원래 dispatch error와 publisher error를 모두 담은 `AggregateError`를 받으므로 실패 알림 reporting이 조용히 누락되지 않습니다.
 
 ## 15.7 FluoShop Context: Order Success Flow
 

--- a/book/intermediate/ch15-notifications.md
+++ b/book/intermediate/ch15-notifications.md
@@ -120,7 +120,7 @@ NotificationsModule.forRoot({
 });
 ```
 
-When `bulkThreshold` is reached, or when options explicitly request it, the service uses the queue adapter instead of direct delivery.
+When `bulkThreshold` is reached, or when options explicitly request it, the service uses the queue adapter instead of direct delivery. Each queued job carries a stable idempotency key: `notification.id` is preserved when supplied, otherwise the key is derived from the notification envelope so repeated requests can be deduplicated by queue backends that support idempotent enqueue operations.
 
 ## 15.6 Lifecycle Events
 
@@ -148,6 +148,8 @@ NotificationsModule.forRoot({
 - `notification.dispatch.failed`: When channel resolution, queue enqueue, or provider delivery fails.
 
 Channel resolution failures are permanent configuration errors: the service publishes `requested`, then `failed`, and throws `NotificationChannelNotFoundError` without enqueueing or calling a provider. Queue enqueue and provider delivery failures also publish `failed`, but retry policy should be based on the underlying queue or provider error. When a channel omits `externalId`, the service creates a deterministic fallback delivery id from the notification envelope rather than using time or random data.
+
+Publication failures for success events are best-effort so they do not turn a completed delivery into an application failure. Publication failures for `notification.dispatch.failed` are different: the caller receives an `AggregateError` containing both the original dispatch error and the publisher error so failed notification reporting is never silently swallowed.
 
 ## 15.7 FluoShop Context: Order Success Flow
 

--- a/packages/notifications/README.ko.md
+++ b/packages/notifications/README.ko.md
@@ -120,6 +120,7 @@ Behavioral contract 메모:
 - `dispatch()`는 queue adapter가 구성되어 있어도 기본적으로 직접 전달을 유지합니다. 단건 알림을 큐로 보내려면 `dispatch(..., { queue: true })`를 사용합니다.
 - queue adapter가 있어도 직접 전달을 강제하려면 `dispatch(..., { queue: false })`를 사용합니다.
 - 큐 기반 전달은 단건 dispatch에서는 opt-in이고, `dispatchMany(...)`에서는 threshold 기반으로 동작합니다.
+- Queue job에는 `notification.id`가 있으면 그 값을, 없으면 notification envelope에서 파생한 deterministic `id` idempotency key가 포함됩니다. Queue adapter는 deduplication을 지원하는 backing queue에 이 값을 전달해야 합니다.
 - `dispatchMany(..., { continueOnError: true })`는 direct delivery에서 첫 실패를 던지는 대신 실패들을 수집합니다.
 - queue enqueue가 실패하면 서비스는 enqueue 에러를 다시 던지기 전에 결정적인 `notification.dispatch.failed` 라이프사이클 이벤트를 발행합니다.
 - `enqueueMany(...)`가 없으면 대량 queue delivery는 각 job을 개별적으로 enqueue하는 방식으로 fallback합니다.
@@ -150,7 +151,7 @@ NotificationsModule.forRoot({
 - `notification.dispatch.delivered`
 - `notification.dispatch.failed`
 
-`events.publisher`가 구성되어 있으면 `publishLifecycleEvents: false`를 설정하지 않는 한 lifecycle event publication은 기본으로 켜집니다. 채널 delivery가 `externalId`를 생략하면 시간이나 난수에 의존하지 않고 notification envelope에서 파생한 deterministic fallback delivery id가 부여되어 dispatch result가 호출자에게 안정적으로 유지됩니다. 채널 해석 실패는 `NotificationChannelNotFoundError`를 던지기 전에 `requested` 이후 `failed` 이벤트를 발행하며, 이는 영구적인 구성 오류로 취급해야 합니다. Queue enqueue와 provider delivery 실패도 `failed` 이벤트를 발행하지만, retry 여부는 underlying adapter/provider error를 기준으로 분류해야 합니다.
+`events.publisher`가 구성되어 있으면 `publishLifecycleEvents: false`를 설정하지 않는 한 lifecycle event publication은 기본으로 켜집니다. 채널 delivery가 `externalId`를 생략하면 시간이나 난수에 의존하지 않고 notification envelope에서 파생한 deterministic fallback delivery id가 부여되어 dispatch result가 호출자에게 안정적으로 유지됩니다. 채널 해석 실패는 `NotificationChannelNotFoundError`를 던지기 전에 `requested` 이후 `failed` 이벤트를 발행하며, 이는 영구적인 구성 오류로 취급해야 합니다. Queue enqueue와 provider delivery 실패도 `failed` 이벤트를 발행하지만, retry 여부는 underlying adapter/provider error를 기준으로 분류해야 합니다. 성공 경로 lifecycle event의 publication failure는 이미 전달된 알림을 애플리케이션 실패로 바꾸지 않도록 best-effort로 유지됩니다. `notification.dispatch.failed` publication failure는 원래 dispatch error와 publisher error를 모두 포함하는 `AggregateError`로 호출자에게 드러나므로 failed-event 보장이 조용히 약해지지 않습니다.
 
 ### 의도적인 제한 사항
 
@@ -170,6 +171,7 @@ foundation 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `NotificationsModule.forRoot(options)` / `NotificationsModule.forRootAsync(options)`
 - `NotificationsService`
 - `NotificationsService.createPlatformStatusSnapshot()`
+- `Notifications`
 - `NOTIFICATIONS`
 - `NOTIFICATION_CHANNELS`
 
@@ -179,6 +181,7 @@ foundation 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `NotificationDispatchOptions`
 - `NotificationDispatchManyOptions`
 - `NotificationDispatchResult`
+- `NotificationDispatchBatchResult`
 - `NotificationDispatchFailure`
 - `NotificationDispatchStatus`
 - `NotificationChannel`
@@ -187,6 +190,8 @@ foundation 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `NotificationPayload`
 - `NotificationsQueueAdapter`
 - `NotificationsQueueJob`
+- `NotificationsQueueOptions`
+- `NotificationsModuleOptions`
 - `NotificationsAsyncModuleOptions`
 - `NotificationsEventsOptions`
 - `NotificationsEventPublisher`

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -120,6 +120,7 @@ Behavioral contract notes:
 - `dispatch()` stays direct by default even when a queue adapter is configured. Use `dispatch(..., { queue: true })` to opt one single notification into queue-backed delivery.
 - Use `dispatch(..., { queue: false })` to force direct delivery even when a queue adapter exists.
 - Queue-backed delivery is opt-in for single dispatch and threshold-driven for `dispatchMany(...)`.
+- Queue jobs include a deterministic `id` idempotency key derived from `notification.id` when present, otherwise from the notification envelope. Queue adapters should pass this value to backing queues that support deduplication.
 - `dispatchMany(..., { continueOnError: true })` collects failures instead of throwing on the first failed direct delivery.
 - When queue enqueue fails, the service emits deterministic `notification.dispatch.failed` lifecycle events before rethrowing the enqueue error to the caller.
 - If `enqueueMany(...)` is unavailable, bulk queue delivery falls back to enqueueing each job individually.
@@ -150,7 +151,7 @@ Published event names:
 - `notification.dispatch.delivered`
 - `notification.dispatch.failed`
 
-If `events.publisher` is configured, lifecycle event publication defaults to on unless `publishLifecycleEvents: false` is set. Channel deliveries that omit `externalId` receive a deterministic fallback delivery id derived from the notification envelope so dispatch results remain stable for callers without relying on time or random data. Channel resolution failures publish `requested` and then `failed` events before throwing `NotificationChannelNotFoundError`; treat those failures as permanent configuration errors. Queue enqueue and provider delivery failures also publish `failed` events, but callers should classify their retry behavior from the underlying adapter/provider error.
+If `events.publisher` is configured, lifecycle event publication defaults to on unless `publishLifecycleEvents: false` is set. Channel deliveries that omit `externalId` receive a deterministic fallback delivery id derived from the notification envelope so dispatch results remain stable for callers without relying on time or random data. Channel resolution failures publish `requested` and then `failed` events before throwing `NotificationChannelNotFoundError`; treat those failures as permanent configuration errors. Queue enqueue and provider delivery failures also publish `failed` events, but callers should classify their retry behavior from the underlying adapter/provider error. Publication failures for success-path lifecycle events remain best-effort so a delivered notification is not converted into an application failure. Publication failures for `notification.dispatch.failed` are caller-visible as `AggregateError` values that include both the original dispatch error and the publisher error so failed-event guarantees are not silently weakened.
 
 ### Intentional limitations
 
@@ -170,6 +171,7 @@ These limitations are part of the package contract so leaf packages can evolve i
 - `NotificationsModule.forRoot(options)` / `NotificationsModule.forRootAsync(options)`
 - `NotificationsService`
 - `NotificationsService.createPlatformStatusSnapshot()`
+- `Notifications`
 - `NOTIFICATIONS`
 - `NOTIFICATION_CHANNELS`
 
@@ -179,6 +181,7 @@ These limitations are part of the package contract so leaf packages can evolve i
 - `NotificationDispatchOptions`
 - `NotificationDispatchManyOptions`
 - `NotificationDispatchResult`
+- `NotificationDispatchBatchResult`
 - `NotificationDispatchFailure`
 - `NotificationDispatchStatus`
 - `NotificationChannel`
@@ -187,6 +190,8 @@ These limitations are part of the package contract so leaf packages can evolve i
 - `NotificationPayload`
 - `NotificationsQueueAdapter`
 - `NotificationsQueueJob`
+- `NotificationsQueueOptions`
+- `NotificationsModuleOptions`
 - `NotificationsAsyncModuleOptions`
 - `NotificationsEventsOptions`
 - `NotificationsEventPublisher`

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -299,6 +299,52 @@ describe('NotificationsModule', () => {
     ]);
   });
 
+  it('surfaces explicit queue enqueue failure publication errors with the original queue error', async () => {
+    const queue = new RecordingQueueAdapter();
+    queue.failOnEnqueue = true;
+    const publisher = new RecordingPublisher();
+    publisher.failOnNames.add('notification.dispatch.failed');
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not run when queue is explicitly requested');
+          },
+        },
+      ],
+      events: {
+        publishLifecycleEvents: true,
+        publisher,
+      },
+      queue: {
+        adapter: queue,
+        bulkThreshold: 50,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+    const dispatch = service.dispatch({ channel: 'email', payload: { template: 'single' } }, { queue: true });
+
+    await expect(dispatch).rejects.toBeInstanceOf(AggregateError);
+    await expect(dispatch).rejects.toThrow(
+      'Notification dispatch failed, and failed lifecycle event publication also failed: queue enqueue failed',
+    );
+
+    try {
+      await dispatch;
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors).toHaveLength(2);
+      expect((error as AggregateError).errors[0]).toMatchObject({ message: 'queue enqueue failed' });
+      expect((error as AggregateError).errors[1]).toMatchObject({
+        message: 'publisher failed:notification.dispatch.failed',
+      });
+    }
+  });
+
   it('defaults lifecycle publication on when an events publisher is configured', async () => {
     const publisher = new RecordingPublisher();
     const container = new Container();
@@ -476,10 +522,12 @@ describe('NotificationsModule', () => {
     const service = await container.resolve(NotificationsService);
     const result = await service.dispatchMany([
       { channel: 'email', payload: { template: 'digest', userId: 'u1' } },
-      { channel: 'email', payload: { template: 'digest', userId: 'u2' } },
+      { channel: 'email', id: 'caller-bulk-job-id', payload: { template: 'digest', userId: 'u2' } },
     ]);
 
     expect(queue.jobs).toHaveLength(2);
+    expect(queue.jobs[0]?.id).toMatch(/^notification:email:/);
+    expect(queue.jobs[1]?.id).toBe('caller-bulk-job-id');
     expect(result).toMatchObject({
       failed: 0,
       queued: 2,
@@ -603,6 +651,58 @@ describe('NotificationsModule', () => {
         name: 'notification.dispatch.failed',
       },
     ]);
+  });
+
+  it('surfaces bulk queue enqueue failure publication errors from allSettled results', async () => {
+    const queue = new RecordingQueueAdapter();
+    queue.failOnEnqueueMany = true;
+    const publisher = new RecordingPublisher();
+    publisher.failOnNames.add('notification.dispatch.failed');
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not be used for queued bulk dispatch');
+          },
+        },
+      ],
+      events: {
+        publishLifecycleEvents: true,
+        publisher,
+      },
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+    const dispatch = service.dispatchMany([
+      { channel: 'email', payload: { template: 'digest', userId: 'u1' } },
+      { channel: 'email', payload: { template: 'digest', userId: 'u2' } },
+    ]);
+
+    await expect(dispatch).rejects.toBeInstanceOf(AggregateError);
+    await expect(dispatch).rejects.toThrow(
+      'Notification dispatch failed, and failed lifecycle event publication also failed: queue enqueueMany failed',
+    );
+
+    try {
+      await dispatch;
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors).toHaveLength(3);
+      expect((error as AggregateError).errors[0]).toMatchObject({ message: 'queue enqueueMany failed' });
+      expect((error as AggregateError).errors[1]).toMatchObject({
+        message: 'publisher failed:notification.dispatch.failed',
+      });
+      expect((error as AggregateError).errors[2]).toMatchObject({
+        message: 'publisher failed:notification.dispatch.failed',
+      });
+    }
   });
 
   it('validates channels before queueing bulk deliveries', async () => {

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -216,6 +216,44 @@ describe('NotificationsModule', () => {
 
     expect(result).toMatchObject({ deliveryId: 'queued:1', queued: true, status: 'queued' });
     expect(queue.jobs).toHaveLength(1);
+    expect(queue.jobs[0]).toMatchObject({
+      channel: 'email',
+      id: 'notification:email:1qpsje2',
+      notification: { channel: 'email', payload: { template: 'single' } },
+    });
+  });
+
+  it('uses stable queue job ids so queue adapters can deduplicate repeated requests', async () => {
+    const queue = new RecordingQueueAdapter();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not run when queue is explicitly requested');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+    const request = { channel: 'email', payload: { template: 'digest', userId: 'u1' } };
+
+    await service.dispatch(request, { queue: true });
+    await service.dispatch(request, { queue: true });
+    await service.dispatch({ ...request, id: 'caller-job-id' }, { queue: true });
+
+    expect(queue.jobs.map((job) => job.id)).toEqual([
+      'notification:email:05en8lg',
+      'notification:email:05en8lg',
+      'caller-job-id',
+    ]);
   });
 
   it('publishes a failed lifecycle event when explicit queue dispatch enqueue fails', async () => {
@@ -644,7 +682,7 @@ describe('NotificationsModule', () => {
     });
   });
 
-  it('preserves underlying delivery errors when lifecycle failure publication also fails', async () => {
+  it('surfaces failed lifecycle publication errors instead of swallowing them', async () => {
     const publisher = new RecordingPublisher();
     publisher.failOnNames.add('notification.dispatch.failed');
     const container = new Container();
@@ -666,9 +704,23 @@ describe('NotificationsModule', () => {
     container.register(...moduleProviders(moduleType));
     const service = await container.resolve(NotificationsService);
 
-    await expect(service.dispatch({ channel: 'email', payload: { template: 'broken' } })).rejects.toThrow(
-      'channel delivery failed',
+    const dispatch = service.dispatch({ channel: 'email', payload: { template: 'broken' } });
+
+    await expect(dispatch).rejects.toBeInstanceOf(AggregateError);
+    await expect(dispatch).rejects.toThrow(
+      'Notification dispatch failed, and failed lifecycle event publication also failed: channel delivery failed',
     );
+
+    try {
+      await dispatch;
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors).toHaveLength(2);
+      expect((error as AggregateError).errors[0]).toMatchObject({ message: 'channel delivery failed' });
+      expect((error as AggregateError).errors[1]).toMatchObject({
+        message: 'publisher failed:notification.dispatch.failed',
+      });
+    }
   });
 
   it('uses deterministic fallback delivery ids when channels omit external ids', async () => {

--- a/packages/notifications/src/public-surface.test.ts
+++ b/packages/notifications/src/public-surface.test.ts
@@ -11,6 +11,8 @@ import type {
   NotificationsEventPublisher,
   NotificationsModuleOptions,
   NotificationsQueueAdapter,
+  NotificationsQueueJob,
+  NotificationsQueueOptions,
   NotificationsStatusAdapterInput,
 } from './index.js';
 
@@ -39,6 +41,14 @@ describe('@fluojs/notifications public API surface', () => {
     expectTypeOf<NotificationChannel>().toHaveProperty('channel');
     expectTypeOf<NotificationChannel>().toHaveProperty('send');
     expectTypeOf<NotificationsQueueAdapter>().toHaveProperty('enqueue');
+    expectTypeOf<NotificationsQueueJob>().toMatchTypeOf<{
+      channel: string;
+      id: string;
+      queuedAt: string;
+    }>();
+    expectTypeOf<NotificationsQueueOptions>().toMatchTypeOf<{
+      adapter: NotificationsQueueAdapter;
+    }>();
     expectTypeOf<NotificationsEventPublisher>().toHaveProperty('publish');
     expectTypeOf<Notifications>().toHaveProperty('dispatch');
     expectTypeOf<Notifications>().toHaveProperty('dispatchMany');

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -70,7 +70,7 @@ export class NotificationsService implements Notifications {
       try {
         this.requireChannel(notification.channel);
       } catch (error) {
-        await this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error);
+        await this.publishFailureLifecycleEvent(notification, options, error);
         throw error;
       }
 
@@ -88,7 +88,7 @@ export class NotificationsService implements Notifications {
 
         return result;
       } catch (error) {
-        await this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error);
+        await this.publishFailureLifecycleEvent(notification, options, error);
         throw error;
       }
     }
@@ -98,7 +98,7 @@ export class NotificationsService implements Notifications {
     try {
       channel = this.requireChannel(notification.channel);
     } catch (error) {
-      await this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error);
+      await this.publishFailureLifecycleEvent(notification, options, error);
       throw error;
     }
 
@@ -121,7 +121,7 @@ export class NotificationsService implements Notifications {
 
       return result;
     } catch (error) {
-      await this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error);
+      await this.publishFailureLifecycleEvent(notification, options, error);
       throw error;
     }
   }
@@ -160,7 +160,7 @@ export class NotificationsService implements Notifications {
         try {
           this.requireChannel(notification.channel);
         } catch (error) {
-          await this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error);
+          await this.publishFailureLifecycleEvent(notification, options, error);
           throw error;
         }
       }
@@ -174,11 +174,20 @@ export class NotificationsService implements Notifications {
           ? await queue.enqueueMany(jobs)
           : await Promise.all(jobs.map((job) => queue.enqueue(job)));
       } catch (error) {
-        await Promise.all(
+        const failurePublicationResults = await Promise.allSettled(
           notifications.map((notification) =>
-            this.publishLifecycleEventSafely('notification.dispatch.failed', notification, options, undefined, error),
+            this.publishLifecycleEvent('notification.dispatch.failed', notification, options, undefined, error),
           ),
         );
+
+        const publicationFailures = failurePublicationResults
+          .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+          .map((result) => result.reason);
+
+        if (publicationFailures.length > 0) {
+          throw createLifecyclePublicationFailureError(error, ...publicationFailures);
+        }
+
         throw error;
       }
 
@@ -249,9 +258,18 @@ export class NotificationsService implements Notifications {
   private createQueueJob<TRequest extends NotificationDispatchRequest>(notification: TRequest): NotificationsQueueJob<TRequest> {
     return {
       channel: notification.channel,
+      id: this.createQueueJobId(notification),
       notification,
       queuedAt: new Date().toISOString(),
     };
+  }
+
+  private createQueueJobId(notification: NotificationDispatchRequest): string {
+    if (notification.id && notification.id.length > 0) {
+      return notification.id;
+    }
+
+    return `notification:${notification.channel}:${stableNotificationHash(notification)}`;
   }
 
   private requireChannel(channelName: string): NotificationChannel {
@@ -349,6 +367,27 @@ export class NotificationsService implements Notifications {
       return;
     }
   }
+
+  private async publishFailureLifecycleEvent<TRequest extends NotificationDispatchRequest>(
+    notification: TRequest,
+    options: NotificationDispatchOptions,
+    error: unknown,
+  ): Promise<void> {
+    try {
+      await this.publishLifecycleEvent('notification.dispatch.failed', notification, options, undefined, error);
+    } catch (publicationError) {
+      throw createLifecyclePublicationFailureError(error, publicationError);
+    }
+  }
+}
+
+function createLifecyclePublicationFailureError(dispatchError: unknown, ...publicationErrors: unknown[]): AggregateError {
+  const primaryMessage = dispatchError instanceof Error ? dispatchError.message : 'Notification dispatch failed.';
+
+  return new AggregateError(
+    [dispatchError, ...publicationErrors],
+    `Notification dispatch failed, and failed lifecycle event publication also failed: ${primaryMessage}`,
+  );
 }
 
 function stableNotificationHash(notification: NotificationDispatchRequest): string {

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -63,6 +63,14 @@ export interface NotificationChannel<
 /** Job payload forwarded to an optional queue adapter for deferred delivery. */
 export interface NotificationsQueueJob<TRequest extends NotificationDispatchRequest = NotificationDispatchRequest> {
   channel: string;
+  /**
+   * Deterministic idempotency key derived from the notification envelope.
+   *
+   * @remarks
+   * Queue adapters should use this value as their deduplication key when the
+   * backing queue supports idempotent enqueue semantics.
+   */
+  id: string;
   notification: TRequest;
   queuedAt: string;
 }


### PR DESCRIPTION
## Summary

- Closes #1684.
- Preserves failed lifecycle event visibility when failure-event publication itself fails.
- Aligns notifications queue idempotency, public API docs, package README mirrors, and book lifecycle wording.

## Changes

- Added deterministic `NotificationsQueueJob.id` idempotency keys derived from `notification.id` or the notification envelope.
- Changed `notification.dispatch.failed` publication failures to surface as `AggregateError` with the original dispatch error and publisher error instead of being swallowed.
- Expanded notifications public-surface and queue-id regression coverage.
- Synced EN/KO package README and affected book chapter semantics.
- Added a minor changeset for `@fluojs/notifications`.

## Testing

- `lsp_diagnostics` on `packages/notifications/src`: 0 errors.
- `pnpm --filter @fluojs/notifications test` (23 tests passed).
- `pnpm --filter @fluojs/notifications typecheck`.
- `pnpm build`.
- `pnpm lint` (completed; existing repo lint warnings outside this changeset, public export TSDoc check passed).
- `pnpm changeset status --since=main` (minor bump for `@fluojs/notifications`).

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.