### PR TITLE
Resolve #1811: Preserve validation mapped DTO metadata

### DIFF
--- a/.changeset/validation-mapped-dto-metadata.md
+++ b/.changeset/validation-mapped-dto-metadata.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/core": patch
+"@fluojs/validation": patch
+---
+
+Preserve mapped DTO field metadata through documented subclassing patterns while preventing subset and partial DTO helpers from inheriting base class-level validators that depend on omitted or optional fields.

--- a/book/beginner/ch06-validation.md
+++ b/book/beginner/ch06-validation.md
@@ -178,7 +178,7 @@ This is a meaningful upgrade for FluoBlog. The create route now has explicit rul
 
 ### Why Mapped DTO Helpers Matter
 
-At first, it is easy to write similar DTOs by hand, and that works in the beginning. But it quickly becomes repetitive and prone to mistakes. Helpers such as `PartialType`, `PickType`, and `OmitType` reduce duplication while preserving validation metadata, so derived contracts can stay tied to one base DTO safely.
+At first, it is easy to write similar DTOs by hand, and that works in the beginning. But it quickly becomes repetitive and prone to mistakes. Helpers such as `PartialType`, `PickType`, and `OmitType` reduce duplication while preserving field-level validation metadata, so derived contracts can stay tied to one base DTO safely. Class-level validators are not copied onto subset or partial DTOs because they may depend on fields that were intentionally omitted or made optional.
 
 ### Creating Specific DTO Variations
 

--- a/packages/core/src/metadata/validation.ts
+++ b/packages/core/src/metadata/validation.ts
@@ -25,6 +25,74 @@ const classValidationStore = createClonedWeakMapStore<Function, ClassValidationR
   rules.map((rule) => cloneMutableValue(rule))
 );
 
