### PR TITLE
Restore terminal logger colors for Bun and Deno

### DIFF
--- a/.changeset/bright-logs-bun-deno.md
+++ b/.changeset/bright-logs-bun-deno.md
@@ -1,0 +1,7 @@
+---
+"@fluojs/runtime": patch
+"@fluojs/platform-bun": patch
+"@fluojs/platform-deno": patch
+---
+
+Restore console-style logger defaults for Bun and Deno terminal startup helpers while keeping shared/root and Worker bootstrap logging transport-neutral.

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -466,6 +466,29 @@ describe('@fluojs/platform-bun', () => {
     expect(source).not.toContain("from '@fluojs/runtime/node'");
   });
 
+  it('uses the console application logger by default for terminal Bun startup helpers', async () => {
+    installMockBun();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    const app = await runBunApplication(AppModule, {
+      hostname: '127.0.0.1',
+      port: 0,
+      shutdownSignals: false,
+    });
+
+    try {
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining(`[fluo] ${String(process.pid)} -`),
+      );
+      expect(log).not.toHaveBeenCalledWith('[fluo] LOG [FluoFactory] Listening on http://127.0.0.1:0');
+    } finally {
+      await app.close();
+    }
+  });
+
   it('translates Bun-style Request semantics into the framework request contract', async () => {
     const fetch = createBunFetchHandler({
       dispatcher: {

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -23,6 +23,7 @@ import type {
 import { createWebRequestResponseFactory, dispatchWebRequest } from '@fluojs/runtime/web';
 import {
   bootstrapHttpAdapterApplication,
+  createConsoleApplicationLogger,
   runHttpAdapterApplication,
   type RunHttpAdapterApplicationOptions,
   type HttpAdapterListenTarget,
@@ -481,9 +482,11 @@ export async function bootstrapBunApplication(
   rootModule: ModuleType,
   options: BootstrapBunApplicationOptions,
 ): Promise<Application> {
+  const logger = options.logger ?? createConsoleApplicationLogger();
+
   return bootstrapHttpAdapterApplication(
     rootModule,
-    options,
+    { ...options, logger },
     createBunAdapter({
       development: options.development,
       hostname: options.hostname,
@@ -509,6 +512,7 @@ export async function runBunApplication(
   rootModule: ModuleType,
   options: RunBunApplicationOptions,
 ): Promise<Application> {
+  const logger = options.logger ?? createConsoleApplicationLogger();
   const adapter = createBunAdapter({
     development: options.development,
     hostname: options.hostname,
@@ -523,6 +527,7 @@ export async function runBunApplication(
 
   return runHttpAdapterApplication(rootModule, {
     ...options,
+    logger,
     shutdownRegistration: createBunShutdownSignalRegistration(options.shutdownSignals ?? defaultBunShutdownSignals()),
   }, adapter);
 }

--- a/packages/platform-cloudflare-workers/src/adapter.test.ts
+++ b/packages/platform-cloudflare-workers/src/adapter.test.ts
@@ -119,6 +119,24 @@ describe('@fluojs/platform-cloudflare-workers', () => {
     expect(source).not.toContain("} from '@fluojs/http';");
   });
 
+  it('keeps Worker bootstrap on the transport-neutral default logger', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    const worker = await bootstrapCloudflareWorkerApplication(AppModule);
+
+    try {
+      expect(log).toHaveBeenCalledWith('[fluo] LOG [FluoFactory] Starting fluo application...');
+      expect(log).not.toHaveBeenCalledWith(
+        expect.stringContaining(`[fluo] ${String(process.pid)} -`),
+      );
+    } finally {
+      await worker.close();
+    }
+  });
+
   it('delegates Worker fetch handling to the shared web adapter core', async () => {
     const adapter = createCloudflareWorkerAdapter({ rawBody: true });
     const dispatcher = {

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -349,6 +349,28 @@ describe('@fluojs/platform-deno', () => {
     expect(() => createDenoAdapter({ port: 1.5 })).toThrow(/port/i);
   });
 
+  it('uses the console application logger by default for terminal Deno startup helpers', async () => {
+    const server = createServeStub();
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    const app = await runDenoApplication(AppModule, {
+      serve: server.serve,
+      shutdownSignals: false,
+    });
+
+    try {
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining(`[fluo] ${String(process.pid)} -`),
+      );
+      expect(log).not.toHaveBeenCalledWith('[fluo] LOG [FluoFactory] Listening on http://localhost:3000 (bound to 0.0.0.0:3000)');
+    } finally {
+      await app.close();
+    }
+  });
+
   it('keeps edge runtime README conformance coverage aligned across English and Korean docs', () => {
     const englishReadme = readFileSync(new URL('../README.md', import.meta.url), 'utf8');
     const koreanReadme = readFileSync(new URL('../README.ko.md', import.meta.url), 'utf8');

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -2,6 +2,7 @@ import { createFetchStyleHttpAdapterRealtimeCapability, type Dispatcher, type Ht
 import type { Application, ApplicationLogger, ModuleType, MultipartOptions } from '@fluojs/runtime';
 import {
   bootstrapHttpAdapterApplication,
+  createConsoleApplicationLogger,
   runHttpAdapterApplication,
   type BootstrapHttpAdapterApplicationOptions,
   type HttpAdapterListenTarget,
@@ -330,7 +331,9 @@ export async function bootstrapDenoApplication(
   rootModule: ModuleType,
   options: BootstrapDenoApplicationOptions = {},
 ): Promise<Application> {
-  return await bootstrapHttpAdapterApplication(rootModule, options, createDenoAdapter(options));
+  const logger = options.logger ?? createConsoleApplicationLogger();
+
+  return await bootstrapHttpAdapterApplication(rootModule, { ...options, logger }, createDenoAdapter(options));
 }
 
 /**
@@ -344,9 +347,11 @@ export async function runDenoApplication(
   rootModule: ModuleType,
   options: RunDenoApplicationOptions = {},
 ): Promise<Application> {
+  const logger = options.logger ?? createConsoleApplicationLogger();
   const adapter = createDenoAdapter(options);
   return await runHttpAdapterApplication(rootModule, {
     ...options,
+    logger,
     shutdownRegistration: options.shutdownSignals === false
       ? undefined
       : createDenoShutdownSignalRegistration(options.shutdownSignals ?? defaultDenoShutdownSignals()),

--- a/packages/runtime/src/adapters/internal-http-adapter.ts
+++ b/packages/runtime/src/adapters/internal-http-adapter.ts
@@ -10,3 +10,4 @@ export {
   type HttpAdapterShutdownRegistration,
   type RunHttpAdapterApplicationOptions,
 } from '../http-adapter-shared.js';
+export { createConsoleApplicationLogger } from '../logging/logger.js';


### PR DESCRIPTION
## Summary
- Restore console-style default logging for Bun and Deno startup helpers
- Keep shared/root HTTP adapter and Cloudflare Workers bootstrap on the transport-neutral default logger
- Add regression coverage for Bun, Deno, and Worker logger defaults
- Add a changeset for affected public packages

Fixes #2034

## Verification
- pnpm --filter @fluojs/runtime build && pnpm --filter @fluojs/platform-bun build && pnpm --filter @fluojs/platform-deno build && pnpm --filter @fluojs/platform-cloudflare-workers build
- pnpm --filter @fluojs/runtime typecheck && pnpm --filter @fluojs/platform-bun typecheck && pnpm --filter @fluojs/platform-deno typecheck && pnpm --filter @fluojs/platform-cloudflare-workers typecheck
- pnpm --filter @fluojs/platform-bun test && pnpm --filter @fluojs/platform-deno test && pnpm --filter @fluojs/platform-cloudflare-workers test