### PR TITLE
Resolve #2047: Throttler request hot-path and coverage cleanup

### DIFF
--- a/.changeset/throttler-request-hot-path.md
+++ b/.changeset/throttler-request-hot-path.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/throttler": patch
+---
+
+Cache resolved throttler handler policies and route keys on the request hot path while adding regression coverage for trusted proxy headers and platform status modes.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -125,7 +125,7 @@ ThrottlerModule.forRoot({
 - `ThrottlerModule.forRoot(options)`: 검증된 throttler 옵션과 `ThrottlerGuard`를 모듈 그래프에 제공합니다.
 - 패키지 수준 등록은 `ThrottlerModule.forRoot(options)`를 통해 지원합니다. 내부 프로바이더 조합 헬퍼와 DI 토큰은 공개 계약에 포함되지 않습니다.
 
-`ttl`과 `limit`은 양의 finite integer여야 합니다. `trustProxyHeaders`와 `keyGenerator`로 client identity를 조정할 수 있습니다. 모듈 옵션은 guard가 연결될 때 검증되고 값으로 캡처되므로, 호출자가 나중에 options 객체를 변경해도 실행 중인 throttling 정책은 바뀌지 않습니다. `store` 옵션을 제공하지 않으면 각 `ThrottlerGuard` 인스턴스가 자체 in-memory store를 소유합니다. 저장소를 공유하거나 외부에서 관리해야 한다면 `RedisThrottlerStore` 같은 `ThrottlerStore` 구현을 전달하세요.
+`ttl`과 `limit`은 양의 finite integer여야 합니다. `global`은 기본값이 `true`입니다. throttler provider를 가져온 모듈 범위에만 유지하려면 `global: false`를 설정하세요. `trustProxyHeaders`와 `keyGenerator`로 client identity를 조정할 수 있습니다. 모듈 옵션은 guard가 연결될 때 검증되고 값으로 캡처되므로, 호출자가 나중에 options 객체를 변경해도 실행 중인 throttling 정책은 바뀌지 않습니다. `store` 옵션을 제공하지 않으면 각 `ThrottlerGuard` 인스턴스가 자체 in-memory store를 소유합니다. 저장소를 공유하거나 외부에서 관리해야 한다면 `RedisThrottlerStore` 같은 `ThrottlerStore` 구현을 전달하세요.
 
 ### 데코레이터
 - `@Throttle({ ttl, limit })`: 클래스나 메서드에 특정 속도 제한을 설정합니다.

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -125,7 +125,7 @@ ThrottlerModule.forRoot({
 - `ThrottlerModule.forRoot(options)`: Provides validated throttler options and `ThrottlerGuard` to the module graph.
 - Package-level registration is supported through `ThrottlerModule.forRoot(options)`. Internal provider-composition helpers and DI tokens are not part of the public contract.
 
-`ttl` and `limit` must be positive finite integers. `trustProxyHeaders` and `keyGenerator` customize client identity. Module options are validated and captured by value when the guard is wired so later mutation of the caller's options object does not change live throttling policy. If no `store` option is supplied, each `ThrottlerGuard` instance owns its own in-memory store; pass a `ThrottlerStore` implementation such as `RedisThrottlerStore` when storage must be shared or externally managed.
+`ttl` and `limit` must be positive finite integers. `global` defaults to `true`; set `global: false` when the throttler providers should stay scoped to the importing module. `trustProxyHeaders` and `keyGenerator` customize client identity. Module options are validated and captured by value when the guard is wired so later mutation of the caller's options object does not change live throttling policy. If no `store` option is supplied, each `ThrottlerGuard` instance owns its own in-memory store; pass a `ThrottlerStore` implementation such as `RedisThrottlerStore` when storage must be shared or externally managed.
 
 ### Decorators
 - `@Throttle({ ttl, limit })`: Sets a specific rate limit for a class or method.

--- a/packages/throttler/src/guard.ts
+++ b/packages/throttler/src/guard.ts
@@ -18,6 +18,13 @@ import { validateThrottleOptions, validateThrottlerModuleOptions, validateThrott
 
 type MetadataBag = Record<PropertyKey, unknown>;
 
+interface ResolvedHandlerPolicy {
+  readonly encodedHandlerKey: string;
+  readonly limit: number;
+  readonly skip: boolean;
+  readonly ttlSeconds: number;
+}
+
 function getClassMetadataBag(target: object): MetadataBag | undefined {
   return getStandardMetadataBag(target);
 }
@@ -38,8 +45,7 @@ function defaultKeyGenerator(ctx: MiddlewareContext, trustProxyHeaders: boolean)
   return resolveClientIdentity(ctx.request, { trustProxyHeaders });
 }
 
-function buildStoreKey(handlerKey: string, clientKey: string): string {
-  const encodedHandlerKey = encodeURIComponent(handlerKey);
+function buildStoreKey(encodedHandlerKey: string, clientKey: string): string {
   const encodedClientKey = encodeURIComponent(clientKey);
 
   return `throttler:${encodedHandlerKey}:${encodedClientKey}`;
@@ -75,6 +81,8 @@ function resolveRetryAfterSeconds(entry: ThrottlerStoreEntry, now: number): numb
 export class ThrottlerGuard implements Guard {
   private readonly options: ThrottlerModuleOptions;
 
+  private readonly resolvedPolicies = new WeakMap<Function, Map<string, ResolvedHandlerPolicy>>();
+
   private readonly store: ThrottlerStore;
 
   constructor(options: ThrottlerModuleOptions) {
@@ -82,6 +90,45 @@ export class ThrottlerGuard implements Guard {
 
     this.options = validatedOptions;
     this.store = validatedOptions.store ?? createMemoryThrottlerStore();
+  }
+
+  private getResolvedPolicy(handler: GuardContext['handler']): ResolvedHandlerPolicy {
+    let controllerPolicies = this.resolvedPolicies.get(handler.controllerToken);
+
+    if (!controllerPolicies) {
+      controllerPolicies = new Map<string, ResolvedHandlerPolicy>();
+      this.resolvedPolicies.set(handler.controllerToken, controllerPolicies);
+    }
+
+    const version = handler.route.version ?? handler.metadata.effectiveVersion ?? 'unversioned';
+    const cacheKey = [handler.methodName, handler.route.method, handler.route.path, version].join('\u0000');
+    const cachedPolicy = controllerPolicies.get(cacheKey);
+
+    if (cachedPolicy) {
+      return cachedPolicy;
+    }
+
+    const classBag = getClassMetadataBag(handler.controllerToken);
+    const methodBag = getMethodMetadataBag(handler.controllerToken, handler.methodName);
+
+    const skip = (classBag ? getClassSkipThrottleMetadata(classBag) : false) ||
+      (methodBag ? getSkipThrottleMetadata(methodBag) : false);
+    const methodThrottle = methodBag ? getThrottleMetadata(methodBag) : undefined;
+    const classThrottle = classBag ? getClassThrottleMetadata(classBag) : undefined;
+    const resolvedThrottle = validateThrottleOptions({
+      limit: methodThrottle?.limit ?? classThrottle?.limit ?? this.options.limit,
+      ttl: methodThrottle?.ttl ?? classThrottle?.ttl ?? this.options.ttl,
+    });
+    const policy: ResolvedHandlerPolicy = {
+      encodedHandlerKey: encodeURIComponent(buildHandlerKey(handler)),
+      limit: resolvedThrottle.limit,
+      skip,
+      ttlSeconds: resolvedThrottle.ttl,
+    };
+
+    controllerPolicies.set(cacheKey, policy);
+
+    return policy;
   }
 
   /**
@@ -93,26 +140,11 @@ export class ThrottlerGuard implements Guard {
    */
   async canActivate(context: GuardContext): Promise<boolean> {
     const { handler, requestContext } = context;
+    const policy = this.getResolvedPolicy(handler);
 
-    const classBag = getClassMetadataBag(handler.controllerToken);
-    const methodBag = getMethodMetadataBag(handler.controllerToken, handler.methodName);
-
-    const classSkip = classBag ? getClassSkipThrottleMetadata(classBag) : false;
-    const methodSkip = methodBag ? getSkipThrottleMetadata(methodBag) : false;
-
-    if (classSkip || methodSkip) {
+    if (policy.skip) {
       return true;
     }
-
-    const methodThrottle = methodBag ? getThrottleMetadata(methodBag) : undefined;
-    const classThrottle = classBag ? getClassThrottleMetadata(classBag) : undefined;
-
-    const resolvedThrottle = validateThrottleOptions({
-      limit: methodThrottle?.limit ?? classThrottle?.limit ?? this.options.limit,
-      ttl: methodThrottle?.ttl ?? classThrottle?.ttl ?? this.options.ttl,
-    });
-    const ttlSeconds = resolvedThrottle.ttl;
-    const limit = resolvedThrottle.limit;
 
     const middlewareCtx: MiddlewareContext = {
       request: requestContext.request,
@@ -124,16 +156,15 @@ export class ThrottlerGuard implements Guard {
       ? this.options.keyGenerator(middlewareCtx)
       : defaultKeyGenerator(middlewareCtx, this.options.trustProxyHeaders ?? false);
 
-    const handlerKey = buildHandlerKey(handler);
-    const storeKey = buildStoreKey(handlerKey, clientKey);
+    const storeKey = buildStoreKey(policy.encodedHandlerKey, clientKey);
     const now = Date.now();
     const rawEntry = await this.store.consume(storeKey, {
       now,
-      ttlSeconds,
+      ttlSeconds: policy.ttlSeconds,
     });
     const entry = validateThrottlerStoreEntry(rawEntry);
 
-    if (entry.count > limit) {
+    if (entry.count > policy.limit) {
       const retryAfter = resolveRetryAfterSeconds(rawEntry, now);
       requestContext.response.setHeader('Retry-After', String(retryAfter));
       throw new TooManyRequestsException('Too Many Requests', { meta: { retryAfter } });

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -389,6 +389,32 @@ describe('ThrottlerGuard — in-memory store', () => {
     );
   });
 
+  it('caches resolved handler policy after the first request while preserving method precedence', async () => {
+    @Throttle({ limit: 10, ttl: 60 })
+    class TestController {
+      @Throttle({ limit: 1, ttl: 60 })
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 100 });
+    const ctx = createRequestContext();
+    const guardContext = createGuardContext(TestController, 'action', ctx);
+
+    await guard.canActivate(guardContext);
+
+    const bag = (TestController as unknown as Record<symbol, unknown>)[metadataSymbol] as Record<PropertyKey, unknown>;
+    const routeMap = bag[Symbol.for('fluo.standard.route')] as Map<string, Record<PropertyKey, unknown>>;
+    const actionRecord = routeMap.get('action');
+
+    if (!actionRecord) {
+      throw new Error('Expected throttle metadata for TestController.action.');
+    }
+
+    actionRecord[Symbol.for('fluo.throttler.throttle')] = { limit: 100, ttl: 60 };
+
+    await expect(guard.canActivate(guardContext)).rejects.toThrow('Too Many Requests');
+  });
+
   it('uses custom keyGenerator output as the client identity for store keys', async () => {
     const store: ThrottlerStore = {
       consume: vi.fn(async (_key: string, input: ThrottlerConsumeInput) => ({
@@ -507,6 +533,25 @@ describe('ThrottlerGuard — in-memory store', () => {
     });
     const secondContext = createRequestContext({
       headers: { forwarded: 'for=198.51.100.11;proto=https' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', firstContext))).resolves.toBe(true);
+    await expect(guard.canActivate(createGuardContext(TestController, 'action', secondContext))).resolves.toBe(true);
+  });
+
+  it('trusts X-Forwarded-For client identity when trustProxyHeaders is enabled', async () => {
+    class TestController {
+      action() {}
+    }
+
+    const guard = new ThrottlerGuard({ ...options, limit: 1, trustProxyHeaders: true });
+    const firstContext = createRequestContext({
+      headers: { 'x-forwarded-for': '198.51.100.10, 10.0.0.10' },
+      raw: { socket: { remoteAddress: '10.0.0.1' } },
+    });
+    const secondContext = createRequestContext({
+      headers: { 'x-forwarded-for': '198.51.100.11, 10.0.0.10' },
       raw: { socket: { remoteAddress: '10.0.0.1' } },
     });
 
@@ -740,18 +785,22 @@ describe('ThrottlerGuard — Redis store mock', () => {
     const slowNodeContext = createRequestContext('10.0.0.2');
     const dateNowSpy = vi.spyOn(Date, 'now');
 
-    dateNowSpy.mockReturnValueOnce(1_710_000_045_000);
-    await expect(
-      fastNodeGuard.canActivate(createGuardContext(TestController, 'action', fastNodeContext)),
-    ).rejects.toThrow('Too Many Requests');
+    try {
+      dateNowSpy.mockReturnValueOnce(1_710_000_045_000);
+      await expect(
+        fastNodeGuard.canActivate(createGuardContext(TestController, 'action', fastNodeContext)),
+      ).rejects.toThrow('Too Many Requests');
 
-    dateNowSpy.mockReturnValueOnce(1_710_000_000_000);
-    await expect(
-      slowNodeGuard.canActivate(createGuardContext(TestController, 'action', slowNodeContext)),
-    ).rejects.toThrow('Too Many Requests');
+      dateNowSpy.mockReturnValueOnce(1_710_000_000_000);
+      await expect(
+        slowNodeGuard.canActivate(createGuardContext(TestController, 'action', slowNodeContext)),
+      ).rejects.toThrow('Too Many Requests');
 
-    expect(fastNodeContext.response.headers['Retry-After']).toBe('45');
-    expect(slowNodeContext.response.headers['Retry-After']).toBe('45');
+      expect(fastNodeContext.response.headers['Retry-After']).toBe('45');
+      expect(slowNodeContext.response.headers['Retry-After']).toBe('45');
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   it('builds store keys from route and token identity context', async () => {

--- a/packages/throttler/src/status.test.ts
+++ b/packages/throttler/src/status.test.ts
@@ -31,6 +31,59 @@ describe('createThrottlerPlatformStatusSnapshot', () => {
     });
   });
 
+  it('reports memory store operation as local-only with framework ownership by default', () => {
+    const snapshot = createThrottlerPlatformStatusSnapshot({
+      storeKind: 'memory',
+    });
+
+    expect(snapshot.ownership).toEqual({ externallyManaged: false, ownsResources: true });
+    expect(snapshot.readiness).toEqual({ critical: false, status: 'ready' });
+    expect(snapshot.health).toEqual({ status: 'healthy' });
+    expect(snapshot.details).toMatchObject({
+      operationMode: 'local-only',
+      storeKind: 'memory',
+      storeOwnershipMode: 'framework',
+    });
+  });
+
+  it('reports custom store operation with external ownership by default', () => {
+    const snapshot = createThrottlerPlatformStatusSnapshot({
+      componentId: 'throttler.custom-quota',
+      storeKind: 'custom',
+    });
+
+    expect(snapshot.ownership).toEqual({ externallyManaged: true, ownsResources: false });
+    expect(snapshot.details).toMatchObject({
+      operationMode: 'custom',
+      storeKind: 'custom',
+      storeOwnershipMode: 'external',
+    });
+  });
+
+  it('reports local-fallback operation mode when explicitly provided', () => {
+    const snapshot = createThrottlerPlatformStatusSnapshot({
+      backingStoreReady: false,
+      backingStoreReason: 'redis unavailable; using local memory fallback',
+      operationMode: 'local-fallback',
+      storeKind: 'memory',
+    });
+
+    expect(snapshot.readiness).toMatchObject({
+      critical: false,
+      reason: 'redis unavailable; using local memory fallback',
+      status: 'degraded',
+    });
+    expect(snapshot.health).toEqual({
+      reason: 'redis unavailable; using local memory fallback',
+      status: 'degraded',
+    });
+    expect(snapshot.details).toMatchObject({
+      operationMode: 'local-fallback',
+      storeKind: 'memory',
+      storeOwnershipMode: 'framework',
+    });
+  });
+
   it('marks non-critical throttler readiness as degraded when backing store is unavailable', () => {
     const snapshot = createThrottlerPlatformStatusSnapshot({
       backingStoreReady: false,


### PR DESCRIPTION
## Summary

Closes #2047

Linked context: https://github.com/fluojs/fluo/issues/2047

## Changes

- Cache resolved throttler handler skip/throttle policy and encoded route key per handler descriptor to avoid stable metadata/key recomputation on each request.
- Add regression coverage for method-over-class policy precedence caching, trusted X-Forwarded-For identity, status helper memory/custom/local-fallback modes, and Date.now spy cleanup.
- Document the public ThrottlerModuleOptions.global option and default in EN/KO README.
- Add a patch changeset for @fluojs/throttler.

## Testing

- lsp_diagnostics on changed TypeScript files: no diagnostics found.
- pnpm --filter @fluojs/throttler... build
- pnpm --dir packages/throttler test
- pnpm --dir packages/throttler typecheck

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: .changeset/throttler-request-hot-path.md

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

No new public exports were added. README public API documentation now explicitly covers ThrottlerModuleOptions.global and its default.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The change preserves method-level over class-level over module-default precedence, skip behavior, trusted proxy opt-in semantics, and existing status helper output contracts.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.

No platform contract governance docs changed. EN/KO package README updates are synchronized, and package-level regression tests cover the throttler contract changes.