### PR TITLE
Resolve #1788: cover metrics endpoint middleware failures

### DIFF
--- a/.changeset/metrics-endpoint-middleware-coverage.md
+++ b/.changeset/metrics-endpoint-middleware-coverage.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/metrics": patch
+---
+
+Record metrics endpoint middleware failures in built-in HTTP instrumentation and validate framework-owned HTTP collector label schemas before shared-registry reuse.

--- a/book/beginner/ch19-metrics.ko.md
+++ b/book/beginner/ch19-metrics.ko.md
@@ -225,7 +225,7 @@ MetricsModule.forRoot({
 })
 ```
 
-`endpointMiddleware`는 scrape endpoint에만 적용되는 route-scoped middleware이며 `@fluojs/http`와 같은 class-based middleware 계약을 따릅니다. `handle(context, next)` 메서드에서 예외를 던지거나 반환하거나 `next()`를 `await`하는 middleware constructor를 전달하세요.
+`endpointMiddleware`는 scrape endpoint에만 적용되는 route-scoped middleware이며 `@fluojs/http`와 같은 class-based middleware 계약을 따릅니다. `handle(context, next)` 메서드에서 예외를 던지거나 반환하거나 `next()`를 `await`하는 middleware constructor를 전달하세요. HTTP 계측을 활성화한 경우 endpoint middleware 실패도 내장 HTTP request/error counter에 포함되므로 거부된 scrape 시도는 이후 성공한 scrape의 같은 metrics stream에서 확인할 수 있습니다.
 
 ### 19.6.1 IP Whitelisting
 프로덕션에서 흔히 쓰이는 패턴은 Prometheus 서버의 IP 주소만 `/metrics` 라우트에 접근할 수 있도록 허용하는 것입니다. 이는 모니터링 도구에 복잡한 인증 로직을 요구하지 않으면서도 강력한 보안 계층을 제공합니다. 대부분의 클라우드 제공업체는 보안 그룹이나 방화벽을 통해 네트워크 수준에서 이를 구현할 수 있게 해주지만, Fluo의 미들웨어 시스템은 코드에서도 이를 유연하게 처리할 수 있는 방법을 제공합니다.

--- a/book/beginner/ch19-metrics.md
+++ b/book/beginner/ch19-metrics.md
@@ -225,7 +225,7 @@ MetricsModule.forRoot({
 })
 ```
 
-`endpointMiddleware` is route-scoped middleware for the scrape endpoint and follows the same class-based middleware contract as `@fluojs/http`: pass middleware constructors whose `handle(context, next)` method either throws, returns, or awaits `next()`.
+`endpointMiddleware` is route-scoped middleware for the scrape endpoint and follows the same class-based middleware contract as `@fluojs/http`: pass middleware constructors whose `handle(context, next)` method either throws, returns, or awaits `next()`. If HTTP instrumentation is enabled, endpoint middleware failures are included in the built-in HTTP request and error counters so rejected scrape attempts are visible in the same metrics stream after a later successful scrape.
 
 ### 19.6.1 IP Whitelisting
 A common production pattern is allowing only the Prometheus server IP address to access the `/metrics` route. This provides a strong security layer without requiring complex authentication logic in the monitoring tool. Most cloud providers let you implement this at the network level through security groups or firewalls, but Fluo's Middleware system also gives you a flexible way to handle it in code.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -91,7 +91,7 @@ MetricsModule.forRoot({
 });
 ```
 
-`endpointMiddleware`는 class-based `@fluojs/http` middleware constructor를 받으며 metrics scrape endpoint에만 바인딩됩니다. middleware function이나 global middleware declaration은 이 option의 패키지 계약이 아닙니다.
+`endpointMiddleware`는 class-based `@fluojs/http` middleware constructor를 받으며 metrics scrape endpoint에만 바인딩됩니다. middleware function이나 global middleware declaration은 이 option의 패키지 계약이 아닙니다. HTTP 계측이 활성화된 경우 endpoint middleware가 던진 실패도 내장 HTTP request/error collector에 기록됩니다.
 
 ### Framework metric과 app metric이 하나의 registry를 공유하기
 
@@ -171,7 +171,7 @@ MetricsModule.forRoot({
 - `path`의 기본값은 `'/metrics'`이며, `path: false`로 스크레이프 엔드포인트를 완전히 비활성화할 수 있습니다.
 - scrape response는 active Registry의 Prometheus content type과 Registry contents를 사용합니다.
 - `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`로 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 끌 수 있습니다.
-- `endpointMiddleware`는 class-based route-scoped middleware를 스크레이프 엔드포인트에만 바인딩합니다.
+- `endpointMiddleware`는 class-based route-scoped middleware를 스크레이프 엔드포인트에만 바인딩합니다. HTTP 계측이 활성화된 경우 endpoint middleware 실패는 내장 HTTP collector에 집계됩니다.
 - HTTP 메트릭은 `http: true` 또는 `http` 옵션 객체를 전달한 경우에만 설치되며, 설치된 뒤에는 기본적으로 템플릿 기반 경로 라벨 정규화를 사용합니다.
 - 내장 HTTP collector와 플랫폼 텔레메트리 Gauge는 같은 Registry를 공유하는 모듈 인스턴스 사이에서 framework-owned이고 예상 label schema를 가진 경우에만 재사용되며, 커스텀 애플리케이션 메트릭 이름 충돌은 Prometheus의 중복 이름 실패 동작을 유지합니다.
 - raw path 라벨은 `allowUnsafeRawPathLabelMode: true`를 명시한 bounded internal route에서만 사용해야 합니다.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -91,7 +91,7 @@ MetricsModule.forRoot({
 });
 ```
 
