### PR TITLE
Resolve #1889: Complete validation decorator TSDoc baseline

### DIFF
--- a/.changeset/validation-decorator-tsdoc-baseline.md
+++ b/.changeset/validation-decorator-tsdoc-baseline.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/validation": patch
+---
+
+Complete the public TSDoc baseline for validation decorator exports so generated API documentation includes matching parameter and return metadata.

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -166,59 +166,105 @@ export const ValidateIf = (
 ) => createValidationDecorator(() => ({ kind: 'validateIf', validateIf, ...options }));
 
 /**
- * Provides the is defined value.
+ * Validates that the decorated field is neither `null` nor `undefined`.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a required-value rule.
  */
 export const IsDefined = createFlagValidationDecorator((options) => ({ kind: 'defined', ...options }));
 /**
- * Provides the is optional value.
+ * Skips subsequent validators when the decorated field is `null` or `undefined`.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers optional-value semantics.
  */
 export const IsOptional = createFlagValidationDecorator((options) => ({ kind: 'optional', ...options }));
 /**
- * Provides the equals value.
+ * Validates that the decorated field strictly equals the expected value.
+ *
+ * @param value Expected value to compare against the field value.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an equality rule.
  */
 export const Equals = createValidationOptionsWithConfigDecorator<unknown>((value, options) => ({ kind: 'equals', value, ...options }));
 /**
- * Provides the not equals value.
+ * Validates that the decorated field does not strictly equal the forbidden value.
+ *
+ * @param value Forbidden value to compare against the field value.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an inequality rule.
  */
 export const NotEquals = createValidationOptionsWithConfigDecorator<unknown>((value, options) => ({ kind: 'notEquals', value, ...options }));
 /**
- * Provides the is empty value.
+ * Validates that the decorated field is empty.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an empty-value rule.
  */
 export const IsEmpty = createFlagValidationDecorator((options) => ({ kind: 'empty', ...options }));
 /**
- * Provides the is not empty value.
+ * Validates that the decorated field is not empty.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a non-empty-value rule.
  */
 export const IsNotEmpty = createFlagValidationDecorator((options) => ({ kind: 'notEmpty', ...options }));
 /**
- * Provides the is in value.
+ * Validates that the decorated field is included in the accepted values.
+ *
+ * @param values Accepted values for the field.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an inclusion rule.
  */
 export const IsIn = createArrayValidationDecorator<unknown>((values, options) => ({ kind: 'in', values, ...options }));
 /**
- * Provides the is not in value.
+ * Validates that the decorated field is not included in the rejected values.
+ *
+ * @param values Rejected values for the field.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an exclusion rule.
  */
 export const IsNotIn = createArrayValidationDecorator<unknown>((values, options) => ({ kind: 'notIn', values, ...options }));
 /**
- * Provides the is date value.
+ * Validates that the decorated field is a `Date` value.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a date validation rule.
  */
 export const IsDate = createFlagValidationDecorator((options) => ({ kind: 'date', ...options }));
 /**
- * Provides the is array value.
+ * Validates that the decorated field is an array.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an array validation rule.
  */
 export const IsArray = createFlagValidationDecorator((options) => ({ kind: 'array', ...options }));
 /**
- * Provides the is object value.
+ * Validates that the decorated field is an object value.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an object validation rule.
  */
 export const IsObject = createFlagValidationDecorator((options) => ({ kind: 'object', ...options }));
 /**
- * Provides the is int value.
+ * Validates that the decorated field is an integer.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an integer validation rule.
  */
 export const IsInt = createFlagValidationDecorator((options) => ({ kind: 'int', ...options }));
 /**
- * Provides the is positive value.
+ * Validates that the decorated field is a positive number.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a positive-number rule.
  */
 export const IsPositive = createFlagValidationDecorator((options) => ({ kind: 'positive', ...options }));
 /**
- * Provides the is negative value.
+ * Validates that the decorated field is a negative number.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a negative-number rule.
  */
 export const IsNegative = createFlagValidationDecorator((options) => ({ kind: 'negative', ...options }));
 
