### PR TITLE
Resolve #2106: use structural Redis client contract for throttler

### DIFF
--- a/.changeset/throttler-redis-client-boundary.md
+++ b/.changeset/throttler-redis-client-boundary.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/throttler": patch
+---
+
+Expose a structural Redis client contract for `RedisThrottlerStore` so the root `@fluojs/throttler` API no longer leaks the concrete `ioredis` constructor type while remaining compatible with `ioredis` and `@fluojs/redis` clients.

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -71,6 +71,8 @@ class AuthController {
 
 다중 인스턴스 배포 환경에서는 `RedisThrottlerStore`를 사용하여 모든 인스턴스 간에 속도 제한 상태를 공유하세요. Redis 기반 윈도우는 Redis 서버 시간을 기준으로 고정되므로, 애플리케이션 노드 간 시계 오차가 있어도 하나의 공통 reset 경계를 강제합니다.
 
+`RedisThrottlerStore`는 패키지 로컬 구조적 `RedisThrottlerClient` 계약을 받습니다. 이 계약은 `eval(script, numberOfKeys, ...args)` 메서드를 제공하는 Redis command client를 의미합니다. `@fluojs/redis`, `ioredis`, 호환 custom client를 전달할 수 있으며, root `@fluojs/throttler` import가 concrete `ioredis` constructor type에 의존하지 않습니다.
+
 ```typescript
 import { ThrottlerModule, RedisThrottlerStore } from '@fluojs/throttler';
 import { REDIS_CLIENT } from '@fluojs/redis';
@@ -138,6 +140,7 @@ ThrottlerModule.forRoot({
 ### 저장소(Store)
 - `createMemoryThrottlerStore()`: 간단한 메모리 내 저장소를 생성합니다 (기본값).
 - `RedisThrottlerStore`: Redis용 저장소 어댑터입니다.
+- `RedisThrottlerClient`: `RedisThrottlerStore`가 받는 구조적 Redis command client 계약입니다.
 - `ThrottlerStore`: custom store를 위한 공개 계약입니다.
 - `ThrottlerConsumeInput`: custom store가 guard의 현재 시간과 TTL window를 공유할 수 있도록 `ThrottlerStore.consume(key, input)`에 전달되는 공개 입력 shape입니다.
 

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -158,7 +158,7 @@ ThrottlerModule.forRoot({
 ## 관련 패키지
 
 - `@fluojs/http`: HTTP 컨텍스트 및 예외 처리를 위해 필요합니다.
-- `@fluojs/redis`: `RedisThrottlerStore` 사용 시 필요합니다.
+- `@fluojs/redis`: `RedisThrottlerStore`를 위한 공식 Redis client 통합입니다. `ioredis`와 호환되는 구조적 client도 지원합니다.
 
 ## 예제 소스
 

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -158,7 +158,7 @@ Method-level `@Throttle(...)` overrides class-level settings, class-level settin
 ## Related Packages
 
 - `@fluojs/http`: Required for HTTP context and Exception handling.
-- `@fluojs/redis`: Required when using `RedisThrottlerStore`.
+- `@fluojs/redis`: Official Redis client integration for `RedisThrottlerStore`; `ioredis` and compatible structural clients are also supported.
 
 ## Example Sources
 

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -71,6 +71,8 @@ class AuthController {
 
 For multi-instance deployments, use `RedisThrottlerStore` to share the rate limit state across all instances. Redis-backed windows are anchored to Redis server time, so distributed app nodes with clock skew still enforce one shared reset boundary.
 
+`RedisThrottlerStore` accepts the package-local structural `RedisThrottlerClient` contract: a Redis command client with an `eval(script, numberOfKeys, ...args)` method. `@fluojs/redis`, `ioredis`, and compatible custom clients can be passed without making the root `@fluojs/throttler` import depend on a concrete `ioredis` constructor type.
+
 ```typescript
 import { ThrottlerModule, RedisThrottlerStore } from '@fluojs/throttler';
 import { REDIS_CLIENT } from '@fluojs/redis';
@@ -138,6 +140,7 @@ ThrottlerModule.forRoot({
 ### Stores
 - `createMemoryThrottlerStore()`: Creates a simple in-memory store (default).
 - `RedisThrottlerStore`: Store adapter for Redis.
+- `RedisThrottlerClient`: Structural Redis command client contract accepted by `RedisThrottlerStore`.
 - `ThrottlerStore`: Public contract for custom stores.
 - `ThrottlerConsumeInput`: Public input shape passed to `ThrottlerStore.consume(key, input)` so custom stores can share the guard's current time and TTL window.
 

--- a/packages/throttler/src/index.ts
+++ b/packages/throttler/src/index.ts
@@ -10,6 +10,7 @@ export {
 export { ThrottlerGuard } from './guard.js';
 export * from './module.js';
 export { RedisThrottlerStore } from './redis-store.js';
+export type { RedisThrottlerClient } from './redis-store.js';
 export * from './status.js';
 export { createMemoryThrottlerStore } from './store.js';
 export type {

--- a/packages/throttler/src/module.test.ts
+++ b/packages/throttler/src/module.test.ts
@@ -3,11 +3,11 @@ import { metadataSymbol } from '@fluojs/core/internal';
 import type { GuardContext, HandlerDescriptor, RequestContext } from '@fluojs/http';
 import { Controller, Get, UseGuards } from '@fluojs/http';
 import { createTestApp } from '@fluojs/testing';
-import type Redis from 'ioredis';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getThrottleMetadata, SkipThrottle, Throttle } from './decorators.js';
 import { ThrottlerGuard } from './guard.js';
 import type {
+  RedisThrottlerClient,
   ThrottlerConsumeInput,
   ThrottlerModuleOptions,
   ThrottlerStore,
@@ -124,6 +124,20 @@ describe('@fluojs/throttler public entrypoints', () => {
       count: 60,
       resetAt: 61_000,
     });
+  });
+
+  it('accepts structural Redis clients from the root barrel without an ioredis constructor type', async () => {
+    const client = {
+      eval: vi.fn(async () => [1, 1_710_000_060_000, 60_000]),
+    } satisfies RedisThrottlerClient;
+    const store = new throttlerExports.RedisThrottlerStore(client);
+
+    await expect(
+      store.consume('throttle:auth:127.0.0.1', {
+        now: 1_710_000_000_000,
+        ttlSeconds: 60,
+      }),
+    ).resolves.toEqual({ count: 1, resetAt: 1_710_000_060_000 });
   });
 });
 
@@ -772,8 +786,8 @@ describe('ThrottlerGuard — Redis store mock', () => {
   it('keeps Retry-After consistent across skewed app clocks when Redis provides the shared window', async () => {
     const client = {
       eval: vi.fn(async () => [2, 1_710_000_090_000, 45_000]),
-    } as unknown as Pick<Redis, 'eval'>;
-    const store = new RedisThrottlerStore(client as Redis);
+    } satisfies RedisThrottlerClient;
+    const store = new RedisThrottlerStore(client);
 
     class TestController {
       action() {}

--- a/packages/throttler/src/redis-store.test.ts
+++ b/packages/throttler/src/redis-store.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type Redis from 'ioredis';
-
-import { RedisThrottlerStore } from './redis-store.js';
+import { RedisThrottlerStore, type RedisThrottlerClient } from './redis-store.js';
 
 function createRedisClientMock(result: unknown) {
   return {
     eval: vi.fn(async () => result),
-  } as unknown as Pick<Redis, 'eval'>;
+  } satisfies RedisThrottlerClient;
 }
 
 function createRedisTimeAnchoredClient(baseNow: number) {
@@ -35,7 +33,7 @@ function createRedisTimeAnchoredClient(baseNow: number) {
 
         return [entry.count, entry.resetAt, entry.resetAt - redisNow];
       }),
-    } as unknown as Pick<Redis, 'eval'>,
+    } satisfies RedisThrottlerClient,
     setRedisNow(nextNow: number) {
       redisNow = nextNow;
     },
@@ -46,7 +44,7 @@ describe('RedisThrottlerStore', () => {
   it('persists the reset window at the TTL boundary with millisecond precision', async () => {
     const now = 1_710_000_000_000;
     const client = createRedisClientMock([1, now + 60_000, 60_000]);
-    const store = new RedisThrottlerStore(client as Redis);
+    const store = new RedisThrottlerStore(client);
 
     const entry = await store.consume('throttle:auth:127.0.0.1', {
       now,
@@ -71,7 +69,7 @@ describe('RedisThrottlerStore', () => {
   it('anchors Redis windows to Redis server time across skewed app nodes', async () => {
     const baseNow = 1_710_000_000_000;
     const { client, setRedisNow } = createRedisTimeAnchoredClient(baseNow);
-    const store = new RedisThrottlerStore(client as Redis);
+    const store = new RedisThrottlerStore(client);
 
     const first = await store.consume('throttle:auth:127.0.0.1', {
       now: baseNow - 30_000,
@@ -100,7 +98,7 @@ describe('RedisThrottlerStore', () => {
 
   it('rejects malformed consume-script responses', async () => {
     const client = createRedisClientMock(['not-a-number', 'still-not-a-number']);
-    const store = new RedisThrottlerStore(client as Redis);
+    const store = new RedisThrottlerStore(client);
 
     await expect(
       store.consume('throttle:auth:127.0.0.1', {

--- a/packages/throttler/src/redis-store.ts
+++ b/packages/throttler/src/redis-store.ts
@@ -1,8 +1,26 @@
-import type Redis from 'ioredis';
-
 import { throttlerRetryAfterMsSymbol } from './store-internals.js';
 import type { ThrottlerConsumeInput, ThrottlerStore, ThrottlerStoreEntry } from './types.js';
 import { validateThrottlerStoreEntry } from './validation.js';
+
+/**
+ * Structural Redis command client accepted by `RedisThrottlerStore`.
+ *
+ * @remarks
+ * This package-local contract keeps the throttler root API independent of
+ * concrete Redis client packages while remaining compatible with `ioredis`,
+ * `@fluojs/redis`, and custom clients that expose Redis `EVAL`.
+ */
+export interface RedisThrottlerClient {
+  /**
+   * Evaluate a Redis Lua script.
+   *
+   * @param script Lua script to evaluate.
+   * @param numberOfKeys Number of key arguments Redis should treat as `KEYS`.
+   * @param args Key and argument values passed to Redis `EVAL`.
+   * @returns The raw Redis response for the script.
+   */
+  eval(script: string, numberOfKeys: number, ...args: string[]): unknown | Promise<unknown>;
+}
 
 const CONSUME_LUA = [
   "local key = KEYS[1]",
@@ -71,7 +89,12 @@ function parseConsumeResult(result: unknown): ThrottlerStoreEntry {
  * requests across instances observe the same counter and reset window.
  */
 export class RedisThrottlerStore implements ThrottlerStore {
-  constructor(private readonly client: Redis) {}
+  /**
+   * Create a Redis-backed throttler store.
+   *
+   * @param client Redis command client that supports `EVAL`.
+   */
+  constructor(private readonly client: RedisThrottlerClient) {}
 
   /**
    * Consume one throttle slot for the provided key.


### PR DESCRIPTION
## Summary
Closes #2106

This PR removes the concrete `ioredis` constructor type from the generic throttler root surface by introducing a package-owned structural Redis client contract.

Linked context: #2106

## Changes
- Adds `RedisThrottlerClient` as a structural package-local contract.
- Updates `RedisThrottlerStore` to accept that structural client instead of concrete `ioredis`.
- Re-exports the structural client type from root.
- Adds regression tests for structural client compatibility.
- Updates EN/KO README and adds a patch changeset for `@fluojs/throttler`.

## Testing
- `pnpm --filter @fluojs/throttler... build`
- `pnpm --filter @fluojs/throttler typecheck`
- `pnpm --filter @fluojs/throttler test` (`50 passed`)
- `GIT_MASTER=1 pnpm verify:public-export-tsdoc`
- `GIT_MASTER=1 pnpm verify:release-readiness` attempted

## Release impact
- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by relevant package regression tests.

## Remaining risks
`pnpm verify:release-readiness` timed out after 600000ms without an observed failure before timeout; rerun in CI. No rebase was performed in the child implementer.
