### PR TITLE
Resolve #1797: harden Express adapter contracts

### DIFF
--- a/.changeset/quiet-pears-smile.md
+++ b/.changeset/quiet-pears-smile.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-express": patch
+---
+
+Validate Express adapter numeric options during setup and align Express runtime docs with the supported server/shutdown contract.

--- a/book/intermediate/ch21-express-node.ko.md
+++ b/book/intermediate/ch21-express-node.ko.md
@@ -48,8 +48,8 @@ async function bootstrap() {
 
   const app = await fluoFactory.create(AppModule, { adapter });
   
-  // 절대적으로 필요한 경우 하부 express 인스턴스에 여전히 접근할 수 있습니다.
-  const expressInstance = adapter.getInstance();
+  // 절대적으로 필요한 경우 하부 Node server를 확인할 수 있습니다.
+  const nativeServer = adapter.getServer?.();
   
   await app.listen();
 }
@@ -61,10 +61,12 @@ bootstrap();
 Express를 선택하는 가장 큰 이유 중 하나는 이미 검증된 미들웨어 생태계입니다. fluo의 Express 어댑터는 이런 미들웨어를 전역 또는 모듈 경계에서 등록할 수 있게 해주며, 기존 운영 자산을 버리지 않고 이식할 수 있게 합니다.
 
 ```typescript
-// 하부 인스턴스에 직접 미들웨어 적용
+// Express 호환 미들웨어는 fluo bootstrap 경계를 통해 등록하는 편을 권장합니다.
 const adapter = createExpressAdapter();
-const instance = adapter.getInstance();
-instance.use(compression());
+const app = await fluoFactory.create(AppModule, {
+  adapter,
+  middleware: [compression()],
+});
 ```
 
 다만 장기 이식성을 생각한다면 미들웨어를 fluo 모듈 시스템 안에서 등록하는 편이 낫습니다. 그래야 다른 런타임으로 옮길 때 플랫폼 전용 코드의 위치가 명확해집니다.
@@ -205,13 +207,11 @@ import { AppModule } from './app.module';
 await runExpressApplication(AppModule, {
   port: 3000,
   globalPrefix: 'api',
-  onShutdown: () => {
-    console.log('Cleaning up resources...');
-  }
+  shutdownSignals: ['SIGINT', 'SIGTERM'],
 });
 ```
 
-이 헬퍼는 프로세스가 종료되기 전에 활성 연결을 정리하도록 도와줍니다. 배포 환경에서는 이런 종료 경계가 로그 유실, 요청 중단, 리소스 누수를 줄이는 데 중요합니다.
+이 헬퍼는 process signal을 표준 fluo shutdown lifecycle에 연결하고, host가 종료되기 전에 활성 연결을 정리하도록 돕습니다. 애플리케이션 cleanup은 `onApplicationShutdown(signal)` 같은 lifecycle-aware provider에 두어야 같은 cleanup 경로가 platform adapter 전반에서 동작합니다. 배포 환경에서는 이런 종료 경계가 로그 유실, 요청 중단, 리소스 누수를 줄이는 데 중요합니다.
 
 ## 21.7 Comparison Summary
 
@@ -229,6 +229,6 @@ await runExpressApplication(AppModule, {
 - `@fluojs/platform-express`를 사용하면 기존 Express 생태계와 운영 자산을 이어서 사용할 수 있습니다.
 - `@fluojs/platform-nodejs`는 최소한의 프레임워크 없는 HTTP 레이어를 제공합니다.
 - 대부분의 fluo 코드(컨트롤러, 프로바이더, 모듈)는 어떤 어댑터가 실행 중인지 전혀 알 필요가 없습니다.
-- 플랫폼 전용 기능이 필요한 경우에만 `getServer()`로 하부 Node 서버에 접근하거나 `getRealtimeCapability()`를 확인하세요.
+- 플랫폼 전용 기능이 필요한 경우에만 `getServer?.()`로 하부 Node server를 확인하거나 `getRealtimeCapability()`를 확인하세요.
 - Runtime은 diagnostic snapshot과 issue 생산을 소유하고, Studio는 해당 artifact의 graph viewing 및 Mermaid rendering을 소유합니다.
 - 크로스 플랫폼 호환성을 유지하려면 fluo의 추상화(예: `MiddlewareConsumer`)를 먼저 검토하세요.

--- a/book/intermediate/ch21-express-node.ko.md
+++ b/book/intermediate/ch21-express-node.ko.md
@@ -10,7 +10,7 @@
 - `@fluojs/platform-express`와 `@fluojs/platform-nodejs`로 부트스트랩 구성을 바꾸는 방법을 배웁니다.
 - 어댑터 교체 뒤에도 비즈니스 로직을 그대로 유지하는 이식성 원칙을 확인합니다.
 - 플랫폼 네이티브 요청과 응답 객체에 접근해야 하는 상황을 살펴봅니다.
-- Express 미들웨어와 Node.js 스트림을 fluo 흐름에 맞게 연결하는 방법을 익힙니다.
+- HTTP 미들웨어와 Node.js 스트림을 fluo 흐름에 맞게 표현하는 방법을 익힙니다.
 - 런타임이 소유하는 diagnostic snapshot과 Studio가 소유하는 graph 및 Mermaid 표현을 구분합니다.
 - FluoShop을 Express 기반 실행 환경으로 옮길 때 점검할 항목을 정리합니다.
 
@@ -21,7 +21,7 @@
 
 ## 21.1 The Express Adapter
 
-Express는 Node.js 생태계에서 여전히 가장 널리 쓰이는 프레임워크입니다. 기존 Express 미들웨어가 운영 경로에 들어 있거나 레거시 Express 앱을 fluo로 단계적으로 옮겨야 한다면, `@fluojs/platform-express`가 현실적인 진입점이 됩니다.
+Express는 Node.js 생태계에서 여전히 가장 널리 쓰이는 프레임워크입니다. 기존 Express 인프라가 운영 경로에 들어 있거나 레거시 Express 앱을 fluo로 단계적으로 옮겨야 한다면, `@fluojs/platform-express`가 현실적인 진입점이 됩니다.
 
 ### 21.1.1 Installation
 
@@ -33,7 +33,7 @@ npm install @fluojs/platform-express express
 
 ### 21.1.2 Bootstrapping with Express
 
-Express 전환은 애플리케이션 진입점의 어댑터 선택을 바꾸는 작업에서 시작합니다. 컨트롤러와 서비스는 그대로 두고 HTTP 엔진 경계만 교체하는 방식입니다. 이 덕분에 기존 비즈니스 로직을 다시 작성하지 않고도 Express 미들웨어 생태계를 활용할 수 있습니다.
+Express 전환은 애플리케이션 진입점의 어댑터 선택을 바꾸는 작업에서 시작합니다. 컨트롤러와 서비스는 그대로 두고 HTTP 엔진 경계만 교체하는 방식입니다. 이 덕분에 기존 비즈니스 로직을 다시 작성하지 않고도 Express를 호스트 엔진으로 사용할 수 있습니다.
 
 ```typescript
 import { createExpressAdapter } from '@fluojs/platform-express';
