### PR TITLE
Resolve #2095: gate queue readiness on worker startup

### DIFF
--- a/.changeset/queue-worker-readiness-status.md
+++ b/.changeset/queue-worker-readiness-status.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/queue": patch
+---
+
+Fix queue readiness snapshots so workers are only reported ready after BullMQ processors start, and expose worker start failures through lifecycle/status diagnostics.

--- a/.changeset/queue-worker-readiness-status.md
+++ b/.changeset/queue-worker-readiness-status.md
@@ -1,7 +1,7 @@
 ---
-"@fluojs/queue": major
+"@fluojs/queue": patch
 ---
 
 Fix queue readiness snapshots so workers are only reported ready after BullMQ processors start, and expose worker start failures through lifecycle/status diagnostics.
 
-Migration note: consumers that exhaustively switch on `QueueLifecycleState` must handle the new `failed` state. Readiness integrations should also expect `started` queue resources to report degraded readiness until every discovered BullMQ worker processor has actually started.
+This is a readiness bug fix: status snapshots now distinguish worker startup failure from healthy startup and avoid reporting ready before BullMQ processors are actually running.

--- a/.changeset/queue-worker-readiness-status.md
+++ b/.changeset/queue-worker-readiness-status.md
@@ -1,5 +1,7 @@
 ---
-"@fluojs/queue": patch
+"@fluojs/queue": major
 ---
 
 Fix queue readiness snapshots so workers are only reported ready after BullMQ processors start, and expose worker start failures through lifecycle/status diagnostics.
+
+Migration note: consumers that exhaustively switch on `QueueLifecycleState` must handle the new `failed` state. Readiness integrations should also expect `started` queue resources to report degraded readiness until every discovered BullMQ worker processor has actually started.

--- a/packages/queue/README.ko.md
+++ b/packages/queue/README.ko.md
@@ -92,7 +92,7 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 ### 부트스트랩 및 종료 수명 주기
 
-Queue는 애플리케이션 부트스트랩 중 worker를 탐색하고 Queue가 소유하는 BullMQ 리소스를 만들지만, BullMQ worker processor는 runtime이 전체 애플리케이션 bootstrap/readiness sequence 완료를 표시한 뒤에만 시작합니다. 다른 `onApplicationBootstrap()` hook에서 enqueue한 job은 Queue 서비스가 초기화된 뒤에는 받을 수 있으며, processor는 뒤에 실행되는 async bootstrap hook이나 애플리케이션 readiness보다 앞서 실행되지 않고 bootstrap-ready handoff 이후 실행됩니다.
+Queue는 애플리케이션 부트스트랩 중 worker를 탐색하고 Queue가 소유하는 BullMQ 리소스를 만들지만, BullMQ worker processor는 runtime이 전체 애플리케이션 bootstrap/readiness sequence 완료를 표시한 뒤에만 시작합니다. 다른 `onApplicationBootstrap()` hook에서 enqueue한 job은 Queue 서비스가 초기화된 뒤에는 받을 수 있으며, processor는 뒤에 실행되는 async bootstrap hook이나 애플리케이션 readiness보다 앞서 실행되지 않고 bootstrap-ready handoff 이후 실행됩니다. Queue status는 해당 BullMQ processor가 실제로 시작될 때까지 degraded readiness를 보고합니다. Processor 시작에 실패하면 lifecycle이 `failed`로 이동하고, status snapshot은 worker를 ready로 숨기지 않고 실패를 노출합니다.
 
 애플리케이션 종료가 시작되면 Queue는 상태를 `stopping`으로 바꾸고 새 enqueue를 거부한 다음 Queue 소유 worker/queue/connection을 닫고 pending dead-letter write를 drain합니다. Worker 종료는 `workerShutdownTimeoutMs`로 bounded wait를 적용하므로 끝나지 않는 active processor가 애플리케이션 종료를 무기한 막을 수 없습니다. Timeout이 지나면 Queue는 로그를 남기고 BullMQ worker에 force-close를 요청한 뒤 나머지 리소스 정리를 계속합니다.
 
@@ -122,7 +122,7 @@ Job은 JSON으로 직렬화 가능한 plain object여야 합니다. Queue는 enq
 ### 핵심 구성 요소
 - `QueueModule`: 큐 기능을 위한 기본 모듈입니다.
 - `QueueModule.forRoot(options)`: 애플리케이션 수준 큐 등록을 구성합니다.
