### PR TITLE
Resolve #1915: Clarify notifications global provider visibility option

### DIFF
--- a/packages/notifications/README.ko.md
+++ b/packages/notifications/README.ko.md
@@ -89,7 +89,7 @@ export class WelcomeService {
 }
 ```
 
-`NotificationsModule.forRoot(...)`와 `NotificationsModule.forRootAsync(...)`는 `NotificationsService`, `NOTIFICATIONS`, `NOTIFICATION_CHANNELS`를 global provider로 export합니다. 애플리케이션 서비스는 fluo의 class-level `@Inject(...)` decorator로 의존성을 선언해야 standard-decorator DI container가 parameter decorator 없이 서비스를 resolve할 수 있습니다.
+`NotificationsModule.forRoot(...)`와 `NotificationsModule.forRootAsync(...)`는 기본적으로 `NotificationsService`, `NOTIFICATIONS`, `NOTIFICATION_CHANNELS`를 global provider로 export합니다. 이 provider들이 notifications module을 import한 module 안에서만 보이도록 유지하려면 `global: false`를 설정합니다. 애플리케이션 서비스는 fluo의 class-level `@Inject(...)` decorator로 의존성을 선언해야 standard-decorator DI container가 parameter decorator 없이 서비스를 resolve할 수 있습니다.
 
 ## 일반적인 패턴
 

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -89,7 +89,7 @@ export class WelcomeService {
 }
 ```
 
-`NotificationsModule.forRoot(...)` and `NotificationsModule.forRootAsync(...)` export `NotificationsService`, `NOTIFICATIONS`, and `NOTIFICATION_CHANNELS` as global providers. Application services should declare dependencies with fluo's class-level `@Inject(...)` decorator so the standard-decorator DI container can resolve the service without parameter decorators.
+`NotificationsModule.forRoot(...)` and `NotificationsModule.forRootAsync(...)` export `NotificationsService`, `NOTIFICATIONS`, and `NOTIFICATION_CHANNELS` as global providers by default. Set `global: false` when these providers should stay visible only to the module that imports the notifications module. Application services should declare dependencies with fluo's class-level `@Inject(...)` decorator so the standard-decorator DI container can resolve the service without parameter decorators.
 
 ## Common Patterns
 


### PR DESCRIPTION
## Summary

Clarifies the `@fluojs/notifications` module provider visibility contract so the README matches the public `global?: boolean` option.

## Changes

- Updated `packages/notifications/README.md` to state that `NotificationsModule.forRoot(...)` and `forRootAsync(...)` export providers globally by default.
- Updated `packages/notifications/README.ko.md` with matching Korean guidance.
- Documented that `global: false` keeps `NotificationsService`, `NOTIFICATIONS`, and `NOTIFICATION_CHANNELS` visible only to the importing module.

## Testing

- LSP diagnostics: `packages/notifications/README.md` — no diagnostics found.
- LSP diagnostics: `packages/notifications/README.ko.md` — no diagnostics found.
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`

## Public export documentation

- No public exports or source TSDoc changed.
- README wording now aligns with the existing `NotificationsModuleOptions.global` public option documented in `packages/notifications/src/types.ts`.

## Behavioral contract

- Doc-only correction; runtime behavior is unchanged.
- The README now describes the existing behavior from `packages/notifications/src/module.ts`: provider exports are global by default via `options.global ?? true`, while `global: false` disables global visibility.
- No changeset is required because this does not alter package behavior or public API shape.

## Platform consistency governance (SSOT)

- EN/KO package README parity was preserved.
- Book docs were checked for `@fluojs/notifications` references; no book update was needed because the relevant chapters cover orchestration/injection examples and do not claim unconditional global provider visibility.
- `pnpm docs:sync-check` and `pnpm verify:platform-consistency-governance` passed.

Closes #1915