### PR TITLE
Restore Node starter log colors

### DIFF
--- a/.changeset/green-logs-node-starters.md
+++ b/.changeset/green-logs-node-starters.md
@@ -1,0 +1,11 @@
+---
+"@fluojs/cli": patch
+"@fluojs/runtime": patch
+"@fluojs/platform-bun": patch
+"@fluojs/platform-deno": patch
+"@fluojs/platform-express": patch
+"@fluojs/platform-fastify": patch
+"@fluojs/platform-nodejs": patch
+---
+
+Restore generated Node starter runtime log colors by using platform startup helpers and internalizing runtime logger selection instead of accepting logger overrides in app options.

--- a/.opencode/agents/README.md
+++ b/.opencode/agents/README.md
@@ -35,7 +35,13 @@ permission:
     'git status*': allow
     'git diff*': allow
     'git log*': allow
+    'git show*': allow
     'git ls-files*': allow
+    'GIT_MASTER=1 git status*': allow
+    'GIT_MASTER=1 git diff*': allow
+    'GIT_MASTER=1 git log*': allow
+    'GIT_MASTER=1 git show*': allow
+    'GIT_MASTER=1 git ls-files*': allow
     # Prefer git ls-files for repeatable package file lists.
     # Add exact find commands only for observed safe read-only prompts.
 
@@ -96,7 +102,13 @@ permission:
     'git status*': allow
     'git diff*': allow
     'git log*': allow
+    'git show*': allow
     'git ls-files*': allow
+    'GIT_MASTER=1 git status*': allow
+    'GIT_MASTER=1 git diff*': allow
+    'GIT_MASTER=1 git log*': allow
+    'GIT_MASTER=1 git show*': allow
+    'GIT_MASTER=1 git ls-files*': allow
     # Prefer git ls-files for repeatable package file lists.
     # Add exact find commands only for observed safe read-only prompts.
 

--- a/.opencode/agents/fluo-code-reviewer.md
+++ b/.opencode/agents/fluo-code-reviewer.md
@@ -10,14 +10,23 @@ permission:
   edit: deny
   bash:
     '*': ask
+    'find *': deny
+    'xargs *': deny
     'git status*': allow
     'git diff*': allow
     'git log*': allow
+    'git show*': allow
     'git ls-files*': allow
-    'sort': allow
+    'GIT_MASTER=1 git status*': allow
+    'GIT_MASTER=1 git diff*': allow
+    'GIT_MASTER=1 git log*': allow
+    'GIT_MASTER=1 git show*': allow
+    'GIT_MASTER=1 git ls-files*': allow
+    'sort*': allow
     'gh pr view*': allow
     'gh pr diff*': allow
     'gh pr checks*': allow
+    'gh run view*': allow
     'gh issue view*': allow
     'gh issue list*': allow
     'gh label list*': allow

--- a/.opencode/agents/fluo-contract-reviewer.md
+++ b/.opencode/agents/fluo-contract-reviewer.md
@@ -10,13 +10,23 @@ permission:
   edit: deny
   bash:
     '*': ask
+    'find *': deny
+    'xargs *': deny
     'git status*': allow
     'git diff*': allow
     'git log*': allow
-    'sort': allow
+    'git show*': allow
+    'git ls-files*': allow
+    'GIT_MASTER=1 git status*': allow
+    'GIT_MASTER=1 git diff*': allow
+    'GIT_MASTER=1 git log*': allow
+    'GIT_MASTER=1 git show*': allow
+    'GIT_MASTER=1 git ls-files*': allow
+    'sort*': allow
     'gh pr view*': allow
     'gh pr diff*': allow
     'gh pr checks*': allow
+    'gh run view*': allow
     'gh issue view*': allow
     'gh issue list*': allow
     'gh label list*': allow

--- a/.opencode/agents/fluo-verification-reviewer.md
+++ b/.opencode/agents/fluo-verification-reviewer.md
@@ -10,11 +10,19 @@ permission:
   edit: deny
   bash:
     '*': ask
+    'find *': deny
+    'xargs *': deny
     'git status*': allow
     'git diff*': allow
     'git log*': allow
+    'git show*': allow
     'git ls-files*': allow
-    'sort': allow
+    'GIT_MASTER=1 git status*': allow
+    'GIT_MASTER=1 git diff*': allow
+    'GIT_MASTER=1 git log*': allow
+    'GIT_MASTER=1 git show*': allow
+    'GIT_MASTER=1 git ls-files*': allow
+    'sort*': allow
     'gh pr view*': allow
     'gh pr diff*': allow
     'gh pr checks*': allow

--- a/.opencode/commands/pr-to-merge.md
+++ b/.opencode/commands/pr-to-merge.md
@@ -34,6 +34,18 @@ argument-hint: "<pr-url|pr-number> [linked-issue-url|number] [base-branch]"
 - 파일을 수정하지 않는다.
 - 실제 merge authority는 사용자 또는 상위 `lane-supervisor`가 별도로 행사한다.
 
+## Reviewer read-only allowlist
+
+`@fluo-contract-reviewer`, `@fluo-code-reviewer`, `@fluo-verification-reviewer`는 같은 PR을 반복 검토할 때 아래 read-only 명령을 frontmatter permission에서 사전 허용해야 한다. 새 reviewer 권한을 추가할 때도 이 목록을 우선 갱신해 동일한 PR에서 같은 권한을 반복 요청하지 않도록 한다.
+
+- `gh pr view*`, `gh pr diff*`, `gh pr checks*`, `gh run view*`
+- `gh issue view*`, `gh issue list*`, `gh label list*`
+- `git status*`, `git diff*`, `git log*`, `git show*`, `git ls-files*`
+- `GIT_MASTER=1 git status*`, `GIT_MASTER=1 git diff*`, `GIT_MASTER=1 git log*`, `GIT_MASTER=1 git show*`, `GIT_MASTER=1 git ls-files*`
+- `sort*`
+
+Mutating commands such as `gh pr merge*`, `gh pr review*`, `gh pr edit*`, `gh issue comment*`, `gh run cancel*`, `gh run rerun*`, `git push*`, branch/worktree cleanup, and label mutation stay denied or unlisted.
+
 ## 컨텍스트 수집
 
 안전한 read-only 명령과 파일 읽기만 사용해 다음을 수집한다.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1010,7 +1010,7 @@ void bootstrap();
     expect(stdoutBuffer.join('')).toContain('cd ./starter-app');
     expect(packageJson).toContain('@fluojs/platform-fastify');
     expect(packageJson).toContain('@fluojs/runtime');
