### PR TITLE
Resolve #1908: Align Socket.IO module options and Bun runtime guidance

### DIFF
--- a/book/intermediate/ch14-socketio.ko.md
+++ b/book/intermediate/ch14-socketio.ko.md
@@ -142,7 +142,7 @@ export class ScalingService {
 
 ## 14.6 Bun engine details
 
-fluo는 Bun의 고성능 WebSocket 구현을 우선 지원합니다. Socket.IO는 보통 Node.js에서 `ws` 패키지를 사용하지만, Bun에서는 `@socket.io/bun-engine`을 사용할 수 있습니다. FluoShop을 Bun에서 실행하면 `@fluojs/socket.io` adapter는 자동으로 환경을 감지하고, 사용 가능한 경우 Bun engine으로 전환합니다. 이 선택은 FluoShop이 표준 Node.js 프로세스보다 낮은 메모리 오버헤드로 많은 동시 지원 채팅을 처리할 수 있게 합니다.
+fluo는 선택한 HTTP adapter 계약을 통해 Bun의 고성능 WebSocket 구현을 지원합니다. Socket.IO는 보통 Node.js에서 `ws` 패키지를 사용하지만, Bun에서는 활성 platform adapter가 Socket.IO adapter에 필요한 fetch-style realtime binding을 제공할 때 `@socket.io/bun-engine`을 사용할 수 있습니다. 따라서 FluoShop은 runtime auto-switching에 의존하지 말고 Bun 호환 platform adapter를 명시적으로 선택해야 합니다. 이 방식은 realtime boundary를 감사 가능한 상태로 유지하면서도 표준 Node.js 프로세스보다 낮은 메모리 오버헤드로 많은 동시 지원 채팅을 처리할 수 있게 합니다.
 
 ## 14.7 여러 room으로 브로드캐스트하기
 

--- a/book/intermediate/ch14-socketio.md
+++ b/book/intermediate/ch14-socketio.md
@@ -146,7 +146,7 @@ During shutdown, Socket.IO owns cleanup for connected Socket.IO clients. The und
 
 ## 14.6 Bun engine details
 
-fluo prioritizes support for Bun's high performance WebSocket implementation. Socket.IO usually uses the `ws` package on Node.js, but on Bun it can use `@socket.io/bun-engine`. When FluoShop runs on Bun, the `@fluojs/socket.io` adapter automatically detects the environment and switches to the Bun engine when available. This choice lets FluoShop handle many concurrent support chats with lower memory overhead than a standard Node.js process.
+fluo supports Bun's high performance WebSocket implementation through the selected HTTP adapter contract. Socket.IO usually uses the `ws` package on Node.js, but on Bun it can use `@socket.io/bun-engine` when the active platform adapter exposes the fetch-style realtime binding that the Socket.IO adapter requires. FluoShop should therefore choose a Bun-compatible platform adapter explicitly instead of relying on runtime auto-switching. This keeps the realtime boundary auditable while still allowing many concurrent support chats with lower memory overhead than a standard Node.js process.
 
 ## 14.7 Broadcasting across many rooms
 

--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -125,14 +125,14 @@ Socket.IO 등록은 소유 모듈의 import 경로에서 구성하여 namespace/
 ## 공개 API 개요
 
 - `SocketIoModule.forRoot(options)`
-- `SocketIoModule.forRoot({ auth, cors, engine, ... })`
+- `SocketIoModule.forRoot({ global, auth, cors, engine, ... })`: provider visibility, namespace/message guard, 명시적 CORS, Engine.IO payload bound를 구성합니다.
 - `SOCKETIO_SERVER`
 - `SOCKETIO_ROOM_SERVICE`
 - `SocketIoRoomService`: 공유 room 계약에 Socket.IO namespace-aware `joinRoom`, `leaveRoom`, `broadcastToRoom`, `getRooms` helper를 더한 타입입니다.
 - `SocketIoLifecycleService`: server와 room-service token 뒤에서 동작하는 lifecycle 기반 구현입니다. 애플리케이션 코드는 일반적으로 `SOCKETIO_SERVER` 또는 `SOCKETIO_ROOM_SERVICE`를 주입하세요.
 - 타입: `SocketIoModuleOptions`, `SocketIoConnectionGuardContext`, `SocketIoConnectionGuard`, `SocketIoMessageGuardContext`, `SocketIoMessageGuard`, `SocketIoGuardRejection`.
 
-`SocketIoModuleOptions`는 `auth`, `buffer`, `cors`, `engine`, `shutdown`, `transports`를 포함합니다. 지원되는 server-backed runtime adapter가 필요하며, unsupported/noop adapter는 bootstrap 중 빠르게 실패합니다.
+`SocketIoModuleOptions`는 `global`, `auth`, `buffer`, `cors`, `engine`, `shutdown`, `transports`를 포함합니다. `global`의 기본값은 `true`이므로 `SOCKETIO_SERVER`와 `SOCKETIO_ROOM_SERVICE`가 앱 전체에서 보입니다. module-local provider visibility가 필요하면 `false`로 설정하세요. 지원되는 server-backed runtime adapter가 필요하며, unsupported/noop adapter는 bootstrap 중 빠르게 실패합니다.
 
 ## 지원 플랫폼
 

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -127,14 +127,14 @@ Register Socket.IO through module imports in the owning module so namespace/mess
 ## Public API Overview
 
 - `SocketIoModule.forRoot(options)`: Main module for Socket.IO integration.
-- `SocketIoModule.forRoot({ auth, cors, engine, ... })`: Configures namespace/message guards plus explicit CORS and Engine.IO payload bounds.
+- `SocketIoModule.forRoot({ global, auth, cors, engine, ... })`: Configures provider visibility, namespace/message guards, explicit CORS, and Engine.IO payload bounds.
 - `SOCKETIO_SERVER`: Token to inject the raw Socket.IO `Server`.
 - `SOCKETIO_ROOM_SERVICE`: Token to inject the `SocketIoRoomService`.
 - `SocketIoRoomService`: Shared room contract plus Socket.IO namespace-aware `joinRoom`, `leaveRoom`, `broadcastToRoom`, and `getRooms` helpers.
 - `SocketIoLifecycleService`: Lifecycle-backed implementation behind the server and room-service tokens; application code should usually inject `SOCKETIO_SERVER` or `SOCKETIO_ROOM_SERVICE` instead.
 - Types: `SocketIoModuleOptions`, `SocketIoConnectionGuardContext`, `SocketIoConnectionGuard`, `SocketIoMessageGuardContext`, `SocketIoMessageGuard`, `SocketIoGuardRejection`.
 
-`SocketIoModuleOptions` covers `auth`, `buffer`, `cors`, `engine`, `shutdown`, and `transports`. A supported server-backed runtime adapter is required; unsupported/noop adapters fail fast during bootstrap.
+`SocketIoModuleOptions` covers `global`, `auth`, `buffer`, `cors`, `engine`, `shutdown`, and `transports`. `global` defaults to `true`, which keeps `SOCKETIO_SERVER` and `SOCKETIO_ROOM_SERVICE` visible across the app; set it to `false` when you want module-local provider visibility. A supported server-backed runtime adapter is required; unsupported/noop adapters fail fast during bootstrap.
 
 ## Supported Platforms
 


### PR DESCRIPTION
## Summary

- Aligns Socket.IO package docs with the existing `SocketIoModuleOptions.global` option.
- Corrects the Socket.IO book's Bun guidance so it describes the adapter-provided fetch-style realtime binding requirement instead of automatic runtime switching.

Closes #1908

## Changes

- Added `global` to the English and Korean `@fluojs/socket.io` README option inventory, including its default and module-local visibility use case.
- Updated English and Korean intermediate Socket.IO book wording for Bun runtime guidance.
- No source/runtime behavior changes.

## Testing

- `lsp_diagnostics` on changed markdown files: no diagnostics.
- `pnpm docs:sync-check`: passed.
- `git diff --check`: passed.
- Build not run: documentation-only change with no code or package build output impact.

## Public export documentation

해당 없음 — public export source는 변경하지 않았고, 기존 public option을 README에 문서화한 docs-only 정렬입니다.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

문서 정렬만 수행했습니다. 기존 `SocketIoModuleOptions.global` 동작과 Bun adapter requirement를 더 정확히 설명하며, documented behavior를 제거하거나 runtime invariant를 변경하지 않습니다.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

Governed platform contract docs는 변경하지 않았습니다. EN/KO package README 및 book mirror를 함께 업데이트했고 `pnpm docs:sync-check`로 locale parity를 확인했습니다.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

## Changeset

해당 없음 — public package behavior/API 변경 없이 문서의 누락/오해 소지를 수정한 docs-only change입니다.