### PR TITLE
Resolve #2103: align Drizzle facade surface

### DIFF
--- a/.changeset/drizzle-facade-surface.md
+++ b/.changeset/drizzle-facade-surface.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/drizzle": patch
+---
+
+Align the Drizzle direct-method facade type and documentation, classify `DrizzleDatabase.createFacade(...)` as a low-level compatibility helper, and remove the stale `@fluojs/http` runtime dependency.

--- a/book/intermediate/ch20-drizzle.ko.md
+++ b/book/intermediate/ch20-drizzle.ko.md
@@ -8,7 +8,7 @@
 ## Learning Objectives
 - fluo에서 Drizzle ORM을 사용할 때의 장점과 적용 위치를 구분합니다.
 - `DrizzleModule` 구성과 드라이버 리소스 수명 주기 관리 방식을 정리합니다.
-- `DrizzleDatabase`를 사용하는 리포지토리 흐름을 구성합니다.
+- 직접 Drizzle query 메서드를 호출하는 리포지토리에 `DrizzleDatabaseFacade`를 사용하는 흐름을 구성합니다.
 - FluoShop 주문 관리용 관계형 스키마를 설계하는 접근을 확인합니다.
 - 상태 스냅샷으로 SQL 연결 상태를 점검하는 운영 기준을 정리합니다.
 
@@ -70,10 +70,10 @@ export class PersistenceModule {}
 
 ## 20.4 Repositories and Connection Management
 
-Fluo에서는 리포지토리에 `DrizzleDatabase` 서비스를 주입합니다. 이는 컨텍스트 인식 프록시 역할을 하며, 쿼리가 루트 데이터베이스 핸들 또는 활성 트랜잭션 핸들 중 올바른 대상에서 실행되도록 맞춰 줍니다.
+Fluo에서는 리포지토리에 `DrizzleDatabase` 서비스를 주입합니다. 리포지토리가 Drizzle query 메서드를 직접 호출한다면 주입 값을 `DrizzleDatabaseFacade<TDatabase>`로 타입 지정하세요. 이 값은 컨텍스트 인식 프록시 역할을 하며, 쿼리가 루트 데이터베이스 핸들 또는 활성 트랜잭션 핸들 중 올바른 대상에서 실행되도록 맞춰 줍니다. `current()`, `transaction(...)`, `requestTransaction(...)`, 상태 스냅샷 같은 wrapper 메서드만 필요하면 `DrizzleDatabase<TDatabase>`를 사용합니다.
 
 ```typescript
-import { DrizzleDatabase } from '@fluojs/drizzle';
+import { DrizzleDatabase, type DrizzleDatabaseFacade } from '@fluojs/drizzle';
 import { Inject } from '@fluojs/core';
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
@@ -83,10 +83,10 @@ type AppDatabase = ReturnType<typeof drizzle>;
 
 @Inject(DrizzleDatabase)
 export class ProductRepository {
-  constructor(private readonly db: DrizzleDatabase<AppDatabase>) {}
+  constructor(private readonly db: DrizzleDatabaseFacade<AppDatabase>) {}
 
   async findById(id: string) {
-    // 기본 흐름: 데이터베이스 핸들을 직접 호출합니다.
+    // 기본 흐름: facade 타입을 통해 Drizzle query 메서드를 호출합니다.
     return this.db
       .select()
       .from(products)
@@ -127,7 +127,7 @@ export const orders = pgTable('orders', {
 });
 ```
 
-`DrizzleDatabase`를 사용하면 서비스가 트랜잭션 핸들을 직접 넘기지 않아도 복잡한 다중 테이블 삽입 작업을 같은 경계 안에서 조율할 수 있습니다. 이 덕분에 checkout 흐름은 저장소 호출 순서에 집중하고, 트랜잭션 선택은 fluo 통합 계층에 맡길 수 있습니다.
+`DrizzleDatabaseFacade`를 사용하면 리포지토리가 트랜잭션 핸들을 직접 넘기지 않아도 복잡한 다중 테이블 삽입 작업을 같은 경계 안에서 조율할 수 있습니다. 이 덕분에 checkout 흐름은 저장소 호출 순서에 집중하고, 트랜잭션 선택은 fluo 통합 계층에 맡길 수 있습니다.
 
 ## 20.7 Observability and Health
 

