### PR TITLE
Resolve #1755: Harden testing portability cleanup

### DIFF
--- a/.changeset/harden-testing-portability-cleanup.md
+++ b/.changeset/harden-testing-portability-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/testing": patch
+---
+
+Report portability harness cleanup failures explicitly while preserving primary assertion failures, and declare fetch-style platform test dependencies so conformance imports remain type-checked.

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -134,6 +134,8 @@ const mailer = createDeepMock(MailService);
 
 프레임워크 지향 플랫폼 패키지를 작성할 때는 `@fluojs/testing/platform-conformance`, `@fluojs/testing/http-adapter-portability`, `@fluojs/testing/web-runtime-adapter-portability` 같은 서브패스를 사용해 적합성 및 이식성 검증을 수행합니다.
 
+이식성 하니스의 cleanup도 계약에 포함됩니다. `app.close()`가 실패하면 하니스는 cleanup 실패를 보고하며, assertion이 이미 실패한 경우에는 assertion 실패와 cleanup 실패를 모두 보존하는 aggregate error를 발생시킵니다.
+
 `HttpAdapterPortabilityHarness` 메서드는 공개 어댑터 계약 체크입니다. 직접 같은 검증을 다시 만들기보다 `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, `assertRemovesShutdownSignalListenersAfterClose()`처럼 초점이 분명한 assertion을 사용하세요.
 
 ## canonical TDD ladder

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -132,6 +132,8 @@ Install `vitest` in the consuming workspace before using the mock helpers so the
 
 Use subpaths like `@fluojs/testing/platform-conformance`, `@fluojs/testing/http-adapter-portability`, and `@fluojs/testing/web-runtime-adapter-portability` when authoring framework-facing platform packages.
 
+Portability harness cleanup is part of the contract: if `app.close()` fails, the harness reports that cleanup failure, and when an assertion already failed it raises an aggregate error that preserves both the assertion failure and the cleanup failure.
+
 `HttpAdapterPortabilityHarness` methods are the public adapter contract checks. Prefer focused assertions such as `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, and `assertRemovesShutdownSignalListenersAfterClose()` instead of hand-rolled equivalents.
 
 ## Canonical TDD Ladder

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -94,6 +94,9 @@
     "vitest": "^3.0.8"
   },
   "devDependencies": {
+    "@fluojs/platform-bun": "workspace:^",
+    "@fluojs/platform-cloudflare-workers": "workspace:^",
+    "@fluojs/platform-deno": "workspace:^",
     "@fluojs/platform-nodejs": "workspace:^",
     "@fluojs/platform-express": "workspace:^",
     "@fluojs/platform-fastify": "workspace:^",

--- a/packages/testing/src/conformance/fetch-style-websocket-conformance.test.ts
+++ b/packages/testing/src/conformance/fetch-style-websocket-conformance.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-// @ts-ignore Vitest workspace alias resolution handles package test imports.
 import { createBunAdapter } from '@fluojs/platform-bun';
-// @ts-ignore Vitest workspace alias resolution handles package test imports.
 import { createCloudflareWorkerAdapter } from '@fluojs/platform-cloudflare-workers';
-// @ts-ignore Vitest workspace alias resolution handles package test imports.
 import { createDenoAdapter } from '@fluojs/platform-deno';
 
 import { createFetchStyleWebSocketConformanceHarness } from './fetch-style-websocket-conformance.js';

--- a/packages/testing/src/portability/http-adapter-portability.test.ts
+++ b/packages/testing/src/portability/http-adapter-portability.test.ts
@@ -1,22 +1,13 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   bootstrapFastifyApplication,
   FastifyHttpApplicationAdapter,
   runFastifyApplication,
 } from '@fluojs/platform-fastify';
-import {
-  bootstrapExpressApplication,
-  runExpressApplication,
-} from '@fluojs/platform-express';
-import {
-  bootstrapNodejsApplication,
-  runNodejsApplication,
-} from '@fluojs/platform-nodejs';
-import {
-  bootstrapNodeApplication,
-  runNodeApplication,
-} from '@fluojs/runtime/node';
+import { bootstrapExpressApplication, runExpressApplication } from '@fluojs/platform-express';
+import { bootstrapNodejsApplication, runNodejsApplication } from '@fluojs/platform-nodejs';
+import { bootstrapNodeApplication, runNodeApplication } from '@fluojs/runtime/node';
 
 import { createHttpAdapterPortabilityHarness } from './http-adapter-portability.js';
 
@@ -135,6 +126,75 @@ function registerPortabilitySuite(
   });
 }
 
