### PR TITLE
Resolve #1804: harden serialization symbol handling

### DIFF
--- a/.changeset/soft-walls-wave.md
+++ b/.changeset/soft-walls-wave.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/serialization": patch
+---
+
+Prevent decorated class serialization from copying non-enumerable symbol properties while keeping enumerable symbol keys and documented transform examples aligned with the public `unknown` transform callback contract.

--- a/book/beginner/ch07-serialization.ko.md
+++ b/book/beginner/ch07-serialization.ko.md
@@ -70,7 +70,7 @@ export class PublicPostDto {
   published = false;
 
   @Expose()
-  @Transform((value) => value.trim())
+  @Transform((value) => String(value).trim())
   summary = '';
 
   @Exclude()

--- a/book/beginner/ch07-serialization.md
+++ b/book/beginner/ch07-serialization.md
@@ -70,7 +70,7 @@ export class PublicPostDto {
   published = false;
 
   @Expose()
-  @Transform((value) => value.trim())
+  @Transform((value) => String(value).trim())
   summary = '';
 
   @Exclude()

--- a/packages/serialization/README.ko.md
+++ b/packages/serialization/README.ko.md
@@ -37,7 +37,7 @@ class UserEntity {
   id = '';
 
   @Expose()
-  @Transform((value) => value.toUpperCase())
+  @Transform((value) => String(value).toUpperCase())
   username = '';
 
   @Exclude()
@@ -76,7 +76,7 @@ class SecureDto {
 import { Transform } from '@fluojs/serialization';
 
 class ProductDto {
-  @Transform((price) => `$${price.toFixed(2)}`)
+  @Transform((price) => `$${Number(price).toFixed(2)}`)
   price = 0;
 }
 ```

--- a/packages/serialization/README.md
+++ b/packages/serialization/README.md
@@ -37,7 +37,7 @@ class UserEntity {
   id = '';
 
   @Expose()
-  @Transform((value) => value.toUpperCase())
+  @Transform((value) => String(value).toUpperCase())
   username = '';
 
   @Exclude()
@@ -76,7 +76,7 @@ class SecureDto {
 import { Transform } from '@fluojs/serialization';
 
 class ProductDto {
-  @Transform((price) => `$${price.toFixed(2)}`)
+  @Transform((price) => `$${Number(price).toFixed(2)}`)
   price = 0;
 }
 ```

--- a/packages/serialization/src/serialize.test.ts
+++ b/packages/serialization/src/serialize.test.ts
@@ -376,6 +376,37 @@ describe('serialize', () => {
     expect(serialized[token]).toEqual({ nested: true });
   });
 
+  it('does not leak non-enumerable symbol-keyed properties from decorated instances', () => {
+    const publicToken = Symbol('public-token');
+    const internalToken = Symbol('internal-token');
+
+    class TokenView {
+      @Expose()
+      id = 'view-1';
+
+      constructor() {
+        Object.defineProperty(this, publicToken, {
+          configurable: true,
+          enumerable: true,
+          value: 'public',
+          writable: true,
+        });
+        Object.defineProperty(this, internalToken, {
+          configurable: true,
+          enumerable: false,
+          value: 'secret',
+          writable: true,
+        });
+      }
+    }
+
+    const serialized = serialize(new TokenView()) as Record<string | symbol, unknown>;
+
+    expect(serialized.id).toBe('view-1');
+    expect(serialized[publicToken]).toBe('public');
+    expect(serialized[internalToken]).toBeUndefined();
+  });
+
   it('serializes null-prototype records without crashing', () => {
     const input = Object.create(null) as Record<string, unknown>;
     input.id = 'p-1';
@@ -404,7 +435,7 @@ describe('serialize', () => {
 
     expect(Object.keys(serialized)).toEqual(['safe', '__proto__']);
     expect(Object.getPrototypeOf(serialized)).toBe(Object.prototype);
-    expect(Object.prototype.hasOwnProperty.call(serialized, '__proto__')).toBe(true);
+    expect(Object.hasOwn(serialized, '__proto__')).toBe(true);
     expect(serialized.safe).toBe(true);
     expect(serialized.__proto__).toEqual({ polluted: true });
     expect((serialized as { polluted?: boolean }).polluted).toBeUndefined();
@@ -435,7 +466,7 @@ describe('serialize', () => {
 
     expect(Object.keys(serialized)).toEqual(['safe', '__proto__']);
     expect(Object.getPrototypeOf(serialized)).toBe(Object.prototype);
-    expect(Object.prototype.hasOwnProperty.call(serialized, '__proto__')).toBe(true);
+    expect(Object.hasOwn(serialized, '__proto__')).toBe(true);
     expect(serialized.safe).toBe(true);
     expect(serialized.__proto__).toEqual({ polluted: true });
     expect((serialized as { polluted?: boolean }).polluted).toBeUndefined();
@@ -603,7 +634,7 @@ describe('serialize', () => {
 
     expect(Object.keys(serialized)).toEqual(['safe', 'constructor']);
     expect(Object.getPrototypeOf(serialized)).toBe(Object.prototype);
-    expect(Object.prototype.hasOwnProperty.call(serialized, 'constructor')).toBe(true);
+    expect(Object.hasOwn(serialized, 'constructor')).toBe(true);
     expect(serialized.safe).toBe(true);
     expect(serialized.constructor).toEqual({ polluted: true });
     expect((serialized as { polluted?: boolean }).polluted).toBeUndefined();
@@ -634,7 +665,7 @@ describe('serialize', () => {
 
     expect(Object.keys(serialized)).toEqual(['safe', 'prototype']);
     expect(Object.getPrototypeOf(serialized)).toBe(Object.prototype);
-    expect(Object.prototype.hasOwnProperty.call(serialized, 'prototype')).toBe(true);
+    expect(Object.hasOwn(serialized, 'prototype')).toBe(true);
     expect(serialized.safe).toBe(true);
     expect(serialized.prototype).toEqual({ polluted: true });
     expect((serialized as { polluted?: boolean }).polluted).toBeUndefined();

--- a/packages/serialization/src/serialize.ts
+++ b/packages/serialization/src/serialize.ts
@@ -76,6 +76,12 @@ function assignSerializedProperty(
   target[propertyKey] = value;
 }
 
+function getEnumerableOwnSymbolKeys(value: Record<string | symbol, unknown>): symbol[] {
+  return Object.getOwnPropertySymbols(value).filter((key) => (
+    Object.prototype.propertyIsEnumerable.call(value, key)
+  ));
+}
+
 function resolveCandidateKeys(
   value: Record<string | symbol, unknown>,
   fieldMetadata: Map<MetadataPropertyKey, SerializationFieldMetadata>,
@@ -89,7 +95,7 @@ function resolveCandidateKeys(
 
   const keys = new Set<MetadataPropertyKey>([
     ...Object.keys(value),
-    ...Object.getOwnPropertySymbols(value),
+    ...getEnumerableOwnSymbolKeys(value),
   ]);
 
   for (const [propertyKey, metadata] of fieldMetadata) {
@@ -217,7 +223,7 @@ function serializeRecord(
   value: Record<string | symbol, unknown>,
   context: SerializationContext,
 ): Record<string | symbol, unknown> {
-  const symbolKeys = Object.getOwnPropertySymbols(value).filter((key) => Object.prototype.propertyIsEnumerable.call(value, key));
+  const symbolKeys = getEnumerableOwnSymbolKeys(value);
   const keys: Array<string | symbol> = [...Object.keys(value), ...symbolKeys];
 
   return serializeWithTrackedReference<Record<string | symbol, unknown>>(value, context, () => ({}), (serialized) => {


### PR DESCRIPTION
## Summary

Closes #1804

Fixes the `@fluojs/serialization` audit finding by keeping transform examples compatible with the public `unknown` callback input contract and preventing decorated class serialization from copying non-enumerable symbol properties.

## Changes

- Filter class-instance symbol candidates to enumerable own symbols unless a symbol field is explicitly exposed by metadata.
- Add regression coverage for decorated instances with enumerable and non-enumerable symbol keys.
- Update EN/KO package README and beginner book examples to narrow transform callback values before calling string/number methods.
- Add a patch changeset for `@fluojs/serialization` because this is a public behavior fix.

## Testing

- `pnpm --filter @fluojs/serialization... build`
- `pnpm --filter @fluojs/serialization typecheck`
- `pnpm --filter @fluojs/serialization test`
- `pnpm exec biome lint packages/serialization/src/serialize.ts packages/serialization/src/serialize.test.ts`
- `lsp_diagnostics` on `packages/serialization/src/serialize.ts` and `packages/serialization/src/serialize.test.ts`: no diagnostics
- `pnpm lint` was also run; changed public-export TSDoc checks passed, while existing repo-wide Biome warnings remain outside this issue's scope.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The behavior change narrows accidental leakage of non-enumerable symbol properties from decorated instances while preserving documented enumerable symbol serialization for plain objects and normal enumerable DTO fields.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or adapter conformance claims changed.