### PR TITLE
Resolve #1757: Restore throttler test timers

### DIFF
--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -1,22 +1,19 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-import type Redis from 'ioredis';
-
 import { metadataSymbol } from '@fluojs/core/internal';
 import type { GuardContext, HandlerDescriptor, RequestContext } from '@fluojs/http';
-
-import * as throttlerExports from './index.js';
-import { SkipThrottle, Throttle, getThrottleMetadata } from './decorators.js';
+import type Redis from 'ioredis';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getThrottleMetadata, SkipThrottle, Throttle } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
-import { ThrottlerModule } from './module.js';
-import { RedisThrottlerStore } from './redis-store.js';
-import { createMemoryThrottlerStore } from './store.js';
 import type {
   ThrottlerConsumeInput,
   ThrottlerModuleOptions,
   ThrottlerStore,
   ThrottlerStoreEntry,
 } from './index.js';
+import * as throttlerExports from './index.js';
+import { ThrottlerModule } from './module.js';
+import { RedisThrottlerStore } from './redis-store.js';
+import { createMemoryThrottlerStore } from './store.js';
 
 function createRequestContext(
   options:
@@ -229,6 +226,10 @@ describe('@fluojs/throttler decorators', () => {
 
 describe('ThrottlerGuard — in-memory store', () => {
   let options: ThrottlerModuleOptions;
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   beforeEach(() => {
     vi.useFakeTimers();

--- a/packages/throttler/vitest.config.ts
+++ b/packages/throttler/vitest.config.ts
@@ -2,6 +2,7 @@ import { createFluoVitestWorkspaceConfig } from '../../tooling/vitest/src';
 
 export default createFluoVitestWorkspaceConfig(new URL('../../', import.meta.url), {
   test: {
+    globals: true,
     include: ['src/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary

Closes #1757

Restore deterministic real-timer cleanup around the `@fluojs/throttler` in-memory fake-timer contract tests so later store/clock tests cannot inherit fake timer state after failures.

## Changes

- Enabled Vitest globals for the throttler package test config so scoped lifecycle hooks are available at runtime and typecheck time.
- Added an `afterEach(() => vi.useRealTimers())` teardown to the in-memory throttler guard tests.
- No changeset: test-only maintainability hardening with no package runtime/API behavior change.

## Testing

- `pnpm exec biome check packages/throttler/src/module.test.ts packages/throttler/vitest.config.ts`
- `pnpm --filter @fluojs/throttler typecheck`
- `pnpm --filter @fluojs/throttler test` (3 files / 40 tests passed)
- LSP diagnostics clean for `packages/throttler/src/module.test.ts` and `packages/throttler/vitest.config.ts`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] No new runtime behavioral contracts were added; README updates are not required.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants remain covered by existing throttler regression tests; this PR hardens test isolation only.

## Platform consistency governance (SSOT)

- [x] No platform contract docs changed.
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] Package README alignment/conformance claims were not changed.