### PR TITLE
Resolve #1971: standardize infra messaging lifecycle coverage

### DIFF
--- a/packages/cqrs/src/status.test.ts
+++ b/packages/cqrs/src/status.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
-import { createCqrsPlatformStatusSnapshot } from './status.js';
+import { createCqrsPlatformStatusSnapshot, type CqrsLifecycleState, type CqrsStatusAdapterInput } from './status.js';
+
+function createCqrsInput(overrides: Partial<CqrsStatusAdapterInput> = {}): CqrsStatusAdapterInput {
+  return {
+    eventHandlersDiscovered: 0,
+    inFlightSagaExecutions: 0,
+    lifecycleState: 'created',
+    sagaLifecycleState: 'created',
+    sagaShutdownDrainTimeouts: 0,
+    sagasDiscovered: 0,
+    shutdownDrainTimeoutMs: 5000,
+    shutdownDrainTimeouts: 0,
+    ...overrides,
+  };
+}
 
 describe('createCqrsPlatformStatusSnapshot', () => {
   it('reports ready pipeline with explicit event-bus dependency edge', () => {
@@ -61,5 +75,54 @@ describe('createCqrsPlatformStatusSnapshot', () => {
       shutdownDrainTimeoutMs: 20,
       shutdownDrainTimeouts: 1,
     });
+  });
+
+  it.each<{
+    healthStatus: 'degraded' | 'healthy' | 'unhealthy';
+    lifecycleState: CqrsLifecycleState;
+    readinessStatus: 'degraded' | 'not-ready';
+  }>([
+    { healthStatus: 'healthy', lifecycleState: 'created', readinessStatus: 'not-ready' },
+    { healthStatus: 'degraded', lifecycleState: 'discovering', readinessStatus: 'degraded' },
+    { healthStatus: 'degraded', lifecycleState: 'stopping', readinessStatus: 'not-ready' },
+    { healthStatus: 'unhealthy', lifecycleState: 'stopped', readinessStatus: 'not-ready' },
+    { healthStatus: 'unhealthy', lifecycleState: 'failed', readinessStatus: 'not-ready' },
+  ])('reports $lifecycleState event-bus lifecycle readiness and health', ({
+    healthStatus,
+    lifecycleState,
+    readinessStatus,
+  }) => {
+    const snapshot = createCqrsPlatformStatusSnapshot(createCqrsInput({
+      lifecycleState,
+      sagaLifecycleState: 'ready',
+    }));
+
+    expect(snapshot.readiness.status).toBe(readinessStatus);
+    expect(snapshot.health.status).toBe(healthStatus);
+    expect(snapshot.details.lifecycleState).toBe(lifecycleState);
+  });
+
+  it.each<{
+    healthStatus: 'degraded' | 'unhealthy';
+    readinessStatus: 'degraded' | 'not-ready';
+    sagaLifecycleState: CqrsLifecycleState;
+  }>([
+    { healthStatus: 'degraded', readinessStatus: 'degraded', sagaLifecycleState: 'discovering' },
+    { healthStatus: 'degraded', readinessStatus: 'not-ready', sagaLifecycleState: 'stopping' },
+    { healthStatus: 'unhealthy', readinessStatus: 'not-ready', sagaLifecycleState: 'stopped' },
+    { healthStatus: 'unhealthy', readinessStatus: 'not-ready', sagaLifecycleState: 'failed' },
+  ])('reports $sagaLifecycleState saga lifecycle readiness and health', ({
+    healthStatus,
+    readinessStatus,
+    sagaLifecycleState,
+  }) => {
+    const snapshot = createCqrsPlatformStatusSnapshot(createCqrsInput({
+      lifecycleState: 'ready',
+      sagaLifecycleState,
+    }));
+
+    expect(snapshot.readiness.status).toBe(readinessStatus);
+    expect(snapshot.health.status).toBe(healthStatus);
+    expect(snapshot.details.sagaLifecycleState).toBe(sagaLifecycleState);
   });
 });

