### PR TITLE
Resolve #2044: harden testing package cleanup

### DIFF
--- a/.changeset/testing-introspection-tooling.md
+++ b/.changeset/testing-introspection-tooling.md
@@ -1,0 +1,10 @@
+---
+'@fluojs/di': minor
+'@fluojs/runtime': patch
+'@fluojs/platform-nodejs': patch
+'@fluojs/platform-express': patch
+'@fluojs/platform-fastify': patch
+'@fluojs/testing': patch
+---
+
+Add an explicit DI container resolution-state introspection seam for framework testing helpers, remove HTTP portability startup-log assertions from global console monkey-patching, cache Vitest workspace alias scans per repository root, and harden testing package documentation and regression coverage.

--- a/book/advanced/ch14-portability-testing.ko.md
+++ b/book/advanced/ch14-portability-testing.ko.md
@@ -184,11 +184,16 @@ describe('MyCustomAdapter Portability', () => {
   it('잘못된 형식의 쿠키를 보존해야 함', () => harness.assertPreservesMalformedCookieValues());
   it('SSE를 처리해야 함', () => harness.assertSupportsSseStreaming());
   it('JSON 및 text 원시 바디를 보존해야 함', () => harness.assertPreservesRawBodyForJsonAndText());
+  it('정확한 원시 바디 바이트를 보존해야 함', () => harness.assertPreservesExactRawBodyBytesForByteSensitivePayloads());
   it('multipart 원시 바디를 제외해야 함', () => harness.assertExcludesRawBodyForMultipart());
+  it('multipart total limit을 max body size로 기본 설정해야 함', () => harness.assertDefaultsMultipartTotalLimitToMaxBodySize());
+  it('close 뒤 stream drain wait를 settle해야 함', () => harness.assertSettlesStreamDrainWaitOnClose());
+  it('설정된 host startup log를 보고해야 함', () => harness.assertReportsConfiguredHostInStartupLogs());
+  it('shutdown signal listener를 제거해야 함', () => harness.assertRemovesShutdownSignalListenersAfterClose());
 });
 ```
 
-이 테스트를 실행할 때는 타이밍 데이터도 함께 봐야 합니다. 이식성 스위트에서 느린 테스트는 플랫폼 프리미티브의 하위 구현이 최적화되지 않았다는 신호일 수 있습니다. 하네스의 피드백을 사용해 어댑터를 정제하면 정확성과 성능을 함께 확인할 수 있습니다.
+이 테스트를 실행할 때는 앞부분 예시 몇 개만 복사하지 말고 cleanup 및 performance-sensitive assertion도 유지하세요. 하네스는 partial-bootstrap cleanup, 정확한 byte 보존, multipart memory boundary, application logger를 통한 startup logging, shutdown listener cleanup, stream-drain settlement를 확인합니다. 또한 타이밍 데이터도 함께 봐야 합니다. 이식성 스위트에서 느린 테스트는 플랫폼 프리미티브의 하위 구현이 최적화되지 않았다는 신호일 수 있습니다. 하네스의 피드백을 사용해 어댑터를 정제하면 정확성과 성능을 함께 확인할 수 있습니다.
 
 ## 14.9 Why Line-by-Line Consistency Matters
 

--- a/book/advanced/ch14-portability-testing.md
+++ b/book/advanced/ch14-portability-testing.md
@@ -184,11 +184,16 @@ describe('MyCustomAdapter Portability', () => {
   it('preserves malformed cookies', () => harness.assertPreservesMalformedCookieValues());
   it('handles SSE', () => harness.assertSupportsSseStreaming());
   it('preserves JSON and text raw bodies', () => harness.assertPreservesRawBodyForJsonAndText());
+  it('preserves exact raw body bytes', () => harness.assertPreservesExactRawBodyBytesForByteSensitivePayloads());
   it('excludes multipart raw bodies', () => harness.assertExcludesRawBodyForMultipart());
+  it('defaults multipart total limit to max body size', () => harness.assertDefaultsMultipartTotalLimitToMaxBodySize());
+  it('settles stream drain waits after close', () => harness.assertSettlesStreamDrainWaitOnClose());
+  it('reports configured host startup logs', () => harness.assertReportsConfiguredHostInStartupLogs());
+  it('removes shutdown signal listeners', () => harness.assertRemovesShutdownSignalListenersAfterClose());
 });
 ```
 
-When you run these tests, you should also inspect timing data. Slow tests in the portability suite can signal that a lower-level implementation of a platform primitive is not optimized. Use feedback from the harness to refine the adapter and check both correctness and performance.
+When you run these tests, keep the cleanup and performance-sensitive assertions enabled instead of copying only the first few examples. The harness checks partial-bootstrap cleanup, exact byte preservation, multipart memory boundaries, startup logging through the application logger, shutdown listener cleanup, and stream-drain settlement. You should also inspect timing data. Slow tests in the portability suite can signal that a lower-level implementation of a platform primitive is not optimized. Use feedback from the harness to refine the adapter and check both correctness and performance.
 
 ## 14.9 Why Line-by-Line Consistency Matters
 

