### PR TITLE
Resolve #1713: Implement core i18n translation service

### DIFF
--- a/.changeset/i18n-package-scaffold.md
+++ b/.changeset/i18n-package-scaffold.md
@@ -2,4 +2,4 @@
 "@fluojs/i18n": minor
 ---
 
-Introduce the initial fluo-native i18n package scaffold with a small root module/service/factory/error surface for future translation features.
+Introduce the fluo-native i18n package with a framework-agnostic core translation service, locale-scoped catalogs, deterministic fallback resolution, interpolation, missing-message hooks, and stable configuration/catalog error codes.

--- a/packages/i18n/README.ko.md
+++ b/packages/i18n/README.ko.md
@@ -25,9 +25,10 @@ npm install @fluojs/i18n
 다가오는 i18n 작업을 위한 안정적인 fluo-native 패키지 경계가 필요할 때 이 패키지를 사용하세요.
 
 - `I18nModule.forRoot(...)`를 통한 애플리케이션 수준 module registration
-- 이후 translation behavior가 확장할 프레임워크 비종속 `I18nService` placeholder
+- explicit locale translation lookup을 제공하는 프레임워크 비종속 `I18nService`
 - module 없이 사용하는 standalone `createI18n(...)` entry point
-- 공유 option, locale, translation-key, error type
+- locale-scoped message catalog, deterministic fallback resolution, interpolation, default, missing-message hook
+- 공유 option, catalog, locale, translation-key, error type
 
 `@fluojs/i18n`은 의도적으로 NestJS, i18next, React, Next.js, HTTP adapter, filesystem loader, ICU/messageformat, validation, type generation에 결합하지 않습니다.
 
@@ -53,26 +54,65 @@ Standalone 사용에서는 service를 직접 생성합니다.
 ```ts
 import { createI18n } from '@fluojs/i18n';
 
-const i18n = createI18n({ defaultLocale: 'en' });
-const options = i18n.snapshotOptions();
+const i18n = createI18n({
+  defaultLocale: 'en',
+  supportedLocales: ['en', 'ko'],
+  fallbackLocales: { ko: ['en'] },
+  catalogs: {
+    en: { app: { title: 'Hello {{ name }}' } },
+    ko: { app: { title: '안녕하세요 {{ name }}' } },
+  },
+});
+
+const title = i18n.translate('app.title', {
+  locale: 'ko',
+  values: { name: 'fluo' },
+});
 ```
 
 ## 현재 범위
 
-이 초기 패키지는 공개 패키지 scaffold와 작은 root API만 확립합니다. Translation lookup, request locale detection, filesystem loading, ICU/messageformat integration, validation integration, type generation, NestJS compatibility, React/Next.js helper, runtime-specific adapter는 이 scaffold의 명시적 non-goal입니다.
+이 패키지는 프레임워크 비종속 core translation engine만 제공합니다. Request locale detection, filesystem loading, HTTP adapter, ICU/messageformat integration, validation integration, generated key union, NestJS compatibility, React/Next.js helper, runtime-specific adapter는 core package의 명시적 non-goal로 남아 있습니다.
 
-Module registration과 standalone creation은 caller-owned options를 저장하기 전에 snapshot으로 분리합니다. 이후 options object 또는 `supportedLocales` array를 변경해도 service가 소유한 options snapshot은 바뀌지 않습니다.
+Message catalog는 하나의 canonical locale-scoped nested tree shape를 사용합니다.
+
+```ts
+const catalogs = {
+  en: {
+    common: {
+      save: 'Save',
+    },
+    app: {
+      title: 'Hello {{ name }}',
+    },
+  },
+};
+```
+
+Key는 dot path로 resolve되므로 `app.title`은 `catalogs.en.app.title`을 읽습니다. Namespace prefixing은 두 번째 resource model 없이 같은 tree를 사용합니다. `translate('save', { locale: 'en', namespace: 'common' })`는 `common.save`를 resolve합니다.
+
+Translation lookup은 deterministic합니다.
+
+1. explicit per-call locale
+2. 해당 locale의 configured fallback chain 또는 global fallback chain
+3. configured `defaultLocale`
+4. per-call `defaultValue`
+5. configured `missingMessage` hook
+
+어느 단계에서도 message가 나오지 않으면 `I18nError`가 `code: 'I18N_MISSING_MESSAGE'`로 throw됩니다. Invalid catalog, locale configuration, per-call translation options는 안정적인 `I18nError` code인 `I18N_INVALID_CATALOG`, `I18N_INVALID_LOCALE_CONFIG`, `I18N_INVALID_OPTIONS`를 throw합니다.
+
+Module registration과 standalone creation은 caller-owned options를 저장하기 전에 snapshot으로 분리합니다. 이후 options object, catalog tree, fallback chain 또는 `supportedLocales` array를 변경해도 service가 소유한 options snapshot은 바뀌지 않습니다.
 
 ## 공개 API
 
 | 클래스/헬퍼 | 설명 |
 |---|---|
