### PR TITLE
Resolve #1970: align Passport auth outcomes

### DIFF
--- a/.changeset/align-passport-header-outcomes.md
+++ b/.changeset/align-passport-header-outcomes.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/passport": patch
+---
+
+Preserve existing response cookies case-insensitively when appending passport auth cookies and add regression coverage for Passport.js fail/pass/error outcomes.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -144,6 +144,8 @@ export class AuthModule {}
 
 Cookie access token은 비어 있지 않은 문자열이어야 합니다. `requireAccessToken: false`일 때만 누락된 cookie가 `{ authenticated: false }`로 resolve될 수 있으며, 존재하지만 malformed인 cookie 값은 JWT 검증 전에 항상 인증 실패로 처리됩니다.
 
+`CookieManager`는 underlying adapter가 기존 header를 `set-cookie`처럼 다른 casing으로 저장했더라도, response에 이미 설정된 cookie를 덮어쓰지 않고 access-token 및 refresh-token `Set-Cookie` 값을 append합니다.
+
 보호된 라우트는 계속 `@UseAuth(...)`를 사용해야 합니다. `requireAccessToken: false`를 설정해도 쿠키가 없을 때는 익명 principal이 아니라 명시적인 미인증 결과를 반환하므로, 보호된 라우트는 요청을 계속 거부합니다.
 
 로그인 사용자와 게스트 호출자를 모두 허용하려는 라우트에서만 `@UseOptionalAuth(...)`를 사용하세요.

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -144,6 +144,8 @@ Import `CookieAuthModule.forRoot(...)`, `JwtModule.forRoot(...)`, and `PassportM
 
 Cookie access tokens must be non-empty strings. Missing cookies can resolve to `{ authenticated: false }` only when `requireAccessToken: false`; malformed present cookie values always fail authentication before JWT verification.
 
+`CookieManager` appends access-token and refresh-token `Set-Cookie` values without overwriting cookies that were already placed on the response, even when the underlying adapter stores the existing header with different casing such as `set-cookie`.
+
 Protected routes must keep using `@UseAuth(...)`. If you configure `requireAccessToken: false`, a missing cookie resolves to an explicit unauthenticated result instead of an anonymous principal, so protected routes still reject the request.
 
 Use `@UseOptionalAuth(...)` only on routes that intentionally support both signed-in and guest callers:

--- a/packages/passport/src/cookie/cookie-auth.test.ts
+++ b/packages/passport/src/cookie/cookie-auth.test.ts
@@ -249,6 +249,25 @@ describe('CookieManager', () => {
     };
   }
 
+  function createAppendSetCookieResponse() {
+    return {
+      ...createMockResponse(),
+      setHeader(name: string, value: string | string[]) {
+        const headerKey = Object.keys(this.headers).find((key) => key.toLowerCase() === name.toLowerCase());
+        const current = headerKey ? this.headers[headerKey] : undefined;
+
+        if (name.toLowerCase() !== 'set-cookie' || current === undefined) {
+          this.headers[name] = value;
+          return;
+        }
+
+        const currentValues = Array.isArray(current) ? current : [current];
+        const nextValues = Array.isArray(value) ? value : [value];
+        this.headers[headerKey ?? name] = [...currentValues, ...nextValues];
+      },
+    };
+  }
+
   it('creates cookie header with correct format', async () => {
     const { CookieManager } = await import('./cookie-manager.js');
     const manager = new CookieManager();
@@ -309,6 +328,22 @@ describe('CookieManager', () => {
     expect(response.headers['Set-Cookie']).toEqual([
       'existing=session; Path=/',
       'access_token=access-jwt; Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Strict',
+    ]);
+    expect(response.headers['set-cookie']).toBeUndefined();
+  });
+
+  it('does not duplicate existing cookies when the adapter appends set-cookie values', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager();
+    const response = createAppendSetCookieResponse();
+    response.headers['set-cookie'] = 'existing=session; Path=/';
+
+    manager.setAuthCookies(response, 'access-jwt', 3600, 'refresh-jwt', 604800);
+
+    expect(response.headers['Set-Cookie']).toEqual([
+      'existing=session; Path=/',
+      'access_token=access-jwt; Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Strict',
+      'refresh_token=refresh-jwt; Max-Age=604800; Path=/; Secure; HttpOnly; SameSite=Strict',
     ]);
     expect(response.headers['set-cookie']).toBeUndefined();
   });

--- a/packages/passport/src/cookie/cookie-auth.test.ts
+++ b/packages/passport/src/cookie/cookie-auth.test.ts
@@ -298,6 +298,21 @@ describe('CookieManager', () => {
     expect(cookies[1]).toContain('refresh_token=refresh-jwt');
   });
 
+  it('appends cookies to an existing set-cookie header regardless of response header casing', async () => {
+    const { CookieManager } = await import('./cookie-manager.js');
+    const manager = new CookieManager();
+    const response = createMockResponse();
+    response.headers['set-cookie'] = 'existing=session; Path=/';
+
+    manager.setAccessTokenCookie(response, 'access-jwt', 3600);
+
+    expect(response.headers['Set-Cookie']).toEqual([
+      'existing=session; Path=/',
+      'access_token=access-jwt; Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Strict',
+    ]);
+    expect(response.headers['set-cookie']).toBeUndefined();
+  });
+
   it('uses custom cookie names', async () => {
     const { CookieManager } = await import('./cookie-manager.js');
     const manager = new CookieManager({

--- a/packages/passport/src/cookie/cookie-manager.ts
+++ b/packages/passport/src/cookie/cookie-manager.ts
@@ -94,6 +94,14 @@ function getHeaderCaseInsensitive(
   return undefined;
 }
 
+function toHeaderValues(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) {
+    return [...value];
+  }
+
+  return value ? [value] : [];
+}
+
 /**
  * Represents the cookie manager.
  */
@@ -178,20 +186,17 @@ export class CookieManager {
 
   private appendSetCookie(response: FrameworkResponse, cookie: string): void {
     const existingHeader = getHeaderCaseInsensitive(response.headers, 'Set-Cookie');
-    const existingCookies = existingHeader?.value;
-    const cookies = Array.isArray(existingCookies)
-      ? existingCookies
-      : existingCookies
-        ? [existingCookies]
-        : [];
+    const cookies = [...toHeaderValues(existingHeader?.value), cookie];
 
-    cookies.push(cookie);
+    response.setHeader('Set-Cookie', cookie);
 
-    if (existingHeader && existingHeader.key !== 'Set-Cookie') {
-      delete response.headers[existingHeader.key];
+    const updatedHeader = getHeaderCaseInsensitive(response.headers, 'Set-Cookie');
+
+    if (updatedHeader?.key && updatedHeader.key !== 'Set-Cookie') {
+      delete response.headers[updatedHeader.key];
     }
 
-    response.setHeader('Set-Cookie', cookies.length === 1 ? cookies[0] : cookies);
+    response.headers['Set-Cookie'] = cookies.length === 1 ? cookies[0] : cookies;
   }
 }
 

--- a/packages/passport/src/cookie/cookie-manager.ts
+++ b/packages/passport/src/cookie/cookie-manager.ts
@@ -1,6 +1,6 @@
 import type { FrameworkResponse } from '@fluojs/http';
 
-import { DEFAULT_COOKIE_AUTH_OPTIONS, type CookieAuthOptions, normalizeCookieAuthOptions } from './cookie-auth.js';
+import { type CookieAuthOptions, normalizeCookieAuthOptions } from './cookie-auth.js';
 
 /**
  * Describes the cookie options contract.
@@ -79,6 +79,19 @@ function buildClearCookieHeader(name: string, options: NormalizedCookieOptions):
     ...options,
     maxAge: 0,
   });
+}
+
+function getHeaderCaseInsensitive(
+  headers: FrameworkResponse['headers'],
+  name: string,
+): { key: string; value: string | string[] } | undefined {
+  for (const [headerName, value] of Object.entries(headers)) {
+    if (headerName.toLowerCase() === name.toLowerCase() && (typeof value === 'string' || Array.isArray(value))) {
+      return { key: headerName, value };
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -164,7 +177,8 @@ export class CookieManager {
   }
 
   private appendSetCookie(response: FrameworkResponse, cookie: string): void {
-    const existingCookies = response.headers['Set-Cookie'];
+    const existingHeader = getHeaderCaseInsensitive(response.headers, 'Set-Cookie');
+    const existingCookies = existingHeader?.value;
     const cookies = Array.isArray(existingCookies)
       ? existingCookies
       : existingCookies
@@ -172,6 +186,11 @@ export class CookieManager {
         : [];
 
     cookies.push(cookie);
+
+    if (existingHeader && existingHeader.key !== 'Set-Cookie') {
+      delete response.headers[existingHeader.key];
+    }
+
     response.setHeader('Set-Cookie', cookies.length === 1 ? cookies[0] : cookies);
   }
 }

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -528,6 +528,147 @@ describe('AuthGuard', () => {
     });
   });
 
+  it('maps Passport.js fail callbacks to the canonical 401 path', async () => {
+    class PassportLikeFailStrategy {
+      fail?: (challenge?: unknown, status?: number) => void;
+
+      authenticate() {
+        this.fail?.({ message: 'Google profile is required.' }, 401);
+      }
+    }
+
+    const bridge = createPassportJsStrategyBridge('google-fail', PassportLikeFailStrategy);
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-fail')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikeFailStrategy,
+      ...bridge.providers,
+      ...createPassportModuleProviders({ defaultStrategy: 'google-fail' }, [bridge.strategy]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/oauth/profile', { 'x-request-id': 'req-passport-fail' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-passport-fail',
+        status: 401,
+      },
+    });
+  });
+
+  it('maps Passport.js pass callbacks to the canonical 401 path', async () => {
+    class PassportLikePassStrategy {
+      pass?: () => void;
+
+      authenticate() {
+        this.pass?.();
+      }
+    }
+
+    const bridge = createPassportJsStrategyBridge('google-pass', PassportLikePassStrategy);
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-pass')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikePassStrategy,
+      ...bridge.providers,
+      ...createPassportModuleProviders({ defaultStrategy: 'google-pass' }, [bridge.strategy]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/oauth/profile', { 'x-request-id': 'req-passport-pass' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-passport-pass',
+        status: 401,
+      },
+    });
+  });
+
+  it('rethrows Passport.js error callbacks without converting infrastructure failures to auth failures', async () => {
+    const originalError = new Error('oauth provider unavailable');
+
+    class PassportLikeErrorStrategy {
+      error?: (error: unknown) => void;
+
+      authenticate() {
+        this.error?.(originalError);
+      }
+    }
+
+    const bridge = createPassportJsStrategyBridge('google-error', PassportLikeErrorStrategy);
+
+    @Controller('/oauth')
+    class ProtectedController {
+      @Get('/profile')
+      @UseAuth('google-error')
+      getProfile() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      PassportLikeErrorStrategy,
+      ...bridge.providers,
+      ...createPassportModuleProviders({ defaultStrategy: 'google-error' }, [bridge.strategy]),
+    );
+    const guardContext = {
+      handler: {
+        controllerToken: ProtectedController,
+        methodName: 'getProfile',
+      },
+      requestContext: {
+        container: root,
+        principal: undefined,
+        request: createRequest('/oauth/profile'),
+        requestId: 'req-passport-error-direct',
+        response: createResponse(),
+      },
+    } as unknown as GuardContext;
+
+    const guard = await root.resolve(AuthGuard);
+
+    await expect(guard.canActivate(guardContext)).rejects.toBe(originalError);
+  });
+
   it('settles Passport.js promise rejections as authentication failures', async () => {
     class PassportLikeAsyncFailureStrategy {
       async authenticate(): Promise<void> {


### PR DESCRIPTION
## Summary

Align `@fluojs/passport` with the audit findings for Passport.js strategy outcomes and response cookie header preservation.

Linked context: Closes #1970

## Changes

- Preserve existing response cookies when `CookieManager` appends auth cookies, including adapters that store existing `set-cookie` headers with lowercase casing.
- Add regression coverage for Passport.js `fail`, `pass`, and `error` bridge outcomes.
- Document the `CookieManager` append/case-insensitive response header behavior in English and Korean README files.
- Add a patch changeset for the public `@fluojs/passport` behavior fix.

## Testing

- `pnpm --filter @fluojs/passport test` — passed, 8 files / 96 tests.
- `pnpm --filter @fluojs/passport... build` — passed after building package dependencies and `@fluojs/passport`.
- LSP diagnostics: clean for changed TypeScript files (`cookie-manager.ts`, `cookie-auth.test.ts`, `guard.test.ts`).

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/align-passport-header-outcomes.md`.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed. README behavior documentation was updated for the affected cookie helper behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The `Set-Cookie` append behavior is documented in `packages/passport/README.md` and `packages/passport/README.ko.md`; Passport.js strategy outcome and header behavior are covered by targeted package tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. Package README EN/KO mirrors were updated together; this is an auth package behavior fix rather than platform conformance work.