### PR TITLE
Resolve #1685: Harden Fastify shutdown conformance tests

### DIFF
--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -25,9 +25,9 @@ import {
   VersioningType,
   type CallHandler,
   type Dispatcher,
-    type FrameworkRequest,
-    type FrameworkResponse,
-    type GuardContext,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  type GuardContext,
   type InterceptorContext,
   type MiddlewareContext,
   type RequestObservationContext,
@@ -1643,8 +1643,9 @@ describe('@fluojs/platform-fastify', () => {
     expect(closeCallCount).toBe(1);
     expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
 
+    const closeInFlight = Reflect.get(adapter, 'closeInFlight') as Promise<void>;
     deferred.resolve();
-    await Promise.resolve();
+    await closeInFlight;
 
     expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
   });
@@ -1696,8 +1697,42 @@ describe('@fluojs/platform-fastify', () => {
 
     await expect(adapter.close()).rejects.toThrow(/shutdown timeout/i);
 
+    const closeInFlight = Reflect.get(adapter, 'closeInFlight') as Promise<void>;
     deferred.resolve();
-    await Promise.resolve();
+    await closeInFlight;
+  });
+
+  it('keeps timed-out shutdown attempts on the same in-flight close until fastify settles', async () => {
+    const adapter = new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
+    const deferred = createDeferred<void>();
+    let closeCallCount = 0;
+    const app = {
+      close: () => {
+        closeCallCount += 1;
+        return deferred.promise;
+      },
+      server: {
+        listening: true,
+      },
+    };
+    const dispatcher = {
+      async dispatch() {},
+    };
+
+    Reflect.set(adapter, 'app', app);
+    Reflect.set(adapter, 'dispatcher', dispatcher);
+
+    await expect(adapter.close()).rejects.toThrow(/shutdown timeout/i);
+    await expect(adapter.close()).rejects.toThrow(/shutdown timeout/i);
+
+    expect(closeCallCount).toBe(1);
+    expect(Reflect.get(adapter, 'dispatcher')).toBe(dispatcher);
+
+    const closeInFlight = Reflect.get(adapter, 'closeInFlight') as Promise<void>;
+    deferred.resolve();
+    await closeInFlight;
+
+    expect(Reflect.get(adapter, 'dispatcher')).toBeUndefined();
   });
 
   it('clears the fastify shutdown timer once close settles', async () => {
@@ -1721,7 +1756,6 @@ describe('@fluojs/platform-fastify', () => {
       expect(vi.getTimerCount()).toBe(1);
 
       deferred.resolve();
-      await Promise.resolve();
       await closePromise;
 
       expect(vi.getTimerCount()).toBe(0);


### PR DESCRIPTION
## Summary

- Closes #1685.
- Strengthens `@fluojs/platform-fastify` shutdown/conformance coverage by removing microtask-flush-dependent assertions from close tests.
- Keeps the change test-only; no runtime behavior, public exports, docs, or release surface changed.

## Changes

- Replaced `await Promise.resolve()` close-settlement probes with awaiting the adapter's in-flight close promise so shutdown cleanup is asserted deterministically.
- Added focused coverage that repeated shutdown calls after a timeout stay bound to the same Fastify close operation until the underlying server close settles.
- Fixed nearby import indentation while touching the test file.

## Testing

- LSP diagnostics on `packages/platform-fastify/src/adapter.test.ts`: no error diagnostics.
- `pnpm --dir packages/platform-fastify test` — 36 tests passed.
- `pnpm build` — passed for workspace packages.
- `pnpm --dir packages/platform-fastify typecheck` — passed.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contracts were introduced; package README updates are not required.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime shutdown invariants are covered by deterministic regression tests.

No release changeset is included because this is test-only hardening for existing `@fluojs/platform-fastify` shutdown behavior and does not change consumer-visible package behavior.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs; no governance docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence; no platform contract docs changed.
- [x] Package shutdown/conformance claims are backed by `packages/platform-fastify/src/adapter.test.ts` regression coverage.