### PR TITLE
Resolve #1796: harden Deno platform contracts

### DIFF
--- a/.changeset/tame-deno-shutdown.md
+++ b/.changeset/tame-deno-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-deno": patch
+---
+
+Preserve Deno adapter graceful shutdown by draining active requests before aborting the serve signal, and document the required Deno websocket binding setup with regression coverage for shutdown and global Deno seams.

--- a/book/intermediate/ch23-deno.ko.md
+++ b/book/intermediate/ch23-deno.ko.md
@@ -87,10 +87,10 @@ console.log(await response.json());
 
 ## 23.4 Native Deno WebSockets
 
-Bun과 마찬가지로 Deno는 `Deno.upgradeWebSocket`을 통한 자체 WebSocket 구현을 제공합니다. fluo는 이를 위한 런타임별 경로를 제공하여 게이트웨이 코드가 플랫폼 업그레이드 세부 사항에 묶이지 않도록 합니다.
+Bun과 마찬가지로 Deno는 `Deno.upgradeWebSocket`을 통한 자체 WebSocket 구현을 제공합니다. fluo는 이를 위한 런타임별 바인딩을 제공하여 게이트웨이 코드가 플랫폼 업그레이드 세부 사항에 묶이지 않도록 합니다. Deno에서 호스팅되는 게이트웨이를 소유한 모듈에 `@fluojs/websockets/deno`의 `DenoWebSocketModule.forRoot()`를 import하세요. Deno HTTP 어댑터는 이 바인딩이 설정된 뒤에만 네이티브 upgrade를 수행합니다.
 
 ```typescript
-// Deno 어댑터가 활성화된 경우 게이트웨이가 자동으로 Deno의 네이티브 업그레이드를 사용합니다.
+// DenoWebSocketModule을 설정하면 게이트웨이가 Deno의 네이티브 업그레이드를 사용합니다.
 import { Module } from '@fluojs/core';
 import { OnMessage, WebSocketGateway } from '@fluojs/websockets';
 import { DenoWebSocketModule } from '@fluojs/websockets/deno';
@@ -101,7 +101,7 @@ export class MyGateway {
   handlePing() {
     return { event: 'pong', data: 'hello from deno' };
   }
-  // fluo가 내부적으로 Deno 네이티브 업그레이드를 처리합니다.
+  // Deno 바인딩이 내부적으로 네이티브 업그레이드를 처리합니다.
 }
 
 @Module({

--- a/book/intermediate/ch23-deno.md
+++ b/book/intermediate/ch23-deno.md
@@ -87,10 +87,10 @@ Alignment with Web standards makes the runtime boundary of fluo apps running on 
 
 ## 23.4 Native Deno WebSockets
 
-Like Bun, Deno provides its own WebSocket implementation through `Deno.upgradeWebSocket`. fluo provides a runtime-specific path for this so gateway code does not become tied to platform upgrade details.
+Like Bun, Deno provides its own WebSocket implementation through `Deno.upgradeWebSocket`. fluo provides a runtime-specific binding for this so gateway code does not become tied to platform upgrade details. Import `DenoWebSocketModule.forRoot()` from `@fluojs/websockets/deno` in the module that owns Deno-hosted gateways; the Deno HTTP adapter only performs native upgrades after that binding is configured.
 
 ```typescript
-// When the Deno adapter is active, gateways automatically use Deno's native upgrade.
+// With DenoWebSocketModule configured, gateways use Deno's native upgrade.
 import { Module } from '@fluojs/core';
 import { OnMessage, WebSocketGateway } from '@fluojs/websockets';
 import { DenoWebSocketModule } from '@fluojs/websockets/deno';
