### PR TITLE
Resolve #2064: Keep runtime HTTP adapter logger seam neutral

### DIFF
--- a/.changeset/runtime-http-adapter-neutral-logger.md
+++ b/.changeset/runtime-http-adapter-neutral-logger.md
@@ -1,0 +1,9 @@
+---
+"@fluojs/runtime": patch
+"@fluojs/platform-bun": patch
+"@fluojs/platform-deno": patch
+"@fluojs/platform-fastify": patch
+"@fluojs/platform-express": patch
+---
+
+Keep the runtime internal HTTP adapter seam free of Node-specific console logger globals, and route platform defaults through either the transport-neutral logger or the explicit Node runtime subpath.

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -464,7 +464,7 @@ describe('@fluojs/platform-bun', () => {
     expect(source).not.toContain("from '@fluojs/runtime/node'");
   });
 
-  it('uses the console application logger by default for terminal Bun startup helpers', async () => {
+  it('uses the transport-neutral application logger by default for terminal Bun startup helpers', async () => {
     installMockBun();
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
@@ -479,9 +479,11 @@ describe('@fluojs/platform-bun', () => {
 
     try {
       expect(log).toHaveBeenCalledWith(
+        '[fluo] LOG [FluoFactory] Listening on http://127.0.0.1:0',
+      );
+      expect(log).not.toHaveBeenCalledWith(
         expect.stringContaining(`[fluo] ${String(process.pid)} -`),
       );
-      expect(log).not.toHaveBeenCalledWith('[fluo] LOG [FluoFactory] Listening on http://127.0.0.1:0');
     } finally {
       await app.close();
     }

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -22,7 +22,7 @@ import type {
 } from '@fluojs/runtime';
 import {
   bootstrapHttpAdapterApplication,
-  createConsoleApplicationLogger,
+  createDefaultApplicationLogger,
   type HttpAdapterListenTarget,
   type RunHttpAdapterApplicationOptions,
   runHttpAdapterApplication,
@@ -483,7 +483,7 @@ export async function bootstrapBunApplication(
   rootModule: ModuleType,
   options: BootstrapBunApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = createDefaultApplicationLogger();
 
   return bootstrapHttpAdapterApplication(
     rootModule,
@@ -514,7 +514,7 @@ export async function runBunApplication(
   rootModule: ModuleType,
   options: RunBunApplicationOptions,
 ): Promise<Application> {
-  const logger = createConsoleApplicationLogger();
+  const logger = createDefaultApplicationLogger();
   const adapter = createBunAdapter({
     development: options.development,
     hostname: options.hostname,

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -347,7 +347,7 @@ describe('@fluojs/platform-deno', () => {
     expect(() => createDenoAdapter({ port: 1.5 })).toThrow(/port/i);
   });
 
-  it('uses the console application logger by default for terminal Deno startup helpers', async () => {
+  it('uses the transport-neutral application logger by default for terminal Deno startup helpers', async () => {
     const server = createServeStub();
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
@@ -361,9 +361,11 @@ describe('@fluojs/platform-deno', () => {
 
     try {
       expect(log).toHaveBeenCalledWith(
+        '[fluo] LOG [FluoFactory] Listening on http://localhost:3000 (bound to 0.0.0.0:3000)',
+      );
+      expect(log).not.toHaveBeenCalledWith(
         expect.stringContaining(`[fluo] ${String(process.pid)} -`),
       );
-      expect(log).not.toHaveBeenCalledWith('[fluo] LOG [FluoFactory] Listening on http://localhost:3000 (bound to 0.0.0.0:3000)');
     } finally {
       await app.close();
     }

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -3,7 +3,7 @@ import type { Application, ApplicationLogger, ModuleType, MultipartOptions } fro
 import {
   type BootstrapHttpAdapterApplicationOptions,
   bootstrapHttpAdapterApplication,
-  createConsoleApplicationLogger,
+  createDefaultApplicationLogger,
   type HttpAdapterListenTarget,
   type RunHttpAdapterApplicationOptions,
   runHttpAdapterApplication,
@@ -333,7 +333,7 @@ export async function bootstrapDenoApplication(
   rootModule: ModuleType,
   options: BootstrapDenoApplicationOptions = {},
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = options.logger ?? createDefaultApplicationLogger();
 
   return await bootstrapHttpAdapterApplication(rootModule, options, createDenoAdapter(options), logger);
 }
@@ -349,7 +349,7 @@ export async function runDenoApplication(
   rootModule: ModuleType,
   options: RunDenoApplicationOptions = {},
 ): Promise<Application> {
-  const logger = options.logger ?? createConsoleApplicationLogger();
+  const logger = options.logger ?? createDefaultApplicationLogger();
   const adapter = createDenoAdapter(options);
   return await runHttpAdapterApplication(rootModule, {
     ...options,

--- a/packages/platform-express/src/adapter.ts
+++ b/packages/platform-express/src/adapter.ts
@@ -42,7 +42,6 @@ import type {
 } from '@fluojs/runtime';
 import {
   bootstrapHttpAdapterApplication,
-  createConsoleApplicationLogger,
   runHttpAdapterApplication,
 } from '@fluojs/runtime/internal/http-adapter';
 import {
@@ -62,6 +61,7 @@ import {
   splitRawRequestUrl,
 } from '@fluojs/runtime/internal-node';
 import {
+  createConsoleApplicationLogger,
   createNodeShutdownSignalRegistration,
   defaultNodeShutdownSignals,
 } from '@fluojs/runtime/node';

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -36,7 +36,6 @@ import type {
 } from '@fluojs/runtime';
 import {
   bootstrapHttpAdapterApplication,
-  createConsoleApplicationLogger,
   runHttpAdapterApplication,
 } from '@fluojs/runtime/internal/http-adapter';
 import {
@@ -53,6 +52,7 @@ import {
   splitRawRequestUrl,
 } from '@fluojs/runtime/internal-node';
 import {
+  createConsoleApplicationLogger,
   createNodeShutdownSignalRegistration,
   defaultNodeShutdownSignals,
 } from '@fluojs/runtime/node';

--- a/packages/runtime/src/adapters/internal-http-adapter.ts
+++ b/packages/runtime/src/adapters/internal-http-adapter.ts
@@ -1,5 +1,6 @@
 export {
   bootstrapHttpAdapterApplication,
+  createDefaultApplicationLogger,
   createHttpAdapterMiddleware,
   formatHttpAdapterListenMessage,
   runHttpAdapterApplication,
@@ -10,4 +11,3 @@ export {
   type HttpAdapterShutdownRegistration,
   type RunHttpAdapterApplicationOptions,
 } from '../http-adapter-shared.js';
-export { createConsoleApplicationLogger } from '../logging/logger.js';

--- a/packages/runtime/src/exports.test.ts
+++ b/packages/runtime/src/exports.test.ts
@@ -56,6 +56,8 @@ describe('runtime export boundaries', () => {
     expect(runtimeNode.createNodeShutdownSignalRegistration).toBeTypeOf('function');
     expect(runtimeNode.defaultNodeShutdownSignals).toBeTypeOf('function');
     expect(runtimeInternalHttpAdapter.bootstrapHttpAdapterApplication).toBeTypeOf('function');
+    expect(runtimeInternalHttpAdapter.createDefaultApplicationLogger).toBeTypeOf('function');
+    expect(runtimeInternalHttpAdapter).not.toHaveProperty('createConsoleApplicationLogger');
     expect(runtimeInternalHttpAdapter.runHttpAdapterApplication).toBeTypeOf('function');
     expect(runtimeInternalRequestResponseFactory.dispatchWithRequestResponseFactory).toBeTypeOf('function');
   });

--- a/packages/runtime/src/http-adapter-shared.ts
+++ b/packages/runtime/src/http-adapter-shared.ts
@@ -18,6 +18,8 @@ import { bootstrapApplication } from './bootstrap.js';
 import { createDefaultApplicationLogger } from './logging/default-logger.js';
 import type { Application, ApplicationLogger, CreateApplicationOptions, ModuleType } from './types.js';
 
+export { createDefaultApplicationLogger };
+
 /**
  * Input type for configuring CORS in an HTTP adapter.
  */


### PR DESCRIPTION
## Summary

Keep the internal HTTP adapter seam free of Node-specific console logger globals.

Linked context: Closes #2064

## Changes

- Replaces the internal HTTP adapter re-export of `createConsoleApplicationLogger` with the transport-neutral `createDefaultApplicationLogger`.
- Updates Bun and Deno startup helpers to default to the neutral logger through the internal seam.
- Keeps Fastify and Express on the Node console logger through the explicit `@fluojs/runtime/node` subpath.
- Adds regression coverage for the runtime export boundary and platform default logger behavior.
- Adds a patch changeset for affected public packages.

## Testing

- Changed-file LSP diagnostics: clean for modified source/test files.
- `pnpm --filter @fluojs/runtime exec vitest run -c vitest.config.ts src/exports.test.ts` ✅
- `pnpm --filter @fluojs/platform-bun exec vitest run -c vitest.config.ts src/adapter.test.ts` ✅
- `pnpm --filter @fluojs/platform-deno exec vitest run -c vitest.config.ts src/adapter.test.ts` ✅
- `pnpm --filter @fluojs/runtime... --filter @fluojs/platform-bun... --filter @fluojs/platform-deno... --filter @fluojs/platform-fastify... --filter @fluojs/platform-express... build` ✅
- `pnpm --filter @fluojs/runtime --filter @fluojs/platform-bun --filter @fluojs/platform-deno --filter @fluojs/platform-fastify --filter @fluojs/platform-express typecheck` ✅
- `pnpm verify:platform-consistency-governance` ✅
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` ✅
- `pnpm verify:release-readiness` attempted; package tests passed after the fix, but the check currently fails on the pre-existing "Starter shape and runtime ownership" assertion in `tooling/release/verify-release-readiness.mjs` for `packages/cli/src/new/scaffold.ts`, which this PR does not modify.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
