### PR TITLE
Resolve #1681: Correct metrics documentation contract

### DIFF
--- a/book/beginner/ch19-metrics.ko.md
+++ b/book/beginner/ch19-metrics.ko.md
@@ -81,19 +81,19 @@ import { MetricsModule } from '@fluojs/metrics';
 export class AppModule {}
 ```
 
-기본적으로 이는 `GET /metrics` 엔드포인트를 노출합니다. 이 엔드포인트에 접속하면 내부 Node.js 메트릭(CPU, 메모리, 가비지 컬렉션)과 Fluo 전용 메트릭이 포함된 텍스트 형식(OpenMetrics)의 데이터를 볼 수 있습니다. 이 "OpenMetrics" 형식은 현대적인 관측성 도구에서 널리 쓰이는 공통 형식이며, 많은 모니터링 도구가 그대로 읽을 수 있습니다.
+기본적으로 이는 `GET /metrics` 엔드포인트를 노출합니다. 응답은 활성 `prom-client` Registry가 제공하는 Prometheus text exposition content type을 사용합니다. `defaultMetrics`를 켜 둔 경우 기본 프로세스 및 Node.js 메트릭과 같은 Registry의 Fluo 전용 메트릭이 함께 포함됩니다. 이것이 현재 `@fluojs/metrics` 패키지 계약입니다. 향후 패키지 버전이 명시적으로 문서화하기 전까지는 이 엔드포인트가 다른 exposition format을 반환한다고 가정하여 스크레이퍼나 테스트를 구성하지 마세요.
 
 ### 19.3.1 Under the Hood: The Registry
-`MetricsModule`은 애플리케이션에 정의된 모든 메트릭의 내부 "레지스트리(Registry)"를 유지 관리합니다. `/metrics` 엔드포인트가 호출되면 모듈은 이 레지스트리를 순회하며 현재 값들을 수집하고 이를 텍스트 응답 형식으로 변환합니다. 이 과정은 스크랩 요청이 애플리케이션 성능에 불필요한 부담을 주지 않도록 가볍게 유지되어야 합니다.
+각 `MetricsModule.forRoot()` 호출은 `registry` option을 명시적으로 전달하지 않는 한 격리된 `prom-client` `Registry`를 소유합니다. `/metrics` 엔드포인트가 호출되면 모듈은 해당 active Registry를 스크레이프하고 현재 값을 수집하여 Prometheus 텍스트 응답 형식으로 변환합니다. 이 과정은 스크랩 요청이 애플리케이션 성능에 불필요한 부담을 주지 않도록 가볍게 유지되어야 합니다.
 
 ### 19.3.2 Scrape Intervals and Resolution
 중요한 고려 사항 중 하나는 Prometheus가 얼마나 자주 애플리케이션을 스크랩해야 하는가입니다. 전형적인 간격은 15초 또는 30초입니다. 간격이 짧을수록 더 고해상도의 데이터를 얻을 수 있지만 서버 부하가 늘어납니다. 간격이 길면 가볍지만 짧은 트래픽 폭주(micro-bursts)를 놓칠 수 있습니다. Fluo의 메트릭은 "스레드 안전"하고 "비차단(Non-Blocking)" 방식으로 설계되어 있으므로, 운영자는 정확도와 비용 사이의 균형을 기준으로 간격을 정하면 됩니다.
 
-### 19.3.3 Customizing the Default Registry
-Fluo는 글로벌 기본 레지스트리를 제공하지만, 때로는 시스템 메트릭과 비즈니스 KPI를 분리하기 위해 여러 레지스트리를 관리해야 할 수도 있습니다. `MetricsModule`을 사용하면 커스텀 레지스트리를 정의하고 주입할 수 있어 데이터가 조직되고 노출되는 방식을 완전히 제어할 수 있습니다. 이는 각 테넌트마다 별도의 메트릭 엔드포인트를 노출하고 싶은 멀티 테넌트 애플리케이션에서 특히 유용합니다.
+### 19.3.3 Choosing a Registry Model
+기본 모델은 격리된 Registry ownership입니다. 하나의 `MetricsModule.forRoot()` 인스턴스가 자신이 소유한 collector를 등록하고 스크레이프합니다. framework metric과 application metric을 하나의 scrape surface에서 공유해야 한다면 직접 `Registry`를 만들고 제한된 custom metric을 등록한 뒤 `MetricsModule.forRoot({ registry })`에 전달하세요. 내장 HTTP collector와 플랫폼 텔레메트리 Gauge는 의도적으로 공유된 모듈 인스턴스 사이에서도 framework-owned이고 예상 label schema를 가진 경우에만 재사용되며, 애플리케이션이 직접 정의한 중복 메트릭 이름은 계속 빠르게 실패합니다.
 
 ### 19.3.4 Integration with Cloud-Native Sidecars
-Istio나 Linkerd와 같은 서비스 메쉬(Service Mesh) 환경에서 애플리케이션은 종종 "사이드카(Sidecar)" 프록시와 함께 실행됩니다. 이러한 프록시들은 자체 메트릭을 가지기도 하지만, Fluo 애플리케이션 메트릭을 합산하고 노출하도록 설정할 수도 있습니다. Fluo가 OpenMetrics 표준을 따르기 때문에 이 데이터는 사이드카 기반 관측성 패턴과 자연스럽게 연결됩니다.
+Istio나 Linkerd와 같은 서비스 메쉬(Service Mesh) 환경에서 애플리케이션은 종종 "사이드카(Sidecar)" 프록시와 함께 실행됩니다. 이러한 프록시들은 자체 메트릭을 가지기도 하지만, Fluo 애플리케이션 메트릭을 합산하고 노출하도록 설정할 수도 있습니다. Fluo는 Prometheus 텍스트 스크레이프 형식을 노출하므로 이 데이터는 Prometheus-compatible 사이드카 관측성 패턴과 자연스럽게 연결됩니다.
 
 ### 19.3.5 Metrics in Distributed Environments
 애플리케이션의 여러 인스턴스가 서로 다른 가용 영역(availability zones)이나 클라우드 제공업체에 걸쳐 실행되는 분산 시스템에서, `MetricsModule`은 지원되는 플랫폼 텔레메트리 라벨을 명시적으로 설정했을 때 각 인스턴스가 데이터를 일관되고 식별 가능한 방식으로 보고하도록 돕습니다. 현재 내장 플랫폼 텔레메트리 계약은 문서화된 `env`와 `instance` 라벨을 지원하며, pod 이름, host IP, zone, region 같은 인프라 라벨을 자동으로 추가하지 않습니다.
@@ -205,18 +205,27 @@ this.metrics.histogram({
 프로덕션 환경에서는 일반 대중에게 내부 메트릭을 공개하고 싶지 않을 것입니다. 메트릭은 트래픽 패턴, 사용자 증가세, 내부 아키텍처에 대한 민감한 정보를 드러낼 수 있습니다. 커스텀 미들웨어나 Fluo의 내장 보안 기능을 사용하여 엔드포인트를 보호할 수 있습니다.
 
 ```typescript
-MetricsModule.forRoot({
-  endpointMiddleware: [
-    (context, next) => {
-      const apiKey = context.request.headers['x-monitoring-key'];
-      if (apiKey !== process.env.MONITORING_SECRET) {
-        throw new ForbiddenException('Restricted Access');
-      }
-      return next();
+import { ForbiddenException, type MiddlewareContext, type Next } from '@fluojs/http';
+
+class MetricsTokenMiddleware {
+  private readonly monitoringSecret = 'configured-secret';
+
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    const apiKey = context.request.headers['x-monitoring-key'];
+    if (apiKey !== this.monitoringSecret) {
+      throw new ForbiddenException('Restricted Access');
     }
-  ],
+
+    await next();
+  }
+}
+
+MetricsModule.forRoot({
+  endpointMiddleware: [MetricsTokenMiddleware],
 })
 ```
+
+`endpointMiddleware`는 scrape endpoint에만 적용되는 route-scoped middleware이며 `@fluojs/http`와 같은 class-based middleware 계약을 따릅니다. `handle(context, next)` 메서드에서 예외를 던지거나 반환하거나 `next()`를 `await`하는 middleware constructor를 전달하세요.
 
 ### 19.6.1 IP Whitelisting
 프로덕션에서 흔히 쓰이는 패턴은 Prometheus 서버의 IP 주소만 `/metrics` 라우트에 접근할 수 있도록 허용하는 것입니다. 이는 모니터링 도구에 복잡한 인증 로직을 요구하지 않으면서도 강력한 보안 계층을 제공합니다. 대부분의 클라우드 제공업체는 보안 그룹이나 방화벽을 통해 네트워크 수준에서 이를 구현할 수 있게 해주지만, Fluo의 미들웨어 시스템은 코드에서도 이를 유연하게 처리할 수 있는 방법을 제공합니다.
@@ -281,7 +290,7 @@ Fluo는 공통적인 사용 사례(예: "API 개요", "데이터베이스 성능
 - **커스텀 추적**: 비즈니스에 중요한 KPI와 시스템 상태를 측정하기 위해 `Counter`, `Gauge`, `Histogram`을 사용하세요.
 - **HTTP 인스트루먼테이션**: Fluo는 `MetricsModule.forRoot({ http: true })` 또는 동등한 HTTP 옵션을 활성화한 경우 기준 가시성을 위한 기본 HTTP 요청, 에러, 지연 시간 메트릭을 제공합니다.
 - **알림**: 성능이 저하되거나 에러율이 급증할 때 팀에 알리도록 Grafana를 활용하여 선제적인 사고 대응을 준비하세요.
-- **표준화**: OpenMetrics 표준을 따름으로써 Fluo는 현대적인 모니터링 생태계와의 호환성을 확보합니다.
+- **표준화**: Prometheus 텍스트 형식 스크레이프를 노출함으로써 Fluo는 Prometheus 모니터링 생태계와의 호환성을 확보합니다.
 
 Part 4: 캐싱과 운영을 마쳤습니다. 이제 FluoBlog에는 더 빠른 읽기 경로와 명확한 헬스 신호, 그리고 실행 중 상태를 관찰할 수 있는 메트릭이 갖춰졌습니다. 마지막 파트에서는 테스트와 최종 프로덕션 점검에 집중합니다.
 

--- a/book/beginner/ch19-metrics.md
+++ b/book/beginner/ch19-metrics.md
@@ -81,19 +81,19 @@ import { MetricsModule } from '@fluojs/metrics';
 export class AppModule {}
 ```
 
-By default, this exposes the `GET /metrics` endpoint. When you access this endpoint, you can see text-format data, OpenMetrics, that includes internal Node.js metrics such as CPU, memory, and garbage collection, as well as Fluo-specific metrics. This "OpenMetrics" format is a common format widely used by modern observability tools, and many monitoring tools can read it as-is.
+By default, this exposes the `GET /metrics` endpoint. The response uses the Prometheus text exposition content type provided by the active `prom-client` registry. It includes default process and Node.js metrics when `defaultMetrics` stays enabled, plus Fluo-specific metrics from the same registry. This is the package contract for `@fluojs/metrics`; do not configure scrapers or tests as if the endpoint returned another exposition format unless a future package version explicitly documents that format.
 
 ### 19.3.1 Under the Hood: The Registry
-`MetricsModule` maintains an internal registry of every metric defined in the application. When the `/metrics` endpoint is called, the Module walks this registry, collects the current values, and converts them into a text response format. This process should stay lightweight so scrape requests do not add unnecessary load to application performance.
+Each `MetricsModule.forRoot()` call owns an isolated `prom-client` `Registry` unless you explicitly pass a `registry` option. When the `/metrics` endpoint is called, the module scrapes that active registry, collects the current values, and converts them into the Prometheus text response format. This process should stay lightweight so scrape requests do not add unnecessary load to application performance.
 
 ### 19.3.2 Scrape Intervals and Resolution
 One important consideration is how often Prometheus should scrape the application. Typical intervals are 15 or 30 seconds. Shorter intervals provide higher-resolution data but increase server load. Longer intervals are lighter, but they can miss short traffic micro-bursts. Fluo's metrics are designed to be thread-safe and non-blocking, so operators can choose an interval based on the balance between accuracy and cost.
 
-### 19.3.3 Customizing the Default Registry
-Fluo provides a global default registry, but sometimes you may need to manage multiple registries to separate system metrics from business KPIs. `MetricsModule` lets you define and inject custom registries, giving you full control over how data is organized and exposed. This is especially useful in multi-tenant applications where you want to expose a separate metrics endpoint for each tenant.
+### 19.3.3 Choosing a Registry Model
+The default model is isolated registry ownership: one `MetricsModule.forRoot()` instance registers and scrapes the collectors it owns. If you need framework metrics and application metrics to share a scrape surface, create a `Registry` yourself, register bounded custom metrics on it, and pass that registry to `MetricsModule.forRoot({ registry })`. Built-in HTTP collectors and platform telemetry gauges are reused across intentionally shared module instances only when they are framework-owned and have the expected label schema; application-defined duplicate metric names still fail fast.
 
 ### 19.3.4 Integration with Cloud-Native Sidecars
-In service mesh environments such as Istio or Linkerd, applications often run with sidecar proxies. These proxies may have their own metrics, but they can also be configured to aggregate and expose Fluo application metrics. Because Fluo follows the OpenMetrics standard, this data connects naturally with sidecar-based observability patterns.
+In service mesh environments such as Istio or Linkerd, applications often run with sidecar proxies. These proxies may have their own metrics, but they can also be configured to aggregate and expose Fluo application metrics. Because Fluo exposes the Prometheus text scrape format, this data connects naturally with Prometheus-compatible sidecar observability patterns.
 
 ### 19.3.5 Metrics in Distributed Environments
 In distributed systems where multiple application instances run across different availability zones or cloud providers, `MetricsModule` helps each instance report data in a consistent and identifiable way when you configure the supported platform telemetry labels explicitly. The built-in platform telemetry contract supports the documented `env` and `instance` labels; it does not automatically add infrastructure labels such as pod names, host IPs, zones, or regions.
@@ -205,18 +205,27 @@ A common monitoring problem is that metrics do not appear in Prometheus until th
 In production, you likely do not want to expose internal metrics to the general public. Metrics can reveal sensitive information about traffic patterns, user growth, and internal architecture. You can protect the endpoint with custom Middleware or Fluo's built-in security features.
 
 ```typescript
-MetricsModule.forRoot({
-  endpointMiddleware: [
-    (context, next) => {
-      const apiKey = context.request.headers['x-monitoring-key'];
-      if (apiKey !== process.env.MONITORING_SECRET) {
-        throw new ForbiddenException('Restricted Access');
-      }
-      return next();
+import { ForbiddenException, type MiddlewareContext, type Next } from '@fluojs/http';
+
+class MetricsTokenMiddleware {
+  private readonly monitoringSecret = 'configured-secret';
+
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    const apiKey = context.request.headers['x-monitoring-key'];
+    if (apiKey !== this.monitoringSecret) {
+      throw new ForbiddenException('Restricted Access');
     }
-  ],
+
+    await next();
+  }
+}
+
+MetricsModule.forRoot({
+  endpointMiddleware: [MetricsTokenMiddleware],
 })
 ```
+
+`endpointMiddleware` is route-scoped middleware for the scrape endpoint and follows the same class-based middleware contract as `@fluojs/http`: pass middleware constructors whose `handle(context, next)` method either throws, returns, or awaits `next()`.
 
 ### 19.6.1 IP Whitelisting
 A common production pattern is allowing only the Prometheus server IP address to access the `/metrics` route. This provides a strong security layer without requiring complex authentication logic in the monitoring tool. Most cloud providers let you implement this at the network level through security groups or firewalls, but Fluo's Middleware system also gives you a flexible way to handle it in code.
@@ -281,7 +290,7 @@ Metrics turn FluoBlog from a "black box" into an observable system. Collecting d
 - **Custom tracking**: Use `Counter`, `Gauge`, and `Histogram` to measure business-critical KPIs and system state.
 - **HTTP instrumentation**: Fluo provides baseline HTTP request, error, and latency metrics when `MetricsModule.forRoot({ http: true })` or equivalent HTTP options are enabled.
 - **Alerting**: Use Grafana to prepare proactive incident response by notifying the team when performance degrades or error rates spike.
-- **Standardization**: By following the OpenMetrics standard, Fluo remains compatible with the modern monitoring ecosystem.
+- **Standardization**: By exposing Prometheus text-format scrapes, Fluo remains compatible with the Prometheus monitoring ecosystem.
 
 Part 4, caching and operations, is complete. FluoBlog now has faster read paths, clear health signals, and metrics for observing runtime state. In the final part, we will focus on testing and final production checks.
 

--- a/examples/ops-metrics-terminus/README.ko.md
+++ b/examples/ops-metrics-terminus/README.ko.md
@@ -8,7 +8,7 @@
 
 - `MetricsModule.forRoot()`를 통한 `/metrics`
 - `TerminusModule.forRoot(...)`를 통한 `/health`, `/ready`
-- `MetricsModule`이 scrape하는 shared Registry에 등록한 custom Prometheus counter 하나
+- `MetricsModule`이 scrape하는 의도적으로 shared Registry에 등록한 custom Prometheus counter 하나
 - terminus와 metrics에 함께 노출되는 runtime-aligned health/readiness semantics
 - `@fluojs/testing`을 사용한 unit / integration / e2e 스타일 검증
 

--- a/examples/ops-metrics-terminus/README.md
+++ b/examples/ops-metrics-terminus/README.md
@@ -8,7 +8,7 @@ Runnable fluo operations example focused on `@fluojs/metrics` and `@fluojs/termi
 
 - `/metrics` via `MetricsModule.forRoot()`
 - `/health` and `/ready` via `TerminusModule.forRoot(...)`
-- one custom Prometheus counter registered on a shared Registry that is scraped through `MetricsModule`
+- one custom Prometheus counter registered on an intentionally shared Registry that is scraped through `MetricsModule`
 - runtime-aligned health/readiness semantics exposed through terminus and metrics
 - unit, integration, and e2e-style verification with `@fluojs/testing`
 

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -40,6 +40,8 @@ class AppModule {}
 
 `MetricsModule.forRoot()`는 기본적으로 `GET /metrics`를 노출합니다. HTTP request instrumentation middleware를 설치하려면 `http: true` 또는 `http` option object를 전달하세요. HTTP 계측이 활성화되면 request total, error count, request duration을 기록합니다. 운영 환경에서는 scrape endpoint boundary를 명시적으로 다루세요. platform-level proxy가 준비될 때까지 `path: false`로 끄거나 dedicated endpoint middleware를 연결할 수 있습니다.
 
+Scrape endpoint는 active `prom-client` Registry output을 해당 Registry의 Prometheus content type으로 반환합니다. `MetricsModule.forRoot()`는 `registry` option을 전달하지 않는 한 격리된 Registry를 생성합니다. framework metric과 application-defined metric이 하나의 scrape surface를 의도적으로 공유해야 할 때만 shared `Registry`를 전달하세요.
+
 ## 공통 패턴
 
 ### HTTP path label 정규화
@@ -88,6 +90,8 @@ MetricsModule.forRoot({
   path: false,
 });
 ```
+
+`endpointMiddleware`는 class-based `@fluojs/http` middleware constructor를 받으며 metrics scrape endpoint에만 바인딩됩니다. middleware function이나 global middleware declaration은 이 option의 패키지 계약이 아닙니다.
 
 ### Framework metric과 app metric이 하나의 registry를 공유하기
 
@@ -165,8 +169,9 @@ MetricsModule.forRoot({
 ### 운영 기본값
 
 - `path`의 기본값은 `'/metrics'`이며, `path: false`로 스크레이프 엔드포인트를 완전히 비활성화할 수 있습니다.
+- scrape response는 active Registry의 Prometheus content type과 Registry contents를 사용합니다.
 - `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`로 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 끌 수 있습니다.
-- `endpointMiddleware`는 스크레이프 엔드포인트에만 route-scoped middleware를 바인딩합니다.
+- `endpointMiddleware`는 class-based route-scoped middleware를 스크레이프 엔드포인트에만 바인딩합니다.
 - HTTP 메트릭은 `http: true` 또는 `http` 옵션 객체를 전달한 경우에만 설치되며, 설치된 뒤에는 기본적으로 템플릿 기반 경로 라벨 정규화를 사용합니다.
 - 내장 HTTP collector와 플랫폼 텔레메트리 Gauge는 같은 Registry를 공유하는 모듈 인스턴스 사이에서 framework-owned이고 예상 label schema를 가진 경우에만 재사용되며, 커스텀 애플리케이션 메트릭 이름 충돌은 Prometheus의 중복 이름 실패 동작을 유지합니다.
 - raw path 라벨은 `allowUnsafeRawPathLabelMode: true`를 명시한 bounded internal route에서만 사용해야 합니다.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -40,6 +40,8 @@ class AppModule {}
 
 `MetricsModule.forRoot()` exposes `GET /metrics` by default. Pass `http: true` (or an `http` options object) when you want the module to install HTTP request instrumentation middleware. When HTTP instrumentation is enabled, the module records request totals, error counts, and request duration. For production deployments, make the scrape endpoint boundary explicit: either disable it with `path: false` until a platform-level proxy is in place, or attach dedicated endpoint middleware.
 
+The scrape endpoint returns the active `prom-client` registry output with that registry's Prometheus content type. `MetricsModule.forRoot()` creates an isolated registry unless you pass a `registry` option; pass a shared `Registry` only when framework metrics and application-defined metrics intentionally share one scrape surface.
+
 ## Common Patterns
 
 ### Normalize HTTP path labels
@@ -88,6 +90,8 @@ MetricsModule.forRoot({
   path: false,
 });
 ```
+
+`endpointMiddleware` accepts class-based `@fluojs/http` middleware constructors and binds them only to the metrics scrape endpoint. Middleware functions or global middleware declarations are not the package contract for this option.
 
 ### Share one registry for framework and app metrics
 
@@ -165,8 +169,9 @@ MetricsModule.forRoot({
 ### Operational defaults
 
 - `path` defaults to `'/metrics'`, and `path: false` disables the scrape endpoint entirely.
+- The scrape response uses the active registry's Prometheus content type and registry contents.
 - `defaultMetrics` defaults to `true`, and `defaultMetrics: false` disables Prometheus default process and Node.js collectors for that registry.
-- `endpointMiddleware` binds route-scoped middleware only to the scrape endpoint.
+- `endpointMiddleware` binds class-based route-scoped middleware only to the scrape endpoint.
 - HTTP metrics are installed only when `http: true` or an `http` options object is provided, and then default to template-normalized path labels.
 - Built-in HTTP collectors and platform telemetry gauges are reused when module instances share one registry only if they are framework-owned and have the expected label schema; custom application metric name collisions keep Prometheus' duplicate-name failure behavior.
 - Raw path labels require `allowUnsafeRawPathLabelMode: true` and should stay limited to bounded internal routes.

--- a/tooling/governance/metrics-docs-contract.test.ts
+++ b/tooling/governance/metrics-docs-contract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const files = {
+  bookEn: 'book/beginner/ch19-metrics.md',
+  bookKo: 'book/beginner/ch19-metrics.ko.md',
+  readmeEn: 'packages/metrics/README.md',
+  readmeKo: 'packages/metrics/README.ko.md',
+} as const;
+
+function read(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+describe('metrics documentation contract', () => {
+  it('documents Prometheus content type and isolated registry ownership', () => {
+    const docs = Object.values(files).map(read).join('\n');
+
+    expect(docs).toContain('Prometheus content type');
+    expect(docs).toContain('isolated registry');
+    expect(docs).toContain('격리된 Registry');
+    expect(docs).not.toMatch(/OpenMetrics|global default registry|글로벌 기본 레지스트리/);
+  });
+
+  it('keeps endpointMiddleware examples aligned with class-based middleware', () => {
+    const docs = Object.values(files).map(read).join('\n');
+
+    expect(docs).toContain('class MetricsTokenMiddleware');
+    expect(docs).toContain('class-based');
+    expect(docs).not.toContain('process.env.MONITORING_SECRET');
+    expect(docs).not.toMatch(/endpointMiddleware:\s*\[\s*\(context, next\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1681

Aligns the metrics book, package README, and example wording with the actual `@fluojs/metrics` contract for Prometheus scrape output, isolated registry ownership, and class-based endpoint middleware.

## Changes

- Rewrote `book/beginner/ch19-metrics.md` and `.ko.md` to describe Prometheus text exposition output instead of OpenMetrics, `forRoot()`-scoped isolated registries instead of a global default registry, and the actual class-based `endpointMiddleware` shape.
- Clarified `packages/metrics/README.md` and `.ko.md` operational defaults for registry content type, isolated/shared registry ownership, and endpoint middleware constructors.
- Updated the ops metrics example README pair to call out intentional shared-registry usage.
- Added `tooling/governance/metrics-docs-contract.test.ts` as a regression guard against the previous docs drift.

## Testing

- `lsp_diagnostics` on `tooling/governance/metrics-docs-contract.test.ts`: clean
- `pnpm build` ✅
- `pnpm --filter @fluojs/metrics run typecheck` ✅
- `pnpm --filter @fluojs/metrics run test` ✅
- `pnpm vitest run tooling/governance/metrics-docs-contract.test.ts` ✅
- `pnpm verify:platform-consistency-governance` ✅

No changeset: documentation-only correction with no runtime/API behavior change.

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. N/A.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. N/A; this aligns docs to the existing contract.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. Documentation contract drift is covered by `tooling/governance/metrics-docs-contract.test.ts`; runtime behavior was unchanged.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. N/A; no governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A; no platform conformance claim changed.