### PR TITLE
Resolve #1806: fix socket.io namespace room helpers

### DIFF
--- a/.changeset/socketio-namespace-room-helpers.md
+++ b/.changeset/socketio-namespace-room-helpers.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/socket.io": patch
+---
+
+Honor explicit namespace paths for Socket.IO room helper joins and leaves even when the same socket id is already registered in another namespace, and configure Bun raw-server bindings before listen when no gateways are discovered.

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -395,6 +395,7 @@ export class SocketIoLifecycleService
     const descriptors = this.discoverGatewayDescriptors();
 
     if (descriptors.length === 0) {
+      this.ensureBunRealtimeBindingForRawServerAccess();
       return;
     }
 
@@ -433,14 +434,14 @@ export class SocketIoLifecycleService
    * @param namespacePath Optional namespace path required when the helper runs outside gateway handler context.
    */
   joinRoom(socketId: string, room: string, namespacePath?: string): void {
-    const socket = this.resolveSocket(socketId);
+    const { namespace, socket } = this.resolveRoomOperationTarget(socketId, namespacePath);
 
     if (socket) {
       void socket.join(room);
       return;
     }
 
-    this.resolveRequiredNamespace(namespacePath).in(socketId).socketsJoin(room);
+    namespace.in(socketId).socketsJoin(room);
   }
 
   /**
@@ -451,14 +452,14 @@ export class SocketIoLifecycleService
    * @param namespacePath Optional namespace path required when the helper runs outside gateway handler context.
    */
   leaveRoom(socketId: string, room: string, namespacePath?: string): void {
-    const socket = this.resolveSocket(socketId);
+    const { namespace, socket } = this.resolveRoomOperationTarget(socketId, namespacePath);
 
     if (socket) {
       void socket.leave(room);
       return;
     }
 
-    this.resolveRequiredNamespace(namespacePath).in(socketId).socketsLeave(room);
+    namespace.in(socketId).socketsLeave(room);
   }
 
   /**
@@ -578,6 +579,14 @@ export class SocketIoLifecycleService
     return pathname === '/socket.io' || pathname === DEFAULT_SOCKETIO_ENGINE_PATH;
   }
 
+  private ensureBunRealtimeBindingForRawServerAccess(): void {
+    if (!hasBunRealtimeBindingHost(this.adapter)) {
+      return;
+    }
+
+    this.getServer();
+  }
+
   private assertNoServerBackedGatewayOptIn(descriptors: readonly WebSocketGatewayDescriptor[]): void {
     const runtime = resolveSocketIoBootstrapRuntime(this.adapter);
 
@@ -639,6 +648,30 @@ export class SocketIoLifecycleService
     }
 
     return namespace;
+  }
+
+  private resolveRoomOperationTarget(socketId: string, namespacePath?: string): { namespace: Namespace; socket?: Socket } {
+    const namespace = namespacePath ? this.resolveRequiredNamespace(namespacePath) : this.resolveContextNamespace();
+
+    if (namespace) {
+      return {
+        namespace,
+        socket: namespace.sockets.get(socketId),
+      };
+    }
+
+    const socket = this.resolveSocket(socketId);
+
+    if (socket) {
+      return {
+        namespace: socket.nsp,
+        socket,
+      };
+    }
+
+    return {
+      namespace: this.resolveRequiredNamespace(namespacePath),
+    };
   }
 
   private resolveSocket(socketId: string): Socket | undefined {

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -16,7 +16,7 @@ import { bootstrapApplication, defineModule, FluoFactory, type Application, type
 import { bootstrapNodeApplication } from '@fluojs/runtime/node';
 import { OnConnect, OnDisconnect, OnMessage, WebSocketGateway } from '@fluojs/websockets';
 import { io as createClient, type Socket as ClientSocket } from 'socket.io-client';
-import type { Server as SocketIoServer, Socket } from 'socket.io';
+import type { Namespace, Server as SocketIoServer, Socket } from 'socket.io';
 
 import { SocketIoModule } from './module.js';
 import * as publicApi from './index.js';
@@ -491,6 +491,38 @@ describe('@fluojs/socket.io', () => {
       expect(state.disconnectReason).toBe('client namespace disconnect');
     });
 
+    await app.close();
+  });
+
+  it('configures the Bun realtime binding before listen when only the raw Socket.IO server is used', async () => {
+    const port = await findAvailablePort();
+    const adapter = new TestBunSocketIoAdapter(port);
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({ transports: ['polling'] })],
+    });
+
+    const app = await bootstrapApplication({
+      adapter,
+      rootModule: AppModule,
+    });
+
+    await app.listen();
+
+    const server = await app.container.resolve<SocketIoServer>(SOCKETIO_SERVER);
+    server.on('connection', (socket: Socket) => {
+      socket.emit('raw:ready', 'ok');
+    });
+
+    const socket = createClient(`http://127.0.0.1:${String(port)}`, {
+      reconnection: false,
+      transports: ['polling'],
+    });
+
+    expect(await onceEvent<string>(socket, 'raw:ready')).toBe('ok');
+
+    socket.close();
     await app.close();
   });
 
@@ -1319,6 +1351,68 @@ describe('@fluojs/socket.io', () => {
     await Promise.resolve();
 
     expect(socketRegistry.has(socket.id)).toBe(false);
+  });
+
+  it('honors an explicit namespace path when joining or leaving a registered socket id', () => {
+    const service = new SocketIoLifecycleService(
+      {} as never,
+      [] as never,
+      createLogger([]),
+      {
+        async close() {},
+        getRealtimeCapability() {
+          return createServerBackedHttpAdapterRealtimeCapability({});
+        },
+      } as never,
+      {
+        transports: ['websocket'],
+      },
+    );
+    const chatJoinedRooms: string[] = [];
+    const chatLeftRooms: string[] = [];
+    const adminJoinedRooms: string[] = [];
+    const adminLeftRooms: string[] = [];
+    const socket = {
+      id: 'socket-1',
+      join(room: string) {
+        chatJoinedRooms.push(room);
+      },
+      leave(room: string) {
+        chatLeftRooms.push(room);
+      },
+      nsp: { name: '/chat' },
+    } as unknown as Socket;
+    const adminNamespace = {
+      in(socketId: string) {
+        expect(socketId).toBe('socket-1');
+        return {
+          socketsJoin(room: string) {
+            adminJoinedRooms.push(room);
+          },
+          socketsLeave(room: string) {
+            adminLeftRooms.push(room);
+          },
+        };
+      },
+      sockets: new Map<string, Socket>(),
+    } as unknown as Namespace;
+    const chatNamespace = {
+      sockets: new Map<string, Socket>([['socket-1', socket]]),
+    } as unknown as Namespace;
+
+    Reflect.set(service, 'attachments', [
+      { descriptors: [], namespace: chatNamespace, path: '/chat' },
+      { descriptors: [], namespace: adminNamespace, path: '/admin' },
+    ]);
+    (Reflect.get(service, 'socketRegistry') as Map<string, Socket>).set('socket-1', socket);
+
+    service.joinRoom('socket-1', 'shared-room', '/admin');
+    service.leaveRoom('socket-1', 'shared-room', '/admin');
+
+    expect(chatJoinedRooms).toEqual([]);
+    expect(chatLeftRooms).toEqual([]);
+    expect(adminJoinedRooms).toEqual(['shared-room']);
+    expect(adminLeftRooms).toEqual(['shared-room']);
   });
 
   for (const scenario of supportedSocketIoAdapterScenarios) {

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -1196,6 +1196,74 @@ describe('@fluojs/socket.io', () => {
     await app.close();
   });
 
+  it('runs message guards for buffered pre-connect events before replaying handlers', async () => {
+    const connected = createDeferred<void>();
+
+    class GatewayState {
+      messages: unknown[] = [];
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/buffered-message-guard' })
+    class BufferedGuardGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnConnect()
+      async onConnect() {
+        await connected.promise;
+      }
+
+      @OnMessage('ping')
+      onPing(payload: unknown) {
+        this.state.messages.push(payload);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({
+        auth: {
+          message({ payload }) {
+            return payload === 'allowed'
+              ? true
+              : { data: { code: 'BUFFERED_REJECTED' }, message: 'Buffered event rejected.' };
+          },
+        },
+        transports: ['websocket'],
+      })],
+      providers: [GatewayState, BufferedGuardGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+    const state = await app.container.resolve(GatewayState);
+
+    await app.listen();
+
+    const socket = createClient(`http://127.0.0.1:${String(port)}/buffered-message-guard`, {
+      reconnection: false,
+      transports: ['websocket'],
+    });
+    await onceConnected(socket);
+
+    const rejectedAck = new Promise<unknown>((resolve) => {
+      socket.emit('ping', 'blocked', (response: unknown) => resolve(response));
+    });
+    socket.emit('ping', 'allowed');
+
+    connected.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(await rejectedAck).toEqual({ data: { code: 'BUFFERED_REJECTED' }, error: 'Buffered event rejected.' });
+    expect(state.messages).toEqual(['allowed']);
+
+    socket.close();
+    await app.close();
+  });
+
   it('drops oldest pre-connect socket.io messages once the pending buffer limit is reached', () => {
     const loggerEvents: string[] = [];
     const service = new SocketIoLifecycleService(


### PR DESCRIPTION
## Summary

Closes #1806.

Fixes Socket.IO namespace-specific room helper behavior and Bun raw-server binding setup for `@fluojs/socket.io`.

## Changes

- Honor explicit `namespacePath` for `joinRoom` and `leaveRoom` before falling back to a socket registered in another namespace.
- Configure Bun Socket.IO realtime bindings during bootstrap even when no gateways are discovered, so raw `SOCKETIO_SERVER` usage is bound before listen.
- Add regression tests for explicit namespace joins/leaves, Bun raw server usage without gateways, and message-guard handling for buffered pre-connect events.
- Add a patch changeset for `@fluojs/socket.io`.

## Testing

- `pnpm --filter @fluojs/socket.io... build`
- `pnpm --filter @fluojs/socket.io test`
- `pnpm --filter @fluojs/socket.io typecheck`
- `pnpm exec biome lint packages/socket.io/src/adapter.ts packages/socket.io/src/module.test.ts`
- LSP diagnostics clean for `packages/socket.io/src/module.test.ts`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests, including the message-guard/buffer edge called out in #1806.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.