### PR TITLE
Restore GitHub changelog generator

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "fluojs/fluo" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Summary
- Restore Changesets to `@changesets/changelog-github` now that the stable release backlog has been consumed.
- Keep the normal PR/author-enriched changelog behavior for future smaller releases.

## Verification
- LSP diagnostics: `.changeset/config.json`
- `pnpm install --frozen-lockfile`
- `pnpm exec node -e "console.log(require.resolve('@changesets/changelog-github'))"`

## Notes
- `pnpm changeset status` reports no changesets for this config-only branch, which is expected because this PR should not trigger a package release.