### PR TITLE
Resolve #1899: Align Cloudflare Workers lifecycle docs

### DIFF
--- a/book/advanced/ch13-custom-adapter.ko.md
+++ b/book/advanced/ch13-custom-adapter.ko.md
@@ -137,9 +137,9 @@ const fluoResponse: FrameworkResponse = {
 
 ## 13.6 서버리스 환경에서의 어댑터 전략
 
-AWS Lambda나 Cloudflare Workers 같은 환경에서는 `listen()` 메서드가 지속적으로 실행되지 않습니다. 대신 이벤트가 들어올 때마다 디스패처가 호출되어야 합니다.
+AWS Lambda나 Cloudflare Workers 같은 환경에서는 플랫폼이 장기 실행 ingress loop를 소유합니다. 애플리케이션은 여전히 `listen()`을 호출해 Fluo dispatcher를 binding하지만, export된 Worker 코드는 socket을 열지 않고 각 incoming event마다 adapter-backed `fetch` handler를 재사용합니다.
 
-`packages/platform-cloudflare-workers/src/adapter.ts`에서는 `fetch` 이벤트가 발생할 때마다 짧은 생명주기를 가진 어댑터가 생성되어 `dispatcher.dispatch`를 실행하고, 응답을 `Response` 객체로 변환해 반환합니다. 이처럼 어댑터 패턴은 전통적인 서버 환경과 현대적인 엣지 런타임을 같은 계약으로 연결합니다.
+`packages/platform-cloudflare-workers/src/adapter.ts`에서는 `listen()`이 shared dispatcher를 한 번 저장하고, 각 `fetch` 이벤트가 그 dispatcher에 위임되어 Web `Response`를 생성합니다. lazy entrypoint helper도 첫 요청에서 한 번 bootstrap한 뒤 resolved Worker application을 재사용하는 동일한 lifecycle을 따릅니다. 이처럼 어댑터 패턴은 request마다 새 adapter를 만든다고 암시하지 않으면서 전통적인 서버 환경과 현대적인 엣지 런타임을 같은 계약으로 연결합니다.
 
 ## 13.7 실시간 통신 역량(Realtime Capability) 보고
 

--- a/book/advanced/ch13-custom-adapter.md
+++ b/book/advanced/ch13-custom-adapter.md
@@ -137,9 +137,9 @@ The `committed` property tells whether the response has already been sent. It is
 
 ## 13.6 Adapter Strategy in Serverless Environments
 
-In environments such as AWS Lambda or Cloudflare Workers, the `listen()` method does not run continuously. Instead, the dispatcher must be called whenever an event arrives.
+In environments such as AWS Lambda or Cloudflare Workers, the platform owns the long-running ingress loop. The application still calls `listen()` to bind the Fluo dispatcher, but exported Worker code reuses the adapter-backed `fetch` handler for each incoming event instead of opening a socket.
 
-In `packages/platform-cloudflare-workers/src/adapter.ts`, a short-lived adapter is created whenever a `fetch` event occurs. It runs `dispatcher.dispatch`, converts the response to a `Response` object, and returns it. In this way, the adapter pattern connects traditional server environments and modern edge runtimes through the same contract.
+In `packages/platform-cloudflare-workers/src/adapter.ts`, `listen()` stores the shared dispatcher once, and each `fetch` event delegates through that dispatcher to produce a Web `Response`. The lazy entrypoint helper follows the same lifecycle by bootstrapping once on first request and then reusing the resolved Worker application. In this way, the adapter pattern connects traditional server environments and modern edge runtimes through the same contract without implying a new adapter per request.
 
 ## 13.7 Reporting Realtime Capability
 

--- a/packages/platform-cloudflare-workers/README.ko.md
+++ b/packages/platform-cloudflare-workers/README.ko.md
@@ -105,6 +105,8 @@ const adapter = createCloudflareWorkerAdapter({
 - `createCloudflareWorkerEntrypoint(module, options)`: 지연 부트스트랩 방식의 Worker 엔트리포인트를 생성합니다.
 - `bootstrapCloudflareWorkerApplication(module, options)`: Worker를 위한 비동기 부트스트랩 헬퍼입니다.
 - `CloudflareWorkerHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
+- `CloudflareWorkerHandler`: Worker application wrapper와 lazy entrypoint가 공유하는 fetch handler interface입니다.
+- `CloudflareWorkerApplication`: `adapter`, `app`, `fetch(...)`, `close(...)`를 제공하는 fully bootstrapped Worker application wrapper입니다.
 - `CloudflareWorkerEntrypoint`: `fetch`, `ready()`, `close()` lifecycle method를 제공하는 lazy entrypoint입니다.
 - Option 및 type: `CloudflareWorkerAdapterOptions`, `BootstrapCloudflareWorkerApplicationOptions`, `CloudflareWorkerExecutionContext`, `CloudflareWorkerWebSocketBinding`, Worker websocket pair/upgrade type.
 

--- a/packages/platform-cloudflare-workers/README.md
+++ b/packages/platform-cloudflare-workers/README.md
@@ -105,6 +105,8 @@ The shared edge portability suite in `packages/testing/src/portability/web-runti
 - `createCloudflareWorkerEntrypoint(module, options)`: Creates a lazy-bootstrapping Worker entrypoint.
 - `bootstrapCloudflareWorkerApplication(module, options)`: Async bootstrap helper for Workers.
 - `CloudflareWorkerHttpApplicationAdapter`: The core adapter implementation.
+- `CloudflareWorkerHandler`: Fetch handler interface shared by Worker application wrappers and lazy entrypoints.
+- `CloudflareWorkerApplication`: Fully bootstrapped Worker application wrapper with `adapter`, `app`, `fetch(...)`, and `close(...)`.
 - `CloudflareWorkerEntrypoint`: Lazy entrypoint with `fetch`, `ready()`, and `close()` lifecycle methods.
 - Options and types: `CloudflareWorkerAdapterOptions`, `BootstrapCloudflareWorkerApplicationOptions`, `CloudflareWorkerExecutionContext`, `CloudflareWorkerWebSocketBinding`, and Worker websocket pair/upgrade types.
 


### PR DESCRIPTION
## Summary

Closes #1899.

Aligns Cloudflare Workers adapter documentation with the actual reusable adapter/listen dispatcher lifecycle and completes the package README public API inventory.

## Changes

- Updated the advanced custom adapter chapter in English and Korean to describe Worker `listen()` dispatcher binding plus per-request `fetch` delegation instead of a short-lived adapter per fetch event.
- Added `CloudflareWorkerHandler` and `CloudflareWorkerApplication` to the English/Korean `@fluojs/platform-cloudflare-workers` Public API Overview.

## Testing

- `lsp_diagnostics` on changed Markdown files: no diagnostics.
- `pnpm docs:sync-check`
- `pnpm install --frozen-lockfile && pnpm exec vitest run packages/platform-cloudflare-workers/src/adapter.test.ts`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No source exports changed. This PR documents existing public types already exported from `packages/platform-cloudflare-workers/src/adapter.ts`.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Doc-only alignment. The documented Worker lifecycle now matches the existing adapter behavior and package-local regression coverage.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance SSOT files changed. EN/KO package README and book mirrors were updated together. Changeset not included because this is doc-only and does not alter public package behavior or API.