### PR TITLE
Resolve #1810: harden throttler guard contract

### DIFF
--- a/.changeset/tiny-buttons-throttle.md
+++ b/.changeset/tiny-buttons-throttle.md
@@ -2,4 +2,4 @@
 "@fluojs/throttler": patch
 ---
 
-Harden throttler guard option capture and align the root barrel with the documented public decorator surface while adding HTTP request-pipeline regression coverage.
+Harden throttler guard option capture while preserving existing root-barrel decorator metadata helper exports and adding HTTP request-pipeline regression coverage.

--- a/.changeset/tiny-buttons-throttle.md
+++ b/.changeset/tiny-buttons-throttle.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/throttler": patch
+---
+
+Harden throttler guard option capture and align the root barrel with the documented public decorator surface while adding HTTP request-pipeline regression coverage.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -125,7 +125,7 @@ ThrottlerModule.forRoot({
 - `ThrottlerModule.forRoot(options)`: 검증된 throttler 옵션과 `ThrottlerGuard`를 모듈 그래프에 제공합니다.
 - 패키지 수준 등록은 `ThrottlerModule.forRoot(options)`를 통해 지원합니다. 내부 프로바이더 조합 헬퍼와 DI 토큰은 공개 계약에 포함되지 않습니다.
 
-`ttl`과 `limit`은 양의 finite integer여야 합니다. `trustProxyHeaders`와 `keyGenerator`로 client identity를 조정할 수 있습니다. `store` 옵션을 제공하지 않으면 각 `ThrottlerGuard` 인스턴스가 자체 in-memory store를 소유합니다. 저장소를 공유하거나 외부에서 관리해야 한다면 `RedisThrottlerStore` 같은 `ThrottlerStore` 구현을 전달하세요.
+`ttl`과 `limit`은 양의 finite integer여야 합니다. `trustProxyHeaders`와 `keyGenerator`로 client identity를 조정할 수 있습니다. 모듈 옵션은 guard가 연결될 때 검증되고 값으로 캡처되므로, 호출자가 나중에 options 객체를 변경해도 실행 중인 throttling 정책은 바뀌지 않습니다. `store` 옵션을 제공하지 않으면 각 `ThrottlerGuard` 인스턴스가 자체 in-memory store를 소유합니다. 저장소를 공유하거나 외부에서 관리해야 한다면 `RedisThrottlerStore` 같은 `ThrottlerStore` 구현을 전달하세요.
 
 ### 데코레이터
 - `@Throttle({ ttl, limit })`: 클래스나 메서드에 특정 속도 제한을 설정합니다.
@@ -153,7 +153,7 @@ ThrottlerModule.forRoot({
 
 ## 예제 소스
 
-- `packages/throttler/src/module.test.ts`: 모듈 설정 및 데코레이터 오버라이드 테스트.
+- `packages/throttler/src/module.test.ts`: 모듈 설정, 데코레이터 오버라이드, `createTestApp(...)` 기반 HTTP guard 통합 테스트.
 - `packages/throttler/src/guard.ts`: 요청 제한 및 헤더 관리 코어 로직.
 - `packages/throttler/src/redis-store.test.ts`: Redis store 계약과 server-time 동작.
 - `packages/throttler/src/status.test.ts`: status 및 diagnostic helper 동작.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -130,6 +130,7 @@ ThrottlerModule.forRoot({
 ### 데코레이터
 - `@Throttle({ ttl, limit })`: 클래스나 메서드에 특정 속도 제한을 설정합니다.
 - `@SkipThrottle()`: 클래스나 메서드에 대해 속도 제한을 비활성화합니다.
+- 기존 root-barrel metadata helper(`throttleRouteMetadataKey`, `getThrottleMetadata`, `getSkipThrottleMetadata`, `getClassThrottleMetadata`, `getClassSkipThrottleMetadata`)는 decorator metadata를 직접 검사하던 advanced integration과의 호환성을 위해 계속 export됩니다.
 
 ### 가드
 - `ThrottlerGuard`: 속도 제한을 강제하는 가드입니다. `ThrottlerModule.forRoot()`는 이를 주입 가능하게 만들며, 라우트 핸들러는 `@UseGuards(ThrottlerGuard)` 같은 Fluo guard metadata로 직접 활성화해야 합니다.

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -130,6 +130,7 @@ ThrottlerModule.forRoot({
 ### Decorators
 - `@Throttle({ ttl, limit })`: Sets a specific rate limit for a class or method.
 - `@SkipThrottle()`: Disables throttling for a class or method.
+- Existing root-barrel metadata helpers (`throttleRouteMetadataKey`, `getThrottleMetadata`, `getSkipThrottleMetadata`, `getClassThrottleMetadata`, and `getClassSkipThrottleMetadata`) remain exported for compatibility with advanced integrations that already inspect decorator metadata directly.
 
 ### Guards
 - `ThrottlerGuard`: The guard responsible for enforcing rate limits. `ThrottlerModule.forRoot()` makes it injectable; route handlers still activate it through Fluo guard metadata such as `@UseGuards(ThrottlerGuard)`.

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -125,7 +125,7 @@ ThrottlerModule.forRoot({
 - `ThrottlerModule.forRoot(options)`: Provides validated throttler options and `ThrottlerGuard` to the module graph.
 - Package-level registration is supported through `ThrottlerModule.forRoot(options)`. Internal provider-composition helpers and DI tokens are not part of the public contract.
 
-`ttl` and `limit` must be positive finite integers. `trustProxyHeaders` and `keyGenerator` customize client identity. If no `store` option is supplied, each `ThrottlerGuard` instance owns its own in-memory store; pass a `ThrottlerStore` implementation such as `RedisThrottlerStore` when storage must be shared or externally managed.
+`ttl` and `limit` must be positive finite integers. `trustProxyHeaders` and `keyGenerator` customize client identity. Module options are validated and captured by value when the guard is wired so later mutation of the caller's options object does not change live throttling policy. If no `store` option is supplied, each `ThrottlerGuard` instance owns its own in-memory store; pass a `ThrottlerStore` implementation such as `RedisThrottlerStore` when storage must be shared or externally managed.
 
 ### Decorators
 - `@Throttle({ ttl, limit })`: Sets a specific rate limit for a class or method.
@@ -153,7 +153,7 @@ Method-level `@Throttle(...)` overrides class-level settings, class-level settin
 
 ## Example Sources
 
-- `packages/throttler/src/module.test.ts`: Tests for module configuration and decorator overrides.
+- `packages/throttler/src/module.test.ts`: Tests for module configuration, decorator overrides, and HTTP guard integration through `createTestApp(...)`.
 - `packages/throttler/src/guard.ts`: The core logic for request throttling and header management.
 - `packages/throttler/src/redis-store.test.ts`: Redis store contract and server-time behavior.
 - `packages/throttler/src/status.test.ts`: Status and diagnostic helper behavior.

--- a/packages/throttler/package.json
+++ b/packages/throttler/package.json
@@ -61,6 +61,7 @@
     }
   },
   "devDependencies": {
+    "@fluojs/testing": "workspace:^",
     "ioredis": "^5.10.0",
     "vitest": "^3.2.4"
   }

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -1,6 +1,6 @@
 import { Inject } from '@fluojs/core';
 import { getStandardMetadataBag } from '@fluojs/core/internal';
-import { TooManyRequestsException, type Guard, type GuardContext, type MiddlewareContext } from '@fluojs/http';
+import { type Guard, type GuardContext, type MiddlewareContext, TooManyRequestsException } from '@fluojs/http';
 import { resolveClientIdentity } from '@fluojs/http/internal';
 
 import {
@@ -10,8 +10,8 @@ import {
   getThrottleMetadata,
   throttleRouteMetadataKey,
 } from './decorators.js';
-import { throttlerRetryAfterMsSymbol } from './store-internals.js';
 import { createMemoryThrottlerStore } from './store.js';
+import { throttlerRetryAfterMsSymbol } from './store-internals.js';
 import { THROTTLER_OPTIONS } from './tokens.js';
 import type { ThrottlerModuleOptions, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
 import { validateThrottleOptions, validateThrottlerModuleOptions, validateThrottlerStoreEntry } from './validation.js';
@@ -73,11 +73,15 @@ function resolveRetryAfterSeconds(entry: ThrottlerStoreEntry, now: number): numb
  */
 @Inject(THROTTLER_OPTIONS)
 export class ThrottlerGuard implements Guard {
+  private readonly options: ThrottlerModuleOptions;
+
   private readonly store: ThrottlerStore;
 
-  constructor(private readonly options: ThrottlerModuleOptions) {
-    validateThrottlerModuleOptions(options);
-    this.store = options.store ?? createMemoryThrottlerStore();
+  constructor(options: ThrottlerModuleOptions) {
+    const validatedOptions = validateThrottlerModuleOptions(options);
+
+    this.options = validatedOptions;
+    this.store = validatedOptions.store ?? createMemoryThrottlerStore();
   }
 
   /**

--- a/packages/throttler/src/index.ts
+++ b/packages/throttler/src/index.ts
@@ -1,4 +1,12 @@
-export { SkipThrottle, Throttle } from './decorators.js';
+export {
+  getClassSkipThrottleMetadata,
+  getClassThrottleMetadata,
+  getSkipThrottleMetadata,
+  getThrottleMetadata,
+  SkipThrottle,
+  Throttle,
+  throttleRouteMetadataKey,
+} from './decorators.js';
 export { ThrottlerGuard } from './guard.js';
 export * from './module.js';
 export { RedisThrottlerStore } from './redis-store.js';

--- a/packages/throttler/src/index.ts
+++ b/packages/throttler/src/index.ts
@@ -1,7 +1,7 @@
-export * from './decorators.js';
+export { SkipThrottle, Throttle } from './decorators.js';
 export { ThrottlerGuard } from './guard.js';
-export { RedisThrottlerStore } from './redis-store.js';
 export * from './module.js';
+export { RedisThrottlerStore } from './redis-store.js';
 export * from './status.js';
 export { createMemoryThrottlerStore } from './store.js';
 export type {

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -103,11 +103,11 @@ describe('@fluojs/throttler public entrypoints', () => {
   it('keeps ThrottlerModule.forRoot as the supported registration entrypoint without exporting internal provider helpers', () => {
     expect(throttlerExports).not.toHaveProperty('createThrottlerProviders');
     expect(throttlerExports).not.toHaveProperty('THROTTLER_OPTIONS');
-    expect(throttlerExports).not.toHaveProperty('throttleRouteMetadataKey');
-    expect(throttlerExports).not.toHaveProperty('getThrottleMetadata');
-    expect(throttlerExports).not.toHaveProperty('getSkipThrottleMetadata');
-    expect(throttlerExports).not.toHaveProperty('getClassThrottleMetadata');
-    expect(throttlerExports).not.toHaveProperty('getClassSkipThrottleMetadata');
+    expect(throttlerExports).toHaveProperty('throttleRouteMetadataKey');
+    expect(throttlerExports).toHaveProperty('getThrottleMetadata');
+    expect(throttlerExports).toHaveProperty('getSkipThrottleMetadata');
+    expect(throttlerExports).toHaveProperty('getClassThrottleMetadata');
+    expect(throttlerExports).toHaveProperty('getClassSkipThrottleMetadata');
     expect(throttlerExports.ThrottlerModule).toBe(ThrottlerModule);
     expect(typeof throttlerExports.ThrottlerModule.forRoot).toBe('function');
     expect(throttlerExports.Throttle).toBe(Throttle);

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -1,5 +1,8 @@
+import { Module } from '@fluojs/core';
 import { metadataSymbol } from '@fluojs/core/internal';
 import type { GuardContext, HandlerDescriptor, RequestContext } from '@fluojs/http';
+import { Controller, Get, UseGuards } from '@fluojs/http';
+import { createTestApp } from '@fluojs/testing';
 import type Redis from 'ioredis';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getThrottleMetadata, SkipThrottle, Throttle } from './decorators.js';
@@ -100,8 +103,15 @@ describe('@fluojs/throttler public entrypoints', () => {
   it('keeps ThrottlerModule.forRoot as the supported registration entrypoint without exporting internal provider helpers', () => {
     expect(throttlerExports).not.toHaveProperty('createThrottlerProviders');
     expect(throttlerExports).not.toHaveProperty('THROTTLER_OPTIONS');
+    expect(throttlerExports).not.toHaveProperty('throttleRouteMetadataKey');
+    expect(throttlerExports).not.toHaveProperty('getThrottleMetadata');
+    expect(throttlerExports).not.toHaveProperty('getSkipThrottleMetadata');
+    expect(throttlerExports).not.toHaveProperty('getClassThrottleMetadata');
+    expect(throttlerExports).not.toHaveProperty('getClassSkipThrottleMetadata');
     expect(throttlerExports.ThrottlerModule).toBe(ThrottlerModule);
     expect(typeof throttlerExports.ThrottlerModule.forRoot).toBe('function');
+    expect(throttlerExports.Throttle).toBe(Throttle);
+    expect(throttlerExports.SkipThrottle).toBe(SkipThrottle);
   });
 
   it('keeps the low-level consume input type available from the root barrel', () => {
@@ -361,6 +371,29 @@ describe('ThrottlerGuard — in-memory store', () => {
     );
   });
 
+  it('captures module options by value before request handling starts', async () => {
+    class TestController {
+      action() {}
+    }
+
+    const mutableOptions: ThrottlerModuleOptions = {
+      limit: 1,
+      store: createMemoryThrottlerStore(),
+      ttl: 60,
+    };
+    const guard = new ThrottlerGuard(mutableOptions);
+    const ctx = createRequestContext();
+
+    mutableOptions.limit = 100;
+    mutableOptions.ttl = 1;
+
+    await guard.canActivate(createGuardContext(TestController, 'action', ctx));
+
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', ctx))).rejects.toThrow(
+      'Too Many Requests',
+    );
+  });
+
   it('uses module-level defaults when no handler-level @Throttle', async () => {
     class TestController {
       action() {}
@@ -531,6 +564,39 @@ describe('ThrottlerGuard — in-memory store', () => {
         }),
       ),
     ).resolves.toBe(true);
+  });
+});
+
+describe('ThrottlerGuard — HTTP request pipeline', () => {
+  it('enforces @UseGuards(ThrottlerGuard) through createTestApp requests', async () => {
+    @Controller('/throttled')
+    class ThrottledController {
+      @Get('/limited')
+      @UseGuards(ThrottlerGuard)
+      getLimited() {
+        return { ok: true };
+      }
+    }
+
+    @Module({
+      controllers: [ThrottledController],
+      imports: [ThrottlerModule.forRoot({ limit: 1, ttl: 60, trustProxyHeaders: true })],
+    })
+    class ThrottledAppModule {}
+
+    const app = await createTestApp({ rootModule: ThrottledAppModule });
+
+    try {
+      const firstResponse = await app.request('GET', '/throttled/limited').header('x-real-ip', '198.51.100.10').send();
+      const secondResponse = await app.request('GET', '/throttled/limited').header('x-real-ip', '198.51.100.10').send();
+
+      expect(firstResponse.status).toBe(200);
+      expect(firstResponse.body).toEqual({ ok: true });
+      expect(secondResponse.status).toBe(429);
+      expect(secondResponse.headers['Retry-After']).toBe('60');
+    } finally {
+      await app.close();
+    }
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -986,6 +986,9 @@ importers:
         specifier: workspace:^
         version: link:../runtime
     devDependencies:
+      '@fluojs/testing':
+        specifier: workspace:^
+        version: link:../testing
       ioredis:
         specifier: ^5.10.0
         version: 5.10.0


### PR DESCRIPTION
## Summary

Closes #1810

Harden `@fluojs/throttler` guard contract behavior and add request-pipeline coverage for `ThrottlerGuard` running through the real HTTP stack.

## Changes

- Capture validated `ThrottlerGuard` module options by value so caller-side option mutation cannot change live throttling policy.
- Preserve existing root-barrel decorator metadata helper exports so the patch changeset does not remove public `@fluojs/throttler@1.0.0` symbols.
- Add `createTestApp(...)` HTTP integration coverage for `@UseGuards(ThrottlerGuard)` returning `429` with `Retry-After`.
- Align EN/KO package README contract text and add a patch changeset for `@fluojs/throttler`.

## Testing

- `pnpm --filter @fluojs/throttler... build`
- `pnpm --filter @fluojs/throttler test`
- `pnpm exec biome check packages/throttler/src/guard.ts packages/throttler/src/index.ts packages/throttler/src/module.test.ts packages/throttler/package.json packages/throttler/README.md packages/throttler/README.ko.md .changeset/tiny-buttons-throttle.md pnpm-lock.yaml`
- `pnpm --filter @fluojs/throttler typecheck`
- `pnpm --filter @fluojs/throttler test && pnpm --filter @fluojs/throttler typecheck`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

Root-barrel decorator helper exports are preserved for compatibility with existing advanced integrations that inspect throttler metadata directly.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; package README EN/KO mirror text was updated together.