### PR TITLE
Resolve #1877: keep generated broker starters import-safe

### DIFF
--- a/.changeset/import-safe-broker-starters.md
+++ b/.changeset/import-safe-broker-starters.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Keep generated NATS, Kafka, and RabbitMQ starters import-safe by lazily creating broker clients inside the Fluo-owned transport lifecycle instead of during module import.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -112,7 +112,7 @@ fluo new my-grpc-service --shape microservice --transport grpc --runtime node --
 
 지원되는 `--shape microservice --transport` 스타터 값은 정확히 `tcp`, `redis-streams`, `nats`, `kafka`, `rabbitmq`, `mqtt`, `grpc`입니다. 유지보수되는 Redis 기반 스타터가 필요하면 `redis-streams`를 사용하고, 더 넓은 Redis 통합 패턴이 필요하면 스캐폴딩 후 `@fluojs/redis`를 수동으로 추가하세요.
 
-NATS/Kafka/RabbitMQ 스타터 계약은 외부 broker와 caller-owned client library 의존성을 숨기지 않고 명시적으로 유지합니다. 생성된 프로젝트는 `src/app.ts`에서 `nats` + `JSONCodec()`, `kafkajs` producer/consumer collaborator, `amqplib` publisher/consumer collaborator를 직접 연결하므로, 기본 fluo 패키지가 그 의존성을 감춘 것처럼 가장하지 않는 runnable starter 계약이 됩니다.
+NATS/Kafka/RabbitMQ 스타터 계약은 외부 broker와 caller-owned client library 의존성을 숨기지 않고 명시적으로 유지합니다. 생성된 프로젝트는 `src/app.ts`에서 `nats` + `JSONCodec()`, `kafkajs` producer/consumer collaborator, `amqplib` publisher/consumer collaborator를 직접 연결하므로, 기본 fluo 패키지가 그 의존성을 감춘 것처럼 가장하지 않는 runnable starter 계약이 됩니다. 해당 broker client는 생성된 transport wrapper가 Fluo lifecycle에서 listen/send/emit을 시작할 때 lazy하게 생성합니다. 따라서 `fluo inspect`, 테스트, static tooling이 `src/app.ts`를 import하는 것만으로는 broker에 연결하거나 lifecycle이 teardown을 소유하기 전에 외부 리소스를 열지 않습니다.
 
 starter 매트릭스에는 mixed single-package starter도 포함됩니다. 하나의 Fastify HTTP 앱과 attached TCP microservice를 같은 생성 프로젝트 안에 함께 배치합니다.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -112,7 +112,7 @@ fluo new my-grpc-service --shape microservice --transport grpc --runtime node --
 
 Supported `--shape microservice --transport` starter values are exactly `tcp`, `redis-streams`, `nats`, `kafka`, `rabbitmq`, `mqtt`, and `grpc`. Use `redis-streams` for the maintained Redis-backed starter, or add `@fluojs/redis` manually after scaffolding when you need broader Redis integration patterns.
 
-The NATS/Kafka/RabbitMQ starter contracts stay explicit about external brokers and caller-owned client libraries. Generated projects wire `nats` + `JSONCodec()`, `kafkajs` producer/consumer collaborators, and `amqplib` publisher/consumer collaborators directly in `src/app.ts` so the starter contract is runnable without pretending the base fluo packages hide those dependencies.
+The NATS/Kafka/RabbitMQ starter contracts stay explicit about external brokers and caller-owned client libraries. Generated projects wire `nats` + `JSONCodec()`, `kafkajs` producer/consumer collaborators, and `amqplib` publisher/consumer collaborators directly in `src/app.ts` so the starter contract is runnable without pretending the base fluo packages hide those dependencies. Those broker clients are created lazily by the generated transport wrapper when the Fluo lifecycle starts listening, sends, or emits; importing `src/app.ts` for `fluo inspect`, tests, or static tooling does not connect to a broker or open external resources before the application lifecycle owns teardown.
 
 The starter matrix also includes a mixed single-package starter: one Fastify HTTP app with an attached TCP microservice in the same generated project.
 

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -11,6 +12,7 @@ import { scaffoldBootstrapApp } from './scaffold.js';
 import { DEFAULT_BOOTSTRAP_SCHEMA } from './resolver.js';
 
 const temporaryDirectories: string[] = [];
