### PR TITLE
Resolve #1963: align foundation contracts

### DIFF
--- a/.changeset/align-foundation-contracts.md
+++ b/.changeset/align-foundation-contracts.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/core": patch
+"@fluojs/runtime": patch
+---
+
+Align foundation package contracts with their documented public surfaces and lifecycle diagnostics guidance.

--- a/packages/core/README.ko.md
+++ b/packages/core/README.ko.md
@@ -81,7 +81,15 @@ class UsesConfigValue {
 }
 ```
 
-여러 constructor 토큰은 `@Inject(A, B)`처럼 variadic 호출로 지정하면 dependency metadata가 표준 데코레이터 사용 방식과 맞게 유지됩니다. `@Inject([A, B])` 배열 형태도 허용되지만, 새 코드는 variadic 형태를 사용하는 것이 좋습니다. 데코레이션 시점에 아직 사용할 수 없는 토큰은 해당 토큰만 `forwardRef(...)`로 감싸고, 없어도 되는 의존성은 해당 토큰만 `optional(...)`로 감쌉니다.
+여러 constructor 토큰은 `@Inject(A, B)`처럼 variadic 호출로 지정하면 dependency metadata가 표준 데코레이터 사용 방식과 맞게 유지됩니다. `@Inject([A, B])` 배열 형태도 허용되지만, 새 코드는 variadic 형태를 사용하는 것이 좋습니다. 데코레이션 시점에 아직 사용할 수 없는 토큰은 해당 토큰만 `forwardRef(...)`로 감싸고, 없어도 되는 의존성은 해당 토큰만 `optional(...)`로 감쌉니다. 이 wrapper helper들은 `@fluojs/di`가 제공하는 runtime DI helper입니다. `@fluojs/core`는 `@Inject(...)`가 받는 공유 wrapper 타입만 export합니다.
+
+```ts
+import { Inject } from '@fluojs/core';
+import { forwardRef, optional } from '@fluojs/di';
+
+@Inject(forwardRef(() => AuditLogger), optional(CacheClient))
+class UsesDeferredAndOptionalDeps {}
+```
 
 ### 형제 패키지를 위한 공용 메타데이터 헬퍼
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -83,7 +83,15 @@ class UsesConfigValue {
 }
 ```
 
-Pass multiple constructor tokens as variadic arguments, such as `@Inject(A, B)`, so dependency metadata stays aligned with standard decorator usage. The array form `@Inject([A, B])` is also accepted, but new code should prefer the variadic form. If a token is unavailable at decoration time, wrap that one token with `forwardRef(...)`; if a dependency may be absent, wrap that token with `optional(...)`.
+Pass multiple constructor tokens as variadic arguments, such as `@Inject(A, B)`, so dependency metadata stays aligned with standard decorator usage. The array form `@Inject([A, B])` is also accepted, but new code should prefer the variadic form. If a token is unavailable at decoration time, wrap that one token with `forwardRef(...)`; if a dependency may be absent, wrap that token with `optional(...)`. The wrapper helpers are runtime DI helpers from `@fluojs/di`; `@fluojs/core` only exports the shared wrapper types accepted by `@Inject(...)`.
+
+```ts
+import { Inject } from '@fluojs/core';
+import { forwardRef, optional } from '@fluojs/di';
+
+@Inject(forwardRef(() => AuditLogger), optional(CacheClient))
+class UsesDeferredAndOptionalDeps {}
+```
 
 ### Shared metadata helpers for sibling packages
 

--- a/packages/core/src/public-api.test.ts
+++ b/packages/core/src/public-api.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
 import * as coreInternalApi from './internal.js';
@@ -26,6 +28,8 @@ describe('@fluojs/core public API surface', () => {
     expect(corePublicApi).not.toHaveProperty('ensureSymbolMetadataPolyfill');
     expect(corePublicApi).not.toHaveProperty('cloneWithFallback');
     expect(corePublicApi).not.toHaveProperty('fallbackClone');
+    expect(corePublicApi).not.toHaveProperty('forwardRef');
+    expect(corePublicApi).not.toHaveProperty('optional');
   });
 
   it('keeps internal metadata helpers available from the internal subpath', () => {
@@ -40,5 +44,12 @@ describe('@fluojs/core public API surface', () => {
     expect(coreInternalApi).toHaveProperty('ensureSymbolMetadataPolyfill');
     expect(coreInternalApi).toHaveProperty('cloneWithFallback');
     expect(coreInternalApi).toHaveProperty('fallbackClone');
+  });
+
+  it('documents that forwardRef and optional wrappers come from @fluojs/di', () => {
+    const readme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
+
+    expect(readme).toContain("import { forwardRef, optional } from '@fluojs/di';");
+    expect(readme).toContain('@fluojs/core` only exports the shared wrapper types');
   });
 });

