### PR TITLE
Fix Mongoose transaction tracking and async isolation

### DIFF
--- a/.changeset/mongoose-transaction-isolation.md
+++ b/.changeset/mongoose-transaction-isolation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/mongoose": patch
+---
+
+Track nested Mongoose request transaction boundaries during manual transactions and isolate async module factory results per application container.

--- a/book/intermediate/ch19-mongoose.ko.md
+++ b/book/intermediate/ch19-mongoose.ko.md
@@ -87,6 +87,8 @@ MongoDB 트랜잭션은 활성화된 **세션(Session)**을 필요로 합니다.
 
 제공된 Mongoose 연결이 `connection.transaction(...)`을 노출하면 fluo는 Mongoose 자체 ambient-session 범위와 정리 의미론을 보존하기 위해 그 API에 트랜잭션 경계를 위임합니다. 그렇지 않으면 `startSession()`, `startTransaction()`, `commitTransaction()` / `abortTransaction()`, `endSession()`을 직접 사용합니다. 요청 범위 트랜잭션은 session 획득 및 위임된 transaction 시작 중에도 request `AbortSignal`을 관찰하므로, 취소된 요청은 repository 작업 실행 전에 중단될 수 있습니다. 두 모드 모두 애플리케이션 종료 중에는 활성 요청 트랜잭션과 session cleanup이 settle될 때까지 `dispose(connection)`을 기다리며, 종료가 시작된 뒤에는 새 수동 또는 요청 범위 트랜잭션 경계를 거부합니다.
 
+Mongoose model 호출에는 명시적인 `{ session }` option이 필요하므로 request-scoped transaction이 repository 호출을 자동으로 다시 쓰지는 않습니다. 기존 수동 `transaction(...)` 안에서 열린 중첩 `requestTransaction(...)`은 ambient session을 재사용하고 활성 request boundary로 추적되며, 종료 중에는 abort되어 바깥 수동 transaction이 connection disposal 전에 rollback할 수 있습니다.
+
 ### Manual Transactions
 
 ```typescript

--- a/book/intermediate/ch19-mongoose.md
+++ b/book/intermediate/ch19-mongoose.md
@@ -87,6 +87,8 @@ MongoDB transactions require an active **session**. Fluo reduces the caller's bu
 
 When the provided Mongoose connection exposes `connection.transaction(...)`, fluo delegates the transaction boundary to that API so Mongoose's own ambient-session scope and cleanup semantics remain intact. Otherwise it falls back to `startSession()`, `startTransaction()`, `commitTransaction()` / `abortTransaction()`, and `endSession()` directly. Request-scoped transactions observe the request `AbortSignal` during session acquisition and delegated transaction startup, so cancelled requests can stop before repository work runs. In both modes, `dispose(connection)` waits until active request transactions and session cleanup settle during application shutdown, and new manual or request-scoped transaction boundaries are rejected once shutdown begins.
 
+Because Mongoose model calls require explicit `{ session }` options, request-scoped transactions do not rewrite repository calls for you. A nested `requestTransaction(...)` opened inside an existing manual `transaction(...)` reuses the ambient session, remains tracked as an active request boundary, and is aborted during shutdown so the outer manual transaction can roll back before connection disposal.
+
 ### Manual Transactions
 
 ```typescript