+describe('http adapter portability cleanup reporting', () => {
+  it('reports close failures when the assertion path succeeds', async () => {
+    const closeError = new Error('close exploded');
+    const signal = 'SIGTERM' as const;
+    const listener = () => {};
+    const harness = createHttpAdapterPortabilityHarness({
+      async bootstrap() {
+        throw new Error('bootstrap should not be used');
+      },
+      name: 'cleanup-only',
+      async run() {
+        process.on(signal, listener);
+
+        return {
+          async close() {
+            process.removeListener(signal, listener);
+            throw closeError;
+          },
+          async listen() {},
+        };
+      },
+    });
+
+    try {
+      await harness.assertRemovesShutdownSignalListenersAfterClose();
+      throw new Error('Expected cleanup failure to be reported.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (!(error instanceof AggregateError)) {
+        throw error;
+      }
+      expect(error.message).toContain('app.close() failed during portability harness cleanup');
+      expect(error.errors).toEqual([closeError]);
+    }
+  });
+
+  it('preserves assertion failures when close also fails', async () => {
+    const closeError = new Error('close exploded');
+    const harness = createHttpAdapterPortabilityHarness({
+      async bootstrap() {
+        throw new Error('bootstrap should not be used');
+      },
+      name: 'assertion-and-cleanup',
+      async run() {
+        return {
+          async close() {
+            throw closeError;
+          },
+          async listen() {},
+        };
+      },
+    });
+
+    try {
+      await harness.assertRemovesShutdownSignalListenersAfterClose();
+      throw new Error('Expected aggregate failure to be reported.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (!(error instanceof AggregateError)) {
+        throw error;
+      }
+      expect(error.message).toContain('assertion failed and app.close() also failed');
+      expect(error.errors).toHaveLength(2);
+      expect(error.errors[0]).toBeInstanceOf(Error);
+      expect(error.errors[1]).toBe(closeError);
+    }
+  });
+});
+
 registerPortabilitySuite(
   'node',
   createHttpAdapterPortabilityHarness({
@@ -172,11 +232,7 @@ const fastifyPortabilityHarness = createHttpAdapterPortabilityHarness({
       addContentTypeParser: (
         contentType: string,
         options: { parseAs: 'buffer' },
-        parser: (
-          request: unknown,
-          body: Buffer,
-          done: (error: Error | null, body: Buffer) => void,
-        ) => void,
+        parser: (request: unknown, body: Buffer, done: (error: Error | null, body: Buffer) => void) => void,
       ) => void;
     };
 

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -1,19 +1,8 @@
 import { createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
 
-import {
-  Controller,
-  Get,
-  Post,
-  SseResponse,
-  type RequestContext,
-} from '@fluojs/http';
-import {
-  defineModule,
-  type ApplicationLogger,
-  type ModuleType,
-  type UploadedFile,
-} from '@fluojs/runtime';
+import { Controller, Get, Post, SseResponse, type RequestContext } from '@fluojs/http';
+import { defineModule, type ApplicationLogger, type ModuleType, type UploadedFile } from '@fluojs/runtime';
 
 declare module '@fluojs/http' {
   interface FrameworkRequest {
@@ -120,10 +109,36 @@ async function requestHttps(url: string): Promise<{ body: string; statusCode: nu
   });
 }
 
-async function closeSilently(app: AppLike): Promise<void> {
+async function runWithCleanup(app: AppLike, adapterName: string, assertion: () => Promise<void>): Promise<void> {
+  let hasAssertionError = false;
+  let assertionError: unknown;
+
+  try {
+    await assertion();
+  } catch (error) {
+    hasAssertionError = true;
+    assertionError = error;
+  }
+
   try {
     await app.close();
-  } catch {}
+  } catch (cleanupError) {
+    if (hasAssertionError) {
+      throw new AggregateError(
+        [assertionError, cleanupError],
+        `${adapterName} adapter portability assertion failed and app.close() also failed during harness cleanup.`,
+      );
+    }
+
+    throw new AggregateError(
+      [cleanupError],
+      `${adapterName} adapter app.close() failed during portability harness cleanup.`,
+    );
+  }
+
+  if (hasAssertionError) {
+    throw assertionError;
+  }
 }
 
 /**
@@ -165,11 +180,14 @@ export class HttpAdapterPortabilityHarness<
     });
 
     const port = await findAvailablePort();
-    const app = await this.options.bootstrap(AppModule, { cors: false, port } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      port,
+    } as TBootstrapOptions);
 
     await app.listen();
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const response = await fetch(`http://127.0.0.1:${String(port)}/cookies`, {
         headers: {
           cookie: 'good=hello%20world; bad=%E0%A4%A',
@@ -177,7 +195,9 @@ export class HttpAdapterPortabilityHarness<
       });
 
       if (response.status !== 200) {
-        throw new Error(`${this.options.name} adapter changed malformed-cookie handling: expected 200 but received ${String(response.status)}.`);
+        throw new Error(
+          `${this.options.name} adapter changed malformed-cookie handling: expected 200 but received ${String(response.status)}.`,
+        );
       }
 
       const body = await response.json();
@@ -192,9 +212,7 @@ export class HttpAdapterPortabilityHarness<
       ) {
         throw new Error(`${this.options.name} adapter changed malformed-cookie normalization.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertPreservesRawBodyForJsonAndText(): Promise<void> {
@@ -223,11 +241,15 @@ export class HttpAdapterPortabilityHarness<
     });
 
     const port = await findAvailablePort();
-    const app = await this.options.bootstrap(AppModule, { cors: false, port, rawBody: true } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      port,
+      rawBody: true,
+    } as TBootstrapOptions);
 
     await app.listen();
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const [jsonResponse, textResponse] = await Promise.all([
         fetch(`http://127.0.0.1:${String(port)}/webhooks/json`, {
           body: JSON.stringify({ provider: 'stripe' }),
@@ -247,16 +269,20 @@ export class HttpAdapterPortabilityHarness<
 
       const [jsonBody, textBody] = await Promise.all([jsonResponse.json(), textResponse.json()]);
 
-      if (JSON.stringify(jsonBody) !== JSON.stringify({ parsed: { provider: 'stripe' }, raw: '{"provider":"stripe"}' })) {
+      if (
+        JSON.stringify(jsonBody) !==
+        JSON.stringify({
+          parsed: { provider: 'stripe' },
+          raw: '{"provider":"stripe"}',
+        })
+      ) {
         throw new Error(`${this.options.name} adapter changed JSON rawBody semantics.`);
       }
 
       if (JSON.stringify(textBody) !== JSON.stringify({ parsed: 'ping=1', raw: 'ping=1' })) {
         throw new Error(`${this.options.name} adapter changed text rawBody semantics.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertPreservesExactRawBodyBytesForByteSensitivePayloads(): Promise<void> {
@@ -276,13 +302,17 @@ export class HttpAdapterPortabilityHarness<
     });
 
     const port = await findAvailablePort();
-    const app = await this.options.bootstrap(AppModule, { cors: false, port, rawBody: true } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      port,
+      rawBody: true,
+    } as TBootstrapOptions);
 
     await this.options.prepareExactRawBodyByteTest?.(app);
 
     await app.listen();
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const payload = Uint8Array.from([0xe9, 0x41]);
       const contentType = this.options.exactRawBodyByteContentType ?? 'text/plain; charset=latin1';
       const response = await fetch(`http://127.0.0.1:${String(port)}/webhooks/bytes`, {
@@ -299,9 +329,7 @@ export class HttpAdapterPortabilityHarness<
       if (JSON.stringify(body) !== JSON.stringify({ rawBytes: Array.from(payload) })) {
         throw new Error(`${this.options.name} adapter changed exact-byte rawBody semantics.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertExcludesRawBodyForMultipart(): Promise<void> {
@@ -323,11 +351,15 @@ export class HttpAdapterPortabilityHarness<
     });
 
     const port = await findAvailablePort();
-    const app = await this.options.bootstrap(AppModule, { cors: false, port, rawBody: true } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      port,
+      rawBody: true,
+    } as TBootstrapOptions);
 
     await app.listen();
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const form = new FormData();
       form.set('name', 'Ada');
       form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
@@ -342,12 +374,17 @@ export class HttpAdapterPortabilityHarness<
       }
 
       const body = await response.json();
-      if (JSON.stringify(body) !== JSON.stringify({ body: { name: 'Ada' }, fileCount: 1, hasRawBody: false })) {
+      if (
+        JSON.stringify(body) !==
+        JSON.stringify({
+          body: { name: 'Ada' },
+          fileCount: 1,
+          hasRawBody: false,
+        })
+      ) {
         throw new Error(`${this.options.name} adapter changed multipart rawBody semantics.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertDefaultsMultipartTotalLimitToMaxBodySize(): Promise<void> {
@@ -379,7 +416,7 @@ export class HttpAdapterPortabilityHarness<
 
     await app.listen();
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const form = new FormData();
       form.set('name', 'Ada');
       form.set('payload', new Blob(['12345678'], { type: 'text/plain' }), 'payload.txt');
@@ -401,9 +438,7 @@ export class HttpAdapterPortabilityHarness<
       ) {
         throw new Error(`${this.options.name} adapter changed multipart limit error semantics.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertSupportsSseStreaming(): Promise<void> {
@@ -429,11 +464,14 @@ export class HttpAdapterPortabilityHarness<
     });
 
     const port = await findAvailablePort();
-    const app = await this.options.bootstrap(AppModule, { cors: false, port } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      port,
+    } as TBootstrapOptions);
 
     await app.listen();
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const response = await fetch(`http://127.0.0.1:${String(port)}/events`, {
         headers: { accept: 'text/event-stream' },
       });
@@ -451,9 +489,7 @@ export class HttpAdapterPortabilityHarness<
       if (!body.includes('event: ready') || !body.includes('data: {"ready":true}')) {
         throw new Error(`${this.options.name} adapter changed SSE body framing.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   /**
@@ -493,11 +529,14 @@ export class HttpAdapterPortabilityHarness<
     });
 
     const port = await findAvailablePort();
-    const app = await this.options.bootstrap(AppModule, { cors: false, port } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      port,
+    } as TBootstrapOptions);
 
     await app.listen();
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const response = await fetch(`http://127.0.0.1:${String(port)}/events`, {
         headers: { accept: 'text/event-stream' },
       });
@@ -507,10 +546,12 @@ export class HttpAdapterPortabilityHarness<
       }
 
       await response.text();
-      await withTimeout(drainWaitSettled, 2_000, `${this.options.name} adapter left response.stream.waitForDrain() pending after close.`);
-    } finally {
-      await closeSilently(app);
-    }
+      await withTimeout(
+        drainWaitSettled,
+        2_000,
+        `${this.options.name} adapter left response.stream.waitForDrain() pending after close.`,
+      );
+    });
   }
 
   async assertReportsConfiguredHostInStartupLogs(): Promise<void> {
@@ -547,7 +588,7 @@ export class HttpAdapterPortabilityHarness<
       port,
     } as TRunOptions);
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const response = await fetch(`http://127.0.0.1:${String(port)}/health`);
 
       if (response.status !== 200) {
@@ -563,9 +604,7 @@ export class HttpAdapterPortabilityHarness<
       if (!loggerEvents.includes(expectedLog)) {
         throw new Error(`${this.options.name} adapter changed startup host logging.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertReportsHttpsStartupUrl(https: { cert: string; key: string }): Promise<void> {
@@ -603,7 +642,7 @@ export class HttpAdapterPortabilityHarness<
       port,
     } as TRunOptions);
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const response = await requestHttps(`https://127.0.0.1:${String(port)}/health`);
 
       if (response.statusCode !== 200) {
@@ -618,9 +657,7 @@ export class HttpAdapterPortabilityHarness<
       if (!loggerEvents.includes(expectedLog)) {
         throw new Error(`${this.options.name} adapter changed HTTPS startup logging.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertRemovesShutdownSignalListenersAfterClose(): Promise<void> {
@@ -655,13 +692,11 @@ export class HttpAdapterPortabilityHarness<
     } as TRunOptions);
     const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       if (registeredListeners.length === 0) {
         throw new Error(`${this.options.name} adapter did not register the expected shutdown listener.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
 
     const remainingListeners = process.listeners(signal);
     const leakedListeners = registeredListeners.filter((listener) => remainingListeners.includes(listener));

--- a/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
@@ -1,16 +1,84 @@
 import { describe, expect, it, vi } from 'vitest';
 
-// biome-ignore lint/suspicious/noTsIgnore: Vitest resolves workspace package aliases after package builds.
-// @ts-ignore Vitest workspace alias resolution handles package test imports.
 import { bootstrapBunApplication, type BunServeOptions, type BunServerLike } from '@fluojs/platform-bun';
-// biome-ignore lint/suspicious/noTsIgnore: Vitest resolves workspace package aliases after package builds.
-// @ts-ignore Vitest workspace alias resolution handles package test imports.
-import { bootstrapCloudflareWorkerApplication, type CloudflareWorkerExecutionContext } from '@fluojs/platform-cloudflare-workers';
-// biome-ignore lint/suspicious/noTsIgnore: Vitest resolves workspace package aliases after package builds.
-// @ts-ignore Vitest workspace alias resolution handles package test imports.
-import { bootstrapDenoApplication, type DenoServeController, type DenoServeHandler, type DenoServeOptions } from '@fluojs/platform-deno';
+import {
+  bootstrapCloudflareWorkerApplication,
+  type CloudflareWorkerExecutionContext,
+} from '@fluojs/platform-cloudflare-workers';
+import {
+  bootstrapDenoApplication,
+  type DenoServeController,
+  type DenoServeHandler,
+  type DenoServeOptions,
+} from '@fluojs/platform-deno';
 
 import { createWebRuntimeHttpAdapterPortabilityHarness } from './web-runtime-adapter-portability.js';
+
+describe('web runtime portability cleanup reporting', () => {
+  it('reports close failures when the assertion path succeeds', async () => {
+    const closeError = new Error('close exploded');
+    const harness = createWebRuntimeHttpAdapterPortabilityHarness({
+      async bootstrap() {
+        return {
+          async close() {
+            throw closeError;
+          },
+          async dispatch() {
+            return Response.json({
+              bad: '�%A',
+              encoded: 'hello world',
+              tag: ['one', 'two'],
+            });
+          },
+        };
+      },
+      name: 'cleanup-only',
+    });
+
+    try {
+      await harness.assertPreservesQueryArraysAndDecoding();
+      throw new Error('Expected cleanup failure to be reported.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (!(error instanceof AggregateError)) {
+        throw error;
+      }
+      expect(error.message).toContain('app.close() failed during portability harness cleanup');
+      expect(error.errors).toEqual([closeError]);
+    }
+  });
+
+  it('preserves assertion failures when close also fails', async () => {
+    const closeError = new Error('close exploded');
+    const harness = createWebRuntimeHttpAdapterPortabilityHarness({
+      async bootstrap() {
+        return {
+          async close() {
+            throw closeError;
+          },
+          async dispatch() {
+            return Response.json({}, { status: 500 });
+          },
+        };
+      },
+      name: 'assertion-and-cleanup',
+    });
+
+    try {
+      await harness.assertPreservesQueryArraysAndDecoding();
+      throw new Error('Expected aggregate failure to be reported.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (!(error instanceof AggregateError)) {
+        throw error;
+      }
+      expect(error.message).toContain('assertion failed and app.close() also failed');
+      expect(error.errors).toHaveLength(2);
+      expect(error.errors[0]).toBeInstanceOf(Error);
+      expect(error.errors[1]).toBe(closeError);
+    }
+  });
+});
 
 type MockBunServer = BunServerLike & {
   fetch(request: Request): Promise<Response>;
@@ -20,6 +88,16 @@ type MockBun = {
   lastServer?: MockBunServer;
   serve: ReturnType<typeof vi.fn<(options: BunServeOptions) => MockBunServer>>;
 };
+
+type BunBootstrapApp = {
+  close(): Promise<void>;
+  listen(): Promise<void>;
+};
+
+type BunBootstrap = (
+  rootModule: Parameters<typeof bootstrapBunApplication>[0],
+  options: Parameters<typeof bootstrapBunApplication>[1],
+) => Promise<BunBootstrapApp>;
 
 function createExecutionContext(): CloudflareWorkerExecutionContext {
   return {
@@ -77,10 +155,21 @@ function installMockBun(): MockBun {
     let server!: MockBunServer;
 
     server = {
-      fetch: async (request: Request): Promise<Response> => await options.fetch(request, server),
+      async fetch(request: Request): Promise<Response> {
+        const response = await options.fetch(request, server);
+
+        if (response === undefined) {
+          throw new Error('Mock Bun server fetch handler did not return a response.');
+        }
+
+        return response;
+      },
       hostname,
       port,
       stop() {},
+      upgrade() {
+        return false;
+      },
       url: new URL(`${protocol}://${hostname}:${String(port)}`),
     };
 
@@ -104,11 +193,11 @@ function restoreMockBun(originalBun: MockBun | undefined): void {
 async function createBunPortabilityApp(
   rootModule: Parameters<typeof bootstrapBunApplication>[0],
   options: Parameters<typeof bootstrapBunApplication>[1],
-  bootstrap: typeof bootstrapBunApplication = bootstrapBunApplication,
+  bootstrap: BunBootstrap = bootstrapBunApplication,
 ) {
   const originalBun = (globalThis as typeof globalThis & { Bun?: MockBun }).Bun;
   const mockBun = installMockBun();
-  let app: Awaited<ReturnType<typeof bootstrapBunApplication>> | undefined;
+  let app: BunBootstrapApp | undefined;
 
   try {
     app = await bootstrap(rootModule, options);
@@ -131,7 +220,13 @@ async function createBunPortabilityApp(
       }
     },
     async dispatch(request: Request) {
-      return await mockBun.lastServer!.fetch(request);
+      const response = await mockBun.lastServer?.fetch(request);
+
+      if (response === undefined) {
+        throw new Error('Mock Bun server did not dispatch a response.');
+      }
+
+      return response;
     },
   };
 }
@@ -213,7 +308,7 @@ describe('bun web runtime adapter cleanup', () => {
           async listen() {
             throw new Error('listen failed');
           },
-        } as Awaited<ReturnType<typeof bootstrapBunApplication>>)),
+        })),
       ).rejects.toThrow('listen failed');
 
       expect(close).toHaveBeenCalledTimes(1);

--- a/packages/testing/src/portability/web-runtime-adapter-portability.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.ts
@@ -1,6 +1,4 @@
-// @ts-ignore Worktree-local LSP does not resolve workspace package aliases.
 import { Controller, Get, Post, SseResponse, type RequestContext } from '@fluojs/http';
-// @ts-ignore Worktree-local LSP does not resolve workspace package aliases.
 import { defineModule, type ModuleType, type UploadedFile } from '@fluojs/runtime';
 
 declare module '@fluojs/http' {
@@ -30,10 +28,40 @@ function decodeUtf8(input: Uint8Array | undefined): string {
   return new TextDecoder().decode(input ?? new Uint8Array());
 }
 
-async function closeSilently(app: WebRuntimePortabilityAppLike): Promise<void> {
+async function runWithCleanup(
+  app: WebRuntimePortabilityAppLike,
+  adapterName: string,
+  assertion: () => Promise<void>,
+): Promise<void> {
+  let hasAssertionError = false;
+  let assertionError: unknown;
+
+  try {
+    await assertion();
+  } catch (error) {
+    hasAssertionError = true;
+    assertionError = error;
+  }
+
   try {
     await app.close();
-  } catch {}
+  } catch (cleanupError) {
+    if (hasAssertionError) {
+      throw new AggregateError(
+        [assertionError, cleanupError],
+        `${adapterName} adapter portability assertion failed and app.close() also failed during harness cleanup.`,
+      );
+    }
+
+    throw new AggregateError(
+      [cleanupError],
+      `${adapterName} adapter app.close() failed during portability harness cleanup.`,
+    );
+  }
+
+  if (hasAssertionError) {
+    throw assertionError;
+  }
 }
 
 /**
@@ -59,10 +87,14 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
       controllers: [QueryController],
     });
 
-    const app = await this.options.bootstrap(AppModule, { cors: false } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+    } as TBootstrapOptions);
 
-    try {
-      const response = await app.dispatch(new Request('https://runtime.test/query?tag=one&tag=two&encoded=hello+world&flag&bad=%E0%A4%A'));
+    await runWithCleanup(app, this.options.name, async () => {
+      const response = await app.dispatch(
+        new Request('https://runtime.test/query?tag=one&tag=two&encoded=hello+world&flag&bad=%E0%A4%A'),
+      );
 
       if (response.status !== 200) {
         throw new Error(`${this.options.name} adapter changed query response status semantics.`);
@@ -70,18 +102,16 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
 
       const body = await response.json();
       if (
-        typeof body !== 'object'
-        || body === null
-        || (body as Record<string, unknown>).bad !== '�%A'
-        || (body as Record<string, unknown>).encoded !== 'hello world'
-        || !Array.isArray((body as Record<string, unknown>).tag)
-        || JSON.stringify((body as Record<string, unknown>).tag) !== JSON.stringify(['one', 'two'])
+        typeof body !== 'object' ||
+        body === null ||
+        (body as Record<string, unknown>).bad !== '�%A' ||
+        (body as Record<string, unknown>).encoded !== 'hello world' ||
+        !Array.isArray((body as Record<string, unknown>).tag) ||
+        JSON.stringify((body as Record<string, unknown>).tag) !== JSON.stringify(['one', 'two'])
       ) {
         throw new Error(`${this.options.name} adapter changed query decoding semantics.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertPreservesMalformedCookieValues(): Promise<void> {
@@ -98,17 +128,23 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
       controllers: [CookieController],
     });
 
-    const app = await this.options.bootstrap(AppModule, { cors: false } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+    } as TBootstrapOptions);
 
-    try {
-      const response = await app.dispatch(new Request('https://runtime.test/cookies', {
-        headers: {
-          cookie: 'good=hello%20world; bad=%E0%A4%A',
-        },
-      }));
+    await runWithCleanup(app, this.options.name, async () => {
+      const response = await app.dispatch(
+        new Request('https://runtime.test/cookies', {
+          headers: {
+            cookie: 'good=hello%20world; bad=%E0%A4%A',
+          },
+        }),
+      );
 
       if (response.status !== 200) {
-        throw new Error(`${this.options.name} adapter changed malformed-cookie handling: expected 200 but received ${String(response.status)}.`);
+        throw new Error(
+          `${this.options.name} adapter changed malformed-cookie handling: expected 200 but received ${String(response.status)}.`,
+        );
       }
 
       const body = await response.json();
@@ -123,9 +159,7 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
       ) {
         throw new Error(`${this.options.name} adapter changed malformed-cookie normalization.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertPreservesRawBodyForJsonAndText(): Promise<void> {
@@ -153,20 +187,27 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
       controllers: [WebhookController],
     });
 
-    const app = await this.options.bootstrap(AppModule, { cors: false, rawBody: true } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      rawBody: true,
+    } as TBootstrapOptions);
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const [jsonResponse, textResponse] = await Promise.all([
-        app.dispatch(new Request('https://runtime.test/webhooks/json', {
-          body: JSON.stringify({ provider: 'stripe' }),
-          headers: { 'content-type': 'application/json' },
-          method: 'POST',
-        })),
-        app.dispatch(new Request('https://runtime.test/webhooks/text', {
-          body: 'ping=1',
-          headers: { 'content-type': 'text/plain; charset=utf-8' },
-          method: 'POST',
-        })),
+        app.dispatch(
+          new Request('https://runtime.test/webhooks/json', {
+            body: JSON.stringify({ provider: 'stripe' }),
+            headers: { 'content-type': 'application/json' },
+            method: 'POST',
+          }),
+        ),
+        app.dispatch(
+          new Request('https://runtime.test/webhooks/text', {
+            body: 'ping=1',
+            headers: { 'content-type': 'text/plain; charset=utf-8' },
+            method: 'POST',
+          }),
+        ),
       ]);
 
       if (jsonResponse.status !== 201 || textResponse.status !== 201) {
@@ -175,16 +216,20 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
 
       const [jsonBody, textBody] = await Promise.all([jsonResponse.json(), textResponse.json()]);
 
-      if (JSON.stringify(jsonBody) !== JSON.stringify({ parsed: { provider: 'stripe' }, raw: '{"provider":"stripe"}' })) {
+      if (
+        JSON.stringify(jsonBody) !==
+        JSON.stringify({
+          parsed: { provider: 'stripe' },
+          raw: '{"provider":"stripe"}',
+        })
+      ) {
         throw new Error(`${this.options.name} adapter changed JSON rawBody semantics.`);
       }
 
       if (JSON.stringify(textBody) !== JSON.stringify({ parsed: 'ping=1', raw: 'ping=1' })) {
         throw new Error(`${this.options.name} adapter changed text rawBody semantics.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertExcludesRawBodyForMultipart(): Promise<void> {
@@ -205,29 +250,39 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
       controllers: [UploadController],
     });
 
-    const app = await this.options.bootstrap(AppModule, { cors: false, rawBody: true } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      rawBody: true,
+    } as TBootstrapOptions);
 
-    try {
+    await runWithCleanup(app, this.options.name, async () => {
       const form = new FormData();
       form.set('name', 'Ada');
       form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
 
-      const response = await app.dispatch(new Request('https://runtime.test/uploads', {
-        body: form,
-        method: 'POST',
-      }));
+      const response = await app.dispatch(
+        new Request('https://runtime.test/uploads', {
+          body: form,
+          method: 'POST',
+        }),
+      );
 
       if (response.status !== 201) {
         throw new Error(`${this.options.name} adapter changed multipart response status semantics.`);
       }
 
       const body = await response.json();
-      if (JSON.stringify(body) !== JSON.stringify({ body: { name: 'Ada' }, fileCount: 1, hasRawBody: false })) {
+      if (
+        JSON.stringify(body) !==
+        JSON.stringify({
+          body: { name: 'Ada' },
+          fileCount: 1,
+          hasRawBody: false,
+        })
+      ) {
         throw new Error(`${this.options.name} adapter changed multipart rawBody semantics.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 
   async assertSupportsSseStreaming(): Promise<void> {
@@ -250,12 +305,16 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
       controllers: [EventsController],
     });
 
-    const app = await this.options.bootstrap(AppModule, { cors: false } as TBootstrapOptions);
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+    } as TBootstrapOptions);
 
-    try {
-      const response = await app.dispatch(new Request('https://runtime.test/events', {
-        headers: { accept: 'text/event-stream' },
-      }));
+    await runWithCleanup(app, this.options.name, async () => {
+      const response = await app.dispatch(
+        new Request('https://runtime.test/events', {
+          headers: { accept: 'text/event-stream' },
+        }),
+      );
       const body = await response.text();
 
       if (response.status !== 200) {
@@ -270,9 +329,7 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
       if (!body.includes('event: ready') || !body.includes('data: {"ready":true}')) {
         throw new Error(`${this.options.name} adapter changed SSE body framing.`);
       }
-    } finally {
-      await closeSilently(app);
-    }
+    });
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -946,6 +946,15 @@ importers:
         specifier: workspace:^
         version: link:../runtime
     devDependencies:
+      '@fluojs/platform-bun':
+        specifier: workspace:^
+        version: link:../platform-bun
+      '@fluojs/platform-cloudflare-workers':
+        specifier: workspace:^
+        version: link:../platform-cloudflare-workers
+      '@fluojs/platform-deno':
+        specifier: workspace:^
+        version: link:../platform-deno
       '@fluojs/platform-express':
         specifier: workspace:^
         version: link:../platform-express

--- a/tooling/scripts/run-workspace-build-closure.mjs
+++ b/tooling/scripts/run-workspace-build-closure.mjs
@@ -172,12 +172,7 @@ function collectWorkspaceManifests(rootDirectory) {
 }
 
 function collectLocalDependencies(manifest, workspaceNames) {
-  const sections = [
-    manifest.dependencies,
-    manifest.devDependencies,
-    manifest.peerDependencies,
-    manifest.optionalDependencies,
-  ];
+  const sections = [manifest.dependencies, manifest.peerDependencies, manifest.optionalDependencies];
 
   const dependencies = new Set();
   for (const section of sections) {
@@ -190,7 +185,10 @@ function collectLocalDependencies(manifest, workspaceNames) {
         continue;
       }
 
-      if (typeof dependencyVersion === 'string' && (dependencyVersion.startsWith('workspace:') || dependencyVersion === 'catalog:')) {
+      if (
+        typeof dependencyVersion === 'string' &&
+        (dependencyVersion.startsWith('workspace:') || dependencyVersion === 'catalog:')
+      ) {
         dependencies.add(dependencyName);
       }
     }

--- a/tooling/scripts/run-workspace-build-closure.test.ts
+++ b/tooling/scripts/run-workspace-build-closure.test.ts
@@ -34,6 +34,38 @@ describe('resolveWorkspaceBuildOrder', () => {
     expectBefore(order, '@fluojs/di', '@fluojs/http');
     expectBefore(order, '@fluojs/http', '@fluojs/runtime');
     expectBefore(order, '@fluojs/runtime', '@fluojs/testing');
+    expect(order).not.toContain('@fluojs/platform-deno');
+    expect(order).not.toContain('@fluojs/platform-bun');
+    expect(order).not.toContain('@fluojs/platform-cloudflare-workers');
+  });
+
+  it('ignores dev-only workspace dependencies when resolving build order', () => {
+    const root = mkdtempSync(join(tmpdir(), 'fluo-build-closure-dev-deps-'));
+
+    mkdirSync(join(root, 'packages', 'app'), { recursive: true });
+    mkdirSync(join(root, 'packages', 'test-helper'), { recursive: true });
+
+    writeFileSync(
+      join(root, 'package.json'),
+      JSON.stringify({ private: true, workspaces: ['packages/*'] }, null, 2),
+      'utf8',
+    );
+    writeFileSync(
+      join(root, 'packages', 'app', 'package.json'),
+      JSON.stringify(
+        { devDependencies: { '@test/helper': 'workspace:^' }, name: '@test/app', version: '0.0.0' },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+    writeFileSync(
+      join(root, 'packages', 'test-helper', 'package.json'),
+      JSON.stringify({ dependencies: { '@test/app': 'workspace:^' }, name: '@test/helper', version: '0.0.0' }, null, 2),
+      'utf8',
+    );
+
+    expect(resolveWorkspaceBuildOrder('@test/app', root)).toEqual(['@test/app']);
   });
 
   it('fails when a child build is terminated by signal', () => {
@@ -169,7 +201,11 @@ describe('resolveWorkspaceBuildOrder', () => {
       JSON.stringify({ name: '@test/app', version: '0.0.0', scripts: { build: 'noop' } }, null, 2),
       'utf8',
     );
-    writeFileSync(join(lockDirectory, 'owner.json'), JSON.stringify({ pid: 999_999, startedAt: Date.now() - 60_000 }), 'utf8');
+    writeFileSync(
+      join(lockDirectory, 'owner.json'),
+      JSON.stringify({ pid: 999_999, startedAt: Date.now() - 60_000 }),
+      'utf8',
+    );
     writeFileSync(fakeManager, '#!/bin/sh\nexit 0\n', 'utf8');
     chmodSync(fakeManager, 0o755);
 


### PR DESCRIPTION
## Summary

Closes #1755.

Hardens `@fluojs/testing` portability/conformance harnesses so cleanup failures are visible without hiding primary assertion failures, and makes fetch-style runtime test dependencies explicit.

## Changes

- Replaced silent portability harness close cleanup with aggregate-error reporting for HTTP and web-runtime harnesses.
- Added regression tests for cleanup-only failures and assertion-plus-cleanup failures.
- Removed `@ts-ignore` suppressions from fetch-style platform imports and declared Bun/Deno/Cloudflare Workers platform devDependencies for `@fluojs/testing`.
- Documented portability cleanup behavior in EN/KO `@fluojs/testing` READMEs and added a patch changeset.
- Adjusted workspace build-closure ordering to ignore dev-only workspace dependencies so explicit test dependencies do not create build-order cycles.

## Testing

- `pnpm --filter @fluojs/testing typecheck`
- `pnpm --filter @fluojs/testing test` (145 tests passed)
- `pnpm vitest run tooling/scripts/run-workspace-build-closure.test.ts` (6 tests passed)
- `pnpm build`
- `pnpm lint` (completed; existing repo-wide Biome warnings remain, `verify:public-export-tsdoc` passed)
- LSP diagnostics: clean on changed TypeScript/MJS files

## Public export documentation

- [x] Changed public exports include a source-level summary. (No new public exports added.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (No exported function signatures changed.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (No platform contract docs changed.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (No new platform conformance claims added.)