### PR TITLE
Partial #1808: clarify Terminus readiness semantics

### DIFF
--- a/book/beginner/ch18-health.ko.md
+++ b/book/beginner/ch18-health.ko.md
@@ -127,9 +127,9 @@ return report;
 ### 18.4.3 Dependency Priority and Cascading Failures
 고도로 연결된 마이크로서비스 아키텍처에서는 작은 서비스 하나가 실패했을 때 전체 시스템이 중단되는 "연쇄 실패(Cascading Failure)"가 발생할 수 있습니다. 차등 모니터링을 사용하면 각 의존성에 **우선순위 레벨(Priority Level)**을 지정할 수 있습니다.
 - **Critical Dependencies (임계 의존성)**: 기본 데이터베이스와 같이 실패 시 준비성 체크가 즉시 실패해야 하는 핵심 요소입니다.
-- **Non-Critical Dependencies (비임계 의존성)**: 필수적이지 않은 검색 인덱서와 같이 실패 시 준비성 체크에서 "경고" 상태를 반환하되, 대부분의 사용자 요청을 처리하기에는 여전히 "준비됨"으로 간주할 수 있는 요소입니다.
+- **Non-Critical Dependencies (비임계 의존성)**: 필수적이지 않은 검색 인덱서와 같이 실패하더라도 대부분의 사용자 요청을 처리할 수 있다면 binary `/ready` gate 대신 health detail, metrics, alert로 보고하는 편이 적합한 요소입니다.
 
-애플리케이션의 헬스에 치명적인 의존성이 무엇인지 전략적으로 결정함으로써, 완전히 실패하기보다는 우아하게 기능이 저하되는 더욱 강력한 시스템을 구축할 수 있습니다. Fluo의 Terminus 구성은 이러한 임계값과 동작을 인디케이터 조합으로 표현할 수 있어, 실제 세계의 복잡한 실패 시나리오를 정밀하게 처리할 수 있는 유연성을 제공합니다.
+애플리케이션의 헬스에 치명적인 의존성이 무엇인지 전략적으로 결정함으로써, 완전히 실패하기보다는 우아하게 기능이 저하되는 더욱 강력한 시스템을 구축할 수 있습니다. Fluo의 Terminus 구성은 indicator 결과, custom readiness check, runtime platform readiness를 조합해 binary `/ready` 결정을 만듭니다. 따라서 non-critical degraded 결과를 포함해 platform readiness가 `ready`가 아니면 인스턴스는 rotation에서 빠지고, severity context는 diagnostic payload에 보존됩니다.
 
 ### 18.4.4 Disk Space and I/O Monitoring
 파일 업로드를 처리하거나 집중적인 로깅을 수행하는 애플리케이션에서 **디스크 공간**은 매우 중요한 리소스입니다. 디스크가 가득 차면 메모리 누수와 마찬가지로 애플리케이션이 충돌하거나 응답하지 않게 될 수 있습니다. Terminus는 디스크 공간과 I/O 성능을 모니터링하기 위한 내장 인디케이터를 포함하고 있습니다. 임계값(예: 디스크가 90% 가득 참)을 설정함으로써, 프로덕션 비상 사태가 발생하기 전에 임시 파일 정리나 스토리지 확장과 같은 조치를 취할 수 있습니다.

--- a/book/beginner/ch18-health.md
+++ b/book/beginner/ch18-health.md
@@ -127,9 +127,9 @@ Beyond external services, you should monitor server resource usage. Memory leaks
 ### 18.4.3 Dependency Priority and Cascading Failures
 In highly connected microservice architectures, the failure of a small service can cause a "cascading failure" that brings down the entire system. With differentiated monitoring, you can assign a **priority level** to each dependency.
 - **Critical Dependencies**: Core elements such as the primary database, where failure should immediately fail the readiness check.
-- **Non-Critical Dependencies**: Elements such as a nonessential search indexer, where failure can return a "warning" state from the readiness check while the application is still considered "ready" to handle most user requests.
+- **Non-Critical Dependencies**: Elements such as a nonessential search indexer, where failure should usually be reported through health details, metrics, or alerts instead of the binary `/ready` gate if the application can still handle most user requests.
 
