### PR TITLE
Resolve #1671: Harden testing Vitest and portability contracts

### DIFF
--- a/.changeset/harden-testing-vitest-portability.md
+++ b/.changeset/harden-testing-vitest-portability.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/core": patch
+"@fluojs/testing": patch
+---
+
+Harden `@fluojs/testing/vitest` module-id and Babel config portability, make HTTP portability harness assertions less flaky, and expose the module metadata reader through the public core entrypoint so testing helpers avoid private internals.

--- a/.changeset/harden-testing-vitest-portability.md
+++ b/.changeset/harden-testing-vitest-portability.md
@@ -1,6 +1,6 @@
 ---
-"@fluojs/core": patch
+"@fluojs/core": minor
 "@fluojs/testing": patch
 ---
 
-Harden `@fluojs/testing/vitest` module-id and Babel config portability, make HTTP portability harness assertions less flaky, and expose the module metadata reader through the public core entrypoint so testing helpers avoid private internals.
+Harden `@fluojs/testing/vitest` module-id and Babel config portability, make HTTP portability harness assertions less flaky, and add a public `getModuleMetadata()` reader through the core root entrypoint so testing helpers avoid private internals.

--- a/book/advanced/ch14-portability-testing.ko.md
+++ b/book/advanced/ch14-portability-testing.ko.md
@@ -225,8 +225,8 @@ const harness = createHttpAdapterPortabilityHarness({
 describe('MyCustomAdapter Portability', () => {
   it('잘못된 형식의 쿠키를 보존해야 함', () => harness.assertPreservesMalformedCookieValues());
   it('SSE를 처리해야 함', () => harness.assertSupportsSseStreaming());
-  it('중단 시그널을 준수해야 함', () => harness.assertPropagatesAbortSignals());
-  it('원시 바디 무결성을 검증해야 함', () => harness.assertPreservesRawBodyBuffer());
+  it('JSON 및 text 원시 바디를 보존해야 함', () => harness.assertPreservesRawBodyForJsonAndText());
+  it('multipart 원시 바디를 제외해야 함', () => harness.assertExcludesRawBodyForMultipart());
 });
 ```
 

--- a/book/advanced/ch14-portability-testing.md
+++ b/book/advanced/ch14-portability-testing.md
@@ -225,8 +225,8 @@ const harness = createHttpAdapterPortabilityHarness({
 describe('MyCustomAdapter Portability', () => {
   it('preserves malformed cookies', () => harness.assertPreservesMalformedCookieValues());
   it('handles SSE', () => harness.assertSupportsSseStreaming());
-  it('respects abort signals', () => harness.assertPropagatesAbortSignals());
-  it('verifies raw body integrity', () => harness.assertPreservesRawBodyBuffer());
+  it('preserves JSON and text raw bodies', () => harness.assertPreservesRawBodyForJsonAndText());
+  it('excludes multipart raw bodies', () => harness.assertExcludesRawBodyForMultipart());
 });
 ```
 

--- a/packages/core/README.ko.md
+++ b/packages/core/README.ko.md
@@ -85,12 +85,12 @@ class UsesConfigValue {
 
 ### 형제 패키지를 위한 공용 메타데이터 헬퍼
 
-내부 메타데이터 reader/writer는 `@fluojs/core/internal` 아래에 있으며, `@fluojs/di`, `@fluojs/http`, `@fluojs/runtime` 같은 패키지들이 같은 메타데이터 모델을 공유할 수 있게 합니다.
+`getModuleMetadata()`는 테스트와 도구에서 read-only 모듈 inspection을 할 수 있도록 공개 루트 엔트리포인트에서 사용할 수 있습니다. 더 넓은 내부 메타데이터 reader/writer는 `@fluojs/core/internal` 아래에 있으며, `@fluojs/di`, `@fluojs/http`, `@fluojs/runtime` 같은 패키지들이 같은 메타데이터 모델을 공유할 수 있게 합니다.
 
-애플리케이션 코드는 공개 데코레이터와 `ensureMetadataSymbol()`을 `@fluojs/core`에서 import해야 합니다. `@fluojs/core/internal` 서브패스는 메타데이터 레코드, 컨트롤러/라우트 헬퍼, injection/validation 헬퍼, clone 유틸리티가 필요한 fluo 패키지를 위한 경로입니다. 표준 metadata bag helper는 current/native `Symbol.metadata`와 fallback symbol이 섞인 lookup을 처리합니다. 어느 era에서 온 own metadata든 같은 key에 대해서는 어느 era에서 온 inherited metadata보다 우선하지만, child가 다른 key만 소유한 경우 parent constructor의 inherited key는 계속 보입니다. DI와 모듈 그래프 hot path의 allocation을 줄이기 위해 `getModuleMetadata()`, `getOwnClassDiMetadata()`, `getInheritedClassDiMetadata()`, `getClassDiMetadata()`는 frozen snapshot을 반환하며 write 사이에는 같은 reference를 재사용할 수 있습니다. 이 결과, collection 필드, module provider descriptor wrapper와 middleware route-config wrapper(그 안의 `routes` 배열 포함)는 immutable로 취급해야 합니다. `useValue` payload 객체와 runtime middleware/guard/interceptor instance는 mutable reference로 유지되며 이 snapshot 때문에 freeze되지 않습니다. 다른 metadata reader는 각 reader의 테스트가 stable-reference 재사용을 문서화하지 않는 한 기존 defensive-read 동작을 유지합니다.
+애플리케이션 코드는 공개 데코레이터, `ensureMetadataSymbol()`, read-only module metadata inspection을 `@fluojs/core`에서 import해야 합니다. `@fluojs/core/internal` 서브패스는 메타데이터 레코드, 컨트롤러/라우트 헬퍼, injection/validation 헬퍼, clone 유틸리티가 필요한 fluo 패키지를 위한 경로입니다. 표준 metadata bag helper는 current/native `Symbol.metadata`와 fallback symbol이 섞인 lookup을 처리합니다. 어느 era에서 온 own metadata든 같은 key에 대해서는 어느 era에서 온 inherited metadata보다 우선하지만, child가 다른 key만 소유한 경우 parent constructor의 inherited key는 계속 보입니다. DI와 모듈 그래프 hot path의 allocation을 줄이기 위해 `getModuleMetadata()`, `getOwnClassDiMetadata()`, `getInheritedClassDiMetadata()`, `getClassDiMetadata()`는 frozen snapshot을 반환하며 write 사이에는 같은 reference를 재사용할 수 있습니다. 이 결과, collection 필드, module provider descriptor wrapper와 middleware route-config wrapper(그 안의 `routes` 배열 포함)는 immutable로 취급해야 합니다. `useValue` payload 객체와 runtime middleware/guard/interceptor instance는 mutable reference로 유지되며 이 snapshot 때문에 freeze되지 않습니다. 다른 metadata reader는 각 reader의 테스트가 stable-reference 재사용을 문서화하지 않는 한 기존 defensive-read 동작을 유지합니다.
 
 ```ts
-import { getModuleMetadata } from '@fluojs/core/internal';
+import { getModuleMetadata } from '@fluojs/core';
 
 const metadata = getModuleMetadata(AppModule);
 console.log(metadata.providers);
@@ -159,7 +159,7 @@ class Logger {}
 
 - **데코레이터**: `Module`, `Global`, `Inject`, `Scope`
 - **에러**: `FluoError`, `InvariantError`, `FluoCodeError`, `FluoErrorOptions`, `formatTokenName`
-- **메타데이터 런타임**: `ensureMetadataSymbol`
+- **메타데이터 런타임**: `ensureMetadataSymbol`, `getModuleMetadata`
 - **타입**: `Constructor<T>`, `Token<T>`, `MaybePromise<T>`, `AsyncModuleOptions`, `MetadataPropertyKey`, `MetadataSource`
 - **내부 서브패스**: `@fluojs/core/internal`을 통한 메타데이터 헬퍼, 컨트롤러/라우트 헬퍼, injection 헬퍼, validation 헬퍼, clone 유틸리티
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -87,12 +87,12 @@ Pass multiple constructor tokens as variadic arguments, such as `@Inject(A, B)`,
 
 ### Shared metadata helpers for sibling packages
 
-Internal readers and writers live under `@fluojs/core/internal`, which is how packages like `@fluojs/di`, `@fluojs/http`, and `@fluojs/runtime` consume the same metadata model.
+`getModuleMetadata()` is available from the public root entrypoint for read-only module inspection in tests and tooling. Broader internal readers and writers live under `@fluojs/core/internal`, which is how packages like `@fluojs/di`, `@fluojs/http`, and `@fluojs/runtime` consume the same metadata model.
 
-Application code should import public decorators and `ensureMetadataSymbol()` from `@fluojs/core`. The `@fluojs/core/internal` subpath is reserved for fluo packages that need metadata records, controller/route helpers, injection and validation helpers, or clone utilities. Standard metadata bag helpers handle mixed-era lookups across current/native `Symbol.metadata` and the fallback symbol: own metadata from either era overrides inherited metadata from either era for the same key, while inherited keys from parent constructors remain visible when the child owns a different key. To reduce DI and module-graph hot-path allocations, `getModuleMetadata()`, `getOwnClassDiMetadata()`, `getInheritedClassDiMetadata()`, and `getClassDiMetadata()` return frozen snapshots and may reuse the same reference between writes. Treat those results, their collection fields, module provider descriptor wrappers, and middleware route-config wrappers (including their `routes` arrays) as immutable. `useValue` payload objects and runtime middleware/guard/interceptor instances remain mutable references and are not frozen by these snapshots. Other metadata readers keep their existing defensive-read behavior unless their own tests document stable-reference reuse.
+Application code should import public decorators, `ensureMetadataSymbol()`, and read-only module metadata inspection from `@fluojs/core`. The `@fluojs/core/internal` subpath is reserved for fluo packages that need metadata records, controller/route helpers, injection and validation helpers, or clone utilities. Standard metadata bag helpers handle mixed-era lookups across current/native `Symbol.metadata` and the fallback symbol: own metadata from either era overrides inherited metadata from either era for the same key, while inherited keys from parent constructors remain visible when the child owns a different key. To reduce DI and module-graph hot-path allocations, `getModuleMetadata()`, `getOwnClassDiMetadata()`, `getInheritedClassDiMetadata()`, and `getClassDiMetadata()` return frozen snapshots and may reuse the same reference between writes. Treat those results, their collection fields, module provider descriptor wrappers, and middleware route-config wrappers (including their `routes` arrays) as immutable. `useValue` payload objects and runtime middleware/guard/interceptor instances remain mutable references and are not frozen by these snapshots. Other metadata readers keep their existing defensive-read behavior unless their own tests document stable-reference reuse.
 
 ```ts
-import { getModuleMetadata } from '@fluojs/core/internal';
+import { getModuleMetadata } from '@fluojs/core';
 
 const metadata = getModuleMetadata(AppModule);
 console.log(metadata.providers);
@@ -161,7 +161,7 @@ Standard decorators cannot automatically infer types for abstract classes or int
 
 - **Decorators**: `Module`, `Global`, `Inject`, `Scope`
 - **Errors**: `FluoError`, `InvariantError`, `FluoCodeError`, `FluoErrorOptions`, `formatTokenName`
-- **Metadata runtime**: `ensureMetadataSymbol`
+- **Metadata runtime**: `ensureMetadataSymbol`, `getModuleMetadata`
 - **Types**: `Constructor<T>`, `Token<T>`, `MaybePromise<T>`, `AsyncModuleOptions`, `MetadataPropertyKey`, `MetadataSource`
 - **Internal subpath**: metadata helpers, controller/route helpers, injection helpers, validation helpers, and clone utilities via `@fluojs/core/internal`
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
 export { Global, Inject, Module, Scope } from './decorators.js';
 export { InvariantError, FluoCodeError, FluoError, formatTokenName, type FluoErrorOptions } from './errors.js';
-export { ensureMetadataSymbol } from './metadata.js';
+export { ensureMetadataSymbol, getModuleMetadata } from './metadata.js';
 export type { AsyncModuleOptions, Constructor, MaybePromise, MetadataPropertyKey, MetadataSource, Token } from './types.js';

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -12,11 +12,11 @@ describe('@fluojs/core public API surface', () => {
     expect(corePublicApi).toHaveProperty('FluoError');
     expect(corePublicApi).toHaveProperty('InvariantError');
     expect(corePublicApi).toHaveProperty('ensureMetadataSymbol');
+    expect(corePublicApi).toHaveProperty('getModuleMetadata');
   });
 
-  it('does not expose internal metadata helpers on the root barrel', () => {
+  it('does not expose internal metadata writers or non-module readers on the root barrel', () => {
     expect(corePublicApi).not.toHaveProperty('defineModuleMetadata');
-    expect(corePublicApi).not.toHaveProperty('getModuleMetadata');
     expect(corePublicApi).not.toHaveProperty('getModuleMetadataVersion');
     expect(corePublicApi).not.toHaveProperty('defineControllerMetadata');
     expect(corePublicApi).not.toHaveProperty('getControllerMetadata');

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -25,7 +25,7 @@ pnpm add -D @fluojs/testing vitest
 
 `vitest`는 mock 헬퍼와 `@fluojs/testing/vitest` 엔트리포인트가 요구하는 peer dependency입니다.
 
-`@fluojs/testing/vitest`를 사용할 때는 `fluoBabelDecoratorsPlugin()`이 런타임에 Babel을 호출하므로, 사용하는 워크스페이스에 `@babel/core`도 함께 설치해야 합니다.
+`@fluojs/testing/vitest`를 사용할 때는 `fluoBabelDecoratorsPlugin()`이 런타임에 Babel을 호출하므로, 사용하는 워크스페이스에 `@babel/core`도 함께 설치해야 합니다. Vitest 플러그인은 Vite query/hash suffix를 제거한 뒤 `.ts`, `.tsx`, `.mts`, `.cts` 소스 id를 변환하고, `node_modules`는 건너뛰며, 가장 가까운 root Babel config인 `babel.config.cjs`, `babel.config.mjs`, `babel.config.js`, `babel.config.json`을 해석합니다.
 
 ```bash
 pnpm add -D @babel/core
@@ -133,6 +133,8 @@ const mailer = createDeepMock(MailService);
 ### 적합성 및 이식성 하니스
 
 프레임워크 지향 플랫폼 패키지를 작성할 때는 `@fluojs/testing/platform-conformance`, `@fluojs/testing/http-adapter-portability`, `@fluojs/testing/web-runtime-adapter-portability` 같은 서브패스를 사용해 적합성 및 이식성 검증을 수행합니다.
+
+`HttpAdapterPortabilityHarness` 메서드는 공개 어댑터 계약 체크입니다. 직접 같은 검증을 다시 만들기보다 `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, `assertRemovesShutdownSignalListenersAfterClose()`처럼 초점이 분명한 assertion을 사용하세요.
 
 ## canonical TDD ladder
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -23,7 +23,7 @@ npm install --save-dev @fluojs/testing vitest
 
 `vitest` is a required peer dependency for the mock helpers and the `@fluojs/testing/vitest` entrypoint.
 
-If you use `@fluojs/testing/vitest`, install `@babel/core` in the consuming workspace as well because `fluoBabelDecoratorsPlugin()` invokes Babel at runtime:
+If you use `@fluojs/testing/vitest`, install `@babel/core` in the consuming workspace as well because `fluoBabelDecoratorsPlugin()` invokes Babel at runtime. The Vitest plugin transforms `.ts`, `.tsx`, `.mts`, and `.cts` source ids after removing Vite query/hash suffixes, skips `node_modules`, and resolves the nearest root Babel config named `babel.config.cjs`, `babel.config.mjs`, `babel.config.js`, or `babel.config.json`:
 
 ```bash
 npm install --save-dev @babel/core
@@ -131,6 +131,8 @@ Install `vitest` in the consuming workspace before using the mock helpers so the
 ### Conformance and portability harnesses
 
 Use subpaths like `@fluojs/testing/platform-conformance`, `@fluojs/testing/http-adapter-portability`, and `@fluojs/testing/web-runtime-adapter-portability` when authoring framework-facing platform packages.
+
+`HttpAdapterPortabilityHarness` methods are the public adapter contract checks. Prefer focused assertions such as `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, and `assertRemovesShutdownSignalListenersAfterClose()` instead of hand-rolled equivalents.
 
 ## Canonical TDD Ladder
 

--- a/packages/testing/src/babel-decorators-plugin.test.ts
+++ b/packages/testing/src/babel-decorators-plugin.test.ts
@@ -1,0 +1,63 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { transformAsync } from '@babel/core';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createFluoBabelDecoratorsPlugin, resolveNearestBabelConfigFile } from './babel-decorators-plugin.js';
+
+vi.mock('@babel/core', () => ({
+  transformAsync: vi.fn(async () => ({
+    code: 'transformed();',
+    map: { mappings: '' },
+  })),
+}));
+
+const mockedTransformAsync = vi.mocked(transformAsync);
+
+function createWorkspaceWithConfig(configFileName: string): { filePath: string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), 'fluo-testing-babel-'));
+  const sourceDirectory = join(root, 'src', 'feature');
+  mkdirSync(sourceDirectory, { recursive: true });
+  writeFileSync(join(root, configFileName), 'module.exports = {};');
+  writeFileSync(join(sourceDirectory, '.keep'), '', { flag: 'w' });
+
+  return {
+    filePath: join(sourceDirectory, 'app.ts'),
+    root,
+  };
+}
+
+describe('fluoBabelDecoratorsPlugin', () => {
+  it('normalizes Vite query-suffixed TypeScript ids before transforming', async () => {
+    mockedTransformAsync.mockClear();
+    const plugin = createFluoBabelDecoratorsPlugin((filePath) => `${filePath}.config.cjs`);
+
+    await expect(plugin.transform('@Module({}) class AppModule {}', '/workspace/src/app.ts?import')).resolves.toEqual({
+      code: 'transformed();',
+      map: { mappings: '' },
+    });
+
+    expect(mockedTransformAsync).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      configFile: '/workspace/src/app.ts.config.cjs',
+      filename: '/workspace/src/app.ts',
+    }));
+  });
+
+  it('transforms TS variants while skipping dependencies', async () => {
+    mockedTransformAsync.mockClear();
+    const plugin = createFluoBabelDecoratorsPlugin((filePath) => `${filePath}.config.cjs`);
+
+    await expect(plugin.transform('class Component {}', '/workspace/src/component.tsx')).resolves.not.toBeNull();
+    await expect(plugin.transform('class Cli {}', '/workspace/src/cli.mts')).resolves.not.toBeNull();
+    await expect(plugin.transform('class Legacy {}', '/workspace/src/legacy.cts')).resolves.not.toBeNull();
+    await expect(plugin.transform('class Dependency {}', '/workspace/node_modules/pkg/index.ts?raw')).resolves.toBeNull();
+  });
+
+  it('resolves supported Babel root config names from query-suffixed ids', () => {
+    const { filePath, root } = createWorkspaceWithConfig('babel.config.mjs');
+
+    expect(resolveNearestBabelConfigFile(`${filePath}?v=123`)).toBe(join(root, 'babel.config.mjs'));
+  });
+});

