### PR TITLE
Resolve #2072: Fail fast for Socket.IO zero-gateway bootstrap

### DIFF
--- a/.changeset/fail-fast-socket-io-zero-gateway.md
+++ b/.changeset/fail-fast-socket-io-zero-gateway.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/socket.io": patch
+---
+
+Fail fast when unsupported realtime adapters bootstrap Socket.IO without discovered gateways, while preserving the Bun binding installation path before listen.

--- a/packages/socket.io/src/adapter.ts
+++ b/packages/socket.io/src/adapter.ts
@@ -607,7 +607,9 @@ export class SocketIoLifecycleService
   }
 
   private async ensureBunRealtimeBindingForRawServerAccess(): Promise<void> {
-    if (!hasBunRealtimeBindingHost(this.adapter)) {
+    const runtime = resolveSocketIoBootstrapRuntime(this.adapter);
+
+    if (runtime.kind !== 'bun') {
       return;
     }
 

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -449,6 +449,20 @@ describe('@fluojs/socket.io', () => {
     ).rejects.toThrow('Socket.IO bootstrap requires a server-backed realtime capability');
   });
 
+  it('fails fast for unsupported adapters even when only the raw Socket.IO server is registered', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SocketIoModule.forRoot()],
+    });
+
+    await expect(
+      bootstrapApplication({
+        adapter: createNoopHttpApplicationAdapter(),
+        rootModule: AppModule,
+      }),
+    ).rejects.toThrow('Socket.IO bootstrap requires a server-backed realtime capability');
+  });
+
   it('rejects serverBacked gateway opt-in on the Bun Socket.IO engine path', async () => {
     const adapter = new TestBunSocketIoAdapter(0);
 


### PR DESCRIPTION
## Summary

Routes the Socket.IO zero-gateway/raw-server bootstrap path through the same runtime resolver used by gateway and raw server access, so unsupported/noop adapters fail fast instead of silently continuing.

Linked context: Closes #2072

## Changes

- Resolve the Socket.IO bootstrap runtime during zero-gateway raw-server bootstrap.
- Preserve the Bun path by still installing the lazy `@socket.io/bun-engine` binding before `listen()`.
- Add regression coverage for unsupported adapters with only `SocketIoModule.forRoot()` registered.
- Add a patch changeset for `@fluojs/socket.io`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/socket.io^... build`
- `pnpm --filter @fluojs/socket.io test -- src/module.test.ts`
- `pnpm --filter @fluojs/socket.io typecheck`
- `pnpm --filter @fluojs/socket.io build`
- Changed-file LSP diagnostics: no diagnostics found for `packages/socket.io/src/adapter.ts` and `packages/socket.io/src/module.test.ts` after dependency build.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were changed. Existing README/package-surface statements already document the supported runtime boundary and unsupported adapter fail-fast behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This preserves the documented Socket.IO runtime boundary: Node.js server-backed adapters and the official Bun engine path are supported; unsupported/noop adapters fail fast.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs changed. Package README and `docs/reference/package-surface.md` were checked and already match the enforced runtime boundary.