--- a/packages/mongoose/README.ko.md
+++ b/packages/mongoose/README.ko.md
@@ -50,7 +50,7 @@ const connection = mongoose.createConnection('mongodb://localhost:27017/test');
 class AppModule {}
 ```
 
-`MongooseModule.forRootAsync(...)`는 주입된 의존성과 동기 또는 비동기로 옵션을 반환하는 `useFactory`를 지원합니다. 여러 모듈에서 async 등록 helper를 공유할 때는 export된 `MongooseAsyncModuleOptions<TConnection>` 타입을 사용하세요. provider를 전역으로 노출해야 할 때는 최상위 async 등록 옵션에 `global`을 전달하세요. 해석된 옵션은 모듈 인스턴스 안에서 재사용되므로 연결 설정과 dispose hook이 모든 provider에서 일관되게 유지됩니다.
+`MongooseModule.forRootAsync(...)`는 주입된 의존성과 동기 또는 비동기로 옵션을 반환하는 `useFactory`를 지원합니다. 여러 모듈에서 async 등록 helper를 공유할 때는 export된 `MongooseAsyncModuleOptions<TConnection>` 타입을 사용하세요. provider를 전역으로 노출해야 할 때는 최상위 async 등록 옵션에 `global`을 전달하세요. 해석된 옵션은 하나의 애플리케이션 container 안에서 재사용되므로 해당 container의 모든 provider에서 연결 설정과 dispose hook이 일관되게 유지됩니다. 테스트나 multi-app 프로세스에서 같은 async module definition을 재사용해도 memoize된 연결을 공유하지 않고 애플리케이션 container마다 새 옵션을 해석합니다.
 
 ## 라이프사이클과 종료
 
@@ -64,6 +64,7 @@ class AppModule {}
 4. 설정한 `dispose(connection)` 훅은 활성 요청 트랜잭션과 ambient session scope가 모두 settled된 뒤에만 실행됩니다.
 
 `createMongoosePlatformStatusSnapshot(...)`은 트래픽 처리 중에는 `ready`, 요청 트랜잭션 drain 중에는 `shutting-down`, dispose 훅 완료 뒤에는 `stopped`를 보고합니다. 상태 details에는 `sessionStrategy`, `transactionContext: 'als'`, 활성 요청/session 개수, 리소스 소유권, strict/session 지원 진단이 포함됩니다. 수동 `transaction()`도 요청 범위 트랜잭션과 같은 명시적 세션 계약을 사용하므로, 트랜잭션에 참여해야 하는 Mongoose 모델 작업에는 repository 코드가 `conn.currentSession()`을 전달해야 합니다. 감싼 Mongoose 연결이 `connection.transaction(...)`을 노출하면 fluo는 Mongoose 자체 ambient-session scope를 보존하기 위해 그 API에 transaction boundary를 위임하면서도 같은 session을 `currentSession()`으로 노출합니다. 요청 범위 트랜잭션은 session을 획득하는 동안과 위임된 `connection.transaction(...)` 작업을 시작하는 동안에도 request `AbortSignal`을 관찰하므로, 요청 취소가 사용자 callback 실행 전에 이러한 시작 단계를 중단할 수 있습니다.
+기존 수동 `transaction(...)` boundary 안에서 열린 중첩 `requestTransaction(...)` 호출은 ambient session을 재사용하고 `details.activeRequestTransactions`에 계속 표시되며, 종료 중에 abort되어 바깥 수동 transaction이 `dispose(connection)` 실행 전에 rollback할 수 있습니다.
 
 ## 공통 패턴
 
@@ -114,7 +115,7 @@ import { MongooseTransactionInterceptor } from '@fluojs/mongoose';
 class UserController {}
 ```
 
-HTTP interceptor 밖에서 같은 request-aware transaction boundary가 필요하다면 `MongooseConnection.requestTransaction(...)`을 직접 사용할 수 있습니다. 중첩된 service transaction은 활성 session boundary를 재사용합니다.
+HTTP interceptor 밖에서 같은 request-aware transaction boundary가 필요하다면 `MongooseConnection.requestTransaction(...)`을 직접 사용할 수 있습니다. 중첩된 service transaction은 활성 session boundary를 재사용하며, 수동 transaction 안에서 열린 중첩 request boundary도 request abort와 shutdown tracking에 참여합니다.
 
 ## 공개 API
 