+function getInheritedTargets(target: object): object[] {
+  const targets: object[] = [];
+  let current: object | null = target;
+
+  while (current && current !== Object.prototype) {
+    targets.unshift(current);
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+
+  return targets;
+}
+
+function getInheritedConstructors(target: Function): Function[] {
+  const targets: Function[] = [];
+  let current: Function | null = target;
+
+  while (current && current !== Function.prototype) {
+    targets.unshift(current);
+    current = Object.getPrototypeOf(current) as Function | null;
+  }
+
+  return targets;
+}
+
+function getInheritedStoredDtoBindingMap(target: object): Map<MetadataPropertyKey, DtoFieldBindingMetadata> {
+  const merged = new Map<MetadataPropertyKey, DtoFieldBindingMetadata>();
+
+  for (const current of getInheritedTargets(target)) {
+    const stored = dtoFieldBindingStore.get(current);
+
+    if (!stored) {
+      continue;
+    }
+
+    for (const [propertyKey, metadata] of stored) {
+      merged.set(propertyKey, cloneMutableValue(metadata));
+    }
+  }
+
+  return merged;
+}
+
+function getInheritedStoredDtoValidationMap(target: object): Map<MetadataPropertyKey, DtoFieldValidationRule[]> {
+  const merged = new Map<MetadataPropertyKey, DtoFieldValidationRule[]>();
+
+  for (const current of getInheritedTargets(target)) {
+    const stored = dtoFieldValidationStore.get(current);
+
+    if (!stored) {
+      continue;
+    }
+
+    for (const [propertyKey, rules] of stored) {
+      const existing = merged.get(propertyKey) ?? [];
+      merged.set(propertyKey, [
+        ...existing,
+        ...rules.map((rule) => cloneMutableValue(rule)),
+      ]);
+    }
+  }
+
+  return merged;
+}
+
+function getInheritedStoredClassValidationRules(target: Function): ClassValidationRule[] {
+  return getInheritedConstructors(target).flatMap((current) => classValidationStore.read(current) ?? []);
+}
+
 function getStandardDtoBindingMap(target: object): Map<MetadataPropertyKey, StandardDtoBindingRecord> | undefined {
   return getStandardConstructorMetadataMap<StandardDtoBindingRecord>(target, standardMetadataKeys.dtoFieldBinding);
 }
@@ -47,7 +115,7 @@ function getStandardClassValidationRules(target: Function): ClassValidationRule[
  * @returns The get dto field binding metadata result.
  */
 export function getDtoFieldBindingMetadata(target: object, propertyKey: MetadataPropertyKey): DtoFieldBindingMetadata | undefined {
-  const stored = dtoFieldBindingStore.get(target)?.get(propertyKey);
+  const stored = getInheritedStoredDtoBindingMap(target).get(propertyKey);
   const standard = getStandardDtoBindingMap(target)?.get(propertyKey);
   const source = stored?.source ?? standard?.source;
 
@@ -114,7 +182,7 @@ export function appendClassValidationRule(target: Function, rule: ClassValidatio
  * @returns The get dto binding schema result.
  */
 export function getDtoBindingSchema(dto: Constructor): DtoBindingSchemaEntry[] {
-  const stored = dtoFieldBindingStore.get(dto.prototype) ?? new Map<MetadataPropertyKey, DtoFieldBindingMetadata>();
+  const stored = getInheritedStoredDtoBindingMap(dto.prototype);
   const standard =
     (getStandardMetadataBag(dto)?.[standardMetadataKeys.dtoFieldBinding] as Map<MetadataPropertyKey, StandardDtoBindingRecord> | undefined) ??
     new Map<MetadataPropertyKey, StandardDtoBindingRecord>();
@@ -153,7 +221,7 @@ export function getDtoBindingSchema(dto: Constructor): DtoBindingSchemaEntry[] {
  * @returns The get dto field validation rules result.
  */
 export function getDtoFieldValidationRules(target: object, propertyKey: MetadataPropertyKey): readonly DtoFieldValidationRule[] {
-  const stored = dtoFieldValidationStore.get(target)?.get(propertyKey) ?? [];
+  const stored = getInheritedStoredDtoValidationMap(target).get(propertyKey) ?? [];
   const standard = getStandardDtoValidationMap(target)?.get(propertyKey) ?? [];
 
   return [
@@ -169,7 +237,7 @@ export function getDtoFieldValidationRules(target: object, propertyKey: Metadata
  * @returns The get dto validation schema result.
  */
 export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEntry[] {
-  const stored = dtoFieldValidationStore.get(dto.prototype) ?? new Map<MetadataPropertyKey, DtoFieldValidationRule[]>();
+  const stored = getInheritedStoredDtoValidationMap(dto.prototype);
   const standard = getStandardDtoValidationMap(dto.prototype) ?? new Map<MetadataPropertyKey, StandardDtoValidationRecord>();
   const keys = mergeMetadataPropertyKeys(stored, standard);
 
@@ -194,5 +262,5 @@ export function getDtoValidationSchema(dto: Constructor): DtoValidationSchemaEnt
  * @returns The get class validation rules result.
  */
 export function getClassValidationRules(target: Function): readonly ClassValidationRule[] {
-  return [...(getStandardClassValidationRules(target) ?? []), ...(classValidationStore.read(target) ?? [])];
+  return [...(getStandardClassValidationRules(target) ?? []), ...getInheritedStoredClassValidationRules(target)];
 }

--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -113,6 +113,11 @@ class EmailOnlyDto extends PickType(UserDto, ['email']) {}
 class UpdateUserDto extends PartialType(UserDto) {}
 ```
 
+Mapped DTO helper는 위와 같은 문서화된 subclassing 패턴에서도 field-level
+validation 및 binding metadata를 보존합니다. `PickType`, `OmitType`,
+`PartialType`은 생략되었거나 optional이 된 필드에 의존할 수 있는 base
+class-level validator를 derived DTO로 전달하지 않습니다.
+
 ### Standard Schema 지원
 
 Standard Schema adapter는 유효하지 않은 입력을 명시적인 issue로 보고해야 합니다. issue가 없는 검증 결과는 성공으로 처리합니다.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -117,6 +117,11 @@ class EmailOnlyDto extends PickType(UserDto, ['email']) {}
 class UpdateUserDto extends PartialType(UserDto) {}
 ```
 
+Mapped DTO helpers preserve field-level validation and binding metadata through
+the documented subclassing pattern shown above. `PickType`, `OmitType`, and
+`PartialType` do not carry base class-level validators onto derived DTOs because
+those validators can depend on fields that were omitted or made optional.
+
 ### Standard Schema support
 
 Standard Schema adapters are expected to report invalid input through explicit issues. Validation results without issues are treated as successful.

--- a/packages/validation/src/mapped-types.test.ts
+++ b/packages/validation/src/mapped-types.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+  defineDtoFieldBindingMetadata,
+  getDtoBindingSchema,
+  getDtoFieldBindingMetadata,
+} from '@fluojs/core/internal';
+
 import { IsEmail, IsString, ValidateClass } from './decorators.js';
 import { IntersectionType, OmitType, PartialType, PickType } from './mapped-types.js';
 import { DefaultValidator } from './validation.js';
@@ -103,6 +109,158 @@ describe('mapped DTO helpers', () => {
     });
 
     await expect(validator.materialize({}, UpdateUserDto)).resolves.toBeInstanceOf(UpdateUserDto);
+  });
+
+  it('preserves binding metadata on mapped DTO subclasses', () => {
+    class TrimConverter {
+      convert(value: unknown) {
+        return value;
+      }
+    }
+
+    class UserDto {
+      id = '';
+      email = '';
+      passwordHash = '';
+    }
+
+    class PagingDto {
+      cursor = '';
+    }
+
+    defineDtoFieldBindingMetadata(UserDto.prototype, 'id', {
+      key: 'userId',
+      source: 'path',
+    });
+    defineDtoFieldBindingMetadata(UserDto.prototype, 'email', {
+      converter: TrimConverter,
+      key: 'email',
+      source: 'body',
+    });
+    defineDtoFieldBindingMetadata(UserDto.prototype, 'passwordHash', {
+      key: 'passwordHash',
+      source: 'body',
+    });
+    defineDtoFieldBindingMetadata(PagingDto.prototype, 'cursor', {
+      key: 'cursor',
+      optional: true,
+      source: 'query',
+    });
+
+    class UserEmailDto extends PickType(UserDto, ['email']) {}
+    class PublicUserDto extends OmitType(UserDto, ['passwordHash']) {}
+    class UpdateUserDto extends PartialType(UserDto) {}
+    class UserPageDto extends IntersectionType(UserDto, PagingDto) {}
+
+    expect(getDtoFieldBindingMetadata(UserEmailDto.prototype, 'email')).toEqual({
+      converter: TrimConverter,
+      key: 'email',
+      source: 'body',
+    });
+    expect(getDtoBindingSchema(UserEmailDto)).toEqual([
+      {
+        propertyKey: 'email',
+        metadata: {
+          converter: TrimConverter,
+          key: 'email',
+          source: 'body',
+        },
+      },
+    ]);
+
+    expect(getDtoFieldBindingMetadata(PublicUserDto.prototype, 'id')).toEqual({
+      key: 'userId',
+      source: 'path',
+    });
+    expect(getDtoFieldBindingMetadata(PublicUserDto.prototype, 'passwordHash')).toBeUndefined();
+    expect(getDtoBindingSchema(PublicUserDto)).toEqual([
+      {
+        propertyKey: 'id',
+        metadata: {
+          key: 'userId',
+          source: 'path',
+        },
+      },
+      {
+        propertyKey: 'email',
+        metadata: {
+          converter: TrimConverter,
+          key: 'email',
+          source: 'body',
+        },
+      },
+    ]);
+
+    expect(getDtoFieldBindingMetadata(UpdateUserDto.prototype, 'id')).toEqual({
+      key: 'userId',
+      optional: true,
+      source: 'path',
+    });
+    expect(getDtoBindingSchema(UpdateUserDto)).toEqual([
+      {
+        propertyKey: 'id',
+        metadata: {
+          key: 'userId',
+          optional: true,
+          source: 'path',
+        },
+      },
+      {
+        propertyKey: 'email',
+        metadata: {
+          converter: TrimConverter,
+          key: 'email',
+          optional: true,
+          source: 'body',
+        },
+      },
+      {
+        propertyKey: 'passwordHash',
+        metadata: {
+          key: 'passwordHash',
+          optional: true,
+          source: 'body',
+        },
+      },
+    ]);
+
+    expect(getDtoFieldBindingMetadata(UserPageDto.prototype, 'cursor')).toEqual({
+      key: 'cursor',
+      optional: true,
+      source: 'query',
+    });
+    expect(getDtoBindingSchema(UserPageDto)).toEqual([
+      {
+        propertyKey: 'id',
+        metadata: {
+          key: 'userId',
+          source: 'path',
+        },
+      },
+      {
+        propertyKey: 'email',
+        metadata: {
+          converter: TrimConverter,
+          key: 'email',
+          source: 'body',
+        },
+      },
+      {
+        propertyKey: 'passwordHash',
+        metadata: {
+          key: 'passwordHash',
+          source: 'body',
+        },
+      },
+      {
+        propertyKey: 'cursor',
+        metadata: {
+          key: 'cursor',
+          optional: true,
+          source: 'query',
+        },
+      },
+    ]);
   });
 
   it('does not copy base class-level validators onto subset or partial DTO helpers', async () => {

--- a/packages/validation/src/mapped-types.test.ts
+++ b/packages/validation/src/mapped-types.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { IsEmail, IsString } from './decorators.js';
+import { IsEmail, IsString, ValidateClass } from './decorators.js';
 import { IntersectionType, OmitType, PartialType, PickType } from './mapped-types.js';
 import { DefaultValidator } from './validation.js';
 
@@ -82,5 +82,52 @@ describe('mapped DTO helpers', () => {
     await expect(validator.materialize({ email: 'not-an-email', name: 'Fluo' }, PublicUserDto)).resolves.toMatchObject({
       name: 'Fluo',
     });
+  });
+
+  it('preserves field metadata when documented mapped DTO subclassing patterns are used', async () => {
+    class UserDto {
+      @IsString()
+      name = '';
+
+      @IsEmail()
+      email = '';
+    }
+
+    class UserEmailDto extends PickType(UserDto, ['email']) {}
+    class UpdateUserDto extends PartialType(UserDto) {}
+
+    const validator = new DefaultValidator();
+
+    await expect(validator.materialize({ email: 'not-an-email' }, UserEmailDto)).rejects.toMatchObject({
+      issues: [{ code: 'EMAIL', field: 'email', message: 'email is invalid.' }],
+    });
+
+    await expect(validator.materialize({}, UpdateUserDto)).resolves.toBeInstanceOf(UpdateUserDto);
+  });
+
+  it('does not copy base class-level validators onto subset or partial DTO helpers', async () => {
+    @ValidateClass((dto: unknown) => {
+      const value = dto as { confirmEmail?: string; email?: string };
+      return value.email === value.confirmEmail
+        ? true
+        : { code: 'EMAIL_MISMATCH', message: 'email and confirmEmail must match' };
+    })
+    class UserDto {
+      @IsEmail()
+      email = '';
+
+      @IsEmail()
+      confirmEmail = '';
+    }
+
+    class UserEmailDto extends PickType(UserDto, ['email']) {}
+    class PublicUserDto extends OmitType(UserDto, ['confirmEmail']) {}
+    class UpdateUserDto extends PartialType(UserDto) {}
+
+    const validator = new DefaultValidator();
+
+    await expect(validator.materialize({ email: 'hello@example.com' }, UserEmailDto)).resolves.toBeInstanceOf(UserEmailDto);
+    await expect(validator.materialize({ email: 'hello@example.com' }, PublicUserDto)).resolves.toBeInstanceOf(PublicUserDto);
+    await expect(validator.materialize({ email: 'hello@example.com' }, UpdateUserDto)).resolves.toBeInstanceOf(UpdateUserDto);
   });
 });

--- a/packages/validation/src/mapped-types.ts
+++ b/packages/validation/src/mapped-types.ts
@@ -52,6 +52,7 @@ function copyDtoMetadata(
   source: DtoConstructor,
   target: DtoConstructor,
   include: (propertyKey: MetadataPropertyKey) => boolean,
+  copyClassRules = false,
 ): void {
   for (const entry of getDtoBindingSchema(source)) {
     if (!include(entry.propertyKey)) {
@@ -71,8 +72,10 @@ function copyDtoMetadata(
     }
   }
 
-  for (const rule of getClassValidationRules(source)) {
-    appendClassValidationRule(target, rule);
+  if (copyClassRules) {
+    for (const rule of getClassValidationRules(source)) {
+      appendClassValidationRule(target, rule);
+    }
   }
 }
 
@@ -205,7 +208,7 @@ export function IntersectionType<TBaseDtos extends readonly [DtoConstructor, Dto
   );
 
   for (const BaseDto of baseDtos) {
-    copyDtoMetadata(BaseDto, IntersectionDto, () => true);
+    copyDtoMetadata(BaseDto, IntersectionDto, () => true, true);
   }
 
   return IntersectionDto as DtoConstructor<IntersectionInstance<TBaseDtos>>;
@@ -259,10 +262,5 @@ export function PartialType<TBase extends DtoConstructor>(BaseDto: TBase): DtoCo
       appendDtoFieldValidationRule(PartialDto.prototype, entry.propertyKey, { kind: 'optional' });
     }
   }
-
-  for (const rule of getClassValidationRules(BaseDto)) {
-    appendClassValidationRule(PartialDto, rule);
-  }
-
   return PartialDto as DtoConstructor<Partial<InstanceType<TBase>>>;
 }


### PR DESCRIPTION
## Summary

Closes #1811

Fixes mapped DTO helper behavior so documented subclassing patterns retain field metadata while subset and partial DTOs do not inherit base class-level validators that may depend on omitted or optional fields.

## Changes

- Added inherited Fluo-owned validation metadata reads for DTO field binding, field validation, and class validation stores in `@fluojs/core`.
- Updated `PickType`, `OmitType`, and `PartialType` to avoid copying base class-level validators, while keeping `IntersectionType` class-level validator behavior for full intersections.
- Added regression coverage for subclassed mapped DTO helpers and class-level validator filtering.
- Documented the mapped DTO field metadata/class-level validator contract in README EN/KO and beginner book material.
- Added a patch changeset for `@fluojs/core` and `@fluojs/validation`.

## Testing

- `pnpm --filter @fluojs/validation test` ✅
- `pnpm --filter @fluojs/validation typecheck` ✅
- `pnpm --filter @fluojs/core test` ✅
- `pnpm --filter @fluojs/validation build` ✅
- `pnpm verify` ✅
- `lsp_diagnostics` on changed TS files ✅
- `pnpm verify:release-readiness` ⚠️ attempted; failed in the pre-existing CLI sandbox matrix path when sandbox `fluo build` exposed a CLI help surface without `build` in the generated mixed starter. The package tests/typecheck/build and full repo `pnpm verify` pass.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.