### PR TITLE
Resolve #1727: Add i18n validation localization

### DIFF
--- a/.changeset/i18n-validation-localized-errors.md
+++ b/.changeset/i18n-validation-localized-errors.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/i18n": minor
+---
+
+Add the `@fluojs/i18n/validation` subpath for opt-in localization of `@fluojs/validation` issue messages while preserving default validation behavior.

--- a/packages/i18n/README.ko.md
+++ b/packages/i18n/README.ko.md
@@ -13,6 +13,7 @@ fluo 애플리케이션을 위한 프레임워크 비종속 국제화 코어 표
 - [포맷팅](#포맷팅)
 - [ICU MessageFormat](#icu-messageformat)
 - [HTTP Locale Context Adapter](#http-locale-context-adapter)
+- [Validation Error Localization](#validation-error-localization)
 - [Node Filesystem Loader](#node-filesystem-loader)
 - [Remote Catalog Loader](#remote-catalog-loader)
 - [Catalog Type Generation](#catalog-type-generation)
@@ -38,6 +39,7 @@ i18n 작업을 위한 안정적인 fluo-native 패키지 경계가 필요할 때
 - `@fluojs/i18n/icu`를 통한 선택적 ICU MessageFormat 복수형/select 포맷팅.
 - 명시적 로케일을 사용하는 표준 `Intl` 포맷팅 헬퍼.
 - `@fluojs/i18n/http`를 통한 명시적 HTTP `RequestContext` 로케일 헬퍼.
+- `@fluojs/i18n/validation`을 통한 opt-in `@fluojs/validation` issue localization.
 - `@fluojs/i18n/loaders/remote`를 통한 provider-backed remote catalog loading.
 - `@fluojs/i18n/typegen`을 통한 opt-in catalog key declaration generation.
 - 공유 옵션, 카탈로그, 로케일, 번역 키 및 에러 타입.
@@ -197,6 +199,39 @@ Adapter는 의도적으로 explicit합니다:
 
 Wildcard `*` range는 parse되지만 자동으로 locale을 선택하지는 않습니다. Wildcard별 동작이 필요한 애플리케이션은 제공된 `Accept-Language` resolver 앞이나 뒤에 resolver를 추가할 수 있습니다.
 
+## Validation Error Localization
+
+Validation issue localization은 `@fluojs/i18n/validation` subpath에서 제공합니다. 따라서 root `@fluojs/i18n` entry point는 framework-agnostic 상태를 유지하고, `@fluojs/validation` 기본 동작도 바꾸지 않습니다. 애플리케이션은 validation 실패 후 `ValidationIssue.message` snapshot을 명시적으로 번역해 opt-in합니다.
+
+```ts
+import { createI18n } from '@fluojs/i18n';
+import { localizeDtoValidationError } from '@fluojs/i18n/validation';
+import { DefaultValidator, DtoValidationError } from '@fluojs/validation';
+
+const i18n = createI18n({
+  defaultLocale: 'en',
+  supportedLocales: ['en', 'ko'],
+  fallbackLocales: { ko: ['en'] },
+  catalogs: {
+    en: { validation: { email: { EMAIL: '{{ field }} must be a valid email address.' } } },
+    ko: { validation: { email: { EMAIL: '{{ field }}에는 올바른 이메일 주소가 필요합니다.' } } },
+  },
+});
+
+try {
+  await new DefaultValidator().materialize(input, CreateUserDto);
+} catch (error) {
+  if (error instanceof DtoValidationError) {
+    throw localizeDtoValidationError(i18n, error, { locale: 'ko' });
+  }
+  throw error;
+}
+```
+
+기본 key candidate 순서는 가장 구체적인 것부터 덜 구체적인 것까지 `source.field.code`, `field.code`, `source.code`, `code`입니다. 기본 namespace는 `validation`이고, 호출자는 catalog 구조에 맞춰 `keyPrefix`, `namespace`, 또는 custom `keyBuilder`를 제공할 수 있습니다. Translation value에는 `code`, `field`, `source`, 원래 `message`가 포함됩니다. 누락된 번역은 기본적으로 원래 validation message를 보존합니다. `fallbackToIssueMessage: false`를 설정하면 `I18N_MISSING_MESSAGE` 코드의 `I18nError`를 throw합니다.
+
+이 통합은 의도적으로 HTTP adapter가 아닙니다. Request locale resolution은 `@fluojs/i18n/http`, CLI configuration, WebSocket session state 또는 다른 application boundary에서 처리하고, 선택된 locale을 validation localization helper에 명시적으로 전달합니다.
+
 ## Node Filesystem Loader
 
 Node 애플리케이션은 dedicated subpath에서 JSON filesystem loader를 선택적으로 사용할 수 있습니다.
@@ -302,6 +337,17 @@ const declarations = generateI18nCatalogTypes([
 
 **타입:** `HttpLocaleContext`, `HttpLocaleResolver`, `HttpLocaleResolverInput`, `HttpLocaleResolverResult`, `ResolveHttpLocaleOptions`, `AcceptLanguageLocaleResolverOptions`, `AcceptLanguagePreference`.
 
+### Validation Integration (@fluojs/i18n/validation)
+
+| Export | 설명 |
+|---|---|
+| `createValidationIssueTranslationKeys(issue, keyPrefix?)` | validation issue source, field path, code에서 기본 translation key candidate를 생성합니다. |
+| `localizeValidationIssue(i18n, issue, options, index?)` | candidate key가 resolve되면 localized message가 포함된 validation issue snapshot을 반환합니다. |
+| `localizeValidationIssues(i18n, issues, options)` | 원본 issue를 mutate하지 않고 issue list를 localize합니다. |
+| `localizeDtoValidationError(i18n, error, options)` | localized issue message를 가진 새 `DtoValidationError`를 생성합니다. |
+
+**타입:** `LocalizeValidationIssuesOptions`, `ValidationIssueTranslationKeyBuilder`, `ValidationIssueTranslationKeyContext`.
+
 ### ICU MessageFormat (@fluojs/i18n/icu)
 
 | Export | 설명 |
@@ -341,9 +387,8 @@ const declarations = generateI18nCatalogTypes([
 ## Post-MVP 로드맵
 
 
-다음 기능은 초기 MVP의 명시적 비목표이며 향후 확장이 계획되어 있습니다.
+다음 기능은 초기 MVP의 명시적 비목표로 남아 있으며 향후 확장이 계획되어 있습니다.
 
-- **`@fluojs/i18n/validation`**: 지역화된 에러 메시지를 위한 `@fluojs/validation`과의 통합.
 - **Additional Transport Adapters**: WebSockets, gRPC 및 CLI 환경을 위한 로케일 처리.
 
 ## 관련 패키지
@@ -351,6 +396,7 @@ const declarations = generateI18nCatalogTypes([
 
 - **`@fluojs/core`**: 이 패키지가 사용하는 module metadata와 shared framework error를 제공합니다.
 - **`@fluojs/config`**: module registration 및 option snapshotting convention에 가장 가까운 package layout model입니다.
+- **`@fluojs/validation`**: `@fluojs/i18n/validation`이 소비하는 opt-in validation issue contract를 제공합니다.
 
 ## 예제 소스
 
@@ -359,6 +405,7 @@ const declarations = generateI18nCatalogTypes([
 - `packages/i18n/src/icu.ts`
 - `packages/i18n/src/loaders/fs.ts`
 - `packages/i18n/src/http.ts`
+- `packages/i18n/src/validation.ts`
 - `packages/i18n/src/index.test.ts`
 - `packages/i18n/src/loaders/remote.ts`
 - `packages/i18n/src/typegen.ts`

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -13,6 +13,7 @@ Framework-agnostic internationalization core surface for fluo applications.
 - [Formatting](#formatting)
 - [ICU MessageFormat](#icu-messageformat)
 - [HTTP Locale Context Adapter](#http-locale-context-adapter)
+- [Validation Error Localization](#validation-error-localization)
 - [Node Filesystem Loader](#node-filesystem-loader)
 - [Remote Catalog Loader](#remote-catalog-loader)
 - [Catalog Type Generation](#catalog-type-generation)
@@ -38,6 +39,7 @@ Use this package when you need a stable fluo-native package boundary for i18n wo
 - optional ICU MessageFormat plural/select formatting through `@fluojs/i18n/icu`
 - standard `Intl` formatting helpers with explicit locales
 - explicit HTTP `RequestContext` locale helpers through `@fluojs/i18n/http`
+- opt-in `@fluojs/validation` issue localization through `@fluojs/i18n/validation`
 - provider-backed remote catalog loading through `@fluojs/i18n/loaders/remote`
 - opt-in catalog key declaration generation through `@fluojs/i18n/typegen`
 - shared option, catalog, locale, translation-key, and error types
@@ -197,6 +199,39 @@ The adapter is intentionally explicit:
 
 Wildcard `*` ranges are parsed but do not automatically select a locale. Applications that want wildcard-specific behavior can add a resolver before or after the provided `Accept-Language` resolver.
 
+## Validation Error Localization
+
+Validation issue localization lives under `@fluojs/i18n/validation` so the root `@fluojs/i18n` entry point stays framework-agnostic and does not change `@fluojs/validation` behavior by default. Applications opt in after validation fails by translating `ValidationIssue.message` snapshots explicitly.
+
+```ts
+import { createI18n } from '@fluojs/i18n';
+import { localizeDtoValidationError } from '@fluojs/i18n/validation';
+import { DefaultValidator, DtoValidationError } from '@fluojs/validation';
+
+const i18n = createI18n({
+  defaultLocale: 'en',
+  supportedLocales: ['en', 'ko'],
+  fallbackLocales: { ko: ['en'] },
+  catalogs: {
+    en: { validation: { email: { EMAIL: '{{ field }} must be a valid email address.' } } },
+    ko: { validation: { email: { EMAIL: '{{ field }}에는 올바른 이메일 주소가 필요합니다.' } } },
+  },
+});
+
+try {
+  await new DefaultValidator().materialize(input, CreateUserDto);
+} catch (error) {
+  if (error instanceof DtoValidationError) {
+    throw localizeDtoValidationError(i18n, error, { locale: 'ko' });
+  }
+  throw error;
+}
+```
+
+The default key candidates are most-specific to least-specific: `source.field.code`, `field.code`, `source.code`, then `code`. The default namespace is `validation`, and callers can provide `keyPrefix`, `namespace`, or a custom `keyBuilder` to match their catalog layout. Translation values include `code`, `field`, `source`, and the original `message`. Missing translations preserve the original validation message unless `fallbackToIssueMessage: false` is set, in which case an `I18nError` with code `I18N_MISSING_MESSAGE` is thrown.
+
+This integration is intentionally not an HTTP adapter. Request locale resolution can happen through `@fluojs/i18n/http`, CLI configuration, WebSocket session state, or any other application boundary, then the chosen locale is passed explicitly to the validation localization helper.
+
 ## Node Filesystem Loader
 
 Node applications can opt into a JSON filesystem loader from the dedicated subpath:
@@ -302,6 +337,17 @@ Both helpers deduplicate keys across locales, sort output for stable diffs, reje
 
 **Types:** `HttpLocaleContext`, `HttpLocaleResolver`, `HttpLocaleResolverInput`, `HttpLocaleResolverResult`, `ResolveHttpLocaleOptions`, `AcceptLanguageLocaleResolverOptions`, `AcceptLanguagePreference`.
 
+### Validation Integration (@fluojs/i18n/validation)
+
+| Export | Description |
+|---|---|
+| `createValidationIssueTranslationKeys(issue, keyPrefix?)` | Builds default translation key candidates from validation issue source, field path, and code. |
+| `localizeValidationIssue(i18n, issue, options, index?)` | Returns a validation issue snapshot with a localized message when a candidate key resolves. |
+| `localizeValidationIssues(i18n, issues, options)` | Localizes an issue list without mutating the original issues. |
+| `localizeDtoValidationError(i18n, error, options)` | Creates a new `DtoValidationError` with localized issue messages. |
+
+**Types:** `LocalizeValidationIssuesOptions`, `ValidationIssueTranslationKeyBuilder`, `ValidationIssueTranslationKeyContext`.
+
 ### ICU MessageFormat (@fluojs/i18n/icu)
 
 | Export | Description |
@@ -340,9 +386,8 @@ Both helpers deduplicate keys across locales, sort output for stable diffs, reje
 
 ## Post-MVP Roadmap
 
-The following features are explicit non-goals for the initial MVP and are planned for future expansion:
+The following feature remains an explicit non-goal for the initial MVP and is planned for future expansion:
 
-- **`@fluojs/i18n/validation`**: Integration with `@fluojs/validation` for localized error messages.
 - **Additional Transport Adapters**: Locale resolution for WebSockets, gRPC, and CLI environments.
 
 ## Related Packages
@@ -350,6 +395,7 @@ The following features are explicit non-goals for the initial MVP and are planne
 
 - **`@fluojs/core`**: Provides module metadata and shared framework errors used by this package.
 - **`@fluojs/config`**: The closest package layout model for module registration and option snapshotting conventions.
+- **`@fluojs/validation`**: Provides the opt-in validation issue contract consumed by `@fluojs/i18n/validation`.
 
 ## Example Sources
 
@@ -358,6 +404,7 @@ The following features are explicit non-goals for the initial MVP and are planne
 - `packages/i18n/src/icu.ts`
 - `packages/i18n/src/loaders/fs.ts`
 - `packages/i18n/src/http.ts`
+- `packages/i18n/src/validation.ts`
 - `packages/i18n/src/index.test.ts`
 - `packages/i18n/src/loaders/remote.ts`
 - `packages/i18n/src/typegen.ts`

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/icu.d.ts",
       "import": "./dist/icu.js"
     },
+    "./validation": {
+      "types": "./dist/validation.d.ts",
+      "import": "./dist/validation.js"
+    },
     "./typegen": {
       "types": "./dist/typegen.d.ts",
       "import": "./dist/typegen.js"
@@ -64,6 +68,7 @@
   "dependencies": {
     "@fluojs/core": "workspace:^",
     "@fluojs/http": "workspace:^",
+    "@fluojs/validation": "workspace:^",
     "intl-messageformat": "^11.2.4"
   },
   "devDependencies": {

--- a/packages/i18n/src/validation.test.ts
+++ b/packages/i18n/src/validation.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import { DefaultValidator, DtoValidationError, IsEmail, IsString, MinLength } from '@fluojs/validation';
+
+import { createI18n } from './index.js';
+import { I18nError } from './errors.js';
+import {
+  createValidationIssueTranslationKeys,
+  localizeDtoValidationError,
+  localizeValidationIssues,
+} from './validation.js';
+import type { LocalizeValidationIssuesOptions, ValidationIssueTranslationKeyBuilder } from './validation.js';
+
+class CreateUserDto {
+  @IsEmail()
+  email = '';
+
+  @IsString()
+  @MinLength(3)
+  name = '';
+}
+
+async function collectValidationError(): Promise<DtoValidationError> {
+  const validator = new DefaultValidator();
+
+  try {
+    await validator.materialize({ email: 'bad-email', name: 'x' }, CreateUserDto);
+  } catch (error) {
+    if (error instanceof DtoValidationError) {
+      return error;
+    }
+  }
+
+  throw new Error('Expected validation to fail.');
+}
+
+describe('@fluojs/i18n/validation localized validation errors', () => {
+  it('keeps validation messages unchanged until applications explicitly localize them', async () => {
+    const error = await collectValidationError();
+
+    expect(error.issues).toEqual([
+      { code: 'EMAIL', field: 'email', message: 'email is invalid.', source: undefined },
+      { code: 'MIN_LENGTH', field: 'name', message: 'name must have length at least 3.', source: undefined },
+    ]);
+  });
+
+  it('localizes validation issues through field/code translation keys', async () => {
+    const error = await collectValidationError();
+    const i18n = createI18n({
+      catalogs: {
+        en: {
+          validation: {
+            email: {
+              EMAIL: '{{ field }} must be a deliverable email address.',
+            },
+            name: {
+              MIN_LENGTH: '{{ field }} is too short.',
+            },
+          },
+        },
+        ko: {
+          validation: {
+            email: {
+              EMAIL: '{{ field }}에는 올바른 이메일 주소가 필요합니다.',
+            },
+            name: {
+              MIN_LENGTH: '{{ field }}의 길이가 너무 짧습니다.',
+            },
+          },
+        },
+      },
+      defaultLocale: 'en',
+      fallbackLocales: { ko: ['en'] },
+      supportedLocales: ['en', 'ko'],
+    });
+
+    const localized = localizeDtoValidationError(i18n, error, { locale: 'ko' });
+
+    expect(localized).toBeInstanceOf(DtoValidationError);
+    expect(localized).not.toBe(error);
+    expect(localized.message).toBe('Validation failed.');
+    expect(localized.issues).toEqual([
+      { code: 'EMAIL', field: 'email', message: 'email에는 올바른 이메일 주소가 필요합니다.', source: undefined },
+      { code: 'MIN_LENGTH', field: 'name', message: 'name의 길이가 너무 짧습니다.', source: undefined },
+    ]);
+    expect(error.issues[0]?.message).toBe('email is invalid.');
+  });
+
+  it('falls back through i18n catalogs and then preserves original messages for missing translations', async () => {
+    const error = await collectValidationError();
+    const i18n = createI18n({
+      catalogs: {
+        en: {
+          validation: {
+            name: {
+              MIN_LENGTH: 'Default {{ field }} length message.',
+            },
+          },
+        },
+        ko: {
+          validation: {},
+        },
+      },
+      defaultLocale: 'en',
+      fallbackLocales: { ko: ['en'] },
+      supportedLocales: ['en', 'ko'],
+    });
+
+    expect(localizeValidationIssues(i18n, error.issues, { locale: 'ko' })).toEqual([
+      { code: 'EMAIL', field: 'email', message: 'email is invalid.', source: undefined },
+      { code: 'MIN_LENGTH', field: 'name', message: 'Default name length message.', source: undefined },
+    ]);
+  });
+
+  it('can make missing validation translations fail explicitly', async () => {
+    const error = await collectValidationError();
+    const i18n = createI18n({
+      catalogs: { en: { validation: {} } },
+      defaultLocale: 'en',
+      supportedLocales: ['en'],
+    });
+
+    expect(() => localizeValidationIssues(i18n, error.issues, { fallbackToIssueMessage: false, locale: 'en' })).toThrow(I18nError);
+  });
+
+  it('supports source/path-specific keys, key prefixes, namespaces, and custom key builders', () => {
+    const i18n = createI18n({
+      catalogs: {
+        en: {
+          errors: {
+            request: {
+              body: {
+                'items[0]': {
+                  name: {
+                    MIN_LENGTH: 'First item name is too short.',
+                  },
+                },
+              },
+            },
+            custom: {
+              CUSTOM_CODE: 'Custom message for {{ field }}.',
+            },
+          },
+        },
+      },
+      defaultLocale: 'en',
+      supportedLocales: ['en'],
+    });
+    const keyBuilder: ValidationIssueTranslationKeyBuilder = ({ issue }) => [`custom.${issue.code}`];
+
+    expect(
+      createValidationIssueTranslationKeys({ code: 'MIN_LENGTH', field: 'items[0].name', message: 'fallback', source: 'body' }, 'request'),
+    ).toEqual([
+      'request.body.items[0].name.MIN_LENGTH',
+      'request.items[0].name.MIN_LENGTH',
+      'request.body.MIN_LENGTH',
+      'request.MIN_LENGTH',
+    ]);
+    expect(
+      localizeValidationIssues(
+        i18n,
+        [{ code: 'MIN_LENGTH', field: 'items[0].name', message: 'fallback', source: 'body' }],
+        { keyPrefix: 'request', locale: 'en', namespace: 'errors' },
+      ),
+    ).toEqual([{ code: 'MIN_LENGTH', field: 'items[0].name', message: 'First item name is too short.', source: 'body' }]);
+    expect(
+      localizeValidationIssues(
+        i18n,
+        [{ code: 'CUSTOM_CODE', field: 'profile', message: 'fallback' }],
+        { keyBuilder, locale: 'en', namespace: 'errors' },
+      ),
+    ).toEqual([{ code: 'CUSTOM_CODE', field: 'profile', message: 'Custom message for profile.' }]);
+  });
+
+  it('exposes the validation subpath without adding validation helpers to the root entry point', async () => {
+    const root = await import('./index.js');
+    const validation = await import('./validation.js');
+    const options: LocalizeValidationIssuesOptions = { locale: 'en' };
+
+    expect(options.locale).toBe('en');
+    expect(Object.keys(root).sort()).toEqual(['I18nError', 'I18nModule', 'I18nService', 'createI18n']);
+    expect(Object.keys(validation).sort()).toEqual([
+      'createValidationIssueTranslationKeys',
+      'localizeDtoValidationError',
+      'localizeValidationIssue',
+      'localizeValidationIssues',
+    ]);
+  });
+});

--- a/packages/i18n/src/validation.ts
+++ b/packages/i18n/src/validation.ts
@@ -1,0 +1,170 @@
+import { DtoValidationError, type ValidationIssue } from '@fluojs/validation';
+
+import { I18nError } from './errors.js';
+import type { I18nInterpolationValues, I18nLocale, I18nTranslationKey } from './types.js';
+import type { I18nService } from './service.js';
+
+/**
+ * Context used to derive translation keys for one validation issue.
+ */
+export interface ValidationIssueTranslationKeyContext {
+  /** Validation issue being localized. */
+  readonly issue: ValidationIssue;
+  /** Zero-based index of the issue in the caller-provided issue list. */
+  readonly index: number;
+}
+
+/**
+ * Builds candidate i18n translation keys for one validation issue.
+ */
+export type ValidationIssueTranslationKeyBuilder = (
+  context: ValidationIssueTranslationKeyContext,
+) => readonly I18nTranslationKey[];
+
+/**
+ * Options for opt-in validation issue localization.
+ */
+export interface LocalizeValidationIssuesOptions {
+  /** Locale used for validation issue message lookup. */
+  readonly locale: I18nLocale;
+  /** Optional namespace passed to `I18nService.translate(...)`. Defaults to `validation`. */
+  readonly namespace?: I18nTranslationKey;
+  /** Optional prefix prepended to generated candidate keys. */
+  readonly keyPrefix?: I18nTranslationKey;
+  /** Custom key builder for applications that own a different catalog shape. */
+  readonly keyBuilder?: ValidationIssueTranslationKeyBuilder;
+  /** Whether missing translations should preserve the original issue message. Defaults to `true`. */
+  readonly fallbackToIssueMessage?: boolean;
+}
+
+const DEFAULT_VALIDATION_NAMESPACE = 'validation';
+
+function isMissingMessageError(error: unknown): boolean {
+  return error instanceof I18nError && error.code === 'I18N_MISSING_MESSAGE';
+}
+
+function appendWithPrefix(keys: string[], keyPrefix: string | undefined, key: string): void {
+  keys.push(keyPrefix === undefined ? key : `${keyPrefix}.${key}`);
+}
+
+function createValidationInterpolationValues(issue: ValidationIssue): I18nInterpolationValues {
+  return {
+    code: issue.code,
+    field: issue.field,
+    message: issue.message,
+    source: issue.source,
+  };
+}
+
+/**
+ * Creates default translation key candidates for a validation issue.
+ *
+ * @remarks
+ * Candidate order is most-specific to least-specific: `source.field.code`, `field.code`, `source.code`, then `code`.
+ * The optional `keyPrefix` is prepended to each candidate. Field paths are preserved as authored by
+ * `@fluojs/validation`, allowing catalogs to mirror dot/bracket validation paths explicitly.
+ *
+ * @param issue Validation issue to map into translation keys.
+ * @param keyPrefix Optional catalog prefix prepended before generated keys.
+ * @returns Ordered translation key candidates.
+ */
+export function createValidationIssueTranslationKeys(
+  issue: ValidationIssue,
+  keyPrefix?: I18nTranslationKey,
+): readonly I18nTranslationKey[] {
+  const keys: string[] = [];
+
+  if (issue.source !== undefined && issue.field !== undefined) {
+    appendWithPrefix(keys, keyPrefix, `${issue.source}.${issue.field}.${issue.code}`);
+  }
+
+  if (issue.field !== undefined) {
+    appendWithPrefix(keys, keyPrefix, `${issue.field}.${issue.code}`);
+  }
+
+  if (issue.source !== undefined) {
+    appendWithPrefix(keys, keyPrefix, `${issue.source}.${issue.code}`);
+  }
+
+  appendWithPrefix(keys, keyPrefix, issue.code);
+
+  return Object.freeze(keys);
+}
+
+/**
+ * Localizes one validation issue by resolving explicit translation key candidates.
+ *
+ * @param i18n I18n service used for catalog lookup.
+ * @param issue Validation issue whose message should be localized.
+ * @param options Explicit locale and optional key mapping controls.
+ * @param index Zero-based index used only by custom key builders.
+ * @returns A new validation issue with a localized message when a candidate resolves.
+ * @throws {I18nError} When no translation resolves and `fallbackToIssueMessage` is `false`.
+ */
+export function localizeValidationIssue(
+  i18n: I18nService,
+  issue: ValidationIssue,
+  options: LocalizeValidationIssuesOptions,
+  index = 0,
+): ValidationIssue {
+  const namespace = options.namespace ?? DEFAULT_VALIDATION_NAMESPACE;
+  const keys = options.keyBuilder?.({ index, issue }) ?? createValidationIssueTranslationKeys(issue, options.keyPrefix);
+  const values = createValidationInterpolationValues(issue);
+
+  for (const key of keys) {
+    try {
+      return {
+        ...issue,
+        message: i18n.translate(key, {
+          locale: options.locale,
+          namespace,
+          values,
+        }),
+      };
+    } catch (error) {
+      if (isMissingMessageError(error)) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  if (options.fallbackToIssueMessage === false) {
+    throw new I18nError(`Missing validation i18n message for issue code: ${issue.code}`, 'I18N_MISSING_MESSAGE');
+  }
+
+  return { ...issue };
+}
+
+/**
+ * Localizes validation issues without mutating the original issue objects.
+ *
+ * @param i18n I18n service used for catalog lookup.
+ * @param issues Validation issues from `@fluojs/validation`.
+ * @param options Explicit locale and optional key mapping controls.
+ * @returns Localized validation issue snapshots.
+ */
+export function localizeValidationIssues(
+  i18n: I18nService,
+  issues: readonly ValidationIssue[],
+  options: LocalizeValidationIssuesOptions,
+): readonly ValidationIssue[] {
+  return Object.freeze(issues.map((issue, index) => localizeValidationIssue(i18n, issue, options, index)));
+}
+
+/**
+ * Creates a new `DtoValidationError` with localized issue messages.
+ *
+ * @param i18n I18n service used for catalog lookup.
+ * @param error Validation error from `@fluojs/validation`.
+ * @param options Explicit locale and optional key mapping controls.
+ * @returns A new validation error that preserves the original top-level error message and localized issue snapshots.
+ */
+export function localizeDtoValidationError(
+  i18n: I18nService,
+  error: DtoValidationError,
+  options: LocalizeValidationIssuesOptions,
+): DtoValidationError {
+  return new DtoValidationError(error.message, localizeValidationIssues(i18n, error.issues, options));
+}

--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -26,6 +26,7 @@ pnpm add @fluojs/validation
 - 컨트롤러나 서비스에서 ad hoc parsing 대신 class 기반 검증 규칙을 쓰고 싶을 때
 - `PickType`, `PartialType`, `IntersectionType` 같은 metadata-preserving mapped DTO helper가 필요할 때
 - `@ValidateClass(...)`로 Zod나 Valibot 같은 Standard Schema validator를 붙이고 싶을 때
+- `@fluojs/i18n/validation`으로 명시적으로 localize할 수 있는 안정적인 validation issue code와 path가 필요할 때
 
 ## 빠른 시작
 
@@ -96,6 +97,8 @@ type ValidationIssue = {
 사용합니다. HTTP 바인딩에서 온 규칙은 `source`를 붙이며, standalone validation이나
 Standard Schema 이슈에서는 값이 없을 수 있습니다.
 
+`@fluojs/validation`은 항상 기존 human-readable `message` 값을 방출합니다. Localized message가 필요한 애플리케이션은 validation 실패 후 `@fluojs/i18n/validation`에 opt-in할 수 있습니다. 이 통합은 validator 실행을 바꾸거나 이 패키지를 HTTP locale resolution에 결합하지 않고 `source`, `field`, `code`를 translation key로 매핑합니다.
+
 ### Mapped DTO 헬퍼
 
 ```ts
@@ -154,6 +157,7 @@ class RestrictedUserDto {
 ## 관련 패키지
 
 - `@fluojs/http`: request data를 bind한 뒤 이 패키지로 검증합니다.
+- `@fluojs/i18n`: opt-in localized validation issue message를 위한 `@fluojs/i18n/validation`을 제공합니다.
 - `@fluojs/serialization`: response side에서 output DTO를 가공합니다.
 - `@fluojs/core`: validation decorator가 사용하는 metadata primitive를 제공합니다.
 

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -26,6 +26,7 @@ pnpm add @fluojs/validation
 - when you want class-based validation rules instead of ad hoc parsing in controllers and services
 - when you need metadata-preserving mapped DTO helpers such as `PickType`, `PartialType`, and `IntersectionType`
 - when you want to attach Standard Schema validators such as Zod or Valibot through `@ValidateClass(...)`
+- when you want stable validation issue codes and paths that can be localized explicitly through `@fluojs/i18n/validation`
 
 ## Quick Start
 
@@ -100,6 +101,8 @@ Nested DTOs use dot paths and collection indexes, such as `address.city` or
 `items[0].name`. HTTP bindings attach `source` when the rule came from request
 metadata; standalone validation and Standard Schema issues may leave it unset.
 
+`@fluojs/validation` always emits its normal human-readable `message` values. Applications that need localized messages can opt into `@fluojs/i18n/validation` after validation fails. That integration maps `source`, `field`, and `code` to translation keys without changing validator execution or coupling this package to HTTP locale resolution.
+
 ### Mapped DTO helpers
 
 ```ts
@@ -158,6 +161,7 @@ Numeric validators, including `@IsLatitude()` and `@IsLongitude()`, validate num
 ## Related Packages
 
 - `@fluojs/http`: binds request data, then uses this package to validate it
+- `@fluojs/i18n`: exposes `@fluojs/i18n/validation` for opt-in localized validation issue messages
 - `@fluojs/serialization`: shapes output DTOs on the response side
 - `@fluojs/core`: provides the metadata primitives used by validation decorators
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
       '@fluojs/http':
         specifier: workspace:^
         version: link:../http
+      '@fluojs/validation':
+        specifier: workspace:^
+        version: link:../validation
       intl-messageformat:
         specifier: ^11.2.4
         version: 11.2.4


### PR DESCRIPTION
## Summary

- Adds the opt-in `@fluojs/i18n/validation` subpath for localized `@fluojs/validation` issue messages.
- Preserves default validation behavior unless applications explicitly localize validation errors.

Closes #1727

## Changes

- Added validation issue translation key generation and localization helpers for issue arrays and `DtoValidationError` snapshots.
- Added the `@fluojs/i18n/validation` package export and workspace dependency on `@fluojs/validation`.
- Documented EN/KO i18n and validation README usage, fallback behavior, and the non-HTTP package boundary.
- Added a minor changeset for `@fluojs/i18n`.

## Testing

- `pnpm --dir packages/i18n test`
- `pnpm --dir packages/di build && pnpm --dir packages/http build && pnpm --dir packages/i18n typecheck && pnpm --dir packages/i18n build`
- `pnpm --dir packages/validation typecheck`
- `pnpm --dir packages/validation test`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm exec biome lint packages/i18n/src/validation.ts packages/i18n/src/validation.test.ts packages/i18n/README.md packages/i18n/README.ko.md packages/validation/README.md packages/validation/README.ko.md packages/i18n/package.json pnpm-lock.yaml .changeset/i18n-validation-localized-errors.md`
- `pnpm verify:public-export-tsdoc`
- LSP diagnostics: clean for `packages/i18n/src/validation.ts`, `packages/i18n/src/validation.test.ts`, and `packages/i18n` errors.

Note: full `pnpm lint` was attempted and is blocked by existing unrelated repository diagnostics outside this PR, while changed-file Biome lint and public export TSDoc checks pass.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform adapter conformance claims changed.