### PR TITLE
Resolve #1786: fix i18n Accept-Language case matching

### DIFF
--- a/.changeset/i18n-accept-language-case.md
+++ b/.changeset/i18n-accept-language-case.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/i18n": patch
+---
+
+Match `Accept-Language` locale ranges case-insensitively while preserving the configured supported locale spelling in HTTP and non-HTTP locale resolvers.

--- a/packages/i18n/README.ko.md
+++ b/packages/i18n/README.ko.md
@@ -199,7 +199,7 @@ Adapter는 의도적으로 explicit합니다:
 - `setHttpLocale(ctx, locale, metadata)`는 `createContextKey(...)`를 사용해 현재 `RequestContext`에 locale metadata를 저장합니다.
 - `getHttpLocale(ctx)`는 global fallback 없이 metadata를 읽습니다.
 - `parseAcceptLanguage(header)`는 q-value 순서로 valid `Accept-Language` range를 parse하고 invalid 또는 q=0 entry를 무시합니다.
-- `createAcceptLanguageLocaleResolver(...)`는 request header에서 첫 번째 supported locale을 선택합니다.
+- `createAcceptLanguageLocaleResolver(...)`는 request header에서 첫 번째 supported locale을 선택하고, language range를 case-insensitive로 match하며, match되면 configured `supportedLocales` spelling을 반환합니다.
 - `createAcceptLanguageLocalePolicyResolver(...)`는 opt-in이며, `en-US` 같은 regional range를 supported `en`으로 normalize하거나 explicit supported range를 모두 확인한 뒤 wildcard fallback을 선택할 수 있습니다.
 - `resolveHttpLocale(ctx, options)`는 application-provided resolver를 배열 순서대로 실행하고 invalid 또는 unsupported resolver output을 무시하며, 아무 resolver도 match하지 않으면 `defaultLocale`을 source `default`로 저장합니다.
 
@@ -264,7 +264,7 @@ Generic adapter contract는 의도적으로 explicit합니다.
 - `resolveLocale(context, options)`는 application-provided resolver를 배열 순서대로 실행하고 empty, invalid, unsupported resolver output을 무시하며, 아무 것도 match하지 않으면 `defaultLocale`을 source `default`로 반환합니다.
 - `bindLocale(context, { store, ...options })`는 locale을 resolve한 뒤 application-provided `LocaleAdapterStore`에 immutable metadata를 저장합니다.
 - `createWeakMapLocaleStore()`는 socket, call, session, request object를 mutate하지 않고 per-object metadata storage를 제공합니다.
-- `createHeaderLocaleResolver(...)`는 HTTP adapter와 같은 q-value 및 wildcard 동작으로 `Accept-Language` style 값을 parse합니다.
+- `createHeaderLocaleResolver(...)`는 HTTP adapter와 같은 q-value, wildcard 동작, case-insensitive matching, supported-locale spelling preservation으로 `Accept-Language` style 값을 parse합니다.
 - `createHeaderLocalePolicyResolver(...)`는 HTTP type을 import하지 않고 동일한 opt-in regional-locale normalization 및 wildcard fallback policy를 제공합니다.
 - `createQueryLocaleResolver(...)`, `createCookieLocaleResolver(...)`, `createStorageLocaleResolver(...)`는 caller-owned abstraction에서 locale candidate를 읽고 browser global이나 framework internal에는 접근하지 않습니다.
 