-- `QueueLifecycleService`: 작업을 큐에 추가(`enqueue(job)`)하기 위한 기본 서비스입니다.
+- `QueueLifecycleService`: 작업을 큐에 추가하고 lifecycle/status snapshot을 생성(`enqueue(job)`, `createPlatformStatusSnapshot()`)하기 위한 기본 서비스입니다.
 - `@QueueWorker(JobClass, options?)`: 특정 작업을 처리할 핸들러를 지정하는 데코레이터입니다.
 - `QUEUE`: queue facade를 위한 호환성 주입 토큰입니다.
 - `createQueuePlatformStatusSnapshot(...)`: lifecycle/readiness diagnostics를 위한 status snapshot helper입니다.
@@ -136,9 +136,9 @@ Job은 JSON으로 직렬화 가능한 plain object여야 합니다. Queue는 enq
 - `QueueBackoffType`: 지원되는 retry backoff strategy 이름(`fixed`, `exponential`)입니다.
 - `QueueBackoffOptions`: 재시도 백오프 설정(`type`, `delayMs`)을 위한 타입입니다.
 - `QueueRateLimiterOptions`: worker 수준 distributed rate limiter 설정(`max`, `duration`)을 위한 타입입니다.
-- `QueueLifecycleState`: Queue status adapter가 보고하는 lifecycle state(`idle`, `starting`, `started`, `stopping`, `stopped`)입니다.
-- `QueueStatusAdapterInput`: `createQueuePlatformStatusSnapshot(...)`에 전달하는 normalized queue metrics 타입입니다.
-- `QueuePlatformStatusSnapshot`: status helper가 반환하는 Queue 전용 readiness, health, ownership, detail snapshot 타입입니다.
+- `QueueLifecycleState`: Queue status adapter가 보고하는 lifecycle state(`idle`, `starting`, `started`, `stopping`, `stopped`, `failed`)입니다.
+- `QueueStatusAdapterInput`: `createQueuePlatformStatusSnapshot(...)`에 전달하는 normalized queue metrics와 worker-start diagnostics 타입입니다.
+- `QueuePlatformStatusSnapshot`: status helper와 `QueueLifecycleService.createPlatformStatusSnapshot()`이 반환하는 Queue 전용 readiness, health, ownership, detail snapshot 타입입니다.
 
 `QueueModuleOptions`에는 `workerShutdownTimeoutMs`, `defaultDeadLetterMaxEntries` 같은 lifecycle 및 dead-letter retention 설정도 포함됩니다.
 
@@ -148,7 +148,7 @@ Job은 JSON으로 직렬화 가능한 plain object여야 합니다. Queue는 enq
 - `workerShutdownTimeoutMs`: 종료 중 active worker processor를 기다리는 최대 시간입니다. 시간이 지나면 BullMQ worker를 force-close합니다. 기본값은 `30_000`입니다.
 - `defaultDeadLetterMaxEntries`: job별로 유지할 dead-letter record의 최대 개수이며, trimming을 끄려면 `false`를 지정합니다. 기본값은 `1_000`입니다.
 
-`createQueuePlatformStatusSnapshot(...)`은 Queue가 `started`에 도달한 뒤에만 readiness를 `ready`로 보고합니다. `starting`은 degraded readiness, `stopping`/`stopped`는 not-ready로 보고합니다. Snapshot details에는 Redis dependency id, lifecycle state, ready/discovered worker 수, pending dead-letter write 수, dead-letter drain timeout, `workerShutdownTimeoutMs`가 포함됩니다.
+`QueueLifecycleService.createPlatformStatusSnapshot()`은 `createQueuePlatformStatusSnapshot(...)`과 같은 공개 snapshot 계약을 사용합니다. Queue가 `started`에 도달하고 탐색된 모든 BullMQ worker processor가 시작된 뒤에만 readiness를 `ready`로 보고합니다. Processor가 아직 pending인 `started` resource와 `starting`은 degraded readiness, `stopping`/`stopped`는 not-ready, worker-start failure는 `workerStartFailures`와 `lastWorkerStartFailure` details를 포함해 not-ready/unhealthy로 보고합니다. Snapshot details에는 Redis dependency id, lifecycle state, ready/discovered worker 수, pending dead-letter write 수, dead-letter drain timeout, `workerShutdownTimeoutMs`가 포함됩니다.
 
 singleton `@QueueWorker()` provider/controller만 등록됩니다. request/transient worker는 discovery 중 건너뜁니다.
 

--- a/packages/queue/README.md
+++ b/packages/queue/README.md
@@ -92,7 +92,7 @@ QueueModule.forRoot({ clientName: 'jobs' })
 
 ### Bootstrap and Shutdown Lifecycle
 
-Queue discovers workers and creates queue-owned BullMQ resources during application bootstrap, but BullMQ worker processors are started only after the runtime marks the full application bootstrap/readiness sequence complete. Jobs enqueued by other `onApplicationBootstrap()` hooks can be accepted once the Queue service is initialized, and their processors run after the bootstrap-ready handoff instead of racing ahead of later async bootstrap hooks or application readiness.
+Queue discovers workers and creates queue-owned BullMQ resources during application bootstrap, but BullMQ worker processors are started only after the runtime marks the full application bootstrap/readiness sequence complete. Jobs enqueued by other `onApplicationBootstrap()` hooks can be accepted once the Queue service is initialized, and their processors run after the bootstrap-ready handoff instead of racing ahead of later async bootstrap hooks or application readiness. Queue status reports degraded readiness until those BullMQ processors have actually started; if a processor fails to start, the lifecycle moves to `failed` and status snapshots expose the failure instead of reporting the workers as ready.
 
 Application shutdown marks Queue as `stopping`, rejects new enqueue attempts, closes queue-owned workers/queues/connections, and drains pending dead-letter writes. Worker shutdown is bounded by `workerShutdownTimeoutMs` so an active processor that never settles cannot block application shutdown indefinitely. When the timeout elapses, Queue logs the timeout and asks BullMQ to force-close the worker before continuing resource cleanup.
 
@@ -122,7 +122,7 @@ Treat low-level provider assembly as an internal implementation detail: low-leve
 ### Core
 - `QueueModule`: Main entry point for queue registration.
 - `QueueModule.forRoot(options)`: Registers queue support for an application module.
-- `QueueLifecycleService`: Primary service for enqueuing jobs (`enqueue(job)`).
+- `QueueLifecycleService`: Primary service for enqueuing jobs and creating lifecycle/status snapshots (`enqueue(job)`, `createPlatformStatusSnapshot()`).
 - `@QueueWorker(JobClass, options?)`: Decorator to mark a class as a job handler.
 - `QUEUE`: Compatibility injection token for the queue facade.
 - `createQueuePlatformStatusSnapshot(...)`: Status snapshot helper for lifecycle/readiness diagnostics.
@@ -136,9 +136,9 @@ Treat low-level provider assembly as an internal implementation detail: low-leve
 - `QueueBackoffType`: Supported retry backoff strategy names (`fixed`, `exponential`).
 - `QueueBackoffOptions`: Retry backoff settings (`type`, `delayMs`).
 - `QueueRateLimiterOptions`: Worker-level distributed rate limiter settings (`max`, `duration`).
-- `QueueLifecycleState`: Lifecycle states reported by Queue status adapters (`idle`, `starting`, `started`, `stopping`, `stopped`).
-- `QueueStatusAdapterInput`: Normalized queue metrics passed to `createQueuePlatformStatusSnapshot(...)`.
-- `QueuePlatformStatusSnapshot`: Queue-specific readiness, health, ownership, and detail snapshot returned by the status helper.
+- `QueueLifecycleState`: Lifecycle states reported by Queue status adapters (`idle`, `starting`, `started`, `stopping`, `stopped`, `failed`).
+- `QueueStatusAdapterInput`: Normalized queue metrics and worker-start diagnostics passed to `createQueuePlatformStatusSnapshot(...)`.
+- `QueuePlatformStatusSnapshot`: Queue-specific readiness, health, ownership, and detail snapshot returned by the status helper and `QueueLifecycleService.createPlatformStatusSnapshot()`.
 
 `QueueModuleOptions` also includes lifecycle and dead-letter retention controls such as `workerShutdownTimeoutMs` and `defaultDeadLetterMaxEntries`.
 
@@ -148,7 +148,7 @@ Treat low-level provider assembly as an internal implementation detail: low-leve
 - `workerShutdownTimeoutMs`: maximum time to wait for active worker processors during shutdown before force-closing the BullMQ worker. Defaults to `30_000`.
 - `defaultDeadLetterMaxEntries`: maximum retained dead-letter records per job, or `false` to disable trimming. Defaults to `1_000`.
 
