### PR TITLE
Deduplicate websocket fetch runtime boundaries

### DIFF
--- a/.changeset/bright-websockets-boundaries.md
+++ b/.changeset/bright-websockets-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/websockets": patch
+---
+
+Deduplicate fetch-style runtime boundary validation for Bun, Deno, and Cloudflare Workers websocket adapters while preserving existing runtime diagnostics and lifecycle behavior.

--- a/packages/websockets/src/bun/bun-service.ts
+++ b/packages/websockets/src/bun/bun-service.ts
@@ -1,33 +1,33 @@
 import { Inject } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
+import type { HttpApplicationAdapter } from '@fluojs/http';
 import type { ApplicationLogger, CompiledModule, OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
-import type {
-  BunServerWebSocket,
-  BunWebSocketBinding,
-  BunWebSocketBindingHost,
-  BunWebSocketMessage,
-  BunServerLike,
-} from './bun-types.js';
-import type { HttpApplicationAdapter } from '@fluojs/http';
-
 import {
+  assertNoFetchStyleServerBackedGatewayOptIn,
+  discoverGatewayDescriptors,
   dispatchGatewayDisconnect,
   dispatchGatewayMessage,
-  discoverGatewayDescriptors,
   isFinitePositiveInteger,
   normalizeGatewayPath,
-  resolveGatewayInstance,
-  runGatewayHandlers,
   type ResolvedGatewayInstance,
+  resolveGatewayInstance,
+  resolveSupportedFetchStyleRealtimeCapability,
+  runGatewayHandlers,
 } from '../internal/shared.js';
 import { WEBSOCKET_OPTIONS_INTERNAL } from '../options-token.internal.js';
 import type {
   WebSocketGatewayDescriptor,
-  WebSocketUpgradeRejection,
   WebSocketRoomService,
+  WebSocketUpgradeRejection,
 } from '../types.js';
-import type { WebSocketModuleOptions } from './bun-types.js';
+import type {
+  BunServerLike,
+  BunServerWebSocket,
+  BunWebSocketBinding,
+  BunWebSocketBindingHost,
+  BunWebSocketMessage,WebSocketModuleOptions 
+} from './bun-types.js';
 
 interface BufferedDisconnectEvent {
   code: number;
@@ -69,61 +69,10 @@ const DEFAULT_MAX_WEBSOCKET_PAYLOAD_BYTES = 1_048_576;
 const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LIFECYCLE_LOG_CONTEXT = 'WebSocketGatewayLifecycleService';
 
-type FetchStyleRealtimeCapability = {
-  contract: 'raw-websocket-expansion';
-  kind: 'fetch-style';
-  mode?: 'request-upgrade';
-  reason: string;
-  support?: 'contract-only' | 'supported';
-  version?: 1;
-};
-
-type RealtimeCapability =
-  | FetchStyleRealtimeCapability
-  | {
-      kind: 'server-backed';
-      reason?: string;
-    }
-  | {
-      kind: 'unsupported';
-      mode?: 'no-op';
-      reason: string;
-    };
-
-type RealtimeAwareHttpApplicationAdapter = HttpApplicationAdapter & {
-  getRealtimeCapability?: () => RealtimeCapability;
-};
-
 function hasBunWebSocketBindingHost(
   adapter: HttpApplicationAdapter,
-): adapter is RealtimeAwareHttpApplicationAdapter & BunWebSocketBindingHost {
+): adapter is HttpApplicationAdapter & BunWebSocketBindingHost {
   return 'configureWebSocketBinding' in adapter && typeof adapter.configureWebSocketBinding === 'function';
-}
-
-function resolveSupportedFetchStyleRealtimeCapability(
-  adapter: RealtimeAwareHttpApplicationAdapter,
-): FetchStyleRealtimeCapability {
-  if (typeof adapter.getRealtimeCapability !== 'function') {
-    throw new Error(
-      'Bun WebSocket gateway bootstrap requires an HTTP adapter with getRealtimeCapability(). Use @fluojs/platform-bun together with @fluojs/websockets/bun.',
-    );
-  }
-
-  const capability = adapter.getRealtimeCapability();
-
-  if (capability.kind !== 'fetch-style' || capability.contract !== 'raw-websocket-expansion') {
-    throw new Error(
-      'Bun WebSocket gateway bootstrap requires a fetch-style raw-websocket-expansion realtime capability from the selected HTTP adapter.',
-    );
-  }
-
-  if (capability.support !== 'supported') {
-    throw new Error(
-      `Bun WebSocket gateway bootstrap requires supported fetch-style websocket hosting. ${capability.reason}`,
-    );
-  }
-
-  return capability;
 }
 
 function isHttpExceptionLike(error: unknown): error is { message: string; status: number } {
@@ -182,9 +131,13 @@ export class BunWebSocketGatewayLifecycleService
       return;
     }
 
-    this.assertNoServerBackedGatewayOptIn(descriptors);
+    assertNoFetchStyleServerBackedGatewayOptIn(descriptors, 'bun');
 
-    resolveSupportedFetchStyleRealtimeCapability(this.adapter);
+    resolveSupportedFetchStyleRealtimeCapability(this.adapter, {
+      packageSubpath: 'bun',
+      platformPackage: '@fluojs/platform-bun',
+      runtimeName: 'Bun',
+    });
 
     if (!hasBunWebSocketBindingHost(this.adapter)) {
       throw new Error(
@@ -194,20 +147,6 @@ export class BunWebSocketGatewayLifecycleService
 
     const bunAdapter = this.adapter as HttpApplicationAdapter & BunWebSocketBindingHost;
     bunAdapter.configureWebSocketBinding(this.createBinding(descriptors));
-  }
-
-  private assertNoServerBackedGatewayOptIn(
-    descriptors: readonly WebSocketGatewayDescriptor[],
-  ): void {
-    const descriptor = descriptors.find((entry) => entry.serverBacked !== undefined);
-
-    if (!descriptor) {
-      return;
-    }
-
-    throw new Error(
-      `@WebSocketGateway({ serverBacked }) is not supported on @fluojs/websockets/bun. Gateway path ${descriptor.path} must use the default fetch-style request-upgrade host instead.`,
-    );
   }
 
   async onApplicationShutdown(): Promise<void> {

--- a/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
+++ b/packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts
@@ -1,18 +1,20 @@
 import { Inject } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
+import type { HttpApplicationAdapter } from '@fluojs/http';
 import type { ApplicationLogger, CompiledModule, OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
-import type { HttpApplicationAdapter } from '@fluojs/http';
 
 import {
+  assertNoFetchStyleServerBackedGatewayOptIn,
+  discoverGatewayDescriptors,
   dispatchGatewayDisconnect,
   dispatchGatewayMessage,
-  discoverGatewayDescriptors,
   isFinitePositiveInteger,
   normalizeGatewayPath,
-  resolveGatewayInstance,
-  runGatewayHandlers,
   type ResolvedGatewayInstance,
+  resolveGatewayInstance,
+  resolveSupportedFetchStyleRealtimeCapability,
+  runGatewayHandlers,
 } from '../internal/shared.js';
 import { WEBSOCKET_OPTIONS_INTERNAL } from '../options-token.internal.js';
 import type { WebSocketGatewayDescriptor, WebSocketRoomService, WebSocketUpgradeRejection } from '../types.js';
@@ -58,61 +60,10 @@ const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LIFECYCLE_LOG_CONTEXT = 'WebSocketGatewayLifecycleService';
 const WEBSOCKET_OPEN_READY_STATE = 1;
 
-type FetchStyleRealtimeCapability = {
-  contract: 'raw-websocket-expansion';
-  kind: 'fetch-style';
-  mode?: 'request-upgrade';
-  reason: string;
-  support?: 'contract-only' | 'supported';
-  version?: 1;
-};
-
-type RealtimeCapability =
-  | FetchStyleRealtimeCapability
-  | {
-      kind: 'server-backed';
-      reason?: string;
-    }
-  | {
-      kind: 'unsupported';
-      mode?: 'no-op';
-      reason: string;
-    };
-
-type RealtimeAwareHttpApplicationAdapter = HttpApplicationAdapter & {
-  getRealtimeCapability?: () => RealtimeCapability;
-};
-
 function hasCloudflareWorkerWebSocketBindingHost(
   adapter: HttpApplicationAdapter,
-): adapter is RealtimeAwareHttpApplicationAdapter & CloudflareWorkerWebSocketBindingHost {
+): adapter is HttpApplicationAdapter & CloudflareWorkerWebSocketBindingHost {
   return 'configureWebSocketBinding' in adapter && typeof adapter.configureWebSocketBinding === 'function';
-}
-
-function resolveSupportedFetchStyleRealtimeCapability(
-  adapter: RealtimeAwareHttpApplicationAdapter,
-): FetchStyleRealtimeCapability {
-  if (typeof adapter.getRealtimeCapability !== 'function') {
-    throw new Error(
-      'Cloudflare Workers WebSocket gateway bootstrap requires an HTTP adapter with getRealtimeCapability(). Use @fluojs/platform-cloudflare-workers together with @fluojs/websockets/cloudflare-workers.',
-    );
-  }
-
-  const capability = adapter.getRealtimeCapability();
-
-  if (capability.kind !== 'fetch-style' || capability.contract !== 'raw-websocket-expansion') {
-    throw new Error(
-      'Cloudflare Workers WebSocket gateway bootstrap requires a fetch-style raw-websocket-expansion realtime capability from the selected HTTP adapter.',
-    );
-  }
-
-  if (capability.support !== 'supported') {
-    throw new Error(
-      `Cloudflare Workers WebSocket gateway bootstrap requires supported fetch-style websocket hosting. ${capability.reason}`,
-    );
-  }
-
-  return capability;
 }
 
 function isWebSocketUpgradeRequest(request: Request): boolean {
@@ -175,9 +126,13 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
       return;
     }
 
-    this.assertNoServerBackedGatewayOptIn(descriptors);
+    assertNoFetchStyleServerBackedGatewayOptIn(descriptors, 'cloudflare-workers');
 
-    resolveSupportedFetchStyleRealtimeCapability(this.adapter);
+    resolveSupportedFetchStyleRealtimeCapability(this.adapter, {
+      packageSubpath: 'cloudflare-workers',
+      platformPackage: '@fluojs/platform-cloudflare-workers',
+      runtimeName: 'Cloudflare Workers',
+    });
 
     if (!hasCloudflareWorkerWebSocketBindingHost(this.adapter)) {
       throw new Error(
@@ -186,20 +141,6 @@ export class CloudflareWorkersWebSocketGatewayLifecycleService
     }
 
     this.adapter.configureWebSocketBinding(this.createBinding(descriptors));
-  }
-
-  private assertNoServerBackedGatewayOptIn(
-    descriptors: readonly WebSocketGatewayDescriptor[],
-  ): void {
-    const descriptor = descriptors.find((entry) => entry.serverBacked !== undefined);
-
-    if (!descriptor) {
-      return;
-    }
-
-    throw new Error(
-      `@WebSocketGateway({ serverBacked }) is not supported on @fluojs/websockets/cloudflare-workers. Gateway path ${descriptor.path} must use the default fetch-style request-upgrade host instead.`,
-    );
   }
 
   async onApplicationShutdown(): Promise<void> {

--- a/packages/websockets/src/deno/deno-service.ts
+++ b/packages/websockets/src/deno/deno-service.ts
@@ -1,18 +1,20 @@
 import { Inject } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
+import type { HttpApplicationAdapter } from '@fluojs/http';
 import type { ApplicationLogger, CompiledModule, OnApplicationBootstrap, OnApplicationShutdown, OnModuleDestroy } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
-import type { HttpApplicationAdapter } from '@fluojs/http';
 
 import {
+  assertNoFetchStyleServerBackedGatewayOptIn,
+  discoverGatewayDescriptors,
   dispatchGatewayDisconnect,
   dispatchGatewayMessage,
-  discoverGatewayDescriptors,
   isFinitePositiveInteger,
   normalizeGatewayPath,
-  resolveGatewayInstance,
-  runGatewayHandlers,
   type ResolvedGatewayInstance,
+  resolveGatewayInstance,
+  resolveSupportedFetchStyleRealtimeCapability,
+  runGatewayHandlers,
 } from '../internal/shared.js';
 import { WEBSOCKET_OPTIONS_INTERNAL } from '../options-token.internal.js';
 import type { WebSocketGatewayDescriptor, WebSocketRoomService, WebSocketUpgradeRejection } from '../types.js';
@@ -58,61 +60,10 @@ const DEFAULT_WEBSOCKET_SHUTDOWN_TIMEOUT_MS = 5_000;
 const LIFECYCLE_LOG_CONTEXT = 'WebSocketGatewayLifecycleService';
 const WEBSOCKET_OPEN_READY_STATE = 1;
 
-type FetchStyleRealtimeCapability = {
-  contract: 'raw-websocket-expansion';
-  kind: 'fetch-style';
-  mode?: 'request-upgrade';
-  reason: string;
-  support?: 'contract-only' | 'supported';
-  version?: 1;
-};
-
-type RealtimeCapability =
-  | FetchStyleRealtimeCapability
-  | {
-      kind: 'server-backed';
-      reason?: string;
-    }
-  | {
-      kind: 'unsupported';
-      mode?: 'no-op';
-      reason: string;
-    };
-
-type RealtimeAwareHttpApplicationAdapter = HttpApplicationAdapter & {
-  getRealtimeCapability?: () => RealtimeCapability;
-};
-
 function hasDenoWebSocketBindingHost(
   adapter: HttpApplicationAdapter,
-): adapter is RealtimeAwareHttpApplicationAdapter & DenoWebSocketBindingHost {
+): adapter is HttpApplicationAdapter & DenoWebSocketBindingHost {
   return 'configureWebSocketBinding' in adapter && typeof adapter.configureWebSocketBinding === 'function';
-}
-
-function resolveSupportedFetchStyleRealtimeCapability(
-  adapter: RealtimeAwareHttpApplicationAdapter,
-): FetchStyleRealtimeCapability {
-  if (typeof adapter.getRealtimeCapability !== 'function') {
-    throw new Error(
-      'Deno WebSocket gateway bootstrap requires an HTTP adapter with getRealtimeCapability(). Use @fluojs/platform-deno together with @fluojs/websockets/deno.',
-    );
-  }
-
-  const capability = adapter.getRealtimeCapability();
-
-  if (capability.kind !== 'fetch-style' || capability.contract !== 'raw-websocket-expansion') {
-    throw new Error(
-      'Deno WebSocket gateway bootstrap requires a fetch-style raw-websocket-expansion realtime capability from the selected HTTP adapter.',
-    );
-  }
-
-  if (capability.support !== 'supported') {
-    throw new Error(
-      `Deno WebSocket gateway bootstrap requires supported fetch-style websocket hosting. ${capability.reason}`,
-    );
-  }
-
-  return capability;
 }
 
 function isWebSocketUpgradeRequest(request: Request): boolean {
@@ -184,9 +135,13 @@ export class DenoWebSocketGatewayLifecycleService
       return;
     }
 
-    this.assertNoServerBackedGatewayOptIn(descriptors);
+    assertNoFetchStyleServerBackedGatewayOptIn(descriptors, 'deno');
 
-    resolveSupportedFetchStyleRealtimeCapability(this.adapter);
+    resolveSupportedFetchStyleRealtimeCapability(this.adapter, {
+      packageSubpath: 'deno',
+      platformPackage: '@fluojs/platform-deno',
+      runtimeName: 'Deno',
+    });
 
     if (!hasDenoWebSocketBindingHost(this.adapter)) {
       throw new Error(
@@ -195,20 +150,6 @@ export class DenoWebSocketGatewayLifecycleService
     }
 
     this.adapter.configureWebSocketBinding(this.createBinding(descriptors));
-  }
-
-  private assertNoServerBackedGatewayOptIn(
-    descriptors: readonly WebSocketGatewayDescriptor[],
-  ): void {
-    const descriptor = descriptors.find((entry) => entry.serverBacked !== undefined);
-
-    if (!descriptor) {
-      return;
-    }
-
-    throw new Error(
-      `@WebSocketGateway({ serverBacked }) is not supported on @fluojs/websockets/deno. Gateway path ${descriptor.path} must use the default fetch-style request-upgrade host instead.`,
-    );
   }
 
   async onApplicationShutdown(): Promise<void> {

--- a/packages/websockets/src/internal/shared.ts
+++ b/packages/websockets/src/internal/shared.ts
@@ -1,6 +1,7 @@
 import type { MetadataPropertyKey, Token } from '@fluojs/core';
 import { getClassDiMetadata } from '@fluojs/core/internal';
-import type { Provider, Container } from '@fluojs/di';
+import type { Container, Provider } from '@fluojs/di';
+import type { FetchStyleHttpAdapterRealtimeCapability, HttpApplicationAdapter } from '@fluojs/http';
 import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
 
 import { getWebSocketGatewayMetadata, getWebSocketHandlerMetadataEntries } from '../metadata.js';
@@ -52,6 +53,13 @@ export type SharedWebSocketIncomingMessage =
   | Uint8Array[]
   | string;
 
+/** Runtime metadata used to validate fetch-style websocket adapter boundaries. */
+export interface FetchStyleRealtimeBoundaryOptions {
+  packageSubpath: string;
+  platformPackage: string;
+  runtimeName: string;
+}
+
 /**
  * Is finite positive integer.
  *
@@ -76,6 +84,61 @@ export function normalizeGatewayPath(path: string): string {
   const normalized = `/${path.replace(/^\/+/, '').replace(/\/+$/, '')}`;
 
   return normalized === '' ? '/' : normalized;
+}
+
+/**
+ * Ensures a fetch-style websocket module is paired with the matching HTTP platform adapter capability.
+ *
+ * @param adapter The HTTP adapter selected by the application runtime.
+ * @param options Runtime-specific package names used in actionable diagnostics.
+ * @returns The supported fetch-style realtime capability exposed by the adapter.
+ */
+export function resolveSupportedFetchStyleRealtimeCapability(
+  adapter: HttpApplicationAdapter,
+  options: FetchStyleRealtimeBoundaryOptions,
+): FetchStyleHttpAdapterRealtimeCapability {
+  if (typeof adapter.getRealtimeCapability !== 'function') {
+    throw new Error(
+      `${options.runtimeName} WebSocket gateway bootstrap requires an HTTP adapter with getRealtimeCapability(). Use ${options.platformPackage} together with @fluojs/websockets/${options.packageSubpath}.`,
+    );
+  }
+
+  const capability = adapter.getRealtimeCapability();
+
+  if (capability.kind !== 'fetch-style' || capability.contract !== 'raw-websocket-expansion') {
+    throw new Error(
+      `${options.runtimeName} WebSocket gateway bootstrap requires a fetch-style raw-websocket-expansion realtime capability from the selected HTTP adapter.`,
+    );
+  }
+
+  if (capability.support !== 'supported') {
+    throw new Error(
+      `${options.runtimeName} WebSocket gateway bootstrap requires supported fetch-style websocket hosting. ${capability.reason}`,
+    );
+  }
+
+  return capability;
+}
+
+/**
+ * Rejects server-backed gateway opt-in on fetch-style websocket runtime modules.
+ *
+ * @param descriptors Discovered gateway descriptors for the application.
+ * @param packageSubpath Runtime subpath used in diagnostics.
+ */
+export function assertNoFetchStyleServerBackedGatewayOptIn(
+  descriptors: readonly WebSocketGatewayDescriptor[],
+  packageSubpath: string,
+): void {
+  const descriptor = descriptors.find((entry) => entry.serverBacked !== undefined);
+
+  if (!descriptor) {
+    return;
+  }
+
+  throw new Error(
+    `@WebSocketGateway({ serverBacked }) is not supported on @fluojs/websockets/${packageSubpath}. Gateway path ${descriptor.path} must use the default fetch-style request-upgrade host instead.`,
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #2004.

Aligns a focused runtime-boundary subset for `@fluojs/websockets` by moving duplicated fetch-style adapter validation into one package-owned helper while preserving existing Bun, Deno, and Cloudflare Workers diagnostics and shutdown behavior.

## Changes

- Added shared fetch-style realtime capability validation in `packages/websockets/src/internal/shared.ts`.
- Reused the shared boundary helper from Bun, Deno, and Cloudflare Workers websocket lifecycle services.
- Reused a shared `serverBacked` rejection helper for fetch-style runtime subpaths.
- Added a patch changeset for `@fluojs/websockets`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/websockets... build`
- `pnpm --filter @fluojs/websockets typecheck`
- `pnpm --filter @fluojs/websockets test` (113 tests passed)
- `pnpm exec biome check packages/websockets/src/internal/shared.ts packages/websockets/src/bun/bun-service.ts packages/websockets/src/deno/deno-service.ts packages/websockets/src/cloudflare-workers/cloudflare-workers-service.ts .changeset/bright-websockets-boundaries.md`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No root public exports changed; the new helpers live in the package internal shared module and include TSDoc.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No behavior change is intended. Existing runtime boundary tests continue to cover Bun, Deno, and Cloudflare Workers capability validation, `serverBacked` rejection, and bounded shutdown cleanup.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed platform docs or package README claims changed. The PR preserves the existing websocket runtime SSOT and uses existing package regression tests rather than adding new documentation claims.