-`endpointMiddleware` accepts class-based `@fluojs/http` middleware constructors and binds them only to the metrics scrape endpoint. Middleware functions or global middleware declarations are not the package contract for this option.
+`endpointMiddleware` accepts class-based `@fluojs/http` middleware constructors and binds them only to the metrics scrape endpoint. Middleware functions or global middleware declarations are not the package contract for this option. When HTTP instrumentation is enabled, failures thrown by endpoint middleware are recorded in the built-in HTTP request and error collectors.
 
 ### Share one registry for framework and app metrics
 
@@ -171,7 +171,7 @@ MetricsModule.forRoot({
 - `path` defaults to `'/metrics'`, and `path: false` disables the scrape endpoint entirely.
 - The scrape response uses the active registry's Prometheus content type and registry contents.
 - `defaultMetrics` defaults to `true`, and `defaultMetrics: false` disables Prometheus default process and Node.js collectors for that registry.
-- `endpointMiddleware` binds class-based route-scoped middleware only to the scrape endpoint.
+- `endpointMiddleware` binds class-based route-scoped middleware only to the scrape endpoint; with HTTP instrumentation enabled, endpoint middleware failures are counted by the built-in HTTP collectors.
 - HTTP metrics are installed only when `http: true` or an `http` options object is provided, and then default to template-normalized path labels.
 - Built-in HTTP collectors and platform telemetry gauges are reused when module instances share one registry only if they are framework-owned and have the expected label schema; custom application metric name collisions keep Prometheus' duplicate-name failure behavior.
 - Raw path labels require `allowUnsafeRawPathLabelMode: true` and should stay limited to bounded internal routes.

--- a/packages/metrics/src/http-metrics-middleware.ts
+++ b/packages/metrics/src/http-metrics-middleware.ts
@@ -190,6 +190,7 @@ function getOrCreateHttpCounter(
       );
     }
 
+    assertHttpMetricLabelSchema(existing, config);
     return existing;
   }
 
@@ -219,6 +220,7 @@ function getOrCreateHttpHistogram(
       );
     }
 
+    assertHttpMetricLabelSchema(existing, config);
     return existing;
   }
 
@@ -229,6 +231,23 @@ function getOrCreateHttpHistogram(
   });
   FRAMEWORK_HTTP_HISTOGRAMS.add(histogram);
   return histogram;
