### PR TITLE
Resolve #1792: harden OpenAPI operation dedupe

### DIFF
--- a/.changeset/openapi-dedupe-precedence.md
+++ b/.changeset/openapi-dedupe-precedence.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/openapi": patch
+---
+
+Deduplicate generated OpenAPI operations by path and method so explicit descriptors consistently take precedence over discovered sources and operation IDs remain unique.

--- a/packages/openapi/README.ko.md
+++ b/packages/openapi/README.ko.md
@@ -69,6 +69,8 @@ await app.listen(3000);
 
 컨트롤러 탐색을 직접 건너뛰고 싶다면 `@fluojs/http`의 `createHandlerMapping(...)`으로 handler descriptor를 만들고 `descriptors`로 전달하세요. `OpenApiModule`은 `@Module({ controllers: [...] })`만으로 핸들러를 자동 추론하지 않습니다.
 
+미리 만든 descriptor와 탐색된 source가 같은 OpenAPI path 및 HTTP method로 해석되면 나중 descriptor가 우선합니다. `OpenApiModule`은 탐색된 `sources`를 먼저, 명시적 `descriptors`를 나중에 합성하므로 명시적 descriptor가 중복 operation을 만들거나 오래된 source metadata를 문서에 남기지 않고 우선합니다.
+
 ## 핵심 기능
 
 ### 자동 명세 생성

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -69,6 +69,8 @@ await app.listen(3000);
 
 If you need to bypass controller discovery, create handler descriptors with `createHandlerMapping(...)` from `@fluojs/http` and pass them through `descriptors`. `OpenApiModule` does not infer handlers from `@Module({ controllers: [...] })` on its own.
 
+When a prebuilt descriptor and a discovered source resolve to the same OpenAPI path and HTTP method, the later descriptor wins. Because `OpenApiModule` composes discovered `sources` first and explicit `descriptors` second, explicit descriptors take precedence without emitting duplicate operations or silently leaving stale source metadata in the generated document.
+
 ## Core Capabilities
 
 ### Automated Specification Generation

--- a/packages/openapi/src/openapi-module.test.ts
+++ b/packages/openapi/src/openapi-module.test.ts
@@ -2031,6 +2031,59 @@ describe('OpenApiModule', () => {
     );
   });
 
