### PR TITLE
Resolve #1751: Restore GraphQL patch cleanup on bootstrap failure

### DIFF
--- a/.changeset/tidy-graphql-instanceof-cleanup.md
+++ b/.changeset/tidy-graphql-instanceof-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Restore the temporary GraphQL `instanceOf` monkey patch when application bootstrap fails, preventing failed startups from leaking process-wide GraphQL behavior into later app attempts.

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -159,6 +159,7 @@ GraphqlModule.forRoot({
 - `graphiql`을 명시적으로 켜거나 `introspection: true`를 설정하지 않으면 스키마 introspection은 기본적으로 비활성화됩니다.
 - 문서 depth, field complexity, aggregate query cost에 대한 request validation budget이 기본적으로 보수적인 값으로 활성화됩니다.
 - Streaming GraphQL 응답은 downstream response stream이 닫히거나 오류를 내면 upstream fetch body를 cancel하므로 SSE subscription 리소스를 즉시 해제합니다.
+- GraphQL 스키마 해석 이후 bootstrap이 실패하면 임시 `graphql/jsutils/instanceOf` 패치를 원복한 뒤 원래 오류를 다시 던지므로, 실패한 시작 시도가 이후 애플리케이션 시작의 process-wide GraphQL 동작을 오염시키지 않습니다.
 - WebSocket 구독 경로에는 별도의 전송 budget이 기본 적용됩니다: 동시 연결 `100`, 최대 payload 크기 `64 KiB`, 연결당 활성 operation `25`개입니다.
 - 무제한 WebSocket 동작이 정말 필요할 때만 `subscriptions.websocket.limits = false`를 사용하고, 그 경우에도 동일한 수준의 외부 제어 수단을 마련해야 합니다.
 - 무제한 동작이 꼭 필요할 때만 `limits: false`를 사용하고, 그 경우에는 외부 제어 수단을 함께 두어야 합니다.

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -159,6 +159,7 @@ GraphqlModule.forRoot({
 - Schema introspection is disabled by default unless you explicitly enable `graphiql` or set `introspection: true`.
 - Request validation budgets are enabled by default with conservative limits for document depth, field complexity, and aggregate query cost.
 - Streaming GraphQL responses cancel the upstream fetch body when the downstream response stream closes or errors, so SSE subscription resources are released promptly.
+- Bootstrap failures after GraphQL schema resolution restore the package's temporary `graphql/jsutils/instanceOf` patch before rethrowing, so failed startups do not leak process-wide GraphQL behavior into later app attempts.
 - WebSocket subscriptions use separate transport budgets by default: `100` concurrent connections, `64 KiB` maximum payload size, and `25` active operations per connection.
 - Set `subscriptions.websocket.limits = false` only when you intentionally need unbounded websocket behavior and can enforce equivalent controls elsewhere.
 - Pass `limits: false` only when you intentionally need unbounded behavior and can compensate with external controls.

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -1470,6 +1470,25 @@ describe('@fluojs/graphql', () => {
     expect(instanceOfModule.instanceOf).toBe(originalInstanceOf);
   });
 
+  it('restores the GraphQL instanceOf helper when bootstrap fails after patch installation', async () => {
+    const instanceOfModule = runtimeRequire('graphql/jsutils/instanceOf.js') as {
+      instanceOf: GraphqlInstanceOf;
+    };
+    const originalInstanceOf = instanceOfModule.instanceOf;
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [GraphqlModule.forRoot()],
+    });
+
+    const port = await findAvailablePort();
+
+    await expect(bootstrapNodeApplication(AppModule, { cors: false, port })).rejects.toThrow(
+      'GraphQL module requires either schema or at least one resolver decorated with @Resolver().',
+    );
+    expect(instanceOfModule.instanceOf).toBe(originalInstanceOf);
+  });
+
   it('keeps internal operation container when custom context includes reserved symbol key', async () => {
     const poisonedOperationContainer = {
       async dispose() {},

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -6,12 +6,7 @@ import type { Duplex } from 'node:stream';
 import { Controller, Get, Post, type FrameworkRequest, type HttpApplicationAdapter, type Middleware, type MiddlewareContext, type Next } from '@fluojs/http';
 import { Inject } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
-import {
-  type ApplicationLogger,
-  type CompiledModule,
-  type OnApplicationBootstrap,
-  type OnApplicationShutdown,
-} from '@fluojs/runtime';
+import type { ApplicationLogger, CompiledModule, OnApplicationBootstrap, OnApplicationShutdown } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 import type {
   GraphQLError as GraphQLErrorType,
@@ -400,7 +395,7 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     private readonly compiledModules: readonly CompiledModule[],
     private readonly logger: ApplicationLogger,
     private readonly adapter: HttpApplicationAdapter,
-  private readonly options: GraphqlModuleOptions,
+    private readonly options: GraphqlModuleOptions,
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
@@ -408,40 +403,54 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
       return;
     }
 
-    const deps = await loadGraphqlDeps();
-    const schema = this.resolveSchema(deps);
-    this.executeGraphqlOperation = deps.execute;
-    this.graphQLErrorConstructor = deps.GraphQLError;
-    this.subscribeGraphqlOperation = deps.subscribe;
-    const requestLimits = resolveGraphqlRequestLimits(this.options.limits);
-    const validationPlugin = createGraphqlValidationPlugin({
-      introspection: this.resolveIntrospectionEnabled(),
-      limits: requestLimits,
-    });
+    try {
+      const deps = await loadGraphqlDeps();
+      const schema = this.resolveSchema(deps);
+      this.executeGraphqlOperation = deps.execute;
+      this.graphQLErrorConstructor = deps.GraphQLError;
+      this.subscribeGraphqlOperation = deps.subscribe;
+      const requestLimits = resolveGraphqlRequestLimits(this.options.limits);
+      const validationPlugin = createGraphqlValidationPlugin({
+        introspection: this.resolveIntrospectionEnabled(),
+        limits: requestLimits,
+      });
 
-    this.yoga = deps.createYoga({
-      context: (contextValue: { request: Request; [GRAPHQL_CONTEXT_OVERRIDE]?: GraphQLContext }) =>
-        contextValue[GRAPHQL_CONTEXT_OVERRIDE] ?? this.buildGraphqlContext(contextValue.request),
-      graphqlEndpoint: '/graphql',
-      graphiql: this.resolveGraphiqlEnabled(),
-      ...((validationPlugin || (this.options.plugins && this.options.plugins.length > 0))
-        ? {
-            plugins: [
-              ...(validationPlugin ? [validationPlugin] : []),
-              ...(this.options.plugins ?? []),
-            ],
-          }
-        : {}),
-      schema,
-    });
+      this.yoga = deps.createYoga({
+        context: (contextValue: { request: Request; [GRAPHQL_CONTEXT_OVERRIDE]?: GraphQLContext }) =>
+          contextValue[GRAPHQL_CONTEXT_OVERRIDE] ?? this.buildGraphqlContext(contextValue.request),
+        graphqlEndpoint: '/graphql',
+        graphiql: this.resolveGraphiqlEnabled(),
+        ...((validationPlugin || (this.options.plugins && this.options.plugins.length > 0))
+          ? {
+              plugins: [
+                ...(validationPlugin ? [validationPlugin] : []),
+                ...(this.options.plugins ?? []),
+              ],
+            }
+          : {}),
+        schema,
+      });
 
-    this.registerWebSocketTransport();
+      this.registerWebSocketTransport();
 
-    this.registerMiddleware();
-    this.middlewareRegistered = true;
+      this.registerMiddleware();
+      this.middlewareRegistered = true;
+    } catch (error) {
+      try {
+        await this.resetGraphqlRuntimeState();
+      } catch (cleanupError) {
+        this.logger.error('Failed to clean up GraphQL runtime after bootstrap failure.', cleanupError, 'GraphqlLifecycleService');
+      }
+
+      throw error;
+    }
   }
 
   async onApplicationShutdown(): Promise<void> {
+    await this.resetGraphqlRuntimeState();
+  }
+
+  private async resetGraphqlRuntimeState(): Promise<void> {
     await this.unregisterWebSocketTransport();
     this.unregisterMiddleware();
     this.middlewareRegistered = false;


### PR DESCRIPTION
## Summary

Closes #1751

Restore `@fluojs/graphql` bootstrap-failure cleanup so the temporary process-wide `graphql/jsutils/instanceOf` patch is released even when schema/bootstrap work fails before normal shutdown can run.

## Changes

- Wrapped GraphQL bootstrap initialization in failure cleanup that unregisters middleware/websocket state and releases the `instanceOf` patch before rethrowing the original error.
- Reused the same runtime reset path for shutdown and bootstrap-failure cleanup.
- Added a regression test for failed bootstrap after patch installation.
- Documented the operational guardrail in `packages/graphql/README.md` and `README.ko.md`.
- Added a patch Changeset for `@fluojs/graphql`.

## Testing

- `lsp_diagnostics` on `packages/graphql/src/service.ts` and `packages/graphql/src/module.test.ts`: no diagnostics.
- `pnpm exec biome lint packages/graphql/src/service.ts packages/graphql/src/module.test.ts packages/graphql/README.md packages/graphql/README.ko.md .changeset/tidy-graphql-instanceof-cleanup.md`: passed.
- `pnpm --filter @fluojs/graphql typecheck`: passed.
- `pnpm --filter @fluojs/graphql test`: passed (8 files, 80 tests).
- `pnpm --filter @fluojs/graphql... build`: passed.
- `pnpm verify:public-export-tsdoc`: passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed; TSDoc changed-mode verification passed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The cleanup guarantee is documented in the GraphQL package README pair and covered by a bootstrap-failure regression test.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or package conformance claims changed.