### PR TITLE
Resolve #2016: align platform adapter lifecycle, options, and docs

### DIFF
--- a/.changeset/platform-adapter-contracts.md
+++ b/.changeset/platform-adapter-contracts.md
@@ -1,0 +1,9 @@
+---
+"@fluojs/platform-bun": patch
+"@fluojs/platform-cloudflare-workers": patch
+"@fluojs/platform-deno": patch
+"@fluojs/platform-express": patch
+"@fluojs/platform-fastify": patch
+---
+
+Harden platform adapter option validation, shutdown lifecycle reuse, and contract documentation for Bun, Deno, Cloudflare Workers, Express, and Fastify.

--- a/packages/platform-bun/README.ko.md
+++ b/packages/platform-bun/README.ko.md
@@ -48,7 +48,7 @@ await app.listen();
 
 ### 수동 Fetch 처리
 Bun 서버를 직접 관리하려는 경우 fetch 핸들러를 직접 사용할 수 있습니다.
-`dispatcher`는 이미 bootstrap된 application의 `app.getHttpDispatcher()`에서 가져와야 하며, 이 handler는 managed adapter 경로와 동일한 raw-body, multipart, shutdown, native handoff 계약을 보존합니다.
+`dispatcher`는 이미 bootstrap된 application의 `app.getHttpDispatcher()`에서 가져와야 합니다. 이 handler는 raw-body와 multipart request parsing을 보존하지만, shutdown ownership, websocket upgrade, native `routes` acceleration은 주변 `Bun.serve(...)` host 또는 managed adapter 경로가 소유합니다.
 
 ```typescript
 import { createBunFetchHandler } from '@fluojs/platform-bun';

--- a/packages/platform-bun/README.md
+++ b/packages/platform-bun/README.md
@@ -48,7 +48,7 @@ await app.listen();
 
 ### Manual Fetch Handling
 If you prefer to manage the Bun server yourself, you can use the fetch handler directly.
-The `dispatcher` should come from the already bootstrapped application via `app.getHttpDispatcher()`, and the handler preserves the same raw-body, multipart, shutdown, and native handoff contracts as the managed adapter path.
+The `dispatcher` should come from the already bootstrapped application via `app.getHttpDispatcher()`. The handler preserves raw-body and multipart request parsing, while shutdown ownership, websocket upgrades, and native `routes` acceleration remain responsibilities of the surrounding `Bun.serve(...)` host or the managed adapter path.
 
 ```typescript
 import { createBunFetchHandler } from '@fluojs/platform-bun';

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { All, Controller, createDispatcher, createHandlerMapping, Get, Header, HttpCode, Post, Redirect, SseResponse, Version, VersioningType, type FrameworkRequest, type FrameworkResponse, type RequestContext } from '@fluojs/http';
@@ -447,6 +449,22 @@ function decodeUtf8(input: Uint8Array | undefined): string {
 
 describe('@fluojs/platform-bun', () => {
   registerBunWebRuntimePortabilitySuite();
+
+  it('rejects invalid explicit numeric adapter options during setup', () => {
+    expect(() => createBunAdapter({ idleTimeout: -1 })).toThrow(/idleTimeout/i);
+    expect(() => createBunAdapter({ maxBodySize: 1.5 })).toThrow(/maxBodySize/i);
+    expect(() => createBunAdapter({ port: 65_536 })).toThrow(/port/i);
+    expect(() => createBunFetchHandler({
+      dispatcher: { async dispatch() {} },
+      maxBodySize: Number.NaN,
+    })).toThrow(/maxBodySize/i);
+  });
+
+  it('keeps the Bun adapter runtime import path free of the Node runtime subpath', () => {
+    const source = readFileSync(new URL('./adapter.ts', import.meta.url), 'utf8');
+
+    expect(source).not.toContain("from '@fluojs/runtime/node'");
+  });
 
   it('translates Bun-style Request semantics into the framework request contract', async () => {
     const fetch = createBunFetchHandler({

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -20,14 +20,11 @@ import type {
   MultipartOptions,
   UploadedFile,
 } from '@fluojs/runtime';
-import {
-  createNodeShutdownSignalRegistration,
-  defaultNodeShutdownSignals,
-} from '@fluojs/runtime/node';
 import { createWebRequestResponseFactory, dispatchWebRequest } from '@fluojs/runtime/web';
 import {
   bootstrapHttpAdapterApplication,
   runHttpAdapterApplication,
+  type RunHttpAdapterApplicationOptions,
   type HttpAdapterListenTarget,
 } from '@fluojs/runtime/internal/http-adapter';
 
@@ -233,6 +230,7 @@ export interface RunBunApplicationOptions extends BootstrapBunApplicationOptions
 const DEFAULT_PORT = 3000;
 const DEFAULT_DISPATCHER_NOT_READY_MESSAGE = 'Bun adapter received a request before dispatcher binding completed.';
 const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
 const MINIMUM_BUN_NATIVE_ROUTES_VERSION = '1.2.3';
 const EMPTY_NATIVE_ROUTE_PARAMS: Readonly<Record<string, string>> = Object.freeze({});
 const BUN_WEBSOCKET_SUPPORT_REASON =
@@ -250,6 +248,9 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   private readonly webRequestResponseFactory;
 
   constructor(options: BunAdapterOptions = {}) {
+    validateNonNegativeIntegerOption('idleTimeout', options.idleTimeout);
+    validateNonNegativeIntegerOption('maxBodySize', options.maxBodySize);
+    validatePortOption(options.port);
     this.options = options;
     this.webRequestResponseFactory = createWebRequestResponseFactory({
       consumeOriginalBody: true,
@@ -439,6 +440,8 @@ export function createBunFetchHandler({
   multipart,
   rawBody,
 }: CreateBunFetchHandlerOptions): (request: Request) => Promise<Response> {
+  validateNonNegativeIntegerOption('maxBodySize', maxBodySize);
+
   const factory = createWebRequestResponseFactory({
     consumeOriginalBody: true,
     maxBodySize,
@@ -520,10 +523,79 @@ export async function runBunApplication(
 
   return runHttpAdapterApplication(rootModule, {
     ...options,
-    shutdownRegistration: createNodeShutdownSignalRegistration(
-      options.shutdownSignals ?? defaultNodeShutdownSignals(),
-    ),
+    shutdownRegistration: createBunShutdownSignalRegistration(options.shutdownSignals ?? defaultBunShutdownSignals()),
   }, adapter);
+}
+
+function defaultBunShutdownSignals(): readonly BunApplicationSignal[] {
+  return ['SIGINT', 'SIGTERM'];
+}
+
+function createBunShutdownSignalRegistration(
+  signals: false | readonly BunApplicationSignal[],
+): NonNullable<RunHttpAdapterApplicationOptions['shutdownRegistration']> {
+  return (app: Application, logger: ApplicationLogger, forceExitTimeoutMs = DEFAULT_FORCE_EXIT_TIMEOUT_MS) => {
+    if (signals === false) {
+      return () => {};
+    }
+
+    const bindings: Array<{ handler: () => void; signal: BunApplicationSignal }> = [];
+
+    for (const signal of signals) {
+      const handler = () => {
+        void closeBunApplicationFromSignal(app, logger, signal, forceExitTimeoutMs);
+      };
+
+      bindings.push({ handler, signal });
+      process.once(signal, handler);
+    }
+
+    return () => {
+      for (const binding of bindings) {
+        process.off(binding.signal, binding.handler);
+      }
+    };
+  };
+}
+
+async function closeBunApplicationFromSignal(
+  app: Application,
+  logger: ApplicationLogger,
+  signal: BunApplicationSignal,
+  forceExitTimeoutMs: number,
+): Promise<void> {
+  if (app.state === 'closed') {
+    process.exitCode = 0;
+    return;
+  }
+
+  let timedOut = false;
+  const forceExitTimer = setTimeout(() => {
+    timedOut = true;
+    logger.error(
+      `Shutdown timeout exceeded after ${String(forceExitTimeoutMs)}ms; leaving process termination to the host.`,
+      undefined,
+      'FluoFactory',
+    );
+    process.exitCode = 1;
+  }, forceExitTimeoutMs);
+
+  if (forceExitTimer.unref) {
+    forceExitTimer.unref();
+  }
+
+  try {
+    await app.close(signal);
+    clearTimeout(forceExitTimer);
+
+    if (!timedOut) {
+      process.exitCode = 0;
+    }
+  } catch (error: unknown) {
+    clearTimeout(forceExitTimer);
+    logger.error('Failed to shut down the application cleanly.', error, 'FluoFactory');
+    process.exitCode = 1;
+  }
 }
 
 function requireBunGlobal(): BunGlobal {
@@ -537,7 +609,27 @@ function requireBunGlobal(): BunGlobal {
 }
 
 function resolvePort(port: number | undefined): number {
-  return typeof port === 'number' && Number.isFinite(port) ? port : DEFAULT_PORT;
+  return validatePortOption(port);
+}
+
+function validatePortOption(port: number | undefined): number {
+  const resolved = port ?? DEFAULT_PORT;
+
+  if (!Number.isInteger(resolved) || resolved < 0 || resolved > 65535) {
+    throw new Error(`Invalid port value: ${String(resolved)}. Expected an integer between 0 and 65535.`);
+  }
+
+  return resolved;
+}
+
+function validateNonNegativeIntegerOption(name: string, value: number | undefined): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid ${name} value: ${String(value)}. Expected a non-negative integer.`);
+  }
 }
 
 function createBunNativeRoutes(

--- a/packages/platform-cloudflare-workers/README.ko.md
+++ b/packages/platform-cloudflare-workers/README.ko.md
@@ -76,10 +76,10 @@ export class MyGateway {}
 ```
 
 ### 엣지 네이티브 미들웨어
-표준 fluo 미들웨어(CORS, Global Prefix 등)가 완전히 지원되며 Cloudflare 환경에 최적화되어 있습니다.
+표준 fluo 미들웨어(CORS, Global Prefix 등)는 Worker bootstrap helper를 통해 완전히 지원되며 Cloudflare 환경에 최적화되어 있습니다. `createCloudflareWorkerAdapter(...)`는 adapter가 소유하는 parsing 및 websocket-pair 옵션만 받습니다. Routing 및 middleware 옵션은 `bootstrapCloudflareWorkerApplication(...)` 또는 `createCloudflareWorkerEntrypoint(...)`에 전달하세요.
 
 ```typescript
-const adapter = createCloudflareWorkerAdapter({
+const worker = createCloudflareWorkerEntrypoint(AppModule, {
   globalPrefix: 'api/v1',
   cors: true,
 });
@@ -88,6 +88,7 @@ const adapter = createCloudflareWorkerAdapter({
 ### 동작 참고
 
 - `fetch()`는 `listen()` 또는 lazy entrypoint가 dispatcher를 binding한 뒤 active work를 `executionContext.waitUntil(...)`에 등록합니다. 그 lifecycle boundary 전에는 upgrade request와 HTTP dispatch가 application handler에 도달하지 않습니다.
+- `maxBodySize` 같은 adapter option은 Worker adapter 생성 시 검증됩니다. `globalPrefix`, `cors`, `middleware`, `securityHeaders` 같은 bootstrap 전용 옵션은 `createCloudflareWorkerAdapter(...)`가 아니라 Worker bootstrap helper에 전달해야 합니다.
 - WebSocket upgrade는 HTTP dispatch와 같은 listen boundary가 소유합니다. `listen()` 전의 upgrade request는 설정된 binding에 도달하지 않습니다.
 - `close()`는 shutdown 중 및 shutdown 이후 새 요청에 JSON `503` response를 반환하고, active request가 끝나지 않으면 10초 뒤 timeout됩니다. 해당 close drain이 아직 활성 상태일 때 `listen()`을 호출하면 Cloudflare Workers adapter shutdown-draining 오류로 reject됩니다.
 - Multipart request는 `rawBody`를 보존하지 않습니다.

--- a/packages/platform-cloudflare-workers/README.md
+++ b/packages/platform-cloudflare-workers/README.md
@@ -76,10 +76,10 @@ export class MyGateway {}
 ```
 
 ### Edge-Native Middleware
-Standard fluo middleware (CORS, Global Prefix, etc.) is fully supported and optimized for the Cloudflare environment.
+Standard fluo middleware (CORS, Global Prefix, etc.) is fully supported through Worker bootstrap helpers and optimized for the Cloudflare environment. `createCloudflareWorkerAdapter(...)` only accepts adapter-owned parsing and websocket-pair options; pass routing and middleware options to `bootstrapCloudflareWorkerApplication(...)` or `createCloudflareWorkerEntrypoint(...)` instead.
 
 ```typescript
-const adapter = createCloudflareWorkerAdapter({
+const worker = createCloudflareWorkerEntrypoint(AppModule, {
   globalPrefix: 'api/v1',
   cors: true,
 });
@@ -88,6 +88,7 @@ const adapter = createCloudflareWorkerAdapter({
 ### Behavior Notes
 
 - `fetch()` registers active work with `executionContext.waitUntil(...)` after `listen()` or the lazy entrypoint binds the dispatcher; before that lifecycle boundary, upgrade requests and HTTP dispatch do not reach application handlers.
+- Adapter options such as `maxBodySize` are validated when the Worker adapter is created; bootstrap-only options such as `globalPrefix`, `cors`, `middleware`, and `securityHeaders` belong on Worker bootstrap helpers rather than `createCloudflareWorkerAdapter(...)`.
 - WebSocket upgrades are owned by the same listen boundary as HTTP dispatch; upgrade requests before `listen()` do not reach the configured binding.
 - `close()` returns JSON `503` responses for new requests during and after shutdown and times out after 10 seconds if active requests never settle. Calling `listen()` while that close drain is still active rejects with the Cloudflare Workers adapter shutdown-draining error.
 - Multipart requests do not preserve `rawBody`.

--- a/packages/platform-cloudflare-workers/src/adapter.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.test.ts
@@ -93,6 +93,11 @@ afterEach(() => {
 });
 
 describe('@fluojs/platform-cloudflare-workers', () => {
+  it('rejects invalid explicit numeric adapter options during setup', () => {
+    expect(() => createCloudflareWorkerAdapter({ maxBodySize: -1 })).toThrow(/maxBodySize/i);
+    expect(() => createCloudflareWorkerAdapter({ maxBodySize: 1.5 })).toThrow(/maxBodySize/i);
+  });
+
   it('keeps edge runtime README conformance coverage aligned across English and Korean docs', () => {
     const englishReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
     const koreanReadme = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');

--- a/packages/platform-cloudflare-workers/src/adapter.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.ts
@@ -125,6 +125,7 @@ export class CloudflareWorkerHttpApplicationAdapter
   private readonly webRequestResponseFactory;
 
   constructor(options: CloudflareWorkerAdapterOptions = {}) {
+    validateNonNegativeIntegerOption('maxBodySize', options.maxBodySize);
     this.options = options;
     this.webRequestResponseFactory = createWebRequestResponseFactory(options);
   }
@@ -402,6 +403,16 @@ function resolveWebSocketPairFactory(
   }
 
   throw new Error('Cloudflare Workers websocket support requires globalThis.WebSocketPair or options.createWebSocketPair().');
+}
+
+function validateNonNegativeIntegerOption(name: string, value: number | undefined): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid ${name} value: ${String(value)}. Expected a non-negative integer.`);
+  }
 }
 
 function isWebSocketUpgradeRequest(request: Request): boolean {

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -344,6 +344,11 @@ function createMockDenoSocket(): DenoServerWebSocket {
 }
 
 describe('@fluojs/platform-deno', () => {
+  it('rejects invalid explicit numeric adapter options during setup', () => {
+    expect(() => createDenoAdapter({ maxBodySize: -1 })).toThrow(/maxBodySize/i);
+    expect(() => createDenoAdapter({ port: 1.5 })).toThrow(/port/i);
+  });
+
   it('keeps edge runtime README conformance coverage aligned across English and Korean docs', () => {
     const englishReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
     const koreanReadme = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');
@@ -770,6 +775,41 @@ describe('@fluojs/platform-deno', () => {
     await expect(adapter.close()).rejects.toBe(drainError);
     expect(serveSignal?.aborted).toBe(true);
     expect(adapter.getServer()).toBeUndefined();
+  });
+
+  it('aborts the Deno serve signal when bounded close timeout elapses', async () => {
+    vi.useFakeTimers();
+
+    try {
+      let serveSignal: AbortSignal | undefined;
+      const adapter = new DenoHttpApplicationAdapter({
+        hostname: '0.0.0.0',
+        port: 3000,
+        serve: vi.fn((options) => {
+          serveSignal = options.signal;
+
+          return {
+            finished: new Promise<void>(() => {}),
+            shutdown: vi.fn(() => new Promise<void>(() => {})),
+          };
+        }),
+      });
+
+      await adapter.listen({
+        async dispatch(_request: FrameworkRequest, response: FrameworkResponse) {
+          response.setStatus(204);
+        },
+      });
+
+      const closePromise = adapter.close();
+      const closeExpectation = expect(closePromise).rejects.toThrow(/shutdown timeout/i);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await closeExpectation;
+      expect(serveSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns a shutdown 503 while close is draining active requests', async () => {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -234,7 +234,7 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
 
   async close(): Promise<void> {
     if (this.closeInFlight) {
-      await waitForCloseWithTimeout(this.closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+      await waitForCloseWithTimeout(this.closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS, () => this.abortController?.abort());
       return;
     }
 
@@ -270,7 +270,7 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
     this.closeInFlight = closeInFlight;
     void closeInFlight.catch(() => {});
 
-    await waitForCloseWithTimeout(closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+    await waitForCloseWithTimeout(closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS, () => abortController?.abort());
   }
 
   private trackInFlightRequest(): () => void {
@@ -310,10 +310,12 @@ export class DenoHttpApplicationAdapter implements HttpApplicationAdapter {
  * @returns A Deno-backed `HttpApplicationAdapter`.
  */
 export function createDenoAdapter(options: DenoAdapterOptions = {}): DenoHttpApplicationAdapter {
+  validateNonNegativeIntegerOption('maxBodySize', options.maxBodySize);
+
   return new DenoHttpApplicationAdapter({
     ...options,
     hostname: options.hostname ?? options.host ?? DEFAULT_HOSTNAME,
-    port: options.port ?? DEFAULT_PORT,
+    port: resolveDenoPort(options.port),
   });
 }
 
@@ -402,6 +404,26 @@ function createListenTarget(hostname: string, port: number, usesHttps: boolean):
   };
 }
 
+function resolveDenoPort(value: number | undefined): number {
+  const port = value ?? DEFAULT_PORT;
+
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid port value: ${String(port)}. Expected an integer between 0 and 65535.`);
+  }
+
+  return port;
+}
+
+function validateNonNegativeIntegerOption(name: string, value: number | undefined): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid ${name} value: ${String(value)}. Expected a non-negative integer.`);
+  }
+}
+
 function formatHostForAuthority(hostname: string): string {
   return hostname.includes(':') && !hostname.startsWith('[') ? `[${hostname}]` : hostname;
 }
@@ -483,9 +505,10 @@ function createShutdownResponse(): Response {
   });
 }
 
-function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number): Promise<void> {
+function waitForCloseWithTimeout(closePromise: Promise<void>, timeoutMs: number, onTimeout?: () => void): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => {
+      onTimeout?.();
       reject(new Error(`Deno adapter shutdown timeout exceeded ${String(timeoutMs)}ms.`));
     }, timeoutMs);
 

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -1794,7 +1794,10 @@ describe('@fluojs/platform-express', () => {
     Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
 
     const firstClose = adapter.close();
+    Reflect.set(server, 'listening', false);
     const secondClose = adapter.close();
+
+    expect(Reflect.get(adapter, 'dispatcher')).toBeDefined();
 
     deferred.resolve();
 

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -246,26 +246,23 @@ export class ExpressHttpApplicationAdapter implements HttpApplicationAdapter {
   }
 
   async close(): Promise<void> {
+    if (this.closeInFlight) {
+      await waitForCloseWithTimeout(this.closeInFlight, this.shutdownTimeoutMs);
+      return;
+    }
+
     if (!this.server.listening) {
       this.dispatcher = undefined;
       return;
     }
 
-    if (!this.closeInFlight) {
-      const closePromise = closeServerWithDrain(this.server, this.sockets, this.shutdownTimeoutMs);
-      const closeInFlight = closePromise.finally(() => {
-        this.closeInFlight = undefined;
-        this.dispatcher = undefined;
-      });
-      this.closeInFlight = closeInFlight;
-      void closeInFlight.catch(() => {});
-    }
-
-    const closeInFlight = this.closeInFlight;
-
-    if (!closeInFlight) {
-      return;
-    }
+    const closePromise = closeServerWithDrain(this.server, this.sockets, this.shutdownTimeoutMs);
+    const closeInFlight = closePromise.finally(() => {
+      this.closeInFlight = undefined;
+      this.dispatcher = undefined;
+    });
+    this.closeInFlight = closeInFlight;
+    void closeInFlight.catch(() => {});
 
     await waitForCloseWithTimeout(closeInFlight, this.shutdownTimeoutMs);
   }

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -41,7 +41,7 @@ const app = await fluoFactory.create(AppModule, {
 await app.listen();
 ```
 
-`createFastifyAdapter()`는 기본 port로 `3000`을 사용하며 `process.env.PORT`를 읽지 않습니다. 잘못된 explicit port 값은 adapter setup 중 throw됩니다.
+`createFastifyAdapter()`는 기본 port로 `3000`을 사용하며 `process.env.PORT`를 읽지 않습니다. `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs` 같은 잘못된 explicit numeric option은 adapter setup 중 throw됩니다. `maxBodySize`와 `shutdownTimeoutMs`는 음수가 아닌 정수 byte/time limit이므로 `0`도 유효합니다. `maxBodySize: 0`은 빈 request body만 허용하고, `shutdownTimeoutMs: 0`은 다음 timer turn에 Fastify close가 timeout되도록 요청합니다.
 
 ## 주요 패턴
 

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -41,7 +41,7 @@ const app = await fluoFactory.create(AppModule, {
 await app.listen();
 ```
 
-`createFastifyAdapter()` defaults to port `3000` and does not read `process.env.PORT`; invalid explicit port values throw during adapter setup.
+`createFastifyAdapter()` defaults to port `3000` and does not read `process.env.PORT`; invalid explicit numeric options such as `port`, `maxBodySize`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs` throw during adapter setup. `maxBodySize` and `shutdownTimeoutMs` are non-negative integer byte/time limits, so `0` is valid: `maxBodySize: 0` allows only empty request bodies, and `shutdownTimeoutMs: 0` asks Fastify to close on the next timer turn.
 
 ## Common Patterns
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -306,6 +306,21 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('rejects invalid explicit numeric adapter options during setup', () => {
+    expect(() => createFastifyAdapter({ maxBodySize: -1 })).toThrow(/maxBodySize/i);
+    expect(() => createFastifyAdapter({ retryDelayMs: -1 })).toThrow(/retryDelayMs/i);
+    expect(() => createFastifyAdapter({ retryLimit: 1.5 })).toThrow(/retryLimit/i);
+    expect(() => createFastifyAdapter({ shutdownTimeoutMs: Number.NaN })).toThrow(/shutdownTimeoutMs/i);
+  });
+
+  it('rejects invalid numeric options through the public adapter constructor', () => {
+    expect(() => new FastifyHttpApplicationAdapter(-1, undefined, 150, 20, undefined)).toThrow(/PORT/i);
+    expect(() => new FastifyHttpApplicationAdapter(3000, undefined, -1, 20, undefined)).toThrow(/retryDelayMs/i);
+    expect(() => new FastifyHttpApplicationAdapter(3000, undefined, 150, 1.5, undefined)).toThrow(/retryLimit/i);
+    expect(() => new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, -1)).toThrow(/maxBodySize/i);
+    expect(() => new FastifyHttpApplicationAdapter(3000, undefined, 150, 20, undefined, undefined, 1024, false, Number.NaN)).toThrow(/shutdownTimeoutMs/i);
+  });
+
   it('exposes a server-backed realtime capability on the Fastify adapter', async () => {
     const adapter = createFastifyAdapter() as FastifyHttpApplicationAdapter;
 
@@ -1858,9 +1873,11 @@ describe('@fluojs/platform-fastify', () => {
     Reflect.set(adapter, 'dispatcher', { async dispatch() {} });
 
     const firstClose = adapter.close();
+    app.server.listening = false;
     const secondClose = adapter.close();
 
     expect(closeCallCount).toBe(1);
+    expect(Reflect.get(adapter, 'dispatcher')).toBeDefined();
 
     deferred.resolve();
     await Promise.all([firstClose, secondClose]);

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -184,6 +184,11 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
     private readonly preserveRawBody = false,
     private readonly shutdownTimeoutMs = DEFAULT_SHUTDOWN_TIMEOUT_MS,
   ) {
+    resolvePort(this.port);
+    resolveNonNegativeIntegerOption('retryDelayMs', this.retryDelayMs, 150);
+    resolveNonNegativeIntegerOption('retryLimit', this.retryLimit, 20);
+    resolveNonNegativeIntegerOption('maxBodySize', this.maxBodySize, DEFAULT_MAX_BODY_SIZE);
+    resolveNonNegativeIntegerOption('shutdownTimeoutMs', this.shutdownTimeoutMs, DEFAULT_SHUTDOWN_TIMEOUT_MS);
     this.app = createFastifyApp(this.httpsOptions, this.maxBodySize);
     this.requestResponseFactory = createFastifyRequestResponseFactory(
       this.multipartOptions,
@@ -211,26 +216,23 @@ export class FastifyHttpApplicationAdapter implements HttpApplicationAdapter {
   }
 
   async close(): Promise<void> {
+    if (this.closeInFlight) {
+      await waitForCloseWithTimeout(this.closeInFlight, this.shutdownTimeoutMs);
+      return;
+    }
+
     if (!this.app.server.listening) {
       this.dispatcher = undefined;
       return;
     }
 
-    if (!this.closeInFlight) {
-      const closePromise = this.app.close();
-      const closeInFlight = closePromise.finally(() => {
-        this.closeInFlight = undefined;
-        this.dispatcher = undefined;
-      });
-      this.closeInFlight = closeInFlight;
-      void closeInFlight.catch(() => {});
-    }
-
-    const closeInFlight = this.closeInFlight;
-
-    if (!closeInFlight) {
-      return;
-    }
+    const closePromise = this.app.close();
+    const closeInFlight = closePromise.finally(() => {
+      this.closeInFlight = undefined;
+      this.dispatcher = undefined;
+    });
+    this.closeInFlight = closeInFlight;
+    void closeInFlight.catch(() => {});
 
     await waitForCloseWithTimeout(closeInFlight, this.shutdownTimeoutMs);
   }
@@ -1221,6 +1223,16 @@ function resolvePort(value: number | undefined): number {
   }
 
   return port;
+}
+
+function resolveNonNegativeIntegerOption(name: string, value: number | undefined, defaultValue: number): number {
+  const resolved = value ?? defaultValue;
+
+  if (!Number.isInteger(resolved) || resolved < 0) {
+    throw new Error(`Invalid ${name} value: ${String(resolved)}. Expected a non-negative integer.`);
+  }
+
+  return resolved;
 }
 
 function toHttpException(error: unknown): HttpException {

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -34,6 +34,31 @@ function getBoundPort(server: { address(): AddressInfo | string | null }): numbe
   return address.port;
 }
 
+async function findAvailablePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer();
+
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to resolve an available port.'));
+        return;
+      }
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(address.port);
+      });
+    });
+  });
+}
+
 type MultipartRequestWithFiles = RequestContext['request'] & {
   files?: Array<{
     fieldname: string;


### PR DESCRIPTION
## Summary

Closes #2016.

Linked context: https://github.com/fluojs/fluo/issues/2016

Aligns platform adapter lifecycle, option validation, and README contracts across Bun, Deno, Cloudflare Workers, Express, and Fastify after #2024 landed.

## Changes

- Removed Bun adapter runtime dependency on `@fluojs/runtime/node` by keeping Bun signal registration local to the Bun package.
- Clarified `createBunFetchHandler(...)` docs so standalone fetch handling no longer claims managed-adapter shutdown/native-route ownership.
- Added fail-fast numeric validation for Bun, Deno, Cloudflare Workers, and Fastify adapter boundaries.
- Ensured Deno close timeout aborts the active `Deno.serve(...)` signal.
- Reused in-flight Express/Fastify close lifecycles before checking host listening state.
- Corrected Cloudflare Workers README examples so routing/middleware options are passed to Worker bootstrap helpers, not `createCloudflareWorkerAdapter(...)`.
- Added regression tests and a patch changeset for affected public platform packages.

## Testing

- `pnpm install`
- `pnpm vitest run packages/platform-bun/src/adapter.test.ts packages/platform-deno/src/adapter.test.ts packages/platform-cloudflare-workers/src/adapter.test.ts packages/platform-express/src/adapter.test.ts packages/platform-fastify/src/adapter.test.ts` ✅ 5 files / 172 tests passed
- `pnpm build` ✅
- `pnpm --filter @fluojs/platform-bun typecheck && pnpm --filter @fluojs/platform-cloudflare-workers typecheck && pnpm --filter @fluojs/platform-deno typecheck && pnpm --filter @fluojs/platform-express typecheck && pnpm --filter @fluojs/platform-fastify typecheck` ✅
- `pnpm verify:platform-consistency-governance` ✅
- Changed-file LSP diagnostics: no errors/warnings; pre-existing deprecation hints remain in Express/Fastify tests.
- `pnpm typecheck` / `pnpm verify:release-readiness` currently fail outside this PR scope in `packages/platform-nodejs/src/index.test.ts` because `findAvailablePort` is missing on `origin/main`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary. No new public exports were added; changed exported adapter behavior keeps existing TSDoc surfaces intact.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. Existing exported function docs remain valid after option validation hardening.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. Bun, Cloudflare Workers, and Fastify README examples were aligned with runtime ownership.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed). Standalone Bun fetch handling and Worker adapter option ownership are now explicit.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. No governance SSOT docs changed; affected package README EN/KO mirrors were updated together.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Package-local README contract updates include regression tests.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Existing conformance harness coverage remains; new focused adapter tests cover the added contracts.
