### PR TITLE
Resolve #1973: harden protocol adapter conformance

### DIFF
--- a/.changeset/protocol-adapters-conformance-hardening.md
+++ b/.changeset/protocol-adapters-conformance-hardening.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/socket.io": patch
+"@fluojs/websockets": patch
+---
+
+Harden WebSocket and Socket.IO protocol-adapter conformance around Bun binary payload handling and Socket.IO namespace teardown.

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -1159,10 +1159,10 @@ export class SocketIoLifecycleService
   private async runShutdownLifecycle(): Promise<void> {
     const io = this.io;
 
-    this.attachments = [];
     this.wired = false;
 
     if (!io) {
+      this.attachments = [];
       this.socketRegistry.clear();
       return;
     }
@@ -1178,6 +1178,7 @@ export class SocketIoLifecycleService
     } finally {
       this.io = undefined;
       this.bunEngine = undefined;
+      this.attachments = [];
       if (hasBunRealtimeBindingHost(this.adapter)) {
         this.adapter.configureRealtimeBinding(undefined);
       }

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -1641,4 +1641,61 @@ describe('@fluojs/socket.io', () => {
       expect(['server shutting down', 'transport close']).toContain(await disconnected);
     });
   }
+
+  it('keeps namespace room helpers available while shutdown disconnect handlers run', async () => {
+    class GatewayState {
+      disconnectRooms: Array<ReadonlySet<string>> = [];
+      disconnects = 0;
+    }
+
+    @Inject(GatewayState, SOCKETIO_ROOM_SERVICE)
+    @WebSocketGateway({ path: '/shutdown-room-cleanup' })
+    class ShutdownRoomGateway {
+      constructor(
+        private readonly state: GatewayState,
+        private readonly rooms: SocketIoRoomService,
+      ) {}
+
+      @OnConnect()
+      onConnect(socket: Socket) {
+        this.rooms.joinRoom(socket.id, 'room:shutdown');
+      }
+
+      @OnDisconnect()
+      onDisconnect(socket: Socket) {
+        this.state.disconnectRooms.push(this.rooms.getRooms(socket.id));
+        this.rooms.leaveRoom(socket.id, 'room:shutdown');
+        this.rooms.broadcastToRoom('room:shutdown', 'shutdown:cleanup', 'done');
+        this.state.disconnects += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot({ transports: ['websocket'] })],
+      providers: [GatewayState, ShutdownRoomGateway],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+    const state = await app.container.resolve(GatewayState);
+
+    await app.listen();
+
+    const socket = createClient(`http://127.0.0.1:${String(port)}/shutdown-room-cleanup`, {
+      reconnection: false,
+      transports: ['websocket'],
+    });
+    await onceConnected(socket);
+
+    const disconnected = onceDisconnected(socket);
+    await app.close();
+
+    expect(['server shutting down', 'transport close']).toContain(await disconnected);
+    expect(state.disconnects).toBe(1);
+    expect(state.disconnectRooms).toEqual([expect.any(Set)]);
+  });
 });

--- a/packages/websockets/src/bun/bun.test.ts
+++ b/packages/websockets/src/bun/bun.test.ts
@@ -1027,4 +1027,63 @@ describe('@fluojs/websockets/bun', () => {
 
     await app.close();
   });
+
+  it('receives Bun ArrayBuffer payloads under the configured limit', async () => {
+    const adapter = new TestBunAdapter();
+
+    class GatewayState {
+      messages: unknown[] = [];
+    }
+
+    @Inject(GatewayState)
+    @WebSocketGateway({ path: '/array-buffer-ok' })
+    class ArrayBufferPayloadGateway {
+      constructor(private readonly state: GatewayState) {}
+
+      @OnMessage('ping')
+      onPing(payload: unknown) {
+        this.state.messages.push(payload);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [BunWebSocketModule.forRoot({
+        limits: {
+          maxPayloadBytes: 64,
+        },
+      })],
+      providers: [GatewayState, ArrayBufferPayloadGateway],
+    });
+
+    const app = await bootstrapApplication({ adapter, rootModule: AppModule });
+    const state = await app.container.resolve<GatewayState>(GatewayState);
+    await app.listen();
+
+    const server = adapter.getServer();
+    await server?.fetch(new Request('http://127.0.0.1:3000/array-buffer-ok', {
+      headers: { upgrade: 'websocket' },
+    }));
+    await flushAsyncWork();
+
+    const socket = server?.lastSocket;
+
+    if (!server || !socket) {
+      throw new Error('Expected Bun test socket to be available after websocket upgrade.');
+    }
+
+    const encodedPayload = new TextEncoder().encode(JSON.stringify({ event: 'ping', data: { value: 'array-buffer' } }));
+    const arrayBufferPayload = encodedPayload.buffer.slice(
+      encodedPayload.byteOffset,
+      encodedPayload.byteOffset + encodedPayload.byteLength,
+    ) as ArrayBuffer;
+
+    await server.emitMessage(arrayBufferPayload);
+    await flushAsyncWork();
+
+    expect(socket.closeCalls).toEqual([]);
+    expect(state.messages).toEqual([{ value: 'array-buffer' }]);
+
+    await app.close();
+  });
 });


### PR DESCRIPTION
## Summary

Harden WebSocket and Socket.IO protocol-adapter conformance around Bun binary payload handling and Socket.IO namespace teardown.

Linked context: Closes #1973

## Changes

- Keep Socket.IO namespace attachments available until `io.close(...)` finishes so shutdown-triggered `@OnDisconnect()` handlers can still use namespace-aware room helpers.
- Add Bun WebSocket ArrayBuffer payload regression coverage under the configured payload limit.
- Add Socket.IO shutdown regression coverage for room helper use inside disconnect cleanup.
- Add patch changeset entries for `@fluojs/websockets` and `@fluojs/socket.io`.

## Testing

- `pnpm vitest run packages/websockets/src/bun/bun.test.ts packages/socket.io/src/module.test.ts` — passed (55 tests).
- `pnpm --filter @fluojs/socket.io... build` — passed.
- `pnpm --filter @fluojs/websockets typecheck` — passed after dependency build.
- `pnpm --filter @fluojs/socket.io typecheck` — passed.
- `pnpm exec biome lint packages/websockets/src/bun/bun.test.ts packages/socket.io/src/adapter.ts packages/socket.io/src/module.test.ts .changeset/protocol-adapters-conformance-hardening.md` — passed.
- LSP diagnostics on changed TypeScript files — clean.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed; this PR changes adapter lifecycle behavior and regression tests only.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The existing README contracts for Bun binary payload normalization and Socket.IO namespace/teardown behavior are preserved and backed by additional regression coverage.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. Regression evidence is in the targeted adapter tests listed above.