### PR TITLE
Resolve #1782: Harden email bootstrap readiness

### DIFF
--- a/.changeset/email-bootstrap-readiness.md
+++ b/.changeset/email-bootstrap-readiness.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Require verified email transports to finish bootstrap readiness before delivery, allow rejected async option factories to retry, and validate Nodemailer display-name address handoff.

--- a/book/intermediate/ch16-email.ko.md
+++ b/book/intermediate/ch16-email.ko.md
@@ -53,6 +53,8 @@ export class AppModule {}
 ### verifyOnModuleInit
 `verifyOnModuleInit: true`를 설정하면 애플리케이션 부트스트랩 중 트랜스포트가 실제로 사용 가능한지 확인할 수 있습니다. SMTP 자격 증명 검증처럼 배포 초기에 실패를 드러내야 하는 경우에 유용합니다. 이렇게 시작 단계에서 문제를 확인하면 첫 주문 확인 메일이 실패한 뒤에야 설정 오류를 발견하는 상황을 줄일 수 있습니다.
 
+Bootstrap 검증이 활성화된 경우 `EmailService`는 검증이 성공적으로 끝나기 전까지 메시지를 transport에 넘기지 않습니다. `EmailModule.forRootAsync(...)`로 구성을 해석하다가 factory가 reject되더라도 fluo는 그 rejection을 영구 memoize하지 않으므로, 이후 provider resolution에서 configuration lookup을 다시 시도할 수 있습니다.
+
 ## 16.3 Node-only SMTP with @fluojs/email/node
 
 Node.js 환경에서 SMTP를 사용할 때는 전용 서브패스를 가져옵니다. 이렇게 분리하면 핵심 패키지가 `nodemailer` 같은 Node 전용 의존성에 묶이지 않고, 다른 런타임에서도 같은 루트 API를 유지할 수 있습니다.
@@ -74,6 +76,8 @@ EmailModule.forRoot({
   }),
 });
 ```
+
+Nodemailer adapter는 `Name <user@example.com>` 같은 문자열을 직접 조합하지 않고 display-name 수신자를 구조화된 address object로 전달합니다. 따라서 쉼표나 따옴표가 들어간 이름도 provider-safe하게 유지하면서, newline 문자는 handoff 전에 거부합니다.
 
 ## 16.4 Standalone Usage: EmailService
 
@@ -176,6 +180,8 @@ EmailModule.forRoot({
 ```
 
 렌더러를 등록하면 notification 요청에서 `template`과 `payload.templateData`를 넘겨 템플릿 기반 메일을 생성할 수 있습니다. 명시적인 `payload.text`, `payload.html`, `subject` 값은 렌더링된 fallback보다 우선합니다.
+
+Renderer는 notification `payload`, `metadata`, `locale`, `subject`, `template`을 받습니다. Attachment, header, recipient override는 payload에 남아 있다가 렌더링 후 최종 email message로 전달됩니다.
 
 ## 16.8 Status and Health Checks
 

--- a/book/intermediate/ch16-email.md
+++ b/book/intermediate/ch16-email.md
@@ -53,6 +53,8 @@ export class AppModule {}
 ### verifyOnModuleInit
 Setting `verifyOnModuleInit: true` lets you confirm during application bootstrap that the transport is actually usable. This is useful when deployment should surface failures early, such as SMTP credential validation. Catching the problem at startup reduces the chance that the first order confirmation email is where you discover a bad setting.
 
+When bootstrap verification is enabled, `EmailService` does not hand a message to the transport until verification has completed successfully. If configuration is resolved through `EmailModule.forRootAsync(...)` and the factory rejects, fluo does not permanently memoize that rejection; a later provider resolution can retry the configuration lookup.
+
 ## 16.3 Node-only SMTP with @fluojs/email/node
 
 When you use SMTP in a Node.js environment, import the dedicated subpath. This separation keeps the core package from being tied to Node-only dependencies such as `nodemailer`, while preserving the same root API for other runtimes.
@@ -74,6 +76,8 @@ EmailModule.forRoot({
   }),
 });
 ```
+
+The Nodemailer adapter forwards display-name recipients as structured address objects instead of interpolating strings such as `Name <user@example.com>`. This keeps names containing commas or quotes provider-safe while rejecting newline characters before handoff.
 
 ## 16.4 Standalone Usage: EmailService
 
@@ -176,6 +180,8 @@ EmailModule.forRoot({
 ```
 
 After registering a renderer, notification requests can pass `template` and `payload.templateData` to create template-based emails. Explicit `payload.text`, `payload.html`, and `subject` values still override rendered fallbacks.
