### PR TITLE
Resolve #1894: Clarify DI public API inventory and NormalizedProvider contract

### DIFF
--- a/book/advanced/ch04-provider-resolution.ko.md
+++ b/book/advanced/ch04-provider-resolution.ko.md
@@ -3,10 +3,10 @@
 
 # Chapter 4. Provider Normalization and Resolution Algorithms
 
-이 장은 Fluo DI 컨테이너가 공개 provider 선언을 내부 레코드로 정규화하고, 그 레코드를 따라 실제 인스턴스를 해결하는 과정을 분석합니다. Chapter 3까지가 데코레이터와 메타데이터 기록에 집중했다면, 이제 그 정보가 런타임 알고리즘으로 소비되는 지점을 살펴봅니다.
+이 장은 Fluo DI 컨테이너가 공개 provider 선언을 검증된 레코드로 정규화하고, 그 레코드를 따라 실제 인스턴스를 해결하는 과정을 분석합니다. Chapter 3까지가 데코레이터와 메타데이터 기록에 집중했다면, 이제 그 정보가 런타임 알고리즘으로 소비되는 지점을 살펴봅니다.
 
 ## Learning Objectives
-- 공개 provider 문법이 내부 정규화 레코드로 바뀌는 과정을 이해합니다.
+- 공개 provider 문법이 검증된 정규화 레코드로 바뀌는 과정을 이해합니다.
 - 등록 단계에서 중복 검사와 스코프 가드레일이 왜 필요한지 설명합니다.
 - token 조회, alias 처리, 인스턴스화로 이어지는 resolve 파이프라인을 분석합니다.
 - optional, `forwardRef`, multi provider가 동일한 리졸버 위에서 어떻게 처리되는지 정리합니다.
@@ -19,11 +19,11 @@
 - 클래스 provider, factory provider, alias provider 같은 DI 기본 용어 이해.
 
 ## 4.1 From public provider syntax to normalized records
-Fluo의 컨테이너는 공개 provider 형태를 그대로 해석하지 않습니다. 첫 단계는 항상 정규화입니다. 이 결정 덕분에 실제 resolve 경로는 작고 예측 가능하게 유지됩니다. 런타임은 다섯 가지 공개 API를 반복 분기하는 대신 하나의 내부 레코드 형태만 다루면 되기 때문입니다.
+Fluo의 컨테이너는 공개 provider 형태를 그대로 해석하지 않습니다. 첫 단계는 항상 정규화입니다. 이 결정 덕분에 실제 resolve 경로는 작고 예측 가능하게 유지됩니다. 런타임은 다섯 가지 공개 API를 반복 분기하는 대신 하나의 검증된 레코드 형태만 다루면 되기 때문입니다.
 
 공개 surface는 `path:packages/di/src/types.ts:36-121`에 선언되어 있습니다. 이 경계에서 Fluo는 class constructor, `{ useClass }`, `{ useFactory }`, `{ useValue }`, `{ useExisting }`를 모두 받습니다. 이 형태들은 작성 편의성용 문법입니다. 실행 모델 자체는 아닙니다.
 
-공개 타입은 provider가 받아들일 수 있는 모양과 정규화 뒤의 내부 모양을 분리해서 보여 줍니다.
+공개 타입은 provider가 받아들일 수 있는 모양과 검증 뒤의 정규화 모양을 분리해서 보여 줍니다.
 
 `path:packages/di/src/types.ts:36-54`
 ```typescript
@@ -47,7 +47,7 @@ export interface FactoryProvider<T = unknown> {
 
 이 발췌는 class provider와 factory provider가 같은 필드 언어를 공유한다는 점을 보여 줍니다. `provide`는 public token이고, `inject`, `scope`, `multi`는 뒤의 정규화와 등록 단계가 읽는 정책 입력입니다.
 
-`useValue`와 `useExisting`까지 포함한 전체 public union은 아래처럼 내부 `NormalizedProvider`와 만납니다.
+`useValue`와 `useExisting`까지 포함한 전체 public union은 아래처럼 `NormalizedProvider`와 만납니다.
 
 `path:packages/di/src/types.ts:56-121`
 ```typescript