+const require = createRequire(import.meta.url);
 const LOCAL_PACKAGE_DIRECTORY_BY_NAME = {
   '@fluojs/platform-bun': 'platform-bun',
   '@fluojs/cli': 'cli',
@@ -192,6 +194,73 @@ function expectPackedManifestUsesPublishedWorkspaceCaretPolicy(tarballPath: stri
       }
     }
   }
+}
+
+function writeStubPackage(projectDirectory: string, packageName: string, source: string): void {
+  const packageDirectory = join(projectDirectory, 'node_modules', ...packageName.split('/'));
+  mkdirSync(packageDirectory, { recursive: true });
+  writeFileSync(
+    join(packageDirectory, 'package.json'),
+    `${JSON.stringify({ exports: './index.js', name: packageName, type: 'module', version: '0.0.0-test' }, null, 2)}\n`,
+    'utf8',
+  );
+  writeFileSync(join(packageDirectory, 'index.js'), source, 'utf8');
+}
+
+function installImportSafeBrokerStarterStubs(projectDirectory: string): void {
+  writeStubPackage(
+    projectDirectory,
+    '@fluojs/core',
+    `export function Module() {\n  return () => undefined;\n}\n`,
+  );
+  writeStubPackage(
+    projectDirectory,
+    '@fluojs/config',
+    `export class ConfigModule {\n  static forRoot() {\n    return class ConfigModuleDefinition {};\n  }\n}\n`,
+  );
+  writeStubPackage(
+    projectDirectory,
+    '@fluojs/microservices',
+    `export function MessagePattern() {\n  return () => undefined;\n}\nexport class KafkaMicroserviceTransport {\n  constructor(options) {\n    this.options = options;\n  }\n  async close() {}\n  async emit() {}\n  async listen() {}\n  async send() {}\n}\nexport class NatsMicroserviceTransport extends KafkaMicroserviceTransport {}\nexport class RabbitMqMicroserviceTransport extends KafkaMicroserviceTransport {}\nexport class MicroservicesModule {\n  static forRoot(options) {\n    globalThis.__fluoGeneratedTransport = options.transport;\n    return class MicroservicesModuleDefinition {};\n  }\n}\n`,
+  );
+  writeStubPackage(
+    projectDirectory,
+    'nats',
+    `export function JSONCodec() {\n  return {\n    decode(value) {\n      return new TextDecoder().decode(value);\n    },\n    encode(value) {\n      return new TextEncoder().encode(value);\n    },\n  };\n}\nexport async function connect() {\n  throw new Error('NATS connect must not run during generated module import or inspect-style close.');\n}\n`,
+  );
+  writeStubPackage(
+    projectDirectory,
+    'kafkajs',
+    `export const logLevel = { NOTHING: 0 };\nexport class Kafka {\n  constructor() {\n    throw new Error('Kafka client construction must not run during generated module import or inspect-style close.');\n  }\n}\n`,
+  );
+  writeStubPackage(
+    projectDirectory,
+    'amqplib',
+    `export async function connect() {\n  throw new Error('RabbitMQ connect must not run during generated module import or inspect-style close.');\n}\n`,
+  );
+}
+
+function assertGeneratedBrokerStarterIsImportAndInspectSafe(projectDirectory: string): void {
+  installImportSafeBrokerStarterStubs(projectDirectory);
+  const scriptPath = join(projectDirectory, 'assert-import-safe.mjs');
+  const moduleUrl = pathToFileURL(join(projectDirectory, 'src', 'app.ts')).href;
+
+  writeFileSync(
+    scriptPath,
+    `const imported = await import(${JSON.stringify(moduleUrl)});\nif (typeof imported.AppModule !== 'function') {\n  throw new Error('Generated app module did not export AppModule.');\n}\nconst transport = globalThis.__fluoGeneratedTransport;\nif (!transport) {\n  throw new Error('Generated app module did not register a microservice transport.');\n}\nawait transport.close();\n`,
+    'utf8',
+  );
+
+  execFileSync(process.execPath, ['--import', require.resolve('tsx'), scriptPath], {
+    cwd: projectDirectory,
+    env: {
+      ...process.env,
+      KAFKA_BROKERS: '127.0.0.1:1',
+      NATS_SERVERS: 'nats://127.0.0.1:1',
+      RABBITMQ_URL: 'amqp://127.0.0.1:1',
+    },
+    stdio: 'pipe',
+  });
 }
 
 describe('scaffoldBootstrapApp', () => {
@@ -864,8 +933,9 @@ describe('scaffoldBootstrapApp', () => {
     expect(readme).toContain('caller-owned `nats` client plus `JSONCodec()`');
     expect(envFile).toContain('NATS_SERVERS=nats://127.0.0.1:4222');
     expect(envFile).toContain('NATS_MESSAGE_SUBJECT=fluo.microservices.messages');
-    expect(appFile).toContain("import { JSONCodec, connect } from 'nats';");
+    expect(appFile).toContain("import { JSONCodec, connect, type NatsConnection } from 'nats';");
     expect(appFile).toContain('new NatsMicroserviceTransport({');
+    expect(appFile).toContain('class LazyNatsTransport implements MicroserviceTransport');
     expect(appFile).toContain("name: 'fluo-microservice-starter'");
   });
 
@@ -904,8 +974,9 @@ describe('scaffoldBootstrapApp', () => {
     expect(readme).toContain('producer/consumer collaborators');
     expect(envFile).toContain('KAFKA_BROKERS=127.0.0.1:9092');
     expect(envFile).toContain('KAFKA_RESPONSE_TOPIC=fluo.microservices.responses');
-    expect(appFile).toContain("import { Kafka, logLevel } from 'kafkajs';");
+    expect(appFile).toContain("import { Kafka, logLevel, type Consumer, type Producer } from 'kafkajs';");
     expect(appFile).toContain('new KafkaMicroserviceTransport({');
+    expect(appFile).toContain('class LazyKafkaTransport implements MicroserviceTransport');
     expect(appFile).toContain('await Promise.all([producer.connect(), consumer.connect()]);');
   });
 
@@ -950,7 +1021,33 @@ describe('scaffoldBootstrapApp', () => {
     expect(envFile).toContain('RABBITMQ_RESPONSE_QUEUE=fluo.microservices.responses');
     expect(appFile).toContain("import { connect } from 'amqplib';");
     expect(appFile).toContain('new RabbitMqMicroserviceTransport({');
+    expect(appFile).toContain('class LazyRabbitMqTransport implements MicroserviceTransport');
     expect(appFile).toContain('createConfirmChannel()');
+  });
+
+  it('keeps generated broker starter modules import-safe for inspect-style tooling without a live broker', async () => {
+    for (const transport of ['nats', 'kafka', 'rabbitmq'] as const) {
+      const targetDirectory = mkdtempSync(join(tmpdir(), `fluo-scaffold-import-safe-${transport}-`));
+      temporaryDirectories.push(targetDirectory);
+
+      await scaffoldBootstrapApp({
+        packageManager: 'pnpm',
+        platform: 'none',
+        projectName: `starter-${transport}`,
+        runtime: 'node',
+        shape: 'microservice',
+        skipInstall: true,
+        targetDirectory,
+        tooling: 'standard',
+        topology: {
+          deferred: true,
+          mode: 'single-package',
+        },
+        transport,
+      });
+
+      assertGeneratedBrokerStarterIsImportAndInspectSafe(targetDirectory);
+    }
   });
 
   it('generates a mixed single-package scaffold with an attached TCP microservice', async () => {

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -572,14 +572,14 @@ function describeMicroserviceStarter(options: Pick<BootstrapOptions, 'transport'
           '- NATS broker: configure `NATS_SERVERS` in `.env` before you start the service',
           '- Subject contract: keep `NATS_MESSAGE_SUBJECT` and `NATS_EVENT_SUBJECT` aligned with the peer services that share the broker namespace',
         ],
-        entrypointNote: '`src/app.ts` opens one caller-owned `nats` client plus `JSONCodec()` and passes both into `NatsMicroserviceTransport` as the canonical starter bootstrap contract',
+        entrypointNote: '`src/app.ts` keeps the caller-owned `nats` client plus `JSONCodec()` contract explicit, but opens the client lazily from the generated transport wrapper when the Fluo lifecycle starts broker work',
         generatedProjectVerification: 'The generated-project verification path typechecks, builds, and tests the scaffold while asserting the NATS starter keeps the `nats` dependency, `.env` contract, and transport entrypoint wiring intact.',
         packageManagerNote: 'runtime choice stays explicit and independent from the package manager you picked; the generated manifest adds the `nats` client because the NATS starter depends on an external broker plus a caller-owned client/bootstrap pair',
         pattern: 'math.sum',
         readmeTransportLabel: 'nats',
         runtimeDependencyNote: 'runtime dependency set: `@fluojs/microservices` plus `nats` for the broker client and codec that `NatsMicroserviceTransport` expects the caller to supply',
         starterNote: 'the NATS starter keeps TCP as the default microservice path when you omit `--transport`, but this scaffold becomes runnable as soon as `NATS_SERVERS` points at a reachable broker cluster',
-        testNote: '`src/app.test.ts` preserves a broker-free integration template via an in-memory transport, while generated-project verification still checks the NATS entrypoint/build contract and the caller-owned client bootstrap wiring.',
+        testNote: '`src/app.test.ts` preserves a broker-free integration template via an in-memory transport, while generated-project verification still checks the NATS entrypoint/build contract and import-safe lazy client bootstrap wiring.',
       };
     case 'kafka':
       return {
@@ -587,14 +587,14 @@ function describeMicroserviceStarter(options: Pick<BootstrapOptions, 'transport'
           '- Kafka brokers: configure `KAFKA_BROKERS` in `.env` before you start the service',
           '- Topic/group contract: `KAFKA_CLIENT_ID`, `KAFKA_CONSUMER_GROUP`, `KAFKA_MESSAGE_TOPIC`, `KAFKA_EVENT_TOPIC`, and `KAFKA_RESPONSE_TOPIC` stay explicit so the starter never hides its shared broker topology',
         ],
-        entrypointNote: '`src/app.ts` opens canonical `kafkajs` producer/consumer collaborators and passes them into `KafkaMicroserviceTransport`, keeping the response-topic contract explicit in starter-owned config',
+        entrypointNote: '`src/app.ts` keeps the canonical `kafkajs` producer/consumer collaborator contract explicit, but creates them lazily from the generated transport wrapper when the Fluo lifecycle starts broker work',
         generatedProjectVerification: 'The generated-project verification path typechecks, builds, and tests the scaffold while asserting the Kafka starter keeps the `kafkajs` dependency, `.env` contract, and transport entrypoint wiring intact.',
         packageManagerNote: 'runtime choice stays explicit and independent from the package manager you picked; the generated manifest adds `kafkajs` because the Kafka starter depends on an external broker plus caller-owned producer/consumer collaborators',
         pattern: 'math.sum',
         readmeTransportLabel: 'kafka',
         runtimeDependencyNote: 'runtime dependency set: `@fluojs/microservices` plus `kafkajs` for the generated producer/consumer/bootstrap contract used by `KafkaMicroserviceTransport`',
         starterNote: 'the Kafka starter keeps TCP as the default microservice path when you omit `--transport`, but this scaffold becomes runnable as soon as `KAFKA_BROKERS` points at a reachable broker set',
-        testNote: '`src/app.test.ts` preserves a broker-free integration template via an in-memory transport, while generated-project verification still checks the Kafka entrypoint/build contract and the explicit topic/client bootstrap wiring.',
+        testNote: '`src/app.test.ts` preserves a broker-free integration template via an in-memory transport, while generated-project verification still checks the Kafka entrypoint/build contract and import-safe lazy topic/client bootstrap wiring.',
       };
     case 'rabbitmq':
       return {
@@ -602,14 +602,14 @@ function describeMicroserviceStarter(options: Pick<BootstrapOptions, 'transport'
           '- RabbitMQ broker: configure `RABBITMQ_URL` in `.env` before you start the service',
           '- Queue contract: `RABBITMQ_MESSAGE_QUEUE`, `RABBITMQ_EVENT_QUEUE`, and `RABBITMQ_RESPONSE_QUEUE` stay explicit so the starter advertises exactly which queues and reply path it owns',
         ],
-        entrypointNote: '`src/app.ts` opens a canonical `amqplib` connection/channel pair and passes caller-owned publisher/consumer collaborators into `RabbitMqMicroserviceTransport`',
+        entrypointNote: '`src/app.ts` keeps the canonical `amqplib` connection/channel pair and caller-owned publisher/consumer collaborator contract explicit, but opens them lazily from the generated transport wrapper when the Fluo lifecycle starts broker work',
         generatedProjectVerification: 'The generated-project verification path typechecks, builds, and tests the scaffold while asserting the RabbitMQ starter keeps the `amqplib` dependency, `.env` contract, and transport entrypoint wiring intact.',
         packageManagerNote: 'runtime choice stays explicit and independent from the package manager you picked; the generated manifest adds `amqplib` because the RabbitMQ starter depends on an external broker plus caller-owned publisher/consumer collaborators',
         pattern: 'math.sum',
         readmeTransportLabel: 'rabbitmq',
         runtimeDependencyNote: 'runtime dependency set: `@fluojs/microservices`, `amqplib`, and `@types/amqplib` for the generated queue client/bootstrap contract used by `RabbitMqMicroserviceTransport`',
         starterNote: 'the RabbitMQ starter keeps TCP as the default microservice path when you omit `--transport`, but this scaffold becomes runnable as soon as `RABBITMQ_URL` points at a reachable broker',
-        testNote: '`src/app.test.ts` preserves a broker-free integration template via an in-memory transport, while generated-project verification still checks the RabbitMQ entrypoint/build contract and the explicit queue/bootstrap wiring.',
+        testNote: '`src/app.test.ts` preserves a broker-free integration template via an in-memory transport, while generated-project verification still checks the RabbitMQ entrypoint/build contract and import-safe lazy queue/bootstrap wiring.',
       };
     default:
       return {
@@ -1188,8 +1188,8 @@ export class AppModule {}
     case 'nats':
       return `import { Module } from '@fluojs/core';
 import { ConfigModule } from '@fluojs/config';
-import { MicroservicesModule, NatsMicroserviceTransport } from '@fluojs/microservices';
-import { JSONCodec, connect } from 'nats';
+import { MicroservicesModule, NatsMicroserviceTransport, type MicroserviceTransport } from '@fluojs/microservices';
+import { JSONCodec, connect, type NatsConnection } from 'nats';
 
 import { MathHandler } from './math/math.handler';
 
@@ -1200,36 +1200,73 @@ const servers = (process.env.NATS_SERVERS ?? 'nats://127.0.0.1:4222')
 const eventSubject = process.env.NATS_EVENT_SUBJECT ?? 'fluo.microservices.events';
 const messageSubject = process.env.NATS_MESSAGE_SUBJECT ?? 'fluo.microservices.messages';
 const codec = JSONCodec();
-const connection = await connect({
-  name: 'fluo-microservice-starter',
-  servers,
-});
-const client = {
-  close() {
-    void connection.close();
-  },
-  publish(subject: string, payload: Uint8Array) {
-    connection.publish(subject, payload);
-  },
-  request(subject: string, payload: Uint8Array, options?: { timeout?: number }) {
-    return connection.request(subject, payload, options);
-  },
-  subscribe(subject: string, handler: (message: { data: Uint8Array; respond(data: Uint8Array): void }) => void) {
-    const subscription = connection.subscribe(subject);
 
-    void (async () => {
-      for await (const message of subscription) {
-        handler(message);
-      }
-    })();
+class LazyNatsTransport implements MicroserviceTransport {
+  private connection: NatsConnection | undefined;
+  private transport: NatsMicroserviceTransport | undefined;
 
-    return {
-      unsubscribe() {
-        subscription.unsubscribe();
+  async close() {
+    await this.transport?.close();
+    await this.connection?.close();
+    this.transport = undefined;
+    this.connection = undefined;
+  }
+
+  async emit(pattern: string, payload: unknown) {
+    await (await this.getTransport()).emit(pattern, payload);
+  }
+
+  async listen(handler: Parameters<MicroserviceTransport['listen']>[0]) {
+    await (await this.getTransport()).listen(handler);
+  }
+
+  async send(pattern: string, payload: unknown, signal?: AbortSignal) {
+    return await (await this.getTransport()).send(pattern, payload, signal);
+  }
+
+  private async getTransport() {
+    if (this.transport) {
+      return this.transport;
+    }
+
+    const connection = await connect({
+      name: 'fluo-microservice-starter',
+      servers,
+    });
+    this.connection = connection;
+    this.transport = new NatsMicroserviceTransport({
+      client: {
+        publish(subject: string, payload: Uint8Array) {
+          connection.publish(subject, payload);
+        },
+        request(subject: string, payload: Uint8Array, options?: { timeout?: number }) {
+          return connection.request(subject, payload, options);
+        },
+        subscribe(subject: string, handler: (message: { data: Uint8Array; respond(data: Uint8Array): void }) => void) {
+          const subscription = connection.subscribe(subject);
+
+          void (async () => {
+            for await (const message of subscription) {
+              handler(message);
+            }
+          })();
+
+          return {
+            unsubscribe() {
+              subscription.unsubscribe();
+            },
+          };
+        },
       },
-    };
-  },
-};
+      codec,
+      eventSubject,
+      messageSubject,
+      requestTimeoutMs: 3_000,
+    });
+
+    return this.transport;
+  }
+}
 
 @Module({
   imports: [
@@ -1238,13 +1275,7 @@ const client = {
       processEnv: process.env,
     }),
     MicroservicesModule.forRoot({
-      transport: new NatsMicroserviceTransport({
-        client,
-        codec,
-        eventSubject,
-        messageSubject,
-        requestTimeoutMs: 3_000,
-      }),
+      transport: new LazyNatsTransport(),
     }),
   ],
   providers: [MathHandler],
@@ -1254,8 +1285,8 @@ export class AppModule {}
     case 'kafka':
       return `import { Module } from '@fluojs/core';
 import { ConfigModule } from '@fluojs/config';
-import { Kafka, logLevel } from 'kafkajs';
-import { KafkaMicroserviceTransport, MicroservicesModule } from '@fluojs/microservices';
+import { Kafka, logLevel, type Consumer, type Producer } from 'kafkajs';
+import { KafkaMicroserviceTransport, MicroservicesModule, type MicroserviceTransport } from '@fluojs/microservices';
 
 import { MathHandler } from './math/math.handler';
 
@@ -1268,61 +1299,105 @@ const consumerGroup = process.env.KAFKA_CONSUMER_GROUP ?? 'fluo-handlers';
 const eventTopic = process.env.KAFKA_EVENT_TOPIC ?? 'fluo.microservices.events';
 const messageTopic = process.env.KAFKA_MESSAGE_TOPIC ?? 'fluo.microservices.messages';
 const responseTopic = process.env.KAFKA_RESPONSE_TOPIC ?? 'fluo.microservices.responses';
-const kafka = new Kafka({
-  brokers,
-  clientId,
-  logLevel: logLevel.NOTHING,
-});
-const producer = kafka.producer();
-const consumer = kafka.consumer({ groupId: consumerGroup });
-await Promise.all([producer.connect(), consumer.connect()]);
 
-const handlers = new Map<string, (message: string) => Promise<void> | void>();
-let consumerRunning = false;
+class LazyKafkaTransport implements MicroserviceTransport {
+  private consumer: Consumer | undefined;
+  private producer: Producer | undefined;
+  private transport: KafkaMicroserviceTransport | undefined;
 
-const producerClient = {
-  async publish(topic: string, message: string) {
-    await producer.send({
-      messages: [{ value: message }],
-      topic,
-    });
-  },
-};
+  async close() {
+    await this.transport?.close();
+    await Promise.all([
+      this.consumer?.disconnect().catch(() => undefined),
+      this.producer?.disconnect().catch(() => undefined),
+    ]);
+    this.consumer = undefined;
+    this.producer = undefined;
+    this.transport = undefined;
+  }
 
-const consumerClient = {
-  async subscribe(topic: string, handler: (message: string) => Promise<void> | void) {
-    handlers.set(topic, handler);
-    await consumer.subscribe({ fromBeginning: false, topic });
+  async emit(pattern: string, payload: unknown) {
+    await (await this.getTransport()).emit(pattern, payload);
+  }
 
-    if (consumerRunning) {
-      return;
+  async listen(handler: Parameters<MicroserviceTransport['listen']>[0]) {
+    await (await this.getTransport()).listen(handler);
+  }
+
+  async send(pattern: string, payload: unknown, signal?: AbortSignal) {
+    return await (await this.getTransport()).send(pattern, payload, signal);
+  }
+
+  private async getTransport() {
+    if (this.transport) {
+      return this.transport;
     }
 
-    consumerRunning = true;
-    void consumer.run({
-      eachMessage: async ({ topic, message }) => {
-        const value = message.value?.toString();
+    const kafka = new Kafka({
+      brokers,
+      clientId,
+      logLevel: logLevel.NOTHING,
+    });
+    const producer = kafka.producer();
+    const consumer = kafka.consumer({ groupId: consumerGroup });
+    await Promise.all([producer.connect(), consumer.connect()]);
 
-        if (!value) {
-          return;
-        }
+    const handlers = new Map<string, (message: string) => Promise<void> | void>();
+    let consumerRunning = false;
 
-        await handlers.get(topic)?.(value);
+    this.producer = producer;
+    this.consumer = consumer;
+    this.transport = new KafkaMicroserviceTransport({
+      consumer: {
+        async subscribe(topic: string, handler: (message: string) => Promise<void> | void) {
+          handlers.set(topic, handler);
+          await consumer.subscribe({ fromBeginning: false, topic });
+
+          if (consumerRunning) {
+            return;
+          }
+
+          consumerRunning = true;
+          void consumer.run({
+            eachMessage: async ({ topic, message }) => {
+              const value = message.value?.toString();
+
+              if (!value) {
+                return;
+              }
+
+              await handlers.get(topic)?.(value);
+            },
+          });
+        },
+        async unsubscribe(topic: string) {
+          handlers.delete(topic);
+
+          if (handlers.size > 0) {
+            return;
+          }
+
+          consumerRunning = false;
+          await consumer.stop();
+        },
       },
+      eventTopic,
+      messageTopic,
+      producer: {
+        async publish(topic: string, message: string) {
+          await producer.send({
+            messages: [{ value: message }],
+            topic,
+          });
+        },
+      },
+      requestTimeoutMs: 3_000,
+      responseTopic,
     });
-  },
-  async unsubscribe(topic: string) {
-    handlers.delete(topic);
 
-    if (handlers.size > 0) {
-      return;
-    }
-
-    consumerRunning = false;
-    await consumer.stop();
-    await Promise.all([consumer.disconnect(), producer.disconnect()]);
-  },
-};
+    return this.transport;
+  }
+}
 
 @Module({
   imports: [
@@ -1331,14 +1406,7 @@ const consumerClient = {
       processEnv: process.env,
     }),
     MicroservicesModule.forRoot({
-      transport: new KafkaMicroserviceTransport({
-        consumer: consumerClient,
-        eventTopic,
-        messageTopic,
-        producer: producerClient,
-        requestTimeoutMs: 3_000,
-        responseTopic,
-      }),
+      transport: new LazyKafkaTransport(),
     }),
   ],
   providers: [MathHandler],
@@ -1350,7 +1418,7 @@ export class AppModule {}
 
 import { Module } from '@fluojs/core';
 import { ConfigModule } from '@fluojs/config';
-import { MicroservicesModule, RabbitMqMicroserviceTransport } from '@fluojs/microservices';
+import { MicroservicesModule, RabbitMqMicroserviceTransport, type MicroserviceTransport } from '@fluojs/microservices';
 
 import { MathHandler } from './math/math.handler';
 
@@ -1358,61 +1426,99 @@ const url = process.env.RABBITMQ_URL ?? 'amqp://127.0.0.1:5672';
 const eventQueue = process.env.RABBITMQ_EVENT_QUEUE ?? 'fluo.microservices.events';
 const messageQueue = process.env.RABBITMQ_MESSAGE_QUEUE ?? 'fluo.microservices.messages';
 const responseQueue = process.env.RABBITMQ_RESPONSE_QUEUE ?? 'fluo.microservices.responses';
-const connection = await connect(url);
-const channel = await connection.createConfirmChannel();
-const consumerTags = new Map<string, string>();
 
-const publisher = {
-  async publish(queue: string, message: string) {
-    await channel.assertQueue(queue, { durable: true });
-    await new Promise<void>((resolve, reject) => {
-      channel.sendToQueue(queue, Buffer.from(message), { persistent: true }, (error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
+class LazyRabbitMqTransport implements MicroserviceTransport {
+  private channel: Awaited<ReturnType<Awaited<ReturnType<typeof connect>>['createConfirmChannel']>> | undefined;
+  private connection: Awaited<ReturnType<typeof connect>> | undefined;
+  private transport: RabbitMqMicroserviceTransport | undefined;
 
-        resolve();
-      });
-    });
-  },
-};
+  async close() {
+    await this.transport?.close();
+    await this.channel?.close().catch(() => undefined);
+    await this.connection?.close().catch(() => undefined);
+    this.channel = undefined;
+    this.connection = undefined;
+    this.transport = undefined;
+  }
 
-const consumer = {
-  async cancel(queue: string) {
-    const consumerTag = consumerTags.get(queue);
+  async emit(pattern: string, payload: unknown) {
+    await (await this.getTransport()).emit(pattern, payload);
+  }
 
-    if (!consumerTag) {
-      return;
+  async listen(handler: Parameters<MicroserviceTransport['listen']>[0]) {
+    await (await this.getTransport()).listen(handler);
+  }
+
+  async send(pattern: string, payload: unknown, signal?: AbortSignal) {
+    return await (await this.getTransport()).send(pattern, payload, signal);
+  }
+
+  private async getTransport() {
+    if (this.transport) {
+      return this.transport;
     }
 
-    consumerTags.delete(queue);
-    await channel.cancel(consumerTag);
+    const connection = await connect(url);
+    const channel = await connection.createConfirmChannel();
+    const consumerTags = new Map<string, string>();
 
-    if (consumerTags.size === 0) {
-      await channel.close();
-      await connection.close();
-    }
-  },
-  async consume(queue: string, handler: (message: string) => Promise<void> | void) {
-    await channel.assertQueue(queue, { durable: true });
-    const result = await channel.consume(queue, (message) => {
-      if (!message) {
-        return;
-      }
+    this.connection = connection;
+    this.channel = channel;
+    this.transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue: string) {
+          const consumerTag = consumerTags.get(queue);
 
-      void Promise.resolve(handler(message.content.toString()))
-        .then(() => {
-          channel.ack(message);
-        })
-        .catch(() => {
-          channel.nack(message, false, false);
-        });
+          if (!consumerTag) {
+            return;
+          }
+
+          consumerTags.delete(queue);
+          await channel.cancel(consumerTag);
+        },
+        async consume(queue: string, handler: (message: string) => Promise<void> | void) {
+          await channel.assertQueue(queue, { durable: true });
+          const result = await channel.consume(queue, (message) => {
+            if (!message) {
+              return;
+            }
+
+            void Promise.resolve(handler(message.content.toString()))
+              .then(() => {
+                channel.ack(message);
+              })
+              .catch(() => {
+                channel.nack(message, false, false);
+              });
+          });
+
+          consumerTags.set(queue, result.consumerTag);
+        },
+      },
+      eventQueue,
+      messageQueue,
+      publisher: {
+        async publish(queue: string, message: string) {
+          await channel.assertQueue(queue, { durable: true });
+          await new Promise<void>((resolve, reject) => {
+            channel.sendToQueue(queue, Buffer.from(message), { persistent: true }, (error) => {
+              if (error) {
+                reject(error);
+                return;
+              }
+
+              resolve();
+            });
+          });
+        },
+      },
+      requestTimeoutMs: 3_000,
+      responseQueue,
     });
 
-    consumerTags.set(queue, result.consumerTag);
-  },
-};
+    return this.transport;
+  }
+}
 
 @Module({
   imports: [
@@ -1421,14 +1527,7 @@ const consumer = {
       processEnv: process.env,
     }),
     MicroservicesModule.forRoot({
-      transport: new RabbitMqMicroserviceTransport({
-        consumer,
-        eventQueue,
-        messageQueue,
-        publisher,
-        requestTimeoutMs: 3_000,
-        responseQueue,
-      }),
+      transport: new LazyRabbitMqTransport(),
     }),
   ],
   providers: [MathHandler],


### PR DESCRIPTION
## Summary

Closes #1877.

Keep generated NATS, Kafka, and RabbitMQ microservice starters import-safe for `fluo inspect`, tests, and static tooling by moving broker client construction behind lazy transport wrappers owned by the Fluo lifecycle.

## Changes

- Replaced import-time NATS/Kafka/RabbitMQ broker setup in generated `src/app.ts` starters with lazy `MicroserviceTransport` wrappers.
- Preserved the documented starter matrix and explicit caller-owned broker dependency contracts.
- Added regression coverage that imports generated broker starters and performs inspect-style close without a live broker.
- Updated `packages/cli` EN/KO README contract text and added a patch changeset for `@fluojs/cli`.

## Testing

- `pnpm install --frozen-lockfile` — passed
- `pnpm exec vitest run -c vitest.config.ts src/new/scaffold.test.ts` (from `packages/cli`) — passed (21 tests)
- `pnpm exec biome lint packages/cli/src/new/scaffold.ts packages/cli/src/new/scaffold.test.ts` — passed
- `lsp_diagnostics` on `packages/cli/src/new/scaffold.ts` — clean
- `lsp_diagnostics` on `packages/cli/src/new/scaffold.test.ts` — clean
- `pnpm --filter @fluojs/cli... build && pnpm --filter @fluojs/cli typecheck` — passed

Notes: direct `pnpm --filter @fluojs/cli typecheck` / `pnpm --filter @fluojs/cli build` before dependency builds failed because workspace dependency `dist` outputs were absent; reran through `@fluojs/cli...` dependency closure successfully.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Contract impact: patch-level contract-preserving behavior fix. Generated broker starters still expose the same transport options and caller-owned broker dependencies, but import/inspect no longer creates broker clients or opens external resources before lifecycle-owned listen/send/emit and teardown.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed.