### PR TITLE
Resolve #2070: Remove CQRS saga async_hooks import

### DIFF
--- a/.changeset/cqrs-runtime-agnostic-saga-context.md
+++ b/.changeset/cqrs-runtime-agnostic-saga-context.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cqrs": patch
+---
+
+Remove the Node.js `node:async_hooks` root import from saga dispatch by threading an explicit runtime-agnostic CQRS dispatch context through nested command, query, event, and saga calls.

--- a/packages/cqrs/README.ko.md
+++ b/packages/cqrs/README.ko.md
@@ -85,7 +85,7 @@ Saga를 사용하면 이벤트를 구독하고 새로운 Command를 트리거하
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { Saga, ISaga, IEvent, ICommand, CommandBusLifecycleService } from '@fluojs/cqrs';
+import { Saga, ISaga, IEvent, ICommand, CqrsDispatchContext, CommandBusLifecycleService } from '@fluojs/cqrs';
 
 class UserCreatedEvent implements IEvent {
   constructor(public readonly userId: string) {}
@@ -100,13 +100,15 @@ class SendWelcomeEmailCommand implements ICommand {
 class UserSaga implements ISaga<UserCreatedEvent> {
   constructor(private readonly commandBus: CommandBusLifecycleService) {}
 
-  async handle(event: UserCreatedEvent): Promise<void> {
-    await this.commandBus.execute(new SendWelcomeEmailCommand(event.userId));
+  async handle(event: UserCreatedEvent, context?: CqrsDispatchContext): Promise<void> {
+    await this.commandBus.execute(new SendWelcomeEmailCommand(event.userId), context);
   }
 }
 ```
 
 Saga 실행은 같은 프로세스 안에서 동일 saga route로 순환 재진입하거나 중첩 hop 수가 32를 넘으면 `SagaTopologyError`로 즉시 실패합니다. 서로 다른 이벤트 단계를 순차 처리하는 multi-stage saga는 계속 허용되지만, in-process saga graph 전체는 비순환(acyclic) 구조를 유지해야 하며, 의도적인 순환/피드백 루프나 더 긴 체인은 외부 transport, scheduler, 또는 다른 bounded boundary 뒤로 이동해야 합니다.
+
+Saga, command handler, query handler, event handler 안에서 다시 CQRS `execute(...)`, `publish(...)`, `publishAll(...)`를 호출할 때는 optional `CqrsDispatchContext` 인자를 그대로 전달하세요. CQRS는 이 명시적인 runtime-agnostic context로 Node.js async-local API에 의존하지 않고 nested dispatch 전반의 saga topology check를 유지합니다.
 
 ### Event 발행 계약
 
@@ -150,6 +152,7 @@ class TokenInjectedService {
 ### 인터페이스
 - `ICommand`, `IQuery<T>`, `IEvent`: 메시지 마커 인터페이스입니다.
 - `ICommandHandler<C, R>`, `IQueryHandler<Q, R>`, `IEventHandler<E>`, `ISaga<E>`: 핸들러 계약입니다.
+- `CqrsDispatchContext`: handler와 saga에서 nested CQRS dispatch로 그대로 전달하는 opaque optional context 값입니다.
 
 ### 오류
 - `CommandHandlerNotFoundException`, `QueryHandlerNotFoundException`: bus에 일치하는 handler가 없을 때 발생합니다.

--- a/packages/cqrs/README.md
+++ b/packages/cqrs/README.md
@@ -85,7 +85,7 @@ Sagas allow you to listen for events and trigger new commands, enabling complex 
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { Saga, ISaga, IEvent, ICommand, CommandBusLifecycleService } from '@fluojs/cqrs';
+import { Saga, ISaga, IEvent, ICommand, CqrsDispatchContext, CommandBusLifecycleService } from '@fluojs/cqrs';
 
 class UserCreatedEvent implements IEvent {
   constructor(public readonly userId: string) {}
@@ -100,13 +100,15 @@ class SendWelcomeEmailCommand implements ICommand {
 class UserSaga implements ISaga<UserCreatedEvent> {
   constructor(private readonly commandBus: CommandBusLifecycleService) {}
 
-  async handle(event: UserCreatedEvent): Promise<void> {
-    await this.commandBus.execute(new SendWelcomeEmailCommand(event.userId));
+  async handle(event: UserCreatedEvent, context?: CqrsDispatchContext): Promise<void> {
+    await this.commandBus.execute(new SendWelcomeEmailCommand(event.userId), context);
   }
 }
 ```
 
 Saga execution fails fast with `SagaTopologyError` when an in-process publish chain re-enters the same saga route cyclically or exceeds 32 nested saga hops. Multi-stage sagas may still react to different event types in sequence, but in-process saga graphs must stay acyclic overall; move intentionally cyclic or long-running feedback loops behind an external transport, scheduler, or other bounded boundary.
+
+When a saga, command handler, query handler, or event handler performs another CQRS `execute(...)`, `publish(...)`, or `publishAll(...)` call, pass the optional `CqrsDispatchContext` argument through unchanged. CQRS uses this explicit runtime-agnostic context to keep saga topology checks intact across nested dispatch without relying on Node.js async-local APIs.
 
 ### Event Publishing Contracts
 
@@ -150,6 +152,7 @@ class TokenInjectedService {
 ### Interfaces
 - `ICommand`, `IQuery<T>`, `IEvent`: Marker interfaces for messages.
 - `ICommandHandler<C, R>`, `IQueryHandler<Q, R>`, `IEventHandler<E>`, `ISaga<E>`: Handler contracts.
+- `CqrsDispatchContext`: Opaque optional context value to pass through nested CQRS dispatch from handlers and sagas.
 
 ### Errors
 - `CommandHandlerNotFoundException`, `QueryHandlerNotFoundException`: Raised when a bus has no matching handler.

--- a/packages/cqrs/src/buses/command-bus.ts
+++ b/packages/cqrs/src/buses/command-bus.ts
@@ -1,14 +1,14 @@
 import { Inject, InvariantError } from '@fluojs/core';
 import type { OnApplicationBootstrap } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
-
+import { CqrsBusBase, createDuplicateHandlerMessage } from '../discovery.js';
 import { CommandHandlerNotFoundException, DuplicateCommandHandlerError } from '../errors.js';
 import { getCommandHandlerMetadata } from '../metadata.js';
-import { CqrsBusBase, createDuplicateHandlerMessage } from '../discovery.js';
 import type {
   CommandBus,
   CommandHandlerDescriptor,
   CommandType,
+  CqrsDispatchContext,
   ICommand,
   ICommandHandler,
 } from '../types.js';
@@ -41,12 +41,13 @@ export class CommandBusLifecycleService extends CqrsBusBase implements CommandBu
    * Executes one command by dispatching it to the discovered handler for its constructor.
    *
    * @param command Command instance to execute.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns The resolved handler result.
    *
    * @throws {CommandHandlerNotFoundException} When no handler is registered for the command type.
    * @throws {InvariantError} When the resolved provider does not implement `execute(command)`.
    */
-  async execute<TCommand extends ICommand, TResult = void>(command: TCommand): Promise<TResult> {
+  async execute<TCommand extends ICommand, TResult = void>(command: TCommand, context?: CqrsDispatchContext): Promise<TResult> {
     await this.ensureDiscovered();
 
     const commandType = command.constructor as CommandType<TCommand>;
@@ -62,7 +63,7 @@ export class CommandBusLifecycleService extends CqrsBusBase implements CommandBu
       throw new InvariantError(`Command handler ${descriptor.targetType.name} must implement execute(command).`);
     }
 
-    return await instance.execute(command) as TResult;
+    return await instance.execute(command, context) as TResult;
   }
 
   private async ensureDiscovered(): Promise<void> {

--- a/packages/cqrs/src/buses/event-bus.ts
+++ b/packages/cqrs/src/buses/event-bus.ts
@@ -1,15 +1,15 @@
 import { Inject, InvariantError } from '@fluojs/core';
-import { EVENT_BUS as FLUO_EVENT_BUS, type EventBus } from '@fluojs/event-bus';
-import type { OnApplicationShutdown, OnApplicationBootstrap } from '@fluojs/runtime';
+import { type EventBus, EVENT_BUS as FLUO_EVENT_BUS } from '@fluojs/event-bus';
+import type { OnApplicationBootstrap, OnApplicationShutdown } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 
 import { CqrsBusBase } from '../discovery.js';
 import { createIsolatedEvent } from '../event-clone.js';
 import { getEventHandlerMetadata } from '../metadata.js';
-import { CQRS_MODULE_OPTIONS } from '../tokens.js';
-import { createCqrsPlatformStatusSnapshot } from '../status.js';
 import type { CqrsModuleOptions } from '../module.js';
-import type { CqrsEventBus, CqrsEventType, EventHandlerDescriptor, IEvent, IEventHandler } from '../types.js';
+import { createCqrsPlatformStatusSnapshot } from '../status.js';
+import { CQRS_MODULE_OPTIONS } from '../tokens.js';
+import type { CqrsDispatchContext, CqrsEventBus, CqrsEventType, EventHandlerDescriptor, IEvent, IEventHandler } from '../types.js';
 import { CqrsSagaLifecycleService } from './saga-bus.js';
 
 const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 5000;
@@ -94,25 +94,27 @@ export class CqrsEventBusService extends CqrsBusBase implements CqrsEventBus, On
    * Publishes one event to matching CQRS handlers, sagas, and the shared event bus.
    *
    * @param event Event instance to publish.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns A promise that resolves once all local CQRS side effects and delegated publication complete.
    *
    * @throws {InvariantError} When a discovered provider does not implement `handle(event)`.
    */
-  async publish<TEvent extends IEvent>(event: TEvent): Promise<void> {
-    await this.trackPublishPipeline(this.runPublishPipeline(event));
+  async publish<TEvent extends IEvent>(event: TEvent, context?: CqrsDispatchContext): Promise<void> {
+    await this.trackPublishPipeline(this.runPublishPipeline(event, context));
   }
 
   /**
    * Publishes a batch of events sequentially through the CQRS event pipeline.
    *
    * @param events Event instances to publish in order.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns A promise that resolves once all events are published.
    */
-  async publishAll<TEvent extends IEvent>(events: readonly TEvent[]): Promise<void> {
-    await this.trackPublishPipeline(this.runPublishAllPipeline(events));
+  async publishAll<TEvent extends IEvent>(events: readonly TEvent[], context?: CqrsDispatchContext): Promise<void> {
+    await this.trackPublishPipeline(this.runPublishAllPipeline(events, context));
   }
 
-  private async runPublishPipeline<TEvent extends IEvent>(event: TEvent): Promise<void> {
+  private async runPublishPipeline<TEvent extends IEvent>(event: TEvent, context?: CqrsDispatchContext): Promise<void> {
     await this.ensureDiscovered();
 
     for (const descriptor of this.matchEventDescriptors(event)) {
@@ -122,16 +124,16 @@ export class CqrsEventBusService extends CqrsBusBase implements CqrsEventBus, On
         throw new InvariantError(`Event handler ${descriptor.targetType.name} must implement handle(event).`);
       }
 
-      await instance.handle(createIsolatedEvent(descriptor.eventType as CqrsEventType<TEvent>, event));
+      await instance.handle(createIsolatedEvent(descriptor.eventType as CqrsEventType<TEvent>, event), context);
     }
 
-    await this.sagaService.dispatch(event);
+    await this.sagaService.dispatch(event, context);
     await this.eventBus.publish(event);
   }
 
-  private async runPublishAllPipeline<TEvent extends IEvent>(events: readonly TEvent[]): Promise<void> {
+  private async runPublishAllPipeline<TEvent extends IEvent>(events: readonly TEvent[], context?: CqrsDispatchContext): Promise<void> {
     for (const event of events) {
-      await this.publish(event);
+      await this.publish(event, context);
     }
   }
 

--- a/packages/cqrs/src/buses/query-bus.ts
+++ b/packages/cqrs/src/buses/query-bus.ts
@@ -1,13 +1,13 @@
 import { Inject, InvariantError } from '@fluojs/core';
-import {
-  type OnApplicationBootstrap,
+import type {
+  OnApplicationBootstrap,
 } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
-
+import { CqrsBusBase, createDuplicateHandlerMessage } from '../discovery.js';
 import { DuplicateQueryHandlerError, QueryHandlerNotFoundException } from '../errors.js';
 import { getQueryHandlerMetadata } from '../metadata.js';
-import { CqrsBusBase, createDuplicateHandlerMessage } from '../discovery.js';
 import type {
+  CqrsDispatchContext,
   IQuery,
   IQueryHandler,
   QueryBus,
@@ -43,12 +43,13 @@ export class QueryBusLifecycleService extends CqrsBusBase implements QueryBus, O
    * Executes one query by dispatching it to the discovered handler for its constructor.
    *
    * @param query Query instance to execute.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns The resolved handler result.
    *
    * @throws {QueryHandlerNotFoundException} When no handler is registered for the query type.
    * @throws {InvariantError} When the resolved provider does not implement `execute(query)`.
    */
-  async execute<TQuery extends IQuery<TResult>, TResult = unknown>(query: TQuery): Promise<TResult> {
+  async execute<TQuery extends IQuery<TResult>, TResult = unknown>(query: TQuery, context?: CqrsDispatchContext): Promise<TResult> {
     await this.ensureDiscovered();
 
     const queryType = query.constructor as QueryType<TResult, TQuery>;
@@ -64,7 +65,7 @@ export class QueryBusLifecycleService extends CqrsBusBase implements QueryBus, O
       throw new InvariantError(`Query handler ${descriptor.targetType.name} must implement execute(query).`);
     }
 
-    return await instance.execute(query) as TResult;
+    return await instance.execute(query, context) as TResult;
   }
 
   private async ensureDiscovered(): Promise<void> {

--- a/packages/cqrs/src/buses/saga-bus.ts
+++ b/packages/cqrs/src/buses/saga-bus.ts
@@ -1,6 +1,4 @@
-import { AsyncLocalStorage } from 'node:async_hooks';
-
-import { Inject, InvariantError, FluoError, type Token } from '@fluojs/core';
+import { FluoError, Inject, InvariantError, type Token } from '@fluojs/core';
 import type { OnApplicationBootstrap, OnApplicationShutdown } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 
@@ -8,18 +6,12 @@ import { CqrsBusBase } from '../discovery.js';
 import { SagaExecutionError, SagaTopologyError } from '../errors.js';
 import { createIsolatedEvent } from '../event-clone.js';
 import { getSagaMetadata } from '../metadata.js';
-import { CQRS_MODULE_OPTIONS } from '../tokens.js';
 import type { CqrsModuleOptions } from '../module.js';
-import type { CqrsEventType, IEvent, ISaga, SagaDescriptor } from '../types.js';
+import { CQRS_MODULE_OPTIONS } from '../tokens.js';
+import type { CqrsDispatchContext, CqrsEventType, IEvent, ISaga, SagaDescriptor } from '../types.js';
 
 const MAX_NESTED_SAGA_DEPTH = 32;
 const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 5000;
-
-interface SagaDispatchContext {
-  activeRoutes: Array<{ eventType: CqrsEventType; token: Token }>;
-  depth: number;
-  path: string[];
-}
 
 function isSaga(value: unknown): value is ISaga<IEvent> {
   if (typeof value !== 'object' || value === null) {
@@ -51,7 +43,6 @@ export class CqrsSagaLifecycleService extends CqrsBusBase implements OnApplicati
   private readonly executionChains = new Map<Token, Promise<void>>();
   private lifecycleState: 'created' | 'discovering' | 'ready' | 'stopping' | 'stopped' | 'failed' = 'created';
   private readonly pendingDispatches = new Set<Promise<void>>();
-  private readonly dispatchContext = new AsyncLocalStorage<SagaDispatchContext>();
   private shutdownDrainTimeouts = 0;
 
   constructor(
@@ -115,7 +106,7 @@ export class CqrsSagaLifecycleService extends CqrsBusBase implements OnApplicati
    * @param event Event instance that may trigger one or more sagas.
    * @returns A promise that resolves once all matching saga chains for the event complete.
    */
-  async dispatch<TEvent extends IEvent>(event: TEvent): Promise<void> {
+  async dispatch<TEvent extends IEvent>(event: TEvent, context?: CqrsDispatchContext): Promise<void> {
     await this.ensureDiscovered();
 
     const descriptors = this.matchSagaDescriptors(event);
@@ -124,7 +115,7 @@ export class CqrsSagaLifecycleService extends CqrsBusBase implements OnApplicati
       return;
     }
 
-    await Promise.all(descriptors.map((descriptor) => this.dispatchWithOrdering(descriptor, event)));
+    await Promise.all(descriptors.map((descriptor) => this.dispatchWithOrdering(descriptor, event, context)));
   }
 
   private matchSagaDescriptors(event: IEvent): SagaDescriptor[] {
@@ -139,9 +130,7 @@ export class CqrsSagaLifecycleService extends CqrsBusBase implements OnApplicati
     return descriptors;
   }
 
-  private async dispatchWithOrdering<TEvent extends IEvent>(descriptor: SagaDescriptor, event: TEvent): Promise<void> {
-    const activeContext = this.dispatchContext.getStore();
-
+  private async dispatchWithOrdering<TEvent extends IEvent>(descriptor: SagaDescriptor, event: TEvent, activeContext?: CqrsDispatchContext): Promise<void> {
     const routeLabel = `${descriptor.targetType.name}(${descriptor.eventType.name})`;
     const isActiveRoute = activeContext?.activeRoutes.some(
       (route) => route.token === descriptor.token && route.eventType === descriptor.eventType,
@@ -163,17 +152,13 @@ export class CqrsSagaLifecycleService extends CqrsBusBase implements OnApplicati
     }
 
     if (isActiveToken) {
-      await this.runInDispatchContext(activeContext, descriptor, routeLabel, async () => {
-        await this.invokeSaga(descriptor, event);
-      });
+      await this.invokeSaga(descriptor, event, this.createDispatchContext(activeContext, descriptor, routeLabel));
       return;
     }
 
     const previous = this.executionChains.get(descriptor.token) ?? Promise.resolve();
     const current = previous.then(async () => {
-      await this.runInDispatchContext(activeContext, descriptor, routeLabel, async () => {
-        await this.invokeSaga(descriptor, event);
-      });
+      await this.invokeSaga(descriptor, event, this.createDispatchContext(activeContext, descriptor, routeLabel));
     });
 
     this.executionChains.set(descriptor.token, current.catch(() => undefined));
@@ -232,22 +217,19 @@ export class CqrsSagaLifecycleService extends CqrsBusBase implements OnApplicati
     return Math.floor(timeoutMs);
   }
 
-  private async runInDispatchContext(
-    activeContext: SagaDispatchContext | undefined,
+  private createDispatchContext(
+    activeContext: CqrsDispatchContext | undefined,
     descriptor: SagaDescriptor,
     routeLabel: string,
-    callback: () => Promise<void>,
-  ): Promise<void> {
-    const nextContext: SagaDispatchContext = {
+  ): CqrsDispatchContext {
+    return {
       activeRoutes: [...(activeContext?.activeRoutes ?? []), { eventType: descriptor.eventType, token: descriptor.token }],
       depth: (activeContext?.depth ?? 0) + 1,
       path: [...(activeContext?.path ?? []), routeLabel],
     };
-
-    await this.dispatchContext.run(nextContext, callback);
   }
 
-  private async invokeSaga<TEvent extends IEvent>(descriptor: SagaDescriptor, event: TEvent): Promise<void> {
+  private async invokeSaga<TEvent extends IEvent>(descriptor: SagaDescriptor, event: TEvent, context: CqrsDispatchContext): Promise<void> {
     const instance = await this.resolveHandlerInstance(descriptor.token);
 
     if (!isSaga(instance)) {
@@ -255,7 +237,7 @@ export class CqrsSagaLifecycleService extends CqrsBusBase implements OnApplicati
     }
 
     try {
-      await instance.handle(createIsolatedEvent(descriptor.eventType as CqrsEventType<TEvent>, event));
+      await instance.handle(createIsolatedEvent(descriptor.eventType as CqrsEventType<TEvent>, event), context);
     } catch (error) {
       if (error instanceof FluoError) {
         throw error;

--- a/packages/cqrs/src/index.ts
+++ b/packages/cqrs/src/index.ts
@@ -1,9 +1,12 @@
+export { CommandBusLifecycleService } from './buses/command-bus.js';
+export { CqrsEventBusService } from './buses/event-bus.js';
+export { QueryBusLifecycleService } from './buses/query-bus.js';
 export { CommandHandler, EventHandler, QueryHandler, Saga } from './decorators.js';
 export {
+  CommandHandlerNotFoundException,
   DuplicateCommandHandlerError,
   DuplicateEventHandlerError,
   DuplicateQueryHandlerError,
-  CommandHandlerNotFoundException,
   QueryHandlerNotFoundException,
   SagaExecutionError,
   SagaTopologyError,
@@ -13,22 +16,19 @@ export {
   defineCommandHandlerMetadata,
   defineEventHandlerMetadata,
   defineQueryHandlerMetadata,
+  defineSagaMetadata,
   eventHandlerMetadataSymbol,
   getCommandHandlerMetadata,
   getCommandHandlerMetadataEntry,
   getEventHandlerMetadata,
   getQueryHandlerMetadata,
   getQueryHandlerMetadataEntry,
-  queryHandlerMetadataSymbol,
-  defineSagaMetadata,
   getSagaMetadata,
+  queryHandlerMetadataSymbol,
   sagaMetadataSymbol,
 } from './metadata.js';
 export { CqrsModule, type CqrsModuleOptions } from './module.js';
 export * from './status.js';
-export { CommandBusLifecycleService } from './buses/command-bus.js';
-export { CqrsEventBusService } from './buses/event-bus.js';
-export { QueryBusLifecycleService } from './buses/query-bus.js';
 export { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 export type {
   CommandBus,
@@ -36,10 +36,11 @@ export type {
   CommandHandlerDescriptor,
   CommandHandlerMetadata,
   CommandType,
+  CqrsDispatchContext,
   CqrsEventBus,
   CqrsEventType,
-  EventHandlerDescriptor,
   EventHandlerClass,
+  EventHandlerDescriptor,
   EventHandlerMetadata,
   ICommand,
   ICommandHandler,

--- a/packages/cqrs/src/module.test.ts
+++ b/packages/cqrs/src/module.test.ts
@@ -1,12 +1,13 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { Inject } from '@fluojs/core';
 import { Container } from '@fluojs/di';
-import { OnEvent, type EventBusTransport } from '@fluojs/event-bus';
-import { bootstrapApplication, defineModule, type ApplicationLogger } from '@fluojs/runtime';
-
-import { CommandHandler, EventHandler, QueryHandler, Saga } from './decorators.js';
+import { type EventBusTransport, OnEvent } from '@fluojs/event-bus';
+import { type ApplicationLogger, bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it, vi } from 'vitest';
 import { CommandBusLifecycleService } from './buses/command-bus.js';
+import { CqrsEventBusService } from './buses/event-bus.js';
+import { QueryBusLifecycleService } from './buses/query-bus.js';
+import { CqrsSagaLifecycleService } from './buses/saga-bus.js';
+import { CommandHandler, EventHandler, QueryHandler, Saga } from './decorators.js';
 import {
   CommandHandlerNotFoundException,
   DuplicateCommandHandlerError,
@@ -15,14 +16,12 @@ import {
   SagaExecutionError,
   SagaTopologyError,
 } from './errors.js';
-import { CqrsEventBusService } from './buses/event-bus.js';
 import { getCommandHandlerMetadata, getEventHandlerMetadata, getQueryHandlerMetadata, getSagaMetadata } from './metadata.js';
 import { CqrsModule } from './module.js';
-import { QueryBusLifecycleService } from './buses/query-bus.js';
-import { CqrsSagaLifecycleService } from './buses/saga-bus.js';
 import { COMMAND_BUS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 import type {
   CommandBus,
+  CqrsDispatchContext,
   CqrsEventBus,
   ICommand,
   ICommandHandler,
@@ -406,9 +405,9 @@ describe('@fluojs/cqrs', () => {
         private readonly store: ProcessStore,
       ) {}
 
-      async execute(command: StartPaymentCommand): Promise<void> {
+      async execute(command: StartPaymentCommand, context?: CqrsDispatchContext): Promise<void> {
         this.store.commandLog.push(`start-payment:${command.orderId}`);
-        await this.eventBus.publish(new PaymentAuthorizedEvent(command.orderId));
+        await this.eventBus.publish(new PaymentAuthorizedEvent(command.orderId), context);
       }
     }
 
@@ -420,9 +419,9 @@ describe('@fluojs/cqrs', () => {
         private readonly store: ProcessStore,
       ) {}
 
-      async execute(command: ReserveInventoryCommand): Promise<void> {
+      async execute(command: ReserveInventoryCommand, context?: CqrsDispatchContext): Promise<void> {
         this.store.commandLog.push(`reserve-inventory:${command.orderId}`);
-        await this.eventBus.publish(new InventoryReservedEvent(command.orderId));
+        await this.eventBus.publish(new InventoryReservedEvent(command.orderId), context);
       }
     }
 
@@ -444,22 +443,22 @@ describe('@fluojs/cqrs', () => {
         private readonly store: ProcessStore,
       ) {}
 
-      async handle(event: IEvent): Promise<void> {
+      async handle(event: IEvent, context?: CqrsDispatchContext): Promise<void> {
         if (event instanceof OrderSubmittedEvent) {
           this.store.sagaLog.push(`submitted:${event.orderId}`);
-          await this.commandBus.execute(new StartPaymentCommand(event.orderId));
+          await this.commandBus.execute(new StartPaymentCommand(event.orderId), context);
           return;
         }
 
         if (event instanceof PaymentAuthorizedEvent) {
           this.store.sagaLog.push(`payment-authorized:${event.orderId}`);
-          await this.commandBus.execute(new ReserveInventoryCommand(event.orderId));
+          await this.commandBus.execute(new ReserveInventoryCommand(event.orderId), context);
           return;
         }
 
         if (event instanceof InventoryReservedEvent) {
           this.store.sagaLog.push(`inventory-reserved:${event.orderId}`);
-          await this.commandBus.execute(new CompleteOrderCommand(event.orderId));
+          await this.commandBus.execute(new CompleteOrderCommand(event.orderId), context);
         }
       }
     }
@@ -567,8 +566,8 @@ describe('@fluojs/cqrs', () => {
     class SelfTriggeringSaga implements ISaga<LoopEvent> {
       constructor(private readonly eventBus: CqrsEventBus) {}
 
-      async handle(event: LoopEvent): Promise<void> {
-        await this.eventBus.publish(new LoopEvent(event.loopId));
+      async handle(event: LoopEvent, context?: CqrsDispatchContext): Promise<void> {
+        await this.eventBus.publish(new LoopEvent(event.loopId), context);
       }
     }
 
@@ -601,8 +600,8 @@ describe('@fluojs/cqrs', () => {
     class StepOneSaga implements ISaga<StepOneEvent> {
       constructor(private readonly eventBus: CqrsEventBus) {}
 
-      async handle(event: StepOneEvent): Promise<void> {
-        await this.eventBus.publish(new StepTwoEvent(event.workflowId));
+      async handle(event: StepOneEvent, context?: CqrsDispatchContext): Promise<void> {
+        await this.eventBus.publish(new StepTwoEvent(event.workflowId), context);
       }
     }
 
@@ -611,8 +610,8 @@ describe('@fluojs/cqrs', () => {
     class StepTwoSaga implements ISaga<StepTwoEvent> {
       constructor(private readonly eventBus: CqrsEventBus) {}
 
-      async handle(event: StepTwoEvent): Promise<void> {
-        await this.eventBus.publish(new StepOneEvent(event.workflowId));
+      async handle(event: StepTwoEvent, context?: CqrsDispatchContext): Promise<void> {
+        await this.eventBus.publish(new StepOneEvent(event.workflowId), context);
       }
     }
 
@@ -652,9 +651,9 @@ describe('@fluojs/cqrs', () => {
       class DepthSaga implements ISaga<TEvent> {
         constructor(private readonly eventBus: CqrsEventBus) {}
 
-        async handle(): Promise<void> {
+        async handle(_event: TEvent, context?: CqrsDispatchContext): Promise<void> {
           if (NextEventType) {
-            await this.eventBus.publish(new NextEventType());
+            await this.eventBus.publish(new NextEventType(), context);
           }
         }
       }

--- a/packages/cqrs/src/module.ts
+++ b/packages/cqrs/src/module.ts
@@ -9,6 +9,7 @@ import { CqrsSagaLifecycleService } from './buses/saga-bus.js';
 import { COMMAND_BUS, CQRS_MODULE_OPTIONS, EVENT_BUS, QUERY_BUS } from './tokens.js';
 import type {
   CommandHandlerClass,
+  CqrsDispatchContext,
   EventHandlerClass,
   ICommand,
   IEvent,
@@ -54,6 +55,24 @@ function collectOptionHandlerProviders(options: CqrsModuleOptions): Provider[] {
   return providers;
 }
 
+function assertCommandBusService(service: unknown): asserts service is CommandBusLifecycleService {
+  if (!(service instanceof CommandBusLifecycleService)) {
+    throw new TypeError('CQRS command bus alias expected CommandBusLifecycleService.');
+  }
+}
+
+function assertQueryBusService(service: unknown): asserts service is QueryBusLifecycleService {
+  if (!(service instanceof QueryBusLifecycleService)) {
+    throw new TypeError('CQRS query bus alias expected QueryBusLifecycleService.');
+  }
+}
+
+function assertCqrsEventBusService(service: unknown): asserts service is CqrsEventBusService {
+  if (!(service instanceof CqrsEventBusService)) {
+    throw new TypeError('CQRS event bus alias expected CqrsEventBusService.');
+  }
+}
+
 /**
  * Creates the providers required for CQRS buses, compatibility aliases, and optional handler registration.
  *
@@ -70,27 +89,39 @@ export function createCqrsProviders(options: CqrsModuleOptions = {}): Provider[]
     {
       inject: [CommandBusLifecycleService],
       provide: COMMAND_BUS,
-      useFactory: (service: unknown) => ({
-        execute: (command: ICommand) => (service as CommandBusLifecycleService).execute(command),
-      }),
+      useFactory: (service: unknown) => {
+        assertCommandBusService(service);
+
+        return {
+          execute: (command: ICommand, context?: CqrsDispatchContext) => service.execute(command, context),
+        };
+      },
     },
     QueryBusLifecycleService,
     {
       inject: [QueryBusLifecycleService],
       provide: QUERY_BUS,
-      useFactory: (service: unknown) => ({
-        execute: (query: IQuery<unknown>) => (service as QueryBusLifecycleService).execute(query),
-      }),
+      useFactory: (service: unknown) => {
+        assertQueryBusService(service);
+
+        return {
+          execute: (query: IQuery<unknown>, context?: CqrsDispatchContext) => service.execute(query, context),
+        };
+      },
     },
     CqrsSagaLifecycleService,
     CqrsEventBusService,
     {
       inject: [CqrsEventBusService],
       provide: EVENT_BUS,
-      useFactory: (service: unknown) => ({
-        publish: (event: IEvent) => (service as CqrsEventBusService).publish(event),
-        publishAll: (events: readonly IEvent[]) => (service as CqrsEventBusService).publishAll(events),
-      }),
+      useFactory: (service: unknown) => {
+        assertCqrsEventBusService(service);
+
+        return {
+          publish: (event: IEvent, context?: CqrsDispatchContext) => service.publish(event, context),
+          publishAll: (events: readonly IEvent[], context?: CqrsDispatchContext) => service.publishAll(events, context),
+        };
+      },
     },
     ...collectOptionHandlerProviders(options),
   ];

--- a/packages/cqrs/src/types.ts
+++ b/packages/cqrs/src/types.ts
@@ -17,9 +17,10 @@ export interface ICommandHandler<TCommand extends ICommand, TResult = void> {
    * Executes one command instance.
    *
    * @param command Command payload to handle.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns The handler result returned to the command bus caller.
    */
-  execute(command: TCommand): TResult | Promise<TResult>;
+  execute(command: TCommand, context?: CqrsDispatchContext): TResult | Promise<TResult>;
 }
 
 /** Contract implemented by classes decorated with {@link QueryHandler}. */
@@ -28,9 +29,10 @@ export interface IQueryHandler<TQuery extends IQuery<TResult>, TResult = unknown
    * Executes one query instance.
    *
    * @param query Query payload to handle.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns The query result returned to the caller.
    */
-  execute(query: TQuery): TResult | Promise<TResult>;
+  execute(query: TQuery, context?: CqrsDispatchContext): TResult | Promise<TResult>;
 }
 
 /** Contract implemented by classes decorated with {@link EventHandler}. */
@@ -39,9 +41,10 @@ export interface IEventHandler<TEvent extends IEvent> {
    * Reacts to one isolated copy of a published event instance.
    *
    * @param event Event payload cloned for this handler before delegated event-bus publication.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns A promise or void once side effects complete.
    */
-  handle(event: TEvent): void | Promise<void>;
+  handle(event: TEvent, context?: CqrsDispatchContext): void | Promise<void>;
 }
 
 /** Contract implemented by classes decorated with {@link Saga}. */
@@ -50,9 +53,25 @@ export interface ISaga<TEvent extends IEvent = IEvent> {
    * Reacts to one isolated copy of an event and typically emits follow-up commands.
    *
    * @param event Event payload cloned for this saga route before delegated event-bus publication.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns A promise or void once orchestration side effects complete.
    */
-  handle(event: TEvent): void | Promise<void>;
+  handle(event: TEvent, context?: CqrsDispatchContext): void | Promise<void>;
+}
+
+/**
+ * Opaque dispatch context used to preserve saga topology guards across nested CQRS calls.
+ *
+ * Pass this value unchanged from handlers and sagas into nested `execute(...)`, `publish(...)`,
+ * or `publishAll(...)` calls. Application code should not inspect or construct it directly.
+ */
+export interface CqrsDispatchContext {
+  /** Saga routes currently active in the in-process CQRS dispatch chain. */
+  readonly activeRoutes: readonly Readonly<{ eventType: CqrsEventType; token: Token }>[];
+  /** Current nested saga depth for in-process topology guarding. */
+  readonly depth: number;
+  /** Human-readable saga route labels used when reporting topology failures. */
+  readonly path: readonly string[];
 }
 
 /** Constructor type used to identify a command message class. */
@@ -150,7 +169,7 @@ export interface CommandBus {
    * @param command Command instance to dispatch.
    * @returns The handler result.
    */
-  execute<TCommand extends ICommand, TResult = void>(command: TCommand): Promise<TResult>;
+  execute<TCommand extends ICommand, TResult = void>(command: TCommand, context?: CqrsDispatchContext): Promise<TResult>;
 }
 
 /** Query dispatch facade exposed by the CQRS module. */
@@ -161,7 +180,7 @@ export interface QueryBus {
    * @param query Query instance to dispatch.
    * @returns The handler result.
    */
-  execute<TQuery extends IQuery<TResult>, TResult = unknown>(query: TQuery): Promise<TResult>;
+  execute<TQuery extends IQuery<TResult>, TResult = unknown>(query: TQuery, context?: CqrsDispatchContext): Promise<TResult>;
 }
 
 /** Event publishing facade exposed by the CQRS module. */
@@ -173,14 +192,16 @@ export interface CqrsEventBus {
    * subscribers receive the original event after local CQRS side effects complete.
    *
    * @param event Event instance to publish.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns A promise that resolves once publication completes.
    */
-  publish<TEvent extends IEvent>(event: TEvent): Promise<void>;
+  publish<TEvent extends IEvent>(event: TEvent, context?: CqrsDispatchContext): Promise<void>;
   /**
    * Publishes a batch of events in order.
    *
    * @param events Event instances to publish.
+   * @param context Optional saga dispatch context to pass through nested CQRS calls.
    * @returns A promise that resolves once all events are published.
    */
-  publishAll<TEvent extends IEvent>(events: readonly TEvent[]): Promise<void>;
+  publishAll<TEvent extends IEvent>(events: readonly TEvent[], context?: CqrsDispatchContext): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Remove the Node.js `node:async_hooks` root import from `@fluojs/cqrs` saga dispatch and replace it with an explicit runtime-agnostic `CqrsDispatchContext` that can be passed through nested CQRS calls.

Linked context: Closes #2070

## Changes

- Removed `AsyncLocalStorage` usage from `CqrsSagaLifecycleService`.
- Added optional `CqrsDispatchContext` propagation through command, query, event, and saga contracts plus compatibility token factories.
- Updated saga topology regression coverage to pass context through nested command/publish chains.
- Documented the explicit nested dispatch context in EN/KO CQRS README files.
- Added a patch changeset for `@fluojs/cqrs`.

## Testing

- `lsp_diagnostics packages/cqrs/src`: pass, 0 errors
- `pnpm --filter @fluojs/cqrs test`: pass, 42 tests
- `pnpm --filter @fluojs/cqrs typecheck`: pass
- `pnpm --filter @fluojs/cqrs build`: pass
- `pnpm exec biome check ...changed files...`: pass
- `pnpm changeset status --since=origin/main`: pass, `@fluojs/cqrs` patch

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/cqrs-runtime-agnostic-saga-context.md`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

`CqrsDispatchContext` is documented in source TSDoc and package README usage guidance.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Saga cycle/depth topology guards remain covered by `packages/cqrs/src/module.test.ts`, now using explicit context propagation through nested dispatch calls.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or conformance claims changed. EN/KO package README updates were kept aligned. Root import portability is verified by source removal and CQRS package test/typecheck/build gates.