### PR TITLE
Align validation and serialization contracts

### DIFF
--- a/.changeset/bright-contracts-smile.md
+++ b/.changeset/bright-contracts-smile.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/serialization": patch
+"@fluojs/validation": patch
+---
+
+Avoid installing `Symbol.metadata` during validation and serialization imports, export the public `TransformFunction` type from serialization, and add regression coverage for documented validation and HTTP serialization contracts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "20"
+          package-manager-cache: false
 
       - name: Verify changeset release lane
         run: node tooling/release/verify-changeset-release-lane.mjs --lane=stable --base-ref=origin/${{ github.base_ref }}

--- a/packages/serialization/README.ko.md
+++ b/packages/serialization/README.ko.md
@@ -126,6 +126,7 @@ Decorated metadata가 없는 class instance도 재귀적으로 순회하므로, 
 - **데코레이터**: `Expose`, `Exclude`, `Transform`
 - **엔진**: `serialize(value)`는 class instance, 배열, plain object, mixed graph를 재귀적으로 순회하며, 직접 transform하지 않은 opaque built-in 및 non-JSON leaf 값은 보존합니다.
 - **HTTP 통합**: `SerializerInterceptor`는 아직 commit되지 않은 handler 결과를 직렬화하고, response가 이미 commit된 뒤에는 handler 소유 값을 그대로 반환합니다.
+- **타입**: `TransformFunction`은 `Transform(...)`에 전달하는 callback 타입으로 root entrypoint에서 export됩니다.
 
 `Expose`는 class와 field에 적용할 수 있습니다. `Exclude`와 `Transform`은 field에 적용합니다.
 

--- a/packages/serialization/README.md
+++ b/packages/serialization/README.md
@@ -126,6 +126,7 @@ Undecorated class instances are still traversed recursively, so decorated nested
 - **Decorators**: `Expose`, `Exclude`, `Transform`
 - **Engine**: `serialize(value)` recursively walks class instances, arrays, plain objects, and mixed graphs while preserving opaque built-ins and non-JSON leaf values unless you transform them
 - **HTTP integration**: `SerializerInterceptor` serializes uncommitted handler results and returns handler-owned values unchanged after the response has already been committed
+- **Types**: `TransformFunction` is exported from the root entrypoint for callbacks passed to `Transform(...)`
 
 `Expose` can be applied to classes and fields. `Exclude` and `Transform` apply to fields.
 

--- a/packages/serialization/src/import-side-effects.test.ts
+++ b/packages/serialization/src/import-side-effects.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const symbolConstructor = Symbol as typeof Symbol & { metadata?: symbol };
+const originalMetadata = symbolConstructor.metadata;
+
+function clearSymbolMetadata(): void {
+  Reflect.deleteProperty(Symbol, 'metadata');
+}
+
+function restoreSymbolMetadata(): void {
+  if (originalMetadata === undefined) {
+    clearSymbolMetadata();
+    return;
+  }
+
+  Object.defineProperty(Symbol, 'metadata', {
+    configurable: true,
+    value: originalMetadata,
+  });
+}
+
+describe('serialization import side effects', () => {
+  afterEach(() => {
+    restoreSymbolMetadata();
+  });
+
+  it('does not install Symbol.metadata when the public entrypoint is imported', async () => {
+    vi.resetModules();
+    clearSymbolMetadata();
+
+    await import('./index.js');
+
+    expect(symbolConstructor.metadata).toBeUndefined();
+  });
+});

--- a/packages/serialization/src/index.ts
+++ b/packages/serialization/src/index.ts
@@ -1,5 +1,6 @@
 export * from './decorators/exclude.js';
 export * from './decorators/expose.js';
 export * from './decorators/transform.js';
+export type { TransformFunction } from './metadata.js';
 export * from './serialize.js';
 export * from './serializer-interceptor.js';

--- a/packages/serialization/src/metadata.ts
+++ b/packages/serialization/src/metadata.ts
@@ -1,5 +1,5 @@
-import { type MetadataPropertyKey } from '@fluojs/core';
-import { ensureMetadataSymbol, getOwnStandardConstructorMetadataBag } from '@fluojs/core/internal';
+import type { MetadataPropertyKey } from '@fluojs/core';
+import { getOwnStandardConstructorMetadataBag } from '@fluojs/core/internal';
 
 type StandardMetadataBag = Record<PropertyKey, unknown>;
 
