### PR TITLE
Resolve #1901: Correct metrics endpoint middleware option docs

### DIFF
--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -163,7 +163,7 @@ MetricsModule.forRoot({
 - `METER_PROVIDER` (Token)
 - `PrometheusMeterProvider`
 - `HttpMetricsMiddleware` 및 HTTP path-label 옵션 타입
-- `provider`(현재는 `'prometheus'`만 지원)와 endpoint `middleware`를 포함한 module option
+- `provider`(현재는 `'prometheus'`만 지원), module-level `middleware`, endpoint-scoped `endpointMiddleware`를 포함한 module option
 - `prom-client`의 `Registry`
 
 ### 운영 기본값

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -163,7 +163,7 @@ MetricsModule.forRoot({
 - `METER_PROVIDER`
 - `PrometheusMeterProvider`
 - `HttpMetricsMiddleware` and HTTP path-label option types
-- Module options including `provider` (currently only `'prometheus'`) and endpoint `middleware`
+- Module options including `provider` (currently only `'prometheus'`), module-level `middleware`, and endpoint-scoped `endpointMiddleware`
 - `Registry` from `prom-client`
 
 ### Operational defaults


### PR DESCRIPTION
## Summary

Corrects the `@fluojs/metrics` package README option inventory so the endpoint-scoped scrape protection option is documented as `endpointMiddleware`.

## Changes

- Updated the English metrics README public API bullet from endpoint `middleware` to endpoint-scoped `endpointMiddleware`.
- Updated the Korean metrics README mirror with the same endpoint-scoped `endpointMiddleware` wording.
- Clarified that module-level `middleware` remains a separate module option.

## Testing

- LSP diagnostics: `packages/metrics/README.md` — no diagnostics found.
- LSP diagnostics: `packages/metrics/README.ko.md` — no diagnostics found.
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`

## Public export documentation

No public exports or source TSDoc were changed. This PR only corrects package README option naming.

## Behavioral contract

Doc-only correction. Runtime behavior is unchanged, and the documented endpoint-scoped option now matches the existing `MetricsModuleOptions.endpointMiddleware` contract while keeping module-level `middleware` distinct.

## Platform consistency governance (SSOT)

English/Korean package README parity is preserved. `pnpm docs:sync-check` and `pnpm verify:platform-consistency-governance` passed.

Closes #1901