@@ -101,7 +101,7 @@ export class MyGateway {
   handlePing() {
     return { event: 'pong', data: 'hello from deno' };
   }
-  // fluo handles Deno-native upgrades internally.
+  // The Deno binding handles native upgrades internally.
 }
 
 @Module({

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -60,12 +60,21 @@ const response = await adapter.handle(new Request('http://localhost:3000/health'
 ```
 
 ### Deno 네이티브 WebSocket 지원
-어댑터는 `@fluojs/websockets/deno` 바인딩을 통해 Deno의 네이티브 `Deno.upgradeWebSocket`을 지원합니다.
+어댑터는 애플리케이션이 `@fluojs/websockets/deno` 바인딩을 import하고 설정한 뒤에 Deno의 네이티브 `Deno.upgradeWebSocket`을 지원합니다. 해당 바인딩이 없으면 websocket upgrade 요청은 암묵적으로 upgrade되지 않고 일반 HTTP dispatch 경로를 계속 따릅니다.
 
 ```typescript
-// Deno 어댑터가 활성화된 경우 게이트웨이는 자동으로 Deno의 네이티브 업그레이드를 사용합니다.
+import { Module } from '@fluojs/core';
+import { WebSocketGateway } from '@fluojs/websockets';
+import { DenoWebSocketModule } from '@fluojs/websockets/deno';
+
 @WebSocketGateway({ path: '/ws' })
 export class MyGateway {}
+
+@Module({
+  imports: [DenoWebSocketModule.forRoot()],
+  providers: [MyGateway],
+})
+export class RealtimeModule {}
 ```
 
 ## HTTPS와 런타임 이식성
@@ -85,11 +94,11 @@ await runDenoApplication(AppModule, {
 
 `hostname`은 Deno 네이티브 옵션 이름으로 유지됩니다. 공유 HTTP 어댑터 테스트와 교차 런타임 설정 헬퍼를 위해 `host`도 이식성 alias로 허용하며, 둘 다 제공하면 `hostname`이 우선합니다.
 
-Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve`, `upgradeWebSocket` seam, `rawBody`, `maxBodySize`, `multipart`, `shutdownSignals`가 포함됩니다. `runDenoApplication(...)`은 기본적으로 `SIGINT`/`SIGTERM`을 연결하고, `shutdownSignals: false`는 signal registration을 끕니다. Close는 active request drain을 최대 10초 기다립니다. `handle(...)`은 `listen()`이 dispatcher를 bind하기 전에는 JSON `500`, shutdown 진행 중에는 JSON `503`을 반환합니다.
+Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve`, `upgradeWebSocket` seam, `rawBody`, `maxBodySize`, `multipart`, `shutdownSignals`가 포함됩니다. Seam을 주입하지 않으면 어댑터는 listen/upgrade 시점에 `globalThis.Deno.serve`와 `globalThis.Deno.upgradeWebSocket`으로 fallback합니다. `runDenoApplication(...)`은 기본적으로 `SIGINT`/`SIGTERM`을 연결하고, `shutdownSignals: false`는 signal registration을 끕니다. Close는 Deno serve signal을 abort하기 전에 active request drain을 최대 10초 기다립니다. `handle(...)`은 `listen()`이 dispatcher를 bind하기 전에는 JSON `500`, shutdown 진행 중에는 JSON `503`을 반환합니다.
 
 ## Conformance 커버리지
 
-`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, HTTPS startup forwarding, `SIGINT`/`SIGTERM` signal listener 등록과 정리, websocket upgrade binding, listen 전 `500` 처리, shutdown 중 `503` 처리, in-flight request drain, bounded 10초 close timeout을 검증합니다.
+`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, HTTPS startup forwarding, `SIGINT`/`SIGTERM` signal listener 등록과 정리, websocket upgrade binding, global Deno serve/upgrade fallback seam, listen 전 `500` 처리, shutdown 중 `503` 처리, serve-signal abort 전 in-flight request drain, bounded 10초 close timeout을 검증합니다.
 
 공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Deno를 Bun 및 Cloudflare Workers와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트의 README parity assertion은 이 edge-runtime 커버리지 문서가 한국어 mirror와 계속 동기화되도록 확인합니다.
 

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -60,12 +60,21 @@ const response = await adapter.handle(new Request('http://localhost:3000/health'
 ```
 
 ### Deno-Native WebSocket Support
-The adapter supports Deno's native `Deno.upgradeWebSocket` through the `@fluojs/websockets/deno` binding.
+The adapter supports Deno's native `Deno.upgradeWebSocket` after the application imports and configures the `@fluojs/websockets/deno` binding. Without that binding, websocket upgrade requests continue through normal HTTP dispatch instead of being upgraded implicitly.
 
 ```typescript
-// Gateways automatically use Deno's native upgrade when the Deno adapter is active
+import { Module } from '@fluojs/core';
+import { WebSocketGateway } from '@fluojs/websockets';
+import { DenoWebSocketModule } from '@fluojs/websockets/deno';
+
 @WebSocketGateway({ path: '/ws' })
 export class MyGateway {}
+
+@Module({
+  imports: [DenoWebSocketModule.forRoot()],
+  providers: [MyGateway],
+})
+export class RealtimeModule {}
 ```
 
 ## HTTPS and Runtime Portability
@@ -85,11 +94,11 @@ await runDenoApplication(AppModule, {
 
 `hostname` remains the Deno-native option name. The adapter also accepts `host` as a portability alias for shared HTTP adapter tests and cross-runtime configuration helpers; when both are provided, `hostname` wins.
 
-Advanced options include injectable `serve` and `upgradeWebSocket` seams for tests or non-hosted runtimes, `rawBody`, `maxBodySize`, `multipart`, and `shutdownSignals`. `runDenoApplication(...)` wires `SIGINT`/`SIGTERM` by default, `shutdownSignals: false` disables signal registration, and close waits up to 10 seconds for active requests to drain. `handle(...)` returns a JSON `500` before `listen()` binds the dispatcher and a JSON `503` while shutdown is in progress.
+Advanced options include injectable `serve` and `upgradeWebSocket` seams for tests or non-hosted runtimes, `rawBody`, `maxBodySize`, `multipart`, and `shutdownSignals`. When a seam is not injected, the adapter falls back to `globalThis.Deno.serve` and `globalThis.Deno.upgradeWebSocket` at listen/upgrade time. `runDenoApplication(...)` wires `SIGINT`/`SIGTERM` by default, `shutdownSignals: false` disables signal registration, and close waits up to 10 seconds for active requests to drain before aborting the Deno serve signal. `handle(...)` returns a JSON `500` before `listen()` binds the dispatcher and a JSON `503` while shutdown is in progress.
 
 ## Conformance Coverage
 
-`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, HTTPS startup forwarding, `SIGINT`/`SIGTERM` signal listener registration and cleanup, websocket upgrade binding, pre-listen `500` handling, shutdown `503` handling, in-flight request drain, and the bounded 10-second close timeout.
+`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, HTTPS startup forwarding, `SIGINT`/`SIGTERM` signal listener registration and cleanup, websocket upgrade binding, global Deno serve/upgrade fallback seams, pre-listen `500` handling, shutdown `503` handling, in-flight request drain before serve-signal abort, and the bounded 10-second close timeout.
 
 The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Deno beside Bun and Cloudflare Workers for malformed cookie preservation, query decoding, JSON/text raw-body capture, multipart raw-body exclusion, and SSE framing. The README parity assertion in the package test keeps these documented edge-runtime coverage claims synchronized with the Korean mirror.
 

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -14,6 +14,7 @@ import {
   type RequestContext,
 } from '@fluojs/http';
 import { defineModule, type Application, type ApplicationLogger, type ModuleType } from '@fluojs/runtime';
+import { createFetchStyleWebSocketConformanceHarness } from '@fluojs/testing/fetch-style-websocket-conformance';
 import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 
 import {
@@ -249,6 +250,38 @@ function installDenoSignalMock() {
       listeners.get(signal)?.();
     },
     removeSignalListener,
+    restore() {
+      if (originalDeno === undefined) {
+        delete (globalThis as typeof globalThis & { Deno?: unknown }).Deno;
+        return;
+      }
+
+      (globalThis as typeof globalThis & { Deno?: unknown }).Deno = originalDeno;
+    },
+  };
+}
+
+function installDenoRuntimeMock(overrides: Partial<{
+  serve: DenoServeFunction;
+  upgradeWebSocket: DenoUpgradeWebSocketFunction;
+}> = {}) {
+  const originalDeno = (globalThis as typeof globalThis & { Deno?: unknown }).Deno;
+  const server = createServeStub();
+  const upgraded = createUpgradeWebSocketStub();
+
+  (globalThis as typeof globalThis & {
+    Deno?: {
+      serve: DenoServeFunction;
+      upgradeWebSocket: DenoUpgradeWebSocketFunction;
+    };
+  }).Deno = {
+    serve: overrides.serve ?? server.serve,
+    upgradeWebSocket: overrides.upgradeWebSocket ?? upgraded.upgrade,
+  };
+
+  return {
+    server,
+    upgraded,
     restore() {
       if (originalDeno === undefined) {
         delete (globalThis as typeof globalThis & { Deno?: unknown }).Deno;
@@ -623,6 +656,76 @@ describe('@fluojs/platform-deno', () => {
     expect(adapter.getServer()).toBeUndefined();
   });
 
+  it('starts graceful server shutdown before aborting the Deno serve signal', async () => {
+    const shutdownDeferred = createDeferred<void>();
+    const finishedDeferred = createDeferred<void>();
+    let signalAbortedWhenShutdownStarted: boolean | undefined;
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: vi.fn((options) => ({
+        finished: finishedDeferred.promise,
+        shutdown: async () => {
+          signalAbortedWhenShutdownStarted = options.signal?.aborted;
+          shutdownDeferred.resolve();
+        },
+      })),
+    });
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        response.setStatus(204);
+      },
+    });
+
+    const closePromise = adapter.close();
+
+    await shutdownDeferred.promise;
+
+    expect(signalAbortedWhenShutdownStarted).toBe(false);
+
+    finishedDeferred.resolve();
+    await closePromise;
+  });
+
+  it('returns a shutdown 503 while close is draining active requests', async () => {
+    const server = createServeStub();
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: server.serve,
+    });
+    const deferred = createDeferred<void>();
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        await deferred.promise;
+        response.setStatus(200);
+        await response.send({ ok: true });
+      },
+    });
+
+    const activeRequest = server.handler!(new Request('https://runtime.test/drain'));
+    const closePromise = adapter.close();
+
+    await Promise.resolve();
+
+    const shutdownResponse = await adapter.handle(new Request('https://runtime.test/new-request'));
+
+    expect(shutdownResponse.status).toBe(503);
+    await expect(shutdownResponse.json()).resolves.toEqual({
+      error: {
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Server is shutting down.',
+        status: 503,
+      },
+    });
+
+    deferred.resolve();
+    await activeRequest;
+    await closePromise;
+  });
+
   it('keeps the Deno dispatcher until drain settles even when close() times out', async () => {
     vi.useFakeTimers();
 
@@ -717,18 +820,40 @@ describe('@fluojs/platform-deno', () => {
     });
   });
 
