### PR TITLE
Resolve #1753: Document Studio viewer asset subpath

### DIFF
--- a/.changeset/studio-viewer-manifest-contract.md
+++ b/.changeset/studio-viewer-manifest-contract.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/studio": patch
+---
+
+Clarify that `@fluojs/studio/viewer` is an asset-only manifest subpath for resolving the packaged HTML viewer entrypoint.

--- a/docs/contracts/manifest-decision.ko.md
+++ b/docs/contracts/manifest-decision.ko.md
@@ -30,8 +30,9 @@
 | Rule | Required shape | Repo grounding |
 | --- | --- | --- |
 | Root export | `"."`를 MUST로 선언하고 `types`와 `import` 타깃을 함께 가져야 합니다. | `packages/core/package.json`, `packages/http/package.json`, `packages/cli/package.json`이 이 형태를 따릅니다. |
-| Subpath export | 패키지가 별도 표면을 의도적으로 노출할 때 추가 subpath를 MAY로 선언할 수 있습니다. 각 subpath는 dist 빌드된 `.js`와 `.d.ts`를 가리켜야 합니다. | `@fluojs/email`은 `./queue`, `./node`를 노출하고, `@fluojs/microservices`는 `./tcp`, `./grpc`, `./rabbitmq` 같은 전송 subpath를 노출합니다. |
-| Dist-only targets | 배포 런타임 코드와 declaration은 모두 `./dist/` 아래 파일을 가리켜야 합니다. | 현재 공개 패키지는 exports를 `./dist/...` 출력으로 매핑합니다. |
+| Code subpath export | 패키지가 별도 JavaScript 표면을 의도적으로 노출할 때 추가 subpath를 MAY로 선언할 수 있습니다. 각 code subpath는 dist 빌드된 `.js`와 `.d.ts`를 가리켜야 합니다. | `@fluojs/email`은 `./queue`, `./node`를 노출하고, `@fluojs/microservices`는 `./tcp`, `./grpc`, `./rabbitmq` 같은 전송 subpath를 노출합니다. |
+| Asset-only subpath export | 패키지 README가 해당 subpath를 asset entrypoint로 문서화하고 TypeScript import 해석이 그 subpath 계약에 포함되지 않을 때, `./dist/` 아래 단일 정적 asset을 MAY로 노출할 수 있습니다. | `@fluojs/studio/viewer`는 호출자가 `require.resolve('@fluojs/studio/viewer')`로 패키징된 브라우저 viewer를 찾을 수 있도록 의도적으로 `./dist/index.html`로 해석됩니다. |
+| Dist-only targets | 배포 런타임 코드, declaration, 문서화된 정적 asset entrypoint는 모두 `./dist/` 아래 파일을 가리켜야 합니다. | 현재 공개 패키지는 exports를 `./dist/...` 출력으로 매핑합니다. |
 | Root manifest alignment | `main`과 `types`는 루트 `exports["."]` 타깃과 맞아야 합니다. | 현재 공개 매니페스트는 루트 export가 같은 파일을 가리킬 때 `main: ./dist/index.js`, `types: ./dist/index.d.ts`를 사용합니다. |
 | Subpath TypeScript resolution | 공개 subpath가 루트 `types`만으로 충분하지 않을 때 `typesVersions`를 SHOULD로 추가합니다. | `@fluojs/email`, `@fluojs/runtime`, `@fluojs/websockets`는 공개 subpath를 위해 `typesVersions`를 정의합니다. |
 | Internal surface control | 문서화되지 않았거나 우발적인 소스 경로를 매니페스트로 노출하면 안 됩니다. | 현재 패키지는 `.` 또는 명시적 named subpath 같은 공개 barrel만 노출하고, raw `src/*` 경로는 노출하지 않습니다. |
@@ -44,3 +45,4 @@
 - 선택적 런타임 통합은 루트 패키지 계약을 약화하지 않도록 peer dependency나 명시적 subpath로 유지하는 편이 맞습니다. 현재 예시는 `@fluojs/microservices`의 optional peer와 Node 전용 `@fluojs/email/node` subpath입니다.
 - 루트 패키지가 이식성을 유지해야 할 때는 런타임 전용 또는 통합 전용 표면을 루트 export에 넣지 않는 편이 맞습니다. 현재 예시는 `@fluojs/email/node`, `@fluojs/email/queue`, `@fluojs/microservices`의 transport subpath입니다.
 - 새 공개 export는 public-export TSDoc baseline과 문서화된 package surface에 맞아야 합니다.
+- Asset-only subpath는 패키지 README에 명시적으로 문서화되어야 하며, JavaScript와 declaration target이 필요한 code subpath를 대체하면 안 됩니다.

