### PR TITLE
Fix Redis connect timeout cleanup

### DIFF
--- a/.changeset/redis-connect-timeout-cleanup.md
+++ b/.changeset/redis-connect-timeout-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/redis": patch
+---
+
+Disconnect lifecycle-owned Redis clients when bootstrap `connect()` times out so in-flight connection attempts are cleaned up before startup failure propagates, and document the exported default and named Redis module option types in the package README API lists.

--- a/packages/redis/README.ko.md
+++ b/packages/redis/README.ko.md
@@ -161,6 +161,8 @@ export class AdvancedService {
 - `createRedisPlatformStatusSnapshot(input)`: Redis 연결 상태를 Fluo 플랫폼 health/readiness 스냅샷으로 변환합니다.
 
 ### 타입
+- `DefaultRedisModuleOptions`: 이름 없는 기본 Redis 등록이 받는 옵션입니다. 선택적 global alias visibility와 lifecycle timeout control을 포함합니다.
+- `NamedRedisModuleOptions`: 추가 이름 있는 Redis 등록이 받는 옵션입니다. 필수 `name`과 scoped lifecycle timeout control을 포함합니다.
 - `RedisModuleOptions`: Fluo가 module-only `name`, `global`, `lifecycle` 필드를 제거한 뒤 `ioredis` 생성자에 전달하는 설정 옵션입니다.
 - `RedisClientOptions`: Fluo가 module-only field를 제거하고 내부에서 `lazyConnect: true`를 강제하기 전의 Redis constructor option입니다.
 - `RedisLifecycleOptions`: Fluo가 소유한 `connect()`와 `quit()` lifecycle command의 timeout을 조정하는 선택적 옵션입니다.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -161,6 +161,8 @@ export class AdvancedService {
 - `createRedisPlatformStatusSnapshot(input)`: Adapts Redis connection state into Fluo's platform health/readiness snapshot contract.
 
 ### Types
+- `DefaultRedisModuleOptions`: Options accepted by the unnamed default Redis registration, including optional global alias visibility and lifecycle timeout controls.
+- `NamedRedisModuleOptions`: Options accepted by additional named Redis registrations, including required `name` and scoped lifecycle timeout controls.
 - `RedisModuleOptions`: Configuration options passed to the `ioredis` constructor after Fluo removes module-only `name`, `global`, and `lifecycle` fields.
 - `RedisClientOptions`: Redis constructor options after Fluo removes module-only fields and before it forces `lazyConnect: true` internally.
 - `RedisLifecycleOptions`: Optional timeout controls for Fluo-owned `connect()` and `quit()` lifecycle commands.

--- a/packages/redis/src/module.test.ts
+++ b/packages/redis/src/module.test.ts
@@ -223,6 +223,7 @@ describe('@fluojs/redis', () => {
 
     await bootstrapAssertion;
     expect(mockRedisState.events).toEqual(['connect', 'disconnect']);
+    expect(mockRedisState.instances[0]?.status).toBe('end');
   });
 
   it('uses global visibility only for unnamed default registrations', () => {

--- a/packages/redis/src/service.ts
+++ b/packages/redis/src/service.ts
@@ -69,11 +69,7 @@ export class RedisLifecycleService implements OnModuleInit, OnApplicationShutdow
       return;
     }
 
-    await withLifecycleTimeout(
-      this.client.connect(),
-      normalizeTimeoutMs(this.lifecycleOptions.connectTimeoutMs),
-      `Redis client ${this.describeClient()} connect timed out after ${String(normalizeTimeoutMs(this.lifecycleOptions.connectTimeoutMs))}ms.`,
-    );
+    await this.connectWithDisconnectFallback();
   }
 
   async onApplicationShutdown(): Promise<void> {
@@ -123,6 +119,20 @@ export class RedisLifecycleService implements OnModuleInit, OnApplicationShutdow
       if (!isClosed(this.client.status)) {
         throw error;
       }
+    }
+  }
+
+  private async connectWithDisconnectFallback(): Promise<void> {
+    try {
+      await withLifecycleTimeout(
+        this.client.connect(),
+        normalizeTimeoutMs(this.lifecycleOptions.connectTimeoutMs),
+        `Redis client ${this.describeClient()} connect timed out after ${String(normalizeTimeoutMs(this.lifecycleOptions.connectTimeoutMs))}ms.`,
+      );
+    } catch (error: unknown) {
+      this.disconnectIfPossible(this.client.status);
+
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

Tighten the remaining Redis scope from #2017 by ensuring lifecycle-owned Redis connect timeouts clean up the in-flight connection attempt and by documenting the exported default/named Redis option types in the package API lists.

Linked context: Closes #2017

## Changes

- Route Redis bootstrap `connect()` through a disconnect fallback so timeout or connect failures close lifecycle-owned clients before propagating startup failure.
- Extend the Redis lifecycle regression assertion to verify timed-out connect attempts leave the mock client closed.
- Add `DefaultRedisModuleOptions` and `NamedRedisModuleOptions` to the English/Korean README public type lists.
- Add a patch changeset for `@fluojs/redis`.

## Testing

- `pnpm install`
- `pnpm --filter @fluojs/redis... build`
- `pnpm --filter @fluojs/redis typecheck`
- `pnpm --filter @fluojs/redis test`
- `pnpm docs:sync-check`
- LSP diagnostics: no diagnostics for `packages/redis/src/service.ts` and `packages/redis/src/module.test.ts` after workspace dependency build

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