-By strategically deciding which dependencies are fatal to application health, you can build a stronger system that degrades gracefully instead of failing completely. Fluo's Terminus configuration can express these thresholds and behaviors through indicator combinations, giving you the flexibility to handle complex real world failure scenarios precisely.
+By strategically deciding which dependencies are fatal to application health, you can build a stronger system that degrades gracefully instead of failing completely. Fluo's Terminus configuration composes indicator results, custom readiness checks, and runtime platform readiness into a binary `/ready` decision: any non-ready platform readiness result, including a non-critical degraded result, keeps the instance out of rotation while the diagnostic payload preserves severity context.
 
 ### 18.4.4 Disk Space and I/O Monitoring
 For applications that handle file uploads or heavy logging, **disk space** is a critical resource. If the disk fills up, the application can crash or stop responding just as it would with a memory leak. Terminus includes built in indicators for monitoring disk space and I/O performance. By setting thresholds, such as disk usage reaching 90%, you can take action before a production emergency occurs, such as cleaning temporary files or expanding storage.

--- a/packages/terminus/README.ko.md
+++ b/packages/terminus/README.ko.md
@@ -29,7 +29,7 @@ pnpm add @fluojs/terminus
 
 - 외부 의존성(데이터베이스, Redis, API 등)의 상태를 애플리케이션 헬스 체크 결과에 포함해야 할 때.
 - 표준 모니터링 패턴에 맞는 구조화된 JSON 헬스 보고서가 필요할 때.
-- 핵심 하위 서비스에 접속할 수 없는 경우 `/ready` 체크가 실패하도록 설정해야 할 때.
+- 필요한 하위 readiness signal이 unavailable 상태일 때 `/ready` 체크가 rotation에서 빠지도록 설정해야 할 때.
 
 ## 빠른 시작
 
