### PR TITLE
Resolve #1715: Add i18n HTTP locale context adapter

### DIFF
--- a/.changeset/i18n-http-locale-context.md
+++ b/.changeset/i18n-http-locale-context.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/i18n": minor
+---
+
+Add the `@fluojs/i18n/http` subpath with explicit fluo HTTP request-context locale helpers, `Accept-Language` parsing, and ordered resolver-chain utilities.

--- a/packages/i18n/README.ko.md
+++ b/packages/i18n/README.ko.md
@@ -11,6 +11,7 @@ fluo 애플리케이션을 위한 프레임워크 비종속 국제화 코어 표
 - [빠른 시작](#빠른-시작)
 - [현재 범위](#현재-범위)
 - [Node Filesystem Loader](#node-filesystem-loader)
+- [HTTP Locale Context Adapter](#http-locale-context-adapter)
 - [공개 API](#공개-api)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -31,9 +32,10 @@ npm install @fluojs/i18n
 - locale-scoped message catalog, deterministic fallback resolution, interpolation, default, missing-message hook
 - `@fluojs/i18n/loaders/fs`를 통한 선택적 Node-only JSON catalog loading
 - explicit locale을 사용하는 standard `Intl` date/time, number, currency, percent, list, relative-time formatting helper
+- `@fluojs/i18n/http`를 통한 explicit HTTP `RequestContext` locale helper
 - 공유 option, catalog, locale, translation-key, error type
 
-`@fluojs/i18n`은 의도적으로 NestJS, i18next, React, Next.js, HTTP adapter, ICU/messageformat, validation, type generation에 결합하지 않습니다. Root export는 runtime-portable하게 유지되며, filesystem loading은 Node-specific `@fluojs/i18n/loaders/fs` subpath에서만 제공합니다.
+`@fluojs/i18n`은 의도적으로 NestJS, i18next, React, Next.js, ICU/messageformat, validation, type generation에 결합하지 않습니다. Root export는 프레임워크 비종속이고 runtime-portable하게 유지됩니다. Filesystem loading은 Node-specific `@fluojs/i18n/loaders/fs` subpath에서만 제공하며, HTTP request locale helper는 `@fluojs/i18n/http` subpath에서만 제공합니다.
 
 ## 빠른 시작
 
@@ -80,7 +82,7 @@ const total = i18n.formatCurrency(12900, {
 
 ## 현재 범위
 
-이 패키지는 프레임워크 비종속 core translation engine, 선택적 Node-only filesystem loader subpath, 작은 standard-first formatting facade만 제공합니다. Request locale detection, HTTP adapter, ICU/messageformat integration, validation integration, generated key union, NestJS compatibility, React/Next.js helper, remote backend/plugin chain, watch/reload behavior, runtime-specific adapter는 core package의 명시적 non-goal로 남아 있습니다.
+이 패키지는 root entry point에서 프레임워크 비종속 core translation engine과 작은 standard-first formatting facade를 제공하고, Node-only filesystem loading과 HTTP request locale context helper를 opt-in subpath로 제공합니다. ICU/messageformat integration, validation integration, generated key union, NestJS compatibility, React/Next.js helper, remote backend/plugin chain, watch/reload behavior, runtime-specific adapter는 이 패키지의 명시적 non-goal로 남아 있습니다.
 
 Formatting helper는 host standard `Intl` implementation에 직접 위임합니다. Locale은 모든 formatting call에서 explicit하며, named formatter option은 `createI18n(...)` 또는 `I18nModule.forRoot(...)`를 통해 service-owned immutable snapshot으로 캡처됩니다.
 
@@ -163,6 +165,40 @@ Loader는 `${rootDir}/${locale}/${namespace}.json`을 읽고 immutable `I18nMess
 
 이 subpath는 Node built-in을 import하며 `@fluojs/i18n` root에서 export하지 않습니다. Bundler가 명시적으로 Node.js를 target하지 않는 한 Bun, Deno, Cloudflare Workers, browser 또는 다른 non-Node runtime-portable bundle에서 import하지 마세요.
 
+## HTTP Locale Context Adapter
+
+HTTP request locale helper는 `@fluojs/i18n/http` subpath에서만 제공됩니다. 따라서 root `@fluojs/i18n` entry point는 프레임워크 비종속으로 유지되며 `@fluojs/http`를 import하지 않습니다.
+
+```ts
+import { createAcceptLanguageLocaleResolver, getHttpLocale, resolveHttpLocale } from '@fluojs/i18n/http';
+import type { RequestContext } from '@fluojs/http';
+
+const acceptLanguage = createAcceptLanguageLocaleResolver();
+
+function bindRequestLocale(ctx: RequestContext) {
+  return resolveHttpLocale(ctx, {
+    defaultLocale: 'en',
+    supportedLocales: ['en', 'ko'],
+    resolvers: [acceptLanguage],
+  });
+}
+
+function handler(ctx: RequestContext) {
+  const locale = getHttpLocale(ctx)?.locale ?? 'en';
+  return { locale };
+}
+```
+
+Adapter는 의도적으로 explicit합니다.
+
+- `setHttpLocale(ctx, locale, metadata)`는 `createContextKey(...)`를 사용해 현재 `RequestContext`에 locale metadata를 저장합니다.
+- `getHttpLocale(ctx)`는 global fallback 없이 metadata를 읽습니다.
+- `parseAcceptLanguage(header)`는 q-value 순서로 valid `Accept-Language` range를 parse하고 invalid 또는 q=0 entry를 무시합니다.
+- `createAcceptLanguageLocaleResolver(...)`는 request header에서 첫 번째 supported locale을 선택합니다.
+- `resolveHttpLocale(ctx, options)`는 application-provided resolver를 배열 순서대로 실행하고 invalid 또는 unsupported resolver output을 무시하며, 아무 resolver도 match하지 않으면 `defaultLocale`을 source `default`로 저장합니다.
+
+Wildcard `*` range는 parse되지만 자동으로 locale을 선택하지는 않습니다. Wildcard별 동작이 필요한 애플리케이션은 제공된 `Accept-Language` resolver 앞이나 뒤에 resolver를 추가할 수 있습니다.
+
 ## 공개 API
 
 | 클래스/헬퍼 | 설명 |
@@ -171,6 +207,7 @@ Loader는 `${rootDir}/${locale}/${namespace}.json`을 읽고 immutable `I18nMess
 | `I18nService` | 분리된 options/catalog snapshot을 소유하고 translation을 resolve하는 core service입니다. |
 | `createI18n(options)` | module registration 없이 standalone `I18nService`를 생성합니다. |
 | `I18nError` | 안정적인 error code를 가진 i18n package base error입니다. |
+| `@fluojs/i18n/http` | Explicit HTTP request locale context helper와 `Accept-Language` resolver utility입니다. |
 
 Node-only `@fluojs/i18n/loaders/fs` subpath는 `FileSystemI18nLoader`, `createFileSystemI18nLoader(options)`, `FileSystemI18nLoaderOptions`, `I18nLoader`를 export합니다.
 
@@ -186,4 +223,5 @@ Root package는 `I18nModuleOptions`, `I18nMessageCatalogs`, `I18nMessageTree`, `
 - `packages/i18n/src/module.ts`
 - `packages/i18n/src/service.ts`
 - `packages/i18n/src/loaders/fs.ts`
+- `packages/i18n/src/http.ts`
 - `packages/i18n/src/index.test.ts`

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -11,6 +11,7 @@ Framework-agnostic internationalization core surface for fluo applications.
 - [Quick Start](#quick-start)
 - [Current Scope](#current-scope)
 - [Node Filesystem Loader](#node-filesystem-loader)
+- [HTTP Locale Context Adapter](#http-locale-context-adapter)
 - [Public API](#public-api)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -31,9 +32,10 @@ Use this package when you need a stable fluo-native package boundary for upcomin
 - locale-scoped message catalogs, deterministic fallback resolution, interpolation, defaults, and missing-message hooks
 - optional Node-only JSON catalog loading through `@fluojs/i18n/loaders/fs`
 - standard `Intl` date/time, number, currency, percent, list, and relative-time formatting helpers with explicit locales
+- explicit HTTP `RequestContext` locale helpers through `@fluojs/i18n/http`
 - shared option, catalog, locale, translation-key, and error types
 
-`@fluojs/i18n` is intentionally not coupled to NestJS, i18next, React, Next.js, HTTP adapters, ICU/messageformat, validation, or type generation. The root export stays runtime-portable; filesystem loading is available only from the Node-specific `@fluojs/i18n/loaders/fs` subpath.
+`@fluojs/i18n` is intentionally not coupled to NestJS, i18next, React, Next.js, ICU/messageformat, validation, or type generation. The root export stays framework-agnostic and runtime-portable; filesystem loading is available only from the Node-specific `@fluojs/i18n/loaders/fs` subpath, and HTTP request locale helpers are available only from the `@fluojs/i18n/http` subpath.
 
 ## Quick Start
 
@@ -80,7 +82,7 @@ const total = i18n.formatCurrency(12900, {
 
 ## Current Scope
 
-This package provides the framework-agnostic core translation engine, an optional Node-only filesystem loader subpath, and a small standard-first formatting facade only. Request locale detection, HTTP adapters, ICU/messageformat integration, validation integration, generated key unions, NestJS compatibility, React/Next.js helpers, remote backend/plugin chains, watch/reload behavior, and runtime-specific adapters remain documented non-goals for this core package.
+This package provides the framework-agnostic core translation engine at the root entry point plus a small standard-first formatting facade and opt-in subpaths for Node-only filesystem loading and HTTP request locale context helpers. ICU/messageformat integration, validation integration, generated key unions, NestJS compatibility, React/Next.js helpers, remote backend/plugin chains, watch/reload behavior, and runtime-specific adapters remain documented non-goals for this package.
 
 Formatting helpers delegate directly to the host standard `Intl` implementation. Locale is explicit on every formatting call, and named formatter options are captured through `createI18n(...)` or `I18nModule.forRoot(...)` as immutable service-owned snapshots:
 
@@ -163,6 +165,40 @@ The loader reads `${rootDir}/${locale}/${namespace}.json` and returns an immutab
 
 This subpath imports Node built-ins and is not exported from `@fluojs/i18n` root. Do not import it in Bun, Deno, Cloudflare Workers, browser, or other non-Node runtime-portable bundles unless your bundler explicitly targets Node.js.
 
+## HTTP Locale Context Adapter
+
+HTTP request locale helpers live only under the `@fluojs/i18n/http` subpath so the root `@fluojs/i18n` entry point remains framework-agnostic and does not import `@fluojs/http`.
+
+```ts
+import { createAcceptLanguageLocaleResolver, getHttpLocale, resolveHttpLocale } from '@fluojs/i18n/http';
+import type { RequestContext } from '@fluojs/http';
+
+const acceptLanguage = createAcceptLanguageLocaleResolver();
+
+function bindRequestLocale(ctx: RequestContext) {
+  return resolveHttpLocale(ctx, {
+    defaultLocale: 'en',
+    supportedLocales: ['en', 'ko'],
+    resolvers: [acceptLanguage],
+  });
+}
+
+function handler(ctx: RequestContext) {
+  const locale = getHttpLocale(ctx)?.locale ?? 'en';
+  return { locale };
+}
+```
+
+The adapter is intentionally explicit:
+
+- `setHttpLocale(ctx, locale, metadata)` stores locale metadata on the current `RequestContext` using `createContextKey(...)`.
+- `getHttpLocale(ctx)` reads the metadata without falling back to globals.
+- `parseAcceptLanguage(header)` parses valid `Accept-Language` ranges by q-value and ignores invalid or q=0 entries.
+- `createAcceptLanguageLocaleResolver(...)` selects the first supported locale from the request header.
+- `resolveHttpLocale(ctx, options)` runs application-provided resolvers in order, ignores invalid or unsupported resolver output, and stores `defaultLocale` with source `default` when nothing matches.
+
+Wildcard `*` ranges are parsed but do not automatically select a locale. Applications that want wildcard-specific behavior can add a resolver before or after the provided `Accept-Language` resolver.
+
 ## Public API
 
 | Class/Helper | Description |
@@ -171,6 +207,7 @@ This subpath imports Node built-ins and is not exported from `@fluojs/i18n` root
 | `I18nService` | Core service that owns detached options/catalog snapshots and resolves translations. |
 | `createI18n(options)` | Creates a standalone `I18nService` without module registration. |
 | `I18nError` | Base i18n package error with a stable error code. |
+| `@fluojs/i18n/http` | Explicit HTTP request locale context helpers and `Accept-Language` resolver utilities. |
 
 The Node-only `@fluojs/i18n/loaders/fs` subpath exports `FileSystemI18nLoader`, `createFileSystemI18nLoader(options)`, `FileSystemI18nLoaderOptions`, and `I18nLoader`.
 
@@ -186,4 +223,5 @@ The root package also exports `I18nModuleOptions`, `I18nMessageCatalogs`, `I18nM
 - `packages/i18n/src/module.ts`
 - `packages/i18n/src/service.ts`
 - `packages/i18n/src/loaders/fs.ts`
+- `packages/i18n/src/http.ts`
 - `packages/i18n/src/index.test.ts`

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -31,6 +31,10 @@
     "./loaders/fs": {
       "types": "./dist/loaders/fs.d.ts",
       "import": "./dist/loaders/fs.js"
+    },
+    "./http": {
+      "types": "./dist/http.d.ts",
+      "import": "./dist/http.js"
     }
   },
   "main": "./dist/index.js",
@@ -46,7 +50,8 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
-    "@fluojs/core": "workspace:^"
+    "@fluojs/core": "workspace:^",
+    "@fluojs/http": "workspace:^"
   },
   "devDependencies": {
     "vitest": "^3.2.4"

--- a/packages/i18n/src/http.test.ts
+++ b/packages/i18n/src/http.test.ts
@@ -90,6 +90,18 @@ describe('@fluojs/i18n/http locale context adapter', () => {
     ]);
   });
 
+  it('rejects invalid Accept-Language parameters and duplicate q-values', () => {
+    expect(
+      parseAcceptLanguage([
+        'valid;q=0.4',
+        'space-before-equals;q =0.5',
+        'space-after-equals;q= 0.5',
+        'unknown;foo=bar',
+        'duplicate;q=0.8;q=0.7',
+      ]),
+    ).toEqual([{ locale: 'valid', quality: 0.4 }]);
+  });
+
   it('runs explicit resolver chains in order', () => {
     const context = createMockContext({ 'accept-language': 'ko;q=1' });
     const first: HttpLocaleResolver = () => 'fr';

--- a/packages/i18n/src/http.test.ts
+++ b/packages/i18n/src/http.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RequestContext } from '@fluojs/http';
+
+import {
+  createAcceptLanguageLocaleResolver,
+  getHttpLocale,
+  parseAcceptLanguage,
+  resolveHttpLocale,
+  setHttpLocale,
+  type HttpLocaleResolver,
+} from './http.js';
+
+function createMockContext(headers: RequestContext['request']['headers'] = {}): RequestContext {
+  return {
+    container: {
+      async dispose() {},
+      async resolve() {
+        throw new Error('No providers are registered in this test request context.');
+      },
+    },
+    metadata: {},
+    request: {
+      body: undefined,
+      cookies: {},
+      headers,
+      method: 'GET',
+      params: {},
+      path: '/localized',
+      query: {},
+      raw: {},
+      url: '/localized',
+    },
+    requestId: 'req_locale',
+    response: {
+      committed: false,
+      headers: {},
+      redirect() {},
+      send() {},
+      setHeader(name, value) {
+        this.headers[name] = value;
+      },
+      setStatus(code) {
+        this.statusCode = code;
+      },
+      statusCode: 200,
+    },
+  };
+}
+
+describe('@fluojs/i18n/http locale context adapter', () => {
+  it('stores locale metadata per request context without leaking across requests', () => {
+    const contextA = createMockContext();
+    const contextB = createMockContext();
+
+    setHttpLocale(contextA, 'en', { source: 'test-a' });
+    setHttpLocale(contextB, 'ko', { source: 'test-b' });
+
+    expect(getHttpLocale(contextA)).toEqual({ locale: 'en', source: 'test-a' });
+    expect(getHttpLocale(contextB)).toEqual({ locale: 'ko', source: 'test-b' });
+  });
+
+  it('parses Accept-Language by q-value and ignores invalid entries', () => {
+    expect(parseAcceptLanguage('fr-CA;q=0.7, ko-KR, invalid tag;q=1, en;q=0.8, ja;q=0, *;q=0.5')).toEqual([
+      { locale: 'ko-KR', quality: 1 },
+      { locale: 'en', quality: 0.8 },
+      { locale: 'fr-CA', quality: 0.7 },
+      { locale: '*', quality: 0.5 },
+    ]);
+  });
+
+  it('runs explicit resolver chains in order', () => {
+    const context = createMockContext({ 'accept-language': 'ko;q=1' });
+    const first: HttpLocaleResolver = () => 'fr';
+    const second = createAcceptLanguageLocaleResolver();
+
+    const locale = resolveHttpLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [first, second],
+      supportedLocales: ['en', 'fr', 'ko'],
+    });
+
+    expect(locale).toEqual({ locale: 'fr' });
+    expect(getHttpLocale(context)).toEqual({ locale: 'fr' });
+  });
+
+  it('skips invalid and unsupported resolver locales', () => {
+    const context = createMockContext({ 'Accept-Language': 'fr;q=1, ko;q=0.9' });
+    const invalid: HttpLocaleResolver = () => 'invalid locale';
+    const unsupported: HttpLocaleResolver = () => ({ locale: 'fr', source: 'unsupported' });
+    const acceptLanguage = createAcceptLanguageLocaleResolver();
+
+    const locale = resolveHttpLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [invalid, unsupported, acceptLanguage],
+      supportedLocales: ['en', 'ko'],
+    });
+
+    expect(locale).toEqual({ locale: 'ko', source: 'accept-language' });
+  });
+
+  it('falls back to the configured default locale when no resolver matches', () => {
+    const context = createMockContext({ 'accept-language': 'fr;q=1, *;q=0.8' });
+
+    const locale = resolveHttpLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [createAcceptLanguageLocaleResolver()],
+      supportedLocales: ['en', 'ko'],
+    });
+
+    expect(locale).toEqual({ locale: 'en', source: 'default' });
+    expect(getHttpLocale(context)).toEqual({ locale: 'en', source: 'default' });
+  });
+});

