### PR TITLE
Resolve #2021: remove recurring test flake patterns

### DIFF
--- a/packages/platform-cloudflare-workers/src/adapter.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.test.ts
@@ -455,38 +455,40 @@ describe('@fluojs/platform-cloudflare-workers', () => {
   it('bounds Worker close() while preserving shutdown responses for new requests', async () => {
     vi.useFakeTimers();
 
-    const adapter = createCloudflareWorkerAdapter();
-    const neverSettles = new Promise<void>(() => {});
+    try {
+      const adapter = createCloudflareWorkerAdapter();
+      const neverSettles = new Promise<void>(() => {});
 
-    await adapter.listen({
-      async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
-        await neverSettles;
-        response.setStatus(200);
-        await response.send({ ok: true });
-      },
-    });
+      await adapter.listen({
+        async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+          await neverSettles;
+          response.setStatus(200);
+          await response.send({ ok: true });
+        },
+      });
 
-    void adapter.fetch(new Request('https://worker.test/stuck'), {}, createExecutionContext());
-    await Promise.resolve();
+      void adapter.fetch(new Request('https://worker.test/stuck'), {}, createExecutionContext());
+      await Promise.resolve();
 
-    const closePromise = adapter.close();
-    const shutdownResponse = await adapter.fetch(new Request('https://worker.test/closing'), {}, createExecutionContext());
+      const closePromise = adapter.close();
+      const shutdownResponse = await adapter.fetch(new Request('https://worker.test/closing'), {}, createExecutionContext());
 
-    expect(shutdownResponse.status).toBe(503);
-    await expect(shutdownResponse.json()).resolves.toMatchObject({
-      error: {
-        code: 'SERVICE_UNAVAILABLE',
-      },
-    });
+      expect(shutdownResponse.status).toBe(503);
+      await expect(shutdownResponse.json()).resolves.toMatchObject({
+        error: {
+          code: 'SERVICE_UNAVAILABLE',
+        },
+      });
 
-    const closeAssertion = expect(closePromise).rejects.toThrow(
-      'Cloudflare Workers adapter shutdown timeout exceeded 10000ms.',
-    );
+      const closeAssertion = expect(closePromise).rejects.toThrow(
+        'Cloudflare Workers adapter shutdown timeout exceeded 10000ms.',
+      );
 
-    await vi.advanceTimersByTimeAsync(10_000);
-    await closeAssertion;
-
-    vi.useRealTimers();
+      await vi.advanceTimersByTimeAsync(10_000);
+      await closeAssertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('creates a lazy Worker entrypoint that bootstraps once and reuses the bound dispatcher', async () => {

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -3,7 +3,7 @@ import {
   request as httpRequest,
 } from 'node:http';
 import { request as httpsRequest } from 'node:https';
-import { createServer as createNetServer } from 'node:net';
+import { type AddressInfo, createServer as createNetServer } from 'node:net';
 
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 
@@ -38,6 +38,7 @@ import {
 import {
   createHealthModule,
   defineModule,
+  FluoFactory,
   fluoFactory,
   type ApplicationLogger,
 } from '@fluojs/runtime';
@@ -64,6 +65,20 @@ function createDeferred<T>(): {
   });
 
   return { promise, reject, resolve };
+}
+
+function getBoundPort(server: unknown): number {
+  if (!server || typeof (server as { address?: unknown }).address !== 'function') {
+    throw new Error('Failed to resolve a bound test server.');
+  }
+
+  const address = (server as { address(): AddressInfo | string | null }).address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to resolve a bound test port.');
+  }
+
+  return address.port;
 }
 
 async function findAvailablePort(): Promise<number> {
@@ -469,7 +484,7 @@ describe('@fluojs/platform-express', () => {
       next();
     });
 
-    const app = await fluoFactory.create(AppModule, { adapter });
+    const app = await FluoFactory.create(AppModule, { adapter });
 
     await app.listen();
 
@@ -518,7 +533,7 @@ describe('@fluojs/platform-express', () => {
       return 'express-native-serializer';
     });
 
-    const app = await fluoFactory.create(AppModule, { adapter });
+    const app = await FluoFactory.create(AppModule, { adapter });
 
     await app.listen();
 
@@ -675,41 +690,43 @@ describe('@fluojs/platform-express', () => {
       controllers: [WebhookController],
     });
 
-    const port = await findAvailablePort();
-    const app = await bootstrapExpressApplication(AppModule, {
-      cors: false,
-      port,
+    const adapter = createExpressAdapter({
+      port: 0,
       rawBody: true,
     });
+    const app = await fluoFactory.create(AppModule, { adapter });
 
-    await app.listen();
+    try {
+      await app.listen();
+      const port = getBoundPort((adapter as ExpressHttpApplicationAdapter).getServer());
 
-    const [jsonResponse, textResponse] = await Promise.all([
-      fetch(`http://127.0.0.1:${String(port)}/webhooks/json`, {
-        body: JSON.stringify({ provider: 'stripe' }),
-        headers: { 'content-type': 'application/json' },
-        method: 'POST',
-      }),
-      fetch(`http://127.0.0.1:${String(port)}/webhooks/text`, {
-        body: 'ping=1',
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-        method: 'POST',
-      }),
-    ]);
+      const [jsonResponse, textResponse] = await Promise.all([
+        fetch(`http://127.0.0.1:${String(port)}/webhooks/json`, {
+          body: JSON.stringify({ provider: 'stripe' }),
+          headers: { 'content-type': 'application/json' },
+          method: 'POST',
+        }),
+        fetch(`http://127.0.0.1:${String(port)}/webhooks/text`, {
+          body: 'ping=1',
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+          method: 'POST',
+        }),
+      ]);
 
-    expect(jsonResponse.status).toBe(201);
-    await expect(jsonResponse.json()).resolves.toEqual({
-      parsed: { provider: 'stripe' },
-      raw: '{"provider":"stripe"}',
-    });
+      expect(jsonResponse.status).toBe(201);
+      await expect(jsonResponse.json()).resolves.toEqual({
+        parsed: { provider: 'stripe' },
+        raw: '{"provider":"stripe"}',
+      });
 
-    expect(textResponse.status).toBe(201);
-    await expect(textResponse.json()).resolves.toEqual({
-      parsed: 'ping=1',
-      raw: 'ping=1',
-    });
-
-    await app.close();
+      expect(textResponse.status).toBe(201);
+      await expect(textResponse.json()).resolves.toEqual({
+        parsed: 'ping=1',
+        raw: 'ping=1',
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('does not preserve rawBody for multipart requests', async () => {
@@ -730,32 +747,34 @@ describe('@fluojs/platform-express', () => {
       controllers: [UploadController],
     });
 
-    const port = await findAvailablePort();
-    const app = await bootstrapExpressApplication(AppModule, {
-      cors: false,
-      port,
+    const adapter = createExpressAdapter({
+      port: 0,
       rawBody: true,
     });
+    const app = await fluoFactory.create(AppModule, { adapter });
 
-    await app.listen();
+    try {
+      await app.listen();
+      const port = getBoundPort((adapter as ExpressHttpApplicationAdapter).getServer());
 
-    const form = new FormData();
-    form.set('name', 'Ada');
-    form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
+      const form = new FormData();
+      form.set('name', 'Ada');
+      form.set('payload', new Blob(['hello'], { type: 'text/plain' }), 'payload.txt');
 
-    const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
-      body: form,
-      method: 'POST',
-    });
+      const response = await fetch(`http://127.0.0.1:${String(port)}/uploads`, {
+        body: form,
+        method: 'POST',
+      });
 
-    expect(response.status).toBe(201);
-    await expect(response.json()).resolves.toEqual({
-      body: { name: 'Ada' },
-      fileCount: 1,
-      hasRawBody: false,
-    });
-
-    await app.close();
+      expect(response.status).toBe(201);
+      await expect(response.json()).resolves.toEqual({
+        body: { name: 'Ada' },
+        fileCount: 1,
+        hasRawBody: false,
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('defaults multipart.maxTotalSize to maxBodySize when no explicit multipart total is provided', async () => {

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1,6 +1,6 @@
 import type { IncomingHttpHeaders } from 'node:http';
 import { request as httpRequest } from 'node:http';
-import { createServer } from 'node:net';
+import { type AddressInfo, createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
 
 import type { FastifyReply, FastifyRequest } from 'fastify';
@@ -34,7 +34,7 @@ import {
   type RequestContext,
   type RequestObserver,
 } from '@fluojs/http';
-import { createHealthModule, defineModule, fluoFactory, type Application, type ApplicationLogger } from '@fluojs/runtime';
+import { createHealthModule, defineModule, FluoFactory, fluoFactory, type Application, type ApplicationLogger } from '@fluojs/runtime';
 import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 
 import {
@@ -60,6 +60,20 @@ function createDeferred<T>(): {
   });
 
   return { promise, reject, resolve };
+}
+
+function getBoundPort(server: unknown): number {
+  if (!server || typeof (server as { address?: unknown }).address !== 'function') {
+    throw new Error('Failed to resolve a bound test server.');
+  }
+
+  const address = (server as { address(): AddressInfo | string | null }).address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to resolve a bound test port.');
+  }
+
+  return address.port;
 }
 
 async function findAvailablePort(): Promise<number> {
@@ -504,7 +518,7 @@ describe('@fluojs/platform-fastify', () => {
       }
     });
 
-    const app = await fluoFactory.create(AppModule, { adapter });
+    const app = await FluoFactory.create(AppModule, { adapter });
 
     await app.listen();
 
@@ -594,41 +608,43 @@ describe('@fluojs/platform-fastify', () => {
       controllers: [WebhookController],
     });
 
-    const port = await findAvailablePort();
-    const app = await bootstrapFastifyApplication(AppModule, {
-      cors: false,
-      port,
+    const adapter = createFastifyAdapter({
+      port: 0,
       rawBody: true,
     });
+    const app = await fluoFactory.create(AppModule, { adapter });
 
-    await app.listen();
+    try {
+      await app.listen();
+      const port = getBoundPort((adapter as FastifyHttpApplicationAdapter).getServer());
 
-    const [jsonResponse, textResponse] = await Promise.all([
-      fetch(`http://127.0.0.1:${String(port)}/webhooks/json`, {
-        body: JSON.stringify({ provider: 'stripe' }),
-        headers: { 'content-type': 'application/json' },
-        method: 'POST',
-      }),
-      fetch(`http://127.0.0.1:${String(port)}/webhooks/text`, {
-        body: 'ping=1',
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-        method: 'POST',
-      }),
-    ]);
+      const [jsonResponse, textResponse] = await Promise.all([
+        fetch(`http://127.0.0.1:${String(port)}/webhooks/json`, {
+          body: JSON.stringify({ provider: 'stripe' }),
+          headers: { 'content-type': 'application/json' },
+          method: 'POST',
+        }),
+        fetch(`http://127.0.0.1:${String(port)}/webhooks/text`, {
+          body: 'ping=1',
+          headers: { 'content-type': 'text/plain; charset=utf-8' },
+          method: 'POST',
+        }),
+      ]);
 
-    expect(jsonResponse.status).toBe(201);
-    await expect(jsonResponse.json()).resolves.toEqual({
-      parsed: { provider: 'stripe' },
-      raw: '{"provider":"stripe"}',
-    });
+      expect(jsonResponse.status).toBe(201);
+      await expect(jsonResponse.json()).resolves.toEqual({
+        parsed: { provider: 'stripe' },
+        raw: '{"provider":"stripe"}',
+      });
 
-    expect(textResponse.status).toBe(201);
-    await expect(textResponse.json()).resolves.toEqual({
-      parsed: 'ping=1',
-      raw: 'ping=1',
-    });
-
-    await app.close();
+      expect(textResponse.status).toBe(201);
+      await expect(textResponse.json()).resolves.toEqual({
+        parsed: 'ping=1',
+        raw: 'ping=1',
+      });
+    } finally {
+      await app.close();
+    }
   });
 
   it('keeps maxBodySize enforced while capturing raw body bytes', async () => {

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -1,4 +1,4 @@
-import { createServer } from 'node:net';
+import { type AddressInfo, createServer } from 'node:net';
 import { Controller, type Dispatcher, FromBody, Get, Post, RequestDto, type RequestContext } from '@fluojs/http';
 import { defineModule, FluoFactory } from '@fluojs/runtime';
 import {
@@ -24,29 +24,14 @@ import {
   runNodejsApplication,
 } from './index.js';
 
-async function findAvailablePort(): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
-    const server = createServer();
+function getBoundPort(server: { address(): AddressInfo | string | null }): number {
+  const address = server.address();
 
-    server.once('error', reject);
-    server.listen(0, () => {
-      const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to resolve a bound test port.');
+  }
 
-      if (!address || typeof address === 'string') {
-        reject(new Error('Failed to resolve an available port.'));
-        return;
-      }
-
-      server.close((error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-
-        resolve(address.port);
-      });
-    });
-  });
+  return address.port;
 }
 
 type MultipartRequestWithFiles = RequestContext['request'] & {
@@ -200,13 +185,14 @@ describe('@fluojs/platform-nodejs', () => {
     class AppModule {}
     defineModule(AppModule, { controllers: [HealthController] });
 
-    const port = await findAvailablePort();
+    const adapter = createNodejsAdapter({ port: 0 });
     const app = await FluoFactory.create(AppModule, {
-      adapter: createNodejsAdapter({ port }),
+      adapter,
     });
 
     try {
       await app.listen();
+      const port = getBoundPort(adapter.getServer());
 
       const response = await fetch(`http://127.0.0.1:${String(port)}/health`);
 
@@ -244,13 +230,12 @@ describe('@fluojs/platform-nodejs', () => {
     const adapter = createNodejsAdapter({
       host: '127.0.0.1',
       port: address.port,
-      retryDelayMs: 10,
+      retryDelayMs: 0,
       retryLimit: 5,
     });
 
     try {
       const listenPromise = adapter.listen(dispatcher);
-      await new Promise((resolve) => setTimeout(resolve, 25));
       await new Promise<void>((resolve, reject) => {
         blocker.close((error) => {
           if (error) {
@@ -281,8 +266,7 @@ describe('@fluojs/platform-nodejs', () => {
   });
 
   it('closes idle keep-alive connections during package adapter shutdown', async () => {
-    const port = await findAvailablePort();
-    const adapter = createNodejsAdapter({ port });
+    const adapter = createNodejsAdapter({ port: 0 });
     const server = adapter.getServer();
     const closeIdleConnections = vi.spyOn(server, 'closeIdleConnections');
     const dispatcher: Dispatcher = {
@@ -314,7 +298,6 @@ describe('@fluojs/platform-nodejs', () => {
 
     const signal = 'SIGTERM' as const;
     const listenersBefore = new Set(process.listeners(signal));
-    const port = await findAvailablePort();
     const app = await runNodejsApplication(AppModule, {
       logger: {
         debug() {},
@@ -322,7 +305,7 @@ describe('@fluojs/platform-nodejs', () => {
         log() {},
         warn() {},
       },
-      port,
+      port: 0,
       shutdownSignals: [signal],
     });
     const registeredListeners = process.listeners(signal).filter((listener) => !listenersBefore.has(listener));
@@ -360,13 +343,14 @@ describe('@fluojs/platform-nodejs', () => {
     class AppModule {}
     defineModule(AppModule, { controllers: [BenchmarkController] });
 
-    const port = await findAvailablePort();
+    const adapter = createNodejsAdapter({ port: 0 });
     const app = await FluoFactory.create(AppModule, {
-      adapter: createNodejsAdapter({ port }),
+      adapter,
     });
 
     try {
       await app.listen();
+      const port = getBoundPort(adapter.getServer());
 
       const queryResponse = await fetch(`http://127.0.0.1:${String(port)}/query-one?tag=one&tag=two&encoded=hello+world`);
 
@@ -405,13 +389,14 @@ describe('@fluojs/platform-nodejs', () => {
     class AppModule {}
     defineModule(AppModule, { controllers: [RequestIdController] });
 
-    const port = await findAvailablePort();
+    const adapter = createNodejsAdapter({ port: 0 });
     const app = await FluoFactory.create(AppModule, {
-      adapter: createNodejsAdapter({ port }),
+      adapter,
     });
 
     try {
       await app.listen();
+      const port = getBoundPort(adapter.getServer());
 
       const response = await fetch(`http://127.0.0.1:${String(port)}/request-id`, {
         headers: {
@@ -464,13 +449,14 @@ describe('@fluojs/platform-nodejs', () => {
     class AppModule {}
     defineModule(AppModule, { controllers: [EchoController] });
 
-    const port = await findAvailablePort();
+    const adapter = createNodejsAdapter({ maxBodySize: 8, port: 0 });
     const app = await FluoFactory.create(AppModule, {
-      adapter: createNodejsAdapter({ maxBodySize: 8, port }),
+      adapter,
     });
 
     try {
       await app.listen();
+      const port = getBoundPort(adapter.getServer());
 
       const boundaryResponse = await fetch(`http://127.0.0.1:${String(port)}/echo/raw`, {
         body: '12345678',
@@ -524,13 +510,14 @@ describe('@fluojs/platform-nodejs', () => {
     class AppModule {}
     defineModule(AppModule, { controllers: [EchoController] });
 
-    const port = await findAvailablePort();
+    const adapter = createNodejsAdapter({ port: 0 });
     const app = await FluoFactory.create(AppModule, {
-      adapter: createNodejsAdapter({ port }),
+      adapter,
     });
 
     try {
       await app.listen();
+      const port = getBoundPort(adapter.getServer());
 
       const response = await fetch(`http://127.0.0.1:${String(port)}/echo/json`, {
         body: JSON.stringify({ ok: true }),
@@ -572,13 +559,14 @@ describe('@fluojs/platform-nodejs', () => {
     class AppModule {}
     defineModule(AppModule, { controllers: [UploadController] });
 
-    const port = await findAvailablePort();
+    const adapter = createNodejsAdapter({ port: 0 });
     const app = await FluoFactory.create(AppModule, {
-      adapter: createNodejsAdapter({ port }),
+      adapter,
     });
 
     try {
       await app.listen();
+      const port = getBoundPort(adapter.getServer());
 
       const form = new FormData();
       form.append('name', 'Ada');

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -1,5 +1,5 @@
 import { createServer as createHttpServer, type IncomingMessage, type Server as NodeHttpServer, type ServerResponse } from 'node:http';
-import { createServer as createNetServer } from 'node:net';
+import { type AddressInfo, createServer as createNetServer } from 'node:net';
 
 import { describe, expect, it } from 'vitest';
 import { Inject, Scope } from '@fluojs/core';
@@ -50,6 +50,16 @@ function createLogger(events: string[]): ApplicationLogger {
       events.push(`warn:${context ?? 'none'}:${message}`);
     },
   };
+}
+
+function getBoundPort(server: { address(): AddressInfo | string | null }): number {
+  const address = server.address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to resolve a bound test port.');
+  }
+
+  return address.port;
 }
 
 async function findAvailablePort(): Promise<number> {
@@ -940,29 +950,32 @@ describe('@fluojs/socket.io', () => {
       providers: [GatewayState, PayloadGateway],
     });
 
-    const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, {
-      cors: false,
-      port,
-    });
+    const adapter = createNodejsAdapter({ port: 0 });
+    const app = await FluoFactory.create(AppModule, { adapter });
     const state = await app.container.resolve<GatewayState>(GatewayState);
 
-    await app.listen();
+    try {
+      await app.listen();
+      const port = getBoundPort(adapter.getServer());
 
-    const socket = createClient(`http://127.0.0.1:${String(port)}/payload-limit`, {
-      reconnection: false,
-      transports: ['websocket'],
-    });
-    await onceConnected(socket);
+      const socket = createClient(`http://127.0.0.1:${String(port)}/payload-limit`, {
+        reconnection: false,
+        transports: ['websocket'],
+      });
+      try {
+        await onceConnected(socket);
 
-    const disconnected = onceDisconnected(socket);
-    socket.emit('ping', 'x'.repeat(256));
+        const disconnected = onceDisconnected(socket);
+        socket.emit('ping', 'x'.repeat(256));
 
-    expect(['transport close', 'transport error']).toContain(await disconnected);
-    await new Promise((resolve) => setTimeout(resolve, 25));
-    expect(state.messages).toEqual([]);
-
-    await app.close();
+        expect(['transport close', 'transport error']).toContain(await disconnected);
+        expect(state.messages).toEqual([]);
+      } finally {
+        socket.close();
+      }
+    } finally {
+      await app.close();
+    }
   });
 
   it('disconnects Bun-style sockets when inbound payloads exceed the configured engine limit', async () => {
@@ -1001,22 +1014,27 @@ describe('@fluojs/socket.io', () => {
     });
     const state = await app.container.resolve<GatewayState>(GatewayState);
 
-    await app.listen();
+    try {
+      await app.listen();
 
-    const socket = createClient(`http://127.0.0.1:${String(port)}/bun-payload-limit`, {
-      reconnection: false,
-      transports: ['polling'],
-    });
-    await onceConnected(socket);
+      const socket = createClient(`http://127.0.0.1:${String(port)}/bun-payload-limit`, {
+        reconnection: false,
+        transports: ['polling'],
+      });
+      try {
+        await onceConnected(socket);
 
-    const disconnected = onceDisconnected(socket);
-    socket.emit('ping', 'x'.repeat(256));
+        const disconnected = onceDisconnected(socket);
+        socket.emit('ping', 'x'.repeat(256));
 
-    expect(['transport close', 'transport error']).toContain(await disconnected);
-    await new Promise((resolve) => setTimeout(resolve, 25));
-    expect(state.messages).toEqual([]);
-
-    await app.close();
+        expect(['transport close', 'transport error']).toContain(await disconnected);
+        expect(state.messages).toEqual([]);
+      } finally {
+        socket.close();
+      }
+    } finally {
+      await app.close();
+    }
   });
 
   for (const scenario of supportedSocketIoAdapterScenarios) {

--- a/packages/terminus/src/module.test.ts
+++ b/packages/terminus/src/module.test.ts
@@ -530,32 +530,38 @@ describe('TerminusModule.forRoot', () => {
       ],
     });
 
-    const app = await bootstrapApplication({ rootModule: AppModule });
+    try {
+      const app = await bootstrapApplication({ rootModule: AppModule });
 
-    const healthResponse = createResponse();
-    await app.dispatch(createRequest('/health'), healthResponse);
+      try {
+        const healthResponse = createResponse();
+        await app.dispatch(createRequest('/health'), healthResponse);
 
-    expect(healthResponse.statusCode).toBe(200);
-    expect(healthResponse.body).toMatchObject({
-      contributors: {
-        down: [],
-      },
-      details: {
-        'primary-api': {
-          status: 'up',
-        },
-        'secondary-api': {
-          status: 'up',
-        },
-      },
-      status: 'ok',
-    });
-    expect((healthResponse.body as { contributors: { up: string[] } }).contributors.up).toEqual(
-      expect.arrayContaining(['primary-api', 'secondary-api']),
-    );
-    expect(fetch).toHaveBeenCalledTimes(2);
-
-    await app.close();
+        expect(healthResponse.statusCode).toBe(200);
+        expect(healthResponse.body).toMatchObject({
+          contributors: {
+            down: [],
+          },
+          details: {
+            'primary-api': {
+              status: 'up',
+            },
+            'secondary-api': {
+              status: 'up',
+            },
+          },
+          status: 'ok',
+        });
+        expect((healthResponse.body as { contributors: { up: string[] } }).contributors.up).toEqual(
+          expect.arrayContaining(['primary-api', 'secondary-api']),
+        );
+        expect(fetch).toHaveBeenCalledTimes(2);
+      } finally {
+        await app.close();
+      }
+    } finally {
+      fetch.mockRestore();
+    }
   });
 
   it('aligns /health and /ready with runtime platform readiness semantics', async () => {

--- a/packages/websockets/src/module.test.ts
+++ b/packages/websockets/src/module.test.ts
@@ -1,4 +1,4 @@
-import { createConnection, createServer } from 'node:net';
+import { type AddressInfo, createConnection, createServer } from 'node:net';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 
@@ -11,7 +11,7 @@ import { Container } from '@fluojs/di';
 import { bootstrapExpressApplication } from '@fluojs/platform-express';
 import { bootstrapFastifyApplication } from '@fluojs/platform-fastify';
 import { bootstrapApplication, defineModule, type ApplicationLogger } from '@fluojs/runtime';
-import { bootstrapNodeApplication } from '@fluojs/runtime/node';
+import { bootstrapNodeApplication, createNodeHttpAdapter } from '@fluojs/runtime/node';
 import { HTTP_APPLICATION_ADAPTER } from '@fluojs/runtime/internal';
 import {
   Controller,
@@ -47,6 +47,20 @@ function createLogger(events: string[]): ApplicationLogger {
       events.push(`warn:${context ?? 'none'}:${message}`);
     },
   };
+}
+
+function getBoundPort(server: unknown): number {
+  if (!server || typeof (server as { address?: unknown }).address !== 'function') {
+    throw new Error('Failed to resolve a bound test server.');
+  }
+
+  const address = (server as { address(): AddressInfo | string | null }).address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to resolve a bound test port.');
+  }
+
+  return address.port;
 }
 
 async function findAvailablePort(): Promise<number> {
@@ -593,32 +607,41 @@ describe('@fluojs/websockets', () => {
       providers: [GatewayState, ChatGateway],
     });
 
-    const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, {
-      cors: false,
-      port,
+    const adapter = createNodeHttpAdapter({ port: 0 });
+    const app = await bootstrapApplication({
+      adapter,
+      rootModule: AppModule,
     });
     const state = await app.container.resolve(GatewayState);
 
-    await app.listen();
+    try {
+      await app.listen();
+      const port = getBoundPort((adapter as { getServer(): unknown }).getServer());
 
-    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
-    await onceOpen(socket);
-    socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
+      const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
+      try {
+        await onceOpen(socket);
+        socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
 
-    const incoming = await onceMessage(socket);
-    expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
+        const incoming = await onceMessage(socket);
+        expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
 
-    await closeWebSocket(socket);
+        await closeWebSocket(socket);
 
-    await waitForAssertion(() => {
-      expect(state.disconnectCount).toBe(1);
-    });
+        await waitForAssertion(() => {
+          expect(state.disconnectCount).toBe(1);
+        });
 
-    expect(state.connectCount).toBe(1);
-    expect(state.messages).toEqual([{ value: 'hello' }]);
-
-    await app.close();
+        expect(state.connectCount).toBe(1);
+        expect(state.messages).toEqual([{ value: 'hello' }]);
+      } finally {
+        if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+          socket.close();
+        }
+      }
+    } finally {
+      await app.close();
+    }
   });
 
   it('boots a Fastify app, connects websocket client, handles message, and disconnects', async () => {

--- a/packages/websockets/src/node/node.test.ts
+++ b/packages/websockets/src/node/node.test.ts
@@ -1,12 +1,12 @@
-import { createServer } from 'node:net';
+import { type AddressInfo, createServer } from 'node:net';
 
 import { describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 
 import { Inject } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
-import { defineModule } from '@fluojs/runtime';
-import { bootstrapNodeApplication } from '@fluojs/runtime/node';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { bootstrapNodeApplication, createNodeHttpAdapter } from '@fluojs/runtime/node';
 
 import { OnConnect, OnDisconnect, OnMessage, WebSocketGateway } from '../decorators.js';
 import * as nodePublicApi from './node.js';
@@ -37,6 +37,20 @@ async function findAvailablePort(): Promise<number> {
       });
     });
   });
+}
+
+function getBoundPort(server: unknown): number {
+  if (!server || typeof (server as { address?: unknown }).address !== 'function') {
+    throw new Error('Failed to resolve a bound test server.');
+  }
+
+  const address = (server as { address(): AddressInfo | string | null }).address();
+
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to resolve a bound test port.');
+  }
+
+  return address.port;
 }
 
 function onceOpen(socket: WebSocket): Promise<void> {
@@ -147,30 +161,39 @@ describe('@fluojs/websockets/node', () => {
       providers: [GatewayState, ChatGateway],
     });
 
-    const port = await findAvailablePort();
-    const app = await bootstrapNodeApplication(AppModule, {
-      cors: false,
-      port,
+    const adapter = createNodeHttpAdapter({ port: 0 });
+    const app = await bootstrapApplication({
+      adapter,
+      rootModule: AppModule,
     });
     const state = await app.container.resolve(GatewayState);
 
-    await app.listen();
+    try {
+      await app.listen();
+      const port = getBoundPort((adapter as { getServer(): unknown }).getServer());
 
-    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
-    await onceOpen(socket);
-    socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
+      const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/chat`);
+      try {
+        await onceOpen(socket);
+        socket.send(JSON.stringify({ event: 'ping', data: { value: 'hello' } }));
 
-    const incoming = await onceMessage(socket);
-    expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
+        const incoming = await onceMessage(socket);
+        expect(JSON.parse(incoming)).toEqual({ event: 'pong', data: { value: 'hello' } });
 
-    socket.close();
-    await Promise.all([onceClosed(socket), disconnected.promise]);
+        socket.close();
+        await Promise.all([onceClosed(socket), disconnected.promise]);
 
-    expect(state.connectCount).toBe(1);
-    expect(state.messages).toEqual([{ value: 'hello' }]);
-    expect(state.disconnectCount).toBe(1);
-
-    await app.close();
+        expect(state.connectCount).toBe(1);
+        expect(state.messages).toEqual([{ value: 'hello' }]);
+        expect(state.disconnectCount).toBe(1);
+      } finally {
+        if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+          socket.close();
+        }
+      }
+    } finally {
+      await app.close();
+    }
   });
 
   it('waits for disconnect cleanup when a socket closes during shutdown drain', async () => {


### PR DESCRIPTION
## Summary

Hardens recurring test-stability patterns found by the package audit.

Linked context: Closes #2021

## Changes

- Replaced reserve-then-release port usage in touched HTTP/WebSocket tests with direct `port: 0` binding and bound-address discovery where the test needs a URL.
- Wrapped HTTP app, WebSocket client, fake timer, and global `fetch` mock cleanup paths in `try/finally`.
- Removed fixed post-disconnect sleeps from Socket.IO payload-limit assertions.

## Testing

- `pnpm test -- packages/platform-nodejs/src/index.test.ts packages/platform-express/src/adapter.test.ts packages/platform-fastify/src/adapter.test.ts packages/platform-cloudflare-workers/src/adapter.test.ts packages/socket.io/src/module.test.ts packages/websockets/src/module.test.ts packages/websockets/src/node/node.test.ts packages/terminus/src/module.test.ts` — passed (Vitest workspace config ran 219 files / 3158 tests).
- `pnpm lint` — passed; pre-existing warnings outside changed files remain, and `verify:public-export-tsdoc` passed.
- `pnpm typecheck` — blocked by pre-existing unresolved `@fluojs/serialization` import in `packages/runtime/src/application.test.ts`.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only stability hardening; no public package behavior, API surface, package contents, or release metadata changed.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

해당 없음 — test-only changes; no public exports changed.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No runtime behavior changed; existing regression tests were hardened to reduce flakes and open-handle risk.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

해당 없음 — no governance docs, package README claims, or platform contract docs changed.
