### PR TITLE
Resolve #1809: harden testing portability cleanup

### DIFF
--- a/.changeset/testing-portability-cleanup.md
+++ b/.changeset/testing-portability-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/testing": patch
+---
+
+Harden portability and conformance harness cleanup so partially bootstrapped HTTP apps are closed after setup failures, web-runtime raw-body checks cover exact bytes, and diagnostics include actionable failure context.

--- a/book/advanced/ch14-portability-testing.ko.md
+++ b/book/advanced/ch14-portability-testing.ko.md
@@ -62,10 +62,12 @@ export interface HttpAdapterPortabilityHarnessOptions<
 하네스는 런타임 사이에서 차이가 발생하기 쉬운 여러 임계 표면을 다룹니다. 목적은 Fluo 추상화 계층이 서로 다른 실행 환경에서도 새지 않도록 확인하는 것입니다:
 
 1. **쿠키 처리(Cookie Handling)**: 잘못된 형식의 쿠키가 서버를 중단시키거나 다른 헤더를 오염시키지 않도록 보장.
-2. **원시 바디 보존(Raw Body Preservation)**: 메모리 절약을 위해 JSON 및 Text에 대해서는 `rawBody`를 사용할 수 있지만 Multipart에 대해서는 제외되는지 확인.
+2. **원시 바디 보존(Raw Body Preservation)**: JSON 및 text에서는 `rawBody`를 사용할 수 있고, byte-sensitive payload에서는 정확한 바이트가 보존되며, 메모리 절약을 위해 multipart request에서는 제외되는지 확인.
 3. **SSE (Server-Sent Events)**: 버퍼링 없이 연결을 열린 상태로 유지하는 적절한 스트리밍 동작 확인.
 4. **시작 로그(Startup Logs)**: 어댑터가 표준화된 훅을 통해 리스닝 호스트와 포트를 올바르게 보고하는지 검증.
 5. **종료 시그널(Shutdown Signals)**: 메모리 누수를 방지하기 위해 `SIGTERM` 및 `SIGINT` 리스너가 종료 후 올바르게 정리되는지 확인.
+
+하니스가 앱을 bootstrap한 뒤 assertion 본문이 실행되기 전에 setup 또는 `listen()`이 실패해도 cleanup은 계약에 포함됩니다. 부분적으로 bootstrap된 앱은 반드시 닫혀야 하며, `close()`까지 실패하면 원래 setup 실패와 cleanup 실패를 함께 보고합니다.
 
 ## 14.4 Implementation Deep Dive: Malformed Cookies
 

--- a/book/advanced/ch14-portability-testing.md
+++ b/book/advanced/ch14-portability-testing.md
@@ -62,10 +62,12 @@ export interface HttpAdapterPortabilityHarnessOptions<
 The harness covers several critical surfaces where runtimes often diverge. The purpose is to make sure the Fluo abstraction layer does not leak across different execution environments:
 
 1. **Cookie Handling**: Ensures malformed cookies do not crash the server or contaminate other headers.
-2. **Raw Body Preservation**: Verifies that `rawBody` is available for JSON and Text to save memory, but excluded for Multipart.
+2. **Raw Body Preservation**: Verifies that `rawBody` is available for JSON and text, preserves exact bytes for byte-sensitive payloads, and is excluded for multipart requests to save memory.
 3. **SSE (Server-Sent Events)**: Confirms proper streaming behavior that keeps the connection open without buffering.
 4. **Startup Logs**: Verifies that adapters correctly report the listening host and port through standardized hooks.
 5. **Shutdown Signals**: Ensures `SIGTERM` and `SIGINT` listeners are cleaned up correctly after shutdown to prevent memory leaks.
+
+If a harness bootstraps an app and setup or `listen()` fails before the assertion body runs, cleanup is still part of the contract: the partially bootstrapped app must be closed, and any `close()` failure is reported together with the original setup failure.
 
 ## 14.4 Implementation Deep Dive: Malformed Cookies
 