--- a/packages/runtime/README.ko.md
+++ b/packages/runtime/README.ko.md
@@ -144,6 +144,7 @@ class UsersModule {}
 - 런타임 health module readiness check는 현재 `RequestContext`를 받으므로, public integration이 internal runtime token을 import하지 않고도 runtime-exposed status provider를 해석할 수 있습니다.
 - 시그널 기반 종료 헬퍼는 bounded drain semantics를 유지하면서 timeout/실패 상황을 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료 소유권은 주변 호스트 런타임에 남겨 둡니다.
 - 플랫폼 snapshot 및 diagnostic issue 생산은 런타임에 남아 있고, 그래프 보기, filtering 표현, Mermaid 렌더링은 CLI 및 자동화 호출자가 소비하는 Studio 소유 계약입니다.
+- 플랫폼 component snapshot은 런타임 소유 계약 payload입니다. 각 component는 `readiness`, `health`, dependency id, telemetry tag, diagnostic issue, 그리고 `ownership.ownsResources` / `ownership.externallyManaged`를 통해 리소스 소유권을 보고합니다. Runtime은 shell snapshot에서 이 ownership flag를 보존하므로 adapter와 package integration이 fluo가 종료해야 하는 리소스와 host가 소유한 외부 관리 리소스를 구분할 수 있습니다.
 - 모듈 그래프 컴파일 결과 캐시는 `moduleGraphCache: true`를 통한 opt-in입니다. 캐시 항목은 root module identity, runtime provider, validation token, core metadata version, compile algorithm version으로 식별되며, 성공한 컴파일만 저장하고 호출자 mutation이 이후 bootstrap을 오염시키지 않도록 격리된 그래프 복사본을 반환합니다.
 
 ## 공개 API 개요
@@ -160,6 +161,7 @@ class UsersModule {}
 - `bootstrapApplication(options)`: 저수준 비동기 부트스트랩 함수입니다.
 - `bootstrapModule(...)`: 저수준 module graph bootstrap helper입니다.
 - `createBootstrapTimingDiagnostics(...)`, `createRuntimeDiagnosticsGraph(...)`: CLI/support tooling을 위한 runtime 소유 diagnostics snapshot helper입니다. 이 helper들은 기계 읽기 가능한 데이터를 생산하며, Studio가 viewer parsing, graph presentation, Mermaid rendering을 소유합니다.
+- `PlatformShell`, `PlatformComponent`, `PlatformShellSnapshot`, `PlatformSnapshot`, `PlatformDiagnosticIssue` 및 관련 platform report 타입: runtime-aware package가 사용하는 공개 lifecycle diagnostics 및 resource-ownership 계약입니다. `RuntimePlatformShell`은 component가 제공한 ownership을 보존하고, consumer가 internal runtime token을 import하지 않아도 validation/readiness/health diagnostics를 내보냅니다.
 - `createRequestAbortContext(...)`, `trackActiveRequestTransaction(...)`, `untrackActiveRequestTransaction(...)`: runtime-aware integration이 사용하는 request abort 및 active transaction helper입니다.
 
 ## 플랫폼 전용 서브경로

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -144,6 +144,7 @@ class UsersModule {}
 - Runtime health module readiness checks receive the current `RequestContext`, allowing public integrations to resolve runtime-exposed status providers without importing internal runtime tokens.
 - Signal-driven shutdown helpers preserve bounded drain semantics, log timeout/failure conditions, and set `process.exitCode` when shutdown does not finish cleanly, but they leave final process termination ownership to the surrounding host runtime.
 - Platform snapshot and diagnostic issue production stay in runtime; graph viewing, filtering presentation, and Mermaid rendering are Studio-owned contracts consumed by CLI and automation callers.