@@ -235,31 +281,59 @@ export function IsEnum(values: Record<string, unknown> | readonly unknown[], opt
 }
 
 /**
- * Provides the is divisible by value.
+ * Validates that the decorated field is divisible by the given divisor.
+ *
+ * @param value Divisor used for the numeric divisibility check.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a divisibility rule.
  */
 export const IsDivisibleBy = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'divisibleBy', value, ...options }));
 /**
- * Provides the min value.
+ * Validates that the decorated field is greater than or equal to the minimum.
+ *
+ * @param value Inclusive minimum allowed numeric value.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a minimum-value rule.
  */
 export const Min = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'min', value, ...options }));
 /**
- * Provides the max value.
+ * Validates that the decorated field is less than or equal to the maximum.
+ *
+ * @param value Inclusive maximum allowed numeric value.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a maximum-value rule.
  */
 export const Max = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'max', value, ...options }));
 /**
- * Provides the min date value.
+ * Validates that the decorated field is on or after the minimum date.
+ *
+ * @param value Inclusive minimum allowed date.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a minimum-date rule.
  */
 export const MinDate = createValidationOptionsWithConfigDecorator<Date>((value, options) => ({ kind: 'minDate', value, ...options }));
 /**
- * Provides the max date value.
+ * Validates that the decorated field is on or before the maximum date.
+ *
+ * @param value Inclusive maximum allowed date.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a maximum-date rule.
  */
 export const MaxDate = createValidationOptionsWithConfigDecorator<Date>((value, options) => ({ kind: 'maxDate', value, ...options }));
 /**
- * Provides the contains value.
+ * Validates that the decorated field contains the required substring.
+ *
+ * @param value Required substring.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a substring-presence rule.
  */
 export const Contains = createValidationOptionsWithConfigDecorator<string>((value, options) => ({ kind: 'contains', value, ...options }));
 /**
- * Provides the not contains value.
+ * Validates that the decorated field does not contain the forbidden substring.
+ *
+ * @param value Forbidden substring.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a substring-exclusion rule.
  */
 export const NotContains = createValidationOptionsWithConfigDecorator<string>((value, options) => ({ kind: 'notContains', value, ...options }));
 
@@ -291,11 +365,19 @@ export function ValidateNested(dto: Constructor | (() => Constructor), options?:
 }
 
 /**
- * Provides the min length value.
+ * Validates that the decorated field has at least the given length.
+ *
+ * @param value Inclusive minimum string length.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a minimum-length rule.
  */
 export const MinLength = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'minLength', value, ...options }));
 /**
- * Provides the max length value.
+ * Validates that the decorated field has at most the given length.
+ *
+ * @param value Inclusive maximum string length.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a maximum-length rule.
  */
 export const MaxLength = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'maxLength', value, ...options }));
 
@@ -332,171 +414,199 @@ export function Matches(
 }
 
 /**
- * Provides the is alpha value.
+ * Validates that the decorated field contains only alphabetic characters.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an alphabetic string rule.
  */
 export const IsAlpha = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('alpha')(undefined, options);
 /**
- * Provides the is alphanumeric value.
+ * Validates that the decorated field contains only alphanumeric characters.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an alphanumeric string rule.
  */
 export const IsAlphanumeric = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('alphanumeric')(undefined, options);
 /**
- * Provides the is ascii value.
+ * Validates that the decorated field contains only ASCII characters.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an ASCII string rule.
  */
 export const IsAscii = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('ascii')(undefined, options);
 /**
- * Provides the is base64 value.
+ * Validates that the decorated field is a Base64 string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a Base64 string rule.
  */
 export const IsBase64 = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('base64')(undefined, options);
 /**
- * Provides the is boolean string value.
+ * Validates that the decorated field is a boolean-like string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a boolean-string rule.
  */
 export const IsBooleanString = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('booleanString')(undefined, options);
 /**
- * Provides the is data uri value.
+ * Validates that the decorated field is a data URI string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a data URI rule.
  */
 export const IsDataURI = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('dataURI')(undefined, options);
 /**
- * Provides the is date string value.
+ * Validates that the decorated field is a date string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a date-string rule.
  */
 export const IsDateString = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('dateString')(undefined, options);
 /**
- * Provides the is decimal value.
+ * Validates that the decorated field is a decimal string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a decimal-string rule.
  */
 export const IsDecimal = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('decimal')(undefined, options);
 /**
- * Provides the is email value.
+ * Validates that the decorated field is an email address.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an email-address rule.
  */
 export const IsEmail = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('email')(undefined, options);
 /**
- * Provides the is fqdn value.
+ * Validates that the decorated field is a fully qualified domain name.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an FQDN rule.
  */
 export const IsFQDN = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('fqdn')(undefined, options);
 /**
- * Provides the is hex color value.
+ * Validates that the decorated field is a hexadecimal color string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a hex-color rule.
  */
 export const IsHexColor = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('hexColor')(undefined, options);
 /**
- * Provides the is hexadecimal value.
+ * Validates that the decorated field is a hexadecimal string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a hexadecimal string rule.
  */
 export const IsHexadecimal = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('hexadecimal')(undefined, options);
 /**
- * Provides the is json value.
+ * Validates that the decorated field is a JSON string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a JSON-string rule.
  */
 export const IsJSON = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('json')(undefined, options);
 /**
- * Provides the is jwt value.
+ * Validates that the decorated field is a JSON Web Token string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a JWT-string rule.
  */
 export const IsJWT = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('jwt')(undefined, options);
 /**
- * Provides the is locale value.
+ * Validates that the decorated field is a locale identifier.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a locale-string rule.
  */
 export const IsLocale = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('locale')(undefined, options);
 /**
- * Provides the is lowercase value.
+ * Validates that the decorated field is lowercase.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a lowercase-string rule.
  */
 export const IsLowercase = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('lowercase')(undefined, options);
 /**
- * Provides the is magnet uri value.
+ * Validates that the decorated field is a magnet URI string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a magnet URI rule.
  */
 export const IsMagnetURI = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('magnetURI')(undefined, options);
 /**
- * Provides the is mime type value.
+ * Validates that the decorated field is a MIME type string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a MIME type rule.
  */
 export const IsMimeType = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('mimeType')(undefined, options);
 /**
- * Provides the is mongo id value.
+ * Validates that the decorated field is a MongoDB object ID string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a MongoDB object ID rule.
  */
 export const IsMongoId = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('mongoId')(undefined, options);
 /**
- * Provides the is number string value.
+ * Validates that the decorated field is a numeric string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a numeric-string rule.
  */
 export const IsNumberString = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('numberString')(undefined, options);
 /**
- * Provides the is port value.
+ * Validates that the decorated field is a network port string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a port-string rule.
  */
 export const IsPort = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('port')(undefined, options);
 /**
- * Provides the is rfc3339 value.
+ * Validates that the decorated field is an RFC 3339 date-time string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an RFC 3339 string rule.
  */
 export const IsRFC3339 = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('rfc3339')(undefined, options);
 /**
- * Provides the is sem ver value.
+ * Validates that the decorated field is a semantic version string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a semantic-version rule.
  */
 export const IsSemVer = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('semVer')(undefined, options);
 /**
- * Provides the is uppercase value.
+ * Validates that the decorated field is uppercase.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an uppercase-string rule.
  */
 export const IsUppercase = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('uppercase')(undefined, options);
 /**
- * Provides the is iso8601 value.
+ * Validates that the decorated field is an ISO 8601 date-time string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an ISO 8601 string rule.
  */
 export const IsISO8601 = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('iso8601')(undefined, options);
 /**
- * Provides the is latitude value.
+ * Validates that the decorated field is a latitude value.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a latitude rule.
  */
 export const IsLatitude = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('latitude')(undefined, options);
 /**
- * Provides the is longitude value.
+ * Validates that the decorated field is a longitude value.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a longitude rule.
  */
 export const IsLongitude = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('longitude')(undefined, options);
 /**
- * Provides the is lat long value.
+ * Validates that the decorated field is a latitude/longitude coordinate string.
  *
- * @param options The options.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a latitude/longitude rule.
  */
 export const IsLatLong = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('latLong')(undefined, options);
 
