### PR TITLE
Resolve #1898: Fix Express CORS option placement in book examples

### DIFF
--- a/book/intermediate/ch21-express-node.ko.md
+++ b/book/intermediate/ch21-express-node.ko.md
@@ -186,7 +186,6 @@ import { AppModule } from './app/app.module';
 async function bootstrap() {
   const adapter = createExpressAdapter({
     port: process.env.PORT ? parseInt(process.env.PORT) : 3000,
-    cors: true,
   });
 
   const app = await fluoFactory.create(AppModule, { adapter });

--- a/book/intermediate/ch21-express-node.md
+++ b/book/intermediate/ch21-express-node.md
@@ -186,7 +186,6 @@ import { AppModule } from './app/app.module';
 async function bootstrap() {
   const adapter = createExpressAdapter({
     port: process.env.PORT ? parseInt(process.env.PORT) : 3000,
-    cors: true,
   });
 
   const app = await fluoFactory.create(AppModule, { adapter });


### PR DESCRIPTION
## Summary

- Corrects the Intermediate book Express migration snippet so it no longer passes `cors` to `createExpressAdapter(...)`.
- Keeps the English and Korean chapter examples aligned with the documented `@fluojs/platform-express` API surface.

Closes #1898

## Changes

- Removed the unsupported `cors: true` option from `book/intermediate/ch21-express-node.md`.
- Applied the same removal to `book/intermediate/ch21-express-node.ko.md` for EN/KO parity.

## Testing

- `lsp_diagnostics` on `book/intermediate/ch21-express-node.md`: passed, no diagnostics.
- `lsp_diagnostics` on `book/intermediate/ch21-express-node.ko.md`: passed, no diagnostics.
- `pnpm docs:sync-check`: passed.

## Public export documentation

- 해당 없음 — public exports or package source were not changed.
- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- 해당 없음 — this is a book example correction only; no runtime behavior or documented package contract changed.
- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- EN/KO book chapter mirror remains synchronized by applying the same snippet correction to both files.
- No platform contract docs, package README conformance claims, or SSOT governance docs changed.
- Changeset: not required because there is no public package behavior/API change.
- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.