+
+The renderer receives the notification `payload`, `metadata`, `locale`, `subject`, and `template`. Attachments, headers, and recipient overrides stay in the payload and are forwarded to the final email message after rendering.
 
 ## 16.8 Status and Health Checks
 

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -140,6 +140,7 @@ Behavioral contract 메모:
 - `createNodemailerEmailTransportFactory(...)`는 Node 전용이며 `@fluojs/email/node`에서만 export됩니다.
 - 이 factory는 자신이 생성한 Nodemailer transporter 리소스를 소유하므로 `EmailService`가 bootstrap 시 검증하고 shutdown 시 닫을 수 있습니다.
 - `createNodemailerEmailTransport(...)`는 이미 존재하는 Nodemailer transporter를 감싸지만 리소스 소유권은 호출자에게 남깁니다.
+- Nodemailer display-name 주소는 구조화된 address object로 전달되며, newline 문자가 포함되면 provider handoff 전에 거부됩니다.
 - SMTP 자격 증명은 여전히 명시적인 옵션 또는 DI를 통해 들어와야 합니다. 루트 패키지와 Node 서브패스 모두 `process.env`를 직접 읽지 않습니다.
 
 ### `EmailService`를 이용한 standalone 전달
@@ -168,7 +169,8 @@ Behavioral contract 메모:
 - `EmailService.send(...)`는 `accepted`, `pending`, `rejected` 수신자를 분리해 보존하므로 provider의 부분 실패가 호출자에게 그대로 보입니다.
 - `EmailService.sendMany(...)`는 기본적으로 fail-fast입니다. 실패를 batch result에 수집하려면 `continueOnError: true`를 전달합니다.
 - `EmailService.createPlatformStatusSnapshot()`은 diagnostics를 위해 lifecycle, readiness, health, transport ownership details를 노출합니다.
-- 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
+- 서비스는 모듈 bootstrap 시 transport를 초기화하며, `verifyOnModuleInit: true`인 경우 bootstrap 검증이 성공적으로 끝날 때까지 delivery가 transport handoff로 진행되지 않습니다.
+- 거부된 `forRootAsync(...)` 옵션 factory 결과는 영구 memoize되지 않으며, 다음 provider resolution에서 configuration lookup을 다시 시도할 수 있습니다.
 - shutdown이 시작된 뒤에는 `EmailService.send(...)`와 `EmailService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `EmailLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다린 뒤 닫습니다.
 - transport `verify()`와 `close()`에서 발생한 provider error는 diagnostics를 위해 lifecycle failure의 `cause`로 보존됩니다.
 - 모듈 옵션은 provider wiring 전에 trim 및 normalize됩니다. 여기에는 sender 기본값, notification channel 이름, transport factory 소유권이 포함됩니다.
@@ -214,6 +216,7 @@ Behavioral contract 메모:
 
 - `EmailChannel`은 `pending` 또는 `rejected` 수신자가 하나라도 있으면 전달을 성공으로 보고하지 않고 notification dispatch를 실패로 처리합니다.
 - `EmailService.sendNotification(...)`은 렌더링된 template output을 payload 및 notification metadata와 병합합니다. payload 필드는 notification fallback보다 우선합니다.
+- Template rendering에는 notification `payload`, `metadata`, `locale`, `subject`, `template`이 전달되며, payload `text`, `html`과 notification `subject`가 렌더링된 fallback보다 우선합니다.
 
 ### 큐 기반 대량 전달
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -140,6 +140,7 @@ Behavioral contract notes:
 - `createNodemailerEmailTransportFactory(...)` is Node-only and is exported exclusively from `@fluojs/email/node`.
 - The factory owns the Nodemailer transporter it creates, so `EmailService` can verify it on bootstrap and close it during shutdown.
 - `createNodemailerEmailTransport(...)` wraps an existing Nodemailer transporter without transferring resource ownership.
+- Nodemailer display-name addresses are forwarded as structured address objects and reject newline characters before provider handoff.
 - SMTP credentials still enter through explicit options or DI. Neither the root package nor the Node subpath reads `process.env` directly.
 
 ### Standalone delivery with `EmailService`
@@ -168,7 +169,8 @@ Behavioral contract notes:
 - `EmailService.send(...)` preserves `accepted`, `pending`, and `rejected` recipients separately so partial provider failures stay caller-visible.
 - `EmailService.sendMany(...)` is fail-fast by default; pass `continueOnError: true` to collect failures in a batch result.
 - `EmailService.createPlatformStatusSnapshot()` exposes lifecycle, readiness, health, and transport ownership details for diagnostics.
