### PR TITLE
Resolve #1807: harden Studio graph rendering

### DIFF
--- a/.changeset/curly-buses-tap.md
+++ b/.changeset/curly-buses-tap.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/studio": patch
+---
+
+Harden Studio viewer rendering for diagnostic documentation links, Mermaid labels, and browser graph external dependency semantics.

--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -69,6 +69,7 @@ Studio는 fluo CLI에서 내보낸 JSON 파일을 소비합니다. 런타임은 
 **Diagnostics issues** 섹션을 사용하여 런타임 부트스트랩 과정에서 수집된 이슈들을 확인합니다.
 - 심각도(Error, Warning)별로 필터링합니다.
 - `fixHint`를 통해 문제를 해결하기 위한 구체적인 조치 방법을 확인합니다.
+- `docsUrl`은 절대 `http:` 또는 `https:` URL일 때만 연결된 문서를 열 수 있습니다. 안전하지 않은 scheme과 상대 경로 또는 URL이 아닌 문자열은 클릭할 수 없으며, Studio는 이를 escaped text로 렌더링합니다.
 - `dependsOn`을 통해 어떤 컴포넌트가 실패 지점을 차단하고 있는지 확인합니다.
 
 ### 아키텍처 다이어그램 내보내기

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -69,6 +69,7 @@ Studio consumes JSON exports from the fluo CLI. Runtime produces snapshots, the 
 Use the **Diagnostics issues** section to see issues collected during the runtime bootstrap process.
 - Filter by severity (Error, Warning).
 - Use `fixHint` to get actionable advice on how to resolve the issue.
+- Use `docsUrl` to open linked documentation when it is an absolute `http:` or `https:` URL. Unsafe schemes and relative or non-URL strings are not clickable; Studio renders them as escaped text instead.
 - View `dependsOn` to see which components are blocking the failing one.
 
 ### Exporting Architecture Diagrams

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { runWorkspaceBuildClosure } from '../../../tooling/scripts/run-workspace-build-closure.mjs';
 import { applyFilters, parseStudioPayload, renderMermaid } from './contracts.js';
 import * as studio from './index.js';
+import { renderDiagnosticDocsUrl, renderDiagnostics, renderGraphSvg } from './viewer-rendering.js';
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(packageDir, '..', '..');
@@ -548,6 +549,26 @@ describe('renderMermaid', () => {
     expect(output).toContain('  classDef notReady stroke:#ef4444,stroke-width:2px');
   });
 