-`createQueuePlatformStatusSnapshot(...)` reports readiness as `ready` only after Queue reaches `started`; `starting` reports degraded readiness, and `stopping`/`stopped` report not-ready. Snapshot details include the Redis dependency id, lifecycle state, ready/discovered worker counts, pending dead-letter writes, the dead-letter drain timeout, and `workerShutdownTimeoutMs`.
+`QueueLifecycleService.createPlatformStatusSnapshot()` uses the same public snapshot contract as `createQueuePlatformStatusSnapshot(...)`. It reports readiness as `ready` only after Queue reaches `started` and every discovered BullMQ worker processor has started. `started` resources with pending processors report degraded readiness, `starting` reports degraded readiness, `stopping`/`stopped` report not-ready, and worker-start failures report not-ready/unhealthy with `workerStartFailures` and `lastWorkerStartFailure` details. Snapshot details include the Redis dependency id, lifecycle state, ready/discovered worker counts, pending dead-letter writes, the dead-letter drain timeout, and `workerShutdownTimeoutMs`.
 
 Only singleton `@QueueWorker()` providers/controllers are registered. Request/transient workers are skipped during discovery.
 

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -55,6 +55,7 @@ const bullmqState = vi.hoisted(() => {
   let sequence = 0;
   const failQueueCreation = new Set<string>();
   const failWorkerCreation = new Set<string>();
+  const failWorkerRun = new Set<string>();
 
   function attemptsFor(job: MockQueueJob): number {
     if (typeof job.opts.attempts === 'number' && Number.isFinite(job.opts.attempts) && job.opts.attempts > 0) {
@@ -110,6 +111,7 @@ const bullmqState = vi.hoisted(() => {
       workers.clear();
       failQueueCreation.clear();
       failWorkerCreation.clear();
+      failWorkerRun.clear();
       sequence = 0;
     },
     createQueue(name: string) {
@@ -150,6 +152,7 @@ const bullmqState = vi.hoisted(() => {
     },
     failQueueCreation,
     failWorkerCreation,
+    failWorkerRun,
     queues,
     workers,
     async dispatch(name: string, job: MockQueueJob) {
@@ -247,7 +250,17 @@ vi.mock('bullmq', () => ({
     }
 
     async run(): Promise<void> {
+      if (bullmqState.failWorkerRun.has(this.worker.name)) {
+        throw new Error(`worker run fail:${this.worker.name}`);
+      }
+
       await bullmqState.runWorker(this.worker);
+    }
+
+    async waitUntilReady(): Promise<void> {
+      if (bullmqState.failWorkerRun.has(this.worker.name)) {
+        throw new Error(`worker run fail:${this.worker.name}`);
+      }
     }
   },
 }));
@@ -936,6 +949,141 @@ describe('@fluojs/queue', () => {
     await waitForQueueWorkers();
     expect(workerStore.received).toEqual(['queued-before-later-hook']);
     expect(workerStore.receivedDuringLaterBootstrap).toBe(false);
+
+    await app.close();
+  });
+
+  it('reports workers as not ready until BullMQ processors start after bootstrap readiness', async () => {
+    const releaseBootstrapReady = createDeferred<void>();
+
+    class DeferredReadyJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(DeferredReadyJob)
+    class DeferredReadyWorker {
+      async handle(_job: DeferredReadyJob): Promise<void> {}
+    }
+
+    class AppModule {}
+
+    const redis = new MockRedisClient();
+    const container = {
+      has: (token: unknown) => token === REDIS_CLIENT,
+      resolve: async (token: unknown) => {
+        if (token === REDIS_CLIENT) {
+          return redis;
+        }
+
+        return new DeferredReadyWorker();
+      },
+    };
+    const service = new QueueLifecycleService(
+      {
+        defaultAttempts: 1,
+        defaultConcurrency: 1,
+        defaultDeadLetterMaxEntries: 1_000,
+        workerShutdownTimeoutMs: 30_000,
+      },
+      container as never,
+      [
+        {
+          definition: { providers: [DeferredReadyWorker] },
+          type: AppModule,
+        },
+      ] as never,
+      createLogger([]),
+      { wait: () => releaseBootstrapReady.promise },
+    );
+
+    await service.onApplicationBootstrap();
+
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        lifecycleState: 'started',
+        workerStartFailures: 0,
+        workersDiscovered: 1,
+        workersReady: 0,
+      },
+      health: {
+        reason: 'Queue workers are waiting for BullMQ processors to start.',
+        status: 'degraded',
+      },
+      readiness: {
+        reason: 'Queue workers are waiting for BullMQ processors to start.',
+        status: 'degraded',
+      },
+    });
+
+    releaseBootstrapReady.resolve();
+    await waitForQueueWorkers();
+
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        lifecycleState: 'started',
+        workersDiscovered: 1,
+        workersReady: 1,
+      },
+      health: { status: 'healthy' },
+      readiness: { status: 'ready' },
+    });
+
+    await service.onApplicationShutdown();
+  });
+
+  it('marks queue lifecycle failed when BullMQ worker run rejects', async () => {
+    const loggerEvents: string[] = [];
+
+    class RunFailureJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(RunFailureJob)
+    class RunFailureWorker {
+      async handle(_job: RunFailureJob): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot()],
+      providers: [RunFailureWorker],
+    });
+
+    bullmqState.failWorkerRun.add('RunFailureJob');
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const service = await app.container.resolve(QueueLifecycleService);
+
+    await waitForQueueWorkers();
+
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        lastWorkerStartFailure: 'worker run fail:RunFailureJob',
+        lifecycleState: 'failed',
+        workerStartFailures: 1,
+        workersDiscovered: 1,
+        workersReady: 0,
+      },
+      health: {
+        reason: 'Queue worker startup failed.',
+        status: 'unhealthy',
+      },
+      readiness: {
+        reason: 'Queue worker startup failed.',
+        status: 'not-ready',
+      },
+    });
+    expect(
+      loggerEvents.some((event) =>
+        event.includes('error:QueueLifecycleService:Failed to start queue worker RunFailureWorker after application bootstrap.'),
+      ),
+    ).toBe(true);
+    await expect(service.enqueue(new RunFailureJob('after-failure'))).rejects.toThrow('Queue lifecycle state is failed.');
 
     await app.close();
   });