@@ -75,7 +75,7 @@ export interface NormalizedProvider<T = unknown> {
 }
 ```
 
-여기서 중요한 차이는 public provider가 여러 문법으로 열려 있어도, 내부 레코드는 `type`과 구현 필드의 조합으로 닫힌다는 점입니다. 뒤의 resolver는 이 내부 모양만 보면 됩니다.
+여기서 중요한 차이는 public provider가 여러 문법으로 열려 있어도, 정규화 레코드는 `type`과 구현 필드의 조합으로 닫힌다는 점입니다. `NormalizedProvider`는 이 record shape를 이미 참조하던 소비자를 위해 root export로 남아 있는 compatibility-only 공개 타입입니다. 애플리케이션 코드는 여전히 `Provider`나 구체 provider interface로 provider를 작성해야 하며, normalized record 생성은 컨테이너가 소유합니다.
 
 실제 정규화 진입점은 `path:packages/di/src/container.ts:54-115`의 `normalizeProvider()`입니다. 이 함수가 이 장의 첫 번째 핵심 알고리즘입니다. 모든 입력 provider를 `type`, `provide`, `inject`, `scope`, 구현 필드를 갖는 `NormalizedProvider`로 변환합니다.
 
@@ -127,7 +127,7 @@ function normalizeInjectToken(token: Token | ForwardRefFn | OptionalToken): Toke
 
 `null`과 `undefined`만 이 단계에서 즉시 차단하고, 일반 token, `forwardRef`, `optional` wrapper는 그대로 다음 단계로 넘깁니다. 따라서 정규화는 dependency entry를 평가하지 않고, 실행 가능한 모양인지 먼저 보장합니다.
 
-또한 정규화는 Fluo의 "지연된 기본값(lazy defaults)"이 적용되는 지점입니다. 프로바이더가 스코프를 지정하지 않으면 `normalizeProvider`는 필드를 비워 두지 않습니다. `path:packages/di/src/container.ts:102-114`처럼 클래스 메타데이터를 읽고 `Scope.DEFAULT`라는 프레임워크 기본값을 채웁니다. 따라서 provider가 등록될 때는 동작 계약이 이미 명시된 상태입니다. 이 명시성 때문에 내부 레코드가 provider 구성의 최종 기준이 됩니다.
+또한 정규화는 Fluo의 "지연된 기본값(lazy defaults)"이 적용되는 지점입니다. 프로바이더가 스코프를 지정하지 않으면 `normalizeProvider`는 필드를 비워 두지 않습니다. `path:packages/di/src/container.ts:102-114`처럼 클래스 메타데이터를 읽고 `Scope.DEFAULT`라는 프레임워크 기본값을 채웁니다. 따라서 provider가 등록될 때는 동작 계약이 이미 명시된 상태입니다. 이 명시성 때문에 정규화 레코드가 provider 구성에 대한 컨테이너의 최종 기준이 됩니다.
 
 factory와 `{ provide, useClass }` 분기는 scope 우선순위와 inject 우선순위를 더 분명히 드러냅니다.
 

--- a/book/advanced/ch04-provider-resolution.md
+++ b/book/advanced/ch04-provider-resolution.md
@@ -3,10 +3,10 @@
 
 # Chapter 4. Provider Normalization and Resolution Algorithms
 
-This chapter analyzes how the Fluo DI container normalizes public Provider declarations into internal records, then resolves real instances from those records. Through Chapter 3, we focused on decorators and metadata recording. Now we look at the point where that information is consumed by runtime algorithms.
+This chapter analyzes how the Fluo DI container normalizes public Provider declarations into validated records, then resolves real instances from those records. Through Chapter 3, we focused on decorators and metadata recording. Now we look at the point where that information is consumed by runtime algorithms.
 
 ## Learning Objectives
-- Understand how public Provider syntax becomes an internal normalized record.
+- Understand how public Provider syntax becomes a validated normalized record.
 - Explain why duplicate checks and Scope guardrails are needed during registration.
 - Analyze the resolve pipeline from Token lookup to alias handling and instantiation.
 - Summarize how optional, `forwardRef`, and multi Provider handling sit on top of the same resolver.
@@ -19,11 +19,11 @@ This chapter analyzes how the Fluo DI container normalizes public Provider decla
 - Understand basic DI terms such as class Provider, factory Provider, and alias Provider.
 
 ## 4.1 From public provider syntax to normalized records
-Fluo's container doesn't interpret public Provider shapes as they are. The first step is always normalization. This decision keeps the actual resolve path small and predictable because the runtime only needs to handle one internal record shape instead of branching over five public APIs again and again.
+Fluo's container doesn't interpret public Provider shapes as they are. The first step is always normalization. This decision keeps the actual resolve path small and predictable because the runtime only needs to handle one validated record shape instead of branching over five public APIs again and again.
 
 The public surface is declared in `path:packages/di/src/types.ts:36-121`. At this boundary, Fluo accepts class constructors, `{ useClass }`, `{ useFactory }`, `{ useValue }`, and `{ useExisting }`. These forms are syntax for authoring convenience. They aren't the execution model itself.
 
-The public types show the separation between the shapes a Provider may accept and the internal shape after normalization.
+The public types show the separation between the shapes a Provider may accept and the normalized shape after validation.
 
 `path:packages/di/src/types.ts:36-54`
 ```typescript
@@ -47,7 +47,7 @@ export interface FactoryProvider<T = unknown> {
 
 This excerpt shows that class Providers and factory Providers share the same field language. `provide` is the public Token, while `inject`, `scope`, and `multi` are policy inputs read by later normalization and registration steps.
 
-The full public union, including `useValue` and `useExisting`, meets the internal `NormalizedProvider` like this.
+The full public union, including `useValue` and `useExisting`, meets `NormalizedProvider` like this.
 
 `path:packages/di/src/types.ts:56-121`
 ```typescript
@@ -75,7 +75,7 @@ export interface NormalizedProvider<T = unknown> {
 }
 ```
 
-The important difference is that public Providers are open across several syntaxes, but the internal record closes them into a combination of `type` and implementation fields. The later resolver only needs to inspect this internal shape.
+The important difference is that public Providers are open across several syntaxes, but the normalized record closes them into a combination of `type` and implementation fields. `NormalizedProvider` remains root-exported as a compatibility-only public type for consumers that already referenced this record shape; application code should still author providers with `Provider` or the specific provider interfaces, while the container owns normalized record construction.
 
 The actual normalization entry point is `normalizeProvider()` in `path:packages/di/src/container.ts:54-115`. This function is the first core algorithm in the chapter. It converts every input Provider into a `NormalizedProvider` with `type`, `provide`, `inject`, `scope`, and implementation fields.
 
@@ -127,7 +127,7 @@ function normalizeInjectToken(token: Token | ForwardRefFn | OptionalToken): Toke
 
 Only `null` and `undefined` are blocked immediately at this step. Ordinary Tokens, `forwardRef`, and `optional` wrappers are passed to the next step as they are. Normalization doesn't evaluate dependency entries. It first guarantees that they have an executable shape.
 
-Normalization is also where Fluo applies lazy defaults. If a Provider doesn't specify a Scope, `normalizeProvider` doesn't leave the field empty. It reads class metadata and fills in the framework default, `Scope.DEFAULT`, as shown in `path:packages/di/src/container.ts:102-114`. By the time a Provider is registered, its behavior contract is already explicit. This explicitness makes the internal record the final source of truth for Provider configuration.
+Normalization is also where Fluo applies lazy defaults. If a Provider doesn't specify a Scope, `normalizeProvider` doesn't leave the field empty. It reads class metadata and fills in the framework default, `Scope.DEFAULT`, as shown in `path:packages/di/src/container.ts:102-114`. By the time a Provider is registered, its behavior contract is already explicit. This explicitness makes the normalized record the container's final source of truth for Provider configuration.
 
 The factory and `{ provide, useClass }` branches make Scope precedence and inject precedence clearer.
 
@@ -207,7 +207,7 @@ The relationship with `@fluojs/core` matters here. `@Inject(...)` and `@Scope(..
 
 There is another hidden rule, inheritance. `getClassDiMetadata()` in `path:packages/core/src/metadata/class-di.ts:50-83` walks the constructor lineage from base to leaf and lets a subclass overwrite only the fields it actually redefined. Provider normalization therefore sees the final inherited contract, not only the class's local metadata.
 
-Operationally, the meaning of 4.1 is clear. Fluo's DI container looks simple at runtime because most complexity is digested early in normalization. By the time `resolve()` begins, the Provider has already been arranged into one internal shape.
+Operationally, the meaning of 4.1 is clear. Fluo's DI container looks simple at runtime because most complexity is digested early in normalization. By the time `resolve()` begins, the Provider has already been arranged into one validated shape.
 
 ## 4.2 Registration semantics, duplicate checks, and scope guardrails
 After normalization, `register()` applies policy. The implementation is in `path:packages/di/src/container.ts:152-191`. This method doesn't simply append to a map. It enforces graph rules so later resolution stays predictable.

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -157,7 +157,7 @@ const service = await container.resolve(DataService);
 
 ## 공개 API
 
-| 클래스/메서드 | 설명 |
+| Export | 설명 |
 |---|---|
 | `Container` | 메인 DI 컨테이너 클래스입니다. |
 | `register(...providers)` | 하나 이상의 프로바이더를 등록합니다. |
@@ -168,8 +168,15 @@ const service = await container.resolve(DataService);
 | `hasRequestScopedDependency(token)` | 토큰 해석 시 provider 그래프에 request-scoped 의존성이나 순환이 있어 request-scope 컨테이너가 필요할 수 있는지 확인합니다. |
 | `dispose()` | request child와 루트가 소유한 singleton instance를 정리합니다. |
 | `forwardRef(fn)` | 선언 순서 문제를 위해 조회를 지연하는 토큰 래퍼를 반환합니다. 실제 생성자 순환을 해석 가능하게 만들지는 않습니다. |
+| `isForwardRef(value)` | `forwardRef(...)`가 만든 값인지 확인하는 type guard입니다. 커스텀 provider tooling이 DI token wrapper와 통합될 때 사용할 수 있습니다. |
 | `optional(token)` | 하나의 의존성을 optional로 표시하는 토큰 래퍼를 반환합니다. 누락된 optional dependency는 `undefined`로 해석됩니다. |
+| `isOptionalToken(value)` | `optional(...)`이 만든 값인지 확인하는 type guard입니다. provider 수준 `inject` 배열을 검사할 때 사용할 수 있습니다. |
 | `Scope` | `DEFAULT`, `REQUEST`, `TRANSIENT` scope 상수를 제공합니다. |
+| Provider types | `Provider`, `ClassProvider`, `FactoryProvider`, `ValueProvider`, `ExistingProvider`는 `register(...)`와 `override(...)`가 받는 공개 registration shape를 설명합니다. |
+| Token wrapper types | `ForwardRefFn`과 `OptionalToken`은 `forwardRef(...)`와 `optional(...)`이 반환하는 wrapper 값을 설명합니다. |
+| Container helper types | `ClassType`, `Disposable`, `RequestScopeContainer`는 typed provider 선언, teardown hook, request-scope helper 경계를 지원합니다. |
+| `NormalizedProvider` | 컨테이너가 검증한 provider record shape를 위한 compatibility-only 공개 타입입니다. provider를 작성할 때는 `Provider`나 구체 provider interface를 우선 사용하세요. normalized record 생성은 컨테이너가 소유합니다. |
+| `DiErrorContext` | DI error에 붙는 구조화된 context입니다. 로그와 테스트가 token, scope, module, dependency chain, hint를 검사할 수 있게 합니다. |
 | 에러 클래스 | `InvalidProviderError`, `ContainerResolutionError`, `RequestScopeResolutionError`, `ScopeMismatchError`, `CircularDependencyError`, `DuplicateProviderError`. |
 
 multi-provider 토큰을 resolve하면 등록 순서대로 해석된 값의 배열이 반환됩니다.

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -157,7 +157,7 @@ Ensure all required providers are registered in the container. If you use `creat
 
 ## Public API
 
-| Class/Method | Description |
+| Export | Description |
 |---|---|
 | `Container` | The main DI container class. |
 | `register(...providers)` | Registers one or more providers. |
@@ -168,8 +168,15 @@ Ensure all required providers are registered in the container. If you use `creat
 | `hasRequestScopedDependency(token)` | Checks whether resolving a token may require a request-scope container because its provider graph contains request-scoped dependencies or is cyclic. |
 | `dispose()` | Disposes request children and root-owned singleton instances. |
 | `forwardRef(fn)` | Returns a token wrapper that defers lookup for declaration-order issues; it does not make constructor dependency cycles resolvable. |
+| `isForwardRef(value)` | Type guard for values produced by `forwardRef(...)`; useful when integrating custom provider tooling with DI token wrappers. |
 | `optional(token)` | Returns a token wrapper that marks one dependency as optional; missing optional dependencies resolve to `undefined`. |
+| `isOptionalToken(value)` | Type guard for values produced by `optional(...)`; useful when inspecting provider-level `inject` arrays. |
 | `Scope` | Exposes `DEFAULT`, `REQUEST`, and `TRANSIENT` scope constants. |
+| Provider types | `Provider`, `ClassProvider`, `FactoryProvider`, `ValueProvider`, and `ExistingProvider` describe the public registration shapes accepted by `register(...)` and `override(...)`. |
+| Token wrapper types | `ForwardRefFn` and `OptionalToken` describe the wrapper values returned by `forwardRef(...)` and `optional(...)`. |
+| Container helper types | `ClassType`, `Disposable`, and `RequestScopeContainer` support typed provider declarations, teardown hooks, and request-scope helper boundaries. |
+| `NormalizedProvider` | Compatibility-only public type for the container's validated provider record shape. Prefer authoring providers with `Provider` or the specific provider interfaces; the container owns normalized record construction. |
+| `DiErrorContext` | Structured context attached to DI errors so logs and tests can inspect tokens, scopes, modules, dependency chains, and hints. |
 | Error classes | `InvalidProviderError`, `ContainerResolutionError`, `RequestScopeResolutionError`, `ScopeMismatchError`, `CircularDependencyError`, `DuplicateProviderError`. |
 
 Resolving a multi-provider token returns an array of resolved values in registration order.

--- a/packages/di/src/types.ts
+++ b/packages/di/src/types.ts
@@ -106,7 +106,12 @@ export interface RequestScopeContainer {
 }
 
 /**
- * Internal normalized provider representation used after the container validates public provider inputs.
+ * Compatibility-only provider record shape produced after the container validates public provider inputs.
+ *
+ * @remarks
+ * This type remains root-exported for consumers that already reference the normalized DI record shape, but
+ * application code should author providers with {@link Provider}, {@link ClassProvider}, {@link FactoryProvider},
+ * {@link ValueProvider}, or {@link ExistingProvider}. The container owns construction of normalized records.
  */
 export interface NormalizedProvider<T = unknown> {
   inject: InjectionToken[];


### PR DESCRIPTION
## Summary

Clarifies the documented @fluojs/di root public API inventory and aligns the NormalizedProvider contract wording without changing runtime behavior.

## Changes

- Expanded the @fluojs/di README public API tables in English and Korean to include provider types, token-wrapper guards, DiErrorContext, and helper types.
- Updated NormalizedProvider TSDoc to describe it as a compatibility-only public type while keeping Provider and specific provider interfaces as the authoring path.
- Aligned the advanced provider-resolution book chapter and Korean companion with the compatibility-only NormalizedProvider wording.

## Testing

- LSP diagnostics on changed files: passed after building @fluojs/core for workspace type resolution.
- pnpm docs:sync-check: passed.
- pnpm verify:platform-consistency-governance: passed.
- pnpm verify:public-export-tsdoc: passed.
- pnpm --filter @fluojs/core build && pnpm --filter @fluojs/di typecheck: passed.
- pnpm lint: completed with existing warnings outside this issue scope in packages/config, packages/core, and packages/cqrs.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Doc-only change: no public API or runtime behavior was changed. NormalizedProvider remains root-exported and is documented as compatibility-only rather than hidden or internalized.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.

Verification evidence: pnpm docs:sync-check and pnpm verify:platform-consistency-governance both passed.

Closes #1894