### PR TITLE
Resolve #1680: Align HTTP docs with request-scope lifecycle

### DIFF
--- a/book/advanced/ch11-request-pipeline.ko.md
+++ b/book/advanced/ch11-request-pipeline.ko.md
@@ -22,18 +22,24 @@
 
 fluo의 모든 HTTP 요청은 `Dispatcher`를 통해 처리됩니다. 디스패처는 특정 HTTP 서버 프레임워크(Fastify, Express 등)에 종속되지 않는 범용 인터페이스를 제공하며, 프레임워크 메타데이터를 실제 실행 로직으로 전환합니다. 따라서 어댑터가 어떤 서버에서 요청을 받아오든, 이후의 라우팅과 파이프라인 실행은 같은 중심 흐름을 따를 수 있습니다.
 
-`packages/http/src/dispatch/dispatcher.ts:L324-L354`
+`packages/http/src/dispatch/dispatcher.ts` (simplified)
 ```typescript
 export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
   const contentNegotiation = resolveContentNegotiation(options.contentNegotiation);
 
   return {
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
-      const phaseContext: DispatchPhaseContext = {
+      const dispatchScope = createRootDispatchScope(options.rootContainer);
+      let phaseContext: DispatchPhaseContext;
+      phaseContext = {
         contentNegotiation,
+        dispatchScope,
         observers: options.observers ?? [],
         options,
-        requestContext: createDispatchContext(createDispatchRequest(request), response, options.rootContainer),
+        requestContext: createDispatchContext(request, response, dispatchScope.container, () => {
+          ensureRequestScope(phaseContext);
+          return phaseContext.dispatchScope.container;
+        }),
         response,
       };
 
@@ -46,7 +52,9 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
         } finally {
           await notifyRequestFinish(phaseContext);
           try {
-            await phaseContext.requestContext.container.dispose();
+            if (phaseContext.dispatchScope.requestScoped) {
+              await phaseContext.dispatchScope.container.dispose();
+            }
           } catch (error) {
             logDispatchFailure(options.logger, 'Request-scoped container dispose threw an error.', error);
           }
@@ -57,13 +65,13 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
 }
 ```
 
-디스패처는 핸들러만 실행하지 않습니다. 전체 생명주기를 관리하고, 오류를 포착하며, 요청 단위 리소스를 안전하게 해제하는 조율 지점입니다.
+디스패처는 핸들러만 실행하지 않습니다. 전체 생명주기를 관리하고, 오류를 포착하며, request scope가 실제로 만들어진 경우 요청 단위 리소스를 안전하게 해제하는 조율 지점입니다.
 
 ## 11.2 요청 파이프라인의 10단계 흐름
 
 하나의 HTTP 요청이 들어오면 fluo는 다음 순서로 파이프라인을 실행합니다. 각 단계는 이전 단계의 결과에 의존하거나, 특정 조건(예: 인증 실패)에 따라 흐름을 중단할 수 있습니다.
 
-1.  **Context Creation**: `RequestContext`를 생성하고 요청별 DI 스코프를 할당합니다. `dispatcher.ts:L93-L101`에서 `createDispatchContext`가 호출됩니다. 이때 생성된 컨테이너는 요청이 끝날 때까지 해당 요청에만 속한 인스턴스를 관리합니다.
+1.  **Context Creation**: `RequestContext`를 생성하고 root DI container에서 시작합니다. `createDispatchContext`는 `RequestContext.container`를 감싸 수동 `resolve()`가 활성 dispatch 중에만 isolated request scope로 승격되게 할 수 있습니다. 또한 활성 middleware, observer, guard, interceptor, DTO conversion, custom binder, request-context handler parameter, request-scoped dependency를 가진 controller graph처럼 request scope가 필요할 수 있는 단계 전에 디스패처가 승격합니다.
 2.  **Notification (Start)**: 등록된 모든 옵저버에게 요청 시작을 알립니다. `dispatcher.ts:L211-L220`에서 `notifyRequestStart`가 수행됩니다. 로깅이나 메트릭 수집이 여기서 시작됩니다.
 3.  **Global Middleware**: 애플리케이션 수준의 전역 미들웨어를 실행합니다. `dispatcher.ts:L267`에서 `runMiddlewareChain`이 시작됩니다. CORS나 보안 헤더 설정 등이 주로 여기서 처리됩니다.
 4.  **Route Matching**: 요청 URL과 메서드를 기반으로 적절한 컨트롤러 핸들러를 찾습니다. `dispatcher.ts:L272`에서 `matchHandlerOrThrow`가 호출됩니다. 여기서 핸들러를 찾지 못하면 404 에러가 발생하며 파이프라인은 즉시 에러 처리 단계로 건너뜁니다.