--- a/docs/CONTEXT.ko.md
+++ b/docs/CONTEXT.ko.md
@@ -37,6 +37,8 @@ Redis 통합의 discoverability는 책임별로 나뉜다. `packages/redis/READM
 
 Queue lifecycle discoverability도 패키지 문서와 governed docs로 나뉜다. `packages/queue/README.ko.md`는 `QueueModule.forRoot(...)`, Redis duplicate ownership, bootstrap-ready worker processor handoff, `workerShutdownTimeoutMs`를 통한 bounded worker shutdown, dead-letter retention, lifecycle status snapshot을 문서화한다. [`docs/contracts/behavioral-contract-policy.md`](./contracts/behavioral-contract-policy.md)는 readiness 및 shutdown ordering을 구현, 문서, regression test가 함께 바뀌어야 하는 behavioral contract로 다루며, [`docs/contracts/testing-guide.md`](./contracts/testing-guide.md)는 queue lifecycle behavior 변경 시 실행할 가까운 package test와 governance command를 안내한다.
 
+HTTP adapter raw-body portability discoverability도 testing package와 governed platform docs로 나뉜다. `packages/testing/README.md`는 byte-sensitive payload를 위한 `createHttpAdapterPortabilityHarness(...)`와 `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`를 문서화한다. [`docs/contracts/platform-conformance-authoring-checklist.ko.md`](./contracts/platform-conformance-authoring-checklist.ko.md)는 HTTP adapter가 Unicode replacement, newline normalization, re-encoding 없이 정확한 `rawBody` byte를 보존해야 한다고 요구하며, [`docs/contracts/testing-guide.ko.md`](./contracts/testing-guide.ko.md)는 HTTP adapter byte preservation behavior가 바뀔 때 실행할 platform portability test와 governance command를 안내한다.
+
 ## File Structure
 
 | Path | Role |

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -37,6 +37,8 @@ Redis integration discoverability is split by responsibility: `packages/redis/RE
 
 Queue lifecycle discoverability is split across the package and governed docs: `packages/queue/README.md` documents `QueueModule.forRoot(...)`, Redis duplicate ownership, the bootstrap-ready worker processor handoff, bounded worker shutdown through `workerShutdownTimeoutMs`, dead-letter retention, and lifecycle status snapshots; [`docs/contracts/behavioral-contract-policy.md`](./contracts/behavioral-contract-policy.md) treats readiness and shutdown ordering as behavioral contracts that require implementation, docs, and regression tests to change together; and [`docs/contracts/testing-guide.md`](./contracts/testing-guide.md) identifies the nearest package tests and governance commands to run when queue lifecycle behavior changes.
 
+HTTP adapter raw-body portability discoverability is split across the testing package and governed platform docs: `packages/testing/README.md` documents `createHttpAdapterPortabilityHarness(...)` and `assertPreservesExactRawBodyBytesForByteSensitivePayloads()` for byte-sensitive payloads; [`docs/contracts/platform-conformance-authoring-checklist.md`](./contracts/platform-conformance-authoring-checklist.md) requires HTTP adapters to preserve exact `rawBody` bytes without Unicode replacement, newline normalization, or re-encoding; and [`docs/contracts/testing-guide.md`](./contracts/testing-guide.md) identifies platform portability tests and governance commands to run when HTTP adapter byte preservation behavior changes.
+
 ## File Structure
 
 | Path | Role |

--- a/docs/contracts/platform-conformance-authoring-checklist.ko.md
+++ b/docs/contracts/platform-conformance-authoring-checklist.ko.md
@@ -27,6 +27,7 @@
 - [ ] MUST: HTTP 어댑터는 `@fluojs/testing/http-adapter-portability`의 `createHttpAdapterPortabilityHarness(...)`를 실행합니다.
 - [ ] MUST: 손상된 cookie 값을 크래시 없이 보존하고 임의 정규화하지 않습니다.
 - [ ] MUST: raw body 캡처가 켜져 있을 때 JSON과 text 요청의 `rawBody`를 보존합니다.
+- [ ] MUST: byte-sensitive payload에 대해 `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`를 검증하여 어댑터가 Unicode replacement, newline normalization, re-encoding 없이 정확한 `rawBody` byte를 보존하는지 확인합니다.
 - [ ] MUST NOT: multipart 요청의 `rawBody`를 보존하지 않습니다.
 - [ ] MUST: `text/event-stream` content type과 안정적인 event framing으로 SSE streaming을 지원합니다.
 - [ ] MUST: 시작 로그에 구성된 host를 보고합니다.

--- a/docs/contracts/platform-conformance-authoring-checklist.md
+++ b/docs/contracts/platform-conformance-authoring-checklist.md
@@ -27,6 +27,7 @@ Use this checklist when authoring or changing official platform-facing packages 
 - [ ] MUST: For HTTP adapters, run `createHttpAdapterPortabilityHarness(...)` from `@fluojs/testing/http-adapter-portability`.
 - [ ] MUST: Preserve malformed cookie values without crashing or normalizing them away.
 - [ ] MUST: Preserve `rawBody` for JSON and text requests when raw-body capture is enabled.
