### PR TITLE
Fix auth persistence lifecycle diagnostics

### DIFF
--- a/.changeset/harden-auth-persistence-boundaries.md
+++ b/.changeset/harden-auth-persistence-boundaries.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/passport": patch
+"@fluojs/prisma": patch
+---
+
+Redact sensitive refresh-token backing store diagnostics in passport status surfaces and remove Prisma's static Node async-hooks import while preserving transaction context behavior.

--- a/.changeset/harden-auth-persistence-boundaries.md
+++ b/.changeset/harden-auth-persistence-boundaries.md
@@ -3,4 +3,4 @@
 "@fluojs/prisma": patch
 ---
 
-Redact sensitive refresh-token backing store diagnostics in passport status surfaces and remove Prisma's static Node async-hooks import while preserving transaction context behavior.
+Redact sensitive refresh-token backing store diagnostics in passport status surfaces and remove Prisma's static Node async-hooks import while preserving transaction context behavior where host AsyncLocalStorage is available. Prisma now rejects transaction boundaries and reports `transactionContext: 'unavailable'` instead of using a synchronous fallback that can lose context across async boundaries when the host cannot provide AsyncLocalStorage.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -235,7 +235,7 @@ Identity-link 결정을 모델링하려면 `createConservativeAccountLinkPolicy(
 
 ### Cookie auth preset
 - `CookieAuthModule`: 내장 cookie-auth preset의 모듈 진입점입니다.
-- `CookieAuthStrategy`, `COOKIE_AUTH_STRATEGY_NAME`, `COOKIE_AUTH_OPTIONS`, `DEFAULT_COOKIE_AUTH_OPTIONS`: Cookie strategy wiring token과 기본값입니다.
+- `CookieAuthStrategy`, `COOKIE_AUTH_STRATEGY_NAME`, `COOKIE_AUTH_OPTIONS`, `DEFAULT_COOKIE_AUTH_OPTIONS`, `DEFAULT_COOKIE_OPTIONS`: Cookie strategy wiring token, preset 기본값, response-cookie 기본값입니다.
 - `CookieAuthOptions`, `CookieAuthPresetConfig`, `CookieManagerConfig`, `CookieOptions`, `SetCookieOptions`: Cookie strategy 및 response cookie 설정 타입입니다.
 - `CookieManager`: HttpOnly access/refresh token cookie를 설정하고 제거하는 유틸리티입니다.
 - Cookie helper: `createCookieAuthPreset`, `createCookieAuthStrategyRegistration`, `createCookieManager`, `normalizeCookieAuthOptions`.
