### PR TITLE
Guard release lane dependency-only majors

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": [
     "@fluojs/example-auth-jwt-passport",
     "@fluojs/example-minimal",

--- a/tooling/release/verify-changeset-release-lane.d.mts
+++ b/tooling/release/verify-changeset-release-lane.d.mts
@@ -16,6 +16,11 @@ export type PackageVersionDelta = {
   previousVersion: string;
 };
 
+export type DependencyOnlyMajorVersionDelta = PackageVersionDelta & {
+  changelogPath: string;
+  reason: string;
+};
+
 export type VerifyChangesetReleaseLaneOptions = {
   baseRef?: string;
   changesetDirectory?: string;
@@ -24,6 +29,7 @@ export type VerifyChangesetReleaseLaneOptions = {
 
 export type VerifyChangesetReleaseLaneResult = {
   allowedBumps: ChangesetReleaseBump[];
+  checkedDependencyOnlyMajorVersionDeltas: DependencyOnlyMajorVersionDelta[];
   checkedIntents: ChangesetReleaseIntent[];
   checkedVersionDeltas: PackageVersionDelta[];
   lane: ChangesetReleaseLane;

--- a/tooling/release/verify-changeset-release-lane.mjs
+++ b/tooling/release/verify-changeset-release-lane.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -222,6 +222,67 @@ function collectPackageVersionDeltas(baseRef, dependencies = {}) {
   });
 }
 
+function packageChangelogPathForPackageJson(packageJsonPath) {
+  return join(dirname(packageJsonPath), 'CHANGELOG.md');
+}
+
+function changelogSectionForVersion(changelog, version) {
+  const heading = `## ${version}`;
+  const headingIndex = changelog.indexOf(heading);
+
+  if (headingIndex === -1) {
+    return null;
+  }
+
+  const nextHeadingIndex = changelog.indexOf('\n## ', headingIndex + heading.length);
+
+  return nextHeadingIndex === -1 ? changelog.slice(headingIndex) : changelog.slice(headingIndex, nextHeadingIndex);
+}
+
+function collectDependencyOnlyMajorVersionDeltas(versionDeltas, dependencies = {}) {
+  const { existsSync: pathExists = existsSync, readFileSync: readFile = readFileSync } = dependencies;
+
+  return versionDeltas.flatMap((delta) => {
+    if (delta.bump !== 'major') {
+      return [];
+    }
+
+    const changelogPath = packageChangelogPathForPackageJson(delta.filePath);
+
+    if (!pathExists(join(repoRoot, changelogPath))) {
+      return [
+        {
+          ...delta,
+          changelogPath,
+          reason: `missing ${changelogPath}`,
+        },
+      ];
+    }
+
+    const section = changelogSectionForVersion(readFile(join(repoRoot, changelogPath), 'utf8'), delta.nextVersion);
+
+    if (!section) {
+      return [
+        {
+          ...delta,
+          changelogPath,
+          reason: `missing changelog section for ${delta.nextVersion}`,
+        },
+      ];
+    }
+
+    return section.includes('### Major Changes')
+      ? []
+      : [
+          {
+            ...delta,
+            changelogPath,
+            reason: 'major version delta only has dependency/patch changelog entries',
+          },
+        ];
+  });
+}
+
 export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
   const baseRef = options.baseRef;
   const changesetDirectory = options.changesetDirectory ?? defaultChangesetDirectory;
@@ -240,8 +301,11 @@ export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
   const disallowedVersionDeltas = versionDeltas.filter(
     (delta) => validBumps.has(delta.bump) && !allowedBumps.has(delta.bump),
   );
+  const dependencyOnlyMajorVersionDeltas = typeof dependencies.collectDependencyOnlyMajorVersionDeltas === 'function'
+    ? dependencies.collectDependencyOnlyMajorVersionDeltas(versionDeltas)
+    : collectDependencyOnlyMajorVersionDeltas(versionDeltas, dependencies);
 
-  if (disallowed.length > 0 || disallowedVersionDeltas.length > 0) {
+  if (disallowed.length > 0 || disallowedVersionDeltas.length > 0 || dependencyOnlyMajorVersionDeltas.length > 0) {
     const details = disallowed
       .map((intent) => `${intent.packageName}@${intent.bump} (${intent.filePath})`)
       .join('\n  - ');
@@ -254,14 +318,28 @@ export function verifyChangesetReleaseLane(options = {}, dependencies = {}) {
     const sections = [
       details.length > 0 ? `changesets:\n  - ${details}` : '',
       versionDetails.length > 0 ? `package version deltas:\n  - ${versionDetails}` : '',
+      dependencyOnlyMajorVersionDeltas.length > 0
+        ? `dependency-only major package version deltas:\n  - ${dependencyOnlyMajorVersionDeltas
+            .map(
+              (delta) =>
+                `${delta.packageName}@major (${delta.previousVersion} -> ${delta.nextVersion}, ${delta.filePath}, ${delta.changelogPath}: ${delta.reason})`,
+            )
+            .join('\n  - ')}`
+        : '',
     ].filter((section) => section.length > 0);
 
     throw new Error(
-      `Changeset release lane check failed: the ${lane} lane only allows ${[...allowedBumps].join(', ')} changesets and package version bumps:\n${sections.join('\n')}`,
+      `Changeset release lane check failed: the ${lane} lane only allows ${[...allowedBumps].join(', ')} changesets and package version bumps with matching major changelog evidence:\n${sections.join('\n')}`,
     );
   }
 
-  return { allowedBumps: [...allowedBumps], checkedIntents: intents, checkedVersionDeltas: versionDeltas, lane };
+  return {
+    allowedBumps: [...allowedBumps],
+    checkedDependencyOnlyMajorVersionDeltas: dependencyOnlyMajorVersionDeltas,
+    checkedIntents: intents,
+    checkedVersionDeltas: versionDeltas,
+    lane,
+  };
 }
 
 export function main(argv = process.argv.slice(2)) {

--- a/tooling/release/verify-changeset-release-lane.test.ts
+++ b/tooling/release/verify-changeset-release-lane.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -14,6 +14,12 @@ function createChangesetDirectory() {
 
 function writeChangeset(directory: string, fileName: string, frontmatter: string) {
   writeFileSync(join(directory, fileName), `---\n${frontmatter}\n---\n\nRelease note.\n`, 'utf8');
+}
+
+function writePackageChangelog(directory: string, packageDirectory: string, changelog: string) {
+  const targetDirectory = join(directory, packageDirectory);
+  mkdirSync(targetDirectory, { recursive: true });
+  writeFileSync(join(targetDirectory, 'CHANGELOG.md'), changelog, 'utf8');
 }
 
 afterEach(() => {
@@ -64,10 +70,64 @@ describe('verifyChangesetReleaseLane', () => {
             previousVersion: '1.0.0',
           },
         ],
+        collectDependencyOnlyMajorVersionDeltas: () => [],
       },
     );
 
     expect(result.checkedVersionDeltas).toMatchObject([{ bump: 'patch' }, { bump: 'minor' }, { bump: 'major' }]);
+  });
+
+  it('rejects major package version deltas without major changelog evidence', () => {
+    const directory = createChangesetDirectory();
+    writePackageChangelog(
+      directory,
+      'packages/i18n',
+      `# @fluojs/i18n\n\n## 2.0.0\n\n### Patch Changes\n\n- Updated dependencies:\n  - @fluojs/http@1.1.0\n`,
+    );
+
+    expect(() =>
+      verifyChangesetReleaseLane(
+        { baseRef: 'origin/main', changesetDirectory: directory, lane: 'stable' },
+        {
+          collectPackageVersionDeltas: () => [
+            {
+              bump: 'major',
+              filePath: 'packages/i18n/package.json',
+              nextVersion: '2.0.0',
+              packageName: '@fluojs/i18n',
+              previousVersion: '1.0.2',
+            },
+          ],
+          existsSync: (targetPath: string) => targetPath.endsWith('packages/i18n/CHANGELOG.md'),
+          readFileSync: () =>
+            `# @fluojs/i18n\n\n## 2.0.0\n\n### Patch Changes\n\n- Updated dependencies:\n  - @fluojs/http@1.1.0\n`,
+        },
+      ),
+    ).toThrow(/dependency-only major package version deltas/u);
+  });
+
+  it('allows major package version deltas with major changelog evidence', () => {
+    const directory = createChangesetDirectory();
+
+    const result = verifyChangesetReleaseLane(
+      { baseRef: 'origin/main', changesetDirectory: directory, lane: 'stable' },
+      {
+        collectPackageVersionDeltas: () => [
+          {
+            bump: 'major',
+            filePath: 'packages/runtime/package.json',
+            nextVersion: '2.0.0',
+            packageName: '@fluojs/runtime',
+            previousVersion: '1.0.0',
+          },
+        ],
+        existsSync: (targetPath: string) => targetPath.endsWith('packages/runtime/CHANGELOG.md'),
+        readFileSync: () =>
+          `# @fluojs/runtime\n\n## 2.0.0\n\n### Major Changes\n\n- Remove a deprecated public API.\n`,
+      },
+    );
+
+    expect(result.checkedDependencyOnlyMajorVersionDeltas).toEqual([]);
   });
 
   it('allows all semver bump intents on the prerelease lane', () => {


### PR DESCRIPTION
## Summary
- Configure Changesets to only update peer dependents when their peer range is out of range.
- Add a release-lane guard that rejects major package version deltas without `### Major Changes` evidence in the generated package changelog.
- Cover dependency-only major rejection and real major allowance with release tooling tests.

## Verification
- pnpm exec biome check .changeset/config.json tooling/release/verify-changeset-release-lane.mjs tooling/release/verify-changeset-release-lane.d.mts tooling/release/verify-changeset-release-lane.test.ts
- pnpm vitest run tooling/release/verify-changeset-release-lane.test.ts
- pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main
- pnpm changeset status --verbose
- tsc -p tsconfig.tools.json --noEmit