### PR TITLE
fix(cron): honor dynamic registry option names

### DIFF
--- a/.changeset/cron-dynamic-registry-option-name.md
+++ b/.changeset/cron-dynamic-registry-option-name.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cron": patch
+---
+
+Honor `options.name` as the registry key, scheduler metadata name, and default distributed lock key for dynamically registered cron, interval, and timeout tasks.

--- a/packages/cron/README.ko.md
+++ b/packages/cron/README.ko.md
@@ -143,7 +143,7 @@ class TaskManager {
 }
 ```
 
-Registry는 `addCron`, `addInterval`, `addTimeout`, `remove`, `enable`, `disable`, `get`, `getAll`, `updateCronExpression`을 제공합니다. Timeout task는 한 번 실행된 뒤 비활성화되지만 registry에는 남아 있어 의도적으로 다시 활성화할 수 있습니다.
+Registry는 `addCron`, `addInterval`, `addTimeout`, `remove`, `enable`, `disable`, `get`, `getAll`, `updateCronExpression`을 제공합니다. 첫 번째 `name` 인자는 기본 registry key이며, `options.name`을 전달하면 dynamic task의 실제 registry key, scheduler metadata name, 기본 distributed lock key가 이를 사용해 decorator naming semantics와 일치합니다. Timeout task는 한 번 실행된 뒤 비활성화되지만 registry에는 남아 있어 의도적으로 다시 활성화할 수 있습니다.
 
 Dynamic cron 등록은 scheduler startup과 원자적으로 처리됩니다. Scheduler가 새 cron job을 거부하면 registry는 half-registered task를 남기지 않습니다. 실행 중인 cron expression update도 rollback-safe합니다. Rescheduling이 실패하면 이전 expression과 scheduled job이 그대로 유지됩니다. Cron task는 scheduler-level no-overlap protection과 fluo의 in-process running guard를 함께 사용하므로 같은 task instance가 overlapping tick으로 실행되지 않습니다.
 

--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -143,7 +143,7 @@ class TaskManager {
 }
 ```
 
-The registry exposes `addCron`, `addInterval`, `addTimeout`, `remove`, `enable`, `disable`, `get`, `getAll`, and `updateCronExpression`. Timeout tasks run once, then disable themselves while remaining in the registry so they can be re-enabled deliberately.
+The registry exposes `addCron`, `addInterval`, `addTimeout`, `remove`, `enable`, `disable`, `get`, `getAll`, and `updateCronExpression`. The first `name` argument is the default registry key; passing `options.name` overrides the actual registry key, scheduler metadata name, and default distributed lock key for dynamic tasks so dynamic registration matches decorator naming semantics. Timeout tasks run once, then disable themselves while remaining in the registry so they can be re-enabled deliberately.
 
 Dynamic cron registration is atomic with scheduler startup: if the scheduler rejects a new cron job, the registry does not retain a half-registered task. Updating a running cron expression is also rollback-safe. If rescheduling fails, the previous expression and scheduled job remain active. Cron tasks use both scheduler-level no-overlap protection and fluo's in-process running guard, so the same task instance will not run overlapping ticks.
 

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -1709,6 +1709,48 @@ describe('@fluojs/cron', () => {
     await closeApplication(app);
   });
 