--- a/book/beginner/ch20-testing.ko.md
+++ b/book/beginner/ch20-testing.ko.md
@@ -79,6 +79,8 @@ export default defineConfig({
 
 `fluoBabelDecoratorsPlugin`은 복잡한 설정 없이도 Vitest가 `fluo`의 표준 데코레이터를 이해할 수 있게 해주는 다리 역할을 합니다. 이 설정을 통해 테스트 환경이 실제 프로덕션 런타임의 데코레이터 처리 방식과 맞춰집니다.
 
+이 플러그인은 런타임에 가장 가까운 root Babel config를 해석하므로 프로젝트 루트에 `babel.config.cjs`, `babel.config.mjs`, `babel.config.js`, `babel.config.json` 중 하나를 추가하세요. 이 파일이 없으면 테스트 transform이 지원되는 root config 이름을 나열하는 오류로 조기에 실패합니다. 이는 테스트가 런타임과 다른 Decorator 의미로 조용히 실행되는 것보다 안전합니다.
+
 ### 20.2.1 Global Setup and Teardown
 규모가 큰 프로젝트의 경우, 모든 테스트가 실행되기 전에 수행해야 할 작업(예: 테스트 데이터베이스 초기화)과 테스트 종료 후의 정리 작업이 필요할 수 있습니다. Vitest는 설정에서 `setupFiles` 배열을 정의할 수 있게 해줍니다. 이곳은 글로벌 환경 변수를 설정하거나 단언문을 단순화하는 커스텀 매처(matcher)를 등록하기에 적합한 장소입니다.
 

--- a/book/beginner/ch20-testing.md
+++ b/book/beginner/ch20-testing.md
@@ -79,6 +79,8 @@ export default defineConfig({
 
 `fluoBabelDecoratorsPlugin` acts as a bridge that lets Vitest understand `fluo` standard Decorators without complex configuration. This setup aligns the test environment with how the actual production runtime processes Decorators.
 
+Because the plugin resolves the nearest root Babel configuration at runtime, add one of `babel.config.cjs`, `babel.config.mjs`, `babel.config.js`, or `babel.config.json` at the project root. Without that file, the test transform fails early with an error that lists the supported root config names, which is safer than silently running tests with mismatched Decorator semantics.
+
 ### 20.2.1 Global Setup and Teardown
 Large projects may need work that runs before all tests, such as initializing a test database, and cleanup work after tests finish. Vitest lets you define a `setupFiles` array in the configuration. This is a good place to set global environment variables or register custom matchers that simplify assertions.
 

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -163,6 +163,7 @@ const service = await container.resolve(DataService);
 | `register(...providers)` | 하나 이상의 프로바이더를 등록합니다. |
 | `override(...providers)` | 기존 provider를 교체하고 cached instance를 무효화하며 오래된 instance를 dispose합니다. |
 | `resolve<T>(token)` | 토큰을 인스턴스로 비동기 해석합니다. |
+| `inspectResolutionState()` | cache ownership을 보존해야 하는 testing/tooling helper를 위한 지원 대상 framework-owned container introspection seam을 노출합니다. 애플리케이션 코드는 `has(...)`와 `resolve(...)`를 우선 사용하세요. |
 | `createRequestScope()` | 요청 스코프 의존성을 위한 자식 컨테이너를 생성합니다. |
 | `has(token)` | 컨테이너나 부모에 토큰이 등록되어 있는지 확인합니다. |
 | `hasRequestScopedDependency(token)` | 토큰 해석 시 provider 그래프에 request-scoped 의존성이나 순환이 있어 request-scope 컨테이너가 필요할 수 있는지 확인합니다. |
@@ -175,6 +176,7 @@ const service = await container.resolve(DataService);
 | Provider types | `Provider`, `ClassProvider`, `FactoryProvider`, `ValueProvider`, `ExistingProvider`는 `register(...)`와 `override(...)`가 받는 공개 registration shape를 설명합니다. |
 | Token wrapper types | `ForwardRefFn`과 `OptionalToken`은 `forwardRef(...)`와 `optional(...)`이 반환하는 wrapper 값을 설명합니다. |
 | Container helper types | `ClassType`, `Disposable`, `RequestScopeContainer`는 typed provider 선언, teardown hook, request-scope helper 경계를 지원합니다. |
+| `ContainerResolutionState` | framework testing/tooling integration을 위해 `inspectResolutionState()`가 반환하는 공개 introspection record입니다. |
 | `NormalizedProvider` | 컨테이너가 검증한 provider record shape를 위한 compatibility-only 공개 타입입니다. provider를 작성할 때는 `Provider`나 구체 provider interface를 우선 사용하세요. normalized record 생성은 컨테이너가 소유합니다. |
 | `DiErrorContext` | DI error에 붙는 구조화된 context입니다. 로그와 테스트가 token, scope, module, dependency chain, hint를 검사할 수 있게 합니다. |
 | 에러 클래스 | `InvalidProviderError`, `ContainerResolutionError`, `RequestScopeResolutionError`, `ScopeMismatchError`, `CircularDependencyError`, `DuplicateProviderError`. |

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -163,6 +163,7 @@ Ensure all required providers are registered in the container. If you use `creat
 | `register(...providers)` | Registers one or more providers. |
 | `override(...providers)` | Replaces existing providers, invalidates cached instances, and disposes stale instances. |
 | `resolve<T>(token)` | Asynchronously resolves a token to an instance. |
+| `inspectResolutionState()` | Exposes the supported framework-owned container introspection seam for testing/tooling helpers that must preserve cache ownership. Prefer `has(...)` and `resolve(...)` for application code. |
 | `createRequestScope()` | Creates a child container for request-scoped dependencies. |
 | `has(token)` | Checks if a token is registered in the container or its parents. |
 | `hasRequestScopedDependency(token)` | Checks whether resolving a token may require a request-scope container because its provider graph contains request-scoped dependencies or is cyclic. |
@@ -175,6 +176,7 @@ Ensure all required providers are registered in the container. If you use `creat
 | Provider types | `Provider`, `ClassProvider`, `FactoryProvider`, `ValueProvider`, and `ExistingProvider` describe the public registration shapes accepted by `register(...)` and `override(...)`. |
 | Token wrapper types | `ForwardRefFn` and `OptionalToken` describe the wrapper values returned by `forwardRef(...)` and `optional(...)`. |
 | Container helper types | `ClassType`, `Disposable`, and `RequestScopeContainer` support typed provider declarations, teardown hooks, and request-scope helper boundaries. |
+| `ContainerResolutionState` | Public introspection record returned by `inspectResolutionState()` for framework testing/tooling integrations. |
 | `NormalizedProvider` | Compatibility-only public type for the container's validated provider record shape. Prefer authoring providers with `Provider` or the specific provider interfaces; the container owns normalized record construction. |
 | `DiErrorContext` | Structured context attached to DI errors so logs and tests can inspect tokens, scopes, modules, dependency chains, and hints. |
 | Error classes | `InvalidProviderError`, `ContainerResolutionError`, `RequestScopeResolutionError`, `ScopeMismatchError`, `CircularDependencyError`, `DuplicateProviderError`. |

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -30,6 +30,20 @@ interface CachedResolutionPlan<T> {
   readonly value: T;
 }
 
+/**
+ * Public read/write seam for framework-owned testing and tooling that need to
+ * inspect a container's resolved provider graph without depending on private
+ * field names or structural casts.
+ */
+export interface ContainerResolutionState {
+  readonly parent?: ContainerResolutionState;
+  readonly registrations: Map<Token, NormalizedProvider>;
+  readonly multiRegistrations: Map<Token, NormalizedProvider[]>;
+  readonly multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>;
+  readonly requestScopeEnabled: boolean;
+  readonly singletonCache: Map<Token, Promise<unknown>>;
+}
+
 function isClassConstructor(value: Provider): value is ClassType {
   return typeof value === 'function';
 }
@@ -326,6 +340,27 @@ export class Container {
    */
   has(token: Token): boolean {
     return this.lookupProvider(token) !== undefined || this.hasMulti(token);
+  }
+
+  /**
+   * Returns the framework-owned resolution state for testing/tooling adapters.
+   *
+   * This method is the supported introspection seam for packages such as
+   * `@fluojs/testing`; callers should prefer ordinary `has(...)` and
+   * `resolve(...)` unless they need to preserve container cache ownership while
+   * implementing a framework-level helper.
+   *
+   * @returns Provider registrations and resolution caches for this container scope.
+   */
+  inspectResolutionState(): ContainerResolutionState {
+    return {
+      parent: this.parent?.inspectResolutionState(),
+      registrations: this.registrations,
+      multiRegistrations: this.multiRegistrations,
+      multiSingletonCache: this.multiSingletonCache,
+      requestScopeEnabled: this.requestScopeEnabled,
+      singletonCache: this.singletonCache,
+    };
   }
 
   /**

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -106,10 +106,12 @@ export interface DenoAdapterOptions {
 
 /** Bootstrap options for creating a Deno-backed app without auto-running it. */
 export interface BootstrapDenoApplicationOptions extends BootstrapHttpAdapterApplicationOptions, DenoAdapterOptions {
+  logger?: ApplicationLogger;
 }
 
 /** Run-helper options for Deno apps, including optional signal wiring. */
 export interface RunDenoApplicationOptions extends RunHttpAdapterApplicationOptions, DenoAdapterOptions {
+  logger?: ApplicationLogger;
   shutdownSignals?: false | readonly DenoApplicationSignal[];
 }
 
@@ -331,7 +333,7 @@ export async function bootstrapDenoApplication(
   rootModule: ModuleType,
   options: BootstrapDenoApplicationOptions = {},
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = options.logger ?? createConsoleApplicationLogger();
 
   return await bootstrapHttpAdapterApplication(rootModule, options, createDenoAdapter(options), logger);
 }
@@ -347,7 +349,7 @@ export async function runDenoApplication(
   rootModule: ModuleType,
   options: RunDenoApplicationOptions = {},
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = options.logger ?? createConsoleApplicationLogger();
   const adapter = createDenoAdapter(options);
   return await runHttpAdapterApplication(rootModule, {
     ...options,

--- a/packages/platform-express/README.ko.md
+++ b/packages/platform-express/README.ko.md
@@ -101,7 +101,7 @@ const adapter = createExpressAdapter(
 - `ExpressHttpApplicationAdapter`: 핵심 어댑터 구현 클래스입니다.
 - Option type: `ExpressAdapterOptions`, `BootstrapExpressApplicationOptions`, `RunExpressApplicationOptions`, `CorsInput`, `ExpressApplicationSignal`.
 
-`createExpressAdapter(options, multipartOptions?)`는 `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 지원합니다. `ExpressHttpApplicationAdapter`를 직접 생성하는 경우에도 factory와 같은 numeric validation이 적용됩니다. `bootstrapExpressApplication(...)`과 `runExpressApplication(...)`은 `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`도 받으며, startup/shutdown diagnostics를 위해 framework console logger를 내부에서 선택합니다.
+`createExpressAdapter(options, multipartOptions?)`는 `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, `shutdownTimeoutMs`를 지원합니다. `ExpressHttpApplicationAdapter`를 직접 생성하는 경우에도 factory와 같은 numeric validation이 적용됩니다. `bootstrapExpressApplication(...)`과 `runExpressApplication(...)`은 `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`, `logger`도 받습니다. startup/shutdown diagnostics에는 framework console logger를 기본으로 사용하며, `logger`가 제공되면 주입된 `ApplicationLogger`를 따릅니다.
 
 ## 관련 패키지
 

--- a/packages/platform-express/README.md
+++ b/packages/platform-express/README.md
@@ -101,7 +101,7 @@ To avoid changing documented fluo semantics, overlapping same-shape param routes
 - `ExpressHttpApplicationAdapter`: The core adapter implementation class.
 - Option types: `ExpressAdapterOptions`, `BootstrapExpressApplicationOptions`, `RunExpressApplicationOptions`, `CorsInput`, `ExpressApplicationSignal`.
 
-`createExpressAdapter(options, multipartOptions?)` supports `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs`. Direct `ExpressHttpApplicationAdapter` construction applies the same numeric validation as the factory. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` also accept `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, and `shutdownSignals`, and select the framework console logger internally for startup and shutdown diagnostics.
+`createExpressAdapter(options, multipartOptions?)` supports `host`, `https`, `maxBodySize`, `port`, `rawBody`, `retryDelayMs`, `retryLimit`, and `shutdownTimeoutMs`. Direct `ExpressHttpApplicationAdapter` construction applies the same numeric validation as the factory. `bootstrapExpressApplication(...)` and `runExpressApplication(...)` also accept `cors`, `globalPrefix`, `globalPrefixExclude`, `middleware`, `multipart`, `securityHeaders`, `forceExitTimeoutMs`, `shutdownSignals`, and `logger`; they use the framework console logger by default for startup and shutdown diagnostics and honor an injected `ApplicationLogger` when provided.
 
 ## Related Packages
 

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -34,6 +34,7 @@ import {
 } from '@fluojs/http/internal';
 import type {
   Application,
+  ApplicationLogger,
   CreateApplicationOptions,
   ModuleType,
   MultipartOptions,
@@ -120,6 +121,7 @@ export interface BootstrapExpressApplicationOptions extends Omit<CreateApplicati
   globalPrefixExclude?: readonly string[];
   host?: string;
   https?: HttpsServerOptions;
+  logger?: ApplicationLogger;
   maxBodySize?: number;
   middleware?: MiddlewareLike[];
   multipart?: MultipartOptions;
@@ -534,7 +536,7 @@ export async function bootstrapExpressApplication(
   rootModule: ModuleType,
   options: BootstrapExpressApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = options.logger ?? createConsoleApplicationLogger();
 
   return bootstrapHttpAdapterApplication(
     rootModule,
@@ -555,7 +557,7 @@ export async function runExpressApplication(
   rootModule: ModuleType,
   options: RunExpressApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = options.logger ?? createConsoleApplicationLogger();
   const adapter = createExpressAdapter(options, options.multipart) as ExpressHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -111,7 +111,7 @@ await bootstrapFastifyApplication(AppModule, {
 ```
 
 ### 로깅 (Logging)
-fluo는 자체 로깅 시스템을 사용합니다. 어댑터는 Fastify 인스턴스를 생성할 때 네이티브 로거를 비활성화하며, `bootstrapFastifyApplication(...)` / `runFastifyApplication(...)`은 활성 런타임과 일관된 startup/shutdown diagnostics를 유지하도록 framework console logger를 내부에서 선택합니다.
+fluo는 자체 로깅 시스템을 사용합니다. 어댑터는 Fastify 인스턴스를 생성할 때 네이티브 로거를 비활성화하며, `bootstrapFastifyApplication(...)` / `runFastifyApplication(...)`은 활성 런타임과 일관된 startup/shutdown diagnostics를 유지하도록 framework console logger를 기본으로 선택합니다. 테스트 하니스나 호스트 애플리케이션이 기본 console logger 대신 주입된 `ApplicationLogger`로 diagnostics를 캡처해야 할 때는 `logger`를 전달하세요.
 
 ### 미들웨어 (Middleware)
 요청이 핸들러에 도달하기 전에 실행되는 런타임 레벨의 미들웨어를 등록할 수 있습니다. 이는 Fastify 전용 플러그인이 아닌 표준 `MiddlewareLike` 함수라는 점에 유의하세요.
@@ -160,7 +160,7 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 
 - **CORS 오류**: `cors` 부트스트랩 옵션을 사용 중인지 확인하세요. Fastify의 네이티브 CORS 플러그인을 사용하지 않으므로 오직 fluo가 관리하는 CORS 로직만 적용됩니다.
 - **미들웨어 문제**: `middleware` 옵션은 런타임 레벨의 `MiddlewareLike[]` 함수 배열을 받습니다. 이는 Fastify 플러그인이 아니며 다른 fluo 어댑터들과 공통으로 사용되는 표준 인터페이스를 따릅니다.
-- **로깅 (Logging)**: 로그 스트림 중복을 방지하기 위해 Fastify의 네이티브 로거가 비활성화됩니다. `runFastifyApplication`과 `bootstrapFastifyApplication`은 framework console logger를 내부에서 선택하므로 application code가 이 helper들에 logger option을 전달하지 않아야 합니다.
+- **로깅 (Logging)**: 로그 스트림 중복을 방지하기 위해 Fastify의 네이티브 로거가 비활성화됩니다. `runFastifyApplication`과 `bootstrapFastifyApplication`은 framework console logger를 기본으로 선택하며, host나 test가 주입된 `ApplicationLogger`를 사용해야 할 때 `logger`를 받습니다.
 - **글로벌 접두사 (Global Prefix)**: 내부 경로 또는 헬스 체크 엔드포인트에 접두사가 붙지 않도록 `globalPrefixExclude`를 적절히 설정하세요.
 - **Malformed Cookie**: 잘못된 cookie header는 request 실패로 이어지지 않고 보존됩니다.
 

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -111,7 +111,7 @@ await bootstrapFastifyApplication(AppModule, {
 ```
 
 ### Logging
-fluo uses its own logging system. The adapter creates the Fastify instance with its native logger disabled, and `bootstrapFastifyApplication(...)` / `runFastifyApplication(...)` select the framework console logger internally so startup and shutdown diagnostics stay consistent with the active runtime.
+fluo uses its own logging system. The adapter creates the Fastify instance with its native logger disabled, and `bootstrapFastifyApplication(...)` / `runFastifyApplication(...)` select the framework console logger by default so startup and shutdown diagnostics stay consistent with the active runtime. Pass `logger` when a test harness or host application needs to capture those diagnostics through an injected `ApplicationLogger` instead of the default console logger.
 
 ### Middleware
 You can register runtime-level middleware that runs before the request reaches the handlers. Note that these are standard `MiddlewareLike` functions, not Fastify-specific plugins.
@@ -160,7 +160,7 @@ The same file also covers Fastify-specific native route registration with wildca
 
 - **CORS Errors**: Ensure you're using the `cors` bootstrap option. Since Fastify's native CORS plugin is not registered, only the fluo-managed CORS logic applies.
 - **Middleware Issues**: The `middleware` option accepts runtime-level `MiddlewareLike[]` functions. These are not Fastify plugins and follow the standard middleware interface used across fluo adapters.
-- **Logging**: The native Fastify logger is disabled to prevent duplicate log streams. `runFastifyApplication` and `bootstrapFastifyApplication` select the framework console logger internally; application code should not pass a logger option to these helpers.
+- **Logging**: The native Fastify logger is disabled to prevent duplicate log streams. `runFastifyApplication` and `bootstrapFastifyApplication` select the framework console logger by default and accept `logger` for hosts or tests that need an injected `ApplicationLogger`.
 - **Global Prefix**: Use `globalPrefixExclude` to prevent the prefix from being applied to internal routes or health check endpoints.
 - **Malformed Cookies**: Malformed cookie headers are preserved rather than failing the request.
 

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -28,6 +28,7 @@ import {
 } from '@fluojs/http/internal';
 import type {
   Application,
+  ApplicationLogger,
   CreateApplicationOptions,
   ModuleType,
   MultipartOptions,
@@ -104,6 +105,7 @@ export interface BootstrapFastifyApplicationOptions extends Omit<CreateApplicati
   globalPrefixExclude?: readonly string[];
   host?: string;
   https?: HttpsServerOptions;
+  logger?: ApplicationLogger;
   maxBodySize?: number;
   middleware?: MiddlewareLike[];
   multipart?: MultipartOptions;
@@ -628,7 +630,7 @@ export async function bootstrapFastifyApplication(
   rootModule: ModuleType,
   options: BootstrapFastifyApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = options.logger ?? createConsoleApplicationLogger();
 
   return bootstrapHttpAdapterApplication(
     rootModule,
@@ -652,7 +654,7 @@ export async function runFastifyApplication(
   rootModule: ModuleType,
   options: RunFastifyApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = options.logger ?? createConsoleApplicationLogger();
   const adapter = createFastifyAdapter(options, options.multipart) as FastifyHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,

--- a/packages/platform-nodejs/README.ko.md
+++ b/packages/platform-nodejs/README.ko.md
@@ -65,6 +65,8 @@ const adapter = createNodejsAdapter({
 
 시그널 기반 종료가 run-helper `forceExitTimeoutMs`를 넘기거나 실패하면 헬퍼는 해당 상태를 로그와 `process.exitCode`로 보고하지만, 최종 프로세스 종료는 호스트 프로세스 소유자에게 맡깁니다. Connection drain bound에는 adapter-level `shutdownTimeoutMs`를, signal handler completion bound에는 run-helper `forceExitTimeoutMs`를 사용하세요.
 
+`bootstrapNodejsApplication(...)`과 `runNodejsApplication(...)`은 framework console logger를 기본으로 사용합니다. host나 portability test가 startup/shutdown diagnostics를 주입된 `ApplicationLogger`로 캡처해야 할 때는 `logger`를 전달하세요.
+
 ```typescript
 import { runNodejsApplication } from '@fluojs/platform-nodejs';
 import { AppModule } from './app.module';

--- a/packages/platform-nodejs/README.md
+++ b/packages/platform-nodejs/README.md
@@ -65,6 +65,8 @@ You can use `runNodejsApplication` for a zero-boilerplate startup that includes 
 
 When signal-driven shutdown exceeds the run-helper `forceExitTimeoutMs` or fails, the helper logs the condition and sets `process.exitCode`, but leaves final process termination to the host process owner. Use adapter-level `shutdownTimeoutMs` for connection drain bounds and run-helper `forceExitTimeoutMs` for signal handler completion bounds.
 
+`bootstrapNodejsApplication(...)` and `runNodejsApplication(...)` use the framework console logger by default. Pass `logger` when a host or portability test needs startup/shutdown diagnostics captured through an injected `ApplicationLogger`.
+
 ```typescript
 import { runNodejsApplication } from '@fluojs/platform-nodejs';
 import { AppModule } from './app.module';

--- a/packages/runtime/src/node/internal-node.ts
+++ b/packages/runtime/src/node/internal-node.ts
@@ -20,7 +20,7 @@ import {
 } from '../http-adapter-shared.js';
 import { createConsoleApplicationLogger } from '../logging/logger.js';
 import type { MultipartOptions, UploadedFile } from '../multipart.js';
-import type { Application, CreateApplicationOptions, ModuleType } from '../types.js';
+import type { Application, ApplicationLogger, CreateApplicationOptions, ModuleType } from '../types.js';
 import {
   compressNodeResponse,
   createNodeResponseCompression,
@@ -98,6 +98,7 @@ export interface BootstrapNodeApplicationOptions extends Omit<CreateApplicationO
   globalPrefixExclude?: readonly string[];
   host?: string;
   https?: HttpsServerOptions;
+  logger?: ApplicationLogger;
   maxBodySize?: number;
   middleware?: MiddlewareLike[];
   multipart?: MultipartOptions;
@@ -309,7 +310,7 @@ export async function bootstrapNodeApplication(
   rootModule: ModuleType,
   options: BootstrapNodeApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = options.logger ?? createConsoleApplicationLogger();
 
   return bootstrapHttpAdapterApplication(
     rootModule,
@@ -330,7 +331,7 @@ export async function runNodeApplication(
   rootModule: ModuleType,
   options: RunNodeApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = options.logger ?? createConsoleApplicationLogger();
   const adapter = createNodeHttpAdapter(options, options.compression ?? false, options.multipart) as NodeHttpApplicationAdapter;
   return runHttpAdapterApplication(rootModule, {
     ...options,

--- a/packages/testing/src/babel-decorators-plugin.test.ts
+++ b/packages/testing/src/babel-decorators-plugin.test.ts
@@ -65,9 +65,12 @@ describe('fluoBabelDecoratorsPlugin', () => {
     await expect(plugin.transform('class Dependency {}', '/workspace/node_modules/pkg/index.ts?raw')).resolves.toBeNull();
   });
 
-  it('resolves supported Babel root config names from query-suffixed ids', () => {
-    const { filePath, root } = createWorkspaceWithConfig('babel.config.mjs');
+  it.each(['babel.config.cjs', 'babel.config.mjs', 'babel.config.js', 'babel.config.json'])(
+    'resolves supported Babel root config name %s from query-suffixed ids',
+    (configFileName) => {
+      const { filePath, root } = createWorkspaceWithConfig(configFileName);
 
-    expect(resolveNearestBabelConfigFile(`${filePath}?v=123`)).toBe(join(root, 'babel.config.mjs'));
-  });
+      expect(resolveNearestBabelConfigFile(`${filePath}?v=123`)).toBe(join(root, configFileName));
+    },
+  );
 });

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -3,6 +3,7 @@ import {
   isForwardRef,
   isOptionalToken,
   type ClassType,
+  type ContainerResolutionState,
   type ForwardRefFn,
   type NormalizedProvider,
   type OptionalToken,
@@ -121,48 +122,10 @@ function normalizeOverride<T>(token: Token<T>, value: Provider<T> | T): Provider
   return { provide: token, useValue: value };
 }
 
-interface ContainerIntrospection {
-  parent?: ContainerIntrospection;
-  registrations: Map<Token, NormalizedProvider>;
-  multiRegistrations: Map<Token, NormalizedProvider[]>;
-  multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>;
-  requestScopeEnabled?: boolean;
-  singletonCache: Map<Token, Promise<unknown>>;
-}
-
-function isContainerIntrospection(value: unknown): value is ContainerIntrospection {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const candidate = value as {
-    multiRegistrations?: unknown;
-    multiSingletonCache?: unknown;
-    parent?: unknown;
-    registrations?: unknown;
-    requestScopeEnabled?: unknown;
-    singletonCache?: unknown;
-  };
-
-  const parentValid = candidate.parent === undefined || isContainerIntrospection(candidate.parent);
-  const requestScopeValid = candidate.requestScopeEnabled === undefined || typeof candidate.requestScopeEnabled === 'boolean';
-
-  return (
-    candidate.registrations instanceof Map &&
-    candidate.multiRegistrations instanceof Map &&
-    candidate.multiSingletonCache instanceof Map &&
-    candidate.singletonCache instanceof Map &&
-    parentValid &&
-    requestScopeValid
-  );
-}
+type ContainerIntrospection = ContainerResolutionState;
 
 function toContainerIntrospection(container: BootstrapResult['container']): ContainerIntrospection {
-  if (!isContainerIntrospection(container)) {
-    throw new Error('Testing container introspection is unavailable for the current container implementation.');
-  }
-
-  return container;
+  return container.inspectResolutionState();
 }
 
 function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {

--- a/packages/testing/src/portability/http-adapter-portability.ts
+++ b/packages/testing/src/portability/http-adapter-portability.ts
@@ -115,19 +115,16 @@ async function requestHttps(url: string): Promise<{ body: string; statusCode: nu
   });
 }
 
-function createConsoleLogCapture(): { messages: string[]; restore(): void } {
+function createLogCaptureLogger(): ApplicationLogger & { messages: string[] } {
   const messages: string[] = [];
-  const originalLog = console.log;
-
-  console.log = (...args: unknown[]) => {
-    messages.push(args.map((arg) => String(arg)).join(' '));
-  };
+  const capture = (...args: unknown[]) => messages.push(args.map((arg) => String(arg)).join(' '));
 
   return {
+    debug: capture,
+    error: capture,
+    log: capture,
     messages,
-    restore() {
-      console.log = originalLog;
-    },
+    warn: capture,
   };
 }
 
@@ -602,7 +599,7 @@ export class HttpAdapterPortabilityHarness<
   }
 
   async assertReportsConfiguredHostInStartupLogs(): Promise<void> {
-    const log = createConsoleLogCapture();
+    const logger = createLogCaptureLogger();
 
     @Controller('/health')
     class HealthController {
@@ -620,33 +617,30 @@ export class HttpAdapterPortabilityHarness<
     const app = await this.options.run(AppModule, {
       cors: false,
       host: '127.0.0.1',
+      logger,
       port: 0,
     } as TRunOptions);
 
-    try {
-      await runWithListeningUrlCleanup(app, this.options.name, async (baseUrl) => {
-        const response = await fetch(`${baseUrl}/health`);
+    await runWithListeningUrlCleanup(app, this.options.name, async (baseUrl) => {
+      const response = await fetch(`${baseUrl}/health`);
 
-        if (response.status !== 200) {
-          throw new Error(`${this.options.name} adapter changed host-bound health response semantics.`);
-        }
+      if (response.status !== 200) {
+        throw new Error(`${this.options.name} adapter changed host-bound health response semantics.`);
+      }
 
-        const body = await response.json();
-        if (JSON.stringify(body) !== JSON.stringify({ ok: true })) {
-          throw new Error(`${this.options.name} adapter changed host-bound response payload.`);
-        }
+      const body = await response.json();
+      if (JSON.stringify(body) !== JSON.stringify({ ok: true })) {
+        throw new Error(`${this.options.name} adapter changed host-bound response payload.`);
+      }
 
-        if (!log.messages.some((message) => message.includes(`Listening on ${baseUrl}`))) {
-          throw new Error(`${this.options.name} adapter changed startup host logging.`);
-        }
-      });
-    } finally {
-      log.restore();
-    }
+      if (!logger.messages.some((message) => message.includes(`Listening on ${baseUrl}`))) {
+        throw new Error(`${this.options.name} adapter changed startup host logging.`);
+      }
+    });
   }
 
   async assertReportsHttpsStartupUrl(https: { cert: string; key: string }): Promise<void> {
-    const log = createConsoleLogCapture();
+    const logger = createLogCaptureLogger();
 
     @Controller('/health')
     class HealthController {
@@ -665,28 +659,25 @@ export class HttpAdapterPortabilityHarness<
       cors: false,
       host: '127.0.0.1',
       https,
+      logger,
       port: 0,
     } as TRunOptions);
 
-    try {
-      await runWithListeningUrlCleanup(app, this.options.name, async (baseUrl) => {
-        const response = await requestHttps(`${baseUrl}/health`);
+    await runWithListeningUrlCleanup(app, this.options.name, async (baseUrl) => {
+      const response = await requestHttps(`${baseUrl}/health`);
 
-        if (response.statusCode !== 200) {
-          throw new Error(`${this.options.name} adapter changed HTTPS response status semantics.`);
-        }
+      if (response.statusCode !== 200) {
+        throw new Error(`${this.options.name} adapter changed HTTPS response status semantics.`);
+      }
 
-        if (JSON.stringify(JSON.parse(response.body)) !== JSON.stringify({ ok: true })) {
-          throw new Error(`${this.options.name} adapter changed HTTPS response payload semantics.`);
-        }
+      if (JSON.stringify(JSON.parse(response.body)) !== JSON.stringify({ ok: true })) {
+        throw new Error(`${this.options.name} adapter changed HTTPS response payload semantics.`);
+      }
 
-        if (!log.messages.some((message) => message.includes(`Listening on ${baseUrl}`))) {
-          throw new Error(`${this.options.name} adapter changed HTTPS startup logging.`);
-        }
-      });
-    } finally {
-      log.restore();
-    }
+      if (!logger.messages.some((message) => message.includes(`Listening on ${baseUrl}`))) {
+        throw new Error(`${this.options.name} adapter changed HTTPS startup logging.`);
+      }
+    });
   }
 
   async assertRemovesShutdownSignalListenersAfterClose(): Promise<void> {

--- a/packages/testing/src/vitest/tooling.test.ts
+++ b/packages/testing/src/vitest/tooling.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { collectWorkspaceAliases } from './tooling.js';
+
+const tempRepoRoots = new Set<string>();
+
+afterEach(() => {
+  for (const root of tempRepoRoots) {
+    rmSync(root, { force: true, recursive: true });
+  }
+
+  tempRepoRoots.clear();
+});
+
+function createRepoRoot(): string {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'fluo-testing-tooling-'));
+  const packageRoot = join(repoRoot, 'packages', 'demo');
+  const sourceRoot = join(packageRoot, 'src');
+
+  tempRepoRoots.add(repoRoot);
+  mkdirSync(sourceRoot, { recursive: true });
+  writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({ name: '@fluojs/demo' }));
+  writeFileSync(join(sourceRoot, 'index.ts'), 'export {}');
+  writeFileSync(join(sourceRoot, 'feature.ts'), 'export const feature = true;');
+
+  return repoRoot;
+}
+
+describe('collectWorkspaceAliases', () => {
+  it('caches package manifest scans per repository root and returns defensive copies', () => {
+    const repoRoot = createRepoRoot();
+    const firstAliases = collectWorkspaceAliases(new URL(`file://${repoRoot}/`));
+
+    expect(firstAliases['@fluojs/demo/feature']).toBe(join(repoRoot, 'packages', 'demo', 'src', 'feature.ts'));
+
+    firstAliases['@fluojs/demo/feature'] = 'mutated';
+    rmSync(join(repoRoot, 'packages', 'demo'), { recursive: true });
+
+    const secondAliases = collectWorkspaceAliases(new URL(`file://${repoRoot}/`));
+    expect(secondAliases['@fluojs/demo/feature']).toBe(join(repoRoot, 'packages', 'demo', 'src', 'feature.ts'));
+  });
+});

--- a/packages/testing/src/vitest/tooling.ts
+++ b/packages/testing/src/vitest/tooling.ts
@@ -6,6 +6,8 @@ import { defineConfig, mergeConfig } from 'vitest/config';
 
 import { fluoBabelDecoratorsPlugin } from '../vitest.js';
 
+const workspaceAliasCache = new Map<string, Record<string, string>>();
+
 function collectSourceEntries(sourceRoot: string): string[] {
   const entries: string[] = [];
 
@@ -81,7 +83,17 @@ function collectWorkspaceAliasesFromRoot(repoRoot: string): Record<string, strin
  * @returns A Vite/Vitest alias map that points public package imports at workspace source files.
  */
 export function collectWorkspaceAliases(repoRootUrl: string | URL): Record<string, string> {
-  return collectWorkspaceAliasesFromRoot(fileURLToPath(repoRootUrl));
+  const repoRoot = fileURLToPath(repoRootUrl);
+  const cachedAliases = workspaceAliasCache.get(repoRoot);
+
+  if (cachedAliases) {
+    return { ...cachedAliases };
+  }
+
+  const aliases = collectWorkspaceAliasesFromRoot(repoRoot);
+  workspaceAliasCache.set(repoRoot, aliases);
+
+  return { ...aliases };
 }
 
 /**


### PR DESCRIPTION
## Summary

Linked context: Closes #2044

Harden the testing package resolver/tooling cleanup by moving DI resolver access behind a supported container introspection seam, replacing HTTP portability startup-log console monkey-patching with injected application loggers, caching Vitest workspace alias scans, and filling tutorial/test coverage gaps.

## Changes

- Added `Container.inspectResolutionState()` / `ContainerResolutionState` as the supported framework-owned DI introspection seam used by `@fluojs/testing`.
- Updated Node/Express/Fastify startup helpers to honor an injected `ApplicationLogger` while preserving the default console logger behavior.
- Removed global `console.log` patching from `HttpAdapterPortabilityHarness` startup-log assertions.
- Cached `collectWorkspaceAliases(...)` scans per repo root and added regression coverage for cache reuse/defensive copies.
- Expanded Babel config filename matrix coverage and documented the root Babel config requirement in EN/KO beginner testing docs.
- Expanded EN/KO portability tutorial examples to include cleanup/performance-sensitive harness assertions.
- Added a Changeset for public `@fluojs/*` behavior/API impact.

## Testing

- `pnpm --dir packages/testing test`
- `node tooling/scripts/run-workspace-build-closure.mjs @fluojs/testing && pnpm --dir packages/testing typecheck` *(initially failed before building platform dev-dependency packages; rerun below covers those types)*
- `pnpm --filter @fluojs/platform-nodejs --filter @fluojs/platform-express --filter @fluojs/platform-fastify --filter @fluojs/platform-bun --filter @fluojs/platform-deno --filter @fluojs/platform-cloudflare-workers build && pnpm --dir packages/testing typecheck`
- `pnpm docs:sync-check`
- `pnpm lint` *(completed; reports pre-existing Biome findings outside this PR scope, while `verify:public-export-tsdoc` passed in changed mode)*
- LSP diagnostics: clean for changed TS files.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
