### PR TITLE
Resolve #1914: Complete microservices status type API docs

### DIFF
--- a/packages/microservices/README.ko.md
+++ b/packages/microservices/README.ko.md
@@ -160,7 +160,7 @@ class ManualMicroserviceProvidersModule {}
 
 ### Type export
 
-Root barrel은 `Microservice`, `MicroserviceModuleOptions`, `MicroserviceModuleRegistrationOptions`, `MicroserviceTransport`, `Pattern`, `ServerStreamWriter`와 `GrpcMicroserviceTransportOptions`, `KafkaMicroserviceTransportOptions`, `MqttMicroserviceTransportOptions`, `NatsMicroserviceTransportOptions`, `RabbitMqMicroserviceTransportOptions`, `RedisPubSubMicroserviceTransportOptions`, `RedisStreamsMicroserviceTransportOptions`, `RedisStreamClientLike` 같은 transport option type을 export합니다.
+Root barrel은 `Microservice`, `MicroserviceLifecycleState`, `MicroserviceHandlerCounts`, `MicroserviceModuleOptions`, `MicroserviceModuleRegistrationOptions`, `MicroservicePlatformStatusSnapshot`, `MicroserviceStatusAdapterInput`, `MicroserviceTransport`, `MicroserviceTransportCapabilities`, `Pattern`, `ServerStreamWriter`와 `GrpcMicroserviceTransportOptions`, `KafkaMicroserviceTransportOptions`, `MqttMicroserviceTransportOptions`, `NatsMicroserviceTransportOptions`, `RabbitMqMicroserviceTransportOptions`, `RedisPubSubMicroserviceTransportOptions`, `RedisStreamsMicroserviceTransportOptions`, `RedisStreamClientLike` 같은 transport option type을 export합니다.
 
 ### 동작 계약
 

--- a/packages/microservices/README.md
+++ b/packages/microservices/README.md
@@ -157,7 +157,7 @@ class ManualMicroserviceProvidersModule {}
 
 ### Type exports
 
-The root barrel exports `Microservice`, `MicroserviceModuleOptions`, `MicroserviceModuleRegistrationOptions`, `MicroserviceTransport`, `Pattern`, `ServerStreamWriter`, and transport option types such as `GrpcMicroserviceTransportOptions`, `KafkaMicroserviceTransportOptions`, `MqttMicroserviceTransportOptions`, `NatsMicroserviceTransportOptions`, `RabbitMqMicroserviceTransportOptions`, `RedisPubSubMicroserviceTransportOptions`, `RedisStreamsMicroserviceTransportOptions`, and `RedisStreamClientLike`.
+The root barrel exports `Microservice`, `MicroserviceLifecycleState`, `MicroserviceHandlerCounts`, `MicroserviceModuleOptions`, `MicroserviceModuleRegistrationOptions`, `MicroservicePlatformStatusSnapshot`, `MicroserviceStatusAdapterInput`, `MicroserviceTransport`, `MicroserviceTransportCapabilities`, `Pattern`, `ServerStreamWriter`, and transport option types such as `GrpcMicroserviceTransportOptions`, `KafkaMicroserviceTransportOptions`, `MqttMicroserviceTransportOptions`, `NatsMicroserviceTransportOptions`, `RabbitMqMicroserviceTransportOptions`, `RedisPubSubMicroserviceTransportOptions`, `RedisStreamsMicroserviceTransportOptions`, and `RedisStreamClientLike`.
 
 ### Behavioral contracts
 


### PR DESCRIPTION
## Summary

Complete the `@fluojs/microservices` README Type exports inventory for status-related public types exported from the root barrel.

## Changes

- Added missing status type exports to `packages/microservices/README.md`.
- Mirrored the same status type export list in `packages/microservices/README.ko.md` to preserve EN/KO parity.
- Kept the change documentation-only with no runtime behavior changes.

## Testing

- LSP diagnostics: `packages/microservices/README.md` — no diagnostics found.
- LSP diagnostics: `packages/microservices/README.ko.md` — no diagnostics found.
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`

## Public export documentation

- [x] Changed public exports include a source-level summary. No source exports changed; this PR documents already root-exported status types in the package README surface inventory.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No exported functions changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. No examples changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. No new runtime contract was introduced; the README now lists the existing status type API surface.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. Not applicable to this doc-only public type inventory update.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. No platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. No new platform conformance claims were added.

Closes #1914