### PR TITLE
Resolve #1964: fix DI override cache invalidation

### DIFF
--- a/.changeset/di-override-cache-invalidation.md
+++ b/.changeset/di-override-cache-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/di": patch
+---
+
+Invalidate cached singleton and request-scope consumers when provider overrides replace one of their dependencies.

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -612,6 +612,36 @@ describe('Container', () => {
       expect(afterOverride).not.toBe(beforeOverride);
     });
 
+    it('invalidates cached singleton consumers through multi-provider dependencies when a target is overridden', async () => {
+      const CONFIG = Symbol('Config');
+      const PLUGINS = Symbol('Plugins');
+
+      class Plugin {
+        constructor(readonly config: string) {}
+      }
+
+      class Consumer {
+        constructor(readonly plugins: Plugin[]) {}
+      }
+
+      const container = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: PLUGINS, useClass: Plugin, inject: [CONFIG], multi: true },
+        { provide: Consumer, useClass: Consumer, inject: [PLUGINS] },
+      );
+
+      const beforeOverride = await container.resolve<Consumer>(Consumer);
+
+      container.override({ provide: CONFIG, useValue: 'after-override' });
+
+      const afterOverride = await container.resolve<Consumer>(Consumer);
+
+      expect(beforeOverride.plugins[0]?.config).toBe('before-override');
+      expect(afterOverride.plugins[0]?.config).toBe('after-override');
+      expect(afterOverride).not.toBe(beforeOverride);
+      expect(afterOverride.plugins[0]).not.toBe(beforeOverride.plugins[0]);
+    });
+
     it('invalidates materialized request-scope consumers when a parent dependency is overridden', async () => {
       const CONFIG = Symbol('Config');
 

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -564,6 +564,78 @@ describe('Container', () => {
       expect(afterOverride.config).toBe('after-override');
     });
 
+    it('invalidates cached singleton consumers when an already-resolved dependency is overridden', async () => {
+      const CONFIG = Symbol('Config');
+
+      class Consumer {
+        constructor(readonly config: string) {}
+      }
+
+      const container = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: Consumer, useClass: Consumer, inject: [CONFIG] },
+      );
+
+      const beforeOverride = await container.resolve<Consumer>(Consumer);
+
+      container.override({ provide: CONFIG, useValue: 'after-override' });
+
+      const afterOverride = await container.resolve<Consumer>(Consumer);
+
+      expect(beforeOverride.config).toBe('before-override');
+      expect(afterOverride.config).toBe('after-override');
+      expect(afterOverride).not.toBe(beforeOverride);
+    });
+
+    it('invalidates cached singleton consumers through alias dependencies when a target is overridden', async () => {
+      const CONFIG = Symbol('Config');
+      const CONFIG_ALIAS = Symbol('ConfigAlias');
+
+      class Consumer {
+        constructor(readonly config: string) {}
+      }
+
+      const container = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: CONFIG_ALIAS, useExisting: CONFIG },
+        { provide: Consumer, useClass: Consumer, inject: [CONFIG_ALIAS] },
+      );
+
+      const beforeOverride = await container.resolve<Consumer>(Consumer);
+
+      container.override({ provide: CONFIG, useValue: 'after-override' });
+
+      const afterOverride = await container.resolve<Consumer>(Consumer);
+
+      expect(beforeOverride.config).toBe('before-override');
+      expect(afterOverride.config).toBe('after-override');
+      expect(afterOverride).not.toBe(beforeOverride);
+    });
+
+    it('invalidates materialized request-scope consumers when a parent dependency is overridden', async () => {
+      const CONFIG = Symbol('Config');
+
+      class RequestConsumer {
+        constructor(readonly config: string) {}
+      }
+
+      const root = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: RequestConsumer, scope: Scope.REQUEST, useClass: RequestConsumer, inject: [CONFIG] },
+      );
+      const requestScope = root.createRequestScope();
+
+      const beforeOverride = await requestScope.resolve<RequestConsumer>(RequestConsumer);
+
+      root.override({ provide: CONFIG, useValue: 'after-override' });
+
+      const afterOverride = await requestScope.resolve<RequestConsumer>(RequestConsumer);
+
+      expect(beforeOverride.config).toBe('before-override');
+      expect(afterOverride.config).toBe('after-override');
+      expect(afterOverride).not.toBe(beforeOverride);
+    });
+
     it('replaces existing multi providers when overriding a token', async () => {
       const token = Symbol('plugins');
       const container = new Container().register(
@@ -1576,6 +1648,33 @@ describe('Container', () => {
       await container.dispose();
 
       expect(events).toEqual(['first', 'second']);
+    });
+
+    it('disposes stale singleton consumers invalidated by dependency overrides exactly once', async () => {
+      const events: string[] = [];
+      const CONFIG = Symbol('DisposableConsumerConfig');
+
+      class Consumer {
+        constructor(readonly config: string) {}
+
+        onDestroy() {
+          events.push(`consumer:${this.config}`);
+        }
+      }
+
+      const container = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: Consumer, useClass: Consumer, inject: [CONFIG] },
+      );
+
+      await container.resolve(Consumer);
+
+      container.override({ provide: CONFIG, useValue: 'after-override' });
+      await Promise.resolve();
+      await container.resolve(Consumer);
+      await container.dispose();
+
+      expect(events).toEqual(['consumer:before-override', 'consumer:after-override']);
     });
 
     it('disposes stale overridden multi singleton instances immediately and exactly once', async () => {

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -299,12 +299,9 @@ export class Container {
         throw new DuplicateProviderError(token);
       }
 
-      const existing = this.lookupProvider(token);
-      const existingMultiProviders = this.collectMultiProviders(token);
-
+      this.invalidateAffectedCachedEntriesInHierarchy(token);
       this.registrations.delete(token);
       this.multiRegistrations.delete(token);
-      this.invalidateCachedEntryInHierarchy(token, existing?.scope ?? existingMultiProviders[0]?.scope ?? firstProvider.scope);
 
       if (containsMultiProvider) {
         this.multiRegistrations.set(token, normalizedProviders);
@@ -1270,8 +1267,8 @@ export class Container {
     return deps;
   }
 
-  private invalidateCachedEntryInHierarchy(token: Token, scope: Scope): void {
-    this.invalidateCachedEntry(token, scope);
+  private invalidateAffectedCachedEntriesInHierarchy(token: Token): void {
+    this.invalidateAffectedCachedEntries(token);
 
     const childScopes = this.root().childScopes;
 
@@ -1281,7 +1278,7 @@ export class Container {
 
     for (const childScope of childScopes) {
       if (this.isAncestorOf(childScope)) {
-        childScope.invalidateCachedEntry(token, scope);
+        childScope.invalidateAffectedCachedEntries(token);
       }
     }
   }
@@ -1300,34 +1297,30 @@ export class Container {
     return false;
   }
 
-  private invalidateCachedEntry(token: Token, scope: Scope): void {
-    if (this.requestCache?.has(token)) {
-      const cached = this.requestCache.get(token);
-
-      if (cached) {
-        this.scheduleStaleDisposal(cached);
+  private invalidateAffectedCachedEntries(token: Token): void {
+    for (const [cachedToken, cached] of this.requestCache?.entries() ?? []) {
+      if (!this.shouldInvalidateCachedToken(cachedToken, token)) {
+        continue;
       }
 
-      this.requestCache.delete(token);
+      this.scheduleStaleDisposal(cached);
+      this.requestCache?.delete(cachedToken);
     }
 
-    if (!this.parent && scope === Scope.DEFAULT) {
-      const singletonCache = this.singletonCache;
-
-      if (singletonCache.has(token)) {
-        const cached = singletonCache.get(token);
-
-        if (cached) {
-          this.scheduleStaleDisposal(cached);
+    if (!this.parent) {
+      for (const [cachedToken, cached] of this.singletonCache.entries()) {
+        if (!this.shouldInvalidateCachedToken(cachedToken, token)) {
+          continue;
         }
 
-        singletonCache.delete(token);
+        this.scheduleStaleDisposal(cached);
+        this.singletonCache.delete(cachedToken);
       }
     }
 
     if (!this.parent) {
       for (const [provider, cached] of this.multiSingletonCache.entries()) {
-        if (provider.provide !== token) {
+        if (!this.shouldInvalidateCachedProvider(provider, token)) {
           continue;
         }
 
@@ -1343,12 +1336,58 @@ export class Container {
     }
 
     for (const [provider, cached] of multiRequestCache.entries()) {
-      if (provider.provide !== token) {
+      if (!this.shouldInvalidateCachedProvider(provider, token)) {
         continue;
       }
 
       this.scheduleStaleDisposal(cached);
       multiRequestCache.delete(provider);
+    }
+  }
+
+  private shouldInvalidateCachedToken(cachedToken: Token, overriddenToken: Token): boolean {
+    if (cachedToken === overriddenToken) {
+      return true;
+    }
+
+    const provider = this.lookupProvider(cachedToken);
+
+    return provider ? this.providerDependsOnToken(provider, overriddenToken, new Set<Token>([provider.provide])) : false;
+  }
+
+  private shouldInvalidateCachedProvider(provider: NormalizedProvider, overriddenToken: Token): boolean {
+    return provider.provide === overriddenToken || this.providerDependsOnToken(provider, overriddenToken, new Set<Token>([provider.provide]));
+  }
+
+  private providerDependsOnToken(provider: NormalizedProvider, token: Token, visited: Set<Token>): boolean {
+    if (provider.type === 'existing' && provider.useExisting !== undefined) {
+      return this.dependencyTokenReferencesToken(provider.useExisting, token, visited);
+    }
+
+    return provider.inject.some((depEntry) => this.dependencyEntryReferencesToken(depEntry, token, visited));
+  }
+
+  private dependencyEntryReferencesToken(depEntry: Token | ForwardRefFn | OptionalToken, token: Token, visited: Set<Token>): boolean {
+    return this.dependencyTokenReferencesToken(this.resolveProviderDependencyToken(depEntry), token, visited);
+  }
+
+  private dependencyTokenReferencesToken(depToken: Token, token: Token, visited: Set<Token>): boolean {
+    if (depToken === token) {
+      return true;
+    }
+
+    if (visited.has(depToken)) {
+      return false;
+    }
+
+    visited.add(depToken);
+
+    try {
+      const provider = this.lookupProvider(depToken);
+
+      return provider ? this.providerDependsOnToken(provider, token, visited) : false;
+    } finally {
+      visited.delete(depToken);
     }
   }
 }

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -1351,8 +1351,15 @@ export class Container {
     }
 
     const provider = this.lookupProvider(cachedToken);
+    const multiProviders = this.collectMultiProviders(cachedToken);
 
-    return provider ? this.providerDependsOnToken(provider, overriddenToken, new Set<Token>([provider.provide])) : false;
+    if (provider && this.providerDependsOnToken(provider, overriddenToken, new Set<Token>([provider.provide]))) {
+      return true;
+    }
+
+    return multiProviders.some((multiProvider) =>
+      this.providerDependsOnToken(multiProvider, overriddenToken, new Set<Token>([multiProvider.provide])),
+    );
   }
 
   private shouldInvalidateCachedProvider(provider: NormalizedProvider, overriddenToken: Token): boolean {
@@ -1384,8 +1391,12 @@ export class Container {
 
     try {
       const provider = this.lookupProvider(depToken);
+      const multiProviders = this.collectMultiProviders(depToken);
 
-      return provider ? this.providerDependsOnToken(provider, token, visited) : false;
+      return (
+        (provider ? this.providerDependsOnToken(provider, token, visited) : false) ||
+        multiProviders.some((multiProvider) => this.providerDependsOnToken(multiProvider, token, visited))
+      );
     } finally {
       visited.delete(depToken);
     }


### PR DESCRIPTION
## Summary

Fixes `@fluojs/di` override invalidation so cached singleton/request consumers are rebuilt when an overridden dependency changes.

Linked context: Closes #1964

## Changes

- Broadens `Container.override(...)` cache invalidation from only the overridden token to cached consumers whose provider graph depends on that token, including alias chains.
- Keeps invalidation scoped to the current container hierarchy so request-local overrides do not poison root singleton caches.
- Adds regression coverage for singleton consumers, alias-backed dependencies, materialized request-scope consumers, and stale disposable consumer lifecycle.
- Adds a patch changeset for the public `@fluojs/di` behavior fix.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/core build`
- `pnpm --filter @fluojs/di test`
- `pnpm --filter @fluojs/di typecheck`
- `pnpm --filter @fluojs/di build`
- `pnpm lint` (passed; Biome reported existing warnings/infos outside this PR scope, and `verify:public-export-tsdoc` passed)
- LSP diagnostics: `packages/di/src/container.ts`, `packages/di/src/container.test.ts` — no errors

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch release for `@fluojs/di`: override behavior now invalidates stale cached consumers that depended on replaced providers.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed; implementation-only behavior fix.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The existing `packages/di/README.md` override contract already states that overrides invalidate cached instances in current containers and materialized request descendants. This PR aligns implementation and tests with that documented behavior.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

해당 없음 — DI package implementation/tests only; no platform or governance docs changed.