### PR TITLE
Resolve #1683: Document Mongoose ALS session surface

### DIFF
--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -29,7 +29,7 @@ fluo는 TC39 표준 데코레이터, 명시적 의존성 경계, 메타데이터
 | Operations | 헬스, 메트릭, 스로틀링 | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
 | Tooling | CLI, 진단 도구, Vite 빌드 통합 | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing`, `@fluojs/vite` |
 
-정식 패키지 및 런타임 범위는 [`docs/reference/package-surface.md`](./reference/package-surface.md)에 있다.
+정식 패키지 및 런타임 범위는 [`docs/reference/package-surface.md`](./reference/package-surface.md)에 있으며, `@fluojs/mongoose`의 ALS/session transaction 책임 같은 persistence 책임도 포함한다.
 
 ## File Structure
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -29,7 +29,7 @@ fluo is a standard-first TypeScript backend framework built on TC39 standard dec
 | Operations | Health, metrics, throttling | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
 | Tooling | CLI, diagnostics, and Vite build integration | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing`, `@fluojs/vite` |
 
-Canonical package and runtime coverage lives in [`docs/reference/package-surface.md`](./reference/package-surface.md).
+Canonical package and runtime coverage lives in [`docs/reference/package-surface.md`](./reference/package-surface.md), including persistence responsibilities such as `@fluojs/mongoose` ALS/session transaction ownership.
 
 ## File Structure
 

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -53,6 +53,7 @@
 - **`@fluojs/websockets`**: 런타임별 서브패스 `@fluojs/websockets/node`, `@fluojs/websockets/bun`, `@fluojs/websockets/deno`, `@fluojs/websockets/cloudflare-workers`를 제공하는 WebSocket 게이트웨이 작성 패키지.
 - **`@fluojs/validation`**: 표준 데코레이터 기반 입력 검증, DTO 실체화(materialization), request-boundary 안전성.
 - **`@fluojs/prisma` / `@fluojs/drizzle`**: ORM 라이프사이클 및 ALS 기반 트랜잭션 컨텍스트.
+- **`@fluojs/mongoose`**: Mongoose 라이프사이클 통합과 ALS/session 인지형 transaction boundary, 요청 범위 transaction interceptor, 모델 작업을 위한 명시적 `currentSession()` 접근, 사용 가능한 경우 `connection.transaction(...)`을 통한 ambient-session 위임, 활성 요청/session drain 상태를 보고하는 shutdown snapshot을 담당합니다.
 
 ### tooling
 - **`@fluojs/cli`**: 프로젝트 스캐폴딩, 생성, codemod, 런타임이 생산한 snapshot에 대한 inspection 내보내기/위임. `fluo inspect`는 CLI argument validation, application bootstrap/close, JSON snapshot serialization, report artifact 쓰기, `--output <path>` file emission, Mermaid rendering을 위한 Studio handoff를 소유합니다.

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -53,6 +53,7 @@
 - **`@fluojs/websockets`**: WebSocket gateway authoring with runtime-specific subpaths `@fluojs/websockets/node`, `@fluojs/websockets/bun`, `@fluojs/websockets/deno`, and `@fluojs/websockets/cloudflare-workers`.
 - **`@fluojs/validation`**: Standard-decorator input validation, DTO materialization, and request-boundary safety.
 - **`@fluojs/prisma` / `@fluojs/drizzle`**: ORM lifecycle and ALS-backed transaction context.
+- **`@fluojs/mongoose`**: Mongoose lifecycle integration with ALS/session-aware transaction boundaries, request-scoped transaction interception, explicit `currentSession()` access for model operations, ambient-session delegation through `connection.transaction(...)` when available, and shutdown snapshots that report active request/session drain state.
 
 ### tooling
 - **`@fluojs/cli`**: Project scaffolding, generation, codemods, and inspection export/delegation for runtime-produced snapshots. `fluo inspect` owns CLI argument validation, application bootstrap/close, JSON snapshot serialization, report artifact writing, `--output <path>` file emission, and the handoff to Studio for Mermaid rendering.

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -11,6 +14,8 @@ import {
 
 type GitResult = { status: number; stdout: string };
 type RunCommand = (command: string, args: string[], options?: { allowFailure?: boolean }) => GitResult;
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 async function loadGovernanceInternals() {
   return (await import('./verify-platform-consistency-governance.mjs')) as unknown as {
@@ -290,5 +295,19 @@ describe('parsePackageNamesFromFamilyTable', () => {
       '@fluojs/email',
       '@fluojs/notifications',
     ]);
+  });
+});
+
+describe('package surface persistence responsibilities', () => {
+  it('documents Mongoose ALS and session transaction ownership in both locales', () => {
+    const englishSurface = readFileSync(join(repoRoot, 'docs/reference/package-surface.md'), 'utf8');
+    const koreanSurface = readFileSync(join(repoRoot, 'docs/reference/package-surface.ko.md'), 'utf8');
+
+    expect(englishSurface).toContain('**`@fluojs/mongoose`**');
+    expect(englishSurface).toContain('ALS/session-aware transaction boundaries');
+    expect(englishSurface).toContain('explicit `currentSession()` access');
+    expect(koreanSurface).toContain('**`@fluojs/mongoose`**');
+    expect(koreanSurface).toContain('ALS/session 인지형 transaction boundary');
+    expect(koreanSurface).toContain('명시적 `currentSession()` 접근');
   });
 });


### PR DESCRIPTION
## Summary

Closes #1683

- Documents the `@fluojs/mongoose` ALS/session transaction responsibility in the canonical package surface matrix.
- Keeps the bilingual docs discoverability path aligned for the governed package-surface update.
- Adds governance regression coverage so the Mongoose package-surface responsibility remains documented in both locales.

## Changes

- Added `@fluojs/mongoose` to the package responsibilities section with ALS/session-aware transaction boundaries, explicit `currentSession()` usage, ambient-session delegation, request-scoped transactions, and shutdown snapshot ownership.
- Mirrored the same responsibility in `docs/reference/package-surface.ko.md`.
- Updated `docs/CONTEXT.md` and `docs/CONTEXT.ko.md` to point readers at the package-surface persistence responsibilities.
- Added a governance test assertion for English/Korean Mongoose surface coverage.

## Testing

- `lsp_diagnostics` on changed docs and governance test files: passed
- `pnpm verify:platform-consistency-governance`: passed
- `pnpm docs:sync-check`: passed
- `pnpm vitest run tooling/governance/verify-platform-consistency-governance.test.ts`: passed
- `pnpm build && pnpm typecheck`: passed

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. Not applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. Not applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. Not applicable: this is a docs matrix clarification of existing `@fluojs/mongoose` README behavior.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. Not applicable for runtime behavior; governance regression covers the docs-only package-surface contract.

No `.changeset` is included because this is a docs/governance clarification only and does not change public package runtime behavior or published package artifacts.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Companion updates include discoverability docs and regression-test evidence for the package-surface change.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable: no package README conformance claim changed.