### PR TITLE
Resolve #1805: align Slack public API contracts

### DIFF
--- a/.changeset/slack-explicit-webhook-fetch.md
+++ b/.changeset/slack-explicit-webhook-fetch.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": major
+---
+
+Require `fetch` when creating the built-in Slack webhook transport so delivery uses an explicit runtime boundary, and align the public API documentation with the exported option/template contracts.

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -78,7 +78,7 @@ export class DeployNotifier {
 
 ### `createSlackProviders`를 이용한 수동 provider 조합
 
-`createSlackProviders(...)`는 애플리케이션이 `SlackModule.forRoot(...)` 밖에서 동일한 provider 정규화 구성을 재사용해야 할 때 지원되는 manual-composition helper입니다.
+애플리케이션-facing 등록에는 `SlackModule.forRoot(...)` 또는 `SlackModule.forRootAsync(...)`를 우선 사용하세요. `createSlackProviders(...)`는 동일하게 정규화된 provider를 직접 조합해야 하는 wrapper module을 위한 low-level compatibility helper로 유지됩니다.
 
 ```typescript
 import { Module } from '@fluojs/core';
@@ -105,6 +105,7 @@ Behavioral contract 메모:
 - 이 helper는 `SlackModule.forRoot(...)`가 구성하는 `SLACK`, `SLACK_CHANNEL`, `SlackService` wiring을 동일하게 유지합니다.
 - `createSlackProviders(...)`는 trim된 기본 채널, notification 채널 fallback, transport 소유권 기본값을 포함해 `SlackModule.forRoot(...)`와 동일한 옵션 정규화를 적용합니다.
 - 이 helper도 여전히 명시적인 `transport`를 요구하며, 패키지의 runtime-portable·no-implicit-env 계약을 약화시키지 않습니다.
+- 새 애플리케이션 코드는 provider 조합이 wrapper module에 compatibility 수준 접근이 필요한 경우를 제외하고 구현 세부 사항으로 남도록 `SlackModule` namespace facade를 우선 사용해야 합니다.
 
 ### `SlackService`를 이용한 standalone 전달
 
@@ -180,7 +181,7 @@ Behavioral contract 메모:
 
 ### 명시적 fetch 주입을 사용하는 webhook-first 전달
 
-런타임에 독립적인 1st-party transport가 필요하다면 fetch-compatible HTTP 경계만 의존하는 `createSlackWebhookTransport(...)`를 사용합니다.
+런타임에 독립적인 1st-party transport가 필요하다면 명시적으로 주입된 fetch-compatible HTTP 경계만 의존하는 `createSlackWebhookTransport(...)`를 사용합니다.
 
 ```typescript
 const transport = createSlackWebhookTransport({
@@ -200,6 +201,7 @@ Behavioral contract 메모:
 
 - 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 실패를 호출자에게 에러를 노출하기 전에 bounded exponential backoff로 재시도합니다.
 - 호출자에게 보이는 `SlackTransportError` 메시지는 기본적으로 raw upstream response body를 포함하지 않습니다.
+- 런타임이 `globalThis.fetch`를 제공하더라도 `fetch`는 필수입니다. 호출자가 런타임 경계를 선택하며, 패키지는 ambient global에 의존하지 않습니다.
 
 ### 의도적인 제한 사항
 
@@ -217,6 +219,8 @@ Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 ### 핵심
 
 - `SlackModule.forRoot(options)` / `SlackModule.forRootAsync(options)`
+- `SlackModuleOptions`
+- `SlackAsyncModuleOptions`
 - `createSlackProviders(options)`
 - `SlackService`
 - `SlackService.send(message, options)`
@@ -250,7 +254,10 @@ Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `SlackTransportReceipt`
 - `SlackFetchLike`
 - `SlackFetchResponse`
+- `SlackWebhookTransportOptions`
 - `SlackTemplateRenderer`
+- `SlackTemplateRenderInput`
+- `SlackTemplateRenderResult`
 - `createSlackWebhookTransport(options)`
 
 ### 상태 및 에러

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -78,7 +78,7 @@ export class DeployNotifier {
 
 ### Manual provider composition with `createSlackProviders`
 
-`createSlackProviders(...)` is the supported manual-composition helper when applications need the same provider normalization outside `SlackModule.forRoot(...)`.
+Prefer `SlackModule.forRoot(...)` or `SlackModule.forRootAsync(...)` for application-facing registration. `createSlackProviders(...)` remains a low-level compatibility helper for wrapper modules that must assemble the same normalized providers manually.
 
 ```typescript
 import { Module } from '@fluojs/core';
@@ -105,6 +105,7 @@ Behavioral contract notes:
 - The helper preserves the same `SLACK`, `SLACK_CHANNEL`, and `SlackService` wiring that `SlackModule.forRoot(...)` installs.
 - `createSlackProviders(...)` applies the same option normalization as `SlackModule.forRoot(...)`, including trimmed default channels, notification channel fallback, and transport ownership defaults.
 - The helper still requires an explicit `transport`; it does not weaken the package's runtime-portable, no-implicit-env contract.
+- New application code should still prefer the `SlackModule` namespace facade so provider assembly remains an implementation detail unless a wrapper module needs compatibility-level access.
 
 ### Standalone delivery with `SlackService`
 
@@ -180,7 +181,7 @@ Behavioral contract notes:
 
 ### Webhook-first delivery with explicit fetch injection
 
-Use `createSlackWebhookTransport(...)` when you want a portable first-party transport that only depends on a fetch-compatible HTTP boundary.
+Use `createSlackWebhookTransport(...)` when you want a portable first-party transport that only depends on an explicitly injected fetch-compatible HTTP boundary.
 
 ```typescript
 const transport = createSlackWebhookTransport({
@@ -200,6 +201,7 @@ Behavioral contract notes:
 
 - The built-in webhook transport retries transient `408`, `429`, and `5xx` failures with bounded exponential backoff before surfacing an error.
 - Caller-visible `SlackTransportError` messages omit raw upstream response bodies by default.
+- `fetch` is required even on runtimes that expose `globalThis.fetch`; callers choose the runtime boundary instead of the package relying on ambient globals.
 
 ### Intentional limitations
 
@@ -217,6 +219,8 @@ These limitations are part of the package contract so runtime choice, provider c
 ### Core
 
 - `SlackModule.forRoot(options)` / `SlackModule.forRootAsync(options)`
+- `SlackModuleOptions`
+- `SlackAsyncModuleOptions`
 - `createSlackProviders(options)`
 - `SlackService`
 - `SlackService.send(message, options)`
@@ -250,7 +254,10 @@ These limitations are part of the package contract so runtime choice, provider c
 - `SlackTransportReceipt`
 - `SlackFetchLike`
 - `SlackFetchResponse`
+- `SlackWebhookTransportOptions`
 - `SlackTemplateRenderer`
+- `SlackTemplateRenderInput`
+- `SlackTemplateRenderResult`
 - `createSlackWebhookTransport(options)`
 
 ### Status and errors

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -85,6 +85,26 @@ class UnsuccessfulTransport implements SlackTransport {
   }
 }
 
+class SelectivelyFailingTransport implements SlackTransport {
+  readonly sent: NormalizedSlackMessage[] = [];
+
+  async send(message: NormalizedSlackMessage) {
+    this.sent.push(message);
+
+    if (message.text === 'fail') {
+      throw new SlackTransportError('selective failure');
+    }
+
+    return {
+      channel: message.channel,
+      ok: true,
+      response: 'ok',
+      statusCode: 200,
+      warnings: [],
+    };
+  }
+}
+
 class DelayedLifecycleTransport implements SlackTransport {
   closeCalls = 0;
   sendCalls = 0;
@@ -222,6 +242,33 @@ describe('SlackModule', () => {
         defaultChannel: '#ops',
       } as never),
     ).toThrowError(new SlackConfigurationError('SlackModule requires an explicit `transport` to be configured.'));
+  });
+
+  it('preserves sendMany order, default channels, and tolerant failure details', async () => {
+    const transport = new SelectivelyFailingTransport();
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: ' #ops ',
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+    const result = await service.sendMany(
+      [{ text: 'one' }, { channel: ' #alerts ', text: 'fail' }, { channel: '   ', text: 'three' }],
+      { continueOnError: true },
+    );
+
+    expect(result.succeeded).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.results.map((entry: { channel?: string }) => entry.channel)).toEqual(['#ops', '#ops']);
+    expect(result.failures[0]?.message).toEqual({ channel: ' #alerts ', text: 'fail' });
+    expect(result.failures[0]?.error).toEqual(new SlackTransportError('selective failure'));
+    expect(transport.sent.map((message) => ({ channel: message.channel, text: message.text }))).toEqual([
+      { channel: '#ops', text: 'one' },
+      { channel: '#alerts', text: 'fail' },
+      { channel: '#ops', text: 'three' },
+    ]);
   });
 
   it('resolves async options once and exposes the compatibility facade and channel token', async () => {
@@ -542,6 +589,14 @@ describe('SlackModule', () => {
     }
   });
 
+  it('requires an explicit fetch boundary for the webhook transport', () => {
+    expect(() =>
+      createSlackWebhookTransport({
+        webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+      } as never),
+    ).toThrowError(new SlackConfigurationError('Slack webhook transport requires an explicit `fetch` implementation.'));
+  });
+
   it('sanitizes webhook failure errors after bounded retries', async () => {
     vi.useFakeTimers();
 
@@ -568,6 +623,32 @@ describe('SlackModule', () => {
       await vi.runAllTimersAsync();
 
       await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sanitizes thrown transport errors after bounded webhook retries', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi.fn<SlackFetchLike>().mockRejectedValue(new Error('secret token xoxb-123 leaked upstream'));
+      const transport = createSlackWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+      });
+
+      const pending = transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Retry path' }, {});
+      const expectation = expect(pending).rejects.toThrowError(
+        new SlackTransportError(
+          'Slack webhook delivery failed after 3 attempt(s). Upstream response details were omitted from the caller-visible error.',
+        ),
+      );
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      await expect(pending).rejects.not.toThrow(/xoxb-123|secret token/);
       expect(fetchLike).toHaveBeenCalledTimes(3);
     } finally {
       vi.useRealTimers();

--- a/packages/slack/src/module.ts
+++ b/packages/slack/src/module.ts
@@ -131,7 +131,10 @@ export class SlackModule {
    * @example
    * ```ts
    * SlackModule.forRoot({
-   *   transport: createSlackWebhookTransport({ webhookUrl: 'https://hooks.slack.com/services/...' }),
+   *   transport: createSlackWebhookTransport({
+   *     fetch: runtime.fetch,
+   *     webhookUrl: 'https://hooks.slack.com/services/...',
+   *   }),
    * });
    * ```
    */

--- a/packages/slack/src/public-surface.test.ts
+++ b/packages/slack/src/public-surface.test.ts
@@ -36,9 +36,9 @@ describe('@fluojs/slack public API surface', () => {
     const readme = readFileSync(resolve(import.meta.dirname, '../README.md'), 'utf8');
     const koreanReadme = readFileSync(resolve(import.meta.dirname, '../README.ko.md'), 'utf8');
 
-    expect(readme).toContain('`createSlackProviders(...)` is the supported manual-composition helper when applications need the same provider normalization outside `SlackModule.forRoot(...)`.');
+    expect(readme).toContain('Prefer `SlackModule.forRoot(...)` or `SlackModule.forRootAsync(...)` for application-facing registration. `createSlackProviders(...)` remains a low-level compatibility helper for wrapper modules that must assemble the same normalized providers manually.');
     expect(readme).toContain('The helper preserves the same `SLACK`, `SLACK_CHANNEL`, and `SlackService` wiring that `SlackModule.forRoot(...)` installs.');
-    expect(koreanReadme).toContain('`createSlackProviders(...)`는 애플리케이션이 `SlackModule.forRoot(...)` 밖에서 동일한 provider 정규화 구성을 재사용해야 할 때 지원되는 manual-composition helper입니다.');
+    expect(koreanReadme).toContain('애플리케이션-facing 등록에는 `SlackModule.forRoot(...)` 또는 `SlackModule.forRootAsync(...)`를 우선 사용하세요. `createSlackProviders(...)`는 동일하게 정규화된 provider를 직접 조합해야 하는 wrapper module을 위한 low-level compatibility helper로 유지됩니다.');
     expect(koreanReadme).toContain('이 helper는 `SlackModule.forRoot(...)`가 구성하는 `SLACK`, `SLACK_CHANNEL`, `SlackService` wiring을 동일하게 유지합니다.');
   });
 

--- a/packages/slack/src/types.ts
+++ b/packages/slack/src/types.ts
@@ -132,7 +132,7 @@ export interface SlackFetchLike {
 
 /** Options accepted by {@link createSlackWebhookTransport}. */
 export interface SlackWebhookTransportOptions {
-  fetch?: SlackFetchLike;
+  fetch: SlackFetchLike;
   webhookUrl: string;
 }
 

--- a/packages/slack/src/webhook.ts
+++ b/packages/slack/src/webhook.ts
@@ -39,13 +39,7 @@ function resolveFetch(fetchLike: SlackFetchLike | undefined): SlackFetchLike {
     return fetchLike;
   }
 
-  if (typeof globalThis.fetch !== 'function') {
-    throw new SlackConfigurationError(
-      'Slack webhook transport requires an explicit fetch implementation when `globalThis.fetch` is unavailable.',
-    );
-  }
-
-  return (input, init) => globalThis.fetch(input, init as never) as Promise<SlackFetchResponse>;
+  throw new SlackConfigurationError('Slack webhook transport requires an explicit `fetch` implementation.');
 }
 
 async function readResponseBody(response: SlackFetchResponse): Promise<string> {
@@ -97,9 +91,9 @@ async function waitForRetry(delayMs: number, signal: AbortSignal | undefined): P
 /**
  * Creates a webhook-first Slack transport backed by an explicit fetch-compatible boundary.
  *
- * @param options Webhook URL plus an optional injected fetch implementation for portable runtimes.
+ * @param options Webhook URL plus the injected fetch implementation for portable runtimes.
  * @returns A Slack transport that posts JSON payloads to one Slack incoming webhook endpoint.
- * @throws {SlackConfigurationError} When the webhook url is empty or no fetch implementation is available.
+ * @throws {SlackConfigurationError} When the webhook url is empty or no explicit fetch implementation is provided.
  * @throws {SlackTransportError} When Slack responds with a non-success HTTP status.
  *
  * @example


### PR DESCRIPTION
## Summary

Closes #1805

Aligns `@fluojs/slack` public API documentation and runtime transport behavior with the package's explicit-boundary contract.

## Changes

- Documents exported Slack module option, webhook option, and template render contracts in EN/KO package READMEs.
- Reframes `createSlackProviders(...)` as a low-level compatibility helper while keeping `SlackModule.forRoot(...)` / `forRootAsync(...)` as the preferred application-facing API.
- Requires an explicit `fetch` implementation for `createSlackWebhookTransport(...)` instead of falling back to ambient `globalThis.fetch`.
- Adds regression coverage for `sendMany(...)` ordering/failure details, channel trimming/default fallback, explicit fetch enforcement, and redacted thrown transport errors.
- Adds a major changeset for the public `SlackWebhookTransportOptions.fetch` requirement.

## Testing

- `lsp_diagnostics` on `packages/slack/src` → 0 diagnostics
- `pnpm --filter @fluojs/slack test`
- `pnpm --filter @fluojs/slack typecheck`
- `pnpm --filter @fluojs/slack... build`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform-governance docs were changed; package README EN/KO mirrors and package-local regression tests cover this Slack contract change.