-- The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
+- The service initializes the configured transport during module bootstrap and, when `verifyOnModuleInit: true`, delivery waits until bootstrap verification has completed successfully before transport handoff.
+- Rejected `forRootAsync(...)` option factories are not memoized permanently; the next provider resolution can retry configuration lookup.
 - Once shutdown starts, `EmailService.send(...)` and `EmailService.sendNotification(...)` fail with `EmailLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited and closed by shutdown.
 - Transport `verify()` and `close()` provider errors are preserved as the `cause` of lifecycle failures for diagnostics.
 - Module options are trimmed and normalized before provider wiring, including sender defaults, notification channel names, and transport factory ownership.
@@ -214,6 +216,7 @@ Behavioral contract notes:
 
 - `EmailChannel` treats any `pending` or `rejected` recipients as a failed notification dispatch instead of reporting the delivery as successful.
 - `EmailService.sendNotification(...)` merges rendered template output with payload and notification metadata; payload fields override notification fallbacks.
+- Template rendering receives notification `payload`, `metadata`, `locale`, `subject`, and `template`; payload `text`, `html`, and notification `subject` override rendered fallbacks.
 
 ### Queue-backed bulk delivery
 

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -146,7 +146,7 @@ import { EmailChannel } from './channel.js';
 import { EmailNotificationQueueJob, EmailNotificationsQueueWorker, createEmailNotificationsQueueAdapter } from './queue.js';
 import { EmailModule } from './module.js';
 import { EmailService } from './service.js';
-import { EMAIL } from './tokens.js';
+import { EMAIL, EMAIL_OPTIONS } from './tokens.js';
 import { EmailConfigurationError, EmailLifecycleError, EmailMessageValidationError } from './errors.js';
 import type { Email, EmailTransport, EmailTransportFactory, NormalizedEmailMessage } from './types.js';
 
@@ -407,6 +407,37 @@ describe('EmailModule', () => {
     expect(result.messageId).toBe('async-1');
     expect(channel.channel).toBe('mailer');
     expect(factoryCalls).toEqual(['smtp.local']);
+  });
+
+  it('retries async options resolution after a rejected factory attempt', async () => {
+    const MAIL_HOST = Symbol('mail-host');
+    let attempts = 0;
+    const container = new Container();
+    const moduleType = EmailModule.forRootAsync({
+      inject: [MAIL_HOST],
+      useFactory: async () => {
+        attempts += 1;
+
+        if (attempts === 1) {
+          throw new Error('temporary configuration lookup failed');
+        }
+
+        return {
+          defaultFrom: 'retry@example.com',
+          transport: createRecordingTransportFactory({ messagePrefix: 'retry' }),
+        };
+      },
+    });
+
+    container.register({ provide: MAIL_HOST as Token<string>, useValue: 'smtp.local' }, ...moduleProviders(moduleType));
+
+    await expect(container.resolve(EMAIL_OPTIONS)).rejects.toThrowError('temporary configuration lookup failed');
+    const options = await container.resolve(EMAIL_OPTIONS);
+    const service = new EmailService(options as never);
+    const result = await service.send({ subject: 'Retry', text: 'ok', to: ['user@example.com'] });
+
+    expect(result.messageId).toBe('retry-1');
+    expect(attempts).toBe(2);
   });
 
   it('renders notification templates and adapts them through EmailChannel', async () => {
@@ -805,6 +836,49 @@ describe('EmailModule', () => {
     expect(createdTransport.verifyCalls).toBe(1);
     expect(verify).toHaveBeenCalledOnce();
     expect(createdTransport.sendCalls).toBe(0);
+  });
+
+  it('waits for bootstrap transport verification before delivery proceeds', async () => {
+    let resolveVerify!: () => void;
+    let resolveVerifyStarted!: () => void;
+    const verifyDelay = new Promise<void>((resolve) => {
+      resolveVerify = resolve;
+    });
+    const verifyStarted = new Promise<void>((resolve) => {
+      resolveVerifyStarted = resolve;
+    });
+    const createdTransport = new DelayedLifecycleTransport();
+    const verify = vi.spyOn(createdTransport, 'verify').mockImplementation(async () => {
+      createdTransport.verifyCalls += 1;
+      resolveVerifyStarted();
+      await verifyDelay;
+    });
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create: async () => createdTransport,
+        ownsResources: true,
+      },
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+    const bootstrap = service.onModuleInit();
+    await verifyStarted;
+
+    const delivery = service.send({ subject: 'Readiness', text: 'hello', to: ['user@example.com'] });
+    await Promise.resolve();
+
+    expect(createdTransport.sendCalls).toBe(0);
+
+    resolveVerify();
+
+    await bootstrap;
+    await expect(delivery).resolves.toMatchObject({ messageId: 'delayed-1' });
+    expect(createdTransport.sendCalls).toBe(1);
+    expect(verify).toHaveBeenCalledOnce();
   });
 
   it('checks notification lifecycle before renderer or validation errors after shutdown', async () => {

--- a/packages/email/src/module.ts
+++ b/packages/email/src/module.ts
@@ -117,7 +117,12 @@ function buildEmailModuleAsync(options: EmailAsyncModuleOptions): ModuleType {
 
   const memoizedFactory = (...deps: unknown[]): Promise<NormalizedEmailModuleOptions> => {
     if (!cachedResult) {
-      cachedResult = Promise.resolve(factory(...deps)).then((resolved) => normalizeEmailModuleOptions(resolved));
+      cachedResult = Promise.resolve(factory(...deps))
+        .then((resolved) => normalizeEmailModuleOptions(resolved))
+        .catch((error) => {
+          cachedResult = undefined;
+          throw error;
+        });
     }
 
     return cachedResult;

--- a/packages/email/src/node/node.test.ts
+++ b/packages/email/src/node/node.test.ts
@@ -90,14 +90,14 @@ describe('@fluojs/email/node', () => {
           }),
         ],
         bcc: ['bcc@example.com'],
-        cc: ['Copy <cc@example.com>'],
-        from: 'Sender <from@example.com>',
+        cc: [{ address: 'cc@example.com', name: 'Copy' }],
+        from: { address: 'from@example.com', name: 'Sender' },
         headers: { 'x-fluo-template': 'welcome' },
         html: '<p>Hello</p>',
         replyTo: ['reply@example.com'],
         subject: 'Subject',
         text: 'Hello',
-        to: ['Recipient <to@example.com>'],
+        to: [{ address: 'to@example.com', name: 'Recipient' }],
       }),
     );
 
@@ -166,5 +166,67 @@ describe('@fluojs/email/node', () => {
     });
     expect(verify).toHaveBeenCalledTimes(1);
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes display-name addresses as structured Nodemailer address objects', async () => {
+    const sendMail = vi.fn().mockResolvedValue({
+      accepted: ['to@example.com'],
+      messageId: 'node-structured-1',
+      pending: [],
+      rejected: [],
+    });
+    const transport = createNodemailerEmailTransport({
+      transporter: {
+        sendMail,
+      } as never,
+    });
+
+    await transport.send(
+      {
+        bcc: [],
+        cc: [],
+        from: { address: 'from@example.com', name: 'Sender, Support' },
+        replyTo: [],
+        subject: 'Structured names',
+        text: 'hello',
+        to: [{ address: 'to@example.com', name: 'Recipient, Team' }],
+      },
+      {},
+    );
+
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: { address: 'from@example.com', name: 'Sender, Support' },
+        to: [{ address: 'to@example.com', name: 'Recipient, Team' }],
+      }),
+    );
+  });
+
+  it('rejects unsafe Nodemailer display names before provider handoff', async () => {
+    const sendMail = vi.fn();
+    const transport = createNodemailerEmailTransport({
+      transporter: {
+        sendMail,
+      } as never,
+    });
+
+    await expect(
+      transport.send(
+        {
+          bcc: [],
+          cc: [],
+          from: { address: 'from@example.com', name: 'Sender\r\nBcc: attacker@example.com' },
+          replyTo: [],
+          subject: 'Unsafe name',
+          text: 'hello',
+          to: [{ address: 'to@example.com' }],
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({
+      message: 'Nodemailer display name must not contain newline characters.',
+      name: 'EmailMessageValidationError',
+    });
+    expect(sendMail).not.toHaveBeenCalled();
   });
 });

--- a/packages/email/src/node/nodemailer.ts
+++ b/packages/email/src/node/nodemailer.ts
@@ -12,6 +12,7 @@ import type {
   EmailTransportReceipt,
   NormalizedEmailMessage,
 } from '../types.js';
+import { EmailMessageValidationError } from '../errors.js';
 
 /** Node-only Nodemailer transporter type used by the explicit `@fluojs/email/node` seam. */
 export type NodemailerTransporter = Mail<SMTPTransport.SentMessageInfo>;
@@ -45,11 +46,24 @@ export interface NodemailerEmailTransportFactoryOptions {
   smtp: SMTPTransport.Options | string;
 }
 
-function createAddress(address: { address: string; name?: string }): string {
-  return address.name ? `${address.name} <${address.address}>` : address.address;
+function assertSafeAddressPart(value: string, label: string): void {
+  if (/\r|\n/.test(value)) {
+    throw new EmailMessageValidationError(`Nodemailer ${label} must not contain newline characters.`);
+  }
 }
 
-function createAddressList(addresses: readonly { address: string; name?: string }[]): string[] | undefined {
+function createAddress(address: { address: string; name?: string }): string | Mail.Address {
+  assertSafeAddressPart(address.address, 'address');
+
+  if (address.name) {
+    assertSafeAddressPart(address.name, 'display name');
+    return { address: address.address, name: address.name };
+  }
+
+  return address.address;
+}
+
+function createAddressList(addresses: readonly { address: string; name?: string }[]): (string | Mail.Address)[] | undefined {
   if (addresses.length === 0) {
     return undefined;
   }

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -101,6 +101,7 @@ function assertMessageContent(message: NormalizedEmailMessage): void {
 @Inject(EMAIL_OPTIONS)
 export class EmailService implements Email, OnModuleInit, OnApplicationShutdown {
   private lifecycleState: EmailServiceLifecycleState = 'created';
+  private bootstrapPromise: Promise<void> | undefined;
   private resolvedTransport: EmailTransport | undefined;
   private transportPromise: Promise<EmailTransport> | undefined;
 
@@ -124,6 +125,22 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
   }
 
   async onModuleInit(): Promise<void> {
+    if (this.bootstrapPromise) {
+      return this.bootstrapPromise;
+    }
+
+    this.bootstrapPromise = this.startTransport();
+
+    try {
+      await this.bootstrapPromise;
+    } finally {
+      if (this.lifecycleState === 'failed') {
+        this.bootstrapPromise = undefined;
+      }
+    }
+  }
+
+  private async startTransport(): Promise<void> {
     if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
       return;
     }
@@ -193,13 +210,21 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
    */
   async send(message: EmailMessage, options: EmailSendOptions = {}): Promise<EmailSendResult> {
     assertNotAborted(options.signal);
-    this.assertCanDeliver();
+    if (this.options.verifyOnModuleInit) {
+      await this.ensureReadyForDelivery();
+    } else {
+      this.assertCanDeliver();
+    }
 
     const transport = await this.ensureTransport();
     const normalized = this.normalizeMessage(message);
     assertMessageContent(normalized);
     assertNotAborted(options.signal);
-    this.assertCanDeliver();
+    if (this.options.verifyOnModuleInit) {
+      await this.ensureReadyForDelivery();
+    } else {
+      this.assertCanDeliver();
+    }
     const result = await transport.send(normalized, options);
 
     return {
@@ -321,6 +346,34 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     }
 
     return this.transportPromise;
+  }
+
+  private async ensureReadyForDelivery(): Promise<void> {
+    this.assertCanDeliver();
+
+    if (!this.options.verifyOnModuleInit) {
+      return;
+    }
+
+    if (this.lifecycleState === 'ready') {
+      return;
+    }
+
+    if (this.lifecycleState === 'created' || this.lifecycleState === 'starting') {
+      await this.onModuleInit();
+    }
+
+    this.assertCanDeliver();
+
+    const state = this.getLifecycleState();
+
+    if (state !== 'ready') {
+      throw createDeliveryLifecycleError(state);
+    }
+  }
+
+  private getLifecycleState(): EmailServiceLifecycleState {
+    return this.lifecycleState;
   }
 
   private assertCanCreateOrUseTransport(): void {


### PR DESCRIPTION
## Summary

Closes #1782.

Hardens `@fluojs/email` bootstrap readiness and Node transport handoff so verified transports cannot be used before readiness, rejected async option factories can retry, and Nodemailer display-name addresses are passed safely.

## Changes

- Gate delivery behind successful bootstrap verification when `verifyOnModuleInit: true` and keep shutdown-time transport creation semantics intact.
- Reset rejected `EmailModule.forRootAsync(...)` option factory memoization so transient configuration lookup failures can retry.
- Forward Nodemailer display-name addresses as structured address objects and reject newline injection before provider handoff.
- Align package README EN/KO and email book EN/KO docs for transport readiness, template payload behavior, queue/attachment guidance, and async factory retry behavior.
- Add a patch changeset for the user-facing `@fluojs/email` behavior fixes.

## Testing

- `pnpm --filter @fluojs/email test` — passed (34 tests)
- `pnpm --filter @fluojs/email typecheck` — passed
- `pnpm --filter @fluojs/email build` — passed
- LSP diagnostics on changed TypeScript files — no diagnostics found

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; existing public behavior documentation was clarified in README/book pairs.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract/governance docs changed; package README and book EN/KO companions were updated together.