### PR TITLE
Resolve #1812: guard Vite node_modules paths on Windows

### DIFF
--- a/.changeset/vite-windows-node-modules.md
+++ b/.changeset/vite-windows-node-modules.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/vite": patch
+---
+
+Preserve the documented Vite plugin `node_modules` skip boundary for Windows-style resolved module IDs that use backslash separators.

--- a/packages/vite/src/index.test.ts
+++ b/packages/vite/src/index.test.ts
@@ -71,6 +71,9 @@ describe('fluoDecoratorsPlugin', () => {
     await expect(
       runTransform(plugin, 'export const value: number = 1;', '/app/node_modules/dependency/index.ts'),
     ).resolves.toBeNull();
+    await expect(
+      runTransform(plugin, 'export const value: number = 1;', 'C:\\app\\node_modules\\dependency\\index.ts'),
+    ).resolves.toBeNull();
     await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.tsx')).resolves.toBeNull();
   });
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -3,12 +3,17 @@ import type { Plugin } from 'vite';
 
 function shouldTransformTypeScriptApplicationFile(id: string): boolean {
   const [filePath] = id.split('?', 1);
+  const normalizedFilePath = filePath.replaceAll('\\', '/');
 
-  if (!filePath.endsWith('.ts') || filePath.endsWith('.d.ts')) {
+  if (!normalizedFilePath.endsWith('.ts') || normalizedFilePath.endsWith('.d.ts')) {
     return false;
   }
 
-  return !filePath.includes('/node_modules/') && !filePath.includes('.test.') && !filePath.includes('.spec.');
+  return (
+    !normalizedFilePath.includes('/node_modules/') &&
+    !normalizedFilePath.includes('.test.') &&
+    !normalizedFilePath.includes('.spec.')
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the `@fluojs/vite` transform boundary so the documented `node_modules` skip contract also applies when Vite provides Windows-style resolved IDs with backslash separators.

Closes #1812

## Changes

- Normalizes Vite transform IDs to POSIX separators before applying `.ts`, declaration, test/spec, and `node_modules` guards.
- Adds a regression assertion for a Windows-style `C:\\...\\node_modules\\...` TypeScript module ID.
- Adds a patch changeset for `@fluojs/vite`.

## Testing

- `lsp_diagnostics` clean for `packages/vite/src/index.ts`
- `lsp_diagnostics` clean for `packages/vite/src/index.test.ts`
- `pnpm --filter @fluojs/vite typecheck`
- `pnpm --filter @fluojs/vite test`
- `pnpm --filter @fluojs/vite build`
- `pnpm lint` (passed; existing non-blocking Biome warnings outside this change were reported)
- `pnpm test` (218 files / 2851 tests passed)

## Public export documentation

- [x] No public exports changed.
- [x] Existing `fluoDecoratorsPlugin()` TSDoc remains intact.
- [x] Source examples and README examples remain unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Existing documented `node_modules` skip behavior is preserved on Windows-style paths.
- [x] Intentional test/spec/declaration/non-`.ts` limitations remain unchanged.
- [x] Runtime invariant is covered by regression test.

## Platform consistency governance (SSOT)

- [x] No platform contract docs changed.
- [x] No SSOT mirror changes required.
- [x] Not a platform adapter conformance change.