### PR TITLE
Resolve #2045: Fix Vite decorator plugin boundaries

### DIFF
--- a/.changeset/vite-decorator-plugin-boundary.md
+++ b/.changeset/vite-decorator-plugin-boundary.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/vite": patch
+---
+
+Fix the Vite decorator plugin boundary so application files with `test` or `spec` substrings still transform, keep the public implementation out of `src/internal`, and avoid requesting Babel sourcemaps when Vite build sourcemaps are disabled.

--- a/packages/vite/README.ko.md
+++ b/packages/vite/README.ko.md
@@ -42,7 +42,7 @@ export default defineConfig({
 });
 ```
 
-이 플러그인은 `.ts` 애플리케이션 파일을 Babel로 변환하며 `2023-11` decorators proposal과 `@babel/preset-typescript`를 사용합니다. 파일 경계를 판단하기 전에 Vite query suffix를 제거한 뒤 declaration 파일, `.test.` 또는 `.spec.` 파일, `node_modules`, `.ts`가 아닌 파일은 건너뛰므로 생성된 Vitest 테스트 파일은 계속 전용 `@fluojs/testing/vitest` transform 경로를 사용합니다.
+이 플러그인은 `.ts` 애플리케이션 파일을 Babel로 변환하며 `2023-11` decorators proposal과 `@babel/preset-typescript`를 사용합니다. 파일 경계를 판단하기 전에 Vite query suffix를 제거한 뒤 declaration 파일, `*.test.ts` 또는 `*.spec.ts` 파일, `node_modules`, `.ts`가 아닌 파일은 건너뛰므로 생성된 Vitest 테스트 파일은 계속 전용 `@fluojs/testing/vitest` transform 경로를 사용합니다.
 
 ## 공개 API
 
@@ -56,5 +56,5 @@ export default defineConfig({
 ## 예제 소스
 
 - `packages/vite/src/index.ts`
-- `packages/vite/src/internal/decorators-plugin.ts`
+- `packages/vite/src/decorators-plugin.ts`
 - `packages/cli/src/new/scaffold.ts`

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -42,7 +42,7 @@ export default defineConfig({
 });
 ```
 
-The plugin transforms `.ts` application files with Babel using the `2023-11` decorators proposal and `@babel/preset-typescript`. It strips Vite query suffixes before deciding the file boundary, then skips declaration files, `.test.` or `.spec.` files, `node_modules`, and non-`.ts` files so generated Vitest test files continue to use the dedicated `@fluojs/testing/vitest` transform path.
+The plugin transforms `.ts` application files with Babel using the `2023-11` decorators proposal and `@babel/preset-typescript`. It strips Vite query suffixes before deciding the file boundary, then skips declaration files, `*.test.ts` or `*.spec.ts` files, `node_modules`, and non-`.ts` files so generated Vitest test files continue to use the dedicated `@fluojs/testing/vitest` transform path.
 
 ## Public API
 
@@ -56,5 +56,5 @@ The plugin transforms `.ts` application files with Babel using the `2023-11` dec
 ## Example Sources
 
 - `packages/vite/src/index.ts`
-- `packages/vite/src/internal/decorators-plugin.ts`
+- `packages/vite/src/decorators-plugin.ts`
 - `packages/cli/src/new/scaffold.ts`

--- a/packages/vite/src/decorators-plugin.ts
+++ b/packages/vite/src/decorators-plugin.ts
@@ -1,10 +1,18 @@
 import { transformAsync } from '@babel/core';