--- a/packages/mongoose/README.md
+++ b/packages/mongoose/README.md
@@ -48,7 +48,7 @@ const connection = mongoose.createConnection('mongodb://localhost:27017/test');
 class AppModule {}
 ```
 
-`MongooseModule.forRootAsync(...)` accepts injected dependencies and a `useFactory` that may return options synchronously or asynchronously. Use the exported `MongooseAsyncModuleOptions<TConnection>` type when sharing async registration helpers across modules. Pass `global` on the top-level async registration when the providers should be visible globally. The resolved options are reused for the module instance, so connection setup and disposal hooks stay consistent across all providers.
+`MongooseModule.forRootAsync(...)` accepts injected dependencies and a `useFactory` that may return options synchronously or asynchronously. Use the exported `MongooseAsyncModuleOptions<TConnection>` type when sharing async registration helpers across modules. Pass `global` on the top-level async registration when the providers should be visible globally. The resolved options are reused within one application container, so connection setup and disposal hooks stay consistent across that container's providers. Reusing the same async module definition across tests or multi-app processes resolves fresh options per application container instead of sharing a memoized connection.
 
 ## Lifecycle and Shutdown
 
@@ -62,6 +62,7 @@ Shutdown preserves transaction cleanup order and rejects new manual or request-s
 4. The configured `dispose(connection)` hook runs only after active request transactions and ambient session scopes have settled.
 
 `createMongoosePlatformStatusSnapshot(...)` reports `ready` while serving traffic, `shutting-down` while request transactions are draining, and `stopped` after the dispose hook completes. The status details include `sessionStrategy`, `transactionContext: 'als'`, active request/session counts, resource ownership, and strict/session support diagnostics. Manual `transaction()` calls still use the same explicit-session contract as request-scoped transactions: repository code must pass `conn.currentSession()` into Mongoose model operations that participate in the transaction. If the wrapped Mongoose connection exposes `connection.transaction(...)`, fluo delegates the transaction boundary to that API so Mongoose's own ambient-session scope is preserved while still exposing the same session through `currentSession()`. Request-scoped transactions observe the request `AbortSignal` while acquiring sessions and while starting delegated `connection.transaction(...)` work, so request cancellation can interrupt those startup phases before user callbacks run.
+Nested `requestTransaction(...)` calls opened inside an existing manual `transaction(...)` boundary reuse the ambient session, stay visible in `details.activeRequestTransactions`, and are aborted during shutdown so the outer manual transaction can roll back before `dispose(connection)` runs.
 
 ## Common Patterns
 
@@ -105,7 +106,7 @@ import { MongooseTransactionInterceptor } from '@fluojs/mongoose';
 class UserController {}
 ```
 
-Use `MongooseConnection.requestTransaction(...)` directly when you need the same request-aware transaction boundary outside an HTTP interceptor. Nested service transactions reuse the active session boundary.
+Use `MongooseConnection.requestTransaction(...)` directly when you need the same request-aware transaction boundary outside an HTTP interceptor. Nested service transactions reuse the active session boundary, and nested request boundaries opened inside a manual transaction still participate in request abort and shutdown tracking.
 
 ## Public API
 

--- a/packages/mongoose/src/connection.ts
+++ b/packages/mongoose/src/connection.ts
@@ -1,16 +1,14 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-
+import { Inject } from '@fluojs/core';
+import type { OnApplicationShutdown } from '@fluojs/runtime';
 import {
   createRequestAbortContext,
   raceWithAbort,
   trackActiveRequestTransaction,
   untrackActiveRequestTransaction,
 } from '@fluojs/runtime';
-import type { OnApplicationShutdown } from '@fluojs/runtime';
-import { Inject } from '@fluojs/core';
-
-import { MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, MONGOOSE_OPTIONS } from './tokens.js';
 import { createMongoosePlatformStatusSnapshot } from './status.js';
