### PR TITLE
Resolve #1978: align testing lifecycle semantics

### DIFF
--- a/.changeset/testing-lifecycle-di-semantics.md
+++ b/.changeset/testing-lifecycle-di-semantics.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/testing": patch
+---
+
+Align testing module compilation and synchronous resolution with production lifecycle and DI ownership semantics.

--- a/packages/testing/README.ko.md
+++ b/packages/testing/README.ko.md
@@ -79,6 +79,8 @@ const service = await module.resolve(UserService);
 
 Testing builder는 route-pipeline 테스트에서 cross-cutting behavior를 교체할 수 있도록 `overrideGuard(...)`, `overrideInterceptor(...)`, `overrideFilter(...)`도 지원합니다.
 
+`compile()`은 lifecycle hook이 있는 singleton provider에 대해 production module bootstrap과 같은 의미를 따릅니다. effective provider graph를 해석하고, testing module을 반환하기 전에 provider 순서대로 각 instance의 `onModuleInit()`을 실행한 뒤 `onApplicationBootstrap()`을 실행합니다. `get()`은 synchronous singleton 및 multi-provider 경로에서도 DI ownership 의미를 보존하므로, 반복 sync read는 같은 singleton contribution을 재사용하고 `module.container.dispose()`가 해당 instance를 계속 정리할 수 있습니다.
+
 ### `overrideModule()` 사용 시 모듈 identity 보존
 
 `createTestingModule({ rootModule })`에는 명시적인 루트 모듈이 필요합니다. 그래야 테스트가 프로덕션 bootstrap과 같은 모듈 그래프 형태를 컴파일합니다. `overrideModule(source, replacement)`로 import된 모듈을 교체해도, 컴파일된 testing module은 provider 해석에 replacement import를 사용하면서 원래 `rootModule`과 컴파일된 `modules[].type` identity를 보존합니다. 따라서 diagnostics, graph assertion, module introspection 헬퍼는 테스트 전용 synthetic wrapper 클래스가 아니라 사용자가 작성한 애플리케이션 모듈 클래스에 계속 연결됩니다.

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -77,6 +77,8 @@ const service = await module.resolve(UserService);
 
 The testing builder also supports `overrideGuard(...)`, `overrideInterceptor(...)`, and `overrideFilter(...)` for route-pipeline tests that need to replace cross-cutting behavior.
 
+`compile()` follows production module-bootstrap semantics for lifecycle-bearing singleton providers: it resolves the effective provider graph, runs `onModuleInit()` for each resolved instance, then runs `onApplicationBootstrap()` in the same provider order before the testing module is returned. `get()` keeps DI ownership semantics for synchronous singleton and multi-provider paths, so repeated sync reads reuse the same singleton contributions and `module.container.dispose()` can still clean them up.
+
 ### Preserve module identity with `overrideModule()`
 
 `createTestingModule({ rootModule })` requires an explicit root module so tests compile the same module graph shape that production bootstrap uses. When `overrideModule(source, replacement)` swaps imported modules, the compiled testing module preserves the original `rootModule` and compiled `modules[].type` identities while using the replacement imports for provider resolution. This keeps diagnostics, graph assertions, and module-introspection helpers tied to the application module classes you authored instead of synthetic test-only wrapper classes.

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -113,6 +113,103 @@ describe('@fluojs/testing', () => {
     expect(events).toEqual(['service:init', 'consumer:init', 'service:bootstrap', 'consumer:bootstrap']);
   });
 
