### PR TITLE
Resolve #1731: Make i18n discoverable in package chooser

### DIFF
--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -29,7 +29,7 @@ fluo는 TC39 표준 데코레이터, 명시적 의존성 경계, 메타데이터
 | Operations | 헬스, 메트릭, 스로틀링 | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
 | Tooling | CLI, 진단 도구, Vite 빌드 통합 | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing`, `@fluojs/vite` |
 
-정식 패키지 및 런타임 범위는 [`docs/reference/package-surface.md`](./reference/package-surface.md)에 있으며, fluo-native `@fluojs/i18n` package boundary 같은 core 추가 항목과 `@fluojs/mongoose`의 ALS/session transaction 책임 같은 persistence 책임도 포함한다.
+정식 패키지 및 런타임 범위는 [`docs/reference/package-surface.md`](./reference/package-surface.md)에 있으며, fluo-native `@fluojs/i18n` package boundary 같은 core 추가 항목과 `@fluojs/mongoose`의 ALS/session transaction 책임 같은 persistence 책임도 포함한다. 작업 기반 패키지 발견성은 [`docs/reference/package-chooser.md`](./reference/package-chooser.md)에 있으며, `@fluojs/i18n`을 위한 localization/i18n 선택 guidance도 포함한다.
 
 ## File Structure
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -29,7 +29,7 @@ fluo is a standard-first TypeScript backend framework built on TC39 standard dec
 | Operations | Health, metrics, throttling | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
 | Tooling | CLI, diagnostics, and Vite build integration | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing`, `@fluojs/vite` |
 
-Canonical package and runtime coverage lives in [`docs/reference/package-surface.md`](./reference/package-surface.md), including core additions such as the fluo-native `@fluojs/i18n` package boundary and persistence responsibilities such as `@fluojs/mongoose` ALS/session transaction ownership.
+Canonical package and runtime coverage lives in [`docs/reference/package-surface.md`](./reference/package-surface.md), including core additions such as the fluo-native `@fluojs/i18n` package boundary and persistence responsibilities such as `@fluojs/mongoose` ALS/session transaction ownership. Task-based package discovery lives in [`docs/reference/package-chooser.md`](./reference/package-chooser.md), including localization/i18n selection guidance for `@fluojs/i18n`.
 
 ## File Structure
 

--- a/docs/reference/package-chooser.ko.md
+++ b/docs/reference/package-chooser.ko.md
@@ -16,6 +16,7 @@
 | Node.js HTTP를 직접 제어해야 함 | `@fluojs/platform-nodejs` | Node.js에서 first-class `fluo new` 애플리케이션 스타터로도 제공됩니다. |
 | 요청 유효성 검사가 필요함 | `@fluojs/validation` | DTO 바인딩과 검증이 필요할 때 추가합니다. |
 | 타입 안전 설정 접근이 필요함 | `@fluojs/config` | 패키지 내부의 직접 `process.env` 접근 대신 사용합니다. |
+| localization 또는 i18n service가 필요함 | `@fluojs/i18n` | framework-agnostic internationalization module registration, standalone service 생성, 공유 option/error type에 사용합니다. |
 
 ## 엣지 / 모던 런타임에 배포
 

--- a/docs/reference/package-chooser.md
+++ b/docs/reference/package-chooser.md
@@ -16,6 +16,7 @@
 | Need direct Node.js HTTP control | `@fluojs/platform-nodejs` | Also available as a first-class `fluo new` application starter on Node.js. |
 | Need request validation | `@fluojs/validation` | Add when DTO binding and validation are required. |
 | Need typed configuration access | `@fluojs/config` | Use instead of direct `process.env` access inside packages. |
+| Need localization or i18n services | `@fluojs/i18n` | Use for framework-agnostic internationalization module registration, standalone service creation, and shared option/error types. |
 
 ## deploy to edge / modern runtimes
 

--- a/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
+++ b/packages/testing/src/conformance/platform-consistency-governance-docs.test.ts
@@ -224,6 +224,26 @@ describe('platform consistency governance docs', () => {
     expect(packageChooserKo).toContain('@fluojs/email/node');
   });
 