+import { MONGOOSE_CONNECTION, MONGOOSE_DISPOSE, MONGOOSE_OPTIONS } from './tokens.js';
 import type {
   MongooseConnectionLike,
   MongooseHandleProvider,
@@ -188,10 +186,17 @@ export class MongooseConnection<TConnection extends MongooseConnectionLike = Mon
   async requestTransaction<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
     const currentSession = this.sessions.getStore();
     if (currentSession) {
-      if (signal) {
-        return raceWithAbort(fn, signal);
+      this.assertRequestTransactionsAvailable();
+
+      const abortContext = createRequestAbortContext(signal);
+      const active = this.trackActiveRequestTransaction(abortContext.controller);
+
+      try {
+        return await raceWithAbort(fn, abortContext.signal);
+      } finally {
+        abortContext.cleanup();
+        this.untrackActiveRequestTransaction(active);
       }
-      return fn();
     }
 
     this.assertRequestTransactionsAvailable();

--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -1,15 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { Global, Inject, Module } from '@fluojs/core';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
+  createMongoosePlatformStatusSnapshot,
   MONGOOSE_CONNECTION,
   MONGOOSE_OPTIONS,
+  MongooseConnection,
   MongooseModule,
   MongooseTransactionInterceptor,
-  createMongoosePlatformStatusSnapshot,
-  MongooseConnection,
 } from './index.js';
 import type { MongooseConnectionLike, MongooseSessionLike } from './types.js';
 
@@ -576,6 +575,77 @@ describe('@fluojs/mongoose', () => {
     expect(sessionCalls).toBe(1);
   });
 
+  it('tracks nested request transactions inside manual transactions through shutdown abort', async () => {
+    const events: string[] = [];
+    let resolveRequestStarted!: () => void;
+    const requestStarted = new Promise<void>((resolve) => {
+      resolveRequestStarted = resolve;
+    });
+    const session = createFakeSession(events);
+
+    const connection: MongooseConnectionLike = {
+      async startSession() {
+        events.push('connection:startSession');
+        return session;
+      },
+    };
+
+    const mongooseModule = MongooseModule.forRoot<typeof connection>({
+      connection,
+      dispose() {
+        events.push('dispose');
+      },
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [mongooseModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const mongoose = await app.container.resolve(MongooseConnection<typeof connection>);
+
+    const openTransaction = mongoose.transaction(() =>
+      mongoose.requestTransaction(async () => {
+        events.push('request:open');
+        resolveRequestStarted();
+        return new Promise<never>(() => undefined);
+      }),
+    );
+
+    await requestStarted;
+
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 1,
+        activeSessions: 1,
+        lifecycleState: 'ready',
+      },
+    });
+
+    const closePromise = app.close();
+
+    await expect(openTransaction).rejects.toThrow('Application shutdown interrupted an open request transaction.');
+    await closePromise;
+
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 0,
+        activeSessions: 0,
+        lifecycleState: 'stopped',
+      },
+    });
+    expect(events).toEqual([
+      'connection:startSession',
+      'transaction:start',
+      'request:open',
+      'transaction:abort',
+      'session:end',
+      'dispose',
+    ]);
+  });
+
   it('uses Mongoose connection.transaction when available without overriding explicit session flow', async () => {
     const events: string[] = [];
     const session = createFakeSession(events);
@@ -1095,6 +1165,74 @@ describe('MongooseModule.forRootAsync', () => {
     expect(conn).toBeInstanceOf(MongooseConnection);
 
     await app.close();
+  });
+
+  it('resolves async options independently for each application container', async () => {
+    type AsyncIsolationConnection = MongooseConnectionLike & { id: string };
+
+    const factoryEvents: string[] = [];
+    let factoryCalls = 0;
+
+    const mongooseModule = MongooseModule.forRootAsync<AsyncIsolationConnection>({
+      useFactory: () => {
+        factoryCalls += 1;
+        const id = `connection-${factoryCalls}`;
+        factoryEvents.push(`factory:${id}`);
+
+        return {
+          connection: {
+            id,
+            async startSession() {
+              factoryEvents.push(`startSession:${id}`);
+              return createFakeSession(factoryEvents);
+            },
+          },
+          dispose(connection: AsyncIsolationConnection) {
+            factoryEvents.push(`dispose:${connection.id}`);
+          },
+        };
+      },
+    });
+
+    class FirstAppModule {}
+    class SecondAppModule {}
+
+    defineModule(FirstAppModule, { imports: [mongooseModule] });
+    defineModule(SecondAppModule, { imports: [mongooseModule] });
+
+    const firstApp = await bootstrapApplication({ rootModule: FirstAppModule });
+    const firstConnection = await firstApp.container.resolve<AsyncIsolationConnection>(MONGOOSE_CONNECTION);
+    const firstMongoose = await firstApp.container.resolve(MongooseConnection);
+
+    const secondApp = await bootstrapApplication({ rootModule: SecondAppModule });
+    const secondConnection = await secondApp.container.resolve<AsyncIsolationConnection>(MONGOOSE_CONNECTION);
+    const secondMongoose = await secondApp.container.resolve(MongooseConnection);
+
+    expect(firstConnection).not.toBe(secondConnection);
+    expect(firstMongoose).not.toBe(secondMongoose);
+    expect(firstConnection.id).toBe('connection-1');
+    expect(secondConnection.id).toBe('connection-2');
+    expect(factoryEvents).toEqual(['factory:connection-1', 'factory:connection-2']);
+
+    await expect(firstMongoose.transaction(async () => 'first')).resolves.toBe('first');
+    await expect(secondMongoose.transaction(async () => 'second')).resolves.toBe('second');
+    await firstApp.close();
+    await secondApp.close();
+
+    expect(factoryEvents).toEqual([
+      'factory:connection-1',
+      'factory:connection-2',
+      'startSession:connection-1',
+      'transaction:start',
+      'transaction:commit',
+      'session:end',
+      'startSession:connection-2',
+      'transaction:start',
+      'transaction:commit',
+      'session:end',
+      'dispose:connection-1',
+      'dispose:connection-2',
+    ]);
   });
 
   it('propagates factory errors during module initialization', async () => {

--- a/packages/mongoose/src/module.ts
+++ b/packages/mongoose/src/module.ts
@@ -73,36 +73,20 @@ function createMongooseRuntimeProviders<TConnection extends MongooseConnectionLi
   ];
 }
 
-function createMemoizedMongooseOptionsResolver<TConnection extends MongooseConnectionLike>(
-  options: MongooseAsyncModuleOptions<TConnection>,
-): (...deps: unknown[]) => Promise<ResolvedMongooseModuleOptions<TConnection>> {
-  let cachedResult: Promise<ResolvedMongooseModuleOptions<TConnection>> | undefined;
-
-  return (...deps: unknown[]) => {
-    if (!cachedResult) {
-      cachedResult = Promise.resolve(options.useFactory(...deps)).then((resolved) =>
-        normalizeMongooseModuleOptions<TConnection>(resolved),
-      );
-    }
-
-    if (!cachedResult) {
-      throw new Error('Mongoose module options resolver initialization failed.');
-    }
-
-    return cachedResult;
-  };
-}
-
 function createMongooseProvidersAsync<TConnection extends MongooseConnectionLike>(
   options: MongooseAsyncModuleOptions<TConnection>,
 ): Provider[] {
-  const resolveOptions = createMemoizedMongooseOptionsResolver(options);
+  const factory = options.useFactory;
 
   const normalizedOptionsProvider = {
     inject: options.inject,
     provide: MONGOOSE_NORMALIZED_OPTIONS,
     scope: 'singleton' as const,
-    useFactory: async (...deps: unknown[]) => resolveOptions(...deps),
+    useFactory: async (...deps: unknown[]) => {
+      const resolvedOptions = await factory(...deps);
+
+      return normalizeMongooseModuleOptions<TConnection>(resolvedOptions);
+    },
   };
 
   return createMongooseRuntimeProviders<TConnection>(normalizedOptionsProvider);
@@ -158,12 +142,22 @@ function buildMongooseModuleAsync<TConnection extends MongooseConnectionLike>(
  * Module entrypoint for wiring a Mongoose connection into the Fluo runtime lifecycle.
  */
 export class MongooseModule {
-  /** Creates a module definition from static Mongoose options. */
+  /**
+   * Registers Mongoose providers from static options.
+   *
+   * @param options Mongoose module options with connection handle, optional dispose hook, and strict transaction mode.
+   * @returns A module definition that exports `MongooseConnection` and `MongooseTransactionInterceptor`.
+   */
   static forRoot<TConnection extends MongooseConnectionLike>(options: MongooseModuleOptions<TConnection>): ModuleType {
     return buildMongooseModule<TConnection>(options);
   }
 
-  /** Creates a module definition from DI-aware async Mongoose options. */
+  /**
+   * Registers Mongoose providers from an async DI factory.
+   *
+   * @param options Async module options that resolve Mongoose connection/module configuration.
+   * @returns A module definition that resolves async options once per application container.
+   */
   static forRootAsync<TConnection extends MongooseConnectionLike>(
     options: MongooseAsyncModuleOptions<TConnection>,
   ): ModuleType {


### PR DESCRIPTION
## Summary

- Fix Mongoose nested `requestTransaction(...)` tracking inside manual transaction boundaries so shutdown aborts and drains the active request boundary before disposal.
- Scope `MongooseModule.forRootAsync(...)` option resolution to each application container instead of memoizing across reused module definitions.
- Add regression coverage, public TSDoc, EN/KO docs parity updates, and a patch changeset for `@fluojs/mongoose`.

## Verification

- `pnpm --filter @fluojs/mongoose test`
- `pnpm --filter @fluojs/mongoose typecheck`
- `pnpm --filter @fluojs/mongoose build`
- `pnpm docs:sync-check`
- `pnpm verify:public-export-tsdoc`
- `pnpm exec biome check packages/mongoose/src/connection.ts packages/mongoose/src/module.ts packages/mongoose/src/module.test.ts packages/mongoose/README.md packages/mongoose/README.ko.md book/intermediate/ch19-mongoose.md book/intermediate/ch19-mongoose.ko.md .changeset/mongoose-transaction-isolation.md`
- LSP diagnostics clean: `packages/mongoose/src/connection.ts`, `packages/mongoose/src/module.ts`, `packages/mongoose/src/module.test.ts`

Closes #1976