-| `I18nModule` | 초기 i18n service surface를 등록하는 module facade입니다. |
-| `I18nService` | 분리된 root options snapshot을 소유하는 placeholder service입니다. |
+| `I18nModule` | core i18n service surface를 등록하는 module facade입니다. |
+| `I18nService` | 분리된 options/catalog snapshot을 소유하고 translation을 resolve하는 core service입니다. |
 | `createI18n(options)` | module registration 없이 standalone `I18nService`를 생성합니다. |
 | `I18nError` | 안정적인 error code를 가진 i18n package base error입니다. |
 
-이 패키지는 `I18nModuleOptions`, `I18nLocale`, `I18nTranslationKey`, `I18nErrorCode` type도 export합니다.
+이 패키지는 `I18nModuleOptions`, `I18nMessageCatalogs`, `I18nMessageTree`, `I18nTranslateOptions`, `I18nInterpolationValues`, `I18nMissingMessageHandler`, `I18nLocale`, `I18nTranslationKey`, `I18nErrorCode` type도 export합니다.
 
 ## 관련 패키지
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -25,9 +25,10 @@ npm install @fluojs/i18n
 Use this package when you need a stable fluo-native package boundary for upcoming i18n work:
 
 - application-level module registration through `I18nModule.forRoot(...)`
-- a framework-agnostic `I18nService` placeholder for later translation behavior
+- a framework-agnostic `I18nService` for explicit-locale translation lookup
 - a standalone `createI18n(...)` entry point for non-module usage
-- shared option, locale, translation-key, and error types
+- locale-scoped message catalogs, deterministic fallback resolution, interpolation, defaults, and missing-message hooks
+- shared option, catalog, locale, translation-key, and error types
 
 `@fluojs/i18n` is intentionally not coupled to NestJS, i18next, React, Next.js, HTTP adapters, filesystem loaders, ICU/messageformat, validation, or type generation.
 
@@ -53,26 +54,65 @@ For standalone usage, create the service directly:
 ```ts
 import { createI18n } from '@fluojs/i18n';
 
-const i18n = createI18n({ defaultLocale: 'en' });
-const options = i18n.snapshotOptions();
+const i18n = createI18n({
+  defaultLocale: 'en',
+  supportedLocales: ['en', 'ko'],
+  fallbackLocales: { ko: ['en'] },
+  catalogs: {
+    en: { app: { title: 'Hello {{ name }}' } },
+    ko: { app: { title: '안녕하세요 {{ name }}' } },
+  },
+});
+
+const title = i18n.translate('app.title', {
+  locale: 'ko',
+  values: { name: 'fluo' },
+});
 ```
 
 ## Current Scope
 
-This initial package only establishes the public package scaffold and small root API. Translation lookup, request locale detection, filesystem loading, ICU/messageformat integration, validation integration, type generation, NestJS compatibility, React/Next.js helpers, and runtime-specific adapters are documented non-goals for this scaffold.
+This package provides the framework-agnostic core translation engine only. Request locale detection, filesystem loading, HTTP adapters, ICU/messageformat integration, validation integration, generated key unions, NestJS compatibility, React/Next.js helpers, and runtime-specific adapters remain documented non-goals for this core package.
 
-Module registration and standalone creation snapshot caller-owned options before storing them. Later mutation of the options object or `supportedLocales` array does not mutate the service-owned options snapshot.
+Message catalogs use one canonical locale-scoped nested tree shape:
+
+```ts
+const catalogs = {
+  en: {
+    common: {
+      save: 'Save',
+    },
+    app: {
+      title: 'Hello {{ name }}',
+    },
+  },
+};
+```
+
+Keys are resolved as dot paths, so `app.title` reads `catalogs.en.app.title`. Namespace prefixing uses the same tree without a second resource model: `translate('save', { locale: 'en', namespace: 'common' })` resolves `common.save`.
+
+Translation lookup is deterministic:
+
+1. the explicit per-call locale
+2. the configured fallback chain for that locale, or the global fallback chain
+3. the configured `defaultLocale`
+4. the per-call `defaultValue`
+5. the configured `missingMessage` hook
+
+If none of those produce a message, `I18nError` is thrown with `code: 'I18N_MISSING_MESSAGE'`. Invalid catalogs, locale configuration, and per-call translation options throw stable `I18nError` codes: `I18N_INVALID_CATALOG`, `I18N_INVALID_LOCALE_CONFIG`, and `I18N_INVALID_OPTIONS`.
+
+Module registration and standalone creation snapshot caller-owned options before storing them. Later mutation of the options object, catalog trees, fallback chains, or `supportedLocales` array does not mutate the service-owned options snapshot.
 
 ## Public API
 
 | Class/Helper | Description |
 |---|---|