+  it('honors dynamic task option names for registry keys and scheduler metadata', async () => {
+    const scheduled = createManualScheduler();
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        CronModule.forRoot({
+          distributed: {
+            enabled: false,
+            keyPrefix: 'dynamic-option-name',
+            lockTtlMs: 1_000,
+          },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const registry = await app.container.resolve<SchedulingRegistry>(SCHEDULING_REGISTRY);
+
+    registry.addCron('dynamic-cron', CronExpression.EVERY_SECOND, () => {}, { name: 'named-dynamic-cron' });
+    registry.addInterval('dynamic-interval', 1_000, () => {}, { name: 'named-dynamic-interval' });
+    registry.addTimeout('dynamic-timeout', 5_000, () => {}, { name: 'named-dynamic-timeout' });
+
+    expect(registry.get('dynamic-cron')).toBeUndefined();
+    expect(registry.get('named-dynamic-cron')).toMatchObject({
+      lockKey: 'dynamic-option-name:named-dynamic-cron',
+      name: 'named-dynamic-cron',
+    });
+    expect(registry.get('named-dynamic-interval')).toMatchObject({
+      lockKey: 'dynamic-option-name:named-dynamic-interval',
+      name: 'named-dynamic-interval',
+    });
+    expect(registry.get('named-dynamic-timeout')).toMatchObject({
+      lockKey: 'dynamic-option-name:named-dynamic-timeout',
+      name: 'named-dynamic-timeout',
+    });
+    expect(scheduled.records[0]?.options.name).toBe('named-dynamic-cron');
+
+    await closeApplication(app);
+  });
+
   it('rolls back dynamic cron registration when the scheduler rejects it', async () => {
     const scheduler: CronScheduler = () => {
       throw new Error('dynamic scheduler boom');

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -50,6 +50,17 @@ function assertValidTaskName(name: string): void {
   }
 }
 
+function resolveDynamicTaskName(name: string, optionName?: string): string {
+  assertValidTaskName(name);
+
+  if (optionName !== undefined) {
+    assertValidTaskName(optionName);
+    return optionName;
+  }
+
+  return name;
+}
+
 function assertValidMs(ms: number, context: string): void {
   if (!Number.isFinite(ms) || !Number.isInteger(ms) || ms <= 0) {
     throw new Error(`${context}: ms must be a positive integer.`);
@@ -117,8 +128,8 @@ export class CronLifecycleService
    * @param options Optional hooks, distributed lock overrides, and timezone.
    */
   addCron(name: string, expression: string, callback: SchedulingTaskCallback, options: CronTaskOptions = {}): void {
-    assertValidTaskName(name);
     assertValidCronExpression(expression);
+    const taskName = resolveDynamicTaskName(name, options.name);
 
     this.registerTask(
       {
@@ -128,11 +139,11 @@ export class CronLifecycleService
         distributed: options.distributed ?? true,
         expression,
         kind: 'cron',
-        lockKey: createLockKey(this.options.distributed.keyPrefix, options.key ?? name),
+        lockKey: createLockKey(this.options.distributed.keyPrefix, options.key ?? taskName),
         lockTtlMs: options.lockTtlMs ?? this.options.distributed.lockTtlMs,
         onError: options.onError,
         onSuccess: options.onSuccess,
-        taskName: name,
+        taskName,
         timezone: options.timezone,
       },
       'dynamic',
@@ -148,8 +159,8 @@ export class CronLifecycleService
    * @param options Optional hooks and distributed lock overrides.
    */
   addInterval(name: string, ms: number, callback: SchedulingTaskCallback, options: IntervalTaskOptions = {}): void {
-    assertValidTaskName(name);
     assertValidMs(ms, 'scheduling registry');
+    const taskName = resolveDynamicTaskName(name, options.name);
 
     this.registerTask(
       {
@@ -158,12 +169,12 @@ export class CronLifecycleService
         callback,
         distributed: options.distributed ?? true,
         kind: 'interval',
-        lockKey: createLockKey(this.options.distributed.keyPrefix, options.key ?? name),
+        lockKey: createLockKey(this.options.distributed.keyPrefix, options.key ?? taskName),
         lockTtlMs: options.lockTtlMs ?? this.options.distributed.lockTtlMs,
         ms,
         onError: options.onError,
         onSuccess: options.onSuccess,
-        taskName: name,
+        taskName,
       },
       'dynamic',
     );
@@ -178,8 +189,8 @@ export class CronLifecycleService
    * @param options Optional hooks and distributed lock overrides.
    */
   addTimeout(name: string, ms: number, callback: SchedulingTaskCallback, options: TimeoutTaskOptions = {}): void {
-    assertValidTaskName(name);
     assertValidMs(ms, 'scheduling registry');
+    const taskName = resolveDynamicTaskName(name, options.name);
 
     this.registerTask(
       {
@@ -188,12 +199,12 @@ export class CronLifecycleService
         callback,
         distributed: options.distributed ?? true,
         kind: 'timeout',
-        lockKey: createLockKey(this.options.distributed.keyPrefix, options.key ?? name),
+        lockKey: createLockKey(this.options.distributed.keyPrefix, options.key ?? taskName),
         lockTtlMs: options.lockTtlMs ?? this.options.distributed.lockTtlMs,
         ms,
         onError: options.onError,
         onSuccess: options.onSuccess,
-        taskName: name,
+        taskName,
       },
       'dynamic',
     );


### PR DESCRIPTION
## Summary
- honor CronTaskOptions.name for dynamic cron, interval, and timeout registry keys
- use the resolved dynamic name for scheduler metadata and default distributed lock keys
- document dynamic option-name behavior in EN/KO README

## Verification
- pnpm --filter @fluojs/cron typecheck
- pnpm --filter @fluojs/cron test
- pnpm --filter @fluojs/cron build
- pnpm docs:sync-check

Closes #2096