### PR TITLE
Resolve #2101: guard socket.io dist contract drift

### DIFF
--- a/.changeset/socketio-dist-contract-drift.md
+++ b/.changeset/socketio-dist-contract-drift.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/socket.io': patch
+---
+
+Republish the Socket.IO runtime and declaration contract so generated package output preserves fail-fast positive-integer option validation, the portable `SocketIoHandshakeRequest` request union, and the async raw-server provider path used by Bun-compatible bootstrap.

--- a/book/advanced/ch07-dynamic-modules.ko.md
+++ b/book/advanced/ch07-dynamic-modules.ko.md
@@ -409,11 +409,11 @@ static forRoot(options: RedisModuleOptions): ModuleType {
 
 이 발췌는 dynamic module이 단순히 provider를 계산하는 데서 끝나지 않는다는 점을 보여 줍니다. 호출자가 넘긴 `name` option이 raw client token과 facade service token을 바꾸고, 그 둘만 export 표면에 올라갑니다.
 
-`SocketIoModule.forRoot()`도 유사한 패턴을 따릅니다. `path:packages/socket.io/src/module.ts:11-31`은 내부 옵션 토큰, lifecycle service, 원시 서버를 위한 팩토리 프로바이더를 정의합니다. 그 다음 **alias provider** (`useExisting`)를 사용하여 `SOCKETIO_ROOM_SERVICE` 토큰을 노출합니다. 마지막으로 `path:packages/socket.io/src/module.ts:54-61`이 내부 구현 세부 사항은 숨긴 채 public room-service와 raw-server 토큰만 export합니다.
+`SocketIoModule.forRoot()`도 유사한 패턴을 따릅니다. `path:packages/socket.io/src/module.ts:12-31`은 내부 옵션 토큰, lifecycle service, 원시 서버를 위한 async factory provider를 정의합니다. 그 다음 **alias provider** (`useExisting`)를 사용하여 `SOCKETIO_ROOM_SERVICE` 토큰을 노출합니다. 마지막으로 `path:packages/socket.io/src/module.ts:55-64`가 내부 구현 세부 사항은 숨긴 채 public room-service와 raw-server 토큰만 export합니다.
 
 Socket.IO 사례는 내부 lifecycle service를 public room-service token으로 노출할 때 `useExisting`을 씁니다.
 
-`path:packages/socket.io/src/module.ts:11-31`
+`path:packages/socket.io/src/module.ts:12-31`
 ```typescript
 function createSocketIoProviderSet(options: SocketIoModuleOptions = {}) {
   return [
@@ -427,7 +427,7 @@ function createSocketIoProviderSet(options: SocketIoModuleOptions = {}) {
     },
     {
       provide: SOCKETIO_SERVER,
-      useFactory: (service: unknown) => (service as SocketIoLifecycleService).getServer(),
+      useFactory: async (service: unknown) => await (service as SocketIoLifecycleService).getServerAsync(),
       inject: [SocketIoLifecycleService],
     },
     {

--- a/book/advanced/ch07-dynamic-modules.md
+++ b/book/advanced/ch07-dynamic-modules.md
@@ -409,11 +409,11 @@ static forRoot(options: RedisModuleOptions): ModuleType {
 
 This excerpt shows that a Dynamic Module does not stop at calculating Providers. The caller's `name` option changes the raw client Token and facade service Token, and only those two go onto the export surface.
 
-`SocketIoModule.forRoot()` follows a similar pattern. `path:packages/socket.io/src/module.ts:11-31` defines an internal options Token, a lifecycle service, and a Factory Provider for the raw server. It then uses an **alias Provider** (`useExisting`) to expose the `SOCKETIO_ROOM_SERVICE` Token. Finally, `path:packages/socket.io/src/module.ts:54-61` exports only the public room-service and raw-server Tokens while hiding internal implementation details.
+`SocketIoModule.forRoot()` follows a similar pattern. `path:packages/socket.io/src/module.ts:12-31` defines an internal options Token, a lifecycle service, and an async Factory Provider for the raw server. It then uses an **alias Provider** (`useExisting`) to expose the `SOCKETIO_ROOM_SERVICE` Token. Finally, `path:packages/socket.io/src/module.ts:55-64` exports only the public room-service and raw-server Tokens while hiding internal implementation details.
 
 The Socket.IO case uses `useExisting` when exposing an internal lifecycle service through a public room-service Token.
 
-`path:packages/socket.io/src/module.ts:11-31`
+`path:packages/socket.io/src/module.ts:12-31`
 ```typescript
 function createSocketIoProviderSet(options: SocketIoModuleOptions = {}) {
   return [
@@ -427,7 +427,7 @@ function createSocketIoProviderSet(options: SocketIoModuleOptions = {}) {
     },
     {
       provide: SOCKETIO_SERVER,
-      useFactory: (service: unknown) => (service as SocketIoLifecycleService).getServer(),
+      useFactory: async (service: unknown) => await (service as SocketIoLifecycleService).getServerAsync(),
       inject: [SocketIoLifecycleService],
     },
     {

--- a/packages/socket.io/README.ko.md
+++ b/packages/socket.io/README.ko.md
@@ -145,5 +145,6 @@ Socket.IO 등록은 소유 모듈의 import 경로에서 구성하여 namespace/
 
 ## 예제 소스
 
+- `packages/socket.io/src/config.internal.test.ts`
 - `packages/socket.io/src/module.test.ts`
 - `packages/socket.io/src/public-surface.test.ts`

--- a/packages/socket.io/README.md
+++ b/packages/socket.io/README.md
@@ -147,5 +147,6 @@ Register Socket.IO through module imports in the owning module so namespace/mess
 
 ## Example Sources
 
+- `packages/socket.io/src/config.internal.test.ts`
 - `packages/socket.io/src/module.test.ts`
 - `packages/socket.io/src/public-surface.test.ts`

--- a/packages/socket.io/src/config.internal.test.ts
+++ b/packages/socket.io/src/config.internal.test.ts
@@ -16,12 +16,28 @@ describe('Socket.IO module option validation', () => {
       options: { engine: { maxHttpBufferSize: 0 } },
     },
     {
+      expectedMessage: 'Socket.IO configuration engine.maxHttpBufferSize must be a positive integer when provided.',
+      options: { engine: { maxHttpBufferSize: -1 } },
+    },
+    {
+      expectedMessage: 'Socket.IO configuration engine.maxHttpBufferSize must be a positive integer when provided.',
+      options: { engine: { maxHttpBufferSize: 1.5 } },
+    },
+    {
       expectedMessage: 'Socket.IO configuration buffer.maxPendingMessagesPerSocket must be a positive integer when provided.',
       options: { buffer: { maxPendingMessagesPerSocket: 1.5 } },
     },
     {
+      expectedMessage: 'Socket.IO configuration buffer.maxPendingMessagesPerSocket must be a positive integer when provided.',
+      options: { buffer: { maxPendingMessagesPerSocket: Number.POSITIVE_INFINITY } },
+    },
+    {
       expectedMessage: 'Socket.IO configuration shutdown.timeoutMs must be a positive integer when provided.',
       options: { shutdown: { timeoutMs: Number.NaN } },
+    },
+    {
+      expectedMessage: 'Socket.IO configuration shutdown.timeoutMs must be a positive integer when provided.',
+      options: { shutdown: { timeoutMs: 0 } },
     },
   ] satisfies Array<{ readonly expectedMessage: string; readonly options: SocketIoModuleOptions }>)(
     'rejects invalid explicit numeric config: $expectedMessage',

--- a/packages/socket.io/src/module.test.ts
+++ b/packages/socket.io/src/module.test.ts
@@ -350,12 +350,12 @@ describe('@fluojs/socket.io', () => {
     expect('SOCKETIO_OPTIONS' in publicApi).toBe(false);
   });
 
-  it('wires lifecycle dependencies through forRoot metadata internally', () => {
+  it('wires lifecycle dependencies through forRoot metadata internally', async () => {
     const providers = getModuleMetadata(SocketIoModule.forRoot())?.providers ?? [];
     const serverProvider = providers.find(
       (provider: unknown) =>
         typeof provider === 'object' && provider !== null && 'provide' in provider && provider.provide === SOCKETIO_SERVER,
-    ) as { inject?: unknown[] } | undefined;
+    ) as { inject?: unknown[]; useFactory?: (service: unknown) => unknown } | undefined;
     const roomProvider = providers.find(
       (provider: unknown) =>
         typeof provider === 'object' &&
@@ -363,8 +363,25 @@ describe('@fluojs/socket.io', () => {
         'provide' in provider &&
         provider.provide === SOCKETIO_ROOM_SERVICE,
     ) as { useExisting?: unknown } | undefined;
+    const rawServer = { marker: 'socketio-server' };
+    const fakeLifecycleService = {
+      getServer() {
+        throw new Error('Sync Socket.IO server access should not satisfy the provider factory.');
+      },
+      async getServerAsync() {
+        return rawServer;
+      },
+    };
+    const serverFactory = serverProvider?.useFactory;
 
     expect(serverProvider?.inject).toEqual([SocketIoLifecycleService]);
+    expect(serverFactory).toBeTypeOf('function');
+    if (!serverFactory) {
+      throw new Error('Expected Socket.IO server provider to define a factory.');
+    }
+    const resolvedServer = await serverFactory(fakeLifecycleService);
+
+    expect(resolvedServer).toBe(rawServer);
     expect(roomProvider?.useExisting).toBe(SocketIoLifecycleService);
   });
 

--- a/packages/socket.io/src/public-surface.test.ts
+++ b/packages/socket.io/src/public-surface.test.ts
@@ -8,7 +8,12 @@ import type { WebSocketRoomService } from '@fluojs/websockets';
 
 import * as socketIo from './index.js';
 import type { SocketIoHandshakeRequest as RootSocketIoHandshakeRequest } from './index.js';
-import type { SocketIoHandshakeRequest, SocketIoRoomService } from './types.js';
+import type {
+  SocketIoConnectionGuardContext,
+  SocketIoHandshakeRequest,
+  SocketIoMessageGuardContext,
+  SocketIoRoomService,
+} from './types.js';
 
 const sourceDir = dirname(fileURLToPath(import.meta.url));
 
@@ -61,5 +66,7 @@ describe('@fluojs/socket.io public surface', () => {
   it('documents the exported handshake request type used by guard contexts', () => {
     expectTypeOf<SocketIoHandshakeRequest>().toEqualTypeOf<import('node:http').IncomingMessage | Request>();
     expectTypeOf<RootSocketIoHandshakeRequest>().toEqualTypeOf<SocketIoHandshakeRequest>();
+    expectTypeOf<SocketIoConnectionGuardContext['request']>().toEqualTypeOf<SocketIoHandshakeRequest>();
+    expectTypeOf<SocketIoMessageGuardContext['request']>().toEqualTypeOf<SocketIoHandshakeRequest>();
   });
 });


### PR DESCRIPTION
## Summary
Closes #2101

This PR adds regression coverage for Socket.IO published-contract drift and updates docs/book snippets to the async server-provider contract.

Linked context: #2101

## Changes
- Extends fail-fast numeric option regression coverage.
- Adds tests for async `getServerAsync()` raw server provider path.
- Adds type-level guard for `SocketIoHandshakeRequest` request union.
- Updates EN/KO advanced book snippets and package README references.
- Adds a patch changeset for `@fluojs/socket.io`.

## Testing
- `pnpm --filter @fluojs/socket.io test`
- `pnpm build`
- `pnpm --filter @fluojs/socket.io typecheck`
- `pnpm --filter @fluojs/socket.io build`
- `pnpm docs:sync-check`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main`
- `pnpm lint`
- LSP diagnostics for `packages/socket.io/src`
- generated `dist` spot-check for fail-fast JS, `SocketIoHandshakeRequest` union d.ts, and async `getServerAsync()` module factory

## Release impact
- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by relevant package regression tests.

## Remaining risks
`pnpm verify:release-readiness` was attempted and failed in unrelated CLI/starter readiness gates. Branch is behind `origin/main` by 1 commit; no rebase was performed in the child implementer.