-  it('reports supported fetch-style websocket hosting for the official Deno binding seam', () => {
-    const adapter = createDenoAdapter();
+  it('falls back to global Deno.serve when no injectable serve seam is provided', async () => {
+    const deno = installDenoRuntimeMock();
 
-    expect(adapter.getRealtimeCapability()).toEqual({
-      contract: 'raw-websocket-expansion',
-      kind: 'fetch-style',
-      mode: 'request-upgrade',
-      reason:
+    try {
+      const adapter = createDenoAdapter({ port: 4321 });
+
+      await adapter.listen({
+        async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+          response.setStatus(204);
+        },
+      });
+
+      expect(deno.server.serve).toHaveBeenCalledTimes(1);
+      expect(deno.server.options).toMatchObject({
+        hostname: '0.0.0.0',
+        port: 4321,
+      });
+
+      await adapter.close();
+    } finally {
+      deno.restore();
+    }
+  });
+
+  it('reports supported fetch-style websocket hosting for the official Deno binding seam', () => {
+    const harness = createFetchStyleWebSocketConformanceHarness({
+      createAdapter: () => createDenoAdapter(),
+      expectedReason:
         'Deno exposes Deno.upgradeWebSocket(request) request-upgrade hosting. Use @fluojs/websockets/deno for the official raw websocket binding.',
-      support: 'supported',
-      version: 1,
+      expectedSupport: 'supported',
+      name: 'deno',
     });
+
+    expect(() => harness.assertExposesRawWebSocketExpansionContract()).not.toThrow();
   });
 
   it('delegates websocket upgrade requests through a configured Deno websocket binding before HTTP dispatch', async () => {
@@ -764,5 +889,34 @@ describe('@fluojs/platform-deno', () => {
     expect(bindingFetch).toHaveBeenCalledTimes(1);
     expect(upgraded.upgrade).toHaveBeenCalledTimes(1);
     expect(httpResponse?.status).toBe(200);
+  });
+
+  it('falls back to global Deno.upgradeWebSocket for configured websocket bindings', async () => {
+    const deno = installDenoRuntimeMock();
+
+    try {
+      const adapter = createDenoAdapter();
+      const bindingFetch = vi.fn<DenoWebSocketBinding['fetch']>(async (request, host) => host.upgrade(request).response);
+
+      adapter.configureWebSocketBinding({
+        fetch: bindingFetch,
+      });
+
+      await adapter.listen({
+        dispatch: vi.fn(async () => undefined),
+      });
+
+      const response = await deno.server.handler?.(new Request('https://runtime.test/chat', {
+        headers: { upgrade: 'websocket' },
+      }));
+
+      expect(response?.status).toBe(200);
+      expect(bindingFetch).toHaveBeenCalledTimes(1);
+      expect(deno.upgraded.upgrade).toHaveBeenCalledTimes(1);
+
+      await adapter.close();
+    } finally {
+      deno.restore();
+    }
   });
 });

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -688,6 +688,65 @@ describe('@fluojs/platform-deno', () => {
     await closePromise;
   });
 
+  it('aborts the Deno serve signal when graceful shutdown rejects', async () => {
+    const shutdownError = new Error('shutdown failed');
+    let serveSignal: AbortSignal | undefined;
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: vi.fn((options) => {
+        serveSignal = options.signal;
+
+        return {
+          finished: Promise.resolve(),
+          shutdown: vi.fn(async () => {
+            throw shutdownError;
+          }),
+        };
+      }),
+    });
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        response.setStatus(204);
+      },
+    });
+
+    await expect(adapter.close()).rejects.toBe(shutdownError);
+    expect(serveSignal?.aborted).toBe(true);
+    expect(adapter.getServer()).toBeUndefined();
+  });
+
+  it('aborts the Deno serve signal when in-flight drain rejects', async () => {
+    const drainError = new Error('drain failed');
+    let serveSignal: AbortSignal | undefined;
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: vi.fn((options) => {
+        serveSignal = options.signal;
+
+        return {
+          finished: Promise.resolve(),
+          shutdown: vi.fn(async () => {}),
+        };
+      }),
+    });
+
+    await adapter.listen({
+      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+        response.setStatus(204);
+      },
+    });
+    Reflect.set(adapter, 'waitForInFlightRequests', vi.fn(async () => {
+      throw drainError;
+    }));
+
+    await expect(adapter.close()).rejects.toBe(drainError);
+    expect(serveSignal?.aborted).toBe(true);
+    expect(adapter.getServer()).toBeUndefined();
+  });
+
   it('returns a shutdown 503 while close is draining active requests', async () => {
     const server = createServeStub();
     const adapter = new DenoHttpApplicationAdapter({

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -432,9 +432,13 @@ function closeDenoServerWithDrain(
   waitForDrain: () => Promise<void>,
 ): Promise<void> {
   return (async () => {
-    await server.shutdown();
-    await waitForDrain();
-    abortController?.abort();
+    try {
+      await server.shutdown();
+      await waitForDrain();
+    } finally {
+      abortController?.abort();
+    }
+
     await server.finished;
   })();
 }

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -432,9 +432,9 @@ function closeDenoServerWithDrain(
   waitForDrain: () => Promise<void>,
 ): Promise<void> {
   return (async () => {
-    abortController?.abort();
     await server.shutdown();
     await waitForDrain();
+    abortController?.abort();
     await server.finished;
   })();
 }

--- a/packages/platform-deno/vitest.config.ts
+++ b/packages/platform-deno/vitest.config.ts
@@ -9,6 +9,10 @@ export default createFluoVitestWorkspaceConfig(new URL('../../', import.meta.url
         find: '@fluojs/testing/http-adapter-portability',
         replacement: fileURLToPath(new URL('../testing/src/portability/http-adapter-portability.ts', import.meta.url)),
       },
+      {
+        find: '@fluojs/testing/fetch-style-websocket-conformance',
+        replacement: fileURLToPath(new URL('../testing/src/conformance/fetch-style-websocket-conformance.ts', import.meta.url)),
+      },
     ],
   },
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,12 @@ export default mergeConfig(
           find: '@fluojs/testing/http-adapter-portability',
           replacement: fileURLToPath(new URL('./packages/testing/src/portability/http-adapter-portability.ts', import.meta.url)),
         },
+        {
+          find: '@fluojs/testing/fetch-style-websocket-conformance',
+          replacement: fileURLToPath(
+            new URL('./packages/testing/src/conformance/fetch-style-websocket-conformance.ts', import.meta.url),
+          ),
+        },
       ],
     },
     test: {


### PR DESCRIPTION
## Summary

- Deno adapter shutdown now starts graceful `server.shutdown()` before aborting the serve signal so active handlers keep their bounded drain window.
- Deno websocket docs now state that `@fluojs/websockets/deno` / `DenoWebSocketModule.forRoot()` is required before native upgrades are performed.
- Added package-local regression coverage for shutdown `503`, global `Deno.serve`/`Deno.upgradeWebSocket` fallback seams, and fetch-style websocket conformance.

Closes #1796

## Changes

- Reordered `DenoHttpApplicationAdapter` close sequencing to drain active requests before aborting the Deno serve signal.
- Expanded `packages/platform-deno/src/adapter.test.ts` and the Vitest alias config for the websocket conformance harness.
- Updated EN/KO package README and EN/KO book chapter companion docs for the Deno websocket binding contract and shutdown coverage.
- Added a patch changeset for `@fluojs/platform-deno` because the public package shutdown behavior is user-visible.

## Testing

- `pnpm --filter @fluojs/platform-deno... build`
- `pnpm --filter @fluojs/platform-deno typecheck`
- `pnpm --filter @fluojs/platform-deno test`
- `pnpm lint` (passes; Biome reports existing repository warnings outside this change, then `verify:public-export-tsdoc` passes)
- LSP diagnostics clean for changed TypeScript files.

## Public export documentation

- [x] Changed public exports include a source-level summary. (No public export signatures changed.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (No public export signatures changed.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governance docs changed.)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (No platform component conformance claim changed; HTTP/websocket portability claims reference package-local and shared harness tests.)