@@ -26,8 +26,6 @@ export interface SerializationFieldMetadata {
 
 const standardSerializationClassMetadataKey = Symbol.for('fluo.standard.serialization.class');
 const standardSerializationFieldMetadataKey = Symbol.for('fluo.standard.serialization.field');
-
-ensureMetadataSymbol();
 
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
   if (metadata === null || metadata === undefined) {
@@ -117,10 +115,13 @@ export function updateFieldSerializationMetadata(
  * @returns The get class serialization options result.
  */
 export function getClassSerializationOptions(constructor: Function): ClassSerializationOptions {
-  return getConstructorMetadataBags(constructor).reduce<ClassSerializationOptions>((options, bag) => ({
-    ...options,
-    ...(bag[standardSerializationClassMetadataKey] as ClassSerializationOptions | undefined),
-  }), {});
+  const options: ClassSerializationOptions = {};
+
+  for (const bag of getConstructorMetadataBags(constructor)) {
+    Object.assign(options, bag[standardSerializationClassMetadataKey] as ClassSerializationOptions | undefined);
+  }
+
+  return options;
 }
 
 /**

--- a/packages/serialization/src/serializer-interceptor.test.ts
+++ b/packages/serialization/src/serializer-interceptor.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CallHandler, FrameworkResponse, InterceptorContext, RequestContext } from '@fluojs/http';
+import {
+  Controller,
+  createDispatcher,
+  createHandlerMapping,
+  Get,
+  UseInterceptors,
+} from '@fluojs/http';
+import type { CallHandler, FrameworkRequest, FrameworkResponse, InterceptorContext, RequestContext } from '@fluojs/http';
 
 import { Exclude } from './decorators/exclude.js';
 import { SerializerInterceptor } from './serializer-interceptor.js';
@@ -19,6 +26,60 @@ function createInterceptorContext(response: Partial<FrameworkResponse> = {}): In
       } as FrameworkResponse,
     } as RequestContext,
   } as InterceptorContext;
+}
+
+function createRequest(path: string): FrameworkRequest {
+  return {
+    body: undefined,
+    cookies: {},
+    headers: {},
+    method: 'GET',
+    params: {},
+    path,
+    query: {},
+    raw: {},
+    url: path,
+  };
+}
+
+function createResponse(): FrameworkResponse & { body?: unknown } {
+  return {
+    committed: false,
+    headers: {},
+    redirect(status: number, location: string) {
+      this.setStatus(status);
+      this.setHeader('Location', location);
+      this.committed = true;
+    },
+    send(body: unknown) {
+      this.body = body;
+      this.committed = true;
+    },
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+    },
+    setStatus(code: number) {
+      this.statusCode = code;
+    },
+    statusCode: undefined,
+  };
+}
+
+function createTestContainer() {
+  return {
+    createRequestScope() {
+      return this;
+    },
+    async dispose() {
+      return undefined;
+    },
+    hasRequestScopedDependency() {
+      return false;
+    },
+    async resolve<T>(token: new (...args: never[]) => T): Promise<T> {
+      return new token();
+    },
+  };
 }
 
 describe('SerializerInterceptor', () => {
@@ -89,5 +150,33 @@ describe('SerializerInterceptor', () => {
     };
 
     await expect(interceptor.intercept(context, next)).resolves.toBe(owner);
+  });
+
+  it('serializes responses through the real HTTP request pipeline', async () => {
+    class UserView {
+      id = 'u-1';
+
+      @Exclude()
+      password = 'secret';
+    }
+
+    @Controller('/users')
+    @UseInterceptors(SerializerInterceptor)
+    class UsersController {
+      @Get('/one')
+      getOne() {
+        return new UserView();
+      }
+    }
+
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: UsersController }]),
+      rootContainer: createTestContainer() as never,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/users/one'), response);
+
+    expect(response.body).toEqual({ id: 'u-1' });
   });
 });

--- a/packages/serialization/src/vitest-module.d.ts
+++ b/packages/serialization/src/vitest-module.d.ts
@@ -1,5 +1,7 @@
 declare module 'vitest' {
+  export const afterEach: typeof globalThis.afterEach;
   export const describe: typeof globalThis.describe;
   export const expect: typeof globalThis.expect;
   export const it: typeof globalThis.it;
+  export const vi: typeof globalThis.vi;
 }

--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -2,14 +2,13 @@ import type {
   Constructor,
   MetadataPropertyKey,
 } from '@fluojs/core';
-import {
-  ensureMetadataSymbol,
-  type ClassValidationRule,
-  type CustomClassValidator,
-  type CustomFieldValidator,
-  type CustomValidationDecoratorOptions,
-  type DtoFieldValidationRule,
-  type ValidationDecoratorOptions,
+import type {
+  ClassValidationRule,
+  CustomClassValidator,
+  CustomFieldValidator,
+  CustomValidationDecoratorOptions,
+  DtoFieldValidationRule,
+  ValidationDecoratorOptions,
 } from '@fluojs/core/internal';
 
 import { createClassValidatorFromStandardSchema, isStandardSchemaLike, type StandardSchemaV1Like } from './standard-schema.js';
@@ -22,8 +21,6 @@ type ValidateClassInput = CustomClassValidator | StandardSchemaV1Like;
 
 const standardDtoValidationMetadataKey = Symbol.for('fluo.standard.dto-validation');
 const standardClassValidationMetadataKey = Symbol.for('fluo.standard.class-validation');
-
-ensureMetadataSymbol();
 
 function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
   if (metadata === null || metadata === undefined) {

--- a/packages/validation/src/import-side-effects.test.ts
+++ b/packages/validation/src/import-side-effects.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const symbolConstructor = Symbol as typeof Symbol & { metadata?: symbol };
+const originalMetadata = symbolConstructor.metadata;
+
+function clearSymbolMetadata(): void {
+  Reflect.deleteProperty(Symbol, 'metadata');
+}
+
+function restoreSymbolMetadata(): void {
+  if (originalMetadata === undefined) {
+    clearSymbolMetadata();
+    return;
+  }
+
+  Object.defineProperty(Symbol, 'metadata', {
+    configurable: true,
+    value: originalMetadata,
+  });
+}
+
+describe('validation import side effects', () => {
+  afterEach(() => {
+    restoreSymbolMetadata();
+  });
+
+  it('does not install Symbol.metadata when decorators are imported', async () => {
+    vi.resetModules();
+    clearSymbolMetadata();
+
+    await import('./decorators.js');
+
+    expect(symbolConstructor.metadata).toBeUndefined();
+  });
+});

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -2,10 +2,11 @@ import { type } from 'arktype';
 import { email, object, pipe, string } from 'valibot';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
+import { defineDtoFieldBindingMetadata } from '@fluojs/core/internal';
 
 import { DefaultValidator } from './validation.js';
 import { DtoValidationError } from './errors.js';
-import { ArrayUnique, IsDateString, IsEmail, IsIP, IsLatitude, IsLongitude, IsNotEmpty, IsNumber, IsString, MinLength, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
+import { ArrayMinSize, ArrayNotEmpty, ArrayUnique, Contains, IsArray, IsBoolean, IsDateString, IsEmail, IsEnum, IsInt, IsIP, IsLatitude, IsLongitude, IsNotEmpty, IsNumber, IsNumberString, IsString, IsUrl, IsUUID, Length, Matches, Max, Min, MinLength, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
 import type { StandardSchemaV1Like } from './index.js';
 
 describe('DefaultValidator', () => {
@@ -142,6 +143,112 @@ describe('DefaultValidator', () => {
 
     expect(result).toBeInstanceOf(CreateUserDto);
     expect(result.email).toBe('hello@example.com');
+  });
+
+  it('validates plain root objects without scalar coercion', async () => {
+    class SearchDto {
+      @IsNumber({ message: 'page must be numeric' })
+      page = 0;
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(validator.validate({ page: 1 }, SearchDto)).resolves.toBeUndefined();
+    await expect(validator.validate({ page: '1' }, SearchDto)).rejects.toMatchObject({
+      issues: [{ field: 'page', message: 'page must be numeric' }],
+    });
+  });
+
+  it('propagates request binding sources into validation issues', async () => {
+    class SearchDto {
+      @IsEmail({ message: 'email must be valid' })
+      email = '';
+    }
+
+    defineDtoFieldBindingMetadata(SearchDto.prototype, 'email', {
+      key: 'email',
+      source: 'query',
+    });
+
+    const validator = new DefaultValidator();
+
+    await expect(validator.validate({ email: 'bad-email' }, SearchDto)).rejects.toMatchObject({
+      issues: [{ field: 'email', message: 'email must be valid', source: 'query' }],
+    });
+  });
+
+  it('covers representative documented validators with pass and fail contracts', async () => {
+    enum Role {
+      Admin = 'admin',
+      User = 'user',
+    }
+
+    class DocumentedValidatorsDto {
+      @IsBoolean({ message: 'active must be boolean' })
+      active = true;
+
+      @IsInt({ message: 'count must be integer' })
+      @Min(1, { message: 'count must be at least one' })
+      @Max(10, { message: 'count must be at most ten' })
+      count = 1;
+
+      @IsEnum(Role, { message: 'role must be supported' })
+      role = Role.User;
+
+      @Length(3, 8, { message: 'slug length must be bounded' })
+      @Contains('-', { message: 'slug must contain a dash' })
+      @Matches(/^[a-z-]+$/, { message: 'slug must be lowercase words' })
+      slug = 'fluo-api';
+
+      @IsUrl({ message: 'homepage must be a URL' })
+      homepage = 'https://fluo.dev';
+
+      @IsUUID('4', { message: 'id must be a UUID v4' })
+      id = '550e8400-e29b-41d4-a716-446655440000';
+
+      @IsNumberString({ message: 'port must be numeric text' })
+      port = '3000';
+
+      @IsArray({ message: 'tags must be an array' })
+      @ArrayNotEmpty({ message: 'tags must not be empty' })
+      @ArrayMinSize(2, { message: 'tags must include at least two entries' })
+      tags = ['api', 'http'];
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(validator.validate(new DocumentedValidatorsDto(), DocumentedValidatorsDto)).resolves.toBeUndefined();
+
+    await expect(
+      validator.validate(
+        Object.assign(new DocumentedValidatorsDto(), {
+          active: 'true',
+          count: 11.5,
+          homepage: 'not a url',
+          id: 'not-a-uuid',
+          port: 'abc',
+          role: 'owner',
+          slug: 'UP',
+          tags: [],
+        }),
+        DocumentedValidatorsDto,
+      ),
+    ).rejects.toMatchObject({
+      issues: [
+        { field: 'active', message: 'active must be boolean' },
+        { field: 'count', message: 'count must be at most ten' },
+        { field: 'count', message: 'count must be integer' },
+        { field: 'role', message: 'role must be supported' },
+        { field: 'slug', message: 'slug must be lowercase words' },
+        { field: 'slug', message: 'slug must contain a dash' },
+        { field: 'slug', message: 'slug length must be bounded' },
+        { field: 'homepage', message: 'homepage must be a URL' },
+        { field: 'id', message: 'id must be a UUID v4' },
+        { field: 'port', message: 'port must be numeric text' },
+        { field: 'tags', message: 'tags must include at least two entries' },
+        { field: 'tags', message: 'tags must not be empty' },
+      ],
+    });
   });
 
   it('validate rejects malformed roots with deterministic validation issues', async () => {


### PR DESCRIPTION
## Summary

Align validation and serialization contracts from the package audit.

Linked context: Closes #2019

## Changes

- Avoid import-time `Symbol.metadata` installation from validation decorators and serialization metadata imports.
- Export and document the public `TransformFunction` type from `@fluojs/serialization`.
- Add regression coverage for validation source propagation, plain root validation, documented validator pass/fail behavior, and real HTTP request-pipeline serialization.
- Add Changesets release metadata for `@fluojs/validation` and `@fluojs/serialization`.

## Testing

- `pnpm --filter @fluojs/validation test`
- `pnpm --filter @fluojs/validation typecheck`
- `pnpm --filter @fluojs/validation build`
- `pnpm --filter @fluojs/serialization test`
- `pnpm --filter @fluojs/serialization typecheck`
- `pnpm --filter @fluojs/serialization build`
- `pnpm exec biome lint packages/validation/src/decorators.ts packages/validation/src/validation.test.ts packages/validation/src/import-side-effects.test.ts packages/serialization/src/metadata.ts packages/serialization/src/index.ts packages/serialization/src/serializer-interceptor.test.ts packages/serialization/src/import-side-effects.test.ts packages/serialization/src/vitest-module.d.ts`
- `pnpm lint` (repository-wide lint reports pre-existing warnings outside this PR, while `verify:public-export-tsdoc` passed)

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
