### PR TITLE
Resolve #1919: Correct StudioPayload public API description

### DIFF
--- a/packages/studio/README.ko.md
+++ b/packages/studio/README.ko.md
@@ -89,7 +89,7 @@ Studio는 주로 웹 애플리케이션이지만, 배포된 패키지는 도구/
 | `PlatformDiagnosticIssue` | 플랫폼 오류 보고 및 수정을 위한 스키마입니다. |
 | `parseStudioPayload(rawJson)` | raw snapshot JSON, standalone timing JSON, snapshot+timing envelope, `fluo inspect --report` artifact를 받아 parsed payload와 원본 JSON string을 반환합니다. |
 | `ParsedPayload` | `parseStudioPayload(...)`가 반환하는 parsed Studio payload shape입니다. |
-| `StudioPayload` | 허용되는 raw snapshot/timing/report input shape입니다. |
+| `StudioPayload` | `parseStudioPayload(...)`가 반환하는 정규화된 parsed payload envelope이며, 선택적 `report`, `snapshot`, `timing` 필드를 포함합니다. |
 | `StudioReportArtifact` | CI/support 자동화를 위해 summary, snapshot, timing 데이터를 함께 보존한 `fluo inspect --report` artifact입니다. |
 | `StudioReportSummary` | report artifact에 포함되는 summary block입니다. |
 | `FilterState` | `applyFilters(...)`가 받는 filter configuration입니다. |

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -89,7 +89,7 @@ Studio is primarily a web application, but the published package also exposes th
 | `PlatformDiagnosticIssue` | Schema for reporting and fixing platform errors. |
 | `parseStudioPayload(rawJson)` | Accepts raw snapshot JSON, standalone timing JSON, snapshot+timing envelopes, and `fluo inspect --report` artifacts; returns the parsed payload plus the original JSON string. |
 | `ParsedPayload` | Parsed Studio payload shape returned by `parseStudioPayload(...)`. |
-| `StudioPayload` | Accepted raw snapshot/timing/report input shapes. |
+| `StudioPayload` | Normalized parsed payload envelope returned by `parseStudioPayload(...)`, with optional `report`, `snapshot`, and `timing` fields. |
 | `StudioReportArtifact` | Preserved `fluo inspect --report` artifact with summary, snapshot, and timing data for CI/support automation. |
 | `StudioReportSummary` | Summary block included in report artifacts. |
 | `FilterState` | Filter configuration accepted by `applyFilters(...)`. |


### PR DESCRIPTION
## Summary

Clarifies the `@fluojs/studio` public API table so `StudioPayload` is documented as the normalized parsed envelope returned by `parseStudioPayload(...)`, not as raw accepted input.

Closes #1919

## Changes

- Updated `packages/studio/README.md` to describe `StudioPayload` as an optional `report` / `snapshot` / `timing` envelope.
- Updated `packages/studio/README.ko.md` with the matching Korean description for EN/KO package README parity.
- No runtime code, type surface, or behavior changes.

## Testing

- `lsp_diagnostics` on `packages/studio/README.md`: passed.
- `lsp_diagnostics` on `packages/studio/README.ko.md`: passed.
- `pnpm lint`: passed after worktree dependency install; existing unrelated Biome warnings/infos were reported in other packages, and `verify:public-export-tsdoc` passed in changed mode.
- `pnpm docs:sync-check`: passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No source public exports changed. This PR only corrects the package README description for the existing `StudioPayload` type.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Documentation-only clarification; no runtime behavior or accepted input contract changes. Changeset not added because issue #1919 marks the impact as doc-only and changeset not required.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform/governance docs changed. Package README EN/KO wording was updated in tandem; `pnpm docs:sync-check` passed.