### PR TITLE
Resolve #2097: event-bus bootstrap leaves partially subscribed transports open on failure

### DIFF
--- a/.changeset/event-bus-bootstrap-subscription-rollback.md
+++ b/.changeset/event-bus-bootstrap-subscription-rollback.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/event-bus": patch
+---
+
+Close the configured event-bus transport when bootstrap subscription wiring fails after partially opening transport channels.

--- a/packages/event-bus/README.ko.md
+++ b/packages/event-bus/README.ko.md
@@ -120,7 +120,7 @@ class UserRegisteredEvent {
 - `EventBus`, `EventPublishOptions`, `EventBusModuleOptions`, `EventType`: 발행, 기본값, 트랜스포트, 안정적인 이벤트 키를 위한 타입 전용 계약입니다.
 - `EventBusLifecycleState`, `EventBusStatusAdapterInput`, `EventBusPlatformStatusSnapshot`: status snapshot 계약입니다.
 
-Transport bootstrap은 unique event channel마다 한 번만 subscribe합니다. `eventKey`가 있으면 transport channel 이름을 제어합니다. 잘못된 JSON transport message는 무시되며, shutdown 시작 뒤 도착한 inbound transport message는 local handler dispatch 전에 무시됩니다.
+Transport bootstrap은 unique event channel마다 한 번만 subscribe합니다. `eventKey`가 있으면 transport channel 이름을 제어합니다. Bootstrap 중 이후 transport subscription이 실패하면 이벤트 버스는 이미 열린 channel을 rollback하기 위해 subscription error를 다시 던지기 전에 transport를 닫습니다. 잘못된 JSON transport message는 무시되며, shutdown 시작 뒤 도착한 inbound transport message는 local handler dispatch 전에 무시됩니다.
 
 ## 런타임별 및 통합 서브패스
 

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -120,7 +120,7 @@ Handlers are discovered from singleton providers and controllers across imported
 - `EventBus`, `EventPublishOptions`, `EventBusModuleOptions`, `EventType`: Type-only contracts for publishing, defaults, transports, and stable event keys.
 - `EventBusLifecycleState`, `EventBusStatusAdapterInput`, `EventBusPlatformStatusSnapshot`: Status snapshot contracts.
 
-Transport bootstrap subscribes once per unique event channel. `eventKey` controls the transport channel name when present. Invalid JSON transport messages are ignored, and inbound transport messages that arrive after shutdown starts are ignored before local handler dispatch.
+Transport bootstrap subscribes once per unique event channel. `eventKey` controls the transport channel name when present. If a later transport subscription fails during bootstrap, the event bus closes the transport to roll back any channels that were already opened before rethrowing the subscription error. Invalid JSON transport messages are ignored, and inbound transport messages that arrive after shutdown starts are ignored before local handler dispatch.
 
 ## Runtime-Specific and Integration Subpaths
 

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -1201,6 +1201,56 @@ describe('@fluojs/event-bus', () => {
       ).toBe(true);
     });
 
