### PR TITLE
Resolve #1784: document GraphQL context portability

### DIFF
--- a/.changeset/graphql-context-portability.md
+++ b/.changeset/graphql-context-portability.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Clarify GraphQL runtime portability boundaries and document resolver-visible context fields, including HTTP principals, custom context values, websocket connection params, and subscription cleanup coverage.

--- a/book/intermediate/ch18-graphql.ko.md
+++ b/book/intermediate/ch18-graphql.ko.md
@@ -23,7 +23,7 @@
 **명시성이 암시성보다 낫다(Explicit Over Implicit)**는 fluo의 철학은 GraphQL의 타입 스키마 모델과 잘 맞습니다. `@fluojs/graphql`을 사용하면 다음과 같은 이점을 얻을 수 있습니다.
 
 - **통합된 DI**: 리졸버는 fluo 컨테이너 안의 최상위 프로바이더로 취급됩니다.
-- **프로토콜 이식성**: 같은 GraphQL API를 Node.js, Bun, Deno, Edge Workers에서 코드 변경 없이 실행할 수 있습니다.
+- **프로토콜 이식성**: HTTP query/mutation과 기본 SSE subscription 경로는 Node.js, Bun, Deno, Edge Workers 전반에서 fluo의 portable HTTP 추상화를 사용합니다. 선택적 WebSocket subscription은 Node HTTP/S upgrade listener를 노출하는 adapter가 필요합니다.
 - **표준 데코레이터**: 레거시 `experimentalDecorators` 플래그에 의존하지 않습니다.
 - **성능**: 런타임 퍼사드(facade)와 직접 통합해 불필요한 오버헤드를 줄입니다.
 
