### PR TITLE
Resolve #2043: clean up validation engine internals

### DIFF
--- a/packages/validation/src/decorators.ts
+++ b/packages/validation/src/decorators.ts
@@ -1,9 +1,5 @@
+import type { Constructor } from '@fluojs/core';
 import type {
-  Constructor,
-  MetadataPropertyKey,
-} from '@fluojs/core';
-import type {
-  ClassValidationRule,
   CustomClassValidator,
   CustomFieldValidator,
   CustomValidationDecoratorOptions,
@@ -11,63 +7,11 @@ import type {
   ValidationDecoratorOptions,
 } from '@fluojs/core/internal';
 
+import { createArrayValidationDecorator, createFlagValidationDecorator, createValidationDecorator, createValidationOptionsWithConfigDecorator, createValidatorJsDecorator } from './internal/decorator-factories.js';
+import { appendStandardClassValidationRule, type ClassDecoratorFn, type FieldDecoratorFn } from './internal/decorator-metadata.js';
 import { createClassValidatorFromStandardSchema, isStandardSchemaLike, type StandardSchemaV1Like } from './standard-schema.js';
 
-type StandardMetadataBag = Record<PropertyKey, unknown>;
-type ClassDecoratorFn = (value: Function, context: ClassDecoratorContext) => void;
-type FieldDecoratorFn = <This, Value>(value: undefined, context: ClassFieldDecoratorContext<This, Value>) => void;
-type ValidatorJsRuleName = Extract<DtoFieldValidationRule, { kind: 'validatorjs' }>['validator'];
 type ValidateClassInput = CustomClassValidator | StandardSchemaV1Like;
-
-const standardDtoValidationMetadataKey = Symbol.for('fluo.standard.dto-validation');
-const standardClassValidationMetadataKey = Symbol.for('fluo.standard.class-validation');
-
-function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
-  if (metadata === null || metadata === undefined) {
-    throw new Error('Decorator metadata is not available. Ensure your environment supports TC39 decorator metadata (Stage 3).');
-  }
-
-  return metadata as StandardMetadataBag;
-}
-
-function getStandardDtoValidationMap(metadata: unknown): Map<MetadataPropertyKey, DtoFieldValidationRule[]> {
-  const bag = getStandardMetadataBag(metadata);
-  const current = bag[standardDtoValidationMetadataKey] as Map<MetadataPropertyKey, DtoFieldValidationRule[]> | undefined;
-
-  if (current) {
-    return current;
-  }
-
-  const created = new Map<MetadataPropertyKey, DtoFieldValidationRule[]>();
-  bag[standardDtoValidationMetadataKey] = created;
-  return created;
-}
-
-function getStandardClassValidationList(metadata: unknown): ClassValidationRule[] {
-  const bag = getStandardMetadataBag(metadata);
-  const current = bag[standardClassValidationMetadataKey] as ClassValidationRule[] | undefined;
-
-  if (current) {
-    return current;
-  }
-
-  const created: ClassValidationRule[] = [];
-  bag[standardClassValidationMetadataKey] = created;
-  return created;
-}
-
-function appendStandardDtoValidationRule(
-  metadata: unknown,
-  propertyKey: MetadataPropertyKey,
-  rule: DtoFieldValidationRule,
-): void {
-  const map = getStandardDtoValidationMap(metadata);
-  map.set(propertyKey, [...(map.get(propertyKey) ?? []), rule]);
-}
-
-function appendStandardClassValidationRule(metadata: unknown, rule: ClassValidationRule): void {
-  getStandardClassValidationList(metadata).push(rule);
-}
 
 function resolveClassValidator(validate: ValidateClassInput): CustomClassValidator {
   if (!isStandardSchemaLike(validate)) {
@@ -75,49 +19,6 @@ function resolveClassValidator(validate: ValidateClassInput): CustomClassValidat
   }
 
   return createClassValidatorFromStandardSchema(validate);
-}
-
-function createValidationDecorator(ruleFactory: () => DtoFieldValidationRule): FieldDecoratorFn {
-  const decorator = <This, Value>(_value: undefined, context: ClassFieldDecoratorContext<This, Value>) => {
-    appendStandardDtoValidationRule(context.metadata, context.name, ruleFactory());
-  };
-
-  return decorator as FieldDecoratorFn;
-}
-
-function createValidationOptionsWithConfigDecorator<T>(
-  ruleFactory: (value: T, options: ValidationDecoratorOptions | undefined) => DtoFieldValidationRule,
-) {
-  return (value: T, options?: ValidationDecoratorOptions): FieldDecoratorFn => {
-    return createValidationDecorator(() => ruleFactory(value, options));
-  };
-}
-
-function createFlagValidationDecorator(
-  ruleFactory: (options: ValidationDecoratorOptions | undefined) => DtoFieldValidationRule,
-) {
-  return (options?: ValidationDecoratorOptions): FieldDecoratorFn => {
-    return createValidationDecorator(() => ruleFactory(options));
-  };
-}
-
-function createArrayValidationDecorator<T>(
-  ruleFactory: (values: readonly T[], options: ValidationDecoratorOptions | undefined) => DtoFieldValidationRule,
-) {
-  return (values: readonly T[], options?: ValidationDecoratorOptions): FieldDecoratorFn => {
-    return createValidationDecorator(() => ruleFactory(values, options));
-  };
-}
-
-function createValidatorJsDecorator(validator: ValidatorJsRuleName) {
-  return (args?: readonly unknown[], options?: ValidationDecoratorOptions): FieldDecoratorFn => {
-    return createValidationDecorator(() => ({
-      args,
-      kind: 'validatorjs',
-      validator,
-      ...options,
-    }));
-  };
 }
 
 /**

--- a/packages/validation/src/internal/decorator-factories.ts
+++ b/packages/validation/src/internal/decorator-factories.ts
@@ -1,0 +1,48 @@
+import type { DtoFieldValidationRule, ValidationDecoratorOptions } from '@fluojs/core/internal';
+
+import { appendStandardDtoValidationRule, type FieldDecoratorFn } from './decorator-metadata.js';
+
+type ValidatorJsRuleName = Extract<DtoFieldValidationRule, { kind: 'validatorjs' }>['validator'];
+
+export function createValidationDecorator(ruleFactory: () => DtoFieldValidationRule): FieldDecoratorFn {
+  const decorator = <This, Value>(_value: undefined, context: ClassFieldDecoratorContext<This, Value>) => {
+    appendStandardDtoValidationRule(context.metadata, context.name, ruleFactory());
+  };
+
+  return decorator as FieldDecoratorFn;
+}
+
+export function createValidationOptionsWithConfigDecorator<T>(
+  ruleFactory: (value: T, options: ValidationDecoratorOptions | undefined) => DtoFieldValidationRule,
+) {
+  return (value: T, options?: ValidationDecoratorOptions): FieldDecoratorFn => {
+    return createValidationDecorator(() => ruleFactory(value, options));
+  };
+}
+
+export function createFlagValidationDecorator(
+  ruleFactory: (options: ValidationDecoratorOptions | undefined) => DtoFieldValidationRule,
+) {
+  return (options?: ValidationDecoratorOptions): FieldDecoratorFn => {
+    return createValidationDecorator(() => ruleFactory(options));
+  };
+}
+
+export function createArrayValidationDecorator<T>(
+  ruleFactory: (values: readonly T[], options: ValidationDecoratorOptions | undefined) => DtoFieldValidationRule,
+) {
+  return (values: readonly T[], options?: ValidationDecoratorOptions): FieldDecoratorFn => {
+    return createValidationDecorator(() => ruleFactory(values, options));
+  };
+}
+
+export function createValidatorJsDecorator(validator: ValidatorJsRuleName) {
+  return (args?: readonly unknown[], options?: ValidationDecoratorOptions): FieldDecoratorFn => {
+    return createValidationDecorator(() => ({
+      args,
+      kind: 'validatorjs',
+      validator,
+      ...options,
+    }));
+  };
+}

--- a/packages/validation/src/internal/decorator-metadata.ts
+++ b/packages/validation/src/internal/decorator-metadata.ts
@@ -1,0 +1,57 @@
+import type { MetadataPropertyKey } from '@fluojs/core';
+import type { ClassValidationRule, DtoFieldValidationRule } from '@fluojs/core/internal';
+
+export type ClassDecoratorFn = (value: Function, context: ClassDecoratorContext) => void;
+export type FieldDecoratorFn = <This, Value>(value: undefined, context: ClassFieldDecoratorContext<This, Value>) => void;
+
+type StandardMetadataBag = Record<PropertyKey, unknown>;
+
+const standardDtoValidationMetadataKey = Symbol.for('fluo.standard.dto-validation');
+const standardClassValidationMetadataKey = Symbol.for('fluo.standard.class-validation');
+
+function getStandardMetadataBag(metadata: unknown): StandardMetadataBag {
+  if (metadata === null || metadata === undefined) {
+    throw new Error('Decorator metadata is not available. Ensure your environment supports TC39 decorator metadata (Stage 3).');
+  }
+
+  return metadata as StandardMetadataBag;
+}
+
+function getStandardDtoValidationMap(metadata: unknown): Map<MetadataPropertyKey, DtoFieldValidationRule[]> {
+  const bag = getStandardMetadataBag(metadata);
+  const current = bag[standardDtoValidationMetadataKey] as Map<MetadataPropertyKey, DtoFieldValidationRule[]> | undefined;
+
+  if (current) {
+    return current;
+  }
+
+  const created = new Map<MetadataPropertyKey, DtoFieldValidationRule[]>();
+  bag[standardDtoValidationMetadataKey] = created;
+  return created;
+}
+
+function getStandardClassValidationList(metadata: unknown): ClassValidationRule[] {
+  const bag = getStandardMetadataBag(metadata);
+  const current = bag[standardClassValidationMetadataKey] as ClassValidationRule[] | undefined;
+
+  if (current) {
+    return current;
+  }
+
+  const created: ClassValidationRule[] = [];
+  bag[standardClassValidationMetadataKey] = created;
+  return created;
+}
+
+export function appendStandardDtoValidationRule(
+  metadata: unknown,
+  propertyKey: MetadataPropertyKey,
+  rule: DtoFieldValidationRule,
+): void {
+  const map = getStandardDtoValidationMap(metadata);
+  map.set(propertyKey, [...(map.get(propertyKey) ?? []), rule]);
+}
+
+export function appendStandardClassValidationRule(metadata: unknown, rule: ClassValidationRule): void {
+  getStandardClassValidationList(metadata).push(rule);
+}

--- a/packages/validation/src/internal/dto-metadata-cache.ts
+++ b/packages/validation/src/internal/dto-metadata-cache.ts
@@ -1,0 +1,91 @@
+import type { Constructor, MetadataPropertyKey } from '@fluojs/core';
+import {
+  getClassValidationRules,
+  getDtoBindingSchema,
+  getDtoValidationSchema,
+  type DtoFieldBindingMetadata,
+  type DtoFieldValidationRule,
+} from '@fluojs/core/internal';
+
+function isClassConstructor(dto: Constructor | (() => Constructor)): dto is Constructor {
+  return typeof dto === 'function' && Function.prototype.toString.call(dto).startsWith('class ');
+}
+
+export function resolveNestedDto(dto: Constructor | (() => Constructor)): Constructor {
+  if (isClassConstructor(dto)) {
+    return dto;
+  }
+
+  return (dto as () => Constructor)();
+}
+
+type DtoValidationSchema = ReturnType<typeof getDtoValidationSchema>;
+
+export interface CachedDtoMetadata {
+  bindingMap: Map<MetadataPropertyKey, DtoFieldBindingMetadata>;
+  classValidationRules: ReturnType<typeof getClassValidationRules>;
+  dtoValidationSchema: DtoValidationSchema;
+  mergedPropertyKeys: Set<MetadataPropertyKey>;
+  nestedDtoTransforms: readonly {
+    each: boolean;
+    propertyKey: MetadataPropertyKey;
+    target: Constructor;
+  }[];
+}
+
+const dtoMetadataCache = new WeakMap<Constructor, CachedDtoMetadata>();
+
+function getDtoBindingMap(target: Constructor): Map<MetadataPropertyKey, DtoFieldBindingMetadata> {
+  return new Map(
+    getDtoBindingSchema(target).map((entry: { propertyKey: MetadataPropertyKey; metadata: DtoFieldBindingMetadata }) => [entry.propertyKey, entry.metadata]),
+  );
+}
+
+function collectNestedDtoTransforms(dtoValidationSchema: DtoValidationSchema): CachedDtoMetadata['nestedDtoTransforms'] {
+  const nestedEntries: CachedDtoMetadata['nestedDtoTransforms'][number][] = [];
+
+  for (const entry of dtoValidationSchema) {
+    const nestedRule = entry.rules.find(
+      (rule: DtoFieldValidationRule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
+    );
+
+    if (!nestedRule) {
+      continue;
+    }
+
+    nestedEntries.push({
+      each: nestedRule.each === true,
+      propertyKey: entry.propertyKey,
+      target: resolveNestedDto(nestedRule.dto),
+    });
+  }
+
+  return nestedEntries;
+}
+
+export function getCachedDtoMetadata(target: Constructor): CachedDtoMetadata {
+  const cached = dtoMetadataCache.get(target);
+
+  if (cached) {
+    return cached;
+  }
+
+  const bindingMap = getDtoBindingMap(target);
+  const dtoValidationSchema = getDtoValidationSchema(target);
+  const classValidationRules = getClassValidationRules(target);
+  const mergedPropertyKeys = new Set<MetadataPropertyKey>([
+    ...bindingMap.keys(),
+    ...dtoValidationSchema.map((entry: { propertyKey: MetadataPropertyKey }) => entry.propertyKey),
+  ]);
+  const nestedDtoTransforms = collectNestedDtoTransforms(dtoValidationSchema);
+  const next: CachedDtoMetadata = {
+    bindingMap,
+    classValidationRules,
+    dtoValidationSchema,
+    mergedPropertyKeys,
+    nestedDtoTransforms,
+  };
+
+  dtoMetadataCache.set(target, next);
+  return next;
+}

--- a/packages/validation/src/internal/object-utils.ts
+++ b/packages/validation/src/internal/object-utils.ts
@@ -1,0 +1,34 @@
+export function getIterableValues(value: unknown): unknown[] | undefined {
+  if (Array.isArray(value)) return value;
+  if (value instanceof Set) return Array.from(value.values());
+  if (value instanceof Map) return Array.from(value.values());
+  return undefined;
+}
+
+export function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+const dangerousKeys = new Set(['__proto__', 'constructor', 'prototype']);
+
+export function assignSafeOwnEnumerableProperties(
+  target: Record<PropertyKey, unknown>,
+  source: Record<PropertyKey, unknown>,
+): void {
+  for (const key of Reflect.ownKeys(source)) {
+    if (typeof key === 'string' && dangerousKeys.has(key)) {
+      continue;
+    }
+
+    if (!Object.prototype.propertyIsEnumerable.call(source, key)) {
+      continue;
+    }
+
+    target[key] = source[key as keyof typeof source];
+  }
+}

--- a/packages/validation/src/internal/rule-handlers.ts
+++ b/packages/validation/src/internal/rule-handlers.ts
@@ -1,0 +1,224 @@
+import type { DtoFieldValidationRule } from '@fluojs/core/internal';
+
+import { isPlainObject } from './object-utils.js';
+import { runValidatorJs } from './validator-js-adapter.js';
+
+type RuleKind = DtoFieldValidationRule['kind'];
+
+export type NonCustomRule = Exclude<DtoFieldValidationRule, { kind: 'custom' | 'nested' }>;
+
+type RuleHandler<K extends RuleKind> = {
+  defaultCode: string;
+  describe: (field: string, rule: Extract<DtoFieldValidationRule, { kind: K }>) => string;
+  validate: (rule: Extract<DtoFieldValidationRule, { kind: K }>, value: unknown) => boolean;
+};
+
+function isEmptyValue(value: unknown): boolean {
+  return value === '' || value === null || value === undefined;
+}
+
+const ruleHandlers: { [K in RuleKind]: RuleHandler<K> } = {
+  validateIf: {
+    defaultCode: 'VALIDATE_IF',
+    describe: (field) => `${field} is conditionally invalid.`,
+    validate: () => true,
+  },
+  defined: {
+    defaultCode: 'REQUIRED',
+    describe: (field) => `${field} is required.`,
+    validate: (_rule, value) => value !== undefined && value !== null,
+  },
+  optional: {
+    defaultCode: 'OPTIONAL',
+    describe: (field) => `${field} is optional.`,
+    validate: () => true,
+  },
+  equals: {
+    defaultCode: 'EQUALS',
+    describe: (field, rule) => `${field} must equal ${String(rule.value)}.`,
+    validate: (rule, value) => value === rule.value,
+  },
+  notEquals: {
+    defaultCode: 'NOT_EQUALS',
+    describe: (field, rule) => `${field} must not equal ${String(rule.value)}.`,
+    validate: (rule, value) => value !== rule.value,
+  },
+  empty: {
+    defaultCode: 'EMPTY',
+    describe: (field) => `${field} must be empty.`,
+    validate: (_rule, value) => isEmptyValue(value),
+  },
+  notEmpty: {
+    defaultCode: 'NOT_EMPTY',
+    describe: (field) => `${field} should not be empty.`,
+    validate: (_rule, value) => !isEmptyValue(value),
+  },
+  in: {
+    defaultCode: 'IN',
+    describe: (field) => `${field} must be one of the allowed values.`,
+    validate: (rule, value) => rule.values.includes(value),
+  },
+  notIn: {
+    defaultCode: 'NOT_IN',
+    describe: (field) => `${field} contains a forbidden value.`,
+    validate: (rule, value) => !rule.values.includes(value),
+  },
+  string: {
+    defaultCode: 'INVALID_STRING',
+    describe: (field) => `${field} must be a string.`,
+    validate: (_rule, value) => typeof value === 'string',
+  },
+  number: {
+    defaultCode: 'INVALID_NUMBER',
+    describe: (field) => `${field} must be a number.`,
+    validate: (rule, value) => typeof value === 'number' && (rule.allowNaN || !Number.isNaN(value)),
+  },
+  boolean: {
+    defaultCode: 'INVALID_BOOLEAN',
+    describe: (field) => `${field} must be a boolean.`,
+    validate: (_rule, value) => typeof value === 'boolean',
+  },
+  date: {
+    defaultCode: 'INVALID_DATE',
+    describe: (field) => `${field} must be a Date instance.`,
+    validate: (_rule, value) => value instanceof Date && !Number.isNaN(value.getTime()),
+  },
+  array: {
+    defaultCode: 'INVALID_ARRAY',
+    describe: (field) => `${field} must be an array.`,
+    validate: (_rule, value) => Array.isArray(value),
+  },
+  object: {
+    defaultCode: 'INVALID_OBJECT',
+    describe: (field) => `${field} must be an object.`,
+    validate: (_rule, value) => isPlainObject(value),
+  },
+  enum: {
+    defaultCode: 'INVALID_ENUM',
+    describe: (field) => `${field} must be a supported enum value.`,
+    validate: (rule, value) => rule.values.includes(value),
+  },
+  int: {
+    defaultCode: 'INVALID_INT',
+    describe: (field) => `${field} must be an integer.`,
+    validate: (_rule, value) => typeof value === 'number' && Number.isInteger(value),
+  },
+  divisibleBy: {
+    defaultCode: 'DIVISIBLE_BY',
+    describe: (field, rule) => `${field} must be divisible by ${String(rule.value)}.`,
+    validate: (rule, value) => typeof value === 'number' && !Number.isNaN(value) && value % rule.value === 0,
+  },
+  positive: {
+    defaultCode: 'POSITIVE',
+    describe: (field) => `${field} must be positive.`,
+    validate: (_rule, value) => typeof value === 'number' && value > 0,
+  },
+  negative: {
+    defaultCode: 'NEGATIVE',
+    describe: (field) => `${field} must be negative.`,
+    validate: (_rule, value) => typeof value === 'number' && value < 0,
+  },
+  min: {
+    defaultCode: 'MIN',
+    describe: (field, rule) => `${field} must be greater than or equal to ${String(rule.value)}.`,
+    validate: (rule, value) => typeof value === 'number' && !Number.isNaN(value) && value >= rule.value,
+  },
+  max: {
+    defaultCode: 'MAX',
+    describe: (field, rule) => `${field} must be less than or equal to ${String(rule.value)}.`,
+    validate: (rule, value) => typeof value === 'number' && !Number.isNaN(value) && value <= rule.value,
+  },
+  minDate: {
+    defaultCode: 'MIN_DATE',
+    describe: (field, rule) => `${field} must be on or after ${rule.value.toISOString()}.`,
+    validate: (rule, value) => value instanceof Date && !Number.isNaN(value.getTime()) && value.getTime() >= rule.value.getTime(),
+  },
+  maxDate: {
+    defaultCode: 'MAX_DATE',
+    describe: (field, rule) => `${field} must be on or before ${rule.value.toISOString()}.`,
+    validate: (rule, value) => value instanceof Date && !Number.isNaN(value.getTime()) && value.getTime() <= rule.value.getTime(),
+  },
+  contains: {
+    defaultCode: 'CONTAINS',
+    describe: (field, rule) => `${field} must contain ${rule.value}.`,
+    validate: (rule, value) => typeof value === 'string' && value.includes(rule.value),
+  },
+  notContains: {
+    defaultCode: 'NOT_CONTAINS',
+    describe: (field, rule) => `${field} must not contain ${rule.value}.`,
+    validate: (rule, value) => typeof value === 'string' && !value.includes(rule.value),
+  },
+  length: {
+    defaultCode: 'LENGTH',
+    describe: (field) => `${field} must have a valid length.`,
+    validate: (rule, value) => typeof value === 'string' && value.length >= rule.min && (rule.max === undefined || value.length <= rule.max),
+  },
+  minLength: {
+    defaultCode: 'MIN_LENGTH',
+    describe: (field, rule) => `${field} must have length at least ${String(rule.value)}.`,
+    validate: (rule, value) => typeof value === 'string' && value.length >= rule.value,
+  },
+  maxLength: {
+    defaultCode: 'MAX_LENGTH',
+    describe: (field, rule) => `${field} must have length at most ${String(rule.value)}.`,
+    validate: (rule, value) => typeof value === 'string' && value.length <= rule.value,
+  },
+  nested: {
+    defaultCode: 'INVALID_NESTED',
+    describe: (field) => `${field} contains invalid nested data.`,
+    validate: () => true,
+  },
+  validatorjs: {
+    defaultCode: 'INVALID_FIELD',
+    describe: (field) => `${field} is invalid.`,
+    validate: (rule, value) => runValidatorJs(rule, value),
+  },
+  arrayContains: {
+    defaultCode: 'ARRAY_CONTAINS',
+    describe: (field) => `${field} must contain the required values.`,
+    validate: (rule, value) => Array.isArray(value) && rule.values.every((expected: unknown) => value.includes(expected)),
+  },
+  arrayNotContains: {
+    defaultCode: 'ARRAY_NOT_CONTAINS',
+    describe: (field) => `${field} contains forbidden values.`,
+    validate: (rule, value) => Array.isArray(value) && rule.values.every((expected: unknown) => !value.includes(expected)),
+  },
+  arrayNotEmpty: {
+    defaultCode: 'ARRAY_NOT_EMPTY',
+    describe: (field) => `${field} must not be an empty array.`,
+    validate: (_rule, value) => Array.isArray(value) && value.length > 0,
+  },
+  arrayMinSize: {
+    defaultCode: 'ARRAY_MIN_SIZE',
+    describe: (field, rule) => `${field} must contain at least ${String(rule.value)} items.`,
+    validate: (rule, value) => Array.isArray(value) && value.length >= rule.value,
+  },
+  arrayMaxSize: {
+    defaultCode: 'ARRAY_MAX_SIZE',
+    describe: (field, rule) => `${field} must contain at most ${String(rule.value)} items.`,
+    validate: (rule, value) => Array.isArray(value) && value.length <= rule.value,
+  },
+  arrayUnique: {
+    defaultCode: 'ARRAY_UNIQUE',
+    describe: (field) => `${field} must contain unique values.`,
+    validate: (rule, value) => {
+      if (!Array.isArray(value)) return false;
+      const seen = new Set<unknown>();
+      for (const entry of value) {
+        const key = rule.selector ? rule.selector(entry) : entry;
+        if (seen.has(key)) return false;
+        seen.add(key);
+      }
+      return true;
+    },
+  },
+  custom: {
+    defaultCode: 'INVALID_FIELD',
+    describe: (field) => `${field} is invalid.`,
+    validate: () => true,
+  },
+};
+
+export function getRuleHandler<K extends RuleKind>(rule: Extract<DtoFieldValidationRule, { kind: K }>): RuleHandler<K> {
+  return ruleHandlers[rule.kind] as RuleHandler<K>;
+}

--- a/packages/validation/src/internal/validator-js-adapter.ts
+++ b/packages/validation/src/internal/validator-js-adapter.ts
@@ -1,0 +1,57 @@
+import validator from 'validator';
+
+import type { DtoFieldValidationRule } from '@fluojs/core/internal';
+
+export function runValidatorJs(rule: Extract<DtoFieldValidationRule, { kind: 'validatorjs' }>, value: unknown): boolean {
+  if (rule.validator === 'latitude') {
+    return typeof value === 'number' && Number.isFinite(value) && value >= -90 && value <= 90;
+  }
+
+  if (rule.validator === 'longitude') {
+    return typeof value === 'number' && Number.isFinite(value) && value >= -180 && value <= 180;
+  }
+
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  switch (rule.validator) {
+    case 'alpha': return validator.isAlpha(value);
+    case 'alphanumeric': return validator.isAlphanumeric(value);
+    case 'ascii': return validator.isAscii(value);
+    case 'base64': return validator.isBase64(value);
+    case 'booleanString': return validator.isBoolean(value);
+    case 'currency': return validator.isCurrency(value, rule.args?.[0] as validator.IsCurrencyOptions | undefined);
+    case 'dataURI': return validator.isDataURI(value);
+    case 'dateString': return validator.isISO8601(value);
+    case 'decimal': return validator.isDecimal(value);
+    case 'email': return validator.isEmail(value, rule.args?.[0] as validator.IsEmailOptions | undefined);
+    case 'fqdn': return validator.isFQDN(value, rule.args?.[0] as validator.IsFQDNOptions | undefined);
+    case 'hexColor': return validator.isHexColor(value);
+    case 'hexadecimal': return validator.isHexadecimal(value);
+    case 'ip': return validator.isIP(value, rule.args?.[0] as '4' | '6' | undefined);
+    case 'isbn': return validator.isISBN(value, rule.args?.[0] as '10' | '13' | undefined);
+    case 'issn': return validator.isISSN(value);
+    case 'json': return validator.isJSON(value);
+    case 'jwt': return validator.isJWT(value);
+    case 'locale': return validator.isLocale(value);
+    case 'lowercase': return validator.isLowercase(value);
+    case 'magnetURI': return validator.isMagnetURI(value);
+    case 'matches': return validator.matches(value, rule.args?.[0] as string, rule.args?.[1] as string | undefined);
+    case 'mimeType': return validator.isMimeType(value);
+    case 'mobilePhone': return validator.isMobilePhone(value, rule.args?.[0] as validator.MobilePhoneLocale | validator.MobilePhoneLocale[] | undefined);
+    case 'mongoId': return validator.isMongoId(value);
+    case 'numberString': return validator.isNumeric(value);
+    case 'port': return validator.isPort(value);
+    case 'postalCode': return validator.isPostalCode(value, (rule.args?.[0] as validator.PostalCodeLocale | 'any' | undefined) ?? 'any');
+    case 'rgbColor': return validator.isRgbColor(value, rule.args?.[0] as boolean | undefined);
+    case 'rfc3339': return validator.isRFC3339(value);
+    case 'semVer': return validator.isSemVer(value);
+    case 'uppercase': return validator.isUppercase(value);
+    case 'url': return validator.isURL(value, rule.args?.[0] as validator.IsURLOptions | undefined);
+    case 'uuid': return validator.isUUID(value, rule.args?.[0] as validator.UUIDVersion | undefined);
+    case 'iso8601': return validator.isISO8601(value);
+    case 'latLong': return validator.isLatLong(value);
+    default: return false;
+  }
+}

--- a/packages/validation/src/validation.test.ts
+++ b/packages/validation/src/validation.test.ts
@@ -6,7 +6,7 @@ import { defineDtoFieldBindingMetadata } from '@fluojs/core/internal';
 
 import { DefaultValidator } from './validation.js';
 import { DtoValidationError } from './errors.js';
-import { ArrayMinSize, ArrayNotEmpty, ArrayUnique, Contains, IsArray, IsBoolean, IsDateString, IsEmail, IsEnum, IsInt, IsIP, IsLatitude, IsLongitude, IsNotEmpty, IsNumber, IsNumberString, IsString, IsUrl, IsUUID, Length, Matches, Max, Min, MinLength, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
+import { ArrayContains, ArrayMaxSize, ArrayMinSize, ArrayNotContains, ArrayNotEmpty, ArrayUnique, Contains, Equals, IsArray, IsAscii, IsBase64, IsBoolean, IsBooleanString, IsCurrency, IsDate, IsDateString, IsDecimal, IsDivisibleBy, IsEmail, IsEmpty, IsEnum, IsFQDN, IsHexColor, IsHexadecimal, IsIn, IsInt, IsIP, IsISO8601, IsJSON, IsJWT, IsLatitude, IsLatLong, IsLocale, IsLongitude, IsLowercase, IsMagnetURI, IsMimeType, IsMongoId, IsNegative, IsNotEmpty, IsNotIn, IsNumber, IsNumberString, IsObject, IsPort, IsPositive, IsPostalCode, IsRFC3339, IsRgbColor, IsSemVer, IsString, IsUppercase, IsUrl, IsUUID, Length, Matches, Max, MaxDate, MaxLength, Min, MinDate, MinLength, NotContains, NotEquals, Validate, ValidateClass, ValidateIf, ValidateNested } from './decorators.js';
 import type { StandardSchemaV1Like } from './index.js';
 
 describe('DefaultValidator', () => {
@@ -248,6 +248,184 @@ describe('DefaultValidator', () => {
         { field: 'tags', message: 'tags must include at least two entries' },
         { field: 'tags', message: 'tags must not be empty' },
       ],
+    });
+  });
+
+  it('covers remaining documented built-in validators with direct pass and fail contracts', async () => {
+    class ExtendedValidatorsDto {
+      @Equals('fluo', { message: 'equalField must equal fluo' })
+      equalField = 'fluo';
+
+      @NotEquals('legacy', { message: 'notEqualField must not equal legacy' })
+      notEqualField = 'modern';
+
+      @IsEmpty({ message: 'emptyField must be empty' })
+      emptyField = '';
+
+      @IsIn(['api', 'http'], { message: 'inField must be allowed' })
+      inField = 'api';
+
+      @IsNotIn(['legacy'], { message: 'notInField must not be forbidden' })
+      notInField = 'standard';
+
+      @IsDate({ message: 'dateField must be a Date' })
+      dateField = new Date('2026-01-01T00:00:00.000Z');
+
+      @IsObject({ message: 'objectField must be a plain object' })
+      objectField = { ok: true };
+
+      @IsDivisibleBy(5, { message: 'divisibleField must be divisible by five' })
+      @IsPositive({ message: 'divisibleField must be positive' })
+      divisibleField = 10;
+
+      @IsNegative({ message: 'negativeField must be negative' })
+      negativeField = -1;
+
+      @MinDate(new Date('2026-01-01T00:00:00.000Z'), { message: 'dateRangeField must be on or after minimum' })
+      @MaxDate(new Date('2026-12-31T23:59:59.999Z'), { message: 'dateRangeField must be on or before maximum' })
+      dateRangeField = new Date('2026-06-01T00:00:00.000Z');
+
+      @MaxLength(4, { message: 'shortCode must be short' })
+      @NotContains('legacy', { message: 'shortCode must not contain legacy' })
+      shortCode = 'api';
+
+      @IsAscii({ message: 'asciiText must be ASCII' })
+      @IsLowercase({ message: 'asciiText must be lowercase' })
+      asciiText = 'fluo';
+
+      @IsUppercase({ message: 'upperText must be uppercase' })
+      upperText = 'FLUO';
+
+      @IsBase64({ message: 'base64Text must be base64' })
+      base64Text = 'Zmx1bw==';
+
+      @IsBooleanString({ message: 'booleanText must be boolean text' })
+      booleanText = 'true';
+
+      @IsDecimal({ message: 'decimalText must be decimal text' })
+      decimalText = '12.5';
+
+      @IsFQDN({ message: 'domainText must be a FQDN' })
+      domainText = 'example.com';
+
+      @IsHexColor({ message: 'hexColorText must be a hex color' })
+      hexColorText = '#ff00aa';
+
+      @IsHexadecimal({ message: 'hexadecimalText must be hexadecimal' })
+      hexadecimalText = 'ff00aa';
+
+      @IsJSON({ message: 'jsonText must be JSON' })
+      jsonText = '{"ok":true}';
+
+      @IsJWT({ message: 'jwtText must be JWT' })
+      jwtText = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJmbHVvIn0.signature';
+
+      @IsLocale({ message: 'localeText must be locale' })
+      localeText = 'en-US';
+
+      @IsMagnetURI({ message: 'magnetText must be magnet URI' })
+      magnetText = 'magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567';
+
+      @IsMimeType({ message: 'mimeText must be MIME type' })
+      mimeText = 'application/json';
+
+      @IsMongoId({ message: 'mongoIdText must be MongoDB ObjectId' })
+      mongoIdText = '507f1f77bcf86cd799439011';
+
+      @IsPort({ message: 'portText must be port' })
+      portText = '3000';
+
+      @IsRFC3339({ message: 'rfc3339Text must be RFC3339' })
+      rfc3339Text = '2026-01-01T00:00:00Z';
+
+      @IsSemVer({ message: 'semverText must be semver' })
+      semverText = '1.2.3';
+
+      @IsISO8601({ message: 'isoText must be ISO8601' })
+      isoText = '2026-01-01T00:00:00.000Z';
+
+      @IsLatLong({ message: 'latLongText must be lat,long' })
+      latLongText = '37.5665,126.9780';
+
+      @IsPostalCode('US', { message: 'postalText must be US postal code' })
+      postalText = '90210';
+
+      @IsRgbColor(false, { message: 'rgbText must be rgb color' })
+      rgbText = 'rgb(255,0,170)';
+
+      @IsCurrency({ message: 'currencyText must be currency' })
+      currencyText = '$12.50';
+
+      @ArrayContains(['api'], { message: 'arrayValues must contain api' })
+      @ArrayNotContains(['legacy'], { message: 'arrayValues must not contain legacy' })
+      @ArrayMaxSize(3, { message: 'arrayValues must contain at most three entries' })
+      arrayValues = ['api', 'http'];
+    }
+
+    const validator = new DefaultValidator();
+
+    await expect(validator.validate(new ExtendedValidatorsDto(), ExtendedValidatorsDto)).resolves.toBeUndefined();
+
+    await expect(
+      validator.validate(
+        Object.assign(new ExtendedValidatorsDto(), {
+          arrayValues: ['legacy', 'extra', 'overflow', 'api'],
+          asciiText: '한글',
+          base64Text: 'not base64',
+          booleanText: 'yes',
+          currencyText: 'not money',
+          dateField: '2026-01-01',
+          dateRangeField: new Date('2027-01-01T00:00:00.000Z'),
+          decimalText: 'abc',
+          divisibleField: -7,
+          domainText: 'not a domain',
+          emptyField: 'not empty',
+          equalField: 'other',
+          hexColorText: 'blue',
+          hexadecimalText: 'xyz',
+          inField: 'other',
+          isoText: 'January 1',
+          jsonText: 'not json',
+          jwtText: 'not jwt',
+          latLongText: 'not coordinates',
+          localeText: 'not_locale',
+          magnetText: 'https://example.com',
+          mimeText: 'not mime',
+          mongoIdText: 'not mongo id',
+          negativeField: 1,
+          notEqualField: 'legacy',
+          notInField: 'legacy',
+          objectField: [],
+          portText: '99999',
+          postalText: 'not postal',
+          rfc3339Text: '2026-01-01',
+          rgbText: 'not rgb',
+          semverText: 'v1',
+          shortCode: 'legacy-code',
+          upperText: 'fluo',
+        }),
+        ExtendedValidatorsDto,
+      ),
+    ).rejects.toMatchObject({
+      issues: expect.arrayContaining([
+        expect.objectContaining({ field: 'equalField', message: 'equalField must equal fluo' }),
+        expect.objectContaining({ field: 'notEqualField', message: 'notEqualField must not equal legacy' }),
+        expect.objectContaining({ field: 'emptyField', message: 'emptyField must be empty' }),
+        expect.objectContaining({ field: 'inField', message: 'inField must be allowed' }),
+        expect.objectContaining({ field: 'notInField', message: 'notInField must not be forbidden' }),
+        expect.objectContaining({ field: 'dateField', message: 'dateField must be a Date' }),
+        expect.objectContaining({ field: 'objectField', message: 'objectField must be a plain object' }),
+        expect.objectContaining({ field: 'divisibleField', message: 'divisibleField must be divisible by five' }),
+        expect.objectContaining({ field: 'divisibleField', message: 'divisibleField must be positive' }),
+        expect.objectContaining({ field: 'negativeField', message: 'negativeField must be negative' }),
+        expect.objectContaining({ field: 'dateRangeField', message: 'dateRangeField must be on or before maximum' }),
+        expect.objectContaining({ field: 'shortCode', message: 'shortCode must not contain legacy' }),
+        expect.objectContaining({ field: 'shortCode', message: 'shortCode must be short' }),
+        expect.objectContaining({ field: 'asciiText', message: 'asciiText must be ASCII' }),
+        expect.objectContaining({ field: 'upperText', message: 'upperText must be uppercase' }),
+        expect.objectContaining({ field: 'arrayValues', message: 'arrayValues must contain at most three entries' }),
+        expect.objectContaining({ field: 'arrayValues', message: 'arrayValues must not contain legacy' }),
+      ]),
     });
   });
 

--- a/packages/validation/src/validation.ts
+++ b/packages/validation/src/validation.ts
@@ -1,34 +1,14 @@
-import validator from 'validator';
-
 import type {
   Constructor,
   MetadataPropertyKey,
 } from '@fluojs/core';
-import {
-  getClassValidationRules,
-  getDtoBindingSchema,
-  getDtoValidationSchema,
-  type ClassValidationRule,
-  type DtoFieldBindingMetadata,
-  type DtoFieldValidationRule,
-  type ValidationIssueMetadata,
-  type ValidationRuleResult,
-} from '@fluojs/core/internal';
+import type { ClassValidationRule, DtoFieldBindingMetadata, DtoFieldValidationRule, ValidationIssueMetadata, ValidationRuleResult } from '@fluojs/core/internal';
 
 import { DtoValidationError } from './errors.js';
+import { getCachedDtoMetadata, resolveNestedDto } from './internal/dto-metadata-cache.js';
+import { assignSafeOwnEnumerableProperties, getIterableValues, isPlainObject } from './internal/object-utils.js';
+import { getRuleHandler, type NonCustomRule } from './internal/rule-handlers.js';
 import type { ValidationIssue, Validator } from './types.js';
-
-function isClassConstructor(dto: Constructor | (() => Constructor)): dto is Constructor {
-  return typeof dto === 'function' && Function.prototype.toString.call(dto).startsWith('class ');
-}
-
-function resolveNestedDto(dto: Constructor | (() => Constructor)): Constructor {
-  if (isClassConstructor(dto)) {
-    return dto;
-  }
-
-  return (dto as () => Constructor)();
-}
 
 function toFieldName(propertyKey: MetadataPropertyKey): string {
   return typeof propertyKey === 'string' ? propertyKey : String(propertyKey);
@@ -68,45 +48,6 @@ function normalizeResult(
   return [normalizeIssue(result as ValidationIssueMetadata, field, source)];
 }
 
-function getIterableValues(value: unknown): unknown[] | undefined {
-  if (Array.isArray(value)) return value;
-  if (value instanceof Set) return Array.from(value.values());
-  if (value instanceof Map) return Array.from(value.values());
-  return undefined;
-}
-
-function isPlainObject(value: unknown): value is Record<PropertyKey, unknown> {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return false;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
-}
-
-const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-function assignSafeOwnEnumerableProperties(
-  target: Record<PropertyKey, unknown>,
-  source: Record<PropertyKey, unknown>,
-): void {
-  for (const key of Reflect.ownKeys(source)) {
-    if (typeof key === 'string' && DANGEROUS_KEYS.has(key)) {
-      continue;
-    }
-
-    if (!Object.prototype.propertyIsEnumerable.call(source, key)) {
-      continue;
-    }
-
-    target[key] = source[key as keyof typeof source];
-  }
-}
-
-function isEmptyValue(value: unknown): boolean {
-  return value === '' || value === null || value === undefined;
-}
-
 function joinFieldPath(parent: string, child?: string): string {
   if (!child) return parent;
   return child.startsWith('[') ? `${parent}${child}` : `${parent}.${child}`;
@@ -118,22 +59,6 @@ function prefixIssues(
   source: ValidationIssue['source'],
 ): ValidationIssue[] {
   return issues.map((issue) => ({ ...issue, field: joinFieldPath(fieldPrefix, issue.field), source: issue.source ?? source }));
-}
-
-type RuleKind = DtoFieldValidationRule['kind'];
-type NonCustomRule = Exclude<DtoFieldValidationRule, { kind: 'custom' | 'nested' }>;
-type DtoValidationSchema = ReturnType<typeof getDtoValidationSchema>;
-
-interface CachedDtoMetadata {
-  bindingMap: Map<MetadataPropertyKey, DtoFieldBindingMetadata>;
-  classValidationRules: ReturnType<typeof getClassValidationRules>;
-  dtoValidationSchema: DtoValidationSchema;
-  mergedPropertyKeys: Set<MetadataPropertyKey>;
-  nestedDtoTransforms: readonly {
-    each: boolean;
-    propertyKey: MetadataPropertyKey;
-    target: Constructor;
-  }[];
 }
 
 interface NestedTraversalContext {
@@ -165,269 +90,6 @@ function exitTraversal(value: unknown, context?: NestedTraversalContext): void {
 
   context.active.delete(value);
 }
-
-const dtoMetadataCache = new WeakMap<Constructor, CachedDtoMetadata>();
-
-function collectNestedDtoTransforms(dtoValidationSchema: DtoValidationSchema): CachedDtoMetadata['nestedDtoTransforms'] {
-  const nestedEntries: CachedDtoMetadata['nestedDtoTransforms'][number][] = [];
-
-  for (const entry of dtoValidationSchema) {
-    const nestedRule = entry.rules.find(
-      (rule: DtoFieldValidationRule): rule is Extract<DtoFieldValidationRule, { kind: 'nested' }> => rule.kind === 'nested',
-    );
-
-    if (!nestedRule) {
-      continue;
-    }
-
-    nestedEntries.push({
-      each: nestedRule.each === true,
-      propertyKey: entry.propertyKey,
-      target: resolveNestedDto(nestedRule.dto),
-    });
-  }
-
-  return nestedEntries;
-}
-
-function getCachedDtoMetadata(target: Constructor): CachedDtoMetadata {
-  const cached = dtoMetadataCache.get(target);
-
-  if (cached) {
-    return cached;
-  }
-
-  const bindingMap = getDtoBindingMap(target);
-  const dtoValidationSchema = getDtoValidationSchema(target);
-  const classValidationRules = getClassValidationRules(target);
-  const mergedPropertyKeys = new Set<MetadataPropertyKey>([
-    ...bindingMap.keys(),
-    ...dtoValidationSchema.map((entry: { propertyKey: MetadataPropertyKey }) => entry.propertyKey),
-  ]);
-  const nestedDtoTransforms = collectNestedDtoTransforms(dtoValidationSchema);
-  const next: CachedDtoMetadata = {
-    bindingMap,
-    classValidationRules,
-    dtoValidationSchema,
-    mergedPropertyKeys,
-    nestedDtoTransforms,
-  };
-
-  dtoMetadataCache.set(target, next);
-  return next;
-}
-
-type RuleHandler<K extends RuleKind> = {
-  defaultCode: string;
-  describe: (field: string, rule: Extract<DtoFieldValidationRule, { kind: K }>) => string;
-  validate: (rule: Extract<DtoFieldValidationRule, { kind: K }>, value: unknown) => boolean;
-};
-
-function getRuleHandler<K extends RuleKind>(rule: Extract<DtoFieldValidationRule, { kind: K }>): RuleHandler<K> {
-  return RULE_HANDLERS[rule.kind] as RuleHandler<K>;
-}
-
-const RULE_HANDLERS: { [K in RuleKind]: RuleHandler<K> } = {
-  validateIf: {
-    defaultCode: 'VALIDATE_IF',
-    describe: (field) => `${field} is conditionally invalid.`,
-    validate: () => true,
-  },
-  defined: {
-    defaultCode: 'REQUIRED',
-    describe: (field) => `${field} is required.`,
-    validate: (_rule, value) => value !== undefined && value !== null,
-  },
-  optional: {
-    defaultCode: 'OPTIONAL',
-    describe: (field) => `${field} is optional.`,
-    validate: () => true,
-  },
-  equals: {
-    defaultCode: 'EQUALS',
-    describe: (field, rule) => `${field} must equal ${String(rule.value)}.`,
-    validate: (rule, value) => value === rule.value,
-  },
-  notEquals: {
-    defaultCode: 'NOT_EQUALS',
-    describe: (field, rule) => `${field} must not equal ${String(rule.value)}.`,
-    validate: (rule, value) => value !== rule.value,
-  },
-  empty: {
-    defaultCode: 'EMPTY',
-    describe: (field) => `${field} must be empty.`,
-    validate: (_rule, value) => isEmptyValue(value),
-  },
-  notEmpty: {
-    defaultCode: 'NOT_EMPTY',
-    describe: (field) => `${field} should not be empty.`,
-    validate: (_rule, value) => !isEmptyValue(value),
-  },
-  in: {
-    defaultCode: 'IN',
-    describe: (field) => `${field} must be one of the allowed values.`,
-    validate: (rule, value) => rule.values.includes(value),
-  },
-  notIn: {
-    defaultCode: 'NOT_IN',
-    describe: (field) => `${field} contains a forbidden value.`,
-    validate: (rule, value) => !rule.values.includes(value),
-  },
-  string: {
-    defaultCode: 'INVALID_STRING',
-    describe: (field) => `${field} must be a string.`,
-    validate: (_rule, value) => typeof value === 'string',
-  },
-  number: {
-    defaultCode: 'INVALID_NUMBER',
-    describe: (field) => `${field} must be a number.`,
-    validate: (rule, value) => typeof value === 'number' && (rule.allowNaN || !Number.isNaN(value)),
-  },
-  boolean: {
-    defaultCode: 'INVALID_BOOLEAN',
-    describe: (field) => `${field} must be a boolean.`,
-    validate: (_rule, value) => typeof value === 'boolean',
-  },
-  date: {
-    defaultCode: 'INVALID_DATE',
-    describe: (field) => `${field} must be a Date instance.`,
-    validate: (_rule, value) => value instanceof Date && !Number.isNaN(value.getTime()),
-  },
-  array: {
-    defaultCode: 'INVALID_ARRAY',
-    describe: (field) => `${field} must be an array.`,
-    validate: (_rule, value) => Array.isArray(value),
-  },
-  object: {
-    defaultCode: 'INVALID_OBJECT',
-    describe: (field) => `${field} must be an object.`,
-    validate: (_rule, value) => isPlainObject(value),
-  },
-  enum: {
-    defaultCode: 'INVALID_ENUM',
-    describe: (field) => `${field} must be a supported enum value.`,
-    validate: (rule, value) => rule.values.includes(value),
-  },
-  int: {
-    defaultCode: 'INVALID_INT',
-    describe: (field) => `${field} must be an integer.`,
-    validate: (_rule, value) => typeof value === 'number' && Number.isInteger(value),
-  },
-  divisibleBy: {
-    defaultCode: 'DIVISIBLE_BY',
-    describe: (field, rule) => `${field} must be divisible by ${String(rule.value)}.`,
-    validate: (rule, value) => typeof value === 'number' && !Number.isNaN(value) && value % rule.value === 0,
-  },
-  positive: {
-    defaultCode: 'POSITIVE',
-    describe: (field) => `${field} must be positive.`,
-    validate: (_rule, value) => typeof value === 'number' && value > 0,
-  },
-  negative: {
-    defaultCode: 'NEGATIVE',
-    describe: (field) => `${field} must be negative.`,
-    validate: (_rule, value) => typeof value === 'number' && value < 0,
-  },
-  min: {
-    defaultCode: 'MIN',
-    describe: (field, rule) => `${field} must be greater than or equal to ${String(rule.value)}.`,
-    validate: (rule, value) => typeof value === 'number' && !Number.isNaN(value) && value >= rule.value,
-  },
-  max: {
-    defaultCode: 'MAX',
-    describe: (field, rule) => `${field} must be less than or equal to ${String(rule.value)}.`,
-    validate: (rule, value) => typeof value === 'number' && !Number.isNaN(value) && value <= rule.value,
-  },
-  minDate: {
-    defaultCode: 'MIN_DATE',
-    describe: (field, rule) => `${field} must be on or after ${rule.value.toISOString()}.`,
-    validate: (rule, value) => value instanceof Date && !Number.isNaN(value.getTime()) && value.getTime() >= rule.value.getTime(),
-  },
-  maxDate: {
-    defaultCode: 'MAX_DATE',
-    describe: (field, rule) => `${field} must be on or before ${rule.value.toISOString()}.`,
-    validate: (rule, value) => value instanceof Date && !Number.isNaN(value.getTime()) && value.getTime() <= rule.value.getTime(),
-  },
-  contains: {
-    defaultCode: 'CONTAINS',
-    describe: (field, rule) => `${field} must contain ${rule.value}.`,
-    validate: (rule, value) => typeof value === 'string' && value.includes(rule.value),
-  },
-  notContains: {
-    defaultCode: 'NOT_CONTAINS',
-    describe: (field, rule) => `${field} must not contain ${rule.value}.`,
-    validate: (rule, value) => typeof value === 'string' && !value.includes(rule.value),
-  },
-  length: {
-    defaultCode: 'LENGTH',
-    describe: (field) => `${field} must have a valid length.`,
-    validate: (rule, value) => typeof value === 'string' && value.length >= rule.min && (rule.max === undefined || value.length <= rule.max),
-  },
-  minLength: {
-    defaultCode: 'MIN_LENGTH',
-    describe: (field, rule) => `${field} must have length at least ${String(rule.value)}.`,
-    validate: (rule, value) => typeof value === 'string' && value.length >= rule.value,
-  },
-  maxLength: {
-    defaultCode: 'MAX_LENGTH',
-    describe: (field, rule) => `${field} must have length at most ${String(rule.value)}.`,
-    validate: (rule, value) => typeof value === 'string' && value.length <= rule.value,
-  },
-  nested: {
-    defaultCode: 'INVALID_NESTED',
-    describe: (field) => `${field} contains invalid nested data.`,
-    validate: () => true,
-  },
-  validatorjs: {
-    defaultCode: 'INVALID_FIELD',
-    describe: (field) => `${field} is invalid.`,
-    validate: (rule, value) => runValidatorJs(rule, value),
-  },
-  arrayContains: {
-    defaultCode: 'ARRAY_CONTAINS',
-    describe: (field) => `${field} must contain the required values.`,
-    validate: (rule, value) => Array.isArray(value) && rule.values.every((expected: unknown) => value.includes(expected)),
-  },
-  arrayNotContains: {
-    defaultCode: 'ARRAY_NOT_CONTAINS',
-    describe: (field) => `${field} contains forbidden values.`,
-    validate: (rule, value) => Array.isArray(value) && rule.values.every((expected: unknown) => !value.includes(expected)),
-  },
-  arrayNotEmpty: {
-    defaultCode: 'ARRAY_NOT_EMPTY',
-    describe: (field) => `${field} must not be an empty array.`,
-    validate: (_rule, value) => Array.isArray(value) && value.length > 0,
-  },
-  arrayMinSize: {
-    defaultCode: 'ARRAY_MIN_SIZE',
-    describe: (field, rule) => `${field} must contain at least ${String(rule.value)} items.`,
-    validate: (rule, value) => Array.isArray(value) && value.length >= rule.value,
-  },
-  arrayMaxSize: {
-    defaultCode: 'ARRAY_MAX_SIZE',
-    describe: (field, rule) => `${field} must contain at most ${String(rule.value)} items.`,
-    validate: (rule, value) => Array.isArray(value) && value.length <= rule.value,
-  },
-  arrayUnique: {
-    defaultCode: 'ARRAY_UNIQUE',
-    describe: (field) => `${field} must contain unique values.`,
-    validate: (rule, value) => {
-      if (!Array.isArray(value)) return false;
-      const seen = new Set<unknown>();
-      for (const entry of value) {
-        const key = rule.selector ? rule.selector(entry) : entry;
-        if (seen.has(key)) return false;
-        seen.add(key);
-      }
-      return true;
-    },
-  },
-  custom: {
-    defaultCode: 'INVALID_FIELD',
-    describe: (field) => `${field} is invalid.`,
-    validate: () => true,
-  },
-};
 
 function createNestedDtoInstance<T>(target: Constructor<T>, rawValue: unknown, context?: NestedTraversalContext): T {
   if (rawValue instanceof target) {
@@ -479,12 +141,6 @@ function materializeNestedDtoValue<T>(target: Constructor<T>, rawValue: unknown,
   return createNestedDtoInstance(target, rawValue, context);
 }
 
-function getDtoBindingMap(target: Constructor): Map<MetadataPropertyKey, DtoFieldBindingMetadata> {
-  return new Map(
-    getDtoBindingSchema(target).map((entry: { propertyKey: MetadataPropertyKey; metadata: DtoFieldBindingMetadata }) => [entry.propertyKey, entry.metadata]),
-  );
-}
-
 function applyBindingValues(
   instance: Record<PropertyKey, unknown>,
   rawValue: Record<PropertyKey, unknown>,
@@ -525,60 +181,6 @@ function describeValidator(rule: DtoFieldValidationRule, field: string): { code:
     code: rule.code ?? (rule.kind === 'validatorjs' ? rule.validator.toUpperCase() : handler.defaultCode),
     message: rule.message ?? handler.describe(field, rule),
   };
-}
-
-function runValidatorJs(rule: Extract<DtoFieldValidationRule, { kind: 'validatorjs' }>, value: unknown): boolean {
-  if (rule.validator === 'latitude') {
-    return typeof value === 'number' && Number.isFinite(value) && value >= -90 && value <= 90;
-  }
-
-  if (rule.validator === 'longitude') {
-    return typeof value === 'number' && Number.isFinite(value) && value >= -180 && value <= 180;
-  }
-
-  if (typeof value !== 'string') {
-    return false;
-  }
-
-  switch (rule.validator) {
-    case 'alpha': return validator.isAlpha(value);
-    case 'alphanumeric': return validator.isAlphanumeric(value);
-    case 'ascii': return validator.isAscii(value);
-    case 'base64': return validator.isBase64(value);
-    case 'booleanString': return validator.isBoolean(value);
-    case 'currency': return validator.isCurrency(value, rule.args?.[0] as validator.IsCurrencyOptions | undefined);
-    case 'dataURI': return validator.isDataURI(value);
-    case 'dateString': return validator.isISO8601(value);
-    case 'decimal': return validator.isDecimal(value);
-    case 'email': return validator.isEmail(value, rule.args?.[0] as validator.IsEmailOptions | undefined);
-    case 'fqdn': return validator.isFQDN(value, rule.args?.[0] as validator.IsFQDNOptions | undefined);
-    case 'hexColor': return validator.isHexColor(value);
-    case 'hexadecimal': return validator.isHexadecimal(value);
-    case 'ip': return validator.isIP(value, rule.args?.[0] as '4' | '6' | undefined);
-    case 'isbn': return validator.isISBN(value, rule.args?.[0] as '10' | '13' | undefined);
-    case 'issn': return validator.isISSN(value);
-    case 'json': return validator.isJSON(value);
-    case 'jwt': return validator.isJWT(value);
-    case 'locale': return validator.isLocale(value);
-    case 'lowercase': return validator.isLowercase(value);
-    case 'magnetURI': return validator.isMagnetURI(value);
-    case 'matches': return validator.matches(value, rule.args?.[0] as string, rule.args?.[1] as string | undefined);
-    case 'mimeType': return validator.isMimeType(value);
-    case 'mobilePhone': return validator.isMobilePhone(value, rule.args?.[0] as validator.MobilePhoneLocale | validator.MobilePhoneLocale[] | undefined);
-    case 'mongoId': return validator.isMongoId(value);
-    case 'numberString': return validator.isNumeric(value);
-    case 'port': return validator.isPort(value);
-    case 'postalCode': return validator.isPostalCode(value, (rule.args?.[0] as validator.PostalCodeLocale | 'any' | undefined) ?? 'any');
-    case 'rgbColor': return validator.isRgbColor(value, rule.args?.[0] as boolean | undefined);
-    case 'rfc3339': return validator.isRFC3339(value);
-    case 'semVer': return validator.isSemVer(value);
-    case 'uppercase': return validator.isUppercase(value);
-    case 'url': return validator.isURL(value, rule.args?.[0] as validator.IsURLOptions | undefined);
-    case 'uuid': return validator.isUUID(value, rule.args?.[0] as validator.UUIDVersion | undefined);
-    case 'iso8601': return validator.isISO8601(value);
-    case 'latLong': return validator.isLatLong(value);
-    default: return false;
-  }
 }
 
 function buildIssue(fallback: { code: string; message: string }, field: string, source: ValidationIssue['source']): ValidationIssue {


### PR DESCRIPTION
## Summary

Refactors @fluojs/validation internals to keep public decorators and validator behavior stable while reducing root-module responsibility size.

Linked context: Closes #2043

## Changes

- Move TC39 decorator metadata bag writes and decorator factory helpers into `src/internal/*`.
- Move DTO metadata caching, safe object copying, rule handlers, and validator.js adapter dispatch into validation internal modules.
- Add direct pass/fail regression coverage for additional documented built-in validators.

## Testing

- `pnpm install`
- `pnpm --dir packages/validation test`
- `pnpm --filter @fluojs/core build`
- `pnpm --dir packages/validation typecheck`
- `pnpm --dir packages/validation build`
- LSP diagnostics: clean for changed validation files and `packages/validation/src/internal`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No-release rationale: this is an internal-only refactor plus regression coverage. Public exports, signatures, documented runtime behavior, package README contracts, and generated release metadata are unchanged.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or removed; existing decorator TSDoc remains in place.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No new behavioral contract was introduced; existing validation behavior is preserved and covered by added tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or package README alignment claims changed.