+  it('forRoot lets explicit descriptors take precedence over duplicate source operations', async () => {
+    @Controller('/duplicate-openapi')
+    class SourceController {
+      @ApiOperation({ summary: 'source summary' })
+      @Get('/')
+      read() {
+        return { source: true };
+      }
+    }
+
+    @Controller('/duplicate-openapi')
+    class ExplicitController {
+      @ApiOperation({ summary: 'explicit summary' })
+      @Get('/')
+      read() {
+        return { explicit: true };
+      }
+    }
+
+    const openApiModule = OpenApiModule.forRoot({
+      descriptors: createHandlerMapping([{ controllerToken: ExplicitController }]).descriptors,
+      sources: [{ controllerToken: SourceController }],
+      title: 'Duplicate API',
+      version: '1.0.0',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      controllers: [SourceController],
+      imports: [openApiModule],
+    });
+
+    const app = registerAppForCleanup(await bootstrapApplication({ rootModule: AppModule }));
+    const response = createResponse();
+
+    await app.dispatch(createRequest('GET', '/openapi.json'), response);
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        paths: {
+          '/duplicate-openapi': {
+            get: expect.objectContaining({
+              operationId: 'ExplicitController_read_get_duplicate_openapi',
+              summary: 'explicit summary',
+            }),
+          },
+        },
+      }),
+    );
+  });
+
   it('keeps descriptor-only registration bounded to explicit descriptors', async () => {
     @Controller('/documented')
     class DocumentedController {

--- a/packages/openapi/src/schema-builder.test.ts
+++ b/packages/openapi/src/schema-builder.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { IsArray, IsEnum, IsOptional, IsString, MinLength, ValidateNested } from '@fluojs/validation';
 import { Controller, FromBody, Get, HttpCode, Post, Produces, RequestDto, createHandlerMapping } from '@fluojs/http';
 
-import { ApiBearerAuth, ApiBody, ApiExcludeEndpoint, ApiOperation, ApiResponse, ApiSecurity } from './decorators.js';
+import { ApiBearerAuth, ApiBody, ApiExcludeEndpoint, ApiOperation, ApiResponse, ApiSecurity, ApiTag } from './decorators.js';
 import { buildOpenApiDocument } from './schema-builder.js';
 
 describe('buildOpenApiDocument', () => {
@@ -480,6 +480,119 @@ describe('buildOpenApiDocument', () => {
     expect(withoutTransform.info.title).toBe('Health API');
     expect(withTransform.info.title).toBe('Health API (Transformed)');
     expect(withTransform.paths).toEqual(withoutTransform.paths);
+  });
+
+  it('dedupes duplicate path and method descriptors with later descriptor precedence', () => {
+    @Controller('/dedupe')
+    class SourceController {
+      @ApiOperation({ summary: 'source operation' })
+      @Get('/')
+      read() {
+        return { source: true };
+      }
+    }
+
+    @Controller('/dedupe')
+    class ExplicitController {
+      @ApiOperation({ summary: 'explicit operation' })
+      @Get('/')
+      read() {
+        return { explicit: true };
+      }
+    }
+
+    const sourceDescriptors = createHandlerMapping([{ controllerToken: SourceController }]).descriptors;
+    const explicitDescriptors = createHandlerMapping([{ controllerToken: ExplicitController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors: [...sourceDescriptors, ...explicitDescriptors],
+      title: 'Dedupe API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/dedupe']?.get?.summary).toBe('explicit operation');
+    expect(document.paths['/dedupe']?.get?.operationId).toBe('ExplicitController_read_get_dedupe');
+  });
+
+  it('keeps operationIds unique when normalized operation names collide', () => {
+    @ApiTag('Reports')
+    @Controller('/reports-export')
+    class ReportsExportController {
+      @Get('/')
+      list() {
+        return [];
+      }
+    }
+
+    @ApiTag('Reports')
+    @Controller('/reports_export')
+    class ReportsUnderscoreController {
+      @Get('/')
+      list() {
+        return [];
+      }
+    }
+
+    const descriptors = createHandlerMapping([
+      { controllerToken: ReportsExportController },
+      { controllerToken: ReportsUnderscoreController },
+    ]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Operation ID API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/reports-export']?.get?.operationId).toBe('Reports_list_get_reports_export');
+    expect(document.paths['/reports_export']?.get?.operationId).toBe('Reports_list_get_reports_export_2');
+  });
+
+  it('preserves explicit multipart request-body content', () => {
+    @Controller('/uploads')
+    class UploadsController {
+      @ApiBody({
+        content: {
+          'multipart/form-data': {
+            schema: {
+              properties: {
+                file: { format: 'binary', type: 'string' },
+              },
+              required: ['file'],
+              type: 'object',
+            },
+          },
+        },
+        required: true,
+      })
+      @Post('/')
+      upload() {
+        return { ok: true };
+      }
+    }
+
+    const descriptors = createHandlerMapping([{ controllerToken: UploadsController }]).descriptors;
+    const document = buildOpenApiDocument({
+      defaultErrorResponsesPolicy: 'omit',
+      descriptors,
+      title: 'Multipart API',
+      version: '1.0.0',
+    });
+
+    expect(document.paths['/uploads']?.post?.requestBody).toEqual({
+      content: {
+        'multipart/form-data': {
+          schema: {
+            properties: {
+              file: { format: 'binary', type: 'string' },
+            },
+            required: ['file'],
+            type: 'object',
+          },
+        },
+      },
+      required: true,
+    });
   });
 
   it('emits explicit composition schemas from response and request decorators', () => {

--- a/packages/openapi/src/schema-builder.ts
+++ b/packages/openapi/src/schema-builder.ts
@@ -232,6 +232,38 @@ function normalizeOperationId(descriptor: HandlerDescriptor): string {
   return `${tag}_${descriptor.methodName}_${descriptor.route.method.toLowerCase()}${path}`;
 }
 
+function createOperationDeduplicationKey(descriptor: HandlerDescriptor): string {
+  return `${descriptor.route.method.toLowerCase()}:${expressPathToOpenApi(descriptor.route.path)}`;
+}
+
+function resolveUniqueOperationId(operationId: string, usedOperationIds: Set<string>): string {
+  if (!usedOperationIds.has(operationId)) {
+    usedOperationIds.add(operationId);
+    return operationId;
+  }
+
+  let suffix = 2;
+  let candidate = `${operationId}_${suffix}`;
+
+  while (usedOperationIds.has(candidate)) {
+    suffix += 1;
+    candidate = `${operationId}_${suffix}`;
+  }
+
+  usedOperationIds.add(candidate);
+  return candidate;
+}
+
+function dedupeDescriptorsByOperation(descriptors: readonly HandlerDescriptor[]): HandlerDescriptor[] {
+  const descriptorsByOperation = new Map<string, HandlerDescriptor>();
+
+  for (const descriptor of descriptors) {
+    descriptorsByOperation.set(createOperationDeduplicationKey(descriptor), descriptor);
+  }
+
+  return Array.from(descriptorsByOperation.values());
+}
+
 type DtoBindingEntry = ReturnType<typeof getDtoBindingSchema>[number];
 type DtoValidationEntry = ReturnType<typeof getDtoValidationSchema>[number];
 
@@ -1121,6 +1153,7 @@ function createOperationObject(
   componentSchemas: Record<string, OpenApiSchemaObject>,
   security: OpenApiSecurityRequirementObject[] | undefined,
   context: BuildSchemaContext,
+  usedOperationIds: Set<string>,
 ): OpenApiOperationObject {
   const parameters = mergeOperationParameters(createParameters(descriptor.route.request, context), methodMeta?.parameters);
   const requestBody = mergeOperationRequestBody(
@@ -1129,7 +1162,7 @@ function createOperationObject(
   );
 
   return {
-    operationId: normalizeOperationId(descriptor),
+    operationId: resolveUniqueOperationId(normalizeOperationId(descriptor), usedOperationIds),
     responses,
     tags: resolveControllerTags(descriptor),
     ...(methodMeta?.operation?.summary !== undefined && { summary: methodMeta.operation.summary }),
@@ -1153,6 +1186,7 @@ function buildOperationEntry(
   componentSchemas: Record<string, OpenApiSchemaObject>,
   defaultErrorResponsesPolicy: DefaultErrorResponsesPolicy,
   context: BuildSchemaContext,
+  usedOperationIds: Set<string>,
 ): BuiltOperationEntry | undefined {
   const openApiPath = expressPathToOpenApi(descriptor.route.path);
   const method = descriptor.route.method.toLowerCase() as OpenApiOperationMethod;
@@ -1170,7 +1204,7 @@ function buildOperationEntry(
     context,
   );
   const security = createOperationSecurity(methodMeta);
-  const operation = createOperationObject(descriptor, methodMeta, responses, componentSchemas, security, context);
+  const operation = createOperationObject(descriptor, methodMeta, responses, componentSchemas, security, context, usedOperationIds);
 
   return {
     method,
@@ -1245,15 +1279,17 @@ export function buildOpenApiDocument(options: BuildOpenApiDocumentOptions): Open
     usedSchemaNames: new Set(defaultErrorResponsesPolicy === 'inject' ? ['ErrorResponse'] : []),
   };
   let hasBearerAuth = false;
+  const usedOperationIds = new Set<string>();
 
   registerExtraModels(options.extraModels, componentSchemas, context);
 
-  for (const descriptor of options.descriptors) {
+  for (const descriptor of dedupeDescriptorsByOperation(options.descriptors)) {
     const entry = buildOperationEntry(
       descriptor,
       componentSchemas,
       defaultErrorResponsesPolicy,
       context,
+      usedOperationIds,
     );
 
     if (!entry) {


### PR DESCRIPTION
## Summary

Closes #1792

Fixes OpenAPI document generation so duplicate path+method descriptors are deduplicated deterministically instead of silently overwriting operations during path assembly.

## Changes

- Deduplicate generated operations by OpenAPI path and HTTP method with later descriptor precedence.
- Preserve explicit descriptor precedence over discovered `sources` in `OpenApiModule` composition.
- Keep generated `operationId` values unique when normalized names collide.
- Add multipart request-body regression coverage and document descriptor precedence in EN/KO package READMEs.
- Add a patch changeset for `@fluojs/openapi`.

## Testing

- `lsp_diagnostics` on changed OpenAPI TS files: no diagnostics found
- `pnpm --filter @fluojs/openapi test`
- `pnpm --filter @fluojs/openapi... build`
- `pnpm --filter @fluojs/openapi typecheck`
- `pnpm lint` (completed with existing repository-wide Biome warnings outside changed OpenAPI files; changed-mode public export TSDoc passed)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Not applicable: no platform contract docs or adapter conformance claims changed.