### PR TITLE
Resolve #1677: Align EventBus book contracts

### DIFF
--- a/.changeset/event-bus-channel-docs.md
+++ b/.changeset/event-bus-channel-docs.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/event-bus": patch
+---
+
+Clarify the EventBus transport subscription contract and align official book examples with class-based event handlers.

--- a/book/intermediate/ch15-notifications.ko.md
+++ b/book/intermediate/ch15-notifications.ko.md
@@ -156,7 +156,7 @@ NotificationsModule.forRoot({
 FluoShop은 주문 확인을 위해 알림을 사용합니다. 이는 Part 2에서 구축한 event-driven 작업 위에 놓입니다. `OrderPlacedEvent`가 `OrderSaga`에 의해 포착되면 알림 dispatch가 트리거되고, 주문 처리와 사용자 알림은 느슨하게 연결된 후속 책임으로 분리됩니다.
 
 ```typescript
-@OnEvent('order.placed')
+@OnEvent(OrderPlacedEvent)
 async onOrderPlaced(event: OrderPlacedEvent) {
   await this.notifications.dispatch({
     channel: 'email',

--- a/book/intermediate/ch15-notifications.md
+++ b/book/intermediate/ch15-notifications.md
@@ -156,7 +156,7 @@ Publication failures for success events are best-effort so they do not turn a co
 FluoShop uses notifications for order confirmations. This sits on top of the event-driven work built in Part 2. When `OrderPlacedEvent` is captured by `OrderSaga`, notification dispatch is triggered, and order processing and user notification become loosely connected follow-up responsibilities.
 
 ```typescript
-@OnEvent('order.placed')
+@OnEvent(OrderPlacedEvent)
 async onOrderPlaced(event: OrderPlacedEvent) {
   await this.notifications.dispatch({
     channel: 'email',

--- a/book/intermediate/ch17-slack-discord.ko.md
+++ b/book/intermediate/ch17-slack-discord.ko.md
@@ -173,7 +173,7 @@ await this.discord.send({
 FluoShop에서는 내부 운영 알림에는 Slack을 사용하고, 공개 커뮤니티에 공유할 주문 알림에는 Discord를 사용합니다. `NotificationsService`를 사용하면 하나의 도메인 이벤트를 정책에 따라 한 플랫폼 또는 여러 플랫폼으로 라우팅할 수 있습니다. 이 구분은 이벤트 생산자에게 채널 선택 책임을 떠넘기지 않고, 알림 정책을 중앙에서 관리하게 해줍니다.
 
 ```typescript
-@OnEvent('order.placed')
+@OnEvent(OrderPlacedEvent)
 async alertOps(event: OrderPlacedEvent) {
   // Slack으로 개발자에게 알림
   await this.notifications.dispatch({

--- a/book/intermediate/ch17-slack-discord.md
+++ b/book/intermediate/ch17-slack-discord.md
@@ -175,7 +175,7 @@ In FluoShop, Slack is used for internal operational notifications, while Discord
 `NotificationsService` lets a single domain event route to one platform or several platforms based on policy.
 
 ```typescript
-@OnEvent('order.placed')
+@OnEvent(OrderPlacedEvent)
 async alertOps(event: OrderPlacedEvent) {
   // Notify developers through Slack
   await this.notifications.dispatch({

--- a/packages/event-bus/src/types.ts
+++ b/packages/event-bus/src/types.ts
@@ -38,8 +38,8 @@ export interface EventBusTransport {
 
   /**
    * Subscribe to incoming messages on the given channel from the external transport.
-   * The event bus calls this once per discovered local handler during bootstrap.
-   * Received messages are deserialized and dispatched to matching local handlers.
+   * The event bus calls this once per unique event channel during bootstrap.
+   * Received messages are dispatched to every matching local handler for that channel.
    */
   subscribe(channel: string, handler: (payload: unknown) => Promise<void>): Promise<void>;
 


### PR DESCRIPTION
## Summary

Align official EventBus learning material and TSDoc with the class-based `@OnEvent(EventClass)` contract.

Closes #1677

## Changes

- Replaced string-based `@OnEvent('order.placed')` examples in the intermediate notifications and Slack/Discord book chapters with `@OnEvent(OrderPlacedEvent)`.
- Kept English/Korean book chapter examples synchronized.
- Clarified `EventBusTransport.subscribe(...)` TSDoc to describe one subscription per unique event channel and fan-out to matching local handlers.
- Added a patch changeset for `@fluojs/event-bus` so the public package TSDoc contract clarification is release-noted.

## Testing

- `pnpm install`
- `pnpm --filter @fluojs/event-bus test` — passed (50 tests)
- `pnpm --filter @fluojs/event-bus typecheck` — passed
- `pnpm changeset status --since=origin/main` — passed, reports `@fluojs/event-bus` patch bump
- `pnpm --filter @fluojs/event-bus build` — passed
- `git diff --check` — passed
- `pnpm verify:platform-consistency-governance` — passed
- Previous source verification: `lsp_diagnostics` on `packages/event-bus/src/types.ts` — no diagnostics after workspace dependency builds

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public export shape changed. The package source change is a TSDoc clarification on the existing `EventBusTransport.subscribe(...)` contract, now covered by `.changeset/event-bus-channel-docs.md`.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This PR aligns docs/comments with the existing class-based EventBus contract and unique-channel transport behavior; it does not change runtime behavior. A patch changeset is included to release-note the public package TSDoc contract clarification.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or package README conformance claims changed.