--- a/book/intermediate/ch20-drizzle.md
+++ b/book/intermediate/ch20-drizzle.md
@@ -8,8 +8,8 @@ This chapter explains how to integrate Drizzle for relational data and SQL-cente
 ## Learning Objectives
 - Distinguish the advantages of using Drizzle ORM in fluo and where to apply it.
 - Outline `DrizzleModule` configuration and driver resource lifecycle management.
-- Build a repository flow that uses `DrizzleDatabase`.
-- Compare manual transactions with the request-scoped transaction Interceptor.
+- Build a repository flow that uses `DrizzleDatabaseFacade` for direct Drizzle query methods.
+- Compare service transactions with explicit `requestTransaction(...)` boundaries.
 - Review an approach to designing a relational schema for FluoShop order management.
 - Define operational standards for checking SQL connection status with status snapshots.
 
@@ -71,10 +71,10 @@ export class PersistenceModule {}
 
 ## 20.4 Repositories and Connection Management
 
-In Fluo, repositories receive the `DrizzleDatabase` service through injection. It acts as a context-aware proxy, ensuring that queries run against the correct target: either the root database handle or the active transaction handle.
+In Fluo, repositories receive the `DrizzleDatabase` service through injection. When repositories call Drizzle query methods directly, type the injected value as `DrizzleDatabaseFacade<TDatabase>`. It acts as a context-aware proxy, ensuring that queries run against the correct target: either the root database handle or the active transaction handle. Use `DrizzleDatabase<TDatabase>` for providers that only need wrapper methods such as `current()`, `transaction(...)`, `requestTransaction(...)`, or status snapshots.
 
 ```typescript
-import { DrizzleDatabase } from '@fluojs/drizzle';
+import { DrizzleDatabase, type DrizzleDatabaseFacade } from '@fluojs/drizzle';
 import { Inject } from '@fluojs/core';
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
@@ -84,10 +84,10 @@ type AppDatabase = ReturnType<typeof drizzle>;
 
 @Inject(DrizzleDatabase)
 export class ProductRepository {
-  constructor(private readonly db: DrizzleDatabase<AppDatabase>) {}
+  constructor(private readonly db: DrizzleDatabaseFacade<AppDatabase>) {}
 
   async findById(id: string) {
-    // Primary flow: call the model directly.
+    // Primary flow: call Drizzle query methods through the facade type.
     return this.db
       .select()
       .from(products)
@@ -130,7 +130,7 @@ export const orders = pgTable('orders', {
 });
 ```
 
-Using `DrizzleDatabase` lets services coordinate complex multi-table insert operations inside the same boundary without passing transaction handles directly.
+Using `DrizzleDatabaseFacade` lets repositories coordinate complex multi-table insert operations inside the same boundary without passing transaction handles directly.
 
 ## 20.7 Observability and Health
 

--- a/packages/drizzle/README.ko.md
+++ b/packages/drizzle/README.ko.md
@@ -70,8 +70,11 @@ export class AppModule {}
 `@Transaction()` 데코레이터는 서비스 레이어에서 트랜잭션 경계를 정의하는 권장 방법입니다. 이 데코레이터가 적용된 메서드 내부에서 발생하는 모든 리포지토리 호출은 동일한 Drizzle 트랜잭션을 공유합니다.
 
 ```ts
-import { Transaction, DrizzleDatabase } from '@fluojs/drizzle';
+import { Transaction, DrizzleDatabase, type DrizzleDatabaseFacade } from '@fluojs/drizzle';
+import { drizzle } from 'drizzle-orm/node-postgres';
 import { users, profiles } from './schema';
+
+type AppDatabase = ReturnType<typeof drizzle>;
 
 export class UserService {
   constructor(private readonly repo: UserRepository) {}
@@ -85,10 +88,10 @@ export class UserService {
 }
 
 export class UserRepository {
-  constructor(private readonly db: DrizzleDatabase) {}
+  constructor(private readonly db: DrizzleDatabaseFacade<AppDatabase>) {}
 
   async create(data: any) {
-    // 리포지토리 호출은 표준 Drizzle 메서드를 사용합니다.
+    // facade 타입은 표준 Drizzle 메서드를 노출합니다.
     // @Transaction() 내부에서 호출되면 자동으로 활성 트랜잭션에 참여합니다.
     return this.db.insert(users).values(data);
   }
@@ -107,11 +110,13 @@ export class UserRepository {
 
 ```ts
 import { DrizzleDatabase } from '@fluojs/drizzle';
