### PR TITLE
Resolve #1972: align notification delivery semantics

### DIFF
--- a/.changeset/notification-delivery-semantics.md
+++ b/.changeset/notification-delivery-semantics.md
@@ -1,0 +1,8 @@
+---
+"@fluojs/email": patch
+"@fluojs/slack": patch
+"@fluojs/discord": patch
+"@fluojs/notifications": patch
+---
+
+Align notification provider delivery semantics by closing owned email transports when bootstrap verification fails, documenting Slack abort/retry handling and Discord direct batch fan-out boundaries, and strengthening notification dependency diagnostics coverage.

--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -95,6 +95,7 @@ DiscordModule.forRootAsync({
 Behavioral contract 메모:
 
 - `DiscordService.send(...)`는 전달 전에 `defaultThreadId`를 해석합니다.
+- `DiscordService.sendMany(...)`는 `DiscordMessage[]`를 직접 순차 전송하는 batch API이며 `continueOnError`를 지원합니다. 이는 multi-recipient `@fluojs/notifications` dispatch shortcut이 아닙니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
 - send는 bootstrap이 transport를 `ready`로 표시한 뒤에만 허용됩니다. bootstrap 전, startup 중, bootstrap 실패 후, shutdown 중, shutdown 후 시도는 전달 전에 거부됩니다.
 - 서비스가 shutdown 중이거나 이미 stopped 상태라면 cached transport를 재사용하지 않고 send를 거부합니다.
@@ -144,7 +145,7 @@ Behavioral contract 메모:
 - 하나의 notification dispatch는 정확히 하나의 Discord thread 경로로 매핑됩니다. `payload.threadId` 또는 `recipients`의 단일 항목을 사용해야 합니다.
 - `payload.threadId`가 없으면 `DiscordService.sendNotification(...)`는 첫 번째 `recipients` 항목을 사용하고, 그것도 없으면 `defaultThreadId`로 폴백합니다.
 - notification metadata는 payload metadata, dispatch metadata, template/subject marker를 합쳐 구성됩니다. `template`은 renderer가 구성된 경우에만 렌더링됩니다.
-- 여러 Discord thread로 fan-out이 필요하다면 하나의 multi-recipient dispatch 대신 `sendMany(...)`를 사용해야 합니다.
+- 여러 Discord thread로 fan-out이 필요한 notification workflow라면 thread별 concrete Discord message를 만들어 `DiscordService.sendMany(...)`로 보내거나 별도 notification dispatch를 실행해야 합니다. 하나의 notification dispatch는 multi-recipient fan-out을 암묵적으로 확장하지 않습니다.
 
 ### 명시적 fetch 주입을 사용하는 webhook-first 전달
 

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -95,6 +95,7 @@ DiscordModule.forRootAsync({
 Behavioral contract notes:
 
 - `DiscordService.send(...)` resolves `defaultThreadId` before delivery.
+- `DiscordService.sendMany(...)` is a direct `DiscordMessage[]` batch API that sends messages sequentially and supports `continueOnError`; it is not a multi-recipient `@fluojs/notifications` dispatch shortcut.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
 - Sends are accepted only after bootstrap marks the transport `ready`; attempts before bootstrap, during startup, after failed bootstrap, while shutting down, or after shutdown are rejected before delivery.
 - Sends attempted while the service is shutting down or already stopped are rejected before reusing the cached transport.
@@ -144,7 +145,7 @@ Behavioral contract notes:
 - One notification dispatch maps to exactly one Discord thread route. Use `payload.threadId` or a single entry in `recipients`.
 - If `payload.threadId` is omitted, `DiscordService.sendNotification(...)` uses the first `recipients` entry or falls back to `defaultThreadId`.
 - Notification metadata is merged from payload metadata, dispatch metadata, and template/subject markers. `template` is rendered only when a renderer is configured.
-- If a notification needs fan-out across multiple Discord threads, call `sendMany(...)` instead of one multi-recipient dispatch.
+- If a notification workflow needs fan-out across multiple Discord threads, create one concrete Discord message per thread with `DiscordService.sendMany(...)` or issue separate notification dispatches; a single notification dispatch never expands multi-recipient fan-out implicitly.
 
 ### Webhook-first delivery with explicit fetch injection
 

--- a/packages/discord/src/module.test.ts
+++ b/packages/discord/src/module.test.ts
@@ -91,6 +91,28 @@ class UnsuccessfulTransport implements DiscordTransport {
   }
 }
 
+class SelectiveFailureDiscordTransport implements DiscordTransport {
+  readonly sent: string[] = [];
+
+  async send(message: NormalizedDiscordMessage) {
+    const content = message.content ?? '';
+    this.sent.push(content);
+
+    if (content.includes('fail')) {
+      throw new Error(`provider rejected ${content}`);
+    }
+
+    return {
+      messageId: `selective-${this.sent.length}`,
+      ok: true,
+      response: 'ok',
+      statusCode: 200,
+      threadId: message.threadId,
+      warnings: [],
+    };
+  }
+}
+
 function createRecordingTransportFactory(
   overrides: Partial<Pick<DiscordTransportFactory, 'kind' | 'ownsResources'>> & { responsePrefix?: string } = {},
 ): DiscordTransportFactory {
@@ -460,6 +482,64 @@ describe('DiscordModule', () => {
         'Discord notifications accept exactly one target thread per dispatch. Use `sendMany(...)` for fan-out delivery.',
       ),
     );
+  });
+
+  it('delivers sendMany messages sequentially as direct Discord message batches', async () => {
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      defaultThreadId: 'thread-ops',
+      transport: createRecordingTransportFactory({ responsePrefix: 'batch' }),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    await service.onModuleInit();
+
+    const result = await service.sendMany([{ content: 'one' }, { content: 'two' }, { content: 'three' }]);
+
+    expect(result).toMatchObject({ failed: 0, succeeded: 3 });
+    expect(result.results.map((entry) => entry.messageId)).toEqual(['batch-1', 'batch-2', 'batch-3']);
+    expect(transportState.sent.map((entry) => entry.content)).toEqual(['one', 'two', 'three']);
+  });
+
+  it('stops sendMany at the first provider error by default', async () => {
+    const transport = new SelectiveFailureDiscordTransport();
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      defaultThreadId: 'thread-ops',
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    await service.onModuleInit();
+
+    await expect(service.sendMany([{ content: 'ok-1' }, { content: 'fail-2' }, { content: 'ok-3' }])).rejects.toThrowError(
+      'provider rejected fail-2',
+    );
+    expect(transport.sent).toEqual(['ok-1', 'fail-2']);
+  });
+
+  it('collects sendMany failures when continueOnError is enabled', async () => {
+    const transport = new SelectiveFailureDiscordTransport();
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      defaultThreadId: 'thread-ops',
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    await service.onModuleInit();
+
+    const result = await service.sendMany([{ content: 'ok-1' }, { content: 'fail-2' }, { content: 'ok-3' }], {
+      continueOnError: true,
+    });
+
+    expect(result).toMatchObject({ failed: 1, succeeded: 2 });
+    expect(result.failures[0]?.error).toMatchObject({ message: 'provider rejected fail-2' });
+    expect(result.results.map((entry) => entry.messageId)).toEqual(['selective-1', 'selective-3']);
+    expect(transport.sent).toEqual(['ok-1', 'fail-2', 'ok-3']);
   });
 
   it('surfaces an unsuccessful transport receipt as a notifications channel failure', async () => {

--- a/packages/discord/src/module.test.ts
+++ b/packages/discord/src/module.test.ts
@@ -12,6 +12,7 @@ import { DISCORD, DISCORD_CHANNEL } from './tokens.js';
 import type {
   Discord,
   DiscordFetchLike,
+  DiscordSendOptions,
   DiscordTransport,
   DiscordTransportFactory,
   NormalizedDiscordMessage,
@@ -104,6 +105,27 @@ class SelectiveFailureDiscordTransport implements DiscordTransport {
 
     return {
       messageId: `selective-${this.sent.length}`,
+      ok: true,
+      response: 'ok',
+      statusCode: 200,
+      threadId: message.threadId,
+      warnings: [],
+    };
+  }
+}
+
+class AbortAfterFirstDiscordTransport implements DiscordTransport {
+  readonly sent: string[] = [];
+
+  constructor(private readonly controller: AbortController) {}
+
+  async send(message: NormalizedDiscordMessage, _options?: DiscordSendOptions) {
+    const content = message.content ?? '';
+    this.sent.push(content);
+    this.controller.abort();
+
+    return {
+      messageId: `abort-after-first-${this.sent.length}`,
       ok: true,
       response: 'ok',
       statusCode: 200,
@@ -540,6 +562,33 @@ describe('DiscordModule', () => {
     expect(result.failures[0]?.error).toMatchObject({ message: 'provider rejected fail-2' });
     expect(result.results.map((entry) => entry.messageId)).toEqual(['selective-1', 'selective-3']);
     expect(transport.sent).toEqual(['ok-1', 'fail-2', 'ok-3']);
+  });
+
+  it('propagates sendMany abort signals between sequential Discord deliveries', async () => {
+    const controller = new AbortController();
+    const transport = new AbortAfterFirstDiscordTransport(controller);
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      defaultThreadId: 'thread-ops',
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    await service.onModuleInit();
+
+    const result = await service.sendMany([{ content: 'ok-1' }, { content: 'aborted-2' }, { content: 'aborted-3' }], {
+      continueOnError: true,
+      signal: controller.signal,
+    });
+
+    expect(result).toMatchObject({ failed: 2, succeeded: 1 });
+    expect(result.results[0]?.messageId).toBe('abort-after-first-1');
+    expect(result.failures.map((entry) => entry.error)).toEqual([
+      expect.objectContaining({ message: 'Discord delivery was aborted.', name: 'AbortError' }),
+      expect.objectContaining({ message: 'Discord delivery was aborted.', name: 'AbortError' }),
+    ]);
+    expect(transport.sent).toEqual(['ok-1']);
   });
 
   it('surfaces an unsuccessful transport receipt as a notifications channel failure', async () => {

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -218,9 +218,13 @@ class PassiveTransport implements EmailTransport {
 }
 
 class FailingLifecycleTransport implements EmailTransport {
+  closeCalls = 0;
+
   constructor(private readonly failurePoint: 'verify' | 'close') {}
 
   async close(): Promise<void> {
+    this.closeCalls += 1;
+
     if (this.failurePoint === 'close') {
       throw new Error('provider close failed');
     }
@@ -239,6 +243,26 @@ class FailingLifecycleTransport implements EmailTransport {
     if (this.failurePoint === 'verify') {
       throw new Error('provider verify failed');
     }
+  }
+}
+
+class SelectiveFailureEmailTransport implements EmailTransport {
+  readonly sent: string[] = [];
+
+  async send(message: NormalizedEmailMessage): Promise<{ accepted: string[]; messageId: string; pending: []; rejected: [] }> {
+    const subject = message.subject ?? '';
+    this.sent.push(subject);
+
+    if (subject.includes('fail')) {
+      throw new Error(`provider rejected ${subject}`);
+    }
+
+    return {
+      accepted: message.to.map((entry) => entry.address),
+      messageId: `selective-${this.sent.length}`,
+      pending: [],
+      rejected: [],
+    };
   }
 }
 
@@ -647,6 +671,139 @@ describe('EmailModule', () => {
     expect(transportState.sent).toHaveLength(0);
   });
 
+  it('aborts direct email delivery before transport handoff', async () => {
+    const controller = new AbortController();
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: createRecordingTransportFactory(),
+    });
+
+    controller.abort();
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    await expect(
+      service.send(
+        {
+          subject: 'Abort direct',
+          text: 'hello',
+          to: ['user@example.com'],
+        },
+        { signal: controller.signal },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(transportState.sent).toHaveLength(0);
+  });
+
+  it('delivers sendMany messages sequentially and returns ordered batch results', async () => {
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: createRecordingTransportFactory({ messagePrefix: 'batch' }),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    const result = await service.sendMany([
+      { subject: 'One', text: 'first', to: ['one@example.com'] },
+      { subject: 'Two', text: 'second', to: ['two@example.com'] },
+      { subject: 'Three', text: 'third', to: ['three@example.com'] },
+    ]);
+
+    expect(result).toMatchObject({ failed: 0, succeeded: 3 });
+    expect(result.results.map((entry) => entry.messageId)).toEqual(['batch-1', 'batch-2', 'batch-3']);
+    expect(transportState.sent.map((entry) => entry.to[0]?.address)).toEqual([
+      'one@example.com',
+      'two@example.com',
+      'three@example.com',
+    ]);
+  });
+
+  it('stops sendMany at the first provider error by default', async () => {
+    const transport = new SelectiveFailureEmailTransport();
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    await expect(
+      service.sendMany([
+        { subject: 'ok-1', text: 'first', to: ['one@example.com'] },
+        { subject: 'fail-2', text: 'second', to: ['two@example.com'] },
+        { subject: 'ok-3', text: 'third', to: ['three@example.com'] },
+      ]),
+    ).rejects.toThrowError('provider rejected fail-2');
+    expect(transport.sent).toEqual(['ok-1', 'fail-2']);
+  });
+
+  it('collects sendMany failures when continueOnError is enabled', async () => {
+    const transport = new SelectiveFailureEmailTransport();
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    const result = await service.sendMany(
+      [
+        { subject: 'ok-1', text: 'first', to: ['one@example.com'] },
+        { subject: 'fail-2', text: 'second', to: ['two@example.com'] },
+        { subject: 'ok-3', text: 'third', to: ['three@example.com'] },
+      ],
+      { continueOnError: true },
+    );
+
+    expect(result).toMatchObject({ failed: 1, succeeded: 2 });
+    expect(result.failures[0]?.error).toMatchObject({ message: 'provider rejected fail-2' });
+    expect(result.results.map((entry) => entry.messageId)).toEqual(['selective-1', 'selective-3']);
+    expect(transport.sent).toEqual(['ok-1', 'fail-2', 'ok-3']);
+  });
+
+  it('propagates sendMany abort signals between sequential deliveries', async () => {
+    const controller = new AbortController();
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        async send(message: NormalizedEmailMessage) {
+          transportState.sent.push(message);
+          controller.abort();
+
+          return {
+            accepted: message.to.map((entry) => entry.address),
+            messageId: 'aborted-batch-1',
+            pending: [],
+            rejected: [],
+          };
+        },
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    const result = await service.sendMany(
+      [
+        { subject: 'first', text: 'first', to: ['one@example.com'] },
+        { subject: 'second', text: 'second', to: ['two@example.com'] },
+      ],
+      { continueOnError: true, signal: controller.signal },
+    );
+
+    expect(result).toMatchObject({ failed: 1, succeeded: 1 });
+    expect(result.failures[0]?.error).toMatchObject({ name: 'AbortError' });
+    expect(transportState.sent.map((entry) => entry.subject)).toEqual(['first']);
+  });
+
   it('aborts notification delivery before template rendering starts', async () => {
     const controller = new AbortController();
     const render = vi.fn(async () => ({ text: 'rendered' }));
@@ -709,11 +866,12 @@ describe('EmailModule', () => {
   });
 
   it('preserves provider errors as lifecycle failure causes', async () => {
+    const verifyTransport = new FailingLifecycleTransport('verify');
     const initContainer = new Container();
     const initModule = EmailModule.forRoot({
       defaultFrom: 'noreply@example.com',
       transport: {
-        create: async () => new FailingLifecycleTransport('verify'),
+        create: async () => verifyTransport,
         ownsResources: true,
       },
       verifyOnModuleInit: true,
@@ -726,12 +884,14 @@ describe('EmailModule', () => {
       cause: expect.objectContaining({ message: 'provider verify failed' }),
       message: 'Email transport failed to initialize.',
     });
+    expect(verifyTransport.closeCalls).toBe(1);
 
+    const closeTransport = new FailingLifecycleTransport('close');
     const shutdownContainer = new Container();
     const shutdownModule = EmailModule.forRoot({
       defaultFrom: 'noreply@example.com',
       transport: {
-        create: async () => new FailingLifecycleTransport('close'),
+        create: async () => closeTransport,
         ownsResources: true,
       },
     });
@@ -744,6 +904,7 @@ describe('EmailModule', () => {
       cause: expect.objectContaining({ message: 'provider close failed' }),
       message: 'Email transport failed to close cleanly.',
     });
+    expect(closeTransport.closeCalls).toBe(1);
   });
 
   it('blocks shutdown-time delivery from reusing or recreating transports', async () => {

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -886,6 +886,9 @@ describe('EmailModule', () => {
     });
     expect(verifyTransport.closeCalls).toBe(1);
 
+    await initService.onApplicationShutdown();
+    expect(verifyTransport.closeCalls).toBe(1);
+
     const closeTransport = new FailingLifecycleTransport('close');
     const shutdownContainer = new Container();
     const shutdownModule = EmailModule.forRoot({

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -185,6 +185,8 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
           await transport.close();
         } catch (cleanupError) {
           cause = createCleanupFailureCause(error, cleanupError);
+        } finally {
+          this.clearResolvedTransport();
         }
       }
 
@@ -365,6 +367,11 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     }
 
     return this.transportPromise;
+  }
+
+  private clearResolvedTransport(): void {
+    this.resolvedTransport = undefined;
+    this.transportPromise = undefined;
   }
 
   private async ensureReadyForDelivery(): Promise<void> {

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -64,6 +64,13 @@ function createDeliveryLifecycleError(state: EmailServiceLifecycleState): EmailL
   return new EmailLifecycleError(`Email delivery cannot start while the service lifecycle is ${state}.`);
 }
 
+function createCleanupFailureCause(originalError: unknown, cleanupError: unknown): unknown {
+  return new AggregateError(
+    [originalError, cleanupError],
+    'Email transport verification failed and the owned transport failed to close.',
+  );
+}
+
 type EmailServiceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping' | 'stopped' | 'failed';
 
 function isShutdownLifecycleState(
@@ -169,7 +176,19 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
       }
 
       this.lifecycleState = 'failed';
-      throw createLifecycleError('Email transport failed to initialize.', error);
+
+      let cause: unknown = error;
+      const transport = this.resolvedTransport;
+
+      if (transport && this.options.transport.ownsResources && transport.close) {
+        try {
+          await transport.close();
+        } catch (cleanupError) {
+          cause = createCleanupFailureCause(error, cleanupError);
+        }
+      }
+
+      throw createLifecycleError('Email transport failed to initialize.', cause);
     }
   }
 

--- a/packages/notifications/README.ko.md
+++ b/packages/notifications/README.ko.md
@@ -208,6 +208,7 @@ foundation 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `NotificationQueueNotConfiguredError`
 
 상태 snapshot은 platform diagnostics를 위해 `operationMode`, dependency diagnostics, ownership, readiness, health 필드를 포함합니다.
+Queue adapter가 구성되면 `details.dependencies`에 `notifications.queue-adapter`가 포함되고, lifecycle event가 event publisher를 통해 발행되면 `notifications.event-publisher`가 포함됩니다. 이러한 선택적 통합은 `ownership.externallyManaged: true`로 표시되지만, foundation 패키지가 concrete queue 또는 event-bus 리소스를 닫지 않으므로 `ownsResources: false`를 유지합니다.
 
 ## 관련 패키지
 

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -208,6 +208,7 @@ These limitations are part of the package contract so leaf packages can evolve i
 - `NotificationQueueNotConfiguredError`
 
 Status snapshots include `operationMode`, dependency diagnostics, ownership, readiness, and health fields for platform diagnostics.
+When a queue adapter is configured, `details.dependencies` includes `notifications.queue-adapter`; when lifecycle events are published through an event publisher, it includes `notifications.event-publisher`. Those optional integrations mark `ownership.externallyManaged: true` while the foundation package still reports `ownsResources: false` because it does not close concrete queue or event-bus resources.
 
 ## Related Packages
 

--- a/packages/notifications/src/status.test.ts
+++ b/packages/notifications/src/status.test.ts
@@ -15,7 +15,14 @@ describe('createNotificationsPlatformStatusSnapshot', () => {
     expect(snapshot.health).toEqual({ status: 'healthy' });
     expect(snapshot.details).toMatchObject({
       channelsRegistered: 2,
+      dependencies: ['notifications.queue-adapter', 'notifications.event-publisher'],
+      eventPublisherConfigured: true,
       operationMode: 'queue-backed-with-events',
+      queueConfigured: true,
+    });
+    expect(snapshot.ownership).toEqual({
+      externallyManaged: true,
+      ownsResources: false,
     });
   });
 
@@ -30,5 +37,49 @@ describe('createNotificationsPlatformStatusSnapshot', () => {
     expect(snapshot.readiness.status).toBe('not-ready');
     expect(snapshot.health.status).toBe('unhealthy');
     expect(snapshot.readiness.reason).toContain('No notification channels');
+    expect(snapshot.details).toMatchObject({
+      dependencies: [],
+      operationMode: 'unconfigured',
+    });
+    expect(snapshot.ownership).toEqual({
+      externallyManaged: false,
+      ownsResources: false,
+    });
+  });
+
+  it('reports event publisher dependency diagnostics without queue ownership', () => {
+    const snapshot = createNotificationsPlatformStatusSnapshot({
+      bulkQueueThreshold: 10,
+      channelsRegistered: 1,
+      eventPublisherConfigured: true,
+      queueConfigured: false,
+    });
+
+    expect(snapshot.details).toMatchObject({
+      dependencies: ['notifications.event-publisher'],
+      operationMode: 'direct-with-events',
+    });
+    expect(snapshot.ownership).toEqual({
+      externallyManaged: true,
+      ownsResources: false,
+    });
+  });
+
+  it('reports queue adapter dependency diagnostics without event publishing', () => {
+    const snapshot = createNotificationsPlatformStatusSnapshot({
+      bulkQueueThreshold: 10,
+      channelsRegistered: 1,
+      eventPublisherConfigured: false,
+      queueConfigured: true,
+    });
+
+    expect(snapshot.details).toMatchObject({
+      dependencies: ['notifications.queue-adapter'],
+      operationMode: 'queue-backed',
+    });
+    expect(snapshot.ownership).toEqual({
+      externallyManaged: true,
+      ownsResources: false,
+    });
   });
 });

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -127,6 +127,7 @@ Behavioral contract 메모:
 
 - `SlackService.send(...)`는 전달 전에 `defaultChannel`을 해석합니다.
 - `SlackService.sendMany(...)`는 메시지를 순차적으로 보내며, fail-fast 대신 batch result가 필요한 호출자를 위해 `continueOnError`를 지원합니다.
+- `SlackService.send(...)`, `SlackService.sendMany(...)`, `SlackService.sendNotification(...)`은 provider handoff 전에 이미 abort된 signal을 존중하며, 같은 signal을 transport 호출로 전달합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
 - shutdown이 시작된 뒤에는 `SlackService.send(...)`와 `SlackService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `SlackLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다린 뒤 닫습니다.
 - `SlackService.createPlatformStatusSnapshot()`은 호출자가 내부 옵션에 접근하지 않아도 lifecycle, readiness, transport 소유권을 보고합니다.
@@ -199,6 +200,7 @@ await slack.send({
 Behavioral contract 메모:
 
 - 내장 webhook transport는 `408`, `429`, `5xx` 같은 일시적 실패를 호출자에게 에러를 노출하기 전에 bounded exponential backoff로 재시도합니다.
+- Abort signal은 주입된 `fetch` 경계로 전달되며, retry backoff를 취소할 때 `AbortError`를 `SlackTransportError`로 감싸지 않습니다.
 - 호출자에게 보이는 `SlackTransportError` 메시지는 기본적으로 raw upstream response body를 포함하지 않습니다.
 
 ### 의도적인 제한 사항

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -127,6 +127,7 @@ Behavioral contract notes:
 
 - `SlackService.send(...)` resolves `defaultChannel` before delivery.
 - `SlackService.sendMany(...)` sends messages sequentially and supports `continueOnError` when callers need a batch result instead of fail-fast behavior.
+- `SlackService.send(...)`, `SlackService.sendMany(...)`, and `SlackService.sendNotification(...)` honor already-aborted signals before provider handoff, and the same signal is propagated to transport calls.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
 - Once shutdown starts, `SlackService.send(...)` and `SlackService.sendNotification(...)` fail with `SlackLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited and closed by shutdown.
 - `SlackService.createPlatformStatusSnapshot()` reports lifecycle, readiness, and transport ownership without requiring callers to reach into internal options.
@@ -199,6 +200,7 @@ For richer API integrations such as `chat.postMessage`, implement the exported `
 Behavioral contract notes:
 
 - The built-in webhook transport retries transient `408`, `429`, and `5xx` failures with bounded exponential backoff before surfacing an error.
+- Abort signals are passed to the injected `fetch` boundary and cancel retry backoff without wrapping `AbortError` values as `SlackTransportError`.
 - Caller-visible `SlackTransportError` messages omit raw upstream response bodies by default.
 
 ### Intentional limitations

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -85,6 +85,28 @@ class UnsuccessfulTransport implements SlackTransport {
   }
 }
 
+class SelectiveFailureSlackTransport implements SlackTransport {
+  readonly sent: string[] = [];
+
+  async send(message: NormalizedSlackMessage) {
+    const text = message.text ?? '';
+    this.sent.push(text);
+
+    if (text.includes('fail')) {
+      throw new Error(`provider rejected ${text}`);
+    }
+
+    return {
+      channel: message.channel,
+      messageTs: `selective-${this.sent.length}`,
+      ok: true,
+      response: 'ok',
+      statusCode: 200,
+      warnings: [],
+    };
+  }
+}
+
 class DelayedLifecycleTransport implements SlackTransport {
   closeCalls = 0;
   sendCalls = 0;
@@ -499,6 +521,96 @@ describe('SlackModule', () => {
     ).rejects.toThrowError(new SlackTransportError('Slack transport reported an unsuccessful delivery.'));
   });
 
+  it('delivers sendMany messages sequentially and returns ordered batch results', async () => {
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport: createRecordingTransportFactory({ responsePrefix: 'batch' }),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    const result = await service.sendMany([{ text: 'one' }, { text: 'two' }, { text: 'three' }]);
+
+    expect(result).toMatchObject({ failed: 0, succeeded: 3 });
+    expect(result.results.map((entry) => entry.messageTs)).toEqual(['batch-1', 'batch-2', 'batch-3']);
+    expect(transportState.sent.map((entry) => entry.text)).toEqual(['one', 'two', 'three']);
+  });
+
+  it('stops sendMany at the first provider error by default', async () => {
+    const transport = new SelectiveFailureSlackTransport();
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    await expect(service.sendMany([{ text: 'ok-1' }, { text: 'fail-2' }, { text: 'ok-3' }])).rejects.toThrowError(
+      'provider rejected fail-2',
+    );
+    expect(transport.sent).toEqual(['ok-1', 'fail-2']);
+  });
+
+  it('collects sendMany failures when continueOnError is enabled', async () => {
+    const transport = new SelectiveFailureSlackTransport();
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    const result = await service.sendMany([{ text: 'ok-1' }, { text: 'fail-2' }, { text: 'ok-3' }], {
+      continueOnError: true,
+    });
+
+    expect(result).toMatchObject({ failed: 1, succeeded: 2 });
+    expect(result.failures[0]?.error).toMatchObject({ message: 'provider rejected fail-2' });
+    expect(result.results.map((entry) => entry.messageTs)).toEqual(['selective-1', 'selective-3']);
+    expect(transport.sent).toEqual(['ok-1', 'fail-2', 'ok-3']);
+  });
+
+  it('propagates sendMany abort signals between sequential deliveries', async () => {
+    const controller = new AbortController();
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport: {
+        async send(message: NormalizedSlackMessage) {
+          transportState.sent.push(message);
+          controller.abort();
+
+          return {
+            channel: message.channel,
+            messageTs: 'aborted-batch-1',
+            ok: true,
+            response: 'ok',
+            statusCode: 200,
+            warnings: [],
+          };
+        },
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    const result = await service.sendMany([{ text: 'first' }, { text: 'second' }], {
+      continueOnError: true,
+      signal: controller.signal,
+    });
+
+    expect(result).toMatchObject({ failed: 1, succeeded: 1 });
+    expect(result.failures[0]?.error).toMatchObject({ name: 'AbortError' });
+    expect(transportState.sent.map((entry) => entry.text)).toEqual(['first']);
+  });
+
   it('retries transient webhook failures with exponential backoff before succeeding', async () => {
     vi.useFakeTimers();
 
@@ -537,6 +649,54 @@ describe('SlackModule', () => {
 
       await expect(pending).resolves.toMatchObject({ ok: true, response: 'ok', statusCode: 200 });
       expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('passes AbortSignal to webhook fetch and does not retry AbortError failures', async () => {
+    const controller = new AbortController();
+    const abortError = new DOMException('The operation was aborted.', 'AbortError');
+    const fetchLike = vi.fn<SlackFetchLike>().mockRejectedValue(abortError);
+    const transport = createSlackWebhookTransport({
+      fetch: fetchLike,
+      webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+    });
+
+    await expect(
+      transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Abort path' }, { signal: controller.signal }),
+    ).rejects.toBe(abortError);
+    expect(fetchLike).toHaveBeenCalledTimes(1);
+    expect(fetchLike.mock.calls[0]?.[1]?.signal).toBe(controller.signal);
+  });
+
+  it('stops webhook retry backoff when the signal is aborted', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const controller = new AbortController();
+      const reason = new DOMException('retry cancelled', 'AbortError');
+      const fetchLike = vi.fn<SlackFetchLike>().mockResolvedValue({
+        ok: false,
+        status: 429,
+        async text() {
+          controller.abort(reason);
+          return 'rate_limited';
+        },
+      });
+      const transport = createSlackWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+      });
+
+      const pending = transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Retry abort path' }, {
+        signal: controller.signal,
+      });
+      const expectation = expect(pending).rejects.toBe(reason);
+      await vi.runAllTimersAsync();
+
+      await expectation;
+      expect(fetchLike).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -165,6 +165,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     const transport = await this.ensureTransport();
     const normalized = this.normalizeMessage(message);
     assertMessageContent(normalized);
+    assertNotAborted(options.signal);
     this.assertCanDeliver();
     const result = await transport.send(normalized, options);
 
@@ -246,7 +247,9 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     this.assertCanDeliver();
 
     const payload = notification.payload;
-    const rendered = await this.renderNotification(notification);
+    const rendered = await this.renderNotification(notification, options.signal);
+
+    assertNotAborted(options.signal);
 
     return this.send(
       {
@@ -338,10 +341,13 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
 
   private async renderNotification(
     notification: SlackNotificationDispatchRequest,
+    signal: AbortSignal | undefined,
   ): Promise<SlackTemplateRenderResult | undefined> {
     if (!notification.template || !this.options.renderer) {
       return undefined;
     }
+
+    assertNotAborted(signal);
 
     return this.options.renderer.render({
       locale: notification.locale,

--- a/packages/slack/src/webhook.ts
+++ b/packages/slack/src/webhook.ts
@@ -77,6 +77,10 @@ async function waitForRetry(delayMs: number, signal: AbortSignal | undefined): P
     return;
   }
 
+  if (signal?.aborted) {
+    throw signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+  }
+
   await new Promise<void>((resolve, reject) => {
     const timer = setTimeout(() => {
       signal?.removeEventListener('abort', onAbort);


### PR DESCRIPTION
## Summary

Align notification provider delivery semantics across email, Slack, Discord, and notifications status diagnostics.

Linked context: Closes #1972

## Changes

- Close factory-owned `@fluojs/email` transports when bootstrap verification fails, preserving initialization error causes and covering cleanup with regression tests.
- Add regression coverage for direct `sendMany` sequencing, `continueOnError`, and abort propagation in email, Slack, and Discord delivery services.
- Tighten Slack abort/retry behavior so already-aborted retry backoff fails without retrying or wrapping abort errors.
- Clarify EN/KO README contracts for Slack abort behavior, Discord direct batch semantics, and notifications dependency diagnostics.
- Add patch Changeset release intent for affected public packages.

## Testing

- `lsp_diagnostics` on changed TS files: passed.
- `pnpm vitest run packages/email/src/module.test.ts packages/slack/src/module.test.ts packages/discord/src/module.test.ts packages/notifications/src/status.test.ts`: passed (77 tests).
- `pnpm build`: passed.
- `pnpm typecheck`: passed.
- `pnpm lint`: completed with pre-existing Biome warnings in unrelated files and `verify:public-export-tsdoc` passed.
- `pnpm verify:release-readiness`: attempted; package/test phases passed, then failed in `packages/cli sandbox:matrix` while refreshing `/var/folders/.../fluo-cli-sandbox/node_modules/.pnpm` with `ENOTEMPTY`, unrelated to this change.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. No new public exports were added; existing public behavior/docs were aligned.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No exported signatures changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. No platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable; this PR changes messaging package delivery semantics, not platform conformance claims.