-| `I18nModule` | Module facade for registering the initial i18n service surface. |
-| `I18nService` | Placeholder service that owns a detached root options snapshot. |
+| `I18nModule` | Module facade for registering the core i18n service surface. |
+| `I18nService` | Core service that owns detached options/catalog snapshots and resolves translations. |
 | `createI18n(options)` | Creates a standalone `I18nService` without module registration. |
 | `I18nError` | Base i18n package error with a stable error code. |
 
-The package also exports `I18nModuleOptions`, `I18nLocale`, `I18nTranslationKey`, and `I18nErrorCode` types.
+The package also exports `I18nModuleOptions`, `I18nMessageCatalogs`, `I18nMessageTree`, `I18nTranslateOptions`, `I18nInterpolationValues`, `I18nMissingMessageHandler`, `I18nLocale`, `I18nTranslationKey`, and `I18nErrorCode` types.
 
 ## Related Packages
 

--- a/packages/i18n/src/errors.ts
+++ b/packages/i18n/src/errors.ts
@@ -3,9 +3,12 @@ import { FluoError } from '@fluojs/core';
 import type { I18nErrorCode } from './types.js';
 
 /**
- * Base error type reserved for caller-visible i18n package failures.
+ * Base error type for caller-visible i18n package failures.
  */
 export class I18nError extends FluoError {
+  /** Stable i18n error code. */
+  declare readonly code: I18nErrorCode;
+
   /**
    * Creates an i18n package error with a stable code.
    *

--- a/packages/i18n/src/index.test.ts
+++ b/packages/i18n/src/index.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
 import { I18nError, I18nModule, createI18n } from './index.js';
-import type { I18nErrorCode, I18nLocale, I18nModuleOptions, I18nTranslationKey } from './index.js';
+import type {
+  I18nErrorCode,
+  I18nLocale,
+  I18nMessageCatalogs,
+  I18nModuleOptions,
+  I18nTranslateOptions,
+  I18nTranslationKey,
+} from './index.js';
+
+function expectI18nCode(action: () => unknown, code: I18nErrorCode): void {
+  try {
+    action();
+  } catch (error) {
+    expect(error).toBeInstanceOf(I18nError);
+    expect((error as I18nError).code).toBe(code);
+    return;
+  }
+
+  throw new Error(`Expected action to fail with ${code}.`);
+}
 
 describe('@fluojs/i18n root public surface', () => {
   it('keeps the root value exports intentionally small', async () => {
@@ -10,8 +29,11 @@ describe('@fluojs/i18n root public surface', () => {
     expect(Object.keys(root).sort()).toEqual(['I18nError', 'I18nModule', 'I18nService', 'createI18n']);
   });
 
-  it('exposes the initial module, service, factory, and error placeholders', () => {
+  it('exposes the module, service, factory, and stable error surface', () => {
     const options: I18nModuleOptions = {
+      catalogs: {
+        en: { app: { title: 'Fluo' } },
+      },
       defaultLocale: 'en' satisfies I18nLocale,
       supportedLocales: ['en', 'ko'],
     };
@@ -25,5 +47,114 @@ describe('@fluojs/i18n root public surface', () => {
     expect(snapshot.supportedLocales).not.toBe(options.supportedLocales);
     expect(I18nModule.forRoot(options)).toBeInstanceOf(Function);
     expect(new I18nError('reserved i18n failure', code).code).toBe('I18N_ERROR');
+  });
+
+  it('resolves nested keys and namespace-prefixed keys with explicit locales', () => {
+    const service = createI18n({
+      catalogs: {
+        en: {
+          app: {
+            title: 'Hello {{ name }}',
+          },
+          common: {
+            action: {
+              save: 'Save',
+            },
+          },
+        },
+      },
+      defaultLocale: 'en',
+    });
+
+    expect(service.translate('app.title', { locale: 'en', values: { name: 'fluo' } })).toBe('Hello fluo');
+    expect(service.translate('action.save', { locale: 'en', namespace: 'common' })).toBe('Save');
+  });
+
+  it('uses deterministic fallback order before default values and missing-message hooks', () => {
+    const service = createI18n({
+      catalogs: {
+        en: { greeting: 'Hello {{ name }}' },
+        fr: { greeting: 'Bonjour {{ name }}' },
+        ko: { other: '다른 문장' },
+      },
+      defaultLocale: 'en',
+      fallbackLocales: {
+        ko: ['fr', 'en'],
+      },
+      missingMessage: ({ attemptedLocales, key }) => `${key}:${attemptedLocales.join('>')}`,
+      supportedLocales: ['en', 'fr', 'ko'],
+    });
+
+    expect(service.resolveLocales('ko')).toEqual(['ko', 'fr', 'en']);
+    expect(service.translate('greeting', { locale: 'ko', values: { name: 'Jinho' } })).toBe('Bonjour Jinho');
+    expect(service.translate('missing', { defaultValue: 'Default {{ name }}', locale: 'ko', values: { name: 'Jinho' } })).toBe(
+      'Default Jinho',
+    );
+    expect(service.translate('missing', { locale: 'ko' })).toBe('missing:ko>fr>en');
+  });
+
+  it('snapshots caller-owned catalog, fallback, and supported-locale inputs', () => {
+    const catalogs = {
+      en: { greeting: 'Hello' },
+      ko: { greeting: '안녕하세요' },
+    } satisfies I18nMessageCatalogs;
+    const supportedLocales = ['en', 'ko'];
+    const fallbackLocales = ['en'];
+    const service = createI18n({ catalogs, defaultLocale: 'en', fallbackLocales, supportedLocales });
+
+    catalogs.en.greeting = 'Changed';
+    supportedLocales.push('fr');
+    fallbackLocales[0] = 'ko';
+
+    expect(service.translate('greeting', { locale: 'en' })).toBe('Hello');
+    expect(service.resolveLocales('ko')).toEqual(['ko', 'en']);
+    expect(service.snapshotOptions().supportedLocales).toEqual(['en', 'ko']);
+  });
+
+  it('fails with stable errors for invalid catalogs, locale config, and translation options', () => {
+    const invalidCatalogs = {
+      en: {
+        count: 1,
+      },
+    } as unknown as I18nMessageCatalogs;
+
+    expectI18nCode(() => createI18n({ catalogs: invalidCatalogs, defaultLocale: 'en' }), 'I18N_INVALID_CATALOG');
+    expectI18nCode(() => createI18n({ defaultLocale: 'en', supportedLocales: ['ko'] }), 'I18N_INVALID_LOCALE_CONFIG');
+    expectI18nCode(
+      () => createI18n({ defaultLocale: 'en', fallbackLocales: { ko: ['fr'] }, supportedLocales: ['en', 'ko'] }),
+      'I18N_INVALID_LOCALE_CONFIG',
+    );
+    expectI18nCode(
+      () => createI18n({ catalogs: { fr: { greeting: 'Bonjour' } }, defaultLocale: 'en', supportedLocales: ['en'] }),
+      'I18N_INVALID_LOCALE_CONFIG',
+    );
+    expectI18nCode(() => createI18n({ catalogs: { en: { greeting: 'Hello' } } }), 'I18N_INVALID_OPTIONS');
+    expectI18nCode(() => createI18n(null as unknown as I18nModuleOptions), 'I18N_INVALID_OPTIONS');
+    expectI18nCode(
+      () => createI18n({ defaultLocale: 'en', missingMessage: 'missing' } as unknown as I18nModuleOptions),
+      'I18N_INVALID_OPTIONS',
+    );
+
+    const service = createI18n({
+      catalogs: { en: { greeting: 'Hello' } },
+      defaultLocale: 'en',
+      supportedLocales: ['en'],
+    });
+
+    expectI18nCode(() => service.translate('', { locale: 'en' }), 'I18N_INVALID_OPTIONS');
+    expectI18nCode(() => service.translate('greeting', { locale: 'ko' }), 'I18N_INVALID_OPTIONS');
+    expectI18nCode(
+      () => service.translate('greeting', { locale: 'en', values: [] } as unknown as I18nTranslateOptions),
+      'I18N_INVALID_OPTIONS',
+    );
+    expectI18nCode(
+      () => service.translate('greeting', { locale: 'en', values: new Date() } as unknown as I18nTranslateOptions),
+      'I18N_INVALID_OPTIONS',
+    );
+    expectI18nCode(
+      () => service.translate('greeting', { defaultValue: 1, locale: 'en' } as unknown as I18nTranslateOptions),
+      'I18N_INVALID_OPTIONS',
+    );
+    expectI18nCode(() => service.translate('missing', { locale: 'en' }), 'I18N_MISSING_MESSAGE');
   });
 });

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,4 +1,16 @@
 export { I18nError } from './errors.js';
 export { I18nModule } from './module.js';
 export { createI18n, I18nService } from './service.js';
-export type { I18nErrorCode, I18nLocale, I18nModuleOptions, I18nTranslationKey } from './types.js';
+export type {
+  I18nErrorCode,
+  I18nFallbackLocales,
+  I18nInterpolationValues,
+  I18nLocale,
+  I18nMessageCatalogs,
+  I18nMessageTree,
+  I18nMissingMessageContext,
+  I18nMissingMessageHandler,
+  I18nModuleOptions,
+  I18nTranslateOptions,
+  I18nTranslationKey,
+} from './types.js';

--- a/packages/i18n/src/module.ts
+++ b/packages/i18n/src/module.ts
@@ -15,13 +15,13 @@ class I18nServiceFactory extends I18nService {
 }
 
 /**
- * Module facade that registers the initial fluo-native i18n service surface.
+ * Module facade that registers the fluo-native core i18n service surface.
  */
 export class I18nModule {
   /**
    * Creates a module class that registers `I18nService` with captured root options.
    *
-   * @param options Root i18n module options reserved for later translation behavior.
+   * @param options Root i18n module options for catalogs, fallback behavior, and service registration.
    * @returns A module type that can be listed in `imports` during bootstrap.
    *
    * @example

--- a/packages/i18n/src/options.ts
+++ b/packages/i18n/src/options.ts
@@ -1,14 +1,166 @@
-import type { I18nModuleOptions } from './types.js';
+import { I18nError } from './errors.js';
+import type { I18nFallbackLocales, I18nMessageCatalogs, I18nMessageTree, I18nModuleOptions } from './types.js';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function assertLocale(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new I18nError(`${label} must be a non-empty string.`, 'I18N_INVALID_LOCALE_CONFIG');
+  }
+}
+
+function assertLocaleList(value: unknown, label: string): asserts value is readonly string[] {
+  if (!Array.isArray(value)) {
+    throw new I18nError(`${label} must be an array of locale strings.`, 'I18N_INVALID_LOCALE_CONFIG');
+  }
+
+  for (const locale of value) {
+    assertLocale(locale, label);
+  }
+}
+
+function assertSupportedLocale(locale: string, supportedLocales: readonly string[] | undefined, label: string): void {
+  if (supportedLocales !== undefined && !supportedLocales.includes(locale)) {
+    throw new I18nError(`${label} must be listed in supportedLocales.`, 'I18N_INVALID_LOCALE_CONFIG');
+  }
+}
+
+function snapshotMessageTree(value: unknown, path: string): I18nMessageTree {
+  if (!isPlainObject(value)) {
+    throw new I18nError(`${path} must be a plain object message tree.`, 'I18N_INVALID_CATALOG');
+  }
+
+  const snapshot: Record<string, string | I18nMessageTree> = {};
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (key.trim() === '') {
+      throw new I18nError(`${path} contains an empty message key segment.`, 'I18N_INVALID_CATALOG');
+    }
+
+    if (typeof entry === 'string') {
+      snapshot[key] = entry;
+      continue;
+    }
+
+    if (isPlainObject(entry)) {
+      snapshot[key] = snapshotMessageTree(entry, `${path}.${key}`);
+      continue;
+    }
+
+    throw new I18nError(`${path}.${key} must be a string or nested message tree.`, 'I18N_INVALID_CATALOG');
+  }
+
+  return Object.freeze(snapshot);
+}
+
+function snapshotCatalogs(
+  catalogs: I18nMessageCatalogs | undefined,
+  supportedLocales: readonly string[] | undefined,
+): I18nMessageCatalogs | undefined {
+  if (catalogs === undefined) {
+    return undefined;
+  }
+
+  if (!isPlainObject(catalogs)) {
+    throw new I18nError('catalogs must be a locale-scoped object.', 'I18N_INVALID_CATALOG');
+  }
+
+  const snapshot: Record<string, I18nMessageTree> = {};
+
+  for (const [locale, tree] of Object.entries(catalogs)) {
+    assertLocale(locale, 'catalog locale');
+    assertSupportedLocale(locale, supportedLocales, 'catalog locale');
+    snapshot[locale] = snapshotMessageTree(tree, `catalogs.${locale}`);
+  }
+
+  return Object.freeze(snapshot);
+}
+
+function snapshotFallbackLocales(
+  fallbackLocales: I18nFallbackLocales | undefined,
+  supportedLocales: readonly string[] | undefined,
+): I18nFallbackLocales | undefined {
+  if (fallbackLocales === undefined) {
+    return undefined;
+  }
+
+  if (Array.isArray(fallbackLocales)) {
+    assertLocaleList(fallbackLocales, 'fallbackLocales');
+    for (const fallbackLocale of fallbackLocales) {
+      assertSupportedLocale(fallbackLocale, supportedLocales, 'fallbackLocales locale');
+    }
+    return Object.freeze([...fallbackLocales]);
+  }
+
+  if (!isPlainObject(fallbackLocales)) {
+    throw new I18nError('fallbackLocales must be an array or locale map.', 'I18N_INVALID_LOCALE_CONFIG');
+  }
+
+  const snapshot: Record<string, readonly string[]> = {};
+
+  for (const [locale, chain] of Object.entries(fallbackLocales)) {
+    assertLocale(locale, 'fallbackLocales locale');
+    assertSupportedLocale(locale, supportedLocales, 'fallbackLocales locale');
+    assertLocaleList(chain, `fallbackLocales.${locale}`);
+    for (const fallbackLocale of chain) {
+      assertSupportedLocale(fallbackLocale, supportedLocales, `fallbackLocales.${locale} locale`);
+    }
+    snapshot[locale] = Object.freeze([...chain]);
+  }
+
+  return Object.freeze(snapshot);
+}
+
+function validateModuleOptions(options: I18nModuleOptions): void {
+  if (!isPlainObject(options)) {
+    throw new I18nError('i18n module options must be a plain object.', 'I18N_INVALID_OPTIONS');
+  }
+
+  if (options.defaultLocale !== undefined) {
+    assertLocale(options.defaultLocale, 'defaultLocale');
+  }
+
+  if (options.global !== undefined && typeof options.global !== 'boolean') {
+    throw new I18nError('global must be a boolean when provided.', 'I18N_INVALID_OPTIONS');
+  }
+
+  if (options.missingMessage !== undefined && typeof options.missingMessage !== 'function') {
+    throw new I18nError('missingMessage must be a function when provided.', 'I18N_INVALID_OPTIONS');
+  }
+
+  if (options.supportedLocales !== undefined) {
+    assertLocaleList(options.supportedLocales, 'supportedLocales');
+
+    if (options.defaultLocale !== undefined) {
+      assertSupportedLocale(options.defaultLocale, options.supportedLocales, 'defaultLocale');
+    }
+  }
+
+  if (options.catalogs !== undefined && options.defaultLocale === undefined) {
+    throw new I18nError('defaultLocale is required when catalogs are configured.', 'I18N_INVALID_OPTIONS');
+  }
+}
 
 /**
  * Creates a detached copy of root i18n module options.
  *
  * @param options Root i18n module options provided by the caller.
- * @returns A shallowly detached options snapshot for module registration or standalone service creation.
+ * @returns A detached options snapshot for module registration or standalone service creation.
  */
 export function snapshotI18nModuleOptions(options: I18nModuleOptions = {}): I18nModuleOptions {
-  return {
+  validateModuleOptions(options);
+
+  return Object.freeze({
     ...options,
-    supportedLocales: options.supportedLocales ? [...options.supportedLocales] : undefined,
-  };
+    catalogs: snapshotCatalogs(options.catalogs, options.supportedLocales),
+    fallbackLocales: snapshotFallbackLocales(options.fallbackLocales, options.supportedLocales),
+    supportedLocales: options.supportedLocales ? Object.freeze([...options.supportedLocales]) : undefined,
+  });
 }

--- a/packages/i18n/src/service.ts
+++ b/packages/i18n/src/service.ts
@@ -1,12 +1,110 @@
 import { snapshotI18nModuleOptions } from './options.js';
-import type { I18nModuleOptions } from './types.js';
+import { I18nError } from './errors.js';
+import type { I18nFallbackLocales, I18nLocale, I18nMessageTree, I18nModuleOptions, I18nTranslateOptions } from './types.js';
+
+function hasOwn(value: unknown, key: string): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && Object.hasOwn(value, key);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function normalizeTranslationKey(key: unknown, namespace: unknown): string {
+  if (typeof key !== 'string') {
+    throw new I18nError('Translation key must be a string.', 'I18N_INVALID_OPTIONS');
+  }
+
+  if (key.trim() === '') {
+    throw new I18nError('Translation key must be a non-empty string.', 'I18N_INVALID_OPTIONS');
+  }
+
+  if (namespace === undefined) {
+    return key;
+  }
+
+  if (typeof namespace !== 'string') {
+    throw new I18nError('Translation namespace must be a string when provided.', 'I18N_INVALID_OPTIONS');
+  }
+
+  if (namespace.trim() === '') {
+    throw new I18nError('Translation namespace must be a non-empty string when provided.', 'I18N_INVALID_OPTIONS');
+  }
+
+  return `${namespace}.${key}`;
+}
+
+function assertInterpolationValues(values: unknown): asserts values is I18nTranslateOptions['values'] {
+  if (values !== undefined && !isPlainObject(values)) {
+    throw new I18nError('Translation values must be a plain object when provided.', 'I18N_INVALID_OPTIONS');
+  }
+}
+
+function assertDefaultValue(defaultValue: unknown): asserts defaultValue is string | undefined {
+  if (defaultValue !== undefined && typeof defaultValue !== 'string') {
+    throw new I18nError('Translation defaultValue must be a string when provided.', 'I18N_INVALID_OPTIONS');
+  }
+}
+
+function interpolate(message: string, values: I18nTranslateOptions['values']): string {
+  if (values === undefined) {
+    return message;
+  }
+
+  return message.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (placeholder, name: string) => {
+    if (!Object.hasOwn(values, name)) {
+      return placeholder;
+    }
+
+    const value = values[name];
+    return value === undefined || value === null ? '' : String(value);
+  });
+}
+
+function resolveMessage(tree: I18nMessageTree | undefined, key: string): string | undefined {
+  if (tree === undefined) {
+    return undefined;
+  }
+
+  if (hasOwn(tree, key)) {
+    const direct = tree[key];
+    return typeof direct === 'string' ? direct : undefined;
+  }
+
+  let current: unknown = tree;
+
+  for (const part of key.split('.')) {
+    if (!hasOwn(current, part)) {
+      return undefined;
+    }
+
+    current = current[part];
+  }
+
+  return typeof current === 'string' ? current : undefined;
+}
+
+function pushUnique(locales: I18nLocale[], locale: I18nLocale | undefined): void {
+  if (locale !== undefined && !locales.includes(locale)) {
+    locales.push(locale);
+  }
+}
+
+function isFallbackMap(value: I18nFallbackLocales): value is Readonly<Record<I18nLocale, readonly I18nLocale[]>> {
+  return !Array.isArray(value);
+}
 
 /**
- * Minimal i18n service placeholder that owns the root package configuration snapshot.
+ * Framework-agnostic core translation service backed by locale-scoped message catalogs.
  *
  * @remarks
- * Translation lookup, locale negotiation, loaders, adapters, and formatter integration are intentionally out of
- * scope for the initial scaffold. Later i18n issues can extend this service without widening the root exports first.
+ * Locale selection is explicit per call. The core service performs deterministic catalog lookup and string
+ * interpolation only; request locale detection, loaders, ICU/messageformat, and framework adapters remain out of scope.
  */
 export class I18nService {
   private readonly options: I18nModuleOptions;
@@ -27,6 +125,85 @@ export class I18nService {
    */
   snapshotOptions(): I18nModuleOptions {
     return snapshotI18nModuleOptions(this.options);
+  }
+
+  /**
+   * Returns the deterministic locale chain used for a translation request.
+   *
+   * @param locale Explicit caller locale to resolve first.
+   * @returns Locale chain ordered as requested locale, configured fallback chain, then default locale.
+   * @throws {I18nError} When the locale is invalid or outside `supportedLocales`.
+   */
+  resolveLocales(locale: I18nLocale): readonly I18nLocale[] {
+    if (typeof locale !== 'string' || locale.trim() === '') {
+      throw new I18nError('Translation locale must be a non-empty string.', 'I18N_INVALID_OPTIONS');
+    }
+
+    if (this.options.supportedLocales !== undefined && !this.options.supportedLocales.includes(locale)) {
+      throw new I18nError(`Unsupported i18n locale: ${locale}`, 'I18N_INVALID_OPTIONS');
+    }
+
+    const chain: I18nLocale[] = [];
+    pushUnique(chain, locale);
+
+    if (Array.isArray(this.options.fallbackLocales)) {
+      for (const fallbackLocale of this.options.fallbackLocales) {
+        pushUnique(chain, fallbackLocale);
+      }
+    } else if (this.options.fallbackLocales !== undefined && isFallbackMap(this.options.fallbackLocales)) {
+      for (const fallbackLocale of this.options.fallbackLocales[locale] ?? []) {
+        pushUnique(chain, fallbackLocale);
+      }
+    }
+
+    pushUnique(chain, this.options.defaultLocale);
+
+    return Object.freeze(chain);
+  }
+
+  /**
+   * Resolves and interpolates a catalog message for an explicit locale.
+   *
+   * @param key Dot-path catalog key, optionally prefixed by `options.namespace`.
+   * @param options Per-call locale, interpolation values, and default value.
+   * @returns The resolved catalog message, default value, or missing-message hook result.
+   * @throws {I18nError} When options are invalid or the message cannot be resolved.
+   */
+  translate(key: string, options: I18nTranslateOptions): string {
+    if (options === undefined || typeof options !== 'object' || options === null) {
+      throw new I18nError('Translation options are required.', 'I18N_INVALID_OPTIONS');
+    }
+
+    assertInterpolationValues(options.values);
+    assertDefaultValue(options.defaultValue);
+
+    const resolvedKey = normalizeTranslationKey(key, options.namespace);
+    const locales = this.resolveLocales(options.locale);
+
+    for (const locale of locales) {
+      const message = resolveMessage(this.options.catalogs?.[locale], resolvedKey);
+
+      if (message !== undefined) {
+        return interpolate(message, options.values);
+      }
+    }
+
+    if (options.defaultValue !== undefined) {
+      return interpolate(options.defaultValue, options.values);
+    }
+
+    const missing = this.options.missingMessage?.({
+      attemptedLocales: locales,
+      key: resolvedKey,
+      locale: options.locale,
+      values: options.values,
+    });
+
+    if (missing !== undefined) {
+      return interpolate(missing, options.values);
+    }
+
+    throw new I18nError(`Missing i18n message: ${resolvedKey}`, 'I18N_MISSING_MESSAGE');
   }
 }
 

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -1,26 +1,93 @@
 /**
- * Locale identifier accepted by the initial i18n package surface.
+ * Locale identifier accepted by the i18n package surface.
  */
 export type I18nLocale = string;
 
 /**
- * Translation key identifier reserved for later translation behavior.
+ * Dot-path translation key resolved from a locale-scoped message catalog.
  */
 export type I18nTranslationKey = string;
 
 /**
  * Stable i18n package error codes for caller-visible failures.
  */
-export type I18nErrorCode = 'I18N_ERROR';
+export type I18nErrorCode =
+  | 'I18N_ERROR'
+  | 'I18N_INVALID_CATALOG'
+  | 'I18N_INVALID_LOCALE_CONFIG'
+  | 'I18N_INVALID_OPTIONS'
+  | 'I18N_MISSING_MESSAGE';
+
+/**
+ * Interpolation values available to simple `{{ name }}` placeholders.
+ */
+export type I18nInterpolationValues = Readonly<Record<string, string | number | boolean | null | undefined>>;
+
+/**
+ * Nested message tree for one locale.
+ */
+export interface I18nMessageTree {
+  /** Message leaf or nested message tree keyed by path segment. */
+  readonly [key: string]: string | I18nMessageTree;
+}
+
+/**
+ * Canonical locale-scoped catalog map consumed by the core translation service.
+ */
+export type I18nMessageCatalogs = Readonly<Record<I18nLocale, I18nMessageTree>>;
+
+/**
+ * Fallback locale chain applied globally or per requested locale.
+ */
+export type I18nFallbackLocales = readonly I18nLocale[] | Readonly<Record<I18nLocale, readonly I18nLocale[]>>;
+
+/**
+ * Context passed to the missing-message hook after catalog/default fallback resolution fails.
+ */
+export interface I18nMissingMessageContext {
+  /** Requested locale supplied explicitly by the translation caller. */
+  readonly locale: I18nLocale;
+  /** Translation key after optional namespace prefixing. */
+  readonly key: I18nTranslationKey;
+  /** Deterministic locale chain inspected before the hook was invoked. */
+  readonly attemptedLocales: readonly I18nLocale[];
+  /** Interpolation values supplied by the caller. */
+  readonly values?: I18nInterpolationValues;
+}
+
+/**
+ * Hook invoked when no message and no default value can satisfy a translation request.
+ */
+export type I18nMissingMessageHandler = (context: I18nMissingMessageContext) => string | undefined;
+
+/**
+ * Per-call translation options. Locale is always explicit in the framework-agnostic core.
+ */
+export interface I18nTranslateOptions {
+  /** Locale to resolve first. */
+  readonly locale: I18nLocale;
+  /** Optional namespace prefix, resolved as `${namespace}.${key}`. */
+  readonly namespace?: I18nTranslationKey;
+  /** Values interpolated into `{{ name }}` placeholders. */
+  readonly values?: I18nInterpolationValues;
+  /** Caller-provided fallback returned before the missing-message hook is invoked. */
+  readonly defaultValue?: string;
+}
 
 /**
  * Root i18n module options captured during package registration.
  */
 export interface I18nModuleOptions {
-  /** Default locale that later translation behavior can use as the primary language. */
+  /** Default fallback locale used after the configured locale chain. */
   defaultLocale?: I18nLocale;
-  /** Supported locale list reserved for future locale selection and validation behavior. */
+  /** Locale-scoped message catalogs. */
+  catalogs?: I18nMessageCatalogs;
+  /** Supported locale allow-list for configuration and per-call locale validation. */
   supportedLocales?: readonly I18nLocale[];
+  /** Global or per-locale deterministic fallback chain inspected before the default locale. */
+  fallbackLocales?: I18nFallbackLocales;
+  /** Hook invoked when no catalog entry and no default value can satisfy a translation request. */
+  missingMessage?: I18nMissingMessageHandler;
   /** Whether the module should expose `I18nService` globally. Defaults to `true`. */
   global?: boolean;
 }


### PR DESCRIPTION
## Summary

- Closes #1713.
- Implements the framework-agnostic `@fluojs/i18n` core translation service on top of the existing package scaffold.
- Documents the new catalog/fallback behavior in the package README mirrors and updates the changeset summary for consumer-visible behavior.

## Changes

- Added canonical locale-scoped nested message catalogs plus exported catalog/fallback/interpolation/missing-message types.
- Implemented `createI18n(...)` / `I18nService` explicit-locale translation with nested key lookup, namespace prefixing, interpolation, `defaultValue`, missing-message hooks, deterministic fallback chains, and option/catalog snapshotting.
- Added stable `I18nError` codes for invalid catalogs, invalid locale config, invalid options, and missing messages.
- Added package-local regression coverage for translation behavior, fallback ordering, snapshots, and stable error codes.

## Testing

- `pnpm --filter @fluojs/core build`
- `pnpm --filter @fluojs/i18n typecheck`
- `pnpm --filter @fluojs/i18n build`
- `pnpm --filter @fluojs/i18n test`
- LSP diagnostics on `packages/i18n/src`: 0 errors
- `pnpm verify:public-export-tsdoc` (changed mode)
- `pnpm verify:platform-consistency-governance`
- `pnpm changeset status --since=main`
- Note: `pnpm verify:public-export-tsdoc:baseline` was also run and failed on pre-existing unrelated CLI/HTTP public export TSDoc backlog entries outside this PR's changed files.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A: no platform contract docs changed.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (N/A: no platform conformance claims added.)