@@ -71,6 +71,8 @@ export class ProductResolver {
 ```
 
 `@Arg(...)`는 resolver input DTO용 필드 데코레이터입니다. GraphQL 인자로 노출할 DTO 필드에 표시한 뒤, operation의 `input` 옵션으로 해당 DTO 클래스를 전달합니다.
+
+Resolver 메서드는 `context: GraphQLContext`도 받을 수 있습니다. 이 context에는 기반 fluo request, HTTP middleware나 guard가 설정한 인증된 `principal`, `GraphqlModule.forRoot({ context })`가 반환한 사용자 정의 필드, 그리고 선택적 WebSocket transport로 들어온 operation의 `connectionParams`/`socket` 값이 포함됩니다.
 
 ### Registering the Module
 

--- a/book/intermediate/ch18-graphql.md
+++ b/book/intermediate/ch18-graphql.md
@@ -23,7 +23,7 @@ This chapter covers how to add a query layer to FluoShop that differs from REST.
 fluo's philosophy of **Explicit Over Implicit** fits well with GraphQL's typed schema model. Using `@fluojs/graphql` gives you these benefits.
 
 - **Unified DI**: Resolvers are treated as top-level Providers inside the fluo container.
-- **Protocol Portability**: The same GraphQL API can run on Node.js, Bun, Deno, and Edge Workers without code changes.
+- **Protocol Portability**: HTTP queries/mutations and the default SSE subscription path use fluo's portable HTTP abstraction across Node.js, Bun, Deno, and Edge Workers; optional WebSocket subscriptions require an adapter that exposes Node HTTP/S upgrade listeners.
 - **Standard Decorators**: It does not depend on the legacy `experimentalDecorators` flag.
 - **Performance**: Direct integration with the runtime facade reduces unnecessary overhead.
 
@@ -71,6 +71,8 @@ export class ProductResolver {
 ```
 
 `@Arg(...)` is a field decorator for resolver input DTOs. Mark the DTO fields you want to expose as GraphQL arguments, then pass that DTO class through the operation's `input` option.
+
+Resolver methods can also receive `context: GraphQLContext`. That context carries the underlying fluo request, any authenticated `principal` set by HTTP middleware or guards, custom fields returned from `GraphqlModule.forRoot({ context })`, and websocket `connectionParams`/`socket` values when the operation arrives through the optional websocket transport.
 
 ### Registering the Module
 

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -107,6 +107,7 @@ class UserResolver {
 - Singleton resolver가 기본값이며, 각 operation에서 애플리케이션 컨테이너를 통해 resolve됩니다.
 - Request-scoped provider를 주입하는 resolver는 resolver 자체에도 `@Scope('request')`를 지정해야 합니다. 이렇게 해야 DI lifetime 규칙이 명시적으로 유지되고 singleton-to-request dependency mismatch를 피할 수 있습니다.
 - `@fluojs/graphql`은 HTTP GraphQL 요청 또는 WebSocket subscription operation마다 operation-scoped DI 컨테이너를 하나 만들고, 해당 operation 안의 resolver 호출들이 이를 공유하며, operation 완료 또는 WebSocket operation 종료 시 dispose합니다.
+- Resolver 메서드는 `GraphQLContext`를 받으며, 내장 필드에는 fluo `request`, middleware 또는 guard가 설정한 인증된 HTTP `principal`, WebSocket subscription의 `connectionParams`와 `socket`, 그리고 `GraphqlModule.forRoot({ context })`가 반환한 사용자 정의 필드가 포함됩니다.
 - Request-scoped DataLoader helper는 같은 `GraphQLContext` operation 경계를 사용하므로 loader cache는 하나의 GraphQL operation 안에서만 공유됩니다.
 
 ```typescript
@@ -136,6 +137,8 @@ class RequestResolver {
 - **HTTP**: 표준 GET/POST 쿼리 및 뮤테이션.
 - **SSE**: Server-Sent Events를 통한 구독(기본값).
 - **WebSockets**: 활성 adapter가 upgrade listener를 지원하는 Node HTTP/S 서버를 노출할 때(예: Node HTTP adapter) 사용할 수 있는 선택적 `graphql-ws` 실시간 구독 지원.
+
+HTTP query/mutation과 기본 SSE subscription 경로는 fluo의 portable HTTP 추상화를 통해 실행됩니다. 선택적 WebSocket transport는 의도적으로 더 좁은 범위를 가집니다. Server-backed Node HTTP/S adapter 표면이 필요하므로 Bun, Deno, Cloudflare Workers 배포에서는 adapter가 호환되는 upgrade listener를 노출하지 않는 한 기본 SSE 경로를 유지해야 합니다.
 
 ```typescript
 GraphqlModule.forRoot({

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -107,6 +107,7 @@ class UserResolver {
 - Singleton resolvers are the default and are resolved from the application container for every operation.
 - Resolvers that inject request-scoped providers must also be marked with `@Scope('request')`; this keeps DI lifetime rules explicit and avoids singleton-to-request dependency mismatches.
 - `@fluojs/graphql` creates one operation-scoped DI container for each HTTP GraphQL request or websocket subscription operation, shares it across resolver calls in that operation, and disposes it when the operation completes or the websocket operation disconnects.
+- Resolver methods receive a `GraphQLContext` whose built-in fields expose the underlying fluo `request`, the authenticated HTTP `principal` when middleware or guards set one, websocket `connectionParams` and `socket` for websocket subscriptions, and any custom fields returned from `GraphqlModule.forRoot({ context })`.
 - Request-scoped DataLoader helpers use the same `GraphQLContext` operation boundary, so loader caches are shared only within one GraphQL operation.
 
 ```typescript
@@ -136,6 +137,8 @@ class RequestResolver {
 - **HTTP**: Standard GET/POST queries and mutations.
 - **SSE**: Subscriptions over Server-Sent Events (default).
 - **WebSockets**: Optional `graphql-ws` support for real-time subscriptions when the active adapter exposes a Node HTTP/S server with upgrade listeners (for example, the Node HTTP adapter).
+
+HTTP queries/mutations and the default SSE subscription path run through fluo's portable HTTP abstraction. The optional websocket transport is intentionally narrower: it requires a server-backed Node HTTP/S adapter surface, so Bun, Deno, and Cloudflare Workers deployments should keep the default SSE path unless their adapter exposes compatible upgrade listeners.
 
 ```typescript
 GraphqlModule.forRoot({

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 
 import { Inject, Scope } from '@fluojs/core';
+import type { MiddlewareContext, Next } from '@fluojs/http';
 import { IsInt, MinLength } from '@fluojs/validation';
 import { defineModule } from '@fluojs/runtime';
 import { bootstrapNodeApplication } from '@fluojs/runtime/node';
@@ -12,7 +13,7 @@ import { GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType } fro
 
 import { Arg, Mutation, Query, Resolver, Subscription } from './decorators.js';
 import { GraphqlModule } from './module.js';
-import { GRAPHQL_OPERATION_CONTAINER, listOf } from './types.js';
+import { GRAPHQL_OPERATION_CONTAINER, type GraphQLContext, listOf } from './types.js';
 
 type GraphqlInstanceOf = (value: unknown, constructor: { prototype?: { [Symbol.toStringTag]?: string } }) => boolean;
 
@@ -43,7 +44,11 @@ async function findAvailablePort(): Promise<number> {
   });
 }
 
-async function postGraphql(port: number, query: string, options?: { operationName?: string }): Promise<unknown> {
+async function postGraphql(
+  port: number,
+  query: string,
+  options?: { headers?: Record<string, string>; operationName?: string },
+): Promise<unknown> {
   const response = await fetch(`http://127.0.0.1:${String(port)}/graphql`, {
     body: JSON.stringify({
       ...(options?.operationName ? { operationName: options.operationName } : {}),
@@ -51,6 +56,7 @@ async function postGraphql(port: number, query: string, options?: { operationNam
     }),
     headers: {
       'content-type': 'application/json',
+      ...(options?.headers ?? {}),
     },
     method: 'POST',
   });
@@ -188,9 +194,9 @@ function onceGraphqlWebSocketMessage(socket: WebSocket): Promise<GraphqlWebSocke
   });
 }
 
-async function connectGraphqlWebSocket(port: number): Promise<WebSocket> {
+async function connectGraphqlWebSocket(port: number, connectionParams?: Record<string, unknown>): Promise<WebSocket> {
   const socket = await openGraphqlWebSocket(port);
-  socket.send(JSON.stringify({ type: 'connection_init' }));
+  socket.send(JSON.stringify({ payload: connectionParams, type: 'connection_init' }));
 
   await expect(onceGraphqlWebSocketMessage(socket)).resolves.toEqual({
     type: 'connection_ack',
@@ -1742,6 +1748,220 @@ describe('@fluojs/graphql — provider scopes', () => {
     firstSocket.close();
     secondSocket.close();
     await Promise.all([onceWebSocketClosed(firstSocket), onceWebSocketClosed(secondSocket)]);
+    await app.close();
+  });
+
+  it('exposes auth and custom context values to HTTP resolvers', async () => {
+    const authMiddleware = {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        context.requestContext.principal = {
+          claims: {
+            tenant: context.request.headers['x-tenant-id'],
+          },
+          issuer: 'test-suite',
+          subject: 'user-1784',
+        };
+        await next();
+      },
+    };
+
+    @Inject()
+    @Resolver('HttpContextResolver')
+    class HttpContextResolver {
+      @Query()
+      contextSnapshot(_input: undefined, context: GraphQLContext): string {
+        return JSON.stringify({
+          principalSubject: context.principal?.subject,
+          requestHeader: context.request.headers['x-tenant-id'],
+          tenantId: context.tenantId,
+        });
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          context: ({ principal, request }) => ({
+            tenantId: principal?.claims.tenant ?? request.headers['x-tenant-id'],
+          }),
+          resolvers: [HttpContextResolver],
+        }),
+      ],
+      providers: [HttpContextResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, middleware: [authMiddleware], port });
+    await app.listen();
+
+    await expect(postGraphql(port, '{ contextSnapshot }', { headers: { 'x-tenant-id': 'tenant-a' } })).resolves.toEqual({
+      data: {
+        contextSnapshot: JSON.stringify({
+          principalSubject: 'user-1784',
+          requestHeader: 'tenant-a',
+          tenantId: 'tenant-a',
+        }),
+      },
+    });
+
+    await app.close();
+  });
+
+  it('exposes websocket connection params, socket, and custom context values to subscription resolvers', async () => {
+    @Inject()
+    @Resolver('WebSocketContextResolver')
+    class WebSocketContextResolver {
+      @Subscription()
+      async *contextSnapshots(_input: undefined, context: GraphQLContext): AsyncGenerator<string, void, void> {
+        yield JSON.stringify({
+          connectionToken: context.connectionParams?.token,
+          customToken: context.connectionToken,
+          hasSocket: Boolean(context.socket),
+          requestPath: context.request.path,
+        });
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          context: ({ connectionParams }) => ({
+            connectionToken: connectionParams?.token,
+          }),
+          resolvers: [WebSocketContextResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+            },
+          },
+        }),
+      ],
+      providers: [WebSocketContextResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+    await app.listen();
+
+    const socket = await connectGraphqlWebSocket(port, { token: 'ws-token-1784' });
+    socket.send(JSON.stringify({
+      id: 'ctx',
+      payload: {
+        query: 'subscription { contextSnapshots }',
+      },
+      type: 'subscribe',
+    }));
+
+    await expect(readGraphqlWebSocketMessages(socket, 2)).resolves.toEqual([
+      {
+        id: 'ctx',
+        payload: {
+          data: {
+            contextSnapshots: JSON.stringify({
+              connectionToken: 'ws-token-1784',
+              customToken: 'ws-token-1784',
+              hasSocket: true,
+              requestPath: '/graphql',
+            }),
+          },
+        },
+        type: 'next',
+      },
+      {
+        id: 'ctx',
+        type: 'complete',
+      },
+    ]);
+
+    socket.close();
+    await onceWebSocketClosed(socket);
+    await app.close();
+  });
+
+  it('disposes request-scoped subscription providers when a websocket operation completes', async () => {
+    const destroyedIds: string[] = [];
+    let destroyedResolve: ((value: string) => void) | undefined;
+    const destroyed = new Promise<string>((resolve) => {
+      destroyedResolve = resolve;
+    });
+
+    @Inject()
+    @Scope('request')
+    class SubscriptionLifecycleProbe {
+      readonly id = 'subscription-probe-1784';
+
+      onDestroy(): void {
+        destroyedIds.push(this.id);
+        destroyedResolve?.(this.id);
+      }
+    }
+
+    @Inject(SubscriptionLifecycleProbe)
+    @Scope('request')
+    @Resolver('SubscriptionTeardownResolver')
+    class SubscriptionTeardownResolver {
+      constructor(private readonly probe: SubscriptionLifecycleProbe) {}
+
+      @Subscription()
+      async *trackedRequestIds(): AsyncGenerator<string, void, void> {
+        yield this.probe.id;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [SubscriptionTeardownResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+            },
+          },
+        }),
+      ],
+      providers: [SubscriptionLifecycleProbe, SubscriptionTeardownResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+    await app.listen();
+
+    const socket = await connectGraphqlWebSocket(port);
+    socket.send(JSON.stringify({
+      id: 'tracked',
+      payload: {
+        query: 'subscription { trackedRequestIds }',
+      },
+      type: 'subscribe',
+    }));
+
+    await expect(readGraphqlWebSocketMessages(socket, 2)).resolves.toEqual([
+      {
+        id: 'tracked',
+        payload: {
+          data: {
+            trackedRequestIds: 'subscription-probe-1784',
+          },
+        },
+        type: 'next',
+      },
+      {
+        id: 'tracked',
+        type: 'complete',
+      },
+    ]);
+
+    await expect(Promise.race([
+      destroyed,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timed out waiting for websocket operation cleanup.')), 250)),
+    ])).resolves.toBe('subscription-probe-1784');
+    expect(destroyedIds).toEqual(['subscription-probe-1784']);
+
+    socket.close();
+    await onceWebSocketClosed(socket);
     await app.close();
   });
 


### PR DESCRIPTION
## Summary

Clarifies @fluojs/graphql runtime portability boundaries and adds resolver-visible context regression coverage for HTTP and websocket operations.

Closes #1784

## Changes

- Documented GraphQLContext fields for authenticated HTTP principals, custom context values, websocket connection params, and sockets in EN/KO package README files.
- Updated the intermediate GraphQL book chapter EN/KO to avoid overstating websocket portability across non-Node runtimes.
- Added package regression tests for HTTP auth/custom context visibility, websocket connection params/custom context visibility, and websocket subscription request-scope disposal.
- Added a patch changeset for the public @fluojs/graphql documentation/contract clarification.

## Testing

- lsp_diagnostics: no errors for packages/graphql/src/module.test.ts
- pnpm --filter @fluojs/graphql test
- pnpm --filter @fluojs/graphql... build
- pnpm --filter @fluojs/graphql typecheck
- pnpm lint (completed; repository-wide pre-existing Biome warnings remain in unrelated packages/config, packages/core, packages/cqrs files; public export TSDoc changed-mode passed)

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs changed; GraphQL websocket portability is documented as adapter-limited while HTTP/SSE remains on the portable HTTP abstraction.