### PR TITLE
Recover stable release changelog generation

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "fluojs/fluo" }],
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -222,18 +222,18 @@ describe('scaffoldBootstrapApp', () => {
 
     expect(packageJson.devDependencies?.typescript).toBe('^6.0.2');
     expect(packageJson.dependencies).toMatchObject({
-      '@fluojs/config': '^1.0.0-beta.7',
-      '@fluojs/core': '^1.0.0-beta.4',
-      '@fluojs/di': '^1.0.0-beta.6',
-      '@fluojs/http': '^1.0.0-beta.10',
-      '@fluojs/platform-fastify': '^1.0.0-beta.8',
-      '@fluojs/runtime': '^1.0.0-beta.11',
-      '@fluojs/validation': '^1.0.0-beta.3',
+      '@fluojs/config': '^1.0.0',
+      '@fluojs/core': '^1.0.0',
+      '@fluojs/di': '^1.0.0',
+      '@fluojs/http': '^1.0.0',
+      '@fluojs/platform-fastify': '^1.0.0',
+      '@fluojs/runtime': '^1.0.0',
+      '@fluojs/validation': '^1.0.0',
     });
     expect(packageJson.devDependencies).toMatchObject({
-      '@fluojs/cli': '^1.0.0-beta.7',
-      '@fluojs/testing': '^1.0.0-beta.2',
-      '@fluojs/vite': '^1.0.0-beta.2',
+      '@fluojs/cli': '^1.0.0',
+      '@fluojs/testing': '^1.0.0',
+      '@fluojs/vite': '^1.0.0',
       '@vitest/coverage-v8': '^3.0.8',
     });
     expect(packageJson.scripts?.build).toBe('fluo build');

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -34,22 +34,22 @@ const PUBLISHED_RUNTIME_DEPENDENCIES = {
 } as const;
 
 const PUBLISHED_INTERNAL_DEPENDENCIES = {
-  '@fluojs/cli': '^1.0.0-beta.7',
-  '@fluojs/config': '^1.0.0-beta.7',
-  '@fluojs/core': '^1.0.0-beta.4',
-  '@fluojs/di': '^1.0.0-beta.6',
-  '@fluojs/http': '^1.0.0-beta.10',
-  '@fluojs/microservices': '^1.0.0-beta.5',
-  '@fluojs/platform-bun': '^1.0.0-beta.6',
-  '@fluojs/platform-cloudflare-workers': '^1.0.0-beta.2',
-  '@fluojs/platform-deno': '^1.0.0-beta.3',
-  '@fluojs/platform-express': '^1.0.0-beta.6',
-  '@fluojs/platform-fastify': '^1.0.0-beta.8',
-  '@fluojs/platform-nodejs': '^1.0.0-beta.4',
-  '@fluojs/runtime': '^1.0.0-beta.11',
-  '@fluojs/testing': '^1.0.0-beta.2',
-  '@fluojs/validation': '^1.0.0-beta.3',
-  '@fluojs/vite': '^1.0.0-beta.2',
+  '@fluojs/cli': '^1.0.0',
+  '@fluojs/config': '^1.0.0',
+  '@fluojs/core': '^1.0.0',
+  '@fluojs/di': '^1.0.0',
+  '@fluojs/http': '^1.0.0',
+  '@fluojs/microservices': '^1.0.0',
+  '@fluojs/platform-bun': '^1.0.0',
+  '@fluojs/platform-cloudflare-workers': '^1.0.0',
+  '@fluojs/platform-deno': '^1.0.0',
+  '@fluojs/platform-express': '^1.0.0',
+  '@fluojs/platform-fastify': '^1.0.0',
+  '@fluojs/platform-nodejs': '^1.0.0',
+  '@fluojs/runtime': '^1.0.0',
+  '@fluojs/testing': '^1.0.0',
+  '@fluojs/validation': '^1.0.0',
+  '@fluojs/vite': '^1.0.0',
 } as const;
 
 


### PR DESCRIPTION
## Summary
- Temporarily switch Changesets versioning to the default changelog generator so the beta-to-stable backlog does not hit GitHub GraphQL validation timeouts.
- Update generated CLI scaffolds to depend on stable `^1.0.0` fluo packages.
- Keep `@changesets/changelog-github` installed so it can be restored after the stable backlog is consumed.

## Verification
- LSP diagnostics: `.changeset/config.json`, `packages/cli/src/new/scaffold.ts`, `packages/cli/src/new/scaffold.test.ts`
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --filter @fluojs/cli test -- src/new/scaffold.test.ts`
- temp worktree: `pnpm install --frozen-lockfile` + `pnpm version-packages`

## Release note
After the stable Version Packages PR is generated and consumed, restore `.changeset/config.json` to `@changesets/changelog-github` for normal-sized releases.