### PR TITLE
Resolve #2105: fix metrics empty-path middleware and counter docs

### DIFF
--- a/.changeset/metrics-empty-path-endpoint.md
+++ b/.changeset/metrics-empty-path-endpoint.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/metrics": patch
+---
+
+Ensure `endpointMiddleware` remains bound when `MetricsModule.forRoot({ path: '' })` exposes an empty-string metrics endpoint.

--- a/book/beginner/ch19-metrics.ko.md
+++ b/book/beginner/ch19-metrics.ko.md
@@ -143,44 +143,59 @@ MetricsModule.forRoot({
 import { Inject } from '@fluojs/core';
 import { MetricsService } from '@fluojs/metrics';
 
+type CreatePostInput = {
+  content: string;
+  title: string;
+};
+
 @Inject(MetricsService)
 export class PostService {
-  constructor(private readonly metrics: MetricsService) {}
+  private readonly postsCreated: ReturnType<MetricsService['counter']>;
 
-  async create(data: any) {
-    const post = await this.prisma.post.create({ data });
-     
-     // 새 포스트가 생성될 때마다 카운터를 증가시킵니다.
-    this.metrics.counter({
+  constructor(metrics: MetricsService) {
+    this.postsCreated = metrics.counter({
       name: 'blog_posts_created_total',
       help: '생성된 블로그 게시물 수',
-    }).inc();
-    
+    });
+  }
+
+  async create(data: CreatePostInput) {
+    const post = await this.prisma.post.create({ data });
+
+    // 새 포스트가 생성될 때마다 기존 카운터를 재사용합니다.
+    this.postsCreated.inc();
+
     return post;
   }
 }
 ```
 
+카운터는 service construction 또는 application startup 중 한 번만 생성하고, 반환된 collector를 재사용하세요. 같은 metric name으로 `MetricsService.counter(...)`를 반복 호출하면 Prometheus collector를 다시 만들려고 하며, Registry 안에서 metric name은 고유해야 하므로 빠르게 실패합니다.
+
 ### Gauge: Measuring Current State
 올라가거나 내려갈 수 있는 값(예: 활성 웹소켓 연결 수, 처리 대기 중인 큐의 아이템 수, 현재 로그인 중인 사용자 수)에는 `Gauge`를 사용하세요. 게이지는 특정 시점의 스냅샷을 나타냅니다.
 
 ```typescript
-// 현재 값을 직접 설정합니다.
-this.metrics.gauge({
+const activeSessions = metrics.gauge({
   name: 'active_sessions_count',
   help: '현재 활성 세션 수',
-}).set(currentSessions);
+});
+
+// 이후 현재 값을 직접 설정합니다.
+activeSessions.set(currentSessions);
 ```
 
 ### Histogram: Measuring Distributions
 퍼센타일을 계산해야 하는 기간이나 크기(예: 백그라운드 작업 처리 시간, 업로드된 이미지의 크기, 검색 결과의 아이템 수)에는 `Histogram`을 사용하세요.
 
 ```typescript
-// 업로드된 파일 크기를 관측합니다.
-this.metrics.histogram({
+const imageUploadSize = metrics.histogram({
   name: 'image_upload_size_bytes',
   help: '업로드된 이미지 크기',
-}).observe(file.size);
+});
+
+// 이후 업로드된 파일 크기를 관측합니다.
+imageUploadSize.observe(file.size);
 ```
 
 ### 19.5.1 Labels: Adding Dimension to Data
@@ -199,12 +214,12 @@ this.metrics.histogram({
 예: `fluoblog_posts_created_total`. 일관된 명명 규칙은 애플리케이션이 수백 개의 서로 다른 메트릭으로 성장하더라도 Grafana에서 메트릭을 찾고 쿼리하는 것을 훨씬 쉽게 만들어 줍니다.
 
 ### 19.5.4 Advanced Label Management: Dynamic Labels
-런타임 전까지 라벨 값을 알 수 없는 경우도 있습니다. Fluo의 메트릭 서비스는 값을 기록할 때 동적으로 라벨을 전달할 수 있게 합니다. 예를 들어 실패한 결제의 `error_code`를 추적할 수 있습니다: `metrics.counter({ name: 'payment_failures_total', help: '실패한 결제 수', labelNames: ['code'] }).inc({ code: error.code })`.
+런타임 전까지 라벨 값을 알 수 없는 경우도 있습니다. Fluo의 메트릭 서비스는 값을 기록할 때 동적으로 라벨을 전달할 수 있게 합니다. 예를 들어 `const paymentFailures = metrics.counter({ name: 'payment_failures_total', help: '실패한 결제 수', labelNames: ['code'] })`를 한 번 생성한 뒤, 각 실패를 `paymentFailures.inc({ code: error.code })`로 기록할 수 있습니다.
 
 여기서 **카디널리티(Cardinality)**를 매우 주의해야 합니다. 만약 `code` 라벨이 수천 개의 고유한 값(예: 스택 트레이스)을 가질 수 있다면 Prometheus에 과부하를 줄 것입니다. 항상 라벨 값이 제한된 범위 내에 있도록 보장하십시오. 고카디널리티 데이터를 추적해야 한다면 메트릭 대신 로그를 사용하세요.
 
 ### 19.5.5 Metric Initialization and "Zeroing"
-모니터링에서 흔히 발생하는 문제는 메트릭이 처음 기록되기 전까지 Prometheus에 나타나지 않는다는 점입니다. 이로 인해 대시보드가 "비어" 보이거나 비율(rate) 계산이 깨질 수 있습니다. 이를 해결하려면 애플리케이션 시작 중에 필요한 카운터, 게이지, 히스토그램을 미리 등록해 두는 것이 좋습니다.
+모니터링에서 흔히 발생하는 문제는 메트릭이 처음 기록되기 전까지 Prometheus에 나타나지 않는다는 점입니다. 이로 인해 대시보드가 "비어" 보이거나 비율(rate) 계산이 깨질 수 있습니다. 이를 해결하려면 애플리케이션 시작 중에 필요한 카운터, 게이지, 히스토그램을 미리 등록해 두는 것이 좋습니다. 이 startup 또는 provider-construction 단계에서 `MetricsService.counter(...)`, `gauge(...)`, `histogram(...)`을 한 번만 호출하고, 이후 request handler는 collector 객체만 재사용해야 합니다.
 
 ## 19.6 Securing the Metrics Endpoint
 프로덕션 환경에서는 일반 대중에게 내부 메트릭을 공개하고 싶지 않을 것입니다. 메트릭은 트래픽 패턴, 사용자 증가세, 내부 아키텍처에 대한 민감한 정보를 드러낼 수 있습니다. 커스텀 미들웨어나 Fluo의 내장 보안 기능을 사용하여 엔드포인트를 보호할 수 있습니다.

--- a/book/beginner/ch19-metrics.md
+++ b/book/beginner/ch19-metrics.md
@@ -143,44 +143,59 @@ Use `Counter` for values that only increase, such as total posts created, emails
 import { Inject } from '@fluojs/core';
 import { MetricsService } from '@fluojs/metrics';
 
+type CreatePostInput = {
+  content: string;
+  title: string;
+};
+
 @Inject(MetricsService)
 export class PostService {
-  constructor(private readonly metrics: MetricsService) {}
+  private readonly postsCreated: ReturnType<MetricsService['counter']>;
 
-  async create(data: any) {
-    const post = await this.prisma.post.create({ data });
-     
-     // Increment the counter each time a new post is created.
-    this.metrics.counter({
+  constructor(metrics: MetricsService) {
+    this.postsCreated = metrics.counter({
       name: 'blog_posts_created_total',
       help: 'Number of blog posts created',
-    }).inc();
-    
+    });
+  }
+
+  async create(data: CreatePostInput) {
+    const post = await this.prisma.post.create({ data });
+
+    // Reuse the existing counter each time a new post is created.
+    this.postsCreated.inc();
+
     return post;
   }
 }
 ```
 
+Create the counter once during service construction or application startup, then reuse the returned collector. Calling `MetricsService.counter(...)` repeatedly with the same metric name recreates a Prometheus collector and fails fast because metric names must stay unique inside a registry.
+
 ### Gauge: Measuring Current State
 Use `Gauge` for values that can go up or down, such as active WebSocket connections, items waiting in a queue, or currently logged-in users. A gauge represents a snapshot at a specific point in time.
 
 ```typescript
-// Set the current value directly.
-this.metrics.gauge({
+const activeSessions = metrics.gauge({
   name: 'active_sessions_count',
   help: 'Current number of active sessions',
-}).set(currentSessions);
+});
+
+// Later, set the current value directly.
+activeSessions.set(currentSessions);
 ```
 
 ### Histogram: Measuring Distributions
 Use `Histogram` for durations or sizes where you need to calculate percentiles, such as background job processing time, uploaded image size, or number of search result items.
 
 ```typescript
-// Observe the uploaded file size.
-this.metrics.histogram({
+const imageUploadSize = metrics.histogram({
   name: 'image_upload_size_bytes',
   help: 'Uploaded image size',
-}).observe(file.size);
+});
+
+// Later, observe the uploaded file size.
+imageUploadSize.observe(file.size);
 ```
 
 ### 19.5.1 Labels: Adding Dimension to Data
@@ -199,12 +214,12 @@ Naming conventions are very important for long-term maintainability. Follow the 
 Example: `fluoblog_posts_created_total`. A consistent naming convention makes it much easier to find and query metrics in Grafana even after an application grows to hundreds of different metrics.
 
 ### 19.5.4 Advanced Label Management: Dynamic Labels
-Sometimes label values are not known until runtime. Fluo's metrics service lets you pass labels dynamically when recording a value. For example, you can track the `error_code` for failed payments: `metrics.counter({ name: 'payment_failures_total', help: 'Number of failed payments', labelNames: ['code'] }).inc({ code: error.code })`.
+Sometimes label values are not known until runtime. Fluo's metrics service lets you pass labels dynamically when recording a value. For example, create `const paymentFailures = metrics.counter({ name: 'payment_failures_total', help: 'Number of failed payments', labelNames: ['code'] })` once, then record each failure with `paymentFailures.inc({ code: error.code })`.
 
 Be very careful with **cardinality** here. If the `code` label can have thousands of unique values, such as stack traces, it will overload Prometheus. Always make sure label values stay within a bounded range. If you need to track high-cardinality data, use logs instead of metrics.
 
 ### 19.5.5 Metric Initialization and "Zeroing"
-A common monitoring problem is that metrics do not appear in Prometheus until they are recorded for the first time. This can make dashboards look "empty" or break rate calculations. To solve this, it is a good idea to pre-register the required counters, gauges, and histograms during application startup.
+A common monitoring problem is that metrics do not appear in Prometheus until they are recorded for the first time. This can make dashboards look "empty" or break rate calculations. To solve this, it is a good idea to pre-register the required counters, gauges, and histograms during application startup. This startup or provider-construction phase is also where you should call `MetricsService.counter(...)`, `gauge(...)`, and `histogram(...)` once so later request handlers only reuse the collector objects.
 
 ## 19.6 Securing the Metrics Endpoint
 In production, you likely do not want to expose internal metrics to the general public. Metrics can reveal sensitive information about traffic patterns, user growth, and internal architecture. You can protect the endpoint with custom Middleware or Fluo's built-in security features.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -50,7 +50,7 @@ Scrape endpoint는 active `prom-client` Registry output을 해당 Registry의 Pr
 | `MetricsService` | Active Registry 위에서 custom `Counter`, `Gauge`, `Histogram`을 만들기 위한 application-facing facade입니다. | 비즈니스/application metric은 package internals 대신 이 서비스를 사용하세요. |
 | `METER_PROVIDER` / `PrometheusMeterProvider` | Provider token이 필요한 first-party package integration용 low-level meter bridge입니다. | Application code는 package-level integration을 직접 조합하는 경우가 아니면 보통 이 token이 필요하지 않습니다. |
 | `middleware` | Framework HTTP metrics와 endpoint-scoped middleware 뒤의 module middleware chain에 참여하는 module-level middleware입니다. | Route-scoped가 아니므로 scrape route만 보호하려면 `endpointMiddleware`를 사용하세요. |
-| `endpointMiddleware` | 설정된 scrape endpoint에만 바인딩되는 class-based `@fluojs/http` middleware constructor입니다. | `path: false`일 때는 무시됩니다. 함수나 global middleware declaration은 이 option의 계약 밖입니다. |
+| `endpointMiddleware` | 설정된 scrape endpoint에만 바인딩되는 class-based `@fluojs/http` middleware constructor입니다. | `path: false`일 때만 무시됩니다. `''`를 포함한 모든 문자열 `path`는 활성 endpoint path입니다. 함수나 global middleware declaration은 이 option의 계약 밖입니다. |
 
 ## 공통 패턴
 
@@ -102,6 +102,33 @@ MetricsModule.forRoot({
 ```
 
 `endpointMiddleware`는 class-based `@fluojs/http` middleware constructor를 받으며 metrics scrape endpoint에만 바인딩됩니다. middleware function이나 global middleware declaration은 이 option의 패키지 계약이 아닙니다. `middleware`는 module-level middleware로 남아 endpoint-scoped middleware 뒤의 module chain에서 실행되고, `endpointMiddleware`는 `path: false`로 scrape route를 비활성화하면 완전히 건너뜁니다. HTTP 계측이 활성화된 경우 endpoint middleware가 던진 실패도 내장 HTTP request/error collector에 기록됩니다.
+
+### Custom metric은 한 번 생성하고 재사용하기
+
+`MetricsService.counter(...)`, `gauge(...)`, `histogram(...)`은 active Registry에 Prometheus collector를 생성합니다. 각 custom metric은 provider construction 또는 application startup 중 한 번만 만들고, business action이 발생할 때는 반환된 collector를 재사용하세요.
+
+```ts
+import { Inject } from '@fluojs/core';
+import { MetricsService } from '@fluojs/metrics';
+
+@Inject(MetricsService)
+class OrdersService {
+  private readonly ordersCreated: ReturnType<MetricsService['counter']>;
+
+  constructor(metrics: MetricsService) {
+    this.ordersCreated = metrics.counter({
+      name: 'orders_created_total',
+      help: 'Total orders created',
+    });
+  }
+
+  recordOrderCreated(): void {
+    this.ordersCreated.inc();
+  }
+}
+```
+
+같은 이름으로 `MetricsService.counter(...)`를 다시 호출하면 collector를 다시 만들려고 하므로 Prometheus의 duplicate-name failure behavior를 따릅니다. 요청이나 command handler마다 새로 만들지 말고 collector를 저장해 재사용하세요.
 
 ### Framework metric과 app metric이 하나의 registry를 공유하기
 
@@ -178,7 +205,7 @@ MetricsModule.forRoot({
 
 ### 운영 기본값
 
-- `path`의 기본값은 `'/metrics'`이며, `path: false`로 스크레이프 엔드포인트를 완전히 비활성화할 수 있습니다.
+- `path`의 기본값은 `'/metrics'`입니다. `''`를 포함한 모든 문자열 path는 scrape endpoint를 노출하며, `path: false`로만 scrape endpoint를 완전히 비활성화할 수 있습니다.
 - scrape response는 active Registry의 Prometheus content type과 Registry contents를 사용합니다.
 - `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`로 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 끌 수 있습니다.
 - `endpointMiddleware`는 class-based route-scoped middleware를 스크레이프 엔드포인트에만 바인딩합니다. HTTP 계측이 활성화된 경우 endpoint middleware 실패는 내장 HTTP collector에 집계됩니다.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -50,7 +50,7 @@ The scrape endpoint returns the active `prom-client` registry output with that r
 | `MetricsService` | Application-facing facade for custom `Counter`, `Gauge`, and `Histogram` metrics on the active registry. | Use this for business/application metrics instead of reaching into package internals. |
 | `METER_PROVIDER` / `PrometheusMeterProvider` | Low-level meter bridge for first-party package integrations that need a provider token. | Application code usually does not need this token unless it is composing package-level integrations. |
 | `middleware` | Module-level middleware that participates in the module middleware chain after framework HTTP metrics and endpoint-scoped middleware. | It is not route-scoped; use `endpointMiddleware` when only the scrape route should be protected. |
-| `endpointMiddleware` | Class-based `@fluojs/http` middleware constructors bound only to the configured scrape endpoint. | Ignored when `path: false`; functions or global middleware declarations are outside this option's contract. |
+| `endpointMiddleware` | Class-based `@fluojs/http` middleware constructors bound only to the configured scrape endpoint. | Ignored only when `path: false`; any string `path`, including `''`, remains an active endpoint path. Functions or global middleware declarations are outside this option's contract. |
 
 ## Common Patterns
 
@@ -102,6 +102,33 @@ MetricsModule.forRoot({
 ```
 
 `endpointMiddleware` accepts class-based `@fluojs/http` middleware constructors and binds them only to the metrics scrape endpoint. Middleware functions or global middleware declarations are not the package contract for this option. `middleware` remains module-level middleware and runs as part of the module chain after endpoint-scoped middleware, while `endpointMiddleware` is skipped entirely when `path: false` disables the scrape route. When HTTP instrumentation is enabled, failures thrown by endpoint middleware are recorded in the built-in HTTP request and error collectors.
+
+### Create custom metrics once and reuse them
+
+`MetricsService.counter(...)`, `gauge(...)`, and `histogram(...)` create Prometheus collectors on the active registry. Create each custom metric once during provider construction or application startup, then reuse the returned collector when business actions occur.
+
+```ts
+import { Inject } from '@fluojs/core';
+import { MetricsService } from '@fluojs/metrics';
+
+@Inject(MetricsService)
+class OrdersService {
+  private readonly ordersCreated: ReturnType<MetricsService['counter']>;
+
+  constructor(metrics: MetricsService) {
+    this.ordersCreated = metrics.counter({
+      name: 'orders_created_total',
+      help: 'Total orders created',
+    });
+  }
+
+  recordOrderCreated(): void {
+    this.ordersCreated.inc();
+  }
+}
+```
+
+Calling `MetricsService.counter(...)` again with the same name recreates the collector and follows Prometheus' duplicate-name failure behavior. Store and reuse the collector instead of creating it inside each request or command handler.
 
 ### Share one registry for framework and app metrics
 
@@ -178,7 +205,7 @@ MetricsModule.forRoot({
 
 ### Operational defaults
 
-- `path` defaults to `'/metrics'`, and `path: false` disables the scrape endpoint entirely.
+- `path` defaults to `'/metrics'`, any string path including `''` exposes a scrape endpoint, and `path: false` disables the scrape endpoint entirely.
 - The scrape response uses the active registry's Prometheus content type and registry contents.
 - `defaultMetrics` defaults to `true`, and `defaultMetrics: false` disables Prometheus default process and Node.js collectors for that registry.
 - `endpointMiddleware` binds class-based route-scoped middleware only to the scrape endpoint; with HTTP instrumentation enabled, endpoint middleware failures are counted by the built-in HTTP collectors.

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -115,6 +115,46 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
+  it('binds endpoint middleware when the scrape endpoint path is empty', async () => {
+    class MetricsAccessMiddleware {
+      async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        if (context.request.headers['x-metrics-token'] !== 'secret-token') {
+          throw new ForbiddenException('Metrics endpoint requires x-metrics-token.');
+        }
+
+        await next();
+      }
+    }
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [
+        MetricsModule.forRoot({
+          defaultMetrics: false,
+          endpointMiddleware: [MetricsAccessMiddleware],
+          path: '',
+        }),
+      ],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+
+    const forbiddenResponse = createResponse();
+    await app.dispatch(createRequest(''), forbiddenResponse);
+    expect(forbiddenResponse.statusCode).toBe(403);
+
+    const metricsResponse = createResponse();
+    await app.dispatch(createRequest('', { 'x-metrics-token': 'secret-token' }), metricsResponse);
+
+    expect(metricsResponse.statusCode).toBe(200);
+    expect(String(metricsResponse.body)).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
+
+    await app.close();
+  });
+
   it('records endpoint middleware failures when HTTP instrumentation is enabled', async () => {
     class MetricsAccessMiddleware {
       async handle(context: MiddlewareContext, next: Next): Promise<void> {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -92,7 +92,7 @@ export class MetricsModule {
       collectDefaultMetrics({ register: registry });
     }
 
-    const endpointMiddleware = metricsPath
+    const endpointMiddleware = typeof metricsPath === 'string'
       ? (options.endpointMiddleware ?? []).map((middlewareClass) => forRoutes(middlewareClass, metricsPath))
       : [];
     const middleware = [


### PR DESCRIPTION
## Summary
Closes #2105

This PR fixes `@fluojs/metrics` empty-string metrics path handling and updates package/book examples to create custom metrics once and reuse them.

Linked context: #2105

## Changes
- Binds `endpointMiddleware` when metrics path is an empty string, matching controller registration semantics.
- Adds regression coverage for empty-path metrics endpoint middleware.
- Updates EN/KO package README custom metric guidance.
- Updates beginner book ch19 EN/KO examples to reuse counters/gauges/histograms.
- Adds a patch changeset for `@fluojs/metrics`.

## Testing
- `pnpm --filter @fluojs/metrics test`
- `pnpm --filter @fluojs/metrics... build`
- `pnpm --filter @fluojs/metrics typecheck`
- `pnpm docs:sync-check`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main`
- `pnpm verify:platform-consistency-governance`

## Release impact
- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation
See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract
See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)
See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by relevant package regression tests.

## Remaining risks
`pnpm verify:release-readiness` was attempted and failed in an unrelated `Starter shape and runtime ownership` release-readiness check. Branch is behind `origin/main` by 1 commit; no rebase was performed in the child implementer.