@@ -58,18 +58,26 @@ bootstrap();
 
 ### 21.1.3 Handling Middleware
 
-Express를 선택하는 가장 큰 이유 중 하나는 이미 검증된 미들웨어 생태계입니다. fluo의 Express 어댑터는 이런 미들웨어를 전역 또는 모듈 경계에서 등록할 수 있게 해주며, 기존 운영 자산을 버리지 않고 이식할 수 있게 합니다.
+Express를 선택하는 가장 큰 이유 중 하나는 이미 검증된 운영 생태계입니다. fluo의 애플리케이션 레벨 `middleware` 옵션은 여전히 공유 `MiddlewareContext` 위에서 `handle(context, next)`를 구현한 fluo 미들웨어 객체나 provider를 기대합니다. `compression()` 같은 Express/Connect `(req, res, next)` 함수는 `fluoFactory.create(...)`에 직접 전달하지 마세요. 해당 동작을 fluo 계약 뒤에 감싸거나 Express가 소유하는 통합 계층에 두어야 합니다.
 
 ```typescript
-// Express 호환 미들웨어는 fluo bootstrap 경계를 통해 등록하는 편을 권장합니다.
+import type { Middleware } from '@fluojs/http';
+
+const compressionHeaders: Middleware = {
+  async handle(context, next) {
+    context.response.setHeader('vary', 'Accept-Encoding');
+    await next();
+  },
+};
+
 const adapter = createExpressAdapter();
 const app = await fluoFactory.create(AppModule, {
   adapter,
-  middleware: [compression()],
+  middleware: [compressionHeaders],
 });
 ```
 
-다만 장기 이식성을 생각한다면 미들웨어를 fluo 모듈 시스템 안에서 등록하는 편이 낫습니다. 그래야 다른 런타임으로 옮길 때 플랫폼 전용 코드의 위치가 명확해집니다.
+장기 이식성을 생각한다면 fluo 계약으로 작성한 미들웨어를 사용하거나 fluo 모듈 시스템 안에서 등록하는 편이 낫습니다. 그래야 다른 런타임으로 옮길 때 플랫폼 전용 코드의 위치가 명확해집니다.
 
 ## 21.2 The Raw Node.js Adapter
 