-    expect(mainFile).toContain("createFastifyAdapter({ port })");
+    expect(mainFile).toContain('runFastifyApplication(AppModule, { port })');
   });
 
   it('scaffolds the Express HTTP starter when the Express platform is selected explicitly', async () => {
@@ -1047,7 +1047,7 @@ void bootstrap();
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(packageJson).toContain('@fluojs/platform-express');
-    expect(mainFile).toContain('createExpressAdapter({ port })');
+    expect(mainFile).toContain('runExpressApplication(AppModule, { port })');
   });
 
   it('scaffolds the raw Node.js HTTP starter when the nodejs platform is selected explicitly', async () => {
@@ -1084,7 +1084,7 @@ void bootstrap();
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(packageJson).toContain('@fluojs/platform-nodejs');
-    expect(mainFile).toContain('createNodejsAdapter({ port })');
+    expect(mainFile).toContain('runNodejsApplication(AppModule, { port })');
   });
 
   it('scaffolds the Bun HTTP starter when the bun runtime is selected explicitly', async () => {
@@ -1121,7 +1121,7 @@ void bootstrap();
     expect(exitCode).toBe(0);
     expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');
     expect(packageJson).toContain('@fluojs/platform-bun');
-    expect(mainFile).toContain('createBunAdapter({ port })');
+    expect(mainFile).toContain('runBunApplication(AppModule, { port })');
   });
 
   it('scaffolds the Deno HTTP starter when the deno runtime is selected explicitly', async () => {
@@ -4310,16 +4310,15 @@ exit 7
     expect(existsSync(join(projectDirectory, 'src', 'greeting', 'greeting.slice.test.ts'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'src', 'app.test.ts'))).toBe(true);
     expect(existsSync(join(projectDirectory, 'test', 'app.e2e.test.ts'))).toBe(true);
-    expect(readmeContent).toContain('Starter contract: `src/main.ts` wires the selected first-class application starter: Node.js runtime + Fastify HTTP via `createFastifyAdapter(...)`');
+    expect(readmeContent).toContain('Starter contract: `src/main.ts` boots the selected first-class application starter: Node.js runtime + Fastify HTTP via `runFastifyApplication(...)`');
     expect(readmeContent).toContain('Default baseline: when you omit `--platform`, `fluo new` still generates the Node.js + Fastify HTTP starter by default');
     expect(readmeContent).toContain('Broader runtime/adapter package coverage is documented in the fluo docs and package READMEs; this generated starter intentionally describes only the wired starter path above');
     expect(readmeContent).not.toContain('@fluojs/runtime/node');
     expect(readmeContent).not.toContain('@fluojs/platform-nodejs');
-    expect(readmeContent).toContain('createFastifyAdapter');
+    expect(readmeContent).toContain('runFastifyApplication');
     expect(readmeContent).toContain('runtime module entrypoints use governed canonical names');
     expect(mainContent).toContain("from '@fluojs/platform-fastify'");
-    expect(mainContent).toContain('adapter: createFastifyAdapter({ port })');
-    expect(mainContent).toContain('await app.listen();');
+    expect(mainContent).toContain('runFastifyApplication(AppModule, { port })');
     expect(appTestContent).toContain("createRequest('/health')");
     expect(appTestContent).toContain("createRequest('/ready')");
     expect(appTestContent).toContain("createRequest('/greeting/')");

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -436,12 +436,6 @@ export async function runInspectCommand(argv: string[], runtime: InspectCommandR
 
     const context = await FluoFactory.createApplicationContext(rootModule, {
       diagnostics: parsed.timing || parsed.report ? { timing: true } : undefined,
-      logger: {
-        debug() {},
-        error() {},
-        log() {},
-        warn() {},
-      },
     });
 
     try {

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -7,9 +7,8 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
-
-import { scaffoldBootstrapApp } from './scaffold.js';
 import { DEFAULT_BOOTSTRAP_SCHEMA } from './resolver.js';
+import { scaffoldBootstrapApp } from './scaffold.js';
 
 const temporaryDirectories: string[] = [];
 const require = createRequire(import.meta.url);
@@ -470,19 +469,17 @@ describe('scaffoldBootstrapApp', () => {
     const readme = readFileSync(join(targetDirectory, 'README.md'), 'utf8');
     const mainFile = readFileSync(join(targetDirectory, 'src', 'main.ts'), 'utf8');
 
-    expect(readme).toContain('Starter contract: `src/main.ts` wires the selected first-class application starter: Node.js runtime + Fastify HTTP via `createFastifyAdapter(...)`');
+    expect(readme).toContain('Starter contract: `src/main.ts` boots the selected first-class application starter: Node.js runtime + Fastify HTTP via `runFastifyApplication(...)`');
     expect(readme).toContain('Default baseline: when you omit `--platform`, `fluo new` still generates the Node.js + Fastify HTTP starter by default');
     expect(readme).toContain('Broader runtime/adapter package coverage is documented in the fluo docs and package READMEs; this generated starter intentionally describes only the wired starter path above');
     expect(readme).not.toContain('Bun');
     expect(readme).not.toContain('Deno');
     expect(readme).not.toContain('Cloudflare');
     expect(readme).not.toContain('@fluojs/platform-nodejs');
-    expect(mainFile).toContain('// The generated starter wires the selected first-class fluo new application path:');
-    expect(mainFile).toContain('// Node.js runtime + Fastify HTTP via createFastifyAdapter(...).');
-    expect(mainFile).toContain('// Application logging defaults to the pretty console logger when logger is omitted.');
-    expect(mainFile).toContain("// import { createJsonApplicationLogger } from '@fluojs/runtime/node';");
-    expect(mainFile).toContain('// Then pass `logger: createJsonApplicationLogger()` to FluoFactory.create(...).');
-    expect(mainFile).not.toContain('logger: createJsonApplicationLogger(),');
+    expect(mainFile).toContain("import { runFastifyApplication } from '@fluojs/platform-fastify';");
+    expect(mainFile).toContain('await runFastifyApplication(AppModule, { port });');
+    expect(mainFile).not.toContain('createConsoleApplicationLogger');
+    expect(mainFile).not.toContain('logger,');
     expect(mainFile).not.toContain('Bun');
     expect(mainFile).not.toContain('Deno');
     expect(mainFile).not.toContain('Cloudflare');
@@ -521,9 +518,11 @@ describe('scaffoldBootstrapApp', () => {
     });
     expect(packageJson.dependencies).not.toHaveProperty('@fluojs/platform-fastify');
     expect(packageJson.dependencies).not.toHaveProperty('@fluojs/platform-nodejs');
-    expect(readme).toContain('Node.js runtime + Express HTTP via `createExpressAdapter(...)`');
-    expect(mainFile).toContain("import { createExpressAdapter } from '@fluojs/platform-express';");
-    expect(mainFile).toContain('adapter: createExpressAdapter({ port })');
+    expect(readme).toContain('Node.js runtime + Express HTTP via `runExpressApplication(...)`');
+    expect(mainFile).toContain("import { runExpressApplication } from '@fluojs/platform-express';");
+    expect(mainFile).toContain('await runExpressApplication(AppModule, { port });');
+    expect(mainFile).not.toContain('createConsoleApplicationLogger');
+    expect(mainFile).not.toContain('logger,');
   });
 
   it('generates the Bun application starter scaffold', async () => {
@@ -569,15 +568,17 @@ describe('scaffoldBootstrapApp', () => {
     expect(packageJson.scripts?.dev).toBe('fluo dev');
     expect(packageJson.scripts?.start).toBe('bun dist/main.js');
     expect(tsconfig.compilerOptions?.types).toEqual(['node', 'bun']);
-    expect(readme).toContain('Bun runtime + Bun native HTTP via `createBunAdapter(...)`');
+    expect(readme).toContain('Bun runtime + Bun native HTTP via `runBunApplication(...)`');
     expect(readme).toContain('defaulting to Bun\'s native watch loop');
     expect(readme).toContain('fluo dev --runner fluo');
     expect(readme).toContain('Bun-native production commands');
     expect(readme).toContain('bun dist/main.js');
     expect(appFile).toContain('processEnv: process.env');
     expect(appFile).not.toContain('Bun.env');
-    expect(mainFile).toContain("import { createBunAdapter } from '@fluojs/platform-bun';");
+    expect(mainFile).toContain("import { runBunApplication } from '@fluojs/platform-bun';");
     expect(mainFile).toContain("Bun.env.PORT ?? '3000'");
+    expect(mainFile).toContain('await runBunApplication(AppModule, { port });');
+    expect(mainFile).not.toContain('FluoFactory.create');
   });
 
   it('generates the raw Node.js application starter scaffold', async () => {
@@ -612,9 +613,11 @@ describe('scaffoldBootstrapApp', () => {
     });
     expect(packageJson.dependencies).not.toHaveProperty('@fluojs/platform-fastify');
     expect(packageJson.dependencies).not.toHaveProperty('@fluojs/platform-express');
-    expect(readme).toContain('Node.js runtime + raw Node.js HTTP via `createNodejsAdapter(...)`');
-    expect(mainFile).toContain("import { createNodejsAdapter } from '@fluojs/platform-nodejs';");
-    expect(mainFile).toContain('adapter: createNodejsAdapter({ port })');
+    expect(readme).toContain('Node.js runtime + raw Node.js HTTP via `runNodejsApplication(...)`');
+    expect(mainFile).toContain("import { runNodejsApplication } from '@fluojs/platform-nodejs';");
+    expect(mainFile).toContain('await runNodejsApplication(AppModule, { port });');
+    expect(mainFile).not.toContain('createConsoleApplicationLogger');
+    expect(mainFile).not.toContain('logger,');
   });
 
   it('generates the Deno application starter scaffold', async () => {
@@ -1098,6 +1101,10 @@ describe('scaffoldBootstrapApp', () => {
     expect(appFile).toContain("import { HealthModule } from '@fluojs/runtime';");
     expect(appFile).toContain('HealthModule.forRoot()');
     expect(appFile).not.toContain('createHealthModule');
+    expect(mainFile).toContain("import { bootstrapFastifyApplication } from '@fluojs/platform-fastify';");
+    expect(mainFile).toContain('const app = await bootstrapFastifyApplication(AppModule, { port });');
+    expect(mainFile).not.toContain('createConsoleApplicationLogger');
+    expect(mainFile).not.toContain('logger,');
     expect(mainFile).toContain('await app.connectMicroservice();');
     expect(mainFile).toContain('await app.startAllMicroservices();');
     expect(appTestFile).toContain('InMemoryLoopbackTransport');

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import { initializeGitRepository, installDependencies } from './install.js';
 import { resolvePackageSpecs } from './package-spec-resolver.js';
-import { resolveBootstrapPlan, type ResolvedBootstrapPlan } from './resolver.js';
+import { type ResolvedBootstrapPlan, resolveBootstrapPlan } from './resolver.js';
 import type { StarterScaffoldRecipeId } from './starter-profiles.js';
 import type { BootstrapOptions, PackageManager } from './types.js';
 
@@ -58,6 +58,7 @@ type ApplicationStarterDescriptor = {
   entrypoint: 'src/main.ts' | 'src/worker.ts';
   packageName?: '@fluojs/platform-bun' | '@fluojs/platform-cloudflare-workers' | '@fluojs/platform-deno' | '@fluojs/platform-express' | '@fluojs/platform-fastify' | '@fluojs/platform-nodejs';
   platformLabel: string;
+  runHelper?: string;
   runtimeLabel: string;
 };
 
@@ -69,6 +70,7 @@ function describeApplicationStarter(options: Pick<BootstrapOptions, 'platform' |
       entrypoint: 'src/main.ts',
       packageName: '@fluojs/platform-bun',
       platformLabel: 'Bun native HTTP',
+      runHelper: 'runBunApplication',
       runtimeLabel: 'Bun runtime',
     };
   }
@@ -99,6 +101,7 @@ function describeApplicationStarter(options: Pick<BootstrapOptions, 'platform' |
         entrypoint: 'src/main.ts',
         packageName: '@fluojs/platform-express',
         platformLabel: 'Express HTTP',
+        runHelper: 'runExpressApplication',
         runtimeLabel: 'Node.js runtime',
       };
     case 'nodejs':
@@ -108,6 +111,7 @@ function describeApplicationStarter(options: Pick<BootstrapOptions, 'platform' |
         entrypoint: 'src/main.ts',
         packageName: '@fluojs/platform-nodejs',
         platformLabel: 'raw Node.js HTTP',
+        runHelper: 'runNodejsApplication',
         runtimeLabel: 'Node.js runtime',
       };
     default:
@@ -117,6 +121,7 @@ function describeApplicationStarter(options: Pick<BootstrapOptions, 'platform' |
         entrypoint: 'src/main.ts',
         packageName: '@fluojs/platform-fastify',
         platformLabel: 'Fastify HTTP',
+        runHelper: 'runFastifyApplication',
         runtimeLabel: 'Node.js runtime',
       };
   }
@@ -465,7 +470,9 @@ function createHttpCommandsSection(options: BootstrapOptions): string {
 function createHttpProjectReadme(options: BootstrapOptions): string {
   const starter = describeApplicationStarter(options);
   const entrypointLabel = starter.entrypoint;
-  const starterContract = options.runtime === 'deno'
+  const starterContract = starter.runHelper
+    ? `\`${entrypointLabel}\` boots the selected first-class application starter: ${starter.runtimeLabel} + ${starter.platformLabel} via \`${starter.runHelper}(...)\``
+    : options.runtime === 'deno'
     ? `\`${entrypointLabel}\` boots the selected first-class application starter: ${starter.runtimeLabel} + ${starter.platformLabel} via \`runDenoApplication(...)\``
     : options.runtime === 'cloudflare-workers'
       ? `\`${entrypointLabel}\` exports the selected first-class application starter: ${starter.runtimeLabel} + ${starter.platformLabel} via \`createCloudflareWorkerEntrypoint(...)\``
@@ -474,7 +481,9 @@ function createHttpProjectReadme(options: BootstrapOptions): string {
     ? '- CORS: defaults to allowOrigin `*`; pass a `cors` option to `createCloudflareWorkerEntrypoint(..., { cors })` when you need edge-specific restrictions'
     : options.runtime === 'deno'
       ? '- CORS: defaults to allowOrigin `*`; configure it through the Deno HTTP bootstrap path before exposing the adapter in production'
-      : `- CORS: defaults to allowOrigin '*'; pass a \`cors\` option to \`FluoFactory.create(..., { cors, adapter: ${starter.adapterFactory}(...) })\` to restrict origins`;
+      : starter.runHelper
+        ? `- CORS: defaults to allowOrigin '*'; pass a \`cors\` option to \`${starter.runHelper}(..., { cors })\` to restrict origins`
+        : `- CORS: defaults to allowOrigin '*'; pass a \`cors\` option to \`FluoFactory.create(..., { cors, adapter: ${starter.adapterFactory}(...) })\` to restrict origins`;
   const testingSection = options.runtime === 'deno'
     ? `## Official generated testing templates\n\n- \`src/app.test.ts\` — Deno-native integration-style dispatch verification for the generated runtime + starter routes.\n\nUse this test when you need confidence that the generated Deno entrypoint and module graph still agree on the same HTTP contract.`
     : `## Official generated testing templates\n\n- \`src/greeting/greeting.repo.test.ts\`, \`src/greeting/greeting.service.test.ts\`, and \`src/greeting/greeting.controller.test.ts\` — unit templates for the starter-owned greeting slice.\n- \`src/greeting/greeting.slice.test.ts\` — module/slice template via \`createTestingModule\` for real DI graph confidence.\n- \`src/app.test.ts\` — integration-style dispatch template for runtime + starter routes.\n- \`test/app.e2e.test.ts\` — default HTTP/e2e-style template powered by \`createTestApp\` and \`app.request(...).send()\` from \`@fluojs/testing\`; older \`src/app.e2e.test.ts\` tests can be moved here without changing the request helper.\n- \`${createExecCommand(options.packageManager, 'fluo g repo User')}\` also adds:\n  - \`src/users/user.repo.test.ts\` (unit template)\n  - \`src/users/user.repo.slice.test.ts\` (slice/integration template via \`createTestingModule\`)\n\nUse unit templates for fast logic checks, \`${createRunCommand(options.packageManager, 'test:e2e')}\` for the dedicated request-level e2e suite, and \`${createRunCommand(options.packageManager, 'test:cov')}\` when your Vitest runtime supports coverage.`;
@@ -931,14 +940,18 @@ export default {
   const portExpression = options.runtime === 'bun'
     ? "Bun.env.PORT ?? '3000'"
     : "process.env.PORT ?? '3000'";
-  const loggerGuidance = options.runtime === 'node'
-    ? `
-// Application logging defaults to the pretty console logger when logger is omitted.
-// JSON logs are opt-in:
-// import { createJsonApplicationLogger } from '@fluojs/runtime/node';
-// Then pass \`logger: createJsonApplicationLogger()\` to FluoFactory.create(...).
-`
-    : '';
+
+  if (starter.runHelper) {
+    return `import { ${starter.runHelper} } from '${starter.packageName}';
+
+import { AppModule } from './app';
+
+const parsedPort = Number.parseInt(${portExpression}, 10);
+const port = Number.isFinite(parsedPort) ? parsedPort : 3000;
+
+await ${starter.runHelper}(AppModule, { port });
+`;
+  }
 
   return `import { ${starter.adapterFactory} } from '${starter.packageName}';
 import { FluoFactory } from '@fluojs/runtime';
@@ -947,7 +960,6 @@ import { AppModule } from './app';
 
 // The generated starter wires the selected first-class fluo new application path:
 // ${starter.runtimeLabel} + ${starter.platformLabel} via ${starter.adapterFactory}(...).
-${loggerGuidance}
 
 const parsedPort = Number.parseInt(${portExpression}, 10);
 const port = Number.isFinite(parsedPort) ? parsedPort : 3000;
@@ -1783,17 +1795,14 @@ export class AppModule {}
 }
 
 function createMixedMainFile(): string {
-  return `import { createFastifyAdapter } from '@fluojs/platform-fastify';
-import { FluoFactory } from '@fluojs/runtime';
+  return `import { bootstrapFastifyApplication } from '@fluojs/platform-fastify';
 
 import { AppModule } from './app';
 
 const parsedPort = Number.parseInt(process.env.PORT ?? '3000', 10);
 const port = Number.isFinite(parsedPort) ? parsedPort : 3000;
 
-const app = await FluoFactory.create(AppModule, {
-  adapter: createFastifyAdapter({ port }),
-});
+const app = await bootstrapFastifyApplication(AppModule, { port });
 await app.connectMicroservice();
 await app.startAllMicroservices();
 await app.listen();

--- a/packages/microservices/src/module.test.ts
+++ b/packages/microservices/src/module.test.ts
@@ -4,7 +4,7 @@ import { Inject, Scope } from '@fluojs/core';
 import { defineControllerMetadata, defineModuleMetadata } from '@fluojs/core/internal';
 import type { Provider } from '@fluojs/di';
 import { bootstrapApplication, FluoFactory } from '@fluojs/runtime';
-import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
+import type { CompiledModule } from '@fluojs/runtime';
 
 import { BidiStreamPattern, ClientStreamPattern, EventPattern, MessagePattern, ServerStreamPattern } from './decorators.js';
 import { KafkaMicroserviceTransport } from './transports/kafka-transport.js';
@@ -700,14 +700,9 @@ describe('@fluojs/microservices', () => {
 
   it('injects the framework logger into transports without changing non-fatal event semantics', async () => {
     const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error?: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log() {},
-      warn() {},
-    };
+    const errorLog = vi.spyOn(console, 'error').mockImplementation((message: unknown, error?: unknown) => {
+      loggerEvents.push(`${String(message)}:${error instanceof Error ? error.message : 'none'}`);
+    });
 
     class LoggerAwareTransport implements MicroserviceTransport {
       private logger: MicroserviceTransportLogger | undefined;
@@ -748,14 +743,19 @@ describe('@fluojs/microservices', () => {
       providers: [Handler],
     });
 
-    const microservice = await FluoFactory.createMicroservice(AppModule, { logger });
-    await microservice.listen();
+    const microservice = await FluoFactory.createMicroservice(AppModule);
 
-    await expect(microservice.emit('audit.fail', { ok: false })).resolves.toBeUndefined();
+    try {
+      await microservice.listen();
 
-    expect(loggerEvents).toContain('error:LoggerAwareTransport:Event handler failed.:event boom');
+      await expect(microservice.emit('audit.fail', { ok: false })).resolves.toBeUndefined();
 
-    await microservice.close();
+      expect(loggerEvents).toContain('[fluo] ERROR [LoggerAwareTransport] Event handler failed.:none');
+      expect(loggerEvents).toContain('Error: event boom:none');
+    } finally {
+      errorLog.mockRestore();
+      await microservice.close();
+    }
   });
 
   it('fails deterministically when multiple message handlers match the same pattern', async () => {

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -1,21 +1,19 @@
 import { readFileSync } from 'node:fs';
-
+import { All, Controller, createDispatcher, createHandlerMapping, type FrameworkRequest, type FrameworkResponse, Get, Header, HttpCode, Post, Redirect, type RequestContext, SseResponse, Version, VersioningType } from '@fluojs/http';
+import { defineModule } from '@fluojs/runtime';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { All, Controller, createDispatcher, createHandlerMapping, Get, Header, HttpCode, Post, Redirect, SseResponse, Version, VersioningType, type FrameworkRequest, type FrameworkResponse, type RequestContext } from '@fluojs/http';
-import { defineModule, type ApplicationLogger } from '@fluojs/runtime';
-
 import {
-  bootstrapBunApplication,
-  BunHttpApplicationAdapter,
-  createBunAdapter,
-  createBunFetchHandler,
-  runBunApplication,
   type BootstrapBunApplicationOptions,
+  BunHttpApplicationAdapter,
   type BunServeOptions,
   type BunServerLike,
   type BunServerWebSocket,
   type BunWebSocketBinding,
+  bootstrapBunApplication,
+  createBunAdapter,
+  createBunFetchHandler,
+  runBunApplication,
 } from './adapter.js';
 
 type MockBunServer = BunServerLike & {
@@ -1206,17 +1204,7 @@ describe('@fluojs/platform-bun', () => {
   });
 
   it('logs listen target and removes registered shutdown listeners on close', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const mockBun = installMockBun();
 
     @Controller('/health')
@@ -1234,7 +1222,6 @@ describe('@fluojs/platform-bun', () => {
     const listenersBefore = process.listeners(signal).length;
     const app = await runBunApplication(AppModule, {
       hostname: '127.0.0.1',
-      logger,
       port: 4312,
       shutdownSignals: [signal],
     });
@@ -1244,25 +1231,18 @@ describe('@fluojs/platform-bun', () => {
 
       expect(response?.status).toBe(200);
       await expect(response?.json()).resolves.toEqual({ ok: true });
-      expect(loggerEvents).toContain('log:FluoFactory:Listening on http://127.0.0.1:4312');
+      expect(log.mock.calls.some(([message]) => String(message).includes('Listening on http://127.0.0.1:4312'))).toBe(true);
       expect(process.listeners(signal).length).toBe(listenersBefore + 1);
     } finally {
       await app.close();
+      log.mockRestore();
     }
 
     expect(process.listeners(signal).length).toBe(listenersBefore);
   });
 
   it('forwards TLS options and reports the HTTPS listen target', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error() {},
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     const mockBun = installMockBun();
     const tls = { cert: 'test-cert', key: 'test-key' };
 
@@ -1279,7 +1259,6 @@ describe('@fluojs/platform-bun', () => {
 
     const app = await runBunApplication(AppModule, {
       hostname: '127.0.0.1',
-      logger,
       port: 4314,
       tls,
     });
@@ -1287,24 +1266,17 @@ describe('@fluojs/platform-bun', () => {
     try {
       expect(mockBun.lastOptions?.tls).toBe(tls);
       expect(mockBun.lastServer?.url?.origin).toBe('https://127.0.0.1:4314');
-      expect(loggerEvents).toContain('log:FluoFactory:Listening on https://127.0.0.1:4314');
+      expect(log.mock.calls.some(([message]) => String(message).includes('Listening on https://127.0.0.1:4314'))).toBe(true);
     } finally {
       await app.close();
+      log.mockRestore();
     }
   });
 
   it('marks shutdown timeout via exitCode without forcing process termination', async () => {
     vi.useFakeTimers();
 
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log() {},
-      warn() {},
-    };
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const mockBun = installMockBun();
 
     @Controller('/health')
@@ -1323,7 +1295,6 @@ describe('@fluojs/platform-bun', () => {
     const app = await runBunApplication(AppModule, {
       forceExitTimeoutMs: 25,
       hostname: '127.0.0.1',
-      logger,
       port: 4313,
       shutdownSignals: ['SIGTERM'],
     });
@@ -1339,13 +1310,12 @@ describe('@fluojs/platform-bun', () => {
 
       expect(exitSpy).not.toHaveBeenCalled();
       expect(process.exitCode).toBe(1);
-      expect(loggerEvents).toContain(
-        'error:FluoFactory:Shutdown timeout exceeded after 25ms; leaving process termination to the host.:none',
-      );
+      expect(errorLog.mock.calls.some(([message]) => String(message).includes('Shutdown timeout exceeded after 25ms; leaving process termination to the host.'))).toBe(true);
     } finally {
       app.close = originalClose;
       await app.close();
       exitSpy.mockRestore();
+      errorLog.mockRestore();
       process.exitCode = originalExitCode;
       vi.useRealTimers();
     }

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -20,14 +20,14 @@ import type {
   MultipartOptions,
   UploadedFile,
 } from '@fluojs/runtime';
-import { createWebRequestResponseFactory, dispatchWebRequest } from '@fluojs/runtime/web';
 import {
   bootstrapHttpAdapterApplication,
   createConsoleApplicationLogger,
-  runHttpAdapterApplication,
-  type RunHttpAdapterApplicationOptions,
   type HttpAdapterListenTarget,
+  type RunHttpAdapterApplicationOptions,
+  runHttpAdapterApplication,
 } from '@fluojs/runtime/internal/http-adapter';
+import { createWebRequestResponseFactory, dispatchWebRequest } from '@fluojs/runtime/web';
 
 declare module '@fluojs/http' {
   interface FrameworkRequest {
@@ -200,8 +200,6 @@ export interface BootstrapBunApplicationOptions extends Omit<CreateApplicationOp
   hostname?: BunHostname;
   /** Idle timeout passed through to `Bun.serve()`. */
   idleTimeout?: number;
-  /** Application logger used for startup, shutdown, and failure reporting. */
-  logger?: ApplicationLogger;
   /** Maximum request body size forwarded as Bun's `maxRequestBodySize`. */
   maxBodySize?: number;
   /** Middleware applied by the shared HTTP bootstrap path. */
@@ -482,11 +480,11 @@ export async function bootstrapBunApplication(
   rootModule: ModuleType,
   options: BootstrapBunApplicationOptions,
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = createConsoleApplicationLogger();
 
   return bootstrapHttpAdapterApplication(
     rootModule,
-    { ...options, logger },
+    options,
     createBunAdapter({
       development: options.development,
       hostname: options.hostname,
@@ -498,6 +496,7 @@ export async function bootstrapBunApplication(
       stopActiveConnections: options.stopActiveConnections,
       tls: options.tls,
     }),
+    logger,
   );
 }
 
@@ -512,7 +511,7 @@ export async function runBunApplication(
   rootModule: ModuleType,
   options: RunBunApplicationOptions,
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = createConsoleApplicationLogger();
   const adapter = createBunAdapter({
     development: options.development,
     hostname: options.hostname,
@@ -527,9 +526,8 @@ export async function runBunApplication(
 
   return runHttpAdapterApplication(rootModule, {
     ...options,
-    logger,
     shutdownRegistration: createBunShutdownSignalRegistration(options.shutdownSignals ?? defaultBunShutdownSignals()),
-  }, adapter);
+  }, adapter, logger);
 }
 
 function defaultBunShutdownSignals(): readonly BunApplicationSignal[] {

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -1,37 +1,35 @@
 import { readFileSync } from 'node:fs';
 import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createServer as createHttpsServer } from 'node:https';
-
+import {
+  Controller,
+  type FrameworkRequest,
+  type FrameworkResponse,
+  Get,
+  Post,
+  type RequestContext,
+  SseResponse,
+} from '@fluojs/http';
+import { type Application, defineModule, type ModuleType } from '@fluojs/runtime';
+import { createFetchStyleWebSocketConformanceHarness } from '@fluojs/testing/fetch-style-websocket-conformance';
+import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  Controller,
-  Get,
-  Post,
-  SseResponse,
-  type FrameworkRequest,
-  type FrameworkResponse,
-  type RequestContext,
-} from '@fluojs/http';
-import { defineModule, type Application, type ApplicationLogger, type ModuleType } from '@fluojs/runtime';
-import { createFetchStyleWebSocketConformanceHarness } from '@fluojs/testing/fetch-style-websocket-conformance';
-import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
-
-import {
-  bootstrapDenoApplication,
   type BootstrapDenoApplicationOptions,
-  DenoHttpApplicationAdapter,
+  bootstrapDenoApplication,
   createDenoAdapter,
-  runDenoApplication,
-  type RunDenoApplicationOptions,
+  DenoHttpApplicationAdapter,
   type DenoServeController,
   type DenoServeFunction,
   type DenoServeHandler,
-  type DenoServerWebSocket,
   type DenoServeOptions,
+  type DenoServerWebSocket,
+  type DenoUpgradeWebSocketFunction,
   type DenoWebSocketBinding,
   type DenoWebSocketMessage,
-  type DenoUpgradeWebSocketFunction,
+  type RunDenoApplicationOptions,
+  runDenoApplication,
 } from './adapter.js';
 
 const TEST_TLS_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
@@ -496,24 +494,16 @@ describe('@fluojs/platform-deno', () => {
     defineModule(AppModule, {});
 
     const server = createServeStub();
-    const logger: ApplicationLogger = {
-      debug() {},
-      error() {},
-      log: vi.fn(),
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     const app = await runDenoApplication(AppModule, {
-      logger,
       serve: server.serve,
     });
 
-    expect(logger.log).toHaveBeenCalledWith(
-      'Listening on http://localhost:3000 (bound to 0.0.0.0:3000)',
-      'FluoFactory',
-    );
+    expect(log.mock.calls.some(([message]) => String(message).includes('Listening on http://localhost:3000 (bound to 0.0.0.0:3000)'))).toBe(true);
 
     await app.close();
+    log.mockRestore();
   });
 
   it('forwards HTTPS certificate options to Deno.serve and reports an HTTPS listen target', async () => {
@@ -521,12 +511,7 @@ describe('@fluojs/platform-deno', () => {
     defineModule(AppModule, {});
 
     const server = createServeStub();
-    const logger: ApplicationLogger = {
-      debug() {},
-      error() {},
-      log: vi.fn(),
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     const app = await runDenoApplication(AppModule, {
       hostname: '127.0.0.1',
@@ -534,7 +519,6 @@ describe('@fluojs/platform-deno', () => {
         cert: TEST_TLS_CERTIFICATE,
         key: TEST_TLS_PRIVATE_KEY,
       },
-      logger,
       port: 3443,
       serve: server.serve,
     });
@@ -545,12 +529,10 @@ describe('@fluojs/platform-deno', () => {
       key: TEST_TLS_PRIVATE_KEY,
       port: 3443,
     });
-    expect(logger.log).toHaveBeenCalledWith(
-      'Listening on https://127.0.0.1:3443',
-      'FluoFactory',
-    );
+    expect(log.mock.calls.some(([message]) => String(message).includes('Listening on https://127.0.0.1:3443'))).toBe(true);
 
     await app.close();
+    log.mockRestore();
   });
 
   it('satisfies the shared HTTPS startup portability expectation', async () => {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -1,12 +1,12 @@
 import { createFetchStyleHttpAdapterRealtimeCapability, type Dispatcher, type HttpApplicationAdapter } from '@fluojs/http/internal';
 import type { Application, ApplicationLogger, ModuleType, MultipartOptions } from '@fluojs/runtime';
 import {
+  type BootstrapHttpAdapterApplicationOptions,
   bootstrapHttpAdapterApplication,
   createConsoleApplicationLogger,
-  runHttpAdapterApplication,
-  type BootstrapHttpAdapterApplicationOptions,
   type HttpAdapterListenTarget,
   type RunHttpAdapterApplicationOptions,
+  runHttpAdapterApplication,
 } from '@fluojs/runtime/internal/http-adapter';
 import { createWebRequestResponseFactory, dispatchWebRequest } from '@fluojs/runtime/web';
 
@@ -331,9 +331,9 @@ export async function bootstrapDenoApplication(
   rootModule: ModuleType,
   options: BootstrapDenoApplicationOptions = {},
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = createConsoleApplicationLogger();
 
-  return await bootstrapHttpAdapterApplication(rootModule, { ...options, logger }, createDenoAdapter(options));
+  return await bootstrapHttpAdapterApplication(rootModule, options, createDenoAdapter(options), logger);
 }
 
 /**
@@ -347,15 +347,14 @@ export async function runDenoApplication(
   rootModule: ModuleType,
   options: RunDenoApplicationOptions = {},
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = createConsoleApplicationLogger();
   const adapter = createDenoAdapter(options);
   return await runHttpAdapterApplication(rootModule, {
     ...options,
-    logger,
     shutdownRegistration: options.shutdownSignals === false
       ? undefined
       : createDenoShutdownSignalRegistration(options.shutdownSignals ?? defaultDenoShutdownSignals()),
-  }, adapter);
+  }, adapter, logger);
 }
 
 function defaultDenoShutdownSignals(): readonly DenoApplicationSignal[] {

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -101,7 +101,7 @@ const adapter = createExpressAdapter(
 - `ExpressHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 - Option type: `ExpressAdapterOptions`, `BootstrapExpressApplicationOptions`, `RunExpressApplicationOptions`, `CorsInput`, `ExpressApplicationSignal`.
 
-`createExpressAdapter(options, multipartOptions?)`는 `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 지원합니다. `ExpressHttpApplicationAdapter`를 직접 생성하는 경우에도 factory와 같은 numeric validation이 적용됩니다. `bootstrapExpressApplication(...)`과 `runExpressApplication(...)`은 `cors`, `globalPrefix`, `globalPrefixExclude`, `logger`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`도 받습니다.
+`createExpressAdapter(options, multipartOptions?)`는 `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 지원합니다. `ExpressHttpApplicationAdapter`를 직접 생성하는 경우에도 factory와 같은 numeric validation이 적용됩니다. `bootstrapExpressApplication(...)`과 `runExpressApplication(...)`은 `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`도 받으며, startup/shutdown diagnostics를 위해 framework console logger를 내부에서 선택합니다.
 
 ## 관련 패키지
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -101,7 +101,7 @@ To avoid changing documented fluo semantics, overlapping same-shape param routes
 - `ExpressHttpApplicationAdapter`: The core adapter implementation class.
 - Option types: `ExpressAdapterOptions`, `BootstrapExpressApplicationOptions`, `RunExpressApplicationOptions`, `CorsInput`, `ExpressApplicationSignal`.
 
-`createExpressAdapter(options, multipartOptions?)` supports `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs`. Direct `ExpressHttpApplicationAdapter` construction applies the same numeric validation as the factory. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` also accept `cors`, `globalPrefix`, `globalPrefixExclude`, `logger`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, and `shutdownSignals`.
+`createExpressAdapter(options, multipartOptions?)` supports `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs`. Direct `ExpressHttpApplicationAdapter` construction applies the same numeric validation as the factory. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` also accept `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, and `shutdownSignals`, and select the framework console logger internally for startup and shutdown diagnostics.
 
 ## Related Packages
 

--- a/packages/platform-express/src/adapter.test.ts
+++ b/packages/platform-express/src/adapter.test.ts
@@ -4,11 +4,6 @@ import {
 } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import { type AddressInfo, createServer as createNetServer } from 'node:net';
-
-import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
-
-import { describe, expect, it, vi } from 'vitest';
-
 import { Container } from '@fluojs/di';
 import {
   All,
@@ -16,33 +11,34 @@ import {
   Controller,
   createDispatcher,
   createHandlerMapping,
+  type FrameworkRequest,
+  type FrameworkResponse,
   Get,
+  type GuardContext,
   Header,
   HttpCode,
+  type InterceptorContext,
+  type MiddlewareContext,
   Post,
   Redirect,
+  type RequestContext,
+  type RequestObservationContext,
+  type RequestObserver,
   SseResponse,
   UseGuards,
   UseInterceptors,
   Version,
   VersioningType,
-  type FrameworkRequest,
-  type FrameworkResponse,
-  type GuardContext,
-  type InterceptorContext,
-  type MiddlewareContext,
-  type RequestObservationContext,
-  type RequestContext,
-  type RequestObserver,
 } from '@fluojs/http';
 import {
   createHealthModule,
   defineModule,
   FluoFactory,
   fluoFactory,
-  type ApplicationLogger,
 } from '@fluojs/runtime';
 import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
+import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   bootstrapExpressApplication,
@@ -954,17 +950,9 @@ describe('@fluojs/platform-express', () => {
   });
 
   it('reports the configured host in startup logs', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const stdoutIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
 
     @Controller('/health')
     class HealthController {
@@ -983,7 +971,6 @@ describe('@fluojs/platform-express', () => {
     const app = await runExpressApplication(AppModule, {
       cors: false,
       host: '127.0.0.1',
-      logger,
       port,
     });
 
@@ -991,19 +978,15 @@ describe('@fluojs/platform-express', () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(loggerEvents).toContain(`log:FluoFactory:Listening on http://127.0.0.1:${String(port)}`);
+    expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on http://127.0.0.1:${String(port)}`))).toBe(true);
+    expect(log.mock.calls.some(([message]) => String(message).includes('\u001b['))).toBe(true);
 
     await app.close();
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: stdoutIsTTY });
+    log.mockRestore();
   });
 
   it('removes registered shutdown signal listeners after close', async () => {
-    const logger: ApplicationLogger = {
-      debug() {},
-      error() {},
-      log() {},
-      warn() {},
-    };
-
     @Controller('/health')
     class HealthController {
       @Get('/')
@@ -1022,7 +1005,6 @@ describe('@fluojs/platform-express', () => {
     const port = await findAvailablePort();
     const app = await runExpressApplication(AppModule, {
       cors: false,
-      logger,
       port,
       shutdownSignals: [signal],
     });
@@ -1695,17 +1677,7 @@ describe('@fluojs/platform-express', () => {
   });
 
   it('supports https startup and reports the https listen URL', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -1728,7 +1700,6 @@ describe('@fluojs/platform-express', () => {
         cert: TEST_TLS_CERTIFICATE,
         key: TEST_TLS_PRIVATE_KEY,
       },
-      logger,
       port,
     });
 
@@ -1736,9 +1707,10 @@ describe('@fluojs/platform-express', () => {
 
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toEqual({ ok: true });
-    expect(loggerEvents).toContain(`log:FluoFactory:Listening on https://127.0.0.1:${String(port)}`);
+    expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on https://127.0.0.1:${String(port)}`))).toBe(true);
 
     await app.close();
+    log.mockRestore();
   });
 
   it('keeps dispatcher until express close settles even when close() times out', async () => {
@@ -1978,17 +1950,7 @@ describe('@fluojs/platform-express', () => {
   it('marks shutdown timeout via exitCode without forcing process termination', async () => {
     vi.useFakeTimers();
 
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -2009,7 +1971,6 @@ describe('@fluojs/platform-express', () => {
     const app = await runExpressApplication(AppModule, {
       cors: false,
       forceExitTimeoutMs: 25,
-      logger,
       port,
       shutdownSignals: ['SIGTERM'],
     });
@@ -2023,13 +1984,12 @@ describe('@fluojs/platform-express', () => {
 
       expect(exitSpy).not.toHaveBeenCalled();
       expect(process.exitCode).toBe(1);
-      expect(loggerEvents).toContain(
-        'error:FluoFactory:Shutdown timeout exceeded after 25ms; leaving process termination to the host.:none',
-      );
+      expect(errorLog.mock.calls.some(([message]) => String(message).includes('Shutdown timeout exceeded after 25ms; leaving process termination to the host.'))).toBe(true);
     } finally {
       app.close = originalClose;
       await app.close();
       exitSpy.mockRestore();
+      errorLog.mockRestore();
       process.exitCode = originalExitCode;
       vi.useRealTimers();
     }

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -9,28 +9,21 @@ import {
 } from 'node:https';
 import type { AddressInfo, Socket } from 'node:net';
 import { Readable } from 'node:stream';
-
-import express, {
-  type Express,
-  type Request as ExpressRequest,
-  type Response as ExpressResponse,
-} from 'express';
-
 import {
   BadRequestException,
-  createServerBackedHttpAdapterRealtimeCapability,
-  createErrorResponse,
-  HttpException,
-  InternalServerErrorException,
-  PayloadTooLargeException,
   type CorsOptions,
+  createErrorResponse,
+  createServerBackedHttpAdapterRealtimeCapability,
   type Dispatcher,
   type FrameworkRequest,
   type FrameworkResponse,
   type FrameworkResponseStream,
   type HandlerDescriptor,
   type HttpApplicationAdapter,
+  HttpException,
+  InternalServerErrorException,
   type MiddlewareLike,
+  PayloadTooLargeException,
   type SecurityHeadersOptions,
 } from '@fluojs/http';
 import {
@@ -41,16 +34,20 @@ import {
 } from '@fluojs/http/internal';
 import type {
   Application,
-  ApplicationLogger,
   CreateApplicationOptions,
   ModuleType,
   MultipartOptions,
   UploadedFile,
 } from '@fluojs/runtime';
 import {
-  createNodeShutdownSignalRegistration,
-  defaultNodeShutdownSignals,
-} from '@fluojs/runtime/node';
+  bootstrapHttpAdapterApplication,
+  createConsoleApplicationLogger,
+  runHttpAdapterApplication,
+} from '@fluojs/runtime/internal/http-adapter';
+import {
+  dispatchWithRequestResponseFactory,
+  type RequestResponseFactory,
+} from '@fluojs/runtime/internal/request-response-factory';
 import {
   cloneRequestHeaders,
   createDeferredFrameworkRequestShell,
@@ -63,15 +60,16 @@ import {
   snapshotSimpleQueryRecord,
   splitRawRequestUrl,
 } from '@fluojs/runtime/internal-node';
+import {
+  createNodeShutdownSignalRegistration,
+  defaultNodeShutdownSignals,
+} from '@fluojs/runtime/node';
 import { parseMultipart } from '@fluojs/runtime/web';
-import {
-  bootstrapHttpAdapterApplication,
-  runHttpAdapterApplication,
-} from '@fluojs/runtime/internal/http-adapter';
-import {
-  dispatchWithRequestResponseFactory,
-  type RequestResponseFactory,
-} from '@fluojs/runtime/internal/request-response-factory';
+import express, {
+  type Express,
+  type Request as ExpressRequest,
+  type Response as ExpressResponse,
+} from 'express';
 
 declare module '@fluojs/http' {
   interface FrameworkRequest {
@@ -122,7 +120,6 @@ export interface BootstrapExpressApplicationOptions extends Omit<CreateApplicati
   globalPrefixExclude?: readonly string[];
   host?: string;
   https?: HttpsServerOptions;
-  logger?: ApplicationLogger;
   maxBodySize?: number;
   middleware?: MiddlewareLike[];
   multipart?: MultipartOptions;
@@ -537,10 +534,13 @@ export async function bootstrapExpressApplication(
   rootModule: ModuleType,
   options: BootstrapExpressApplicationOptions,
 ): Promise<Application> {
+  const logger = createConsoleApplicationLogger();
+
   return bootstrapHttpAdapterApplication(
     rootModule,
     options,
     createExpressAdapter(options, options.multipart),
+    logger,
   );
 }
 
@@ -555,13 +555,14 @@ export async function runExpressApplication(
   rootModule: ModuleType,
   options: RunExpressApplicationOptions,
 ): Promise<Application> {
+  const logger = createConsoleApplicationLogger();
   const adapter = createExpressAdapter(options, options.multipart) as ExpressHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,
     shutdownRegistration: createNodeShutdownSignalRegistration(
       options.shutdownSignals ?? defaultNodeShutdownSignals(),
     ),
-  }, adapter);
+  }, adapter, logger);
 }
 
 function createFrameworkResponse(response: ExpressResponse): ExpressFrameworkResponse {

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -111,14 +111,7 @@ await bootstrapFastifyApplication(AppModule, {
 ```
 
 ### 로깅 (Logging)
-fluo는 자체 로깅 시스템을 사용합니다. 어댑터는 Fastify 인스턴스를 생성할 때 네이티브 로거를 비활성화하며, 부트스트랩 옵션에 제공된 fluo 로거를 통해 로그를 기록합니다.
-
-```typescript
-await runFastifyApplication(AppModule, {
-  logger: myLogger,
-  port: 3000,
-});
-```
+fluo는 자체 로깅 시스템을 사용합니다. 어댑터는 Fastify 인스턴스를 생성할 때 네이티브 로거를 비활성화하며, `bootstrapFastifyApplication(...)` / `runFastifyApplication(...)`은 활성 런타임과 일관된 startup/shutdown diagnostics를 유지하도록 framework console logger를 내부에서 선택합니다.
 
 ### 미들웨어 (Middleware)
 요청이 핸들러에 도달하기 전에 실행되는 런타임 레벨의 미들웨어를 등록할 수 있습니다. 이는 Fastify 전용 플러그인이 아닌 표준 `MiddlewareLike` 함수라는 점에 유의하세요.
@@ -167,7 +160,7 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 
 - **CORS 오류**: `cors` 부트스트랩 옵션을 사용 중인지 확인하세요. Fastify의 네이티브 CORS 플러그인을 사용하지 않으므로 오직 fluo가 관리하는 CORS 로직만 적용됩니다.
 - **미들웨어 문제**: `middleware` 옵션은 런타임 레벨의 `MiddlewareLike[]` 함수 배열을 받습니다. 이는 Fastify 플러그인이 아니며 다른 fluo 어댑터들과 공통으로 사용되는 표준 인터페이스를 따릅니다.
-- **로깅 (Logging)**: 로그 스트림 중복을 방지하기 위해 Fastify의 네이티브 로거가 비활성화됩니다. 모든 로깅 설정은 `runFastifyApplication` 또는 `bootstrapFastifyApplication`의 `logger` 옵션을 통해 이루어져야 합니다.
+- **로깅 (Logging)**: 로그 스트림 중복을 방지하기 위해 Fastify의 네이티브 로거가 비활성화됩니다. `runFastifyApplication`과 `bootstrapFastifyApplication`은 framework console logger를 내부에서 선택하므로 application code가 이 helper들에 logger option을 전달하지 않아야 합니다.
 - **글로벌 접두사 (Global Prefix)**: 내부 경로 또는 헬스 체크 엔드포인트에 접두사가 붙지 않도록 `globalPrefixExclude`를 적절히 설정하세요.
 - **Malformed Cookie**: 잘못된 cookie header는 request 실패로 이어지지 않고 보존됩니다.
 

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -111,14 +111,7 @@ await bootstrapFastifyApplication(AppModule, {
 ```
 
 ### Logging
-fluo uses its own logging system. The adapter creates the Fastify instance with its native logger disabled and pipes through the fluo logger provided in the bootstrap options.
-
-```typescript
-await runFastifyApplication(AppModule, {
-  logger: myLogger,
-  port: 3000,
-});
-```
+fluo uses its own logging system. The adapter creates the Fastify instance with its native logger disabled, and `bootstrapFastifyApplication(...)` / `runFastifyApplication(...)` select the framework console logger internally so startup and shutdown diagnostics stay consistent with the active runtime.
 
 ### Middleware
 You can register runtime-level middleware that runs before the request reaches the handlers. Note that these are standard `MiddlewareLike` functions, not Fastify-specific plugins.
@@ -167,7 +160,7 @@ The same file also covers Fastify-specific native route registration with wildca
 
 - **CORS Errors**: Ensure you're using the `cors` bootstrap option. Since Fastify's native CORS plugin is not registered, only the fluo-managed CORS logic applies.
 - **Middleware Issues**: The `middleware` option accepts runtime-level `MiddlewareLike[]` functions. These are not Fastify plugins and follow the standard middleware interface used across fluo adapters.
-- **Logging**: The native Fastify logger is disabled to prevent duplicate log streams. All logging should be configured via the fluo `logger` option in `runFastifyApplication` or `bootstrapFastifyApplication`.
+- **Logging**: The native Fastify logger is disabled to prevent duplicate log streams. `runFastifyApplication` and `bootstrapFastifyApplication` select the framework console logger internally; application code should not pass a logger option to these helpers.
 - **Global Prefix**: Use `globalPrefixExclude` to prevent the prefix from being applied to internal routes or health check endpoints.
 - **Malformed Cookies**: Malformed cookie headers are preserved rather than failing the request.
 

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1,45 +1,42 @@
 import type { IncomingHttpHeaders } from 'node:http';
 import { request as httpRequest } from 'node:http';
-import { type AddressInfo, createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
-
-import type { FastifyReply, FastifyRequest } from 'fastify';
-
-import { describe, expect, it, vi } from 'vitest';
-
+import { type AddressInfo, createServer } from 'node:net';
 import { Container } from '@fluojs/di';
 import {
   All,
+  type CallHandler,
   Controller,
   createDispatcher,
   createHandlerMapping,
+  type Dispatcher,
+  type FrameworkRequest,
+  type FrameworkResponse,
   Get,
+  type GuardContext,
   Header,
   HttpCode,
+  type InterceptorContext,
+  type MiddlewareContext,
   Post,
   Redirect,
+  type RequestContext,
+  type RequestObservationContext,
+  type RequestObserver,
   SseResponse,
   UseGuards,
   UseInterceptors,
   Version,
   VersioningType,
-  type CallHandler,
-  type Dispatcher,
-  type FrameworkRequest,
-  type FrameworkResponse,
-  type GuardContext,
-  type InterceptorContext,
-  type MiddlewareContext,
-  type RequestObservationContext,
-  type RequestContext,
-  type RequestObserver,
 } from '@fluojs/http';
-import { createHealthModule, defineModule, FluoFactory, fluoFactory, type Application, type ApplicationLogger } from '@fluojs/runtime';
+import { type Application, createHealthModule, defineModule, FluoFactory, fluoFactory } from '@fluojs/runtime';
 import { createHttpAdapterPortabilityHarness } from '@fluojs/testing/http-adapter-portability';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
-  bootstrapFastifyApplication,
   type BootstrapFastifyApplicationOptions,
+  bootstrapFastifyApplication,
   createFastifyAdapter,
   FastifyHttpApplicationAdapter,
   isFastifyMultipartTooLargeError,
@@ -1465,17 +1462,9 @@ describe('@fluojs/platform-fastify', () => {
   });
 
   it('reports the configured host in startup logs', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const stdoutIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
 
     @Controller('/health')
     class HealthController {
@@ -1494,7 +1483,6 @@ describe('@fluojs/platform-fastify', () => {
     const app = await runFastifyApplication(AppModule, {
       cors: false,
       host: '127.0.0.1',
-      logger,
       port,
     });
 
@@ -1502,19 +1490,15 @@ describe('@fluojs/platform-fastify', () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(loggerEvents).toContain(`log:FluoFactory:Listening on http://127.0.0.1:${String(port)}`);
+    expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on http://127.0.0.1:${String(port)}`))).toBe(true);
+    expect(log.mock.calls.some(([message]) => String(message).includes('\u001b['))).toBe(true);
 
     await app.close();
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: stdoutIsTTY });
+    log.mockRestore();
   });
 
   it('removes registered shutdown signal listeners after close', async () => {
-    const logger: ApplicationLogger = {
-      debug() {},
-      error() {},
-      log() {},
-      warn() {},
-    };
-
     @Controller('/health')
     class HealthController {
       @Get('/')
@@ -1533,7 +1517,6 @@ describe('@fluojs/platform-fastify', () => {
     const port = await findAvailablePort();
     const app = await runFastifyApplication(AppModule, {
       cors: false,
-      logger,
       port,
       shutdownSignals: [signal],
     });
@@ -1776,17 +1759,7 @@ describe('@fluojs/platform-fastify', () => {
   });
 
   it('supports https startup and reports the https listen URL', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -1809,7 +1782,6 @@ describe('@fluojs/platform-fastify', () => {
         cert: TEST_TLS_CERTIFICATE,
         key: TEST_TLS_PRIVATE_KEY,
       },
-      logger,
       port,
     });
 
@@ -1817,9 +1789,10 @@ describe('@fluojs/platform-fastify', () => {
 
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toEqual({ ok: true });
-    expect(loggerEvents).toContain(`log:FluoFactory:Listening on https://127.0.0.1:${String(port)}`);
+    expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on https://127.0.0.1:${String(port)}`))).toBe(true);
 
     await app.close();
+    log.mockRestore();
   });
 
   it('keeps dispatcher until fastify close settles even when close() times out', async () => {
@@ -1974,17 +1947,7 @@ describe('@fluojs/platform-fastify', () => {
   it('marks shutdown timeout via exitCode without forcing process termination', async () => {
     vi.useFakeTimers();
 
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -2005,7 +1968,6 @@ describe('@fluojs/platform-fastify', () => {
     const app = await runFastifyApplication(AppModule, {
       cors: false,
       forceExitTimeoutMs: 25,
-      logger,
       port,
       shutdownSignals: ['SIGTERM'],
     });
@@ -2019,13 +1981,12 @@ describe('@fluojs/platform-fastify', () => {
 
       expect(exitSpy).not.toHaveBeenCalled();
       expect(process.exitCode).toBe(1);
-      expect(loggerEvents).toContain(
-        'error:FluoFactory:Shutdown timeout exceeded after 25ms; leaving process termination to the host.:none',
-      );
+      expect(errorLog.mock.calls.some(([message]) => String(message).includes('Shutdown timeout exceeded after 25ms; leaving process termination to the host.'))).toBe(true);
     } finally {
       app.close = originalClose;
       await app.close();
       exitSpy.mockRestore();
+      errorLog.mockRestore();
       process.exitCode = originalExitCode;
       vi.useRealTimers();
     }

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -4,22 +4,20 @@ import type { AddressInfo } from 'node:net';
 import { Transform } from 'node:stream';
 
 import multipart from '@fastify/multipart';
-import fastify, { type FastifyReply, type FastifyRequest } from 'fastify';
-
 import {
-  createServerBackedHttpAdapterRealtimeCapability,
-  createErrorResponse,
-  HttpException,
-  type HandlerDescriptor,
-  InternalServerErrorException,
-  PayloadTooLargeException,
   type CorsOptions,
+  createErrorResponse,
+  createServerBackedHttpAdapterRealtimeCapability,
   type Dispatcher,
   type FrameworkRequest,
   type FrameworkResponse,
   type FrameworkResponseStream,
+  type HandlerDescriptor,
   type HttpApplicationAdapter,
+  HttpException,
+  InternalServerErrorException,
   type MiddlewareLike,
+  PayloadTooLargeException,
   type SecurityHeadersOptions,
 } from '@fluojs/http';
 import {
@@ -28,18 +26,22 @@ import {
   consumeRawRequestNativeRouteHandoff,
   isRoutePathNormalizationSensitive,
 } from '@fluojs/http/internal';
-import {
-  type Application,
-  type ApplicationLogger,
-  type CreateApplicationOptions,
-  type ModuleType,
-  type MultipartOptions,
-  type UploadedFile,
+import type {
+  Application,
+  CreateApplicationOptions,
+  ModuleType,
+  MultipartOptions,
+  UploadedFile,
 } from '@fluojs/runtime';
 import {
-  createNodeShutdownSignalRegistration,
-  defaultNodeShutdownSignals,
-} from '@fluojs/runtime/node';
+  bootstrapHttpAdapterApplication,
+  createConsoleApplicationLogger,
+  runHttpAdapterApplication,
+} from '@fluojs/runtime/internal/http-adapter';
+import {
+  dispatchWithRequestResponseFactory,
+  type RequestResponseFactory,
+} from '@fluojs/runtime/internal/request-response-factory';
 import {
   cloneHeaderValue,
   createDeferredFrameworkRequestShell,
@@ -50,13 +52,10 @@ import {
   splitRawRequestUrl,
 } from '@fluojs/runtime/internal-node';
 import {
-  bootstrapHttpAdapterApplication,
-  runHttpAdapterApplication,
-} from '@fluojs/runtime/internal/http-adapter';
-import {
-  dispatchWithRequestResponseFactory,
-  type RequestResponseFactory,
-} from '@fluojs/runtime/internal/request-response-factory';
+  createNodeShutdownSignalRegistration,
+  defaultNodeShutdownSignals,
+} from '@fluojs/runtime/node';
+import fastify, { type FastifyReply, type FastifyRequest } from 'fastify';
 
 declare module '@fluojs/http' {
   interface FrameworkRequest {
@@ -105,7 +104,6 @@ export interface BootstrapFastifyApplicationOptions extends Omit<CreateApplicati
   globalPrefixExclude?: readonly string[];
   host?: string;
   https?: HttpsServerOptions;
-  logger?: ApplicationLogger;
   maxBodySize?: number;
   middleware?: MiddlewareLike[];
   multipart?: MultipartOptions;
@@ -453,7 +451,7 @@ function readSimpleQueryRecord(query: unknown): Record<string, string | string[]
   const record = query as Record<string, unknown>;
 
   for (const key in record) {
-    if (!Object.prototype.hasOwnProperty.call(record, key)) {
+    if (!Object.hasOwn(record, key)) {
       continue;
     }
 
@@ -630,10 +628,13 @@ export async function bootstrapFastifyApplication(
   rootModule: ModuleType,
   options: BootstrapFastifyApplicationOptions,
 ): Promise<Application> {
+  const logger = createConsoleApplicationLogger();
+
   return bootstrapHttpAdapterApplication(
     rootModule,
     options,
     createFastifyAdapter(options, options.multipart),
+    logger,
   );
 }
 
@@ -651,13 +652,14 @@ export async function runFastifyApplication(
   rootModule: ModuleType,
   options: RunFastifyApplicationOptions,
 ): Promise<Application> {
+  const logger = createConsoleApplicationLogger();
   const adapter = createFastifyAdapter(options, options.multipart) as FastifyHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,
     shutdownRegistration: createNodeShutdownSignalRegistration(
       options.shutdownSignals ?? defaultNodeShutdownSignals(),
     ),
-  }, adapter);
+  }, adapter, logger);
 }
 
 class MutableFastifyFrameworkResponse implements FastifyFrameworkResponse {
@@ -899,7 +901,7 @@ function normalizeNativeRouteParams(params: unknown): Readonly<Record<string, st
   let normalized: Record<string, string> | undefined;
 
   for (const key in params as Record<string, unknown>) {
-    if (!Object.prototype.hasOwnProperty.call(params, key)) {
+    if (!Object.hasOwn(params, key)) {
       continue;
     }
 
@@ -918,7 +920,7 @@ function normalizeNativeRouteParams(params: unknown): Readonly<Record<string, st
 
 function hasNativeRouteParamSeparators(params: Readonly<Record<string, string>>): boolean {
   for (const key in params) {
-    if (Object.prototype.hasOwnProperty.call(params, key) && params[key]?.includes('/')) {
+    if (Object.hasOwn(params, key) && params[key]?.includes('/')) {
       return true;
     }
   }

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -344,6 +344,7 @@ describe('@fluojs/platform-nodejs', () => {
     const originalNoColor = process.env.NO_COLOR;
     const originalForceColor = process.env.FORCE_COLOR;
     const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    const stdoutHasColorsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'hasColors');
 
     class AppModule {}
     defineModule(AppModule, {});
@@ -351,6 +352,7 @@ describe('@fluojs/platform-nodejs', () => {
     process.env.NO_COLOR = '1';
     delete process.env.FORCE_COLOR;
     Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+    Object.defineProperty(process.stdout, 'hasColors', { configurable: true, value: () => false });
 
     const loggedMessages: string[] = [];
     const log = vi.spyOn(console, 'log').mockImplementation((message: unknown) => {
@@ -361,7 +363,9 @@ describe('@fluojs/platform-nodejs', () => {
       const app = await bootstrapNodejsApplication(AppModule, { port: 0 });
       await app.close();
 
-      expect(loggedMessages.some((message) => message.includes('LOG [FluoFactory]'))).toBe(true);
+      const normalizedMessages = loggedMessages.map((message) => message.replace(/\u001B\[[\d;]*m/g, ''));
+
+      expect(normalizedMessages.some((message) => message.includes('LOG [FluoFactory]'))).toBe(true);
       expect(loggedMessages.every((message) => !message.includes('\u001B['))).toBe(true);
     } finally {
       log.mockRestore();
@@ -382,6 +386,12 @@ describe('@fluojs/platform-nodejs', () => {
         Object.defineProperty(process.stdout, 'isTTY', stdoutIsTtyDescriptor);
       } else {
         Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: undefined });
+      }
+
+      if (stdoutHasColorsDescriptor) {
+        Object.defineProperty(process.stdout, 'hasColors', stdoutHasColorsDescriptor);
+      } else {
+        Object.defineProperty(process.stdout, 'hasColors', { configurable: true, value: undefined });
       }
     }
   });

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -363,7 +363,8 @@ describe('@fluojs/platform-nodejs', () => {
       const app = await bootstrapNodejsApplication(AppModule, { port: 0 });
       await app.close();
 
-      const normalizedMessages = loggedMessages.map((message) => message.replace(/\u001B\[[\d;]*m/g, ''));
+      const ansiPattern = new RegExp(String.raw`\u001B\[[\d;]*m`, 'g');
+      const normalizedMessages = loggedMessages.map((message) => message.replace(ansiPattern, ''));
 
       expect(normalizedMessages.some((message) => message.includes('LOG [FluoFactory]'))).toBe(true);
       expect(loggedMessages.every((message) => !message.includes('\u001B['))).toBe(true);

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -1,6 +1,6 @@
 import { type AddressInfo, createServer } from 'node:net';
-import { Controller, type Dispatcher, FromBody, Get, Post, RequestDto, type RequestContext } from '@fluojs/http';
-import { type ApplicationLogger, defineModule, FluoFactory } from '@fluojs/runtime';
+import { Controller, type Dispatcher, FromBody, Get, Post, type RequestContext, RequestDto } from '@fluojs/http';
+import { defineModule, FluoFactory } from '@fluojs/runtime';
 import {
   type BootstrapNodeApplicationOptions,
   bootstrapNodeApplication,
@@ -365,19 +365,13 @@ describe('@fluojs/platform-nodejs', () => {
     class AppModule {}
     defineModule(AppModule, { providers: [FailingShutdownHook] });
 
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown) {
-        if (message === 'Failed to shut down the application cleanly.' && error === shutdownFailure) {
-          failureLogged();
-        }
-      },
-      log() {},
-      warn() {},
-    };
+    const errorLog = vi.spyOn(console, 'error').mockImplementation((message: unknown) => {
+      if (String(message).includes('Failed to shut down the application cleanly.')) {
+        failureLogged();
+      }
+    });
     const port = await findAvailablePort();
     const app = await runNodejsApplication(AppModule, {
-      logger,
       port,
       shutdownSignals: [signal],
     });
@@ -391,6 +385,7 @@ describe('@fluojs/platform-nodejs', () => {
 
       expect(process.exitCode).toBe(1);
     } finally {
+      errorLog.mockRestore();
       process.exitCode = originalExitCode;
       await app.close().catch(() => undefined);
     }
@@ -418,20 +413,14 @@ describe('@fluojs/platform-nodejs', () => {
     class AppModule {}
     defineModule(AppModule, { providers: [SlowShutdownHook] });
 
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string) {
-        if (message === 'Shutdown timeout exceeded after 1ms; leaving process termination to the host.') {
-          timeoutLogged();
-        }
-      },
-      log() {},
-      warn() {},
-    };
+    const errorLog = vi.spyOn(console, 'error').mockImplementation((message: unknown) => {
+      if (String(message).includes('Shutdown timeout exceeded after 1ms; leaving process termination to the host.')) {
+        timeoutLogged();
+      }
+    });
     const port = await findAvailablePort();
     const app = await runNodejsApplication(AppModule, {
       forceExitTimeoutMs: 1,
-      logger,
       port,
       shutdownSignals: [signal],
     });
@@ -445,6 +434,7 @@ describe('@fluojs/platform-nodejs', () => {
 
       expect(process.exitCode).toBe(1);
     } finally {
+      errorLog.mockRestore();
       releaseShutdown();
       process.exitCode = originalExitCode;
       await app.close().catch(() => undefined);

--- a/packages/platform-nodejs/src/index.test.ts
+++ b/packages/platform-nodejs/src/index.test.ts
@@ -324,12 +324,6 @@ describe('@fluojs/platform-nodejs', () => {
     const signal = 'SIGTERM' as const;
     const listenersBefore = new Set(process.listeners(signal));
     const app = await runNodejsApplication(AppModule, {
-      logger: {
-        debug() {},
-        error() {},
-        log() {},
-        warn() {},
-      },
       port: 0,
       shutdownSignals: [signal],
     });
@@ -343,6 +337,52 @@ describe('@fluojs/platform-nodejs', () => {
 
     for (const listener of registeredListeners) {
       expect(process.listeners(signal)).not.toContain(listener);
+    }
+  });
+
+  it('honors NO_COLOR when selecting the internal console logger', async () => {
+    const originalNoColor = process.env.NO_COLOR;
+    const originalForceColor = process.env.FORCE_COLOR;
+    const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+
+    class AppModule {}
+    defineModule(AppModule, {});
+
+    process.env.NO_COLOR = '1';
+    delete process.env.FORCE_COLOR;
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+
+    const loggedMessages: string[] = [];
+    const log = vi.spyOn(console, 'log').mockImplementation((message: unknown) => {
+      loggedMessages.push(String(message));
+    });
+
+    try {
+      const app = await bootstrapNodejsApplication(AppModule, { port: 0 });
+      await app.close();
+
+      expect(loggedMessages.some((message) => message.includes('LOG [FluoFactory]'))).toBe(true);
+      expect(loggedMessages.every((message) => !message.includes('\u001B['))).toBe(true);
+    } finally {
+      log.mockRestore();
+
+      if (originalNoColor === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = originalNoColor;
+      }
+
+      if (originalForceColor === undefined) {
+        delete process.env.FORCE_COLOR;
+      } else {
+        process.env.FORCE_COLOR = originalForceColor;
+      }
+
+      if (stdoutIsTtyDescriptor) {
+        Object.defineProperty(process.stdout, 'isTTY', stdoutIsTtyDescriptor);
+      } else {
+        Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: undefined });
+      }
     }
   });
 

--- a/packages/runtime/src/application.test.ts
+++ b/packages/runtime/src/application.test.ts
@@ -1,29 +1,27 @@
-import { createServer } from 'node:net';
 import { request as httpsRequest } from 'node:https';
-
-import { afterEach, describe, expect, it, vi } from 'vitest';
-
+import { createServer } from 'node:net';
 import { Inject, Scope } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
 import {
   Controller,
-  FromBody,
-  FromQuery,
-  FromCookie,
-  Get,
-  Post,
-  Version,
-  VersioningType,
-  SseResponse,
+  type Converter,
   createSecurityHeadersMiddleware,
-  type RequestContext,
-  RequestDto,
   type FrameworkRequest,
   type FrameworkResponse,
+  FromBody,
+  FromCookie,
+  FromQuery,
+  Get,
   type HttpApplicationAdapter,
-  type Converter,
+  Post,
+  type RequestContext,
+  RequestDto,
+  SseResponse,
+  Version,
+  VersioningType,
 } from '@fluojs/http';
 import { Exclude, Expose, SerializerInterceptor } from '@fluojs/serialization';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { bootstrapApplication, defineModule, FluoFactory } from './bootstrap.js';
 import { ModuleInjectionMetadataError } from './errors.js';
 import { createHealthModule } from './health/health.js';
@@ -1286,17 +1284,7 @@ describe('bootstrapApplication', () => {
   });
 
   it('runs node applications with runtime-owned defaults', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message, error, context) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message, context) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -1313,7 +1301,6 @@ describe('bootstrapApplication', () => {
 
     const port = await findAvailablePort();
     const app = await runNodeApplication(AppModule, {
-      logger,
       port,
     });
 
@@ -1328,23 +1315,14 @@ describe('bootstrapApplication', () => {
     // CORS is opt-in — without explicit cors option, no CORS middleware is applied
     expect(corsPreflight.status).toBe(404);
     expect(corsPreflight.headers.get('access-control-allow-origin')).toBeNull();
-    expect(loggerEvents.some((event) => event.includes(`Listening on http://localhost:${String(port)}`))).toBe(true);
+    expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on http://localhost:${String(port)}`))).toBe(true);
 
     await app.close();
+    log.mockRestore();
   });
 
   it('reports the configured host in the startup log', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message, error, context) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message, context) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -1363,7 +1341,6 @@ describe('bootstrapApplication', () => {
     const app = await runNodeApplication(AppModule, {
       cors: false,
       host: '127.0.0.1',
-      logger,
       port,
     });
 
@@ -1371,19 +1348,13 @@ describe('bootstrapApplication', () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(loggerEvents).toContain(`log:FluoFactory:Listening on http://127.0.0.1:${String(port)}`);
+    expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on http://127.0.0.1:${String(port)}`))).toBe(true);
 
     await app.close();
+    log.mockRestore();
   });
 
   it('removes registered shutdown signal listeners after close', async () => {
-    const logger: ApplicationLogger = {
-      debug() {},
-      error() {},
-      log() {},
-      warn() {},
-    };
-
     @Controller('/health')
     class HealthController {
       @Get('/')
@@ -1402,7 +1373,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await runNodeApplication(AppModule, {
       cors: false,
-      logger,
       port,
       shutdownSignals: [signal],
     });
@@ -1417,15 +1387,7 @@ describe('bootstrapApplication', () => {
   it('marks signal-driven shutdown timeouts without terminating the host process directly', async () => {
     vi.useFakeTimers();
 
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message, error, context) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log() {},
-      warn() {},
-    };
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -1445,7 +1407,6 @@ describe('bootstrapApplication', () => {
     const app = await runNodeApplication(AppModule, {
       cors: false,
       forceExitTimeoutMs: 25,
-      logger,
       port,
       shutdownSignals: ['SIGTERM'],
     });
@@ -1458,12 +1419,11 @@ describe('bootstrapApplication', () => {
       await vi.advanceTimersByTimeAsync(26);
 
       expect(process.exitCode).toBe(1);
-      expect(loggerEvents).toContain(
-        'error:FluoFactory:Shutdown timeout exceeded after 25ms; leaving process termination to the host.:none',
-      );
+      expect(errorLog.mock.calls.some(([message]) => String(message).includes('Shutdown timeout exceeded after 25ms; leaving process termination to the host.'))).toBe(true);
     } finally {
       app.close = originalClose;
       await app.close();
+      errorLog.mockRestore();
       process.exitCode = originalExitCode;
       vi.useRealTimers();
     }
@@ -1472,19 +1432,11 @@ describe('bootstrapApplication', () => {
   it('marks signal-driven shutdown failures without terminating the host process directly', async () => {
     const shutdownLogged = createDeferred<void>();
     const shutdownError = new Error('close failed');
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message, error, context) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-
-        if (message === 'Failed to shut down the application cleanly.') {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation((message: unknown) => {
+        if (String(message).includes('Failed to shut down the application cleanly.')) {
           shutdownLogged.resolve();
         }
-      },
-      log() {},
-      warn() {},
-    };
+      });
 
     @Controller('/health')
     class HealthController {
@@ -1503,7 +1455,6 @@ describe('bootstrapApplication', () => {
     const port = await findAvailablePort();
     const app = await runNodeApplication(AppModule, {
       cors: false,
-      logger,
       port,
       shutdownSignals: ['SIGTERM'],
     });
@@ -1520,26 +1471,17 @@ describe('bootstrapApplication', () => {
 
       expect(observedSignal).toBe('SIGTERM');
       expect(process.exitCode).toBe(1);
-      expect(loggerEvents).toContain('error:FluoFactory:Failed to shut down the application cleanly.:close failed');
+      expect(errorLog.mock.calls.some(([message]) => String(message).includes('Failed to shut down the application cleanly.'))).toBe(true);
     } finally {
       app.close = originalClose;
       await app.close();
+      errorLog.mockRestore();
       process.exitCode = originalExitCode;
     }
   });
 
   it('supports https startup and reports the https listen URL', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message, error, context) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message, context) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -1562,7 +1504,6 @@ describe('bootstrapApplication', () => {
         cert: TEST_TLS_CERTIFICATE,
         key: TEST_TLS_PRIVATE_KEY,
       },
-      logger,
       port,
     });
 
@@ -1570,23 +1511,14 @@ describe('bootstrapApplication', () => {
 
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toEqual({ ok: true });
-    expect(loggerEvents).toContain(`log:FluoFactory:Listening on https://127.0.0.1:${String(port)}`);
+    expect(log.mock.calls.some(([message]) => String(message).includes(`Listening on https://127.0.0.1:${String(port)}`))).toBe(true);
 
     await app.close();
+    log.mockRestore();
   });
 
   it('reports both a friendly localhost URL and the bind target for wildcard hosts', async () => {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message, error, context) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message, context) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
     @Controller('/health')
     class HealthController {
@@ -1605,7 +1537,6 @@ describe('bootstrapApplication', () => {
     const app = await runNodeApplication(AppModule, {
       cors: false,
       host: '0.0.0.0',
-      logger,
       port,
     });
 
@@ -1614,11 +1545,12 @@ describe('bootstrapApplication', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
 
-    const listenEvent = loggerEvents.find((event) => event.includes(`Listening on http://localhost:${String(port)}`));
+    const listenEvent = log.mock.calls.find(([message]) => String(message).includes(`Listening on http://localhost:${String(port)}`));
     expect(listenEvent).toBeDefined();
-    expect(listenEvent).toContain('bound to');
+    expect(String(listenEvent?.[0])).toContain('bound to');
 
     await app.close();
+    log.mockRestore();
   });
 
   it('applies a global prefix to application routes and runtime-owned paths by default', async () => {

--- a/packages/runtime/src/bootstrap.test.ts
+++ b/packages/runtime/src/bootstrap.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { Global, Inject, Module, Scope as ScopeDecorator } from '@fluojs/core';
-import { Controller, Convert, FromQuery, Get, RequestDto, type FrameworkRequest, type FrameworkResponse } from '@fluojs/http';
+import { Controller, Convert, type FrameworkRequest, type FrameworkResponse, FromQuery, Get, RequestDto } from '@fluojs/http';
+import { describe, expect, it, vi } from 'vitest';
 
 import { bootstrapApplication, bootstrapModule, FluoFactory } from './bootstrap.js';
 import { DuplicateProviderError, ModuleGraphError, ModuleInjectionMetadataError, ModuleVisibilityError } from './errors.js';
@@ -698,10 +697,8 @@ describe('FluoFactory.createApplicationContext', () => {
         ],
       });
 
-      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
         duplicateProviderPolicy,
-        logger,
       });
 
       const first = await context.get<{ id: number }>(CACHE_TOKEN);
@@ -724,10 +721,8 @@ describe('FluoFactory.createApplicationContext', () => {
       class AppModule {}
       defineRuntimeModuleMetadata(AppModule, {});
 
-      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
         duplicateProviderPolicy,
-        logger,
         providers: [
           {
             provide: CACHE_TOKEN,
@@ -1089,10 +1084,8 @@ describe('FluoFactory.createApplicationContext', () => {
         ],
       });
 
-      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
         duplicateProviderPolicy,
-        logger,
       });
 
       expect(events).toEqual(['winning:init', 'winning:bootstrap']);
@@ -1117,10 +1110,8 @@ describe('FluoFactory.createApplicationContext', () => {
       class AppModule {}
       defineRuntimeModuleMetadata(AppModule, {});
 
-      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
         duplicateProviderPolicy,
-        logger,
         providers: [
           {
             provide: LIFECYCLE_VALUE,
@@ -1205,10 +1196,8 @@ describe('FluoFactory.createApplicationContext', () => {
         ],
       });
 
-      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
         duplicateProviderPolicy,
-        logger,
       });
 
       expect(events).toEqual([]);
@@ -1228,10 +1217,8 @@ describe('FluoFactory.createApplicationContext', () => {
       class AppModule {}
       defineRuntimeModuleMetadata(AppModule, {});
 
-      const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
       const context = await FluoFactory.createApplicationContext(AppModule, {
         duplicateProviderPolicy,
-        logger,
         providers: [
           {
             provide: LIFECYCLE_VALUE,
@@ -1659,7 +1646,7 @@ describe('FluoFactory.createMicroservice', () => {
   it('preserves the original microservice bootstrap error when cleanup fails', async () => {
     const MICROSERVICE_TOKEN = Symbol.for('fluo.microservices.service');
     const cleanupFailure = new Error('cleanup failed');
-    const logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     class CleanupHook {
       onModuleDestroy() {
@@ -1678,14 +1665,12 @@ describe('FluoFactory.createMicroservice', () => {
       ],
     });
 
-    await expect(FluoFactory.createMicroservice(AppModule, { logger })).rejects.toThrow(
+    await expect(FluoFactory.createMicroservice(AppModule)).rejects.toThrow(
       'Resolved microservice token does not implement listen().',
     );
-    expect(logger.error).toHaveBeenCalledWith(
-      'Failed to clean up after microservice bootstrap failure.',
-      cleanupFailure,
-      'FluoFactory',
-    );
+    expect(errorLog.mock.calls.some(([message]) => String(message).includes('Failed to clean up after microservice bootstrap failure.'))).toBe(true);
+    expect(errorLog.mock.calls.some(([message]) => message === cleanupFailure)).toBe(true);
+    errorLog.mockRestore();
   });
 
   it('supports hybrid composition with FluoFactory.create()', async () => {

--- a/packages/runtime/src/bootstrap.ts
+++ b/packages/runtime/src/bootstrap.ts
@@ -1602,7 +1602,7 @@ export class FluoFactory {
   ): Promise<ApplicationContext> {
     const studioDevtools = createStudioDevtoolsRuntimeFromConfig();
     const effectiveOptions = applyStudioDevtoolsContextOptions(options, studioDevtools);
-    const logger = effectiveOptions.logger ?? createDefaultApplicationLogger();
+    const logger = createDefaultApplicationLogger();
     let lifecycleInstances: unknown[] = [];
     let bootstrappedContainer: Container | undefined;
     let bootstrappedModules: CompiledModule[] = [];
@@ -1732,7 +1732,7 @@ export class FluoFactory {
     rootModule: ModuleType,
     options: CreateMicroserviceOptions = {},
   ): Promise<MicroserviceApplication> {
-    const logger = options.logger ?? createDefaultApplicationLogger();
+    const logger = createDefaultApplicationLogger();
     const microserviceToken = options.microserviceToken ?? DEFAULT_MICROSERVICE_TOKEN;
     const context = await FluoFactory.createApplicationContext(rootModule, options);
 

--- a/packages/runtime/src/http-adapter-shared.test.ts
+++ b/packages/runtime/src/http-adapter-shared.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from 'vitest';
-
 import type { Middleware } from '@fluojs/http';
+import { describe, expect, it } from 'vitest';
 
 import { defineModule } from './bootstrap.js';
 import { createHttpAdapterMiddleware, runHttpAdapterApplication } from './http-adapter-shared.js';
@@ -182,14 +181,13 @@ describe('runHttpAdapterApplication', () => {
 
     const app = await runHttpAdapterApplication(AppModule, {
       forceExitTimeoutMs: 123,
-      logger,
       shutdownRegistration(application, _logger, forceExitTimeoutMs) {
         events.push(`register:${application.state}:${String(forceExitTimeoutMs)}`);
         return () => {
           events.push('unregister');
         };
       },
-    }, adapter);
+    }, adapter, logger);
 
     expect(events).toEqual([
       'adapter:listen',
@@ -236,11 +234,10 @@ describe('runHttpAdapterApplication', () => {
     };
 
     await expect(runHttpAdapterApplication(AppModule, {
-      logger,
       shutdownRegistration() {
         throw registrationFailure;
       },
-    }, adapter)).rejects.toBe(registrationFailure);
+    }, adapter, logger)).rejects.toBe(registrationFailure);
 
     expect(events).toEqual([
       'adapter:listen',
@@ -277,14 +274,13 @@ describe('runHttpAdapterApplication', () => {
     };
 
     const app = await runHttpAdapterApplication(AppModule, {
-      logger,
       shutdownRegistration() {
         return () => {
           events.push('unregister');
           throw unregisterFailure;
         };
       },
-    }, adapter);
+    }, adapter, logger);
 
     await expect(app.close('SIGTERM')).rejects.toBe(unregisterFailure);
 
@@ -326,14 +322,13 @@ describe('runHttpAdapterApplication', () => {
     };
 
     const app = await runHttpAdapterApplication(AppModule, {
-      logger,
       shutdownRegistration() {
         return () => {
           events.push('unregister');
           throw unregisterFailure;
         };
       },
-    }, adapter);
+    }, adapter, logger);
 
     try {
       await app.close('SIGTERM');

--- a/packages/runtime/src/http-adapter-shared.ts
+++ b/packages/runtime/src/http-adapter-shared.ts
@@ -1,16 +1,16 @@
 import {
+  type CorsOptions,
   createCorsMiddleware,
   createErrorResponse,
   createSecurityHeadersMiddleware,
-  matchRoutePattern,
-  normalizeRoutePattern,
-  NotFoundException,
-  type CorsOptions,
   type FrameworkResponse,
   type HttpApplicationAdapter,
   type MiddlewareContext,
   type MiddlewareLike,
+  matchRoutePattern,
   type Next,
+  NotFoundException,
+  normalizeRoutePattern,
   type SecurityHeadersOptions,
 } from '@fluojs/http';
 
@@ -53,10 +53,8 @@ export interface HttpAdapterMiddlewareOptions {
  * Options for bootstrapping an HTTP adapter application.
  */
 export interface BootstrapHttpAdapterApplicationOptions
-  extends Omit<CreateApplicationOptions, 'adapter' | 'logger' | 'middleware'>,
+  extends Omit<CreateApplicationOptions, 'adapter' | 'middleware'>,
     HttpAdapterMiddlewareOptions {
-  /** Optional custom application logger. */
-  logger?: ApplicationLogger;
 }
 
 /**
@@ -94,11 +92,12 @@ export async function bootstrapHttpAdapterApplication(
   rootModule: ModuleType,
   options: BootstrapHttpAdapterApplicationOptions,
   adapter: HttpApplicationAdapter,
+  logger: ApplicationLogger = createDefaultApplicationLogger(),
 ): Promise<Application> {
   return bootstrapApplication({
     ...options,
     adapter,
-    logger: options.logger ?? createDefaultApplicationLogger(),
+    logger,
     middleware: createHttpAdapterMiddleware(options),
     rootModule,
   });
@@ -155,8 +154,8 @@ export async function runHttpAdapterApplication(
   rootModule: ModuleType,
   options: RunHttpAdapterApplicationOptions,
   adapter: ManagedHttpApplicationAdapter,
+  logger: ApplicationLogger = createDefaultApplicationLogger(),
 ): Promise<Application> {
-  const logger = options.logger ?? createDefaultApplicationLogger();
   const app = await bootstrapApplication({
     ...options,
     adapter,

--- a/packages/runtime/src/http-adapter-shared.ts
+++ b/packages/runtime/src/http-adapter-shared.ts
@@ -86,6 +86,7 @@ type ManagedHttpApplicationAdapter = HttpApplicationAdapter & {
  * @param rootModule The root application module class.
  * @param options Bootstrap configuration for middleware and logging.
  * @param adapter The HTTP platform adapter to use.
+ * @param logger Logger instance used for bootstrap diagnostics.
  * @returns A promise that resolves to the initialized application instance.
  */
 export async function bootstrapHttpAdapterApplication(
@@ -148,6 +149,7 @@ export function formatHttpAdapterListenMessage(target: HttpAdapterListenTarget):
  * @param rootModule - The root application module class.
  * @param options - Run configuration including shutdown and logging settings.
  * @param adapter - The managed HTTP platform adapter to use.
+ * @param logger - Logger instance used for runtime diagnostics.
  * @returns A promise that resolves to the running application instance.
  */
 export async function runHttpAdapterApplication(

--- a/packages/runtime/src/logging/logger.ts
+++ b/packages/runtime/src/logging/logger.ts
@@ -85,6 +85,10 @@ function shouldUseColor(stream: NodeJS.WriteStream, environment: ConsoleApplicat
     return true;
   }
 
+  if (typeof stream.hasColors === 'function') {
+    return stream.hasColors();
+  }
+
   return Boolean(stream.isTTY);
 }
 

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -20,7 +20,7 @@ import {
 } from '../http-adapter-shared.js';
 import { createConsoleApplicationLogger } from '../logging/logger.js';
 import type { MultipartOptions, UploadedFile } from '../multipart.js';
-import type { Application, CreateApplicationOptions, ModuleType } from '../types.js';
+import type { Application, ApplicationLogger, CreateApplicationOptions, ModuleType } from '../types.js';
 import {
   compressNodeResponse,
   createNodeResponseCompression,
@@ -298,6 +298,15 @@ export function createNodeHttpAdapter(options: NodeHttpAdapterOptions = {}, comp
   );
 }
 
+function createNodeConsoleApplicationLogger(): ApplicationLogger {
+  return createConsoleApplicationLogger({
+    environment: {
+      forceColor: process.env.FORCE_COLOR,
+      noColor: process.env.NO_COLOR !== undefined,
+    },
+  });
+}
+
 /**
  * Bootstrap node application.
  *
@@ -309,7 +318,7 @@ export async function bootstrapNodeApplication(
   rootModule: ModuleType,
   options: BootstrapNodeApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = createNodeConsoleApplicationLogger();
 
   return bootstrapHttpAdapterApplication(
     rootModule,
@@ -330,7 +339,7 @@ export async function runNodeApplication(
   rootModule: ModuleType,
   options: RunNodeApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = createNodeConsoleApplicationLogger();
   const adapter = createNodeHttpAdapter(options, options.compression ?? false, options.multipart) as NodeHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -20,7 +20,7 @@ import {
 } from '../http-adapter-shared.js';
 import { createConsoleApplicationLogger } from '../logging/logger.js';
 import type { MultipartOptions, UploadedFile } from '../multipart.js';
-import type { Application, ApplicationLogger, CreateApplicationOptions, ModuleType } from '../types.js';
+import type { Application, CreateApplicationOptions, ModuleType } from '../types.js';
 import {
   compressNodeResponse,
   createNodeResponseCompression,
@@ -298,15 +298,6 @@ export function createNodeHttpAdapter(options: NodeHttpAdapterOptions = {}, comp
   );
 }
 
-function createNodeConsoleApplicationLogger(): ApplicationLogger {
-  return createConsoleApplicationLogger({
-    environment: {
-      forceColor: process.env.FORCE_COLOR,
-      noColor: process.env.NO_COLOR !== undefined,
-    },
-  });
-}
-
 /**
  * Bootstrap node application.
  *
@@ -318,7 +309,7 @@ export async function bootstrapNodeApplication(
   rootModule: ModuleType,
   options: BootstrapNodeApplicationOptions,
 ): Promise<Application> {
-  const logger = createNodeConsoleApplicationLogger();
+  const logger = createConsoleApplicationLogger();
 
   return bootstrapHttpAdapterApplication(
     rootModule,
@@ -339,7 +330,7 @@ export async function runNodeApplication(
   rootModule: ModuleType,
   options: RunNodeApplicationOptions,
 ): Promise<Application> {
-  const logger = createNodeConsoleApplicationLogger();
+  const logger = createConsoleApplicationLogger();
   const adapter = createNodeHttpAdapter(options, options.compression ?? false, options.multipart) as NodeHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -3,36 +3,41 @@ import { createServer as createHttpsServer, type ServerOptions as HttpsServerOpt
 import type { AddressInfo, Socket } from 'node:net';
 
 import {
-  createServerBackedHttpAdapterRealtimeCapability,
   type CorsOptions,
+  createServerBackedHttpAdapterRealtimeCapability,
   type Dispatcher,
   type HttpApplicationAdapter,
   type MiddlewareLike,
   type SecurityHeadersOptions,
 } from '@fluojs/http';
-
+import {
+  dispatchWithRequestResponseFactory,
+  type RequestResponseFactory,
+} from '../adapters/request-response-factory.js';
 import {
   bootstrapHttpAdapterApplication,
   runHttpAdapterApplication,
 } from '../http-adapter-shared.js';
 import { createConsoleApplicationLogger } from '../logging/logger.js';
+import type { MultipartOptions, UploadedFile } from '../multipart.js';
+import type { Application, CreateApplicationOptions, ModuleType } from '../types.js';
 import {
-  createNodeResponseCompression,
   compressNodeResponse,
+  createNodeResponseCompression,
 } from './internal-node-compression.js';
 import {
   cloneHeaderValue,
   cloneRequestHeaders,
-  createDeferredFrameworkRequestShell,
   createDeferredFrameworkRequest,
+  createDeferredFrameworkRequestShell,
   createMemoizedAsyncValue,
   createMemoizedValue,
+  createRequestSignal,
+  materializeFrameworkRequestBody,
   NodeRequestPayloadTooLargeException,
   normalizePrimaryContentType,
   parseCookieHeader,
   parseQueryParamsFromSearch,
-  createRequestSignal,
-  materializeFrameworkRequestBody,
   readPrimaryHeaderValue,
   resolveAbsoluteRequestUrl,
   resolveRequestIdFromHeaders,
@@ -49,12 +54,6 @@ import {
   defaultNodeShutdownSignals,
   registerShutdownSignals,
 } from './internal-node-shutdown.js';
-import type { MultipartOptions, UploadedFile } from '../multipart.js';
-import {
-  dispatchWithRequestResponseFactory,
-  type RequestResponseFactory,
-} from '../adapters/request-response-factory.js';
-import type { Application, ApplicationLogger, CreateApplicationOptions, ModuleType } from '../types.js';
 
 declare module '@fluojs/http' {
   interface FrameworkRequest {
@@ -99,7 +98,6 @@ export interface BootstrapNodeApplicationOptions extends Omit<CreateApplicationO
   globalPrefixExclude?: readonly string[];
   host?: string;
   https?: HttpsServerOptions;
-  logger?: ApplicationLogger;
   maxBodySize?: number;
   middleware?: MiddlewareLike[];
   multipart?: MultipartOptions;
@@ -311,12 +309,13 @@ export async function bootstrapNodeApplication(
   rootModule: ModuleType,
   options: BootstrapNodeApplicationOptions,
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = createConsoleApplicationLogger();
 
   return bootstrapHttpAdapterApplication(
     rootModule,
-    { ...options, logger },
+    options,
     createNodeHttpAdapter(options, options.compression ?? false, options.multipart),
+    logger,
   );
 }
 
@@ -331,15 +330,14 @@ export async function runNodeApplication(
   rootModule: ModuleType,
   options: RunNodeApplicationOptions,
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = createConsoleApplicationLogger();
   const adapter = createNodeHttpAdapter(options, options.compression ?? false, options.multipart) as NodeHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,
-    logger,
     shutdownRegistration: createNodeShutdownSignalRegistration(
       options.shutdownSignals ?? defaultNodeShutdownSignals(),
     ),
-  }, adapter);
+  }, adapter, logger);
 }
 
 export {
@@ -349,9 +347,9 @@ export {
   createDeferredFrameworkRequestShell,
   createMemoizedAsyncValue,
   createMemoizedValue,
-  createRequestSignal,
   createNodeResponseCompression,
   createNodeShutdownSignalRegistration,
+  createRequestSignal,
   defaultNodeShutdownSignals,
   normalizePrimaryContentType,
   parseCookieHeader,

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -169,11 +169,11 @@ export interface BootstrapApplicationOptions {
 }
 
 /** Options accepted by `FluoFactory.create(...)`. */
-export type CreateApplicationOptions = Omit<BootstrapApplicationOptions, 'rootModule'>;
+export type CreateApplicationOptions = Omit<BootstrapApplicationOptions, 'logger' | 'rootModule'>;
 
 /** Options accepted by `FluoFactory.createApplicationContext(...)`. */
 export interface CreateApplicationContextOptions
-  extends Omit<BootstrapApplicationOptions, 'adapter' | 'converters' | 'filters' | 'middleware' | 'observers' | 'rootModule'> {
+  extends Omit<BootstrapApplicationOptions, 'adapter' | 'converters' | 'filters' | 'logger' | 'middleware' | 'observers' | 'rootModule'> {
 }
 
 /** Runtime transport contract used by microservice application shells. */

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -53,7 +53,7 @@ function createLogger(events: string[]): ApplicationLogger {
 }
 
 function stripAnsi(value: string): string {
-  return value.replace(/\u001B\[[\d;]*m/g, '');
+  return value.replace(new RegExp(String.raw`\u001B\[[\d;]*m`, 'g'), '');
 }
 
 function getBoundPort(server: { address(): AddressInfo | string | null }): number {

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -1,7 +1,7 @@
 import { createServer as createHttpServer, type IncomingMessage, type Server as NodeHttpServer, type ServerResponse } from 'node:http';
 import { type AddressInfo, createServer as createNetServer } from 'node:net';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Inject, Scope } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import {
@@ -50,6 +50,10 @@ function createLogger(events: string[]): ApplicationLogger {
       events.push(`warn:${context ?? 'none'}:${message}`);
     },
   };
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001B\[[\d;]*m/g, '');
 }
 
 function getBoundPort(server: { address(): AddressInfo | string | null }): number {
@@ -926,9 +930,11 @@ describe('@fluojs/socket.io', () => {
     });
 
     const port = await findAvailablePort();
+    const errorLog = vi.spyOn(console, 'error').mockImplementation((message: unknown, error?: unknown) => {
+      loggerEvents.push(`${String(message)}:${error instanceof Error ? error.message : 'none'}`);
+    });
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      logger: createLogger(loggerEvents),
       port,
     });
     const state = await app.container.resolve<GatewayState>(GatewayState);
@@ -955,12 +961,12 @@ describe('@fluojs/socket.io', () => {
       expect(unhandledRejections).toEqual([]);
       expect(
         loggerEvents.some((event) =>
-          event.includes(
-            'error:SocketIoLifecycleService:Socket.IO message guard for event ping on socket',
-          ) && event.endsWith(':Forbidden event.'),
+          stripAnsi(event).includes('[SocketIoLifecycleService] Socket.IO message guard for event ping on socket'),
         ),
       ).toBe(true);
+      expect(loggerEvents.some((event) => event.includes('Forbidden event.'))).toBe(true);
     } finally {
+      errorLog.mockRestore();
       process.off('unhandledRejection', onUnhandledRejection);
       socket.close();
       await app.close();
@@ -1163,6 +1169,9 @@ describe('@fluojs/socket.io', () => {
 
   it('warns and skips non-singleton gateways', async () => {
     const loggerEvents: string[] = [];
+    const warnLog = vi.spyOn(console, 'warn').mockImplementation((message: unknown) => {
+      loggerEvents.push(String(message));
+    });
 
     @Scope('request')
     @WebSocketGateway({ path: '/request-gateway' })
@@ -1179,19 +1188,19 @@ describe('@fluojs/socket.io', () => {
 
     const app = await bootstrapNodeApplication(AppModule, {
       cors: false,
-      logger: createLogger(loggerEvents),
       port: await findAvailablePort(),
     });
 
-    expect(
-      loggerEvents.some((event) =>
-        event.includes(
-          'warn:SocketIoLifecycleService:RequestGateway in module AppModule declares @WebSocketGateway() but is registered with request scope.',
+    try {
+      expect(
+        loggerEvents.some((event) =>
+          stripAnsi(event).includes('[SocketIoLifecycleService] RequestGateway in module AppModule declares @WebSocketGateway() but is registered with request scope.'),
         ),
-      ),
-    ).toBe(true);
-
-    await app.close();
+      ).toBe(true);
+    } finally {
+      warnLog.mockRestore();
+      await app.close();
+    }
   });
 
   it('buffers messages and disconnects until async connect handlers complete', async () => {

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -1,7 +1,7 @@
 import { request as httpsRequest } from 'node:https';
 
-import { Controller, Get, Post, SseResponse, type RequestContext } from '@fluojs/http';
-import { defineModule, type ApplicationLogger, type ModuleType, type UploadedFile } from '@fluojs/runtime';
+import { Controller, Get, Post, type RequestContext, SseResponse } from '@fluojs/http';
+import { type ApplicationLogger, defineModule, type ModuleType, type UploadedFile } from '@fluojs/runtime';
 
 declare module '@fluojs/http' {
   interface FrameworkRequest {
@@ -113,6 +113,22 @@ async function requestHttps(url: string): Promise<{ body: string; statusCode: nu
     request.on('error', reject);
     request.end();
   });
+}
+
+function createConsoleLogCapture(): { messages: string[]; restore(): void } {
+  const messages: string[] = [];
+  const originalLog = console.log;
+
+  console.log = (...args: unknown[]) => {
+    messages.push(args.map((arg) => String(arg)).join(' '));
+  };
+
+  return {
+    messages,
+    restore() {
+      console.log = originalLog;
+    },
+  };
 }
 
 async function runWithCleanup(app: AppLike, adapterName: string, assertion: () => Promise<void>): Promise<void> {
@@ -586,17 +602,7 @@ export class HttpAdapterPortabilityHarness<
   }
 
   async assertReportsConfiguredHostInStartupLogs(): Promise<void> {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = createConsoleLogCapture();
 
     @Controller('/health')
     class HealthController {
@@ -614,41 +620,33 @@ export class HttpAdapterPortabilityHarness<
     const app = await this.options.run(AppModule, {
       cors: false,
       host: '127.0.0.1',
-      logger,
       port: 0,
     } as TRunOptions);
 
-    await runWithListeningUrlCleanup(app, this.options.name, async (baseUrl) => {
-      const response = await fetch(`${baseUrl}/health`);
+    try {
+      await runWithListeningUrlCleanup(app, this.options.name, async (baseUrl) => {
+        const response = await fetch(`${baseUrl}/health`);
 
-      if (response.status !== 200) {
-        throw new Error(`${this.options.name} adapter changed host-bound health response semantics.`);
-      }
+        if (response.status !== 200) {
+          throw new Error(`${this.options.name} adapter changed host-bound health response semantics.`);
+        }
 
-      const body = await response.json();
-      if (JSON.stringify(body) !== JSON.stringify({ ok: true })) {
-        throw new Error(`${this.options.name} adapter changed host-bound response payload.`);
-      }
+        const body = await response.json();
+        if (JSON.stringify(body) !== JSON.stringify({ ok: true })) {
+          throw new Error(`${this.options.name} adapter changed host-bound response payload.`);
+        }
 
-      const expectedLog = `log:FluoFactory:Listening on ${baseUrl}`;
-      if (!loggerEvents.includes(expectedLog)) {
-        throw new Error(`${this.options.name} adapter changed startup host logging.`);
-      }
-    });
+        if (!log.messages.some((message) => message.includes(`Listening on ${baseUrl}`))) {
+          throw new Error(`${this.options.name} adapter changed startup host logging.`);
+        }
+      });
+    } finally {
+      log.restore();
+    }
   }
 
   async assertReportsHttpsStartupUrl(https: { cert: string; key: string }): Promise<void> {
-    const loggerEvents: string[] = [];
-    const logger: ApplicationLogger = {
-      debug() {},
-      error(message: string, error: unknown, context?: string) {
-        loggerEvents.push(`error:${context}:${message}:${error instanceof Error ? error.message : 'none'}`);
-      },
-      log(message: string, context?: string) {
-        loggerEvents.push(`log:${context}:${message}`);
-      },
-      warn() {},
-    };
+    const log = createConsoleLogCapture();
 
     @Controller('/health')
     class HealthController {
@@ -667,26 +665,28 @@ export class HttpAdapterPortabilityHarness<
       cors: false,
       host: '127.0.0.1',
       https,
-      logger,
       port: 0,
     } as TRunOptions);
 
-    await runWithListeningUrlCleanup(app, this.options.name, async (baseUrl) => {
-      const response = await requestHttps(`${baseUrl}/health`);
+    try {
+      await runWithListeningUrlCleanup(app, this.options.name, async (baseUrl) => {
+        const response = await requestHttps(`${baseUrl}/health`);
 
-      if (response.statusCode !== 200) {
-        throw new Error(`${this.options.name} adapter changed HTTPS response status semantics.`);
-      }
+        if (response.statusCode !== 200) {
+          throw new Error(`${this.options.name} adapter changed HTTPS response status semantics.`);
+        }
 
-      if (JSON.stringify(JSON.parse(response.body)) !== JSON.stringify({ ok: true })) {
-        throw new Error(`${this.options.name} adapter changed HTTPS response payload semantics.`);
-      }
+        if (JSON.stringify(JSON.parse(response.body)) !== JSON.stringify({ ok: true })) {
+          throw new Error(`${this.options.name} adapter changed HTTPS response payload semantics.`);
+        }
 
-      const expectedLog = `log:FluoFactory:Listening on ${baseUrl}`;
-      if (!loggerEvents.includes(expectedLog)) {
-        throw new Error(`${this.options.name} adapter changed HTTPS startup logging.`);
-      }
-    });
+        if (!log.messages.some((message) => message.includes(`Listening on ${baseUrl}`))) {
+          throw new Error(`${this.options.name} adapter changed HTTPS startup logging.`);
+        }
+      });
+    } finally {
+      log.restore();
+    }
   }
 
   async assertRemovesShutdownSignalListenersAfterClose(): Promise<void> {

--- a/tooling/benchmarks/manifest-decision.ts
+++ b/tooling/benchmarks/manifest-decision.ts
@@ -3,16 +3,9 @@ import { performance } from 'node:perf_hooks';
 import { Module } from '../../packages/core/src/index';
 import { defineClassDiMetadata } from '../../packages/core/src/internal';
 import { Controller, Get } from '../../packages/http/src/index';
-import { FluoFactory, type ApplicationLogger, type ModuleType } from '../../packages/runtime/src/index';
+import { FluoFactory, type ModuleType } from '../../packages/runtime/src/index';
 
 type ConstructorToken = new (...args: never[]) => unknown;
-
-const silentLogger: ApplicationLogger = {
-  debug() {},
-  error() {},
-  log() {},
-  warn() {},
-};
 
 function createProvider(
   scenarioName: string,
@@ -117,9 +110,7 @@ async function measureScenario(name: string, rootModule: ModuleType, iterations 
 
   for (let iteration = 0; iteration < iterations; iteration += 1) {
     const startedAt = performance.now();
-    const app = await FluoFactory.create(rootModule, {
-      logger: silentLogger,
-    });
+    const app = await FluoFactory.create(rootModule);
     const bootstrapMs = performance.now() - startedAt;
 
     await app.close('benchmark');

--- a/tooling/governance/verify-platform-consistency-governance.test.ts
+++ b/tooling/governance/verify-platform-consistency-governance.test.ts
@@ -443,8 +443,8 @@ describe('repository governance contracts', () => {
     expect(releaseWorkflow).toContain('publish: pnpm publish-packages');
     expect(releaseWorkflow).toContain('createGithubReleases: true');
     expect(releaseWorkflow).toContain('NPM_CONFIG_PROVENANCE: true');
-    expect(releaseWorkflow).toContain('NPM_TOKEN: ${{ secrets.NPM_TOKEN }}');
-    expect(releaseWorkflow).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
+    expect(releaseWorkflow).toContain(`NPM_TOKEN: \${{ secrets.NPM_TOKEN }}`);
+    expect(releaseWorkflow).toContain(`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}`);
   });
 
   it('keeps Changesets release safety gates before versioning or publish', () => {

--- a/tooling/governance/verify-public-export-tsdoc.test.ts
+++ b/tooling/governance/verify-public-export-tsdoc.test.ts
@@ -214,7 +214,7 @@ describe('changedPublicExportSourcePathsFromGit', () => {
       ' */',
       'export class ExampleService {',
       '  greet(name: string, locale: string): string {',
-      "    return `${locale}:${name}`;",
+      `    return \`\${locale}:\${name}\`;`,
       '  }',
       '}',
       '',


### PR DESCRIPTION
## Summary
- remove the public runtime logger option so apps do not choose logger behavior directly
- select console application loggers internally for Node and HTTP platform helpers
- update generated starters and portability tests to preserve colored startup logs

Closes #2037

## Changes
- Node and HTTP platform runtime helpers select framework console loggers internally instead of exposing logger selection through helper options.
- Generated starters now route through the runtime/platform helpers so `fluo dev` and `fluo start` preserve runtime-colored logs.
- Platform README/README.ko files no longer document passing logger options to Express/Fastify startup helpers.
- `pr-to-merge` reviewer agents now allow the recurring same-PR read-only `gh` and `GIT_MASTER=1 git` inspection commands up front while keeping mutating commands denied.

## Testing
- pnpm exec biome check packages/runtime/src packages/platform-nodejs/src packages/platform-bun/src packages/platform-deno/src packages/platform-express/src packages/platform-fastify/src packages/cli/src packages/testing/src
- pnpm vitest run packages/runtime/src/application.test.ts packages/runtime/src/bootstrap.test.ts packages/runtime/src/http-adapter-shared.test.ts packages/platform-nodejs/src/index.test.ts packages/platform-bun/src/adapter.test.ts packages/platform-deno/src/adapter.test.ts packages/platform-express/src/adapter.test.ts packages/platform-fastify/src/adapter.test.ts packages/cli/src/new/scaffold.test.ts
- pnpm vitest run packages/platform-nodejs/src/index.test.ts packages/runtime/src/node/internal-node.test.ts packages/microservices/src/module.test.ts packages/socket.io/src/module.test.ts
- pnpm verify:platform-consistency-governance
- pnpm typecheck
- pnpm build
- pnpm lint

## Release impact
- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch release intent is intentional for #2037. The user-facing behavior restored here is Node CLI/runtime startup log color preservation while keeping logger selection internal to framework helpers.

## Public export documentation
- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This PR keeps the root runtime bootstrap default transport-neutral while Node/platform helper startup paths select console logging internally and preserve `NO_COLOR` behavior.