### PR TITLE
Resolve #1897: Correct Node.js adapter multipart TSDoc boundary

### DIFF
--- a/packages/platform-nodejs/src/index.ts
+++ b/packages/platform-nodejs/src/index.ts
@@ -75,7 +75,7 @@ export const bootstrapNodejsApplication: typeof bootstrapNodeApplication = boots
  * Use this factory for adapter-first startup through `fluoFactory.create(...)` when the application
  * should run directly on Node's built-in `http` or `https` server primitives.
  *
- * @param options Transport-level Node.js settings such as port, retries, multipart, and HTTPS options.
+ * @param options Transport-level Node.js settings such as port, retries, body-size limits, and HTTPS options.
  * @returns The Node.js HTTP adapter instance used by the Fluo runtime.
  *
  * @example


### PR DESCRIPTION
## Summary

Closes #1897.

Clarifies the `createNodejsAdapter(...)` public TSDoc boundary so adapter options no longer imply a direct `multipart` option that is not part of `NodeHttpAdapterOptions`.

## Changes

- Replaced the `createNodejsAdapter(...)` `@param options` wording from `multipart` to `body-size limits`.
- Preserved the documented separation where multipart overrides belong to `bootstrapNodejsApplication(...)` / `runNodejsApplication(...)` options.

## Testing

- `pnpm build`
- `pnpm lint` (completed; existing repository-wide Biome warnings/infos were reported outside the changed file, and `verify:public-export-tsdoc` passed)
- `pnpm --filter @fluojs/platform-nodejs typecheck`
- `pnpm verify:public-export-tsdoc`
- LSP diagnostics on `packages/platform-nodejs/src/index.ts`: no diagnostics found after workspace build/dependency setup

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public API shape changed; this is a source TSDoc wording correction for an existing export.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No runtime behavior changed. The existing README continues to document that multipart total-size overrides are supplied through bootstrap/run helpers, not adapter options.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

해당 변경은 governance docs 또는 package README mirror를 수정하지 않는 TSDoc-only correction입니다. EN/KO README parity에는 변경이 없습니다.

## Release / changeset

No changeset. This is a doc-only TSDoc boundary clarification with no public behavior, runtime contract, or API shape change.