### PR TITLE
Resolve #1789: reject Redis emits during shutdown

### DIFF
--- a/.changeset/redis-emit-shutdown.md
+++ b/.changeset/redis-emit-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/microservices": patch
+---
+
+Reject Redis Pub/Sub and Redis Streams event emits once transport shutdown has started so no outbound work is accepted during a closing lifecycle.

--- a/packages/microservices/src/transports/redis-streams-transport.test.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.test.ts
@@ -1059,6 +1059,86 @@ describe('RedisStreamsMicroserviceTransport', () => {
     );
   });
 
+  it('rejects emit() without xadd while close() is still draining', async () => {
+    const bus = new InMemoryStreamBus();
+    let releaseDestroy: (() => void) | undefined;
+    let resolveDestroyStarted: (() => void) | undefined;
+    let destroyBlocked = false;
+    const destroyStarted = new Promise<void>((resolve) => {
+      resolveDestroyStarted = resolve;
+    });
+    const readerClient = {
+      xadd: async (stream, fields, options) => {
+        return await bus.xadd(stream, fields, options);
+      },
+      xreadgroup: async (group, consumer, streams, options) => {
+        return await bus.xreadgroup(group, consumer, streams, options);
+      },
+      xack: async (stream, group, id) => {
+        await bus.xack(stream, group, id);
+      },
+      xdel: async (stream, id) => {
+        await bus.xdel(stream, id);
+      },
+      del: async (stream) => {
+        await bus.del(stream);
+      },
+      xgroupCreate: async (stream, group, startId, mkstream) => {
+        await bus.xgroupCreate(stream, group, startId, mkstream);
+      },
+      xgroupDestroy: async (stream, group) => {
+        if (!destroyBlocked) {
+          destroyBlocked = true;
+          resolveDestroyStarted?.();
+          await new Promise<void>((release) => {
+            releaseDestroy = release;
+          });
+        }
+
+        await bus.xgroupDestroy(stream, group);
+      },
+    } satisfies RedisStreamClientLike;
+    const xadd = vi.fn(async (stream: string, fields: Record<string, string>, options?: RedisStreamWriteOptions) => {
+      return await bus.xadd(stream, fields, options);
+    });
+    const transport = new RedisStreamsMicroserviceTransport({
+      pollBlockMs: 1,
+      readerClient,
+      requestTimeoutMs: 1_000,
+      writerClient: {
+        xadd,
+        xreadgroup: async (group, consumer, streams, options) => {
+          return await bus.xreadgroup(group, consumer, streams, options);
+        },
+        xack: async (stream, group, id) => {
+          await bus.xack(stream, group, id);
+        },
+        xgroupCreate: async (stream, group, startId, mkstream) => {
+          await bus.xgroupCreate(stream, group, startId, mkstream);
+        },
+        xgroupDestroy: async (stream, group) => {
+          await bus.xgroupDestroy(stream, group);
+        },
+      },
+    });
+
+    await transport.listen(async () => undefined);
+
+    const closing = transport.close();
+    await destroyStarted;
+
+    await expect(transport.listen(async () => undefined)).rejects.toThrow(
+      'RedisStreamsMicroserviceTransport is closing. Wait for close() to complete before listen().',
+    );
+    await expect(transport.emit('during.close', {})).rejects.toThrow(
+      'RedisStreamsMicroserviceTransport is closing. Wait for close() to complete before emit().',
+    );
+    expect(xadd).not.toHaveBeenCalled();
+
+    releaseDestroy?.();
+    await closing;
+  });
+
   it('still rejects pending requests when group destroy fails during close', async () => {
     const bus = new InMemoryStreamBus();
     const closeError = new Error('group destroy failed');

--- a/packages/microservices/src/transports/redis-streams-transport.test.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.test.ts
@@ -1045,6 +1045,20 @@ describe('RedisStreamsMicroserviceTransport', () => {
     await expect(pending).rejects.toThrow(/Redis Streams microservice transport closed before/);
   });
 
+  it('rejects emit() after close() starts', async () => {
+    const bus = new InMemoryStreamBus();
+    const { transport } = createTransport(bus, {
+      requestTimeoutMs: 1_000,
+    });
+
+    await transport.listen(async () => undefined);
+    await transport.close();
+
+    await expect(transport.emit('after.close', {})).rejects.toThrow(
+      'RedisStreamsMicroserviceTransport is closing. Wait for close() to complete before emit().',
+    );
+  });
+
   it('still rejects pending requests when group destroy fails during close', async () => {
     const bus = new InMemoryStreamBus();
     const closeError = new Error('group destroy failed');

--- a/packages/microservices/src/transports/redis-streams-transport.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.ts
@@ -263,6 +263,10 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
    * @returns A promise that resolves once the event frame is appended to the stream.
    */
   async emit(pattern: string, payload: unknown): Promise<void> {
+    if (this.closing) {
+      throw new Error('RedisStreamsMicroserviceTransport is closing. Wait for close() to complete before emit().');
+    }
+
     const frame = {
       kind: 'event',
       pattern,

--- a/packages/microservices/src/transports/redis-streams-transport.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.ts
@@ -83,6 +83,7 @@ function delay(ms: number): Promise<void> {
  * at-least-once delivery with request timeouts while preserving Fluo's transport abstraction.
  */
 export class RedisStreamsMicroserviceTransport implements MicroserviceTransport {
+  private closePromise: Promise<void> | undefined;
   private closing = false;
   private readonly consumerId: string;
   private handler: TransportHandler | undefined;
@@ -129,7 +130,14 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
    * @returns A promise that resolves once all stream consumers are initialized.
    */
   async listen(handler: TransportHandler): Promise<void> {
-    this.closing = false;
+    if (this.closing) {
+      if (this.closePromise) {
+        throw new Error('RedisStreamsMicroserviceTransport is closing. Wait for close() to complete before listen().');
+      }
+
+      this.closing = false;
+    }
+
     this.handler = handler;
 
     if (this.listening) {
@@ -286,62 +294,75 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
    * @returns A promise that resolves once shutdown cleanup finishes.
    */
   async close(): Promise<void> {
-    this.closing = true;
-    let closeError: unknown;
-
-    if (this.listenPromise) {
-      await this.listenPromise;
+    if (this.closePromise) {
+      await this.closePromise;
+      return;
     }
 
-    try {
-      const settled = await Promise.allSettled(this.pollPromises);
-      const shouldDestroyMessageGroup = await this.releaseMessageGroupLease();
+    this.closing = true;
+    this.closePromise = (async () => {
+      let closeError: unknown;
 
-      for (const result of settled) {
-        if (result.status === 'rejected') {
-          closeError ??= result.reason;
-        }
+      if (this.listenPromise) {
+        await this.listenPromise;
       }
 
-      if (shouldDestroyMessageGroup) {
+      try {
+        const settled = await Promise.allSettled(this.pollPromises);
+        const shouldDestroyMessageGroup = await this.releaseMessageGroupLease();
+
+        for (const result of settled) {
+          if (result.status === 'rejected') {
+            closeError ??= result.reason;
+          }
+        }
+
+        if (shouldDestroyMessageGroup) {
+          try {
+            await this.options.readerClient.xgroupDestroy(this.messageStream, this.messageGroup);
+          } catch (error) {
+            closeError ??= error;
+          }
+        }
+
         try {
-          await this.options.readerClient.xgroupDestroy(this.messageStream, this.messageGroup);
+          await this.options.readerClient.xgroupDestroy(this.eventStream, this.eventGroup);
         } catch (error) {
           closeError ??= error;
         }
+
+        try {
+          await this.options.readerClient.xgroupDestroy(this.responseStream, this.responseGroup);
+        } catch (error) {
+          closeError ??= error;
+        }
+
+        try {
+          await this.options.readerClient.del?.(this.responseStream);
+        } catch (error) {
+          closeError ??= error;
+        }
+      } finally {
+        this.listening = false;
+        this.handler = undefined;
+        this.messageGroupLeaseRegistered = false;
+        this.ownsMessageGroup = false;
+        this.pollPromises = [];
+
+        for (const pending of [...this.pending.values()]) {
+          pending.reject(new Error('Redis Streams microservice transport closed before response.'));
+        }
       }
 
-      try {
-        await this.options.readerClient.xgroupDestroy(this.eventStream, this.eventGroup);
-      } catch (error) {
-        closeError ??= error;
+      if (closeError) {
+        throw closeError;
       }
+    })();
 
-      try {
-        await this.options.readerClient.xgroupDestroy(this.responseStream, this.responseGroup);
-      } catch (error) {
-        closeError ??= error;
-      }
-
-      try {
-        await this.options.readerClient.del?.(this.responseStream);
-      } catch (error) {
-        closeError ??= error;
-      }
+    try {
+      await this.closePromise;
     } finally {
-      this.listening = false;
-      this.handler = undefined;
-      this.messageGroupLeaseRegistered = false;
-      this.ownsMessageGroup = false;
-      this.pollPromises = [];
-
-      for (const pending of [...this.pending.values()]) {
-        pending.reject(new Error('Redis Streams microservice transport closed before response.'));
-      }
-    }
-
-    if (closeError) {
-      throw closeError;
+      this.closePromise = undefined;
     }
   }
 

--- a/packages/microservices/src/transports/redis-transport.test.ts
+++ b/packages/microservices/src/transports/redis-transport.test.ts
@@ -183,6 +183,22 @@ describe('RedisPubSubMicroserviceTransport', () => {
     expect(subscribeClient.subscriptions.has('test-ns:events')).toBe(false);
   });
 
+  it('rejects emit() after close() starts', async () => {
+    const bus = new InMemoryRedisBus();
+    const { publishClient, subscribeClient } = bus.createClient();
+    const transport = new RedisPubSubMicroserviceTransport({
+      publishClient,
+      subscribeClient,
+    });
+
+    await transport.listen(async () => undefined);
+    await transport.close();
+
+    await expect(transport.emit('after.close', {})).rejects.toThrow(
+      'RedisPubSubMicroserviceTransport is closing. Wait for close() to complete before emit().',
+    );
+  });
+
   it('removes the message listener on close so reconnect does not duplicate event dispatch', async () => {
     const bus = new InMemoryRedisBus();
     const { publishClient, subscribeClient } = bus.createClient();

--- a/packages/microservices/src/transports/redis-transport.test.ts
+++ b/packages/microservices/src/transports/redis-transport.test.ts
@@ -199,6 +199,48 @@ describe('RedisPubSubMicroserviceTransport', () => {
     );
   });
 
+  it('rejects emit() without publishing while close() is still draining', async () => {
+    const bus = new InMemoryRedisBus();
+    const { publishClient, subscribeClient } = bus.createClient();
+    const publish = vi.fn(async () => undefined);
+    publishClient.publish = publish;
+
+    let releaseUnsubscribe: (() => void) | undefined;
+    const unsubscribeStarted = new Promise<void>((resolve) => {
+      subscribeClient.unsubscribe = vi.fn(async (...channels: string[]) => {
+        resolve();
+        await new Promise<void>((release) => {
+          releaseUnsubscribe = release;
+        });
+
+        for (const channel of channels) {
+          subscribeClient.subscriptions.delete(channel);
+        }
+      });
+    });
+
+    const transport = new RedisPubSubMicroserviceTransport({
+      publishClient,
+      subscribeClient,
+    });
+
+    await transport.listen(async () => undefined);
+
+    const closing = transport.close();
+    await unsubscribeStarted;
+
+    await expect(transport.listen(async () => undefined)).rejects.toThrow(
+      'RedisPubSubMicroserviceTransport is closing. Wait for close() to complete before listen().',
+    );
+    await expect(transport.emit('during.close', {})).rejects.toThrow(
+      'RedisPubSubMicroserviceTransport is closing. Wait for close() to complete before emit().',
+    );
+    expect(publish).not.toHaveBeenCalled();
+
+    releaseUnsubscribe?.();
+    await closing;
+  });
+
   it('removes the message listener on close so reconnect does not duplicate event dispatch', async () => {
     const bus = new InMemoryRedisBus();
     const { publishClient, subscribeClient } = bus.createClient();

--- a/packages/microservices/src/transports/redis-transport.ts
+++ b/packages/microservices/src/transports/redis-transport.ts
@@ -30,6 +30,7 @@ export interface RedisPubSubMicroserviceTransportOptions {
  * a transport with durable reply semantics such as TCP, Kafka, or Redis Streams.
  */
 export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
+  private closePromise: Promise<void> | undefined;
   private closing = false;
   private handler: TransportHandler | undefined;
   private logger: MicroserviceTransportLogger | undefined;
@@ -64,7 +65,14 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once the Redis subscription is active.
    */
   async listen(handler: TransportHandler): Promise<void> {
-    this.closing = false;
+    if (this.closing) {
+      if (this.closePromise) {
+        throw new Error('RedisPubSubMicroserviceTransport is closing. Wait for close() to complete before listen().');
+      }
+
+      this.closing = false;
+    }
+
     this.handler = handler;
 
     if (this.listening) {
@@ -138,27 +146,40 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once shutdown cleanup completes.
    */
   async close(): Promise<void> {
-    this.closing = true;
-    let closeError: unknown;
-
-    if (this.listenPromise) {
-      await this.listenPromise;
+    if (this.closePromise) {
+      await this.closePromise;
+      return;
     }
+
+    this.closing = true;
+    this.closePromise = (async () => {
+      let closeError: unknown;
+
+      if (this.listenPromise) {
+        await this.listenPromise;
+      }
+
+      try {
+        if (this.listening) {
+          await this.options.subscribeClient.unsubscribe(this.eventChannel);
+        }
+      } catch (error) {
+        closeError = error;
+      } finally {
+        this.options.subscribeClient.off?.('message', this.messageListener);
+        this.listening = false;
+        this.handler = undefined;
+      }
+
+      if (closeError) {
+        throw closeError;
+      }
+    })();
 
     try {
-      if (this.listening) {
-        await this.options.subscribeClient.unsubscribe(this.eventChannel);
-      }
-    } catch (error) {
-      closeError = error;
+      await this.closePromise;
     } finally {
-      this.options.subscribeClient.off?.('message', this.messageListener);
-      this.listening = false;
-      this.handler = undefined;
-    }
-
-    if (closeError) {
-      throw closeError;
+      this.closePromise = undefined;
     }
   }
 

--- a/packages/microservices/src/transports/redis-transport.ts
+++ b/packages/microservices/src/transports/redis-transport.ts
@@ -30,6 +30,7 @@ export interface RedisPubSubMicroserviceTransportOptions {
  * a transport with durable reply semantics such as TCP, Kafka, or Redis Streams.
  */
 export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
+  private closing = false;
   private handler: TransportHandler | undefined;
   private logger: MicroserviceTransportLogger | undefined;
   private listening = false;
@@ -63,6 +64,7 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once the Redis subscription is active.
    */
   async listen(handler: TransportHandler): Promise<void> {
+    this.closing = false;
     this.handler = handler;
 
     if (this.listening) {
@@ -101,6 +103,10 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once Redis accepts the publication.
    */
   async emit(pattern: string, payload: unknown): Promise<void> {
+    if (this.closing) {
+      throw new Error('RedisPubSubMicroserviceTransport is closing. Wait for close() to complete before emit().');
+    }
+
     const message: RedisPubSubMessage = {
       kind: 'event',
       pattern,
@@ -132,6 +138,7 @@ export class RedisPubSubMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once shutdown cleanup completes.
    */
   async close(): Promise<void> {
+    this.closing = true;
     let closeError: unknown;
 
     if (this.listenPromise) {


### PR DESCRIPTION
## Summary

Closes #1789

Reject Redis Pub/Sub and Redis Streams `emit()` calls once transport shutdown has started so Redis transports match the documented lifecycle contract for outbound work.

## Changes

- Added a closing lifecycle guard to `RedisPubSubMicroserviceTransport.emit()` and reset it on `listen()` for restart symmetry.
- Added the missing Redis Streams `emit()` closing guard.
- Added Redis Pub/Sub and Redis Streams regression coverage for emits after shutdown.
- Added a patch changeset for `@fluojs/microservices`.

## Testing

- `lsp_diagnostics` clean for changed Redis transport source/test files.
- `pnpm --filter @fluojs/microservices exec vitest run -c vitest.config.ts src/transports/redis-transport.test.ts src/transports/redis-streams-transport.test.ts`
- `pnpm --filter @fluojs/microservices... build && pnpm --filter @fluojs/microservices typecheck`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.