### PR TITLE
Resolve #1732: Harden i18n edge-case regression tests

### DIFF
--- a/packages/i18n/src/http.test.ts
+++ b/packages/i18n/src/http.test.ts
@@ -69,6 +69,15 @@ describe('@fluojs/i18n/http locale context adapter', () => {
     ]);
   });
 
+  it('preserves original header order when Accept-Language q-values tie', () => {
+    expect(parseAcceptLanguage('fr;q=0.8, ko;q=0.8, en;q=0.8, ja;q=0.7')).toEqual([
+      { locale: 'fr', quality: 0.8 },
+      { locale: 'ko', quality: 0.8 },
+      { locale: 'en', quality: 0.8 },
+      { locale: 'ja', quality: 0.7 },
+    ]);
+  });
+
   it('rejects non-spec Accept-Language q-value syntax', () => {
     expect(
       parseAcceptLanguage([
@@ -132,6 +141,23 @@ describe('@fluojs/i18n/http locale context adapter', () => {
     expect(locale).toEqual({ locale: 'ko', source: 'accept-language' });
   });
 
+  it('uses custom Accept-Language header name and source options', () => {
+    const context = createMockContext({ 'x-locale-preference': 'fr;q=1, ko;q=0.9' });
+    const resolver = createAcceptLanguageLocaleResolver({
+      headerName: 'X-Locale-Preference',
+      source: 'custom-header',
+    });
+
+    const locale = resolveHttpLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [resolver],
+      supportedLocales: ['en', 'ko'],
+    });
+
+    expect(locale).toEqual({ locale: 'ko', source: 'custom-header' });
+    expect(getHttpLocale(context)).toEqual({ locale: 'ko', source: 'custom-header' });
+  });
+
   it('skips non-string resolver outputs instead of validating them as locales', () => {
     const context = createMockContext();
     const numberLocale: HttpLocaleResolver = () => 123;
@@ -158,5 +184,33 @@ describe('@fluojs/i18n/http locale context adapter', () => {
 
     expect(locale).toEqual({ locale: 'en', source: 'default' });
     expect(getHttpLocale(context)).toEqual({ locale: 'en', source: 'default' });
+  });
+
+  it('rejects invalid defaultLocale values before resolving request locales', () => {
+    const context = createMockContext({ 'accept-language': 'ko;q=1' });
+
+    expect(() =>
+      resolveHttpLocale(context, {
+        defaultLocale: 'invalid locale',
+        resolvers: [createAcceptLanguageLocaleResolver()],
+        supportedLocales: ['en', 'ko'],
+      }),
+    ).toThrow(TypeError);
+
+    expect(getHttpLocale(context)).toBeUndefined();
+  });
+
+  it('rejects unsupported defaultLocale values before resolving request locales', () => {
+    const context = createMockContext({ 'accept-language': 'ko;q=1' });
+
+    expect(() =>
+      resolveHttpLocale(context, {
+        defaultLocale: 'fr',
+        resolvers: [createAcceptLanguageLocaleResolver()],
+        supportedLocales: ['en', 'ko'],
+      }),
+    ).toThrow(TypeError);
+
+    expect(getHttpLocale(context)).toBeUndefined();
   });
 });

--- a/packages/i18n/src/loaders/fs.test.ts
+++ b/packages/i18n/src/loaders/fs.test.ts
@@ -31,6 +31,18 @@ async function expectI18nRejection(action: () => Promise<unknown>, code: I18nErr
   throw new Error(`Expected action to fail with ${code}.`);
 }
 
+function expectI18nThrow(action: () => unknown, code: I18nErrorCode): void {
+  try {
+    action();
+  } catch (error) {
+    expect(error).toBeInstanceOf(I18nError);
+    expect((error as I18nError).code).toBe(code);
+    return;
+  }
+
+  throw new Error(`Expected action to fail with ${code}.`);
+}
+
 describe('@fluojs/i18n/loaders/fs', () => {
   beforeEach(async () => {
     rootDir = await mkdtemp(join(tmpdir(), 'fluo-i18n-fs-'));
@@ -63,6 +75,40 @@ describe('@fluojs/i18n/loaders/fs', () => {
     const loader = new FileSystemI18nLoader({ rootDir });
 
     await expectI18nRejection(() => loader.load('en', 'common'), 'I18N_INVALID_CATALOG');
+  });
+
+  it('fails with a stable code for valid JSON that is not a message tree', async () => {
+    await writeCatalog('en', 'array', JSON.stringify(['not', 'a', 'tree']));
+    await writeCatalog('en', 'number', JSON.stringify(123));
+    await writeCatalog('en', 'boolean-entry', JSON.stringify({ enabled: true }));
+    await writeCatalog('en', 'array-entry', JSON.stringify({ labels: ['save'] }));
+    await writeCatalog('en', 'empty-key', JSON.stringify({ '': 'blank' }));
+
+    const loader = new FileSystemI18nLoader({ rootDir });
+
+    await expectI18nRejection(() => loader.load('en', 'array'), 'I18N_INVALID_CATALOG');
+    await expectI18nRejection(() => loader.load('en', 'number'), 'I18N_INVALID_CATALOG');
+    await expectI18nRejection(() => loader.load('en', 'boolean-entry'), 'I18N_INVALID_CATALOG');
+    await expectI18nRejection(() => loader.load('en', 'array-entry'), 'I18N_INVALID_CATALOG');
+    await expectI18nRejection(() => loader.load('en', 'empty-key'), 'I18N_INVALID_CATALOG');
+  });
+
+  it('rejects invalid rootDir constructor options', () => {
+    const invalidOptions: readonly unknown[] = [
+      undefined,
+      null,
+      {},
+      { rootDir: '' },
+      { rootDir: '   ' },
+      { rootDir: 123 },
+    ];
+
+    for (const options of invalidOptions) {
+      expectI18nThrow(
+        () => new FileSystemI18nLoader(options as { readonly rootDir: string }),
+        'I18N_INVALID_LOADER_OPTIONS',
+      );
+    }
   });
 
   it('fails before disk reads for invalid locale values', async () => {


### PR DESCRIPTION
## Summary

Closes #1732.

Harden `@fluojs/i18n` HTTP locale resolution and filesystem loader edge-case regression coverage without changing runtime behavior.

## Changes

- Added equal-q `parseAcceptLanguage(...)` tie-order coverage.
- Added `resolveHttpLocale(...)` validation coverage for invalid and unsupported `defaultLocale` values.
- Added custom `createAcceptLanguageLocaleResolver(...)` `headerName`/`source` coverage.
- Added filesystem loader coverage for invalid valid-JSON message-tree shapes and invalid `rootDir` constructor options.

## Testing

- `pnpm --dir packages/i18n test`
- `pnpm --filter @fluojs/http... build && pnpm --dir packages/i18n typecheck`
- LSP diagnostics clean for `packages/i18n/src/http.test.ts`
- LSP diagnostics clean for `packages/i18n/src/loaders/fs.test.ts`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new behavioral contracts; this PR only hardens regression tests for existing contracts.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] No platform contract docs changed.
- [x] No package README alignment/conformance claims changed.