+- [ ] MUST: Verify `assertPreservesExactRawBodyBytesForByteSensitivePayloads()` for byte-sensitive payloads so adapters preserve exact `rawBody` bytes without Unicode replacement, newline normalization, or re-encoding.
 - [ ] MUST NOT: Preserve `rawBody` for multipart requests.
 - [ ] MUST: Support SSE streaming with `text/event-stream` content type and stable event framing.
 - [ ] MUST: Report the configured host in startup logs.

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -138,6 +138,8 @@ const mailer = createDeepMock(MailService);
 
 `HttpAdapterPortabilityHarness`와 web-runtime portability harness 메서드는 공개 어댑터 계약 체크입니다. 직접 같은 검증을 다시 만들기보다 `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, `assertRemovesShutdownSignalListenersAfterClose()`처럼 초점이 분명한 assertion을 사용하세요.
 
+HTTP 어댑터가 런타임 전반에서 `rawBody`의 byte-sensitive payload byte를 그대로 보존하는지 증명해야 할 때는 `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`를 사용하세요.
+
 ## canonical TDD ladder
 
 애플리케이션 기능 테스트는 가장 작은 명시적 dependency boundary에서 시작해 바깥쪽으로 확장합니다.

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -23,7 +23,7 @@ fluo 애플리케이션을 위한 기본 request-level 테스트 헬퍼, 모듈 
 pnpm add -D @fluojs/testing vitest
 ```
 
-`vitest`는 mock 헬퍼와 `@fluojs/testing/vitest` 엔트리포인트가 요구하는 peer dependency입니다.
+`vitest`는 mock 헬퍼와 `@fluojs/testing/vitest` 엔트리포인트가 요구하는 peer dependency입니다. `@babel/core`는 Vitest decorators plugin이 사용하는 워크스페이스의 Babel을 로드하기 때문에 peer로 선언되어 있습니다. 따라서 non-Vitest harness subpath만 사용하더라도 패키지 매니저가 해당 peer 경고를 표시할 수 있습니다.
 
 `@fluojs/testing/vitest`를 사용할 때는 `fluoBabelDecoratorsPlugin()`이 런타임에 Babel을 호출하므로, 사용하는 워크스페이스에 `@babel/core`도 함께 설치해야 합니다. Vitest 플러그인은 Vite query/hash suffix를 제거한 뒤 `.ts`, `.tsx`, `.mts`, `.cts` 소스 id를 변환하고, `node_modules`는 건너뛰며, 가장 가까운 root Babel config인 `babel.config.cjs`, `babel.config.mjs`, `babel.config.js`, `babel.config.json`을 해석합니다.
 
@@ -134,9 +134,9 @@ const mailer = createDeepMock(MailService);
 
 프레임워크 지향 플랫폼 패키지를 작성할 때는 `@fluojs/testing/platform-conformance`, `@fluojs/testing/http-adapter-portability`, `@fluojs/testing/web-runtime-adapter-portability` 같은 서브패스를 사용해 적합성 및 이식성 검증을 수행합니다.
 
-이식성 하니스의 cleanup도 계약에 포함됩니다. `app.close()`가 실패하면 하니스는 cleanup 실패를 보고하며, assertion이 이미 실패한 경우에는 assertion 실패와 cleanup 실패를 모두 보존하는 aggregate error를 발생시킵니다.
+이식성 하니스의 cleanup도 계약에 포함됩니다. 앱이 bootstrap된 뒤 setup, `listen()`, assertion이 실패하면 하니스는 해당 partial app을 닫습니다. `app.close()`가 실패하면 하니스는 cleanup 실패를 보고하며, setup 또는 assertion이 이미 실패한 경우에는 원래 실패와 cleanup 실패를 모두 보존하는 aggregate error를 발생시킵니다.
 
