### PR TITLE
chore(i18n): dedupe lookup helpers and close coverage gaps

### DIFF
--- a/packages/i18n/README.ko.md
+++ b/packages/i18n/README.ko.md
@@ -422,7 +422,7 @@ typedI18n.translateInNamespace('admin/common', 'dashboard.title', { locale: 'en'
 | `I18nModule` | DI 등록을 위한 모듈입니다. |
 | `I18nService` | Detached option/catalog snapshot을 소유하고 translation을 resolve하며 explicit-locale `Intl` formatting helper(`formatDateTime`, `formatNumber`, `formatCurrency`, `formatPercent`, `formatList`, `formatRelativeTime`)를 제공하는 core service입니다. |
 | `createI18n` | 독립형 서비스를 생성하기 위한 헬퍼입니다. |
-| `I18nError` | 패키지 전용 에러 클래스입니다. |
+| `I18nError` | 안정적인 에러 코드를 포함하는 기본 i18n 패키지 에러입니다. |
 
 **타입:** `I18nModuleOptions`, `I18nMessageCatalogs`, `I18nMessageTree`, `I18nTranslateOptions`, `I18nInterpolationValues`, `I18nMissingMessageHandler`, `I18nMissingMessageContext`, `I18nLocale`, `I18nTranslationKey`, `I18nErrorCode`, `I18nFallbackLocales`, `I18nFormatOptions`, `I18nFormatterOptions`, `I18nDateTimeFormatOptions`, `I18nNumberFormatOptions`, `I18nCurrencyFormatOptions`, `I18nListFormatOptions`, `I18nRelativeTimeFormatOptions`, `I18nNamedDateTimeFormats`, `I18nNamedNumberFormats`, `I18nNamedListFormats`, `I18nNamedRelativeTimeFormats`.
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -89,6 +89,7 @@
     }
   },
   "devDependencies": {
+    "@fluojs/testing": "workspace:^",
     "@fluojs/http": "workspace:^",
     "@fluojs/validation": "workspace:^",
     "intl-messageformat": "^11.2.4",

--- a/packages/i18n/src/catalog.ts
+++ b/packages/i18n/src/catalog.ts
@@ -1,0 +1,82 @@
+import { I18nError } from './errors.js';
+import type { I18nMessageTree } from './types.js';
+
+/**
+ * Checks whether a value is a plain object suitable for i18n option or catalog validation.
+ *
+ * @param value Candidate value to inspect.
+ * @returns `true` when the value is a plain object or null-prototype object.
+ */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Creates a detached immutable message tree from untrusted catalog-like input.
+ *
+ * @param value Catalog-like value to validate and snapshot.
+ * @param path Diagnostic path used in validation errors.
+ * @returns A frozen message tree detached from caller-owned data.
+ */
+export function snapshotMessageTree(value: unknown, path: string): I18nMessageTree {
+  if (!isPlainObject(value)) {
+    throw new I18nError(`${path} must be a plain object message tree.`, 'I18N_INVALID_CATALOG');
+  }
+
+  const snapshot: Record<string, string | I18nMessageTree> = {};
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (key.trim() === '') {
+      throw new I18nError(`${path} contains an empty message key segment.`, 'I18N_INVALID_CATALOG');
+    }
+
+    if (typeof entry === 'string') {
+      snapshot[key] = entry;
+      continue;
+    }
+
+    if (isPlainObject(entry)) {
+      snapshot[key] = snapshotMessageTree(entry, `${path}.${key}`);
+      continue;
+    }
+
+    throw new I18nError(`${path}.${key} must be a string or nested message tree.`, 'I18N_INVALID_CATALOG');
+  }
+
+  return Object.freeze(snapshot);
+}
+
+/**
+ * Resolves a direct or dot-path message from an immutable i18n message tree.
+ *
+ * @param tree Locale-scoped catalog tree to inspect.
+ * @param key Direct key or dot-path key to resolve.
+ * @returns The resolved message string, or `undefined` when the key is absent or not a string leaf.
+ */
+export function resolveCatalogMessage(tree: I18nMessageTree | undefined, key: string): string | undefined {
+  if (tree === undefined) {
+    return undefined;
+  }
+
+  if (Object.hasOwn(tree, key)) {
+    const direct = tree[key];
+    return typeof direct === 'string' ? direct : undefined;
+  }
+
+  let current: unknown = tree;
+
+  for (const part of key.split('.')) {
+    if (!isPlainObject(current) || !Object.hasOwn(current, part)) {
+      return undefined;
+    }
+
+    current = current[part];
+  }
+
+  return typeof current === 'string' ? current : undefined;
+}

