### PR TITLE
Resolve #1669: Add serialization safety regression coverage

### DIFF
--- a/packages/serialization/src/serialize.test.ts
+++ b/packages/serialization/src/serialize.test.ts
@@ -500,13 +500,24 @@ describe('serialize', () => {
     expect(serialized.total).toBe(1n);
   });
 
-  it('preserves opaque built-in objects instead of flattening them as DTO-like instances', () => {
+  it('preserves every documented opaque built-in instead of flattening them as DTO-like instances', () => {
+    const createdAt = new Date('2026-03-24T00:00:00.000Z');
     const roles = new Map([['admin', true]]);
     const tags = new Set(['framework']);
     const profileUrl = new URL('https://fluo.dev/users/u-1');
+    const searchParams = new URLSearchParams([['role', 'admin']]);
+    const routePattern = /^\/users\/[a-z0-9-]+$/u;
     const failure = new Error('not serialized as an empty object');
+    const binaryBuffer = new ArrayBuffer(8);
+    const typedScores = new Uint16Array([100, 200]);
+    const weakRoles = new WeakMap<object, string>();
+    const weakTags = new WeakSet<object>();
+    const pendingProfile = Promise.resolve({ id: 'u-1' });
 
     class UserView {
+      @Expose()
+      createdAt = createdAt;
+
       @Expose()
       roles = roles;
 
@@ -517,19 +528,115 @@ describe('serialize', () => {
       profileUrl = profileUrl;
 
       @Expose()
+      searchParams = searchParams;
+
+      @Expose()
+      routePattern = routePattern;
+
+      @Expose()
       failure = failure;
+
+      @Expose()
+      binaryBuffer = binaryBuffer;
+
+      @Expose()
+      typedScores = typedScores;
+
+      @Expose()
+      weakRoles = weakRoles;
+
+      @Expose()
+      weakTags = weakTags;
+
+      @Expose()
+      pendingProfile = pendingProfile;
     }
 
     const serialized = serialize(new UserView()) as {
+      createdAt: Date;
       roles: Map<string, boolean>;
       tags: Set<string>;
       profileUrl: URL;
+      searchParams: URLSearchParams;
+      routePattern: RegExp;
       failure: Error;
+      binaryBuffer: ArrayBuffer;
+      typedScores: Uint16Array;
+      weakRoles: WeakMap<object, string>;
+      weakTags: WeakSet<object>;
+      pendingProfile: Promise<{ id: string }>;
     };
 
+    expect(serialized.createdAt).toBe(createdAt);
     expect(serialized.roles).toBe(roles);
     expect(serialized.tags).toBe(tags);
     expect(serialized.profileUrl).toBe(profileUrl);
+    expect(serialized.searchParams).toBe(searchParams);
+    expect(serialized.routePattern).toBe(routePattern);
     expect(serialized.failure).toBe(failure);
+    expect(serialized.binaryBuffer).toBe(binaryBuffer);
+    expect(serialized.typedScores).toBe(typedScores);
+    expect(serialized.weakRoles).toBe(weakRoles);
+    expect(serialized.weakTags).toBe(weakTags);
+    expect(serialized.pendingProfile).toBe(pendingProfile);
+  });
+
+  it('serializes exposed own constructor keys on decorated instances without prototype mutation', () => {
+    @Expose({ excludeExtraneous: false })
+    class DangerousView {
+      @Expose()
+      safe = true;
+
+      constructor() {
+        Object.defineProperty(this, 'constructor', {
+          configurable: true,
+          enumerable: true,
+          value: {
+            polluted: true,
+          },
+          writable: true,
+        });
+      }
+    }
+
+    const serialized = serialize(new DangerousView()) as Record<string, unknown>;
+
+    expect(Object.keys(serialized)).toEqual(['safe', 'constructor']);
+    expect(Object.getPrototypeOf(serialized)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(serialized, 'constructor')).toBe(true);
+    expect(serialized.safe).toBe(true);
+    expect(serialized.constructor).toEqual({ polluted: true });
+    expect((serialized as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  it('serializes exposed own prototype keys on decorated instances without prototype mutation', () => {
+    @Expose({ excludeExtraneous: true })
+    class DangerousView {
+      @Expose()
+      safe = true;
+
+      @Expose()
+      prototype!: Record<string, unknown>;
+
+      constructor() {
+        Object.defineProperty(this, 'prototype', {
+          configurable: true,
+          enumerable: true,
+          value: {
+            polluted: true,
+          },
+          writable: true,
+        });
+      }
+    }
+
+    const serialized = serialize(new DangerousView()) as Record<string, unknown>;
+
+    expect(Object.keys(serialized)).toEqual(['safe', 'prototype']);
+    expect(Object.getPrototypeOf(serialized)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(serialized, 'prototype')).toBe(true);
+    expect(serialized.safe).toBe(true);
+    expect(serialized.prototype).toEqual({ polluted: true });
+    expect((serialized as { polluted?: boolean }).polluted).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes #1669

Adds focused regression coverage for the documented `@fluojs/serialization` safety contracts around opaque built-ins and dangerous own keys on decorated instances.

## Changes

- Expanded `serialize()` opaque built-in coverage to include every README-documented opaque value: `Date`, `Map`, `Set`, `URL`, `URLSearchParams`, `RegExp`, `Error`, `ArrayBuffer`, typed arrays, `WeakMap`, `WeakSet`, and `Promise`.
- Added decorated-instance regression coverage for own `constructor` and `prototype` keys to ensure they serialize as data fields without mutating output prototypes.
- No docs changes: this locks already documented behavior without changing or narrowing the package contract.
- No changeset: tests-only regression coverage, no consumer-facing runtime/API/docs behavior change.

## Testing

- LSP diagnostics: `packages/serialization/src/serialize.test.ts` — no diagnostics found.
- `pnpm --filter @fluojs/serialization... build`
- `pnpm --filter @fluojs/serialization typecheck`
- `pnpm --filter @fluojs/serialization test` — 2 files / 28 tests passed.
- `pnpm lint` — completed successfully; `verify:public-export-tsdoc` passed in changed mode.

## Public export documentation

- [x] No public exports changed.
- [x] Changed public exports include a source-level summary. N/A.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. N/A.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. N/A.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. N/A; existing documented contracts only.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. N/A; no governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A.