### PR TITLE
Resolve #2063: Guard HTTP request context storage resolution

### DIFF
--- a/.changeset/fuzzy-pans-guard.md
+++ b/.changeset/fuzzy-pans-guard.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/http": patch
+---
+
+Guard request-context storage resolution so importing `@fluojs/http` does not crash when host `async_hooks` probes throw, while preserving lazy ALS resolution and synchronous fallback behavior.

--- a/packages/http/README.ko.md
+++ b/packages/http/README.ko.md
@@ -96,7 +96,7 @@ function someDeepHelper() {
 }
 ```
 
-`runWithRequestContext(...)`는 호스트가 `globalThis.AsyncLocalStorage` 또는 Node 내장 `node:async_hooks` 모듈로 `AsyncLocalStorage`를 제공할 때 활성 컨텍스트를 `await` 이후까지 보존합니다. 선언된 `>=20.0.0` 지원 범위의 Node 런타임은 `process.getBuiltinModule(...)`이 없어도 `node:async_hooks`를 동적으로 해석해 ALS 의미론을 유지합니다. 비동기 컨텍스트 primitive가 없는 비 Node 호스트에서는 동기 stack fallback을 사용하며, 겹치는 비동기 요청이 서로의 컨텍스트를 관찰하지 않도록 awaited continuation이 재개되기 전에 컨텍스트를 비웁니다.
+`runWithRequestContext(...)`는 호스트가 `globalThis.AsyncLocalStorage` 또는 Node 내장 `node:async_hooks` 모듈로 `AsyncLocalStorage`를 제공할 때 활성 컨텍스트를 `await` 이후까지 보존합니다. 루트 `@fluojs/http` import는 async-context storage를 probe하거나 instantiate하지 않습니다. Helper가 처음 사용될 때 storage를 lazy하게 해석하고, `process.getBuiltinModule(...)` 실패를 guard하며, 동기 probe를 노출하지 않는 Node host에서는 계속 `node:async_hooks`를 동적으로 해석할 수 있습니다. 비동기 컨텍스트 primitive가 없는 비 Node 호스트에서는 동기 stack fallback을 사용하며, 겹치는 비동기 요청이 서로의 컨텍스트를 관찰하지 않도록 awaited continuation이 재개되기 전에 컨텍스트를 비웁니다.
 
 ### 프록시 뒤의 속도 제한
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -98,7 +98,7 @@ function someDeepHelper() {
 }
 ```
 
-`runWithRequestContext(...)` preserves the active context across awaited work when the host provides `AsyncLocalStorage` through `globalThis.AsyncLocalStorage` or Node's built-in `node:async_hooks` module. Node runtimes in the declared `>=20.0.0` support range keep ALS semantics even when `process.getBuiltinModule(...)` is unavailable by resolving `node:async_hooks` dynamically. Non-Node hosts without an async-context primitive use a synchronous stack fallback that clears the context before awaited continuations resume, avoiding cross-request leaks instead of pretending to isolate overlapping async work.
+`runWithRequestContext(...)` preserves the active context across awaited work when the host provides `AsyncLocalStorage` through `globalThis.AsyncLocalStorage` or Node's built-in `node:async_hooks` module. The root `@fluojs/http` import does not probe or instantiate async-context storage; helpers resolve storage lazily on first use, guard `process.getBuiltinModule(...)` failures, and can still resolve `node:async_hooks` dynamically for Node hosts that do not expose the synchronous probe. Non-Node hosts without an async-context primitive use a synchronous stack fallback that clears the context before awaited continuations resume, avoiding cross-request leaks instead of pretending to isolate overlapping async work.
 
 ### Rate limiting behind proxies
 