--- a/docs/contracts/manifest-decision.md
+++ b/docs/contracts/manifest-decision.md
@@ -30,8 +30,9 @@ This document defines the current package manifest contract for public `@fluojs/
 | Rule | Required shape | Repo grounding |
 | --- | --- | --- |
 | Root export | MUST declare `"."` with both `types` and `import` targets. | `packages/core/package.json`, `packages/http/package.json`, and `packages/cli/package.json` follow this shape. |
-| Subpath export | MAY declare additional subpaths when the package intentionally exposes separate surfaces. Each subpath MUST point to dist-built `.js` and `.d.ts` files. | `@fluojs/email` exports `./queue` and `./node`. `@fluojs/microservices` exports transport subpaths such as `./tcp`, `./grpc`, and `./rabbitmq`. |
-| Dist-only targets | MUST point at files under `./dist/` for published runtime code and declarations. | Current public packages map exports to `./dist/...` outputs. |
+| Code subpath export | MAY declare additional subpaths when the package intentionally exposes separate JavaScript surfaces. Each code subpath MUST point to dist-built `.js` and `.d.ts` files. | `@fluojs/email` exports `./queue` and `./node`. `@fluojs/microservices` exports transport subpaths such as `./tcp`, `./grpc`, and `./rabbitmq`. |
+| Asset-only subpath export | MAY expose a single static asset under `./dist/` when the package README documents the subpath as an asset entrypoint and TypeScript import resolution is not part of that subpath contract. | `@fluojs/studio/viewer` intentionally resolves to `./dist/index.html` so callers can locate the packaged browser viewer with `require.resolve('@fluojs/studio/viewer')`. |
+| Dist-only targets | MUST point at files under `./dist/` for published runtime code, declarations, and documented static asset entrypoints. | Current public packages map exports to `./dist/...` outputs. |
 | Root manifest alignment | `main` and `types` MUST match the root `exports["."]` targets. | Current public manifests use `main: ./dist/index.js` and `types: ./dist/index.d.ts` when the root export points to the same files. |
 | Subpath TypeScript resolution | SHOULD add `typesVersions` when published subpaths need TypeScript path hints beyond the root `types` field. | `@fluojs/email`, `@fluojs/runtime`, and `@fluojs/websockets` define `typesVersions` for published subpaths. |
 | Internal surface control | MUST NOT expose undocumented or accidental source paths through the manifest. | Current packages expose explicit public barrels such as `.` or named subpaths, not raw `src/*` paths. |
@@ -44,3 +45,4 @@ This document defines the current package manifest contract for public `@fluojs/
 - Optional runtime integrations SHOULD stay explicit through peer dependencies or explicit subpaths instead of weakening the root package contract. Current examples include optional peers in `@fluojs/microservices` and the Node-only `@fluojs/email/node` subpath.
 - Runtime-specific or integration-only surfaces SHOULD stay out of the root export when the root package is meant to remain portable. Current examples include `@fluojs/email/node`, `@fluojs/email/queue`, and transport subpaths in `@fluojs/microservices`.
 - New public exports MUST stay aligned with the public-export TSDoc baseline and the documented package surface.
+- Asset-only subpaths MUST stay explicitly documented in the package README and MUST NOT replace code subpaths that need JavaScript and declaration targets.

--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -104,6 +104,7 @@ Studio는 주로 웹 애플리케이션이지만, 배포된 패키지는 도구/
 - `@fluojs/studio/viewer`: 브라우저 뷰어 번들의 `dist/index.html` 진입 파일
 
 `@fluojs/studio`와 `@fluojs/studio/contracts`는 동등한 helper barrel을 노출합니다.
+`@fluojs/studio/viewer`는 asset-only manifest subpath입니다. 호출자는 JavaScript module이나 TypeScript declaration entrypoint가 아니라 패키징된 HTML 파일 경로를 resolve합니다.
 
 ## 관련 패키지
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -104,6 +104,7 @@ Studio is primarily a web application, but the published package also exposes th
 - `@fluojs/studio/viewer`: packaged `dist/index.html` entrypoint for the browser viewer bundle.
 
 `@fluojs/studio` and `@fluojs/studio/contracts` expose equivalent helper barrels.
+`@fluojs/studio/viewer` is an asset-only manifest subpath: callers resolve the packaged HTML file path, not a JavaScript module or TypeScript declaration entrypoint.
 
 ## Related Packages
 


### PR DESCRIPTION
## Summary

Closes #1753

Aligns the governed package manifest contract with the documented `@fluojs/studio/viewer` HTML export by encoding an asset-only subpath exception.

## Changes

- Split manifest subpath rules into code subpaths and documented asset-only subpaths.
- Documented `@fluojs/studio/viewer` as the concrete `./dist/index.html` asset-only example in EN/KO contract docs.
- Clarified the Studio README/README.ko viewer entrypoint contract.
- Added a patch changeset for `@fluojs/studio` consumer-facing documentation.

## Testing

- `lsp_diagnostics` on changed Markdown files: no diagnostics.
- `pnpm verify:platform-consistency-governance`: passed.
- `pnpm --dir packages/studio test`: passed (23 tests).
- `pnpm changeset status --since=main`: completed successfully.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] No source public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. N/A.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. N/A.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. N/A: documentation-only contract clarification; existing Studio test covers published helper and viewer entrypoints.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A: package manifest governance doc only.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. N/A.