### PR TITLE
Resolve #1688: Fix email queue worker book example

### DIFF
--- a/book/intermediate/ch16-email.ko.md
+++ b/book/intermediate/ch16-email.ko.md
@@ -128,22 +128,36 @@ export class AppModule {}
 루프 안에서 이메일 1,000개를 직접 보내면 이벤트 루프를 오래 점유하거나 공급자 속도 제한에 걸리기 쉽습니다. 대량 발송은 `@fluojs/email/queue` 서브패스로 백그라운드 작업에 넘기는 편이 안전합니다.
 
 ```typescript
-import { createEmailNotificationsQueueAdapter } from '@fluojs/email/queue';
-import { QueueLifecycleService } from '@fluojs/queue';
+import { Module } from '@fluojs/core';
+import { EmailModule, EMAIL_CHANNEL } from '@fluojs/email';
+import {
+  createEmailNotificationsQueueAdapter,
+  EmailNotificationsQueueWorker,
+} from '@fluojs/email/queue';
+import { NotificationsModule } from '@fluojs/notifications';
+import { QueueLifecycleService, QueueModule } from '@fluojs/queue';
 
-NotificationsModule.forRootAsync({
-  inject: [EMAIL_CHANNEL, QueueLifecycleService],
-  useFactory: (channel, queue) => ({
-    channels: [channel],
-    queue: {
-      adapter: createEmailNotificationsQueueAdapter(queue),
-      bulkThreshold: 25,
-    },
-  }),
-});
+@Module({
+  imports: [
+    QueueModule.forRoot(),
+    EmailModule.forRoot({ ... }),
+    NotificationsModule.forRootAsync({
+      inject: [EMAIL_CHANNEL, QueueLifecycleService],
+      useFactory: (channel, queue) => ({
+        channels: [channel],
+        queue: {
+          adapter: createEmailNotificationsQueueAdapter(queue),
+          bulkThreshold: 25,
+        },
+      }),
+    }),
+  ],
+  providers: [EmailNotificationsQueueWorker],
+})
+export class AppModule {}
 ```
 
-큐 어댑터는 대량 알림을 개별 백그라운드 작업으로 나누고, 각 작업에 설정 가능한 재시도와 백오프 정책을 적용합니다.
+큐 어댑터는 대량 알림을 개별 백그라운드 작업으로 나누고, 각 작업에 설정 가능한 재시도와 백오프 정책을 적용합니다. 큐에 쌓인 이메일 작업이 실제로 소비되도록 같은 애플리케이션 모듈의 provider에 `EmailNotificationsQueueWorker`를 등록해야 합니다.
 
 ## 16.7 Template Rendering
 

--- a/book/intermediate/ch16-email.md
+++ b/book/intermediate/ch16-email.md
@@ -128,22 +128,36 @@ After integration, calls to `NotificationsService.dispatch({ channel: 'email', .
 Sending 1,000 emails directly inside a loop can occupy the event loop for too long or hit provider rate limits. Bulk delivery is safer when handed off to background jobs through the `@fluojs/email/queue` subpath.
 
 ```typescript
-import { createEmailNotificationsQueueAdapter } from '@fluojs/email/queue';
-import { QueueLifecycleService } from '@fluojs/queue';
+import { Module } from '@fluojs/core';
+import { EmailModule, EMAIL_CHANNEL } from '@fluojs/email';
+import {
+  createEmailNotificationsQueueAdapter,
+  EmailNotificationsQueueWorker,
+} from '@fluojs/email/queue';
+import { NotificationsModule } from '@fluojs/notifications';
+import { QueueLifecycleService, QueueModule } from '@fluojs/queue';
 
-NotificationsModule.forRootAsync({
-  inject: [EMAIL_CHANNEL, QueueLifecycleService],
-  useFactory: (channel, queue) => ({
-    channels: [channel],
-    queue: {
-      adapter: createEmailNotificationsQueueAdapter(queue),
-      bulkThreshold: 25,
-    },
-  }),
-});
+@Module({
+  imports: [
+    QueueModule.forRoot(),
+    EmailModule.forRoot({ ... }),
+    NotificationsModule.forRootAsync({
+      inject: [EMAIL_CHANNEL, QueueLifecycleService],
+      useFactory: (channel, queue) => ({
+        channels: [channel],
+        queue: {
+          adapter: createEmailNotificationsQueueAdapter(queue),
+          bulkThreshold: 25,
+        },
+      }),
+    }),
+  ],
+  providers: [EmailNotificationsQueueWorker],
+})
+export class AppModule {}
 ```
 
-The queue adapter splits bulk notifications into individual background jobs and applies configurable retry and backoff policies to each job.
+The queue adapter splits bulk notifications into individual background jobs and applies configurable retry and backoff policies to each job. Register `EmailNotificationsQueueWorker` as a provider in the same application module so those queued email jobs are actually consumed.
 
 ## 16.7 Template Rendering
 


### PR DESCRIPTION
## Summary

Fixes the official book queue-backed email example so readers register the worker that consumes queued email notification jobs.

Closes #1688

## Changes

- Updated `book/intermediate/ch16-email.md` queue-backed bulk delivery example to import and register `EmailNotificationsQueueWorker`.
- Mirrored the same fix in `book/intermediate/ch16-email.ko.md`.
- Kept `packages/email` source and README contract unchanged because the existing package contract already documents the required worker registration.

## Testing

- `lsp_diagnostics` clean for `book/intermediate/ch16-email.md`
- `lsp_diagnostics` clean for `book/intermediate/ch16-email.ko.md`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`

## Public export documentation

- [x] No public exports changed; TSDoc baseline is not applicable.
- [x] No exported functions changed; `@param` / `@returns` tags are not applicable.
- [x] Source `@example` blocks and README scenario examples remain unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new package behavioral contracts were introduced; the book now matches the existing `@fluojs/email` README queue contract.
- [x] Intentional limitations remain explicit: queue workers are not auto-registered by `EmailModule`.
- [x] Runtime invariants are covered by existing package tests; this PR is docs/book-only and adds no runtime behavior change.

No release changeset is included because this is a book documentation correction only and does not change public package behavior or published package artifacts.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed book pages.
- [x] No platform contract docs changed.
- [x] No package README alignment/conformance claims changed.