@@ -597,23 +707,42 @@ export function IsCurrency(options?: ValidationDecoratorOptions): FieldDecorator
 }
 
 /**
- * Provides the array contains value.
+ * Validates that the decorated array contains all required values.
+ *
+ * @param values Required values that must be present in the array.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an array-contains rule.
  */
 export const ArrayContains = createArrayValidationDecorator<unknown>((values, options) => ({ kind: 'arrayContains', values, ...options }));
 /**
- * Provides the array not contains value.
+ * Validates that the decorated array excludes all forbidden values.
+ *
+ * @param values Forbidden values that must not be present in the array.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an array-exclusion rule.
  */
 export const ArrayNotContains = createArrayValidationDecorator<unknown>((values, options) => ({ kind: 'arrayNotContains', values, ...options }));
 /**
- * Provides the array not empty value.
+ * Validates that the decorated array is not empty.
+ *
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a non-empty-array rule.
  */
 export const ArrayNotEmpty = createFlagValidationDecorator((options) => ({ kind: 'arrayNotEmpty', ...options }));
 /**
- * Provides the array min size value.
+ * Validates that the decorated array has at least the given size.
+ *
+ * @param value Inclusive minimum array length.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a minimum-array-size rule.
  */
 export const ArrayMinSize = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'arrayMinSize', value, ...options }));
 /**
- * Provides the array max size value.
+ * Validates that the decorated array has at most the given size.
+ *
+ * @param value Inclusive maximum array length.
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers a maximum-array-size rule.
  */
 export const ArrayMaxSize = createValidationOptionsWithConfigDecorator<number>((value, options) => ({ kind: 'arrayMaxSize', value, ...options }));
 


### PR DESCRIPTION
## Summary

Completes the public export TSDoc baseline for `@fluojs/validation` decorator constants identified in #1889.

Closes #1889

## Changes

- Added matching `@param` and `@returns` tags to validation decorator constants in `packages/validation/src/decorators.ts`.
- Replaced placeholder summaries with caller-facing decorator descriptions.
- Added a patch changeset for the public package documentation surface update.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm verify:public-export-tsdoc` — passed
- `pnpm --filter @fluojs/core build` — passed, required to generate workspace dependency types
- `pnpm --filter @fluojs/validation typecheck` — passed after core build
- `pnpm --filter @fluojs/validation build` — passed
- LSP diagnostics on `packages/validation/src/decorators.ts` — no diagnostics found after workspace dependency build

Note: `pnpm verify:public-export-tsdoc:baseline` was checked for context and still reports unrelated pre-existing full-surface gaps in `packages/cli` and `packages/http`; this PR is scoped to #1889 and the changed-file gate passes.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No runtime behavior, ordering, thrown errors, validation semantics, or public API signatures changed. This is documentation/TSDoc-only.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs, platform contract docs, package README files, book pages, or examples changed; EN/KO docs parity remains unaffected.