-`HttpAdapterPortabilityHarness` 메서드는 공개 어댑터 계약 체크입니다. 직접 같은 검증을 다시 만들기보다 `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, `assertRemovesShutdownSignalListenersAfterClose()`처럼 초점이 분명한 assertion을 사용하세요.
+`HttpAdapterPortabilityHarness`와 web-runtime portability harness 메서드는 공개 어댑터 계약 체크입니다. 직접 같은 검증을 다시 만들기보다 `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, `assertRemovesShutdownSignalListenersAfterClose()`처럼 초점이 분명한 assertion을 사용하세요.
 
 ## canonical TDD ladder
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -21,7 +21,7 @@ Default request-level testing helpers, testing module construction, and provider
 npm install --save-dev @fluojs/testing vitest
 ```
 
-`vitest` is a required peer dependency for the mock helpers and the `@fluojs/testing/vitest` entrypoint.
+`vitest` is a required peer dependency for the mock helpers and the `@fluojs/testing/vitest` entrypoint. `@babel/core` is declared as a peer because the Vitest decorators plugin loads Babel from the consuming workspace; package managers may surface that peer even when you only use the non-Vitest harness subpaths.
 
 If you use `@fluojs/testing/vitest`, install `@babel/core` in the consuming workspace as well because `fluoBabelDecoratorsPlugin()` invokes Babel at runtime. The Vitest plugin transforms `.ts`, `.tsx`, `.mts`, and `.cts` source ids after removing Vite query/hash suffixes, skips `node_modules`, and resolves the nearest root Babel config named `babel.config.cjs`, `babel.config.mjs`, `babel.config.js`, or `babel.config.json`:
 
@@ -132,9 +132,9 @@ Install `vitest` in the consuming workspace before using the mock helpers so the
 
 Use subpaths like `@fluojs/testing/platform-conformance`, `@fluojs/testing/http-adapter-portability`, and `@fluojs/testing/web-runtime-adapter-portability` when authoring framework-facing platform packages.
 
-Portability harness cleanup is part of the contract: if `app.close()` fails, the harness reports that cleanup failure, and when an assertion already failed it raises an aggregate error that preserves both the assertion failure and the cleanup failure.
+Portability harness cleanup is part of the contract: if setup, `listen()`, or an assertion fails after an app has been bootstrapped, the harness closes that partial app. If `app.close()` fails, the harness reports that cleanup failure, and when setup or an assertion already failed it raises an aggregate error that preserves both the original failure and the cleanup failure.
 
-`HttpAdapterPortabilityHarness` methods are the public adapter contract checks. Prefer focused assertions such as `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, and `assertRemovesShutdownSignalListenersAfterClose()` instead of hand-rolled equivalents.
+`HttpAdapterPortabilityHarness` and web-runtime portability harness methods are the public adapter contract checks. Prefer focused assertions such as `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, and `assertRemovesShutdownSignalListenersAfterClose()` instead of hand-rolled equivalents.
 
 ## Canonical TDD Ladder
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -136,6 +136,8 @@ Portability harness cleanup is part of the contract: if setup, `listen()`, or an
 
 `HttpAdapterPortabilityHarness` and web-runtime portability harness methods are the public adapter contract checks. Prefer focused assertions such as `assertPreservesMalformedCookieValues()`, `assertSupportsSseStreaming()`, `assertPreservesRawBodyForJsonAndText()`, `assertPreservesExactRawBodyBytesForByteSensitivePayloads()`, `assertExcludesRawBodyForMultipart()`, `assertDefaultsMultipartTotalLimitToMaxBodySize()`, `assertSettlesStreamDrainWaitOnClose()`, `assertReportsConfiguredHostInStartupLogs()`, `assertReportsHttpsStartupUrl(...)`, and `assertRemovesShutdownSignalListenersAfterClose()` instead of hand-rolled equivalents.
 
+Use `assertPreservesExactRawBodyBytesForByteSensitivePayloads()` when an HTTP adapter must prove `rawBody` keeps byte-sensitive payload bytes intact across runtimes.
+
 ## Canonical TDD Ladder
 
 For application features, build tests from the smallest explicit dependency boundary outward:

--- a/packages/testing/src/conformance/platform-conformance.test.ts
+++ b/packages/testing/src/conformance/platform-conformance.test.ts
@@ -193,6 +193,90 @@ describe('platform conformance harness', () => {
     await expect(harness.assertStartIsDeterministic()).rejects.toThrow('not idempotent');
   });
 
+  it('reports cleanup failures after successful start determinism checks', async () => {
+    class StopFailureComponent extends TestPlatformComponent {
+      async stop(): Promise<void> {
+        throw new Error('stop exploded');
+      }
+    }
+
+    const harness = createPlatformConformanceHarness({
+      createComponent: () => new StopFailureComponent('cache.default', 'cache'),
+    });
+
+    try {
+      await harness.assertStartIsDeterministic();
+      throw new Error('Expected cleanup failure to be reported.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (!(error instanceof AggregateError)) {
+        throw error;
+      }
+      expect(error.message).toContain('failed during platform conformance cleanup');
+      expect(error.errors[0]).toBeInstanceOf(Error);
+      expect((error.errors[0] as Error).message).toBe('stop exploded');
+    }
+  });
+
+  it('preserves snapshot scenario assertions when cleanup also fails', async () => {
+    class SnapshotFailureComponent extends TestPlatformComponent {
+      snapshot(): PlatformSnapshot {
+        throw new Error('snapshot exploded');
+      }
+
+      async stop(): Promise<void> {
+        throw new Error('stop exploded');
+      }
+    }
+
+    const harness = createPlatformConformanceHarness({
+      createComponent: () => new TestPlatformComponent('cache.default', 'cache'),
+      scenarios: {
+        degraded: {
+          createComponent: () => new SnapshotFailureComponent('cache.default', 'cache', { state: 'degraded' }),
+          enterState: () => undefined,
+          name: 'degraded',
+        },
+        failed: {
+          createComponent: () => new TestPlatformComponent('cache.default', 'cache', { state: 'failed' }),
+          enterState: () => undefined,
+          name: 'failed',
+        },
+      },
+    });
+
+    try {
+      await harness.assertSnapshotSafeInDegradedAndFailedStates();
+      throw new Error('Expected aggregate cleanup failure to be reported.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (!(error instanceof AggregateError)) {
+        throw error;
+      }
+      expect(error.message).toContain('preserving the original conformance assertion failure');
+      expect((error.errors[0] as Error).message).toContain('snapshot() must be safe in "degraded" state');
+      expect((error.errors[1] as Error).message).toBe('stop exploded');
+    }
+  });
+
+  it('includes diagnostic messages when fixHint enforcement fails', async () => {
+    const harness = createPlatformConformanceHarness({
+      createComponent: () =>
+        new TestPlatformComponent('queue.default', 'queue', {
+          diagnostics: [
+            {
+              code: 'QUEUE_DEPENDENCY_NOT_READY',
+              componentId: 'queue.default',
+              message: 'Queue startup requires ready Redis.',
+              severity: 'error',
+            },
+          ],
+        }),
+    });
+
+    await expect(harness.assertStableDiagnostics()).rejects.toThrow('Queue startup requires ready Redis.');
+  });
+
   it('fails when snapshot details leak unsanitized credential keys', async () => {
     const harness = createPlatformConformanceHarness({
       createComponent: () =>

--- a/packages/testing/src/conformance/platform-conformance.ts
+++ b/packages/testing/src/conformance/platform-conformance.ts
@@ -96,6 +96,29 @@ async function captureOutcome(action: () => Promise<void>): Promise<{ ok: true }
   }
 }
 
+async function runCleanupWithAssertionContext(
+  cleanup: () => Promise<void>,
+  cleanupLabel: string,
+  assertionError?: unknown,
+): Promise<void> {
+  try {
+    await cleanup();
+  } catch (cleanupError) {
+    if (assertionError !== undefined) {
+      throw new AggregateError(
+        [assertionError, cleanupError],
+        `${cleanupLabel} failed while preserving the original conformance assertion failure.`,
+      );
+    }
+
+    throw new AggregateError([cleanupError], `${cleanupLabel} failed during platform conformance cleanup.`);
+  }
+
+  if (assertionError !== undefined) {
+    throw assertionError;
+  }
+}
+
 function collectForbiddenKeyPaths(
   value: unknown,
   patterns: readonly RegExp[],
@@ -164,25 +187,30 @@ export class PlatformConformanceHarness {
   async assertStartIsDeterministic(): Promise<void> {
     const component = this.options.createComponent();
     const compare = this.options.snapshot?.compare ?? defaultCompare;
+    let assertionError: unknown;
 
-    const firstStart = await captureOutcome(() => component.start());
-    const firstSnapshot = component.snapshot();
-    const secondStart = await captureOutcome(() => component.start());
-    const secondSnapshot = component.snapshot();
+    try {
+      const firstStart = await captureOutcome(() => component.start());
+      const firstSnapshot = component.snapshot();
+      const secondStart = await captureOutcome(() => component.start());
+      const secondSnapshot = component.snapshot();
 
-    if (firstStart.ok !== secondStart.ok) {
-      throw new Error('start() is not deterministic: first and second calls had different outcomes.');
+      if (firstStart.ok !== secondStart.ok) {
+        throw new Error('start() is not deterministic: first and second calls had different outcomes.');
+      }
+
+      if (!firstStart.ok && !secondStart.ok && firstStart.message !== secondStart.message) {
+        throw new Error('start() rejection messages changed across duplicate calls.');
+      }
+
+      if (firstStart.ok && secondStart.ok && !compare(firstSnapshot, secondSnapshot)) {
+        throw new Error('start() is not idempotent: duplicate calls changed component snapshot output.');
+      }
+    } catch (error) {
+      assertionError = error;
     }
 
-    if (!firstStart.ok && !secondStart.ok && firstStart.message !== secondStart.message) {
-      throw new Error('start() rejection messages changed across duplicate calls.');
-    }
-
-    if (firstStart.ok && secondStart.ok && !compare(firstSnapshot, secondSnapshot)) {
-      throw new Error('start() is not idempotent: duplicate calls changed component snapshot output.');
-    }
-
-    await captureOutcome(() => component.stop());
+    await runCleanupWithAssertionContext(() => component.stop(), 'stop() after start() determinism check', assertionError);
   }
 
   async assertStopIsIdempotent(): Promise<void> {
@@ -228,21 +256,30 @@ export class PlatformConformanceHarness {
 
     for (const scenario of [scenarios.degraded, scenarios.failed]) {
       const component = scenario.createComponent();
-      await scenario.enterState(component);
 
-      if (scenario.expectedState !== undefined && component.state() !== scenario.expectedState) {
-        throw new Error(
-          `Scenario "${scenario.name}" expected state "${scenario.expectedState}" but received "${component.state()}".`,
+      try {
+        await scenario.enterState(component);
+
+        if (scenario.expectedState !== undefined && component.state() !== scenario.expectedState) {
+          throw new Error(
+            `Scenario "${scenario.name}" expected state "${scenario.expectedState}" but received "${component.state()}".`,
+          );
+        }
+
+        component.snapshot();
+      } catch (error) {
+        const assertionError =
+          error instanceof Error && error.message.startsWith('Scenario ')
+            ? error
+            : new Error(`snapshot() must be safe in "${scenario.name}" state: ${toErrorMessage(error)}`);
+        await runCleanupWithAssertionContext(
+          () => component.stop(),
+          `stop() after "${scenario.name}" snapshot scenario`,
+          assertionError,
         );
       }
 
-      try {
-        component.snapshot();
-      } catch (error) {
-        throw new Error(`snapshot() must be safe in "${scenario.name}" state: ${toErrorMessage(error)}`);
-      } finally {
-        await captureOutcome(() => component.stop());
-      }
+      await runCleanupWithAssertionContext(() => component.stop(), `stop() after "${scenario.name}" snapshot scenario`);
     }
   }
 
@@ -261,11 +298,13 @@ export class PlatformConformanceHarness {
 
     for (const issue of diagnostics) {
       if (issue.code.trim().length === 0) {
-        throw new Error('Diagnostics must provide a stable non-empty code.');
+        throw new Error(`Diagnostics must provide a stable non-empty code. Received message: ${issue.message}`);
       }
 
       if (requiredFixHintSeverities.includes(issue.severity) && (!issue.fixHint || issue.fixHint.trim().length === 0)) {
-        throw new Error(`Diagnostic ${issue.code} (${issue.severity}) must provide a fixHint.`);
+        throw new Error(
+          `Diagnostic ${issue.code} (${issue.severity}) must provide a fixHint. Message: ${issue.message}`,
+        );
       }
     }
 
@@ -279,8 +318,11 @@ export class PlatformConformanceHarness {
     const normalizedExpectedCodes = normalizeCodes(expectedCodes);
 
     if (!defaultCompare(actualCodes, normalizedExpectedCodes)) {
+      const actualDetails = diagnostics
+        .map((diagnostic) => `${diagnostic.code}(${diagnostic.severity}): ${diagnostic.message}`)
+        .join('; ');
       throw new Error(
-        `Diagnostic code set changed. Expected [${normalizedExpectedCodes.join(', ')}] but received [${actualCodes.join(', ')}].`,
+        `Diagnostic code set changed. Expected [${normalizedExpectedCodes.join(', ')}] but received [${actualCodes.join(', ')}]. Actual diagnostics: ${actualDetails}`,
       );
     }
   }

--- a/packages/testing/src/portability/http-adapter-portability.test.ts
+++ b/packages/testing/src/portability/http-adapter-portability.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   bootstrapFastifyApplication,
@@ -127,6 +127,61 @@ function registerPortabilitySuite(
 }
 
 describe('http adapter portability cleanup reporting', () => {
+  it('closes partially bootstrapped apps when listen fails before assertion cleanup registration', async () => {
+    const listenError = new Error('listen exploded');
+    const close = vi.fn(async () => {});
+    const harness = createHttpAdapterPortabilityHarness({
+      async bootstrap() {
+        return {
+          close,
+          async listen() {
+            throw listenError;
+          },
+        };
+      },
+      name: 'listen-cleanup',
+      async run() {
+        throw new Error('run should not be used');
+      },
+    });
+
+    await expect(harness.assertPreservesMalformedCookieValues()).rejects.toBe(listenError);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves listen and cleanup failures when partially bootstrapped app cleanup fails', async () => {
+    const listenError = new Error('listen exploded');
+    const closeError = new Error('close exploded');
+    const harness = createHttpAdapterPortabilityHarness({
+      async bootstrap() {
+        return {
+          async close() {
+            throw closeError;
+          },
+          async listen() {
+            throw listenError;
+          },
+        };
+      },
+      name: 'listen-cleanup-fails',
+      async run() {
+        throw new Error('run should not be used');
+      },
+    });
+
+    try {
+      await harness.assertPreservesMalformedCookieValues();
+      throw new Error('Expected listen cleanup failure to be reported.');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (!(error instanceof AggregateError)) {
+        throw error;
+      }
+      expect(error.message).toContain('portability setup failed and app.close() also failed');
+      expect(error.errors).toEqual([listenError, closeError]);
+    }
+  });
+
   it('reports close failures when the assertion path succeeds', async () => {
     const closeError = new Error('close exploded');
     const signal = 'SIGTERM' as const;

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -141,6 +141,28 @@ async function runWithCleanup(app: AppLike, adapterName: string, assertion: () =
   }
 }
 
+async function prepareAndListenWithCleanup(
+  app: AppLike,
+  adapterName: string,
+  prepare?: () => Promise<void>,
+): Promise<void> {
+  try {
+    await prepare?.();
+    await app.listen();
+  } catch (setupError) {
+    try {
+      await app.close();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [setupError, cleanupError],
+        `${adapterName} adapter portability setup failed and app.close() also failed during harness cleanup.`,
+      );
+    }
+
+    throw setupError;
+  }
+}
+
 /**
  * A portability harness for testing HTTP adapters to ensure they behave
  * consistently across different environments.
@@ -185,7 +207,7 @@ export class HttpAdapterPortabilityHarness<
       port,
     } as TBootstrapOptions);
 
-    await app.listen();
+    await prepareAndListenWithCleanup(app, this.options.name);
 
     await runWithCleanup(app, this.options.name, async () => {
       const response = await fetch(`http://127.0.0.1:${String(port)}/cookies`, {