+}
+
+function assertHttpMetricLabelSchema(
+  metric: Counter<string> | Histogram<string>,
+  config: {
+    labelNames: readonly string[];
+    name: string;
+  },
+): void {
+  const registeredLabels = ((metric as (Counter<string> | Histogram<string>) & { labelNames?: string[] }).labelNames ?? []).join(',');
+  const expectedLabels = config.labelNames.join(',');
+
+  if (registeredLabels !== expectedLabels) {
+    throw new Error(
+      `Metric name "${config.name}" is already registered with labels [${registeredLabels}]. Built-in HTTP metrics require labels [${expectedLabels}].`,
+    );
+  }
 }
 
 function normalizePathToTemplate(path: string, params: Readonly<Record<string, string>>): string {

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -115,6 +115,49 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
+  it('records endpoint middleware failures when HTTP instrumentation is enabled', async () => {
+    class MetricsAccessMiddleware {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        if (context.request.headers['x-metrics-token'] !== 'secret-token') {
+          throw new ForbiddenException('Metrics endpoint requires x-metrics-token.');
+        }
+
+        await next();
+      }
+    }
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [
+        MetricsModule.forRoot({
+          defaultMetrics: false,
+          endpointMiddleware: [MetricsAccessMiddleware],
+          http: true,
+        }),
+      ],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const forbiddenResponse = createResponse();
+    await app.dispatch(createRequest('/metrics'), forbiddenResponse);
+    expect(forbiddenResponse.statusCode).toBe(403);
+
+    const metricsResponse = createResponse();
+    await app.dispatch(createRequest('/metrics', { 'x-metrics-token': 'secret-token' }), metricsResponse);
+
+    const metricsText = String(metricsResponse.body);
+
+    expect(metricsResponse.statusCode).toBe(200);
+    expect(metricsText).toContain('http_requests_total{method="GET",path="/metrics",status="403"} 1');
+    expect(metricsText).toContain('http_errors_total{method="GET",path="/metrics",status="403"} 1');
+
+    await app.close();
+  });
+
   it('serves Prometheus text with Node/process metrics', async () => {
     class AppModule {}
 
@@ -436,6 +479,30 @@ describe('MetricsModule', () => {
     expect(metricsText).toContain('fluo_metrics_registry_mode{mode="shared"} 1');
 
     await app.close();
+  });
+
+  it('validates framework-owned HTTP collector label schemas before reuse', () => {
+    const sharedRegistry = new Registry();
+
+    MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-a', registry: sharedRegistry });
+    const requestsCounter = sharedRegistry.getSingleMetric('http_requests_total') as Counter<string> & { labelNames: string[] };
+    requestsCounter.labelNames = ['method'];
+
+    expect(() => MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-b', registry: sharedRegistry })).toThrow(
+      'Metric name "http_requests_total" is already registered with labels [method]. Built-in HTTP metrics require labels [method,path,status].',
+    );
+  });
+
+  it('validates framework-owned HTTP duration histogram label schemas before reuse', () => {
+    const sharedRegistry = new Registry();
+
+    MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-a', registry: sharedRegistry });
+    const durationHistogram = sharedRegistry.getSingleMetric('http_request_duration_seconds') as Histogram<string> & { labelNames: string[] };
+    durationHistogram.labelNames = ['method', 'path'];
+
+    expect(() => MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-b', registry: sharedRegistry })).toThrow(
+      'Metric name "http_request_duration_seconds" is already registered with labels [method,path]. Built-in HTTP metrics require labels [method,path,status].',
+    );
   });
 
   it('reuses framework-owned platform telemetry gauges when module instances share one registry', async () => {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -83,8 +83,8 @@ export class MetricsModule {
       ? (options.endpointMiddleware ?? []).map((middlewareClass) => forRoutes(middlewareClass, metricsPath))
       : [];
     const middleware = [
-      ...endpointMiddleware,
       ...(httpOptions ? [new HttpMetricsMiddleware(registry, httpOptions)] : []),
+      ...endpointMiddleware,
       ...(options.middleware ?? []),
     ];
 


### PR DESCRIPTION
## Summary

Closes #1788

Fixes the `@fluojs/metrics` HTTP instrumentation gap where scrape `endpointMiddleware` failures could happen before the built-in HTTP metrics middleware observed the request.

## Changes

- Run `HttpMetricsMiddleware` before route-scoped metrics endpoint middleware so rejected scrape attempts are counted when `http` instrumentation is enabled.
- Validate framework-owned built-in HTTP collector label schemas before shared-registry reuse, matching the platform telemetry reuse guard.
- Document the endpoint middleware failure coverage in the metrics README EN/KO and beginner metrics chapter EN/KO.
- Add a patch changeset for the public `@fluojs/metrics` behavior fix.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/metrics test`
- `pnpm --filter @fluojs/metrics... build`
- `pnpm --filter @fluojs/metrics typecheck`
- `pnpm lint` (completed; existing repository-wide Biome warnings remain outside this change, public export TSDoc check passed)
- `lsp_diagnostics` on changed source/docs/changeset files: clean

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; existing exported behavior documentation was updated in README/book content.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The behavior is a patch-level coverage fix: endpoint middleware failures are now visible in built-in HTTP metrics when HTTP instrumentation is enabled, and shared-registry collector reuse rejects schema drift.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; EN/KO README and book companion text were kept aligned.