### PR TITLE
Resolve #1911: Complete queue public type inventory

### DIFF
--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -129,9 +129,16 @@ Job은 JSON으로 직렬화 가능한 plain object여야 합니다. Queue는 enq
 
 
 ### 타입
+- `Queue`: 애플리케이션 코드와 `QUEUE` 토큰에서 사용하는 `enqueue(job)` 호환성 facade입니다.
+- `QueueJobType`: job payload class를 식별하고 rehydrate하는 데 사용하는 constructor 타입입니다.
 - `QueueModuleOptions`: 전역 큐 설정(clientName, 기본 시도 횟수, `defaultBackoff`, 동시성, 전송률 제한, dead-letter retention 등)을 위한 타입입니다.
 - `QueueWorkerOptions`: 개별 작업 설정(시도 횟수, 백오프, 동시성, jobName, 전송률 제한 등)을 위한 타입입니다.
+- `QueueBackoffType`: 지원되는 retry backoff strategy 이름(`fixed`, `exponential`)입니다.
 - `QueueBackoffOptions`: 재시도 백오프 설정(`type`, `delayMs`)을 위한 타입입니다.
+- `QueueRateLimiterOptions`: worker 수준 distributed rate limiter 설정(`max`, `duration`)을 위한 타입입니다.
+- `QueueLifecycleState`: Queue status adapter가 보고하는 lifecycle state(`idle`, `starting`, `started`, `stopping`, `stopped`)입니다.
+- `QueueStatusAdapterInput`: `createQueuePlatformStatusSnapshot(...)`에 전달하는 normalized queue metrics 타입입니다.
+- `QueuePlatformStatusSnapshot`: status helper가 반환하는 Queue 전용 readiness, health, ownership, detail snapshot 타입입니다.
 
 `QueueModuleOptions`에는 `workerShutdownTimeoutMs`, `defaultDeadLetterMaxEntries` 같은 lifecycle 및 dead-letter retention 설정도 포함됩니다.
 

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -129,9 +129,16 @@ Treat low-level provider assembly as an internal implementation detail: low-leve
 
 
 ### Types
+- `Queue`: Compatibility facade with `enqueue(job)` for application code and the `QUEUE` token.
+- `QueueJobType`: Constructor type used to identify and rehydrate a job payload class.
 - `QueueModuleOptions`: Global queue settings (clientName, default attempts, `defaultBackoff`, concurrency, rate limiting, dead-letter retention).
 - `QueueWorkerOptions`: Per-job settings (attempts, backoff, concurrency, jobName, rate limiting).
+- `QueueBackoffType`: Supported retry backoff strategy names (`fixed`, `exponential`).
 - `QueueBackoffOptions`: Retry backoff settings (`type`, `delayMs`).
+- `QueueRateLimiterOptions`: Worker-level distributed rate limiter settings (`max`, `duration`).
+- `QueueLifecycleState`: Lifecycle states reported by Queue status adapters (`idle`, `starting`, `started`, `stopping`, `stopped`).
+- `QueueStatusAdapterInput`: Normalized queue metrics passed to `createQueuePlatformStatusSnapshot(...)`.
+- `QueuePlatformStatusSnapshot`: Queue-specific readiness, health, ownership, and detail snapshot returned by the status helper.
 
 `QueueModuleOptions` also includes lifecycle and dead-letter retention controls such as `workerShutdownTimeoutMs` and `defaultDeadLetterMaxEntries`.
 


### PR DESCRIPTION
## Summary

- Completes the `@fluojs/queue` README public type inventory for consumer-facing root-barrel exports.
- Keeps the English and Korean package README public API sections aligned.

Closes #1911

## Changes

- Added `Queue`, `QueueJobType`, `QueueBackoffType`, `QueueRateLimiterOptions`, `QueueLifecycleState`, `QueueStatusAdapterInput`, and `QueuePlatformStatusSnapshot` to `packages/queue/README.md`.
- Added matching Korean descriptions for the same exported types in `packages/queue/README.ko.md`.
- Left runtime code and package exports unchanged.

## Testing

- `lsp_diagnostics` on `packages/queue/README.md`: no diagnostics.
- `lsp_diagnostics` on `packages/queue/README.ko.md`: no diagnostics.
- `pnpm lint`: completed; `verify:public-export-tsdoc` passed in changed mode. Biome reported pre-existing warnings/infos outside the changed README files.
- `pnpm docs:sync-check`: passed.
- `git diff --check`: passed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No source exports changed. This PR documents already-exported queue types in the package README public API overview.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Documentation-only inventory update. No runtime behavior, lifecycle ordering, readiness, shutdown, or public API shape changed.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. Package README EN/KO parity was preserved and checked with `pnpm docs:sync-check`.

## Changeset

Not added. This is a documentation-only inventory update for already-exported public types and does not change public package behavior or API shape.