### PR TITLE
Resolve #1791: Harden notifications queued bulk lifecycle

### DIFF
--- a/.changeset/notifications-queued-bulk-lifecycle.md
+++ b/.changeset/notifications-queued-bulk-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/notifications": patch
+---
+
+Ensure queued bulk notification dispatch publishes terminal lifecycle events for every requested notification and reports partial sequential enqueue fallback results when `continueOnError` is enabled.

--- a/book/intermediate/ch15-notifications.ko.md
+++ b/book/intermediate/ch15-notifications.ko.md
@@ -120,7 +120,7 @@ NotificationsModule.forRoot({
 });
 ```
 
-`bulkThreshold`에 도달하거나 옵션을 통해 명시적으로 요청된 경우, service는 직접 전송 대신 queue adapter를 사용합니다. 각 queued job은 안정적인 idempotency key를 포함합니다. `notification.id`가 있으면 그 값을 보존하고, 없으면 notification envelope에서 key를 파생하므로 idempotent enqueue를 지원하는 queue backend가 반복 요청을 중복 제거할 수 있습니다.
+`bulkThreshold`에 도달하거나 옵션을 통해 명시적으로 요청된 경우, service는 직접 전송 대신 queue adapter를 사용합니다. 각 queued job은 안정적인 idempotency key를 포함합니다. `notification.id`가 있으면 그 값을 보존하고, 없으면 notification envelope에서 key를 파생하므로 idempotent enqueue를 지원하는 queue backend가 반복 요청을 중복 제거할 수 있습니다. Adapter가 `enqueueMany()`를 구현하지 않으면 fluo는 input order대로 job을 하나씩 enqueue합니다. 이때 `continueOnError: true`이면 성공한 queued result를 보존하고 실패한 enqueue 시도는 batch failures 목록으로 반환합니다.
 
 ## 15.6 Lifecycle Events
 
@@ -147,7 +147,7 @@ NotificationsModule.forRoot({
 - `notification.dispatch.delivered`: 채널이 성공적인 전송을 확인했을 때.
 - `notification.dispatch.failed`: 채널 해석, queue enqueue, provider delivery가 실패했을 때.
 
-채널 해석 실패는 영구적인 구성 오류입니다. 서비스는 `requested` 다음 `failed`를 발행하고, queue에 넣거나 provider를 호출하지 않은 채 `NotificationChannelNotFoundError`를 던집니다. Queue enqueue와 provider delivery 실패도 `failed`를 발행하지만, retry 정책은 underlying queue/provider error를 기준으로 판단해야 합니다. 채널이 `externalId`를 생략하면 서비스는 시간이나 난수가 아니라 notification envelope에서 deterministic fallback delivery id를 만듭니다.
+채널 해석 실패는 영구적인 구성 오류입니다. 서비스는 `requested` 다음 `failed`를 발행하고, queue에 넣거나 provider를 호출하지 않은 채 `NotificationChannelNotFoundError`를 던집니다. Queue enqueue와 provider delivery 실패도 `failed`를 발행하지만, retry 정책은 underlying queue/provider error를 기준으로 판단해야 합니다. Queued bulk dispatch는 queue 미구성, channel 해석, 순차 fallback enqueue 실패를 포함해 `requested`를 발행한 모든 notification에 terminal `queued` 또는 `failed` 이벤트를 발행합니다. 채널이 `externalId`를 생략하면 서비스는 시간이나 난수가 아니라 notification envelope에서 deterministic fallback delivery id를 만듭니다.
 
 성공 이벤트 publication failure는 이미 완료된 delivery를 애플리케이션 실패로 바꾸지 않도록 best-effort입니다. 반면 `notification.dispatch.failed` publication failure는 다르게 처리됩니다. 호출자는 원래 dispatch error와 publisher error를 모두 담은 `AggregateError`를 받으므로 실패 알림 reporting이 조용히 누락되지 않습니다.
 

--- a/book/intermediate/ch15-notifications.md
+++ b/book/intermediate/ch15-notifications.md
@@ -120,7 +120,7 @@ NotificationsModule.forRoot({
 });
 ```
 
