### PR TITLE
fix(cli): harden dev runner spawn failures

### DIFF
--- a/.changeset/fuzzy-rockets-grab.md
+++ b/.changeset/fuzzy-rockets-grab.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cli': patch
+---
+
+Harden the development restart runner so child process spawn failures clean up watchers and resolve with a failure exit code.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -469,6 +469,36 @@ describe('CLI command runner', () => {
   });
 
   it.each([
+    ['--no-update-notifier flag', ['--no-update-notifier', 'analyze'], updateCheckEnv],
+    ['FLUO_NO_UPDATE_CHECK env', ['analyze'], { ...updateCheckEnv, FLUO_NO_UPDATE_CHECK: '1' }],
+    ['npm lifecycle event env', ['analyze'], { ...updateCheckEnv, npm_lifecycle_event: 'dev' }],
+    ['npm lifecycle script env', ['analyze'], { ...updateCheckEnv, npm_lifecycle_script: 'fluo dev' }],
+    ['rerun-after-update env', ['analyze'], { ...updateCheckEnv, FLUO_UPDATE_CHECK_REEXEC: '1' }],
+  ] as const)('skips update checks for %s', async (_caseName, argv, env) => {
+    let fetchCount = 0;
+    const stdoutBuffer: string[] = [];
+
+    const exitCode = await runCli([...argv], {
+      env,
+      stderr: createTtyBufferStream([]),
+      stdin: { isTTY: true },
+      stdout: createTtyBufferStream(stdoutBuffer),
+      updateCheck: {
+        cacheFile: createUpdateCacheFile(),
+        currentVersion: '1.0.0-beta.1',
+        fetchLatestVersion: async (): Promise<string> => {
+          fetchCount += 1;
+          return '1.0.0-beta.2';
+        },
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fetchCount).toBe(0);
+    expect(stdoutBuffer.join('')).toContain('fluo analyze');
+  });
+
+  it.each([
     ['help'],
     ['help', 'info'],
     ['--help'],
@@ -2074,6 +2104,41 @@ void bootstrap();
 
     children[1]?.emit('close', 0);
     await expect(runPromise).resolves.toBe(0);
+  });
+
+  it('cleans up and resolves with failure when spawning the app child fails', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    mkdirSync(join(workspaceDirectory, 'src'), { recursive: true });
+    writeFileSync(join(workspaceDirectory, 'src', 'main.ts'), 'console.log("hello");\n');
+    const signalTarget = createSignalTarget();
+    const stderrBuffer: string[] = [];
+    let watcherClosed = false;
+
+    const runPromise = runNodeRestartRunner({
+      env: {},
+      projectDirectory: workspaceDirectory,
+      signalTarget: signalTarget.target,
+      spawnChild: () => {
+        const child = createMockChild();
+        queueMicrotask(() => {
+          child.emit('error', new Error('spawn ENOENT'));
+          child.emit('close', 0);
+        });
+        return child;
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      watchTarget: () => ({
+        close: () => {
+          watcherClosed = true;
+        },
+      }) as never,
+    });
+
+    await expect(runPromise).resolves.toBe(1);
+    expect(stderrBuffer.join('')).toContain('[fluo] failed to start app child: spawn ENOENT');
+    expect(watcherClosed).toBe(true);
+    expect(signalTarget.offCalls).toEqual(['SIGINT', 'SIGTERM']);
   });
 
   it('does not advance the restart content baseline while the previous child is still closing', async () => {

--- a/packages/cli/src/dev-runner/node-restart-runner.ts
+++ b/packages/cli/src/dev-runner/node-restart-runner.ts
@@ -309,7 +309,22 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
       env,
       stdio: 'inherit',
     });
+    let childSettled = false;
+    child.once('error', (error) => {
+      if (childSettled) {
+        return;
+      }
+      childSettled = true;
+      restarting = false;
+      stderr.write(`[fluo] failed to start app child: ${error.message}\n`);
+      cleanup();
+      resolveExitCode(1);
+    });
     child.once('close', (code) => {
+      if (childSettled) {
+        return;
+      }
+      childSettled = true;
       if (restarting) {
         return;
       }

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -98,7 +98,7 @@ function createLocalPackageCacheDirectory(repoRoot: string): string {
 
 function createFixtureLocalRepo(): string {
   const repoRoot = mkdtempSync(join(tmpdir(), 'fluo-local-repo-'));
-  temporaryDirectories.push(repoRoot);
+  temporaryDirectories.push(repoRoot, createLocalPackageCacheDirectory(repoRoot));
 
   for (const [packageName, packageDirectory] of Object.entries(LOCAL_PACKAGE_DIRECTORY_BY_NAME)) {
     const packageRoot = join(repoRoot, 'packages', packageDirectory);

--- a/tooling/governance/runtime-matrix-docs-contract.test.ts
+++ b/tooling/governance/runtime-matrix-docs-contract.test.ts
@@ -4,8 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-const packageRoot = dirname(fileURLToPath(import.meta.url));
-const repoRoot = join(packageRoot, '..', '..', '..');
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 function read(relativePath: string) {
   return readFileSync(join(repoRoot, relativePath), 'utf8');


### PR DESCRIPTION
## Summary

Harden @fluojs/cli dev-runner spawn failure handling and expand regression coverage for update-check skip paths from issue #1999.

Closes #1999

## Changes

- Add child `error` handling in the Node restart runner so spawn failures report a failure, clean up watchers/signals, and do not double-resolve on later `close`.
- Add focused CLI update-check skip coverage for `--no-update-notifier`, `FLUO_NO_UPDATE_CHECK`, npm lifecycle env, and rerun-after-update env.
- Move runtime matrix/book/examples governance assertions out of the CLI package suite into `tooling/governance`.
- Register fixture local package cache directories for scaffold test cleanup.
- Add a patch changeset for the public `@fluojs/cli` package.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/cli/src/cli.test.ts packages/cli/src/new/scaffold.test.ts tooling/governance/runtime-matrix-docs-contract.test.ts`
- `pnpm --filter @fluojs/cli... build`
- `pnpm --filter @fluojs/cli typecheck`
- Changed-file LSP diagnostics: clean for `packages/cli/src/dev-runner/node-restart-runner.ts`, `packages/cli/src/cli.test.ts`, `packages/cli/src/new/scaffold.test.ts`, and `tooling/governance/runtime-matrix-docs-contract.test.ts`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] No public exports were added or changed.
- [x] Existing public export documentation remains applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] Spawn-failure cleanup behavior is covered by regression tests.
- [x] Update-check skip invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] Governance assertions were moved to `tooling/governance` instead of remaining in the CLI package suite.
- [x] No platform contract docs or SSOT mirror content changed.
- [x] Package README alignment/conformance claims were not changed.