--- a/packages/queue/src/public-surface.test.ts
+++ b/packages/queue/src/public-surface.test.ts
@@ -27,11 +27,15 @@ describe('@fluojs/queue root barrel public surface', () => {
     );
     expect(readme).toContain('low-level provider assembly as an internal implementation detail');
     expect(readme).toContain('low-level provider helpers are not part of the documented root-barrel contract.');
+    expect(readme).toContain('`QueueLifecycleService.createPlatformStatusSnapshot()` uses the same public snapshot contract');
+    expect(readme).toContain('worker-start failures report not-ready/unhealthy with `workerStartFailures`');
     expect(koreanReadme).toContain(
       '`QueueModule.forRoot(...)`는 애플리케이션 수준 큐 등록을 위한 지원되는 루트 엔트리포인트입니다.',
     );
     expect(koreanReadme).toContain('저수준 provider 조합을 루트 barrel API의 일부가 아니라 내부 구현 세부사항으로 취급해야 합니다.');
     expect(koreanReadme).toContain('저수준 provider helper는 문서화된 루트 barrel 계약에 포함되지 않습니다.');
+    expect(koreanReadme).toContain('`QueueLifecycleService.createPlatformStatusSnapshot()`은 `createQueuePlatformStatusSnapshot(...)`과 같은 공개 snapshot 계약');
+    expect(koreanReadme).toContain('worker-start failure는 `workerStartFailures`와 `lastWorkerStartFailure` details를 포함해 not-ready/unhealthy');
   });
 
   it('keeps the README worker options aligned with the supported public contract', () => {

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -20,7 +20,11 @@ import { Queue as BullQueue, Worker as BullWorker, type ConnectionOptions, type 
 
 import { QueueDeadLetterManager, type QueueRedisDeadLetterClient } from './dead-letter-manager.js';
 import { normalizePositiveInteger, withTimeout } from './helpers.js';
-import { createQueuePlatformStatusSnapshot } from './status.js';
+import {
+  createQueuePlatformStatusSnapshot,
+  type QueueLifecycleState,
+  type QueuePlatformStatusSnapshot,
+} from './status.js';
 import { QUEUE_OPTIONS } from './tokens.js';
 import { discoverQueueWorkerDescriptors } from './worker-discovery.js';
 import type {
@@ -34,8 +38,6 @@ import type {
 type QueuePayload = Record<string, unknown>;
 type QueueInstance = BullQueue;
 type WorkerInstance = BullWorker;
-
-type QueueLifecycleState = 'idle' | 'starting' | 'started' | 'stopping' | 'stopped';
 
 type QueueOwnedConnection = ConnectionOptions & {
   connect(): Promise<unknown>;
@@ -80,6 +82,17 @@ interface InitializedWorkerResources {
 interface ReadyWorker {
   descriptor: QueueWorkerDescriptor;
   worker: WorkerInstance;
+}
+
+interface RunnableWorkerControls {
+  run?: () => Promise<void> | void;
+  waitUntilReady?: () => Promise<unknown>;
+}
+
+interface WorkerStartFailure {
+  jobName: string;
+  message: string;
+  workerName: string;
 }
 
 interface ResolvedWorkerHandler {
@@ -160,6 +173,9 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   private readonly ownedConnections: QueueOwnedConnection[] = [];
   private readonly deadLetterManager: QueueDeadLetterManager;
   private readonly readyWorkers: ReadyWorker[] = [];
+  private readonly runningWorkerJobNames = new Set<string>();
+  private readonly failedWorkerJobNames = new Set<string>();
+  private readonly workerStartFailures: WorkerStartFailure[] = [];
   private lifecycleState: QueueLifecycleState = 'idle';
   private redisClient: QueueRedisClient | undefined;
   private startPromise: Promise<void> | undefined;
@@ -227,15 +243,19 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
    *
    * @returns A structured snapshot describing lifecycle state, discovered workers, and pending dead-letter writes.
    */
-  createPlatformStatusSnapshot() {
+  createPlatformStatusSnapshot(): QueuePlatformStatusSnapshot {
+    const lastWorkerStartFailure = this.workerStartFailures[this.workerStartFailures.length - 1];
+
     return createQueuePlatformStatusSnapshot({
       dependencyId: getRedisComponentId(this.options.clientName),
       lifecycleState: this.lifecycleState,
+      ...(lastWorkerStartFailure ? { lastWorkerStartFailure: lastWorkerStartFailure.message } : {}),
       pendingDeadLetterWrites: this.deadLetterManager.pendingWriteCount,
       queuesReady: this.queuesByJobName.size,
+      workerStartFailures: this.workerStartFailures.length,
       workerShutdownTimeoutMs: this.options.workerShutdownTimeoutMs,
       workersDiscovered: this.descriptorsByJobType.size,
-      workersReady: this.workersByJobName.size,
+      workersReady: this.runningWorkerJobNames.size,
     });
   }
 
@@ -244,7 +264,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
       return;
     }
 
-    if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+    if (this.lifecycleState === 'failed' || this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
       throw new Error(`Queue lifecycle state is ${this.lifecycleState}.`);
     }
 
@@ -431,6 +451,12 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
         return;
       }
 
+      this.lifecycleState = 'failed';
+      this.workerStartFailures.push({
+        jobName: '*',
+        message: this.toErrorMessage(error),
+        workerName: 'bootstrap-ready-signal',
+      });
       this.logger.error(
         'Failed to start queue workers after application bootstrap readiness.',
         error,
@@ -440,19 +466,84 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   }
 
   private runWorker(descriptor: QueueWorkerDescriptor, worker: WorkerInstance): void {
-    const runnableWorker = worker as WorkerInstance & { run?: () => Promise<void> | void };
+    const runnableWorker = worker as WorkerInstance & RunnableWorkerControls;
 
     if (typeof runnableWorker.run !== 'function') {
+      this.recordWorkerStartFailure(
+        descriptor,
+        new Error(`Queue worker ${descriptor.workerName} cannot start because BullMQ Worker.run() is unavailable.`),
+      );
       return;
     }
 
-    void Promise.resolve(runnableWorker.run()).catch((error: unknown) => {
-      this.logger.error(
-        `Failed to start queue worker ${descriptor.workerName} after application bootstrap.`,
-        error,
-        'QueueLifecycleService',
-      );
+    let runResult: Promise<void> | void;
+
+    try {
+      runResult = runnableWorker.run();
+    } catch (error) {
+      this.recordWorkerStartFailure(descriptor, error);
+      return;
+    }
+
+    const runPromise = Promise.resolve(runResult);
+
+    void runPromise.catch((error: unknown) => {
+      this.recordWorkerStartFailure(descriptor, error);
     });
+
+    void this.markWorkerReadyWhenStarted(descriptor, runnableWorker, runPromise).catch((error: unknown) => {
+      this.recordWorkerStartFailure(descriptor, error);
+    });
+  }
+
+  private async markWorkerReadyWhenStarted(
+    descriptor: QueueWorkerDescriptor,
+    worker: WorkerInstance & RunnableWorkerControls,
+    runPromise: Promise<void>,
+  ): Promise<void> {
+    if (typeof worker.waitUntilReady === 'function') {
+      await Promise.race([worker.waitUntilReady(), runPromise]);
+    } else {
+      await Promise.race([Promise.resolve(), runPromise]);
+    }
+
+    if (this.lifecycleState !== 'started' || this.failedWorkerJobNames.has(descriptor.jobName)) {
+      return;
+    }
+
+    this.runningWorkerJobNames.add(descriptor.jobName);
+  }
+
+  private recordWorkerStartFailure(descriptor: QueueWorkerDescriptor, error: unknown): void {
+    if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+      return;
+    }
+
+    if (this.failedWorkerJobNames.has(descriptor.jobName)) {
+      return;
+    }
+
+    this.failedWorkerJobNames.add(descriptor.jobName);
+    this.runningWorkerJobNames.delete(descriptor.jobName);
+    this.workerStartFailures.push({
+      jobName: descriptor.jobName,
+      message: this.toErrorMessage(error),
+      workerName: descriptor.workerName,
+    });
+
+    if (this.lifecycleState === 'started' || this.lifecycleState === 'starting') {
+      this.lifecycleState = 'failed';
+    }
+
+    this.logger.error(
+      `Failed to start queue worker ${descriptor.workerName} after application bootstrap.`,
+      error,
+      'QueueLifecycleService',
+    );
+  }
+
+  private toErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 
   private async cleanupWorkerInitializationFailure(resources: WorkerInitializationResources): Promise<void> {
@@ -579,6 +670,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     this.workersByJobName.clear();
     this.queuesByJobName.clear();
     this.readyWorkers.splice(0);
+    this.runningWorkerJobNames.clear();
 
     for (const worker of workers) {
       await this.tryCloseWorker(worker);

--- a/packages/queue/src/status.test.ts
+++ b/packages/queue/src/status.test.ts
@@ -8,6 +8,7 @@ function createQueueInput(overrides: Partial<QueueStatusAdapterInput> = {}): Que
     lifecycleState: 'idle',
     pendingDeadLetterWrites: 0,
     queuesReady: 0,
+    workerStartFailures: 0,
     workerShutdownTimeoutMs: 30_000,
     workersDiscovered: 0,
     workersReady: 0,
@@ -22,6 +23,7 @@ describe('createQueuePlatformStatusSnapshot', () => {
       lifecycleState: 'started',
       pendingDeadLetterWrites: 0,
       queuesReady: 2,
+      workerStartFailures: 0,
       workerShutdownTimeoutMs: 30_000,
       workersDiscovered: 2,
       workersReady: 2,
@@ -80,6 +82,56 @@ describe('createQueuePlatformStatusSnapshot', () => {
     expect(snapshot.health).toEqual({
       reason: 'Queue dead-letter writes are still pending.',
       status: 'degraded',
+    });
+  });
+
+  it('keeps started queues degraded until discovered BullMQ processors have started', () => {
+    const snapshot = createQueuePlatformStatusSnapshot(createQueueInput({
+      lifecycleState: 'started',
+      queuesReady: 1,
+      workersDiscovered: 1,
+      workersReady: 0,
+    }));
+
+    expect(snapshot.readiness).toEqual({
+      critical: true,
+      reason: 'Queue workers are waiting for BullMQ processors to start.',
+      status: 'degraded',
+    });
+    expect(snapshot.health).toEqual({
+      reason: 'Queue workers are waiting for BullMQ processors to start.',
+      status: 'degraded',
+    });
+    expect(snapshot.details).toMatchObject({
+      workerStartFailures: 0,
+      workersDiscovered: 1,
+      workersReady: 0,
+    });
+  });
+
+  it('reports worker startup failures as not-ready and unhealthy status details', () => {
+    const snapshot = createQueuePlatformStatusSnapshot(createQueueInput({
+      lastWorkerStartFailure: 'worker run fail:EmailJob',
+      lifecycleState: 'failed',
+      queuesReady: 1,
+      workerStartFailures: 1,
+      workersDiscovered: 1,
+      workersReady: 0,
+    }));
+
+    expect(snapshot.readiness).toEqual({
+      critical: true,
+      reason: 'Queue worker startup failed.',
+      status: 'not-ready',
+    });
+    expect(snapshot.health).toEqual({
+      reason: 'Queue worker startup failed.',
+      status: 'unhealthy',
+    });
+    expect(snapshot.details).toMatchObject({
+      lastWorkerStartFailure: 'worker run fail:EmailJob',
+      lifecycleState: 'failed',
+      workerStartFailures: 1,
     });
   });
 });

--- a/packages/queue/src/status.ts
+++ b/packages/queue/src/status.ts
@@ -1,14 +1,16 @@
 import type { PlatformHealthReport, PlatformReadinessReport, PlatformSnapshot } from '@fluojs/runtime';
 
 /** Lifecycle phases reported by the queue platform status adapter. */
-export type QueueLifecycleState = 'idle' | 'starting' | 'started' | 'stopping' | 'stopped';
+export type QueueLifecycleState = 'idle' | 'starting' | 'started' | 'stopping' | 'stopped' | 'failed';
 
 /** Input payload used to derive queue readiness, health, and dependency details. */
 export interface QueueStatusAdapterInput {
   dependencyId?: string;
+  lastWorkerStartFailure?: string;
   lifecycleState: QueueLifecycleState;
   pendingDeadLetterWrites: number;
   queuesReady: number;
+  workerStartFailures?: number;
   workerShutdownTimeoutMs: number;
   workersDiscovered: number;
   workersReady: number;
@@ -23,7 +25,25 @@ export interface QueuePlatformStatusSnapshot {
 }
 
 function createReadiness(input: QueueStatusAdapterInput): PlatformReadinessReport {
+  const workerStartFailures = input.workerStartFailures ?? 0;
+
+  if (input.lifecycleState === 'failed' || workerStartFailures > 0) {
+    return {
+      critical: true,
+      reason: 'Queue worker startup failed.',
+      status: 'not-ready',
+    };
+  }
+
   if (input.lifecycleState === 'started') {
+    if (input.workersReady < input.workersDiscovered) {
+      return {
+        critical: true,
+        reason: 'Queue workers are waiting for BullMQ processors to start.',
+        status: 'degraded',
+      };
+    }
+
     return {
       critical: true,
       status: 'ready',
@@ -62,6 +82,15 @@ function createReadiness(input: QueueStatusAdapterInput): PlatformReadinessRepor
 }
 
 function createHealth(input: QueueStatusAdapterInput): PlatformHealthReport {
+  const workerStartFailures = input.workerStartFailures ?? 0;
+
+  if (input.lifecycleState === 'failed' || workerStartFailures > 0) {
+    return {
+      reason: 'Queue worker startup failed.',
+      status: 'unhealthy',
+    };
+  }
+
   if (input.lifecycleState === 'stopped') {
     return {
       reason: 'Queue workers are stopped.',
@@ -79,6 +108,13 @@ function createHealth(input: QueueStatusAdapterInput): PlatformHealthReport {
   if (input.lifecycleState === 'stopping') {
     return {
       reason: 'Queue workers are draining during shutdown.',
+      status: 'degraded',
+    };
+  }
+
+  if (input.lifecycleState === 'started' && input.workersReady < input.workersDiscovered) {
+    return {
+      reason: 'Queue workers are waiting for BullMQ processors to start.',
       status: 'degraded',
     };
   }
@@ -109,13 +145,17 @@ function createHealth(input: QueueStatusAdapterInput): PlatformHealthReport {
  * @returns Readiness, health, ownership, and queue detail fields.
  */
 export function createQueuePlatformStatusSnapshot(input: QueueStatusAdapterInput): QueuePlatformStatusSnapshot {
+  const workerStartFailures = input.workerStartFailures ?? 0;
+
   return {
     details: {
       deadLetterDrainTimeoutMs: 5_000,
       dependencies: [input.dependencyId ?? 'redis.default'],
       lifecycleState: input.lifecycleState,
+      ...(input.lastWorkerStartFailure ? { lastWorkerStartFailure: input.lastWorkerStartFailure } : {}),
       pendingDeadLetterWrites: input.pendingDeadLetterWrites,
       queuesReady: input.queuesReady,
+      workerStartFailures,
       workerShutdownTimeoutMs: input.workerShutdownTimeoutMs,
       workersDiscovered: input.workersDiscovered,
       workersReady: input.workersReady,


### PR DESCRIPTION
## Summary
Closes #2095

This PR makes queue readiness reflect BullMQ worker startup instead of reporting ready before processors actually start.

Linked context: #2095

## Changes
- Tracks pending/running/failed worker startup state.
- Reports degraded readiness before worker startup is confirmed.
- Moves queue lifecycle/status to failed on worker startup failure.
- Documents `QueueLifecycleService.createPlatformStatusSnapshot()` and readiness semantics in EN/KO README.
- Adds a patch changeset for `@fluojs/queue`.

## Testing
- `pnpm --filter @fluojs/queue... build`
- `pnpm --filter @fluojs/queue test`
- `pnpm --filter @fluojs/queue typecheck`
- `pnpm exec biome lint packages/queue/src/service.ts packages/queue/src/status.ts packages/queue/src/module.test.ts packages/queue/src/status.test.ts packages/queue/src/public-surface.test.ts`
- `pnpm verify:public-export-tsdoc`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `GIT_MASTER=1 git diff --check`
- LSP diagnostics: 0 errors after dependency install/build

## Release impact
- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by relevant package regression tests.

## Remaining risks
`pnpm verify:release-readiness` was attempted and failed in an unrelated repo-wide CLI scaffold timeout while queue tests in that run passed. Branch is behind `origin/main` by 1 commit; no rebase was performed in the child implementer.
