### PR TITLE
Exit beta prerelease mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@fluojs/example-auth-jwt-passport": "0.0.0",


### PR DESCRIPTION
## Summary
- Exit Changesets beta prerelease mode by switching `.changeset/pre.json` from `pre` to `exit`.
- Preserve Changesets as the source of truth so the Version Packages flow can generate stable package versions and changelogs.

## Verification
- `pnpm verify:release-readiness`
- `pnpm changeset status`

## Notes
- Local `pnpm version-packages` was not included because `@changesets/changelog-github` hit GitHub GraphQL validation timeout while generating changelog metadata.
- No local publish, tags, or GitHub releases were created.