@@ -142,7 +150,7 @@ function ensureRequestNotAborted(request: FrameworkRequest): void {
 [Incoming Request]
        │
        ▼
-[Create RequestContext & DI Scope] ─── (Failure) ──┐
+[Create RequestContext] ────────────── (Failure) ──┐
        │                                           │
        ▼                                           │
 [Notify: onRequestStart] ───────────── (Failure) ──┤
@@ -175,13 +183,13 @@ function ensureRequestNotAborted(request: FrameworkRequest): void {
 [Notify: onRequestFinish] ◀─────────────────────────────────────────────┘
        │
        ▼
-[Dispose DI Scope]
+[Dispose request scope if promoted]
        │
        ▼
 [End of Request]
 ```
 
-이 다이어그램은 fluo 아키텍처의 핵심인 "보증된 정리(Guaranteed Cleanup)" 원칙을 보여 줍니다. 각 레이어는 독립적이지만, 디스패처는 이를 하나의 흐름으로 묶습니다. 성공, 예상된 에러, 예기치 못한 패닉 중 어떤 경로를 지나도 리소스 해제 단계는 반드시 실행되도록 설계되어 있습니다.
+이 다이어그램은 fluo 아키텍처의 핵심인 "보증된 정리(Guaranteed Cleanup)" 원칙을 보여 줍니다. 각 레이어는 독립적이지만, 디스패처는 이를 하나의 흐름으로 묶습니다. 성공, 예상된 에러, 예기치 못한 패닉 중 어떤 경로를 지나도 request-scoped container가 생성된 경우 리소스 해제 단계가 실행되도록 설계되어 있습니다. 끝까지 승격되지 않은 singleton-only fast-path 요청은 root container를 계속 사용하며 이를 dispose하지 않습니다.
 
 ## 11.7 DispatchPhaseContext: 단계별 상태 공유
 
@@ -214,11 +222,11 @@ interface DispatchPhaseContext {
 
 디스패처는 라우트 매칭 시 매번 복잡한 연산을 수행하지 않습니다. `packages/http/src/dispatch/dispatch-routing-policy.ts` 내부에서는 `WeakMap`을 사용하여 컨트롤러 클래스와 해당 클래스의 라우트 메타데이터를 캐싱합니다. `WeakMap`을 사용하기 때문에 컨트롤러 클래스가 가비지 컬렉션 대상이 되었을 때 캐시 데이터도 함께 제거됩니다.
 
-또한 디스패처 생성 시점에 `resolveContentNegotiation`을 통해 설정을 미리 계산해 두어 요청당 오버헤드를 줄입니다. `packages/http/src/public-api.test.ts:L39-L52` 수준의 통합 테스트는 대규모 애플리케이션에서도 일관된 라우팅 지연 시간(Latency)을 유지하는지 확인합니다. 이런 최적화 덕분에 Fluo는 매 요청마다 컨테이너를 생성하고 해제하는 비용을 감수하면서도 높은 처리량(Throughput)을 유지할 수 있습니다.
+또한 디스패처 생성 시점에 `resolveContentNegotiation`을 통해 설정을 미리 계산해 두어 요청당 오버헤드를 줄입니다. `packages/http/src/public-api.test.ts:L39-L52` 수준의 통합 테스트는 대규모 애플리케이션에서도 일관된 라우팅 지연 시간(Latency)을 유지하는지 확인합니다. 이런 최적화 덕분에 Fluo는 singleton-only route를 root-container fast path에 유지하면서도, 파이프라인이 request-scoped provider를 필요로 할 때는 isolated request scope로 승격해 높은 처리량(Throughput)을 유지할 수 있습니다.
 
 ## 11.10 리소스 정리: DI 스코프 소멸
 
-요청 처리가 끝나면 반드시 `requestContext.container.dispose()`를 호출합니다. 이는 해당 요청 기간 동안 생성된 싱글톤이 아닌 객체(Request-scoped providers)의 `onDispose` 훅을 실행하고 메모리를 해제하여 누수를 막습니다.
+요청 처리가 끝나면 승격된 request-scoped container를 반드시 dispose해야 합니다. 이는 해당 요청 기간 동안 생성된 싱글톤이 아닌 객체(Request-scoped providers)의 `onDispose` 훅을 실행하고 메모리를 해제하여 누수를 막습니다. 요청이 singleton-only로 유지되어 승격이 일어나지 않았다면 cleanup 경로는 root container를 그대로 둡니다.
 
 `packages/http/src/dispatch/dispatcher.ts:L240-L255`
 ```typescript
@@ -229,7 +237,9 @@ async function finalizeRequest(phaseContext: DispatchPhaseContext): Promise<void
     phaseContext.options.logger?.error('Observer onRequestFinish threw an error', error);
   } finally {
     try {
-      await phaseContext.requestContext.container.dispose();
+      if (phaseContext.dispatchScope.requestScoped) {
+        await phaseContext.dispatchScope.container.dispose();
+      }
     } catch (error) {
       phaseContext.options.logger?.error('Request-scoped container dispose threw an error', error);
     }
@@ -237,7 +247,7 @@ async function finalizeRequest(phaseContext: DispatchPhaseContext): Promise<void
 }
 ```
 
-이 과정은 `finally` 블록 안에서 수행되어 요청의 성공/실패 여부와 관계없이 항상 실행됩니다. `packages/http/src/public-api.test.ts:L39-L52`에서는 요청 컨테이너가 해제된 뒤 해당 컨테이너에 속했던 프로바이더에 더 이상 접근할 수 없음을 확인하여 격리 및 해제 정책이 지켜지는지 검증합니다.
+이 과정은 `finally` 블록 안에서 수행되어 요청의 성공/실패 여부와 관계없이 항상 cleanup 여부를 확인합니다. `packages/http/src/dispatch/dispatcher.test.ts`는 singleton-only route가 request-scope 생성을 건너뛰는 경우와, request-scoped controller, 활성 middleware, observer, custom binder, DTO converter, 수동 container resolution이 isolated scope를 사용한 뒤 dispatch 후 dispose되는 경우를 모두 검증합니다.
 
 또한 `RequestContext` 내부에 저장된 임시 파일 참조나 열려 있는 스트림도 이 단계에서 닫힙니다. Fluo의 HTTP 디스패처는 누수 방지 중심 설계를 통해 많은 요청이 흐르는 프로덕션 환경에서도 메모리 점유율을 안정적으로 유지하도록 돕습니다.
 
@@ -246,7 +256,7 @@ async function finalizeRequest(phaseContext: DispatchPhaseContext): Promise<void
 - **10단계 파이프라인**: 전역 미들웨어부터 응답 쓰기까지 명확히 정의된 단계별 실행을 보장합니다.
 - **비동기 격리**: `AsyncLocalStorage` 기반의 `RequestContext`로 요청 간 데이터를 격리합니다.
 - **관찰성 계층**: 옵저버 패턴을 통해 비즈니스 로직 수정 없이 전 구간 모니터링이 가능합니다.
-- **신뢰할 수 있는 정리**: `AbortSignal` 감시와 강제 `dispose()` 호출로 리소스 낭비를 줄입니다.
+- **신뢰할 수 있는 정리**: `AbortSignal` 감시와 isolated request scope로 승격된 dispatch의 request-scope disposal로 리소스 낭비를 줄입니다.
 
 ## 다음 챕터 예고
 다음 챕터에서는 가드, 인터셉터, 미들웨어가 어떻게 "체인"을 형성하고 서로의 실행을 제어하는지 더 깊게 살펴봅니다. `reduceRight`를 활용한 체인 구성이 어떤 실행 순서를 만드는지도 함께 다룹니다.

--- a/book/advanced/ch11-request-pipeline.md
+++ b/book/advanced/ch11-request-pipeline.md
@@ -22,18 +22,24 @@ This chapter looks at the internal steps the Fluo HTTP Dispatcher follows from r
 
 Every HTTP request in fluo is handled through the `Dispatcher`. The Dispatcher provides a general interface that does not depend on a specific HTTP server framework, such as Fastify or Express, and turns framework metadata into real execution logic. As a result, once an adapter hands a request to the framework, routing and pipeline execution can follow the same central flow regardless of the server that received it.
 
-`packages/http/src/dispatch/dispatcher.ts:L324-L354`
+`packages/http/src/dispatch/dispatcher.ts` (simplified)
 ```typescript
 export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
   const contentNegotiation = resolveContentNegotiation(options.contentNegotiation);
 
   return {
     async dispatch(request: FrameworkRequest, response: FrameworkResponse): Promise<void> {
-      const phaseContext: DispatchPhaseContext = {
+      const dispatchScope = createRootDispatchScope(options.rootContainer);
+      let phaseContext: DispatchPhaseContext;
+      phaseContext = {
         contentNegotiation,
+        dispatchScope,
         observers: options.observers ?? [],
         options,
-        requestContext: createDispatchContext(createDispatchRequest(request), response, options.rootContainer),
+        requestContext: createDispatchContext(request, response, dispatchScope.container, () => {
+          ensureRequestScope(phaseContext);
+          return phaseContext.dispatchScope.container;
+        }),
         response,
       };
 
@@ -46,7 +52,9 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
         } finally {
           await notifyRequestFinish(phaseContext);
           try {
-            await phaseContext.requestContext.container.dispose();
+            if (phaseContext.dispatchScope.requestScoped) {
+              await phaseContext.dispatchScope.container.dispose();
+            }
           } catch (error) {
             logDispatchFailure(options.logger, 'Request-scoped container dispose threw an error.', error);
           }
@@ -57,13 +65,13 @@ export function createDispatcher(options: CreateDispatcherOptions): Dispatcher {
 }
 ```
 
-The Dispatcher does not only run handlers. It is the coordination point that manages the full lifecycle, catches errors, and safely releases request-scoped resources.
+The Dispatcher does not only run handlers. It is the coordination point that manages the full lifecycle, catches errors, and safely releases request-scoped resources when a request scope is actually created.
 
 ## 11.2 The Ten-Step Request Pipeline Flow
 
 When a single HTTP request arrives, fluo runs the pipeline in the following order. Each stage depends on the result of the previous stage or can stop the flow under a specific condition, such as failed authentication.
 
-1.  **Context Creation**: Creates a `RequestContext` and assigns a request-specific DI Scope. `createDispatchContext` is called in `dispatcher.ts:L93-L101`. The container created at this point manages instances that belong only to this request until the request ends.
+1.  **Context Creation**: Creates a `RequestContext` and starts from the root DI container. `createDispatchContext` can wrap `RequestContext.container` so a manual `resolve()` promotes the request to an isolated request scope only while dispatch is active. The Dispatcher also promotes before stages that may need request scope, such as active middleware, observers, guards, interceptors, DTO conversion, a custom binder, request-context handler parameters, or a controller graph with request-scoped dependencies.
 2.  **Notification (Start)**: Notifies every registered observer that the request has started. `notifyRequestStart` runs in `dispatcher.ts:L211-L220`. Logging or metrics collection usually starts here.
 3.  **Global Middleware**: Runs application-level global Middleware. `runMiddlewareChain` starts in `dispatcher.ts:L267`. CORS, security headers, and similar concerns are usually handled here.
 4.  **Route Matching**: Finds the right Controller handler from the request URL and method. `matchHandlerOrThrow` is called in `dispatcher.ts:L272`. If no handler is found, a 404 error is raised and the pipeline jumps directly to error handling.
@@ -142,7 +150,7 @@ The full flow can be visualized as follows. The arrows between stages represent 
 [Incoming Request]
        │
        ▼
-[Create RequestContext & DI Scope] ─── (Failure) ──┐
+[Create RequestContext] ────────────── (Failure) ──┐
        │                                           │
        ▼                                           │
 [Notify: onRequestStart] ───────────── (Failure) ──┤
@@ -175,13 +183,13 @@ The full flow can be visualized as follows. The arrows between stages represent 
 [Notify: onRequestFinish] ◀─────────────────────────────────────────────┘
        │
        ▼
-[Dispose DI Scope]
+[Dispose request scope if promoted]
        │
        ▼
 [End of Request]
 ```
 
-This diagram shows Guaranteed Cleanup, a core principle of fluo architecture. Each layer is independent, but the Dispatcher ties them together as one flow. Whether the request takes a success path, an expected error path, or an unexpected panic path, the resource release stage is designed to run every time.
+This diagram shows Guaranteed Cleanup, a core principle of fluo architecture. Each layer is independent, but the Dispatcher ties them together as one flow. Whether the request takes a success path, an expected error path, or an unexpected panic path, the request-scope release stage is designed to run every time a request-scoped container was created. Singleton-only fast-path requests that never promote keep using the root container and do not dispose it.
 
 ## 11.7 DispatchPhaseContext, Phase-Level State Sharing
 
@@ -214,13 +222,13 @@ If an error occurs anywhere in the pipeline, `handleDispatchError` is called and
 
 The Dispatcher does not repeat complex work on every route match. Inside `packages/http/src/dispatch/dispatch-routing-policy.ts`, it uses a `WeakMap` to cache Controller classes and the route metadata for those classes. Because this is a `WeakMap`, the cached data is removed as well when the Controller class becomes eligible for garbage collection.
 
-The Dispatcher also precomputes configuration at creation time through `resolveContentNegotiation`, reducing per-request overhead. The integration tests at the level of `packages/http/src/public-api.test.ts:L39-L52` verify that routing latency stays consistent even in large applications. These optimizations let Fluo keep high throughput even while paying the cost of creating and disposing a container for every request.
+The Dispatcher also precomputes configuration at creation time through `resolveContentNegotiation`, reducing per-request overhead. The integration tests at the level of `packages/http/src/public-api.test.ts:L39-L52` verify that routing latency stays consistent even in large applications. These optimizations let Fluo keep high throughput by keeping singleton-only routes on the root-container fast path while still promoting to isolated request scopes when the pipeline needs request-scoped providers.
 
 ## 11.10 Resource Cleanup, DI Scope Disposal
 
-When request handling ends, `requestContext.container.dispose()` must be called. This runs `onDispose` hooks for non-singleton objects created during the request, meaning request-scoped providers, and releases memory to prevent leaks.
+When request handling ends, a promoted request-scoped container must be disposed. This runs `onDispose` hooks for non-singleton objects created during the request, meaning request-scoped providers, and releases memory to prevent leaks. If the request stayed singleton-only and no promotion occurred, the cleanup path leaves the root container alive.
 
-`packages/http/src/dispatch/dispatcher.ts:L240-L255`
+`packages/http/src/dispatch/dispatcher.ts` (simplified)
 ```typescript
 async function finalizeRequest(phaseContext: DispatchPhaseContext): Promise<void> {
   try {
@@ -229,7 +237,9 @@ async function finalizeRequest(phaseContext: DispatchPhaseContext): Promise<void
     phaseContext.options.logger?.error('Observer onRequestFinish threw an error', error);
   } finally {
     try {
-      await phaseContext.requestContext.container.dispose();
+      if (phaseContext.dispatchScope.requestScoped) {
+        await phaseContext.dispatchScope.container.dispose();
+      }
     } catch (error) {
       phaseContext.options.logger?.error('Request-scoped container dispose threw an error', error);
     }
@@ -237,7 +247,7 @@ async function finalizeRequest(phaseContext: DispatchPhaseContext): Promise<void
 }
 ```
 
-This process runs inside a `finally` block, so it always runs regardless of whether the request succeeds or fails. `packages/http/src/public-api.test.ts:L39-L52` verifies the isolation and disposal policy by confirming that providers that belonged to a request container can no longer be accessed after that container is disposed.
+This process runs inside a `finally` block, so it always checks cleanup regardless of whether the request succeeds or fails. `packages/http/src/dispatch/dispatcher.test.ts` verifies both sides of the policy: singleton-only routes skip request-scope creation, while request-scoped controllers, active middleware, observers, custom binders, DTO converters, and manual container resolution use isolated scopes that are disposed after the dispatch.
 
 Temporary file references or open streams stored inside `RequestContext` are also closed at this stage. Fluo's HTTP Dispatcher uses a leak-prevention-centered design to help keep memory usage stable in production environments with heavy request traffic.
 
@@ -246,7 +256,7 @@ Temporary file references or open streams stored inside `RequestContext` are als
 - **Ten-step pipeline**: Guarantees clearly defined phase-by-phase execution from global Middleware to response writing.
 - **Async isolation**: Isolates data between requests with `AsyncLocalStorage`-based `RequestContext`.
 - **Observability layer**: Enables monitoring across the full flow through the observer pattern without changing business logic.
-- **Reliable cleanup**: Reduces wasted resources through `AbortSignal` checks and forced `dispose()` calls.
+- **Reliable cleanup**: Reduces wasted resources through `AbortSignal` checks and request-scope disposal whenever dispatch promoted to an isolated request scope.
 
 ## Next Chapter Preview
 The next chapter looks more deeply at how Guards, Interceptors, and Middleware form chains and control each other's execution. It also covers what execution order is produced by chain composition with `reduceRight`.

--- a/book/advanced/ch12-execution-chain.ko.md
+++ b/book/advanced/ch12-execution-chain.ko.md
@@ -41,7 +41,7 @@ export async function runMiddlewareChain(
 ): Promise<void> {
   const chain = middlewares.reduceRight(
     (next, middleware) => async () => {
-      await middleware.use(context, next);
+      await middleware.handle(context, next);
     },
     terminal
   );
@@ -49,7 +49,7 @@ export async function runMiddlewareChain(
 }
 ```
 
-이 구조에서는 `next()` 호출 이후의 로직이 역순으로 실행됩니다. 그래서 미들웨어는 요청이 안쪽으로 들어가는 단계뿐 아니라 응답이 바깥쪽으로 나오는 단계에도 개입할 수 있습니다. `reduceRight`를 쓰는 이유는 리스트의 마지막 요소가 `terminal`(가장 안쪽 로직)을 감싸야 하기 때문입니다.
+이 구조에서는 각 class-based middleware가 `handle(context, next)`를 구현하며, `next()` 호출 이후의 로직이 역순으로 실행됩니다. 그래서 미들웨어는 요청이 안쪽으로 들어가는 단계뿐 아니라 응답이 바깥쪽으로 나오는 단계에도 개입할 수 있습니다. `reduceRight`를 쓰는 이유는 리스트의 마지막 요소가 `terminal`(가장 안쪽 로직)을 감싸야 하기 때문입니다.
 
 ## 12.3 가드(Guard): 철저한 출입 통제
 

--- a/book/advanced/ch12-execution-chain.md
+++ b/book/advanced/ch12-execution-chain.md
@@ -41,7 +41,7 @@ export async function runMiddlewareChain(
 ): Promise<void> {
   const chain = middlewares.reduceRight(
     (next, middleware) => async () => {
-      await middleware.use(context, next);
+      await middleware.handle(context, next);
     },
     terminal
   );
@@ -49,7 +49,7 @@ export async function runMiddlewareChain(
 }
 ```
 
-In this structure, logic after the `next()` call runs in reverse order. That lets Middleware participate not only when the request moves inward, but also when the response moves outward. `reduceRight` is used because the last element in the list must wrap `terminal`, the innermost logic.
+In this structure, each class-based middleware implements `handle(context, next)`, and logic after the `next()` call runs in reverse order. That lets Middleware participate not only when the request moves inward, but also when the response moves outward. `reduceRight` is used because the last element in the list must wrap `terminal`, the innermost logic.
 
 ## 12.3 Guard: Strict Access Control
 

--- a/docs/architecture/http-runtime.ko.md
+++ b/docs/architecture/http-runtime.ko.md
@@ -7,7 +7,7 @@
 ## Request Lifecycle
 
 1. 어댑터는 정규화된 `FrameworkRequest`와 `FrameworkResponse`를 `Dispatcher.dispatch(...)`에 전달한다.
-2. dispatcher는 request params를 복사하고 request-scoped container를 만든 뒤, request metadata와 선택적 `x-request-id`를 포함하는 `RequestContext`를 생성한다.
+2. dispatcher는 request params를 복사하고 request metadata와 선택적 `x-request-id`를 포함하는 `RequestContext`를 생성한다. 시작 시에는 root container를 사용하고, 매칭된 graph, 활성 middleware, observer, DTO conversion, binder, guard, interceptor, controller dependency graph, 또는 수동 `RequestContext.container.resolve(...)` 접근이 request scope를 필요로 할 수 있을 때만 isolated request-scoped container로 승격한다.
 3. 등록된 request observer는 route matching 전에 `onRequestStart`를 받는다.
 4. 전역 application middleware가 `runMiddlewareChain(...)`을 통해 가장 먼저 실행된다.
 5. `matchHandlerOrThrow(...)`는 `HandlerMapping`에서 하나의 handler를 해석하거나 `HandlerNotFoundError`를 던진다.
@@ -19,7 +19,7 @@
 11. controller method는 `(input, requestContext)`를 받고 handler 결과를 반환한다.
 12. 성공한 non-SSE 결과는 `writeSuccessResponse(...)`를 통해 기록되며, 여기서 redirect metadata, route header, formatter 선택, 기본 성공 status 규칙이 적용된다.
 13. 어느 단계에서든 예외가 발생하면 dispatcher는 설정된 경우 `onError`를 실행하고, 그렇지 않으면 `writeErrorResponse(...)`가 기본 에러 응답을 기록한다.
-14. dispatcher는 항상 `onRequestFinish`를 호출하고 요청이 끝나기 전에 request-scoped container를 dispose 한다.
+14. dispatcher는 항상 `onRequestFinish`를 호출한다. request scope가 생성되었거나 lazy promotion 되었다면 요청이 끝나기 전에 해당 isolated request-scoped container를 dispose하며, 끝까지 승격되지 않은 singleton-only fast-path 요청은 root container를 dispose하지 않는다.
 
 ## Routing Rules
 

--- a/docs/architecture/http-runtime.md
+++ b/docs/architecture/http-runtime.md
@@ -7,7 +7,7 @@ This document defines the current request execution contract implemented by `@fl
 ## Request Lifecycle
 
 1. The adapter supplies a normalized `FrameworkRequest` and `FrameworkResponse` to `Dispatcher.dispatch(...)`.
-2. The dispatcher clones request params, creates a request-scoped container, and builds a `RequestContext` with request metadata and an optional `x-request-id`.
+2. The dispatcher clones request params and builds a `RequestContext` with request metadata and an optional `x-request-id`. It starts on the root container and promotes to an isolated request-scoped container only when the matched graph, active middleware, observers, DTO conversion, binder, guard, interceptor, controller dependency graph, or manual `RequestContext.container.resolve(...)` access may need request scope.
 3. Registered request observers receive `onRequestStart` before route matching.
 4. Global application middleware runs first through `runMiddlewareChain(...)`.
 5. `matchHandlerOrThrow(...)` resolves one handler from the `HandlerMapping` or throws `HandlerNotFoundError`.
@@ -19,7 +19,7 @@ This document defines the current request execution contract implemented by `@fl
 11. The controller method receives `(input, requestContext)` and returns the handler result.
 12. Successful non-SSE results are written through `writeSuccessResponse(...)`, which applies redirect metadata, route headers, formatter selection, and default success status rules.
 13. If any stage throws, the dispatcher runs `onError` when configured, otherwise `writeErrorResponse(...)` writes the default error response.
-14. The dispatcher always emits `onRequestFinish` and disposes the request-scoped container before the request ends.
+14. The dispatcher always emits `onRequestFinish`. When a request scope was created or lazily promoted, it disposes that isolated request-scoped container before the request ends; singleton-only fast-path requests that never promote do not dispose the root container.
 
 ## Routing Rules
 

--- a/docs/architecture/security-middleware.ko.md
+++ b/docs/architecture/security-middleware.ko.md
@@ -37,14 +37,14 @@
 
 | Stage | Current order | Result | Source anchor |
 | --- | --- | --- | --- |
-| 1 | Request context creation and request observers start | 미들웨어 실행 전에 요청 범위와 요청 메타데이터를 생성합니다. | `packages/http/src/dispatch/dispatcher.ts` |
+| 1 | Request context creation and request observers start | 미들웨어 실행 전에 요청 메타데이터를 생성하고, 활성 파이프라인이 request scope를 필요로 할 수 있을 때만 request scope로 승격합니다. | `packages/http/src/dispatch/dispatcher.ts` |
 | 2 | Global application middleware | 모든 요청에서 `appMiddleware`를 먼저 실행합니다. | `packages/http/src/dispatch/dispatcher.ts` |
 | 3 | Route match and param update | 모듈 미들웨어 전에 핸들러를 선택하고 라우트 파라미터를 기록합니다. | `packages/http/src/dispatch/dispatcher.ts` |
 | 4 | Module middleware | 라우트 매칭 후, guard 전에 라우트 모듈 미들웨어를 실행합니다. | `packages/http/src/dispatch/dispatcher.ts` |
 | 5 | Guard chain | `AuthGuard`, `ThrottlerGuard` 같은 라우트 guard를 실행합니다. | `packages/http/src/dispatch/dispatcher.ts`, `packages/passport/src/guard.ts`, `packages/throttler/src/guard.ts` |
 | 6 | Interceptor chain | guard가 성공한 뒤 전역 및 라우트 interceptor를 실행합니다. | `packages/http/src/dispatch/dispatcher.ts` |
 | 7 | Handler invocation and response write | 컨트롤러 핸들러를 실행한 뒤, 응답이 이미 커밋되지 않았다면 성공 응답을 기록합니다. | `packages/http/src/dispatch/dispatcher.ts` |
-| 8 | Error mapping and request-scope disposal | 처리되지 않은 실패를 정규화하고, 오류 응답을 기록하고, finish observer를 호출한 뒤 요청 컨테이너를 dispose합니다. | `packages/http/src/dispatch/dispatcher.ts` |
+| 8 | Error mapping and request-scope disposal | 처리되지 않은 실패를 정규화하고, 오류 응답을 기록하고, finish observer를 호출한 뒤 isolated request scope로 승격된 dispatch에서만 요청 컨테이너를 dispose합니다. | `packages/http/src/dispatch/dispatcher.ts` |
 
 미들웨어별 순서 규칙:
 

--- a/docs/architecture/security-middleware.md
+++ b/docs/architecture/security-middleware.md
@@ -37,14 +37,14 @@ The current HTTP dispatcher order is fixed by `createDispatcher(...)`.
 
 | Stage | Current order | Result | Source anchor |
 | --- | --- | --- | --- |
-| 1 | Request context creation and request observers start | Creates request scope and request metadata before middleware execution. | `packages/http/src/dispatch/dispatcher.ts` |
+| 1 | Request context creation and request observers start | Creates request metadata before middleware execution and promotes to a request scope only when the active pipeline may need one. | `packages/http/src/dispatch/dispatcher.ts` |
 | 2 | Global application middleware | Runs `appMiddleware` first for every request. | `packages/http/src/dispatch/dispatcher.ts` |
 | 3 | Route match and param update | Selects handler and writes route params before module middleware. | `packages/http/src/dispatch/dispatcher.ts` |
 | 4 | Module middleware | Runs route-module middleware after route match and before guards. | `packages/http/src/dispatch/dispatcher.ts` |
 | 5 | Guard chain | Runs route guards such as `AuthGuard` and `ThrottlerGuard`. | `packages/http/src/dispatch/dispatcher.ts`, `packages/passport/src/guard.ts`, `packages/throttler/src/guard.ts` |
 | 6 | Interceptor chain | Runs global and route interceptors after guards succeed. | `packages/http/src/dispatch/dispatcher.ts` |
 | 7 | Handler invocation and response write | Executes the controller handler, then writes success output unless the response is already committed. | `packages/http/src/dispatch/dispatcher.ts` |
-| 8 | Error mapping and request-scope disposal | Normalizes unhandled failures, writes error responses, notifies finish observers, then disposes the request container. | `packages/http/src/dispatch/dispatcher.ts` |
+| 8 | Error mapping and request-scope disposal | Normalizes unhandled failures, writes error responses, notifies finish observers, then disposes the request container only when the dispatch promoted to an isolated request scope. | `packages/http/src/dispatch/dispatcher.ts` |
 
 Middleware-specific ordering rules:
 


### PR DESCRIPTION
## Summary

Closes #1680

- Aligns HTTP architecture docs and advanced book chapters with the current request-scope lifecycle: root-container start, promotion only when the active pipeline may need request scope, and disposal only for promoted request scopes.
- Updates stale middleware chain snippets from `use(context, next)` to the current class-based `handle(context, next)` contract.
- Keeps English/Korean docs and book pairs synchronized.

## Changes

- Updated `docs/architecture/http-runtime*.md` and `docs/architecture/security-middleware*.md` lifecycle wording.
- Updated `book/advanced/ch11-request-pipeline*.md` request lifecycle snippets and cleanup explanation.
- Updated `book/advanced/ch12-execution-chain*.md` middleware chain snippet and contract wording.
- No changeset added: this is docs/book-only and does not change public package behavior, exports, or runtime contracts.

## Testing

- `lsp_diagnostics` on `.worktrees/issue-1680-align-http-book-docs`: 0 diagnostics across scanned Markdown files.
- `pnpm verify:docs` passed after installing the worktree dependencies with `pnpm install --frozen-lockfile`.
  - `pnpm docs:sync-check` passed: 42 en/ko page pairs and 10 navigation metadata pairs.
  - `pnpm docs:typecheck` passed.
  - `pnpm docs:build` passed.

## Public export documentation

- [x] No public exports changed.
- [x] No exported function `@param` / `@returns` changes required.
- [x] Source `@example` blocks and README scenario examples were not changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new runtime behavioral contracts were introduced; docs now reflect the existing `@fluojs/http` lifecycle and middleware contracts.
- [x] Intentional lifecycle limits are explicitly stated: singleton-only fast-path requests do not dispose the root container, while promoted request scopes are disposed.
- [x] Runtime invariants were not changed; existing package tests cover the behavior.

## Platform consistency governance (SSOT)

- [x] English/Korean mirror structure remains synchronized for changed docs/book pairs.
- [x] Platform contract docs were not changed.
- [x] Package README conformance claims were not changed.