### PR TITLE
Resolve #1675: Align Vite spec file build exclusion

### DIFF
--- a/.changeset/vite-spec-build-skip.md
+++ b/.changeset/vite-spec-build-skip.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/vite": patch
+---
+
+Keep package build outputs aligned with the documented Vite plugin boundary by excluding `src/**/*.spec.ts` files alongside `src/**/*.test.ts` files.

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "prebuild": "node ../../tooling/scripts/clean-dist.mjs",
-    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
+    "build": "pnpm exec babel src --extensions .ts --ignore 'src/**/*.test.ts','src/**/*.spec.ts' --out-dir dist --config-file ../../tooling/babel/babel.config.cjs && pnpm exec tsc -p tsconfig.build.json",
     "typecheck": "pnpm exec tsc -p tsconfig.json --noEmit",
     "test": "pnpm exec vitest run -c vitest.config.ts",
     "test:watch": "pnpm exec vitest -c vitest.config.ts"

--- a/packages/vite/src/index.test.ts
+++ b/packages/vite/src/index.test.ts
@@ -1,7 +1,43 @@
+import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 import type { Plugin } from 'vite';
 
 import { fluoDecoratorsPlugin } from './index.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+async function readJsonFile(path: URL): Promise<Record<string, unknown>> {
+  const content = await readFile(path, 'utf8');
+  const parsed: unknown = JSON.parse(content);
+
+  if (!isRecord(parsed)) {
+    throw new Error(`Expected ${path.pathname} to contain a JSON object.`);
+  }
+
+  return parsed;
+}
+
+function readRecordProperty(source: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = source[key];
+
+  if (!isRecord(value)) {
+    throw new Error(`Expected ${key} to contain a JSON object.`);
+  }
+
+  return value;
+}
+
+function readStringArrayProperty(source: Record<string, unknown>, key: string): string[] {
+  const value = source[key];
+
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error(`Expected ${key} to contain a string array.`);
+  }
+
+  return value;
+}
 
 function runTransform(plugin: Plugin, code: string, id: string): unknown {
   if (typeof plugin.transform !== 'function') {
@@ -16,6 +52,15 @@ describe('fluoDecoratorsPlugin', () => {
     const plugin = fluoDecoratorsPlugin();
 
     await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/app.test.ts')).resolves.toBeNull();
+  });
+
+  it('keeps package build outputs aligned with the documented test/spec skip contract', async () => {
+    const packageJson = await readJsonFile(new URL('../package.json', import.meta.url));
+    const buildConfig = await readJsonFile(new URL('../tsconfig.build.json', import.meta.url));
+    const scripts = readRecordProperty(packageJson, 'scripts');
+
+    expect(scripts.build).toContain("--ignore 'src/**/*.test.ts','src/**/*.spec.ts'");
+    expect(readStringArrayProperty(buildConfig, 'exclude')).toEqual(['src/**/*.test.ts', 'src/**/*.spec.ts']);
   });
 
   it('keeps the Vite transform boundary on application TypeScript files', async () => {

--- a/packages/vite/tsconfig.build.json
+++ b/packages/vite/tsconfig.build.json
@@ -6,5 +6,5 @@
     "outDir": "dist",
     "noEmit": false
   },
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary

Aligns the `@fluojs/vite` package build output with the documented transform boundary so `src/**/*.spec.ts` files are excluded like `src/**/*.test.ts` files.

Closes #1675

## Changes

- Extends the Babel build ignore list to skip `src/**/*.spec.ts`.
- Extends `tsconfig.build.json` declaration emit exclusion to skip `src/**/*.spec.ts`.
- Adds a regression test that locks the package build script and TypeScript build exclude list to the documented test/spec skip contract.
- Adds a patch changeset for the public `@fluojs/vite` package behavior fix.

## Testing

- `lsp_diagnostics` on `packages/vite/src/index.test.ts`, `packages/vite/package.json`, and `packages/vite/tsconfig.build.json`: no diagnostics.
- `pnpm --dir packages/vite test`: passed, 4 tests.
- `pnpm --dir packages/vite typecheck`: passed.
- `pnpm --dir packages/vite build`: passed.
- `pnpm lint`: completed with existing unrelated repository warnings; changed-mode public export TSDoc check passed.
- `pnpm verify:platform-consistency-governance`: passed.
- `pnpm verify:release-readiness`: attempted; package/build/typecheck/split package/apps/examples/tooling tests passed before failing in the existing CLI sandbox check with `Expected the starter scaffold to include src/app.e2e.test.ts` under the local temp sandbox.

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contract was added; the implementation now preserves the existing README-documented test/spec skip contract.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime/build invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs (none changed).
- [x] No platform contract docs changed.
- [x] No package README alignment/conformance claims changed.