### PR TITLE
test(studio): cover viewer loading contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build scoped test closure
+        if: github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped' && needs.resolve-pr-verification-scope.outputs.test_package_names != ''
+        run: pnpm -r --if-present ${{ needs.resolve-pr-verification-scope.outputs.build_filter_args }} run build
+
       - name: Test (scoped PR package scripts)
         if: github.event_name == 'pull_request' && needs.resolve-pr-verification-scope.outputs.mode == 'scoped' && needs.resolve-pr-verification-scope.outputs.test_package_names != ''
         run: pnpm -r --if-present ${{ needs.resolve-pr-verification-scope.outputs.test_filter_args }} run test

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -12,10 +12,15 @@ import * as studio from './index.js';
 import { renderDiagnosticDocsUrl, renderDiagnostics, renderGraphSvg } from './viewer-rendering.js';
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const packageCommandTimeoutMs = 120_000;
+const packageCommandKillSignal: NodeJS.Signals = 'SIGTERM';
+
 function runPackageCommand(args: string[]): void {
   const result = spawnSync('pnpm', ['exec', ...args], {
     cwd: packageDir,
     encoding: 'utf8',
+    killSignal: packageCommandKillSignal,
+    timeout: packageCommandTimeoutMs,
   });
 
   expect(result.status, [result.stdout, result.stderr].filter(Boolean).join('\n')).toBe(0);
@@ -113,6 +118,13 @@ const snapshotFixture: PlatformShellSnapshot = {
   },
 };
 
+async function loadStudioViewer(): Promise<void> {
+  vi.resetModules();
+  document.body.innerHTML = '<div id="app"></div>';
+
+  await import('./main.js');
+}
+
 describe('parseStudioPayload', () => {
   it('publishes contract helpers from the root package entrypoint', () => {
     expect(studio.parseStudioPayload).toBeTypeOf('function');
@@ -129,9 +141,11 @@ describe('parseStudioPayload', () => {
   });
 
   it('parses platform snapshot payload', () => {
-    const parsed = parseStudioPayload(JSON.stringify(snapshotFixture));
+    const rawJson = JSON.stringify(snapshotFixture);
+    const parsed = parseStudioPayload(rawJson);
     expect(parsed.payload.snapshot?.components[0]?.id).toBe('redis.default');
     expect(parsed.payload.snapshot?.diagnostics[0]?.code).toBe('QUEUE_DEPENDENCY_NOT_READY');
+    expect(parsed.rawJson).toBe(rawJson);
   });
 
   it('rejects arbitrary JSON objects that are not Studio inspect artifacts', () => {
@@ -430,9 +444,7 @@ describe('parseStudioPayload', () => {
   });
 
   it('keeps viewer filter controls focused across search, readiness, and severity rerenders', async () => {
-    document.body.innerHTML = '<div id="app"></div>';
-
-    await import('./main.js');
+    await loadStudioViewer();
 
     const fileInput = document.querySelector<HTMLInputElement>('#file-input');
     expect(fileInput).not.toBeNull();
@@ -479,6 +491,32 @@ describe('parseStudioPayload', () => {
     const restoredSeverityInput = document.querySelector<HTMLInputElement>('#severity-warning');
     expect(document.activeElement).toBe(restoredSeverityInput);
     expect(restoredSeverityInput?.checked).toBe(true);
+  });
+
+  it('loads a dropped Studio JSON file into graph, summary, and diagnostics views', async () => {
+    await loadStudioViewer();
+
+    const dropZone = document.querySelector<HTMLElement>('#drop-zone');
+    expect(dropZone).not.toBeNull();
+
+    const dropEvent = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(dropEvent, 'dataTransfer', {
+      configurable: true,
+      value: {
+        files: [new File([JSON.stringify(snapshotFixture)], 'snapshot.json', { type: 'application/json' })],
+      },
+    });
+
+    dropZone?.dispatchEvent(dropEvent);
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('#graph-host')?.textContent).toContain('redis.default');
+    });
+
+    expect(document.querySelector('#drop-zone')?.textContent).toContain('Diagnostics file loaded successfully.');
+    expect(document.querySelector('section:nth-of-type(2)')?.textContent).toContain('components: 2');
+    expect(document.querySelector('section:nth-of-type(2)')?.textContent).toContain('diagnostics: 1');
+    expect(document.body.textContent).toContain('QUEUE_DEPENDENCY_NOT_READY');
   });
 
   it('build emits isolated published helper and file-first viewer entrypoints', () => {


### PR DESCRIPTION
## Summary

Closes #2003.

Adds targeted Studio regression coverage for documented viewer payload preservation, drag-and-drop loading, and bounded isolated build checks.

No changeset: this is test-only hardening for existing documented @fluojs/studio behavior with no public API, runtime behavior, package contents, or release metadata change.

## Changes

- Assert parseStudioPayload(rawJson) returns the exact original rawJson string for a supported snapshot payload.
- Add a happy-dom drop-event regression test that loads a JSON File through the viewer drop zone and verifies graph, summary, and diagnostics updates.
- Bound the isolated build child processes with spawnSync timeout and killSignal options.

## Testing

- pnpm --dir packages/studio test
- pnpm -r --filter @fluojs/studio... --if-present run build
- pnpm --dir packages/studio typecheck
- lsp_diagnostics packages/studio/src/contracts.test.ts: clean

## Public export documentation

- No public exports changed. Existing public export documentation remains unchanged.

## Behavioral contract

- No documented behavioral contracts were removed or changed.
- Regression tests now cover existing Studio contracts for raw JSON preservation, drag-and-drop file loading, and bounded build verification.

## Platform consistency governance (SSOT)

- No platform contract docs or SSOT mirror structures changed.
- Package README alignment remains unchanged; this PR only adds regression coverage for already documented Studio behavior.
