### PR TITLE
Resolve #1749: Preserve JWT fractional expiresIn precision

### DIFF
--- a/.changeset/jwt-fractional-expires-in.md
+++ b/.changeset/jwt-fractional-expires-in.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/jwt": patch
+---
+
+Preserve fractional NumericDate precision for numeric per-call `JwtService.sign(..., { expiresIn })` values so short fractional TTLs no longer collapse to whole seconds.

--- a/packages/jwt/README.ko.md
+++ b/packages/jwt/README.ko.md
@@ -110,7 +110,7 @@ const principal = await verifier.verifyAccessToken(token);
 // principal: { subject: 'user-123', roles: ['admin'], scopes: ['read:profile'], ... }
 ```
 
-`JwtService.sign(payload, { expiresIn })`를 사용할 때는 payload 안에 기존 `exp` 값이 있더라도 호출 시점의 `expiresIn` 재정의가 항상 우선합니다. 따라서 토큰 수명은 호출 위치에서 결정적으로 제어됩니다. `expiresIn`은 초 단위의 0 이상 숫자 또는 `60s`, `15m`, `1h`, `7d` 같은 짧은 duration 문자열을 받을 수 있습니다.
+`JwtService.sign(payload, { expiresIn })`를 사용할 때는 payload 안에 기존 `exp` 값이 있더라도 호출 시점의 `expiresIn` 재정의가 항상 우선합니다. 따라서 토큰 수명은 호출 위치에서 결정적으로 제어됩니다. `expiresIn`은 초 단위의 0 이상 숫자 또는 `60s`, `15m`, `1h`, `7d` 같은 짧은 duration 문자열을 받을 수 있습니다. 숫자 초 값은 JWT NumericDate의 소수 정밀도를 보존하며, 문자열 duration은 기존처럼 정수 초 리터럴로 처리됩니다.
 
 ## 일반적인 패턴
 

--- a/packages/jwt/README.md
+++ b/packages/jwt/README.md
@@ -110,7 +110,7 @@ const principal = await verifier.verifyAccessToken(token);
 // principal: { subject: 'user-123', roles: ['admin'], scopes: ['read:profile'], ... }
 ```
 
-When you use `JwtService.sign(payload, { expiresIn })`, the per-call `expiresIn` override always wins over any pre-existing `payload.exp` value so token lifetime stays deterministic at the call site. `expiresIn` accepts a non-negative number of seconds or short duration strings such as `60s`, `15m`, `1h`, or `7d`.
+When you use `JwtService.sign(payload, { expiresIn })`, the per-call `expiresIn` override always wins over any pre-existing `payload.exp` value so token lifetime stays deterministic at the call site. `expiresIn` accepts a non-negative number of seconds or short duration strings such as `60s`, `15m`, `1h`, or `7d`. Numeric seconds preserve fractional JWT NumericDate precision; string durations remain whole-second literals.
 
 ## Common Patterns
 

--- a/packages/jwt/src/service.test.ts
+++ b/packages/jwt/src/service.test.ts
@@ -146,6 +146,28 @@ describe('JwtService', () => {
     expect((decoded as { exp: number }).exp).toBeGreaterThanOrEqual(now + 59);
   });
 
+  it('preserves fractional NumericDate precision for numeric per-call expiresIn', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    try {
+      const service = createJwtService({
+        algorithms: ['HS256'],
+        issuer: 'jwt-service-tests',
+        secret: 'service-secret',
+      });
+      const now = Math.floor(Date.now() / 1000);
+      const token = await service.sign({ sub: 'fractional-user' }, { expiresIn: 0.75 });
+
+      expect(service.decode(token)).toMatchObject({
+        exp: now + 0.75,
+        sub: 'fractional-user',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('decodes payload without signature verification', async () => {
     const service = createJwtService({
       algorithms: ['HS256'],

--- a/packages/jwt/src/service.ts
+++ b/packages/jwt/src/service.ts
@@ -36,7 +36,7 @@ function parseExpiresInSeconds(expiresIn: SignOptions['expiresIn']): number | un
       throw new Error('JwtService.sign() options.expiresIn must be a non-negative finite number.');
     }
 
-    return Math.floor(expiresIn);
+    return expiresIn;
   }
 
   const trimmed = expiresIn.trim();
@@ -74,7 +74,8 @@ export interface SignOptions {
    * Sets the token lifetime relative to the current clock.
    *
    * Accepts seconds or a short duration literal such as `"60s"`, `"15m"`,
-   * `"1h"`, or `"7d"`.
+   * `"1h"`, or `"7d"`. Numeric seconds preserve fractional JWT
+   * NumericDate precision.
    */
   expiresIn?: number | `${number}${DurationUnit}`;
   /**


### PR DESCRIPTION
## Summary

Preserve the documented JWT NumericDate precision for numeric per-call `JwtService.sign(..., { expiresIn })` overrides.

Closes #1749

## Changes

- Stop flooring numeric per-call `expiresIn` values before computing `exp`.
- Add regression coverage for fractional numeric `expiresIn` values below one second.
- Clarify EN/KO `@fluojs/jwt` README behavior and add a patch changeset.

## Testing

- `lsp_diagnostics` on `packages/jwt/src/service.ts`: passed after dependency graph build.
- `lsp_diagnostics` on `packages/jwt/src/service.test.ts`: passed.
- `pnpm --filter @fluojs/jwt test`: passed (7 files, 101 tests).
- `pnpm --filter @fluojs/jwt... build && pnpm --filter @fluojs/jwt typecheck`: passed.
- `pnpm lint`: passed; Biome reported pre-existing warnings/infos in unrelated `packages/config` and `packages/core` files, and `verify:public-export-tsdoc` passed in changed mode.

## Release readiness evidence

Fresh fix-back verification executed in `/Users/playground/Documents/fluo/.worktrees/issue-1749-preserve-jwt-fractional-expires-in` on 2026-05-11:

- `pnpm verify:release-readiness`: passed.
  - Representative output:

```text
Test Files 4 passed (4)
Tests 12 passed (12)

Test Files 12 passed (12)
Tests 119 passed (119)

[cli sandbox] Sandbox verification passed
[cli sandbox] Sandbox verification passed
[cli sandbox] Sandbox verification passed
Release readiness checks passed without writing draft artifacts.
```

- `pnpm changeset status --since=main`: passed.

```text
> fluo@ changeset /Users/playground/Documents/fluo/.worktrees/issue-1749-preserve-jwt-fractional-expires-in
> changeset status --since=main

🦋  info Packages to be bumped at patch:
🦋  info 
🦋  - @fluojs/jwt
🦋  ---
🦋  info Packages to be bumped at minor:
🦋  info 
🦋  - @fluojs/i18n
🦋  ---
🦋  info NO packages to be bumped at major
```

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or package platform conformance claims changed in this PR.