+- Platform component snapshots are runtime-owned contract payloads: each component reports `readiness`, `health`, dependency ids, telemetry tags, diagnostic issues, and resource ownership through `ownership.ownsResources` / `ownership.externallyManaged`. Runtime preserves those ownership flags in shell snapshots so adapters and package integrations can distinguish resources fluo must stop from externally managed resources the host owns.
 - Module graph compile-result caching is opt-in through `moduleGraphCache: true`; it keys entries by root module identity, runtime providers, validation tokens, core metadata versions, and the compile algorithm version, caches only successful compilations, and returns isolated graph copies so caller mutations cannot poison later bootstraps.
 
 ## Public API Overview
@@ -160,6 +161,7 @@ class UsersModule {}
 - `bootstrapApplication(options)`: Lower-level async bootstrap function.
 - `bootstrapModule(...)`: Lower-level module graph bootstrap helper.
 - `createBootstrapTimingDiagnostics(...)`, `createRuntimeDiagnosticsGraph(...)`: Runtime-owned diagnostics snapshot helpers for CLI/support tooling. They produce machine-readable data; Studio owns viewer parsing, graph presentation, and Mermaid rendering.
+- `PlatformShell`, `PlatformComponent`, `PlatformShellSnapshot`, `PlatformSnapshot`, `PlatformDiagnosticIssue`, and related platform report types: Public lifecycle diagnostics and resource-ownership contracts used by runtime-aware packages. `RuntimePlatformShell` preserves component-provided ownership and emits validation/readiness/health diagnostics without requiring consumers to import internal runtime tokens.
 - `createRequestAbortContext(...)`, `trackActiveRequestTransaction(...)`, `untrackActiveRequestTransaction(...)`: Request abort and active transaction helpers used by runtime-aware integrations.
 
 ## Platform-Specific Subpaths

--- a/packages/runtime/src/platform-shell.test.ts
+++ b/packages/runtime/src/platform-shell.test.ts
@@ -173,6 +173,10 @@ describe('RuntimePlatformShell', () => {
     expect(snapshot.health.status).toBe('degraded');
     expect(snapshot.components.map((component) => component.id)).toEqual(['cache.default', 'search.default']);
     expect(snapshot.components.find((component) => component.id === 'search.default')?.dependencies).toEqual(['cache.default']);
+    expect(snapshot.components.find((component) => component.id === 'search.default')?.ownership).toEqual({
+      externallyManaged: false,
+      ownsResources: true,
+    });
 
     await shell.stop();
   });


### PR DESCRIPTION
## Summary

Aligns foundation package public-contract documentation and tests for `@fluojs/core` and `@fluojs/runtime`.

Linked context: Closes #1963

## Changes

- Clarified that `forwardRef(...)` and `optional(...)` wrapper helpers are imported from `@fluojs/di`, while `@fluojs/core` exposes the shared wrapper types accepted by `@Inject(...)`.
- Documented runtime platform diagnostics and resource ownership contracts for `PlatformShell`, `PlatformSnapshot`, `PlatformDiagnosticIssue`, and related public types in English/Korean runtime READMEs.
- Added regression coverage for core public-surface boundaries and runtime shell snapshot ownership preservation.
- Added a patch changeset for `@fluojs/core` and `@fluojs/runtime` contract-alignment release impact.

## Testing

- `lsp_diagnostics` on `packages/core/src/public-api.test.ts`: no diagnostics
- `lsp_diagnostics` on `packages/runtime/src/platform-shell.test.ts`: no diagnostics
- `pnpm --filter @fluojs/core test -- src/public-api.test.ts`
- `pnpm --filter @fluojs/runtime test -- src/platform-shell.test.ts src/platform-contract.test.ts` (package script ran the runtime test project; 20 files / 246 tests passed)
- `pnpm --filter @fluojs/runtime... build`
- `pnpm --filter @fluojs/runtime typecheck`
- `pnpm lint` completed with existing Biome warnings in unrelated packages and `verify:public-export-tsdoc` passed in changed mode

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. No new public exports were added; existing public contract docs were aligned with current exports.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. No exported function signatures changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. README examples now clarify the correct `@fluojs/di` import source for wrapper helpers.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. Package README English/Korean mirrors were updated together.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Runtime package README discoverability and platform shell regression coverage were updated.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable; this PR does not add platform adapter conformance claims.