### PR TITLE
Resolve #1798: harden Fastify portability

### DIFF
--- a/.changeset/fastify-portability-rawbody.md
+++ b/.changeset/fastify-portability-rawbody.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-fastify": patch
+---
+
+Preserve Fastify raw-body portability and body-limit enforcement under the shared HTTP adapter harness.

--- a/book/advanced/ch13-custom-adapter.ko.md
+++ b/book/advanced/ch13-custom-adapter.ko.md
@@ -77,7 +77,7 @@ const fluoRequest: FrameworkRequest = {
 
 ## 13.4 실전: Fastify 어댑터 핵심 로직 분석
 
-`@fluojs/platform-fastify` 패키지는 이 인터페이스를 어떻게 구현할까요? Fastify는 이미 고도로 최적화된 라우팅과 플러그인 시스템을 갖추고 있지만, Fluo 어댑터는 이를 전송 계층으로만 사용합니다.
+`@fluojs/platform-fastify` 패키지는 이 인터페이스를 어떻게 구현할까요? Fastify는 이미 고도로 최적화된 라우팅과 플러그인 시스템을 갖추고 있으며, 실제 프로덕션 어댑터는 Fluo dispatcher의 소유권을 빼앗지 않는 범위에서만 그 시스템을 사용합니다.
 
 ```typescript
 // packages/platform-fastify/src/adapter.ts (개념적 코드)
@@ -85,7 +85,22 @@ export class FastifyAdapter implements HttpApplicationAdapter {
   constructor(private instance = fastify()) {}
 
   async listen(dispatcher: Dispatcher) {
-    // 모든 경로를 Fluo 디스패처로 위임
+    // Fastify router에 안전한 native route를 등록합니다.
+    for (const route of this.describeSafeRoutes(dispatcher)) {
+      this.instance.route({
+        method: route.method,
+        url: route.path,
+        handler: async (req, reply) => {
+          await dispatcher.dispatchNativeRoute?.(
+            { descriptor: route.descriptor, params: req.params },
+            this.mapRequest(req),
+            this.mapResponse(reply)
+          );
+        },
+      });
+    }
+
+    // 매칭되지 않거나 이식성에 민감한 경우를 위해 wildcard fallback을 유지합니다.
     this.instance.all('*', async (req, reply) => {
       await dispatcher.dispatch(
         this.mapRequest(req),
@@ -101,7 +116,9 @@ export class FastifyAdapter implements HttpApplicationAdapter {
 }
 ```
 
-Fastify의 와일드카드 핸들러(`all('*')`)를 사용해 모든 경로의 제어권을 Fluo 디스패처로 넘기는 방식이 전형적인 패턴입니다. Fastify는 네트워크와 플러그인 실행을 담당하고, Fluo는 라우트 해석 이후의 프레임워크 파이프라인을 담당하므로 두 책임이 겹치지 않습니다.
+Fastify는 networking, plugin execution, 그리고 명시적 route에 대한 안전한 path selection을 담당합니다. 하지만 route handoff 이후의 framework pipeline, 즉 middleware, guards, interceptors, observers, body semantics, streaming, errors, 최종 dispatch behavior는 여전히 공유 dispatcher contract 안에서 Fluo가 소유합니다. 어댑터는 매칭되지 않은 path, `@All(...)`, version-sensitive route, 중복 parameter shape, multipart request, duplicate-slash 또는 trailing-slash variant, native registration이 Fluo의 route ordering semantics를 좁힐 수 있는 모든 경우를 위해 `all('*')` fallback을 유지합니다.
+
+이 분리는 `packages/platform-fastify/src/adapter.test.ts`의 공유 `createHttpAdapterPortabilityHarness(...)` 검사로 커버됩니다. 여기에는 malformed cookie, raw-body byte preservation, multipart raw-body exclusion, SSE framing, HTTPS startup, shutdown signal cleanup이 포함됩니다. Fastify의 raw-body pre-parsing hook도 byte를 복사하는 동안 Fastify의 encoded-length accounting을 유지하므로, capture stream 때문에 `maxBodySize` enforcement가 우회되지 않고 adapter가 계속 소유합니다.
 
 ## 13.5 FrameworkResponse와 응답 쓰기 위임
 

--- a/book/advanced/ch13-custom-adapter.md
+++ b/book/advanced/ch13-custom-adapter.md
@@ -77,7 +77,7 @@ The `signal` property must be connected to the platform's request abort signal, 
 
 ## 13.4 In Practice: Analyzing the Core Fastify Adapter Logic
 
-How does the `@fluojs/platform-fastify` package implement this interface? Fastify already has a highly optimized routing and plugin system, but the Fluo adapter uses it only as the transport layer.
+How does the `@fluojs/platform-fastify` package implement this interface? Fastify already has a highly optimized routing and plugin system, and the production adapter now uses that system only where it can do so without taking ownership away from Fluo's dispatcher.
 
 ```typescript
 // packages/platform-fastify/src/adapter.ts (conceptual code)
@@ -85,7 +85,22 @@ export class FastifyAdapter implements HttpApplicationAdapter {
   constructor(private instance = fastify()) {}
 
   async listen(dispatcher: Dispatcher) {
-    // Delegate every route to the Fluo dispatcher
+    // Register safe native routes for Fastify's router.
+    for (const route of this.describeSafeRoutes(dispatcher)) {
+      this.instance.route({
+        method: route.method,
+        url: route.path,
+        handler: async (req, reply) => {
+          await dispatcher.dispatchNativeRoute?.(
+            { descriptor: route.descriptor, params: req.params },
+            this.mapRequest(req),
+            this.mapResponse(reply)
+          );
+        },
+      });
+    }
+
+    // Keep the wildcard fallback for unmatched or portability-sensitive cases.
     this.instance.all('*', async (req, reply) => {
       await dispatcher.dispatch(
         this.mapRequest(req),
@@ -101,7 +116,9 @@ export class FastifyAdapter implements HttpApplicationAdapter {
 }
 ```
 
-Using Fastify's wildcard handler, `all('*')`, to hand control of every route to the Fluo dispatcher is the typical pattern. Fastify owns networking and plugin execution, while Fluo owns the framework pipeline after route handoff, so the two responsibilities do not overlap.
+Fastify owns networking, plugin execution, and safe path selection for explicit routes. Fluo still owns the framework pipeline after route handoff: middleware, guards, interceptors, observers, body semantics, streaming, errors, and final dispatch behavior stay inside the shared dispatcher contract. The adapter keeps `all('*')` as a fallback for unmatched paths, `@All(...)`, version-sensitive routes, duplicate parameter shapes, multipart requests, duplicate-slash or trailing-slash variants, and any case where native registration could narrow Fluo's route ordering semantics.
+
+This split is covered by the shared `createHttpAdapterPortabilityHarness(...)` checks in `packages/platform-fastify/src/adapter.test.ts`, including malformed cookies, raw-body byte preservation, multipart raw-body exclusion, SSE framing, HTTPS startup, and shutdown signal cleanup. Fastify's raw-body pre-parsing hook also keeps Fastify's encoded-length accounting intact while it copies bytes, so `maxBodySize` enforcement remains owned by the adapter instead of being bypassed by the capture stream.
 
 ## 13.5 FrameworkResponse and Delegated Response Writing
 

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -11,6 +11,7 @@ fluo 런타임을 위한 Fastify 기반 HTTP 어댑터 패키지입니다.
 - [빠른 시작](#빠른-시작)
 - [주요 패턴](#주요-패턴)
 - [성능](#성능)
+- [적합성 커버리지](#적합성-커버리지)
 - [공개 API 개요](#공개-api-개요)
 - [트러블슈팅](#트러블슈팅)
 - [관련 패키지](#관련-패키지)
@@ -146,6 +147,12 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 | Fastify 어댑터 | **~58,000** | **2.1ms** |
 
 *표준 `/health` 엔드포인트에서 `wrk`를 사용하여 측정되었습니다.*
+
+## 적합성 커버리지
+
+`packages/platform-fastify/src/adapter.test.ts`는 문서화된 Fastify 어댑터 계약을 위한 package-local regression target입니다. 이 파일은 공유 `createHttpAdapterPortabilityHarness(...)` 검사를 실행하여 malformed cookie 보존, JSON/text raw-body capture, byte-exact raw-body capture, multipart raw-body 제외, multipart total-size 기본값, SSE framing, response stream drain settlement, host 및 HTTPS startup logging, shutdown signal listener cleanup을 확인합니다.
+
+같은 파일은 Fastify 전용 native route registration과 wildcard fallback, duplicate shape route fallback, middleware/guard/interceptor/observer ordering, CORS ownership, global prefix behavior, malformed cookie preservation, response serialization parity, raw-body pre-parsing behavior, multipart limit handling도 함께 다룹니다. startup, routing, adapter portability behavior를 변경할 때는 README 예제 포인터를 이 테스트 파일 및 custom adapter book chapter와 맞추어 유지하세요.
 
 ## 공개 API 개요
 

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -11,6 +11,7 @@ Fastify-backed HTTP adapter for the fluo runtime.
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
 - [Performance](#performance)
+- [Conformance Coverage](#conformance-coverage)
 - [Public API Overview](#public-api-overview)
 - [Troubleshooting](#troubleshooting)
 - [Related Packages](#related-packages)
@@ -146,6 +147,12 @@ fluo's Fastify adapter significantly outperforms the raw Node.js adapter in high
 | Fastify Adapter | **~58,000** | **2.1ms** |
 
 *Measured using `wrk` on a standard `/health` endpoint.*
+
+## Conformance Coverage
+
+`packages/platform-fastify/src/adapter.test.ts` is the package-local regression target for the documented Fastify adapter contract. It runs the shared `createHttpAdapterPortabilityHarness(...)` checks for malformed cookie preservation, JSON/text raw-body capture, byte-exact raw-body capture, multipart raw-body exclusion, multipart total-size defaults, SSE framing, response stream drain settlement, host and HTTPS startup logging, and shutdown signal listener cleanup.
+
+The same file also covers Fastify-specific native route registration with wildcard fallback, duplicate shape route fallback, middleware/guard/interceptor/observer ordering, CORS ownership, global prefix behavior, malformed cookie preservation, response serialization parity, raw-body pre-parsing behavior, and multipart limit handling. Keep README example pointers aligned with that test file and the custom adapter book chapter when changing startup, routing, or adapter portability behavior.
 
 ## Public API Overview
 

--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@fluojs/di": "workspace:^",
+    "@fluojs/testing": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -34,13 +34,16 @@ import {
   type RequestContext,
   type RequestObserver,
 } from '@fluojs/http';
-import { createHealthModule, defineModule, fluoFactory, type ApplicationLogger } from '@fluojs/runtime';
+import { createHealthModule, defineModule, fluoFactory, type Application, type ApplicationLogger } from '@fluojs/runtime';
+import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 
 import {
   bootstrapFastifyApplication,
+  type BootstrapFastifyApplicationOptions,
   createFastifyAdapter,
   FastifyHttpApplicationAdapter,
   isFastifyMultipartTooLargeError,
+  type RunFastifyApplicationOptions,
   runFastifyApplication,
 } from './adapter.js';
 
@@ -193,11 +196,66 @@ fHFvqyh6pXZV7XKcPxCTNuIw2rpw2WqY5/H+lTmUFmSXieFZAAMRueGH8Y5trCHU
 JNCDpGwh8us=
 -----END CERTIFICATE-----`;
 
+const fastifyPortabilityHarness = createHttpAdapterPortabilityHarness<
+  BootstrapFastifyApplicationOptions,
+  RunFastifyApplicationOptions,
+  Application
+>({
+  bootstrap: bootstrapFastifyApplication,
+  name: 'fastify',
+  run: runFastifyApplication,
+});
+
 interface FastifyReplySerializerHost {
   setReplySerializer(serializer: (payload: unknown, statusCode: number) => string): void;
 }
 
 describe('@fluojs/platform-fastify', () => {
+  describe('adapter portability', () => {
+    it('preserves malformed cookie values', async () => {
+      await fastifyPortabilityHarness.assertPreservesMalformedCookieValues();
+    });
+
+    it('preserves raw body for JSON and text requests when enabled', async () => {
+      await fastifyPortabilityHarness.assertPreservesRawBodyForJsonAndText();
+    });
+
+    it('preserves exact raw body bytes for byte-sensitive payloads', async () => {
+      await fastifyPortabilityHarness.assertPreservesExactRawBodyBytesForByteSensitivePayloads();
+    });
+
+    it('does not preserve rawBody for multipart requests', async () => {
+      await fastifyPortabilityHarness.assertExcludesRawBodyForMultipart();
+    });
+
+    it('defaults multipart.maxTotalSize to maxBodySize', async () => {
+      await fastifyPortabilityHarness.assertDefaultsMultipartTotalLimitToMaxBodySize();
+    });
+
+    it('supports SSE streaming', async () => {
+      await fastifyPortabilityHarness.assertSupportsSseStreaming();
+    });
+
+    it('settles stream drain waits when the stream closes first', async () => {
+      await fastifyPortabilityHarness.assertSettlesStreamDrainWaitOnClose();
+    });
+
+    it('reports the configured host in startup logs', async () => {
+      await fastifyPortabilityHarness.assertReportsConfiguredHostInStartupLogs();
+    });
+
+    it('supports https startup and reports the https listen URL', async () => {
+      await fastifyPortabilityHarness.assertReportsHttpsStartupUrl({
+        cert: TEST_TLS_CERTIFICATE,
+        key: TEST_TLS_PRIVATE_KEY,
+      });
+    });
+
+    it('removes registered shutdown signal listeners after close', async () => {
+      await fastifyPortabilityHarness.assertRemovesShutdownSignalListenersAfterClose();
+    });
+  });
+
   it('uses the runtime default port instead of process.env.PORT', async () => {
     const previousPort = process.env.PORT;
     process.env.PORT = '4321';
@@ -571,6 +629,43 @@ describe('@fluojs/platform-fastify', () => {
     });
 
     await app.close();
+  });
+
+  it('keeps maxBodySize enforced while capturing raw body bytes', async () => {
+    @Controller('/webhooks')
+    class WebhookController {
+      @Post('/json')
+      handleJson() {
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [WebhookController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      maxBodySize: 8,
+      port,
+      rawBody: true,
+    });
+
+    await app.listen();
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${String(port)}/webhooks/json`, {
+        body: JSON.stringify({ tooLarge: true }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(413);
+    } finally {
+      await app.close();
+    }
   });
 
   it('preserves raw body as exact bytes for byte-sensitive payloads when enabled', async () => {

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -1159,6 +1159,7 @@ function captureRawBodyPreParsingHook(
           : Buffer.from(String(chunk), 'utf8');
 
       chunks.push(bufferChunk);
+      capture.receivedEncodedLength += bufferChunk.byteLength;
       callback(null, chunk);
     },
     flush(callback) {
@@ -1168,7 +1169,8 @@ function captureRawBodyPreParsingHook(
 
       callback();
     },
-  });
+  }) as Transform & { receivedEncodedLength: number };
+  capture.receivedEncodedLength = 0;
 
   payload.on('error', (error) => {
     capture.destroy(error);

--- a/packages/platform-fastify/vitest.config.ts
+++ b/packages/platform-fastify/vitest.config.ts
@@ -1,6 +1,16 @@
+import { fileURLToPath } from 'node:url';
+
 import { createFluoVitestWorkspaceConfig } from '../../tooling/vitest/src';
 
 export default createFluoVitestWorkspaceConfig(new URL('../../', import.meta.url), {
+  resolve: {
+    alias: [
+      {
+        find: '@fluojs/testing/http-adapter-portability',
+        replacement: fileURLToPath(new URL('../../packages/testing/src/portability/http-adapter-portability.ts', import.meta.url)),
+      },
+    ],
+  },
   test: {
     include: ['src/**/*.test.ts'],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,6 +704,9 @@ importers:
       '@fluojs/di':
         specifier: workspace:^
         version: link:../di
+      '@fluojs/testing':
+        specifier: workspace:^
+        version: link:../testing
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)


### PR DESCRIPTION
## Summary

Closes #1798.

- Harden the Fastify raw-body pre-parsing path so byte capture preserves Fastify encoded-length accounting for `maxBodySize` enforcement.
- Add canonical shared HTTP adapter portability harness coverage for `@fluojs/platform-fastify`.
- Align Fastify package docs and the custom adapter book chapter with native route + wildcard fallback behavior.

## Changes

- Added `createHttpAdapterPortabilityHarness(...)` checks to `packages/platform-fastify/src/adapter.test.ts` for malformed cookies, raw-body byte preservation, multipart exclusion/default limits, SSE, HTTPS/host logging, stream drain settlement, and shutdown listener cleanup.
- Added a Fastify-specific regression test proving `rawBody: true` still returns `413` when `maxBodySize` is exceeded.
- Updated Fastify README EN/KO conformance coverage and advanced book EN/KO Fastify adapter discussion.
- Added a patch changeset for `@fluojs/platform-fastify`.

## Testing

- `pnpm --filter @fluojs/platform-fastify... build`
- `pnpm --dir packages/platform-fastify typecheck`
- `pnpm --dir packages/platform-fastify test`
- LSP diagnostics clean for changed Fastify source/test/config files.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Fastify raw-body capture and body limit ownership are covered by package-local regression tests plus the shared HTTP adapter portability harness.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed platform contract document changed. Package README conformance claims are backed by `createHttpAdapterPortabilityHarness(...)` in `packages/platform-fastify/src/adapter.test.ts`.