### PR TITLE
Resolve #2130: correct email README public contract

### DIFF
--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -301,8 +301,9 @@ email 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 
 ### 계약과 헬퍼
 
-- `Email`: `EMAIL` 호환성 토큰이 노출하는 전송 facade로, `EmailService`가 뒷받침하는 `send(...)`, `sendMany(...)`, `sendNotification(...)` 메서드를 제공합니다.
+- `Email`: `EMAIL` 호환성 토큰이 노출하는 애플리케이션용 전송 facade이며 address 값이 아닙니다. `EmailService`가 뒷받침하는 `send(...)`, `sendMany(...)`, `sendNotification(...)` 메서드를 제공합니다.
 - `EmailAddress` / `EmailAddressLike`: `EmailService`가 정규화하기 전에 허용하는 구조화 또는 축약 recipient 값입니다.
+- `EmailAttachment`: `EmailMessage.attachments`에서 허용되고 설정된 transport로 전달되는 file attachment payload입니다. `filename`, `content`, 선택적 `contentType` 필드를 포함합니다.
 - `EmailModuleOptions` / `EmailAsyncModuleOptions`: sender 기본값, renderer, lifecycle 검증, transport factory wiring을 포함하는 동기/비동기 모듈 등록 계약입니다.
 - `EmailMessage`
 - `EmailNotificationDispatchRequest` / `EmailNotificationPayload`: `EmailChannel`이 소비하는 notification channel payload 계약입니다.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -301,8 +301,9 @@ These limitations are part of the package contract so transport selection, templ
 
 ### Contracts and helpers
 
-- `Email`: Sending facade exposed by the `EMAIL` compatibility token, with `send(...)`, `sendMany(...)`, and `sendNotification(...)` methods backed by `EmailService`.
+- `Email`: Application-facing sending facade exposed by the `EMAIL` compatibility token, not an address value; it provides `send(...)`, `sendMany(...)`, and `sendNotification(...)` methods backed by `EmailService`.
 - `EmailAddress` / `EmailAddressLike`: Structured or shorthand recipient values accepted by `EmailService` before normalization.
+- `EmailAttachment`: File attachment payload accepted on `EmailMessage.attachments` and forwarded to the configured transport with `filename`, `content`, and optional `contentType` fields.
 - `EmailModuleOptions` / `EmailAsyncModuleOptions`: Synchronous and async module registration contracts, including sender defaults, renderer, lifecycle verification, and transport factory wiring.
 - `EmailMessage`
 - `EmailNotificationDispatchRequest` / `EmailNotificationPayload`: Notification channel payload contracts consumed by `EmailChannel`.


### PR DESCRIPTION
## Summary

Closes #2130.

Linked context: https://github.com/fluojs/fluo/issues/2130

Aligns the `@fluojs/email` README public API inventory with the existing source exports for the `Email` facade and `EmailAttachment`.

## Changes

- Clarify that `Email` is the application-facing sending facade exposed through `EMAIL`, not an address value.
- Keep `EmailAddress` / `EmailAddressLike` positioned as the recipient value contracts.
- Add `EmailAttachment` to the English and Korean README public API inventories with its forwarded payload fields.

## Testing

- Changed-file diagnostics: no diagnostics for `packages/email/README.md` and `packages/email/README.ko.md`.
- `pnpm docs:sync-check`
- `pnpm lint` (passed; Biome reported existing warnings/infos outside the changed files, and `verify:public-export-tsdoc` changed-mode passed)
- `pnpm --filter @fluojs/email... build`
- `pnpm --filter @fluojs/email typecheck` (initial run before dependency build failed on missing workspace package declarations; rerun after dependency build passed)
- `pnpm --filter @fluojs/email test`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only package README alignment; no package behavior, API surface, package contents, or release metadata changed.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No source public exports changed. The README inventory now describes the existing `Email` and `EmailAttachment` public types.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

Docs-only alignment to the existing source contract; no runtime behavior changed and no new regression test was required.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

English and Korean package README entries were updated together. No platform contract docs or package conformance claims changed.
