### PR TITLE
Resolve #2015: fix runtime lifecycle and shutdown contract gaps

### DIFF
--- a/.changeset/quiet-dragons-shutdown.md
+++ b/.changeset/quiet-dragons-shutdown.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/runtime": patch
+"@fluojs/platform-nodejs": patch
+---
+
+Keep root runtime bootstrap defaults transport-neutral while preserving Node-specific logger behavior on `@fluojs/runtime/node`, and add regression coverage for documented Node shutdown and lifecycle failure contracts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "20"
+          package-manager-cache: false
 
       - name: Verify changeset release lane
         run: node tooling/release/verify-changeset-release-lane.mjs --lane=stable --base-ref=origin/${{ github.base_ref }}

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -43,7 +43,7 @@ await app.listen();
 ## 주요 패턴
 
 ### 서버 옵션 커스텀
-어댑터는 HTTPS 설정 및 바디 크기 제한을 포함한 표준 Node.js 서버 옵션을 수용합니다.
+어댑터는 문서화된 Node.js transport 옵션인 host/port 바인딩, HTTPS 설정, request body 제한, raw-body 보존, listen retry 설정, shutdown drain bound를 제공합니다.
 
 ```typescript
 const adapter = createNodejsAdapter({

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -43,7 +43,7 @@ await app.listen();
 ## Common Patterns
 
 ### Customizing Server Options
-The adapter accepts standard Node.js server options including HTTPS configuration and body size limits.
+The adapter exposes the documented Node.js transport options: host/port binding, HTTPS configuration, request body limits, raw-body preservation, listen retry settings, and shutdown drain bounds.
 
 ```typescript
 const adapter = createNodejsAdapter({

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'node:net';
 import { Controller, type Dispatcher, FromBody, Get, Post, RequestDto, type RequestContext } from '@fluojs/http';
-import { defineModule, FluoFactory } from '@fluojs/runtime';
+import { type ApplicationLogger, defineModule, FluoFactory } from '@fluojs/runtime';
 import {
   type BootstrapNodeApplicationOptions,
   bootstrapNodeApplication,
@@ -335,6 +335,111 @@ describe('@fluojs/platform-nodejs', () => {
 
     for (const listener of registeredListeners) {
       expect(process.listeners(signal)).not.toContain(listener);
+    }
+  });
+
+  it('logs signal-driven shutdown failures and sets exitCode through the platform run helper', async () => {
+    const originalExitCode = process.exitCode;
+    const signal = 'SIGTERM' as const;
+    const listenersBefore = new Set(process.listeners(signal));
+    const shutdownFailure = new Error('shutdown failed');
+    let failureLogged!: () => void;
+    const loggedFailure = new Promise<void>((resolve) => {
+      failureLogged = resolve;
+    });
+
+    class FailingShutdownHook {
+      onModuleDestroy() {
+        throw shutdownFailure;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { providers: [FailingShutdownHook] });
+
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message: string, error: unknown) {
+        if (message === 'Failed to shut down the application cleanly.' && error === shutdownFailure) {
+          failureLogged();
+        }
+      },
+      log() {},
+      warn() {},
+    };
+    const port = await findAvailablePort();
+    const app = await runNodejsApplication(AppModule, {
+      logger,
+      port,
+      shutdownSignals: [signal],
+    });
+
+    try {
+      const registeredListener = process.listeners(signal).find((listener) => !listenersBefore.has(listener));
+      expect(registeredListener).toBeTypeOf('function');
+
+      (registeredListener as () => void)();
+      await loggedFailure;
+
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = originalExitCode;
+      await app.close().catch(() => undefined);
+    }
+  });
+
+  it('logs signal-driven shutdown timeouts and sets exitCode through the platform run helper', async () => {
+    const originalExitCode = process.exitCode;
+    const signal = 'SIGTERM' as const;
+    const listenersBefore = new Set(process.listeners(signal));
+    let releaseShutdown!: () => void;
+    let timeoutLogged!: () => void;
+    const shutdownGate = new Promise<void>((resolve) => {
+      releaseShutdown = resolve;
+    });
+    const loggedTimeout = new Promise<void>((resolve) => {
+      timeoutLogged = resolve;
+    });
+
+    class SlowShutdownHook {
+      async onModuleDestroy() {
+        await shutdownGate;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { providers: [SlowShutdownHook] });
+
+    const logger: ApplicationLogger = {
+      debug() {},
+      error(message: string) {
+        if (message === 'Shutdown timeout exceeded after 1ms; leaving process termination to the host.') {
+          timeoutLogged();
+        }
+      },
+      log() {},
+      warn() {},
+    };
+    const port = await findAvailablePort();
+    const app = await runNodejsApplication(AppModule, {
+      forceExitTimeoutMs: 1,
+      logger,
+      port,
+      shutdownSignals: [signal],
+    });
+
+    try {
+      const registeredListener = process.listeners(signal).find((listener) => !listenersBefore.has(listener));
+      expect(registeredListener).toBeTypeOf('function');
+
+      (registeredListener as () => void)();
+      await loggedTimeout;
+
+      expect(process.exitCode).toBe(1);
+    } finally {
+      releaseShutdown();
+      process.exitCode = originalExitCode;
+      await app.close().catch(() => undefined);
     }
   });
 

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -14,7 +14,7 @@ import { DuplicateProviderError } from './errors.js';
 import { createBootstrapTimingDiagnostics, type BootstrapTimingPhase } from './health/diagnostics.js';
 import { defineRuntimeModuleMetadata, getRuntimeClassDiMetadata } from './internal/core-metadata.js';
 import { RuntimeDefaultBinder } from './internal/http-runtime.js';
-import { createConsoleApplicationLogger } from './logging/logger.js';
+import { createDefaultApplicationLogger } from './logging/default-logger.js';
 import { compileModuleGraph, providerToken } from './module-graph.js';
 import { createRuntimePlatformShell, type RuntimePlatformShell } from './platform-shell.js';
 import { APPLICATION_LOGGER, BOOTSTRAP_READY_SIGNAL, COMPILED_MODULES, HTTP_APPLICATION_ADAPTER, PLATFORM_SHELL, RUNTIME_CLEANUP_REGISTRATION, RUNTIME_CONTAINER } from './tokens.js';
@@ -1417,7 +1417,7 @@ function createRuntimeDispatcher(
  * @throws {Error} Propagates module-graph, lifecycle, or runtime initialization failures.
  */
 export async function bootstrapApplication(options: BootstrapApplicationOptions): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = options.logger ?? createDefaultApplicationLogger();
   let lifecycleInstances: unknown[] = [];
   let bootstrappedContainer: Container | undefined;
   let bootstrappedModules: CompiledModule[] = [];
@@ -1582,7 +1582,7 @@ export class FluoFactory {
     rootModule: ModuleType,
     options: CreateApplicationContextOptions = {},
   ): Promise<ApplicationContext> {
-    const logger = options.logger ?? createConsoleApplicationLogger();
+    const logger = options.logger ?? createDefaultApplicationLogger();
     let lifecycleInstances: unknown[] = [];
     let bootstrappedContainer: Container | undefined;
     let bootstrappedModules: CompiledModule[] = [];
@@ -1703,7 +1703,7 @@ export class FluoFactory {
     rootModule: ModuleType,
     options: CreateMicroserviceOptions = {},
   ): Promise<MicroserviceApplication> {
-    const logger = options.logger ?? createConsoleApplicationLogger();
+    const logger = options.logger ?? createDefaultApplicationLogger();
     const microserviceToken = options.microserviceToken ?? DEFAULT_MICROSERVICE_TOKEN;
     const context = await FluoFactory.createApplicationContext(rootModule, options);
 

--- a/packages/runtime/src/exports.test.ts
+++ b/packages/runtime/src/exports.test.ts
@@ -18,6 +18,14 @@ describe('runtime export boundaries', () => {
     expect(runtime).not.toHaveProperty('bootstrapHttpAdapterApplication');
   });
 
+  it('keeps root bootstrap defaults detached from Node-only logger modules', () => {
+    const bootstrapSource = readFileSync(new URL('./bootstrap.ts', import.meta.url), 'utf8');
+
+    expect(bootstrapSource).not.toContain('./logging/logger.js');
+    expect(bootstrapSource).not.toContain('./logging/json-logger.js');
+    expect(bootstrapSource).toContain('./logging/default-logger.js');
+  });
+
   it('keeps only bootstrap-scoped operational helpers on the runtime root barrel', () => {
     expect(runtime.HealthModule).toBeTypeOf('function');
     expect(runtime.HealthModule.forRoot).toBeTypeOf('function');

--- a/packages/runtime/src/http-adapter-shared.test.ts
+++ b/packages/runtime/src/http-adapter-shared.test.ts
@@ -295,4 +295,60 @@ describe('runHttpAdapterApplication', () => {
       'adapter:close:SIGTERM',
     ]);
   });
+
+  it('aggregates custom shutdown unregistration and application close failures', async () => {
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    const events: string[] = [];
+    const unregisterFailure = new Error('unregister failed');
+    const closeFailure = new Error('close failed');
+    const logger: ApplicationLogger = {
+      debug() {},
+      error() {},
+      log() {},
+      warn() {},
+    };
+    const adapter = {
+      async close(signal?: string) {
+        events.push(`adapter:close:${signal ?? 'none'}`);
+        throw closeFailure;
+      },
+      getListenTarget() {
+        return {
+          bindTarget: 'runtime://test',
+          url: 'runtime://test',
+        };
+      },
+      async listen() {
+        events.push('adapter:listen');
+      },
+    };
+
+    const app = await runHttpAdapterApplication(AppModule, {
+      logger,
+      shutdownRegistration() {
+        return () => {
+          events.push('unregister');
+          throw unregisterFailure;
+        };
+      },
+    }, adapter);
+
+    try {
+      await app.close('SIGTERM');
+      expect.unreachable('close should aggregate unregister and close failures');
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      if (error instanceof AggregateError) {
+        expect(error.errors).toEqual([unregisterFailure, closeFailure]);
+      }
+    }
+
+    expect(events).toEqual([
+      'adapter:listen',
+      'unregister',
+      'adapter:close:SIGTERM',
+    ]);
+  });
 });

--- a/packages/runtime/src/http-adapter-shared.ts
+++ b/packages/runtime/src/http-adapter-shared.ts
@@ -15,7 +15,7 @@ import {
 } from '@fluojs/http';
 
 import { bootstrapApplication } from './bootstrap.js';
-import { createConsoleApplicationLogger } from './logging/logger.js';
+import { createDefaultApplicationLogger } from './logging/default-logger.js';
 import type { Application, ApplicationLogger, CreateApplicationOptions, ModuleType } from './types.js';
 
 /**
@@ -98,7 +98,7 @@ export async function bootstrapHttpAdapterApplication(
   return bootstrapApplication({
     ...options,
     adapter,
-    logger: options.logger ?? createConsoleApplicationLogger(),
+    logger: options.logger ?? createDefaultApplicationLogger(),
     middleware: createHttpAdapterMiddleware(options),
     rootModule,
   });
@@ -156,7 +156,7 @@ export async function runHttpAdapterApplication(
   options: RunHttpAdapterApplicationOptions,
   adapter: ManagedHttpApplicationAdapter,
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = options.logger ?? createDefaultApplicationLogger();
   const app = await bootstrapApplication({
     ...options,
     adapter,

--- a/packages/runtime/src/logging/default-logger.test.ts
+++ b/packages/runtime/src/logging/default-logger.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createDefaultApplicationLogger } from './default-logger.js';
+
+describe('createDefaultApplicationLogger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes transport-neutral console output without process metadata', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    createDefaultApplicationLogger().log('Application started', 'Bootstrap');
+
+    expect(log).toHaveBeenCalledWith('[fluo] LOG [Bootstrap] Application started');
+  });
+
+  it('writes error objects after the formatted message', () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const error = new Error('boom');
+
+    createDefaultApplicationLogger().error('Application failed', error, 'Bootstrap');
+
+    expect(errorLog).toHaveBeenNthCalledWith(1, '[fluo] ERROR [Bootstrap] Application failed');
+    expect(errorLog).toHaveBeenNthCalledWith(2, error);
+  });
+});

--- a/packages/runtime/src/logging/default-logger.ts
+++ b/packages/runtime/src/logging/default-logger.ts
@@ -4,6 +4,11 @@ function formatDefaultLog(level: 'DEBUG' | 'ERROR' | 'LOG' | 'WARN', context: st
   return `[fluo] ${level} [${context}] ${message}`;
 }
 
+/**
+ * Creates the transport-neutral runtime logger used by default root bootstrap flows.
+ *
+ * @returns Application logger that writes through `console` without Node-only process metadata.
+ */
 export function createDefaultApplicationLogger(): ApplicationLogger {
   return {
     debug(message, context = 'fluo') {

--- a/packages/runtime/src/logging/default-logger.ts
+++ b/packages/runtime/src/logging/default-logger.ts
@@ -1,0 +1,26 @@
+import type { ApplicationLogger } from '../types.js';
+
+function formatDefaultLog(level: 'DEBUG' | 'ERROR' | 'LOG' | 'WARN', context: string, message: string): string {
+  return `[fluo] ${level} [${context}] ${message}`;
+}
+
+export function createDefaultApplicationLogger(): ApplicationLogger {
+  return {
+    debug(message, context = 'fluo') {
+      console.debug(formatDefaultLog('DEBUG', context, message));
+    },
+    error(message, error, context = 'fluo') {
+      console.error(formatDefaultLog('ERROR', context, message));
+
+      if (error) {
+        console.error(error);
+      }
+    },
+    log(message, context = 'fluo') {
+      console.log(formatDefaultLog('LOG', context, message));
+    },
+    warn(message, context = 'fluo') {
+      console.warn(formatDefaultLog('WARN', context, message));
+    },
+  };
+}

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -15,6 +15,7 @@ import {
   bootstrapHttpAdapterApplication,
   runHttpAdapterApplication,
 } from '../http-adapter-shared.js';
+import { createConsoleApplicationLogger } from '../logging/logger.js';
 import {
   createNodeResponseCompression,
   compressNodeResponse,
@@ -310,9 +311,11 @@ export async function bootstrapNodeApplication(
   rootModule: ModuleType,
   options: BootstrapNodeApplicationOptions,
 ): Promise<Application> {
+  const logger = options.logger ?? createConsoleApplicationLogger();
+
   return bootstrapHttpAdapterApplication(
     rootModule,
-    options,
+    { ...options, logger },
     createNodeHttpAdapter(options, options.compression ?? false, options.multipart),
   );
 }
@@ -328,9 +331,11 @@ export async function runNodeApplication(
   rootModule: ModuleType,
   options: RunNodeApplicationOptions,
 ): Promise<Application> {
+  const logger = options.logger ?? createConsoleApplicationLogger();
   const adapter = createNodeHttpAdapter(options, options.compression ?? false, options.multipart) as NodeHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,
+    logger,
     shutdownRegistration: createNodeShutdownSignalRegistration(
       options.shutdownSignals ?? defaultNodeShutdownSignals(),
     ),

--- a/packages/runtime/src/node/node.test.ts
+++ b/packages/runtime/src/node/node.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { defineModule } from '../bootstrap.js';
 import * as rootRuntimeApi from '../index.js';
 import * as publicNodeApi from '../node.js';
 import type { NodeHttpAdapterOptions, NodeHttpApplicationAdapter } from '../node.js';
@@ -57,6 +58,24 @@ describe('createNodeHttpAdapter', () => {
     expect(() => Function.prototype.call.call(publicNodeApi.createNodeHttpAdapter, undefined, { maxBodySize: '1mb' })).toThrow(
       'Invalid maxBodySize value: 1mb. Expected a non-negative integer number of bytes.',
     );
+  });
+
+  it('fails fast before bootstrap when maxBodySize is invalid', async () => {
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    await expect(
+      publicNodeApi.bootstrapNodeApplication(AppModule, { maxBodySize: -1 }),
+    ).rejects.toThrow('Invalid maxBodySize value: -1. Expected a non-negative integer number of bytes.');
+  });
+
+  it('fails fast before run helper startup when maxBodySize is invalid', async () => {
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    await expect(
+      publicNodeApi.runNodeApplication(AppModule, { maxBodySize: 1.5, shutdownSignals: false }),
+    ).rejects.toThrow('Invalid maxBodySize value: 1.5. Expected a non-negative integer number of bytes.');
   });
 
   it.each([


### PR DESCRIPTION
## Summary

Linked context: Closes #2015

Fixes runtime lifecycle and shutdown contract gaps from the package audit by keeping root runtime logging transport-neutral, preserving Node helper logger behavior, and adding regression coverage for documented shutdown and option-validation contracts.

## Changes

- Added a root-runtime default logger that avoids Node-only `process` metadata while keeping Node-specific logger factories on `@fluojs/runtime/node`.
- Preserved pretty Node logger defaults for Node bootstrap/run helpers after isolating root defaults.
- Added runtime regression tests for aggregate shutdown unregistration + close failures and invalid `maxBodySize` bootstrap/run helper fail-fast behavior.
- Added package-local `@fluojs/platform-nodejs` signal-driven shutdown failure/timeout coverage.
- Clarified the documented Node adapter option surface in English and Korean READMEs.
- Added a patch changeset for `@fluojs/runtime` and `@fluojs/platform-nodejs`.

## Testing

- `pnpm --filter @fluojs/runtime test` — passed (252 tests).
- `pnpm --filter @fluojs/platform-nodejs test` — passed (27 tests).
- `pnpm --filter @fluojs/runtime... build && pnpm --filter @fluojs/platform-nodejs... build` — passed.
- Changed-file LSP diagnostics — passed after dependency build for changed TypeScript files.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public export was added. Existing public Node helper docs remain in place; README wording was clarified for `@fluojs/platform-nodejs`.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The change preserves the documented `@fluojs/runtime/node` logger helpers and adds regression tests for shutdown cleanup aggregation, invalid `maxBodySize` fail-fast behavior, and signal-driven shutdown timeout/failure reporting.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance SSOT files changed. The platform README EN/KO pair was kept in sync, and package-local `packages/platform-nodejs/src/index.test.ts` now covers the documented signal shutdown behavior.