-When `bulkThreshold` is reached, or when options explicitly request it, the service uses the queue adapter instead of direct delivery. Each queued job carries a stable idempotency key: `notification.id` is preserved when supplied, otherwise the key is derived from the notification envelope so repeated requests can be deduplicated by queue backends that support idempotent enqueue operations.
+When `bulkThreshold` is reached, or when options explicitly request it, the service uses the queue adapter instead of direct delivery. Each queued job carries a stable idempotency key: `notification.id` is preserved when supplied, otherwise the key is derived from the notification envelope so repeated requests can be deduplicated by queue backends that support idempotent enqueue operations. If an adapter does not implement `enqueueMany()`, fluo enqueues jobs one by one in input order; `continueOnError: true` preserves successful queued results while returning failed enqueue attempts in the batch failures list.
 
 ## 15.6 Lifecycle Events
 
@@ -147,7 +147,7 @@ NotificationsModule.forRoot({
 - `notification.dispatch.delivered`: When the channel confirms successful delivery.
 - `notification.dispatch.failed`: When channel resolution, queue enqueue, or provider delivery fails.
 
-Channel resolution failures are permanent configuration errors: the service publishes `requested`, then `failed`, and throws `NotificationChannelNotFoundError` without enqueueing or calling a provider. Queue enqueue and provider delivery failures also publish `failed`, but retry policy should be based on the underlying queue or provider error. When a channel omits `externalId`, the service creates a deterministic fallback delivery id from the notification envelope rather than using time or random data.
+Channel resolution failures are permanent configuration errors: the service publishes `requested`, then `failed`, and throws `NotificationChannelNotFoundError` without enqueueing or calling a provider. Queue enqueue and provider delivery failures also publish `failed`, but retry policy should be based on the underlying queue or provider error. Queued bulk dispatch publishes a terminal `queued` or `failed` event for every notification that emitted `requested`, including queue-missing, channel-resolution, and sequential fallback enqueue failures. When a channel omits `externalId`, the service creates a deterministic fallback delivery id from the notification envelope rather than using time or random data.
 
 Publication failures for success events are best-effort so they do not turn a completed delivery into an application failure. Publication failures for `notification.dispatch.failed` are different: the caller receives an `AggregateError` containing both the original dispatch error and the publisher error so failed notification reporting is never silently swallowed.
 

--- a/packages/notifications/README.ko.md
+++ b/packages/notifications/README.ko.md
@@ -121,9 +121,9 @@ Behavioral contract 메모:
 - queue adapter가 있어도 직접 전달을 강제하려면 `dispatch(..., { queue: false })`를 사용합니다.
 - 큐 기반 전달은 단건 dispatch에서는 opt-in이고, `dispatchMany(...)`에서는 threshold 기반으로 동작합니다.
 - Queue job에는 `notification.id`가 있으면 그 값을, 없으면 notification envelope에서 파생한 deterministic `id` idempotency key가 포함됩니다. Queue adapter는 deduplication을 지원하는 backing queue에 이 값을 전달해야 합니다.
-- `dispatchMany(..., { continueOnError: true })`는 direct delivery에서 첫 실패를 던지는 대신 실패들을 수집합니다.
-- queue enqueue가 실패하면 서비스는 enqueue 에러를 다시 던지기 전에 결정적인 `notification.dispatch.failed` 라이프사이클 이벤트를 발행합니다.
-- `enqueueMany(...)`가 없으면 대량 queue delivery는 각 job을 개별적으로 enqueue하는 방식으로 fallback합니다.
+- `dispatchMany(..., { continueOnError: true })`는 direct delivery 또는 순차 queue fallback enqueue에서 첫 실패를 던지는 대신 실패들을 수집합니다.
+- queue enqueue가 실패하면 서비스는 enqueue 에러를 다시 던지기 전에 결정적인 `notification.dispatch.failed` 라이프사이클 이벤트를 발행합니다. queued bulk dispatch는 queue 미구성, channel 해석, provider/adapter failure 경로를 포함해 이미 `requested`를 발행한 모든 notification에 대해 terminal `queued` 또는 `failed` 이벤트도 발행합니다.
+- `enqueueMany(...)`가 없으면 대량 queue delivery는 input order대로 각 job을 개별 enqueue하는 방식으로 fallback합니다. `continueOnError: true`이면 성공한 enqueue는 `results`에 남고 실패한 enqueue는 `failures`로 반환됩니다. 그렇지 않으면 첫 enqueue failure를 다시 던지기 전에 아직 terminal 상태가 없는 나머지 requested fallback job에 `failed` 라이프사이클 이벤트를 발행합니다.
 - foundation 패키지는 특정 큐 구현을 가정하거나 import하지 않습니다.
 
 ### 이벤트 발행자를 통한 라이프사이클 발행

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -121,9 +121,9 @@ Behavioral contract notes:
 - Use `dispatch(..., { queue: false })` to force direct delivery even when a queue adapter exists.
 - Queue-backed delivery is opt-in for single dispatch and threshold-driven for `dispatchMany(...)`.
 - Queue jobs include a deterministic `id` idempotency key derived from `notification.id` when present, otherwise from the notification envelope. Queue adapters should pass this value to backing queues that support deduplication.
-- `dispatchMany(..., { continueOnError: true })` collects failures instead of throwing on the first failed direct delivery.
-- When queue enqueue fails, the service emits deterministic `notification.dispatch.failed` lifecycle events before rethrowing the enqueue error to the caller.
-- If `enqueueMany(...)` is unavailable, bulk queue delivery falls back to enqueueing each job individually.
+- `dispatchMany(..., { continueOnError: true })` collects failures instead of throwing on the first failed direct delivery or sequential queue fallback enqueue.
+- When queue enqueue fails, the service emits deterministic `notification.dispatch.failed` lifecycle events before rethrowing the enqueue error to the caller. Queued bulk dispatch also publishes a terminal `queued` or `failed` event for every notification that already emitted `requested`, including queue-missing, channel-resolution, and provider/adapter failure paths.
+- If `enqueueMany(...)` is unavailable, bulk queue delivery falls back to enqueueing each job individually in input order. With `continueOnError: true`, successful enqueues remain visible in `results` while failed enqueues are returned in `failures`; without it, the first enqueue failure is rethrown after the remaining requested fallback jobs receive `failed` lifecycle events.
 - The foundation package does not assume or import a concrete queue implementation.
 
 ### Lifecycle publication through an event publisher

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -670,6 +670,68 @@ describe('NotificationsModule', () => {
     ]);
   });
 
