### PR TITLE
Resolve #1673: Align throttler public API docs

### DIFF
--- a/.changeset/throttler-public-api-docs.md
+++ b/.changeset/throttler-public-api-docs.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/throttler": minor
+---
+
+Remove the undocumented throttler DI token from the root entrypoint and clarify that default in-memory storage is guard-owned unless callers provide a custom `ThrottlerStore`.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -122,10 +122,10 @@ ThrottlerModule.forRoot({
 ## 공개 API 개요
 
 ### 모듈
-- `ThrottlerModule.forRoot(options)`: throttler 옵션, 저장소, `ThrottlerGuard`를 모듈 그래프에 제공합니다.
-- 패키지 수준 등록은 `ThrottlerModule.forRoot(options)`를 통해 지원합니다. 내부 프로바이더 조합 헬퍼는 공개 계약에 포함되지 않습니다.
+- `ThrottlerModule.forRoot(options)`: 검증된 throttler 옵션과 `ThrottlerGuard`를 모듈 그래프에 제공합니다.
+- 패키지 수준 등록은 `ThrottlerModule.forRoot(options)`를 통해 지원합니다. 내부 프로바이더 조합 헬퍼와 DI 토큰은 공개 계약에 포함되지 않습니다.
 
-`ttl`과 `limit`은 양의 finite integer여야 합니다. `store`, `trustProxyHeaders`, `keyGenerator`로 persistence와 client identity를 조정할 수 있습니다.
+`ttl`과 `limit`은 양의 finite integer여야 합니다. `trustProxyHeaders`와 `keyGenerator`로 client identity를 조정할 수 있습니다. `store` 옵션을 제공하지 않으면 각 `ThrottlerGuard` 인스턴스가 자체 in-memory store를 소유합니다. 저장소를 공유하거나 외부에서 관리해야 한다면 `RedisThrottlerStore` 같은 `ThrottlerStore` 구현을 전달하세요.
 
 ### 데코레이터
 - `@Throttle({ ttl, limit })`: 클래스나 메서드에 특정 속도 제한을 설정합니다.

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -122,10 +122,10 @@ ThrottlerModule.forRoot({
 ## Public API Overview
 
 ### Modules
-- `ThrottlerModule.forRoot(options)`: Provides throttler options, storage, and `ThrottlerGuard` to the module graph.
-- Package-level registration is supported through `ThrottlerModule.forRoot(options)`. Internal provider-composition helpers are not part of the public contract.
+- `ThrottlerModule.forRoot(options)`: Provides validated throttler options and `ThrottlerGuard` to the module graph.
+- Package-level registration is supported through `ThrottlerModule.forRoot(options)`. Internal provider-composition helpers and DI tokens are not part of the public contract.
 
-`ttl` and `limit` must be positive finite integers. `store`, `trustProxyHeaders`, and `keyGenerator` customize persistence and client identity.
+`ttl` and `limit` must be positive finite integers. `trustProxyHeaders` and `keyGenerator` customize client identity. If no `store` option is supplied, each `ThrottlerGuard` instance owns its own in-memory store; pass a `ThrottlerStore` implementation such as `RedisThrottlerStore` when storage must be shared or externally managed.
 
 ### Decorators
 - `@Throttle({ ttl, limit })`: Sets a specific rate limit for a class or method.

--- a/packages/throttler/src/index.ts
+++ b/packages/throttler/src/index.ts
@@ -4,7 +4,6 @@ export { RedisThrottlerStore } from './redis-store.js';
 export * from './module.js';
 export * from './status.js';
 export { createMemoryThrottlerStore } from './store.js';
-export { THROTTLER_OPTIONS } from './tokens.js';
 export type {
   ThrottlerConsumeInput,
   ThrottlerHandlerOptions,

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -102,6 +102,7 @@ function createGuardContext(
 describe('@fluojs/throttler public entrypoints', () => {
   it('keeps ThrottlerModule.forRoot as the supported registration entrypoint without exporting internal provider helpers', () => {
     expect(throttlerExports).not.toHaveProperty('createThrottlerProviders');
+    expect(throttlerExports).not.toHaveProperty('THROTTLER_OPTIONS');
     expect(throttlerExports.ThrottlerModule).toBe(ThrottlerModule);
     expect(typeof throttlerExports.ThrottlerModule.forRoot).toBe('function');
   });


### PR DESCRIPTION
## Summary

Closes #1673.

- Aligns `@fluojs/throttler` README contract language with the current guard-owned default storage behavior.
- Removes the undocumented `THROTTLER_OPTIONS` DI token from the package root entrypoint so consumers do not couple to provider internals.
- Adds a changeset for the public surface cleanup.

## Changes

- Clarified EN/KO README wording: `ThrottlerModule.forRoot(options)` provides validated options and `ThrottlerGuard`, while default in-memory storage is owned by each guard instance unless a custom `ThrottlerStore` is supplied.
- Stopped exporting `THROTTLER_OPTIONS` from `packages/throttler/src/index.ts`.
- Extended the public-entrypoint regression test to assert internal provider helpers and DI tokens are not root exports.
- Added `.changeset/throttler-public-api-docs.md` for `@fluojs/throttler` minor release metadata.

## Testing

- `lsp_diagnostics` on `packages/throttler/src/index.ts`: clean.
- `lsp_diagnostics` on `packages/throttler/src/module.test.ts`: clean.
- `pnpm install --frozen-lockfile`: passed.
- `pnpm build`: passed.
- `pnpm --dir packages/throttler typecheck`: passed.
- `pnpm --dir packages/throttler test`: passed (3 files, 40 tests).
- `pnpm lint`: passed; Biome reported existing informational/warning diagnostics outside this change and `verify:public-export-tsdoc` passed in changed mode.
- `pnpm changeset status --since=main`: passed; reports `@fluojs/throttler` minor bump.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public declaration was added. This PR removes an undocumented root export while retaining TSDoc-covered supported exports.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The README now explicitly states that default in-memory storage is guard-owned unless callers provide a custom `ThrottlerStore`.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed.