### PR TITLE
Resolve #1750: Block notification sends during shutdown

### DIFF
--- a/.changeset/notification-shutdown-transport-guards.md
+++ b/.changeset/notification-shutdown-transport-guards.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/email": patch
+"@fluojs/slack": patch
+---
+
+Block email and Slack sends once shutdown begins so factory-owned notification transports are not reused or recreated during teardown.

--- a/.changeset/notification-shutdown-transport-guards.md
+++ b/.changeset/notification-shutdown-transport-guards.md
@@ -1,6 +1,6 @@
 ---
-"@fluojs/email": patch
-"@fluojs/slack": patch
+"@fluojs/email": minor
+"@fluojs/slack": minor
 ---
 
-Block email and Slack sends once shutdown begins so factory-owned notification transports are not reused or recreated during teardown.
+Add lifecycle-gated email and Slack delivery failures once shutdown begins so factory-owned notification transports are not reused or recreated during teardown, and expose lifecycle error classes for callers that handle send/shutdown races.

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -169,6 +169,7 @@ Behavioral contract 메모:
 - `EmailService.sendMany(...)`는 기본적으로 fail-fast입니다. 실패를 batch result에 수집하려면 `continueOnError: true`를 전달합니다.
 - `EmailService.createPlatformStatusSnapshot()`은 diagnostics를 위해 lifecycle, readiness, health, transport ownership details를 노출합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
+- shutdown이 시작된 뒤에는 `EmailService.send(...)`와 `EmailService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `EmailLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다린 뒤 닫습니다.
 - transport `verify()`와 `close()`에서 발생한 provider error는 diagnostics를 위해 lifecycle failure의 `cause`로 보존됩니다.
 - 모듈 옵션은 provider wiring 전에 trim 및 normalize됩니다. 여기에는 sender 기본값, notification channel 이름, transport factory 소유권이 포함됩니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.
@@ -310,6 +311,7 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 - `createEmailPlatformStatusSnapshot(...)`
 - `EmailConfigurationError`
+- `EmailLifecycleError`
 - `EmailMessageValidationError`
 
 ### Node 전용 서브패스

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -311,7 +311,7 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 - `createEmailPlatformStatusSnapshot(...)`
 - `EmailConfigurationError`
-- `EmailLifecycleError`
+- `EmailLifecycleError`: lifecycle로 차단된 전달, transport 초기화 또는 검증, 소유 리소스 shutdown 실패에서 발생합니다. 애플리케이션 teardown과 전송이 경합할 수 있다면 이 에러를 catch하세요.
 - `EmailMessageValidationError`
 
 ### Node 전용 서브패스

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -169,6 +169,7 @@ Behavioral contract notes:
 - `EmailService.sendMany(...)` is fail-fast by default; pass `continueOnError: true` to collect failures in a batch result.
 - `EmailService.createPlatformStatusSnapshot()` exposes lifecycle, readiness, health, and transport ownership details for diagnostics.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
+- Once shutdown starts, `EmailService.send(...)` and `EmailService.sendNotification(...)` fail with `EmailLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited and closed by shutdown.
 - Transport `verify()` and `close()` provider errors are preserved as the `cause` of lifecycle failures for diagnostics.
 - Module options are trimmed and normalized before provider wiring, including sender defaults, notification channel names, and transport factory ownership.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.
@@ -310,6 +311,7 @@ These limitations are part of the package contract so transport selection, templ
 
 - `createEmailPlatformStatusSnapshot(...)`
 - `EmailConfigurationError`
+- `EmailLifecycleError`
 - `EmailMessageValidationError`
 
 ### Node-only subpath

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -311,7 +311,7 @@ These limitations are part of the package contract so transport selection, templ
 
 - `createEmailPlatformStatusSnapshot(...)`
 - `EmailConfigurationError`
-- `EmailLifecycleError`
+- `EmailLifecycleError`: thrown by lifecycle-gated delivery, transport initialization or verification, and owned-resource shutdown failures. Catch this error when sends can race with application teardown.
 - `EmailMessageValidationError`
 
 ### Node-only subpath

--- a/packages/email/src/errors.ts
+++ b/packages/email/src/errors.ts
@@ -17,3 +17,13 @@ export class EmailMessageValidationError extends Error {
     this.name = 'EmailMessageValidationError';
   }
 }
+
+/**
+ * Thrown when email delivery is requested after the service lifecycle has started shutting down.
+ */
+export class EmailLifecycleError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'EmailLifecycleError';
+  }
+}

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,5 +1,6 @@
 export {
   EmailConfigurationError,
+  EmailLifecycleError,
   EmailMessageValidationError,
 } from './errors.js';
 export { EmailChannel } from './channel.js';

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -245,6 +245,9 @@ class FailingLifecycleTransport implements EmailTransport {
 class DelayedLifecycleTransport implements EmailTransport {
   closeCalls = 0;
   sendCalls = 0;
+  verifyCalls = 0;
+
+  constructor(private readonly verifyDelay: Promise<void> | undefined = undefined) {}
 
   async close(): Promise<void> {
     this.closeCalls += 1;
@@ -259,6 +262,11 @@ class DelayedLifecycleTransport implements EmailTransport {
       pending: [],
       rejected: [],
     };
+  }
+
+  async verify(): Promise<void> {
+    this.verifyCalls += 1;
+    await this.verifyDelay;
   }
 }
 
@@ -742,6 +750,86 @@ describe('EmailModule', () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(createdTransport.closeCalls).toBe(1);
     expect(createdTransport.sendCalls).toBe(0);
+  });
+
+  it('does not mark the service ready when shutdown interrupts bootstrap verification', async () => {
+    let resolveVerify!: () => void;
+    let resolveVerifyStarted!: () => void;
+    const verifyDelay = new Promise<void>((resolve) => {
+      resolveVerify = resolve;
+    });
+    const verifyStarted = new Promise<void>((resolve) => {
+      resolveVerifyStarted = resolve;
+    });
+    const createdTransport = new DelayedLifecycleTransport(
+      verifyDelay.then(() => undefined),
+    );
+    const verify = vi.spyOn(createdTransport, 'verify').mockImplementation(async () => {
+      createdTransport.verifyCalls += 1;
+      resolveVerifyStarted();
+      await verifyDelay;
+    });
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create: async () => createdTransport,
+        ownsResources: true,
+      },
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+    const bootstrap = service.onModuleInit();
+    await verifyStarted;
+    const shutdown = service.onApplicationShutdown();
+
+    await shutdown;
+    resolveVerify();
+    await bootstrap;
+
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'stopped' },
+      readiness: { status: 'not-ready' },
+    });
+    await expect(
+      service.sendNotification({
+        channel: 'email',
+        payload: {},
+        recipients: ['user@example.com'],
+        subject: 'After interrupted bootstrap',
+      }),
+    ).rejects.toThrowError(new EmailLifecycleError('Email delivery cannot start while the service lifecycle is stopped.'));
+    expect(createdTransport.closeCalls).toBe(1);
+    expect(createdTransport.verifyCalls).toBe(1);
+    expect(verify).toHaveBeenCalledOnce();
+    expect(createdTransport.sendCalls).toBe(0);
+  });
+
+  it('checks notification lifecycle before renderer or validation errors after shutdown', async () => {
+    const render = vi.fn(async () => ({ text: 'rendered' }));
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      renderer: { render },
+      transport: createRecordingTransportFactory(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+    await service.onApplicationShutdown();
+
+    await expect(
+      service.sendNotification({
+        channel: 'email',
+        payload: {},
+        recipients: ['user@example.com'],
+        template: 'shutdown-template',
+      }),
+    ).rejects.toThrowError(new EmailLifecycleError('Email delivery cannot start while the service lifecycle is stopped.'));
+    expect(render).not.toHaveBeenCalled();
+    expect(transportState.sent).toHaveLength(0);
   });
 
   it('accepts custom provider-backed transports without bootstrap verification', async () => {

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -147,7 +147,7 @@ import { EmailNotificationQueueJob, EmailNotificationsQueueWorker, createEmailNo
 import { EmailModule } from './module.js';
 import { EmailService } from './service.js';
 import { EMAIL } from './tokens.js';
-import { EmailConfigurationError, EmailMessageValidationError } from './errors.js';
+import { EmailConfigurationError, EmailLifecycleError, EmailMessageValidationError } from './errors.js';
 import type { Email, EmailTransport, EmailTransportFactory, NormalizedEmailMessage } from './types.js';
 
 class PartialDeliveryTransport implements EmailTransport {
@@ -239,6 +239,26 @@ class FailingLifecycleTransport implements EmailTransport {
     if (this.failurePoint === 'verify') {
       throw new Error('provider verify failed');
     }
+  }
+}
+
+class DelayedLifecycleTransport implements EmailTransport {
+  closeCalls = 0;
+  sendCalls = 0;
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
+
+  async send(): Promise<{ accepted: string[]; messageId: string; pending: []; rejected: [] }> {
+    this.sendCalls += 1;
+
+    return {
+      accepted: ['user@example.com'],
+      messageId: 'delayed-1',
+      pending: [],
+      rejected: [],
+    };
   }
 }
 
@@ -685,6 +705,43 @@ describe('EmailModule', () => {
       cause: expect.objectContaining({ message: 'provider close failed' }),
       message: 'Email transport failed to close cleanly.',
     });
+  });
+
+  it('blocks shutdown-time delivery from reusing or recreating transports', async () => {
+    let resolveTransport!: (transport: DelayedLifecycleTransport) => void;
+    const createdTransport = new DelayedLifecycleTransport();
+    const create = vi.fn(
+      () =>
+        new Promise<EmailTransport>((resolve) => {
+          resolveTransport = resolve;
+        }),
+    );
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+    const sendDuringCreate = service.send({ subject: 'Shutdown race', text: 'hello', to: ['user@example.com'] });
+    const shutdown = service.onApplicationShutdown();
+
+    resolveTransport(createdTransport);
+
+    await expect(sendDuringCreate).rejects.toThrowError(
+      new EmailLifecycleError('Email delivery cannot start while the service lifecycle is stopped.'),
+    );
+    await shutdown;
+    await expect(
+      service.send({ subject: 'After shutdown', text: 'hello', to: ['user@example.com'] }),
+    ).rejects.toThrowError(new EmailLifecycleError('Email delivery cannot start while the service lifecycle is stopped.'));
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(createdTransport.closeCalls).toBe(1);
+    expect(createdTransport.sendCalls).toBe(0);
   });
 
   it('accepts custom provider-backed transports without bootstrap verification', async () => {

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -11,17 +11,17 @@ import type {
   EmailAddressLike,
   EmailMessage,
   EmailNotificationDispatchRequest,
-    EmailSendBatchResult,
-    EmailSendFailure,
-    EmailSendManyOptions,
-    EmailSendOptions,
-    EmailSendResult,
-    EmailTemplateRenderResult,
-    EmailTransport,
-    NormalizedEmailAddressList,
-    NormalizedEmailMessage,
-    NormalizedEmailModuleOptions,
-  } from './types.js';
+  EmailSendBatchResult,
+  EmailSendFailure,
+  EmailSendManyOptions,
+  EmailSendOptions,
+  EmailSendResult,
+  EmailTemplateRenderResult,
+  EmailTransport,
+  NormalizedEmailAddressList,
+  NormalizedEmailMessage,
+  NormalizedEmailModuleOptions,
+} from './types.js';
 
 function normalizeAddress(address: EmailAddressLike): EmailAddress {
   if (typeof address === 'string') {
@@ -65,6 +65,12 @@ function createDeliveryLifecycleError(state: EmailServiceLifecycleState): EmailL
 }
 
 type EmailServiceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
+
+function isShutdownLifecycleState(
+  state: EmailServiceLifecycleState,
+): state is Extract<EmailServiceLifecycleState, 'stopping' | 'stopped'> {
+  return state === 'stopping' || state === 'stopped';
+}
 
 function assertMessageContent(message: NormalizedEmailMessage): void {
   if (message.to.length === 0) {
@@ -141,7 +147,7 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
 
       this.lifecycleState = 'ready';
     } catch (error) {
-      if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+      if (isShutdownLifecycleState(this.lifecycleState)) {
         throw error;
       }
 

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -2,7 +2,7 @@ import { Inject } from '@fluojs/core';
 import type { OnApplicationShutdown, OnModuleInit } from '@fluojs/runtime';
 
 import { DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS } from './constants.js';
-import { EmailMessageValidationError } from './errors.js';
+import { EmailLifecycleError, EmailMessageValidationError } from './errors.js';
 import { createEmailPlatformStatusSnapshot } from './status.js';
 import { EMAIL_OPTIONS } from './tokens.js';
 import type {
@@ -57,8 +57,14 @@ function assertNotAborted(signal: AbortSignal | undefined): void {
 }
 
 function createLifecycleError(message: string, cause: unknown): Error {
-  return new Error(message, { cause });
+  return new EmailLifecycleError(message, { cause });
 }
+
+function createDeliveryLifecycleError(state: EmailServiceLifecycleState): EmailLifecycleError {
+  return new EmailLifecycleError(`Email delivery cannot start while the service lifecycle is ${state}.`);
+}
+
+type EmailServiceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
 
 function assertMessageContent(message: NormalizedEmailMessage): void {
   if (message.to.length === 0) {
@@ -88,7 +94,7 @@ function assertMessageContent(message: NormalizedEmailMessage): void {
  */
 @Inject(EMAIL_OPTIONS)
 export class EmailService implements Email, OnModuleInit, OnApplicationShutdown {
-  private lifecycleState: 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'created';
+  private lifecycleState: EmailServiceLifecycleState = 'created';
   private resolvedTransport: EmailTransport | undefined;
   private transportPromise: Promise<EmailTransport> | undefined;
 
@@ -98,8 +104,10 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     this.lifecycleState = 'stopping';
 
     try {
-      if (this.resolvedTransport && this.options.transport.ownsResources && this.resolvedTransport.close) {
-        await this.resolvedTransport.close();
+      const transport = this.resolvedTransport ?? (this.transportPromise ? await this.transportPromise : undefined);
+
+      if (transport && this.options.transport.ownsResources && transport.close) {
+        await transport.close();
       }
 
       this.lifecycleState = 'stopped';
@@ -163,11 +171,13 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
    */
   async send(message: EmailMessage, options: EmailSendOptions = {}): Promise<EmailSendResult> {
     assertNotAborted(options.signal);
+    this.assertCanDeliver();
 
     const transport = await this.ensureTransport();
     const normalized = this.normalizeMessage(message);
     assertMessageContent(normalized);
     assertNotAborted(options.signal);
+    this.assertCanDeliver();
     const result = await transport.send(normalized, options);
 
     return {
@@ -272,6 +282,8 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
   }
 
   private async ensureTransport(): Promise<EmailTransport> {
+    this.assertCanCreateOrUseTransport();
+
     if (this.resolvedTransport) {
       return this.resolvedTransport;
     }
@@ -284,6 +296,16 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     }
 
     return this.transportPromise;
+  }
+
+  private assertCanCreateOrUseTransport(): void {
+    if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped' || this.lifecycleState === 'failed') {
+      throw createDeliveryLifecycleError(this.lifecycleState);
+    }
+  }
+
+  private assertCanDeliver(): void {
+    this.assertCanCreateOrUseTransport();
   }
 
   private normalizeMessage(message: EmailMessage): NormalizedEmailMessage {

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -118,17 +118,33 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
   }
 
   async onModuleInit(): Promise<void> {
+    if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+      return;
+    }
+
     this.lifecycleState = 'starting';
 
     try {
       const transport = await this.ensureTransport();
 
+      if (this.lifecycleState !== 'starting') {
+        return;
+      }
+
       if (this.options.verifyOnModuleInit && transport.verify) {
         await transport.verify();
       }
 
+      if (this.lifecycleState !== 'starting') {
+        return;
+      }
+
       this.lifecycleState = 'ready';
     } catch (error) {
+      if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+        throw error;
+      }
+
       this.lifecycleState = 'failed';
       throw createLifecycleError('Email transport failed to initialize.', error);
     }
@@ -254,6 +270,9 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     notification: EmailNotificationDispatchRequest,
     options: EmailSendOptions = {},
   ): Promise<EmailSendResult> {
+    assertNotAborted(options.signal);
+    this.assertCanDeliver();
+
     const payload = notification.payload;
     const rendered = await this.renderNotification(notification, options.signal);
 

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -219,7 +219,10 @@ Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `SlackModule.forRoot(options)` / `SlackModule.forRootAsync(options)`
 - `createSlackProviders(options)`
 - `SlackService`
+- `SlackService.send(message, options)`
 - `SlackService.sendMany(messages, options)`
+- `SlackService.sendNotification(notification, options)`
+- `SlackService.createPlatformStatusSnapshot()`
 - `SlackChannel`
 - `SLACK`
 - `SLACK_CHANNEL`
@@ -257,7 +260,7 @@ Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `SlackLifecycleState`
 - `SlackStatusAdapterInput`
 - `SlackConfigurationError`
-- `SlackLifecycleError`
+- `SlackLifecycleError`: lifecycle로 차단된 전달, transport 초기화, 소유 리소스 shutdown 실패에서 발생합니다. 애플리케이션 teardown과 전송이 경합할 수 있다면 이 에러를 catch하세요.
 - `SlackMessageValidationError`
 - `SlackTransportError`
 

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -128,6 +128,7 @@ Behavioral contract 메모:
 - `SlackService.send(...)`는 전달 전에 `defaultChannel`을 해석합니다.
 - `SlackService.sendMany(...)`는 메시지를 순차적으로 보내며, fail-fast 대신 batch result가 필요한 호출자를 위해 `continueOnError`를 지원합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
+- shutdown이 시작된 뒤에는 `SlackService.send(...)`와 `SlackService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `SlackLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다린 뒤 닫습니다.
 - `SlackService.createPlatformStatusSnapshot()`은 호출자가 내부 옵션에 접근하지 않아도 lifecycle, readiness, transport 소유권을 보고합니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.
 
@@ -256,6 +257,7 @@ Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `SlackLifecycleState`
 - `SlackStatusAdapterInput`
 - `SlackConfigurationError`
+- `SlackLifecycleError`
 - `SlackMessageValidationError`
 - `SlackTransportError`
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -128,6 +128,7 @@ Behavioral contract notes:
 - `SlackService.send(...)` resolves `defaultChannel` before delivery.
 - `SlackService.sendMany(...)` sends messages sequentially and supports `continueOnError` when callers need a batch result instead of fail-fast behavior.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
+- Once shutdown starts, `SlackService.send(...)` and `SlackService.sendNotification(...)` fail with `SlackLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited and closed by shutdown.
 - `SlackService.createPlatformStatusSnapshot()` reports lifecycle, readiness, and transport ownership without requiring callers to reach into internal options.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.
 
@@ -256,6 +257,7 @@ These limitations are part of the package contract so runtime choice, provider c
 - `SlackLifecycleState`
 - `SlackStatusAdapterInput`
 - `SlackConfigurationError`
+- `SlackLifecycleError`
 - `SlackMessageValidationError`
 - `SlackTransportError`
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -219,7 +219,10 @@ These limitations are part of the package contract so runtime choice, provider c
 - `SlackModule.forRoot(options)` / `SlackModule.forRootAsync(options)`
 - `createSlackProviders(options)`
 - `SlackService`
+- `SlackService.send(message, options)`
 - `SlackService.sendMany(messages, options)`
+- `SlackService.sendNotification(notification, options)`
+- `SlackService.createPlatformStatusSnapshot()`
 - `SlackChannel`
 - `SLACK`
 - `SLACK_CHANNEL`
@@ -257,7 +260,7 @@ These limitations are part of the package contract so runtime choice, provider c
 - `SlackLifecycleState`
 - `SlackStatusAdapterInput`
 - `SlackConfigurationError`
-- `SlackLifecycleError`
+- `SlackLifecycleError`: thrown by lifecycle-gated delivery, transport initialization, and owned-resource shutdown failures. Catch this error when sends can race with application teardown.
 - `SlackMessageValidationError`
 - `SlackTransportError`
 

