### PR TITLE
Resolve #1878: align e2e imports with starter root module

### DIFF
--- a/.changeset/align-e2e-starter-imports.md
+++ b/.changeset/align-e2e-starter-imports.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Align generated e2e test imports with the default `fluo new` starter root module at `src/app` while preserving explicit root module import overrides.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -155,7 +155,7 @@ fluo generate service users --dry-run
 
 `fluo generate module <name> --with-test`는 작성한 module을 `createTestingModule({ rootModule })`로 컴파일하는 `*.slice.test.ts`를 추가합니다. `fluo generate resource <name>`는 module, controller, service, repository, request DTO, response DTO, test를 포함하는 완전한 feature slice를 생성합니다. `--with-slice-test`를 추가하면 provider override와 service resolution을 보여 주는 resource-level slice test도 포함합니다. 생성된 resource module은 parent module에 자동으로 연결하지 않으므로, slice를 활성화할 준비가 되었을 때 직접 import하세요.
 
-`fluo generate e2e <name>`는 generated starter와 같은 app-level test 영역에 request-pipeline test를 두도록 `createTestApp({ rootModule: AppModule })`을 사용하는 `test/<name>.e2e.test.ts`를 작성합니다. 생성된 unit test는 직접 class 동작 검증에, slice test는 DI wiring과 override 검증에, e2e test는 virtual app을 통과하는 route, guard, interceptor, DTO validation, response writing 검증에 사용하세요.
+`fluo generate e2e <name>`는 generated starter와 같은 app-level test 영역에 request-pipeline test를 두도록 `createTestApp({ rootModule: AppModule })`을 사용하는 `test/<name>.e2e.test.ts`를 작성하고, 기본 starter root module인 `../src/app`에서 `AppModule`을 import합니다. 생성된 unit test는 직접 class 동작 검증에, slice test는 DI wiring과 override 검증에, e2e test는 virtual app을 통과하는 route, guard, interceptor, DTO validation, response writing 검증에 사용하세요.
 
 Request DTO 생성은 feature 디렉터리와 DTO 클래스 이름을 분리해서 받습니다. 따라서 `CreateUser`, `UpdateUser` 같은 여러 입력 계약을 같은 `src/users/` 슬라이스 안에 둘 수 있습니다.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -155,7 +155,7 @@ Auto-registered generators are `controller`, `service`, `repo`, `guard`, `interc
 
 `fluo generate module <name> --with-test` adds a `*.slice.test.ts` that compiles the authored module with `createTestingModule({ rootModule })`. `fluo generate resource <name>` creates a complete feature slice with a module, controller, service, repository, request DTO, response DTO, and tests; add `--with-slice-test` to include a resource-level slice test that demonstrates provider override and service resolution. It does not wire the resource module into a parent module automatically; import the generated module when you are ready to activate the slice.
 
-`fluo generate e2e <name>` writes `test/<name>.e2e.test.ts` with `createTestApp({ rootModule: AppModule })` so request-pipeline tests live in the same app-level test area as generated starters. Use generated unit tests for direct class behavior, slice tests for DI wiring and overrides, and e2e tests for routes, guards, interceptors, DTO validation, and response writing through the virtual app.
+`fluo generate e2e <name>` writes `test/<name>.e2e.test.ts` with `createTestApp({ rootModule: AppModule })` and imports `AppModule` from the default starter root module at `../src/app`, so request-pipeline tests live in the same app-level test area as generated starters. Use generated unit tests for direct class behavior, slice tests for DI wiring and overrides, and e2e tests for routes, guards, interceptors, DTO validation, and response writing through the virtual app.
 
 Request DTO generation accepts the feature directory separately from the DTO class name, so multiple input contracts such as `CreateUser` and `UpdateUser` can live inside the same `src/users/` slice.
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -3677,7 +3677,7 @@ exit 7
     );
     expect(readFileSync(join(workspaceDirectory, 'src', 'users', 'user.slice.test.ts'), 'utf8')).toContain('overrideProvider(UserRepo');
     expect(readFileSync(join(workspaceDirectory, 'test', 'users.e2e.test.ts'), 'utf8')).toContain(
-      "import { AppModule } from '../src/app.module';",
+      "import { AppModule } from '../src/app';",
     );
   });
 

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -349,17 +349,30 @@ export { PostModule };
     expect(sliceContent).toContain('await testingModule.resolve<UserService>(UserService)');
   });
 
-  it('generates e2e tests under the project test directory', () => {
+  it('generates e2e tests under the project test directory with the starter app import', () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
     tempDirectories.push(workspaceDirectory);
 
     const sourceDirectory = join(workspaceDirectory, 'src');
+    mkdirSync(sourceDirectory, { recursive: true });
+    writeFileSync(join(sourceDirectory, 'app.ts'), 'export class AppModule {}\n', 'utf8');
     const result = runGenerateCommand('e2e', 'Users', sourceDirectory);
     const e2ePath = join(workspaceDirectory, 'test', 'users.e2e.test.ts');
     const e2eContent = readFileSync(e2ePath, 'utf8');
 
     expect(result.generatedFiles).toEqual([e2ePath]);
-    expect(e2eContent).toContain("import { AppModule } from '../src/app.module';");
+    expect(e2eContent).toContain("import { AppModule } from '../src/app';");
     expect(e2eContent).toContain('createTestApp({ rootModule: AppModule })');
+  });
+
+  it('preserves explicit e2e root module import overrides', () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-generate-'));
+    tempDirectories.push(workspaceDirectory);
+
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    runGenerateCommand('e2e', 'Users', sourceDirectory, { e2eRootModuleImport: '../src/custom-root.module' });
+    const e2eContent = readFileSync(join(workspaceDirectory, 'test', 'users.e2e.test.ts'), 'utf8');
+
+    expect(e2eContent).toContain("import { AppModule } from '../src/custom-root.module';");
   });
 });

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -77,7 +77,7 @@ function toImportSpecifier(path: string): string {
 }
 
 function resolveE2eRootModuleImport(domainDirectory: string, resolvedBase: string): string {
-  return toImportSpecifier(relative(domainDirectory, join(resolvedBase, 'app.module')));
+  return toImportSpecifier(relative(domainDirectory, join(resolvedBase, 'app')));
 }
 
 function resolveDomainDirectory(kind: GeneratorKind, resolvedBase: string, kebab: string, options: GenerateOptions): string {

--- a/packages/cli/src/generators.test.ts
+++ b/packages/cli/src/generators.test.ts
@@ -72,10 +72,10 @@ describe('CLI generators', () => {
   });
 
   it('emits e2e templates based on createTestApp', () => {
-    const content = generateE2eFiles('Users', { e2eRootModuleImport: '../src/app.module' })[0]?.content ?? '';
+    const content = generateE2eFiles('Users', { e2eRootModuleImport: '../src/app' })[0]?.content ?? '';
 
     expect(content).toContain("import { createTestApp } from '@fluojs/testing';");
-    expect(content).toContain("import { AppModule } from '../src/app.module';");
+    expect(content).toContain("import { AppModule } from '../src/app';");
     expect(content).toContain('createTestApp({ rootModule: AppModule })');
     expect(content).toContain("app.request('GET', '/users').send()");
   });

--- a/packages/cli/src/generators/e2e.ts
+++ b/packages/cli/src/generators/e2e.ts
@@ -12,7 +12,7 @@ import { toKebabCase } from './utils.js';
  */
 export function generateE2eFiles(name: string, options: GenerateOptions = {}): GeneratedFile[] {
   const kebab = toKebabCase(name);
-  const rootModuleImport = options.e2eRootModuleImport ?? '../src/app.module';
+  const rootModuleImport = options.e2eRootModuleImport ?? '../src/app';
 
   return [
     {


### PR DESCRIPTION
## Summary

Resolve #1878 by aligning generated e2e tests with the default `fluo new` starter root module path.

Closes #1878

## Changes

- Default `fluo generate e2e` root module imports now resolve to `../src/app` for standard starter layouts.
- Explicit `e2eRootModuleImport` overrides remain preserved.
- Added regression coverage for generated starter/e2e compatibility and override behavior.
- Updated `@fluojs/cli` README EN/KO generated e2e behavior notes and added a patch changeset.

## Testing

- LSP diagnostics: clean for changed TS files
- `pnpm --dir packages/cli exec vitest run -c vitest.config.ts src/commands/generate.test.ts src/generators.test.ts`
- `pnpm --filter @fluojs/cli... build`
- `pnpm --filter @fluojs/cli typecheck`

## Public export documentation

- [x] No public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.