### PR TITLE
Resolve #1916: Complete email API docs and queue worker guidance

### DIFF
--- a/book/intermediate/ch16-email.ko.md
+++ b/book/intermediate/ch16-email.ko.md
@@ -161,7 +161,7 @@ import { QueueLifecycleService, QueueModule } from '@fluojs/queue';
 export class AppModule {}
 ```
 
-큐 어댑터는 대량 알림을 개별 백그라운드 작업으로 나누고, 각 작업에 설정 가능한 재시도와 백오프 정책을 적용합니다. 큐에 쌓인 이메일 작업이 실제로 소비되도록 같은 애플리케이션 모듈의 provider에 `EmailNotificationsQueueWorker`를 등록해야 합니다.
+큐 어댑터는 대량 알림을 개별 백그라운드 작업으로 나누고, 내장 `EmailNotificationsQueueWorker`는 `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`로 export되는 고정 기본값으로 이를 소비합니다. 기본값은 3회 시도, 1초부터 시작하는 exponential backoff, concurrency 5, 초당 50건 rate limiter, `fluo.email.notification` job name입니다. 큐에 쌓인 이메일 작업이 실제로 소비되도록 같은 애플리케이션 모듈의 provider에 `EmailNotificationsQueueWorker`를 등록해야 합니다. 내장 worker 대신 커스텀 queue adapter 또는 worker를 사용한다면 동일한 retry, backoff, concurrency, rate-limit, job-name 계약이 필요할 때 이 기본값을 명시적으로 미러링하세요.
 
 ## 16.7 Template Rendering
 
@@ -218,7 +218,7 @@ async sendOrderConfirmation(order: Order) {
 }
 ```
 
-오케스트레이션 계층을 거치면 SMTP 서버나 외부 공급자가 잠시 불안정해도 백그라운드 재시도 정책을 일관되게 적용할 수 있습니다. 주문 처리와 메일 전송 실패 대응이 분리되므로, 사용자의 결제 흐름을 불필요하게 지연시키지 않습니다.
+오케스트레이션 계층을 거치면 SMTP 서버나 외부 공급자가 잠시 불안정해도 queued email delivery가 내장 worker 기본값을 일관되게 사용할 수 있습니다. FluoShop이 나중에 커스텀 worker로 교체한다면 email API에 per-job retry 또는 backoff 설정이 있다고 가정하지 말고, 해당 기본값을 의도적으로 미러링해야 합니다. 주문 처리와 메일 전송 실패 대응이 분리되므로, 사용자의 결제 흐름을 불필요하게 지연시키지 않습니다.
 
 ## Conclusion
 

--- a/book/intermediate/ch16-email.md
+++ b/book/intermediate/ch16-email.md
@@ -161,7 +161,7 @@ import { QueueLifecycleService, QueueModule } from '@fluojs/queue';
 export class AppModule {}
 ```
 
-The queue adapter splits bulk notifications into individual background jobs and applies configurable retry and backoff policies to each job. Register `EmailNotificationsQueueWorker` as a provider in the same application module so those queued email jobs are actually consumed.
+The queue adapter splits bulk notifications into individual background jobs, and the built-in `EmailNotificationsQueueWorker` consumes them with the fixed defaults exported as `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS`: 3 attempts, exponential backoff starting at 1 second, concurrency 5, a 50-per-second rate limiter, and the `fluo.email.notification` job name. Register `EmailNotificationsQueueWorker` as a provider in the same application module so those queued email jobs are actually consumed. If you replace the built-in worker with a custom queue adapter or worker, mirror those defaults explicitly when you need the same retry, backoff, concurrency, rate-limit, and job-name contract.
 
 ## 16.7 Template Rendering
 
@@ -218,7 +218,7 @@ async sendOrderConfirmation(order: Order) {
 }
 ```
 
-Going through the orchestration layer lets you apply background retry policies consistently, even when the SMTP server or an external provider is briefly unstable.
+Going through the orchestration layer lets queued email delivery use the built-in worker defaults consistently, even when the SMTP server or an external provider is briefly unstable. If FluoShop later swaps in a custom worker, it should mirror those defaults deliberately instead of assuming per-job retry or backoff configuration exists on the email API.
 
 ## Conclusion
 

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -301,10 +301,21 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 ### 계약과 헬퍼
 
+- `Email`: `address`와 선택적 display `name`을 포함하는 정규화된 이메일 주소 값입니다.
+- `EmailAddress` / `EmailAddressLike`: `EmailService`가 정규화하기 전에 허용하는 구조화 또는 축약 recipient 값입니다.
+- `EmailModuleOptions` / `EmailAsyncModuleOptions`: sender 기본값, renderer, lifecycle 검증, transport factory wiring을 포함하는 동기/비동기 모듈 등록 계약입니다.
 - `EmailMessage`
+- `EmailNotificationDispatchRequest` / `EmailNotificationPayload`: `EmailChannel`이 소비하는 notification channel payload 계약입니다.
+- `EmailSendOptions` / `EmailSendManyOptions`: abort signal과 batch failure 수집 같은 per-send 제어 옵션입니다.
+- `EmailSendResult` / `EmailSendBatchResult` / `EmailSendFailure`: accepted, pending, rejected, failed message를 보존하는 직접/배치 전달 결과 계약입니다.
+- `EmailTransportReceipt`: `EmailSendResult`에 보존되는 transport-level provider receipt입니다.
 - `EmailTransport`
+- `EmailTransportContext`
 - `EmailTransportFactory`
+- `EmailTemplateRenderInput`
 - `EmailTemplateRenderer`
+- `EmailTemplateRenderResult`
+- `NormalizedEmailAddressList` / `NormalizedEmailMessage`: typed integration과 테스트를 위해 노출되는 내부 정규화 message shape입니다.
 
 ### 통합 서브패스
 
@@ -313,6 +324,9 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 ### 상태 및 에러
 
 - `createEmailPlatformStatusSnapshot(...)`
+- `EmailLifecycleState`
+- `EmailPlatformStatusSnapshot`
+- `EmailStatusAdapterInput`
 - `EmailConfigurationError`
 - `EmailLifecycleError`: lifecycle로 차단된 전달, transport 초기화 또는 검증, 소유 리소스 shutdown 실패에서 발생합니다. 애플리케이션 teardown과 전송이 경합할 수 있다면 이 에러를 catch하세요.
 - `EmailMessageValidationError`

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -301,10 +301,21 @@ These limitations are part of the package contract so transport selection, templ
 
 ### Contracts and helpers
 
+- `Email`: Normalized email address value with an `address` and optional display `name`.
+- `EmailAddress` / `EmailAddressLike`: Structured or shorthand recipient values accepted by `EmailService` before normalization.
+- `EmailModuleOptions` / `EmailAsyncModuleOptions`: Synchronous and async module registration contracts, including sender defaults, renderer, lifecycle verification, and transport factory wiring.
 - `EmailMessage`
+- `EmailNotificationDispatchRequest` / `EmailNotificationPayload`: Notification channel payload contracts consumed by `EmailChannel`.
+- `EmailSendOptions` / `EmailSendManyOptions`: Per-send controls such as abort signals and batch failure collection.
+- `EmailSendResult` / `EmailSendBatchResult` / `EmailSendFailure`: Direct and batch delivery result contracts that preserve accepted, pending, rejected, and failed messages.
+- `EmailTransportReceipt`: Transport-level provider receipt preserved by `EmailSendResult`.
 - `EmailTransport`
+- `EmailTransportContext`
 - `EmailTransportFactory`
+- `EmailTemplateRenderInput`
 - `EmailTemplateRenderer`
+- `EmailTemplateRenderResult`
+- `NormalizedEmailAddressList` / `NormalizedEmailMessage`: Internal-normalized message shapes exposed for typed integrations and tests.
 
 ### Integration subpaths
 
@@ -313,6 +324,9 @@ These limitations are part of the package contract so transport selection, templ
 ### Status and errors
 
 - `createEmailPlatformStatusSnapshot(...)`
+- `EmailLifecycleState`
+- `EmailPlatformStatusSnapshot`
+- `EmailStatusAdapterInput`
 - `EmailConfigurationError`
 - `EmailLifecycleError`: thrown by lifecycle-gated delivery, transport initialization or verification, and owned-resource shutdown failures. Catch this error when sends can race with application teardown.
 - `EmailMessageValidationError`


### PR DESCRIPTION
## Summary

Complete the `@fluojs/email` public API docs and align the email book queue-worker guidance with the actual built-in worker contract.

## Changes

- Expanded the EN/KO `packages/email` README Public API Overview with root-exported email types such as `Email`, `EmailAddress`, `EmailModuleOptions`, `EmailSendResult`, and `EmailPlatformStatusSnapshot`.
- Revised EN/KO Chapter 16 queue guidance to describe the fixed `DEFAULT_EMAIL_QUEUE_WORKER_OPTIONS` defaults and custom worker mirroring.
- Removed unsupported wording that implied configurable per-job retry/backoff policies on the email API.

## Testing

- LSP diagnostics: `packages/email/README.md`, `packages/email/README.ko.md`, `book/intermediate/ch16-email.md`, `book/intermediate/ch16-email.ko.md` — no diagnostics.
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:public-export-tsdoc`

## Public export documentation

- [x] Changed public exports include a source-level summary. (No source exports changed; README now documents the existing root export inventory.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (No source exports changed.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (Docs now reference the existing fixed queue worker defaults.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests. (Doc-only change; existing package tests cover public surface and status contracts.)

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (No platform contract docs changed.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (No new platform conformance claims.)

Closes #1916