+  it('runs bootstrap lifecycle hooks from the effective override provider', async () => {
+    const SERVICE_TOKEN = Symbol('service-token');
+    const events: string[] = [];
+
+    class ReplacementService {
+      onModuleInit() {
+        events.push('replacement:init');
+      }
+
+      onApplicationBootstrap() {
+        events.push('replacement:bootstrap');
+      }
+    }
+
+    @Module({ providers: [{ provide: SERVICE_TOKEN, useValue: { name: 'original' } }] })
+    class LifecycleOverrideModule {}
+
+    const testingModule = await createTestingModule({ rootModule: LifecycleOverrideModule })
+      .overrideProvider(SERVICE_TOKEN, { provide: SERVICE_TOKEN, useClass: ReplacementService })
+      .compile();
+
+    expect(await testingModule.resolve(SERVICE_TOKEN)).toBeInstanceOf(ReplacementService);
+    expect(events).toEqual(['replacement:init', 'replacement:bootstrap']);
+  });
+
+  it('runs bootstrap lifecycle hooks from lifecycle-bearing useValue overrides', async () => {
+    const SERVICE_TOKEN = Symbol('service-token');
+    const events: string[] = [];
+    const replacement = {
+      onModuleInit: () => events.push('value:init'),
+      onApplicationBootstrap: () => events.push('value:bootstrap'),
+    };
+
+    @Module({ providers: [{ provide: SERVICE_TOKEN, useFactory: () => ({ name: 'original' }) }] })
+    class LifecycleValueOverrideModule {}
+
+    const testingModule = await createTestingModule({ rootModule: LifecycleValueOverrideModule })
+      .overrideProvider(SERVICE_TOKEN, replacement)
+      .compile();
+
+    expect(await testingModule.resolve(SERVICE_TOKEN)).toBe(replacement);
+    expect(events).toEqual(['value:init', 'value:bootstrap']);
+  });
+
+  it('does not run bootstrap lifecycle hooks for decorated request or transient providers', async () => {
+    const events: string[] = [];
+
+    @ScopeDecorator('request')
+    class RequestLifecycleService {
+      onModuleInit() {
+        events.push('request:init');
+      }
+    }
+
+    @ScopeDecorator('transient')
+    class TransientLifecycleService {
+      onModuleInit() {
+        events.push('transient:init');
+      }
+    }
+
+    @Module({ providers: [RequestLifecycleService, TransientLifecycleService] })
+    class ScopedLifecycleModule {}
+
+    await createTestingModule({ rootModule: ScopedLifecycleModule }).compile();
+
+    expect(events).toEqual([]);
+  });
+
+  it('uses useClass decorator metadata when deciding bootstrap lifecycle scope', async () => {
+    const SERVICE_TOKEN = Symbol('service-token');
+    const events: string[] = [];
+
+    @ScopeDecorator('transient')
+    class TransientReplacementService {
+      onModuleInit() {
+        events.push('transient:init');
+      }
+    }
+
+    @ScopeDecorator('request')
+    class RequestReplacementService {
+      onModuleInit() {
+        events.push('request:init');
+      }
+    }
+
+    @Module({ providers: [{ provide: SERVICE_TOKEN, useClass: TransientReplacementService }] })
+    class UseClassScopedLifecycleModule {}
+
+    await createTestingModule({ rootModule: UseClassScopedLifecycleModule })
+      .overrideProvider(SERVICE_TOKEN, { provide: SERVICE_TOKEN, useClass: RequestReplacementService })
+      .compile();
+
+    expect(events).toEqual([]);
+  });
+
   it('shares singleton identity between get() and resolve()', async () => {
     class CounterService {
       count = 0;

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -78,6 +78,41 @@ describe('@fluojs/testing', () => {
     expect(service.logger.name).toBe('logger');
   });
 
+  it('runs bootstrap lifecycle hooks when compiling a testing module', async () => {
+    const events: string[] = [];
+
+    class LifecycleService {
+      onModuleInit() {
+        events.push('service:init');
+      }
+
+      onApplicationBootstrap() {
+        events.push('service:bootstrap');
+      }
+    }
+
+    @Inject(LifecycleService)
+    class LifecycleConsumer {
+      constructor(readonly service: LifecycleService) {}
+
+      onModuleInit() {
+        events.push('consumer:init');
+      }
+
+      onApplicationBootstrap() {
+        events.push('consumer:bootstrap');
+      }
+    }
+
+    @Module({ providers: [LifecycleService, LifecycleConsumer] })
+    class LifecycleModule {}
+
+    const testingModule = await createTestingModule({ rootModule: LifecycleModule }).compile();
+
+    expect(await testingModule.resolve(LifecycleConsumer)).toBeInstanceOf(LifecycleConsumer);
+    expect(events).toEqual(['service:init', 'consumer:init', 'service:bootstrap', 'consumer:bootstrap']);
+  });
+
   it('shares singleton identity between get() and resolve()', async () => {
     class CounterService {
       count = 0;
@@ -95,6 +130,55 @@ describe('@fluojs/testing', () => {
 
     expect(asyncService).toBe(syncService);
     expect(asyncService.count).toBe(7);
+  });
+
+  it('preserves singleton and disposal semantics for sync multi-provider get()', async () => {
+    const PLUGINS = Symbol('plugins');
+    const disposed: string[] = [];
+
+    class PluginA {
+      count = 0;
+
+      onDestroy() {
+        disposed.push('a');
+      }
+    }
+
+    class PluginB {
+      count = 0;
+
+      onDestroy() {
+        disposed.push('b');
+      }
+    }
+
+    @Module({
+      providers: [
+        { provide: PLUGINS, useClass: PluginA, multi: true },
+        { provide: PLUGINS, useClass: PluginB, multi: true },
+      ],
+    })
+    class MultiProviderModule {}
+
+    const testingModule = await createTestingModule({ rootModule: MultiProviderModule }).compile();
+
+    const first = testingModule.get<Array<PluginA | PluginB>>(PLUGINS);
+    first[0].count = 1;
+    first[1].count = 2;
+
+    const second = testingModule.get<Array<PluginA | PluginB>>(PLUGINS);
+    const resolved = await testingModule.resolve<Array<PluginA | PluginB>>(PLUGINS);
+
+    expect(second).not.toBe(first);
+    expect(second[0]).toBe(first[0]);
+    expect(second[1]).toBe(first[1]);
+    expect(resolved[0]).toBe(first[0]);
+    expect(resolved[1]).toBe(first[1]);
+    expect(resolved.map((plugin) => plugin.count)).toEqual([1, 2]);
+
+    await testingModule.container.dispose();
+
+    expect(disposed).toEqual(['b', 'a']);
   });
 
   it('overrides providers before resolution', async () => {

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -7,6 +7,7 @@ import {
   type NormalizedProvider,
   type OptionalToken,
   type Provider,
+  Scope,
 } from '@fluojs/di';
 import type { BootstrapResult, ModuleDefinition, ModuleType } from '@fluojs/runtime';
 import { bootstrapModule, defineModule } from '@fluojs/runtime';
@@ -124,6 +125,7 @@ interface ContainerIntrospection {
   parent?: ContainerIntrospection;
   registrations: Map<Token, NormalizedProvider>;
   multiRegistrations: Map<Token, NormalizedProvider[]>;
+  multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>;
   requestScopeEnabled?: boolean;
   singletonCache: Map<Token, Promise<unknown>>;
 }
@@ -135,6 +137,7 @@ function isContainerIntrospection(value: unknown): value is ContainerIntrospecti
 
   const candidate = value as {
     multiRegistrations?: unknown;
+    multiSingletonCache?: unknown;
     parent?: unknown;
     registrations?: unknown;
     requestScopeEnabled?: unknown;
@@ -147,6 +150,7 @@ function isContainerIntrospection(value: unknown): value is ContainerIntrospecti
   return (
     candidate.registrations instanceof Map &&
     candidate.multiRegistrations instanceof Map &&
+    candidate.multiSingletonCache instanceof Map &&
     candidate.singletonCache instanceof Map &&
     parentValid &&
     requestScopeValid
@@ -172,9 +176,111 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
 interface SyncResolverState {
   factoryResolutionKinds: WeakMap<NormalizedProvider, 'async' | 'sync'>;
   introspection: ContainerIntrospection;
+  multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>;
   resolutionChain: Set<Token>;
   singletonCache: Map<Token, Promise<unknown>>;
+  syncMultiSingletonValues: Map<NormalizedProvider, unknown>;
   syncSingletonValues: Map<Token, unknown>;
+}
+
+interface SyncResolver {
+  get<T>(token: Token<T>): T;
+  syncFromContainer(): Promise<void>;
+}
+
+type LifecycleHookName = 'onModuleInit' | 'onApplicationBootstrap';
+
+function hasLifecycleHook(value: unknown, hookName: LifecycleHookName): value is Record<LifecycleHookName, () => MaybePromise<void>> {
+  return (
+    (typeof value === 'object' || typeof value === 'function') &&
+    value !== null &&
+    typeof (value as Record<LifecycleHookName, unknown>)[hookName] === 'function'
+  );
+}
+
+function hasAnyBootstrapLifecycleHook(value: unknown): boolean {
+  return hasLifecycleHook(value, 'onModuleInit') || hasLifecycleHook(value, 'onApplicationBootstrap');
+}
+
+function providerToken(provider: Provider): Token {
+  return isProviderDescriptor(provider) ? provider.provide : provider;
+}
+
+function isValueProvider(provider: Provider): provider is Extract<Provider, { useValue: unknown }> {
+  return isProviderDescriptor(provider) && 'useValue' in provider;
+}
+
+function isLifecycleValueProvider(provider: Provider): provider is Extract<Provider, { useValue: unknown }> {
+  return isValueProvider(provider) && hasAnyBootstrapLifecycleHook(provider.useValue);
+}
+
+function isDirectSingletonLifecycleProvider(provider: Provider): boolean {
+  if (isLifecycleValueProvider(provider)) {
+    return true;
+  }
+
+  if (isProviderDescriptor(provider)) {
+    return 'useClass' in provider ? (provider.scope ?? Scope.DEFAULT) === Scope.DEFAULT : false;
+  }
+
+  return isClassConstructor(provider);
+}
+
+async function resolveTestingLifecycleInstances(bootstrapped: BootstrapResult): Promise<unknown[]> {
+  const lifecycleProviders = [
+    ...bootstrapped.effectiveProviders.runtimeProviders,
+    ...bootstrapped.effectiveProviders.moduleProviders,
+  ];
+  const instances: unknown[] = [];
+  const seen = new Set<Token>();
+
+  for (const provider of lifecycleProviders) {
+    const token = providerToken(provider);
+
+    if (seen.has(token)) {
+      continue;
+    }
+
+    if (isLifecycleValueProvider(provider)) {
+      seen.add(token);
+      instances.push(provider.useValue);
+      continue;
+    }
+
+    if (!isDirectSingletonLifecycleProvider(provider)) {
+      continue;
+    }
+
+    seen.add(token);
+
+    try {
+      instances.push(await bootstrapped.container.resolve(token));
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('Request-scoped provider')) {
+        continue;
+      }
+
+      throw error;
+    }
+  }
+
+  return instances;
+}
+
+async function runTestingBootstrapLifecycle(bootstrapped: BootstrapResult): Promise<void> {
+  const instances = await resolveTestingLifecycleInstances(bootstrapped);
+
+  for (const instance of instances) {
+    if (hasLifecycleHook(instance, 'onModuleInit')) {
+      await instance.onModuleInit();
+    }
+  }
+
+  for (const instance of instances) {
+    if (hasLifecycleHook(instance, 'onApplicationBootstrap')) {
+      await instance.onApplicationBootstrap();
+    }
+  }
 }
 
 function rootContainerIntrospection(target: ContainerIntrospection): ContainerIntrospection {
@@ -288,6 +394,28 @@ function canPromoteCachedSingleton(state: SyncResolverState, token: Token): bool
   return provider !== undefined && provider.scope !== 'request' && providerGraphIsSyncResolvable(state, token);
 }
 
+function providerGraphForProviderIsSyncResolvable(
+  state: SyncResolverState,
+  provider: NormalizedProvider,
+  visited = new Set<Token>(),
+): boolean {
+  if (provider.type === 'factory') {
+    return state.factoryResolutionKinds.get(provider) === 'sync';
+  }
+
+  if (provider.type === 'existing') {
+    return provider.useExisting !== undefined && providerGraphIsSyncResolvable(state, provider.useExisting, visited);
+  }
+
+  return provider.inject.every((entry) => {
+    if (isOptionalToken(entry) && !hasToken(state, entry.token)) {
+      return true;
+    }
+
+    return providerGraphIsSyncResolvable(state, dependencyToken(entry), visited);
+  });
+}
+
 function resolveSyncDependency(entry: Token | ForwardRefFn | OptionalToken, state: SyncResolverState): unknown {
   if (isOptionalToken(entry)) {
     if (!hasToken(state, entry.token)) {
@@ -371,6 +499,31 @@ function resolveSyncProvider(provider: NormalizedProvider, state: SyncResolverSt
   return instance;
 }
 
+function resolveSyncMultiProvider(provider: NormalizedProvider, state: SyncResolverState): unknown {
+  if (provider.scope === 'request' && !state.introspection.requestScopeEnabled) {
+    throw new Error(`Request-scoped provider ${String(provider.provide)} cannot be resolved outside request scope.`);
+  }
+
+  if (provider.scope === 'transient') {
+    return instantiateSyncProvider(provider, state);
+  }
+
+  if (state.syncMultiSingletonValues.has(provider)) {
+    return state.syncMultiSingletonValues.get(provider);
+  }
+
+  if (state.multiSingletonCache.has(provider)) {
+    throw new Error(
+      `Token ${String(provider.provide)} was already resolved asynchronously. Use resolve() instead of get() for this provider.`,
+    );
+  }
+
+  const instance = instantiateSyncProvider(provider, state);
+  state.syncMultiSingletonValues.set(provider, instance);
+  state.multiSingletonCache.set(provider, Promise.resolve(instance));
+  return instance;
+}
+
 function resolveSyncToken(token: Token, state: SyncResolverState): unknown {
   if (state.resolutionChain.has(token)) {
     throw new Error(`Circular dependency detected while resolving token ${String(token)} via get().`);
@@ -382,7 +535,7 @@ function resolveSyncToken(token: Token, state: SyncResolverState): unknown {
     const multiProviders = collectMultiProviders(state.introspection, token);
 
     if (multiProviders.length > 0) {
-      return multiProviders.map((provider) => instantiateSyncProvider(provider, state));
+      return multiProviders.map((provider) => resolveSyncMultiProvider(provider, state));
     }
 
     const provider = lookupProvider(state.introspection, token);
@@ -397,12 +550,7 @@ function resolveSyncToken(token: Token, state: SyncResolverState): unknown {
   }
 }
 
-function createSyncResolver(
-  container: BootstrapResult['container'],
-): {
-  get<T>(token: Token<T>): T;
-  syncFromContainer(): Promise<void>;
-} {
+function createSyncResolver(container: BootstrapResult['container']): SyncResolver {
   const introspection = toContainerIntrospection(container);
   const factoryResolutionKinds = new WeakMap<NormalizedProvider, 'async' | 'sync'>();
 
@@ -411,8 +559,10 @@ function createSyncResolver(
   const state: SyncResolverState = {
     factoryResolutionKinds,
     introspection,
+    multiSingletonCache: rootContainerIntrospection(introspection).multiSingletonCache,
     resolutionChain: new Set<Token>(),
     singletonCache: rootContainerIntrospection(introspection).singletonCache,
+    syncMultiSingletonValues: new Map<NormalizedProvider, unknown>(),
     syncSingletonValues: new Map<Token, unknown>(),
   };
 
@@ -425,6 +575,14 @@ function createSyncResolver(
         }
 
         state.syncSingletonValues.set(token, await promise);
+      }
+
+      for (const [provider, promise] of state.multiSingletonCache) {
+        if (!providerGraphForProviderIsSyncResolvable(state, provider)) {
+          continue;
+        }
+
+        state.syncMultiSingletonValues.set(provider, await promise);
       }
     },
   };
@@ -516,8 +674,12 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
 
   async compile(): Promise<TestingModuleRef> {
     const bootstrapped = this.bootstrapTestingModule();
+    const syncResolver = createSyncResolver(bootstrapped.container);
 
-    return this.createTestingModuleRef(bootstrapped);
+    await runTestingBootstrapLifecycle(bootstrapped);
+    await syncResolver.syncFromContainer();
+
+    return this.createTestingModuleRef(bootstrapped, syncResolver);
   }
 
   private bootstrapTestingModule(): BootstrapResult {
@@ -542,9 +704,8 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
     }
   }
 
-  private createTestingModuleRef(bootstrapped: BootstrapResult): TestingModuleRef {
+  private createTestingModuleRef(bootstrapped: BootstrapResult, syncResolver: SyncResolver): TestingModuleRef {
     const dispatcher = createTestingDispatcher(bootstrapped);
-    const syncResolver = createSyncResolver(bootstrapped.container);
 
     return {
       ...bootstrapped,

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -206,69 +206,76 @@ function providerToken(provider: Provider): Token {
   return isProviderDescriptor(provider) ? provider.provide : provider;
 }
 
-function isValueProvider(provider: Provider): provider is Extract<Provider, { useValue: unknown }> {
-  return isProviderDescriptor(provider) && 'useValue' in provider;
-}
+function effectiveProvidersForToken(introspection: ContainerIntrospection, token: Token): NormalizedProvider[] {
+  const multiProviders = collectMultiProviders(introspection, token);
 
-function isLifecycleValueProvider(provider: Provider): provider is Extract<Provider, { useValue: unknown }> {
-  return isValueProvider(provider) && hasAnyBootstrapLifecycleHook(provider.useValue);
-}
-
-function isDirectSingletonLifecycleProvider(provider: Provider): boolean {
-  if (isLifecycleValueProvider(provider)) {
-    return true;
+  if (multiProviders.length > 0) {
+    return multiProviders;
   }
 
-  if (isProviderDescriptor(provider)) {
-    return 'useClass' in provider ? (provider.scope ?? Scope.DEFAULT) === Scope.DEFAULT : false;
-  }
-
-  return isClassConstructor(provider);
+  const provider = lookupProvider(introspection, token);
+  return provider ? [provider] : [];
 }
 
-async function resolveTestingLifecycleInstances(bootstrapped: BootstrapResult): Promise<unknown[]> {
+function isSingletonLifecycleProvider(provider: NormalizedProvider): boolean {
+  if (provider.multi === true) {
+    return false;
+  }
+
+  if (provider.scope !== Scope.DEFAULT) {
+    return false;
+  }
+
+  return provider.type === 'class' || (provider.type === 'value' && hasAnyBootstrapLifecycleHook(provider.useValue));
+}
+
+async function resolveTestingLifecycleInstances(bootstrapped: BootstrapResult, overrides: readonly Provider[] = []): Promise<unknown[]> {
   const lifecycleProviders = [
     ...bootstrapped.effectiveProviders.runtimeProviders,
     ...bootstrapped.effectiveProviders.moduleProviders,
+    ...overrides,
   ];
   const instances: unknown[] = [];
-  const seen = new Set<Token>();
+  const seenProviders = new Set<NormalizedProvider>();
+  const introspection = toContainerIntrospection(bootstrapped.container);
 
   for (const provider of lifecycleProviders) {
     const token = providerToken(provider);
+    const effectiveProviders = effectiveProvidersForToken(introspection, token);
 
-    if (seen.has(token)) {
-      continue;
-    }
-
-    if (isLifecycleValueProvider(provider)) {
-      seen.add(token);
-      instances.push(provider.useValue);
-      continue;
-    }
-
-    if (!isDirectSingletonLifecycleProvider(provider)) {
-      continue;
-    }
-
-    seen.add(token);
-
-    try {
-      instances.push(await bootstrapped.container.resolve(token));
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('Request-scoped provider')) {
+    for (const effectiveProvider of effectiveProviders) {
+      if (seenProviders.has(effectiveProvider)) {
         continue;
       }
 
-      throw error;
+      seenProviders.add(effectiveProvider);
+
+      if (!isSingletonLifecycleProvider(effectiveProvider)) {
+        continue;
+      }
+
+      if (effectiveProvider.type === 'value') {
+        instances.push(effectiveProvider.useValue);
+        continue;
+      }
+
+      try {
+        instances.push(await bootstrapped.container.resolve(token));
+      } catch (error) {
+        if (error instanceof Error && error.message.includes('Request-scoped provider')) {
+          continue;
+        }
+
+        throw error;
+      }
     }
   }
 
   return instances;
 }
 
-async function runTestingBootstrapLifecycle(bootstrapped: BootstrapResult): Promise<void> {
-  const instances = await resolveTestingLifecycleInstances(bootstrapped);
+async function runTestingBootstrapLifecycle(bootstrapped: BootstrapResult, overrides: readonly Provider[] = []): Promise<void> {
+  const instances = await resolveTestingLifecycleInstances(bootstrapped, overrides);
 
   for (const instance of instances) {
     if (hasLifecycleHook(instance, 'onModuleInit')) {
@@ -676,7 +683,7 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
     const bootstrapped = this.bootstrapTestingModule();
     const syncResolver = createSyncResolver(bootstrapped.container);
 
-    await runTestingBootstrapLifecycle(bootstrapped);
+    await runTestingBootstrapLifecycle(bootstrapped, this.overrides);
     await syncResolver.syncFromContainer();
 
     return this.createTestingModuleRef(bootstrapped, syncResolver);


### PR DESCRIPTION
## Summary

Fixes `@fluojs/testing` module compilation so testing modules execute bootstrap lifecycle hooks and keep synchronous DI reads aligned with container ownership semantics.

Linked context: Closes #1978

## Changes

- Run `onModuleInit()` and `onApplicationBootstrap()` for lifecycle-bearing singleton providers during `createTestingModule(...).compile()`.
- Preserve singleton/multi-provider ownership for synchronous `TestingModuleRef.get()` so repeated reads reuse DI-owned singleton contributions and disposal still works.
- Add lifecycle and multi-provider regression coverage.
- Document the testing module lifecycle/DI behavior in English and Korean READMEs.
- Add a patch changeset for `@fluojs/testing` public behavior impact.

## Testing

- `pnpm --filter @fluojs/testing typecheck`
- `pnpm --filter @fluojs/testing test`
- `pnpm lint` (passed; Biome reported existing warnings in unrelated packages, and changed-mode `verify:public-export-tsdoc` passed)
- LSP diagnostics: no errors for `packages/testing/src/module.ts` and `packages/testing/src/module.test.ts`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/testing-lifecycle-di-semantics.md`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed; README docs were updated for the changed behavior.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

`@fluojs/testing` now documents and tests bootstrap lifecycle hook execution plus sync singleton/multi-provider DI ownership semantics.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed. README English/Korean behavioral text was kept aligned.