### PR TITLE
Resolve #1968: align validation and serialization edge contracts

### DIFF
--- a/.changeset/align-validation-serialization-edge-contracts.md
+++ b/.changeset/align-validation-serialization-edge-contracts.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/validation": patch
+"@fluojs/serialization": patch
+---
+
+Align validation and serialization edge contracts with regression coverage for IP options, dangerous keys, custom scalar validators, cyclic arrays, and mixed object graphs.

--- a/packages/serialization/README.ko.md
+++ b/packages/serialization/README.ko.md
@@ -103,7 +103,7 @@ class UsersController {
 
 ### 순환 참조 처리
 
-fluo의 직렬화 엔진은 활성 순환 참조를 자동으로 감지하고 `undefined`로 절단하여 무한 루프와 스택 오버플로를 방지합니다. 이미 직렬화가 끝난 공유 참조는 삭제하지 않고 직렬화된 그래프 안에서 재사용합니다. 예를 들어 두 sibling 필드가 같은 원본 객체를 가리키면 두 직렬화 결과도 같은 직렬화 객체를 가리키며, 현재 직렬화 중인 객체를 다시 만나는 활성 cycle만 `undefined`로 절단됩니다.
+fluo의 직렬화 엔진은 활성 순환 참조를 자동으로 감지하고 `undefined`로 절단하여 무한 루프와 스택 오버플로를 방지합니다. 같은 reference tracker가 class instance, plain object, 배열, mixed object-array graph 전체에서 공유됩니다. 자기 자신을 참조하는 배열과 object-array cycle은 활성 back edge에서 절단되고, 이미 직렬화가 끝난 공유 참조는 삭제하지 않고 직렬화된 그래프 안에서 재사용합니다. 예를 들어 두 sibling 필드 또는 객체 필드와 배열 항목이 같은 원본 객체를 가리키면 두 직렬화 결과도 같은 직렬화 객체를 가리키며, 현재 직렬화 중인 값을 다시 만나는 활성 cycle만 `undefined`로 절단됩니다.
 
 ### 상속된 데코레이터 계약
 
@@ -124,8 +124,8 @@ Decorated metadata가 없는 class instance도 재귀적으로 순회하므로, 
 ## 공개 API 개요
 
 - **데코레이터**: `Expose`, `Exclude`, `Transform`
-- **엔진**: `serialize(value)`
-- **HTTP 통합**: `SerializerInterceptor`
+- **엔진**: `serialize(value)`는 class instance, 배열, plain object, mixed graph를 재귀적으로 순회하며, 직접 transform하지 않은 opaque built-in 및 non-JSON leaf 값은 보존합니다.
+- **HTTP 통합**: `SerializerInterceptor`는 아직 commit되지 않은 handler 결과를 직렬화하고, response가 이미 commit된 뒤에는 handler 소유 값을 그대로 반환합니다.
 
 `Expose`는 class와 field에 적용할 수 있습니다. `Exclude`와 `Transform`은 field에 적용합니다.
 

--- a/packages/serialization/README.md
+++ b/packages/serialization/README.md
@@ -103,7 +103,7 @@ class UsersController {
 
 ### Cycle-safe serialization
 
-The serializer cuts active cyclic references safely instead of recursing forever, so complex object graphs can still be turned into plain response-shaped objects without unbounded recursion. Completed shared references are reused in the serialized graph rather than dropped: if two sibling fields point at the same source object, both serialized fields point at the same serialized object. Only an object that is encountered again while it is already being serialized is cut to `undefined`.
+The serializer cuts active cyclic references safely instead of recursing forever, so complex object graphs can still be turned into plain response-shaped objects without unbounded recursion. The same reference tracker is shared across class instances, plain objects, arrays, and mixed object-array graphs. Self-referential arrays and object-array cycles are cut at the active back edge, while completed shared references are reused in the serialized graph rather than dropped: if two sibling fields, or an object field and an array entry, point at the same source object, both serialized fields point at the same serialized object. Only a value that is encountered again while it is already being serialized is cut to `undefined`.
 
 ### Inherited decorator contracts
 
@@ -124,8 +124,8 @@ Undecorated class instances are still traversed recursively, so decorated nested
 ## Public API Overview
 
 - **Decorators**: `Expose`, `Exclude`, `Transform`
-- **Engine**: `serialize(value)`
-- **HTTP integration**: `SerializerInterceptor`
+- **Engine**: `serialize(value)` recursively walks class instances, arrays, plain objects, and mixed graphs while preserving opaque built-ins and non-JSON leaf values unless you transform them
+- **HTTP integration**: `SerializerInterceptor` serializes uncommitted handler results and returns handler-owned values unchanged after the response has already been committed
 
 `Expose` can be applied to classes and fields. `Exclude` and `Transform` apply to fields.
 

--- a/packages/serialization/src/serialize.test.ts
+++ b/packages/serialization/src/serialize.test.ts
@@ -200,6 +200,52 @@ describe('serialize', () => {
     expect(() => JSON.stringify(serialized)).not.toThrow();
   });
 
+  it('cuts self-referential arrays to undefined', () => {
+    const input: unknown[] = ['root'];
+    input.push(input);
+
+    const serialized = serialize(input) as unknown[];
+
+    expect(serialized).toEqual(['root', undefined]);
+    expect(() => JSON.stringify(serialized)).not.toThrow();
+  });
+
+  it('handles mixed object-array cycles without recursion', () => {
+    const input: { id: string; children: unknown[] } = {
+      children: [],
+      id: 'root',
+    };
+    input.children.push({ id: 'child', parent: input });
+
+    const serialized = serialize(input) as {
+      children: Array<{ id: string; parent?: unknown }>;
+      id: string;
+    };
+
+    expect(serialized).toEqual({
+      children: [{ id: 'child', parent: undefined }],
+      id: 'root',
+    });
+    expect(() => JSON.stringify(serialized)).not.toThrow();
+  });
+
+  it('preserves shared references across array and object boundaries', () => {
+    const shared = { id: 'shared-node' };
+    const input = {
+      items: [shared],
+      primary: shared,
+    };
+
+    const serialized = serialize(input) as {
+      items: Array<{ id: string }>;
+      primary: { id: string };
+    };
+
+    expect(serialized.items[0]).toEqual({ id: 'shared-node' });
+    expect(serialized.primary).toEqual({ id: 'shared-node' });
+    expect(serialized.primary).toBe(serialized.items[0]);
+  });
+
   it('preserves shared references instead of dropping revisited objects', () => {
     const shared = { id: 'shared-node' };
     const input = {

--- a/packages/serialization/src/serialize.ts
+++ b/packages/serialization/src/serialize.ts
@@ -263,10 +263,13 @@ function serializeInternal<T = unknown>(value: T, context: SerializationContext)
 }
 
 /**
- * Serializes class instances and object graphs into plain response-shaped values.
+ * Serializes class instances, arrays, plain records, and mixed object graphs
+ * into plain response-shaped values.
  *
  * Serialization honors `@Expose()`, `@Exclude()`, and `@Transform()` metadata.
- * Cycles and repeated references are handled without unbounded recursion.
+ * Cycles and repeated references are handled without unbounded recursion across
+ * both object and array boundaries. Active cycles are cut to `undefined`, while
+ * completed shared references reuse the previously serialized value.
  * Opaque built-ins and non-JSON leaf values such as `Date`, `Map`, `Set`, `URL`, `Error`, `bigint`, functions, and symbols pass through unchanged unless you normalize them before or during serialization.
  *
  * @typeParam T Input value type.

--- a/packages/serialization/src/serializer-interceptor.ts
+++ b/packages/serialization/src/serializer-interceptor.ts
@@ -8,7 +8,9 @@ import { serialize } from './serialize.js';
  * @remarks
  * Use this at the controller or route level when handlers return class instances
  * and you want `@Expose()`, `@Exclude()`, and `@Transform()` metadata applied
- * automatically.
+ * automatically. If the handler already committed `RequestContext.response`,
+ * the interceptor returns the handler-owned value unchanged so streaming and
+ * manually written responses keep their response ownership.
  */
 export class SerializerInterceptor implements Interceptor {
   async intercept(context: InterceptorContext, next: CallHandler): Promise<unknown> {

--- a/packages/validation/README.ko.md
+++ b/packages/validation/README.ko.md
@@ -136,6 +136,13 @@ class RestrictedUserDto {
 
 `ValidateClass(...)`는 custom class-level validator도 받을 수 있습니다. `Validate(...)`는 built-in decorator만으로 부족할 때 custom field-level validator를 붙이고, `ValidateIf(...)`는 predicate가 false를 반환하면 dependent validator를 short-circuit합니다.
 
+### 네트워크 검증기
+
+`@IsIP()`는 기본적으로 IPv4와 IPv6 문자열을 모두 검증합니다. 한 IP 버전으로
+제한하려면 `@IsIP('4')` 또는 `@IsIP('6')`을 전달하세요.
+`@IsIP('4_or_6')`은 `@IsIP()`와 같은 런타임 동작을 유지하면서 "IPv4 또는
+IPv6 모두 허용" 계약을 명시하고 싶을 때 사용할 수 있습니다.
+
 ### 중첩 검증
 
 `@ValidateNested(...)`는 객체 필드, 배열, `Set`, `Map`을 지원합니다. 중첩 DTO path는 validation issue에서 dot/index 표기법을 사용하며, cycle은 안전하게 감지되고 shared reference는 허용됩니다.

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -140,6 +140,13 @@ class RestrictedUserDto {
 
 `ValidateClass(...)` also accepts custom class-level validators. `Validate(...)` attaches custom field-level validators when built-in decorators are not enough, and `ValidateIf(...)` short-circuits dependent validators when its predicate returns false.
 
+### Network validators
+
+`@IsIP()` validates IPv4 and IPv6 strings by default. Pass `@IsIP('4')` or
+`@IsIP('6')` to restrict a field to one IP version, or pass
+`@IsIP('4_or_6')` when you want to state the default "either IPv4 or IPv6"
+contract explicitly while still using the same runtime behavior as `@IsIP()`.
+
 ### Nested validation
 
 `@ValidateNested(...)` supports object fields, arrays, `Set`, and `Map`. Nested DTO paths use dot/index notation in validation issues, cycles are detected safely, and shared references are allowed.

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -1,6 +1,6 @@
-import {
-  type Constructor,
-  type MetadataPropertyKey,
+import type {
+  Constructor,
+  MetadataPropertyKey,
 } from '@fluojs/core';
 import {
   ensureMetadataSymbol,
@@ -611,14 +611,18 @@ export const IsLongitude = (options?: ValidationDecoratorOptions) => createValid
 export const IsLatLong = (options?: ValidationDecoratorOptions) => createValidatorJsDecorator('latLong')(undefined, options);
 
 /**
- *  Validates that a value is an IPv4/IPv6 address.
+ * Validates that a value is an IPv4 and/or IPv6 address.
  *
- * @param version The version.
- * @param options The options.
- * @returns The is ip result.
+ * Passing `'4_or_6'` preserves the default validator.js behavior and accepts
+ * either IP version. Passing `'4'` or `'6'` restricts validation to that
+ * version only.
+ *
+ * @param version Optional IP version filter (`'4'`, `'6'`, or `'4_or_6'`).
+ * @param options Optional validation behavior (`message`, `groups`, `always`, `each`).
+ * @returns A field decorator that registers an IP-address rule.
  */
 export function IsIP(version?: '4' | '6' | '4_or_6', options?: ValidationDecoratorOptions): FieldDecoratorFn {
-  return createValidatorJsDecorator('ip')(version ? [version] : undefined, options);
+  return createValidatorJsDecorator('ip')(version && version !== '4_or_6' ? [version] : undefined, options);
 }
 
 /**

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 import { DefaultValidator } from './validation.js';
 import { DtoValidationError } from './errors.js';
-import { ArrayUnique, IsDateString, IsEmail, IsLatitude, IsLongitude, IsNotEmpty, IsNumber, IsString, MinLength, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
+import { ArrayUnique, IsDateString, IsEmail, IsIP, IsLatitude, IsLongitude, IsNotEmpty, IsNumber, IsString, MinLength, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
 import type { StandardSchemaV1Like } from './index.js';
 
 describe('DefaultValidator', () => {
@@ -38,6 +38,54 @@ describe('DefaultValidator', () => {
       validator.validate(Object.assign(new CreateScheduleDto(), { scheduledAt: 'March 30, 2026' }), CreateScheduleDto),
     ).rejects.toMatchObject({
       issues: [{ field: 'scheduledAt', message: 'scheduledAt must be a valid ISO-8601 date string' }],
+    });
+  });
+
+  it('treats IsIP 4_or_6 as the default IPv4 or IPv6 contract', async () => {
+    class NetworkDto {
+      @IsIP('4_or_6', { message: 'address must be IPv4 or IPv6' })
+      address = '';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(Object.assign(new NetworkDto(), { address: '127.0.0.1' }), NetworkDto),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      validator.validate(Object.assign(new NetworkDto(), { address: '2001:db8::1' }), NetworkDto),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      validator.validate(Object.assign(new NetworkDto(), { address: 'not-an-ip-address' }), NetworkDto),
+    ).rejects.toMatchObject({
+      issues: [{ field: 'address', message: 'address must be IPv4 or IPv6' }],
+    });
+  });
+
+  it('restricts IsIP validation to IPv4 or IPv6 when a version is provided', async () => {
+    class NetworkDto {
+      @IsIP('4', { message: 'ipv4 must be IPv4' })
+      ipv4 = '';
+
+      @IsIP('6', { message: 'ipv6 must be IPv6' })
+      ipv6 = '';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(Object.assign(new NetworkDto(), { ipv4: '127.0.0.1', ipv6: '2001:db8::1' }), NetworkDto),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      validator.validate(Object.assign(new NetworkDto(), { ipv4: '2001:db8::1', ipv6: '127.0.0.1' }), NetworkDto),
+    ).rejects.toMatchObject({
+      issues: [
+        { field: 'ipv4', message: 'ipv4 must be IPv4' },
+        { field: 'ipv6', message: 'ipv6 must be IPv6' },
+      ],
     });
   });
 
@@ -358,16 +406,23 @@ describe('DefaultValidator', () => {
     }
 
     const validator = new DefaultValidator();
-    const payload = JSON.parse('{"child":{"city":"Seoul","__proto__":{"polluted":true}}}') as {
-      child: { city: string; __proto__: { polluted: boolean } };
-    };
+    const dangerousPayloads = [
+      JSON.parse('{"child":{"city":"Seoul","__proto__":{"polluted":true}}}') as Record<string, unknown>,
+      { child: { city: 'Seoul', constructor: { polluted: true } } },
+      { child: { city: 'Seoul', prototype: { polluted: true } } },
+    ];
 
-    const result = await validator.materialize<ParentDto>(payload, ParentDto);
+    for (const payload of dangerousPayloads) {
+      const result = await validator.materialize<ParentDto>(payload, ParentDto);
 
-    expect(result.child).toBeInstanceOf(ChildDto);
-    expect(result.child.city).toBe('Seoul');
-    expect(Object.getPrototypeOf(result.child)).toBe(ChildDto.prototype);
-    expect('polluted' in (result.child as object)).toBe(false);
+      expect(result.child).toBeInstanceOf(ChildDto);
+      expect(result.child.city).toBe('Seoul');
+      expect(Object.getPrototypeOf(result.child)).toBe(ChildDto.prototype);
+      expect(Object.hasOwn(result.child, '__proto__')).toBe(false);
+      expect(Object.hasOwn(result.child, 'constructor')).toBe(false);
+      expect(Object.hasOwn(result.child, 'prototype')).toBe(false);
+      expect('polluted' in (result.child as object)).toBe(false);
+    }
   });
 
   it('materialize throws DtoValidationError on invalid input', async () => {
@@ -797,6 +852,29 @@ describe('DefaultValidator', () => {
         { code: 'CUSTOM_PREFIX', field: 'entries[1]', message: 'entry must start with ok' },
         { code: 'CUSTOM_POSITIVE', field: 'counts[1]', message: 'count must be positive' },
       ],
+    });
+  });
+
+  it('supports custom validators on scalar fields', async () => {
+    class CustomScalarDto {
+      @Validate((value: unknown) => (
+        typeof value === 'string' && value.startsWith('token_')
+          ? true
+          : { code: 'CUSTOM_TOKEN', message: 'token must use the token_ prefix' }
+      ))
+      token = '';
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(
+      validator.validate(Object.assign(new CustomScalarDto(), { token: 'token_123' }), CustomScalarDto),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      validator.validate(Object.assign(new CustomScalarDto(), { token: 'bad' }), CustomScalarDto),
+    ).rejects.toMatchObject({
+      issues: [{ code: 'CUSTOM_TOKEN', field: 'token', message: 'token must use the token_ prefix' }],
     });
   });
 


### PR DESCRIPTION
## Summary
- Align `@fluojs/validation` `IsIP('4_or_6')` with the default IPv4-or-IPv6 runtime contract and add regression coverage for IP versions, dangerous keys, and custom scalar validators.
- Document validation/serialization public edge contracts with EN/KO README parity.
- Add `@fluojs/serialization` regression coverage for cyclic arrays, mixed object-array cycles, and shared references across array/object boundaries.

Closes #1968

## Verification
- `pnpm --filter @fluojs/validation test`
- `pnpm --filter @fluojs/serialization test`
- `pnpm --filter @fluojs/validation typecheck`
- `pnpm --filter @fluojs/serialization typecheck`
- `pnpm --filter @fluojs/validation build && pnpm --filter @fluojs/serialization build`
- `pnpm docs:sync-check`
- `pnpm verify:public-export-tsdoc`
- `pnpm exec biome lint packages/validation/src/decorators.ts packages/validation/src/validation.test.ts packages/serialization/src/serialize.ts packages/serialization/src/serializer-interceptor.ts packages/serialization/src/serialize.test.ts`

Note: full `pnpm lint` currently reports pre-existing diagnostics outside this PR in `packages/config`, `packages/core`, `packages/cqrs`, etc.; changed-file lint passes.