### PR TITLE
Resolve #1793: Harden passport edge contracts

### DIFF
--- a/.changeset/issue-1793-passport-edge-issues.md
+++ b/.changeset/issue-1793-passport-edge-issues.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/passport": patch
+---
+
+Harden Passport bridge, cookie auth, refresh subject normalization, refresh rotation coverage, and conservative account-linking edge contracts.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -106,7 +106,7 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 });
 ```
 
-브릿지는 각 Passport.js 전략 실행을 정확히 한 번만 정착(settle)시킵니다. 전략은 바인딩된 Passport 액션(`success`, `fail`, `redirect`, `pass`, `error`) 중 하나를 호출해야 하며, promise rejection 또는 액션 없이 완료된 promise는 요청을 미해결 상태로 두지 않고 인증 실패로 처리됩니다. 커스텀 `mapPrincipal` 함수는 비어 있지 않은 `subject`와 객체 형태의 `claims`를 포함한 유효한 fluo `Principal`을 반환해야 합니다.
+브릿지는 각 Passport.js 전략 실행을 정확히 한 번만 정착(settle)시킵니다. 전략은 바인딩된 Passport 액션(`success`, `fail`, `redirect`, `pass`, `error`) 중 하나를 호출해야 하며, promise rejection, 액션 없이 완료된 promise, 그리고 제한된 action timeout을 초과한 callback-style 실행은 요청을 미해결 상태로 두지 않고 인증 실패로 처리됩니다. 커스텀 `mapPrincipal` 함수는 비어 있지 않은 `subject`와 객체 형태의 `claims`를 포함한 유효한 fluo `Principal`을 반환해야 합니다.
 
 ### 쿠키 인증 프리셋
 
@@ -201,11 +201,11 @@ export class AuthController {
 
 `RefreshTokenModule.forRoot(...)`를 `PassportModule.forRoot(...)`와 함께 import 하여 refresh-token 전략과 공유 `REFRESH_TOKEN_SERVICE` alias를 같은 모듈 wiring에서 사용하세요.
 
-`RefreshTokenStrategy`는 `body.refreshToken`, `Authorization: Bearer ...`, `x-refresh-token`에서 token을 읽습니다. Malformed non-string token은 인증 실패로 처리됩니다. `JwtRefreshTokenAdapter`는 `secret`과 backing store가 필요하며, `store: 'memory'`는 development 및 single-instance deployment용입니다.
+`RefreshTokenStrategy`는 `body.refreshToken`, `Authorization: Bearer ...`, `x-refresh-token`에서 token을 읽습니다. Malformed non-string token은 인증 실패로 처리됩니다. Rotation 후에는 `@fluojs/jwt`가 반환한 정규화 access-token principal subject를 신뢰합니다. `JwtRefreshTokenAdapter`는 `secret`과 backing store가 필요하며, `store: 'memory'`는 development 및 single-instance deployment용이고 rotation은 store consume contract를 통해 재사용을 감지합니다.
 
 ### Account linking과 status
 
-Identity-link 결정을 모델링하려면 `createConservativeAccountLinkPolicy(...)`와 `resolveAccountLinking(...)`을 사용합니다. 기본 conservative policy는 명시적인 existing link 또는 user-confirmed match만 연결하고, 그 외에는 create/skip/reject/conflict를 결정적으로 처리합니다.
+Identity-link 결정을 모델링하려면 `createConservativeAccountLinkPolicy(...)`와 `resolveAccountLinking(...)`을 사용합니다. 기본 conservative policy는 모호하지 않은 단일 existing account link 또는 user-confirmed match만 연결하고, 여러 existing link는 conflict로 보고하며, 그 외에는 create/skip/reject/conflict를 결정적으로 처리합니다.
 
 `createPassportPlatformStatusSnapshot(...)`와 `createPassportPlatformDiagnosticIssues(...)`는 등록된 strategy, default strategy 설정, preset, refresh-token store readiness에 대한 readiness/health diagnostic을 노출합니다.
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -106,7 +106,7 @@ const googleBridge = createPassportJsStrategyBridge('google', GoogleStrategy, {
 });
 ```
 