+  it('escapes Mermaid label control characters without changing graph edges', () => {
+    const output = renderMermaid({
+      ...snapshotFixture,
+      components: [
+        {
+          ...snapshotFixture.components[0],
+          dependencies: ['cache\\primary'],
+          id: 'api\\gateway\nprimary',
+          kind: 'http "adapter"',
+        },
+      ],
+      diagnostics: [],
+    });
+
+    expect(output).toContain('api\\\\gateway\\nprimary');
+    expect(output).toContain('kind: http \\"adapter\\"');
+    expect(output).toContain('cache\\\\primary');
+    expect(output).not.toContain('api\\gateway\nprimary');
+  });
+
   it('uses distinct external node ids when dependency names sanitize to the same base', () => {
     const output = renderMermaid({
       ...snapshotFixture,
@@ -569,5 +590,54 @@ describe('renderMermaid', () => {
     expect(dotNodeId).not.toBe(dashNodeId);
     expect(output).toContain(`  C1 --> ${dotNodeId}`);
     expect(output).toContain(`  C1 --> ${dashNodeId}`);
+  });
+});
+
+describe('viewer rendering helpers', () => {
+  it('renders only http and https diagnostic docsUrl values as links', () => {
+    expect(renderDiagnosticDocsUrl('https://fluo.dev/docs/runtime')).toContain('href="https://fluo.dev/docs/runtime"');
+    expect(renderDiagnosticDocsUrl('javascript:alert(1)')).toBe('<p><strong>docs:</strong> <span>javascript:alert(1)</span></p>');
+    expect(renderDiagnosticDocsUrl('docs/runtime')).toBe('<p><strong>docs:</strong> <span>docs/runtime</span></p>');
+  });
+
+  it('escapes diagnostic docsUrl text even when no link is rendered', () => {
+    expect(renderDiagnosticDocsUrl('javascript:<script>alert(1)</script>')).toContain('javascript:&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(renderDiagnosticDocsUrl('javascript:<script>alert(1)</script>')).not.toContain('<script>');
+  });
+
+  it('uses sanitized docsUrl rendering inside diagnostic cards', () => {
+    const html = renderDiagnostics({
+      ...snapshotFixture,
+      diagnostics: [
+        {
+          code: 'UNSAFE_DOCS_URL',
+          componentId: 'queue.default',
+          docsUrl: 'javascript:alert(1)',
+          message: 'Invalid docs URL should not be clickable.',
+          severity: 'warning',
+        },
+      ],
+    });
+
+    expect(html).toContain('<span>javascript:alert(1)</span>');
+    expect(html).not.toContain('href="javascript:alert(1)"');
+  });
+
+  it('renders browser graph edges and nodes for external dependencies', () => {
+    const html = renderGraphSvg({
+      ...snapshotFixture,
+      components: [
+        {
+          ...snapshotFixture.components[0],
+          dependencies: ['aws.sqs.orders'],
+          id: 'queue.consumer',
+        },
+      ],
+      diagnostics: [],
+    }, undefined);
+
+    expect(html).toContain('aws.sqs.orders');
+    expect(html).toContain('component-external');
+    expect(html).toContain('class="edge-line"');
   });
 });

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -330,7 +330,12 @@ export function applyFilters(snapshot: PlatformShellSnapshot, filter: FilterStat
 }
 
 function escapeMermaidText(value: string): string {
-  return value.replaceAll('"', '\\"');
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"')
+    .replaceAll('\r\n', '\\n')
+    .replaceAll('\r', '\\n')
+    .replaceAll('\n', '\\n');
 }
 
 function sanitizeMermaidNodeIdSegment(value: string): string {

--- a/packages/studio/src/main.ts
+++ b/packages/studio/src/main.ts
@@ -10,7 +10,12 @@ import {
   type StudioPayload,
 } from './contracts.js';
 
-import type { PlatformDiagnosticIssue, PlatformShellSnapshot, PlatformSnapshot } from '@fluojs/runtime';
+import type { PlatformShellSnapshot, PlatformSnapshot } from '@fluojs/runtime';
+import {
+  escapeHtml,
+  renderDiagnostics,
+  renderGraphSvg,
+} from './viewer-rendering.js';
 
 interface StudioState {
   payload?: StudioPayload;
@@ -49,15 +54,6 @@ const state: StudioState = {
     severities: [],
   },
 };
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#039;');
-}
 
 function downloadTextFile(filename: string, content: string): void {
   const blob = new Blob([content], { type: 'application/json' });
@@ -138,75 +134,6 @@ function computeFilteredSnapshot(): void {
   state.selectedComponentId = selected?.id;
 }
 
-function renderGraphSvg(snapshot: PlatformShellSnapshot, selectedComponentId: string | undefined): string {
-  const width = 900;
-  const height = 460;
-  const radius = Math.min(width, height) / 2 - 70;
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const components = snapshot.components;
-  const positions = new Map<string, { x: number; y: number }>();
-
-  components.forEach((component: PlatformSnapshot, index: number) => {
-    const angle = (Math.PI * 2 * index) / Math.max(components.length, 1);
-    positions.set(component.id, {
-      x: centerX + radius * Math.cos(angle),
-      y: centerY + radius * Math.sin(angle),
-    });
-  });
-
-  const edgeLines = components
-    .flatMap((component: PlatformSnapshot) =>
-      component.dependencies.map((dependency: string) => {
-        const from = positions.get(component.id);
-        const to = positions.get(dependency);
-        if (!from || !to) {
-          return '';
-        }
-
-        return `<line x1="${from.x}" y1="${from.y}" x2="${to.x}" y2="${to.y}" class="edge-line" marker-end="url(#arrow)" />`;
-      }))
-    .join('');
-
-  const nodeCircles = components
-    .map((component: PlatformSnapshot) => {
-      const point = positions.get(component.id);
-      if (!point) {
-        return '';
-      }
-
-      const readinessClass = component.readiness.status === 'not-ready'
-        ? 'component-not-ready'
-        : component.readiness.status === 'degraded'
-        ? 'component-degraded'
-        : 'component-ready';
-
-      const classes = [
-        'module-node',
-        readinessClass,
-        component.id === selectedComponentId ? 'module-selected' : '',
-      ]
-        .filter(Boolean)
-        .join(' ');
-
-      return `<g>
-  <circle cx="${point.x}" cy="${point.y}" r="34" class="${classes}" data-component="${escapeHtml(component.id)}" />
-  <text x="${point.x}" y="${point.y + 4}" text-anchor="middle" class="module-label">${escapeHtml(component.id)}</text>
-</g>`;
-    })
-    .join('');
-
-  return `<svg viewBox="0 0 ${width} ${height}" role="img" aria-label="Platform component dependency graph">
-  <defs>
-    <marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" class="edge-arrow" />
-    </marker>
-  </defs>
-  ${edgeLines}
-  ${nodeCircles}
-</svg>`;
-}
-
 function renderDetails(component: PlatformSnapshot | undefined): string {
   if (!component) {
     return '<p class="muted">No component selected.</p>';
@@ -274,36 +201,6 @@ function renderSnapshotSummary(snapshot: PlatformShellSnapshot | undefined): str
       <span class="chip">ready/degraded/not-ready: ${counts.ready}/${counts.degraded}/${counts.notReady}</span>
     </div>
   `;
-}
-
-function renderDiagnostics(snapshot: PlatformShellSnapshot | undefined): string {
-  if (!snapshot) {
-    return '<p class="muted">No platform snapshot loaded.</p>';
-  }
-
-  if (snapshot.diagnostics.length === 0) {
-    return '<p class="muted">No diagnostics issues.</p>';
-  }
-
-  return `<div class="diagnostics-list">
-    ${snapshot.diagnostics
-      .map((issue: PlatformDiagnosticIssue) => {
-        const dependsOn = issue.dependsOn && issue.dependsOn.length > 0
-          ? `<div class="chips">${issue.dependsOn.map((dependency: string) => `<span class="chip">dependsOn: ${escapeHtml(dependency)}</span>`).join('')}</div>`
-          : '';
-
-        return `<article class="card issue severity-${escapeHtml(issue.severity)}">
-          <h3>${escapeHtml(issue.code)}</h3>
-          <p><strong>severity:</strong> ${escapeHtml(issue.severity)} · <strong>component:</strong> ${escapeHtml(issue.componentId)}</p>
-          <p>${escapeHtml(issue.message)}</p>
-          ${issue.cause ? `<p><strong>cause:</strong> ${escapeHtml(issue.cause)}</p>` : ''}
-          ${issue.fixHint ? `<p><strong>fix hint:</strong> ${escapeHtml(issue.fixHint)}</p>` : ''}
-          ${issue.docsUrl ? `<p><strong>docs:</strong> <a href="${escapeHtml(issue.docsUrl)}" target="_blank" rel="noreferrer">${escapeHtml(issue.docsUrl)}</a></p>` : ''}
-          ${dependsOn}
-        </article>`;
-      })
-      .join('')}
-  </div>`;
 }
 
 function renderApp(options: RenderAppOptions | string = {}): void {

--- a/packages/studio/src/styles.css
+++ b/packages/studio/src/styles.css
@@ -175,6 +175,11 @@ pre {
   fill: #7f1d1d;
 }
 
+.component-external {
+  fill: #312e81;
+  cursor: default;
+}
+
 .module-selected {
   stroke: #f59e0b;
   stroke-width: 3;

--- a/packages/studio/src/viewer-rendering.ts
+++ b/packages/studio/src/viewer-rendering.ts
@@ -1,0 +1,205 @@
+import type { PlatformDiagnosticIssue, PlatformShellSnapshot, PlatformSnapshot } from '@fluojs/runtime';
+
+/**
+ * Escapes caller-provided text before inserting it into Studio-owned HTML templates.
+ *
+ * @param value - Raw text to render in an HTML text or attribute context.
+ * @returns The escaped HTML text.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function safeDiagnosticDocsHref(docsUrl: string): string | undefined {
+  try {
+    const parsed = new URL(docsUrl);
+
+    if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+      return parsed.href;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Renders a diagnostic documentation URL without turning unsafe schemes into clickable links.
+ *
+ * @param docsUrl - Diagnostic documentation URL from a loaded platform snapshot.
+ * @returns HTML for the docs field, using a link only for `http:` and `https:` URLs.
+ */
+export function renderDiagnosticDocsUrl(docsUrl: string): string {
+  const safeHref = safeDiagnosticDocsHref(docsUrl);
+  const label = escapeHtml(docsUrl);
+
+  if (!safeHref) {
+    return `<p><strong>docs:</strong> <span>${label}</span></p>`;
+  }
+
+  return `<p><strong>docs:</strong> <a href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer">${label}</a></p>`;
+}
+
+function collectExternalDependencies(components: PlatformSnapshot[]): string[] {
+  const componentIds = new Set(components.map((component) => component.id));
+  const externalDependencies: string[] = [];
+  const seen = new Set<string>();
+
+  for (const component of components) {
+    for (const dependency of component.dependencies) {
+      if (componentIds.has(dependency) || seen.has(dependency)) {
+        continue;
+      }
+
+      seen.add(dependency);
+      externalDependencies.push(dependency);
+    }
+  }
+
+  return externalDependencies;
+}
+
+function resolveNodePositions(snapshot: PlatformShellSnapshot, width: number, height: number): Map<string, { x: number; y: number }> {
+  const radius = Math.min(width, height) / 2 - 70;
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const positions = new Map<string, { x: number; y: number }>();
+  const externalDependencies = collectExternalDependencies(snapshot.components);
+  const nodeIds = [
+    ...snapshot.components.map((component) => component.id),
+    ...externalDependencies,
+  ];
+
+  nodeIds.forEach((id, index) => {
+    const angle = (Math.PI * 2 * index) / Math.max(nodeIds.length, 1);
+    positions.set(id, {
+      x: centerX + radius * Math.cos(angle),
+      y: centerY + radius * Math.sin(angle),
+    });
+  });
+
+  return positions;
+}
+
+/**
+ * Renders Studio's browser graph SVG with the same internal and external dependency semantics as Mermaid output.
+ *
+ * @param snapshot - Filtered platform snapshot currently shown in the viewer.
+ * @param selectedComponentId - Optional selected component id to highlight.
+ * @returns SVG markup for the browser graph panel.
+ */
+export function renderGraphSvg(snapshot: PlatformShellSnapshot, selectedComponentId: string | undefined): string {
+  const width = 900;
+  const height = 460;
+  const components = snapshot.components;
+  const positions = resolveNodePositions(snapshot, width, height);
+  const externalDependencies = collectExternalDependencies(components);
+
+  const edgeLines = components
+    .flatMap((component: PlatformSnapshot) =>
+      component.dependencies.map((dependency: string) => {
+        const from = positions.get(component.id);
+        const to = positions.get(dependency);
+        if (!from || !to) {
+          return '';
+        }
+
+        return `<line x1="${from.x}" y1="${from.y}" x2="${to.x}" y2="${to.y}" class="edge-line" marker-end="url(#arrow)" />`;
+      }))
+    .join('');
+
+  const componentNodes = components
+    .map((component: PlatformSnapshot) => {
+      const point = positions.get(component.id);
+      if (!point) {
+        return '';
+      }
+
+      const readinessClass = component.readiness.status === 'not-ready'
+        ? 'component-not-ready'
+        : component.readiness.status === 'degraded'
+        ? 'component-degraded'
+        : 'component-ready';
+
+      const classes = [
+        'module-node',
+        readinessClass,
+        component.id === selectedComponentId ? 'module-selected' : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+      return `<g>
+  <circle cx="${point.x}" cy="${point.y}" r="34" class="${classes}" data-component="${escapeHtml(component.id)}" />
+  <text x="${point.x}" y="${point.y + 4}" text-anchor="middle" class="module-label">${escapeHtml(component.id)}</text>
+</g>`;
+    })
+    .join('');
+
+  const externalNodes = externalDependencies
+    .map((dependency) => {
+      const point = positions.get(dependency);
+      if (!point) {
+        return '';
+      }
+
+      return `<g>
+  <rect x="${point.x - 42}" y="${point.y - 20}" width="84" height="40" rx="10" class="module-node component-external" />
+  <text x="${point.x}" y="${point.y + 4}" text-anchor="middle" class="module-label">${escapeHtml(dependency)}</text>
+</g>`;
+    })
+    .join('');
+
+  return `<svg viewBox="0 0 ${width} ${height}" role="img" aria-label="Platform component dependency graph">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" class="edge-arrow" />
+    </marker>
+  </defs>
+  ${edgeLines}
+  ${componentNodes}
+  ${externalNodes}
+</svg>`;
+}
+
+/**
+ * Renders diagnostic issue cards for the Studio browser viewer.
+ *
+ * @param snapshot - Loaded platform snapshot, if one is available.
+ * @returns HTML markup for the diagnostics section.
+ */
+export function renderDiagnostics(snapshot: PlatformShellSnapshot | undefined): string {
+  if (!snapshot) {
+    return '<p class="muted">No platform snapshot loaded.</p>';
+  }
+
+  if (snapshot.diagnostics.length === 0) {
+    return '<p class="muted">No diagnostics issues.</p>';
+  }
+
+  return `<div class="diagnostics-list">
+    ${snapshot.diagnostics
+      .map((issue: PlatformDiagnosticIssue) => {
+        const dependsOn = issue.dependsOn && issue.dependsOn.length > 0
+          ? `<div class="chips">${issue.dependsOn.map((dependency: string) => `<span class="chip">dependsOn: ${escapeHtml(dependency)}</span>`).join('')}</div>`
+          : '';
+
+        return `<article class="card issue severity-${escapeHtml(issue.severity)}">
+          <h3>${escapeHtml(issue.code)}</h3>
+          <p><strong>severity:</strong> ${escapeHtml(issue.severity)} · <strong>component:</strong> ${escapeHtml(issue.componentId)}</p>
+          <p>${escapeHtml(issue.message)}</p>
+          ${issue.cause ? `<p><strong>cause:</strong> ${escapeHtml(issue.cause)}</p>` : ''}
+          ${issue.fixHint ? `<p><strong>fix hint:</strong> ${escapeHtml(issue.fixHint)}</p>` : ''}
+          ${issue.docsUrl ? renderDiagnosticDocsUrl(issue.docsUrl) : ''}
+          ${dependsOn}
+        </article>`;
+      })
+      .join('')}
+  </div>`;
+}


### PR DESCRIPTION
## Summary

Closes #1807.

Hardens `@fluojs/studio` viewer and rendering contracts found by the package audit: diagnostic docs links are scheme-gated, Mermaid labels escape control characters, and the browser graph now includes external dependency semantics matching Mermaid output.

## Changes

- Added Studio viewer rendering helpers for safe HTML escaping, diagnostic docsUrl link rendering, diagnostics cards, and browser graph SVG output.
- Render only `http:`/`https:` diagnostic `docsUrl` values as clickable links; unsafe or relative strings remain escaped text.
- Escaped Mermaid label backslashes and line breaks in addition to quotes.
- Added browser SVG nodes/edges for external dependencies and styling for external graph nodes.
- Added package-local regression tests and a patch changeset for `@fluojs/studio`.

## Testing

- `lsp_diagnostics` clean for changed TS files.
- `pnpm --dir packages/studio test`
- `pnpm --dir packages/studio typecheck`
- `pnpm exec biome lint packages/studio/src/contracts.ts packages/studio/src/main.ts packages/studio/src/viewer-rendering.ts packages/studio/src/contracts.test.ts packages/studio/src/styles.css .changeset/curly-buses-tap.md`
- `pnpm verify:public-export-tsdoc`
- `pnpm --dir packages/studio build`

Note: full `pnpm lint --changed=origin/main` is not a supported repo script argument and also reports unrelated existing Biome findings outside this PR; changed-file Biome lint and public-export TSDoc checks passed.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.