--- a/packages/cron/src/status.test.ts
+++ b/packages/cron/src/status.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
-import { createCronPlatformStatusSnapshot } from './status.js';
+import { createCronPlatformStatusSnapshot, type CronLifecycleState, type CronStatusAdapterInput } from './status.js';
+
+function createCronInput(overrides: Partial<CronStatusAdapterInput> = {}): CronStatusAdapterInput {
+  return {
+    activeTicks: 0,
+    distributedEnabled: false,
+    enabledTasks: 0,
+    lifecycleState: 'created',
+    lockOwnershipLosses: 0,
+    lockRenewalFailures: 0,
+    ownedLocks: 0,
+    redisDependencyResolved: false,
+    runningTasks: 0,
+    totalTasks: 0,
+    ...overrides,
+  };
+}
 
 describe('createCronPlatformStatusSnapshot', () => {
   it('reports distributed dependency edge and ready/healthy state', () => {
@@ -44,5 +60,38 @@ describe('createCronPlatformStatusSnapshot', () => {
 
     expect(snapshot.health.status).toBe('degraded');
     expect(snapshot.readiness.status).toBe('ready');
+  });
+
+  it.each<{
+    healthStatus: 'degraded' | 'healthy' | 'unhealthy';
+    lifecycleState: CronLifecycleState;
+    readinessStatus: 'degraded' | 'not-ready';
+  }>([
+    { healthStatus: 'healthy', lifecycleState: 'created', readinessStatus: 'not-ready' },
+    { healthStatus: 'degraded', lifecycleState: 'starting', readinessStatus: 'degraded' },
+    { healthStatus: 'degraded', lifecycleState: 'stopping', readinessStatus: 'not-ready' },
+    { healthStatus: 'unhealthy', lifecycleState: 'stopped', readinessStatus: 'not-ready' },
+    { healthStatus: 'unhealthy', lifecycleState: 'failed', readinessStatus: 'not-ready' },
+  ])('reports $lifecycleState lifecycle readiness and health', ({ healthStatus, lifecycleState, readinessStatus }) => {
+    const snapshot = createCronPlatformStatusSnapshot(createCronInput({ lifecycleState }));
+
+    expect(snapshot.readiness.status).toBe(readinessStatus);
+    expect(snapshot.health.status).toBe(healthStatus);
+    expect(snapshot.details.lifecycleState).toBe(lifecycleState);
+  });
+
+  it('marks distributed cron not-ready when the Redis dependency is unresolved', () => {
+    const snapshot = createCronPlatformStatusSnapshot(createCronInput({
+      distributedEnabled: true,
+      lifecycleState: 'ready',
+      redisDependencyResolved: false,
+    }));
+
+    expect(snapshot.readiness).toEqual({
+      critical: true,
+      reason: 'Distributed cron mode requires a ready Redis lock client.',
+      status: 'not-ready',
+    });
+    expect(snapshot.health).toEqual({ status: 'healthy' });
   });
 });

--- a/packages/event-bus/src/status.test.ts
+++ b/packages/event-bus/src/status.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
-import { createEventBusPlatformStatusSnapshot } from './status.js';
+import {
+  createEventBusPlatformStatusSnapshot,
+  type EventBusLifecycleState,
+  type EventBusStatusAdapterInput,
+} from './status.js';
+
+function createEventBusInput(overrides: Partial<EventBusStatusAdapterInput> = {}): EventBusStatusAdapterInput {
+  return {
+    handlersDiscovered: 0,
+    lifecycleState: 'created',
+    shutdownDrainTimeoutMs: 5000,
+    shutdownDrainTimeouts: 0,
+    subscribedChannels: 0,
+    transportCloseFailures: 0,
+    transportConfigured: false,
+    transportPublishFailures: 0,
+    transportSubscribeFailures: 0,
+    waitForHandlersDefault: true,
+    ...overrides,
+  };
+}
 
 describe('createEventBusPlatformStatusSnapshot', () => {
   it('reports local-only ready semantics when transport is absent', () => {
@@ -65,6 +85,43 @@ describe('createEventBusPlatformStatusSnapshot', () => {
     expect(snapshot.details).toMatchObject({
       shutdownDrainTimeoutMs: 20,
       shutdownDrainTimeouts: 1,
+    });
+  });
+
+  it.each<{
+    healthStatus: 'degraded' | 'healthy' | 'unhealthy';
+    lifecycleState: EventBusLifecycleState;
+    readinessStatus: 'degraded' | 'not-ready';
+  }>([
+    { healthStatus: 'healthy', lifecycleState: 'created', readinessStatus: 'not-ready' },
+    { healthStatus: 'degraded', lifecycleState: 'discovering', readinessStatus: 'degraded' },
+    { healthStatus: 'degraded', lifecycleState: 'stopping', readinessStatus: 'not-ready' },
+    { healthStatus: 'unhealthy', lifecycleState: 'stopped', readinessStatus: 'not-ready' },
+    { healthStatus: 'unhealthy', lifecycleState: 'failed', readinessStatus: 'not-ready' },
+  ])('reports $lifecycleState lifecycle readiness and health', ({ healthStatus, lifecycleState, readinessStatus }) => {
+    const snapshot = createEventBusPlatformStatusSnapshot(createEventBusInput({ lifecycleState }));
+
+    expect(snapshot.readiness.status).toBe(readinessStatus);
+    expect(snapshot.health.status).toBe(healthStatus);
+    expect(snapshot.details.lifecycleState).toBe(lifecycleState);
+  });
+
+  it.each<{
+    field: 'transportCloseFailures' | 'transportPublishFailures';
+  }>([
+    { field: 'transportCloseFailures' },
+    { field: 'transportPublishFailures' },
+  ])('surfaces $field as degraded health while keeping ready subscriptions ready', ({ field }) => {
+    const snapshot = createEventBusPlatformStatusSnapshot(createEventBusInput({
+      [field]: 1,
+      lifecycleState: 'ready',
+      transportConfigured: true,
+    }));
+
+    expect(snapshot.readiness).toEqual({ critical: true, status: 'ready' });
+    expect(snapshot.health).toEqual({
+      reason: 'Event bus reported recoverable runtime failures.',
+      status: 'degraded',
     });
   });
 });

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -190,6 +190,53 @@ class InMemoryLoopbackTransport implements MicroserviceTransport {
   }
 }
 
+class SignalRecordingTransport implements MicroserviceTransport {
+  bidiStreamSignal: AbortSignal | undefined;
+  clientStreamSignal: AbortSignal | undefined;
+  sendSignal: AbortSignal | undefined;
+  serverStreamSignal: AbortSignal | undefined;
+
+  async listen(): Promise<void> {}
+
+  async close(): Promise<void> {}
+
+  async send(_pattern: string, _payload: unknown, signal?: AbortSignal): Promise<unknown> {
+    this.sendSignal = signal;
+    return 'ok';
+  }
+
+  async emit(): Promise<void> {}
+
+  serverStream(_pattern: string, _payload: unknown, signal?: AbortSignal): AsyncIterable<unknown> {
+    this.serverStreamSignal = signal;
+    return streamFrom([]);
+  }
+
+  clientStream(_pattern: string, signal?: AbortSignal): { writer: ServerStreamWriter; result: Promise<unknown> } {
+    this.clientStreamSignal = signal;
+    return {
+      result: Promise.resolve('ok'),
+      writer: createNoopWriter(),
+    };
+  }
+
+  bidiStream(_pattern: string, signal?: AbortSignal): { reader: AsyncIterable<unknown>; writer: ServerStreamWriter } {
+    this.bidiStreamSignal = signal;
+    return {
+      reader: streamFrom([]),
+      writer: createNoopWriter(),
+    };
+  }
+}
+
+function createNoopWriter(): ServerStreamWriter {
+  return {
+    end() {},
+    error() {},
+    write() {},
+  };
+}
+
 describe('@fluojs/microservices', () => {
   it('supports createMicroservice with message and event handlers', async () => {
     class Store {
@@ -250,6 +297,32 @@ describe('@fluojs/microservices', () => {
     expect(typeof microserviceByToken.close).toBe('function');
     expect(typeof microserviceByToken.send).toBe('function');
     expect(typeof microserviceByToken.emit).toBe('function');
+
+    await app.close();
+  });
+
+  it('forwards AbortSignal through the lifecycle facade transport operations', async () => {
+    const transport = new SignalRecordingTransport();
+    const controller = new AbortController();
+
+    class AppModule {}
+    defineModuleMetadata(AppModule, {
+      imports: [MicroservicesModule.forRoot({ transport })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const microservice = await app.container.resolve(MicroserviceLifecycleService);
+
+    await microservice.send('signal.send', { ok: true }, controller.signal);
+    const serverReader = microservice.serverStream('signal.server', { ok: true }, controller.signal);
+    await serverReader[Symbol.asyncIterator]().next();
+    microservice.clientStream('signal.client', controller.signal);
+    microservice.bidiStream('signal.bidi', controller.signal);
+
+    expect(transport.sendSignal).toBe(controller.signal);
+    expect(transport.serverStreamSignal).toBe(controller.signal);
+    expect(transport.clientStreamSignal).toBe(controller.signal);
+    expect(transport.bidiStreamSignal).toBe(controller.signal);
 
     await app.close();
   });

--- a/packages/microservices/src/status.test.ts
+++ b/packages/microservices/src/status.test.ts
@@ -1,6 +1,33 @@
 import { describe, expect, it } from 'vitest';
 
-import { createMicroservicePlatformStatusSnapshot } from './status.js';
+import {
+  createMicroservicePlatformStatusSnapshot,
+  type MicroserviceLifecycleState,
+  type MicroserviceStatusAdapterInput,
+} from './status.js';
+
+function createStatusInput(
+  overrides: Partial<MicroserviceStatusAdapterInput> = {},
+): MicroserviceStatusAdapterInput {
+  return {
+    handlerCounts: {
+      'bidi-stream': 0,
+      'client-stream': 0,
+      event: 0,
+      message: 0,
+      'server-stream': 0,
+    },
+    lifecycleState: 'created',
+    transportCapabilities: {
+      bidiStream: false,
+      clientStream: false,
+      emit: true,
+      send: true,
+      serverStream: false,
+    },
+    ...overrides,
+  };
+}
 
 describe('createMicroservicePlatformStatusSnapshot', () => {
   it('reports ready state with transport capability visibility', () => {
@@ -31,27 +58,72 @@ describe('createMicroservicePlatformStatusSnapshot', () => {
   });
 
   it('marks failed listener state as not-ready/unhealthy', () => {
-    const snapshot = createMicroservicePlatformStatusSnapshot({
-      handlerCounts: {
-        'bidi-stream': 0,
-        'client-stream': 0,
-        event: 0,
-        message: 0,
-        'server-stream': 0,
-      },
+    const snapshot = createMicroservicePlatformStatusSnapshot(createStatusInput({
       lastListenError: 'bind EADDRINUSE',
       lifecycleState: 'failed',
-      transportCapabilities: {
-        bidiStream: false,
-        clientStream: false,
-        emit: true,
-        send: true,
-        serverStream: false,
-      },
-    });
+    }));
 
     expect(snapshot.readiness.status).toBe('not-ready');
     expect(snapshot.health.status).toBe('unhealthy');
     expect(snapshot.readiness.reason).toContain('EADDRINUSE');
+  });
+
+  it.each<{
+    healthReason: string | undefined;
+    healthStatus: 'degraded' | 'healthy' | 'unhealthy';
+    lifecycleState: MicroserviceLifecycleState;
+    readinessReason: string;
+    readinessStatus: 'degraded' | 'not-ready';
+  }>([
+    {
+      healthReason: undefined,
+      healthStatus: 'healthy',
+      lifecycleState: 'created',
+      readinessReason: 'Microservice transport listener has not started yet.',
+      readinessStatus: 'not-ready',
+    },
+    {
+      healthReason: 'Microservice transport listener is transitioning lifecycle state.',
+      healthStatus: 'degraded',
+      lifecycleState: 'starting',
+      readinessReason: 'Microservice transport listener is still starting.',
+      readinessStatus: 'degraded',
+    },
+    {
+      healthReason: 'Microservice transport listener is transitioning lifecycle state.',
+      healthStatus: 'degraded',
+      lifecycleState: 'stopping',
+      readinessReason: 'Microservice transport listener is shutting down.',
+      readinessStatus: 'not-ready',
+    },
+    {
+      healthReason: 'Microservice transport listener is unavailable.',
+      healthStatus: 'unhealthy',
+      lifecycleState: 'stopped',
+      readinessReason: 'Microservice transport listener is stopped.',
+      readinessStatus: 'not-ready',
+    },
+  ])('reports $lifecycleState lifecycle readiness and health', ({
+    healthReason,
+    healthStatus,
+    lifecycleState,
+    readinessReason,
+    readinessStatus,
+  }) => {
+    const snapshot = createMicroservicePlatformStatusSnapshot(createStatusInput({ lifecycleState }));
+
+    expect(snapshot.readiness).toEqual({
+      critical: true,
+      reason: readinessReason,
+      status: readinessStatus,
+    });
+    expect(snapshot.health).toEqual(
+      healthReason ? { reason: healthReason, status: healthStatus } : { status: healthStatus },
+    );
+    expect(snapshot.details.lifecycleState).toBe(lifecycleState);
+    expect(snapshot.ownership).toEqual({
+      externallyManaged: true,
+      ownsResources: false,
+    });
   });
 });

--- a/packages/microservices/src/transports/kafka-transport.test.ts
+++ b/packages/microservices/src/transports/kafka-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { KafkaMicroserviceTransport, type KafkaMicroserviceTransportOptions } from './kafka-transport.js';
 
@@ -237,6 +237,37 @@ describe('KafkaMicroserviceTransport', () => {
     await transport.close();
 
     await expect(pending).rejects.toThrow(/Kafka microservice transport closed before/);
+  });
+
+  it('leaves caller-owned producer and consumer collaborators open during close()', async () => {
+    const bus = new InMemoryTopicBus();
+    const disconnectConsumer = vi.fn();
+    const disconnectProducer = vi.fn();
+    const consumer = {
+      disconnect: disconnectConsumer,
+      subscribe: async (topic: string, handler: (message: string) => Promise<void> | void) => {
+        await bus.subscribe(topic, handler);
+      },
+      unsubscribe: async (topic: string) => {
+        await bus.unsubscribe(topic);
+      },
+    };
+    const producer = {
+      disconnect: disconnectProducer,
+      publish: async (topic: string, message: string) => {
+        await bus.publish(topic, message);
+      },
+    };
+    const transport = new KafkaMicroserviceTransport({
+      consumer,
+      producer,
+    });
+
+    await transport.listen(async () => undefined);
+    await transport.close();
+
+    expect(disconnectConsumer).not.toHaveBeenCalled();
+    expect(disconnectProducer).not.toHaveBeenCalled();
   });
 
   it('still rejects pending requests when unsubscribe fails during close', async () => {

--- a/packages/microservices/src/transports/rabbitmq-transport.test.ts
+++ b/packages/microservices/src/transports/rabbitmq-transport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { RabbitMqMicroserviceTransport } from './rabbitmq-transport.js';
 
@@ -288,6 +288,37 @@ describe('RabbitMqMicroserviceTransport', () => {
     await transport.close();
 
     await expect(Promise.all([first, second])).rejects.toThrow(/RabbitMQ microservice transport closed before/);
+  });
+
+  it('leaves caller-owned publisher and connection collaborators open during close()', async () => {
+    const bus = new InMemoryQueueBus();
+    const closeConnection = vi.fn();
+    const closePublisher = vi.fn();
+    const consumer = {
+      async cancel(queue: string) {
+        await bus.unsubscribe(queue);
+      },
+      closeConnection,
+      async consume(queue: string, handler: (message: string) => Promise<void> | void) {
+        await bus.subscribe(queue, handler);
+      },
+    };
+    const publisher = {
+      close: closePublisher,
+      async publish(queue: string, message: string) {
+        await bus.publish(queue, message);
+      },
+    };
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer,
+      publisher,
+    });
+
+    await transport.listen(async () => undefined);
+    await transport.close();
+
+    expect(closeConnection).not.toHaveBeenCalled();
+    expect(closePublisher).not.toHaveBeenCalled();
   });
 
   it('still rejects pending requests when queue cancellation fails during close', async () => {

--- a/packages/microservices/src/transports/tcp-transport.test.ts
+++ b/packages/microservices/src/transports/tcp-transport.test.ts
@@ -65,9 +65,14 @@ describe('TcpMicroserviceTransport', () => {
 
   it('rejects in-flight send when AbortSignal aborts', async () => {
     const transport = createTransport({ port: 0, requestTimeoutMs: 5_000 });
+    let markHandlerEntered!: () => void;
+    const handlerEntered = new Promise<void>((resolve) => {
+      markHandlerEntered = resolve;
+    });
 
     await transport.listen(async (packet) => {
       if (packet.kind === 'message') {
+        markHandlerEntered();
         await new Promise<void>(() => undefined);
       }
 
@@ -77,7 +82,7 @@ describe('TcpMicroserviceTransport', () => {
     const controller = new AbortController();
     const pending = transport.send('aborted.inflight', {}, controller.signal);
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await handlerEntered;
     controller.abort();
 
     await expect(pending).rejects.toThrow('Microservice send aborted.');

--- a/packages/microservices/src/transports/tcp-transport.test.ts
+++ b/packages/microservices/src/transports/tcp-transport.test.ts
@@ -50,6 +50,39 @@ describe('TcpMicroserviceTransport', () => {
 
   });
 
+  it('rejects send when AbortSignal is already aborted', async () => {
+    const transport = createTransport({ port: 0, requestTimeoutMs: 1_000 });
+
+    await transport.listen(async () => 'ok');
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(transport.send('aborted.before.dispatch', {}, controller.signal)).rejects.toThrow(
+      'Microservice send aborted before dispatch.',
+    );
+  });
+
+  it('rejects in-flight send when AbortSignal aborts', async () => {
+    const transport = createTransport({ port: 0, requestTimeoutMs: 5_000 });
+
+    await transport.listen(async (packet) => {
+      if (packet.kind === 'message') {
+        await new Promise<void>(() => undefined);
+      }
+
+      return undefined;
+    });
+
+    const controller = new AbortController();
+    const pending = transport.send('aborted.inflight', {}, controller.signal);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    controller.abort();
+
+    await expect(pending).rejects.toThrow('Microservice send aborted.');
+  });
+
   it('rejects send and emit after close() stops the listener', async () => {
     const transport = createTransport({ port: 0, requestTimeoutMs: 1_000 });
 

--- a/packages/queue/src/status.test.ts
+++ b/packages/queue/src/status.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import { createQueuePlatformStatusSnapshot } from './status.js';
+import { createQueuePlatformStatusSnapshot, type QueueLifecycleState, type QueueStatusAdapterInput } from './status.js';
+
+function createQueueInput(overrides: Partial<QueueStatusAdapterInput> = {}): QueueStatusAdapterInput {
+  return {
+    dependencyId: 'redis.default',
+    lifecycleState: 'idle',
+    pendingDeadLetterWrites: 0,
+    queuesReady: 0,
+    workerShutdownTimeoutMs: 30_000,
+    workersDiscovered: 0,
+    workersReady: 0,
+    ...overrides,
+  };
+}
 
 describe('createQueuePlatformStatusSnapshot', () => {
   it('reports ready/healthy semantics with dependency visibility', () => {
@@ -25,18 +38,48 @@ describe('createQueuePlatformStatusSnapshot', () => {
   });
 
   it('marks shutdown drain as degraded health and not-ready readiness', () => {
-    const snapshot = createQueuePlatformStatusSnapshot({
-      dependencyId: 'redis.default',
+    const snapshot = createQueuePlatformStatusSnapshot(createQueueInput({
       lifecycleState: 'stopping',
       pendingDeadLetterWrites: 1,
       queuesReady: 1,
-      workerShutdownTimeoutMs: 30_000,
       workersDiscovered: 1,
       workersReady: 1,
-    });
+    }));
 
     expect(snapshot.readiness.status).toBe('not-ready');
     expect(snapshot.health.status).toBe('degraded');
     expect(snapshot.readiness.reason).toContain('draining');
+  });
+
+  it.each<{
+    healthStatus: 'degraded' | 'unhealthy';
+    lifecycleState: QueueLifecycleState;
+    readinessStatus: 'degraded' | 'not-ready';
+  }>([
+    { healthStatus: 'unhealthy', lifecycleState: 'idle', readinessStatus: 'not-ready' },
+    { healthStatus: 'degraded', lifecycleState: 'starting', readinessStatus: 'degraded' },
+    { healthStatus: 'unhealthy', lifecycleState: 'stopped', readinessStatus: 'not-ready' },
+  ])('reports $lifecycleState lifecycle readiness and health', ({ healthStatus, lifecycleState, readinessStatus }) => {
+    const snapshot = createQueuePlatformStatusSnapshot(createQueueInput({ lifecycleState }));
+
+    expect(snapshot.readiness.status).toBe(readinessStatus);
+    expect(snapshot.health.status).toBe(healthStatus);
+    expect(snapshot.details.lifecycleState).toBe(lifecycleState);
+  });
+
+  it('keeps started queues ready while dead-letter writes are still draining', () => {
+    const snapshot = createQueuePlatformStatusSnapshot(createQueueInput({
+      lifecycleState: 'started',
+      pendingDeadLetterWrites: 2,
+      queuesReady: 1,
+      workersDiscovered: 1,
+      workersReady: 1,
+    }));
+
+    expect(snapshot.readiness).toEqual({ critical: true, status: 'ready' });
+    expect(snapshot.health).toEqual({
+      reason: 'Queue dead-letter writes are still pending.',
+      status: 'degraded',
+    });
   });
 });

--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -151,6 +151,7 @@ export class AdvancedService {
 ### 핵심 구성 요소
 - `RedisModule`: Redis 클라이언트 등록 및 수명 주기 훅을 관리합니다.
 - `RedisModule.forRoot(options)`: `name`을 생략하면 기본 Redis 클라이언트와 `RedisService` 파사드를 등록하고, `name`을 제공하면 추가 이름 있는 Redis 클라이언트를 등록합니다. 기본 등록은 기본적으로 global이고, 이름 있는 등록은 scoped입니다. `lifecycle.connectTimeoutMs`와 `lifecycle.quitTimeoutMs`로 Fluo가 소유한 연결 시작/종료 시간을 제한할 수 있습니다.
+- lifecycle hook은 `RedisModule.forRoot(...).lifecycle`로만 설정합니다. 내부 lifecycle service는 의도적으로 public API에 포함하지 않습니다.
 - `RedisService`: JSON 코덱 지원 및 `get`/`set`/`del` 메서드를 제공하는 파사드입니다.
 - `REDIS_CLIENT`: 내부 `ioredis` 인스턴스에 접근하기 위한 DI 토큰입니다.
 - `DEFAULT_REDIS_CLIENT_NAME`: 안정적인 기본 Redis client name입니다.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -151,6 +151,7 @@ export class AdvancedService {
 ### Core
 - `RedisModule`: Registers Redis clients and lifecycle hooks.
 - `RedisModule.forRoot(options)`: Registers the default Redis client plus `RedisService` facade when `name` is omitted, or an additional named Redis client when `name` is provided. The default registration is global by default; named registrations are scoped. Use `lifecycle.connectTimeoutMs` and `lifecycle.quitTimeoutMs` to bound Fluo-owned connection startup and shutdown.
+- Lifecycle hooks are configured only through `RedisModule.forRoot(...).lifecycle`; the internal lifecycle service is intentionally not part of the public API.
 - `RedisService`: Facade with JSON codec support and `get`/`set`/`del` methods.
 - `REDIS_CLIENT`: DI token for the underlying `ioredis` instance.
 - `DEFAULT_REDIS_CLIENT_NAME`: Stable default Redis client name.

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -398,6 +398,32 @@ describe('@fluojs/redis', () => {
     expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
   });
 
+  it('forces disconnect for a named lifecycle-owned client when quit exceeds the configured timeout', async () => {
+    vi.useFakeTimers();
+    mockRedisState.quitHangs = true;
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        RedisModule.forRoot({
+          db: 1,
+          host: '127.0.0.1',
+          lifecycle: { quitTimeoutMs: 25 },
+          name: 'cache',
+          port: 6380,
+        }),
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const closePromise = app.close();
+    const closeAssertion = expect(closePromise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(25);
+
+    await closeAssertion;
+    expect(mockRedisState.events).toEqual(['connect', 'quit', 'disconnect']);
+  });
+
   it('rethrows quit failures when disconnect does not close the client', async () => {
     mockRedisState.disconnectLeavesOpen = true;
     mockRedisState.quitError = new Error('quit failed');


### PR DESCRIPTION
## Summary

Adds regression coverage for infra/messaging shutdown, readiness, and resource lifecycle contracts.

Linked context: Closes #1971

## Changes

- Expanded status snapshot lifecycle matrices for `@fluojs/queue`, `@fluojs/cron`, `@fluojs/cqrs`, `@fluojs/event-bus`, and `@fluojs/microservices`.
- Added microservices lifecycle facade coverage for `AbortSignal` forwarding across request/stream APIs.
- Added TCP abort regression coverage and Kafka/RabbitMQ caller-owned resource ownership tests.
- Added explicit `@fluojs/redis` named-client lifecycle quit-timeout disconnect fallback coverage and documented that lifecycle hooks are configured through `RedisModule.forRoot(...).lifecycle`, while the internal lifecycle service remains non-public.
- Made the TCP in-flight abort regression deterministic by awaiting handler entry before aborting instead of relying on a timer delay.

## Testing

- `pnpm exec biome lint packages/queue/src/status.test.ts packages/cron/src/status.test.ts packages/cqrs/src/status.test.ts packages/event-bus/src/status.test.ts packages/microservices/src/status.test.ts packages/microservices/src/module.test.ts packages/microservices/src/transports/tcp-transport.test.ts packages/microservices/src/transports/kafka-transport.test.ts packages/microservices/src/transports/rabbitmq-transport.test.ts`
- `pnpm exec vitest run packages/queue/src/status.test.ts packages/cron/src/status.test.ts packages/cqrs/src/status.test.ts packages/event-bus/src/status.test.ts packages/microservices/src/status.test.ts packages/microservices/src/module.test.ts packages/microservices/src/transports/tcp-transport.test.ts packages/microservices/src/transports/kafka-transport.test.ts packages/microservices/src/transports/rabbitmq-transport.test.ts`
- `pnpm --filter @fluojs/redis build`
- `pnpm --filter @fluojs/event-bus build`
- `pnpm --filter @fluojs/queue typecheck && pnpm --filter @fluojs/cron typecheck && pnpm --filter @fluojs/cqrs typecheck && pnpm --filter @fluojs/event-bus typecheck && pnpm --filter @fluojs/microservices typecheck`
- `pnpm --filter @fluojs/queue build && pnpm --filter @fluojs/cron build && pnpm --filter @fluojs/cqrs build && pnpm --filter @fluojs/microservices build`
- `pnpm exec biome lint packages/microservices/src/transports/tcp-transport.test.ts packages/redis/src/module.test.ts packages/redis/README.md packages/redis/README.ko.md`
- `pnpm exec vitest run packages/microservices/src/transports/tcp-transport.test.ts packages/redis/src/module.test.ts`
- `pnpm --filter @fluojs/redis typecheck && pnpm --filter @fluojs/microservices typecheck`
- `pnpm --filter @fluojs/redis build && pnpm --filter @fluojs/microservices build`
- LSP diagnostics clean for `packages/microservices/src/transports/tcp-transport.test.ts` and `packages/redis/src/module.test.ts`.

Note: full `pnpm lint` was attempted and is currently blocked by pre-existing unrelated Biome diagnostics outside this PR's changed files, primarily under `packages/config`, `packages/core`, and existing `packages/cqrs` source imports.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset: this PR only adds regression tests for existing documented lifecycle/resource contracts and does not change public package behavior, API surface, package contents, or release metadata.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were changed; `@fluojs/redis` README/README.ko now explicitly documents the lifecycle configuration path and non-public lifecycle service boundary.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This PR strengthens regression coverage for existing shutdown/readiness/resource lifecycle contracts without changing runtime behavior.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs, platform contract docs, or package README conformance claims were changed.