### PR TITLE
Resolve #1880: harden CLI dev fallback watchers

### DIFF
--- a/.changeset/harden-cli-dev-fallback-watchers.md
+++ b/.changeset/harden-cli-dev-fallback-watchers.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Harden the fluo-owned dev restart runner fallback so platforms without recursive `fs.watch` still restart on nested source-tree changes.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -2142,6 +2142,94 @@ void bootstrap();
     await expect(runPromise).resolves.toBe(0);
   });
 
+  it('watches nested source directories when recursive source watching falls back', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const nestedDirectory = join(sourceDirectory, 'features', 'users');
+    mkdirSync(nestedDirectory, { recursive: true });
+    const sourceFile = join(nestedDirectory, 'users.service.ts');
+    writeFileSync(sourceFile, 'export const users = "one";\n');
+    const children: ChildProcess[] = [];
+    const watchListeners = new Map<string, (event: string, filename: string | Buffer | null) => void>();
+
+    const runPromise = runNodeRestartRunner({
+      debounceMs: 1,
+      env: {},
+      projectDirectory: workspaceDirectory,
+      signalTarget: createSignalTarget().target,
+      spawnChild: () => {
+        const child = createMockChild();
+        children.push(child);
+        return child;
+      },
+      watchTarget: (target, optionsOrListener, listener) => {
+        if (typeof optionsOrListener !== 'function') {
+          throw new Error('recursive watch unavailable');
+        }
+        watchListeners.set(target, listener ?? optionsOrListener);
+
+        return { close: () => undefined } as never;
+      },
+    });
+
+    expect([...watchListeners.keys()]).toEqual(expect.arrayContaining([sourceDirectory, join(sourceDirectory, 'features'), nestedDirectory]));
+
+    writeFileSync(sourceFile, 'export const users = "two";\n');
+    watchListeners.get(nestedDirectory)?.('change', 'users.service.ts');
+
+    await waitForCondition(() => children.length === 2);
+
+    children[1]?.emit('close', 0);
+    await expect(runPromise).resolves.toBe(0);
+  });
+
+  it('adds fallback watchers for source directories created after startup', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    mkdirSync(sourceDirectory, { recursive: true });
+    writeFileSync(join(sourceDirectory, 'main.ts'), 'export const app = "one";\n');
+    const children: ChildProcess[] = [];
+    const watchListeners = new Map<string, (event: string, filename: string | Buffer | null) => void>();
+
+    const runPromise = runNodeRestartRunner({
+      debounceMs: 1,
+      env: {},
+      projectDirectory: workspaceDirectory,
+      signalTarget: createSignalTarget().target,
+      spawnChild: () => {
+        const child = createMockChild();
+        children.push(child);
+        return child;
+      },
+      watchTarget: (target, optionsOrListener, listener) => {
+        if (typeof optionsOrListener !== 'function') {
+          throw new Error('recursive watch unavailable');
+        }
+        watchListeners.set(target, listener ?? optionsOrListener);
+
+        return { close: () => undefined } as never;
+      },
+    });
+
+    const createdDirectory = join(sourceDirectory, 'generated', 'admin');
+    mkdirSync(createdDirectory, { recursive: true });
+    const createdFile = join(createdDirectory, 'admin.module.ts');
+    writeFileSync(createdFile, 'export const admin = "one";\n');
+    watchListeners.get(sourceDirectory)?.('rename', 'generated');
+
+    await waitForCondition(() => watchListeners.has(createdDirectory));
+
+    writeFileSync(createdFile, 'export const admin = "two";\n');
+    watchListeners.get(createdDirectory)?.('change', 'admin.module.ts');
+
+    await waitForCondition(() => children.length === 2);
+
+    children[1]?.emit('close', 0);
+    await expect(runPromise).resolves.toBe(0);
+  });
+
   it('resolves terminal shutdown while a planned restart is waiting for the previous child to close', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);

--- a/packages/cli/src/dev-runner/node-restart-runner.ts
+++ b/packages/cli/src/dev-runner/node-restart-runner.ts
@@ -136,6 +136,33 @@ function collectWatchedContentPaths(paths: Iterable<string>, projectDirectory: s
   return collected;
 }
 
