### PR TITLE
Resolve #1758: Harden platform signal listener tests

### DIFF
--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1337,9 +1337,12 @@ describe('@fluojs/platform-fastify', () => {
     });
 
     const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
-    expect(registeredListeners.length).toBeGreaterThan(0);
 
-    await app.close();
+    try {
+      expect(registeredListeners.length).toBeGreaterThan(0);
+    } finally {
+      await app.close();
+    }
 
     for (const listener of registeredListeners) {
       expect(process.listeners(signal)).not.toContain(listener);

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -244,9 +244,11 @@ describe('@fluojs/platform-nodejs', () => {
     });
     const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
 
-    expect(registeredListeners.length).toBeGreaterThan(0);
-
-    await app.close();
+    try {
+      expect(registeredListeners.length).toBeGreaterThan(0);
+    } finally {
+      await app.close();
+    }
 
     for (const listener of registeredListeners) {
       expect(process.listeners(signal)).not.toContain(listener);


### PR DESCRIPTION
## Summary

- Makes platform shutdown signal listener lifecycle tests failure-safe by closing created apps from `finally` blocks.
- Keeps listener removal assertions after `app.close()` while ensuring failed intermediate assertions cannot leak listeners/resources.

Closes #1758

## Changes

- Updated `packages/platform-nodejs/src/index.test.ts` shutdown listener test to always close the app after creation.
- Updated `packages/platform-fastify/src/adapter.test.ts` shutdown listener test with the same `try`/`finally` cleanup pattern.
- No runtime behavior, public API, docs, or changeset changes; tests-only hardening.

## Testing

- LSP diagnostics: `packages/platform-nodejs/src/index.test.ts` clean; `packages/platform-fastify/src/adapter.test.ts` has no errors/warnings (existing deprecation hints for `createHealthModule`).
- `pnpm --filter @fluojs/platform-nodejs test`
- `pnpm --filter @fluojs/platform-fastify test`
- `pnpm build`
- `pnpm --filter @fluojs/platform-nodejs typecheck && pnpm --filter @fluojs/platform-fastify typecheck`
- `pnpm exec biome lint packages/platform-nodejs/src/index.test.ts packages/platform-fastify/src/adapter.test.ts`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.