--- a/packages/i18n/src/icu.test.ts
+++ b/packages/i18n/src/icu.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { I18nError, createI18n } from './index.js';
 import { IcuI18nService, createIcuI18n } from './icu.js';
+import type { I18nIcuValues } from './icu.js';
 
 function expectI18nCode(action: () => unknown, code: I18nError['code']): void {
   try {
@@ -131,6 +132,23 @@ describe('@fluojs/i18n/icu MessageFormat subpath', () => {
 
     expectI18nCode(() => service.translate('invalid', { locale: 'en', values: { count: 1 } }), 'I18N_INVALID_MESSAGE_FORMAT');
     expectI18nCode(() => service.translate('missingValue', { locale: 'en' }), 'I18N_INVALID_MESSAGE_FORMAT');
+  });
+
+  it('rejects non-string rich formatting results with the stable invalid format code', () => {
+    const service = createIcuI18n({
+      catalogs: {
+        en: {
+          rich: 'Click <link>here</link>',
+        },
+      },
+      defaultLocale: 'en',
+      supportedLocales: ['en'],
+    });
+    const richValues = {
+      link: (chunks: readonly string[]) => ({ chunks }),
+    } as unknown as I18nIcuValues;
+
+    expectI18nCode(() => service.translate('rich', { locale: 'en', values: richValues }), 'I18N_INVALID_MESSAGE_FORMAT');
   });
 
   it('can wrap an existing core service without changing core translation behavior', () => {

--- a/packages/i18n/src/icu.ts
+++ b/packages/i18n/src/icu.ts
@@ -1,9 +1,10 @@
 import { FormatError, IntlMessageFormat } from 'intl-messageformat';
 import type { Formats } from 'intl-messageformat';
 
+import { resolveCatalogMessage } from './catalog.js';
 import { I18nError } from './errors.js';
 import { I18nService, createI18n } from './service.js';
-import type { I18nInterpolationValues, I18nLocale, I18nMessageTree, I18nModuleOptions, I18nTranslateOptions } from './types.js';
+import type { I18nInterpolationValues, I18nLocale, I18nModuleOptions, I18nTranslateOptions } from './types.js';
 
 /**
  * Primitive values accepted by the ICU MessageFormat subpath.
@@ -55,39 +56,12 @@ function toMessageFormatValues(values: I18nIcuValues | undefined): Record<string
   return Object.fromEntries(Object.entries(values));
 }
 
-function hasOwn(value: unknown, key: string): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && Object.hasOwn(value, key);
-}
-
-function resolveMessage(tree: I18nMessageTree | undefined, key: string): string | undefined {
-  if (tree === undefined) {
-    return undefined;
-  }
-
-  if (hasOwn(tree, key)) {
-    const direct = tree[key];
-    return typeof direct === 'string' ? direct : undefined;
-  }
-
-  let current: unknown = tree;
-
-  for (const part of key.split('.')) {
-    if (!hasOwn(current, part)) {
-      return undefined;
-    }
-
-    current = current[part];
-  }
-
-  return typeof current === 'string' ? current : undefined;
-}
-
 function resolveMessageLocale(service: I18nService, key: string, options: I18nIcuTranslateOptions): I18nLocale {
   const resolvedKey = options.namespace === undefined ? key : `${options.namespace}.${key}`;
   const snapshot = service.snapshotOptions();
 
   for (const locale of service.resolveLocales(options.locale)) {
-    if (resolveMessage(snapshot.catalogs?.[locale], resolvedKey) !== undefined) {
+    if (resolveCatalogMessage(snapshot.catalogs?.[locale], resolvedKey) !== undefined) {
       return locale;
     }
   }

--- a/packages/i18n/src/index.test.ts
+++ b/packages/i18n/src/index.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import { Module } from '@fluojs/core';
+import { createTestingModule } from '@fluojs/testing';
+
 import { I18nError, I18nModule, createI18n } from './index.js';
+import { I18nService } from './service.js';
 import type {
   I18nErrorCode,
   I18nLocale,
@@ -47,6 +51,30 @@ describe('@fluojs/i18n root public surface', () => {
     expect(snapshot.supportedLocales).not.toBe(options.supportedLocales);
     expect(I18nModule.forRoot(options)).toBeInstanceOf(Function);
     expect(new I18nError('reserved i18n failure', code).code).toBe('I18N_ERROR');
+  });
+
+  it('resolves I18nModule.forRoot providers through a compiled testing module graph', async () => {
+    @Module({
+      imports: [
+        I18nModule.forRoot({
+          catalogs: {
+            en: { app: { title: 'Hello {{ name }}' } },
+            ko: { app: { title: '안녕하세요 {{ name }}' } },
+          },
+          defaultLocale: 'en',
+          fallbackLocales: { ko: ['en'] },
+          supportedLocales: ['en', 'ko'],
+        }),
+      ],
+    })
+    class AppModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AppModule }).compile();
+    const service = await testingModule.resolve<I18nService>(I18nService);
+
+    expect(service.translate('app.title', { locale: 'ko', values: { name: 'fluo' } })).toBe('안녕하세요 fluo');
+    expect(service.resolveLocales('ko')).toEqual(['ko', 'en']);
+    expect(testingModule.get(I18nService)).toBe(service);
   });
 
   it('resolves nested keys and namespace-prefixed keys with explicit locales', () => {

--- a/packages/i18n/src/loaders/remote.test.ts
+++ b/packages/i18n/src/loaders/remote.test.ts
@@ -102,6 +102,24 @@ describe('@fluojs/i18n/loaders/remote', () => {
     expect(providerCalls).toBe(2);
   });
 
+  it('separates default cache entries by caller-owned catalog version', async () => {
+    let providerCalls = 0;
+    const loader = new RemoteI18nLoader({
+      provider: () => {
+        providerCalls += 1;
+        return { title: `Welcome ${providerCalls}` };
+      },
+    });
+    const stableCatalog = createCachedRemoteI18nLoader({ loader, ttlMs: 1_000, version: 'stable' });
+    const canaryCatalog = createCachedRemoteI18nLoader({ loader, ttlMs: 1_000, version: 'canary' });
+
+    await expect(stableCatalog.load('en', 'common')).resolves.toEqual({ title: 'Welcome 1' });
+    await expect(stableCatalog.load('en', 'common')).resolves.toEqual({ title: 'Welcome 1' });
+    await expect(canaryCatalog.load('en', 'common')).resolves.toEqual({ title: 'Welcome 2' });
+    await expect(canaryCatalog.load('en', 'common')).resolves.toEqual({ title: 'Welcome 2' });
+    expect(providerCalls).toBe(2);
+  });
+
   it('supports caller-owned cache keys and explicit invalidation', async () => {
     let providerCalls = 0;
     const loader = new RemoteI18nLoader({

--- a/packages/i18n/src/loaders/shared.ts
+++ b/packages/i18n/src/loaders/shared.ts
@@ -1,4 +1,5 @@
 import { I18nError } from '../errors.js';
+import { isPlainObject, snapshotMessageTree } from '../catalog.js';
 import type { I18nLocale, I18nMessageTree, I18nTranslationKey } from '../types.js';
 
 const SAFE_LOCALE_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?(?:-[A-Za-z0-9](?:[A-Za-z0-9_-]*[A-Za-z0-9])?)*$/;
@@ -27,20 +28,7 @@ export interface I18nLoader {
   load(locale: I18nLocale, namespace: I18nTranslationKey, options?: I18nLoaderLoadOptions): Promise<I18nMessageTree>;
 }
 
-/**
- * Checks whether a value is a plain object suitable for loader option or catalog validation.
- *
- * @param value Candidate value to inspect.
- * @returns `true` when the value is a plain object or null-prototype object.
- */
-export function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
+export { isPlainObject } from '../catalog.js';
 
 /**
  * Validates a loader locale before a backend is called.
@@ -87,29 +75,5 @@ export function validateLoaderNamespace(namespace: unknown, label: string): asse
  * @returns A frozen message tree detached from caller-owned data.
  */
 export function snapshotLoaderMessageTree(value: unknown, path: string): I18nMessageTree {
-  if (!isPlainObject(value)) {
-    throw new I18nError(`${path} must be a plain object message tree.`, 'I18N_INVALID_CATALOG');
-  }
-
-  const snapshot: Record<string, string | I18nMessageTree> = {};
-
-  for (const [key, entry] of Object.entries(value)) {
-    if (key.trim() === '') {
-      throw new I18nError(`${path} contains an empty message key segment.`, 'I18N_INVALID_CATALOG');
-    }
-
-    if (typeof entry === 'string') {
-      snapshot[key] = entry;
-      continue;
-    }
-
-    if (isPlainObject(entry)) {
-      snapshot[key] = snapshotLoaderMessageTree(entry, `${path}.${key}`);
-      continue;
-    }
-
-    throw new I18nError(`${path}.${key} must be a string or nested message tree.`, 'I18N_INVALID_CATALOG');
-  }
-
-  return Object.freeze(snapshot);
+  return snapshotMessageTree(value, path);
 }

--- a/packages/i18n/src/options.ts
+++ b/packages/i18n/src/options.ts
@@ -1,14 +1,6 @@
 import { I18nError } from './errors.js';
+import { isPlainObject, snapshotMessageTree } from './catalog.js';
 import type { I18nFallbackLocales, I18nFormatOptions, I18nMessageCatalogs, I18nMessageTree, I18nModuleOptions } from './types.js';
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
 
 function assertLocale(value: unknown, label: string): asserts value is string {
   if (typeof value !== 'string' || value.trim() === '') {
@@ -77,34 +69,6 @@ function snapshotFormats(formats: I18nFormatOptions | undefined): I18nFormatOpti
     number: snapshotNamedIntlFormats(formats.number, 'formats.number') as I18nFormatOptions['number'],
     relativeTime: snapshotNamedIntlFormats(formats.relativeTime, 'formats.relativeTime') as I18nFormatOptions['relativeTime'],
   });
-}
-
-function snapshotMessageTree(value: unknown, path: string): I18nMessageTree {
-  if (!isPlainObject(value)) {
-    throw new I18nError(`${path} must be a plain object message tree.`, 'I18N_INVALID_CATALOG');
-  }
-
-  const snapshot: Record<string, string | I18nMessageTree> = {};
-
-  for (const [key, entry] of Object.entries(value)) {
-    if (key.trim() === '') {
-      throw new I18nError(`${path} contains an empty message key segment.`, 'I18N_INVALID_CATALOG');
-    }
-
-    if (typeof entry === 'string') {
-      snapshot[key] = entry;
-      continue;
-    }
-
-    if (isPlainObject(entry)) {
-      snapshot[key] = snapshotMessageTree(entry, `${path}.${key}`);
-      continue;
-    }
-
-    throw new I18nError(`${path}.${key} must be a string or nested message tree.`, 'I18N_INVALID_CATALOG');
-  }
-
-  return Object.freeze(snapshot);
 }
 
 function snapshotCatalogs(

--- a/packages/i18n/src/service.ts
+++ b/packages/i18n/src/service.ts
@@ -1,3 +1,4 @@
+import { isPlainObject, resolveCatalogMessage } from './catalog.js';
 import { snapshotI18nModuleOptions } from './options.js';
 import { I18nError } from './errors.js';
 import type {
@@ -6,25 +7,11 @@ import type {
   I18nFallbackLocales,
   I18nListFormatOptions,
   I18nLocale,
-  I18nMessageTree,
   I18nModuleOptions,
   I18nNumberFormatOptions,
   I18nRelativeTimeFormatOptions,
   I18nTranslateOptions,
 } from './types.js';
-
-function hasOwn(value: unknown, key: string): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && Object.hasOwn(value, key);
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
 
 function normalizeTranslationKey(key: unknown, namespace: unknown): string {
   if (typeof key !== 'string') {
@@ -119,29 +106,6 @@ function interpolate(message: string, values: I18nTranslateOptions['values']): s
     const value = values[name];
     return value === undefined || value === null ? '' : String(value);
   });
-}
-
-function resolveMessage(tree: I18nMessageTree | undefined, key: string): string | undefined {
-  if (tree === undefined) {
-    return undefined;
-  }
-
-  if (hasOwn(tree, key)) {
-    const direct = tree[key];
-    return typeof direct === 'string' ? direct : undefined;
-  }
-
-  let current: unknown = tree;
-
-  for (const part of key.split('.')) {
-    if (!hasOwn(current, part)) {
-      return undefined;
-    }
-
-    current = current[part];
-  }
-
-  return typeof current === 'string' ? current : undefined;
 }
 
 function pushUnique(locales: I18nLocale[], locale: I18nLocale | undefined): void {
@@ -376,7 +340,7 @@ export class I18nService {
     const locales = this.resolveLocales(options.locale);
 
     for (const locale of locales) {
-      const message = resolveMessage(this.options.catalogs?.[locale], resolvedKey);
+      const message = resolveCatalogMessage(this.options.catalogs?.[locale], resolvedKey);
 
       if (message !== undefined) {
         return interpolate(message, options.values);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,9 @@ importers:
       '@fluojs/http':
         specifier: workspace:^
         version: link:../http
+      '@fluojs/testing':
+        specifier: workspace:^
+        version: link:../testing
       '@fluojs/validation':
         specifier: workspace:^
         version: link:../validation


### PR DESCRIPTION
## Summary

Closes #2002.

Deduplicates internal `@fluojs/i18n` catalog lookup/snapshot helpers and closes the documented i18n module, ICU, remote cache, and Korean README parity gaps without changing public runtime behavior.

## Changes

- Added a shared internal `catalog.ts` helper for plain-object checks, immutable catalog snapshots, and direct/dot-path message lookup.
- Reused the shared helper from core service lookup, ICU fallback-locale detection, root option snapshotting, and loader catalog validation.
- Added regression coverage for `I18nModule.forRoot(...)` provider resolution, ICU non-string rich formatting failures, and remote cache version key separation.
- Aligned `README.ko.md` with the English stable `I18nError` error-code wording.

## Testing

- `pnpm --filter @fluojs/i18n test`
- `pnpm --filter @fluojs/i18n typecheck`
- `pnpm --filter @fluojs/i18n build`
- Changed-file LSP diagnostics: no diagnostics on changed TS files.

## Public export documentation

- No public exports or public API signatures were added or changed.
- The new helper module is internal and is not exported from any package entrypoint.

## Behavioral contract

- Contract-preserving refactor: fallback ordering, missing-message/default-value behavior, ICU error code behavior, loader catalog validation, and cache key semantics remain aligned with the documented contracts.
- New regression tests cover the documented module registration, ICU invalid-format, and remote cache version behavior.
- No changeset added: no consumer-visible behavior/API/package-surface change; this is internal dedupe plus test/docs parity.

## Platform consistency governance (SSOT)

- No platform contract docs or platform conformance claims changed.
- SSOT governance docs were not modified.
- The affected package README Korean mirror was aligned for the existing stable error-code wording.