### PR TITLE
Resolve #1954: document HTTP SSE usage

### DIFF
--- a/book/intermediate/ch21-express-node.ko.md
+++ b/book/intermediate/ch21-express-node.ko.md
@@ -118,24 +118,38 @@ async function bootstrap() {
 
 ### 21.3.1 SSE (Server-Sent Events) in Express
 
-Express 어댑터는 `SseResponse` 유틸리티를 통해 SSE를 지원합니다. 단방향 스트리밍이 필요한 알림이나 상태 업데이트에서는 WebSocket보다 단순한 운영 모델로 충분할 수 있습니다.
+Express 어댑터는 `@Sse()`와 `SseResponse` 유틸리티를 통해 SSE를 지원합니다. 단방향 스트리밍이 필요한 알림이나 상태 업데이트에서는 WebSocket보다 단순한 운영 모델로 충분할 수 있습니다. 현재 Phase 1 계약에서 `@Sse()`는 `GET` 라우트와 `text/event-stream` metadata만 등록합니다. `AsyncIterable` 또는 Observable 반환값을 stream frame으로 변환하지 않습니다.
 
 ```typescript
-import { Get, SseResponse, type RequestContext } from '@fluojs/http';
+import { Sse, SseResponse, type RequestContext } from '@fluojs/http';
 
-@Get('notifications')
+@Sse('notifications')
 async stream(_input: undefined, ctx: RequestContext) {
   const sse = new SseResponse(ctx);
-  
+
   const interval = setInterval(() => {
-    sse.send({ data: { message: 'New order received!' } });
+    sse.send({ message: 'New order received!' }, { event: 'order.created' });
   }, 5000);
 
-  ctx.request.signal?.addEventListener('abort', () => clearInterval(interval), { once: true });
-  
+  const heartbeat = setInterval(() => {
+    sse.comment('heartbeat');
+  }, 15_000);
+
+  ctx.request.signal?.addEventListener(
+    'abort',
+    () => {
+      clearInterval(interval);
+      clearInterval(heartbeat);
+      sse.close();
+    },
+    { once: true },
+  );
+
   return sse;
 }
 ```
+
+브라우저 `EventSource` client는 연결을 소유하는 React effect cleanup에서 연결을 닫아야 합니다. 내장 `EventSource` API는 임의의 `Authorization` 헤더를 붙일 수 없으므로 인증된 stream에는 same-origin cookie, 명시적인 CORS credentials 정책과 함께 쓰는 `withCredentials`, 또는 짧은 수명의 signed URL/query token을 선호하세요. 운영 환경에서는 `text/event-stream`에 대해 proxy buffering과 compression을 비활성화하고, idle timeout을 heartbeat interval보다 길게 유지하며, 재연결 후 `Last-Event-ID`부터 replay할 수 있을 만큼 event history를 저장하세요.
 
 ### 21.3.2 Using Raw Node streams
 

--- a/book/intermediate/ch21-express-node.md
+++ b/book/intermediate/ch21-express-node.md
@@ -118,24 +118,38 @@ Sometimes you need to work a little more directly with fluo abstractions to hand
 
 ### 21.3.1 SSE (Server-Sent Events) in Express
 
-The Express Adapter supports SSE through the `SseResponse` utility. For notifications or status updates that only need one-way streaming, SSE can be enough with a simpler operational model than WebSockets.
+The Express Adapter supports SSE through `@Sse()` and the `SseResponse` utility. For notifications or status updates that only need one-way streaming, SSE can be enough with a simpler operational model than WebSockets. In the current Phase 1 contract, `@Sse()` only registers a `GET` route and `text/event-stream` metadata; it does not convert `AsyncIterable` or Observable return values into stream frames.
 
 ```typescript
-import { Get, SseResponse, type RequestContext } from '@fluojs/http';
+import { Sse, SseResponse, type RequestContext } from '@fluojs/http';
 
-@Get('notifications')
+@Sse('notifications')
 async stream(_input: undefined, ctx: RequestContext) {
   const sse = new SseResponse(ctx);
-  
+
   const interval = setInterval(() => {
-    sse.send({ data: { message: 'New order received!' } });
+    sse.send({ message: 'New order received!' }, { event: 'order.created' });
   }, 5000);
 
-  ctx.request.signal?.addEventListener('abort', () => clearInterval(interval), { once: true });
-  
+  const heartbeat = setInterval(() => {
+    sse.comment('heartbeat');
+  }, 15_000);
+
+  ctx.request.signal?.addEventListener(
+    'abort',
+    () => {
+      clearInterval(interval);
+      clearInterval(heartbeat);
+      sse.close();
+    },
+    { once: true },
+  );
+
   return sse;
 }
 ```
+
+Browser `EventSource` clients should close the connection from the owning React effect cleanup. Because the built-in `EventSource` API cannot attach arbitrary `Authorization` headers, prefer same-origin cookies, `withCredentials` with an explicit CORS credentials policy, or short-lived signed URL/query tokens for authenticated streams. In production, keep proxy buffering and compression disabled for `text/event-stream`, keep idle timeouts above your heartbeat interval, and store enough event history to replay from `Last-Event-ID` after reconnects.
 
 ### 21.3.2 Using Raw Node streams
 

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -13,6 +13,7 @@
 | `@Module({ imports, controllers, providers, exports })` | `@fluojs/core`의 `@Module({ imports, controllers, providers, exports })` | 모듈 경계와 명시적 export는 그대로 주요 구성 단위다. |
 | `@Controller('/users')` | `@fluojs/http`의 `@Controller('/users')` | 컨트롤러 데코레이터는 코어 패키지가 아니라 HTTP 패키지에 속한다. |
 | `@Get()`, `@Post()` 등 라우트 데코레이터 | `@fluojs/http`의 `@Get()`, `@Post()` 등 | HTTP 라우트 선언은 계속 메서드 기반 데코레이터를 사용한다. |
+| `@Sse()` | `@fluojs/http`의 `@Sse()`와 명시적인 `SseResponse` 반환 | fluo의 Phase 1 SSE 데코레이터는 `text/event-stream` metadata를 가진 `GET` 라우트로 매핑된다. NestJS Observable 또는 `AsyncIterable` 반환값을 자동 변환하지 않는다. |
 | `NestFactory.create(AppModule)` | `@fluojs/runtime`의 `FluoFactory.create(AppModule, { adapter })` | 부트스트랩 시 `createFastifyAdapter()` 같은 명시적 플랫폼 어댑터가 필요하다. |
 | `@Injectable()` 프로바이더 마커 | `@Module(...).providers`에 등록된 프로바이더 클래스 또는 provider definition | fluo는 필수 프로바이더 등록 단계로 `@Injectable()`을 사용하지 않는다. |
 | `emitDecoratorMetadata`를 통한 생성자 타입 리플렉션 | `@fluojs/core`의 `@Inject(TokenA, TokenB)` | 생성자 의존성은 데코레이터 인자 순서대로 명시한다. |
@@ -26,6 +27,7 @@
 - 부트스트랩은 adapter-first 방식이다. `FluoFactory.create(...)`는 HTTP 플랫폼을 암묵적으로 고르는 대신 `adapter` 옵션을 반드시 받아야 한다.
 - 검증은 `class-validator` 우선 계약을 유지하지 않고 Standard Schema 방향으로 반드시 옮겨야 한다.
 - 컨트롤러 데코레이터는 반드시 `@fluojs/http`에서 가져오고, `@Module` 같은 구조 데코레이터는 `@fluojs/core`에서 가져온다.
+- Observable을 반환하는 NestJS `@Sse()` 핸들러는 반드시 `SseResponse`를 만들고, `send(...)` 또는 `comment(...)`를 호출하며, request abort 또는 application cleanup 경로에서 stream을 닫도록 재작성해야 한다.
 
 ## Removed Concepts
 

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -13,6 +13,7 @@ Apply the fluo construct in the second column, not the NestJS source pattern, wh
 | `@Module({ imports, controllers, providers, exports })` | `@Module({ imports, controllers, providers, exports })` from `@fluojs/core` | Module boundaries and explicit exports remain the primary composition unit. |
 | `@Controller('/users')` | `@Controller('/users')` from `@fluojs/http` | Controller decoration is part of the HTTP package, not the core package. |
 | `@Get()`, `@Post()`, other route decorators | `@Get()`, `@Post()`, other route decorators from `@fluojs/http` | HTTP route decoration remains method-based. |
+| `@Sse()` | `@Sse()` from `@fluojs/http` plus an explicit `SseResponse` return | fluo's Phase 1 SSE decorator maps to a `GET` route with `text/event-stream` metadata. It does not automatically convert NestJS Observable or `AsyncIterable` return values. |
 | `NestFactory.create(AppModule)` | `FluoFactory.create(AppModule, { adapter })` from `@fluojs/runtime` | Bootstrap requires an explicit platform adapter such as `createFastifyAdapter()`. |
 | `@Injectable()` provider marker | provider class or provider definition listed in `@Module(...).providers` | fluo does not use `@Injectable()` as a required provider registration step. |
 | constructor type reflection via `emitDecoratorMetadata` | `@Inject(TokenA, TokenB)` from `@fluojs/core` | Constructor dependencies are declared explicitly in decorator argument order. |
@@ -26,6 +27,7 @@ Apply the fluo construct in the second column, not the NestJS source pattern, wh
 - Bootstrap is adapter-first. `FluoFactory.create(...)` REQUIRES an `adapter` option instead of selecting the HTTP platform implicitly.
 - Validation MUST be migrated to the Standard Schema direction instead of keeping a `class-validator`-first contract.
 - Controller decorators MUST be imported from `@fluojs/http`, while structural decorators such as `@Module` come from `@fluojs/core`.
+- NestJS `@Sse()` handlers that return Observables MUST be rewritten to construct `SseResponse`, call `send(...)` or `comment(...)`, and close the stream from request abort or application cleanup paths.
 
 ## Removed Concepts
 

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -105,17 +105,70 @@ function someDeepHelper() {
 ### 서버 전송 이벤트
 
 ```ts
-import { Sse, SseResponse, type RequestContext } from '@fluojs/http';
+import { Controller, Sse, SseResponse, type RequestContext } from '@fluojs/http';
 
-@Sse('/events')
-stream(_input: undefined, ctx: RequestContext) {
-  const sse = new SseResponse(ctx);
-  sse.send({ message: 'hello' });
-  return sse;
+@Controller('/orders')
+export class OrdersEventsController {
+  @Sse('/events')
+  stream(_input: undefined, ctx: RequestContext) {
+    const sse = new SseResponse(ctx);
+
+    sse.send({ status: 'connected' }, { event: 'ready' });
+
+    const heartbeat = setInterval(() => {
+      sse.comment('heartbeat');
+    }, 15_000);
+
+    ctx.request.signal?.addEventListener(
+      'abort',
+      () => {
+        clearInterval(heartbeat);
+        sse.close();
+      },
+      { once: true },
+    );
+
+    return sse;
+  }
 }
 ```
 
 `@Sse(path)`는 Phase 1 thin route decorator입니다. `GET` 라우트를 등록하고 `text/event-stream` produced media type metadata를 선언할 뿐입니다. Handler는 계속 `SseResponse`를 직접 만들고 반환해야 합니다. `AsyncIterable` 또는 Observable 값을 SSE stream으로 자동 변환하는 기능은 범위 밖입니다.
+
+브라우저 쪽에서는 해당 연결을 소유하는 React effect 안에서 `EventSource`를 만들고 cleanup 함수에서 항상 닫아야 합니다. 그래야 route 변경, Strict Mode remount, component unmount가 중복 stream을 남기지 않습니다.
+
+```tsx
+import { useEffect, useState } from 'react';
+
+export function OrderEvents({ orderId }: { orderId: string }) {
+  const [events, setEvents] = useState<string[]>([]);
+
+  useEffect(() => {
+    const source = new EventSource(`/orders/events?orderId=${encodeURIComponent(orderId)}`, {
+      withCredentials: true,
+    });
+
+    source.addEventListener('ready', (event) => {
+      setEvents((current) => [...current, event.data]);
+    });
+
+    source.onerror = () => {
+      // 서버가 terminal status로 닫지 않는 한 브라우저가 자동으로 재연결합니다.
+      console.warn('Order event stream disconnected; waiting for browser retry.');
+    };
+
+    return () => {
+      source.close();
+    };
+  }, [orderId]);
+
+  return <output>{events.join('\n')}</output>;
+}
+```
+
+브라우저 `EventSource`는 호출자가 임의의 `Authorization` 헤더를 붙일 수 없습니다. SSE 엔드포인트는 same-origin cookie, `withCredentials`와 명시적인 CORS credentials 정책, 또는 guard가 검증하는 짧은 수명의 signed URL/query token으로 인증하세요. 내장 `EventSource` API가 아니라 fetch 기반 custom SSE client를 쓰는 경우가 아니라면 bearer header 브라우저 예제를 문서화하지 마세요.
+
+운영 환경에서는 SSE 연결을 buffering 없이 오래 유지해야 합니다. 신뢰한 origin에 대해서만 CORS credentials를 허용하고, proxy buffering과 response transform을 비활성화하며(`SseResponse`는 `Cache-Control: no-cache, no-transform` 및 `X-Accel-Buffering: no`를 설정합니다), `text/event-stream`을 buffering하는 compression middleware를 피하고, load balancer 또는 platform idle timeout을 heartbeat interval보다 길게 두고, `sse.comment('heartbeat')` 같은 comment heartbeat를 보내며, 클라이언트가 재연결 후 replay가 필요할 때 `Last-Event-ID`를 처리할 수 있도록 충분한 event history를 보존하세요.
 
 ### Versioning
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -107,17 +107,70 @@ function someDeepHelper() {
 ### Server-sent events
 
 ```ts
-import { Sse, SseResponse, type RequestContext } from '@fluojs/http';
+import { Controller, Sse, SseResponse, type RequestContext } from '@fluojs/http';
 
-@Sse('/events')
-stream(_input: undefined, ctx: RequestContext) {
-  const sse = new SseResponse(ctx);
-  sse.send({ message: 'hello' });
-  return sse;
+@Controller('/orders')
+export class OrdersEventsController {
+  @Sse('/events')
+  stream(_input: undefined, ctx: RequestContext) {
+    const sse = new SseResponse(ctx);
+
+    sse.send({ status: 'connected' }, { event: 'ready' });
+
+    const heartbeat = setInterval(() => {
+      sse.comment('heartbeat');
+    }, 15_000);
+
+    ctx.request.signal?.addEventListener(
+      'abort',
+      () => {
+        clearInterval(heartbeat);
+        sse.close();
+      },
+      { once: true },
+    );
+
+    return sse;
+  }
 }
 ```
 
 `@Sse(path)` is a Phase 1 thin route decorator: it registers a `GET` route and declares `text/event-stream` produced media type metadata. The handler is still responsible for creating and returning `SseResponse`. Automatic conversion from `AsyncIterable` or Observable values into SSE streams is out of scope.
+
+On the browser side, create the `EventSource` inside the React effect that owns it and always close it from the cleanup function so route changes, Strict Mode remounts, and component unmounts do not leave duplicate streams open:
+
+```tsx
+import { useEffect, useState } from 'react';
+
+export function OrderEvents({ orderId }: { orderId: string }) {
+  const [events, setEvents] = useState<string[]>([]);
+
+  useEffect(() => {
+    const source = new EventSource(`/orders/events?orderId=${encodeURIComponent(orderId)}`, {
+      withCredentials: true,
+    });
+
+    source.addEventListener('ready', (event) => {
+      setEvents((current) => [...current, event.data]);
+    });
+
+    source.onerror = () => {
+      // Browsers reconnect automatically unless the server closes with a terminal status.
+      console.warn('Order event stream disconnected; waiting for browser retry.');
+    };
+
+    return () => {
+      source.close();
+    };
+  }, [orderId]);
+
+  return <output>{events.join('\n')}</output>;
+}
+```
+
+Browser `EventSource` does not let callers attach arbitrary `Authorization` headers. Authenticate SSE endpoints with same-origin cookies, `withCredentials` plus explicit CORS credentials policy, or a short-lived signed URL/query token that your guard validates. Do not document a bearer-header browser example unless you are using a custom fetch-based SSE client instead of the built-in `EventSource` API.
+
+Operationally, keep SSE connections unbuffered and long-lived: allow credentials in CORS only for trusted origins, disable proxy buffering and response transforms (`SseResponse` sets `Cache-Control: no-cache, no-transform` and `X-Accel-Buffering: no`), avoid compression middleware that buffers `text/event-stream`, set load balancer or platform idle timeouts above your heartbeat interval, send comment heartbeats such as `sse.comment('heartbeat')`, and persist enough event history to honor `Last-Event-ID` when clients reconnect and need replay.
 
 ### Versioning
 


### PR DESCRIPTION
## Summary

Document the Phase 1 HTTP SSE path added by `@Sse()` and `SseResponse`, including backend usage, React `EventSource` cleanup, authentication limits, and production operations guidance.

Linked context: Closes #1954

## Changes

- Expanded `packages/http` README EN/KO SSE examples to use `@Sse()` with explicit `SseResponse` creation, heartbeat comments, React `EventSource` cleanup, auth caveats, and operational caveats.
- Added NestJS migration EN/KO mapping for `@Sse()` to fluo `@Sse()` plus explicit `SseResponse` handling.
- Updated the intermediate Express/Node chapter EN/KO so the SSE learning path references `@Sse()` while keeping `SseResponse` as the Phase 1 primitive.
- Kept docs explicit that automatic `AsyncIterable`/Observable conversion is not part of the current contract.

## Testing

- `pnpm docs:sync-check` — passed: 42 en/ko page pairs and 10 navigation metadata pairs.
- `pnpm verify:docs` — passed (`docs:sync-check`, `docs:typecheck`, and `docs:build`).
- `pnpm lint` — completed with pre-existing Biome warnings outside changed docs; `verify:public-export-tsdoc` passed in changed mode.
- Targeted `pnpm exec biome lint <changed markdown files>` was attempted, but Biome ignores these Markdown paths in the current configuration, so no Markdown files were processed.
- LSP diagnostics: not applicable; no TypeScript source files changed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only update; no runtime behavior, public API surface, package contents, or release metadata changed, so no changeset is included.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed; boxes are satisfied as not applicable.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This PR documents existing Phase 1 SSE behavior and limitations only; no runtime contract or tests changed.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract implementation changed; EN/KO documentation parity was verified.