### PR TITLE
Resolve #1672: Harden Prisma request transaction cleanup

### DIFF
--- a/.changeset/prisma-request-transaction-cleanup.md
+++ b/.changeset/prisma-request-transaction-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/prisma": patch
+---
+
+Ensure request-scoped transaction bookkeeping is released when Prisma transaction validation fails before the request transaction starts.

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -768,6 +768,20 @@ describe('@fluojs/prisma', () => {
     await app.close();
   });
 
+  it('cleans up request transaction tracking when strict transaction validation throws synchronously', async () => {
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+    };
+
+    const prisma = new PrismaService<typeof client>(client, { strictTransactions: true });
+
+    await expect(prisma.requestTransaction(async () => 'never')).rejects.toThrow(
+      'Transaction not supported: Prisma client does not implement $transaction.',
+    );
+    expect(prisma.createPlatformStatusSnapshot().details).toMatchObject({ activeRequestTransactions: 0 });
+  });
+
   it('reports ownership/readiness/health semantics in platform snapshot shape', () => {
     const snapshot = createPrismaPlatformStatusSnapshot({
       activeRequestTransactions: 1,

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -192,15 +192,14 @@ export class PrismaService<
   async requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal, options?: TTransactionOptions): Promise<T> {
     const abortContext = createRequestAbortContext(signal);
     const active = this.trackActiveRequestTransaction(abortContext.controller);
-    const transactionPromise = this.runWithTransactionClient<T>(
-      () => raceWithAbort(fn, abortContext.signal),
-      (callback, transactionOptions) =>
-        this.runRequestTransactionWithAbortSignal(callback, abortContext.signal, transactionOptions),
-      options,
-    );
 
     try {
-      return await transactionPromise;
+      return await this.runWithTransactionClient<T>(
+        () => raceWithAbort(fn, abortContext.signal),
+        (callback, transactionOptions) =>
+          this.runRequestTransactionWithAbortSignal(callback, abortContext.signal, transactionOptions),
+        options,
+      );
     } finally {
       abortContext.cleanup();
       this.untrackActiveRequestTransaction(active);


### PR DESCRIPTION
## Summary

Closes #1672

Harden `@fluojs/prisma` request-scoped transaction cleanup so bookkeeping is released even when transaction validation fails before Prisma starts a transaction.

## Changes

- Moved `requestTransaction()` execution inside the cleanup `try/finally` boundary.
- Added regression coverage for strict transaction validation throwing synchronously without leaving active request transaction tracking behind.
- Added a patch Changeset for the public `@fluojs/prisma` behavior fix.

## Testing

- `lsp_diagnostics` on `packages/prisma/src/service.ts`: clean
- `lsp_diagnostics` on `packages/prisma/src/module.test.ts`: clean
- `pnpm --filter @fluojs/prisma test`: passed
- `pnpm --filter @fluojs/prisma typecheck`: passed
- `pnpm --filter @fluojs/prisma build`: passed
- `pnpm verify:platform-consistency-governance`: passed
- `pnpm changeset status --since=origin/main`: passed
- `pnpm verify:release-readiness`: attempted; failed in the existing CLI sandbox matrix with `Expected the starter scaffold to include src/app.e2e.test.ts` under local Node.js v24.9.0, after package tests and governance tests had passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public export signatures were changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This preserves the documented request transaction drain/status contract by ensuring failed pre-start request transactions do not remain tracked.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or package README conformance claims were changed.