### PR TITLE
[codex] fix socket.io node import crash

### DIFF
--- a/.changeset/socketio-bun-engine-lazy-import.md
+++ b/.changeset/socketio-bun-engine-lazy-import.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/socket.io": patch
+---
+
+Defer the Bun engine dependency load until the Bun Socket.IO bootstrap path is actually selected, preventing Node server-backed applications from crashing during package import.

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -18,7 +18,7 @@ import {
   type WebSocketGatewayDescriptor,
   type WebSocketGatewayHandlerDescriptor,
 } from '@fluojs/websockets';
-import { Server as BunEngineServer } from '@socket.io/bun-engine';
+import type { Server as BunEngineServer } from '@socket.io/bun-engine';
 import { type Namespace, Server, type ServerOptions, type Socket } from 'socket.io';
 
 import { SOCKETIO_OPTIONS_INTERNAL } from './options-token.internal.js';
@@ -130,6 +130,12 @@ type SocketIoBootstrapRuntime =
       capability: FetchStyleRealtimeCapability;
       kind: 'bun';
     };
+
+type BunEngineServerConstructor = typeof import('@socket.io/bun-engine')['Server'];
+
+async function loadBunEngineServer(): Promise<BunEngineServerConstructor> {
+  return (await import('@socket.io/bun-engine')).Server;
+}
 
 function normalizeGuardRejection(
   result: boolean | SocketIoGuardRejection | void,
@@ -370,20 +376,31 @@ export class SocketIoLifecycleService
     const runtime = resolveSocketIoBootstrapRuntime(this.adapter);
 
     if (runtime.kind === 'server-backed') {
-      const httpServer = runtime.capability.server;
+      this.io = this.createNodeServer(runtime);
+      return this.io;
+    }
 
-      if (!isNodeHttpServerLike(httpServer)) {
-        throw new Error(
-          'Socket.IO bootstrap requires the selected realtime capability to expose a Node HTTP/S server instance.',
-        );
-      }
+    throw new Error('Socket.IO Bun engine bootstrap is asynchronous. Use getServerAsync() for Bun-style adapters.');
+  }
 
-      this.io = new Server(httpServer as never, this.createServerOptions());
+  async getServerAsync(): Promise<Server> {
+    if (this.shutdownStarted) {
+      throw new Error('Socket.IO server access is unavailable after application shutdown has started.');
+    }
+
+    if (this.io) {
+      return this.io;
+    }
+
+    const runtime = resolveSocketIoBootstrapRuntime(this.adapter);
+
+    if (runtime.kind === 'server-backed') {
+      this.io = this.createNodeServer(runtime);
       return this.io;
     }
 
     this.io = new Server(this.createServerOptions());
-    this.installBunSocketIoBinding(runtime, this.io);
+    await this.installBunSocketIoBinding(runtime, this.io);
     return this.io;
   }
 
@@ -398,13 +415,13 @@ export class SocketIoLifecycleService
     const descriptors = this.discoverGatewayDescriptors();
 
     if (descriptors.length === 0) {
-      this.ensureBunRealtimeBindingForRawServerAccess();
+      await this.ensureBunRealtimeBindingForRawServerAccess();
       return;
     }
 
     this.assertNoServerBackedGatewayOptIn(descriptors);
 
-    const io = this.getServer();
+    const io = await this.getServerAsync();
     const attachments = this.prepareNamespaceAttachments(io, descriptors);
 
     for (const attachment of attachments) {
@@ -509,6 +526,18 @@ export class SocketIoLifecycleService
     return options;
   }
 