--- a/packages/slack/src/errors.ts
+++ b/packages/slack/src/errors.ts
@@ -19,6 +19,16 @@ export class SlackMessageValidationError extends Error {
 }
 
 /**
+ * Thrown when Slack delivery is requested after the service lifecycle has started shutting down.
+ */
+export class SlackLifecycleError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'SlackLifecycleError';
+  }
+}
+
+/**
  * Thrown when one concrete Slack transport reports a caller-visible delivery failure.
  */
 export class SlackTransportError extends Error {

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -1,5 +1,6 @@
 export {
   SlackConfigurationError,
+  SlackLifecycleError,
   SlackMessageValidationError,
   SlackTransportError,
 } from './errors.js';

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -6,7 +6,7 @@ import { Container, type Provider } from '@fluojs/di';
 import { NOTIFICATION_CHANNELS, NotificationsModule, NotificationsService } from '@fluojs/notifications';
 
 import { SlackChannel } from './channel.js';
-import { SlackConfigurationError, SlackMessageValidationError, SlackTransportError } from './errors.js';
+import { SlackConfigurationError, SlackLifecycleError, SlackMessageValidationError, SlackTransportError } from './errors.js';
 import { SlackModule, createSlackProviders } from './module.js';
 import { SlackService } from './service.js';
 import { SLACK, SLACK_CHANNEL } from './tokens.js';
@@ -79,6 +79,27 @@ class UnsuccessfulTransport implements SlackTransport {
       channel: message.channel,
       ok: false,
       response: 'denied',
+      statusCode: 200,
+      warnings: [],
+    };
+  }
+}
+
+class DelayedLifecycleTransport implements SlackTransport {
+  closeCalls = 0;
+  sendCalls = 0;
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+  }
+
+  async send(message: NormalizedSlackMessage) {
+    this.sendCalls += 1;
+
+    return {
+      channel: message.channel,
+      ok: true,
+      response: 'ok',
       statusCode: 200,
       warnings: [],
     };
@@ -650,6 +671,43 @@ describe('SlackModule', () => {
         status: 'not-ready',
       },
     });
