### PR TITLE
Resolve #1674: Make Terminus Drizzle health lifecycle-aware

### DIFF
--- a/.changeset/terminus-drizzle-lifecycle-health.md
+++ b/.changeset/terminus-drizzle-lifecycle-health.md
@@ -1,0 +1,9 @@
+---
+"@fluojs/terminus": patch
+"@fluojs/drizzle": patch
+"@fluojs/runtime": patch
+---
+
+Make Terminus Drizzle health checks lifecycle-aware by resolving the public Drizzle wrapper token before raw ping fallback, so shutdown and stopped Drizzle integrations now report unavailable health/readiness.
+
+Expose the `/ready` request context to runtime health readiness checks so integrations can resolve public runtime status providers without importing runtime internals.

--- a/packages/cli/scripts/local-test-env.mjs
+++ b/packages/cli/scripts/local-test-env.mjs
@@ -345,8 +345,8 @@ function verifySandboxProject(projectName) {
     }
   }
 
-  if (starterContract === 'application' && !existsSync(join(projectDirectory, 'src', 'app.e2e.test.ts'))) {
-    throw new Error('Expected the starter scaffold to include src/app.e2e.test.ts.');
+  if (starterContract === 'application' && !existsSync(join(projectDirectory, 'test', 'app.e2e.test.ts'))) {
+    throw new Error('Expected the starter scaffold to include test/app.e2e.test.ts.');
   }
 
   if (!existsSync(join(projectDirectory, 'vite.config.ts'))) {

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -144,11 +144,13 @@ defineModule(ManualDrizzleModule, {
 - `DrizzleModule.forRoot(options)` / `DrizzleModule.forRootAsync(options)`
 - `DrizzleDatabase`
 - `DrizzleTransactionInterceptor`
-- `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_OPTIONS`
+- `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_HANDLE_PROVIDER`, `DRIZZLE_OPTIONS`
 - `createDrizzlePlatformStatusSnapshot(...)`
 - `DrizzleDatabaseLike`
 - `DrizzleModuleOptions`
 - `DrizzleHandleProvider`
+
+`DRIZZLE_HANDLE_PROVIDER`는 lifecycle-aware `DrizzleDatabase` wrapper를 가리키는 alias token입니다. `@fluojs/terminus` 같은 health integration은 이 token을 통해 raw database ping으로 fallback하기 전에 `createPlatformStatusSnapshot()`을 읽습니다.
 
 ### `DrizzleModule`
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -144,11 +144,13 @@ defineModule(ManualDrizzleModule, {
 - `DrizzleModule.forRoot(options)` / `DrizzleModule.forRootAsync(options)`
 - `DrizzleDatabase`
 - `DrizzleTransactionInterceptor`
-- `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_OPTIONS`
+- `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_HANDLE_PROVIDER`, `DRIZZLE_OPTIONS`
 - `createDrizzlePlatformStatusSnapshot(...)`
 - `DrizzleDatabaseLike`
 - `DrizzleModuleOptions`
 - `DrizzleHandleProvider`
+
+`DRIZZLE_HANDLE_PROVIDER` is an alias token for the lifecycle-aware `DrizzleDatabase` wrapper. Health integrations such as `@fluojs/terminus` use this token to read `createPlatformStatusSnapshot()` before falling back to raw database pings.
 
 ### `DrizzleModule`
 

--- a/packages/drizzle/src/module.ts
+++ b/packages/drizzle/src/module.ts
@@ -3,7 +3,7 @@ import type { Provider } from '@fluojs/di';
 import { defineModule, type ModuleType } from '@fluojs/runtime';
 
 import { DrizzleDatabase } from './database.js';
-import { DRIZZLE_DATABASE, DRIZZLE_DISPOSE, DRIZZLE_OPTIONS } from './tokens.js';
+import { DRIZZLE_DATABASE, DRIZZLE_DISPOSE, DRIZZLE_HANDLE_PROVIDER, DRIZZLE_OPTIONS } from './tokens.js';
 import { DrizzleTransactionInterceptor } from './transaction.js';
 import type { DrizzleDatabaseLike, DrizzleModuleOptions } from './types.js';
 
@@ -27,7 +27,7 @@ type DrizzleAsyncModuleOptions<
   Pick<DrizzleModuleOptions<TDatabase, TTransactionDatabase, TTransactionOptions>, 'global'>;
 
 const DRIZZLE_NORMALIZED_OPTIONS = Symbol('fluo.drizzle.normalized-options');
-const DRIZZLE_MODULE_EXPORTS = [DrizzleDatabase, DrizzleTransactionInterceptor];
+const DRIZZLE_MODULE_EXPORTS = [DrizzleDatabase, DrizzleTransactionInterceptor, DRIZZLE_HANDLE_PROVIDER];
 
 function normalizeDrizzleModuleOptions<
   TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
@@ -74,6 +74,10 @@ function createDrizzleRuntimeProviders<
         ),
     },
     DrizzleDatabase,
+    {
+      provide: DRIZZLE_HANDLE_PROVIDER,
+      useExisting: DrizzleDatabase,
+    },
     DrizzleTransactionInterceptor,
   ];
 }

--- a/packages/drizzle/src/public-api.test.ts
+++ b/packages/drizzle/src/public-api.test.ts
@@ -10,6 +10,7 @@ describe('@fluojs/drizzle public API surface', () => {
     expect(drizzlePublicApi).toHaveProperty('createDrizzlePlatformStatusSnapshot');
     expect(drizzlePublicApi).toHaveProperty('DRIZZLE_DATABASE');
     expect(drizzlePublicApi).toHaveProperty('DRIZZLE_DISPOSE');
+    expect(drizzlePublicApi).toHaveProperty('DRIZZLE_HANDLE_PROVIDER');
     expect(drizzlePublicApi).toHaveProperty('DRIZZLE_OPTIONS');
   });
 

--- a/packages/drizzle/src/tokens.ts
+++ b/packages/drizzle/src/tokens.ts
@@ -1,5 +1,7 @@
 /** Dependency-injection token for the raw Drizzle database handle. */
 export const DRIZZLE_DATABASE = Symbol.for('fluo.drizzle.database');
+/** Dependency-injection token for the lifecycle-aware Drizzle database wrapper. */
+export const DRIZZLE_HANDLE_PROVIDER = Symbol.for('fluo.drizzle.handle-provider');
 /** Dependency-injection token for the optional Drizzle shutdown dispose hook. */
 export const DRIZZLE_DISPOSE = Symbol.for('fluo.drizzle.dispose');
 /** Dependency-injection token for normalized Drizzle runtime options. */

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -137,6 +137,7 @@ class UsersModule {}
 - `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, `runNodeApplication(...)`는 `maxBodySize`를 0 이상의 정수 바이트 수로만 받으며, 값이 잘못되면 어댑터 생성/부트스트랩 단계에서 즉시 실패합니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.
 - 런타임 health 모듈은 bootstrap이 ready로 표시하기 전까지 `/ready`를 HTTP 503과 `starting`으로 보고하며, 애플리케이션/컨텍스트 종료가 시작되는 즉시, 종료 시도가 실패하더라도 다시 `starting`으로 내려갑니다.
+- 런타임 health module readiness check는 현재 `RequestContext`를 받으므로, public integration이 internal runtime token을 import하지 않고도 runtime-exposed status provider를 해석할 수 있습니다.
 - 시그널 기반 종료 헬퍼는 bounded drain semantics를 유지하면서 timeout/실패 상황을 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료 소유권은 주변 호스트 런타임에 남겨 둡니다.
 - 플랫폼 snapshot 및 diagnostic issue 생산은 런타임에 남아 있고, 그래프 보기, filtering 표현, Mermaid 렌더링은 CLI 및 자동화 호출자가 소비하는 Studio 소유 계약입니다.
 - 모듈 그래프 컴파일 결과 캐시는 `moduleGraphCache: true`를 통한 opt-in입니다. 캐시 항목은 root module identity, runtime provider, validation token, core metadata version, compile algorithm version으로 식별되며, 성공한 컴파일만 저장하고 호출자 mutation이 이후 bootstrap을 오염시키지 않도록 격리된 그래프 복사본을 반환합니다.
@@ -150,6 +151,7 @@ class UsersModule {}
 - `LifecycleHooks`: `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `OnApplicationShutdown`를 묶는 편의 union 타입입니다.
 - `HealthModule.forRoot(options)`: bootstrap 및 shutdown 라이프사이클 전이에 맞춰 readiness marker를 관리하는 런타임 소유 `/health`, `/ready` 모듈 파사드입니다.
 - `createHealthModule(options)`: 같은 런타임 health module 계약을 위한 deprecated compatibility helper입니다. 애플리케이션-facing module import에서는 `HealthModule.forRoot(...)`를 우선 사용하세요.
+- `ReadinessCheck`: runtime health module이 사용하는 function type입니다. Check는 `/ready` request context를 받고 boolean 또는 promise를 반환합니다.
 - `defineModule(cls, metadata)`: 프로그래밍 방식의 모듈 정의 헬퍼입니다.
 - `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다.
 - `bootstrapModule(...)`: 저수준 module graph bootstrap helper입니다.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -137,6 +137,7 @@ class UsersModule {}
 - `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, and `runNodeApplication(...)` accept `maxBodySize` only as a non-negative integer byte count and fail fast during adapter creation/bootstrap when the value is invalid.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.
 - Runtime health modules report `/ready` as `starting` with HTTP 503 until bootstrap marks them ready, and they return to `starting` as soon as application/context shutdown begins, including failed shutdown attempts.
+- Runtime health module readiness checks receive the current `RequestContext`, allowing public integrations to resolve runtime-exposed status providers without importing internal runtime tokens.
 - Signal-driven shutdown helpers preserve bounded drain semantics, log timeout/failure conditions, and set `process.exitCode` when shutdown does not finish cleanly, but they leave final process termination ownership to the surrounding host runtime.
 - Platform snapshot and diagnostic issue production stay in runtime; graph viewing, filtering presentation, and Mermaid rendering are Studio-owned contracts consumed by CLI and automation callers.
 - Module graph compile-result caching is opt-in through `moduleGraphCache: true`; it keys entries by root module identity, runtime providers, validation tokens, core metadata versions, and the compile algorithm version, caches only successful compilations, and returns isolated graph copies so caller mutations cannot poison later bootstraps.
@@ -150,6 +151,7 @@ class UsersModule {}
 - `LifecycleHooks`: Convenience union covering `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, and `OnApplicationShutdown`.
 - `HealthModule.forRoot(options)`: Runtime-owned `/health` and `/ready` module facade whose readiness marker follows bootstrap and shutdown lifecycle transitions.
 - `createHealthModule(options)`: Deprecated compatibility helper for the same runtime health module contract; prefer `HealthModule.forRoot(...)` in application-facing module imports.
+- `ReadinessCheck`: Function type used by runtime health modules. Checks receive the `/ready` request context and return a boolean or promise.
 - `defineModule(cls, metadata)`: Programmatic module definition helper.
 - `bootstrapApplication(options)`: Lower-level async bootstrap function.
 - `bootstrapModule(...)`: Lower-level module graph bootstrap helper.

--- a/packages/runtime/src/health/health.test.ts
+++ b/packages/runtime/src/health/health.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { FrameworkRequest, FrameworkResponse } from '@fluojs/http';
+import type { FrameworkRequest, FrameworkResponse, RequestContext } from '@fluojs/http';
 
 import { bootstrapApplication, defineModule } from '../bootstrap.js';
 import type { ModuleType } from '../types.js';
@@ -9,7 +9,7 @@ import * as healthModuleExports from './health.js';
 
 type TestResponse = FrameworkResponse & { body?: unknown };
 type ReadinessManagedModule = ModuleType & {
-  addReadinessCheck(fn: () => boolean | Promise<boolean>): void;
+  addReadinessCheck(fn: (ctx: RequestContext) => boolean | Promise<boolean>): void;
   markReady(): void;
   markStarting(): void;
 };
@@ -152,6 +152,28 @@ describe('createHealthModule', () => {
     await app.dispatch(createRequest('/ready'), readyResponse);
     expect(readyResponse.statusCode).toBe(503);
     expect(readyResponse.body).toEqual({ status: 'unavailable' });
+
+    await app.close();
+  });
+
+  it('passes the request context into readiness checks', async () => {
+    const healthModule = HealthModule.forRoot() as ReadinessManagedModule;
+    healthModule.addReadinessCheck((ctx) => ctx.request.path === '/ready');
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [healthModule],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const readyResponse = createResponse();
+    await app.dispatch(createRequest('/ready'), readyResponse);
+    expect(readyResponse.statusCode).toBe(200);
+    expect(readyResponse.body).toEqual({ status: 'ready' });
 
     await app.close();
   });

--- a/packages/runtime/src/health/health.ts
+++ b/packages/runtime/src/health/health.ts
@@ -39,7 +39,7 @@ export interface HealthModuleOptions {
 /**
  * Defines the readiness check type.
  */
-export type ReadinessCheck = () => boolean | Promise<boolean>;
+export type ReadinessCheck = (ctx: import('@fluojs/http').RequestContext) => boolean | Promise<boolean>;
 
 function createRuntimeHealthModule(options: HealthModuleOptions = {}): ModuleType {
   const basePath = options.path ?? '';
@@ -84,7 +84,7 @@ function createRuntimeHealthModule(options: HealthModuleOptions = {}): ModuleTyp
       }
 
       for (const check of readinessChecks) {
-        const result = await check();
+        const result = await check(ctx);
 
         if (!result) {
           ctx.response.setStatus(503);

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -91,6 +91,8 @@ TerminusModule.forRoot({
 });
 ```
 
+Drizzle의 경우 `createDrizzleHealthIndicatorProvider()`는 `@fluojs/drizzle`이 노출하는 lifecycle-aware `DrizzleDatabase` wrapper를 우선 사용합니다. Drizzle이 종료 중이거나 중지되었거나 `DrizzleDatabase.createPlatformStatusSnapshot()` 기준으로 준비되지 않은 상태이면 SQL probe를 실행하기 전에 해당 indicator를 `down`으로 보고합니다. legacy raw `DRIZZLE_DATABASE` handle만 등록된 경우에는 기존 lightweight SQL probe 동작을 유지합니다.
+
 ### 실행 가드레일
 
 커스텀 인디케이터가 멈추거나 느린 하위 서비스에 의존할 수 있다면 `execution.indicatorTimeoutMs`를 사용하세요. probe가 설정된 시간을 넘기면 Terminus는 무기한 대기하지 않고 해당 인디케이터를 `down`으로 표시합니다.
@@ -119,6 +121,7 @@ TerminusModule.forRoot({
 - 같은 실행에서 이미 보고된 key를 다른 인디케이터가 다시 사용하면, Terminus는 먼저 기록된 entry를 유지하고 데이터를 조용히 덮어쓰는 대신 결정적인 `*-duplicate-key-error` contributor를 추가합니다.
 - 플랫폼 health/readiness 실패는 `/health` 응답에서 결정적인 `fluo-platform-health`, `fluo-platform-readiness` contributor로 노출됩니다.
 - Runtime diagnostics가 있으면 `/health` response에 platform health/readiness detail을 담은 `platform` block이 포함될 수 있습니다.
+- DI provider로 생성한 Drizzle indicator는 SQL probe보다 먼저 Drizzle lifecycle readiness/health state를 반영하므로, underlying driver가 raw ping을 아직 받을 수 있어도 종료 중이거나 중지된 통합은 `/health`와 `/ready`를 unavailable로 표시합니다.
 
 ## 공개 API 개요
 

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -89,6 +89,8 @@ TerminusModule.forRoot({
 });
 ```
 
+For Drizzle, `createDrizzleHealthIndicatorProvider()` prefers the lifecycle-aware `DrizzleDatabase` wrapper exported by `@fluojs/drizzle`. The indicator reports `down` before probing SQL whenever Drizzle is shutting down, stopped, or otherwise not ready according to `DrizzleDatabase.createPlatformStatusSnapshot()`. If only the legacy raw `DRIZZLE_DATABASE` handle is registered, the provider keeps the previous lightweight SQL probe behavior.
+
 ### Execution Guardrails
 
 Use `execution.indicatorTimeoutMs` when custom indicators might hang or depend on slow downstreams. When a probe exceeds the configured timeout, Terminus marks that indicator as `down` instead of waiting forever.
@@ -119,6 +121,7 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 - If an indicator reuses a key that was already reported earlier in the same run, Terminus keeps the first entry and adds a deterministic `*-duplicate-key-error` contributor instead of silently overwriting data.
 - Platform health/readiness failures are surfaced as deterministic `fluo-platform-health` and `fluo-platform-readiness` contributors in `/health` responses.
 - `/health` responses may include a `platform` block with platform health/readiness details when runtime diagnostics are available.
+- Drizzle indicators created through the DI provider map Drizzle lifecycle readiness/health state before SQL probing, so shutdown or stopped integrations mark `/health` and `/ready` as unavailable even if the underlying driver still accepts a raw ping.
 
 ## Public API Overview
 

--- a/packages/terminus/src/indicators/drizzle.test.ts
+++ b/packages/terminus/src/indicators/drizzle.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { HealthCheckError } from '../errors.js';
-import { createDrizzleHealthIndicator, DrizzleHealthIndicator } from './drizzle.js';
+import { createDrizzleHealthIndicator, createDrizzleHealthIndicatorProvider, DrizzleHealthIndicator } from './drizzle.js';
 
 describe('DrizzleHealthIndicator', () => {
   it('supports execute-capable drizzle handles', async () => {
@@ -16,6 +16,108 @@ describe('DrizzleHealthIndicator', () => {
       },
     });
     expect(execute).toHaveBeenCalledWith('select 1');
+  });
+
+  it('maps Drizzle lifecycle readiness before pinging', async () => {
+    const execute = vi.fn(async (_query: unknown) => undefined);
+    const indicator = createDrizzleHealthIndicator({
+      handleProvider: {
+        createPlatformStatusSnapshot: () => ({
+          details: {
+            activeRequestTransactions: 0,
+            lifecycleState: 'shutting-down',
+          },
+          health: {
+            reason: 'Drizzle integration is draining request transactions during shutdown.',
+            status: 'degraded',
+          },
+          readiness: {
+            reason: 'Drizzle integration is shutting down.',
+            status: 'not-ready',
+          },
+        }),
+        current: () => ({ execute }),
+      },
+    });
+
+    await expect(indicator.check('drizzle')).rejects.toMatchObject({
+      causes: {
+        drizzle: {
+          details: {
+            activeRequestTransactions: 0,
+            lifecycleState: 'shutting-down',
+          },
+          healthStatus: 'degraded',
+          message: 'Drizzle integration is shutting down.',
+          readinessStatus: 'not-ready',
+          status: 'down',
+        },
+      },
+      message: 'Drizzle health check failed.',
+      name: 'HealthCheckError',
+    } satisfies Partial<HealthCheckError>);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('includes lifecycle status when lifecycle-aware Drizzle is ready', async () => {
+    const execute = vi.fn(async (_query: unknown) => undefined);
+    const indicator = createDrizzleHealthIndicator({
+      handleProvider: {
+        createPlatformStatusSnapshot: () => ({
+          details: {
+            activeRequestTransactions: 0,
+            lifecycleState: 'ready',
+          },
+          health: { status: 'healthy' },
+          readiness: { status: 'ready' },
+        }),
+        current: () => ({ execute }),
+      },
+    });
+
+    await expect(indicator.check('drizzle')).resolves.toEqual({
+      drizzle: {
+        details: {
+          activeRequestTransactions: 0,
+          lifecycleState: 'ready',
+        },
+        healthStatus: 'healthy',
+        readinessStatus: 'ready',
+        status: 'up',
+      },
+    });
+    expect(execute).toHaveBeenCalledWith('select 1');
+  });
+
+  it('provider factory prefers lifecycle-aware Drizzle handles over raw pings', async () => {
+    const execute = vi.fn(async (_query: unknown) => undefined);
+    const provider = createDrizzleHealthIndicatorProvider();
+
+    if (typeof provider === 'function' || !('useFactory' in provider)) {
+      throw new Error('Expected Drizzle health indicator provider factory.');
+    }
+
+    const indicator = provider.useFactory({
+      createPlatformStatusSnapshot: () => ({
+        details: { lifecycleState: 'stopped' },
+        health: { reason: 'Drizzle integration has been disposed.', status: 'unhealthy' },
+        readiness: { reason: 'Drizzle integration is stopped.', status: 'not-ready' },
+      }),
+      current: () => ({ execute }),
+    }, { execute }) as DrizzleHealthIndicator;
+
+    await expect(indicator.check('drizzle')).rejects.toMatchObject({
+      causes: {
+        drizzle: {
+          healthStatus: 'unhealthy',
+          message: 'Drizzle integration is stopped.',
+          readinessStatus: 'not-ready',
+          status: 'down',
+        },
+      },
+      name: 'HealthCheckError',
+    } satisfies Partial<HealthCheckError>);
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it('supports ping callbacks and throws HealthCheckError for unsupported handles', async () => {

--- a/packages/terminus/src/indicators/drizzle.ts
+++ b/packages/terminus/src/indicators/drizzle.ts
@@ -1,17 +1,36 @@
-import type { Provider } from '@fluojs/di';
+import { optional, type Provider } from '@fluojs/di';
 
 import { createDownResult, createUpResult, resolveIndicatorKey, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
 
 const DRIZZLE_DATABASE = Symbol.for('fluo.drizzle.database');
+const DRIZZLE_HANDLE_PROVIDER = Symbol.for('fluo.drizzle.handle-provider');
 
 interface DrizzleExecuteLike {
   execute?: (query: unknown) => Promise<unknown>;
 }
 
+interface DrizzleLifecycleSnapshotLike {
+  details?: Record<string, unknown>;
+  health: {
+    reason?: string;
+    status: 'healthy' | 'degraded' | 'unhealthy';
+  };
+  readiness: {
+    reason?: string;
+    status: 'ready' | 'not-ready';
+  };
+}
+
+interface DrizzleHandleProviderLike {
+  createPlatformStatusSnapshot?: () => DrizzleLifecycleSnapshotLike;
+  current?: () => DrizzleExecuteLike | unknown;
+}
+
 /** Options for probing Drizzle-backed database connectivity. */
 export interface DrizzleHealthIndicatorOptions {
   database?: DrizzleExecuteLike;
+  handleProvider?: DrizzleHandleProviderLike;
   key?: string;
   ping?: () => Promise<unknown> | unknown;
   query?: unknown;
@@ -27,7 +46,7 @@ async function runDrizzlePing(options: DrizzleHealthIndicatorOptions): Promise<v
     return;
   }
 
-  const database = options.database;
+  const database = options.database ?? resolveCurrentDatabase(options.handleProvider);
 
   if (!database || typeof database.execute !== 'function') {
     throw new Error(
@@ -38,11 +57,51 @@ async function runDrizzlePing(options: DrizzleHealthIndicatorOptions): Promise<v
   await database.execute(options.query ?? DEFAULT_DRIZZLE_QUERY);
 }
 
+function resolveCurrentDatabase(handleProvider: DrizzleHandleProviderLike | undefined): DrizzleExecuteLike | undefined {
+  if (!handleProvider || typeof handleProvider.current !== 'function') {
+    return undefined;
+  }
+
+  return handleProvider.current() as DrizzleExecuteLike;
+}
+
+function createDrizzleLifecycleDownResult(
+  indicatorKey: string,
+  snapshot: DrizzleLifecycleSnapshotLike,
+): HealthIndicatorResult | undefined {
+  const healthStatus = snapshot.health.status;
+  const readinessStatus = snapshot.readiness.status;
+
+  if (healthStatus === 'healthy' && readinessStatus === 'ready') {
+    return undefined;
+  }
+
+  const message = snapshot.readiness.reason
+    ?? snapshot.health.reason
+    ?? `Drizzle lifecycle reported health=${healthStatus} readiness=${readinessStatus}.`;
+
+  return createDownResult(indicatorKey, message, {
+    details: snapshot.details,
+    healthStatus,
+    readinessStatus,
+  });
+}
+
+function createDrizzleLifecycleSnapshot(
+  handleProvider: DrizzleHandleProviderLike | undefined,
+): DrizzleLifecycleSnapshotLike | undefined {
+  if (!handleProvider || typeof handleProvider.createPlatformStatusSnapshot !== 'function') {
+    return undefined;
+  }
+
+  return handleProvider.createPlatformStatusSnapshot();
+}
+
 /**
  * Create a Drizzle health indicator.
  *
- * @param options Optional database handle, ping callback, timeout, query, and key override.
- * @returns A health indicator that executes a lightweight Drizzle query.
+ * @param options Optional lifecycle-aware handle provider, database handle, ping callback, timeout, query, and key override.
+ * @returns A health indicator that checks Drizzle lifecycle state before executing a lightweight query.
  */
 export function createDrizzleHealthIndicator(options: DrizzleHealthIndicatorOptions = {}): HealthIndicator {
   return new DrizzleHealthIndicator(options);
@@ -54,15 +113,25 @@ export function createDrizzleHealthIndicator(options: DrizzleHealthIndicatorOpti
  * @param options Optional timeout, query override, key override, or custom ping callback.
  * @returns A factory provider that exposes `DrizzleHealthIndicator` from the DI container.
  */
-export function createDrizzleHealthIndicatorProvider(options: Omit<DrizzleHealthIndicatorOptions, 'database'> = {}): Provider {
+export function createDrizzleHealthIndicatorProvider(options: Omit<DrizzleHealthIndicatorOptions, 'database' | 'handleProvider'> = {}): Provider {
   return {
-    inject: [DRIZZLE_DATABASE],
+    inject: [optional(DRIZZLE_HANDLE_PROVIDER), optional(DRIZZLE_DATABASE)],
     provide: DrizzleHealthIndicator,
-    useFactory: (database: unknown) => new DrizzleHealthIndicator({ ...options, database: database as DrizzleExecuteLike }),
+    useFactory: (handleProvider: unknown, database: unknown) => {
+      const resolvedHandleProvider = typeof handleProvider === 'object' && handleProvider !== null
+        ? handleProvider as DrizzleHandleProviderLike
+        : undefined;
+
+      return new DrizzleHealthIndicator({
+        ...options,
+        database: database as DrizzleExecuteLike | undefined,
+        handleProvider: resolvedHandleProvider,
+      });
+    },
   };
 }
 
-/** Health indicator that probes Drizzle connectivity with an execute-capable handle. */
+/** Health indicator that maps Drizzle lifecycle state and probes connectivity with an execute-capable handle. */
 export class DrizzleHealthIndicator implements HealthIndicator {
   readonly key: string | undefined;
 
@@ -75,9 +144,28 @@ export class DrizzleHealthIndicator implements HealthIndicator {
     const timeoutMs = this.options.timeoutMs ?? DEFAULT_DRIZZLE_TIMEOUT_MS;
 
     try {
+      const snapshot = createDrizzleLifecycleSnapshot(this.options.handleProvider);
+      const lifecycleDownResult = snapshot
+        ? createDrizzleLifecycleDownResult(indicatorKey, snapshot)
+        : undefined;
+
+      if (lifecycleDownResult) {
+        throwHealthCheckError('Drizzle health check failed.', lifecycleDownResult);
+      }
+
       await withIndicatorTimeout(runDrizzlePing(this.options), timeoutMs, indicatorKey);
-      return createUpResult(indicatorKey);
+      return createUpResult(indicatorKey, snapshot
+        ? {
+            details: snapshot.details,
+            healthStatus: snapshot.health.status,
+            readinessStatus: snapshot.readiness.status,
+          }
+        : {});
     } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'HealthCheckError') {
+        throw error;
+      }
+
       throwHealthCheckError('Drizzle health check failed.', createDownResult(
         indicatorKey,
         error instanceof Error ? error.message : 'Drizzle health check failed.',

--- a/packages/terminus/src/module.ts
+++ b/packages/terminus/src/module.ts
@@ -1,13 +1,14 @@
+import type { Token } from '@fluojs/core';
 import type { Provider } from '@fluojs/di';
 import type { RequestContext } from '@fluojs/http';
 import {
-  createHealthModule,
   defineModule,
+  HealthModule,
   type ModuleType,
+  PLATFORM_SHELL,
   type PlatformHealthReport,
   type PlatformReadinessReport,
 } from '@fluojs/runtime';
-import { PLATFORM_SHELL, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 
 import { TerminusHealthService } from './health-check.js';
 import { TERMINUS_HEALTH_INDICATORS, TERMINUS_INDICATOR_PROVIDER_TOKENS } from './tokens.js';
@@ -15,8 +16,8 @@ import type { HealthCheckReport, HealthIndicator, HealthIndicatorState, Terminus
 
 const TERMINUS_OPTIONS = Symbol.for('fluo.terminus.options');
 
-type ReadinessManagedModule = ReturnType<typeof createHealthModule> & {
-  addReadinessCheck(fn: () => boolean | Promise<boolean>): void;
+type ReadinessManagedModule = ReturnType<typeof HealthModule.forRoot> & {
+  addReadinessCheck(fn: (ctx: RequestContext) => boolean | Promise<boolean>): void;
 };
 
 function copyIndicators(indicators: readonly HealthIndicator[] | undefined): HealthIndicator[] {
@@ -27,9 +28,9 @@ function copyProviders(providers: readonly Provider[] | undefined): Provider[] {
   return [...(providers ?? [])];
 }
 
-function providerToken(provider: Provider): unknown {
+function providerToken(provider: Provider): Token | undefined {
   if (typeof provider === 'function') {
-    return provider;
+    return provider as Token;
   }
 
   if ('provide' in provider) {
@@ -62,9 +63,9 @@ function createTerminusProviders(options: TerminusModuleOptions = {}): Provider[
       useValue: indicatorProviderTokens,
     },
     {
-      inject: [TERMINUS_OPTIONS, TERMINUS_INDICATOR_PROVIDER_TOKENS, RUNTIME_CONTAINER],
+      inject: [TERMINUS_OPTIONS, ...indicatorProviderTokens],
       provide: TERMINUS_HEALTH_INDICATORS,
-      useFactory: async (resolvedOptions: unknown, registeredTokens: unknown, runtimeContainer: unknown) => {
+      useFactory: (resolvedOptions: unknown, ...resolvedProviderIndicators: unknown[]) => {
         const resolvedIndicators: HealthIndicator[] = [];
 
         if (typeof resolvedOptions === 'object' && resolvedOptions !== null && 'indicators' in resolvedOptions) {
@@ -72,17 +73,8 @@ function createTerminusProviders(options: TerminusModuleOptions = {}): Provider[
           resolvedIndicators.push(...copyIndicators(indicators));
         }
 
-        if (
-          runtimeContainer
-          && typeof runtimeContainer === 'object'
-          && runtimeContainer !== null
-          && 'resolve' in runtimeContainer
-          && typeof (runtimeContainer as { resolve?: unknown }).resolve === 'function'
-          && Array.isArray(registeredTokens)
-        ) {
-          for (const token of registeredTokens) {
-            resolvedIndicators.push(await (runtimeContainer as { resolve(token: unknown): Promise<HealthIndicator> }).resolve(token));
-          }
+        for (const providerIndicator of resolvedProviderIndicators) {
+          resolvedIndicators.push(providerIndicator as HealthIndicator);
         }
 
         return resolvedIndicators;
@@ -220,7 +212,7 @@ function withPlatformDiagnostics(
 
 function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): ModuleType {
   const readinessChecks = [...(options.readinessChecks ?? [])];
-  const healthModule = createHealthModule({
+  const healthModule = HealthModule.forRoot({
     healthCheck: async (ctx: RequestContext) => {
       const healthService = await ctx.container.resolve(TerminusHealthService);
       const platformShell = await ctx.container.resolve(PLATFORM_SHELL);
@@ -259,22 +251,17 @@ function createTerminusRuntimeModule(options: TerminusModuleOptions = {}): Modul
         readinessChecks,
       }),
       {
-        inject: [TerminusHealthService, RUNTIME_CONTAINER],
+        inject: [TerminusHealthService],
         provide: TERMINUS_READINESS_REGISTRAR,
-        useFactory: (...deps: unknown[]) => {
-          const [healthService, runtimeContainer] = deps as [{
+        useFactory: (resolvedHealthService: unknown) => {
+          const healthService = resolvedHealthService as {
             isHealthy(): Promise<boolean>;
-          }, {
-            resolve(token: unknown): Promise<{
-              ready(): Promise<PlatformReadinessReport>;
-              health(): Promise<PlatformHealthReport>;
-            }>;
-          }];
+          };
 
           return {
             onApplicationBootstrap(): void {
-              healthModule.addReadinessCheck(async () => {
-                const platformShell = await runtimeContainer.resolve(PLATFORM_SHELL);
+              healthModule.addReadinessCheck(async (ctx: RequestContext) => {
+                const platformShell = await ctx.container.resolve(PLATFORM_SHELL);
                 const [indicatorHealthy, readiness] = await Promise.all([
                   healthService.isHealthy(),
                   platformShell.ready(),


### PR DESCRIPTION
## Summary

Closes #1674.

- Replaces Terminus runtime-internal container wiring with the public runtime readiness context / `PLATFORM_SHELL` seam.
- Makes `createDrizzleHealthIndicatorProvider()` prefer the lifecycle-aware Drizzle wrapper before raw SQL ping fallback.
- Documents and releases the runtime, Drizzle, and Terminus contract updates.

## Changes

- Runtime `ReadinessCheck` now receives the `/ready` `RequestContext`, allowing integrations to resolve public runtime status providers without `@fluojs/runtime/internal`.
- Drizzle exports `DRIZZLE_HANDLE_PROVIDER` as an alias to the lifecycle-aware `DrizzleDatabase` wrapper.
- Terminus resolves indicator providers without `RUNTIME_CONTAINER` and maps Drizzle lifecycle snapshots into `down` health results when readiness/health is not ready/healthy.
- Added EN/KO README updates and a changeset for `@fluojs/runtime`, `@fluojs/drizzle`, and `@fluojs/terminus`.

## Testing

- [x] `lsp_diagnostics` clean for changed source files.
- [x] `pnpm --filter @fluojs/terminus test`
- [x] `pnpm --filter @fluojs/runtime test`
- [x] `pnpm --filter @fluojs/drizzle test`
- [x] `pnpm --filter @fluojs/runtime typecheck`
- [x] `pnpm --filter @fluojs/terminus typecheck`
- [x] `pnpm --filter @fluojs/drizzle typecheck`
- [x] `pnpm --filter @fluojs/terminus build`
- [x] `pnpm verify:platform-consistency-governance`
- [x] `pnpm lint` (completed with pre-existing Biome warnings in `packages/config`; public export TSDoc passed)
- [x] `node --check packages/cli/scripts/local-test-env.mjs`
- [x] `pnpm --dir packages/cli sandbox:matrix`
- [x] `pnpm verify:release-readiness` (passed after aligning the CLI sandbox verifier with the generated `test/app.e2e.test.ts` starter scaffold path.)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.