### PR TITLE
Resolve #1917: Complete Slack public API overview types

### DIFF
--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -217,6 +217,8 @@ Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 ### 핵심
 
 - `SlackModule.forRoot(options)` / `SlackModule.forRootAsync(options)`
+- `SlackModuleOptions`
+- `SlackAsyncModuleOptions`
 - `createSlackProviders(options)`
 - `SlackService`
 - `SlackService.send(message, options)`
@@ -250,8 +252,11 @@ Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `SlackTransportReceipt`
 - `SlackFetchLike`
 - `SlackFetchResponse`
-- `SlackTemplateRenderer`
+- `SlackWebhookTransportOptions`
 - `createSlackWebhookTransport(options)`
+- `SlackTemplateRenderer`
+- `SlackTemplateRenderInput`
+- `SlackTemplateRenderResult`
 
 ### 상태 및 에러
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -217,6 +217,8 @@ These limitations are part of the package contract so runtime choice, provider c
 ### Core
 
 - `SlackModule.forRoot(options)` / `SlackModule.forRootAsync(options)`
+- `SlackModuleOptions`
+- `SlackAsyncModuleOptions`
 - `createSlackProviders(options)`
 - `SlackService`
 - `SlackService.send(message, options)`
@@ -250,8 +252,11 @@ These limitations are part of the package contract so runtime choice, provider c
 - `SlackTransportReceipt`
 - `SlackFetchLike`
 - `SlackFetchResponse`
-- `SlackTemplateRenderer`
+- `SlackWebhookTransportOptions`
 - `createSlackWebhookTransport(options)`
+- `SlackTemplateRenderer`
+- `SlackTemplateRenderInput`
+- `SlackTemplateRenderResult`
 
 ### Status and errors
 


### PR DESCRIPTION
## Summary

Complete the `@fluojs/slack` README Public API Overview so root-exported option, template, and webhook types are discoverable in both English and Korean docs.

## Changes

- Added `SlackModuleOptions` and `SlackAsyncModuleOptions` to the Slack core API overview.
- Added `SlackWebhookTransportOptions` alongside the webhook helper and fetch-compatible transport contracts.
- Added `SlackTemplateRenderInput` and `SlackTemplateRenderResult` alongside `SlackTemplateRenderer`.
- Preserved EN/KO README parity for the public API overview update.

## Testing

- LSP diagnostics: `packages/slack/README.md` — clean
- LSP diagnostics: `packages/slack/README.ko.md` — clean
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:public-export-tsdoc`

## Public export documentation

- [x] No public exports were changed; this PR documents already root-exported Slack types in the package README overview.
- [x] Source TSDoc verifier passes in changed mode.
- [x] README scenario examples remain unchanged; only the public API inventory was completed.

## Behavioral contract

- [x] No runtime behavior changed.
- [x] No documented behavioral contracts were removed.
- [x] This is a documentation-only discoverability update for existing public exports.
- [x] No changeset is required for this doc-only issue.

## Platform consistency governance (SSOT)

- [x] EN/KO package README public API overview entries remain synchronized.
- [x] Platform consistency governance verification passes.
- [x] No platform contract docs or conformance claims changed.

Closes #1917