@@ -263,7 +263,7 @@ Identity-link 결정을 모델링하려면 `createConservativeAccountLinkPolicy(
 - `createPassportPlatformDiagnosticIssues(...)`: Empty registry, 누락된 default strategy, cookie preset readiness, refresh-token backing store readiness 문제에 대한 diagnostic issue를 생성합니다.
 - `PassportPlatformStatusSnapshot`, `PassportStatusAdapterInput`: Status helper input/output 계약입니다.
 
-`UseOptionalAuth`는 scope가 필요 없는 route에서만 credential 누락을 우회합니다. Scoped route에는 여전히 principal이 필요합니다. Passport.js bridge의 `redirect()`는 response를 commit하고 protected handler를 건너뛰며, `pass()`와 Passport action 없이 완료된 strategy는 인증 실패입니다.
+`UseOptionalAuth`는 scope가 필요 없는 route에서만 credential 누락을 우회합니다. Scoped route에는 여전히 principal이 필요합니다. Passport.js bridge의 `redirect()`는 response를 commit하고 protected handler를 건너뛰며, `pass()`와 Passport action 없이 완료된 strategy는 인증 실패입니다. Refresh-token backing store status 및 diagnostic surface는 readiness, health, details, diagnostic cause를 노출하기 전에 secret처럼 보이는 reason 문자열을 redact합니다.
 
 ## 관련 패키지
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -235,7 +235,7 @@ Use `createConservativeAccountLinkPolicy(...)` and `resolveAccountLinking(...)` 
 
 ### Cookie Auth Preset
 - `CookieAuthModule`: Module entry point for the built-in cookie-auth preset.
-- `CookieAuthStrategy`, `COOKIE_AUTH_STRATEGY_NAME`, `COOKIE_AUTH_OPTIONS`, `DEFAULT_COOKIE_AUTH_OPTIONS`: Cookie strategy wiring tokens and defaults.
+- `CookieAuthStrategy`, `COOKIE_AUTH_STRATEGY_NAME`, `COOKIE_AUTH_OPTIONS`, `DEFAULT_COOKIE_AUTH_OPTIONS`, `DEFAULT_COOKIE_OPTIONS`: Cookie strategy wiring tokens, preset defaults, and response-cookie defaults.
 - `CookieAuthOptions`, `CookieAuthPresetConfig`, `CookieManagerConfig`, `CookieOptions`, `SetCookieOptions`: Cookie strategy and response cookie configuration types.
 - `CookieManager`: Utility for setting and clearing HttpOnly access/refresh token cookies.
 - Cookie helpers: `createCookieAuthPreset`, `createCookieAuthStrategyRegistration`, `createCookieManager`, `normalizeCookieAuthOptions`.
@@ -263,7 +263,7 @@ Use `createConservativeAccountLinkPolicy(...)` and `resolveAccountLinking(...)` 
 - `createPassportPlatformDiagnosticIssues(...)`: Emits diagnostic issues for empty registries, missing default strategies, cookie preset readiness, and refresh-token backing store readiness.
 - `PassportPlatformStatusSnapshot`, `PassportStatusAdapterInput`: Status helper input/output contracts.
 
-`UseOptionalAuth` only bypasses missing credentials when no scopes are required; scoped routes still need a principal. Passport.js bridge `redirect()` commits the response and skips the protected handler, while `pass()` and strategy completion without a Passport action are authentication failures.
+`UseOptionalAuth` only bypasses missing credentials when no scopes are required; scoped routes still need a principal. Passport.js bridge `redirect()` commits the response and skips the protected handler, while `pass()` and strategy completion without a Passport action are authentication failures. Refresh-token backing store status and diagnostic surfaces redact secret-like reason strings before exposing readiness, health, details, or diagnostic causes.
 
 ## Related Packages
 

--- a/packages/passport/src/status.test.ts
+++ b/packages/passport/src/status.test.ts
@@ -68,6 +68,33 @@ describe('createPassportPlatformStatusSnapshot', () => {
       },
     });
   });
+
+  it('redacts sensitive refresh-token backing store details from status surfaces', () => {
+    const snapshot = createPassportPlatformStatusSnapshot({
+      defaultStrategy: 'refresh-token',
+      refreshTokenDependencyId: 'redis.auth-refresh',
+      refreshTokenEnabled: true,
+      refreshTokenStoreReady: false,
+      refreshTokenStoreReason: 'Redis refused password=hunter2 while loading refreshToken=raw-secret-token',
+      registeredStrategies: ['refresh-token'],
+    });
+
+    expect(snapshot.readiness.reason).toBe(
+      'Refresh token backing store is unavailable; sensitive diagnostic detail was redacted.',
+    );
+    expect(snapshot.health.reason).toBe(
+      'Refresh token backing store is unavailable; sensitive diagnostic detail was redacted.',
+    );
+    expect(snapshot.details).toMatchObject({
+      presets: {
+        refreshToken: {
+          backingStore: {
+            reason: 'Refresh token backing store is unavailable; sensitive diagnostic detail was redacted.',
+          },
+        },
+      },
+    });
+  });
 });
 
 describe('createPassportPlatformDiagnosticIssues', () => {
@@ -102,5 +129,19 @@ describe('createPassportPlatformDiagnosticIssues', () => {
 
     expect(issues).toHaveLength(2);
     expect(issues.every((issue) => issue.severity === 'error')).toBe(true);
+  });
+
+  it('redacts sensitive refresh-token backing store diagnostic causes', () => {
+    const issues = createPassportPlatformDiagnosticIssues({
+      refreshTokenEnabled: true,
+      refreshTokenStoreReady: false,
+      refreshTokenStoreReason: 'connection failed with authorization bearer secret-token',
+      registeredStrategies: ['refresh-token'],
+    });
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.cause).toBe(
+      'Refresh token backing store is unavailable; sensitive diagnostic detail was redacted.',
+    );
   });
 });

--- a/packages/passport/src/status.ts
+++ b/packages/passport/src/status.ts
@@ -55,6 +55,18 @@ function isRefreshTokenStoreReady(input: PassportStatusAdapterInput): boolean {
   return input.refreshTokenStoreReady ?? true;
 }
 
+function redactSensitiveDiagnosticReason(reason: string | undefined): string | undefined {
+  if (reason === undefined) {
+    return undefined;
+  }
+
+  if (/(accessToken|api[-_ ]?key|authorization|bearer|cookie|credential|password|passwd|refreshToken|secret|token\s*[:=])/i.test(reason)) {
+    return 'Refresh token backing store is unavailable; sensitive diagnostic detail was redacted.';
+  }
+
+  return reason;
+}
+
 function collectReadinessReasons(input: PassportStatusAdapterInput): string[] {
   const reasons: string[] = [];
 
@@ -71,7 +83,7 @@ function collectReadinessReasons(input: PassportStatusAdapterInput): string[] {
   }
 
   if (!isRefreshTokenStoreReady(input)) {
-    reasons.push(input.refreshTokenStoreReason ?? 'Refresh token backing store is unavailable.');
+    reasons.push(redactSensitiveDiagnosticReason(input.refreshTokenStoreReason) ?? 'Refresh token backing store is unavailable.');
   }
 
   return reasons;
@@ -142,7 +154,7 @@ export function createPassportPlatformStatusSnapshot(input: PassportStatusAdapte
         refreshToken: {
           backingStore: {
             dependencyId: input.refreshTokenDependencyId,
-            reason: input.refreshTokenStoreReason,
+            reason: redactSensitiveDiagnosticReason(input.refreshTokenStoreReason),
             ready: isRefreshTokenStoreReady(input),
           },
           enabled: input.refreshTokenEnabled ?? false,
@@ -218,7 +230,7 @@ export function createPassportPlatformDiagnosticIssues(input: PassportStatusAdap
     issues.push({
       code: 'AUTH_PASSPORT_REFRESH_TOKEN_BACKING_STORE_NOT_READY',
       componentId,
-      cause: input.refreshTokenStoreReason,
+      cause: redactSensitiveDiagnosticReason(input.refreshTokenStoreReason),
       dependsOn: input.refreshTokenDependencyId ? [input.refreshTokenDependencyId] : undefined,
       fixHint: 'Restore refresh token backing store readiness, or disable refresh-token strategy for this environment.',
       message: 'Refresh token strategy is enabled, but its backing dependency is not ready.',

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -208,6 +208,10 @@ defineModule(ManualPrismaModule, {
 - `requestTransaction(fn, signal?, options?): Promise<T>`
   - HTTP 요청 라이프사이클에 특화된 트랜잭션 경계를 실행합니다. Abort를 인식하고, shutdown 중에는 disconnect 전에 열린 요청 트랜잭션을 drain하며, Prisma client가 `signal` 옵션을 거부하면 해당 옵션 없이 재시도합니다. `transaction()`과 마찬가지로 중첩 호출은 활성 트랜잭션 컨텍스트를 재사용하고, 트랜잭션 설정을 조용히 무시하지 않도록 중첩 옵션을 거부합니다.
 
+### `PrismaTransactionInterceptor`
+
+- 기본 이름 없는 `PrismaService` 등록을 위한 HTTP interceptor입니다. 요청 handler를 `PrismaService.requestTransaction(...)`으로 감싸 downstream `current()` 호출이 같은 transaction client를 공유하게 합니다.
+
 ### `PRISMA_CLIENT` (Token)
 
 원시 `PrismaClient` 인스턴스를 위한 주입 토큰입니다.

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -167,6 +167,8 @@ PrismaModule.forRootAsync({
 
 하나의 컴파일된 애플리케이션 안에서는 하위 provider가 동일하게 resolve된 `PrismaService`, ALS 트랜잭션 컨텍스트, 라이프사이클 관리 대상 클라이언트를 공유합니다. 서로 다른 애플리케이션 컨테이너는 독립된 factory 결과를 받으므로 `$connect` / `$disconnect` 소유권과 요청 트랜잭션 상태가 격리됩니다.
 
+트랜잭션 경계에는 호스트가 제공하는 `AsyncLocalStorage` 지원이 필요합니다. `@fluojs/prisma`는 런타임이 노출하는 `globalThis.AsyncLocalStorage` 또는 Node.js의 `process.getBuiltinModule('node:async_hooks')` 호스트 경계를 통해 이를 resolve합니다. 두 경로 모두 사용할 수 없으면 동기 stack fallback으로 async boundary 사이의 `current()`를 잃는 대신, Prisma 트랜잭션을 열기 전에 `transaction()`과 `requestTransaction()`이 예외를 던집니다. 이 상태는 `createPlatformStatusSnapshot().details.transactionContext`에 `unavailable`로 보고됩니다.
+
 ### 수동 모듈 조합
 
 `PrismaModule.forRoot(...)` / `forRootAsync(...)`를 사용해 Prisma를 등록합니다. 커스텀 `defineModule(...)` 등록 안에서 Prisma 지원을 조합해야 할 때도 동일한 모듈 entrypoint를 import해서 사용하세요.

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -208,6 +208,10 @@ defineModule(ManualPrismaModule, {
 - `requestTransaction(fn, signal?, options?): Promise<T>`
   - Specialized transaction boundary for HTTP request lifecycles. It is abort-aware, drains during shutdown before disconnect, and retries without `signal` when a Prisma client rejects that option. Like `transaction()`, nested calls reuse the active transaction context and reject nested options to avoid silently ignoring transaction settings.
 
+### `PrismaTransactionInterceptor`
+
+- HTTP interceptor for the default unnamed `PrismaService` registration. It wraps a request handler in `PrismaService.requestTransaction(...)` so downstream `current()` calls share the same transaction client.
+
 ### `PRISMA_CLIENT` (Token)
 
 Injectable token for the raw `PrismaClient` instance.

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -167,6 +167,8 @@ PrismaModule.forRootAsync({
 
 Within one compiled application, downstream providers share the same resolved `PrismaService`, ALS transaction context, and lifecycle-managed client. Separate application containers receive independent factory results, so `$connect` / `$disconnect` ownership and request transaction state remain isolated.
 
+Transaction boundaries require host-provided `AsyncLocalStorage` support. `@fluojs/prisma` resolves it through `globalThis.AsyncLocalStorage` when a runtime exposes one, or through the host's `process.getBuiltinModule('node:async_hooks')` boundary on Node.js. If neither path is available, `transaction()` and `requestTransaction()` reject before opening a Prisma transaction instead of using a synchronous stack fallback that would lose `current()` across async boundaries; `createPlatformStatusSnapshot().details.transactionContext` reports `unavailable` in that state.
+
 ### Manual Module Composition
 
 Use `PrismaModule.forRoot(...)` / `forRootAsync(...)` to register Prisma. When you need to compose Prisma support inside a custom `defineModule(...)` registration, import the module entrypoint there as well.

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -379,6 +379,59 @@ describe('@fluojs/prisma', () => {
     await app.close();
   });
 
+  it('rejects transaction boundaries instead of using a synchronous context fallback when ALS is unavailable', async () => {
+    const host = globalThis as typeof globalThis & { AsyncLocalStorage?: unknown };
+    const originalAsyncLocalStorage = host.AsyncLocalStorage;
+    const originalGetBuiltinModule = process.getBuiltinModule.bind(process);
+    const getBuiltinModuleSpy = vi.spyOn(process, 'getBuiltinModule').mockImplementation(((id: string) => {
+      if (id === 'node:async_hooks') {
+        return {};
+      }
+
+      return originalGetBuiltinModule(id as never);
+    }) as typeof process.getBuiltinModule);
+    let transactionCalls = 0;
+    const transactionClient = { kind: 'transaction' as const };
+    const client = {
+      async $connect() {},
+      async $disconnect() {},
+      async $transaction<T>(callback: (value: typeof transactionClient) => Promise<T>): Promise<T> {
+        transactionCalls += 1;
+        return callback(transactionClient);
+      },
+    };
+
+    host.AsyncLocalStorage = undefined;
+
+    try {
+      const prisma = new PrismaService<typeof client, typeof transactionClient>(client);
+      await prisma.onModuleInit();
+
+      expect(prisma.createPlatformStatusSnapshot().details).toMatchObject({ transactionContext: 'unavailable' });
+      expect(prisma.createPlatformStatusSnapshot().readiness).toEqual({
+        critical: true,
+        reason: 'Prisma transaction context requires AsyncLocalStorage support from the host runtime.',
+        status: 'not-ready',
+      });
+      await expect(prisma.transaction(async () => prisma.current())).rejects.toThrow(
+        'Prisma transaction context requires AsyncLocalStorage support from the host runtime.',
+      );
+      await expect(prisma.requestTransaction(async () => prisma.current())).rejects.toThrow(
+        'Prisma transaction context requires AsyncLocalStorage support from the host runtime.',
+      );
+      expect(prisma.createPlatformStatusSnapshot().details).toMatchObject({ activeRequestTransactions: 0 });
+      expect(transactionCalls).toBe(0);
+    } finally {
+      if (originalAsyncLocalStorage === undefined) {
+        delete host.AsyncLocalStorage;
+      } else {
+        host.AsyncLocalStorage = originalAsyncLocalStorage;
+      }
+
+      getBuiltinModuleSpy.mockRestore();
+    }
+  });
+
   it('rolls back open request transactions before disconnect on shutdown', async () => {
     const events: string[] = [];
     const transactionClient = {};

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -1025,6 +1025,38 @@ describe('@fluojs/prisma', () => {
     expect(snapshot.readiness.status).toBe('not-ready');
     expect(snapshot.health.status).toBe('degraded');
   });
+
+  it('marks stopped state as not-ready and unhealthy after disconnect', async () => {
+    const events: string[] = [];
+    const client = {
+      async $connect() {
+        events.push('connect');
+      },
+      async $disconnect() {
+        events.push('disconnect');
+      },
+      async $transaction<T>(callback: (value: Record<string, never>) => Promise<T>): Promise<T> {
+        return callback({});
+      },
+    };
+    const prisma = new PrismaService<typeof client>(client);
+
+    await prisma.onModuleInit();
+    await prisma.onApplicationShutdown();
+
+    const snapshot = prisma.createPlatformStatusSnapshot();
+    expect(events).toEqual(['connect', 'disconnect']);
+    expect(snapshot.readiness).toEqual({
+      critical: true,
+      reason: 'Prisma integration is stopped.',
+      status: 'not-ready',
+    });
+    expect(snapshot.health).toEqual({
+      reason: 'Prisma integration has been disconnected.',
+      status: 'unhealthy',
+    });
+    expect(snapshot.details).toMatchObject({ lifecycleState: 'stopped' });
+  });
 });
 
 describe('PrismaModule.forRootAsync', () => {

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -20,6 +20,8 @@ import type {
 const NESTED_TRANSACTION_OPTIONS_NOT_SUPPORTED_ERROR =
   'Nested Prisma transaction options are not supported because the active transaction context is reused.';
 const REQUEST_TRANSACTION_UNAVAILABLE_ERROR = 'Prisma request transactions are not available during shutdown.';
+const TRANSACTION_CONTEXT_UNAVAILABLE_ERROR =
+  'Prisma transaction context requires AsyncLocalStorage support from the host runtime.';
 
 interface PrismaServiceOptions {
   strictTransactions: boolean;
@@ -44,6 +46,7 @@ type TransactionContext<TTransactionClient> = {
 };
 
 interface TransactionContextStore<TTransactionClient> {
+  readonly kind: 'als' | 'unavailable';
   getStore(): TransactionContext<TTransactionClient> | undefined;
   run<T>(context: TransactionContext<TTransactionClient>, callback: () => T): T;
 }
@@ -66,21 +69,33 @@ type AsyncLocalStorageResolutionHost = typeof globalThis & {
   };
 };
 
-class StackTransactionContextStore<TTransactionClient> implements TransactionContextStore<TTransactionClient> {
-  private readonly contexts: Array<TransactionContext<TTransactionClient>> = [];
+class AsyncLocalStorageTransactionContextStore<TTransactionClient> implements TransactionContextStore<TTransactionClient> {
+  readonly kind = 'als' as const;
+
+  private readonly storage: AsyncContextStore<TransactionContext<TTransactionClient>>;
+
+  constructor(AsyncLocalStorage: AsyncLocalStorageConstructor) {
+    this.storage = new AsyncLocalStorage<TransactionContext<TTransactionClient>>();
+  }
 
   getStore(): TransactionContext<TTransactionClient> | undefined {
-    return this.contexts.at(-1);
+    return this.storage.getStore();
   }
 
   run<T>(context: TransactionContext<TTransactionClient>, callback: () => T): T {
-    this.contexts.push(context);
+    return this.storage.run(context, callback);
+  }
+}
 
-    try {
-      return callback();
-    } finally {
-      this.contexts.pop();
-    }
+class UnavailableTransactionContextStore<TTransactionClient> implements TransactionContextStore<TTransactionClient> {
+  readonly kind = 'unavailable' as const;
+
+  getStore(): TransactionContext<TTransactionClient> | undefined {
+    return undefined;
+  }
+
+  run<T>(_context: TransactionContext<TTransactionClient>, _callback: () => T): T {
+    throw new Error(TRANSACTION_CONTEXT_UNAVAILABLE_ERROR);
   }
 }
 
@@ -98,10 +113,10 @@ function createTransactionContextStore<TTransactionClient>(): TransactionContext
   const AsyncLocalStorage = resolveAsyncLocalStorageConstructor();
 
   if (typeof AsyncLocalStorage === 'function') {
-    return new AsyncLocalStorage<TransactionContext<TTransactionClient>>();
+    return new AsyncLocalStorageTransactionContextStore<TTransactionClient>(AsyncLocalStorage);
   }
 
-  return new StackTransactionContextStore<TTransactionClient>();
+  return new UnavailableTransactionContextStore<TTransactionClient>();
 }
 
 /**
@@ -167,6 +182,8 @@ export class PrismaService<
       return fn();
     }
 
+    this.assertTransactionContextAvailable();
+
     const deferredRequestTransactionHandles = new Set<ActiveRequestTransactionHandle>();
 
     try {
@@ -220,6 +237,7 @@ export class PrismaService<
       supportsDisconnect: typeof this.client.$disconnect === 'function',
       supportsTransaction: typeof this.client.$transaction === 'function',
       transactionAbortSignalSupport: this.transactionAbortSignalSupport,
+      transactionContext: this.transactions.kind,
     });
   }
 
@@ -319,6 +337,8 @@ export class PrismaService<
       return fn();
     }
 
+    this.assertTransactionContextAvailable();
+
     return run(
       (transactionClient) => this.transactions.run({ client: transactionClient, requestAbortSignal: signal }, fn),
       options,
@@ -365,6 +385,12 @@ export class PrismaService<
   private assertRequestTransactionsAvailable(): void {
     if (this.lifecycleState === 'shutting-down' || this.lifecycleState === 'stopped') {
       throw new Error(REQUEST_TRANSACTION_UNAVAILABLE_ERROR);
+    }
+  }
+
+  private assertTransactionContextAvailable(): void {
+    if (this.transactions.kind === 'unavailable') {
+      throw new Error(TRANSACTION_CONTEXT_UNAVAILABLE_ERROR);
     }
   }
 

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -1,5 +1,3 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-
 import {
   createAbortError,
   createRequestAbortContext,
@@ -45,6 +43,67 @@ type TransactionContext<TTransactionClient> = {
   requestAbortSignal?: AbortSignal;
 };
 
+interface TransactionContextStore<TTransactionClient> {
+  getStore(): TransactionContext<TTransactionClient> | undefined;
+  run<T>(context: TransactionContext<TTransactionClient>, callback: () => T): T;
+}
+
+type AsyncContextStore<TContext> = {
+  getStore(): TContext | undefined;
+  run<T>(context: TContext, callback: () => T): T;
+};
+
+type AsyncLocalStorageConstructor = new <TContext>() => AsyncContextStore<TContext>;
+
+type NodeAsyncHooksModule = {
+  AsyncLocalStorage?: AsyncLocalStorageConstructor;
+};
+
+type AsyncLocalStorageResolutionHost = typeof globalThis & {
+  AsyncLocalStorage?: AsyncLocalStorageConstructor;
+  process?: {
+    getBuiltinModule?(id: 'node:async_hooks'): NodeAsyncHooksModule;
+  };
+};
+
+class StackTransactionContextStore<TTransactionClient> implements TransactionContextStore<TTransactionClient> {
+  private readonly contexts: Array<TransactionContext<TTransactionClient>> = [];
+
+  getStore(): TransactionContext<TTransactionClient> | undefined {
+    return this.contexts.at(-1);
+  }
+
+  run<T>(context: TransactionContext<TTransactionClient>, callback: () => T): T {
+    this.contexts.push(context);
+
+    try {
+      return callback();
+    } finally {
+      this.contexts.pop();
+    }
+  }
+}
+
+function resolveAsyncLocalStorageConstructor(
+  host: AsyncLocalStorageResolutionHost = globalThis,
+): AsyncLocalStorageConstructor | undefined {
+  if (typeof host.AsyncLocalStorage === 'function') {
+    return host.AsyncLocalStorage;
+  }
+
+  return host.process?.getBuiltinModule?.('node:async_hooks').AsyncLocalStorage;
+}
+
+function createTransactionContextStore<TTransactionClient>(): TransactionContextStore<TTransactionClient> {
+  const AsyncLocalStorage = resolveAsyncLocalStorageConstructor();
+
+  if (typeof AsyncLocalStorage === 'function') {
+    return new AsyncLocalStorage<TransactionContext<TTransactionClient>>();
+  }
+
+  return new StackTransactionContextStore<TTransactionClient>();
+}
+
 /**
  * Prisma runtime facade that owns lifecycle hooks and transaction context access.
  *
@@ -60,7 +119,7 @@ export class PrismaService<
 >
   implements PrismaHandleProvider<TClient, TTransactionClient, TTransactionOptions>, OnModuleInit, OnApplicationShutdown
 {
-  private readonly transactions = new AsyncLocalStorage<TransactionContext<TTransactionClient>>();
+  private readonly transactions = createTransactionContextStore<TTransactionClient>();
   private readonly activeRequestTransactions = new Set<ActiveRequestTransaction>();
   private transactionAbortSignalSupport: TransactionAbortSignalSupport = 'unknown';
   private lifecycleState: 'created' | 'ready' | 'shutting-down' | 'stopped' = 'created';

--- a/packages/prisma/src/status.ts
+++ b/packages/prisma/src/status.ts
@@ -14,6 +14,7 @@ type PrismaPlatformStatusSnapshotInput = {
   supportsDisconnect: boolean;
   supportsTransaction: boolean;
   transactionAbortSignalSupport: 'unknown' | 'supported' | 'unsupported';
+  transactionContext?: 'als' | 'unavailable';
 };
 
 function createReadiness(input: PrismaPlatformStatusSnapshotInput): PlatformReadinessReport {
@@ -45,6 +46,14 @@ function createReadiness(input: PrismaPlatformStatusSnapshotInput): PlatformRead
     return {
       critical: true,
       reason: 'Prisma strictTransactions is enabled but client.$transaction is unavailable.',
+      status: 'not-ready',
+    };
+  }
+
+  if (input.supportsTransaction && input.transactionContext === 'unavailable') {
+    return {
+      critical: true,
+      reason: 'Prisma transaction context requires AsyncLocalStorage support from the host runtime.',
       status: 'not-ready',
     };
   }
@@ -84,6 +93,8 @@ function createHealth(input: PrismaPlatformStatusSnapshotInput): PlatformHealthR
 export function createPrismaPlatformStatusSnapshot(
   input: PrismaPlatformStatusSnapshotInput,
 ): PersistencePlatformStatusSnapshot {
+  const transactionContext = input.transactionContext ?? 'als';
+
   return {
     details: {
       activeRequestTransactions: input.activeRequestTransactions,
@@ -93,7 +104,7 @@ export function createPrismaPlatformStatusSnapshot(
       supportsDisconnect: input.supportsDisconnect,
       supportsTransaction: input.supportsTransaction,
       transactionAbortSignalSupport: input.transactionAbortSignalSupport,
-      transactionContext: 'als',
+      transactionContext,
     },
     health: createHealth(input),
     ownership: {


### PR DESCRIPTION
## Summary

Harden auth/persistence package lifecycle boundaries from #2017.

Linked context: Refs #2017

## Scope note

This PR resolves the Passport diagnostic redaction and Prisma runtime-boundary/status documentation findings from #2017. The Redis findings listed in #2017 remain outside this PR and should be handled separately before the issue is closed.

## Changes

- Redact secret-like refresh-token backing store failure reasons before passport readiness, health, details, or diagnostic causes expose them.
- Remove Prisma's static root import of `node:async_hooks` by resolving host async context support through the runtime boundary.
- Reject Prisma transaction boundaries and report `transactionContext: 'unavailable'` when the host cannot provide AsyncLocalStorage, instead of falling back to a synchronous stack that loses context across async boundaries.
- Add Prisma stopped snapshot regression coverage and align Passport/Prisma EN/KO README public API/contract notes.
- Add a patch changeset for `@fluojs/passport` and `@fluojs/prisma`.

## Testing

- `pnpm --filter @fluojs/passport test`
- `pnpm --filter @fluojs/prisma test`
- `pnpm --filter @fluojs/passport typecheck`
- `pnpm --filter @fluojs/prisma typecheck`
- `pnpm --filter @fluojs/passport build`
- `pnpm --filter @fluojs/prisma build`
- `pnpm exec biome lint packages/passport/src/status.ts packages/passport/src/status.test.ts packages/prisma/src/service.ts packages/prisma/src/module.test.ts packages/passport/README.md packages/passport/README.ko.md packages/prisma/README.md packages/prisma/README.ko.md .changeset/harden-auth-persistence-boundaries.md`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- LSP diagnostics clean on changed TS files

Note: full `pnpm lint` currently reports unrelated existing warnings in packages/config and packages/cqrs; changed-file lint passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added; README public API inventories were aligned for existing exports.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or conformance claims were changed.