+  });
+
+  it('blocks shutdown-time delivery from reusing or recreating transports', async () => {
+    let resolveTransport!: (transport: DelayedLifecycleTransport) => void;
+    const createdTransport = new DelayedLifecycleTransport();
+    const create = vi.fn(
+      () =>
+        new Promise<SlackTransport>((resolve) => {
+          resolveTransport = resolve;
+        }),
+    );
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport: {
+        create,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+    const sendDuringCreate = service.send({ text: 'Shutdown race' });
+    const shutdown = service.onApplicationShutdown();
+
+    resolveTransport(createdTransport);
+
+    await expect(sendDuringCreate).rejects.toThrowError(
+      new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is stopped.'),
+    );
+    await shutdown;
+    await expect(service.send({ text: 'After shutdown' })).rejects.toThrowError(
+      new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is stopped.'),
+    );
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(createdTransport.closeCalls).toBe(1);
+    expect(createdTransport.sendCalls).toBe(0);
   });
 
   it('rejects module registration without an explicit transport contract', () => {

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -88,6 +88,9 @@ class UnsuccessfulTransport implements SlackTransport {
 class DelayedLifecycleTransport implements SlackTransport {
   closeCalls = 0;
   sendCalls = 0;
+  verifyCalls = 0;
+
+  constructor(private readonly verifyDelay: Promise<void> | undefined = undefined) {}
 
   async close(): Promise<void> {
     this.closeCalls += 1;
@@ -103,6 +106,11 @@ class DelayedLifecycleTransport implements SlackTransport {
       statusCode: 200,
       warnings: [],
     };
+  }
+
+  async verify(): Promise<void> {
+    this.verifyCalls += 1;
+    await this.verifyDelay;
   }
 }
 
@@ -708,6 +716,82 @@ describe('SlackModule', () => {
     expect(create).toHaveBeenCalledTimes(1);
     expect(createdTransport.closeCalls).toBe(1);
     expect(createdTransport.sendCalls).toBe(0);
+  });
+
+  it('does not mark the service ready when shutdown interrupts bootstrap verification', async () => {
+    let resolveVerify!: () => void;
+    let resolveVerifyStarted!: () => void;
+    const verifyDelay = new Promise<void>((resolve) => {
+      resolveVerify = resolve;
+    });
+    const verifyStarted = new Promise<void>((resolve) => {
+      resolveVerifyStarted = resolve;
+    });
+    const createdTransport = new DelayedLifecycleTransport(verifyDelay);
+    const verify = vi.spyOn(createdTransport, 'verify').mockImplementation(async () => {
+      createdTransport.verifyCalls += 1;
+      resolveVerifyStarted();
+      await verifyDelay;
+    });
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport: {
+        create: async () => createdTransport,
+        ownsResources: true,
+      },
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+    const bootstrap = service.onModuleInit();
+    await verifyStarted;
+    const shutdown = service.onApplicationShutdown();
+
+    await shutdown;
+    resolveVerify();
+    await bootstrap;
+
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'stopped' },
+      readiness: { status: 'not-ready' },
+    });
+    await expect(
+      service.sendNotification({
+        channel: 'slack',
+        payload: { text: 'After interrupted bootstrap' },
+        recipients: ['#ops'],
+      }),
+    ).rejects.toThrowError(new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is stopped.'));
+    expect(createdTransport.closeCalls).toBe(1);
+    expect(createdTransport.verifyCalls).toBe(1);
+    expect(verify).toHaveBeenCalledOnce();
+    expect(createdTransport.sendCalls).toBe(0);
+  });
+
+  it('checks notification lifecycle before renderer or validation errors after shutdown', async () => {
+    const render = vi.fn(async () => ({ text: 'rendered' }));
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      renderer: { render },
+      transport: createRecordingTransportFactory(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+    await service.onApplicationShutdown();
+
+    await expect(
+      service.sendNotification({
+        channel: 'slack',
+        payload: {},
+        recipients: ['#eng', '#ops'],
+        template: 'shutdown-template',
+      }),
+    ).rejects.toThrowError(new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is stopped.'));
+    expect(render).not.toHaveBeenCalled();
+    expect(transportState.sent).toHaveLength(0);
   });
 
   it('rejects module registration without an explicit transport contract', () => {

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -41,6 +41,12 @@ function createDeliveryLifecycleError(state: SlackServiceLifecycleState): SlackL
   return new SlackLifecycleError(`Slack delivery cannot start while the service lifecycle is ${state}.`);
 }
 
+function isShutdownLifecycleState(
+  state: SlackServiceLifecycleState,
+): state is Extract<SlackServiceLifecycleState, 'stopping' | 'stopped'> {
+  return state === 'stopping' || state === 'stopped';
+}
+
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
@@ -111,7 +117,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
 
       this.lifecycleState = 'ready';
     } catch (error) {
-      if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+      if (isShutdownLifecycleState(this.lifecycleState)) {
         throw error;
       }
 
@@ -323,7 +329,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
 
     if (recipients.length > 1) {
       throw new SlackMessageValidationError(
-      'Slack notifications accept exactly one target channel per dispatch. Use `sendMany(...)` for fan-out delivery.',
+        'Slack notifications accept exactly one target channel per dispatch. Use `sendMany(...)` for fan-out delivery.',
       );
     }
 

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@fluojs/core';
 import type { OnApplicationShutdown, OnModuleInit } from '@fluojs/runtime';
 
-import { SlackMessageValidationError } from './errors.js';
+import { SlackLifecycleError, SlackMessageValidationError } from './errors.js';
 import { createSlackPlatformStatusSnapshot } from './status.js';
 import { SLACK_OPTIONS } from './tokens.js';
 import type {
@@ -23,6 +23,16 @@ function createAbortError(): Error {
   const error = new Error('Slack delivery was aborted.');
   error.name = 'AbortError';
   return error;
+}
+
+type SlackServiceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
+
+function createLifecycleError(message: string, cause: unknown): SlackLifecycleError {
+  return new SlackLifecycleError(message, { cause });
+}
+
+function createDeliveryLifecycleError(state: SlackServiceLifecycleState): SlackLifecycleError {
+  return new SlackLifecycleError(`Slack delivery cannot start while the service lifecycle is ${state}.`);
 }
 
 function normalizeOptionalString(value: string | undefined): string | undefined {
@@ -48,7 +58,7 @@ function assertMessageContent(message: NormalizedSlackMessage): void {
  */
 @Inject(SLACK_OPTIONS)
 export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown {
-  private lifecycleState: 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'created';
+  private lifecycleState: SlackServiceLifecycleState = 'created';
   private resolvedTransport: SlackTransport | undefined;
   private transportPromise: Promise<SlackTransport> | undefined;
 
@@ -58,14 +68,16 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     this.lifecycleState = 'stopping';
 
     try {
-      if (this.resolvedTransport && this.options.transport.ownsResources && this.resolvedTransport.close) {
-        await this.resolvedTransport.close();
+      const transport = this.resolvedTransport ?? (this.transportPromise ? await this.transportPromise : undefined);
+
+      if (transport && this.options.transport.ownsResources && transport.close) {
+        await transport.close();
       }
 
       this.lifecycleState = 'stopped';
-    } catch {
+    } catch (error) {
       this.lifecycleState = 'failed';
-      throw new Error('Slack transport failed to close cleanly.');
+      throw createLifecycleError('Slack transport failed to close cleanly.', error);
     }
   }
 
@@ -80,9 +92,9 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
       }
 
       this.lifecycleState = 'ready';
-    } catch {
+    } catch (error) {
       this.lifecycleState = 'failed';
-      throw new Error('Slack transport failed to initialize.');
+      throw createLifecycleError('Slack transport failed to initialize.', error);
     }
   }
 
@@ -122,10 +134,12 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     if (options.signal?.aborted) {
       throw createAbortError();
     }
+    this.assertCanDeliver();
 
     const transport = await this.ensureTransport();
     const normalized = this.normalizeMessage(message);
     assertMessageContent(normalized);
+    this.assertCanDeliver();
     const result = await transport.send(normalized, options);
 
     return {
@@ -231,6 +245,8 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
   }
 
   private async ensureTransport(): Promise<SlackTransport> {
+    this.assertCanCreateOrUseTransport();
+
     if (this.resolvedTransport) {
       return this.resolvedTransport;
     }
@@ -243,6 +259,16 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     }
 
     return this.transportPromise;
+  }
+
+  private assertCanCreateOrUseTransport(): void {
+    if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped' || this.lifecycleState === 'failed') {
+      throw createDeliveryLifecycleError(this.lifecycleState);
+    }
+  }
+
+  private assertCanDeliver(): void {
+    this.assertCanCreateOrUseTransport();
   }
 
   private normalizeMessage(message: SlackMessage): NormalizedSlackMessage {

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -25,6 +25,12 @@ function createAbortError(): Error {
   return error;
 }
 
+function assertNotAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+}
+
 type SlackServiceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
 
 function createLifecycleError(message: string, cause: unknown): SlackLifecycleError {
@@ -82,17 +88,33 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
   }
 
   async onModuleInit(): Promise<void> {
+    if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+      return;
+    }
+
     this.lifecycleState = 'starting';
 
     try {
       const transport = await this.ensureTransport();
 
+      if (this.lifecycleState !== 'starting') {
+        return;
+      }
+
       if (this.options.verifyOnModuleInit && transport.verify) {
         await transport.verify();
       }
 
+      if (this.lifecycleState !== 'starting') {
+        return;
+      }
+
       this.lifecycleState = 'ready';
     } catch (error) {
+      if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+        throw error;
+      }
+
       this.lifecycleState = 'failed';
       throw createLifecycleError('Slack transport failed to initialize.', error);
     }
@@ -131,9 +153,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
    * ```
    */
   async send(message: SlackMessage, options: SlackSendOptions = {}): Promise<SlackSendResult> {
-    if (options.signal?.aborted) {
-      throw createAbortError();
-    }
+    assertNotAborted(options.signal);
     this.assertCanDeliver();
 
     const transport = await this.ensureTransport();
@@ -216,6 +236,9 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     notification: SlackNotificationDispatchRequest,
     options: SlackSendOptions = {},
   ): Promise<SlackSendResult> {
+    assertNotAborted(options.signal);
+    this.assertCanDeliver();
+
     const payload = notification.payload;
     const rendered = await this.renderNotification(notification);
 


### PR DESCRIPTION
## Summary

Closes #1750

Block `@fluojs/email` and `@fluojs/slack` delivery paths from reusing or lazily creating transports once application shutdown has started.

## Changes

- Added public `EmailLifecycleError` and `SlackLifecycleError` types for lifecycle-gated delivery failures.
- Guarded `send(...)`/`sendNotification(...)` transport creation and handoff after `stopping`, `stopped`, or `failed` lifecycle states.
- Updated shutdown to await any pending factory-owned transport creation before closing resources.
- Fixed the review-blocking TS2367 lifecycle-state comparisons in email/slack initialization paths.
- Aligned English/Korean package READMEs with the public lifecycle error exports and send/shutdown race handling guidance.
- Reclassified the changeset to `minor` for `@fluojs/email` and `@fluojs/slack` because the PR adds public lifecycle error exports and a contract-visible shutdown behavior guarantee.
- Added regression coverage for in-flight transport creation races and post-shutdown sends.

## Testing

- `pnpm install --frozen-lockfile` — passed
- LSP diagnostics clean for `packages/email/src/service.ts` and `packages/slack/src/service.ts`
- `pnpm --filter @fluojs/email... --filter @fluojs/slack... build` — passed
- `pnpm --filter @fluojs/email typecheck && pnpm --filter @fluojs/slack typecheck` — passed
- `pnpm --filter @fluojs/email test && pnpm --filter @fluojs/slack test` — passed (`@fluojs/email`: 4 files / 30 tests, `@fluojs/slack`: 3 files / 27 tests)
- `pnpm changeset status --since=main` — reports `@fluojs/email` and `@fluojs/slack` in the `minor` bucket; no patch/major bumps
- `pnpm verify` — passed (`217` files / `2789` tests)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

README public API sections now identify `EmailLifecycleError` and `SlackLifecycleError` as caller-visible lifecycle/shutdown race errors.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Shutdown-started delivery now fails deterministically with package lifecycle errors instead of reusing or recreating transports during teardown.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims were changed.