### PR TITLE
Resolve #1799: harden Node.js platform lifecycle

### DIFF
--- a/.changeset/nodejs-platform-lifecycle-coverage.md
+++ b/.changeset/nodejs-platform-lifecycle-coverage.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/platform-nodejs": patch
+"@fluojs/runtime": patch
+---
+
+Harden the Node.js platform contract by validating lifecycle retry/shutdown options, preserving `x-correlation-id` as the request ID fallback on Node-backed requests, and documenting package-local coverage for listen retry and keep-alive shutdown behavior.

--- a/book/intermediate/ch21-express-node.ko.md
+++ b/book/intermediate/ch21-express-node.ko.md
@@ -229,6 +229,6 @@ await runExpressApplication(AppModule, {
 - `@fluojs/platform-express`를 사용하면 기존 Express 생태계와 운영 자산을 이어서 사용할 수 있습니다.
 - `@fluojs/platform-nodejs`는 최소한의 프레임워크 없는 HTTP 레이어를 제공합니다.
 - 대부분의 fluo 코드(컨트롤러, 프로바이더, 모듈)는 어떤 어댑터가 실행 중인지 전혀 알 필요가 없습니다.
-- 플랫폼 전용 기능이 필요한 경우에만 `getInstance()`로 하부 엔진에 접근하세요.
+- 플랫폼 전용 기능이 필요한 경우에만 `getServer()`로 하부 Node 서버에 접근하거나 `getRealtimeCapability()`를 확인하세요.
 - Runtime은 diagnostic snapshot과 issue 생산을 소유하고, Studio는 해당 artifact의 graph viewing 및 Mermaid rendering을 소유합니다.
 - 크로스 플랫폼 호환성을 유지하려면 fluo의 추상화(예: `MiddlewareConsumer`)를 먼저 검토하세요.

--- a/book/intermediate/ch21-express-node.md
+++ b/book/intermediate/ch21-express-node.md
@@ -229,6 +229,6 @@ This helper helps clean up active connections before the process exits. In deplo
 - `@fluojs/platform-express` lets you continue using the existing Express ecosystem and operational assets.
 - `@fluojs/platform-nodejs` provides a minimal HTTP layer without a framework.
 - Most fluo code (Controllers, Providers, Modules) does not need to know which adapter is running at all.
-- Access the underlying engine with `getInstance()` only when you need platform-specific features.
+- Access the underlying Node server with `getServer()` or inspect `getRealtimeCapability()` only when you need platform-specific features.
 - Runtime owns diagnostic snapshot and issue production; Studio owns graph viewing and Mermaid rendering of those artifacts.
 - To maintain cross-platform compatibility, review fluo abstractions first, such as `MiddlewareConsumer`.

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -58,7 +58,7 @@ const adapter = createNodejsAdapter({
 
 `maxBodySize`는 바이트 수를 나타내는 숫자만 받습니다. 이 값은 raw Node 요청 바디가 아직 스트리밍되는 동안 바로 강제되며, 부트스트랩 시 `multipart.maxTotalSize`를 따로 재정의하지 않으면 같은 값이 멀티파트 전체 페이로드 한도의 기본값으로도 사용됩니다.
 
-`createNodejsAdapter()`는 기본 port로 `3000`을 사용하고 `process.env.PORT`를 무시하며, `port` 또는 `maxBodySize`가 잘못되면 throw합니다. 기본 request body cap은 `1 MiB`입니다.
+`createNodejsAdapter()`는 기본 port로 `3000`을 사용하고 `process.env.PORT`를 무시하며, `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`가 잘못되면 throw합니다. 기본 request body cap은 `1 MiB`입니다.
 
 ### 직접 애플리케이션 실행
 `runNodejsApplication`을 사용하여 graceful shutdown 및 로깅이 포함된 보일러플레이트 없는 시작이 가능합니다.
@@ -87,16 +87,16 @@ await app.listen();
 
 - `createNodejsAdapter(options)`는 Node 내장 `http` 또는 `https` 서버 primitive 위에서 fluo를 직접 실행하는 adapter-first 진입점입니다.
 - `maxBodySize`는 0 이상의 정수 바이트 수만 받으며, raw Node 요청 바이트가 아직 스트리밍되는 동안 강제되고, 부트스트랩/실행 헬퍼에서 `multipart.maxTotalSize`를 명시적으로 제공하지 않으면 멀티파트 전체 크기 한도의 기본값이 됩니다.
-- Raw Node adapter는 대소문자가 섞인 JSON 및 multipart `content-type` 값을 normalize하고, request body가 `maxBodySize`를 넘으면 `413`을 반환하며, `getServer()` / `getRealtimeCapability()`를 통해 server-backed realtime capability를 노출합니다.
+- Raw Node adapter는 대소문자가 섞인 JSON 및 multipart `content-type` 값을 normalize하고, request body가 `maxBodySize`를 넘으면 `413`을 반환하며, `x-request-id`와 `x-correlation-id` fallback을 request context와 error response에 전파하고, `getServer()` / `getRealtimeCapability()`를 통해 server-backed realtime capability를 노출합니다.
 - `bootstrapNodejsApplication(module, options)`는 raw Node 어댑터가 포함된 애플리케이션을 만들지만 리스닝은 시작하지 않으므로 이후 `app.listen()`과 `app.close()` 생명주기는 호출자가 소유합니다.
-- `runNodejsApplication(module, options)`는 부트스트랩, 리스닝 시작, graceful shutdown 배선을 함께 수행합니다. 시그널 기반 종료가 타임아웃되거나 실패하면 해당 상태를 로그와 `process.exitCode`로 보고하며, 최종 프로세스 종료는 호스트 프로세스가 계속 소유합니다.
+- `runNodejsApplication(module, options)`는 부트스트랩, 리스닝 시작, graceful shutdown 배선을 함께 수행합니다. Listen retry는 `retryLimit`/`retryDelayMs`를 따르고, shutdown은 bounded drain 전에 idle keep-alive connection을 닫으며, 시그널 기반 종료가 타임아웃되거나 실패하면 해당 상태를 로그와 `process.exitCode`로 보고합니다. 최종 프로세스 종료는 호스트 프로세스가 계속 소유합니다.
 - 고급 압축 및 shutdown 유틸리티 함수는 이 기본 platform startup surface가 아니라 `@fluojs/runtime/node` 또는 runtime 내부 seam에 남아 있습니다.
 
 ## Conformance 커버리지
 
 `packages/platform-nodejs/src/index.test.ts`는 문서화된 Node.js 계약을 위한 package-local regression target입니다. 이 파일은 공유 `createHttpAdapterPortabilityHarness(...)` 검사를 실행하여 malformed cookie 보존, JSON/text raw-body capture, byte-exact raw-body capture, multipart raw-body 제외, multipart 전체 크기 기본값, SSE framing, response stream drain settlement, host 및 HTTPS startup logging, shutdown signal listener cleanup을 검증합니다.
 
-같은 파일은 package-specific public surface, type alias, adapter-first startup, `maxBodySize` failure, 대소문자가 섞인 JSON 및 multipart content-type parsing, server-backed realtime capability 노출도 함께 다룹니다. Startup behavior를 바꿀 때는 README 예제 포인터를 아래 테스트 파일 및 Node.js 챕터 예제와 맞춰 유지하세요.
+같은 파일은 package-specific public surface, type alias, adapter-first startup, lifecycle option validation, listen retry behavior, idle keep-alive shutdown, `maxBodySize` failure, 대소문자가 섞인 JSON 및 multipart content-type parsing, `x-correlation-id` request ID fallback, server-backed realtime capability 노출도 함께 다룹니다. Startup behavior를 바꿀 때는 README 예제 포인터를 아래 테스트 파일 및 Node.js 챕터 예제와 맞춰 유지하세요.
 
 ## 공개 API 개요
 

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -58,7 +58,7 @@ const adapter = createNodejsAdapter({
 
 `maxBodySize` accepts a byte count number. It is enforced while the raw Node request body is still streaming, and the same limit becomes the default total multipart payload cap unless you override `multipart.maxTotalSize` during bootstrap.
 
-`createNodejsAdapter()` defaults to port `3000`, ignores `process.env.PORT`, and throws when `port` or `maxBodySize` are invalid. The default request body cap is `1 MiB`.
+`createNodejsAdapter()` defaults to port `3000`, ignores `process.env.PORT`, and throws when `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, or `shutdownTimeoutMs` are invalid. The default request body cap is `1 MiB`.
 
 ### Direct Application Execution
 You can use `runNodejsApplication` for a zero-boilerplate startup that includes graceful shutdown and logging.
@@ -87,16 +87,16 @@ await app.listen();
 
 - `createNodejsAdapter(options)` is the adapter-first entrypoint for running fluo directly on Node's built-in `http` or `https` server primitives.
 - `maxBodySize` accepts a non-negative integer byte count, is enforced while raw Node request bytes are still streaming, and becomes the default multipart total-size cap unless `multipart.maxTotalSize` is explicitly provided through the bootstrap/run helpers.
-- The raw Node adapter normalizes mixed-case JSON and multipart `content-type` values, returns `413` when request bodies exceed `maxBodySize`, and exposes a server-backed realtime capability through `getServer()` / `getRealtimeCapability()`.
+- The raw Node adapter normalizes mixed-case JSON and multipart `content-type` values, returns `413` when request bodies exceed `maxBodySize`, propagates `x-request-id` with `x-correlation-id` fallback into the request context and error responses, and exposes a server-backed realtime capability through `getServer()` / `getRealtimeCapability()`.
 - `bootstrapNodejsApplication(module, options)` creates an application with the raw Node adapter but does not start listening, so the caller owns the subsequent `app.listen()` and `app.close()` lifecycle.
-- `runNodejsApplication(module, options)` bootstraps, starts, and wires graceful shutdown. When signal-driven shutdown times out or fails, it logs the condition and sets `process.exitCode`; final process termination remains owned by the host process.
+- `runNodejsApplication(module, options)` bootstraps, starts, and wires graceful shutdown. Listen retries honor `retryLimit`/`retryDelayMs`, shutdown closes idle keep-alive connections before bounded drain, and when signal-driven shutdown times out or fails it logs the condition and sets `process.exitCode`; final process termination remains owned by the host process.
 - Advanced compression and shutdown utility functions remain on `@fluojs/runtime/node` or internal runtime seams rather than this primary platform startup surface.
 
 ## Conformance Coverage
 
 `packages/platform-nodejs/src/index.test.ts` is the package-local regression target for the documented Node.js contract. It runs the shared `createHttpAdapterPortabilityHarness(...)` checks for malformed cookie preservation, JSON/text raw-body capture, byte-exact raw-body capture, multipart raw-body exclusion, multipart total-size defaults, SSE framing, response stream drain settlement, host and HTTPS startup logging, and shutdown signal listener cleanup.
 
-The same file also covers the package-specific public surface, type aliases, adapter-first startup, `maxBodySize` failures, mixed-case JSON and multipart content-type parsing, and server-backed realtime capability exposure. Keep README example pointers aligned with that test file and the Node.js chapter examples below when changing startup behavior.
+The same file also covers the package-specific public surface, type aliases, adapter-first startup, lifecycle option validation, listen retry behavior, idle keep-alive shutdown, `maxBodySize` failures, mixed-case JSON and multipart content-type parsing, `x-correlation-id` request ID fallback, and server-backed realtime capability exposure. Keep README example pointers aligned with that test file and the Node.js chapter examples below when changing startup behavior.
 
 ## Public API Overview
 

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'node:net';
-import { Controller, FromBody, Get, Post, RequestDto, type RequestContext } from '@fluojs/http';
+import { Controller, type Dispatcher, FromBody, Get, Post, RequestDto, type RequestContext } from '@fluojs/http';
 import { defineModule, FluoFactory } from '@fluojs/runtime';
 import {
   type BootstrapNodeApplicationOptions,
@@ -11,7 +11,7 @@ import {
   runNodeApplication,
 } from '@fluojs/runtime/node';
 import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import * as platformNodejsApi from './index.js';
 import {
   type BootstrapNodejsApplicationOptions,
@@ -217,6 +217,89 @@ describe('@fluojs/platform-nodejs', () => {
     }
   });
 
+  it('fails fast when Node lifecycle options are invalid through the platform adapter', () => {
+    expect(() => createNodejsAdapter({ retryDelayMs: -1 })).toThrow(
+      'Invalid retryDelayMs value: -1. Expected a non-negative integer.',
+    );
+    expect(() => createNodejsAdapter({ retryLimit: 1.5 })).toThrow(
+      'Invalid retryLimit value: 1.5. Expected a non-negative integer.',
+    );
+    expect(() => createNodejsAdapter({ shutdownTimeoutMs: -1 })).toThrow(
+      'Invalid shutdownTimeoutMs value: -1. Expected a non-negative integer.',
+    );
+  });
+
+  it('retries listen through the package adapter until the address is released', async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve) => {
+      blocker.listen(0, '127.0.0.1', resolve);
+    });
+    const address = blocker.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Failed to bind a retry test port.');
+    }
+    const dispatcher: Dispatcher = {
+      async dispatch() {},
+    };
+    const adapter = createNodejsAdapter({
+      host: '127.0.0.1',
+      port: address.port,
+      retryDelayMs: 10,
+      retryLimit: 5,
+    });
+
+    try {
+      const listenPromise = adapter.listen(dispatcher);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await new Promise<void>((resolve, reject) => {
+        blocker.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+
+      await expect(listenPromise).resolves.toBeUndefined();
+    } finally {
+      await adapter.close();
+      if (blocker.listening) {
+        await new Promise<void>((resolve, reject) => {
+          blocker.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+
+            resolve();
+          });
+        });
+      }
+    }
+  });
+
+  it('closes idle keep-alive connections during package adapter shutdown', async () => {
+    const port = await findAvailablePort();
+    const adapter = createNodejsAdapter({ port });
+    const server = adapter.getServer();
+    const closeIdleConnections = vi.spyOn(server, 'closeIdleConnections');
+    const dispatcher: Dispatcher = {
+      async dispatch() {},
+    };
+
+    try {
+      await adapter.listen(dispatcher);
+      await adapter.close();
+
+      expect(closeIdleConnections).toHaveBeenCalled();
+    } finally {
+      closeIdleConnections.mockRestore();
+      await adapter.close();
+    }
+  });
+
   it('removes registered shutdown signal listeners after close through the platform run helper', async () => {
     @Controller('/health')
     class HealthController {
@@ -304,6 +387,41 @@ describe('@fluojs/platform-nodejs', () => {
       expect(bodyResponse.status).toBe(201);
       await expect(bodyResponse.json()).resolves.toEqual({
         body: { ok: true, source: 'node' },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('propagates x-correlation-id as the request id through the public Node adapter path', async () => {
+    @Controller('/request-id')
+    class RequestIdController {
+      @Get('/')
+      readRequestId(_input: undefined, context: RequestContext) {
+        return { requestId: context.request.requestId };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [RequestIdController] });
+
+    const port = await findAvailablePort();
+    const app = await FluoFactory.create(AppModule, {
+      adapter: createNodejsAdapter({ port }),
+    });
+
+    try {
+      await app.listen();
+
+      const response = await fetch(`http://127.0.0.1:${String(port)}/request-id`, {
+        headers: {
+          'x-correlation-id': 'correlation-platform-nodejs',
+        },
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        requestId: 'correlation-platform-nodejs',
       });
     } finally {
       await app.close();

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -126,6 +126,7 @@ class UsersModule {}
 - `@fluojs/runtime/node`에서는 Node 요청 바디 파싱 전에 primary `content-type` media type을 normalize한 뒤 JSON 및 멀티파트 여부를 판단하므로, 대소문자가 섞인 JSON/멀티파트 헤더도 문서화된 파서 동작을 그대로 유지합니다.
 - Node 기반 및 Web 표준 요청 wrapper는 바디 파싱 전에 저비용 요청 metadata를 snapshot으로 고정한 뒤 dispatch 경계에서 `body`/`rawBody`를 한 번 materialize하므로 userland는 계속 동기 parsed 값을 관찰합니다.
 - Node 기반 쿠키/쿼리 값과 Web 표준 헤더는 요청 wrapper가 생성되는 시점에 snapshot으로 고정된 뒤 요청별로 lazy하게 normalize되고 memoize됩니다. 이후 upstream 객체가 변경되어도 `FrameworkRequest` view는 바뀌지 않습니다.
+- Node 기반 request context ID는 `x-request-id`를 우선 사용하고, `x-request-id`가 없으면 `x-correlation-id`로 fallback합니다. 따라서 error response와 request-aware integration이 upstream correlation identifier를 유지합니다.
 - `ApplicationContext.get()`과 `Application.get()`은 bootstrap 시점에 알려진 직접 root singleton class/factory provider 조회만 memoize하며, alias, request, transient, 종료 이후, multi-provider, `container.override()` 해석 의미는 그대로 유지합니다.
 - `multi: true` provider token은 context cache에 memoize되지 않습니다. 각 `get()` 호출은 DI로 위임되어 컨테이너가 새로운 contribution 배열을 조립하며, 각 contribution 자체는 해당 provider scope에 따라 재사용됩니다.
 - `duplicateProviderPolicy`가 `warn` 또는 `ignore`일 때 context cache 적격성과 lifecycle hook 실행은 bootstrap이 선택한 effective winning provider를 기준으로 결정됩니다. stale losing provider는 cache entry나 lifecycle hook을 만들지 않습니다.
@@ -137,7 +138,7 @@ class UsersModule {}
 - `FluoFactory.createMicroservice()`는 cleanup이 실패해도 원래 bootstrap/runtime 해석 오류를 보존하고 cleanup 실패는 별도로 로그로 남깁니다.
 - Bootstrap은 독립적인 singleton lifecycle provider를 병렬로 해석한 뒤 lifecycle hook은 결정적인 provider 순서대로 실행합니다.
 - 멀티파트 파싱은 누적 바디 크기가 설정된 `multipart.maxTotalSize`를 넘으면 즉시 거부되며, 런타임 어댑터는 별도 재정의가 없으면 이 한도를 `maxBodySize`와 동일하게 맞춥니다. 업로드된 파일 버퍼는 Web 표준 `Uint8Array` 값이므로 공유 Web 런타임 경로가 Bun, Deno, Cloudflare Workers 전반에서 portable하게 유지됩니다.
-- `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, `runNodeApplication(...)`는 `maxBodySize`를 0 이상의 정수 바이트 수로만 받으며, 값이 잘못되면 어댑터 생성/부트스트랩 단계에서 즉시 실패합니다.
+- `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, `runNodeApplication(...)`는 `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 0 이상의 정수로만 받으며, 값이 잘못되면 어댑터 생성/부트스트랩 단계에서 즉시 실패합니다.
 - 응답 스트림 백프레셔 헬퍼는 `drain`, `close`, `error` 중 어느 경우에도 `waitForDrain()`을 완료시켜 끊어진 연결에서 스트리밍 작성기가 멈추지 않도록 합니다.
 - 런타임 health 모듈은 bootstrap이 ready로 표시하기 전까지 `/ready`를 HTTP 503과 `starting`으로 보고하며, 애플리케이션/컨텍스트 종료가 시작되는 즉시, 종료 시도가 실패하더라도 다시 `starting`으로 내려갑니다.
 - 런타임 health module readiness check는 현재 `RequestContext`를 받으므로, public integration이 internal runtime token을 import하지 않고도 runtime-exposed status provider를 해석할 수 있습니다.
@@ -195,11 +196,11 @@ const adapter = createNodeHttpAdapter({
 });
 ```
 
-공개 Node 런타임 surface에서 `maxBodySize`는 바이트 수를 나타내는 숫자만 허용합니다. `'1mb'` 같은 값은 나중에 암묵 변환되지 않고 어댑터 생성 시점에 즉시 거부됩니다.
+공개 Node 런타임 surface에서 `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`는 숫자로 표현된 0 이상의 정수만 허용합니다. `'1mb'`, 소수 retry 횟수, 음수 shutdown timeout 같은 값은 나중에 암묵 변환되지 않고 어댑터 생성 시점에 즉시 거부됩니다. Node request context ID는 `x-request-id`를 우선 사용하며, 없으면 `x-correlation-id`를 runtime error response와 request-aware integration의 request ID fallback으로 사용합니다.
 
 - `createConsoleApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 컬러 콘솔 로거입니다. 기본값은 pretty 형식입니다. 더 간결한 `[fluo] LEVEL [context] message` 줄을 원하면 `{ mode: 'minimal' }`, 런타임 로거 출력을 숨기려면 `{ mode: 'silent' }`, 낮은 심각도 메시지를 걸러내려면 `{ level: 'warn' }` 같은 threshold, 결정적인 비컬러 출력을 원하면 `{ color: false }`를 전달하세요.
 - `createJsonApplicationLogger()`: `process.stdout`/`process.stderr`를 사용하는 구조화된 JSON 로거.
-- `createNodeHttpAdapter()`: 어댑터 우선 런타임 구성을 위한 raw Node `http`/`https` 어댑터 팩토리입니다. primary Node 요청 `content-type`을 JSON/멀티파트 판별 전에 normalize하며, `maxBodySize`는 숫자 바이트 수만 받습니다.
+- `createNodeHttpAdapter()`: 어댑터 우선 런타임 구성을 위한 raw Node `http`/`https` 어댑터 팩토리입니다. primary Node 요청 `content-type`을 JSON/멀티파트 판별 전에 normalize하며, `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`는 0 이상의 정수만 받습니다.
 - `bootstrapNodeApplication()` / `runNodeApplication()`: 직접 Node runtime flow에서 사용하는 Node 전용 부트스트랩 헬퍼.
 - `createNodeShutdownSignalRegistration()`, `defaultNodeShutdownSignals()`, `registerShutdownSignals()`: 호스트가 명시적으로 시그널 wiring을 제어할 때 쓰는 종료 등록 헬퍼.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -126,6 +126,7 @@ class UsersModule {}
 - On `@fluojs/runtime/node`, Node request body parsing normalizes the primary `content-type` media type before JSON and multipart detection, so mixed-case JSON and multipart headers preserve the documented parser behavior.
 - Node-backed and Web-standard request wrappers snapshot cheap request metadata before body parsing, then materialize `body`/`rawBody` once at the dispatch boundary so userland continues to observe synchronous parsed values.
 - Node-backed cookies/query values and Web-standard headers are snapshotted when the request wrapper is created, then lazily normalized and memoized per request; later upstream object mutations do not change the `FrameworkRequest` view.
+- Node-backed request context IDs prefer `x-request-id` and fall back to `x-correlation-id` when `x-request-id` is absent, so error responses and request-aware integrations keep the upstream correlation identifier.
 - `ApplicationContext.get()` and `Application.get()` memoize only direct root singleton class/factory provider lookups known at bootstrap, while preserving alias, request, transient, post-close, multi-provider, and `container.override()` resolution semantics.
 - `multi: true` provider tokens are not context-cache memoized: each `get()` call delegates to DI so the container can assemble a fresh contribution array while still reusing each contribution according to its own provider scope.
 - When `duplicateProviderPolicy` is `warn` or `ignore`, context-cache eligibility and lifecycle hook execution are based on the effective winning provider selected by bootstrap; stale losing providers do not seed cache entries or lifecycle hooks.
@@ -137,7 +138,7 @@ class UsersModule {}
 - `FluoFactory.createMicroservice()` preserves the original bootstrap/runtime-resolution error when cleanup fails and logs cleanup failures separately.
 - Bootstrap resolves independent singleton lifecycle providers concurrently, then runs lifecycle hooks in deterministic provider order.
 - Multipart parsing rejects payloads when the cumulative body size exceeds the configured `multipart.maxTotalSize`; runtime adapters default that limit to `maxBodySize` unless you override it, and uploaded file buffers are Web-standard `Uint8Array` values so the shared Web runtime path stays portable across Bun, Deno, and Cloudflare Workers.
-- `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, and `runNodeApplication(...)` accept `maxBodySize` only as a non-negative integer byte count and fail fast during adapter creation/bootstrap when the value is invalid.
+- `createNodeHttpAdapter(...)`, `bootstrapNodeApplication(...)`, and `runNodeApplication(...)` accept `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` only as non-negative integers and fail fast during adapter creation/bootstrap when any value is invalid.
 - Response stream backpressure helpers settle `waitForDrain()` on `drain`, `close`, or `error` so streaming writers do not hang on dead connections.
 - Runtime health modules report `/ready` as `starting` with HTTP 503 until bootstrap marks them ready, and they return to `starting` as soon as application/context shutdown begins, including failed shutdown attempts.
 - Runtime health module readiness checks receive the current `RequestContext`, allowing public integrations to resolve runtime-exposed status providers without importing internal runtime tokens.
@@ -195,11 +196,11 @@ const adapter = createNodeHttpAdapter({
 });
 ```
 
-For the public Node runtime surface, `maxBodySize` is a byte-count number only. Values such as `'1mb'` are rejected immediately during adapter creation instead of being coerced later.
+For the public Node runtime surface, `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` are number-only non-negative integers. Values such as `'1mb'`, fractional retry counts, or negative shutdown timeouts are rejected immediately during adapter creation instead of being coerced later. Node request context IDs prefer `x-request-id`; when it is absent, `x-correlation-id` is used as the request ID fallback for runtime error responses and request-aware integrations.
 
 - `createConsoleApplicationLogger()`: Colorized console logger using `process.stdout`/`process.stderr`. The default remains the pretty format. Pass `{ mode: 'minimal' }` for concise `[fluo] LEVEL [context] message` lines, `{ mode: 'silent' }` to suppress runtime logger output, `{ level: 'warn' }` or another threshold to filter lower-severity messages, and `{ color: false }` when you need deterministic non-colored output.
 - `createJsonApplicationLogger()`: Structured JSON logger using `process.stdout`/`process.stderr`.
-- `createNodeHttpAdapter()`: Raw Node `http`/`https` adapter factory for adapter-first runtime setup. The helper normalizes the primary Node request `content-type` before JSON/multipart detection and accepts `maxBodySize` only as numeric bytes.
+- `createNodeHttpAdapter()`: Raw Node `http`/`https` adapter factory for adapter-first runtime setup. The helper normalizes the primary Node request `content-type` before JSON/multipart detection and accepts `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` only as non-negative integers.
 - `bootstrapNodeApplication()` / `runNodeApplication()`: Node-specific bootstrap helpers used by direct Node runtime flows.
 - `createNodeShutdownSignalRegistration()`, `defaultNodeShutdownSignals()`, `registerShutdownSignals()`: Shutdown registration helpers for hosts that need explicit signal wiring.
 

--- a/packages/runtime/src/node/internal-node-request.ts
+++ b/packages/runtime/src/node/internal-node-request.ts
@@ -340,8 +340,7 @@ export function resolveRequestIdFromHeaders(headers: IncomingHttpHeaders): strin
 }
 
 function resolvePrimaryRequestIdFromHeaders(headers: IncomingHttpHeaders): string | undefined {
-  const requestId = headers['x-request-id'];
-  return Array.isArray(requestId) ? requestId[0] : requestId;
+  return resolveRequestIdFromHeaders(headers);
 }
 
 /**

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -160,6 +160,11 @@ export class NodeHttpApplicationAdapter implements HttpApplicationAdapter {
     preserveRawBody = false,
     private readonly shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
   ) {
+    validateNodeLifecycleOptions({
+      retryDelayMs: this.retryDelayMs,
+      retryLimit: this.retryLimit,
+      shutdownTimeoutMs: this.shutdownTimeoutMs,
+    });
     this.requestResponseFactory = createNodeRequestResponseFactory(
       compression,
       multipartOptions,
@@ -574,6 +579,18 @@ function formatHostForAuthority(host: string): string {
 
 function closeIdleConnections(server: import('node:http').Server): void {
   server.closeIdleConnections?.();
+}
+
+function validateNodeLifecycleOptions(options: Required<Pick<NodeHttpAdapterOptions, 'retryDelayMs' | 'retryLimit' | 'shutdownTimeoutMs'>>): void {
+  validateNonNegativeIntegerOption('retryDelayMs', options.retryDelayMs);
+  validateNonNegativeIntegerOption('retryLimit', options.retryLimit);
+  validateNonNegativeIntegerOption('shutdownTimeoutMs', options.shutdownTimeoutMs);
+}
+
+function validateNonNegativeIntegerOption(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid ${name} value: ${String(value)}. Expected a non-negative integer.`);
+  }
 }
 
 function forceCloseConnections(server: import('node:http').Server, sockets: ReadonlySet<Socket>): void {

--- a/packages/runtime/src/node/node-request.test.ts
+++ b/packages/runtime/src/node/node-request.test.ts
@@ -146,6 +146,33 @@ describe('node request adapter', () => {
     expect(frameworkRequest.body).toEqual({ ok: true });
   });
 
+  it('uses x-correlation-id as the Node request id fallback', async () => {
+    const request = createIncomingMessage({
+      headers: {
+        'x-correlation-id': 'correlation-123',
+      },
+      url: '/request-id',
+    });
+
+    const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+
+    expect(frameworkRequest.requestId).toBe('correlation-123');
+  });
+
+  it('prefers x-request-id over x-correlation-id for Node request ids', async () => {
+    const request = createIncomingMessage({
+      headers: {
+        'x-correlation-id': 'correlation-123',
+        'x-request-id': 'request-123',
+      },
+      url: '/request-id',
+    });
+
+    const frameworkRequest = await createFrameworkRequest(request, new AbortController().signal);
+
+    expect(frameworkRequest.requestId).toBe('request-123');
+  });
+
   it('parses JSON bodies when the primary content-type uses mixed-case media types', async () => {
     const request = createIncomingMessage({
       body: '{"ok":true}',

--- a/packages/runtime/src/node/node.test.ts
+++ b/packages/runtime/src/node/node.test.ts
@@ -6,7 +6,7 @@ import type { Dispatcher } from '@fluojs/http';
 
 import * as rootRuntimeApi from '../index.js';
 import * as publicNodeApi from '../node.js';
-import type { NodeHttpApplicationAdapter } from '../node.js';
+import type { NodeHttpAdapterOptions, NodeHttpApplicationAdapter } from '../node.js';
 
 describe('createNodeHttpAdapter', () => {
   it('keeps Node lifecycle helpers out of the runtime root barrel', () => {
@@ -61,6 +61,14 @@ describe('createNodeHttpAdapter', () => {
     expect(() => Function.prototype.call.call(publicNodeApi.createNodeHttpAdapter, undefined, { maxBodySize: '1mb' })).toThrow(
       'Invalid maxBodySize value: 1mb. Expected a non-negative integer number of bytes.',
     );
+  });
+
+  it.each([
+    ['retryDelayMs', -1, 'Invalid retryDelayMs value: -1. Expected a non-negative integer.'],
+    ['retryLimit', 1.5, 'Invalid retryLimit value: 1.5. Expected a non-negative integer.'],
+    ['shutdownTimeoutMs', Number.NaN, 'Invalid shutdownTimeoutMs value: NaN. Expected a non-negative integer.'],
+  ] as const)('fails fast when %s is not a non-negative integer', (name, value, message) => {
+    expect(() => publicNodeApi.createNodeHttpAdapter({ [name]: value } as unknown as NodeHttpAdapterOptions)).toThrow(message);
   });
 
   it('cancels pending listen retries when the adapter closes during shutdown', async () => {


### PR DESCRIPTION
## Summary

Closes #1799

Harden the `@fluojs/platform-nodejs` behavioral contract around Node lifecycle options, listen retry/shutdown coverage, and request ID propagation.

## Changes

- Add package-local regression coverage for lifecycle option validation, listen retry behavior, idle keep-alive shutdown, and `x-correlation-id` request ID fallback.
- Make Node-backed request context request IDs use the same `x-request-id` / `x-correlation-id` fallback as Node error responses.
- Validate Node adapter lifecycle options (`retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`) as non-negative integers during adapter creation.
- Align `@fluojs/platform-nodejs` EN/KO README coverage notes and fix Chapter 21 EN/KO raw Node adapter guidance from `getInstance()` to `getServer()` / `getRealtimeCapability()`.
- Add a patch changeset for `@fluojs/runtime` and `@fluojs/platform-nodejs`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/platform-nodejs test` (25 passed)
- `pnpm build`
- `pnpm --filter @fluojs/runtime typecheck && pnpm --filter @fluojs/platform-nodejs typecheck`
- `pnpm lint` (completed; existing unrelated Biome warnings remain in `packages/config`, `packages/core`, `packages/cqrs`, etc.; changed public export TSDoc check passed)
- LSP diagnostics: clean for changed TypeScript files

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or renamed; existing runtime helper TSDoc remains intact.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

`packages/platform-nodejs/src/index.test.ts` now covers the Node package-local lifecycle/listen/shutdown and request ID invariants called out by this issue.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed platform contract document headings changed. Package README EN/KO and book EN/KO mirrors were updated together, with regression evidence in `packages/platform-nodejs/src/index.test.ts`.