-The bridge settles each Passport.js strategy execution exactly once. A strategy must call one of the bound Passport actions (`success`, `fail`, `redirect`, `pass`, or `error`); promise rejections and promise completion without an action become authentication failures instead of leaving the request unresolved. Custom `mapPrincipal` functions must return a valid fluo `Principal` with a non-empty `subject` and object `claims`.
+The bridge settles each Passport.js strategy execution exactly once. A strategy must call one of the bound Passport actions (`success`, `fail`, `redirect`, `pass`, or `error`); promise rejections, promise completion without an action, and callback-style executions that exceed the bounded action timeout become authentication failures instead of leaving the request unresolved. Custom `mapPrincipal` functions must return a valid fluo `Principal` with a non-empty `subject` and object `claims`.
 
 ### Cookie Auth Preset
 
@@ -201,11 +201,11 @@ export class AuthController {
 
 Import `RefreshTokenModule.forRoot(...)` alongside `PassportModule.forRoot(...)` so the refresh-token strategy and shared `REFRESH_TOKEN_SERVICE` alias are available in the same module wiring.
 
-`RefreshTokenStrategy` reads tokens from `body.refreshToken`, `Authorization: Bearer ...`, or `x-refresh-token`; malformed non-string tokens fail authentication. `JwtRefreshTokenAdapter` requires a `secret` and a backing store; `store: 'memory'` is for development and single-instance deployments only.
+`RefreshTokenStrategy` reads tokens from `body.refreshToken`, `Authorization: Bearer ...`, or `x-refresh-token`; malformed non-string tokens fail authentication. After rotation, it trusts the normalized access-token principal subject returned by `@fluojs/jwt`. `JwtRefreshTokenAdapter` requires a `secret` and a backing store; `store: 'memory'` is for development and single-instance deployments only, and rotation detects reuse through the store consume contract.
 
 ### Account Linking and Status
 
-Use `createConservativeAccountLinkPolicy(...)` and `resolveAccountLinking(...)` to model identity-link decisions. The default conservative policy links explicit existing links or user-confirmed matches, and otherwise creates, skips, rejects, or reports conflicts deterministically.
+Use `createConservativeAccountLinkPolicy(...)` and `resolveAccountLinking(...)` to model identity-link decisions. The default conservative policy links one unambiguous existing account link or user-confirmed matches, reports multiple existing links as conflicts, and otherwise creates, skips, rejects, or reports conflicts deterministically.
 
 `createPassportPlatformStatusSnapshot(...)` and `createPassportPlatformDiagnosticIssues(...)` expose readiness/health diagnostics for registered strategies, default strategy configuration, presets, and refresh-token store readiness.
 

--- a/packages/passport/src/account/account-linking.test.ts
+++ b/packages/passport/src/account/account-linking.test.ts
@@ -94,6 +94,54 @@ describe('resolveAccountLinking', () => {
     }
   });
 