+  it('preserves sequential queue fallback partial results when failed lifecycle publication fails under continueOnError', async () => {
+    const queue = new FailingEnqueueOnlyQueueAdapter(2);
+    const publisher = new RecordingPublisher();
+    publisher.failOnNames.add('notification.dispatch.failed');
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not be used for queued bulk dispatch');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+      events: {
+        publisher,
+      },
+    });
+
+    const notifications = [
+      { channel: 'email', id: 'first-job', payload: { template: 'digest', userId: 'u1' } },
+      { channel: 'email', id: 'second-job', payload: { template: 'digest', userId: 'u2' } },
+      { channel: 'email', id: 'third-job', payload: { template: 'digest', userId: 'u3' } },
+    ];
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+    const result = await service.dispatchMany(notifications, { continueOnError: true });
+
+    expect(queue.jobs.map((job) => job.id)).toEqual(['first-job', 'third-job']);
+    expect(result).toMatchObject({
+      failed: 1,
+      queued: 2,
+      succeeded: 2,
+    });
+    expect(result.results.map((entry: NotificationDispatchResult) => entry.deliveryId)).toEqual(['queued:1', 'queued:2']);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.notification).toBe(notifications[1]);
+    expect(result.failures[0]?.error).toBeInstanceOf(AggregateError);
+
+    const failureError = result.failures[0]?.error;
+
+    if (!(failureError instanceof AggregateError)) {
+      throw new Error('Expected sequential fallback failure to include lifecycle publication failure details.');
+    }
+
+    expect(failureError.errors).toHaveLength(2);
+    expect(failureError.errors[0]).toMatchObject({ message: 'queue enqueue failed:2' });
+    expect(failureError.errors[1]).toMatchObject({ message: 'publisher failed:notification.dispatch.failed' });
+    expect(publisher.events).toMatchObject([
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', deliveryId: 'queued:1', name: 'notification.dispatch.queued' },
+      { channel: 'email', deliveryId: 'queued:2', name: 'notification.dispatch.queued' },
+    ]);
+  });
+
   it('publishes terminal events for all requested sequential fallback jobs after an enqueue failure', async () => {
     const queue = new FailingEnqueueOnlyQueueAdapter(2);
     const publisher = new RecordingPublisher();

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -1,17 +1,16 @@
-import { describe, expect, it } from 'vitest';
-
-import { Inject, type Constructor, type Token } from '@fluojs/core';
+import { type Constructor, Inject, type Token } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Container, type Provider } from '@fluojs/di';
+import { describe, expect, it } from 'vitest';
 
-import { NotificationChannelNotFoundError } from './errors.js';
+import { NotificationChannelNotFoundError, NotificationQueueNotConfiguredError } from './errors.js';
 import { NotificationsModule } from './module.js';
 import { NotificationsService } from './service.js';
 import { NOTIFICATION_CHANNELS, NOTIFICATIONS } from './tokens.js';
 import type {
   NotificationChannel,
-  NotificationDispatchResult,
   NotificationDispatchRequest,
+  NotificationDispatchResult,
   NotificationLifecycleEvent,
   Notifications,
   NotificationsEventPublisher,
@@ -70,6 +69,24 @@ class EnqueueOnlyQueueAdapter implements NotificationsQueueAdapter {
   readonly jobs: NotificationsQueueJob[] = [];
 
   async enqueue(job: NotificationsQueueJob): Promise<string> {
+    this.jobs.push(job);
+    return `queued:${this.jobs.length}`;
+  }
+}
+
+class FailingEnqueueOnlyQueueAdapter implements NotificationsQueueAdapter {
+  readonly jobs: NotificationsQueueJob[] = [];
+  private calls = 0;
+
+  constructor(private readonly failOnCall: number) {}
+
+  async enqueue(job: NotificationsQueueJob): Promise<string> {
+    this.calls += 1;
+
+    if (this.calls === this.failOnCall) {
+      throw new Error(`queue enqueue failed:${this.failOnCall}`);
+    }
+
     this.jobs.push(job);
     return `queued:${this.jobs.length}`;
   }
@@ -597,6 +614,160 @@ describe('NotificationsModule', () => {
     ]);
   });
 
+  it('reports partial enqueue results from sequential queue fallback when continueOnError is enabled', async () => {
+    const queue = new FailingEnqueueOnlyQueueAdapter(2);
+    const publisher = new RecordingPublisher();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not be used for queued bulk dispatch');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+      events: {
+        publisher,
+      },
+    });
+
+    const notifications = [
+      { channel: 'email', id: 'first-job', payload: { template: 'digest', userId: 'u1' } },
+      { channel: 'email', id: 'second-job', payload: { template: 'digest', userId: 'u2' } },
+      { channel: 'email', id: 'third-job', payload: { template: 'digest', userId: 'u3' } },
+    ];
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+    const result = await service.dispatchMany(notifications, { continueOnError: true });
+
+    expect(queue.jobs.map((job) => job.id)).toEqual(['first-job', 'third-job']);
+    expect(result).toMatchObject({
+      failed: 1,
+      queued: 2,
+      succeeded: 2,
+    });
+    expect(result.results.map((entry: NotificationDispatchResult) => entry.deliveryId)).toEqual(['queued:1', 'queued:2']);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.notification).toBe(notifications[1]);
+    expect(result.failures[0]?.error).toMatchObject({ message: 'queue enqueue failed:2' });
+    expect(publisher.events).toMatchObject([
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', deliveryId: 'queued:1', name: 'notification.dispatch.queued' },
+      {
+        channel: 'email',
+        error: { message: 'queue enqueue failed:2', name: 'Error' },
+        name: 'notification.dispatch.failed',
+      },
+      { channel: 'email', deliveryId: 'queued:2', name: 'notification.dispatch.queued' },
+    ]);
+  });
+
+  it('publishes terminal events for all requested sequential fallback jobs after an enqueue failure', async () => {
+    const queue = new FailingEnqueueOnlyQueueAdapter(2);
+    const publisher = new RecordingPublisher();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not be used for queued bulk dispatch');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+      events: {
+        publisher,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await expect(
+      service.dispatchMany([
+        { channel: 'email', id: 'first-job', payload: { template: 'digest', userId: 'u1' } },
+        { channel: 'email', id: 'second-job', payload: { template: 'digest', userId: 'u2' } },
+        { channel: 'email', id: 'third-job', payload: { template: 'digest', userId: 'u3' } },
+      ]),
+    ).rejects.toThrow('queue enqueue failed:2');
+
+    expect(queue.jobs.map((job) => job.id)).toEqual(['first-job']);
+    expect(publisher.events).toMatchObject([
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', deliveryId: 'queued:1', name: 'notification.dispatch.queued' },
+      {
+        channel: 'email',
+        error: { message: 'queue enqueue failed:2', name: 'Error' },
+        name: 'notification.dispatch.failed',
+      },
+      {
+        channel: 'email',
+        error: { message: 'queue enqueue failed:2', name: 'Error' },
+        name: 'notification.dispatch.failed',
+      },
+    ]);
+  });
+
+  it('publishes failed lifecycle events for queued bulk dispatch when the queue is missing', async () => {
+    const publisher = new RecordingPublisher();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not be used for queued bulk dispatch');
+          },
+        },
+      ],
+      events: {
+        publisher,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await expect(
+      service.dispatchMany(
+        [
+          { channel: 'email', payload: { template: 'digest', userId: 'u1' } },
+          { channel: 'email', payload: { template: 'digest', userId: 'u2' } },
+        ],
+        { queue: true },
+      ),
+    ).rejects.toBeInstanceOf(NotificationQueueNotConfiguredError);
+
+    expect(publisher.events).toMatchObject([
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      { channel: 'email', name: 'notification.dispatch.requested' },
+      {
+        channel: 'email',
+        error: { message: 'Queue-backed notification delivery requires a configured queue adapter.', name: 'NotificationQueueNotConfiguredError' },
+        name: 'notification.dispatch.failed',
+      },
+      {
+        channel: 'email',
+        error: { message: 'Queue-backed notification delivery requires a configured queue adapter.', name: 'NotificationQueueNotConfiguredError' },
+        name: 'notification.dispatch.failed',
+      },
+    ]);
+  });
+
   it('publishes deterministic failed lifecycle events when bulk queue enqueue fails', async () => {
     const queue = new RecordingQueueAdapter();
     queue.failOnEnqueueMany = true;
@@ -745,6 +916,11 @@ describe('NotificationsModule', () => {
       {
         channel: 'discord',
         name: 'notification.dispatch.requested',
+      },
+      {
+        channel: 'email',
+        error: { message: 'No notification channel is registered for "discord".', name: 'NotificationChannelNotFoundError' },
+        name: 'notification.dispatch.failed',
       },
       {
         channel: 'discord',

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -425,7 +425,7 @@ export class NotificationsService implements Notifications {
         results.push(result);
         await this.publishLifecycleEventSafely('notification.dispatch.queued', notification, options, deliveryId);
       } catch (error) {
-        const failure = {
+        const failure: { error: Error; notification: TRequest } = {
           error: error instanceof Error ? error : new Error('Notification queue enqueue failed.'),
           notification,
         };
@@ -435,8 +435,15 @@ export class NotificationsService implements Notifications {
           throw error;
         }
 
+        try {
+          await this.publishFailureLifecycleEvent(notification, options, error);
+        } catch (publicationError) {
+          failure.error = publicationError instanceof Error
+            ? publicationError
+            : createLifecyclePublicationFailureError(error, publicationError);
+        }
+
         failures.push(failure);
-        await this.publishFailureLifecycleEvent(notification, options, error);
       }
     }
 

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -150,44 +150,40 @@ export class NotificationsService implements Notifications {
     }
 
     if (this.shouldQueue(notifications.length, options)) {
-      const queue = this.requireQueueAdapter();
-
       for (const notification of notifications) {
         await this.publishLifecycleEventSafely('notification.dispatch.requested', notification, options);
       }
 
-      for (const notification of notifications) {
-        try {
+      let queue: ReturnType<NotificationsService['requireQueueAdapter']>;
+
+      try {
+        queue = this.requireQueueAdapter();
+      } catch (error) {
+        await this.publishFailureLifecycleEvents(notifications, options, error);
+        throw error;
+      }
+
+      try {
+        for (const notification of notifications) {
           this.requireChannel(notification.channel);
-        } catch (error) {
-          await this.publishFailureLifecycleEvent(notification, options, error);
-          throw error;
         }
+      } catch (error) {
+        await this.publishFailureLifecycleEvents(notifications, options, error);
+        throw error;
       }
 
       const jobs = notifications.map((notification) => this.createQueueJob(notification));
 
+      if (!queue.enqueueMany) {
+        return this.dispatchManyThroughSequentialQueueFallback(notifications, jobs, options);
+      }
+
       let ids: readonly string[];
 
       try {
-        ids = queue.enqueueMany
-          ? await queue.enqueueMany(jobs)
-          : await Promise.all(jobs.map((job) => queue.enqueue(job)));
+        ids = await queue.enqueueMany(jobs);
       } catch (error) {
-        const failurePublicationResults = await Promise.allSettled(
-          notifications.map((notification) =>
-            this.publishLifecycleEvent('notification.dispatch.failed', notification, options, undefined, error),
-          ),
-        );
-
-        const publicationFailures = failurePublicationResults
-          .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
-          .map((result) => result.reason);
-
-        if (publicationFailures.length > 0) {
-          throw createLifecyclePublicationFailureError(error, ...publicationFailures);
-        }
-
+        await this.publishFailureLifecycleEvents(notifications, options, error);
         throw error;
       }
 
@@ -378,6 +374,79 @@ export class NotificationsService implements Notifications {
     } catch (publicationError) {
       throw createLifecyclePublicationFailureError(error, publicationError);
     }
+  }
+
+  private async publishFailureLifecycleEvents<TRequest extends NotificationDispatchRequest>(
+    notifications: readonly TRequest[],
+    options: NotificationDispatchOptions,
+    error: unknown,
+  ): Promise<void> {
+    const failurePublicationResults = await Promise.allSettled(
+      notifications.map((notification) =>
+        this.publishLifecycleEvent('notification.dispatch.failed', notification, options, undefined, error),
+      ),
+    );
+
+    const publicationFailures = failurePublicationResults
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map((result) => result.reason);
+
+    if (publicationFailures.length > 0) {
+      throw createLifecyclePublicationFailureError(error, ...publicationFailures);
+    }
+  }
+
+  private async dispatchManyThroughSequentialQueueFallback<TRequest extends NotificationDispatchRequest>(
+    notifications: readonly TRequest[],
+    jobs: readonly NotificationsQueueJob<TRequest>[],
+    options: NotificationDispatchManyOptions,
+  ): Promise<NotificationDispatchBatchResult<TRequest>> {
+    const queue = this.requireQueueAdapter();
+    const results: NotificationDispatchResult[] = [];
+    const failures: Array<{ error: Error; notification: TRequest }> = [];
+
+    for (let index = 0; index < jobs.length; index += 1) {
+      const job = jobs[index];
+      const notification = notifications[index];
+
+      if (!job || !notification) {
+        continue;
+      }
+
+      try {
+        const deliveryId = this.normalizeDeliveryId(await queue.enqueue(job), notification);
+        const result: NotificationDispatchResult = {
+          channel: notification.channel,
+          deliveryId,
+          queued: true,
+          status: 'queued',
+        };
+
+        results.push(result);
+        await this.publishLifecycleEventSafely('notification.dispatch.queued', notification, options, deliveryId);
+      } catch (error) {
+        const failure = {
+          error: error instanceof Error ? error : new Error('Notification queue enqueue failed.'),
+          notification,
+        };
+
+        if (!(options.continueOnError ?? false)) {
+          await this.publishFailureLifecycleEvents(notifications.slice(index), options, error);
+          throw error;
+        }
+
+        failures.push(failure);
+        await this.publishFailureLifecycleEvent(notification, options, error);
+      }
+    }
+
+    return {
+      failed: failures.length,
+      failures,
+      queued: results.length,
+      results,
+      succeeded: results.length,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #1791.

Hardens `@fluojs/notifications` queued bulk dispatch so requested lifecycle events reach terminal states and sequential queue fallback reports partial enqueue outcomes instead of hiding them behind `Promise.all` rejection.

## Changes

- Validates queued bulk dispatch after publishing `requested` events and emits `failed` terminal events for queue-missing and channel-resolution failures.
- Replaces `Promise.all` sequential fallback with ordered enqueue handling that can preserve successful queued results under `continueOnError: true`.
- Adds regression coverage for queue-missing, channel-resolution, enqueueMany failure, sequential fallback partial success, and terminal lifecycle publication.
- Updates EN/KO package README and intermediate notifications chapter to document queue fallback and lifecycle semantics.
- Adds a patch changeset for `@fluojs/notifications` user-facing behavior alignment.

## Testing

- `pnpm install` (worktree dependency setup)
- `pnpm --filter @fluojs/validation --filter @fluojs/http --filter @fluojs/runtime build` (dependency dist setup for package verification)
- `pnpm --filter @fluojs/notifications typecheck`
- `pnpm --filter @fluojs/notifications test`
- `pnpm --filter @fluojs/notifications build`
- `pnpm exec biome check packages/notifications/src/service.ts packages/notifications/src/module.test.ts packages/notifications/README.md packages/notifications/README.ko.md book/intermediate/ch15-notifications.md book/intermediate/ch15-notifications.ko.md .changeset/notifications-queued-bulk-lifecycle.md`
- LSP diagnostics: clean on `packages/notifications/src/service.ts` and `packages/notifications/src/module.test.ts`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or removed; behavior was aligned inside existing `NotificationsService` contracts.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; package README/book EN/KO mirrors were kept aligned.