--- a/packages/i18n/src/http.test.ts
+++ b/packages/i18n/src/http.test.ts
@@ -69,6 +69,27 @@ describe('@fluojs/i18n/http locale context adapter', () => {
     ]);
   });
 
+  it('rejects non-spec Accept-Language q-value syntax', () => {
+    expect(
+      parseAcceptLanguage([
+        'ko;q=0.123',
+        'en;q=1.000',
+        'hex;q=0x1',
+        'scientific;q=1e-1',
+        'precise;q=0.1234',
+        'large;q=1.001',
+        'two;q=2',
+        'negative;q=-0.1',
+        'malformed;q',
+        'empty;q=',
+        'extra;q=0.5=oops',
+      ]),
+    ).toEqual([
+      { locale: 'en', quality: 1 },
+      { locale: 'ko', quality: 0.123 },
+    ]);
+  });
+
   it('runs explicit resolver chains in order', () => {
     const context = createMockContext({ 'accept-language': 'ko;q=1' });
     const first: HttpLocaleResolver = () => 'fr';
@@ -97,6 +118,21 @@ describe('@fluojs/i18n/http locale context adapter', () => {
     });
 
     expect(locale).toEqual({ locale: 'ko', source: 'accept-language' });
+  });
+
+  it('skips non-string resolver outputs instead of validating them as locales', () => {
+    const context = createMockContext();
+    const numberLocale: HttpLocaleResolver = () => 123;
+    const objectLocale: HttpLocaleResolver = () => ({ locale: ['ko'], source: 'array-locale' });
+    const valid: HttpLocaleResolver = () => ({ locale: 'ko', source: 'valid' });
+
+    const locale = resolveHttpLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [numberLocale, objectLocale, valid],
+      supportedLocales: ['en', 'ko'],
+    });
+
+    expect(locale).toEqual({ locale: 'ko', source: 'valid' });
   });
 
   it('falls back to the configured default locale when no resolver matches', () => {

--- a/packages/i18n/src/http.ts
+++ b/packages/i18n/src/http.ts
@@ -53,7 +53,7 @@ export interface HttpLocaleResolverResult {
 /**
  * Explicit locale resolver used by `resolveHttpLocale(...)` in application-defined order.
  */
-export type HttpLocaleResolver = (input: HttpLocaleResolverInput) => HttpLocaleResolverResult | I18nLocale | undefined;
+export type HttpLocaleResolver = (input: HttpLocaleResolverInput) => unknown;
 
 /**
  * Options for resolving a request locale from an ordered resolver chain.
@@ -84,9 +84,15 @@ export const HTTP_LOCALE_CONTEXT_KEY = createContextKey<HttpLocaleContext>('fluo
 
 const DEFAULT_ACCEPT_LANGUAGE_SOURCE = 'accept-language';
 const LOCALE_PATTERN = /^[A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*$/;
+const ACCEPT_LANGUAGE_QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
 
-function isValidLocale(locale: string): boolean {
-  return LOCALE_PATTERN.test(locale);
+interface ResolverCandidate {
+  readonly locale: unknown;
+  readonly source?: string;
+}
+
+function isValidLocale(locale: unknown): locale is I18nLocale {
+  return typeof locale === 'string' && LOCALE_PATTERN.test(locale);
 }
 
 function isSupportedLocale(locale: I18nLocale, supportedLocales: readonly I18nLocale[] | undefined): boolean {
@@ -106,8 +112,8 @@ function readHeader(request: FrameworkRequest, headerName: string): string | str
 }
 
 function normalizeResolverResult(
-  result: HttpLocaleResolverResult | I18nLocale | undefined,
-): HttpLocaleResolverResult | undefined {
+  result: unknown,
+): ResolverCandidate | undefined {
   if (result === undefined) {
     return undefined;
   }
@@ -116,7 +122,39 @@ function normalizeResolverResult(
     return { locale: result };
   }
 
-  return result;
+  if (typeof result !== 'object' || result === null || !Object.hasOwn(result, 'locale')) {
+    return undefined;
+  }
+
+  const { locale, source } = result as { readonly locale?: unknown; readonly source?: unknown };
+
+  if (source !== undefined && typeof source !== 'string') {
+    return undefined;
+  }
+
+  return { locale, source };
+}
+
+function parseAcceptLanguageQuality(parameters: readonly string[]): number | undefined {
+  let quality = 1;
+
+  for (const parameter of parameters) {
+    const [rawName, rawValue, ...extraParts] = parameter.split('=');
+
+    if (rawName?.trim().toLowerCase() !== 'q') {
+      continue;
+    }
+
+    const value = rawValue?.trim();
+
+    if (extraParts.length > 0 || value === undefined || !ACCEPT_LANGUAGE_QVALUE_PATTERN.test(value)) {
+      return undefined;
+    }
+
+    quality = Number(value);
+  }
+
+  return quality;
 }
 
 /**
@@ -167,28 +205,9 @@ export function parseAcceptLanguage(header: string | readonly string[] | undefin
       continue;
     }
 
-    let quality = 1;
-    let invalidQuality = false;
+    const quality = parseAcceptLanguageQuality(parameters);
 
-    for (const parameter of parameters) {
-      const [rawName, rawValue] = parameter.split('=');
-
-      if (rawName?.trim().toLowerCase() !== 'q') {
-        continue;
-      }
-
-      const value = rawValue?.trim();
-      const parsed = value === undefined || value === '' ? Number.NaN : Number(value);
-
-      if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
-        invalidQuality = true;
-        break;
-      }
-
-      quality = parsed;
-    }
-
-    if (!invalidQuality && quality > 0) {
+    if (quality !== undefined && quality > 0) {
       preferences.push({ index, locale, quality });
     }
   }

--- a/packages/i18n/src/http.ts
+++ b/packages/i18n/src/http.ts
@@ -1,0 +1,263 @@
+import {
+  createContextKey,
+  getContextValue,
+  setContextValue,
+  type FrameworkRequest,
+  type RequestContext,
+} from '@fluojs/http';
+
+import type { I18nLocale } from './types.js';
+
+/**
+ * Locale metadata stored on a fluo HTTP request context.
+ */
+export interface HttpLocaleContext {
+  /** Locale selected for the active request. */
+  readonly locale: I18nLocale;
+  /** Optional resolver name or application-defined source that selected the locale. */
+  readonly source?: string;
+}
+
+/**
+ * Parsed `Accept-Language` preference ordered by caller priority.
+ */
+export interface AcceptLanguagePreference {
+  /** Locale range from the header, such as `ko-KR`, `en`, or `*`. */
+  readonly locale: I18nLocale;
+  /** Normalized q-value between 0 and 1. */
+  readonly quality: number;
+}
+
+/**
+ * Input shared by explicit HTTP locale resolvers.
+ */
+export interface HttpLocaleResolverInput {
+  /** Current request context being resolved. */
+  readonly context: RequestContext;
+  /** Supported locale allow-list. Empty or omitted lists allow any syntactically valid locale. */
+  readonly supportedLocales?: readonly I18nLocale[];
+  /** Default locale used when no resolver selects a supported locale. */
+  readonly defaultLocale: I18nLocale;
+}
+
+/**
+ * Result returned by one HTTP locale resolver.
+ */
+export interface HttpLocaleResolverResult {
+  /** Locale selected by the resolver. */
+  readonly locale: I18nLocale;
+  /** Resolver name or application-defined source that selected the locale. */
+  readonly source?: string;
+}
+
+/**
+ * Explicit locale resolver used by `resolveHttpLocale(...)` in application-defined order.
+ */
+export type HttpLocaleResolver = (input: HttpLocaleResolverInput) => HttpLocaleResolverResult | I18nLocale | undefined;
+
+/**
+ * Options for resolving a request locale from an ordered resolver chain.
+ */
+export interface ResolveHttpLocaleOptions {
+  /** Supported locale allow-list. Empty or omitted lists allow any syntactically valid locale. */
+  readonly supportedLocales?: readonly I18nLocale[];
+  /** Default locale returned when no resolver selects a supported locale. */
+  readonly defaultLocale: I18nLocale;
+  /** Resolver chain executed in array order. */
+  readonly resolvers?: readonly HttpLocaleResolver[];
+}
+
+/**
+ * Options for creating an `Accept-Language` resolver.
+ */
+export interface AcceptLanguageLocaleResolverOptions {
+  /** Header name to inspect. Defaults to `accept-language`. */
+  readonly headerName?: string;
+  /** Resolver source label returned with matches. Defaults to `accept-language`. */
+  readonly source?: string;
+}
+
+/**
+ * Request-context key used by `setHttpLocale(...)` and `getHttpLocale(...)`.
+ */
+export const HTTP_LOCALE_CONTEXT_KEY = createContextKey<HttpLocaleContext>('fluo.i18n.http.locale');
+
+const DEFAULT_ACCEPT_LANGUAGE_SOURCE = 'accept-language';
+const LOCALE_PATTERN = /^[A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*$/;
+
+function isValidLocale(locale: string): boolean {
+  return LOCALE_PATTERN.test(locale);
+}
+
+function isSupportedLocale(locale: I18nLocale, supportedLocales: readonly I18nLocale[] | undefined): boolean {
+  return supportedLocales === undefined || supportedLocales.length === 0 || supportedLocales.includes(locale);
+}
+
+function readHeader(request: FrameworkRequest, headerName: string): string | string[] | undefined {
+  const normalizedName = headerName.toLowerCase();
+
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (name.toLowerCase() === normalizedName) {
+      return value as string | string[] | undefined;
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeResolverResult(
+  result: HttpLocaleResolverResult | I18nLocale | undefined,
+): HttpLocaleResolverResult | undefined {
+  if (result === undefined) {
+    return undefined;
+  }
+
+  if (typeof result === 'string') {
+    return { locale: result };
+  }
+
+  return result;
+}
+
+/**
+ * Stores locale metadata on a fluo HTTP request context.
+ *
+ * @param context Request context to update.
+ * @param locale Locale selected for the request.
+ * @param metadata Additional locale metadata such as a resolver source.
+ */
+export function setHttpLocale(
+  context: RequestContext,
+  locale: I18nLocale,
+  metadata: Omit<HttpLocaleContext, 'locale'> = {},
+): void {
+  setContextValue(context, HTTP_LOCALE_CONTEXT_KEY, Object.freeze({ ...metadata, locale }));
+}
+
+/**
+ * Reads locale metadata from a fluo HTTP request context.
+ *
+ * @param context Request context to inspect.
+ * @returns Stored locale metadata, or `undefined` when the request has no locale.
+ */
+export function getHttpLocale(context: RequestContext): HttpLocaleContext | undefined {
+  return getContextValue(context, HTTP_LOCALE_CONTEXT_KEY);
+}
+
+/**
+ * Parses an `Accept-Language` header into quality-sorted locale preferences.
+ *
+ * @param header Raw header value or adapter-provided repeated header values.
+ * @returns Valid language ranges ordered by descending q-value and original header order for ties.
+ */
+export function parseAcceptLanguage(header: string | readonly string[] | undefined): readonly AcceptLanguagePreference[] {
+  const rawHeader = typeof header === 'string' ? header : header?.join(',');
+
+  if (rawHeader === undefined || rawHeader.trim() === '') {
+    return [];
+  }
+
+  const preferences: Array<AcceptLanguagePreference & { readonly index: number }> = [];
+
+  for (const [index, rawPart] of rawHeader.split(',').entries()) {
+    const [rawLocale, ...parameters] = rawPart.split(';');
+    const locale = rawLocale?.trim();
+
+    if (locale === undefined || locale === '' || (locale !== '*' && !isValidLocale(locale))) {
+      continue;
+    }
+
+    let quality = 1;
+    let invalidQuality = false;
+
+    for (const parameter of parameters) {
+      const [rawName, rawValue] = parameter.split('=');
+
+      if (rawName?.trim().toLowerCase() !== 'q') {
+        continue;
+      }
+
+      const value = rawValue?.trim();
+      const parsed = value === undefined || value === '' ? Number.NaN : Number(value);
+
+      if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) {
+        invalidQuality = true;
+        break;
+      }
+
+      quality = parsed;
+    }
+
+    if (!invalidQuality && quality > 0) {
+      preferences.push({ index, locale, quality });
+    }
+  }
+
+  return [...preferences]
+    .sort((left, right) => right.quality - left.quality || left.index - right.index)
+    .map(({ locale, quality }) => ({ locale, quality }));
+}
+
+/**
+ * Creates a resolver that selects the first supported `Accept-Language` locale.
+ *
+ * @param options Header name and source label options.
+ * @returns Locale resolver that inspects the current request headers.
+ */
+export function createAcceptLanguageLocaleResolver(
+  options: AcceptLanguageLocaleResolverOptions = {},
+): HttpLocaleResolver {
+  const headerName = options.headerName ?? 'accept-language';
+  const source = options.source ?? DEFAULT_ACCEPT_LANGUAGE_SOURCE;
+
+  return ({ context, supportedLocales }) => {
+    const header = readHeader(context.request, headerName);
+    const preferences = parseAcceptLanguage(header);
+
+    for (const preference of preferences) {
+      if (preference.locale === '*') {
+        continue;
+      }
+
+      if (isSupportedLocale(preference.locale, supportedLocales)) {
+        return { locale: preference.locale, source };
+      }
+    }
+
+    return undefined;
+  };
+}
+
+/**
+ * Runs an explicit resolver chain and stores the selected request locale.
+ *
+ * @param context Request context to resolve and update.
+ * @param options Default locale, supported locales, and ordered resolvers.
+ * @returns Stored locale metadata selected by the first valid resolver or the configured default locale.
+ * @throws {TypeError} When the configured default locale is invalid or unsupported.
+ */
+export function resolveHttpLocale(context: RequestContext, options: ResolveHttpLocaleOptions): HttpLocaleContext {
+  if (!isValidLocale(options.defaultLocale)) {
+    throw new TypeError('defaultLocale must be a syntactically valid locale string.');
+  }
+
+  if (!isSupportedLocale(options.defaultLocale, options.supportedLocales)) {
+    throw new TypeError('defaultLocale must be listed in supportedLocales when supportedLocales is provided.');
+  }
+
+  for (const resolver of options.resolvers ?? []) {
+    const result = normalizeResolverResult(
+      resolver({ context, defaultLocale: options.defaultLocale, supportedLocales: options.supportedLocales }),
+    );
+
+    if (result === undefined || !isValidLocale(result.locale) || !isSupportedLocale(result.locale, options.supportedLocales)) {
+      continue;
+    }
+
+    setHttpLocale(context, result.locale, { source: result.source });
+    return getHttpLocale(context) ?? { locale: result.locale, source: result.source };
+  }
+
+  setHttpLocale(context, options.defaultLocale, { source: 'default' });
+  return getHttpLocale(context) ?? { locale: options.defaultLocale, source: 'default' };
+}

--- a/packages/i18n/src/http.ts
+++ b/packages/i18n/src/http.ts
@@ -137,20 +137,23 @@ function normalizeResolverResult(
 
 function parseAcceptLanguageQuality(parameters: readonly string[]): number | undefined {
   let quality = 1;
+  let hasQuality = false;
 
   for (const parameter of parameters) {
-    const [rawName, rawValue, ...extraParts] = parameter.split('=');
+    const normalizedParameter = parameter.trim();
+    const qualityMatch = /^q=(.+)$/i.exec(normalizedParameter);
 
-    if (rawName?.trim().toLowerCase() !== 'q') {
-      continue;
-    }
-
-    const value = rawValue?.trim();
-
-    if (extraParts.length > 0 || value === undefined || !ACCEPT_LANGUAGE_QVALUE_PATTERN.test(value)) {
+    if (qualityMatch === null || hasQuality) {
       return undefined;
     }
 
+    const [, value] = qualityMatch;
+
+    if (value === undefined || !ACCEPT_LANGUAGE_QVALUE_PATTERN.test(value)) {
+      return undefined;
+    }
+
+    hasQuality = true;
     quality = Number(value);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,6 +460,9 @@ importers:
       '@fluojs/core':
         specifier: workspace:^
         version: link:../core
+      '@fluojs/http':
+        specifier: workspace:^
+        version: link:../http
     devDependencies:
       vitest:
         specifier: ^3.2.4


### PR DESCRIPTION
## Summary

Adds an explicit `@fluojs/i18n/http` locale context adapter for fluo HTTP request contexts while keeping the root `@fluojs/i18n` entry point framework-agnostic.

Closes #1715

## Changes

- Added the `./http` package export for `@fluojs/i18n` and a workspace dependency on `@fluojs/http` scoped to that subpath.
- Added `HTTP_LOCALE_CONTEXT_KEY`, `setHttpLocale(...)`, `getHttpLocale(...)`, `parseAcceptLanguage(...)`, `createAcceptLanguageLocaleResolver(...)`, and `resolveHttpLocale(...)`.
- Documented explicit HTTP locale context behavior in `packages/i18n/README.md`.
- Added a minor Changeset for the public subpath addition.

## Testing

- `lsp_diagnostics packages/i18n/src` — passed
- `pnpm --filter @fluojs/core --filter @fluojs/di --filter @fluojs/validation --filter @fluojs/http build` — passed
- `pnpm --filter @fluojs/i18n typecheck` — passed
- `pnpm --filter @fluojs/i18n test` — passed (11 tests)
- `pnpm --filter @fluojs/i18n build` — passed
- `pnpm exec biome lint packages/i18n/src/http.ts packages/i18n/src/http.test.ts` — passed
- `pnpm verify:public-export-tsdoc` — passed
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm changeset status --since=main` — passed; reports `@fluojs/i18n` minor bump
- `pnpm lint` — completed with existing repository-wide Biome diagnostics outside this PR's changed files; changed i18n files pass targeted Biome lint
- `pnpm verify:release-readiness` — failed in existing CLI sandbox smoke because generated sandbox typecheck could not find the `node` type definition file after sandbox install; package/tests/governance checks above passed

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs or platform conformance claims changed.