+function collectWatchDirectories(directoryPath: string, projectDirectory: string, ignorePatterns: string[], directories: Set<string>): void {
+  if (shouldIgnorePath(directoryPath, projectDirectory, ignorePatterns)) {
+    return;
+  }
+
+  try {
+    const stats = statSync(directoryPath);
+    if (!stats.isDirectory()) {
+      return;
+    }
+
+    directories.add(directoryPath);
+    for (const entry of readdirSync(directoryPath)) {
+      collectWatchDirectories(join(directoryPath, entry), projectDirectory, ignorePatterns, directories);
+    }
+  } catch (_error: unknown) {
+    return;
+  }
+}
+
+function getFallbackWatchDirectories(directoryPath: string, projectDirectory: string, ignorePatterns: string[]): string[] {
+  const directories = new Set<string>();
+  collectWatchDirectories(directoryPath, projectDirectory, ignorePatterns, directories);
+
+  return [...directories];
+}
+
 /**
  * Creates a content-diff gate for fluo-owned dev restarts.
  *
@@ -265,7 +292,8 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
   const appArgs = options.appArgs ?? [];
   const debounceMs = options.debounceMs ?? Number(env.FLUO_DEV_RELOAD_DEBOUNCE_MS ?? DEFAULT_DEBOUNCE_MS);
   const childShutdownTimeoutMs = Number(env.FLUO_DEV_CHILD_SHUTDOWN_TIMEOUT_MS ?? DEFAULT_CHILD_SHUTDOWN_TIMEOUT_MS);
-  const gate = createContentChangeGate(projectDirectory, parseIgnorePatterns(env));
+  const ignorePatterns = parseIgnorePatterns(env);
+  const gate = createContentChangeGate(projectDirectory, ignorePatterns);
   const watchTargets = getWatchTargets(projectDirectory);
   let child: ChildProcess | undefined;
   const pendingRestartPaths = new Set<string>();
@@ -404,6 +432,32 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
 
     startChild(resolveExitCode, cleanup);
 
+    const watchedFallbackDirectories = new Set<string>();
+
+    const watchFallbackDirectory = (directoryPath: string) => {
+      if (watchedFallbackDirectories.has(directoryPath) || shouldIgnorePath(directoryPath, projectDirectory, ignorePatterns)) {
+        return;
+      }
+
+      watchedFallbackDirectories.add(directoryPath);
+      const listener = (_event: string, filename: string | Buffer | null) => {
+        const fileName = filename ? String(filename) : basename(directoryPath);
+        const changedPath = filename ? join(directoryPath, fileName) : directoryPath;
+        scheduleRestart(changedPath, resolveExitCode, cleanup);
+
+        for (const nextDirectoryPath of getFallbackWatchDirectories(changedPath, projectDirectory, ignorePatterns)) {
+          watchFallbackDirectory(nextDirectoryPath);
+        }
+      };
+
+      try {
+        watchers.push(watchTarget(directoryPath, listener));
+      } catch (error: unknown) {
+        watchedFallbackDirectories.delete(directoryPath);
+        stderr.write(`[fluo] unable to watch ${directoryPath}: ${error instanceof Error ? error.message : String(error)}\n`);
+      }
+    };
+
     for (const target of watchTargets) {
       try {
         const stats = statSync(target);
@@ -418,7 +472,9 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
           if (!stats.isDirectory()) {
             throw error;
           }
-          watchers.push(watchTarget(target, listener));
+          for (const directoryPath of getFallbackWatchDirectories(target, projectDirectory, ignorePatterns)) {
+            watchFallbackDirectory(directoryPath);
+          }
         }
       } catch (error: unknown) {
         stderr.write(`[fluo] unable to watch ${target}: ${error instanceof Error ? error.message : String(error)}\n`);


### PR DESCRIPTION
## Summary

Closes #1880

Harden the `@fluojs/cli` fluo-owned dev restart runner so non-recursive fallback watching still preserves nested source-tree restart behavior for generated projects.

## Changes

- Register fallback watchers for every discovered source subdirectory when recursive `fs.watch` is unavailable.
- Add fallback watchers for newly created source subdirectories as watch events arrive.
- Preserve existing debounce/content-hash/noisy-path ignore semantics by routing fallback events through the same restart scheduling and content gate.
- Add a patch Changeset for the public CLI lifecycle portability fix.

## Testing

- `lsp_diagnostics` on `packages/cli/src/dev-runner/node-restart-runner.ts`: pass
- `lsp_diagnostics` on `packages/cli/src/cli.test.ts`: pass
- `pnpm --filter @fluojs/cli typecheck`: pass
- `pnpm --filter @fluojs/cli test`: pass (`10 passed`, `344 passed`)
- `pnpm --filter @fluojs/cli build`: pass

Note: the first CLI test/typecheck attempt failed because the fresh worktree had no built workspace dependency outputs for `@fluojs/runtime`; after installing dependencies and building the needed dependency chain (`@fluojs/validation`, `@fluojs/http`, `@fluojs/runtime`), the relevant CLI checks passed.

## Public export documentation

해당 없음 — public export/API surface를 변경하지 않았고, CLI dev runner 내부 watcher fallback 동작만 보강했습니다.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

`packages/cli/README.md`가 문서화한 generated Node.js project의 source/config watch restart contract를 보존하는 portability fix입니다. 새 사용자-facing 옵션이나 제한은 추가하지 않았고, non-recursive watcher fallback에서도 nested `src` 변경을 감지하도록 regression tests를 추가했습니다.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

해당 없음 — platform contract docs 또는 SSOT English/Korean governance mirror를 변경하지 않았습니다. 영향 범위는 `@fluojs/cli` dev restart runner fallback과 해당 regression tests/change intent에 한정됩니다.

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.