### PR TITLE
Resolve #1918: Complete Discord public API overview types

### DIFF
--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -185,7 +185,10 @@ Discord 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 ### 핵심
 
+- `Discord`
 - `DiscordModule.forRoot(options)` / `DiscordModule.forRootAsync(options)`
+- `DiscordModuleOptions`
+- `DiscordAsyncModuleOptions`
 - `DiscordService`
 - `DiscordChannel`
 - `DISCORD`
@@ -197,11 +200,11 @@ Discord 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 - `DiscordMessage`
 - `NormalizedDiscordMessage`
-- `DiscordAsyncModuleOptions`
 - `DiscordWebhookTransportOptions`
 - `DiscordFetchLike`
 - `DiscordFetchResponse`
 - `DiscordSendResult`
+- `DiscordSendOptions`
 - `DiscordSendManyOptions`
 - `DiscordSendBatchResult`
 - `DiscordSendFailure`
@@ -213,7 +216,9 @@ Discord 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `DiscordEmbed`
 - `DiscordPoll`
 - `DiscordTransport`
+- `DiscordTransportContext`
 - `DiscordTransportFactory`
+- `DiscordTransportReceipt`
 - `DiscordTemplateRenderInput`
 - `DiscordTemplateRenderResult`
 - `DiscordTemplateRenderer`
@@ -223,6 +228,8 @@ Discord 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 - `createDiscordPlatformStatusSnapshot(...)`
 - `DiscordLifecycleState`
+- `DiscordPlatformStatusSnapshot`
+- `DiscordStatusAdapterInput`
 - `DiscordConfigurationError`
 - `DiscordMessageValidationError`
 - `DiscordTransportError`

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -185,7 +185,10 @@ These limitations are part of the package contract so runtime choice, provider c
 
 ### Core
 
+- `Discord`
 - `DiscordModule.forRoot(options)` / `DiscordModule.forRootAsync(options)`
+- `DiscordModuleOptions`
+- `DiscordAsyncModuleOptions`
 - `DiscordService`
 - `DiscordChannel`
 - `DISCORD`
@@ -197,11 +200,11 @@ Compose applications through `DiscordModule` and integrate notifications through
 
 - `DiscordMessage`
 - `NormalizedDiscordMessage`
-- `DiscordAsyncModuleOptions`
 - `DiscordWebhookTransportOptions`
 - `DiscordFetchLike`
 - `DiscordFetchResponse`
 - `DiscordSendResult`
+- `DiscordSendOptions`
 - `DiscordSendManyOptions`
 - `DiscordSendBatchResult`
 - `DiscordSendFailure`
@@ -213,7 +216,9 @@ Compose applications through `DiscordModule` and integrate notifications through
 - `DiscordEmbed`
 - `DiscordPoll`
 - `DiscordTransport`
+- `DiscordTransportContext`
 - `DiscordTransportFactory`
+- `DiscordTransportReceipt`
 - `DiscordTemplateRenderInput`
 - `DiscordTemplateRenderResult`
 - `DiscordTemplateRenderer`
@@ -223,6 +228,8 @@ Compose applications through `DiscordModule` and integrate notifications through
 
 - `createDiscordPlatformStatusSnapshot(...)`
 - `DiscordLifecycleState`
+- `DiscordPlatformStatusSnapshot`
+- `DiscordStatusAdapterInput`
 - `DiscordConfigurationError`
 - `DiscordMessageValidationError`
 - `DiscordTransportError`


### PR DESCRIPTION
## Summary

Completes the `@fluojs/discord` package README public API overview so it reflects the current barrel exports and closes the package-audit documentation gap.

## Changes

- Added omitted Discord facade/module option exports to the English and Korean Public API Overview sections.
- Added missing send option, transport context/receipt, and status snapshot/input types to the overview lists.
- Kept the update documentation-only with EN/KO README parity.

## Testing

- LSP diagnostics: `packages/discord/README.md` — no diagnostics
- LSP diagnostics: `packages/discord/README.ko.md` — no diagnostics
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:public-export-tsdoc`

## Public export documentation

- No source exports were added, removed, or renamed.
- The package README public API overview now lists the omitted current exports: `Discord`, `DiscordModuleOptions`, `DiscordSendOptions`, `DiscordTransportContext`, `DiscordTransportReceipt`, `DiscordPlatformStatusSnapshot`, and `DiscordStatusAdapterInput`.
- Existing exports remain preserved, including `Discord`, `DiscordModuleOptions`, `DiscordSendOptions`, `DiscordTransportContext`, `DiscordTransportReceipt`, `DiscordPlatformStatusSnapshot`, and `DiscordStatusAdapterInput`.

## Behavioral contract

- Documentation-only change; runtime behavior, package initialization, transport behavior, and status snapshot semantics are unchanged.
- No documented behavioral contracts were removed or relaxed.
- Changeset not required per issue context because this does not change runtime behavior or public export shape.

## Platform consistency governance (SSOT)

- Package README EN/KO mirrors were updated together.
- `docs/book` impact checked: no book changes were needed because existing book references cover usage/tutorial guidance and do not duplicate the package README public API inventory.
- `docs`/website references checked: no companion docs changes were needed because the current package/docs references link to the package README rather than duplicating the detailed export list.
- Governance verification passed with `pnpm docs:sync-check` and `pnpm verify:platform-consistency-governance`.

Closes #1918