@@ -113,7 +113,7 @@ TerminusModule.forRoot({
 인디케이터가 실패하면 `HealthCheckError`를 던집니다. `TerminusHealthService`는 이 실패들을 모아 보고서를 작성합니다.
 
 - 하나 이상의 인디케이터가 실패하면 `/health`는 HTTP `503`을 반환합니다.
-- 준비 상태(readiness)와 관련된 인디케이터가 실패하면 `/ready`는 HTTP `503`을 반환합니다.
+- 등록된 indicator가 실패하거나, custom readiness check가 `false`를 반환하거나, runtime shutdown이 시작되었거나, platform readiness가 `ready`가 아닌 경우 `/ready`는 HTTP `503`을 반환합니다. Platform `critical` metadata는 diagnostics에 보존되지만 HTTP readiness endpoint 자체는 binary ready/unavailable gate이며 warning severity bucket을 노출하지 않습니다.
 - 응답 본문은 `status`, `contributors`, `info`, `error`, `details`를 포함한 구조화된 JSON 객체입니다.
 - 하나의 인디케이터가 여러 keyed entry를 반환할 수도 있으며, 이 경우 `/health`는 모든 entry를 `details`와 `contributors.up` / `contributors.down` 요약에 그대로 반영합니다.
 - 지원하지 않는 status, 빈 결과, 객체가 아닌 인디케이터 결과는 조용히 버려지지 않고 `down` 진단으로 보고됩니다.
@@ -151,7 +151,7 @@ TerminusModule.forRoot({
 
 ### `@fluojs/terminus/node`
 
-- `MemoryHealthIndicator`, `DiskHealthIndicator`, `createMemoryHealthIndicator()`, `createDiskHealthIndicator()`
+- `MemoryHealthIndicator`, `DiskHealthIndicator`, `createMemoryHealthIndicator()`, `createDiskHealthIndicator()`, `createMemoryHealthIndicatorProvider()`, `createDiskHealthIndicatorProvider()`
   - Node 전용 indicator helper는 호환성을 위해 root에서도 계속 export되며 이 전용 subpath에서도 export됩니다. Disk check의 filesystem access는 lazy-load되므로 root package import 시점에는 Node filesystem module을 load하지 않습니다.
 
 

--- a/packages/terminus/README.md
+++ b/packages/terminus/README.md
@@ -27,7 +27,7 @@ pnpm add @fluojs/terminus
 
 - When you need to monitor external dependencies (databases, Redis, APIs) as part of your application's health status.
 - When you want a structured JSON health report that aligns with standard monitoring patterns.
-- When you need your `/ready` check to fail if critical downstream services are unreachable.
+- When you need your `/ready` check to leave rotation while required downstream readiness signals are unavailable.
 
 ## Quick Start
 
@@ -113,7 +113,7 @@ Use `path` to mount the health endpoints under a custom path, and `readinessChec
 When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthService` aggregates these failures into a report:
 
 - `/health` returns HTTP `503` if any indicator fails.
-- `/ready` returns HTTP `503` if any indicator associated with readiness fails.
+- `/ready` returns HTTP `503` when registered indicators fail, a custom readiness check returns `false`, runtime shutdown has begun, or platform readiness is anything other than `ready`. Platform `critical` metadata is preserved in diagnostics, but the HTTP readiness endpoint itself is a binary ready/unavailable gate and does not expose warning severity buckets.
 - The response body contains a structured JSON object with `status`, `contributors`, `info`, `error`, and `details`.
 - Indicators may emit multiple keyed entries in a single check result; `/health` preserves every keyed entry in `details` and in the `contributors.up` / `contributors.down` summaries.
 - Unsupported, empty, or non-object indicator results are reported as `down` diagnostics instead of being silently discarded.
@@ -151,7 +151,7 @@ When an indicator fails, it throws a `HealthCheckError`. The `TerminusHealthServ
 
 ### `@fluojs/terminus/node`
 
-- `MemoryHealthIndicator`, `DiskHealthIndicator`, `createMemoryHealthIndicator()`, `createDiskHealthIndicator()`
+- `MemoryHealthIndicator`, `DiskHealthIndicator`, `createMemoryHealthIndicator()`, `createDiskHealthIndicator()`, `createMemoryHealthIndicatorProvider()`, `createDiskHealthIndicatorProvider()`
   - Node-specific indicator helpers remain root-exported for compatibility and are also exported from this dedicated subpath. Filesystem access for disk checks is lazy-loaded so importing the root package does not load Node filesystem modules at module initialization time.
 
 

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -10,6 +10,20 @@ import type { HealthIndicator } from './types.js';
 
 type TestResponse = FrameworkResponse & { body?: unknown };
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+
+  return { promise, resolve };
+}
+
 function createRequest(path: string): FrameworkRequest {
   return {
     body: undefined,
@@ -541,6 +555,126 @@ describe('TerminusModule.forRoot', () => {
     expect(readyResponse.body).toEqual({ status: 'unavailable' });
 
     await app.close();
+  });
+
+  it('treats non-critical degraded platform readiness as unavailable for the HTTP readiness gate', async () => {
+    const component: PlatformComponent = {
+      async health() {
+        return { status: 'healthy' };
+      },
+      id: 'search.optional',
+      kind: 'search',
+      async ready() {
+        return { critical: false, reason: 'search index warming', status: 'degraded' };
+      },
+      snapshot() {
+        return {
+          dependencies: [],
+          details: { mode: 'optional' },
+          health: { status: 'healthy' },
+          id: 'search.optional',
+          kind: 'search',
+          ownership: { externallyManaged: true, ownsResources: false },
+          readiness: { critical: false, reason: 'search index warming', status: 'degraded' },
+          state: 'degraded',
+          telemetry: { namespace: 'search', tags: {} },
+        };
+      },
+      async start() {},
+      state() {
+        return 'degraded';
+      },
+      async stop() {},
+      async validate() {
+        return { issues: [], ok: true };
+      },
+    };
+    const indicators: HealthIndicator[] = [
+      {
+        key: 'database',
+        check: async (key: string) => ({ [key]: { status: 'up' } }),
+      },
+    ];
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [TerminusModule.forRoot({ indicators })],
+    });
+
+    const app = await bootstrapApplication({
+      platform: {
+        components: [component],
+      },
+      rootModule: AppModule,
+    });
+
+    const healthResponse = createResponse();
+    await app.dispatch(createRequest('/health'), healthResponse);
+
+    expect(healthResponse.statusCode).toBe(503);
+    expect(healthResponse.body).toMatchObject({
+      error: {
+        'fluo-platform-readiness': {
+          critical: false,
+          message: 'search index warming',
+          platformStatus: 'degraded',
+          status: 'down',
+        },
+      },
+      status: 'error',
+    });
+
+    const readyResponse = createResponse();
+    await app.dispatch(createRequest('/ready'), readyResponse);
+
+    expect(readyResponse.statusCode).toBe(503);
+    expect(readyResponse.body).toEqual({ status: 'unavailable' });
+
+    await app.close();
+  });
+
+  it('keeps Terminus HTTP readiness out of rotation while shutdown is in progress', async () => {
+    const shutdownBlocker = createDeferred<void>();
+    const shutdownStarted = createDeferred<void>();
+
+    class BlockingShutdownService {
+      onApplicationShutdown() {
+        shutdownStarted.resolve();
+
+        return shutdownBlocker.promise;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [TerminusModule.forRoot({
+        indicators: [
+          {
+            key: 'database',
+            check: async (key: string) => ({ [key]: { status: 'up' } }),
+          },
+        ],
+      })],
+      providers: [BlockingShutdownService],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    const readyBeforeClose = createResponse();
+    await app.dispatch(createRequest('/ready'), readyBeforeClose);
+    expect(readyBeforeClose.statusCode).toBe(200);
+    expect(readyBeforeClose.body).toEqual({ status: 'ready' });
+
+    const closePromise = app.close('SIGTERM');
+    await shutdownStarted.promise;
+
+    const readyDuringClose = createResponse();
+    await app.dispatch(createRequest('/ready'), readyDuringClose);
+    expect(readyDuringClose.statusCode).toBe(503);
+    expect(readyDuringClose.body).toEqual({ status: 'starting' });
+
+    shutdownBlocker.resolve();
+    await closePromise;
   });
 
   it('reports platform health failures as explicit Terminus diagnostics', async () => {

--- a/packages/terminus/src/public-surface.test.ts
+++ b/packages/terminus/src/public-surface.test.ts
@@ -32,6 +32,8 @@ describe('terminus public surface', () => {
     expect(terminusNode).toHaveProperty('DiskHealthIndicator');
     expect(terminusNode).toHaveProperty('MemoryHealthIndicator');
     expect(terminusNode).toHaveProperty('createDiskHealthIndicator');
+    expect(terminusNode).toHaveProperty('createDiskHealthIndicatorProvider');
     expect(terminusNode).toHaveProperty('createMemoryHealthIndicator');
+    expect(terminusNode).toHaveProperty('createMemoryHealthIndicatorProvider');
   });
 });


### PR DESCRIPTION
## Summary

related to #1808.

This PR clarifies Terminus readiness semantics so the docs no longer imply warning-style readiness severity buckets, and strengthens regression coverage around shutdown readiness and platform degraded readiness behavior.

This PR is intentionally scoped as non-closing work for issue 1808. The remaining audit scope is tracked in #1846:

- same-type indicator provider DI conflict
- timeout/request-facing endpoint coverage hardening

## Changes

- Updated `@fluojs/terminus` EN/KO README readiness wording to describe `/ready` as a binary ready/unavailable gate.
- Aligned beginner book EN/KO guidance so non-critical dependency degradation is documented as health/metrics/alerting rather than a ready-with-warning state.
- Added Terminus regression tests for non-critical degraded platform readiness and in-progress shutdown readiness.
- Extended public surface coverage for `@fluojs/terminus/node` provider helper exports.

## Testing

- `pnpm --filter @fluojs/terminus... build`
- `pnpm --filter @fluojs/terminus typecheck`
- `pnpm --filter @fluojs/terminus test`
- `pnpm lint` (completed with existing repository lint warnings outside this change; public export TSDoc check passed)
- `pnpm exec biome check packages/terminus/src/module.test.ts packages/terminus/src/public-surface.test.ts packages/terminus/README.md packages/terminus/README.ko.md book/beginner/ch18-health.md book/beginner/ch18-health.ko.md`
- `lsp_diagnostics` clean for changed TypeScript files

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public export implementation changed; README/public surface tests now explicitly document and cover existing `@fluojs/terminus/node` provider helper exports.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This is docs plus behavior-coverage alignment for existing Terminus readiness behavior. No release changeset is included because runtime behavior and package exports are unchanged.

Remaining behavior/coverage work from #1808 is split to #1846, so this PR should be reviewed as related work rather than an issue-closing change.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; Terminus package README/book EN/KO pairs were updated together with package-local regression tests.