### PR TITLE
Resolve #1730: Add i18n locale adapters

### DIFF
--- a/.changeset/i18n-non-http-locale-adapters.md
+++ b/.changeset/i18n-non-http-locale-adapters.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/i18n": minor
+---
+
+Add the `@fluojs/i18n/adapters` subpath with opt-in non-HTTP locale resolvers and stores for WebSocket, gRPC, CLI, local storage, and request-style abstractions.

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -29,7 +29,7 @@ fluo는 TC39 표준 데코레이터, 명시적 의존성 경계, 메타데이터
 | Operations | 헬스, 메트릭, 스로틀링 | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
 | Tooling | CLI, 진단 도구, Vite 빌드 통합 | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing`, `@fluojs/vite` |
 
-정식 패키지 및 런타임 범위는 [`docs/reference/package-surface.md`](./reference/package-surface.md)에 있으며, fluo-native `@fluojs/i18n` package boundary, plural/select localization을 위한 `@fluojs/i18n/icu` ICU MessageFormat subpath 같은 core 추가 항목과 `@fluojs/mongoose`의 ALS/session transaction 책임 같은 persistence 책임도 포함한다. 작업 기반 패키지 발견성은 [`docs/reference/package-chooser.md`](./reference/package-chooser.md)에 있으며, `@fluojs/i18n`과 그 ICU subpath를 위한 localization/i18n 선택 guidance도 포함한다.
+정식 패키지 및 런타임 범위는 [`docs/reference/package-surface.md`](./reference/package-surface.md)에 있으며, fluo-native `@fluojs/i18n` package boundary, plural/select localization을 위한 `@fluojs/i18n/icu` ICU MessageFormat subpath, opt-in non-HTTP locale resolution을 위한 `@fluojs/i18n/adapters` subpath 같은 core 추가 항목과 `@fluojs/mongoose`의 ALS/session transaction 책임 같은 persistence 책임도 포함한다. 작업 기반 패키지 발견성은 [`docs/reference/package-chooser.md`](./reference/package-chooser.md)에 있으며, `@fluojs/i18n`, 그 ICU subpath, non-HTTP adapter subpath를 위한 localization/i18n 선택 guidance도 포함한다.
 
 ## File Structure
 

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -29,7 +29,7 @@ fluo is a standard-first TypeScript backend framework built on TC39 standard dec
 | Operations | Health, metrics, throttling | `@fluojs/metrics`, `@fluojs/terminus`, `@fluojs/throttler` |
 | Tooling | CLI, diagnostics, and Vite build integration | `@fluojs/cli`, `@fluojs/studio`, `@fluojs/testing`, `@fluojs/vite` |
 
-Canonical package and runtime coverage lives in [`docs/reference/package-surface.md`](./reference/package-surface.md), including core additions such as the fluo-native `@fluojs/i18n` package boundary, its `@fluojs/i18n/icu` ICU MessageFormat subpath for plural/select localization, and persistence responsibilities such as `@fluojs/mongoose` ALS/session transaction ownership. Task-based package discovery lives in [`docs/reference/package-chooser.md`](./reference/package-chooser.md), including localization/i18n selection guidance for `@fluojs/i18n` and its ICU subpath.
+Canonical package and runtime coverage lives in [`docs/reference/package-surface.md`](./reference/package-surface.md), including core additions such as the fluo-native `@fluojs/i18n` package boundary, its `@fluojs/i18n/icu` ICU MessageFormat subpath for plural/select localization, its `@fluojs/i18n/adapters` subpath for opt-in non-HTTP locale resolution, and persistence responsibilities such as `@fluojs/mongoose` ALS/session transaction ownership. Task-based package discovery lives in [`docs/reference/package-chooser.md`](./reference/package-chooser.md), including localization/i18n selection guidance for `@fluojs/i18n`, its ICU subpath, and its non-HTTP adapter subpath.
 
 ## File Structure
 

--- a/docs/reference/package-chooser.ko.md
+++ b/docs/reference/package-chooser.ko.md
@@ -16,7 +16,7 @@
 | Node.js HTTP를 직접 제어해야 함 | `@fluojs/platform-nodejs` | Node.js에서 first-class `fluo new` 애플리케이션 스타터로도 제공됩니다. |
 | 요청 유효성 검사가 필요함 | `@fluojs/validation` | DTO 바인딩과 검증이 필요할 때 추가합니다. |
 | 타입 안전 설정 접근이 필요함 | `@fluojs/config` | 패키지 내부의 직접 `process.env` 접근 대신 사용합니다. |
-| localization 또는 i18n service가 필요함 | `@fluojs/i18n` | framework-agnostic internationalization module registration, standalone service 생성, 공유 option/error type, `@fluojs/i18n/icu` ICU MessageFormat plural/select 지원에 사용합니다. |
+| localization 또는 i18n service가 필요함 | `@fluojs/i18n` | framework-agnostic internationalization module registration, standalone service 생성, 공유 option/error type, `@fluojs/i18n/icu` ICU MessageFormat plural/select 지원, `@fluojs/i18n/adapters` opt-in non-HTTP locale resolution에 사용합니다. |
 
 ## 엣지 / 모던 런타임에 배포
 

--- a/docs/reference/package-chooser.md
+++ b/docs/reference/package-chooser.md
@@ -16,7 +16,7 @@
 | Need direct Node.js HTTP control | `@fluojs/platform-nodejs` | Also available as a first-class `fluo new` application starter on Node.js. |
 | Need request validation | `@fluojs/validation` | Add when DTO binding and validation are required. |
 | Need typed configuration access | `@fluojs/config` | Use instead of direct `process.env` access inside packages. |
-| Need localization or i18n services | `@fluojs/i18n` | Use for framework-agnostic internationalization module registration, standalone service creation, shared option/error types, and `@fluojs/i18n/icu` ICU MessageFormat plural/select support. |
+| Need localization or i18n services | `@fluojs/i18n` | Use for framework-agnostic internationalization module registration, standalone service creation, shared option/error types, `@fluojs/i18n/icu` ICU MessageFormat plural/select support, and `@fluojs/i18n/adapters` opt-in non-HTTP locale resolution. |
 
 ## deploy to edge / modern runtimes
 

--- a/docs/reference/package-surface.ko.md
+++ b/docs/reference/package-surface.ko.md
@@ -33,7 +33,7 @@
 - **`@fluojs/core`**: 메타데이터 헬퍼 및 TC39 표준 데코레이터 지원.
 - **`@fluojs/di`**: 프로바이더 해결, 라이프사이클 스코프, 의존성 그래프 분석.
 - **`@fluojs/config`**: 환경 인식 설정 로딩 및 타입 안전 접근.
-- **`@fluojs/i18n`**: module registration, standalone service factory, reserved core option/error type, `@fluojs/i18n/icu`를 통한 ICU MessageFormat 지원을 제공하는 framework-agnostic internationalization package boundary.
+- **`@fluojs/i18n`**: module registration, standalone service factory, reserved core option/error type, `@fluojs/i18n/icu`를 통한 ICU MessageFormat 지원, `@fluojs/i18n/adapters`를 통한 opt-in non-HTTP locale adapter를 제공하는 framework-agnostic internationalization package boundary.
 - **`@fluojs/runtime`**: 애플리케이션 부트스트랩, 모듈 오케스트레이션, 플랫폼 셸 등록, 플랫폼 snapshot 생산. 공개 런타임 헬퍼는 `@fluojs/runtime/node`와 `@fluojs/runtime/web`에서 제공됩니다.
 
 ### adapters

--- a/docs/reference/package-surface.md
+++ b/docs/reference/package-surface.md
@@ -33,7 +33,7 @@
 - **`@fluojs/core`**: Metadata helpers and TC39-standard decorator support.
 - **`@fluojs/di`**: Provider resolution, lifecycle scopes, and dependency graph analysis.
 - **`@fluojs/config`**: Environment-aware configuration loading and typed access.
-- **`@fluojs/i18n`**: Framework-agnostic internationalization package boundary with module registration, a standalone service factory, reserved core option/error types, and ICU MessageFormat support through `@fluojs/i18n/icu`.
+- **`@fluojs/i18n`**: Framework-agnostic internationalization package boundary with module registration, a standalone service factory, reserved core option/error types, ICU MessageFormat support through `@fluojs/i18n/icu`, and opt-in non-HTTP locale adapters through `@fluojs/i18n/adapters`.
 - **`@fluojs/runtime`**: Application bootstrap, module orchestration, platform shell registration, and platform snapshot production. Public runtime helpers are exposed through `@fluojs/runtime/node` and `@fluojs/runtime/web`.
 
 ### adapters

--- a/packages/i18n/README.ko.md
+++ b/packages/i18n/README.ko.md
@@ -13,6 +13,7 @@ fluo 애플리케이션을 위한 프레임워크 비종속 국제화 코어 표
 - [포맷팅](#포맷팅)
 - [ICU MessageFormat](#icu-messageformat)
 - [HTTP Locale Context Adapter](#http-locale-context-adapter)
+- [Non-HTTP Locale Adapters](#non-http-locale-adapters)
 - [Validation Error Localization](#validation-error-localization)
 - [Node Filesystem Loader](#node-filesystem-loader)
 - [Remote Catalog Loader](#remote-catalog-loader)
@@ -39,6 +40,7 @@ i18n 작업을 위한 안정적인 fluo-native 패키지 경계가 필요할 때
 - `@fluojs/i18n/icu`를 통한 선택적 ICU MessageFormat 복수형/select 포맷팅.
 - 명시적 로케일을 사용하는 표준 `Intl` 포맷팅 헬퍼.
 - `@fluojs/i18n/http`를 통한 명시적 HTTP `RequestContext` 로케일 헬퍼.
+- `@fluojs/i18n/adapters`를 통한 WebSocket, gRPC, CLI, local storage, server-request abstraction용 opt-in non-HTTP locale adapter.
 - `@fluojs/i18n/validation`을 통한 opt-in `@fluojs/validation` issue localization.
 - `@fluojs/i18n/loaders/remote`를 통한 provider-backed remote catalog loading.
 - `@fluojs/i18n/typegen`을 통한 opt-in catalog key declaration generation.
@@ -199,6 +201,62 @@ Adapter는 의도적으로 explicit합니다:
 
 Wildcard `*` range는 parse되지만 자동으로 locale을 선택하지는 않습니다. Wildcard별 동작이 필요한 애플리케이션은 제공된 `Accept-Language` resolver 앞이나 뒤에 resolver를 추가할 수 있습니다.
 
+## Non-HTTP Locale Adapters
+
+Non-HTTP locale helper는 `@fluojs/i18n/adapters` subpath에서 제공합니다. WebSocket handshake, gRPC metadata, CLI option object, local storage wrapper, server session, request-like abstraction에 resolver-order locale selection을 제공하되 root package를 browser global, Node process state, framework-specific transport package와 결합하지 않습니다.
+
+```ts
+import {
+  bindLocale,
+  createHeaderLocaleResolver,
+  createQueryLocaleResolver,
+  createWeakMapLocaleStore,
+  getAdapterLocale,
+} from '@fluojs/i18n/adapters';
+
+interface SocketContext {
+  readonly handshake: {
+    readonly headers: Readonly<Record<string, string | undefined>>;
+    readonly query: Readonly<Record<string, string | undefined>>;
+  };
+}
+
+const socketLocales = createWeakMapLocaleStore<SocketContext>();
+
+const queryLocale = createQueryLocaleResolver<SocketContext>({
+  getQueryValue: (socket) => socket.handshake.query.locale,
+  source: 'socket-query',
+});
+const headerLocale = createHeaderLocaleResolver<SocketContext>({
+  getHeader: (socket) => socket.handshake.headers['accept-language'],
+  source: 'socket-accept-language',
+});
+
+function bindSocketLocale(socket: SocketContext) {
+  return bindLocale(socket, {
+    defaultLocale: 'en',
+    supportedLocales: ['en', 'ko'],
+    resolvers: [queryLocale, headerLocale],
+    store: socketLocales,
+  });
+}
+
+function handleSocketMessage(socket: SocketContext) {
+  const locale = getAdapterLocale(socketLocales, socket)?.locale ?? 'en';
+  return locale;
+}
+```
+
+Generic adapter contract는 의도적으로 explicit합니다.
+
+- `resolveLocale(context, options)`는 application-provided resolver를 배열 순서대로 실행하고 empty, invalid, unsupported resolver output을 무시하며, 아무 것도 match하지 않으면 `defaultLocale`을 source `default`로 반환합니다.
+- `bindLocale(context, { store, ...options })`는 locale을 resolve한 뒤 application-provided `LocaleAdapterStore`에 immutable metadata를 저장합니다.
+- `createWeakMapLocaleStore()`는 socket, call, session, request object를 mutate하지 않고 per-object metadata storage를 제공합니다.
+- `createHeaderLocaleResolver(...)`는 HTTP adapter와 같은 q-value 및 wildcard 동작으로 `Accept-Language` style 값을 parse합니다.
+- `createQueryLocaleResolver(...)`, `createCookieLocaleResolver(...)`, `createStorageLocaleResolver(...)`는 caller-owned abstraction에서 locale candidate를 읽고 browser global이나 framework internal에는 접근하지 않습니다.
+
+애플리케이션이 context shape와 accessor function을 선택합니다. 예를 들어 gRPC 통합은 `getHeader`로 metadata를 읽고, CLI 통합은 parsed `--locale` option을 `getQueryValue` 또는 `getStoredLocale`로 읽으며, browser application은 `localStorage` around safe wrapper를 `getStoredLocale`에 전달할 수 있습니다.
+
 ## Validation Error Localization
 
 Validation issue localization은 `@fluojs/i18n/validation` subpath에서 제공합니다. 따라서 root `@fluojs/i18n` entry point는 framework-agnostic 상태를 유지하고, `@fluojs/validation` 기본 동작도 바꾸지 않습니다. 애플리케이션은 validation 실패 후 `ValidationIssue.message` snapshot을 명시적으로 번역해 opt-in합니다.
@@ -337,6 +395,22 @@ const declarations = generateI18nCatalogTypes([
 
 **타입:** `HttpLocaleContext`, `HttpLocaleResolver`, `HttpLocaleResolverInput`, `HttpLocaleResolverResult`, `ResolveHttpLocaleOptions`, `AcceptLanguageLocaleResolverOptions`, `AcceptLanguagePreference`.
 
+### Non-HTTP Adapters (@fluojs/i18n/adapters)
+
+| Export | 설명 |
+|---|---|
+| `resolveLocale` | 명시적 non-HTTP resolver chain에서 locale metadata를 resolve합니다. |
+| `bindLocale` | Caller-provided adapter store에 locale metadata를 resolve하고 저장합니다. |
+| `setAdapterLocale` | Caller-provided adapter store에 locale metadata를 수동으로 저장합니다. |
+| `getAdapterLocale` | Caller-provided adapter store에서 locale metadata를 가져옵니다. |
+| `createWeakMapLocaleStore` | Transport context를 mutate하지 않는 per-object metadata storage를 생성합니다. |
+| `createHeaderLocaleResolver` | Caller-owned header abstraction용 `Accept-Language` style resolver를 생성합니다. |
+| `createQueryLocaleResolver` | Query, CLI option, request parameter abstraction용 resolver를 생성합니다. |
+| `createCookieLocaleResolver` | Caller-owned cookie abstraction용 resolver를 생성합니다. |
+| `createStorageLocaleResolver` | Local storage, server session, socket data, CLI config abstraction용 resolver를 생성합니다. |
+
+**타입:** `LocaleAdapterContext`, `LocaleAdapterResolver`, `LocaleAdapterResolverInput`, `LocaleAdapterResolverResult`, `LocaleAdapterStore`, `ResolveLocaleOptions`, `BindLocaleOptions`, `HeaderLocaleResolverOptions`, `QueryLocaleResolverOptions`, `CookieLocaleResolverOptions`, `StorageLocaleResolverOptions`.
+
 ### Validation Integration (@fluojs/i18n/validation)
 
 | Export | 설명 |
@@ -386,10 +460,7 @@ const declarations = generateI18nCatalogTypes([
 
 ## Post-MVP 로드맵
 
-
-다음 기능은 초기 MVP의 명시적 비목표로 남아 있으며 향후 확장이 계획되어 있습니다.
-
-- **Additional Transport Adapters**: WebSockets, gRPC 및 CLI 환경을 위한 로케일 처리.
+WebSocket, gRPC, CLI, local storage, request-style abstraction을 위한 core locale-resolution roadmap item은 이제 `@fluojs/i18n/adapters`에서 사용할 수 있습니다. 향후 transport 작업은 dedicated framework package가 통합을 소유하지 않는 한 opt-in 및 subpath-scoped 상태를 유지해야 합니다.
 
 ## 관련 패키지
 
@@ -405,6 +476,7 @@ const declarations = generateI18nCatalogTypes([
 - `packages/i18n/src/icu.ts`
 - `packages/i18n/src/loaders/fs.ts`
 - `packages/i18n/src/http.ts`
+- `packages/i18n/src/adapters.ts`
 - `packages/i18n/src/validation.ts`
 - `packages/i18n/src/index.test.ts`
 - `packages/i18n/src/loaders/remote.ts`

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -13,6 +13,7 @@ Framework-agnostic internationalization core surface for fluo applications.
 - [Formatting](#formatting)
 - [ICU MessageFormat](#icu-messageformat)
 - [HTTP Locale Context Adapter](#http-locale-context-adapter)
+- [Non-HTTP Locale Adapters](#non-http-locale-adapters)
 - [Validation Error Localization](#validation-error-localization)
 - [Node Filesystem Loader](#node-filesystem-loader)
 - [Remote Catalog Loader](#remote-catalog-loader)
@@ -39,6 +40,7 @@ Use this package when you need a stable fluo-native package boundary for i18n wo
 - optional ICU MessageFormat plural/select formatting through `@fluojs/i18n/icu`
 - standard `Intl` formatting helpers with explicit locales
 - explicit HTTP `RequestContext` locale helpers through `@fluojs/i18n/http`
+- opt-in non-HTTP locale adapters for WebSocket, gRPC, CLI, local storage, and server-request abstractions through `@fluojs/i18n/adapters`
 - opt-in `@fluojs/validation` issue localization through `@fluojs/i18n/validation`
 - provider-backed remote catalog loading through `@fluojs/i18n/loaders/remote`
 - opt-in catalog key declaration generation through `@fluojs/i18n/typegen`
@@ -199,6 +201,62 @@ The adapter is intentionally explicit:
 
 Wildcard `*` ranges are parsed but do not automatically select a locale. Applications that want wildcard-specific behavior can add a resolver before or after the provided `Accept-Language` resolver.
 
+## Non-HTTP Locale Adapters
+
+Non-HTTP locale helpers live under the `@fluojs/i18n/adapters` subpath. They provide resolver-order locale selection for WebSocket handshakes, gRPC metadata, CLI option objects, local storage wrappers, server sessions, and request-like abstractions without coupling the root package to browser globals, Node process state, or framework-specific transport packages.
+
+```ts
+import {
+  bindLocale,
+  createHeaderLocaleResolver,
+  createQueryLocaleResolver,
+  createWeakMapLocaleStore,
+  getAdapterLocale,
+} from '@fluojs/i18n/adapters';
+
+interface SocketContext {
+  readonly handshake: {
+    readonly headers: Readonly<Record<string, string | undefined>>;
+    readonly query: Readonly<Record<string, string | undefined>>;
+  };
+}
+
+const socketLocales = createWeakMapLocaleStore<SocketContext>();
+
+const queryLocale = createQueryLocaleResolver<SocketContext>({
+  getQueryValue: (socket) => socket.handshake.query.locale,
+  source: 'socket-query',
+});
+const headerLocale = createHeaderLocaleResolver<SocketContext>({
+  getHeader: (socket) => socket.handshake.headers['accept-language'],
+  source: 'socket-accept-language',
+});
+
+function bindSocketLocale(socket: SocketContext) {
+  return bindLocale(socket, {
+    defaultLocale: 'en',
+    supportedLocales: ['en', 'ko'],
+    resolvers: [queryLocale, headerLocale],
+    store: socketLocales,
+  });
+}
+
+function handleSocketMessage(socket: SocketContext) {
+  const locale = getAdapterLocale(socketLocales, socket)?.locale ?? 'en';
+  return locale;
+}
+```
+
+The generic adapter contract is intentionally explicit:
+
+- `resolveLocale(context, options)` runs application-provided resolvers in order, ignores empty, invalid, and unsupported resolver output, and returns `defaultLocale` with source `default` when nothing matches.
+- `bindLocale(context, { store, ...options })` resolves a locale and stores immutable metadata in an application-provided `LocaleAdapterStore`.
+- `createWeakMapLocaleStore()` provides per-object metadata storage for socket, call, session, or request objects without mutating those objects.
+- `createHeaderLocaleResolver(...)` parses `Accept-Language`-style values with the same q-value and wildcard behavior as the HTTP adapter.
+- `createQueryLocaleResolver(...)`, `createCookieLocaleResolver(...)`, and `createStorageLocaleResolver(...)` read locale candidates from caller-owned abstractions and never access browser globals or framework internals.
+
+Applications choose the context shape and accessor functions. For example, a gRPC integration can read metadata through `getHeader`, a CLI integration can read a parsed `--locale` option through `getQueryValue` or `getStoredLocale`, and a browser application can pass a safe wrapper around `localStorage` through `getStoredLocale`.
+
 ## Validation Error Localization
 
 Validation issue localization lives under `@fluojs/i18n/validation` so the root `@fluojs/i18n` entry point stays framework-agnostic and does not change `@fluojs/validation` behavior by default. Applications opt in after validation fails by translating `ValidationIssue.message` snapshots explicitly.
@@ -337,6 +395,22 @@ Both helpers deduplicate keys across locales, sort output for stable diffs, reje
 
 **Types:** `HttpLocaleContext`, `HttpLocaleResolver`, `HttpLocaleResolverInput`, `HttpLocaleResolverResult`, `ResolveHttpLocaleOptions`, `AcceptLanguageLocaleResolverOptions`, `AcceptLanguagePreference`.
 
+### Non-HTTP Adapters (@fluojs/i18n/adapters)
+
+| Export | Description |
+|---|---|
+| `resolveLocale` | Resolves locale metadata from an explicit non-HTTP resolver chain. |
+| `bindLocale` | Resolves and stores locale metadata in a caller-provided adapter store. |
+| `setAdapterLocale` | Manually stores locale metadata in a caller-provided adapter store. |
+| `getAdapterLocale` | Retrieves locale metadata from a caller-provided adapter store. |
+| `createWeakMapLocaleStore` | Creates per-object metadata storage without mutating transport contexts. |
+| `createHeaderLocaleResolver` | Creates an `Accept-Language`-style resolver for caller-owned header abstractions. |
+| `createQueryLocaleResolver` | Creates a resolver for query, CLI option, or request parameter abstractions. |
+| `createCookieLocaleResolver` | Creates a resolver for caller-owned cookie abstractions. |
+| `createStorageLocaleResolver` | Creates a resolver for local storage, server session, socket data, or CLI config abstractions. |
+
+**Types:** `LocaleAdapterContext`, `LocaleAdapterResolver`, `LocaleAdapterResolverInput`, `LocaleAdapterResolverResult`, `LocaleAdapterStore`, `ResolveLocaleOptions`, `BindLocaleOptions`, `HeaderLocaleResolverOptions`, `QueryLocaleResolverOptions`, `CookieLocaleResolverOptions`, `StorageLocaleResolverOptions`.
+
 ### Validation Integration (@fluojs/i18n/validation)
 
 | Export | Description |
@@ -386,9 +460,7 @@ Both helpers deduplicate keys across locales, sort output for stable diffs, reje
 
 ## Post-MVP Roadmap
 
-The following feature remains an explicit non-goal for the initial MVP and is planned for future expansion:
-
-- **Additional Transport Adapters**: Locale resolution for WebSockets, gRPC, and CLI environments.
+The core locale-resolution roadmap item for WebSocket, gRPC, CLI, local storage, and request-style abstractions is now available through `@fluojs/i18n/adapters`. Future transport work should stay opt-in and subpath-scoped unless a dedicated framework package owns the integration.
 
 ## Related Packages
 
@@ -404,6 +476,7 @@ The following feature remains an explicit non-goal for the initial MVP and is pl
 - `packages/i18n/src/icu.ts`
 - `packages/i18n/src/loaders/fs.ts`
 - `packages/i18n/src/http.ts`
+- `packages/i18n/src/adapters.ts`
 - `packages/i18n/src/validation.ts`
 - `packages/i18n/src/index.test.ts`
 - `packages/i18n/src/loaders/remote.ts`

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/http.d.ts",
       "import": "./dist/http.js"
     },
+    "./adapters": {
+      "types": "./dist/adapters.d.ts",
+      "import": "./dist/adapters.js"
+    },
     "./icu": {
       "types": "./dist/icu.d.ts",
       "import": "./dist/icu.js"

--- a/packages/i18n/src/adapters.test.ts
+++ b/packages/i18n/src/adapters.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest';
+
+import { createAcceptLanguageLocaleResolver, resolveHttpLocale, type HttpLocaleResolver } from './http.js';
+import {
+  bindLocale,
+  createCookieLocaleResolver,
+  createHeaderLocaleResolver,
+  createQueryLocaleResolver,
+  createStorageLocaleResolver,
+  createWeakMapLocaleStore,
+  getAdapterLocale,
+  resolveLocale,
+  setAdapterLocale,
+  type LocaleAdapterResolver,
+} from './adapters.js';
+
+type HttpRequestContext = Parameters<typeof resolveHttpLocale>[0];
+
+interface TransportContext {
+  readonly headers?: Readonly<Record<string, string | readonly string[] | undefined>>;
+  readonly query?: Readonly<Record<string, string | readonly string[] | undefined>>;
+  readonly cookies?: Readonly<Record<string, string | undefined>>;
+  readonly storage?: Readonly<Record<string, string | undefined>>;
+}
+
+function createMockHttpContext(headers: HttpRequestContext['request']['headers'] = {}): HttpRequestContext {
+  const responseHeaders: Record<string, string | string[]> = {};
+
+  return {
+    container: {
+      async dispose() {},
+      async resolve() {
+        throw new Error('No providers are registered in this test request context.');
+      },
+    },
+    metadata: {},
+    request: {
+      body: undefined,
+      cookies: {},
+      headers,
+      method: 'GET',
+      params: {},
+      path: '/localized',
+      query: {},
+      raw: {},
+      url: '/localized',
+    },
+    requestId: 'req_locale',
+    response: {
+      committed: false,
+      headers: responseHeaders,
+      redirect() {},
+      send() {},
+      setHeader(name: string, value: string | string[]) {
+        responseHeaders[name] = value;
+      },
+      setStatus(code: number) {
+        this.statusCode = code;
+      },
+      statusCode: 200,
+    },
+  };
+}
+
+describe('@fluojs/i18n/adapters locale adapter surface', () => {
+  it('keeps the adapter exports isolated from the root package surface', async () => {
+    const root = await import('./index.js');
+    const adapters = await import('./adapters.js');
+
+    expect(Object.keys(root).sort()).toEqual(['I18nError', 'I18nModule', 'I18nService', 'createI18n']);
+    expect(Object.keys(adapters).sort()).toEqual([
+      'bindLocale',
+      'createCookieLocaleResolver',
+      'createHeaderLocaleResolver',
+      'createQueryLocaleResolver',
+      'createStorageLocaleResolver',
+      'createWeakMapLocaleStore',
+      'getAdapterLocale',
+      'resolveLocale',
+      'setAdapterLocale',
+    ]);
+  });
+
+  it('resolves header, query, cookie, and storage adapters in explicit order', () => {
+    const context: TransportContext = {
+      cookies: { locale: 'ko' },
+      headers: { 'accept-language': 'fr;q=1, ko;q=0.9' },
+      query: { locale: 'en' },
+      storage: { locale: 'ja' },
+    };
+
+    const locale = resolveLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [
+        createQueryLocaleResolver({ getQueryValue: (ctx) => ctx.query?.locale }),
+        createCookieLocaleResolver({ getCookieValue: (ctx) => ctx.cookies?.locale }),
+        createHeaderLocaleResolver({ getHeader: (ctx) => ctx.headers?.['accept-language'] }),
+        createStorageLocaleResolver({ getStoredLocale: (ctx) => ctx.storage?.locale }),
+      ],
+      supportedLocales: ['en', 'ko', 'fr', 'ja'],
+    });
+
+    expect(locale).toEqual({ locale: 'en', source: 'query' });
+  });
+
+  it('supports Accept-Language style header fallback without HTTP imports in adapter callers', () => {
+    const context: TransportContext = {
+      headers: { metadata: ['invalid locale;q=1', 'fr;q=0.6, ko;q=0.9, *;q=0.8'] },
+    };
+
+    const locale = resolveLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [createHeaderLocaleResolver({ getHeader: (ctx) => ctx.headers?.metadata, source: 'grpc-metadata' })],
+      supportedLocales: ['en', 'ko'],
+    });
+
+    expect(locale).toEqual({ locale: 'ko', source: 'grpc-metadata' });
+  });
+
+  it('ignores empty, invalid, and unsupported adapter output before using storage fallback', () => {
+    const context: TransportContext = {
+      cookies: { locale: '' },
+      query: { locale: ['invalid locale', 'ko'] },
+      storage: { locale: 'ko' },
+    };
+    const invalidObject: LocaleAdapterResolver<TransportContext> = () => ({ locale: 'en', source: 123 });
+
+    const locale = resolveLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [
+        createCookieLocaleResolver({ getCookieValue: (ctx) => ctx.cookies?.locale }),
+        createQueryLocaleResolver({ getQueryValue: (ctx) => ctx.query?.locale }),
+        invalidObject,
+        createStorageLocaleResolver({ getStoredLocale: (ctx) => ctx.storage?.locale, source: 'socket-data' }),
+      ],
+      supportedLocales: ['en', 'ko'],
+    });
+
+    expect(locale).toEqual({ locale: 'ko', source: 'socket-data' });
+  });
+
+  it('uses the configured default locale when no non-HTTP resolver matches', () => {
+    const context: TransportContext = {
+      headers: { 'accept-language': 'fr;q=1, *;q=0.8' },
+      query: { locale: 'invalid locale' },
+    };
+
+    const locale = resolveLocale(context, {
+      defaultLocale: 'en',
+      resolvers: [
+        createQueryLocaleResolver({ getQueryValue: (ctx) => ctx.query?.locale }),
+        createHeaderLocaleResolver({ getHeader: (ctx) => ctx.headers?.['accept-language'] }),
+      ],
+      supportedLocales: ['en', 'ko'],
+    });
+
+    expect(locale).toEqual({ locale: 'en', source: 'default' });
+  });
+
+  it('rejects invalid and unsupported default locales before storing metadata', () => {
+    const context: TransportContext = { query: { locale: 'ko' } };
+    const store = createWeakMapLocaleStore<TransportContext>();
+
+    expect(() =>
+      bindLocale(context, {
+        defaultLocale: 'invalid locale',
+        resolvers: [createQueryLocaleResolver({ getQueryValue: (ctx) => ctx.query?.locale })],
+        store,
+        supportedLocales: ['en', 'ko'],
+      }),
+    ).toThrow(TypeError);
+    expect(() =>
+      bindLocale(context, {
+        defaultLocale: 'fr',
+        resolvers: [createQueryLocaleResolver({ getQueryValue: (ctx) => ctx.query?.locale })],
+        store,
+        supportedLocales: ['en', 'ko'],
+      }),
+    ).toThrow(TypeError);
+    expect(getAdapterLocale(store, context)).toBeUndefined();
+  });
+
+  it('stores metadata per non-HTTP context without leaking between contexts', () => {
+    const store = createWeakMapLocaleStore<TransportContext>();
+    const contextA: TransportContext = { query: { locale: 'ko' } };
+    const contextB: TransportContext = { query: { locale: 'en' } };
+
+    const resolvedA = bindLocale(contextA, {
+      defaultLocale: 'en',
+      resolvers: [createQueryLocaleResolver({ getQueryValue: (ctx) => ctx.query?.locale })],
+      store,
+      supportedLocales: ['en', 'ko'],
+    });
+    setAdapterLocale(store, contextB, 'en', { source: 'manual' });
+
+    expect(resolvedA).toEqual({ locale: 'ko', source: 'query' });
+    expect(getAdapterLocale(store, contextA)).toEqual({ locale: 'ko', source: 'query' });
+    expect(getAdapterLocale(store, contextB)).toEqual({ locale: 'en', source: 'manual' });
+  });
+
+  it('preserves current HTTP helper behavior while sharing locale validation semantics', () => {
+    const adapterContext: TransportContext = { headers: { 'accept-language': 'ko;q=1' } };
+    const httpContext = createMockHttpContext({ 'accept-language': 'ko;q=1' });
+    const adapterResolver = createHeaderLocaleResolver<TransportContext>({ getHeader: (ctx) => ctx.headers?.['accept-language'] });
+    const httpResolver: HttpLocaleResolver = createAcceptLanguageLocaleResolver();
+
+    expect(
+      resolveLocale(adapterContext, {
+        defaultLocale: 'en',
+        resolvers: [adapterResolver],
+        supportedLocales: ['en', 'ko'],
+      }),
+    ).toEqual({ locale: 'ko', source: 'accept-language' });
+    expect(
+      resolveHttpLocale(httpContext, {
+        defaultLocale: 'en',
+        resolvers: [httpResolver],
+        supportedLocales: ['en', 'ko'],
+      }),
+    ).toEqual({ locale: 'ko', source: 'accept-language' });
+  });
+});

--- a/packages/i18n/src/adapters.ts
+++ b/packages/i18n/src/adapters.ts
@@ -1,0 +1,302 @@
+import type { I18nLocale } from './types.js';
+import {
+  isSupportedLocale,
+  isValidLocale,
+  normalizeLocaleResolverResult,
+  parseLocalePreferences,
+} from './locale-resolution.js';
+
+/**
+ * Locale metadata resolved for a non-HTTP transport context.
+ */
+export interface LocaleAdapterContext {
+  /** Locale selected for the active context. */
+  readonly locale: I18nLocale;
+  /** Optional resolver name or application-defined source that selected the locale. */
+  readonly source?: string;
+}
+
+/**
+ * Input shared by opt-in non-HTTP locale resolvers.
+ */
+export interface LocaleAdapterResolverInput<TContext> {
+  /** Transport-specific context supplied by the application boundary. */
+  readonly context: TContext;
+  /** Supported locale allow-list. Empty or omitted lists allow any syntactically valid locale. */
+  readonly supportedLocales?: readonly I18nLocale[];
+  /** Default locale used when no resolver selects a supported locale. */
+  readonly defaultLocale: I18nLocale;
+}
+
+/**
+ * Result returned by one non-HTTP locale resolver.
+ */
+export interface LocaleAdapterResolverResult {
+  /** Locale selected by the resolver. */
+  readonly locale: I18nLocale;
+  /** Resolver name or application-defined source that selected the locale. */
+  readonly source?: string;
+}
+
+/**
+ * Explicit locale resolver used by `resolveLocale(...)` in application-defined order.
+ */
+export type LocaleAdapterResolver<TContext> = (input: LocaleAdapterResolverInput<TContext>) => unknown;
+
+/**
+ * Adapter-owned locale metadata store for transport contexts that have session, socket, call, or request state.
+ */
+export interface LocaleAdapterStore<TContext> {
+  /** Reads previously stored locale metadata from the context. */
+  get(context: TContext): LocaleAdapterContext | undefined;
+  /** Stores locale metadata on or alongside the context. */
+  set(context: TContext, locale: LocaleAdapterContext): void;
+}
+
+/**
+ * Options for resolving a locale from an ordered non-HTTP resolver chain.
+ */
+export interface ResolveLocaleOptions<TContext> {
+  /** Supported locale allow-list. Empty or omitted lists allow any syntactically valid locale. */
+  readonly supportedLocales?: readonly I18nLocale[];
+  /** Default locale returned when no resolver selects a supported locale. */
+  readonly defaultLocale: I18nLocale;
+  /** Resolver chain executed in array order. */
+  readonly resolvers?: readonly LocaleAdapterResolver<TContext>[];
+}
+
+/**
+ * Options for resolving and storing a locale in a transport-local store.
+ */
+export interface BindLocaleOptions<TContext> extends ResolveLocaleOptions<TContext> {
+  /** Store used to persist the selected locale metadata for the active context. */
+  readonly store: LocaleAdapterStore<TContext>;
+}
+
+/**
+ * Options for creating an `Accept-Language`-style header resolver without importing HTTP types.
+ */
+export interface HeaderLocaleResolverOptions<TContext> {
+  /** Reads the relevant header value from a WebSocket handshake, gRPC metadata object, or server request abstraction. */
+  readonly getHeader: (context: TContext) => string | readonly string[] | undefined;
+  /** Resolver source label returned with matches. Defaults to `accept-language`. */
+  readonly source?: string;
+}
+
+/**
+ * Options for creating a query parameter resolver.
+ */
+export interface QueryLocaleResolverOptions<TContext> {
+  /** Reads a query value from a socket handshake, RPC metadata bag, CLI args object, or request abstraction. */
+  readonly getQueryValue: (context: TContext) => string | readonly string[] | undefined;
+  /** Resolver source label returned with matches. Defaults to `query`. */
+  readonly source?: string;
+}
+
+/**
+ * Options for creating a cookie resolver.
+ */
+export interface CookieLocaleResolverOptions<TContext> {
+  /** Reads a cookie value from the application-provided context abstraction. */
+  readonly getCookieValue: (context: TContext) => string | undefined;
+  /** Resolver source label returned with matches. Defaults to `cookie`. */
+  readonly source?: string;
+}
+
+/**
+ * Options for creating a storage-backed resolver.
+ */
+export interface StorageLocaleResolverOptions<TContext> {
+  /** Reads a stored locale from local storage, server session state, socket data, or CLI configuration. */
+  readonly getStoredLocale: (context: TContext) => string | undefined;
+  /** Resolver source label returned with matches. Defaults to `storage`. */
+  readonly source?: string;
+}
+
+/**
+ * Creates an in-memory per-object locale store backed by `WeakMap`.
+ *
+ * @returns A store suitable for socket, call, or request objects without mutating them.
+ */
+export function createWeakMapLocaleStore<TContext extends object>(): LocaleAdapterStore<TContext> {
+  const locales = new WeakMap<TContext, LocaleAdapterContext>();
+
+  return {
+    get(context) {
+      return locales.get(context);
+    },
+    set(context, locale) {
+      locales.set(context, Object.freeze({ ...locale }));
+    },
+  };
+}
+
+/**
+ * Stores locale metadata through an application-provided store abstraction.
+ *
+ * @param store Store that owns persistence for the transport context.
+ * @param context Transport context to update.
+ * @param locale Locale selected for the context.
+ * @param metadata Additional locale metadata such as a resolver source.
+ */
+export function setAdapterLocale<TContext>(
+  store: LocaleAdapterStore<TContext>,
+  context: TContext,
+  locale: I18nLocale,
+  metadata: Omit<LocaleAdapterContext, 'locale'> = {},
+): void {
+  store.set(context, Object.freeze({ ...metadata, locale }));
+}
+
+/**
+ * Reads locale metadata from an application-provided store abstraction.
+ *
+ * @param store Store that owns persistence for the transport context.
+ * @param context Transport context to inspect.
+ * @returns Stored locale metadata, or `undefined` when the context has no locale.
+ */
+export function getAdapterLocale<TContext>(
+  store: LocaleAdapterStore<TContext>,
+  context: TContext,
+): LocaleAdapterContext | undefined {
+  return store.get(context);
+}
+
+/**
+ * Runs an explicit non-HTTP resolver chain and returns selected locale metadata.
+ *
+ * @param context Transport context supplied by the application boundary.
+ * @param options Default locale, supported locales, and ordered resolvers.
+ * @returns Locale metadata selected by the first valid resolver or the configured default locale.
+ * @throws {TypeError} When the configured default locale is invalid or unsupported.
+ */
+export function resolveLocale<TContext>(context: TContext, options: ResolveLocaleOptions<TContext>): LocaleAdapterContext {
+  if (!isValidLocale(options.defaultLocale)) {
+    throw new TypeError('defaultLocale must be a syntactically valid locale string.');
+  }
+
+  if (!isSupportedLocale(options.defaultLocale, options.supportedLocales)) {
+    throw new TypeError('defaultLocale must be listed in supportedLocales when supportedLocales is provided.');
+  }
+
+  for (const resolver of options.resolvers ?? []) {
+    const result = normalizeLocaleResolverResult(
+      resolver({ context, defaultLocale: options.defaultLocale, supportedLocales: options.supportedLocales }),
+    );
+
+    if (result === undefined || !isValidLocale(result.locale) || !isSupportedLocale(result.locale, options.supportedLocales)) {
+      continue;
+    }
+
+    return Object.freeze({ locale: result.locale, source: result.source });
+  }
+
+  return Object.freeze({ locale: options.defaultLocale, source: 'default' });
+}
+
+/**
+ * Runs a resolver chain and stores the selected locale metadata in the provided transport-local store.
+ *
+ * @param context Transport context supplied by the application boundary.
+ * @param options Default locale, supported locales, ordered resolvers, and metadata store.
+ * @returns Stored locale metadata selected by the first valid resolver or the configured default locale.
+ * @throws {TypeError} When the configured default locale is invalid or unsupported.
+ */
+export function bindLocale<TContext>(context: TContext, options: BindLocaleOptions<TContext>): LocaleAdapterContext {
+  const resolved = resolveLocale(context, options);
+  setAdapterLocale(options.store, context, resolved.locale, { source: resolved.source });
+  return getAdapterLocale(options.store, context) ?? resolved;
+}
+
+/**
+ * Creates a resolver that selects the first supported locale from an `Accept-Language`-style header.
+ *
+ * @param options Header accessor and optional source label.
+ * @returns Locale resolver that remains independent of HTTP, WebSocket, gRPC, and browser APIs.
+ */
+export function createHeaderLocaleResolver<TContext>(
+  options: HeaderLocaleResolverOptions<TContext>,
+): LocaleAdapterResolver<TContext> {
+  const source = options.source ?? 'accept-language';
+
+  return ({ context, supportedLocales }) => {
+    for (const preference of parseLocalePreferences(options.getHeader(context))) {
+      if (preference.locale === '*') {
+        continue;
+      }
+
+      if (isSupportedLocale(preference.locale, supportedLocales)) {
+        return { locale: preference.locale, source };
+      }
+    }
+
+    return undefined;
+  };
+}
+
+/**
+ * Creates a resolver that reads the first query parameter value from an application-owned abstraction.
+ *
+ * @param options Query accessor and optional source label.
+ * @returns Locale resolver that ignores empty, invalid, and unsupported query values.
+ */
+export function createQueryLocaleResolver<TContext>(
+  options: QueryLocaleResolverOptions<TContext>,
+): LocaleAdapterResolver<TContext> {
+  const source = options.source ?? 'query';
+
+  return ({ context, supportedLocales }) => {
+    const rawValue = options.getQueryValue(context);
+    const locale = Array.isArray(rawValue) ? rawValue[0] : rawValue;
+
+    if (locale === undefined || !isValidLocale(locale) || !isSupportedLocale(locale, supportedLocales)) {
+      return undefined;
+    }
+
+    return { locale, source };
+  };
+}
+
+/**
+ * Creates a resolver that reads locale from an application-owned cookie abstraction.
+ *
+ * @param options Cookie accessor and optional source label.
+ * @returns Locale resolver that ignores empty, invalid, and unsupported cookie values.
+ */
+export function createCookieLocaleResolver<TContext>(
+  options: CookieLocaleResolverOptions<TContext>,
+): LocaleAdapterResolver<TContext> {
+  const source = options.source ?? 'cookie';
+
+  return ({ context, supportedLocales }) => {
+    const locale = options.getCookieValue(context);
+
+    if (locale === undefined || !isValidLocale(locale) || !isSupportedLocale(locale, supportedLocales)) {
+      return undefined;
+    }
+
+    return { locale, source };
+  };
+}
+
+/**
+ * Creates a resolver that reads locale from storage, session, socket, call, request, or CLI configuration state.
+ *
+ * @param options Storage accessor and optional source label.
+ * @returns Locale resolver that ignores empty, invalid, and unsupported stored values.
+ */
+export function createStorageLocaleResolver<TContext>(
+  options: StorageLocaleResolverOptions<TContext>,
+): LocaleAdapterResolver<TContext> {
+  const source = options.source ?? 'storage';
+
+  return ({ context, supportedLocales }) => {
+    const locale = options.getStoredLocale(context);
+
+    if (locale === undefined || !isValidLocale(locale) || !isSupportedLocale(locale, supportedLocales)) {
+      return undefined;
+    }
+
+    return { locale, source };
+  };
+}

--- a/packages/i18n/src/http.ts
+++ b/packages/i18n/src/http.ts
@@ -7,6 +7,12 @@ import {
 } from '@fluojs/http';
 
 import type { I18nLocale } from './types.js';
+import {
+  isSupportedLocale,
+  isValidLocale,
+  normalizeLocaleResolverResult,
+  parseLocalePreferences,
+} from './locale-resolution.js';
 
 /**
  * Locale metadata stored on a fluo HTTP request context.
@@ -83,22 +89,6 @@ export interface AcceptLanguageLocaleResolverOptions {
 export const HTTP_LOCALE_CONTEXT_KEY = createContextKey<HttpLocaleContext>('fluo.i18n.http.locale');
 
 const DEFAULT_ACCEPT_LANGUAGE_SOURCE = 'accept-language';
-const LOCALE_PATTERN = /^[A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*$/;
-const ACCEPT_LANGUAGE_QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
-
-interface ResolverCandidate {
-  readonly locale: unknown;
-  readonly source?: string;
-}
-
-function isValidLocale(locale: unknown): locale is I18nLocale {
-  return typeof locale === 'string' && LOCALE_PATTERN.test(locale);
-}
-
-function isSupportedLocale(locale: I18nLocale, supportedLocales: readonly I18nLocale[] | undefined): boolean {
-  return supportedLocales === undefined || supportedLocales.length === 0 || supportedLocales.includes(locale);
-}
-
 function readHeader(request: FrameworkRequest, headerName: string): string | string[] | undefined {
   const normalizedName = headerName.toLowerCase();
 
@@ -109,55 +99,6 @@ function readHeader(request: FrameworkRequest, headerName: string): string | str
   }
 
   return undefined;
-}
-
-function normalizeResolverResult(
-  result: unknown,
-): ResolverCandidate | undefined {
-  if (result === undefined) {
-    return undefined;
-  }
-
-  if (typeof result === 'string') {
-    return { locale: result };
-  }
-
-  if (typeof result !== 'object' || result === null || !Object.hasOwn(result, 'locale')) {
-    return undefined;
-  }
-
-  const { locale, source } = result as { readonly locale?: unknown; readonly source?: unknown };
-
-  if (source !== undefined && typeof source !== 'string') {
-    return undefined;
-  }
-
-  return { locale, source };
-}
-
-function parseAcceptLanguageQuality(parameters: readonly string[]): number | undefined {
-  let quality = 1;
-  let hasQuality = false;
-
-  for (const parameter of parameters) {
-    const normalizedParameter = parameter.trim();
-    const qualityMatch = /^q=(.+)$/i.exec(normalizedParameter);
-
-    if (qualityMatch === null || hasQuality) {
-      return undefined;
-    }
-
-    const [, value] = qualityMatch;
-
-    if (value === undefined || !ACCEPT_LANGUAGE_QVALUE_PATTERN.test(value)) {
-      return undefined;
-    }
-
-    hasQuality = true;
-    quality = Number(value);
-  }
-
-  return quality;
 }
 
 /**
@@ -192,32 +133,7 @@ export function getHttpLocale(context: RequestContext): HttpLocaleContext | unde
  * @returns Valid language ranges ordered by descending q-value and original header order for ties.
  */
 export function parseAcceptLanguage(header: string | readonly string[] | undefined): readonly AcceptLanguagePreference[] {
-  const rawHeader = typeof header === 'string' ? header : header?.join(',');
-
-  if (rawHeader === undefined || rawHeader.trim() === '') {
-    return [];
-  }
-
-  const preferences: Array<AcceptLanguagePreference & { readonly index: number }> = [];
-
-  for (const [index, rawPart] of rawHeader.split(',').entries()) {
-    const [rawLocale, ...parameters] = rawPart.split(';');
-    const locale = rawLocale?.trim();
-
-    if (locale === undefined || locale === '' || (locale !== '*' && !isValidLocale(locale))) {
-      continue;
-    }
-
-    const quality = parseAcceptLanguageQuality(parameters);
-
-    if (quality !== undefined && quality > 0) {
-      preferences.push({ index, locale, quality });
-    }
-  }
-
-  return [...preferences]
-    .sort((left, right) => right.quality - left.quality || left.index - right.index)
-    .map(({ locale, quality }) => ({ locale, quality }));
+  return parseLocalePreferences(header);
 }
 
 /**
@@ -268,7 +184,7 @@ export function resolveHttpLocale(context: RequestContext, options: ResolveHttpL
   }
 
   for (const resolver of options.resolvers ?? []) {
-    const result = normalizeResolverResult(
+    const result = normalizeLocaleResolverResult(
       resolver({ context, defaultLocale: options.defaultLocale, supportedLocales: options.supportedLocales }),
     );
 

--- a/packages/i18n/src/locale-resolution.ts
+++ b/packages/i18n/src/locale-resolution.ts
@@ -1,0 +1,98 @@
+import type { I18nLocale } from './types.js';
+
+export interface LocaleResolverCandidate {
+  readonly locale: unknown;
+  readonly source?: string;
+}
+
+export interface AcceptLanguagePreferenceInternal {
+  readonly locale: I18nLocale;
+  readonly quality: number;
+}
+
+const LOCALE_PATTERN = /^[A-Za-z]{1,8}(?:-[A-Za-z0-9]{1,8})*$/;
+const ACCEPT_LANGUAGE_QVALUE_PATTERN = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/;
+
+export function isValidLocale(locale: unknown): locale is I18nLocale {
+  return typeof locale === 'string' && LOCALE_PATTERN.test(locale);
+}
+
+export function isSupportedLocale(locale: I18nLocale, supportedLocales: readonly I18nLocale[] | undefined): boolean {
+  return supportedLocales === undefined || supportedLocales.length === 0 || supportedLocales.includes(locale);
+}
+
+export function normalizeLocaleResolverResult(result: unknown): LocaleResolverCandidate | undefined {
+  if (result === undefined) {
+    return undefined;
+  }
+
+  if (typeof result === 'string') {
+    return { locale: result };
+  }
+
+  if (typeof result !== 'object' || result === null || !Object.hasOwn(result, 'locale')) {
+    return undefined;
+  }
+
+  const candidate = result as { readonly locale?: unknown; readonly source?: unknown };
+
+  if (candidate.source !== undefined && typeof candidate.source !== 'string') {
+    return undefined;
+  }
+
+  return { locale: candidate.locale, source: candidate.source };
+}
+
+function parseAcceptLanguageQuality(parameters: readonly string[]): number | undefined {
+  let quality = 1;
+  let hasQuality = false;
+
+  for (const parameter of parameters) {
+    const normalizedParameter = parameter.trim();
+    const qualityMatch = /^q=(.+)$/i.exec(normalizedParameter);
+
+    if (qualityMatch === null || hasQuality) {
+      return undefined;
+    }
+
+    const [, value] = qualityMatch;
+
+    if (value === undefined || !ACCEPT_LANGUAGE_QVALUE_PATTERN.test(value)) {
+      return undefined;
+    }
+
+    hasQuality = true;
+    quality = Number(value);
+  }
+
+  return quality;
+}
+
+export function parseLocalePreferences(header: string | readonly string[] | undefined): readonly AcceptLanguagePreferenceInternal[] {
+  const rawHeader = typeof header === 'string' ? header : header?.join(',');
+
+  if (rawHeader === undefined || rawHeader.trim() === '') {
+    return [];
+  }
+
+  const preferences: Array<AcceptLanguagePreferenceInternal & { readonly index: number }> = [];
+
+  for (const [index, rawPart] of rawHeader.split(',').entries()) {
+    const [rawLocale, ...parameters] = rawPart.split(';');
+    const locale = rawLocale?.trim();
+
+    if (locale === undefined || locale === '' || (locale !== '*' && !isValidLocale(locale))) {
+      continue;
+    }
+
+    const quality = parseAcceptLanguageQuality(parameters);
+
+    if (quality !== undefined && quality > 0) {
+      preferences.push({ index, locale, quality });
+    }
+  }
+
+  return [...preferences]
+    .sort((left, right) => right.quality - left.quality || left.index - right.index)
+    .map(({ locale, quality }) => ({ locale, quality }));
+}

--- a/tooling/governance/verify-platform-consistency-governance.mjs
+++ b/tooling/governance/verify-platform-consistency-governance.mjs
@@ -674,8 +674,16 @@ function enforceCanonicalRuntimeMatrixReferences() {
     'docs/reference/package-chooser.md must keep @fluojs/i18n discoverable for localization tasks.',
   );
   assert(
+    packageSurface.includes('@fluojs/i18n/adapters') && packageChooser.includes('@fluojs/i18n/adapters'),
+    'docs/reference package-surface and package-chooser must keep @fluojs/i18n/adapters discoverable for non-HTTP locale resolution.',
+  );
+  assert(
     packageChooserKo.includes('@fluojs/i18n') && packageChooserKo.includes('localization'),
     'docs/reference/package-chooser.ko.md must keep @fluojs/i18n discoverable for localization tasks.',
+  );
+  assert(
+    packageSurfaceKo.includes('@fluojs/i18n/adapters') && packageChooserKo.includes('@fluojs/i18n/adapters'),
+    'docs/reference package-surface.ko.md and package-chooser.ko.md must keep @fluojs/i18n/adapters discoverable for non-HTTP locale resolution.',
   );
 
   assert(
@@ -691,8 +699,16 @@ function enforceCanonicalRuntimeMatrixReferences() {
     'docs/CONTEXT.md must point readers to package chooser i18n discovery guidance.',
   );
   assert(
+    docsContext.includes('@fluojs/i18n/adapters'),
+    'docs/CONTEXT.md must mention @fluojs/i18n/adapters when non-HTTP locale resolution is documented.',
+  );
+  assert(
     docsContextKo.includes('docs/reference/package-chooser.md') && docsContextKo.includes('@fluojs/i18n'),
     'docs/CONTEXT.ko.md must point readers to package chooser i18n discovery guidance.',
+  );
+  assert(
+    docsContextKo.includes('@fluojs/i18n/adapters'),
+    'docs/CONTEXT.ko.md must mention @fluojs/i18n/adapters when non-HTTP locale resolution is documented.',
   );
   assert(rootReadme.includes('docs/reference/package-surface.md'), 'README.md must point to the canonical runtime package matrix page.');
   assert(


### PR DESCRIPTION
## Summary

- `@fluojs/i18n/adapters` subpath를 추가해 HTTP 외 WebSocket/gRPC/CLI/local storage/server-request style abstraction에서 opt-in locale resolution을 사용할 수 있게 했습니다.
- 기존 `@fluojs/i18n/http`의 Accept-Language parsing/validation semantics는 공유 internal helper로 보존했습니다.

Closes #1730

## Changes

- Generic resolver chain API: `resolveLocale`, `bindLocale`, `LocaleAdapterStore`, `createWeakMapLocaleStore`.
- Header/query/cookie/storage resolver factories를 추가하고 browser global 또는 framework-specific dependency 없이 accessor 기반으로 동작하게 했습니다.
- i18n package export map, EN/KO README, package surface/chooser/docs context, governance assertion, changeset을 갱신했습니다.

## Testing

- ✅ LSP diagnostics: changed i18n source files clean (`adapters.ts`, `adapters.test.ts`, `locale-resolution.ts`, `http.ts`).
- ✅ `pnpm --filter @fluojs/i18n... --if-present run build`
- ✅ `pnpm --dir packages/i18n build`
- ✅ `pnpm --dir packages/i18n typecheck`
- ✅ `pnpm --dir packages/i18n test` (8 files, 68 tests)
- ✅ `pnpm verify:platform-consistency-governance`
- ✅ `pnpm verify:public-export-tsdoc`
- ✅ `pnpm docs:sync-check`
- ✅ `pnpm exec biome lint packages/i18n/src/adapters.ts packages/i18n/src/adapters.test.ts packages/i18n/src/locale-resolution.ts packages/i18n/src/http.ts tooling/governance/verify-platform-consistency-governance.mjs`
- ✅ `pnpm changeset status --since=origin/main`
- ⚠️ `pnpm lint` still reports pre-existing warnings outside this change set (for example `packages/config`, `packages/core`, `packages/cqrs`, `packages/cron`); changed-file lint passed as listed above.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (N/A: no platform alignment claim added.)