--- a/packages/http/src/context/request-context-node-store.ts
+++ b/packages/http/src/context/request-context-node-store.ts
@@ -19,6 +19,38 @@ type AsyncLocalStorageResolutionHost = {
 type NodeAsyncHooksLoader = () => Promise<NodeAsyncHooksModule>;
 
 /**
+ * Resolves host-provided `AsyncLocalStorage` without async imports or throwing host probes.
+ *
+ * @param host Host global-like object to inspect for synchronous async-context support.
+ * @returns The resolved `AsyncLocalStorage` constructor, or `undefined` when unavailable.
+ */
+export function resolveImmediateAsyncLocalStorageConstructor(
+  host: AsyncLocalStorageResolutionHost = globalThis,
+): AsyncLocalStorageConstructor | undefined {
+  if (typeof host.AsyncLocalStorage === 'function') {
+    return host.AsyncLocalStorage;
+  }
+
+  const getBuiltinModule = host.process?.getBuiltinModule;
+
+  if (typeof getBuiltinModule !== 'function') {
+    return undefined;
+  }
+
+  try {
+    const builtinAsyncLocalStorage = getBuiltinModule('node:async_hooks')?.AsyncLocalStorage;
+
+    if (typeof builtinAsyncLocalStorage === 'function') {
+      return builtinAsyncLocalStorage;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/**
  * Resolves the host `AsyncLocalStorage` constructor without eagerly importing Node built-ins.
  *
  * @param host Host global-like object to inspect for async-context support.
@@ -29,14 +61,10 @@ export async function resolveAsyncLocalStorageConstructor(
   host: AsyncLocalStorageResolutionHost = globalThis,
   loadNodeAsyncHooks: NodeAsyncHooksLoader = importNodeAsyncHooks,
 ): Promise<AsyncLocalStorageConstructor | undefined> {
-  if (typeof host.AsyncLocalStorage === 'function') {
-    return host.AsyncLocalStorage;
-  }
+  const immediateAsyncLocalStorage = resolveImmediateAsyncLocalStorageConstructor(host);
 
-  const builtinAsyncLocalStorage = host.process?.getBuiltinModule?.('node:async_hooks').AsyncLocalStorage;
-
-  if (typeof builtinAsyncLocalStorage === 'function') {
-    return builtinAsyncLocalStorage;
+  if (typeof immediateAsyncLocalStorage === 'function') {
+    return immediateAsyncLocalStorage;
   }
 
   if (!isNodeHost(host)) {

--- a/packages/http/src/context/request-context-node-store.ts
+++ b/packages/http/src/context/request-context-node-store.ts
@@ -80,6 +80,18 @@ export async function resolveAsyncLocalStorageConstructor(
   }
 }
 
+/**
+ * Reports whether the host can still resolve Node async-context storage asynchronously.
+ *
+ * @param host Host global-like object to inspect for Node runtime markers.
+ * @returns `true` when the host is Node.js and can use a lazy `node:async_hooks` import.
+ */
+export function canResolveAsyncLocalStorageDynamically(
+  host: AsyncLocalStorageResolutionHost = globalThis,
+): boolean {
+  return isNodeHost(host);
+}
+
 function isNodeHost(host: AsyncLocalStorageResolutionHost): boolean {
   return typeof host.process?.versions?.node === 'string';
 }

--- a/packages/http/src/context/request-context.test.ts
+++ b/packages/http/src/context/request-context.test.ts
@@ -168,13 +168,45 @@ describe('request context store', () => {
       const requestContext = await import('./request-context.js');
       const context = requestContext.createRequestContext(createMockContext());
 
-      const requestId = await requestContext.runWithRequestContext(context, async () => {
+      const requestIdResult = requestContext.runWithRequestContext(context, async () => {
         await Promise.resolve();
 
         return requestContext.assertRequestContext().requestId;
       });
 
+      expect(requestIdResult).toBeInstanceOf(Promise);
+
+      const requestId = await requestIdResult;
+
       expect(requestId).toBe('req_123');
+    } finally {
+      if (getBuiltinModuleDescriptor) {
+        Object.defineProperty(process, 'getBuiltinModule', getBuiltinModuleDescriptor);
+      }
+      vi.resetModules();
+    }
+  });
+
+  it('returns a synchronous value on the first public helper call when dynamic storage resolution is pending', async () => {
+    vi.resetModules();
+    const getBuiltinModuleDescriptor = Object.getOwnPropertyDescriptor(process, 'getBuiltinModule');
+
+    Object.defineProperty(process, 'getBuiltinModule', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const requestContext = await import('./request-context.js');
+      const context = requestContext.createRequestContext(createMockContext());
+
+      const requestId = requestContext.runWithRequestContext(
+        context,
+        () => requestContext.assertRequestContext().requestId,
+      );
+
+      expect(requestId).toBe('req_123');
+      expect(requestId).not.toBeInstanceOf(Promise);
     } finally {
       if (getBuiltinModuleDescriptor) {
         Object.defineProperty(process, 'getBuiltinModule', getBuiltinModuleDescriptor);

--- a/packages/http/src/context/request-context.test.ts
+++ b/packages/http/src/context/request-context.test.ts
@@ -155,6 +155,58 @@ describe('request context store', () => {
     expect(AsyncLocalStorage).toBeUndefined();
   });
 
+  it('preserves context across awaited work on the first public helper call when getBuiltinModule is unavailable', async () => {
+    vi.resetModules();
+    const getBuiltinModuleDescriptor = Object.getOwnPropertyDescriptor(process, 'getBuiltinModule');
+
+    Object.defineProperty(process, 'getBuiltinModule', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const requestContext = await import('./request-context.js');
+      const context = requestContext.createRequestContext(createMockContext());
+
+      const requestId = await requestContext.runWithRequestContext(context, async () => {
+        await Promise.resolve();
+
+        return requestContext.assertRequestContext().requestId;
+      });
+
+      expect(requestId).toBe('req_123');
+    } finally {
+      if (getBuiltinModuleDescriptor) {
+        Object.defineProperty(process, 'getBuiltinModule', getBuiltinModuleDescriptor);
+      }
+      vi.resetModules();
+    }
+  });
+
+  it('preserves context across awaited work on the first public helper call when getBuiltinModule throws', async () => {
+    vi.resetModules();
+
+    const getBuiltinModule = vi.spyOn(process, 'getBuiltinModule').mockImplementation(() => {
+      throw new Error('async_hooks probe failed');
+    });
+
+    try {
+      const requestContext = await import('./request-context.js');
+      const context = requestContext.createRequestContext(createMockContext());
+
+      const requestId = await requestContext.runWithRequestContext(context, async () => {
+        await Promise.resolve();
+
+        return requestContext.assertRequestContext().requestId;
+      });
+
+      expect(requestId).toBe('req_123');
+    } finally {
+      getBuiltinModule.mockRestore();
+      vi.resetModules();
+    }
+  });
+
   it('does not probe async hooks while importing the HTTP root barrel', async () => {
     const getBuiltinModule = vi.spyOn(process, 'getBuiltinModule').mockImplementation(() => {
       throw new Error('async_hooks should not be probed during import');

--- a/packages/http/src/context/request-context.test.ts
+++ b/packages/http/src/context/request-context.test.ts
@@ -187,6 +187,32 @@ describe('request context store', () => {
     }
   });
 
+  it('preserves context for promise-returning non-async callbacks when getBuiltinModule is unavailable', async () => {
+    vi.resetModules();
+    const getBuiltinModuleDescriptor = Object.getOwnPropertyDescriptor(process, 'getBuiltinModule');
+
+    Object.defineProperty(process, 'getBuiltinModule', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const requestContext = await import('./request-context.js');
+      const context = requestContext.createRequestContext(createMockContext());
+
+      const requestId = await requestContext.runWithRequestContext(context, () =>
+        Promise.resolve().then(() => requestContext.assertRequestContext().requestId),
+      );
+
+      expect(requestId).toBe('req_123');
+    } finally {
+      if (getBuiltinModuleDescriptor) {
+        Object.defineProperty(process, 'getBuiltinModule', getBuiltinModuleDescriptor);
+      }
+      vi.resetModules();
+    }
+  });
+
   it('returns a synchronous value on the first public helper call when dynamic storage resolution is pending', async () => {
     vi.resetModules();
     const getBuiltinModuleDescriptor = Object.getOwnPropertyDescriptor(process, 'getBuiltinModule');
@@ -231,6 +257,28 @@ describe('request context store', () => {
 
         return requestContext.assertRequestContext().requestId;
       });
+
+      expect(requestId).toBe('req_123');
+    } finally {
+      getBuiltinModule.mockRestore();
+      vi.resetModules();
+    }
+  });
+
+  it('preserves context for promise-returning non-async callbacks when getBuiltinModule throws', async () => {
+    vi.resetModules();
+
+    const getBuiltinModule = vi.spyOn(process, 'getBuiltinModule').mockImplementation(() => {
+      throw new Error('async_hooks probe failed');
+    });
+
+    try {
+      const requestContext = await import('./request-context.js');
+      const context = requestContext.createRequestContext(createMockContext());
+
+      const requestId = await requestContext.runWithRequestContext(context, () =>
+        Promise.resolve().then(() => requestContext.assertRequestContext().requestId),
+      );
 
       expect(requestId).toBe('req_123');
     } finally {

--- a/packages/http/src/context/request-context.test.ts
+++ b/packages/http/src/context/request-context.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
-
 import { Container } from '@fluojs/di';
+import { describe, expect, it, vi } from 'vitest';
+import type { RequestContext } from '../types.js';
 
 import {
   assertRequestContext,
@@ -11,10 +11,12 @@ import {
   runWithRequestContext,
   setContextValue,
 } from './request-context.js';
-import { resolveAsyncLocalStorageConstructor } from './request-context-node-store.js';
+import {
+  resolveAsyncLocalStorageConstructor,
+  resolveImmediateAsyncLocalStorageConstructor,
+} from './request-context-node-store.js';
 import { createStackRequestContextStore } from './request-context-stack-store.js';
 import type { RequestContextStore } from './request-context-store.js';
-import type { RequestContext } from '../types.js';
 
 class MockAsyncLocalStorage implements RequestContextStore {
   readonly #store = createStackRequestContextStore();
@@ -121,6 +123,49 @@ describe('request context store', () => {
     );
 
     expect(AsyncLocalStorage).toBe(MockAsyncLocalStorage);
+  });
+
+  it('guards throwing getBuiltinModule probes and falls back to the dynamic Node loader', async () => {
+    const AsyncLocalStorage = await resolveAsyncLocalStorageConstructor(
+      {
+        process: {
+          getBuiltinModule() {
+            throw new Error('async_hooks probe failed');
+          },
+          versions: {
+            node: '20.0.0',
+          },
+        },
+      },
+      async () => ({ AsyncLocalStorage: MockAsyncLocalStorage }),
+    );
+
+    expect(AsyncLocalStorage).toBe(MockAsyncLocalStorage);
+  });
+
+  it('returns undefined from the immediate probe when getBuiltinModule throws', () => {
+    const AsyncLocalStorage = resolveImmediateAsyncLocalStorageConstructor({
+      process: {
+        getBuiltinModule() {
+          throw new Error('async_hooks probe failed');
+        },
+      },
+    });
+
+    expect(AsyncLocalStorage).toBeUndefined();
+  });
+
+  it('does not probe async hooks while importing the HTTP root barrel', async () => {
+    const getBuiltinModule = vi.spyOn(process, 'getBuiltinModule').mockImplementation(() => {
+      throw new Error('async_hooks should not be probed during import');
+    });
+
+    try {
+      await import('../index.js');
+      expect(getBuiltinModule).not.toHaveBeenCalled();
+    } finally {
+      getBuiltinModule.mockRestore();
+    }
   });
 
   it('does not load Node async hooks for non-Node hosts without async storage', async () => {

--- a/packages/http/src/context/request-context.ts
+++ b/packages/http/src/context/request-context.ts
@@ -1,11 +1,16 @@
 import { FluoError } from '@fluojs/core';
 
 import type { ContextKey, RequestContext } from '../types.js';
-import { resolveAsyncLocalStorageConstructor } from './request-context-node-store.js';
+import {
+  resolveAsyncLocalStorageConstructor,
+  resolveImmediateAsyncLocalStorageConstructor,
+} from './request-context-node-store.js';
 import { createStackRequestContextStore } from './request-context-stack-store.js';
 import type { RequestContextStore } from './request-context-store.js';
 
-const requestContextStore: RequestContextStore = await createRequestContextStore();
+let requestContextStore: RequestContextStore | undefined;
+let requestContextStoreResolution: Promise<RequestContextStore> | undefined;
+let fallbackRequestContextStore: RequestContextStore | undefined;
 
 /**
  * Runs a callback inside the request-scoped async context.
@@ -19,7 +24,7 @@ const requestContextStore: RequestContextStore = await createRequestContextStore
  * @returns The return value from `callback`.
  */
 export function runWithRequestContext<T>(context: RequestContext, callback: () => T): T {
-  return requestContextStore.run(context, callback);
+  return getRequestContextStore().run(context, callback);
 }
 
 /**
@@ -28,7 +33,7 @@ export function runWithRequestContext<T>(context: RequestContext, callback: () =
  * @returns The active request context, or `undefined` when no request scope is bound.
  */
 export function getCurrentRequestContext(): RequestContext | undefined {
-  return requestContextStore.getStore();
+  return getRequestContextStore().getStore();
 }
 
 /**
@@ -97,12 +102,46 @@ export function setContextValue<T>(context: RequestContext, key: ContextKey<T>, 
   context.metadata[key.id] = value;
 }
 
+function getRequestContextStore(): RequestContextStore {
+  if (requestContextStore) {
+    return requestContextStore;
+  }
+
+  const AsyncLocalStorage = resolveImmediateAsyncLocalStorageConstructor();
+
+  if (typeof AsyncLocalStorage === 'function') {
+    requestContextStore = new AsyncLocalStorage();
+
+    return requestContextStore;
+  }
+
+  void resolveRequestContextStore();
+
+  return getFallbackRequestContextStore();
+}
+
+async function resolveRequestContextStore(): Promise<RequestContextStore> {
+  requestContextStoreResolution ??= createRequestContextStore();
+
+  return requestContextStoreResolution;
+}
+
 async function createRequestContextStore(): Promise<RequestContextStore> {
   const AsyncLocalStorage = await resolveAsyncLocalStorageConstructor();
 
   if (typeof AsyncLocalStorage === 'function') {
-    return new AsyncLocalStorage();
+    requestContextStore = new AsyncLocalStorage();
+
+    return requestContextStore;
   }
 
-  return createStackRequestContextStore();
+  requestContextStore = getFallbackRequestContextStore();
+
+  return requestContextStore;
+}
+
+function getFallbackRequestContextStore(): RequestContextStore {
+  fallbackRequestContextStore ??= createStackRequestContextStore();
+
+  return fallbackRequestContextStore;
 }

--- a/packages/http/src/context/request-context.ts
+++ b/packages/http/src/context/request-context.ts
@@ -35,6 +35,12 @@ export function runWithRequestContext<T>(context: RequestContext, callback: () =
     return getFallbackRequestContextStore().run(context, callback);
   }
 
+  if (!isAsyncCallback(callback)) {
+    void resolveRequestContextStore();
+
+    return getFallbackRequestContextStore().run(context, callback);
+  }
+
   return runWithResolvedRequestContextStore(context, callback) as T;
 }
 
@@ -168,4 +174,8 @@ function getFallbackRequestContextStore(): RequestContextStore {
   fallbackRequestContextStore ??= createStackRequestContextStore();
 
   return fallbackRequestContextStore;
+}
+
+function isAsyncCallback<T>(callback: () => T): callback is () => T & Promise<Awaited<T>> {
+  return callback.constructor.name === 'AsyncFunction';
 }

--- a/packages/http/src/context/request-context.ts
+++ b/packages/http/src/context/request-context.ts
@@ -12,6 +12,7 @@ import type { RequestContextStore } from './request-context-store.js';
 let requestContextStore: RequestContextStore | undefined;
 let requestContextStoreResolution: Promise<RequestContextStore> | undefined;
 let fallbackRequestContextStore: RequestContextStore | undefined;
+const dynamicResolutionFallbackStack: RequestContext[] = [];
 
 /**
  * Runs a callback inside the request-scoped async context.
@@ -36,9 +37,7 @@ export function runWithRequestContext<T>(context: RequestContext, callback: () =
   }
 
   if (!isAsyncCallback(callback)) {
-    void resolveRequestContextStore();
-
-    return getFallbackRequestContextStore().run(context, callback);
+    return runWithDynamicResolutionFallbackContext(context, callback);
   }
 
   return runWithResolvedRequestContextStore(context, callback) as T;
@@ -50,7 +49,7 @@ export function runWithRequestContext<T>(context: RequestContext, callback: () =
  * @returns The active request context, or `undefined` when no request scope is bound.
  */
 export function getCurrentRequestContext(): RequestContext | undefined {
-  return getRequestContextStore().getStore();
+  return getRequestContextStore().getStore() ?? getDynamicResolutionFallbackContext();
 }
 
 /**
@@ -174,6 +173,50 @@ function getFallbackRequestContextStore(): RequestContextStore {
   fallbackRequestContextStore ??= createStackRequestContextStore();
 
   return fallbackRequestContextStore;
+}
+
+function runWithDynamicResolutionFallbackContext<T>(context: RequestContext, callback: () => T): T {
+  dynamicResolutionFallbackStack.push(context);
+
+  try {
+    const result = callback();
+
+    void resolveRequestContextStore();
+
+    if (isPromiseLike(result)) {
+      return result.finally(() => {
+        removeDynamicResolutionFallbackContext(context);
+      }) as T;
+    }
+
+    removeDynamicResolutionFallbackContext(context);
+
+    return result;
+  } catch (error) {
+    removeDynamicResolutionFallbackContext(context);
+
+    throw error;
+  }
+}
+
+function getDynamicResolutionFallbackContext(): RequestContext | undefined {
+  if (dynamicResolutionFallbackStack.length !== 1) {
+    return undefined;
+  }
+
+  return dynamicResolutionFallbackStack[0];
+}
+
+function removeDynamicResolutionFallbackContext(context: RequestContext): void {
+  const index = dynamicResolutionFallbackStack.lastIndexOf(context);
+
+  if (index >= 0) {
+    dynamicResolutionFallbackStack.splice(index, 1);
+  }
+}
+
+function isPromiseLike<T>(value: T): value is T & Promise<Awaited<T>> {
+  return typeof value === 'object' && value !== null && 'then' in value && 'finally' in value;
 }
 
 function isAsyncCallback<T>(callback: () => T): callback is () => T & Promise<Awaited<T>> {

--- a/packages/http/src/context/request-context.ts
+++ b/packages/http/src/context/request-context.ts
@@ -2,6 +2,7 @@ import { FluoError } from '@fluojs/core';
 
 import type { ContextKey, RequestContext } from '../types.js';
 import {
+  canResolveAsyncLocalStorageDynamically,
   resolveAsyncLocalStorageConstructor,
   resolveImmediateAsyncLocalStorageConstructor,
 } from './request-context-node-store.js';
@@ -24,7 +25,17 @@ let fallbackRequestContextStore: RequestContextStore | undefined;
  * @returns The return value from `callback`.
  */
 export function runWithRequestContext<T>(context: RequestContext, callback: () => T): T {
-  return getRequestContextStore().run(context, callback);
+  const store = getResolvedRequestContextStore();
+
+  if (store) {
+    return store.run(context, callback);
+  }
+
+  if (!canResolveAsyncLocalStorageDynamically()) {
+    return getFallbackRequestContextStore().run(context, callback);
+  }
+
+  return runWithResolvedRequestContextStore(context, callback) as T;
 }
 
 /**
@@ -103,6 +114,10 @@ export function setContextValue<T>(context: RequestContext, key: ContextKey<T>, 
 }
 
 function getRequestContextStore(): RequestContextStore {
+  return getResolvedRequestContextStore() ?? getFallbackRequestContextStore();
+}
+
+function getResolvedRequestContextStore(): RequestContextStore | undefined {
   if (requestContextStore) {
     return requestContextStore;
   }
@@ -117,7 +132,16 @@ function getRequestContextStore(): RequestContextStore {
 
   void resolveRequestContextStore();
 
-  return getFallbackRequestContextStore();
+  return undefined;
+}
+
+async function runWithResolvedRequestContextStore<T>(
+  context: RequestContext,
+  callback: () => T,
+): Promise<Awaited<T>> {
+  const store = await resolveRequestContextStore();
+
+  return store.run(context, callback) as Awaited<T>;
 }
 
 async function resolveRequestContextStore(): Promise<RequestContextStore> {


### PR DESCRIPTION
## Summary

Guard HTTP request-context storage resolution so root `@fluojs/http` imports do not crash when host `async_hooks` probes fail.

Linked context: Closes #2063

## Changes

- Removed eager top-level request-context store creation from the HTTP root import path.
- Added guarded immediate `AsyncLocalStorage` probing and lazy request-context store resolution with the existing stack fallback preserved.
- Added regression coverage for throwing `process.getBuiltinModule(...)` probes and root-barrel import safety.
- Updated EN/KO `@fluojs/http` README request-context behavior text and added a patch changeset.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/http test -- src/context/request-context.test.ts` (Vitest ran the package suite: 15 files / 204 tests passed)
- `pnpm --filter @fluojs/core --filter @fluojs/di --filter @fluojs/validation build && pnpm --filter @fluojs/http typecheck && pnpm --filter @fluojs/http build`
- `pnpm exec biome check packages/http/src/context/request-context.ts packages/http/src/context/request-context-node-store.ts packages/http/src/context/request-context.test.ts packages/http/README.md packages/http/README.ko.md .changeset/fuzzy-pans-guard.md`
- LSP diagnostics clean for changed TypeScript files after dependency build.
- `pnpm verify:release-readiness` was attempted; package/governance tests passed before the CLI sandbox step failed with `ERR_MODULE_NOT_FOUND` for sandbox-installed `@fluojs/validation/dist/decorators.js`. This appears outside the #2063 HTTP change path and is called out for follow-up.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/fuzzy-pans-guard.md` for `@fluojs/http`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

Added TSDoc for the new guarded resolver helper; no root public barrel API was added.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The fallback remains synchronous-only when no async-context primitive is available.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. EN/KO package README text was updated together; regression coverage lives in `packages/http/src/context/request-context.test.ts`.