@@ -219,7 +227,7 @@ await runExpressApplication(AppModule, {
 | :--- | :--- | :--- | :--- |
 | **Performance** | Good | Excellent | High |
 | **Ecosystem** | Massive | Standard Lib | Large |
-| **Middleware** | Connect-style | Custom | Hook-style |
+| **Middleware** | Express host 위의 fluo contract | Custom | Fastify host 위의 fluo contract |
 | **Footprint** | Moderate | Minimal | Moderate |
 | **Best For** | Legacy Migrations | Micro-services | Standard Apps |
 

--- a/book/intermediate/ch21-express-node.ko.md
+++ b/book/intermediate/ch21-express-node.ko.md
@@ -237,6 +237,6 @@ await runExpressApplication(AppModule, {
 - `@fluojs/platform-express`를 사용하면 기존 Express 생태계와 운영 자산을 이어서 사용할 수 있습니다.
 - `@fluojs/platform-nodejs`는 최소한의 프레임워크 없는 HTTP 레이어를 제공합니다.
 - 대부분의 fluo 코드(컨트롤러, 프로바이더, 모듈)는 어떤 어댑터가 실행 중인지 전혀 알 필요가 없습니다.
-- 플랫폼 전용 기능이 필요한 경우에만 `getServer?.()`로 하부 Node server를 확인하거나 `getRealtimeCapability()`를 확인하세요.
+- 플랫폼 전용 기능이 필요한 경우에만 `getServer?.()`로 하부 Node server에 접근하거나 `getRealtimeCapability()`를 확인하세요.
 - Runtime은 diagnostic snapshot과 issue 생산을 소유하고, Studio는 해당 artifact의 graph viewing 및 Mermaid rendering을 소유합니다.
 - 크로스 플랫폼 호환성을 유지하려면 fluo의 추상화(예: `MiddlewareConsumer`)를 먼저 검토하세요.

--- a/book/intermediate/ch21-express-node.md
+++ b/book/intermediate/ch21-express-node.md
@@ -10,7 +10,7 @@ This chapter explains how to choose between the Express and raw Node.js adapters
 - Learn how to change bootstrap configuration with `@fluojs/platform-express` and `@fluojs/platform-nodejs`.
 - Confirm the portability principle that keeps business logic unchanged after swapping adapters.
 - Review situations where you need access to platform-native request and response objects.
-- Learn how to connect Express middleware and Node.js streams to the fluo flow.
+- Learn how to model HTTP middleware and Node.js streams through the fluo flow.
 - Distinguish runtime-owned diagnostic snapshots from Studio-owned graph and Mermaid presentation.
 - Summarize the checklist for moving FluoShop to an Express-based runtime environment.
 
@@ -21,7 +21,7 @@ This chapter explains how to choose between the Express and raw Node.js adapters
 
 ## 21.1 The Express Adapter
 
-Express is still the most widely used framework in the Node.js ecosystem. If existing Express middleware is part of your operational path, or if you need to move a legacy Express app into fluo gradually, `@fluojs/platform-express` is a practical entry point.
+Express is still the most widely used framework in the Node.js ecosystem. If existing Express infrastructure is part of your operational path, or if you need to move a legacy Express app into fluo gradually, `@fluojs/platform-express` is a practical entry point.
 
 ### 21.1.1 Installation
 
@@ -33,7 +33,7 @@ npm install @fluojs/platform-express express
 
 ### 21.1.2 Bootstrapping with Express
 
-The switch to Express starts by changing the adapter selection in the application entrypoint. Controllers and services stay the same; only the HTTP engine boundary is replaced. This lets you use the Express middleware ecosystem without rewriting existing business logic.
+The switch to Express starts by changing the adapter selection in the application entrypoint. Controllers and services stay the same; only the HTTP engine boundary is replaced. This lets you use Express as the host engine without rewriting existing business logic.
 
 ```typescript
 import { createExpressAdapter } from '@fluojs/platform-express';
@@ -58,18 +58,26 @@ bootstrap();
 
 ### 21.1.3 Handling Middleware
 
-One of the biggest reasons to choose Express is its proven middleware ecosystem. fluo's Express adapter lets you register that middleware globally or at Module boundaries, so you can migrate existing operational assets without throwing them away.
+One of the biggest reasons to choose Express is its proven operational ecosystem. fluo's application-level `middleware` option still expects fluo middleware: an object or provider that implements `handle(context, next)` over the shared `MiddlewareContext`. Do not pass an Express/Connect `(req, res, next)` function such as `compression()` directly to `fluoFactory.create(...)`; wrap that behavior behind the fluo contract or keep it in an Express-owned integration layer.
 
 ```typescript
-// Prefer registering Express-compatible middleware through the fluo bootstrap boundary.
+import type { Middleware } from '@fluojs/http';
+
+const compressionHeaders: Middleware = {
+  async handle(context, next) {
+    context.response.setHeader('vary', 'Accept-Encoding');
+    await next();
+  },
+};
+
 const adapter = createExpressAdapter();
 const app = await fluoFactory.create(AppModule, {
   adapter,
-  middleware: [compression()],
+  middleware: [compressionHeaders],
 });
 ```
 
-For long-term portability, however, it is better to register middleware inside the fluo Module system. That keeps the location of platform-specific code clear when you move to another runtime.
+For long-term portability, prefer middleware written to the fluo contract or registered through the fluo Module system. That keeps the location of platform-specific code clear when you move to another runtime.
 
 ## 21.2 The Raw Node.js Adapter
 
@@ -219,7 +227,7 @@ This helper wires process signals to the standard fluo shutdown lifecycle and he
 | :--- | :--- | :--- | :--- |
 | **Performance** | Good | Excellent | High |
 | **Ecosystem** | Massive | Standard Lib | Large |
-| **Middleware** | Connect-style | Custom | Hook-style |
+| **Middleware** | fluo contract over Express host | Custom | fluo contract over Fastify host |
 | **Footprint** | Moderate | Minimal | Moderate |
 | **Best For** | Legacy Migrations | Micro-services | Standard Apps |
 

--- a/book/intermediate/ch21-express-node.md
+++ b/book/intermediate/ch21-express-node.md
@@ -237,6 +237,6 @@ This helper wires process signals to the standard fluo shutdown lifecycle and he
 - `@fluojs/platform-express` lets you continue using the existing Express ecosystem and operational assets.
 - `@fluojs/platform-nodejs` provides a minimal HTTP layer without a framework.
 - Most fluo code (Controllers, Providers, Modules) does not need to know which adapter is running at all.
-- Inspect the underlying Node server with `getServer?.()` or inspect `getRealtimeCapability()` only when you need platform-specific features.
+- Access the underlying Node server with `getServer?.()` or inspect `getRealtimeCapability()` only when you need platform-specific features.
 - Runtime owns diagnostic snapshot and issue production; Studio owns graph viewing and Mermaid rendering of those artifacts.
 - To maintain cross-platform compatibility, review fluo abstractions first, such as `MiddlewareConsumer`.

--- a/book/intermediate/ch21-express-node.md
+++ b/book/intermediate/ch21-express-node.md
@@ -48,8 +48,8 @@ async function bootstrap() {
 
   const app = await fluoFactory.create(AppModule, { adapter });
   
-  // You can still access the underlying express instance when absolutely necessary.
-  const expressInstance = adapter.getInstance();
+  // You can still inspect the underlying Node server when absolutely necessary.
+  const nativeServer = adapter.getServer?.();
   
   await app.listen();
 }
@@ -61,10 +61,12 @@ bootstrap();
 One of the biggest reasons to choose Express is its proven middleware ecosystem. fluo's Express adapter lets you register that middleware globally or at Module boundaries, so you can migrate existing operational assets without throwing them away.
 
 ```typescript
-// Apply middleware directly to the underlying instance
+// Prefer registering Express-compatible middleware through the fluo bootstrap boundary.
 const adapter = createExpressAdapter();
-const instance = adapter.getInstance();
-instance.use(compression());
+const app = await fluoFactory.create(AppModule, {
+  adapter,
+  middleware: [compression()],
+});
 ```
 
 For long-term portability, however, it is better to register middleware inside the fluo Module system. That keeps the location of platform-specific code clear when you move to another runtime.
@@ -205,13 +207,11 @@ import { AppModule } from './app.module';
 await runExpressApplication(AppModule, {
   port: 3000,
   globalPrefix: 'api',
-  onShutdown: () => {
-    console.log('Cleaning up resources...');
-  }
+  shutdownSignals: ['SIGINT', 'SIGTERM'],
 });
 ```
 
-This helper helps clean up active connections before the process exits. In deployment environments, this shutdown boundary is important for reducing lost logs, interrupted requests, and resource leaks.
+This helper wires process signals to the standard fluo shutdown lifecycle and helps clean up active connections before the host exits. Put application cleanup in lifecycle-aware providers, such as `onApplicationShutdown(signal)`, so the same cleanup path works across platform adapters. In deployment environments, this shutdown boundary is important for reducing lost logs, interrupted requests, and resource leaks.
 
 ## 21.7 Comparison Summary
 
@@ -229,6 +229,6 @@ This helper helps clean up active connections before the process exits. In deplo
 - `@fluojs/platform-express` lets you continue using the existing Express ecosystem and operational assets.
 - `@fluojs/platform-nodejs` provides a minimal HTTP layer without a framework.
 - Most fluo code (Controllers, Providers, Modules) does not need to know which adapter is running at all.
-- Access the underlying Node server with `getServer()` or inspect `getRealtimeCapability()` only when you need platform-specific features.
+- Inspect the underlying Node server with `getServer?.()` or inspect `getRealtimeCapability()` only when you need platform-specific features.
 - Runtime owns diagnostic snapshot and issue production; Studio owns graph viewing and Mermaid rendering of those artifacts.
 - To maintain cross-platform compatibility, review fluo abstractions first, such as `MiddlewareConsumer`.

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -39,7 +39,7 @@ const app = await fluoFactory.create(AppModule, {
 await app.listen();
 ```
 
-`createExpressAdapter()`는 기본 port로 `3000`을 사용하며 `process.env.PORT`를 읽지 않습니다. `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs` 같은 잘못된 explicit numeric option은 adapter setup 중 throw됩니다.
+`createExpressAdapter()`는 기본 port로 `3000`을 사용하며 `process.env.PORT`를 읽지 않습니다. `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs` 같은 잘못된 explicit numeric option은 adapter setup 중 throw됩니다. `maxBodySize`와 `shutdownTimeoutMs`는 음수가 아닌 정수 byte/time limit이므로 `0`도 유효합니다. `maxBodySize: 0`은 빈 request body만 허용하고, `shutdownTimeoutMs: 0`은 shutdown이 timer queue로 양보되는 즉시 connection을 force-close합니다.
 
 ## 주요 패턴
 
@@ -90,7 +90,7 @@ const adapter = createExpressAdapter(
 - **버저닝 parity**: Express Router가 최초 path match를 하더라도 header/media-type/custom version 선택은 계속 dispatcher가 최종 결정합니다.
 - **Middleware rewrite parity**: App middleware가 method/path를 rewrite하면 native handoff는 무효화되고 rewrite된 요청을 기준으로 다시 매칭합니다.
 - **응답 serialization parity**: String response는 기본적으로 `text/plain`, object/array는 JSON, binary payload는 `application/octet-stream`으로 serialize되며 `set-cookie` 값은 병합됩니다.
-- **Startup과 shutdown**: 어댑터는 HTTP/HTTPS startup, retry option에 따른 `EADDRINUSE` 재시도, close 시 socket drain, shutdown timeout 이후 force-close를 지원합니다.
+- **Startup과 shutdown**: 어댑터는 HTTP/HTTPS startup, retry option에 따른 `EADDRINUSE` 재시도, close 시 socket drain, shutdown timeout 이후 force-close를 지원하며, `shutdownTimeoutMs`가 `0`이면 즉시 force-close합니다.
 
 ## 공개 API 개요
 
@@ -101,7 +101,7 @@ const adapter = createExpressAdapter(
 - `ExpressHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 - Option type: `ExpressAdapterOptions`, `BootstrapExpressApplicationOptions`, `RunExpressApplicationOptions`, `CorsInput`, `ExpressApplicationSignal`.
 
-`createExpressAdapter(options, multipartOptions?)`는 `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 지원합니다. `bootstrapExpressApplication(...)`과 `runExpressApplication(...)`은 `cors`, `globalPrefix`, `globalPrefixExclude`, `logger`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`도 받습니다.
+`createExpressAdapter(options, multipartOptions?)`는 `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 지원합니다. `ExpressHttpApplicationAdapter`를 직접 생성하는 경우에도 factory와 같은 numeric validation이 적용됩니다. `bootstrapExpressApplication(...)`과 `runExpressApplication(...)`은 `cors`, `globalPrefix`, `globalPrefixExclude`, `logger`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`도 받습니다.
 
 ## 관련 패키지
 

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -39,7 +39,7 @@ const app = await fluoFactory.create(AppModule, {
 await app.listen();
 ```
 
-`createExpressAdapter()`는 기본 port로 `3000`을 사용하며 `process.env.PORT`를 읽지 않습니다. 잘못된 explicit port 값은 adapter setup 중 throw됩니다.
+`createExpressAdapter()`는 기본 port로 `3000`을 사용하며 `process.env.PORT`를 읽지 않습니다. `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs` 같은 잘못된 explicit numeric option은 adapter setup 중 throw됩니다.
 
 ## 주요 패턴
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -39,7 +39,7 @@ const app = await fluoFactory.create(AppModule, {
 await app.listen();
 ```
 
-`createExpressAdapter()` defaults to port `3000` and does not read `process.env.PORT`; invalid explicit port values throw during adapter setup.
+`createExpressAdapter()` defaults to port `3000` and does not read `process.env.PORT`; invalid explicit numeric options such as `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` throw during adapter setup.
 
 ## Common Patterns
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -39,7 +39,7 @@ const app = await fluoFactory.create(AppModule, {
 await app.listen();
 ```
 
-`createExpressAdapter()` defaults to port `3000` and does not read `process.env.PORT`; invalid explicit numeric options such as `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` throw during adapter setup.
+`createExpressAdapter()` defaults to port `3000` and does not read `process.env.PORT`; invalid explicit numeric options such as `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` throw during adapter setup. `maxBodySize` and `shutdownTimeoutMs` are non-negative integer byte/time limits, so `0` is valid: `maxBodySize: 0` allows only empty request bodies, and `shutdownTimeoutMs: 0` force-closes connections as soon as shutdown yields to the timer queue.
 
 ## Common Patterns
 
@@ -90,7 +90,7 @@ To avoid changing documented fluo semantics, overlapping same-shape param routes
 - **Versioning parity**: Header/media-type/custom version selection remains dispatcher-owned even when Express Router handles the initial path match.
 - **Middleware rewrite parity**: App middleware that rewrites method or path invalidates native handoff and rematches the rewritten request.
 - **Response serialization parity**: String responses default to `text/plain`, objects/arrays serialize as JSON, binary payloads default to `application/octet-stream`, and `set-cookie` values are merged.
-- **Startup and shutdown**: The adapter supports HTTP/HTTPS startup, retries `EADDRINUSE` according to retry options, drains sockets on close, and can force-close connections after shutdown timeout.
+- **Startup and shutdown**: The adapter supports HTTP/HTTPS startup, retries `EADDRINUSE` according to retry options, drains sockets on close, and can force-close connections after shutdown timeout, including immediate force-close when `shutdownTimeoutMs` is `0`.
 
 ## Public API Overview
 
@@ -101,7 +101,7 @@ To avoid changing documented fluo semantics, overlapping same-shape param routes
 - `ExpressHttpApplicationAdapter`: The core adapter implementation class.
 - Option types: `ExpressAdapterOptions`, `BootstrapExpressApplicationOptions`, `RunExpressApplicationOptions`, `CorsInput`, `ExpressApplicationSignal`.
 
-`createExpressAdapter(options, multipartOptions?)` supports `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs`. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` also accept `cors`, `globalPrefix`, `globalPrefixExclude`, `logger`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, and `shutdownSignals`.
+`createExpressAdapter(options, multipartOptions?)` supports `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs`. Direct `ExpressHttpApplicationAdapter` construction applies the same numeric validation as the factory. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` also accept `cors`, `globalPrefix`, `globalPrefixExclude`, `logger`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, and `shutdownSignals`.
 
 ## Related Packages
 

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -261,10 +261,18 @@ describe('@fluojs/platform-express', () => {
   });
 
   it('rejects invalid explicit numeric adapter options during setup', () => {
-    expect(() => createExpressAdapter({ maxBodySize: 0 })).toThrow(/maxBodySize/i);
+    expect(() => createExpressAdapter({ maxBodySize: -1 })).toThrow(/maxBodySize/i);
     expect(() => createExpressAdapter({ retryDelayMs: -1 })).toThrow(/retryDelayMs/i);
     expect(() => createExpressAdapter({ retryLimit: 1.5 })).toThrow(/retryLimit/i);
     expect(() => createExpressAdapter({ shutdownTimeoutMs: Number.NaN })).toThrow(/shutdownTimeoutMs/i);
+  });
+
+  it('rejects invalid numeric options through the public adapter constructor', () => {
+    expect(() => new ExpressHttpApplicationAdapter(-1, undefined, 150, 20, undefined)).toThrow(/PORT/i);
+    expect(() => new ExpressHttpApplicationAdapter(3000, undefined, -1, 20, undefined)).toThrow(/retryDelayMs/i);
+    expect(() => new ExpressHttpApplicationAdapter(3000, undefined, 150, 1.5, undefined)).toThrow(/retryLimit/i);
+    expect(() => new ExpressHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, -1)).toThrow(/maxBodySize/i);
+    expect(() => new ExpressHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, Number.NaN)).toThrow(/shutdownTimeoutMs/i);
   });
 
   it('preserves response parity for simple JSON and non-fast-path responses', async () => {
@@ -840,6 +848,54 @@ describe('@fluojs/platform-express', () => {
         error: {
           code: 'PAYLOAD_TOO_LARGE',
           message: 'Request body exceeds the size limit.',
+        },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('treats maxBodySize zero as a valid zero-byte body limit', async () => {
+    @Controller('/zero-body-limit')
+    class ZeroBodyLimitController {
+      @Post('/')
+      echo(_input: undefined, context: RequestContext) {
+        return { body: context.request.body ?? null };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [ZeroBodyLimitController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapExpressApplication(AppModule, {
+      cors: false,
+      maxBodySize: 0,
+      port,
+    });
+
+    await app.listen();
+
+    try {
+      const emptyResponse = await fetch(`http://127.0.0.1:${String(port)}/zero-body-limit`, {
+        body: '',
+        headers: { 'content-type': 'text/plain' },
+        method: 'POST',
+      });
+      const overflowResponse = await fetch(`http://127.0.0.1:${String(port)}/zero-body-limit`, {
+        body: '1',
+        headers: { 'content-type': 'text/plain' },
+        method: 'POST',
+      });
+
+      expect(emptyResponse.status).toBe(201);
+      await expect(emptyResponse.json()).resolves.toEqual({ body: null });
+      expect(overflowResponse.status).toBe(413);
+      await expect(overflowResponse.json()).resolves.toMatchObject({
+        error: {
+          code: 'PAYLOAD_TOO_LARGE',
         },
       });
     } finally {
@@ -1743,6 +1799,40 @@ describe('@fluojs/platform-express', () => {
       await closePromise;
 
       expect(closeAllConnections).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('treats shutdownTimeoutMs zero as an immediate force-close timeout', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const adapter = new ExpressHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 0);
+      let closeCallback: ((error?: Error | null) => void) | undefined;
+      const closeAllConnections = vi.fn();
+      const server = {
+        close(callback: (error?: Error | null) => void) {
+          closeCallback = callback;
+          return this;
+        },
+        closeAllConnections,
+        closeIdleConnections: vi.fn(),
+        listening: true,
+      } as unknown as ReturnType<typeof createHttpServer>;
+
+      Reflect.set(adapter, 'server', server);
+      Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
+
+      const closePromise = adapter.close();
+      const closeExpectation = expect(closePromise).rejects.toThrow(/shutdown timeout/i);
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      await closeExpectation;
+      expect(closeAllConnections).toHaveBeenCalledTimes(1);
+
+      closeCallback?.(undefined);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -260,6 +260,13 @@ describe('@fluojs/platform-express', () => {
     });
   });
 
+  it('rejects invalid explicit numeric adapter options during setup', () => {
+    expect(() => createExpressAdapter({ maxBodySize: 0 })).toThrow(/maxBodySize/i);
+    expect(() => createExpressAdapter({ retryDelayMs: -1 })).toThrow(/retryDelayMs/i);
+    expect(() => createExpressAdapter({ retryLimit: 1.5 })).toThrow(/retryLimit/i);
+    expect(() => createExpressAdapter({ shutdownTimeoutMs: Number.NaN })).toThrow(/shutdownTimeoutMs/i);
+  });
+
   it('preserves response parity for simple JSON and non-fast-path responses', async () => {
     @Controller('/responses')
     class ResponsesController {
@@ -1291,6 +1298,11 @@ describe('@fluojs/platform-express', () => {
         },
       });
       expect(lifecycle).toContain('observer:error:native route boom');
+      expect(lifecycle.indexOf('observer:start:GET')).toBeLessThan(lifecycle.indexOf('middleware:before:GET'));
+      expect(lifecycle.indexOf('middleware:before:GET')).toBeLessThan(lifecycle.indexOf('observer:matched:GET:/errors'));
+      expect(lifecycle.indexOf('observer:matched:GET:/errors')).toBeLessThan(lifecycle.indexOf('observer:error:native route boom'));
+      expect(lifecycle.indexOf('observer:error:native route boom')).toBeLessThan(lifecycle.indexOf('observer:finish:GET'));
+      expect(lifecycle).not.toContain('observer:success:object');
 
       const missingResponse = await requestHttp({
         method: 'GET',
@@ -1701,6 +1713,39 @@ describe('@fluojs/platform-express', () => {
     Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
 
     await expect(adapter.close()).rejects.toThrow(/shutdown timeout/i);
+  });
+
+  it('force-closes active connections after the shutdown timeout', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const adapter = new ExpressHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, 20);
+      let closeCallback: ((error?: Error | null) => void) | undefined;
+      const closeAllConnections = vi.fn(() => {
+        closeCallback?.(undefined);
+      });
+      const server = {
+        close(callback: (error?: Error | null) => void) {
+          closeCallback = callback;
+          return this;
+        },
+        closeAllConnections,
+        closeIdleConnections: vi.fn(),
+        listening: true,
+      } as unknown as ReturnType<typeof createHttpServer>;
+
+      Reflect.set(adapter, 'server', server);
+      Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
+
+      const closePromise = adapter.close();
+
+      await vi.advanceTimersByTimeAsync(20);
+      await closePromise;
+
+      expect(closeAllConnections).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('clears the express shutdown timer once close settles', async () => {

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -203,6 +203,11 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
     private readonly preserveRawBody = false,
     private readonly shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
   ) {
+    resolvePort(this.port);
+    resolveNonNegativeIntegerOption('retryDelayMs', this.retryDelayMs, 150);
+    resolveNonNegativeIntegerOption('retryLimit', this.retryLimit, 20);
+    resolveNonNegativeIntegerOption('maxBodySize', this.maxBodySize, DEFAULT_MAX_BODY_SIZE);
+    resolveNonNegativeIntegerOption('shutdownTimeoutMs', this.shutdownTimeoutMs, DEFAULT_SHUTDOWN_TIMEOUT_MS);
     this.app = express();
     this.requestResponseFactory = createExpressRequestResponseFactory(
       this.multipartOptions,
@@ -518,9 +523,9 @@ export function createExpressAdapter(
     resolveNonNegativeIntegerOption('retryLimit', options.retryLimit, 20),
     options.https,
     multipartOptions,
-    resolvePositiveIntegerOption('maxBodySize', options.maxBodySize, DEFAULT_MAX_BODY_SIZE),
+    resolveNonNegativeIntegerOption('maxBodySize', options.maxBodySize, DEFAULT_MAX_BODY_SIZE),
     options.rawBody,
-    resolvePositiveIntegerOption('shutdownTimeoutMs', options.shutdownTimeoutMs, DEFAULT_SHUTDOWN_TIMEOUT_MS),
+    resolveNonNegativeIntegerOption('shutdownTimeoutMs', options.shutdownTimeoutMs, DEFAULT_SHUTDOWN_TIMEOUT_MS),
   );
 }
 
@@ -904,16 +909,6 @@ function resolveNonNegativeIntegerOption(name: string, value: number | undefined
 
   if (!Number.isInteger(resolved) || resolved < 0) {
     throw new Error(`Invalid ${name} value: ${String(resolved)}. Expected a non-negative integer.`);
-  }
-
-  return resolved;
-}
-
-function resolvePositiveIntegerOption(name: string, value: number | undefined, defaultValue: number): number {
-  const resolved = value ?? defaultValue;
-
-  if (!Number.isInteger(resolved) || resolved <= 0) {
-    throw new Error(`Invalid ${name} value: ${String(resolved)}. Expected a positive integer.`);
   }
 
   return resolved;

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -514,13 +514,13 @@ export function createExpressAdapter(
   return new ExpressHttpApplicationAdapter(
     resolvePort(options.port),
     options.host,
-    options.retryDelayMs,
-    options.retryLimit,
+    resolveNonNegativeIntegerOption('retryDelayMs', options.retryDelayMs, 150),
+    resolveNonNegativeIntegerOption('retryLimit', options.retryLimit, 20),
     options.https,
     multipartOptions,
-    options.maxBodySize,
+    resolvePositiveIntegerOption('maxBodySize', options.maxBodySize, DEFAULT_MAX_BODY_SIZE),
     options.rawBody,
-    options.shutdownTimeoutMs,
+    resolvePositiveIntegerOption('shutdownTimeoutMs', options.shutdownTimeoutMs, DEFAULT_SHUTDOWN_TIMEOUT_MS),
   );
 }
 
@@ -897,6 +897,26 @@ function resolvePort(value: number | undefined): number {
   }
 
   return port;
+}
+
+function resolveNonNegativeIntegerOption(name: string, value: number | undefined, defaultValue: number): number {
+  const resolved = value ?? defaultValue;
+
+  if (!Number.isInteger(resolved) || resolved < 0) {
+    throw new Error(`Invalid ${name} value: ${String(resolved)}. Expected a non-negative integer.`);
+  }
+
+  return resolved;
+}
+
+function resolvePositiveIntegerOption(name: string, value: number | undefined, defaultValue: number): number {
+  const resolved = value ?? defaultValue;
+
+  if (!Number.isInteger(resolved) || resolved <= 0) {
+    throw new Error(`Invalid ${name} value: ${String(resolved)}. Expected a positive integer.`);
+  }
+
+  return resolved;
 }
 
 async function listenServer(server: ExpressServer, port: number, host: string | undefined): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #1797

Harden the `@fluojs/platform-express` adapter contract by validating explicit numeric options and aligning the Express book/package documentation with the supported native server and shutdown lifecycle surfaces.

## Changes

- Validate `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` during Express adapter setup.
- Add regression coverage for invalid numeric options, native-route error lifecycle ordering, and shutdown timeout force-close behavior.
- Replace unsupported `getInstance()` / `onShutdown` Express book examples with `getServer?.()`, middleware registration through fluo bootstrap, and lifecycle-provider cleanup guidance.
- Update EN/KO package README numeric-option contract and add a patch changeset for `@fluojs/platform-express`.

## Testing

- `pnpm --filter @fluojs/platform-express... build`
- `pnpm --filter @fluojs/platform-express typecheck`
- `pnpm exec biome lint packages/platform-express/src/adapter.ts packages/platform-express/src/adapter.test.ts`
- `pnpm --filter @fluojs/platform-express test`
- LSP diagnostics clean for `packages/platform-express/src/adapter.ts` and `packages/platform-express/src/adapter.test.ts`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public export shape was added or removed; existing TSDoc remains applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Package README and book EN/KO mirrors were updated together. Runtime contract changes are covered in `packages/platform-express/src/adapter.test.ts`; no platform governance SSOT document changed.