### PR TITLE
fix(prisma): align service facade public surface

### DIFF
--- a/.changeset/prisma-service-facade.md
+++ b/.changeset/prisma-service-facade.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/prisma": patch
+---
+
+Expose a typed Prisma service facade for direct generated delegate calls and align Prisma documentation with the runtime facade contract.

--- a/book/beginner/ch12-prisma.ko.md
+++ b/book/beginner/ch12-prisma.ko.md
@@ -184,19 +184,19 @@ export class AppModule {}
 
 ## 12.6 Using PrismaService
 
-등록이 끝난 뒤에는 애플리케이션 코드가 데이터베이스와 어떻게 대화할지 정해야 합니다. `@fluojs/prisma` 패키지는 생성된 Prisma Client를 감싸는 `PrismaService`를 제공합니다.
+등록이 끝난 뒤에는 애플리케이션 코드가 데이터베이스와 어떻게 대화할지 정해야 합니다. `@fluojs/prisma` 패키지는 생성된 Prisma Client를 감싸는 `PrismaService`와, 생성된 delegate를 직접 호출하는 repository를 위한 `PrismaServiceFacade<TClient>`를 제공합니다.
 
 ### Data Access Object (DAO) Pattern
 데이터베이스 로직을 비즈니스 로직과 분리하는 것이 좋습니다. `PostsRepository`를 만들어 보겠습니다.
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { PrismaService } from '@fluojs/prisma';
+import { PrismaService, type PrismaServiceFacade } from '@fluojs/prisma';
 import { PrismaClient } from '@prisma/client';
 
 @Inject(PrismaService)
 export class PostsRepository {
-  constructor(private readonly prisma: PrismaService<PrismaClient>) {}
+  constructor(private readonly prisma: PrismaServiceFacade<PrismaClient>) {}
 
   async createPost(data: { title: string; content?: string; authorId: number }) {
     // 기본 흐름: 모델을 직접 호출합니다.

--- a/book/beginner/ch12-prisma.md
+++ b/book/beginner/ch12-prisma.md
@@ -184,19 +184,19 @@ You still use `forRoot` for the default application-wide Prisma client in `AppMo
 
 ## 12.6 Using PrismaService
 
-After registration, you need to decide how application code will talk to the database. The `@fluojs/prisma` package provides `PrismaService`, which wraps the generated Prisma Client.
+After registration, you need to decide how application code will talk to the database. The `@fluojs/prisma` package provides `PrismaService`, which wraps the generated Prisma Client, and `PrismaServiceFacade<TClient>` for repositories that call generated delegates directly.
 
 ### Data Access Object (DAO) Pattern
 It is best to separate database logic from business logic. Let's create `PostsRepository`.
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { PrismaService } from '@fluojs/prisma';
+import { PrismaService, type PrismaServiceFacade } from '@fluojs/prisma';
 import { PrismaClient } from '@prisma/client';
 
 @Inject(PrismaService)
 export class PostsRepository {
-  constructor(private readonly prisma: PrismaService<PrismaClient>) {}
+  constructor(private readonly prisma: PrismaServiceFacade<PrismaClient>) {}
 
   async createPost(data: { title: string; content?: string; authorId: number }) {
     // Primary flow: call the model directly.

--- a/book/beginner/ch13-transactions.ko.md
+++ b/book/beginner/ch13-transactions.ko.md
@@ -71,12 +71,12 @@ export class UsersService {
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { PrismaService } from '@fluojs/prisma';
+import { PrismaService, type PrismaServiceFacade } from '@fluojs/prisma';
 import { PrismaClient } from '@prisma/client';
 
 @Inject(PrismaService)
 export class UsersRepository {
-  constructor(private readonly prisma: PrismaService<PrismaClient>) {}
+  constructor(private readonly prisma: PrismaServiceFacade<PrismaClient>) {}
 
   async create(data) {
     // 이제 기본 흐름에서 .current()를 명시적으로 호출할 필요가 없습니다!

--- a/book/beginner/ch13-transactions.md
+++ b/book/beginner/ch13-transactions.md
@@ -72,12 +72,12 @@ Notice that in the example above, the service calls `usersRepo.create()` and `pr
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { PrismaService } from '@fluojs/prisma';
+import { PrismaService, type PrismaServiceFacade } from '@fluojs/prisma';
 import { PrismaClient } from '@prisma/client';
 
 @Inject(PrismaService)
 export class UsersRepository {
-  constructor(private readonly prisma: PrismaService<PrismaClient>) {}
+  constructor(private readonly prisma: PrismaServiceFacade<PrismaClient>) {}
 
   async create(data) {
     // We don't need .current() anymore for primary flows!

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -148,8 +148,9 @@ export class AdvancedRepository {
 
 ```typescript
 await this.prisma.transaction(async () => {
-  const user = await this.prisma.user.create({ data });
-  await this.prisma.profile.create({ data: { userId: user.id } });
+  const tx = this.prisma.current();
+  const user = await tx.user.create({ data });
+  await tx.profile.create({ data: { userId: user.id } });
 });
 ```
 

--- a/packages/prisma/README.ko.md
+++ b/packages/prisma/README.ko.md
@@ -2,6 +2,7 @@
 
 <p><a href="./README.md"><kbd>English</kbd></a> <strong><kbd>한국어</kbd></strong></p>
 
+fluo 애플리케이션을 위한 Prisma lifecycle 및 ALS 기반 transaction context입니다. `PrismaClient`를 모듈 시스템에 연결하고 자동 연결 관리와 요청 범위 트랜잭션을 제공합니다.
 
 ## 목차
 
@@ -60,7 +61,8 @@ class AppModule {}
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { Transaction } from '@fluojs/prisma';
+import { PrismaService, Transaction, type PrismaServiceFacade } from '@fluojs/prisma';
+import { PrismaClient } from '@prisma/client';
 import { UserRepository } from './user.repository';
 
 export class UserService {
@@ -76,10 +78,10 @@ export class UserService {
 
 @Inject(PrismaService)
 export class UserRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaServiceFacade<PrismaClient>) {}
 
   async create(data: any) {
-    // 리포지토리 호출은 표준 PrismaClient 메서드를 사용합니다.
+    // facade 타입은 표준 PrismaClient delegate를 노출합니다.
     // @Transaction() 내부에서 호출되면 자동으로 활성 트랜잭션에 참여합니다.
     return this.prisma.user.create({ data });
   }
@@ -98,7 +100,7 @@ export class UserRepository {
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { PrismaModule, PrismaService, getPrismaServiceToken, Transaction } from '@fluojs/prisma';
+import { PrismaModule, PrismaService, getPrismaServiceToken, Transaction, type PrismaServiceFacade } from '@fluojs/prisma';
 
 const usersPrismaModule = PrismaModule.forRoot({ name: 'users', client: usersPrisma });
 const analyticsPrismaModule = PrismaModule.forRoot({ name: 'analytics', client: analyticsPrisma });
@@ -106,8 +108,8 @@ const analyticsPrismaModule = PrismaModule.forRoot({ name: 'analytics', client: 
 @Inject(getPrismaServiceToken('users'), getPrismaServiceToken('analytics'))
 export class MultiDatabaseService {
   constructor(
-    private readonly users: PrismaService<typeof usersPrisma>,
-    private readonly analytics: PrismaService<typeof analyticsPrisma>,
+    private readonly users: PrismaServiceFacade<typeof usersPrisma>,
+    private readonly analytics: PrismaServiceFacade<typeof analyticsPrisma>,
   ) {}
 
   @Transaction((self) => self.users)
@@ -155,6 +157,7 @@ await this.prisma.transaction(async () => {
 
 ### 종료와 status 계약
 
+`PrismaService.requestTransaction(...)`은 정상 serving 전과 중에는 사용할 수 있지만, 애플리케이션 shutdown이 시작된 뒤에는 새 요청 범위 트랜잭션을 거부합니다. 종료 중에는 열린 요청 트랜잭션을 abort하고, 가장 바깥 transaction boundary가 settle될 때까지 추적한 다음 `$disconnect()` 실행 전에 drain합니다. 기존 수동 `transaction(...)` boundary 안에서 열린 중첩 `requestTransaction(...)` 호출도 동일합니다. 해당 호출은 ambient Prisma transaction client를 재사용하고, 바깥 boundary가 끝날 때까지 `details.activeRequestTransactions`에 표시되며, 두 번째 Prisma transaction을 열지 않습니다.
 
 `createPrismaPlatformStatusSnapshot(...)`와 `PrismaService.createPlatformStatusSnapshot()`은 같은 라이프사이클 계약을 진단 surface에 노출합니다.
 
@@ -225,6 +228,8 @@ defineModule(ManualPrismaModule, {
 - `requestTransaction(fn, signal?, options?): Promise<T>`
   - HTTP 요청 라이프사이클에 특화된 트랜잭션 경계를 실행합니다. Abort를 인식하고, shutdown 중에는 disconnect 전에 열린 요청 트랜잭션을 drain하며, Prisma client가 `signal` 옵션을 거부하면 해당 옵션 없이 재시도합니다. `transaction()`과 마찬가지로 중첩 호출은 활성 트랜잭션 컨텍스트를 재사용하고, 트랜잭션 설정을 조용히 무시하지 않도록 중첩 옵션을 거부합니다.
 
+Provider가 `current()`, `transaction(...)`, `requestTransaction(...)`, `createPlatformStatusSnapshot()` 같은 wrapper 메서드만 필요로 한다면 `PrismaService<TClient>`를 사용하세요. 생성된 Prisma Client delegate를 직접 호출하는 repository 주입에는 `PrismaServiceFacade<TClient>`를 사용하세요. 이 facade는 활성 트랜잭션이 있으면 해당 트랜잭션 client로, 없으면 root client로 호출을 전달합니다. `PrismaService.createFacade(...)`는 module-provider wiring을 위한 저수준 compatibility helper로 유지되며, 애플리케이션 코드는 `PrismaModule.forRoot(...)` / `forRootAsync(...)`를 우선 사용해야 합니다.
+
 ### `Transaction`
 
 - 서비스 계층 트랜잭션 경계를 위한 표준 TC39 method decorator입니다. 기본적으로 ambient `PrismaService`를 resolve하고, 이름 있는 client에는 accessor를 받을 수 있으며, 외부 경계에는 Prisma transaction option을 전달할 수 있습니다.
@@ -256,6 +261,7 @@ defineModule(ManualPrismaModule, {
 - `PrismaModuleOptions`
 - `PrismaClientLike`
 - `PrismaHandleProvider`
+- `PrismaServiceFacade<TClient>`
 - `PrismaTransactionClient<TClient>`
 - `InferPrismaTransactionClient<TClient>`
 - `InferPrismaTransactionOptions<TClient>`

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -149,8 +149,9 @@ Use `prisma.transaction()` for manual interactive transaction blocks:
 
 ```typescript
 await this.prisma.transaction(async () => {
-  const user = await this.prisma.user.create({ data });
-  await this.prisma.profile.create({ data: { userId: user.id } });
+  const tx = this.prisma.current();
+  const user = await tx.user.create({ data });
+  await tx.profile.create({ data: { userId: user.id } });
 });
 ```
 

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -61,7 +61,8 @@ The `@Transaction()` decorator is the recommended way to define transaction boun
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { Transaction } from '@fluojs/prisma';
+import { PrismaService, Transaction, type PrismaServiceFacade } from '@fluojs/prisma';
+import { PrismaClient } from '@prisma/client';
 import { UserRepository } from './user.repository';
 
 export class UserService {
@@ -77,10 +78,10 @@ export class UserService {
 
 @Inject(PrismaService)
 export class UserRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaServiceFacade<PrismaClient>) {}
 
   async create(data: any) {
-    // Repository calls use standard PrismaClient methods.
+    // The facade type exposes standard PrismaClient delegates.
     // When called inside @Transaction(), they automatically participate in the ambient transaction.
     return this.prisma.user.create({ data });
   }
@@ -99,7 +100,7 @@ When one application container needs more than one Prisma client, register each 
 
 ```typescript
 import { Inject } from '@fluojs/core';
-import { PrismaModule, PrismaService, getPrismaServiceToken, Transaction } from '@fluojs/prisma';
+import { PrismaModule, PrismaService, getPrismaServiceToken, Transaction, type PrismaServiceFacade } from '@fluojs/prisma';
 
 const usersPrismaModule = PrismaModule.forRoot({ name: 'users', client: usersPrisma });
 const analyticsPrismaModule = PrismaModule.forRoot({ name: 'analytics', client: analyticsPrisma });
@@ -107,8 +108,8 @@ const analyticsPrismaModule = PrismaModule.forRoot({ name: 'analytics', client: 
 @Inject(getPrismaServiceToken('users'), getPrismaServiceToken('analytics'))
 export class MultiDatabaseService {
   constructor(
-    private readonly users: PrismaService<typeof usersPrisma>,
-    private readonly analytics: PrismaService<typeof analyticsPrisma>,
+    private readonly users: PrismaServiceFacade<typeof usersPrisma>,
+    private readonly analytics: PrismaServiceFacade<typeof analyticsPrisma>,
   ) {}
 
   @Transaction((self) => self.users)
@@ -228,6 +229,8 @@ defineModule(ManualPrismaModule, {
 - `requestTransaction(fn, signal?, options?): Promise<T>`
   - Specialized transaction boundary for HTTP request lifecycles. It is abort-aware, drains during shutdown before disconnect, and retries without `signal` when a Prisma client rejects that option. Like `transaction()`, nested calls reuse the active transaction context and reject nested options to avoid silently ignoring transaction settings.
 
+Use `PrismaService<TClient>` when a provider only needs wrapper methods such as `current()`, `transaction(...)`, `requestTransaction(...)`, or `createPlatformStatusSnapshot()`. Use `PrismaServiceFacade<TClient>` for repository injections that call generated Prisma Client delegates directly; the facade forwards those calls to the active transaction client when one exists and to the root client otherwise. `PrismaService.createFacade(...)` is retained as a low-level compatibility helper for module-provider wiring; application code should prefer `PrismaModule.forRoot(...)` / `forRootAsync(...)`.
+
 ### `Transaction`
 
 - Standard TC39 method decorator for service-layer transaction boundaries. It resolves the ambient `PrismaService` by default, accepts an accessor for named clients, and can forward Prisma transaction options to the outer boundary.
@@ -261,6 +264,7 @@ token are deliberately not exported.
 - `PrismaModuleOptions`
 - `PrismaClientLike`
 - `PrismaHandleProvider`
+- `PrismaServiceFacade<TClient>`
 - `PrismaTransactionClient<TClient>`
 - `InferPrismaTransactionClient<TClient>`
 - `InferPrismaTransactionOptions<TClient>`

--- a/packages/prisma/src/module.test.ts
+++ b/packages/prisma/src/module.test.ts
@@ -11,6 +11,7 @@ import {
   PRISMA_OPTIONS,
   PrismaModule,
   PrismaService,
+  type PrismaServiceFacade,
   type PrismaTransactionClient,
 } from './index.js';
 
@@ -36,19 +37,26 @@ type GeneratedPrismaClient = {
 };
 
 type InferredPrismaService = PrismaService<GeneratedPrismaClient>;
+type InferredPrismaServiceFacade = PrismaServiceFacade<GeneratedPrismaClient>;
 type InferredCurrentHandle = ReturnType<InferredPrismaService['current']>;
 type InferredTransactionHandle = PrismaTransactionClient<GeneratedPrismaClient>;
+type InferredFacadeFindUniqueResult = ReturnType<InferredPrismaServiceFacade['user']['findUnique']>;
 
 type _PrismaServiceCurrentInference = Assert<
   IsEqual<InferredCurrentHandle, GeneratedPrismaClient | GeneratedTransactionClient>
 >;
 type _PrismaTransactionClientInference = Assert<IsEqual<InferredTransactionHandle, GeneratedTransactionClient>>;
+type _PrismaServiceFacadeDelegateInference = Assert<
+  IsEqual<InferredFacadeFindUniqueResult, Promise<{ id: string } | null>>
+>;
 
 const prismaServiceCurrentInferenceChecked: _PrismaServiceCurrentInference = true;
 const prismaTransactionClientInferenceChecked: _PrismaTransactionClientInference = true;
+const prismaServiceFacadeDelegateInferenceChecked: _PrismaServiceFacadeDelegateInference = true;
 
 void prismaServiceCurrentInferenceChecked;
 void prismaTransactionClientInferenceChecked;
+void prismaServiceFacadeDelegateInferenceChecked;
 
 describe('@fluojs/prisma', () => {
   it('connects, reuses transaction-scoped handles, and disconnects through lifecycle hooks', async () => {

--- a/packages/prisma/src/module.ts
+++ b/packages/prisma/src/module.ts
@@ -1,4 +1,4 @@
-import { Inject, type AsyncModuleOptions, type Token } from '@fluojs/core';
+import type { AsyncModuleOptions, Token } from '@fluojs/core';
 import type { Provider } from '@fluojs/di';
 import { defineModule, type ModuleType } from '@fluojs/runtime';
 
@@ -36,6 +36,10 @@ type PrismaAsyncModuleOptions<
 };
 
 const PRISMA_NORMALIZED_OPTIONS = Symbol('fluo.prisma.normalized-options');
+
+type PrismaRuntimeOptions = {
+  strictTransactions: boolean;
+};
 
 function isObjectLike(value: unknown): value is object {
   return (typeof value === 'object' && value !== null) || typeof value === 'function';
@@ -86,26 +90,20 @@ function normalizePrismaModuleOptions<
   };
 }
 
-function createNamedPrismaServiceProvider<
+function createPrismaServiceProvider<
   TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
   TTransactionClient,
   TTransactionOptions,
->(name: string): Provider[] {
-  const clientToken = getPrismaClientToken(name);
-  const optionsToken = getPrismaOptionsToken(name);
-  const serviceToken = getPrismaServiceToken(name);
-
-  class NamedPrismaService extends PrismaService<TClient, TTransactionClient, TTransactionOptions> {}
-
-  Inject(clientToken, optionsToken)(NamedPrismaService, {} as ClassDecoratorContext);
-
-  return [
-    NamedPrismaService,
-    {
-      provide: serviceToken,
-      useExisting: NamedPrismaService,
-    },
-  ];
+>(provide: Token, clientToken: Token, optionsToken: Token): Provider {
+  return {
+    inject: [clientToken, optionsToken],
+    provide,
+    useFactory: (client: unknown, serviceOptions: unknown) =>
+      PrismaService.createFacade<TClient, TTransactionClient, TTransactionOptions>(
+        client as TClient,
+        serviceOptions as PrismaRuntimeOptions,
+      ),
+  };
 }
 
 function createPrismaRuntimeProviders<
@@ -138,13 +136,23 @@ function createPrismaRuntimeProviders<
     },
     ...(name === undefined
       ? [
-        PrismaService,
+        createPrismaServiceProvider<TClient, TTransactionClient, TTransactionOptions>(
+          PrismaService,
+          clientToken,
+          optionsToken,
+        ),
         {
           provide: getPrismaServiceToken(),
           useExisting: PrismaService,
         },
       ]
-      : createNamedPrismaServiceProvider<TClient, TTransactionClient, TTransactionOptions>(name)),
+      : [
+        createPrismaServiceProvider<TClient, TTransactionClient, TTransactionOptions>(
+          getPrismaServiceToken(name),
+          clientToken,
+          optionsToken,
+        ),
+      ]),
   ];
 }
 

--- a/packages/prisma/src/service.ts
+++ b/packages/prisma/src/service.ts
@@ -69,6 +69,21 @@ type AsyncLocalStorageResolutionHost = typeof globalThis & {
   };
 };
 
+function createCurrentClientPrismaFacade<TTarget extends { current(): unknown }>(target: TTarget): TTarget {
+  return new Proxy(target, {
+    get(service, prop, receiver) {
+      if (prop in service) {
+        return Reflect.get(service, prop, receiver);
+      }
+
+      const currentClient = service.current() as Record<PropertyKey, unknown>;
+      const value = Reflect.get(currentClient, prop, currentClient);
+
+      return typeof value === 'function' ? value.bind(currentClient) : value;
+    },
+  });
+}
+
 class AsyncLocalStorageTransactionContextStore<TTransactionClient> implements TransactionContextStore<TTransactionClient> {
   readonly kind = 'als' as const;
 
@@ -144,6 +159,31 @@ export class PrismaService<
     private readonly serviceOptions: PrismaServiceOptions = { strictTransactions: false },
   ) {
     this.installCurrentClientFacade();
+  }
+
+  /**
+   * Creates the low-level DI facade that forwards unknown Prisma API properties to the ambient `current()` client.
+   *
+   * @remarks
+   * This compatibility helper is used by `PrismaModule` provider wiring. Application code should prefer
+   * `PrismaModule.forRoot(...)` or `PrismaModule.forRootAsync(...)`, then type injected repository handles as
+   * `PrismaServiceFacade<TClient>` when direct generated Prisma delegates are needed.
+   *
+   * @param client Root Prisma client registered in the module.
+   * @param serviceOptions Runtime transaction options consumed by the Fluo wrapper.
+   * @returns A transaction-aware facade that exposes wrapper methods plus the root Prisma client surface.
+   */
+  static createFacade<
+    TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+    TTransactionClient = InferPrismaTransactionClient<TClient>,
+    TTransactionOptions = InferPrismaTransactionOptions<TClient>,
+  >(
+    client: TClient,
+    serviceOptions: PrismaServiceOptions = { strictTransactions: false },
+  ): PrismaServiceFacade<TClient, TTransactionClient, TTransactionOptions> {
+    return createCurrentClientPrismaFacade(
+      new PrismaService<TClient, TTransactionClient, TTransactionOptions>(client, serviceOptions),
+    ) as PrismaServiceFacade<TClient, TTransactionClient, TTransactionOptions>;
   }
 
   private installCurrentClientFacade(): void {
@@ -506,3 +546,22 @@ export class PrismaService<
     untrackActiveRequestTransaction(this.activeRequestTransactions, handle);
   }
 }
+
+/**
+ * Injection-facing Prisma facade type that combines the Fluo wrapper methods with the registered Prisma client surface.
+ *
+ * @remarks
+ * `PrismaModule` resolves `PrismaService` to a facade that forwards unknown properties to `current()`. Use this type in
+ * repositories that call generated Prisma delegates directly, and use `PrismaService<TClient>` when only wrapper methods
+ * (`current()`, `transaction(...)`, `requestTransaction(...)`, and status snapshots) are needed.
+ *
+ * @typeParam TClient Root Prisma client shape registered in the module.
+ * @typeParam TTransactionClient Transaction-scoped client resolved inside `$transaction(...)` callbacks.
+ * @typeParam TTransactionOptions Options forwarded to Prisma interactive transactions.
+ */
+export type PrismaServiceFacade<
+  TClient extends PrismaClientLike<TTransactionClient, TTransactionOptions>,
+  TTransactionClient = InferPrismaTransactionClient<TClient>,
+  TTransactionOptions = InferPrismaTransactionOptions<TClient>,
+> = PrismaService<TClient, TTransactionClient, TTransactionOptions> &
+  Omit<TClient, keyof PrismaService<TClient, TTransactionClient, TTransactionOptions>>;

--- a/packages/prisma/src/transaction-decorator.red.test.ts
+++ b/packages/prisma/src/transaction-decorator.red.test.ts
@@ -270,10 +270,10 @@ describe('@fluojs/prisma Transaction decorator contract (RED - pending Task 7 im
 
     @Inject(PrismaService)
     class UserRepository {
-      constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
+      constructor(private readonly prisma: PrismaServiceFacade<typeof client, typeof transactionClient>) {}
 
       async create(email: string) {
-        return (this.prisma as unknown as typeof client).user.create({ data: { email } });
+        return this.prisma.user.create({ data: { email } });
       }
     }
 

--- a/packages/prisma/src/transaction-decorator.red.test.ts
+++ b/packages/prisma/src/transaction-decorator.red.test.ts
@@ -2,7 +2,7 @@ import { Inject } from '@fluojs/core';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
 
-import { PrismaModule, PrismaService, Transaction, getPrismaServiceToken } from './index.js';
+import { PrismaModule, PrismaService, Transaction, getPrismaServiceToken, type PrismaServiceFacade } from './index.js';
 
 describe('@fluojs/prisma Transaction decorator contract (RED - pending Task 7 impl)', () => {
   it('exports Transaction and opens a transaction for current-less repository calls', async () => {
@@ -44,10 +44,10 @@ describe('@fluojs/prisma Transaction decorator contract (RED - pending Task 7 im
 
     @Inject(PrismaService)
     class UserRepository {
-      constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
+      constructor(private readonly prisma: PrismaServiceFacade<typeof client, typeof transactionClient>) {}
 
       async create(email: string) {
-        return (this.prisma as unknown as typeof client).user.create({ data: { email } });
+        return this.prisma.user.create({ data: { email } });
       }
     }
 
@@ -120,10 +120,10 @@ describe('@fluojs/prisma Transaction decorator contract (RED - pending Task 7 im
 
     @Inject(PrismaService)
     class UserRepository {
-      constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
+      constructor(private readonly prisma: PrismaServiceFacade<typeof client, typeof transactionClient>) {}
 
       async create(email: string) {
-        return (this.prisma as unknown as typeof client).user.create({ data: { email } });
+        return this.prisma.user.create({ data: { email } });
       }
     }
 
@@ -198,10 +198,10 @@ describe('@fluojs/prisma Transaction decorator contract (RED - pending Task 7 im
 
     @Inject(PrismaService)
     class QueryRepository {
-      constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
+      constructor(private readonly prisma: PrismaServiceFacade<typeof client, typeof transactionClient>) {}
 
       async load() {
-        return (this.prisma as unknown as typeof client).$queryRaw('select 1');
+        return this.prisma.$queryRaw('select 1');
       }
     }
 
@@ -368,9 +368,11 @@ describe('@fluojs/prisma Transaction decorator — named/accessor contract', () 
     )
     class MultiDatabaseService {
       constructor(
-        private readonly usersPrisma: PrismaService<typeof usersClient, typeof usersTransactionClient>,
+        usersPrisma: PrismaService<typeof usersClient, typeof usersTransactionClient>,
         private readonly analyticsPrisma: PrismaService<typeof analyticsClient, typeof analyticsTransactionClient>,
-      ) {}
+      ) {
+        void usersPrisma;
+      }
 
       @Transaction((self: MultiDatabaseService) => self.analyticsPrisma)
       async loadAnalytics() {
@@ -448,9 +450,11 @@ describe('@fluojs/prisma Transaction decorator — named/accessor contract', () 
     )
     class DualClientService {
       constructor(
-        private readonly usersPrisma: PrismaService<typeof usersClient>,
+        usersPrisma: PrismaService<typeof usersClient>,
         private readonly analyticsPrisma: PrismaService<typeof analyticsClient, typeof analyticsTransactionClient>,
-      ) {}
+      ) {
+        void usersPrisma;
+      }
 
       @Transaction((self: DualClientService) => self.analyticsPrisma)
       async decoratedAnalytics() {

--- a/packages/prisma/src/vertical-slice.test.ts
+++ b/packages/prisma/src/vertical-slice.test.ts
@@ -12,7 +12,7 @@ import {
   type FrameworkResponse,
 } from '@fluojs/http';
 
-import { PrismaModule, PrismaService, Transaction } from './index.js';
+import { PrismaModule, PrismaService, Transaction, type PrismaServiceFacade } from './index.js';
 
 function createResponse(events?: string[]): FrameworkResponse & { body?: unknown } {
   return {
@@ -120,10 +120,10 @@ describe('@fluojs/prisma service boundary primary flow', () => {
 
     @Inject(PrismaService)
     class UserRepository {
-      constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
+      constructor(private readonly prisma: PrismaServiceFacade<typeof client, typeof transactionClient>) {}
 
       async create(input: CreateUserRequest) {
-        return (this.prisma as unknown as typeof client).user.create({
+        return this.prisma.user.create({
           data: {
             email: input.email,
             name: input.name,
@@ -227,10 +227,10 @@ describe('@fluojs/prisma service boundary primary flow', () => {
 
     @Inject(PrismaService)
     class UserRepository {
-      constructor(private readonly prisma: PrismaService<typeof client, typeof transactionClient>) {}
+      constructor(private readonly prisma: PrismaServiceFacade<typeof client, typeof transactionClient>) {}
 
       async create(input: CreateUserRequest) {
-        return (this.prisma as unknown as typeof client).user.create({ data: input });
+        return this.prisma.user.create({ data: input });
       }
     }
 


### PR DESCRIPTION
## Summary
- expose a typed PrismaServiceFacade for delegate-style repository injections
- wire PrismaModule providers to resolve facade instances while preserving wrapper methods
- align EN/KO README and book examples with the facade contract

## Verification

### Canonical full-scope CI (required by resolver)
- Resolve PR verification scope: full
- Verify changeset release lane: pass
- Lint: pass
- Official web runtime adapter portability (bun): pass
- Official web runtime adapter portability (deno): pass
- Official web runtime adapter portability (cloudflare-workers): pass
- Verify platform consistency governance: pass
- Build and typecheck: pass
- Test: pass
- Verify: pass

### Focused package checks run on the PR branch
- pnpm --filter @fluojs/prisma typecheck
- pnpm --filter @fluojs/prisma test
- pnpm --filter @fluojs/prisma build
- pnpm docs:sync-check

Closes #2102