--- a/packages/testing/src/babel-decorators-plugin.ts
+++ b/packages/testing/src/babel-decorators-plugin.ts
@@ -1,20 +1,35 @@
 import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, extname, join } from 'node:path';
 
 import { transformAsync } from '@babel/core';
 
 const babelConfigFileCache = new Map<string, string>();
+const babelConfigFileNames = ['babel.config.cjs', 'babel.config.mjs', 'babel.config.js', 'babel.config.json'] as const;
+
+function normalizeTransformId(id: string): string {
+  const withoutQuery = id.split(/[?#]/, 1)[0] ?? id;
+
+  return withoutQuery.startsWith('\0') ? withoutQuery.slice(1) : withoutQuery;
+}
+
+function isNodeModulesPath(filePath: string): boolean {
+  return /(?:^|[/\\])node_modules(?:[/\\]|$)/.test(filePath);
+}
+
+function isTypeScriptSource(filePath: string): boolean {
+  return ['.cts', '.mts', '.ts', '.tsx'].includes(extname(filePath));
+}
 
 /**
- * Resolves the nearest `babel.config.cjs` file starting from the given file path
+ * Resolves the nearest Babel root configuration file starting from the given file path
  * and searching upwards through the directory hierarchy.
  *
  * @param filePath - The path to the file whose nearest Babel configuration should be found.
- * @returns The absolute path to the nearest `babel.config.cjs` file.
+ * @returns The absolute path to the nearest Babel root configuration file.
  * @throws Error if no configuration file can be located.
  */
 export function resolveNearestBabelConfigFile(filePath: string): string {
-  let currentDirectory = dirname(filePath);
+  let currentDirectory = dirname(normalizeTransformId(filePath));
 
   while (true) {
     const cachedConfigFile = babelConfigFileCache.get(currentDirectory);
@@ -23,17 +38,19 @@ export function resolveNearestBabelConfigFile(filePath: string): string {
       return cachedConfigFile;
     }
 
-    const configFile = join(currentDirectory, 'babel.config.cjs');
+    for (const configFileName of babelConfigFileNames) {
+      const configFile = join(currentDirectory, configFileName);
 
-    if (existsSync(configFile)) {
-      babelConfigFileCache.set(currentDirectory, configFile);
-      return configFile;
+      if (existsSync(configFile)) {
+        babelConfigFileCache.set(currentDirectory, configFile);
+        return configFile;
+      }
     }
 
     const parentDirectory = dirname(currentDirectory);
 
     if (parentDirectory === currentDirectory) {
-      throw new Error(`Unable to locate babel.config.cjs for ${filePath}.`);
+      throw new Error(`Unable to locate a Babel root config (${babelConfigFileNames.join(', ')}) for ${filePath}.`);
     }
 
     currentDirectory = parentDirectory;
@@ -53,14 +70,16 @@ export function createFluoBabelDecoratorsPlugin(
   return {
     name: 'fluo-babel-decorators',
     async transform(code: string, id: string) {
-      if (!id.endsWith('.ts') || id.includes('/node_modules/')) {
+      const filePath = normalizeTransformId(id);
+
+      if (!isTypeScriptSource(filePath) || isNodeModulesPath(filePath)) {
         return null;
       }
 
       const result = await transformAsync(code, {
         babelrc: false,
-        configFile: resolveConfigFile(id),
-        filename: id,
+        configFile: resolveConfigFile(filePath),
+        filename: filePath,
         sourceMaps: true,
       });
 

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -1,5 +1,4 @@
-import type { MaybePromise, Token } from '@fluojs/core';
-import { getModuleMetadata } from '@fluojs/core/internal';
+import { getModuleMetadata, type MaybePromise, type Token } from '@fluojs/core';
 import {
   isForwardRef,
   isOptionalToken,

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -415,9 +415,9 @@ export class HttpAdapterPortabilityHarness<
 
         stream.comment('connected');
         stream.send({ ready: true }, { event: 'ready', id: 'evt-1' });
-        setTimeout(() => {
+        queueMicrotask(() => {
           stream.close();
-        }, 10);
+        });
 
         return stream;
       }

--- a/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 // biome-ignore lint/suspicious/noTsIgnore: Vitest resolves workspace package aliases after package builds.
 // @ts-ignore Vitest workspace alias resolution handles package test imports.
@@ -101,6 +101,41 @@ function restoreMockBun(originalBun: MockBun | undefined): void {
   (globalThis as typeof globalThis & { Bun?: MockBun }).Bun = originalBun;
 }
 
+async function createBunPortabilityApp(
+  rootModule: Parameters<typeof bootstrapBunApplication>[0],
+  options: Parameters<typeof bootstrapBunApplication>[1],
+  bootstrap: typeof bootstrapBunApplication = bootstrapBunApplication,
+) {
+  const originalBun = (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
+  const mockBun = installMockBun();
+  let app: Awaited<ReturnType<typeof bootstrapBunApplication>> | undefined;
+
+  try {
+    app = await bootstrap(rootModule, options);
+    await app.listen();
+  } catch (error) {
+    if (app) {
+      await app.close().catch(() => {});
+    }
+
+    restoreMockBun(originalBun);
+    throw error;
+  }
+
+  return {
+    async close() {
+      try {
+        await app.close();
+      } finally {
+        restoreMockBun(originalBun);
+      }
+    },
+    async dispatch(request: Request) {
+      return await mockBun.lastServer!.fetch(request);
+    },
+  };
+}
+
 function registerWebRuntimePortabilitySuite(
   name: string,
   harness: {
@@ -138,38 +173,56 @@ registerWebRuntimePortabilitySuite(
   'bun',
   createWebRuntimeHttpAdapterPortabilityHarness({
     async bootstrap(rootModule, options) {
-      const originalBun = (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
-      const mockBun = installMockBun();
-      let app: Awaited<ReturnType<typeof bootstrapBunApplication>> | undefined;
-
-      try {
-        app = await bootstrapBunApplication(rootModule, options);
-        await app.listen();
-      } catch (error) {
-        if (app) {
-          await app.close().catch(() => {});
-        }
-
-        restoreMockBun(originalBun);
-        throw error;
-      }
-
-      return {
-        async close() {
-          try {
-            await app.close();
-          } finally {
-            restoreMockBun(originalBun);
-          }
-        },
-        async dispatch(request: Request) {
-          return await mockBun.lastServer!.fetch(request);
-        },
-      };
+      return await createBunPortabilityApp(rootModule, options);
     },
     name: 'bun',
   }),
 );
+
+describe('bun web runtime adapter cleanup', () => {
+  it('restores mocked Bun when bootstrap throws before listen', async () => {
+    class BrokenModule {}
+    const previousBun = (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
+    const originalBun = { serve: vi.fn() } as MockBun;
+    (globalThis as typeof globalThis & { Bun?: MockBun }).Bun = originalBun;
+
+    try {
+      await expect(
+        createBunPortabilityApp(BrokenModule, {} as Parameters<typeof bootstrapBunApplication>[1], async () => {
+          throw new Error('bootstrap failed');
+        }),
+      ).rejects.toThrow('bootstrap failed');
+
+      expect((globalThis as typeof globalThis & { Bun?: MockBun }).Bun).toBe(originalBun);
+    } finally {
+      restoreMockBun(previousBun);
+    }
+  });
+
+  it('restores mocked Bun and closes partial apps when listen throws', async () => {
+    class BrokenModule {}
+    const previousBun = (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
+    const originalBun = { serve: vi.fn() } as MockBun;
+    const close = vi.fn(async () => {});
+    (globalThis as typeof globalThis & { Bun?: MockBun }).Bun = originalBun;
+
+    try {
+      await expect(
+        createBunPortabilityApp(BrokenModule, {} as Parameters<typeof bootstrapBunApplication>[1], async () => ({
+          close,
+          async listen() {
+            throw new Error('listen failed');
+          },
+        } as Awaited<ReturnType<typeof bootstrapBunApplication>>)),
+      ).rejects.toThrow('listen failed');
+
+      expect(close).toHaveBeenCalledTimes(1);
+      expect((globalThis as typeof globalThis & { Bun?: MockBun }).Bun).toBe(originalBun);
+    } finally {
+      restoreMockBun(previousBun);
+    }
+  });
+});
 
 registerWebRuntimePortabilitySuite(
   'deno',

--- a/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, vi } from 'vitest';
 
+// biome-ignore lint/suspicious/noTsIgnore: Vitest resolves workspace package aliases after package builds.
 // @ts-ignore Vitest workspace alias resolution handles package test imports.
 import { bootstrapBunApplication, type BunServeOptions, type BunServerLike } from '@fluojs/platform-bun';
+// biome-ignore lint/suspicious/noTsIgnore: Vitest resolves workspace package aliases after package builds.
 // @ts-ignore Vitest workspace alias resolution handles package test imports.
 import { bootstrapCloudflareWorkerApplication, type CloudflareWorkerExecutionContext } from '@fluojs/platform-cloudflare-workers';
+// biome-ignore lint/suspicious/noTsIgnore: Vitest resolves workspace package aliases after package builds.
 // @ts-ignore Vitest workspace alias resolution handles package test imports.
 import { bootstrapDenoApplication, type DenoServeController, type DenoServeHandler, type DenoServeOptions } from '@fluojs/platform-deno';
 
@@ -89,6 +92,15 @@ function installMockBun(): MockBun {
   return mockBun;
 }
 
+function restoreMockBun(originalBun: MockBun | undefined): void {
+  if (originalBun === undefined) {
+    delete (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
+    return;
+  }
+
+  (globalThis as typeof globalThis & { Bun?: MockBun }).Bun = originalBun;
+}
+
 function registerWebRuntimePortabilitySuite(
   name: string,
   harness: {
@@ -128,20 +140,27 @@ registerWebRuntimePortabilitySuite(
     async bootstrap(rootModule, options) {
       const originalBun = (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
       const mockBun = installMockBun();
-      const app = await bootstrapBunApplication(rootModule, options);
+      let app: Awaited<ReturnType<typeof bootstrapBunApplication>> | undefined;
 
-      await app.listen();
+      try {
+        app = await bootstrapBunApplication(rootModule, options);
+        await app.listen();
+      } catch (error) {
+        if (app) {
+          await app.close().catch(() => {});
+        }
+
+        restoreMockBun(originalBun);
+        throw error;
+      }
 
       return {
         async close() {
-          await app.close();
-
-          if (originalBun === undefined) {
-            delete (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
-            return;
+          try {
+            await app.close();
+          } finally {
+            restoreMockBun(originalBun);
           }
-
-          (globalThis as typeof globalThis & { Bun?: MockBun }).Bun = originalBun;
         },
         async dispatch(request: Request) {
           return await mockBun.lastServer!.fetch(request);


### PR DESCRIPTION
## Summary

Closes #1671.

Harden the `@fluojs/testing` Vitest decorator plugin and portability harness contracts so common Vite/Vitest ids, Babel config shapes, and runtime cleanup paths remain stable.

## Changes

- Normalized Vitest transform ids before extension/config checks, added TS variant coverage, and resolved additional Babel root config filenames.
- Exposed `getModuleMetadata()` from `@fluojs/core` root and moved testing helpers off the private core internal subpath.
- Made SSE harness close scheduling deterministic and restored mocked `globalThis.Bun` through failure paths.
- Updated `@fluojs/testing` README/KO and advanced chapter 14 EN/KO examples to match the current harness API.
- Added a patch changeset for `@fluojs/core` and `@fluojs/testing`.

## Testing

- `pnpm install`
- `pnpm build`
- `pnpm --dir packages/testing test`
- `pnpm --dir packages/core typecheck && pnpm --dir packages/testing typecheck`
- `pnpm exec biome lint "packages/testing/src/babel-decorators-plugin.ts" "packages/testing/src/babel-decorators-plugin.test.ts" "packages/testing/src/module.ts" "packages/core/src/index.ts" "packages/testing/src/portability/http-adapter-portability.ts" "packages/testing/src/portability/web-runtime-adapter-portability.test.ts"`
- `pnpm verify:public-export-tsdoc`
- LSP diagnostics clean on changed TypeScript files

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.