+  it('keeps the i18n package discoverable from task-based package chooser guidance', () => {
+    const packageSurface = readFileSync(resolve(repoRoot, 'docs/reference/package-surface.md'), 'utf8');
+    const packageSurfaceKo = readFileSync(resolve(repoRoot, 'docs/reference/package-surface.ko.md'), 'utf8');
+    const packageChooser = readFileSync(resolve(repoRoot, 'docs/reference/package-chooser.md'), 'utf8');
+    const packageChooserKo = readFileSync(resolve(repoRoot, 'docs/reference/package-chooser.ko.md'), 'utf8');
+    const docsContext = readFileSync(resolve(repoRoot, 'docs/CONTEXT.md'), 'utf8');
+    const docsContextKo = readFileSync(resolve(repoRoot, 'docs/CONTEXT.ko.md'), 'utf8');
+
+    expect(packageSurface).toContain('@fluojs/i18n');
+    expect(packageSurfaceKo).toContain('@fluojs/i18n');
+    expect(packageChooser).toContain('@fluojs/i18n');
+    expect(packageChooser).toContain('localization');
+    expect(packageChooserKo).toContain('@fluojs/i18n');
+    expect(packageChooserKo).toContain('localization');
+    expect(docsContext).toContain('docs/reference/package-chooser.md');
+    expect(docsContext).toContain('@fluojs/i18n');
+    expect(docsContextKo).toContain('docs/reference/package-chooser.md');
+    expect(docsContextKo).toContain('@fluojs/i18n');
+  });
+
   it('keeps the websockets README shutdown contract scoped to fetch-style runtimes with linked regression evidence', () => {
     const websocketsReadme = readFileSync(resolve(repoRoot, 'packages/websockets/README.md'), 'utf8');
     const websocketsReadmeKo = readFileSync(resolve(repoRoot, 'packages/websockets/README.ko.md'), 'utf8');

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -669,6 +669,14 @@ function enforceCanonicalRuntimeMatrixReferences() {
     packageChooserKo.includes('./package-surface.ko.md#canonical-runtime-package-matrix'),
     'docs/reference/package-chooser.ko.md must point to the canonical runtime package matrix anchor.',
   );
+  assert(
+    packageChooser.includes('@fluojs/i18n') && packageChooser.includes('localization'),
+    'docs/reference/package-chooser.md must keep @fluojs/i18n discoverable for localization tasks.',
+  );
+  assert(
+    packageChooserKo.includes('@fluojs/i18n') && packageChooserKo.includes('localization'),
+    'docs/reference/package-chooser.ko.md must keep @fluojs/i18n discoverable for localization tasks.',
+  );
 
   assert(
     docsContext.includes('docs/reference/package-surface.md'),
@@ -677,6 +685,14 @@ function enforceCanonicalRuntimeMatrixReferences() {
   assert(
     docsContextKo.includes('docs/reference/package-surface.md'),
     'docs/CONTEXT.ko.md must point readers to the canonical runtime package matrix page.',
+  );
+  assert(
+    docsContext.includes('docs/reference/package-chooser.md') && docsContext.includes('@fluojs/i18n'),
+    'docs/CONTEXT.md must point readers to package chooser i18n discovery guidance.',
+  );
+  assert(
+    docsContextKo.includes('docs/reference/package-chooser.md') && docsContextKo.includes('@fluojs/i18n'),
+    'docs/CONTEXT.ko.md must point readers to package chooser i18n discovery guidance.',
   );
   assert(rootReadme.includes('docs/reference/package-surface.md'), 'README.md must point to the canonical runtime package matrix page.');
   assert(


### PR DESCRIPTION
## Summary

- Closes #1731.
- Makes `@fluojs/i18n` discoverable from task-based package chooser guidance while preserving `package-surface.md` as the responsibility source of truth.

## Changes

- Added EN/KO package chooser rows for localization/i18n tasks pointing to `@fluojs/i18n`.
- Updated EN/KO `docs/CONTEXT` discoverability guidance for the chooser path.
- Added governance enforcement and regression coverage so package chooser i18n discovery stays present.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm verify:docs`
- `pnpm verify:platform-consistency-governance`
- `pnpm vitest run packages/testing/src/conformance/platform-consistency-governance-docs.test.ts`
- `pnpm docs:sync-check`
- LSP diagnostics clean for changed Markdown, governance script, and regression test files.

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new runtime behavioral contracts were introduced; docs-only discovery update.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests where applicable; added docs/governance regression coverage.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Companion discoverability, tooling enforcement, and regression-test evidence are included for this contract-governed docs update.
- [x] No package README alignment/conformance claims changed.