### PR TITLE
Resolve #1904: Align GraphQL README and book runtime option docs

### DIFF
--- a/book/intermediate/ch18-graphql.ko.md
+++ b/book/intermediate/ch18-graphql.ko.md
@@ -173,7 +173,7 @@ GraphqlModule.forRoot({
 
 GraphQL API는 깊게 중첩되거나 비용이 큰 쿼리에 취약할 수 있습니다. Fluo는 이런 위험을 줄이기 위해 **운영 가드레일**을 기본 설정에 포함합니다.
 
-- **인트로스펙션(Introspection)**: 프로덕션 환경에서는 기본적으로 비활성화됩니다.
+- **인트로스펙션(Introspection)**: `graphiql`을 활성화하거나 `introspection: true`를 명시적으로 설정하지 않으면 기본적으로 비활성화됩니다.
 - **복잡도 제한**: `GraphqlModule.forRoot(...)` 경계에서 `maxDepth`, `maxComplexity`, `maxCost`를 설정해 과도한 쿼리 비용과 서비스 거부(DoS) 공격 가능성을 줄입니다. 이 제한은 module-level guardrail이며, 현재 런타임 계약은 필드별 비용 데코레이터를 제공하지 않습니다.
 
 ```typescript

--- a/book/intermediate/ch18-graphql.md
+++ b/book/intermediate/ch18-graphql.md
@@ -173,7 +173,7 @@ GraphqlModule.forRoot({
 
 GraphQL APIs can be vulnerable to deeply nested or expensive queries. Fluo includes **operational guardrails** in the default configuration to reduce these risks.
 
-- **Introspection**: Disabled by default in production environments.
+- **Introspection**: Disabled by default unless `graphiql` is enabled or `introspection: true` is set explicitly.
 - **Complexity limits**: Configure `maxDepth`, `maxComplexity`, and `maxCost` at the `GraphqlModule.forRoot(...)` boundary to reduce excessive query cost and the possibility of denial-of-service (DoS) attacks. These limits are module-level guardrails; the current runtime contract does not expose per-field cost decorators.
 
 ```typescript

--- a/packages/graphql/README.ko.md
+++ b/packages/graphql/README.ko.md
@@ -199,7 +199,7 @@ GraphqlModule.forRoot({
 - `listOf`, `isGraphqlListTypeRef`: list output type reference helper.
 - `GraphQLContext` 및 export되는 option/metadata type: GraphQL 실행과 module 설정을 위한 타입 정의.
 
-지원되는 module option에는 `schema`, `context`, `plugins`, `graphiql`, `introspection`, `limits`, `subscriptions.websocket.enabled`, `subscriptions.websocket.limits`, `connectionInitWaitTimeoutMs`, `keepAliveMs`가 포함됩니다.
+지원되는 module option에는 `schema`, `context`, `plugins`, `graphiql`, `introspection`, `limits`, `subscriptions.websocket.enabled`, `subscriptions.websocket.limits`, `subscriptions.websocket.connectionInitWaitTimeoutMs`, `subscriptions.websocket.keepAliveMs`가 포함됩니다.
 
 ## 관련 패키지
 

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -199,7 +199,7 @@ GraphqlModule.forRoot({
 - `listOf`, `isGraphqlListTypeRef`: Helpers for list output type references.
 - `GraphQLContext` and exported option/metadata types: Type definitions for GraphQL execution and module configuration.
 
-Supported module options include `schema`, `context`, `plugins`, `graphiql`, `introspection`, `limits`, `subscriptions.websocket.enabled`, `subscriptions.websocket.limits`, `connectionInitWaitTimeoutMs`, and `keepAliveMs`.
+Supported module options include `schema`, `context`, `plugins`, `graphiql`, `introspection`, `limits`, `subscriptions.websocket.enabled`, `subscriptions.websocket.limits`, `subscriptions.websocket.connectionInitWaitTimeoutMs`, and `subscriptions.websocket.keepAliveMs`.
 
 ## Related Packages
 


### PR DESCRIPTION
## Summary

Align GraphQL documentation with the public option shape and runtime introspection default described in #1904.

## Changes

- Document `connectionInitWaitTimeoutMs` and `keepAliveMs` under `subscriptions.websocket` in the GraphQL README EN/KO pair.
- Remove production-only introspection wording from the GraphQL book chapter EN/KO pair.
- Preserve documentation-only EN/KO parity without changing runtime behavior.

## Testing

- LSP diagnostics: no diagnostics for `packages/graphql/README.md`, `packages/graphql/README.ko.md`, `book/intermediate/ch18-graphql.md`, and `book/intermediate/ch18-graphql.ko.md`.
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`

## Public export documentation

No public exports changed. Source TSDoc baseline is not affected.

## Behavioral contract

Doc-only alignment with the existing behavior: introspection remains disabled by default unless `graphiql` is enabled or `introspection: true` is set explicitly.

## Platform consistency governance (SSOT)

English/Korean README and book surfaces were updated in matching pairs. Platform governance verification passed with `pnpm verify:platform-consistency-governance`.

Closes #1904