+  it('throws AccountLinkConflictError when multiple existing links match different accounts', async () => {
+    const policy = createConservativeAccountLinkPolicy();
+
+    await expect(
+      resolveAccountLinking(
+        createContext({
+          candidates: [
+            {
+              accountId: 'account-1',
+              reason: 'existing-link',
+            },
+            {
+              accountId: 'account-2',
+              reason: 'existing-link',
+            },
+          ],
+        }),
+        policy,
+      ),
+    ).rejects.toThrow(AccountLinkConflictError);
+  });
+
+  it('links duplicate existing-link candidates only when they resolve to the same account', async () => {
+    const policy = createConservativeAccountLinkPolicy();
+
+    const result = await resolveAccountLinking(
+      createContext({
+        candidates: [
+          {
+            accountId: 'account-1',
+            reason: 'existing-link',
+          },
+          {
+            accountId: 'account-1',
+            reason: 'existing-link',
+          },
+        ],
+      }),
+      policy,
+    );
+
+    expect(result).toEqual({
+      accountId: 'account-1',
+      reason: 'Existing identity link found.',
+      status: 'linked',
+    });
+  });
+
   it('returns skipped when no policy is configured (non-linking fallback)', async () => {
     const result = await resolveAccountLinking(
       createContext({

--- a/packages/passport/src/account/account-linking.ts
+++ b/packages/passport/src/account/account-linking.ts
@@ -113,12 +113,27 @@ export class AccountLinkRejectedError extends FluoError {
 export function createConservativeAccountLinkPolicy(): AccountLinkPolicy {
   return {
     evaluate(context) {
-      const existingLink = context.candidates.find((candidate) => candidate.reason === 'existing-link');
-      if (existingLink) {
+      const existingLinkAccountIds = Array.from(
+        new Set(
+          context.candidates
+            .filter((candidate) => candidate.reason === 'existing-link')
+            .map((candidate) => candidate.accountId),
+        ),
+      );
+
+      if (existingLinkAccountIds.length === 1) {
         return {
           action: 'link',
-          accountId: existingLink.accountId,
+          accountId: existingLinkAccountIds[0],
           reason: 'Existing identity link found.',
+        };
+      }
+
+      if (existingLinkAccountIds.length > 1) {
+        return {
+          action: 'conflict',
+          candidateAccountIds: existingLinkAccountIds,
+          reason: 'Multiple existing identity links matched. Explicit review is required before linking.',
         };
       }
 

--- a/packages/passport/src/adapters/passport-js.ts
+++ b/packages/passport/src/adapters/passport-js.ts
@@ -32,6 +32,7 @@ export interface PassportJsStrategyLike {
 type PassportJsExecutableStrategy = PassportJsStrategyLike & PassportJsActionBindings;
 
 interface PassportJsRequestState {
+  clearActionTimeout?: () => void;
   context: GuardContext;
   mapPrincipal: PassportJsPrincipalMapper;
   reject: (reason?: unknown) => void;
@@ -64,9 +65,13 @@ export type PassportJsPrincipalMapper = (input: PassportJsPrincipalMapperInput) 
 export interface PassportJsAuthStrategyOptions {
   /** Optional options to pass to the Passport strategy's `authenticate` method. */
   authenticateOptions?: Readonly<Record<string, unknown>>;
+  /** Maximum time to wait for callback-style strategies to call a bound Passport action. */
+  actionTimeoutMs?: number;
   /** Optional custom mapper for converting user data to a principal. */
   mapPrincipal?: PassportJsPrincipalMapper;
 }
+
+const DEFAULT_ACTION_TIMEOUT_MS = 30_000;
 
 /**
  * Bridge interface containing DI providers and strategy registration for Passport.js.
@@ -195,7 +200,17 @@ export class PassportJsAuthStrategy implements AuthStrategy {
     const mapPrincipal = this.options.mapPrincipal ?? defaultPrincipalMapper;
 
     return new Promise((resolve, reject) => {
+      let actionTimeout: ReturnType<typeof setTimeout> | undefined;
+
+      const clearActionTimeout = () => {
+        if (actionTimeout) {
+          clearTimeout(actionTimeout);
+          actionTimeout = undefined;
+        }
+      };
+
       this.requestState.set(strategy, {
+        clearActionTimeout,
         context,
         mapPrincipal,
         reject,
@@ -206,17 +221,29 @@ export class PassportJsAuthStrategy implements AuthStrategy {
 
       this.bindStrategyActions(strategy);
 
+      const actionTimeoutMs = this.options.actionTimeoutMs ?? DEFAULT_ACTION_TIMEOUT_MS;
+
+      if (Number.isFinite(actionTimeoutMs) && actionTimeoutMs >= 0) {
+        actionTimeout = setTimeout(() => {
+          this.settle(strategy, (state) => {
+            state.reject(new AuthenticationRequiredError('Passport strategy did not settle authentication.'));
+          });
+        }, actionTimeoutMs);
+      }
+
       try {
         const result = strategy.authenticate(request, this.options.authenticateOptions);
 
         if (isPromiseLike(result)) {
           result.then(
             () => {
+              clearActionTimeout();
               this.settle(strategy, (state) => {
                 state.reject(new AuthenticationRequiredError('Passport strategy did not settle authentication.'));
               });
             },
             (error: unknown) => {
+              clearActionTimeout();
               this.settle(strategy, (state) => {
                 state.reject(error);
               });
@@ -224,6 +251,7 @@ export class PassportJsAuthStrategy implements AuthStrategy {
           );
         }
       } catch (error: unknown) {
+        clearActionTimeout();
         this.settle(strategy, () => reject(error));
       }
     });
@@ -260,6 +288,7 @@ export class PassportJsAuthStrategy implements AuthStrategy {
     try {
       handler(state);
     } finally {
+      state.clearActionTimeout?.();
       this.requestState.delete(strategy);
     }
   }

--- a/packages/passport/src/cookie/cookie-auth.test.ts
+++ b/packages/passport/src/cookie/cookie-auth.test.ts
@@ -139,6 +139,15 @@ describe('CookieAuthStrategy', () => {
       expect(verifier.verifyAccessToken).not.toHaveBeenCalled();
     });
 
+    it('throws AuthenticationRequiredError for present empty access token cookies even when optional', async () => {
+      const verifier = createMockVerifier();
+      const strategy = new CookieAuthStrategy(verifier, { requireAccessToken: false });
+      const context = createGuardContext({ access_token: '' });
+
+      await expect(strategy.authenticate(context)).rejects.toThrow(AuthenticationRequiredError);
+      expect(verifier.verifyAccessToken).not.toHaveBeenCalled();
+    });
+
     it('handles non-Error verification failures gracefully', async () => {
       const verifier = createMockVerifier({
         verifyAccessToken: vi.fn().mockRejectedValue('string error'),

--- a/packages/passport/src/cookie/cookie-auth.ts
+++ b/packages/passport/src/cookie/cookie-auth.ts
@@ -83,7 +83,7 @@ export class CookieAuthStrategy implements AuthStrategy {
 
     const accessToken = cookies[this.options.accessTokenCookieName];
 
-    if (accessToken === undefined || accessToken === '') {
+    if (accessToken === undefined) {
       if (this.options.requireAccessToken) {
         throw new AuthenticationRequiredError('Access token cookie is required.');
       }

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -618,6 +618,51 @@ describe('AuthGuard', () => {
     });
   });
 
+  it('rejects synchronous Passport.js strategies that never settle a strategy action', async () => {
+    class PassportLikeSyncUnsettledStrategy {
+      authenticate(): void {}
+    }
+
+    const bridge = createPassportJsStrategyBridge('google-sync-unsettled', PassportLikeSyncUnsettledStrategy, {
+      actionTimeoutMs: 0,
+    });
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-sync-unsettled')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikeSyncUnsettledStrategy,
+      ...bridge.providers,
+      ...createPassportModuleProviders({ defaultStrategy: 'google-sync-unsettled' }, [bridge.strategy]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/oauth/profile', { 'x-request-id': 'req-sync-unsettled' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-sync-unsettled',
+        status: 401,
+      },
+    });
+  });
+
   it('isolates Passport.js bridge request state across concurrent authentications', async () => {
     let sequence = 0;
 

--- a/packages/passport/src/refresh/jwt-refresh-token-adapter.test.ts
+++ b/packages/passport/src/refresh/jwt-refresh-token-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { DefaultJwtSigner, DefaultJwtVerifier, JwtConfigurationError, type RefreshTokenStore } from '@fluojs/jwt';
+import { DefaultJwtSigner, DefaultJwtVerifier, JwtConfigurationError, JwtInvalidTokenError, type RefreshTokenStore } from '@fluojs/jwt';
 
 import { JwtRefreshTokenAdapter } from './jwt-refresh-token-adapter.js';
 
@@ -19,6 +19,20 @@ function createVerifier(): DefaultJwtVerifier {
 }
 
 describe('JwtRefreshTokenAdapter', () => {
+  function createRotationCapableStore(): RefreshTokenStore {
+    return {
+      async consume() {
+        return 'invalid';
+      },
+      async find() {
+        return undefined;
+      },
+      async revoke() {},
+      async revokeBySubject() {},
+      async save() {},
+    };
+  }
+
   it('requires an explicit refresh token secret', () => {
     expect(() =>
       new JwtRefreshTokenAdapter(createSigner(), createVerifier(), {
@@ -78,5 +92,39 @@ describe('JwtRefreshTokenAdapter', () => {
 
     expect(rotated.accessToken).toContain('.');
     expect(rotated.refreshToken).toBe(issued);
+  });
+
+  it('detects refresh token reuse when rotation is enabled with the in-memory store', async () => {
+    const store = createRotationCapableStore();
+    const signer = new DefaultJwtSigner({
+      algorithms: ['HS256'],
+      refreshToken: {
+        expiresInSeconds: 3600,
+        rotation: true,
+        secret: 'refresh-secret',
+        store,
+      },
+      secret: 'access-secret',
+    });
+    const verifier = new DefaultJwtVerifier({
+      algorithms: ['HS256'],
+      refreshToken: {
+        expiresInSeconds: 3600,
+        rotation: true,
+        secret: 'refresh-secret',
+        store,
+      },
+      secret: 'access-secret',
+    });
+    const adapter = new JwtRefreshTokenAdapter(signer, verifier, {
+      secret: 'refresh-secret',
+      store: 'memory',
+    });
+
+    const issued = await adapter.issueRefreshToken('user-1');
+    const firstRotation = await adapter.rotateRefreshToken(issued);
+
+    expect(firstRotation.refreshToken).not.toBe(issued);
+    await expect(adapter.rotateRefreshToken(issued)).rejects.toThrow(JwtInvalidTokenError);
   });
 });

--- a/packages/passport/src/refresh/refresh-token.test.ts
+++ b/packages/passport/src/refresh/refresh-token.test.ts
@@ -25,7 +25,7 @@ function createMockRefreshTokenService(overrides: Partial<RefreshTokenService> =
 
 function createMockVerifier(subject = 'user-1'): DefaultJwtVerifier {
   return {
-    verifyAccessToken: vi.fn().mockResolvedValue({ claims: { sub: subject } }),
+    verifyAccessToken: vi.fn().mockResolvedValue({ claims: { sub: subject }, subject }),
     verifyRefreshToken: vi.fn().mockResolvedValue({ claims: { sub: subject } }),
   } as unknown as DefaultJwtVerifier;
 }
@@ -244,6 +244,23 @@ describe('RefreshTokenStrategy', () => {
       await expect(strategy.authenticate(context)).rejects.toThrow(
         'Refresh token service returned an access token without a valid subject claim.',
       );
+    });
+
+    it('uses the normalized verifier subject when rotated access token claims omit sub', async () => {
+      const service = createMockRefreshTokenService();
+      const verifier = createMockVerifier();
+      vi.mocked(verifier.verifyAccessToken).mockResolvedValue({
+        claims: { providerSubject: 'issuer-specific-id' },
+        subject: 'normalized-user-1',
+      });
+      const strategy = new RefreshTokenStrategy(service, verifier);
+      const context = createGuardContext({ refreshToken: 'valid-token' });
+
+      const result = await strategy.authenticate(context);
+
+      expect(result).toMatchObject({
+        subject: 'normalized-user-1',
+      });
     });
   });
 

--- a/packages/passport/src/refresh/refresh-token.ts
+++ b/packages/passport/src/refresh/refresh-token.ts
@@ -133,11 +133,11 @@ export class RefreshTokenStrategy implements AuthStrategy {
 
   private async extractVerifiedSubject(accessToken: string): Promise<string> {
     const principal = await this.verifier.verifyAccessToken(accessToken);
-    const sub = principal.claims.sub;
-    if (typeof sub !== 'string' || sub.length === 0) {
+    if (typeof principal.subject !== 'string' || principal.subject.length === 0) {
       throw new InvariantError('Refresh token service returned an access token without a valid subject claim.');
     }
-    return sub;
+
+    return principal.subject;
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #1793

Fixes Passport bridge, cookie auth, refresh-token, and account-linking edge behavior so documented auth contracts fail closed instead of hanging or linking ambiguously.

## Changes

- Added a bounded Passport.js bridge action timeout and regression coverage for synchronous strategies that never call a Passport action.
- Treat present empty cookie access-token values as malformed even when access tokens are optional.
- Use the normalized JWT verifier subject after refresh rotation and cover refresh-token reuse through the passport JWT adapter.
- Report multiple existing account links as conflicts while preserving duplicate same-account existing-link behavior.
- Updated EN/KO passport README contract text and added a patch changeset.

## Testing

- `pnpm --filter @fluojs/passport typecheck`
- `pnpm --filter @fluojs/passport... build`
- `pnpm --filter @fluojs/passport build`
- `pnpm --filter @fluojs/passport test`
- `pnpm test`
- `pnpm exec biome lint packages/passport/src/account/account-linking.ts packages/passport/src/account/account-linking.test.ts packages/passport/src/adapters/passport-js.ts packages/passport/src/cookie/cookie-auth.ts packages/passport/src/cookie/cookie-auth.test.ts packages/passport/src/guard.test.ts packages/passport/src/refresh/jwt-refresh-token-adapter.test.ts packages/passport/src/refresh/refresh-token.ts packages/passport/src/refresh/refresh-token.test.ts packages/passport/README.md packages/passport/README.ko.md .changeset/issue-1793-passport-edge-issues.md`
- `lsp_diagnostics` clean for all changed TypeScript files

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs were changed; package README EN/KO mirror text was kept aligned.