+  private createNodeServer(runtime: Extract<SocketIoBootstrapRuntime, { kind: 'server-backed' }>): Server {
+    const httpServer = runtime.capability.server;
+
+    if (!isNodeHttpServerLike(httpServer)) {
+      throw new Error(
+        'Socket.IO bootstrap requires the selected realtime capability to expose a Node HTTP/S server instance.',
+      );
+    }
+
+    return new Server(httpServer as never, this.createServerOptions());
+  }
+
   private createBunEngineOptions(): BunEngineOptions {
     const options: BunEngineOptions = {
       path: DEFAULT_SOCKETIO_ENGINE_PATH,
@@ -528,11 +557,12 @@ export class SocketIoLifecycleService
     return resolveSocketIoMaxHttpBufferSize(this.moduleOptions);
   }
 
-  private installBunSocketIoBinding(runtime: Extract<SocketIoBootstrapRuntime, { kind: 'bun' }>, io: Server): void {
+  private async installBunSocketIoBinding(runtime: Extract<SocketIoBootstrapRuntime, { kind: 'bun' }>, io: Server): Promise<void> {
     if (this.bunEngine) {
       return;
     }
 
+    const BunEngineServer = await loadBunEngineServer();
     const engine = new BunEngineServer(this.createBunEngineOptions());
     io.bind(engine);
     runtime.bindingHost.configureRealtimeBinding(this.createBunSocketIoBinding(engine));
@@ -576,12 +606,12 @@ export class SocketIoLifecycleService
     return pathname === '/socket.io' || pathname === DEFAULT_SOCKETIO_ENGINE_PATH;
   }
 
-  private ensureBunRealtimeBindingForRawServerAccess(): void {
+  private async ensureBunRealtimeBindingForRawServerAccess(): Promise<void> {
     if (!hasBunRealtimeBindingHost(this.adapter)) {
       return;
     }
 
-    this.getServer();
+    await this.getServerAsync();
   }
 
   private assertNoServerBackedGatewayOptIn(descriptors: readonly WebSocketGatewayDescriptor[]): void {

--- a/packages/socket.io/src/module.ts
+++ b/packages/socket.io/src/module.ts
@@ -21,7 +21,7 @@ function createSocketIoProviderSet(options: SocketIoModuleOptions = {}) {
     },
     {
       provide: SOCKETIO_SERVER,
-      useFactory: (service: unknown) => (service as SocketIoLifecycleService).getServer(),
+      useFactory: async (service: unknown) => await (service as SocketIoLifecycleService).getServerAsync(),
       inject: [SocketIoLifecycleService],
     },
     {

--- a/packages/socket.io/src/public-surface.test.ts
+++ b/packages/socket.io/src/public-surface.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import type { WebSocketRoomService } from '@fluojs/websockets';
@@ -6,7 +10,15 @@ import * as socketIo from './index.js';
 import type { SocketIoHandshakeRequest as RootSocketIoHandshakeRequest } from './index.js';
 import type { SocketIoHandshakeRequest, SocketIoRoomService } from './types.js';
 
+const sourceDir = dirname(fileURLToPath(import.meta.url));
+
 describe('@fluojs/socket.io public surface', () => {
+  it('keeps the Bun engine dependency out of the Node module-load path', () => {
+    const adapterSource = readFileSync(resolve(sourceDir, 'adapter.ts'), 'utf8');
+
+    expect(adapterSource).not.toMatch(/^import\s+\{[^}]*BunEngineServer[^}]*\}\s+from\s+['"]@socket\.io\/bun-engine['"];$/m);
+  });
+
   it('keeps the root barrel aligned with the documented module and room contract', () => {
     expect(socketIo).toHaveProperty('SocketIoModule');
     expect((socketIo as { SocketIoModule: { forRoot: unknown } }).SocketIoModule).toHaveProperty('forRoot');


### PR DESCRIPTION
## Summary

Fixes #2060.

`@fluojs/socket.io` no longer imports `@socket.io/bun-engine` at module load time. Node server-backed applications can import and bootstrap the package without evaluating the Bun-only engine dependency.

## Root Cause

`packages/socket.io/src/adapter.ts` imported `Server` from `@socket.io/bun-engine` as a value at the top level. The published Bun engine package is not safe to evaluate from Node ESM in this path, so Node apps crashed before the adapter could select the normal server-backed runtime.

## Changes

- Convert the Bun engine import to a type-only import.
- Add `getServerAsync()` for bootstrap/provider paths that may need the Bun engine.
- Keep the existing synchronous `getServer()` path for server-backed Node adapters.
- Add a regression test that prevents reintroducing a top-level Bun engine value import.
- Add a patch changeset for `@fluojs/socket.io`.

## Verification

- `pnpm --dir packages/socket.io test`
- `pnpm --dir packages/socket.io typecheck` after build completed
- `pnpm --filter @fluojs/socket.io... build`
- `node --input-type=module -e "import('./packages/socket.io/dist/index.js').then(()=>console.log('import ok')).catch(e=>{console.error(e.stack); process.exit(1)})"`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main`

Note: an earlier parallel `typecheck` run overlapped with `build` cleaning dependency `dist` directories and failed transiently; rerunning sequentially after build passed.
