### PR TITLE
Restore throttler afterEach test import

### DIFF
--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -1,7 +1,7 @@
 import { metadataSymbol } from '@fluojs/core/internal';
 import type { GuardContext, HandlerDescriptor, RequestContext } from '@fluojs/http';
 import type Redis from 'ioredis';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getThrottleMetadata, SkipThrottle, Throttle } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
 import type {

--- a/packages/throttler/src/vitest-module.d.ts
+++ b/packages/throttler/src/vitest-module.d.ts
@@ -1,4 +1,5 @@
 declare module 'vitest' {
+  export const afterEach: typeof globalThis.afterEach;
   export const beforeEach: typeof globalThis.beforeEach;
   export const describe: typeof globalThis.describe;
   export const expect: typeof globalThis.expect;


### PR DESCRIPTION
## Summary
- Restore the missing `afterEach` import in `packages/throttler/src/module.test.ts`.
- Extend the package-local Vitest module shim so typecheck recognizes the imported teardown helper.

## Verification
- LSP diagnostics clean for `packages/throttler/src/module.test.ts`
- LSP diagnostics clean for `packages/throttler/src/vitest-module.d.ts`
- `pnpm --filter @fluojs/throttler typecheck`
- `pnpm --filter @fluojs/throttler test -- src/module.test.ts`
- `pnpm exec biome lint packages/throttler/src/module.test.ts packages/throttler/src/vitest-module.d.ts`