@@ -420,7 +420,7 @@ typedI18n.translateInNamespace('admin/common', 'dashboard.title', { locale: 'en'
 | Export | 설명 |
 |---|---|
 | `I18nModule` | DI 등록을 위한 모듈입니다. |
-| `I18nService` | 번역 및 포맷팅을 위한 코어 서비스입니다. |
+| `I18nService` | Detached option/catalog snapshot을 소유하고 translation을 resolve하며 explicit-locale `Intl` formatting helper(`formatDateTime`, `formatNumber`, `formatCurrency`, `formatPercent`, `formatList`, `formatRelativeTime`)를 제공하는 core service입니다. |
 | `createI18n` | 독립형 서비스를 생성하기 위한 헬퍼입니다. |
 | `I18nError` | 패키지 전용 에러 클래스입니다. |
 

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -199,7 +199,7 @@ The adapter is intentionally explicit:
 - `setHttpLocale(ctx, locale, metadata)` stores locale metadata on the current `RequestContext` using `createContextKey(...)`.
 - `getHttpLocale(ctx)` reads the metadata without falling back to globals.
 - `parseAcceptLanguage(header)` parses valid `Accept-Language` ranges by q-value and ignores invalid or q=0 entries.
-- `createAcceptLanguageLocaleResolver(...)` selects the first supported locale from the request header.
+- `createAcceptLanguageLocaleResolver(...)` selects the first supported locale from the request header, matches language ranges case-insensitively, and returns the configured `supportedLocales` spelling when a match is found.
 - `createAcceptLanguageLocalePolicyResolver(...)` is opt-in and can normalize regional ranges such as `en-US` to supported `en` or select a wildcard fallback only after explicit supported ranges are exhausted.
 - `resolveHttpLocale(ctx, options)` runs application-provided resolvers in order, ignores invalid or unsupported resolver output, and stores `defaultLocale` with source `default` when nothing matches.
 
@@ -264,7 +264,7 @@ The generic adapter contract is intentionally explicit:
 - `resolveLocale(context, options)` runs application-provided resolvers in order, ignores empty, invalid, and unsupported resolver output, and returns `defaultLocale` with source `default` when nothing matches.
 - `bindLocale(context, { store, ...options })` resolves a locale and stores immutable metadata in an application-provided `LocaleAdapterStore`.
 - `createWeakMapLocaleStore()` provides per-object metadata storage for socket, call, session, or request objects without mutating those objects.
-- `createHeaderLocaleResolver(...)` parses `Accept-Language`-style values with the same q-value and wildcard behavior as the HTTP adapter.
+- `createHeaderLocaleResolver(...)` parses `Accept-Language`-style values with the same q-value, wildcard behavior, case-insensitive matching, and supported-locale spelling preservation as the HTTP adapter.
 - `createHeaderLocalePolicyResolver(...)` provides the same opt-in regional-locale normalization and wildcard fallback policy without importing HTTP types.
 - `createQueryLocaleResolver(...)`, `createCookieLocaleResolver(...)`, and `createStorageLocaleResolver(...)` read locale candidates from caller-owned abstractions and never access browser globals or framework internals.
 
@@ -420,7 +420,7 @@ Both helpers deduplicate keys across locales, sort output for stable diffs, reje
 | Export | Description |
 |---|---|
 | `I18nModule` | Module facade for registering the core i18n service surface. |
-| `I18nService` | Core service that owns detached options/catalog snapshots and resolves translations. |
+| `I18nService` | Core service that owns detached options/catalog snapshots, resolves translations, and exposes explicit-locale `Intl` formatting helpers (`formatDateTime`, `formatNumber`, `formatCurrency`, `formatPercent`, `formatList`, `formatRelativeTime`). |
 | `createI18n(options)` | Creates a standalone `I18nService` without module registration. |
 | `I18nError` | Base i18n package error with a stable error code. |
 

--- a/packages/i18n/src/adapters.test.ts
+++ b/packages/i18n/src/adapters.test.ts
@@ -118,6 +118,20 @@ describe('@fluojs/i18n/adapters locale adapter surface', () => {
     expect(locale).toEqual({ locale: 'ko', source: 'grpc-metadata' });
   });
 
+  it('matches adapter Accept-Language ranges case-insensitively while preserving supported locale spelling', () => {
+    const context: TransportContext = {
+      headers: { metadata: 'EN-us;q=1, KO;q=0.8' },
+    };
+
+    const locale = resolveLocale(context, {
+      defaultLocale: 'ko-KR',
+      resolvers: [createHeaderLocaleResolver({ getHeader: (ctx) => ctx.headers?.metadata, source: 'grpc-metadata' })],
+      supportedLocales: ['en-US', 'ko-KR'],
+    });
+
+    expect(locale).toEqual({ locale: 'en-US', source: 'grpc-metadata' });
+  });
+
   it('ignores empty, invalid, and unsupported adapter output before using storage fallback', () => {
     const context: TransportContext = {
       cookies: { locale: '' },

--- a/packages/i18n/src/adapters.test.ts
+++ b/packages/i18n/src/adapters.test.ts
@@ -132,6 +132,30 @@ describe('@fluojs/i18n/adapters locale adapter surface', () => {
     expect(locale).toEqual({ locale: 'en-US', source: 'grpc-metadata' });
   });
 
+  it('keeps query, cookie, storage, and custom resolver locale validation case-sensitive', () => {
+    const context: TransportContext = {
+      cookies: { locale: 'KO-kr' },
+      headers: { metadata: 'EN-us;q=1' },
+      query: { locale: 'EN-us' },
+      storage: { locale: 'ko-kr' },
+    };
+    const wrongCaseCustom: LocaleAdapterResolver<TransportContext> = () => ({ locale: 'en-us', source: 'custom' });
+
+    const locale = resolveLocale(context, {
+      defaultLocale: 'ko-KR',
+      resolvers: [
+        createQueryLocaleResolver({ getQueryValue: (ctx) => ctx.query?.locale }),
+        createCookieLocaleResolver({ getCookieValue: (ctx) => ctx.cookies?.locale }),
+        createStorageLocaleResolver({ getStoredLocale: (ctx) => ctx.storage?.locale }),
+        wrongCaseCustom,
+        createHeaderLocaleResolver({ getHeader: (ctx) => ctx.headers?.metadata, source: 'grpc-metadata' }),
+      ],
+      supportedLocales: ['en-US', 'ko-KR'],
+    });
+
+    expect(locale).toEqual({ locale: 'en-US', source: 'grpc-metadata' });
+  });
+
   it('ignores empty, invalid, and unsupported adapter output before using storage fallback', () => {
     const context: TransportContext = {
       cookies: { locale: '' },
@@ -233,6 +257,22 @@ describe('@fluojs/i18n/adapters locale adapter surface', () => {
         supportedLocales: ['en', 'ko'],
       }),
     ).toThrow(TypeError);
+    expect(getAdapterLocale(store, context)).toBeUndefined();
+  });
+
+  it('rejects default locale casing that does not exactly match supportedLocales before storing metadata', () => {
+    const context: TransportContext = { headers: { metadata: 'EN-us;q=1' } };
+    const store = createWeakMapLocaleStore<TransportContext>();
+
+    expect(() =>
+      bindLocale(context, {
+        defaultLocale: 'ko-kr',
+        resolvers: [createHeaderLocaleResolver({ getHeader: (ctx) => ctx.headers?.metadata })],
+        store,
+        supportedLocales: ['en-US', 'ko-KR'],
+      }),
+    ).toThrow(TypeError);
+
     expect(getAdapterLocale(store, context)).toBeUndefined();
   });
 

--- a/packages/i18n/src/adapters.ts
+++ b/packages/i18n/src/adapters.ts
@@ -4,6 +4,7 @@ import {
   isValidLocale,
   normalizeLocaleResolverResult,
   parseLocalePreferences,
+  resolveSupportedLocale,
   selectLocaleFromAcceptLanguagePolicy,
 } from './locale-resolution.js';
 import type { I18nLocale } from './types.js';
@@ -234,8 +235,10 @@ export function createHeaderLocaleResolver<TContext>(
         continue;
       }
 
-      if (isSupportedLocale(preference.locale, supportedLocales)) {
-        return { locale: preference.locale, source };
+      const locale = resolveSupportedLocale(preference.locale, supportedLocales);
+
+      if (locale !== undefined) {
+        return { locale, source };
       }
     }
 

--- a/packages/i18n/src/http.test.ts
+++ b/packages/i18n/src/http.test.ts
@@ -141,6 +141,19 @@ describe('@fluojs/i18n/http locale context adapter', () => {
     expect(locale).toEqual({ locale: 'ko', source: 'accept-language' });
   });
 
+  it('matches Accept-Language ranges case-insensitively while preserving supported locale spelling', () => {
+    const context = createMockContext({ 'accept-language': 'EN-us;q=1, KO;q=0.8' });
+
+    const locale = resolveHttpLocale(context, {
+      defaultLocale: 'ko-KR',
+      resolvers: [createAcceptLanguageLocaleResolver()],
+      supportedLocales: ['en-US', 'ko-KR'],
+    });
+
+    expect(locale).toEqual({ locale: 'en-US', source: 'accept-language' });
+    expect(getHttpLocale(context)).toEqual({ locale: 'en-US', source: 'accept-language' });
+  });
+
   it('uses custom Accept-Language header name and source options', () => {
     const context = createMockContext({ 'x-locale-preference': 'fr;q=1, ko;q=0.9' });
     const resolver = createAcceptLanguageLocaleResolver({

--- a/packages/i18n/src/http.test.ts
+++ b/packages/i18n/src/http.test.ts
@@ -154,6 +154,19 @@ describe('@fluojs/i18n/http locale context adapter', () => {
     expect(getHttpLocale(context)).toEqual({ locale: 'en-US', source: 'accept-language' });
   });
 
+  it('keeps custom resolver locale validation case-sensitive', () => {
+    const context = createMockContext({ 'accept-language': 'ko-KR;q=1' });
+    const wrongCase: HttpLocaleResolver = () => ({ locale: 'EN-us', source: 'custom' });
+
+    const locale = resolveHttpLocale(context, {
+      defaultLocale: 'ko-KR',
+      resolvers: [wrongCase, createAcceptLanguageLocaleResolver()],
+      supportedLocales: ['en-US', 'ko-KR'],
+    });
+
+    expect(locale).toEqual({ locale: 'ko-KR', source: 'accept-language' });
+  });
+
   it('uses custom Accept-Language header name and source options', () => {
     const context = createMockContext({ 'x-locale-preference': 'fr;q=1, ko;q=0.9' });
     const resolver = createAcceptLanguageLocaleResolver({
@@ -265,6 +278,20 @@ describe('@fluojs/i18n/http locale context adapter', () => {
         defaultLocale: 'fr',
         resolvers: [createAcceptLanguageLocaleResolver()],
         supportedLocales: ['en', 'ko'],
+      }),
+    ).toThrow(TypeError);
+
+    expect(getHttpLocale(context)).toBeUndefined();
+  });
+
+  it('rejects defaultLocale casing that does not exactly match supportedLocales', () => {
+    const context = createMockContext({ 'accept-language': 'EN-us;q=1' });
+
+    expect(() =>
+      resolveHttpLocale(context, {
+        defaultLocale: 'ko-kr',
+        resolvers: [createAcceptLanguageLocaleResolver()],
+        supportedLocales: ['en-US', 'ko-KR'],
       }),
     ).toThrow(TypeError);
 

--- a/packages/i18n/src/http.ts
+++ b/packages/i18n/src/http.ts
@@ -11,6 +11,7 @@ import {
   isValidLocale,
   normalizeLocaleResolverResult,
   parseLocalePreferences,
+  resolveSupportedLocale,
   selectLocaleFromAcceptLanguagePolicy,
 } from './locale-resolution.js';
 import type { I18nLocale } from './types.js';
@@ -163,8 +164,10 @@ export function createAcceptLanguageLocaleResolver(
         continue;
       }
 
-      if (isSupportedLocale(preference.locale, supportedLocales)) {
-        return { locale: preference.locale, source };
+      const locale = resolveSupportedLocale(preference.locale, supportedLocales);
+
+      if (locale !== undefined) {
+        return { locale, source };
       }
     }
 

--- a/packages/i18n/src/locale-resolution.ts
+++ b/packages/i18n/src/locale-resolution.ts
@@ -58,18 +58,18 @@ export function isValidLocale(locale: unknown): locale is I18nLocale {
 }
 
 /**
- * Checks whether a valid locale is allowed by an optional supported-locale list.
+ * Checks whether a valid locale exactly matches an optional supported-locale list.
  *
  * @param locale Locale identifier to check.
  * @param supportedLocales Optional list of supported locale identifiers.
- * @returns Whether the locale is supported, or `true` when no supported-locale list is configured.
+ * @returns Whether the locale is supported with identical spelling, or `true` when no supported-locale list is configured.
  */
 export function isSupportedLocale(locale: I18nLocale, supportedLocales: readonly I18nLocale[] | undefined): boolean {
-  return resolveSupportedLocale(locale, supportedLocales) !== undefined;
+  return supportedLocales === undefined || supportedLocales.length === 0 || supportedLocales.includes(locale);
 }
 
 /**
- * Resolves a valid locale candidate to the caller-configured supported locale spelling.
+ * Resolves a valid locale candidate to the caller-configured supported locale spelling with case-insensitive matching.
  *
  * @param locale Locale identifier to check.
  * @param supportedLocales Optional list of supported locale identifiers.

--- a/packages/i18n/src/locale-resolution.ts
+++ b/packages/i18n/src/locale-resolution.ts
@@ -65,7 +65,26 @@ export function isValidLocale(locale: unknown): locale is I18nLocale {
  * @returns Whether the locale is supported, or `true` when no supported-locale list is configured.
  */
 export function isSupportedLocale(locale: I18nLocale, supportedLocales: readonly I18nLocale[] | undefined): boolean {
-  return supportedLocales === undefined || supportedLocales.length === 0 || supportedLocales.includes(locale);
+  return resolveSupportedLocale(locale, supportedLocales) !== undefined;
+}
+
+/**
+ * Resolves a valid locale candidate to the caller-configured supported locale spelling.
+ *
+ * @param locale Locale identifier to check.
+ * @param supportedLocales Optional list of supported locale identifiers.
+ * @returns The matching supported locale spelling, the original locale when no list is configured, or `undefined` when unsupported.
+ */
+export function resolveSupportedLocale(
+  locale: I18nLocale,
+  supportedLocales: readonly I18nLocale[] | undefined,
+): I18nLocale | undefined {
+  if (supportedLocales === undefined || supportedLocales.length === 0) {
+    return locale;
+  }
+
+  const normalizedLocale = locale.toLowerCase();
+  return supportedLocales.find((supportedLocale) => supportedLocale.toLowerCase() === normalizedLocale);
 }
 
 /**
@@ -86,7 +105,7 @@ export function normalizeSupportedLocale(
   }
 
   const normalizedLocale = locale.toLowerCase();
-  const exact = supportedLocales.find((supportedLocale) => supportedLocale.toLowerCase() === normalizedLocale);
+  const exact = resolveSupportedLocale(locale, supportedLocales);
 
   if (exact !== undefined) {
     return exact;


### PR DESCRIPTION
## Summary

- Closes #1786
- Fixes `@fluojs/i18n` HTTP and non-HTTP `Accept-Language` resolver matching so language ranges compare case-insensitively while preserving configured supported-locale spelling.
- Aligns EN/KO package README contract language and adds a patch changeset for the public behavior fix.

## Changes

- Added `resolveSupportedLocale(...)` as the shared supported-locale matcher and reused it from HTTP/non-HTTP header resolvers.
- Added package-local regression tests for mixed-case `Accept-Language` ranges in `@fluojs/i18n/http` and `@fluojs/i18n/adapters`.
- Documented case-insensitive matching and explicit `Intl` formatting helpers in `packages/i18n/README.md` and `README.ko.md`.

## Testing

- `pnpm install --offline --ignore-scripts`
- `pnpm --filter @fluojs/i18n test`
- `pnpm --filter @fluojs/di build && pnpm --filter @fluojs/validation build && pnpm --filter @fluojs/http build && pnpm --filter @fluojs/i18n typecheck`
- `pnpm --filter @fluojs/i18n build`
- `pnpm lint` (passes; existing repository-wide Biome warnings are reported outside this change, and changed-file public-export TSDoc passes)
- `lsp_diagnostics` clean on changed TypeScript files after dependency build

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed; package README EN/KO mirror updates are aligned. The platform conformance checklist item is not applicable to this i18n resolver change.