### PR TITLE
Resolve #1803: harden runtime web portability

### DIFF
--- a/.changeset/runtime-web-multipart-portability.md
+++ b/.changeset/runtime-web-multipart-portability.md
@@ -1,5 +1,7 @@
 ---
-"@fluojs/runtime": patch
+"@fluojs/runtime": major
 ---
 
 Keep Web runtime multipart uploads portable across Web-standard hosts by returning `Uint8Array` file buffers, and make Node adapter listen retries cancellable during shutdown.
+
+This is a breaking change for consumers that typed `UploadedFile.buffer` as Node.js `Buffer` or called Buffer-only methods on multipart uploads. Update multipart handlers to treat `UploadedFile.buffer` as `Uint8Array`, and wrap it with `Buffer.from(file.buffer)` only when Node-specific Buffer APIs are required.

--- a/.changeset/runtime-web-multipart-portability.md
+++ b/.changeset/runtime-web-multipart-portability.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/runtime": patch
+---
+
+Keep Web runtime multipart uploads portable across Web-standard hosts by returning `Uint8Array` file buffers, and make Node adapter listen retries cancellable during shutdown.

--- a/book/advanced/ch09-app-context.ko.md
+++ b/book/advanced/ch09-app-context.ko.md
@@ -23,11 +23,11 @@ Fluo runtime internals를 오해하는 가장 쉬운 방법은 `Application`, `A
 
 세 shell 모두 `path:packages/runtime/src/bootstrap.ts` 안에서 조립됩니다. 그리고 더 아래쪽 bootstrap spine을 공유합니다. module graph compilation, container registration, runtime token registration, lifecycle singleton resolution, hook execution, platform-shell startup이 공통입니다.
 
-`path:packages/runtime/src/types.ts:163-199`의 public type을 보면 닮은 점이 분명합니다. `ApplicationContext`는 `container`, `modules`, `rootModule`, `get()`, `close()`를 노출합니다. `Application`은 여기에 `state`, `dispatcher`, `listen()`, `ready()`, `connectMicroservice()`, `startAllMicroservices()`를 추가합니다. `MicroserviceApplication`은 context surface를 재사용하면서 `listen()`, `send()`, `emit()` 같은 transport method를 더합니다.
+`path:packages/runtime/src/types.ts:196-232`의 public type을 보면 닮은 점이 분명합니다. `ApplicationContext`는 `container`, `modules`, `rootModule`, `get()`, `close()`를 노출합니다. `Application`은 여기에 `state`, `dispatcher`, `listen()`, `ready()`, `connectMicroservice()`, `startAllMicroservices()`를 추가합니다. `MicroserviceApplication`은 context surface를 재사용하면서 `listen()`, `send()`, `emit()` 같은 transport method를 더합니다.
 
 이것은 우연한 API 대칭이 아닙니다. 구현 순서의 반영입니다. Fluo는 먼저 transport-neutral한 DI/lifecycle baseline을 만든 뒤, 각 shell type이 약속한 capability만 래핑해 노출합니다.
 
-source에서도 분기 지점이 직접 보입니다. `path:packages/runtime/src/bootstrap.ts:920-1029`의 `bootstrapApplication()`은 `new FluoApplication(...)`을 반환합니다. `path:packages/runtime/src/bootstrap.ts:1059-1153`의 `FluoFactory.createApplicationContext()`는 `new FluoApplicationContext(...)`를 반환합니다. `path:packages/runtime/src/bootstrap.ts:1164-1189`의 `FluoFactory.createMicroservice()`는 먼저 application context를 만든 다음, resolve된 runtime token을 `FluoMicroserviceApplication`으로 감쌉니다.
+source에서도 분기 지점이 직접 보입니다. `path:packages/runtime/src/bootstrap.ts:1419-1552`의 `bootstrapApplication()`은 `new FluoApplication(...)`을 반환합니다. `path:packages/runtime/src/bootstrap.ts:1581-1691`의 `FluoFactory.createApplicationContext()`는 `new FluoApplicationContext(...)`를 반환합니다. `path:packages/runtime/src/bootstrap.ts:1702-1735`의 `FluoFactory.createMicroservice()`는 먼저 application context를 만든 다음, resolve된 runtime token을 `FluoMicroserviceApplication`으로 감쌉니다.
 
 full application branch의 대표 지점은 반환부입니다. 앞선 module bootstrap과 lifecycle 실행은 공유하지만, 이 branch만 dispatcher, adapter, adapter 보유 여부, platform shell reference를 함께 넣어 `FluoApplication`을 만듭니다.
 
@@ -52,7 +52,7 @@ full application branch의 대표 지점은 반환부입니다. 앞선 module bo
 
 context branch는 같은 spine을 지나지만 반환 객체가 다릅니다. dispatcher와 HTTP adapter를 만들지 않고, DI와 lifecycle 제어에 필요한 값만 `FluoApplicationContext`로 감쌉니다.
 
-`path:packages/runtime/src/bootstrap.ts:1128-1135`
+`path:packages/runtime/src/bootstrap.ts:1654-1671`
 ```typescript
       return new FluoApplicationContext(
         bootstrapped.container,
@@ -66,7 +66,7 @@ context branch는 같은 spine을 지나지만 반환 객체가 다릅니다. di
 
 microservice branch는 또 다른 독립 bootstrap이 아닙니다. 먼저 context를 만든 뒤, 그 context에서 transport runtime token을 resolve하고 wrapper를 얹습니다.
 
-`path:packages/runtime/src/bootstrap.ts:1168-1180`
+`path:packages/runtime/src/bootstrap.ts:1706-1717`
 ```typescript
     const logger = options.logger ?? createConsoleApplicationLogger();
     const microserviceToken = options.microserviceToken ?? DEFAULT_MICROSERVICE_TOKEN;
@@ -128,13 +128,13 @@ class FluoApplicationContext implements ApplicationContext {
 
 public method도 `get()`과 `close()`뿐입니다. 이 미니멀한 표면이 핵심입니다. application context는 CLI task, worker, migration, 혹은 HTTP listener가 필요 없는 모든 DI-driven process를 위한 runtime baseline입니다.
 
-실제 bootstrap path는 `path:packages/runtime/src/bootstrap.ts:1059-1153`의 `FluoFactory.createApplicationContext()`입니다. 이 함수를 `bootstrapApplication()`과 비교하면, 대부분의 순서가 동일합니다. 여전히 logger, platform shell, runtime provider list, compiled module, runtime context token, lifecycle instance, timing diagnostics를 만듭니다.
+실제 bootstrap path는 `path:packages/runtime/src/bootstrap.ts:1581-1691`의 `FluoFactory.createApplicationContext()`입니다. 이 함수를 `bootstrapApplication()`과 비교하면, 대부분의 순서가 동일합니다. 여전히 logger, platform shell, runtime provider list, compiled module, runtime context token, lifecycle instance, timing diagnostics를 만듭니다.
 
 핵심 차이는 token registration입니다. full application에서는 `registerRuntimeBootstrapTokens()`가 `HTTP_APPLICATION_ADAPTER`와 `PLATFORM_SHELL`을 모두 추가합니다. context에서는 `registerRuntimeApplicationContextTokens()`가 `PLATFORM_SHELL`만 추가합니다.
 
 토큰 등록 함수는 이 차이를 가장 작게 보여 줍니다. application branch는 HTTP adapter token을 추가하고, context branch는 platform shell만 더한 뒤 공통 context token 등록 helper로 내려갑니다.
 
-`path:packages/runtime/src/bootstrap.ts:783-795`
+`path:packages/runtime/src/bootstrap.ts:1271-1288`
 ```typescript
 function registerRuntimeBootstrapTokens(
   bootstrapped: BootstrapResult,
@@ -153,7 +153,7 @@ function registerRuntimeBootstrapTokens(
 
 이 첫 발췌는 full application branch가 HTTP adapter token을 추가한다는 점만 좁혀 보여 줍니다. 이어지는 공통 helper를 보면 context branch가 같은 baseline token을 공유하면서 adapter token만 제외한다는 차이가 닫힙니다.
 
-`path:packages/runtime/src/bootstrap.ts:797-816`
+`path:packages/runtime/src/bootstrap.ts:1290-1318`
 ```typescript
 function registerRuntimeContextTokens(bootstrapped: BootstrapResult, ...providers: Provider[]): void {
   bootstrapped.container.register(
@@ -187,7 +187,7 @@ lifecycle 동작도 완전합니다. 같은 테스트 파일의 `path:packages/r
 
 context와 application이 lifecycle을 공유한다는 점은 공통 helper에서 확인할 수 있습니다. bootstrap은 singleton lifecycle instance를 resolve하고, hook을 실행한 뒤 platform shell을 시작하고 readiness state를 표시합니다.
 
-`path:packages/runtime/src/bootstrap.ts:818-841`
+`path:packages/runtime/src/bootstrap.ts:1320-1350`
 ```typescript
 async function resolveBootstrapLifecycleInstances(
   bootstrapped: BootstrapResult,
@@ -211,7 +211,7 @@ async function runBootstrapLifecycle(
 
 이 발췌는 lifecycle 대상 목록을 runtime provider와 compiled module provider에서 함께 만든다는 점을 보여 줍니다. 다음 발췌는 그 목록을 실제 bootstrap phase에서 어떻게 실행하는지로 초점을 좁힙니다.
 
-`path:packages/runtime/src/bootstrap.ts:830-841`
+`path:packages/runtime/src/bootstrap.ts:1337-1350`
 ```typescript
 async function runBootstrapLifecycle(
   modules: CompiledModule[],
@@ -247,11 +247,11 @@ createApplicationContext(rootModule)
 그래서 context API는 고급 툴링에서 특히 유용합니다. 같은 validated module graph, 같은 singleton state, 같은 shutdown semantics를 얻으면서도, DI에 접근하려고 HTTP adapter를 억지로 만들 필요가 없습니다.
 
 ## 9.3 Full applications add dispatcher state, readiness checks, and adapter-driven listen semantics
-`FluoApplication`은 `path:packages/runtime/src/bootstrap.ts:403-529`에 정의되어 있습니다. context가 가지는 모든 것을 저장하면서, 추가로 `dispatcher`, adapter 존재 여부 상태, platform shell reference, connected microservice list, `ApplicationState`를 보관합니다.
+`FluoApplication`은 `path:packages/runtime/src/bootstrap.ts:580-801`에 정의되어 있습니다. context가 가지는 모든 것을 저장하면서, 추가로 `dispatcher`, adapter 존재 여부 상태, platform shell reference, connected microservice list, in-flight listen promise, `ApplicationState`를 보관합니다.
 
 application shell의 constructor는 context baseline 위에 무엇이 추가되는지 직접 보여 줍니다. 같은 `container`, `modules`, `rootModule`을 받지만, dispatcher와 adapter 상태가 함께 들어옵니다.
 
-`path:packages/runtime/src/bootstrap.ts:403-424`
+`path:packages/runtime/src/bootstrap.ts:580-605`
 ```typescript
 class FluoApplication implements Application {
   private applicationState: ApplicationState = 'bootstrapped';
@@ -281,11 +281,11 @@ class FluoApplication implements Application {
 
 `ApplicationState`는 `path:packages/runtime/src/types.ts:91-92`에 선언되어 있습니다. 허용 값은 `'bootstrapped'`, `'ready'`, `'closed'`입니다. 이 state는 HTTP 전용이 아닙니다. application과 microservice shell의 runtime lifecycle progression을 표현합니다.
 
-가장 먼저 볼 계약은 `path:packages/runtime/src/bootstrap.ts:437-443`의 `ready()`입니다. 이 메서드는 `adapter.listen()`을 호출하지 않습니다. application이 이미 닫혀 있지 않은지만 확인한 뒤, `platformShell.assertCriticalReadiness()`에 위임합니다.
+가장 먼저 볼 계약은 `path:packages/runtime/src/bootstrap.ts:622-628`의 `ready()`입니다. 이 메서드는 `adapter.listen()`을 호출하지 않습니다. application이 이미 닫혀 있지 않은지만 확인한 뒤, `platformShell.assertCriticalReadiness()`에 위임합니다.
 
 `ready()`는 transport bind가 아니라 platform readiness gate입니다. adapter로 요청을 받기 전에 critical component 상태를 확인하는 단계로 분리되어 있습니다.
 
-`path:packages/runtime/src/bootstrap.ts:437-443`
+`path:packages/runtime/src/bootstrap.ts:622-628`
 ```typescript
   async ready(): Promise<void> {
     if (this.applicationState === 'closed') {
@@ -298,11 +298,11 @@ class FluoApplication implements Application {
 
 즉 Fluo에서 readiness는 "server socket이 bind되었다"의 동의어가 아닙니다. platform shell에 기반한 pre-listen gate입니다. critical platform component가 ready라고 보고해야만 transport startup이 허용됩니다.
 
-`path:packages/runtime/src/bootstrap.ts:466-491`의 `listen()`은 그 readiness gate 위에 adapter behavior를 얹습니다. app이 closed면 throw하고, 이미 ready면 바로 return하며, adapter가 없으면 `options.adapter`를 제공하거나 `createApplicationContext()`를 쓰라는 invariant error를 던집니다.
+`path:packages/runtime/src/bootstrap.ts:691-739`의 `listen()`은 그 readiness gate 위에 adapter behavior를 얹습니다. app이 closed면 throw하고, 겹치는 startup 호출은 in-flight startup을 공유하며, 이미 ready면 바로 return하고, adapter가 없으면 `options.adapter`를 제공하거나 `createApplicationContext()`를 쓰라는 invariant error를 던집니다.
 
 그 다음 `listen()`이 adapter 정책을 적용합니다. adapter 없는 application bootstrap은 허용되지만, adapter 없이 listen하는 것은 이 guard에서 막힙니다.
 
-`path:packages/runtime/src/bootstrap.ts:466-491`
+`path:packages/runtime/src/bootstrap.ts:691-739`
 ```typescript
   async listen(): Promise<void> {
     if (this.applicationState === 'closed') {
@@ -338,11 +338,11 @@ class FluoApplication implements Application {
 
 이 guard를 통과한 뒤에야 `listen()`은 `await this.ready()`를 호출하고, 그 다음 `await this.adapter.listen(this.dispatcher)`를 실행합니다. 성공하면 state를 `'ready'`로 바꾸고 startup log를 남깁니다. 즉 transport adapter가 application state transition을 단독으로 소유하지 않습니다. 더 큰 runtime shell policy의 일부로 참여합니다.
 
-dispatcher 조립은 그보다 앞서 `path:packages/runtime/src/bootstrap.ts:890-910`의 `createRuntimeDispatcher()`에서 일어납니다. runtime은 compiled module controller로부터 handler mapping을 만들고, route mapping을 로그로 남기며, middleware, converters, interceptors, observers, optional exception filter로 dispatcher를 생성합니다.
+dispatcher 조립은 그보다 앞서 `path:packages/runtime/src/bootstrap.ts:1389-1409`의 `createRuntimeDispatcher()`에서 일어납니다. runtime은 compiled module controller로부터 handler mapping을 만들고, route mapping을 로그로 남기며, middleware, converters, interceptors, observers, optional exception filter로 dispatcher를 생성합니다.
 
 dispatcher 생성은 full application branch에만 필요한 request-facing 단계입니다. compiled module baseline에서 handler source를 만들고, HTTP pipeline 옵션을 묶은 뒤 dispatcher를 반환합니다.
 
-`path:packages/runtime/src/bootstrap.ts:890-910`
+`path:packages/runtime/src/bootstrap.ts:1389-1409`
 ```typescript
 function createRuntimeDispatcher(
   bootstrapped: BootstrapResult,
@@ -389,11 +389,11 @@ source가 구현하는 모델도 정확히 이것입니다. application shell은
 ## 9.4 Shutdown and failure cleanup are first-class runtime contracts, not afterthoughts
 application context와 application shell은 모두 신중한 close semantics를 구현합니다. 이 부분은 runtime에서 특히 성숙한 설계 중 하나입니다.
 
-공유 cleanup primitive는 `path:packages/runtime/src/bootstrap.ts:119-153`의 `closeRuntimeResources()`입니다. 순서는 명시적입니다. 먼저 runtime cleanup callback을 실행하고, 그 다음 shutdown hook, 그 다음 adapter가 있으면 adapter close, 마지막으로 container disposal을 수행합니다. 필요하면 에러를 누적한 뒤 하나로 다시 던집니다.
+공유 cleanup primitive는 `path:packages/runtime/src/bootstrap.ts:165-202`의 `closeRuntimeResources()`입니다. 순서는 명시적입니다. 먼저 readiness를 초기화하고, runtime cleanup callback을 실행하고, 그 다음 shutdown hook, 그 다음 adapter가 있으면 adapter close, 마지막으로 container disposal을 수행합니다. 필요하면 에러를 누적한 뒤 하나로 다시 던집니다.
 
 cleanup primitive는 application과 context가 공유하지만, adapter는 optional로 처리합니다. 이 구조 때문에 context close는 같은 shutdown hook과 container disposal을 쓰면서도 HTTP adapter close를 건너뜁니다.
 
-`path:packages/runtime/src/bootstrap.ts:119-153`
+`path:packages/runtime/src/bootstrap.ts:165-202`
 ```typescript
 async function closeRuntimeResources(options: {
   adapter?: HttpApplicationAdapter;
@@ -437,11 +437,11 @@ async function closeRuntimeResources(options: {
 }
 ```
 
-failure-path cleanup은 형제 helper인 `path:packages/runtime/src/bootstrap.ts:155-189`의 `runBootstrapFailureCleanup()`이 담당합니다. bootstrap이 일부 lifecycle instance나 resource를 만든 뒤 실패하더라도, runtime은 여전히 cleanup을 시도하고, cleanup failure는 로그로 남기면서, 원래의 bootstrap error는 보존합니다.
+failure-path cleanup은 형제 helper인 `path:packages/runtime/src/bootstrap.ts:204-241`의 `runBootstrapFailureCleanup()`이 담당합니다. bootstrap이 일부 lifecycle instance나 resource를 만든 뒤 실패하더라도, runtime은 여전히 cleanup을 시도하고, cleanup failure는 로그로 남기면서, 원래의 bootstrap error는 보존합니다.
 
 failure cleanup도 scope label만 다르고 같은 rollback 원칙을 씁니다. application 실패와 application context 실패가 서로 다른 메시지를 남기되, lifecycle hook과 container cleanup 시도는 공유됩니다.
 
-`path:packages/runtime/src/bootstrap.ts:155-172`
+`path:packages/runtime/src/bootstrap.ts:204-224`
 ```typescript
 async function runBootstrapFailureCleanup(options: {
   container?: Container;
@@ -465,7 +465,7 @@ async function runBootstrapFailureCleanup(options: {
 
 이 첫 failure-cleanup 발췌는 bootstrap 실패 후에도 lifecycle shutdown hook을 호출하려고 시도한다는 점을 보여 줍니다. 이어지는 발췌는 container disposal과 cleanup failure logging을 분리해서 보여 줍니다.
 
-`path:packages/runtime/src/bootstrap.ts:174-189`
+`path:packages/runtime/src/bootstrap.ts:226-241`
 ```typescript
   if (options.container) {
     try {
@@ -493,11 +493,11 @@ async function runBootstrapFailureCleanup(options: {
 
 close idempotency도 의도적인 설계입니다. `FluoApplication.close()`와 `FluoApplicationContext.close()`는 모두 `closingPromise`를 memoize합니다. close가 이미 진행 중이면, 뒤늦은 호출자는 같은 promise를 기다립니다. close가 성공하면 이후 호출은 즉시 return합니다. close가 실패하면 promise를 비워 재시도를 허용합니다.
 
-lifecycle hook ordering은 `path:packages/runtime/src/bootstrap.ts:710-722`의 `runShutdownHooks()`가 담당합니다. instance를 역순으로 순회하고, 먼저 `onModuleDestroy()`를 모두 실행한 뒤, 그 다음 `onApplicationShutdown(signal)`을 실행합니다. 가능한 한 startup dependency 방향을 거꾸로 되돌리는 ordering이라고 볼 수 있습니다.
+lifecycle hook ordering은 `path:packages/runtime/src/bootstrap.ts:1181-1193`의 `runShutdownHooks()`가 담당합니다. instance를 역순으로 순회하고, 먼저 `onModuleDestroy()`를 모두 실행한 뒤, 그 다음 `onApplicationShutdown(signal)`을 실행합니다. 가능한 한 startup dependency 방향을 거꾸로 되돌리는 ordering이라고 볼 수 있습니다.
 
 shutdown hook ordering은 별도 helper로 고정되어 있습니다. 두 hook family 모두 reverse order로 처리되므로, startup 때 만들어진 singleton lifecycle instance를 반대 방향으로 정리합니다.
 
-`path:packages/runtime/src/bootstrap.ts:710-722`
+`path:packages/runtime/src/bootstrap.ts:1181-1193`
 ```typescript
 async function runShutdownHooks(instances: readonly unknown[], signal?: string): Promise<void> {
   for (const instance of [...instances].reverse()) {

--- a/book/advanced/ch09-app-context.md
+++ b/book/advanced/ch09-app-context.md
@@ -23,15 +23,15 @@ The easiest way to misunderstand Fluo runtime internals is to assume that `Appli
 
 All three shells are assembled inside `path:packages/runtime/src/bootstrap.ts`. They also share the lower bootstrap spine. Module Graph compilation, container registration, runtime Token registration, lifecycle singleton resolution, hook execution, and platform-shell startup are common.
 
-The public types in `path:packages/runtime/src/types.ts:163-199` make the similarity clear. `ApplicationContext` exposes `container`, `modules`, `rootModule`, `get()`, and `close()`. `Application` adds `state`, `dispatcher`, `listen()`, `ready()`, `connectMicroservice()`, and `startAllMicroservices()`. `MicroserviceApplication` reuses the context surface while adding transport methods such as `listen()`, `send()`, and `emit()`.
+The public types in `path:packages/runtime/src/types.ts:196-232` make the similarity clear. `ApplicationContext` exposes `container`, `modules`, `rootModule`, `get()`, and `close()`. `Application` adds `state`, `dispatcher`, `listen()`, `ready()`, `connectMicroservice()`, and `startAllMicroservices()`. `MicroserviceApplication` reuses the context surface while adding transport methods such as `listen()`, `send()`, and `emit()`.
 
 This is not accidental API symmetry. It reflects the implementation order. Fluo first builds a transport-neutral DI and lifecycle baseline, then each shell type wraps and exposes only the capabilities it promises.
 
-The branch points are visible directly in the source. `bootstrapApplication()` in `path:packages/runtime/src/bootstrap.ts:920-1029` returns `new FluoApplication(...)`. `FluoFactory.createApplicationContext()` in `path:packages/runtime/src/bootstrap.ts:1059-1153` returns `new FluoApplicationContext(...)`. `FluoFactory.createMicroservice()` in `path:packages/runtime/src/bootstrap.ts:1164-1189` first creates an application context, then wraps the resolved runtime Token in `FluoMicroserviceApplication`.
+The branch points are visible directly in the source. `bootstrapApplication()` in `path:packages/runtime/src/bootstrap.ts:1419-1552` returns `new FluoApplication(...)`. `FluoFactory.createApplicationContext()` in `path:packages/runtime/src/bootstrap.ts:1581-1691` returns `new FluoApplicationContext(...)`. `FluoFactory.createMicroservice()` in `path:packages/runtime/src/bootstrap.ts:1702-1735` first creates an application context, then wraps the resolved runtime Token in `FluoMicroserviceApplication`.
 
 The representative point in the full application branch is the return statement. The earlier module bootstrap and lifecycle execution are shared, but only this branch passes the dispatcher, adapter, adapter availability flag, and platform shell reference into `FluoApplication`.
 
-`path:packages/runtime/src/bootstrap.ts:1000-1012`
+`path:packages/runtime/src/bootstrap.ts:1509-1532`
 ```typescript
     return new FluoApplication(
       bootstrapped.container,
@@ -52,7 +52,7 @@ The fact that `dispatcher` and `adapter` enter together marks the application sh
 
 The context branch passes through the same spine, but returns a different object. It does not create a dispatcher or HTTP adapter. It only wraps the values needed for DI and lifecycle control in `FluoApplicationContext`.
 
-`path:packages/runtime/src/bootstrap.ts:1128-1135`
+`path:packages/runtime/src/bootstrap.ts:1654-1671`
 ```typescript
       return new FluoApplicationContext(
         bootstrapped.container,
@@ -66,7 +66,7 @@ The context branch passes through the same spine, but returns a different object
 
 The microservice branch is not another independent bootstrap. It first creates a context, then resolves a transport runtime Token from that context and puts a wrapper on top.
 
-`path:packages/runtime/src/bootstrap.ts:1168-1180`
+`path:packages/runtime/src/bootstrap.ts:1706-1717`
 ```typescript
     const logger = options.logger ?? createConsoleApplicationLogger();
     const microserviceToken = options.microserviceToken ?? DEFAULT_MICROSERVICE_TOKEN;
@@ -95,16 +95,16 @@ bootstrap graph + container + lifecycle baseline
   -> FluoMicroserviceApplication (context + resolved transport runtime)
 ```
 
-The tests reinforce this shared ancestry. `path:packages/runtime/src/bootstrap.test.ts:522-629` verifies context bootstrap, `path:packages/runtime/src/application.test.ts:175-235` verifies the full application lifecycle, and `path:packages/runtime/src/bootstrap.test.ts:764-859` verifies the microservice wrapper path.
+The tests reinforce this shared ancestry. `path:packages/runtime/src/bootstrap.test.ts:523-628` verifies context bootstrap, `path:packages/runtime/src/application.test.ts:175-235` verifies the full application lifecycle, and `path:packages/runtime/src/bootstrap.test.ts:1504-1625` verifies the microservice wrapper path.
 
 This shared bootstrap spine is the foundation of this chapter. To understand the rest of the runtime contract, first see that the context, application, and microservice shells are siblings built from one compiled module and container baseline.
 
 ## 9.2 Application context is the adapterless baseline and still runs full lifecycle bootstrap
-`FluoApplicationContext` is defined in `path:packages/runtime/src/bootstrap.ts:531-575`. Its surface is intentionally small. It stores only the `container`, `modules`, `rootModule`, optional bootstrap timing diagnostics, lifecycle instances, and cleanup callbacks.
+`FluoApplicationContext` is defined in `path:packages/runtime/src/bootstrap.ts:803-856`. Its surface is intentionally small. It stores only the `container`, `modules`, `rootModule`, optional bootstrap timing diagnostics, lifecycle instances, cleanup callbacks, and context cache eligibility metadata.
 
 The context shell itself shows that intent. The stored values are the ones needed for the compiled Module baseline and lifecycle cleanup, and the public behavior is DI lookup and close.
 
-`path:packages/runtime/src/bootstrap.ts:531-548`
+`path:packages/runtime/src/bootstrap.ts:803-826`
 ```typescript
 class FluoApplicationContext implements ApplicationContext {
   private closed = false;
@@ -128,13 +128,13 @@ This excerpt has no dispatcher, adapter, or listen state. So a context is not a 
 
 The only public methods are `get()` and `close()`. That minimal surface is the point. An application context is the runtime baseline for CLI tasks, workers, migrations, and every DI-driven process that does not need an HTTP listener.
 
-The actual bootstrap path is `FluoFactory.createApplicationContext()` in `path:packages/runtime/src/bootstrap.ts:1059-1153`. Compared with `bootstrapApplication()`, most of the order is the same. It still creates the logger, platform shell, runtime Provider list, compiled Module, runtime context Tokens, lifecycle instances, and timing diagnostics.
+The actual bootstrap path is `FluoFactory.createApplicationContext()` in `path:packages/runtime/src/bootstrap.ts:1581-1691`. Compared with `bootstrapApplication()`, most of the order is the same. It still creates the logger, platform shell, runtime Provider list, compiled Module, runtime context Tokens, lifecycle instances, and timing diagnostics.
 
 The key difference is Token registration. In a full application, `registerRuntimeBootstrapTokens()` adds both `HTTP_APPLICATION_ADAPTER` and `PLATFORM_SHELL`. In a context, `registerRuntimeApplicationContextTokens()` adds only `PLATFORM_SHELL`.
 
 The Token registration functions show this difference in the smallest form. The application branch adds the HTTP adapter Token. The context branch adds only the platform shell, then falls through to the shared context Token registration helper.
 
-`path:packages/runtime/src/bootstrap.ts:783-795`
+`path:packages/runtime/src/bootstrap.ts:1271-1288`
 ```typescript
 function registerRuntimeBootstrapTokens(
   bootstrapped: BootstrapResult,
@@ -153,7 +153,7 @@ function registerRuntimeBootstrapTokens(
 
 This first excerpt narrows the full application branch to the fact that it adds the HTTP adapter Token. The shared helper below closes the comparison by showing that the context branch shares the same baseline Tokens while excluding only the adapter Token.
 
-`path:packages/runtime/src/bootstrap.ts:797-816`
+`path:packages/runtime/src/bootstrap.ts:1290-1318`
 ```typescript
 function registerRuntimeContextTokens(bootstrapped: BootstrapResult, ...providers: Provider[]): void {
   bootstrapped.container.register(
@@ -187,7 +187,7 @@ Lifecycle behavior is also complete. `path:packages/runtime/src/bootstrap.test.t
 
 The fact that context and application share lifecycle behavior is visible in the shared helpers. Bootstrap resolves singleton lifecycle instances, runs hooks, starts the platform shell, and marks readiness state.
 
-`path:packages/runtime/src/bootstrap.ts:818-841`
+`path:packages/runtime/src/bootstrap.ts:1320-1350`
 ```typescript
 async function resolveBootstrapLifecycleInstances(
   bootstrapped: BootstrapResult,
@@ -211,7 +211,7 @@ async function runBootstrapLifecycle(
 
 This excerpt shows that the lifecycle target list is built from both runtime Providers and compiled Module Providers. The next excerpt narrows the focus to how that list runs in the actual bootstrap phase.
 
-`path:packages/runtime/src/bootstrap.ts:830-841`
+`path:packages/runtime/src/bootstrap.ts:1337-1350`
 ```typescript
 async function runBootstrapLifecycle(
   modules: CompiledModule[],
@@ -247,11 +247,11 @@ createApplicationContext(rootModule)
 That is why the context API is especially useful for advanced tooling. You get the same validated Module Graph, the same singleton state, and the same shutdown semantics without forcing an HTTP adapter into existence just to access DI.
 
 ## 9.3 Full applications add dispatcher state, readiness checks, and adapter-driven listen semantics
-`FluoApplication` is defined in `path:packages/runtime/src/bootstrap.ts:403-529`. It stores everything the context stores, and also keeps the `dispatcher`, adapter availability state, platform shell reference, connected microservice list, and `ApplicationState`.
+`FluoApplication` is defined in `path:packages/runtime/src/bootstrap.ts:580-801`. It stores everything the context stores, and also keeps the `dispatcher`, adapter availability state, platform shell reference, connected microservice list, in-flight listen promise, and `ApplicationState`.
 
 The application shell constructor shows directly what is added on top of the context baseline. It receives the same `container`, `modules`, and `rootModule`, but dispatcher and adapter state come with them.
 
-`path:packages/runtime/src/bootstrap.ts:403-424`
+`path:packages/runtime/src/bootstrap.ts:580-605`
 ```typescript
 class FluoApplication implements Application {
   private applicationState: ApplicationState = 'bootstrapped';
@@ -279,13 +279,13 @@ class FluoApplication implements Application {
 
 Because of this structure, the application shell includes context functionality while also managing HTTP adapter and dispatcher state. It uses the same baseline as a context, but it is not the same contract.
 
-`ApplicationState` is declared in `path:packages/runtime/src/types.ts:91-92`. The allowed values are `'bootstrapped'`, `'ready'`, and `'closed'`. This state is not HTTP-only. It expresses runtime lifecycle progression for application and microservice shells.
+`ApplicationState` is declared in `path:packages/runtime/src/types.ts:113`. The allowed values are `'bootstrapped'`, `'ready'`, and `'closed'`. This state is not HTTP-only. It expresses runtime lifecycle progression for application and microservice shells.
 
-The first contract to inspect is `ready()` in `path:packages/runtime/src/bootstrap.ts:437-443`. This method does not call `adapter.listen()`. It only checks that the application is not already closed, then delegates to `platformShell.assertCriticalReadiness()`.
+The first contract to inspect is `ready()` in `path:packages/runtime/src/bootstrap.ts:622-628`. This method does not call `adapter.listen()`. It only checks that the application is not already closed, then delegates to `platformShell.assertCriticalReadiness()`.
 
 `ready()` is not a transport bind. It is a platform readiness gate, separated as the step that checks critical component state before the adapter starts receiving requests.
 
-`path:packages/runtime/src/bootstrap.ts:437-443`
+`path:packages/runtime/src/bootstrap.ts:622-628`
 ```typescript
   async ready(): Promise<void> {
     if (this.applicationState === 'closed') {
@@ -298,11 +298,11 @@ The first contract to inspect is `ready()` in `path:packages/runtime/src/bootstr
 
 So in Fluo, readiness is not synonymous with "the server socket has been bound." It is a pre-listen gate based on the platform shell. Transport startup is allowed only if critical platform components report that they are ready.
 
-`listen()` in `path:packages/runtime/src/bootstrap.ts:466-491` layers adapter behavior on top of that readiness gate. It throws if the app is closed, returns immediately if it is already ready, and throws an invariant error if there is no adapter, telling the user to provide `options.adapter` or use `createApplicationContext()`.
+`listen()` in `path:packages/runtime/src/bootstrap.ts:691-739` layers adapter behavior on top of that readiness gate. It throws if the app is closed, shares an in-flight startup for overlapping callers, returns immediately if it is already ready, and throws an invariant error if there is no adapter, telling the user to provide `options.adapter` or use `createApplicationContext()`.
 
 Then `listen()` applies the adapter policy. Adapterless application bootstrap is allowed, but listening without an adapter is blocked by this guard.
 
-`path:packages/runtime/src/bootstrap.ts:466-491`
+`path:packages/runtime/src/bootstrap.ts:691-739`
 ```typescript
   async listen(): Promise<void> {
     if (this.applicationState === 'closed') {
@@ -338,11 +338,11 @@ That exact error string is verified in `path:packages/runtime/src/application.te
 
 Only after this guard passes does `listen()` call `await this.ready()`, then `await this.adapter.listen(this.dispatcher)`. On success, it changes state to `'ready'` and writes the startup log. The transport adapter does not own the application state transition by itself. It participates as part of the larger runtime shell policy.
 
-Dispatcher assembly happens earlier, in `createRuntimeDispatcher()` at `path:packages/runtime/src/bootstrap.ts:890-910`. The runtime builds handler mapping from compiled Module controllers, logs route mappings, then creates a dispatcher with middleware, converters, interceptors, observers, and an optional exception filter.
+Dispatcher assembly happens earlier, in `createRuntimeDispatcher()` at `path:packages/runtime/src/bootstrap.ts:1389-1409`. The runtime builds handler mapping from compiled Module controllers, logs route mappings, then creates a dispatcher with middleware, converters, interceptors, observers, and an optional exception filter.
 
 Dispatcher creation is the request-facing step needed only by the full application branch. It creates handler sources from the compiled Module baseline, groups HTTP pipeline options, and returns the dispatcher.
 
-`path:packages/runtime/src/bootstrap.ts:890-910`
+`path:packages/runtime/src/bootstrap.ts:1389-1409`
 ```typescript
 function createRuntimeDispatcher(
   bootstrapped: BootstrapResult,
@@ -389,11 +389,11 @@ The model implemented by the source is exactly this. An application shell is not
 ## 9.4 Shutdown and failure cleanup are first-class runtime contracts, not afterthoughts
 The application context and application shell both implement careful close semantics. This is one of the more mature parts of the runtime design.
 
-The shared cleanup primitive is `closeRuntimeResources()` in `path:packages/runtime/src/bootstrap.ts:119-153`. The order is explicit. It first runs runtime cleanup callbacks, then shutdown hooks, then adapter close if an adapter exists, and finally container disposal. If needed, it accumulates errors and rethrows them as one error.
+The shared cleanup primitive is `closeRuntimeResources()` in `path:packages/runtime/src/bootstrap.ts:165-202`. The order is explicit. It resets readiness, runs runtime cleanup callbacks, then shutdown hooks, then adapter close if an adapter exists, and finally container disposal. If needed, it accumulates errors and rethrows them as one error.
 
 The application and context share the cleanup primitive, but the adapter is optional. Because of that structure, context close uses the same shutdown hooks and container disposal while skipping HTTP adapter close.
 
-`path:packages/runtime/src/bootstrap.ts:119-153`
+`path:packages/runtime/src/bootstrap.ts:165-202`
 ```typescript
 async function closeRuntimeResources(options: {
   adapter?: HttpApplicationAdapter;
@@ -415,7 +415,7 @@ async function closeRuntimeResources(options: {
 
 The first cleanup excerpt shows that runtime cleanup callbacks and shutdown hooks run before the adapter. The next excerpt continues into the branch that closes the adapter only when it exists, then finishes with container disposal and error aggregation.
 
-`path:packages/runtime/src/bootstrap.ts:136-153`
+`path:packages/runtime/src/bootstrap.ts:185-202`
 ```typescript
   if (options.adapter) {
     try {
@@ -437,11 +437,11 @@ The first cleanup excerpt shows that runtime cleanup callbacks and shutdown hook
 }
 ```
 
-Failure-path cleanup is owned by the sibling helper `runBootstrapFailureCleanup()` in `path:packages/runtime/src/bootstrap.ts:155-189`. Even if bootstrap fails after creating some lifecycle instances or resources, the runtime still tries to clean them up. Cleanup failures are logged, while the original bootstrap error is preserved.
+Failure-path cleanup is owned by the sibling helper `runBootstrapFailureCleanup()` in `path:packages/runtime/src/bootstrap.ts:204-241`. Even if bootstrap fails after creating some lifecycle instances or resources, the runtime still tries to clean them up. Cleanup failures are logged, while the original bootstrap error is preserved.
 
 Failure cleanup uses the same rollback principle with a different scope label. Application failure and application context failure leave different messages, but they share the attempt to run lifecycle hooks and clean up the container.
 
-`path:packages/runtime/src/bootstrap.ts:155-172`
+`path:packages/runtime/src/bootstrap.ts:204-224`
 ```typescript
 async function runBootstrapFailureCleanup(options: {
   container?: Container;
@@ -465,7 +465,7 @@ async function runBootstrapFailureCleanup(options: {
 
 This first failure-cleanup excerpt shows that the runtime tries to call lifecycle shutdown hooks even after bootstrap failure. The following excerpt separates container disposal from cleanup failure logging.
 
-`path:packages/runtime/src/bootstrap.ts:174-189`
+`path:packages/runtime/src/bootstrap.ts:226-241`
 ```typescript
   if (options.container) {
     try {
@@ -493,11 +493,11 @@ Tests make this guarantee concrete. `path:packages/runtime/src/application.test.
 
 Close idempotency is also intentional. Both `FluoApplication.close()` and `FluoApplicationContext.close()` memoize `closingPromise`. If close is already in progress, a later caller waits for the same promise. If close succeeds, later calls return immediately. If close fails, the promise is cleared so a retry is allowed.
 
-Lifecycle hook ordering is handled by `runShutdownHooks()` in `path:packages/runtime/src/bootstrap.ts:710-722`. It walks instances in reverse order, first running every `onModuleDestroy()`, then running every `onApplicationShutdown(signal)`. You can read this as an ordering that unwinds the startup dependency direction as much as possible.
+Lifecycle hook ordering is handled by `runShutdownHooks()` in `path:packages/runtime/src/bootstrap.ts:1181-1193`. It walks instances in reverse order, first running every `onModuleDestroy()`, then running every `onApplicationShutdown(signal)`. You can read this as an ordering that unwinds the startup dependency direction as much as possible.
 
 Shutdown hook ordering is fixed in a separate helper. Both hook families run in reverse order, so singleton lifecycle instances created during startup are cleaned up in the opposite direction.
 
-`path:packages/runtime/src/bootstrap.ts:710-722`
+`path:packages/runtime/src/bootstrap.ts:1181-1193`
 ```typescript
 async function runShutdownHooks(instances: readonly unknown[], signal?: string): Promise<void> {
   for (const instance of [...instances].reverse()) {

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -136,7 +136,7 @@ class UsersModule {}
 - 연결된 microservice는 부모 `Application`이 소유하는 child입니다. `startAllMicroservices()`는 순차적으로 시작하며 이후 child 시작이 실패하면 이미 시작된 child를 `bootstrap-failed`로 rollback하고, `Application.close(signal)`은 부모 lifecycle hook, adapter 종료, container dispose보다 먼저 연결된 child를 닫습니다.
 - `FluoFactory.createMicroservice()`는 cleanup이 실패해도 원래 bootstrap/runtime 해석 오류를 보존하고 cleanup 실패는 별도로 로그로 남깁니다.
 - Bootstrap은 독립적인 singleton lifecycle provider를 병렬로 해석한 뒤 lifecycle hook은 결정적인 provider 순서대로 실행합니다.
-- 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다.
+- 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다. 업로드된 파일 버퍼는 Web 표준 `Uint8Array` 값이므로 공유 Web 런타임 경로가 Bun, Deno, Cloudflare Workers 전반에서 portable하게 유지됩니다.
 - `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, `runNodeApplication(...)`는 `maxBodySize`를 0 이상의 정수 바이트 수로만 받으며, 값이 잘못되면 어댑터 생성/부트스트랩 단계에서 즉시 실패합니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.
 - 런타임 health 모듈은 bootstrap이 ready로 표시하기 전까지 `/ready`를 HTTP 503과 `starting`으로 보고하며, 애플리케이션/컨텍스트 종료가 시작되는 즉시, 종료 시도가 실패하더라도 다시 `starting`으로 내려갑니다.
@@ -151,6 +151,8 @@ class UsersModule {}
 - `FluoFactory`: 명시적 static 접근을 제공하는 클래스 기반 런타임 부트스트랩 파사드입니다.
 - `Application`: `ApplicationContext`를 확장하며 `listen()`, `dispatch()`, `state`를 포함합니다.
 - `ApplicationContext`: `get<T>(token)`, `close()` 기능을 제공하며 `container`, `modules`, bootstrap diagnostics에 접근할 수 있습니다.
+- `MicroserviceRuntime`: 설정된 microservice token에서 해석되는 transport contract입니다. Runtime은 `listen()`을 제공하고 필요에 따라 `send()`, `emit()`, `close(signal)`를 제공할 수 있습니다.
+- `MicroserviceApplication`: `state`, `listen()`, `send()`, `emit()`을 제공하는 context 기반 microservice shell입니다.
 - `LifecycleHooks`: `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `OnApplicationShutdown`를 묶는 편의 union 타입입니다.
 - `HealthModule.forRoot(options)`: bootstrap 및 shutdown 라이프사이클 전이에 맞춰 readiness marker를 관리하는 런타임 소유 `/health`, `/ready` 모듈 파사드입니다.
 - `createHealthModule(options)`: 같은 런타임 health module 계약을 위한 deprecated compatibility helper입니다. 애플리케이션-facing module import에서는 `HealthModule.forRoot(...)`를 우선 사용하세요.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -136,7 +136,7 @@ class UsersModule {}
 - Connected microservices are owned children of their parent `Application`: `startAllMicroservices()` starts them sequentially and rolls back already-started children with `bootstrap-failed` if a later child fails, while `Application.close(signal)` closes connected children before parent lifecycle hooks, adapter shutdown, and container disposal.
 - `FluoFactory.createMicroservice()` preserves the original bootstrap/runtime-resolution error when cleanup fails and logs cleanup failures separately.
 - Bootstrap resolves independent singleton lifecycle providers concurrently, then runs lifecycle hooks in deterministic provider order.
-- Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it.
+- Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it, and uploaded file buffers are Web-standard `Uint8Array` values so the shared Web runtime path stays portable across Bun, Deno, and Cloudflare Workers.
 - `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, and `runNodeApplication(...)` accept `maxBodySize` only as a non-negative integer byte count and fail fast during adapter creation/bootstrap when the value is invalid.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.
 - Runtime health modules report `/ready` as `starting` with HTTP 503 until bootstrap marks them ready, and they return to `starting` as soon as application/context shutdown begins, including failed shutdown attempts.
@@ -151,6 +151,8 @@ class UsersModule {}
 - `FluoFactory`: Class-based runtime bootstrap facade with explicit static access.
 - `Application`: Extends `ApplicationContext` with `listen()`, `dispatch()`, and `state`.
 - `ApplicationContext`: Provides `get<T>(token)`, `close()`, and access to `container`, `modules`, and bootstrap diagnostics.
+- `MicroserviceRuntime`: Transport contract resolved from the configured microservice token; runtimes provide `listen()` and may provide `send()`, `emit()`, and `close(signal)`.
+- `MicroserviceApplication`: Context-backed microservice shell with `state`, `listen()`, `send()`, and `emit()`.
 - `LifecycleHooks`: Convenience union covering `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, and `OnApplicationShutdown`.
 - `HealthModule.forRoot(options)`: Runtime-owned `/health` and `/ready` module facade whose readiness marker follows bootstrap and shutdown lifecycle transitions.
 - `createHealthModule(options)`: Deprecated compatibility helper for the same runtime health module contract; prefer `HealthModule.forRoot(...)` in application-facing module imports.

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -1288,9 +1288,35 @@ describe('FluoFactory.createApplicationContext', () => {
 
     expect(context.bootstrapTiming?.version).toBe(1);
     expect(context.bootstrapTiming?.totalMs ?? 0).toBeGreaterThanOrEqual(0);
-    expect(context.bootstrapTiming?.phases.some((phase) => phase.name === 'bootstrap_module')).toBe(true);
+    expect(context.bootstrapTiming?.phases.map((phase) => phase.name)).toEqual([
+      'bootstrap_module',
+      'register_runtime_tokens',
+      'resolve_lifecycle_instances',
+      'run_bootstrap_lifecycle',
+    ]);
 
     await context.close();
+  });
+
+  it('collects full application bootstrap timing diagnostics through dispatcher creation', async () => {
+    class AppModule {}
+    defineRuntimeModuleMetadata(AppModule, {});
+
+    const app = await FluoFactory.create(AppModule, {
+      diagnostics: {
+        timing: true,
+      },
+    });
+
+    expect(app.bootstrapTiming?.phases.map((phase) => phase.name)).toEqual([
+      'bootstrap_module',
+      'register_runtime_tokens',
+      'resolve_lifecycle_instances',
+      'run_bootstrap_lifecycle',
+      'create_dispatcher',
+    ]);
+
+    await app.close();
   });
 
   it('surfaces shutdown hook failures from application context close()', async () => {

--- a/packages/runtime/src/health/diagnostics.test.ts
+++ b/packages/runtime/src/health/diagnostics.test.ts
@@ -7,7 +7,6 @@ import { compileModuleGraph } from '../module-graph.js';
 import {
   createBootstrapTimingDiagnostics,
   createRuntimeDiagnosticsGraph,
-  renderRuntimeDiagnosticsMermaid,
 } from './diagnostics.js';
 
 describe('runtime diagnostics graph export', () => {
@@ -86,23 +85,6 @@ describe('runtime diagnostics graph export', () => {
     });
   });
 
-  it('renders module-level Mermaid output', () => {
-    class SharedModule {}
-    defineRuntimeModuleMetadata(SharedModule, {});
-
-    class AppModule {}
-    defineRuntimeModuleMetadata(AppModule, {
-      imports: [SharedModule],
-    });
-
-    const graph = createRuntimeDiagnosticsGraph(compileModuleGraph(AppModule), AppModule);
-    const mermaid = renderRuntimeDiagnosticsMermaid(graph);
-
-    expect(mermaid).toContain('graph TD');
-    expect(mermaid).toContain('AppModule');
-    expect(mermaid).toContain('SharedModule');
-    expect(mermaid).toContain('-->');
-  });
 });
 
 describe('bootstrap timing diagnostics', () => {

--- a/packages/runtime/src/health/diagnostics.ts
+++ b/packages/runtime/src/health/diagnostics.ts
@@ -238,50 +238,6 @@ export function createRuntimeDiagnosticsGraph(modules: readonly CompiledModule[]
 }
 
 /**
- * Render runtime diagnostics mermaid.
- *
- * @param graph The graph.
- * @returns The render runtime diagnostics mermaid result.
- */
-export function renderRuntimeDiagnosticsMermaid(graph: RuntimeDiagnosticsGraph): string {
-  const lines: string[] = ['graph TD'];
-  const nodeByModule = new Map<string, string>();
-
-  for (const [index, module] of graph.modules.entries()) {
-    const nodeId = `M${String(index + 1)}`;
-    nodeByModule.set(module.name, nodeId);
-
-    const summary = [
-      module.name,
-      `providers: ${String(module.providers.length)}`,
-      `controllers: ${String(module.controllers.length)}`,
-      `exports: ${String(module.exports.length)}`,
-    ].join('\\n');
-
-    lines.push(`  ${nodeId}["${summary}"]`);
-  }
-
-  for (const relation of graph.relationships.moduleImports) {
-    const from = nodeByModule.get(relation.from);
-    const to = nodeByModule.get(relation.to);
-
-    if (!from || !to) {
-      continue;
-    }
-
-    lines.push(`  ${from} --> ${to}`);
-  }
-
-  const rootNodeId = nodeByModule.get(graph.rootModule);
-  if (rootNodeId) {
-    lines.push(`  class ${rootNodeId} rootModule`);
-    lines.push('  classDef rootModule stroke:#2563eb,stroke-width:2px');
-  }
-
-  return lines.join('\n');
-}
-
-/**
  * Create bootstrap timing diagnostics.
  *
  * @param phases The phases.

--- a/packages/runtime/src/multipart.test.ts
+++ b/packages/runtime/src/multipart.test.ts
@@ -4,6 +4,8 @@ import { PayloadTooLargeException } from '@fluojs/http';
 
 import { parseMultipart } from './multipart.js';
 
+const textBytes = (value: string) => new TextEncoder().encode(value);
+
 describe('parseMultipart', () => {
   it('parses fields and uploaded files from a web Request', async () => {
     const form = new FormData();
@@ -24,7 +26,7 @@ describe('parseMultipart', () => {
       },
       files: [
         {
-          buffer: Buffer.from('hello'),
+          buffer: textBytes('hello'),
           fieldname: 'payload',
           mimetype: 'text/plain',
           originalname: 'payload.txt',
@@ -55,7 +57,7 @@ describe('parseMultipart', () => {
       fields: { name: 'Ada' },
       files: [
         {
-          buffer: Buffer.from('hello'),
+          buffer: textBytes('hello'),
           fieldname: 'payload',
           mimetype: 'text/plain',
           originalname: 'payload.txt',

--- a/packages/runtime/src/multipart.ts
+++ b/packages/runtime/src/multipart.ts
@@ -7,7 +7,7 @@ export interface UploadedFile {
   fieldname: string;
   originalname: string;
   mimetype: string;
-  buffer: Buffer;
+  buffer: Uint8Array;
   size: number;
 }
 
@@ -43,6 +43,7 @@ const DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
 const DEFAULT_MAX_FILES = 10;
 const DEFAULT_MAX_TOTAL_SIZE = 10 * 1024 * 1024;
 const MULTIPART_BODY_LIMIT_MESSAGE = 'Multipart body exceeds the maximum size of';
+const TEXT_ENCODER = new TextEncoder();
 
 /**
  * Parses a multipart request into string fields and in-memory uploaded files.
@@ -67,7 +68,7 @@ export async function parseMultipart(
 
   for (const [fieldname, value] of formData.entries()) {
     if (typeof value === 'string') {
-      totalSize += Buffer.byteLength(value, 'utf8');
+      totalSize += TEXT_ENCODER.encode(value).byteLength;
 
       if (totalSize > maxTotalSize) {
         throw new PayloadTooLargeException(`${MULTIPART_BODY_LIMIT_MESSAGE} ${String(maxTotalSize)} bytes.`);
@@ -92,7 +93,7 @@ export async function parseMultipart(
     }
 
     files.push({
-      buffer: Buffer.from(await value.arrayBuffer()),
+      buffer: new Uint8Array(await value.arrayBuffer()),
       fieldname,
       mimetype: value.type,
       originalname: value.name,

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -128,6 +128,7 @@ interface NodeListenRetryOptions {
   port: number;
   retryDelayMs: number;
   retryLimit: number;
+  signal?: AbortSignal;
 }
 
 type NodeServer = ReturnType<typeof createHttpServer> | ReturnType<typeof createHttpsServer>;
@@ -139,6 +140,7 @@ type NodeRequestListener = RequestListener;
 export class NodeHttpApplicationAdapter implements HttpApplicationAdapter {
   private readonly server: NodeServer;
   private dispatcher?: Dispatcher;
+  private listenAbortController?: AbortController;
   private readonly requestResponseFactory: RequestResponseFactory<
     import('node:http').IncomingMessage,
     import('node:http').ServerResponse,
@@ -189,16 +191,28 @@ export class NodeHttpApplicationAdapter implements HttpApplicationAdapter {
 
   async listen(dispatcher: Dispatcher): Promise<void> {
     this.dispatcher = dispatcher;
-    await listenNodeServerWithRetry(this.server, {
-      host: this.host,
-      port: this.port,
-      retryDelayMs: this.retryDelayMs,
-      retryLimit: this.retryLimit,
-    });
+    this.listenAbortController?.abort();
+    const listenAbortController = new AbortController();
+    this.listenAbortController = listenAbortController;
+
+    try {
+      await listenNodeServerWithRetry(this.server, {
+        host: this.host,
+        port: this.port,
+        retryDelayMs: this.retryDelayMs,
+        retryLimit: this.retryLimit,
+        signal: listenAbortController.signal,
+      });
+    } finally {
+      if (this.listenAbortController === listenAbortController) {
+        this.listenAbortController = undefined;
+      }
+    }
   }
 
   async close(): Promise<void> {
     const server = this.server;
+    this.listenAbortController?.abort();
 
     if (!server.listening) {
       this.dispatcher = undefined;
@@ -363,23 +377,84 @@ function createNodeServer(
 
 function listenNodeServerWithRetry(server: NodeServer, options: NodeListenRetryOptions): Promise<void> {
   return new Promise<void>((resolve, reject) => {
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let onErrorListener: ((error: NodeJS.ErrnoException) => void) | undefined;
+    let onListeningListener: (() => void) | undefined;
+    let settled = false;
+
+    const cleanup = () => {
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = undefined;
+      }
+
+      if (onErrorListener) {
+        server.off('error', onErrorListener);
+        onErrorListener = undefined;
+      }
+
+      if (onListeningListener) {
+        server.off('listening', onListeningListener);
+        onListeningListener = undefined;
+      }
+
+      options.signal?.removeEventListener('abort', abortListen);
+    };
+
+    const settle = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const abortListen = () => {
+      settle(() => {
+        reject(new Error('Node HTTP adapter listen retry was cancelled during shutdown.'));
+      });
+    };
+
+    if (options.signal?.aborted) {
+      abortListen();
+      return;
+    }
+
+    options.signal?.addEventListener('abort', abortListen, { once: true });
+
     const tryListen = (attempt: number) => {
+      if (options.signal?.aborted) {
+        abortListen();
+        return;
+      }
+
       const onError = (error: NodeJS.ErrnoException) => {
         server.off('listening', onListening);
+        onErrorListener = undefined;
+        onListeningListener = undefined;
 
         if (error.code === 'EADDRINUSE' && attempt < options.retryLimit) {
-          scheduleNodeListenRetry(server, attempt, options.retryDelayMs, tryListen);
+          scheduleNodeListenRetry(server, attempt, options.retryDelayMs, tryListen, (timer) => {
+            retryTimer = timer;
+          });
           return;
         }
 
-        reject(error);
+        settle(() => {
+          reject(error);
+        });
       };
 
       const onListening = () => {
         server.off('error', onError);
-        resolve();
+        onErrorListener = undefined;
+        settle(resolve);
       };
 
+      onErrorListener = onError;
+      onListeningListener = onListening;
       server.once('error', onError);
       server.once('listening', onListening);
       server.listen({ host: options.host, port: options.port });
@@ -394,12 +469,19 @@ function scheduleNodeListenRetry(
   attempt: number,
   retryDelayMs: number,
   tryListen: (attempt: number) => void,
+  setTimer: (timer: ReturnType<typeof setTimeout>) => void,
 ): void {
-  server.close(() => {
-    setTimeout(() => {
+  const schedule = () => {
+    setTimer(setTimeout(() => {
       tryListen(attempt + 1);
-    }, retryDelayMs);
-  });
+    }, retryDelayMs));
+  };
+
+  try {
+    server.close(schedule);
+  } catch {
+    schedule();
+  }
 }
 
 function closeNodeServerWithDrain(

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -436,7 +436,12 @@ function listenNodeServerWithRetry(server: NodeServer, options: NodeListenRetryO
         onListeningListener = undefined;
 
         if (error.code === 'EADDRINUSE' && attempt < options.retryLimit) {
-          scheduleNodeListenRetry(server, attempt, options.retryDelayMs, tryListen, (timer) => {
+          scheduleNodeListenRetry(server, attempt, options.retryDelayMs, tryListen, () => settled || options.signal?.aborted === true, (timer) => {
+            if (settled || options.signal?.aborted) {
+              clearTimeout(timer);
+              return;
+            }
+
             retryTimer = timer;
           });
           return;
@@ -469,15 +474,35 @@ function scheduleNodeListenRetry(
   attempt: number,
   retryDelayMs: number,
   tryListen: (attempt: number) => void,
+  isCancelled: () => boolean,
   setTimer: (timer: ReturnType<typeof setTimeout>) => void,
 ): void {
   const schedule = () => {
-    setTimer(setTimeout(() => {
+    if (isCancelled()) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (isCancelled()) {
+        return;
+      }
+
       tryListen(attempt + 1);
-    }, retryDelayMs));
+    }, retryDelayMs);
+
+    if (isCancelled()) {
+      clearTimeout(timer);
+      return;
+    }
+
+    setTimer(timer);
   };
 
   try {
+    if (isCancelled()) {
+      return;
+    }
+
     server.close(schedule);
   } catch {
     schedule();

--- a/packages/runtime/src/node/node-request.test.ts
+++ b/packages/runtime/src/node/node-request.test.ts
@@ -186,7 +186,7 @@ describe('node request adapter', () => {
     expect(frameworkRequest.body).toEqual({ name: 'Ada' });
     expect(frameworkRequest.files).toEqual([
       {
-        buffer: Buffer.from('hello'),
+        buffer: new TextEncoder().encode('hello'),
         fieldname: 'payload',
         mimetype: 'text/plain',
         originalname: 'payload.txt',

--- a/packages/runtime/src/node/node.test.ts
+++ b/packages/runtime/src/node/node.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
@@ -88,6 +88,64 @@ describe('createNodeHttpAdapter', () => {
       await expect(listenPromise).rejects.toThrow('Node HTTP adapter listen retry was cancelled during shutdown.');
     } finally {
       await adapter.close();
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    }
+  });
+
+  it('does not register a retry timer when shutdown wins the server close callback race', async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve) => {
+      blocker.listen(0, '127.0.0.1', resolve);
+    });
+
+    const { port } = blocker.address() as AddressInfo;
+    const adapter = publicNodeApi.createNodeHttpAdapter({
+      host: '127.0.0.1',
+      port,
+      retryDelayMs: 10_000,
+      retryLimit: 1,
+    }) as NodeHttpApplicationAdapter;
+    const dispatcher: Dispatcher = {
+      async dispatch() {},
+    };
+    const server = adapter.getServer();
+    const originalClose = server.close.bind(server);
+    let releaseRetryClose: (() => void) | undefined;
+    const retryCloseRequested = new Promise<void>((resolve) => {
+      vi.spyOn(server, 'close').mockImplementation(((callback?: (error?: Error) => void) => {
+        releaseRetryClose = () => {
+          callback?.();
+        };
+        resolve();
+        return server;
+      }) as typeof server.close);
+    });
+
+    try {
+      const listenPromise = adapter.listen(dispatcher);
+      await retryCloseRequested;
+
+      await adapter.close();
+      vi.useFakeTimers();
+
+      releaseRetryClose?.();
+
+      expect(vi.getTimerCount()).toBe(0);
+      await expect(listenPromise).rejects.toThrow('Node HTTP adapter listen retry was cancelled during shutdown.');
+    } finally {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+      await adapter.close();
+      server.close = originalClose;
       await new Promise<void>((resolve, reject) => {
         blocker.close((error) => {
           if (error) {

--- a/packages/runtime/src/node/node.test.ts
+++ b/packages/runtime/src/node/node.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import type { Dispatcher } from '@fluojs/http';
 
 import * as rootRuntimeApi from '../index.js';
 import * as publicNodeApi from '../node.js';
@@ -57,5 +61,43 @@ describe('createNodeHttpAdapter', () => {
     expect(() => Function.prototype.call.call(publicNodeApi.createNodeHttpAdapter, undefined, { maxBodySize: '1mb' })).toThrow(
       'Invalid maxBodySize value: 1mb. Expected a non-negative integer number of bytes.',
     );
+  });
+
+  it('cancels pending listen retries when the adapter closes during shutdown', async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve) => {
+      blocker.listen(0, '127.0.0.1', resolve);
+    });
+
+    const { port } = blocker.address() as AddressInfo;
+    const adapter = publicNodeApi.createNodeHttpAdapter({
+      host: '127.0.0.1',
+      port,
+      retryDelayMs: 10_000,
+      retryLimit: 2,
+    }) as NodeHttpApplicationAdapter;
+    const dispatcher: Dispatcher = {
+      async dispatch() {},
+    };
+
+    try {
+      const listenPromise = adapter.listen(dispatcher);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await adapter.close();
+
+      await expect(listenPromise).rejects.toThrow('Node HTTP adapter listen retry was cancelled during shutdown.');
+    } finally {
+      await adapter.close();
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    }
   });
 });

--- a/packages/runtime/src/platform-shell.test.ts
+++ b/packages/runtime/src/platform-shell.test.ts
@@ -244,4 +244,74 @@ describe('RuntimePlatformShell', () => {
       'stop:redis.default',
     ]);
   });
+
+  it('accumulates diagnostics for validate, readiness, health, and snapshot failures', async () => {
+    const events: string[] = [];
+    const validateFailure = new StubPlatformComponent(
+      'validate.default',
+      'validate',
+      events,
+      { critical: true, status: 'ready' },
+      { status: 'healthy' },
+      {
+        issues: [{ code: 'validate.failed', componentId: 'validate.default', message: 'validation failed', severity: 'error' }],
+        ok: false,
+      },
+    );
+    const probeFailure: PlatformComponent = {
+      async health() {
+        throw new Error('health failed');
+      },
+      id: 'probe.default',
+      kind: 'probe',
+      async ready() {
+        throw new Error('ready failed');
+      },
+      snapshot() {
+        throw new Error('snapshot failed');
+      },
+      async start() {},
+      state() {
+        return 'ready';
+      },
+      async stop() {},
+      async validate() {
+        return { issues: [], ok: true };
+      },
+    };
+
+    const validationShell = RuntimePlatformShell.fromInputs([{ component: validateFailure, dependencies: [] }]);
+    await expect(validationShell.start()).rejects.toThrow('Platform shell validation failed: validate.default:validate.failed');
+    expect((await validationShell.snapshot()).diagnostics).toContainEqual(
+      expect.objectContaining({ code: 'validate.failed', componentId: 'validate.default' }),
+    );
+
+    const probeShell = RuntimePlatformShell.fromInputs([{ component: probeFailure, dependencies: [] }]);
+
+    expect(await probeShell.ready()).toEqual(expect.objectContaining({ status: 'not-ready' }));
+    expect(await probeShell.health()).toEqual(expect.objectContaining({ status: 'unhealthy' }));
+
+    const snapshot = await probeShell.snapshot();
+    expect(snapshot.readiness.status).toBe('not-ready');
+    expect(snapshot.health.status).toBe('unhealthy');
+    expect(snapshot.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'RUNTIME_PLATFORM_COMPONENT_FAILURE',
+          componentId: 'probe.default',
+          message: 'Platform component failed during ready.',
+        }),
+        expect.objectContaining({
+          code: 'RUNTIME_PLATFORM_COMPONENT_FAILURE',
+          componentId: 'probe.default',
+          message: 'Platform component failed during health.',
+        }),
+        expect.objectContaining({
+          code: 'RUNTIME_PLATFORM_COMPONENT_FAILURE',
+          componentId: 'probe.default',
+          message: 'Platform component failed during snapshot.',
+        }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes #1803

- Hardens `@fluojs/runtime` Web multipart parsing so uploaded file buffers use Web-standard `Uint8Array` instead of Node `Buffer`.
- Makes Node adapter listen retry delays cancellable when shutdown starts.
- Refreshes runtime diagnostics/test/docs coverage for timing phases, platform diagnostic failure accumulation, Studio-owned Mermaid rendering, and advanced book source references.

## Changes

- Replaced multipart parser `Buffer` dependencies with `TextEncoder`/`Uint8Array` and documented the EN/KO runtime contract.
- Added Node listen retry cancellation via an adapter-owned `AbortController` plus regression coverage.
- Removed runtime-owned Mermaid renderer implementation/test coverage because graph presentation is Studio-owned.
- Added regression coverage for full bootstrap timing phase order and platform validate/readiness/health/snapshot diagnostics.
- Updated `book/advanced/ch09-app-context.md` and `.ko.md` source line references.
- Added `.changeset/runtime-web-multipart-portability.md` for the public `@fluojs/runtime` behavior/API surface adjustment.

## Testing

- `pnpm --filter @fluojs/runtime test` ✅
- `pnpm --filter @fluojs/runtime... build && pnpm --filter @fluojs/runtime typecheck` ✅
- `pnpm lint && pnpm docs:sync-check` ✅ (Biome reported existing warnings outside the changed runtime/book files; command completed successfully.)
- LSP diagnostics on changed runtime source/test files ✅

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs were changed; runtime README/book EN/KO mirrors were kept aligned and verified with `pnpm docs:sync-check`.