-import type { Plugin } from 'vite';
+import type { Plugin, ResolvedConfig } from 'vite';
 
 function readViteFilePath(id: string): string {
-  const [filePath] = id.split('?', 1);
+  const filePath = id.split(/[?#]/, 1)[0] ?? id;
 
   return filePath;
+}
+
+function isNodeModulesPath(filePath: string): boolean {
+  return /(?:^|\/)node_modules(?:\/|$)/u.test(filePath);
+}
+
+function isTypeScriptTestFile(filePath: string): boolean {
+  return /\.(?:test|spec)\.ts$/u.test(filePath);
 }
 
 function shouldTransformTypeScriptApplicationFile(id: string): boolean {
@@ -14,11 +22,11 @@ function shouldTransformTypeScriptApplicationFile(id: string): boolean {
     return false;
   }
 
-  return (
-    !normalizedFilePath.includes('/node_modules/') &&
-    !normalizedFilePath.includes('.test.') &&
-    !normalizedFilePath.includes('.spec.')
-  );
+  return !isNodeModulesPath(normalizedFilePath) && !isTypeScriptTestFile(normalizedFilePath);
+}
+
+function shouldRequestBabelSourceMaps(config: Pick<ResolvedConfig, 'build' | 'command'>): boolean {
+  return config.command === 'serve' || Boolean(config.build.sourcemap);
 }
 
 /**
@@ -38,8 +46,13 @@ function shouldTransformTypeScriptApplicationFile(id: string): boolean {
  * ```
  */
 export function fluoDecoratorsPlugin(): Plugin {
+  let shouldGenerateSourceMaps = false;
+
   return {
     name: 'fluo-babel-decorators',
+    configResolved(config) {
+      shouldGenerateSourceMaps = shouldRequestBabelSourceMaps(config);
+    },
     async transform(code: string, id: string) {
       if (!shouldTransformTypeScriptApplicationFile(id)) {
         return null;
@@ -51,7 +64,7 @@ export function fluoDecoratorsPlugin(): Plugin {
         filename: readViteFilePath(id),
         plugins: [['@babel/plugin-proposal-decorators', { version: '2023-11' }]],
         presets: [['@babel/preset-typescript', { allowDeclareFields: true }]],
-        sourceMaps: true,
+        sourceMaps: shouldGenerateSourceMaps,
       });
 
       if (!result?.code) {

--- a/packages/vite/src/index.test.ts
+++ b/packages/vite/src/index.test.ts
@@ -5,6 +5,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { fluoDecoratorsPlugin } from './index.js';
 
+type MinimalResolvedViteConfig = {
+  readonly command: 'build' | 'serve';
+  readonly build: {
+    readonly sourcemap: boolean | 'hidden' | 'inline';
+  };
+};
+
 vi.mock('@babel/core', async (importOriginal) => {
   const babelCore = await importOriginal<typeof import('@babel/core')>();
 
@@ -57,6 +64,14 @@ function runTransform(plugin: Plugin, code: string, id: string): unknown {
   return Reflect.apply(plugin.transform, {}, [code, id]);
 }
 
+function runConfigResolved(plugin: Plugin, config: MinimalResolvedViteConfig): void {
+  if (typeof plugin.configResolved !== 'function') {
+    throw new Error('Expected fluoDecoratorsPlugin to expose a callable configResolved hook.');
+  }
+
+  Reflect.apply(plugin.configResolved, {}, [config]);
+}
+
 const transformAsyncMock = vi.mocked(transformAsync);
 
 describe('fluoDecoratorsPlugin', () => {
@@ -101,6 +116,41 @@ describe('fluoDecoratorsPlugin', () => {
     await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/component.ts?import')).resolves.toEqual(
       expect.objectContaining({ code: expect.any(String) }),
     );
+  });
+
+  it('transforms application TypeScript files whose names contain test or spec substrings', async () => {
+    const plugin = fluoDecoratorsPlugin();
+
+    await expect(runTransform(plugin, 'export const value: number = 1;', '/app/src/latest.service.ts')).resolves.toEqual(
+      expect.objectContaining({ code: expect.any(String) }),
+    );
+    await expect(
+      runTransform(plugin, 'export const value: number = 1;', '/app/src/features/order.spec.builder.ts'),
+    ).resolves.toEqual(expect.objectContaining({ code: expect.any(String) }));
+  });
+
+  it('omits Babel sourcemaps during builds when Vite build sourcemaps are disabled', async () => {
+    const plugin = fluoDecoratorsPlugin();
+    runConfigResolved(plugin, { command: 'build', build: { sourcemap: false } });
+
+    await runTransform(plugin, 'export const value: number = 1;', '/app/src/example.ts');
+
+    expect(transformAsyncMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ sourceMaps: false }));
+  });
+
+  it('requests Babel sourcemaps when Vite serves modules or build sourcemaps are enabled', async () => {
+    const servePlugin = fluoDecoratorsPlugin();
+    runConfigResolved(servePlugin, { command: 'serve', build: { sourcemap: false } });
+
+    await runTransform(servePlugin, 'export const value: number = 1;', '/app/src/dev.ts');
+
+    const buildPlugin = fluoDecoratorsPlugin();
+    runConfigResolved(buildPlugin, { command: 'build', build: { sourcemap: 'hidden' } });
+
+    await runTransform(buildPlugin, 'export const value: number = 1;', '/app/src/build.ts');
+
+    expect(transformAsyncMock.mock.calls[0]?.[1]).toEqual(expect.objectContaining({ sourceMaps: true }));
+    expect(transformAsyncMock.mock.calls[1]?.[1]).toEqual(expect.objectContaining({ sourceMaps: true }));
   });
 
   it('transforms TypeScript files with standard decorators through Babel', async () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,1 +1,1 @@
-export { fluoDecoratorsPlugin } from './internal/decorators-plugin.js';
+export { fluoDecoratorsPlugin } from './decorators-plugin.js';


### PR DESCRIPTION
## Summary

Fixes the Vite decorator plugin file-boundary bug and keeps the public implementation outside `src/internal`.

Linked context: Closes #2045

## Changes

- Narrowed test/spec skipping to `*.test.ts` and `*.spec.ts` boundaries after stripping Vite query suffixes.
- Moved the public plugin implementation to `packages/vite/src/decorators-plugin.ts` while preserving the root export.
- Requests Babel sourcemaps only for Vite dev server transforms or builds with sourcemaps enabled.
- Updated EN/KO README source references and skip wording.

## Testing

- `pnpm --dir packages/vite test`
- `pnpm --dir packages/vite typecheck`
- `pnpm --dir packages/vite build`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Changeset: `.changeset/vite-decorator-plugin-boundary.md`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

The root public export remains `fluoDecoratorsPlugin()`. The implementation moved out of `src/internal` without changing the public import path.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The README now documents `*.test.ts` / `*.spec.ts` boundaries precisely, and tests cover application filenames that merely contain `test` or `spec` substrings.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. Package README EN/KO companion text was updated together; package-level regression tests cover the runtime contract.