-import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
 import { users } from './schema';
 
+type AppDatabase = ReturnType<typeof drizzle>;
+
 export class AdvancedRepository {
-  constructor(private readonly db: DrizzleDatabase) {}
+  constructor(private readonly db: DrizzleDatabase<AppDatabase>) {}
 
   async customOperation() {
     const tx = this.db.current();
@@ -126,8 +131,10 @@ export class AdvancedRepository {
 
 ```ts
 await this.db.transaction(async () => {
-  await this.db.insert(users).values(user);
-  await this.db.insert(profiles).values(profile);
+  const current = this.db.current();
+
+  await current.insert(users).values(user);
+  await current.insert(profiles).values(profile);
 });
 ```
 
@@ -173,6 +180,7 @@ defineModule(ManualDrizzleModule, {
 
 - `DrizzleModule.forRoot(options)` / `DrizzleModule.forRootAsync(options)`
 - `DrizzleDatabase`
+- `DrizzleDatabaseFacade<TDatabase>`
 - `Transaction`
 - `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_HANDLE_PROVIDER`, `DRIZZLE_OPTIONS`
 - `createDrizzlePlatformStatusSnapshot(...)`
@@ -181,6 +189,8 @@ defineModule(ManualDrizzleModule, {
 - `DrizzleHandleProvider`
 
 `DRIZZLE_HANDLE_PROVIDER`는 lifecycle-aware `DrizzleDatabase` wrapper를 가리키는 alias token입니다. `@fluojs/terminus` 같은 health integration은 이 token을 통해 raw database ping으로 fallback하기 전에 `createPlatformStatusSnapshot()`을 읽습니다.
+
+provider가 `current()`, `transaction(...)`, `requestTransaction(...)`, `createPlatformStatusSnapshot()` 같은 wrapper 메서드만 필요로 하면 `DrizzleDatabase<TDatabase>`를 사용하세요. 리포지토리 주입에서 Drizzle query 메서드를 직접 호출해야 한다면 `DrizzleDatabaseFacade<TDatabase>`를 사용합니다. 이 facade는 활성 트랜잭션 handle이 있으면 그 handle로, 없으면 root handle로 호출을 전달합니다. `DrizzleDatabase.createFacade(...)`는 module provider wiring을 위한 low-level compatibility helper로 유지됩니다. 애플리케이션 코드는 `DrizzleModule.forRoot(...)` / `forRootAsync(...)`를 우선 사용하세요.
 
 `Transaction`은 서비스 계층 트랜잭션 경계를 위한 표준 TC39 method decorator입니다. 기본적으로 ambient `DrizzleDatabase`를 resolve하고, 명시적 client 선택에는 accessor를 받을 수 있으며, 외부 경계에는 Drizzle transaction option을 전달할 수 있습니다.
 

--- a/packages/drizzle/README.md
+++ b/packages/drizzle/README.md
@@ -70,8 +70,11 @@ export class AppModule {}
 The `@Transaction()` decorator is the recommended way to define transaction boundaries in your service layer. It ensures that all repository calls made within the decorated method share the same Drizzle transaction.
 
 ```ts
-import { Transaction, DrizzleDatabase } from '@fluojs/drizzle';
+import { Transaction, DrizzleDatabase, type DrizzleDatabaseFacade } from '@fluojs/drizzle';
+import { drizzle } from 'drizzle-orm/node-postgres';
 import { users, profiles } from './schema';
+
+type AppDatabase = ReturnType<typeof drizzle>;
 
 export class UserService {
   constructor(private readonly repo: UserRepository) {}
@@ -85,10 +88,10 @@ export class UserService {
 }
 
 export class UserRepository {
-  constructor(private readonly db: DrizzleDatabase) {}
+  constructor(private readonly db: DrizzleDatabaseFacade<AppDatabase>) {}
 
   async create(data: any) {
-    // Repository calls use standard Drizzle methods.
+    // The facade type exposes standard Drizzle methods.
     // When called inside @Transaction(), they automatically participate in the ambient transaction.
     return this.db.insert(users).values(data);
   }
@@ -107,11 +110,13 @@ The `DrizzleDatabase` provides a `current()` method that returns the active tran
 
 ```ts
 import { DrizzleDatabase } from '@fluojs/drizzle';
-import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
 import { users } from './schema';
 
+type AppDatabase = ReturnType<typeof drizzle>;
+
 export class AdvancedRepository {
-  constructor(private readonly db: DrizzleDatabase) {}
+  constructor(private readonly db: DrizzleDatabase<AppDatabase>) {}
 
   async customOperation() {
     const tx = this.db.current();
@@ -126,8 +131,10 @@ Use `db.transaction()` for manual transaction blocks:
 
 ```ts
 await this.db.transaction(async () => {
-  await this.db.insert(users).values(user);
-  await this.db.insert(profiles).values(profile);
+  const current = this.db.current();
+
+  await current.insert(users).values(user);
+  await current.insert(profiles).values(profile);
 });
 ```
 
@@ -173,6 +180,7 @@ defineModule(ManualDrizzleModule, {
 
 - `DrizzleModule.forRoot(options)` / `DrizzleModule.forRootAsync(options)`
 - `DrizzleDatabase`
+- `DrizzleDatabaseFacade<TDatabase>`
 - `Transaction`
 - `DRIZZLE_DATABASE`, `DRIZZLE_DISPOSE`, `DRIZZLE_HANDLE_PROVIDER`, `DRIZZLE_OPTIONS`
 - `createDrizzlePlatformStatusSnapshot(...)`
@@ -181,6 +189,8 @@ defineModule(ManualDrizzleModule, {
 - `DrizzleHandleProvider`
 
 `DRIZZLE_HANDLE_PROVIDER` is an alias token for the lifecycle-aware `DrizzleDatabase` wrapper. Health integrations such as `@fluojs/terminus` use this token to read `createPlatformStatusSnapshot()` before falling back to raw database pings.
+
+Use `DrizzleDatabase<TDatabase>` when a provider only needs wrapper methods such as `current()`, `transaction(...)`, `requestTransaction(...)`, or `createPlatformStatusSnapshot()`. Use `DrizzleDatabaseFacade<TDatabase>` for repository injections that call Drizzle query methods directly; the facade forwards those calls to the active transaction handle when one exists and to the root handle otherwise. `DrizzleDatabase.createFacade(...)` is retained as a low-level compatibility helper for module-provider wiring; application code should prefer `DrizzleModule.forRoot(...)` / `forRootAsync(...)`.
 
 `Transaction` is a standard TC39 method decorator for service-layer transaction boundaries. It resolves the ambient `DrizzleDatabase` by default, accepts an accessor for explicit client selection, and can forward Drizzle transaction options to the outer boundary.
 

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "@fluojs/core": "workspace:^",
-    "@fluojs/http": "workspace:^",
     "@fluojs/di": "workspace:^",
     "@fluojs/runtime": "workspace:^"
   },
@@ -57,6 +56,7 @@
     }
   },
   "devDependencies": {
+    "@fluojs/http": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -142,7 +142,19 @@ export class DrizzleDatabase<
     private readonly databaseOptions: DrizzleRuntimeOptions = { strictTransactions: false },
   ) {}
 
-  /** Creates the DI-facing facade that forwards unknown Drizzle API properties to the ambient `current()` handle. */
+  /**
+   * Creates the low-level DI facade that forwards unknown Drizzle API properties to the ambient `current()` handle.
+   *
+   * @remarks
+   * This compatibility helper is used by `DrizzleModule` provider wiring. Application code should prefer
+   * `DrizzleModule.forRoot(...)` or `DrizzleModule.forRootAsync(...)`, then type injected repository handles as
+   * `DrizzleDatabaseFacade<TDatabase>` when direct Drizzle methods are needed.
+   *
+   * @param database Root Drizzle database handle registered in the module.
+   * @param dispose Optional shutdown hook used to close pools or driver resources.
+   * @param databaseOptions Runtime transaction options consumed by the Fluo wrapper.
+   * @returns A transaction-aware facade that exposes wrapper methods plus the root Drizzle handle surface.
+   */
   static createFacade<
     TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
     TTransactionDatabase = TDatabase,
@@ -151,10 +163,10 @@ export class DrizzleDatabase<
     database: TDatabase,
     dispose?: (database: TDatabase) => Promise<void> | void,
     databaseOptions: DrizzleRuntimeOptions = { strictTransactions: false },
-  ): DrizzleDatabase<TDatabase, TTransactionDatabase, TTransactionOptions> {
+  ): DrizzleDatabaseFacade<TDatabase, TTransactionDatabase, TTransactionOptions> {
     return createCurrentlessDrizzleFacade(
       new DrizzleDatabase<TDatabase, TTransactionDatabase, TTransactionOptions>(database, dispose, databaseOptions),
-    );
+    ) as DrizzleDatabaseFacade<TDatabase, TTransactionDatabase, TTransactionOptions>;
   }
 
   /**
@@ -455,3 +467,22 @@ export class DrizzleDatabase<
     return this.database.transaction.bind(this.database) as DrizzleTransactionRunner<TTransactionDatabase, TTransactionOptions>;
   }
 }
+
+/**
+ * Injection-facing Drizzle facade type that combines the Fluo wrapper methods with the registered database handle.
+ *
+ * @remarks
+ * `DrizzleModule` resolves `DrizzleDatabase` to a proxy that forwards unknown properties to `current()`. Use this type
+ * in repositories that call Drizzle query methods directly, and use `DrizzleDatabase<TDatabase>` when only the wrapper
+ * methods (`current()`, `transaction(...)`, `requestTransaction(...)`, and status snapshots) are needed.
+ *
+ * @typeParam TDatabase Root Drizzle database handle registered in the module.
+ * @typeParam TTransactionDatabase Transaction-scoped database handle resolved inside `database.transaction(...)` callbacks.
+ * @typeParam TTransactionOptions Options forwarded to the underlying Drizzle transaction runner.
+ */
+export type DrizzleDatabaseFacade<
+  TDatabase extends DrizzleDatabaseLike<TTransactionDatabase, TTransactionOptions>,
+  TTransactionDatabase = TDatabase,
+  TTransactionOptions = unknown,
+> = DrizzleDatabase<TDatabase, TTransactionDatabase, TTransactionOptions> &
+  Omit<TDatabase, keyof DrizzleDatabase<TDatabase, TTransactionDatabase, TTransactionOptions>>;

--- a/packages/drizzle/src/transaction-decorator.red.test.ts
+++ b/packages/drizzle/src/transaction-decorator.red.test.ts
@@ -2,7 +2,7 @@ import { Inject } from '@fluojs/core';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
 
-import { DrizzleDatabase, DrizzleModule, Transaction } from './index.js';
+import { DrizzleDatabase, DrizzleModule, Transaction, type DrizzleDatabaseFacade } from './index.js';
 
 describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 impl)', () => {
   it('exports Transaction and opens a transaction for current-less repository calls', async () => {
@@ -63,7 +63,7 @@ describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 i
 
     @Inject(DrizzleDatabase)
     class UserRepository {
-      constructor(private readonly db: DrizzleDatabase<typeof database, typeof transactionDatabase> & typeof database) {}
+      constructor(private readonly db: DrizzleDatabaseFacade<typeof database, typeof transactionDatabase>) {}
 
       async create(email: string) {
         return this.db.insert(users).values({ email });
@@ -152,7 +152,7 @@ describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 i
 
     @Inject(DrizzleDatabase)
     class UserRepository {
-      constructor(private readonly db: DrizzleDatabase<typeof database, typeof transactionDatabase> & typeof database) {}
+      constructor(private readonly db: DrizzleDatabaseFacade<typeof database, typeof transactionDatabase>) {}
 
       async create(email: string) {
         return this.db.insert(users).values({ email });
@@ -234,7 +234,7 @@ describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 i
 
     @Inject(DrizzleDatabase)
     class UserRepository {
-      constructor(private readonly db: DrizzleDatabase<typeof database, typeof transactionDatabase> & typeof database) {}
+      constructor(private readonly db: DrizzleDatabaseFacade<typeof database, typeof transactionDatabase>) {}
 
       async create(email: string) {
         return this.db.insert(users).values({ email });

--- a/packages/drizzle/src/vertical-slice.test.ts
+++ b/packages/drizzle/src/vertical-slice.test.ts
@@ -12,7 +12,7 @@ import {
   type FrameworkResponse,
 } from '@fluojs/http';
 
-import { DrizzleModule, DrizzleDatabase, Transaction } from './index.js';
+import { DrizzleModule, DrizzleDatabase, Transaction, type DrizzleDatabaseFacade } from './index.js';
 
 function createResponse(events?: string[]): FrameworkResponse & { body?: unknown } {
   return {
@@ -112,10 +112,10 @@ describe('@fluojs/drizzle service boundary primary flow', () => {
 
     @Inject(DrizzleDatabase)
     class UserRepository {
-      constructor(private readonly db: DrizzleDatabase<typeof database, typeof transactionDatabase>) {}
+      constructor(private readonly db: DrizzleDatabaseFacade<typeof database, typeof transactionDatabase>) {}
 
       async create(input: CreateUserRequest) {
-        return (this.db as unknown as typeof database).insert('users').values({
+        return this.db.insert('users').values({
           email: input.email,
           name: input.name,
         });
@@ -207,10 +207,10 @@ describe('@fluojs/drizzle service boundary primary flow', () => {
 
     @Inject(DrizzleDatabase)
     class UserRepository {
-      constructor(private readonly db: DrizzleDatabase<typeof database, typeof transactionDatabase>) {}
+      constructor(private readonly db: DrizzleDatabaseFacade<typeof database, typeof transactionDatabase>) {}
 
       async create(input: CreateUserRequest) {
-        return (this.db as unknown as typeof database).insert('users').values(input);
+        return this.db.insert('users').values(input);
       }
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,9 +332,6 @@ importers:
       '@fluojs/di':
         specifier: workspace:^
         version: link:../di
-      '@fluojs/http':
-        specifier: workspace:^
-        version: link:../http
       '@fluojs/runtime':
         specifier: workspace:^
         version: link:../runtime
@@ -342,6 +339,9 @@ importers:
         specifier: '>=0.30.0'
         version: 0.45.1(@opentelemetry/api@1.9.0)(@prisma/client@7.5.0(typescript@6.0.2))
     devDependencies:
+      '@fluojs/http':
+        specifier: workspace:^
+        version: link:../http
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)


### PR DESCRIPTION
## Summary

Linked context: Closes #2103

Align the `@fluojs/drizzle` direct-method facade contract so docs, types, and package metadata describe the same database API surface.

## Changes

- Added the public `DrizzleDatabaseFacade<TDatabase>` type for repository injections that call Drizzle query methods directly.
- Documented `DrizzleDatabase.createFacade(...)` as a low-level compatibility helper for module-provider wiring.
- Updated `packages/drizzle` English/Korean README examples and `book/intermediate/ch20-drizzle` English/Korean content to distinguish wrapper-only `DrizzleDatabase<TDatabase>` usage from direct-method `DrizzleDatabaseFacade<TDatabase>` usage.
- Moved `@fluojs/http` from the `@fluojs/drizzle` runtime dependencies to dev dependencies because only tests import it now.
- Added `.changeset/drizzle-facade-surface.md` with a patch release intent for `@fluojs/drizzle`.

## Testing

- `lsp_diagnostics` on changed Drizzle TS files: pass, no diagnostics.
- `pnpm install --ignore-scripts --frozen-lockfile`: pass.
- `pnpm --filter @fluojs/drizzle... build`: pass.
- `pnpm --filter @fluojs/drizzle typecheck`: pass.
- `pnpm --filter @fluojs/drizzle test`: pass, 5 files / 41 tests.
- `pnpm verify:public-export-tsdoc`: pass.
- `pnpm docs:sync-check`: pass.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`: pass.
- `pnpm verify:release-readiness`: attempted, but blocked by an unrelated existing `packages/cli/src/cli.test.ts` failure in `keeps the local sandbox outside the repo workspace` where `fallbackResult.status` was `1` instead of `0`.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Release note source: `.changeset/drizzle-facade-surface.md` (`@fluojs/drizzle`: patch).

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

`DrizzleDatabaseFacade<TDatabase>` includes TSDoc, and `DrizzleDatabase.createFacade(...)` now documents compatibility-helper scope, parameters, and return value.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This aligns the documented direct-method facade with the typed API surface; runtime transaction behavior is unchanged.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. EN/KO README and book mirrors were updated together, and `pnpm docs:sync-check` passed.