@@ -247,7 +269,7 @@ export class HttpAdapterPortabilityHarness<
       rawBody: true,
     } as TBootstrapOptions);
 
-    await app.listen();
+    await prepareAndListenWithCleanup(app, this.options.name);
 
     await runWithCleanup(app, this.options.name, async () => {
       const [jsonResponse, textResponse] = await Promise.all([
@@ -308,9 +330,9 @@ export class HttpAdapterPortabilityHarness<
       rawBody: true,
     } as TBootstrapOptions);
 
-    await this.options.prepareExactRawBodyByteTest?.(app);
-
-    await app.listen();
+    await prepareAndListenWithCleanup(app, this.options.name, async () => {
+      await this.options.prepareExactRawBodyByteTest?.(app);
+    });
 
     await runWithCleanup(app, this.options.name, async () => {
       const payload = Uint8Array.from([0xe9, 0x41]);
@@ -357,7 +379,7 @@ export class HttpAdapterPortabilityHarness<
       rawBody: true,
     } as TBootstrapOptions);
 
-    await app.listen();
+    await prepareAndListenWithCleanup(app, this.options.name);
 
     await runWithCleanup(app, this.options.name, async () => {
       const form = new FormData();
@@ -414,7 +436,7 @@ export class HttpAdapterPortabilityHarness<
       port,
     } as TBootstrapOptions);
 
-    await app.listen();
+    await prepareAndListenWithCleanup(app, this.options.name);
 
     await runWithCleanup(app, this.options.name, async () => {
       const form = new FormData();
@@ -469,7 +491,7 @@ export class HttpAdapterPortabilityHarness<
       port,
     } as TBootstrapOptions);
 
-    await app.listen();
+    await prepareAndListenWithCleanup(app, this.options.name);
 
     await runWithCleanup(app, this.options.name, async () => {
       const response = await fetch(`http://127.0.0.1:${String(port)}/events`, {
@@ -534,7 +556,7 @@ export class HttpAdapterPortabilityHarness<
       port,
     } as TBootstrapOptions);
 
-    await app.listen();
+    await prepareAndListenWithCleanup(app, this.options.name);
 
     await runWithCleanup(app, this.options.name, async () => {
       const response = await fetch(`http://127.0.0.1:${String(port)}/events`, {

--- a/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.test.ts
@@ -235,6 +235,7 @@ function registerWebRuntimePortabilitySuite(
   name: string,
   harness: {
     assertExcludesRawBodyForMultipart(): Promise<void>;
+    assertPreservesExactRawBodyBytesForByteSensitivePayloads(): Promise<void>;
     assertPreservesQueryArraysAndDecoding(): Promise<void>;
     assertPreservesMalformedCookieValues(): Promise<void>;
     assertPreservesRawBodyForJsonAndText(): Promise<void>;
@@ -252,6 +253,10 @@ function registerWebRuntimePortabilitySuite(
 
     it('preserves raw body for JSON and text requests when enabled', async () => {
       await harness.assertPreservesRawBodyForJsonAndText();
+    });
+
+    it('preserves exact raw body bytes for byte-sensitive payloads', async () => {
+      await harness.assertPreservesExactRawBodyBytesForByteSensitivePayloads();
     });
 
     it('does not preserve rawBody for multipart requests', async () => {

--- a/packages/testing/src/portability/web-runtime-adapter-portability.ts
+++ b/packages/testing/src/portability/web-runtime-adapter-portability.ts
@@ -232,6 +232,51 @@ export class WebRuntimeHttpAdapterPortabilityHarness<
     });
   }
 
+  /**
+   * Asserts that byte-sensitive request bodies preserve their exact raw bytes.
+   */
+  async assertPreservesExactRawBodyBytesForByteSensitivePayloads(): Promise<void> {
+    @Controller('/webhooks')
+    class WebhookController {
+      @Post('/bytes')
+      handleBytes(_input: undefined, context: RequestContext) {
+        return {
+          rawBytes: Array.from(context.request.rawBody ?? new Uint8Array()),
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [WebhookController],
+    });
+
+    const app = await this.options.bootstrap(AppModule, {
+      cors: false,
+      rawBody: true,
+    } as TBootstrapOptions);
+
+    await runWithCleanup(app, this.options.name, async () => {
+      const payload = Uint8Array.from([0xe9, 0x41]);
+      const response = await app.dispatch(
+        new Request('https://runtime.test/webhooks/bytes', {
+          body: payload,
+          headers: { 'content-type': 'application/octet-stream' },
+          method: 'POST',
+        }),
+      );
+
+      if (response.status !== 201) {
+        throw new Error(`${this.options.name} adapter changed byte-sensitive rawBody response status semantics.`);
+      }
+
+      const body = await response.json();
+      if (JSON.stringify(body) !== JSON.stringify({ rawBytes: Array.from(payload) })) {
+        throw new Error(`${this.options.name} adapter changed exact-byte rawBody semantics.`);
+      }
+    });
+  }
+
   async assertExcludesRawBodyForMultipart(): Promise<void> {
     @Controller('/uploads')
     class UploadController {

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -418,3 +418,18 @@ describe('Queue lifecycle discoverability', () => {
     }
   });
 });
+
+describe('HTTP adapter raw-body portability discoverability', () => {
+  const englishContext = readFileSync(join(repoRoot, 'docs/CONTEXT.md'), 'utf8');
+  const koreanContext = readFileSync(join(repoRoot, 'docs/CONTEXT.ko.md'), 'utf8');
+  const englishReadme = readFileSync(join(repoRoot, 'packages/testing/README.md'), 'utf8');
+  const koreanReadme = readFileSync(join(repoRoot, 'packages/testing/README.ko.md'), 'utf8');
+
+  it('keeps byte-sensitive raw-body portability docs discoverable from the context hub', () => {
+    for (const content of [englishContext, koreanContext, englishReadme, koreanReadme]) {
+      expect(content).toContain('assertPreservesExactRawBodyBytesForByteSensitivePayloads');
+      expect(content).toContain('byte-sensitive');
+      expect(content).toContain('rawBody');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1809

Harden `@fluojs/testing` portability and conformance harness contracts so adapter authors get deterministic cleanup and diagnostics for setup, raw-body, and lifecycle failures.

## Changes

- Close partially bootstrapped HTTP apps when harness setup or `listen()` fails, preserving cleanup failures with the original setup failure in an `AggregateError`.
- Add web-runtime exact raw-byte portability coverage to match byte-sensitive HTTP raw-body checks.
- Report platform conformance cleanup failures instead of swallowing them, and include diagnostic messages in fixHint/code-set failures.
- Align `@fluojs/testing` EN/KO README and advanced book companion docs with cleanup, peer dependency, and raw-byte contract details.
- Add a patch changeset for `@fluojs/testing`.

## Testing

- `pnpm --filter @fluojs/testing test -- src/conformance/platform-conformance.test.ts src/portability/http-adapter-portability.test.ts src/portability/web-runtime-adapter-portability.test.ts`
- `pnpm build && pnpm --filter @fluojs/testing typecheck`
- LSP diagnostics clean for changed source files.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.