### PR TITLE
docs(email): align Email facade description

### DIFF
--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -301,7 +301,7 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 ### 계약과 헬퍼
 
-- `Email`: `address`와 선택적 display `name`을 포함하는 정규화된 이메일 주소 값입니다.
+- `Email`: `EMAIL` 호환성 토큰이 노출하는 전송 facade로, `EmailService`가 뒷받침하는 `send(...)`, `sendMany(...)`, `sendNotification(...)` 메서드를 제공합니다.
 - `EmailAddress` / `EmailAddressLike`: `EmailService`가 정규화하기 전에 허용하는 구조화 또는 축약 recipient 값입니다.
 - `EmailModuleOptions` / `EmailAsyncModuleOptions`: sender 기본값, renderer, lifecycle 검증, transport factory wiring을 포함하는 동기/비동기 모듈 등록 계약입니다.
 - `EmailMessage`

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -301,7 +301,7 @@ These limitations are part of the package contract so transport selection, templ
 
 ### Contracts and helpers
 
-- `Email`: Normalized email address value with an `address` and optional display `name`.
+- `Email`: Sending facade exposed by the `EMAIL` compatibility token, with `send(...)`, `sendMany(...)`, and `sendNotification(...)` methods backed by `EmailService`.
 - `EmailAddress` / `EmailAddressLike`: Structured or shorthand recipient values accepted by `EmailService` before normalization.
 - `EmailModuleOptions` / `EmailAsyncModuleOptions`: Synchronous and async module registration contracts, including sender defaults, renderer, lifecycle verification, and transport factory wiring.
 - `EmailMessage`


### PR DESCRIPTION
## Summary

Align the `@fluojs/email` README description of the public `Email` interface with the current sending facade exposed through the `EMAIL` compatibility token.

Linked context: Closes #2100

## Changes

- Replace the English README entry that described `Email` as an address value with a sending facade description.
- Apply the same correction to the Korean README mirror.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm docs:sync-check` — passed
- `pnpm verify:platform-consistency-governance` — passed
- `pnpm lint` — passed; Biome reported existing warnings/infos outside this docs change and `verify:public-export-tsdoc` passed in changed mode

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only README correction; no runtime behavior, public API shape, package contents, or release metadata changed, so no changeset was added.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No source exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

Documentation now matches the existing `Email` facade contract; no runtime invariant changed.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or conformance claims changed.