+    it('rolls back opened transport subscriptions when later bootstrap wiring fails', async () => {
+      const loggerEvents: string[] = [];
+      const openedChannels = new Set<string>();
+      const subscribedChannels: string[] = [];
+      let closeCalls = 0;
+      const transport = {
+        async publish(_channel: string, _payload: unknown) {},
+        async subscribe(channel: string, _handler: (payload: unknown) => Promise<void>) {
+          subscribedChannels.push(channel);
+
+          if (subscribedChannels.length === 2) {
+            throw new Error('second subscribe failed');
+          }
+
+          openedChannels.add(channel);
+        },
+        async close() {
+          closeCalls += 1;
+          openedChannels.clear();
+        },
+      } satisfies EventBusTransport;
+
+      class UserCreatedHandler {
+        @OnEvent(UserCreatedEvent)
+        onUserCreated(_event: UserCreatedEvent) {}
+      }
+
+      class PasswordResetHandler {
+        @OnEvent(PasswordResetEvent)
+        onPasswordReset(_event: PasswordResetEvent) {}
+      }
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [EventBusModule.forRoot({ transport })],
+        providers: [UserCreatedHandler, PasswordResetHandler],
+      });
+
+      await expect(
+        bootstrapApplication({ logger: createLogger(loggerEvents), rootModule: AppModule }),
+      ).rejects.toThrow('second subscribe failed');
+
+      expect(subscribedChannels).toHaveLength(2);
+      expect(closeCalls).toBe(1);
+      expect(openedChannels.size).toBe(0);
+      expect(
+        loggerEvents.some((event) => event.includes('EventBusTransport failed to subscribe to channel "PasswordResetEvent".')),
+      ).toBe(true);
+    });
+
     it('dispatches incoming transport messages to local handlers', async () => {
       const transport = createMockTransport();
 

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -1,12 +1,7 @@
 import { Inject, type MetadataPropertyKey, type Token } from '@fluojs/core';
 import { cloneWithFallback, getClassDiMetadata } from '@fluojs/core/internal';
 import type { Container, Provider } from '@fluojs/di';
-import {
-  type ApplicationLogger,
-  type CompiledModule,
-  type OnApplicationBootstrap,
-  type OnApplicationShutdown,
-} from '@fluojs/runtime';
+import type { ApplicationLogger, CompiledModule, OnApplicationBootstrap, OnApplicationShutdown } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
 
 import { getEventHandlerMetadataEntries } from './metadata.js';
@@ -103,6 +98,7 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
   private shutdownDrainTimeouts = 0;
   private readonly activeDispatches = new Set<Promise<void>>();
   private readonly transport: EventBusTransport | undefined;
+  private transportClosed = false;
 
   constructor(
     private readonly runtimeContainer: Container,
@@ -128,22 +124,17 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
 
   async onApplicationShutdown(): Promise<void> {
     this.lifecycleState = 'stopping';
+    let transportClosedCleanly = true;
 
     if (this.activeDispatches.size > 0) {
       await this.drainActiveDispatches();
     }
 
     if (this.transport) {
-      try {
-        await this.transport.close();
-      } catch (error) {
-        this.transportCloseFailures += 1;
-        this.lifecycleState = 'failed';
-        this.logger.error('EventBusTransport failed to close.', error, 'EventBusLifecycleService');
-      }
+      transportClosedCleanly = await this.closeTransportOrRecordFailure('EventBusTransport failed to close.');
     }
 
-    if (this.lifecycleState !== 'failed') {
+    if (transportClosedCleanly) {
       this.lifecycleState = 'stopped';
     }
   }
@@ -486,9 +477,43 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
       descriptorsByChannel.set(channel, channelDescriptors);
     }
 
-    for (const [channel, channelDescriptors] of descriptorsByChannel) {
-      await this.subscribeTransportChannel(channel, channelDescriptors);
+    try {
+      for (const [channel, channelDescriptors] of descriptorsByChannel) {
+        await this.subscribeTransportChannel(channel, channelDescriptors);
+      }
+    } catch (error) {
+      await this.rollbackTransportSubscriptionsAfterBootstrapFailure();
+      throw error;
     }
+  }
+
+  private async rollbackTransportSubscriptionsAfterBootstrapFailure(): Promise<void> {
+    await this.closeTransportOrRecordFailure('EventBusTransport failed to close after bootstrap subscription failure.');
+  }
+
+  private async closeTransportOrRecordFailure(message: string): Promise<boolean> {
+    try {
+      await this.closeTransport();
+      return true;
+    } catch (error) {
+      this.transportCloseFailures += 1;
+      this.lifecycleState = 'failed';
+      this.logger.error(message, error, 'EventBusLifecycleService');
+
+      return false;
+    }
+  }
+
+  private async closeTransport(): Promise<void> {
+    const transport = this.transport;
+
+    if (!transport || this.transportClosed) {
+      return;
+    }
+
+    await transport.close();
+    this.transportClosed = true;
+    this.subscribedChannels.clear();
   }
 
   private async subscribeTransportChannel(


### PR DESCRIPTION
## Summary

Closes #2097.

Linked context: https://github.com/fluojs/fluo/issues/2097

Fixes event-bus transport bootstrap so a subscription failure closes the configured transport before the bootstrap error is rethrown, preventing previously opened channels from staying subscribed.

## Changes

- Close the configured `EventBusTransport` when bootstrap subscription wiring fails.
- Make transport close idempotent inside `EventBusLifecycleService` so rollback and normal shutdown share the same close path.
- Add a regression test for partial subscription rollback after a later channel subscribe failure.
- Document the bootstrap rollback behavior in `packages/event-bus/README.md` and `packages/event-bus/README.ko.md`.
- Add `.changeset/event-bus-bootstrap-subscription-rollback.md` for the public `@fluojs/event-bus` patch behavior fix.

## Testing

- [x] Changed-file LSP diagnostics: `packages/event-bus/src/service.ts`, `packages/event-bus/src/module.test.ts` — no diagnostics.
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @fluojs/event-bus... build`
- [x] `pnpm --filter @fluojs/event-bus build`
- [x] `pnpm --filter @fluojs/event-bus typecheck`
- [x] `pnpm --filter @fluojs/event-bus test` — 5 files, 64 tests passed.
- [x] `pnpm exec biome lint packages/event-bus/src/service.ts packages/event-bus/src/module.test.ts packages/event-bus/README.md packages/event-bus/README.ko.md .changeset/event-bus-bootstrap-subscription-rollback.md`
- [x] `pnpm verify:public-export-tsdoc`
- [ ] `pnpm verify:release-readiness` was attempted and failed at `Starter shape and runtime ownership`; the failure appears outside the event-bus change path and is noted for reviewer follow-up.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. 해당 없음 — no public export signatures were added or changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. 해당 없음 — no exported function signatures were added or changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. 해당 없음 — no new examples were added.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. Package README EN/KO changes were kept in parity; no governance SSOT docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. 해당 없음 — no platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. 해당 없음 — this is event-bus transport lifecycle behavior, covered by `packages/event-bus/src/module.test.ts`.
