### PR TITLE
Resolve #2142: reject Drizzle transactions after shutdown begins

### DIFF
--- a/.changeset/drizzle-shutdown-nested-transactions.md
+++ b/.changeset/drizzle-shutdown-nested-transactions.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/drizzle": patch
+---
+
+Reject nested Drizzle transaction calls once application shutdown begins so ambient transaction reuse cannot bypass the documented shutdown boundary.

--- a/packages/drizzle/src/database.ts
+++ b/packages/drizzle/src/database.ts
@@ -258,6 +258,12 @@ export class DrizzleDatabase<
     const current = this.transactions.getStore();
 
     if (current) {
+      if (requestScoped) {
+        this.assertRequestTransactionsAvailable();
+      } else {
+        this.assertTransactionsAvailable();
+      }
+
       if (options !== undefined) {
         throw new Error(NESTED_TRANSACTION_OPTIONS_NOT_SUPPORTED_ERROR);
       }

--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -396,6 +396,44 @@ describe('@fluojs/drizzle', () => {
     expect(events).toEqual(['dispose:start', 'dispose:end']);
   });
 
+  it('rejects nested manual transactions once shutdown begins', async () => {
+    let releaseNestedAttempt!: () => void;
+    const nestedAttemptBarrier = new Promise<void>((resolve) => {
+      releaseNestedAttempt = resolve;
+    });
+    let transactionCalls = 0;
+    const transactionDatabase = {};
+    const database = {
+      async transaction<T>(callback: (value: typeof transactionDatabase) => Promise<T>): Promise<T> {
+        transactionCalls += 1;
+        return callback(transactionDatabase);
+      },
+    };
+    const drizzle = new DrizzleDatabase<typeof database, typeof transactionDatabase>(database);
+
+    const outerTransaction = drizzle.transaction(async () => {
+      await nestedAttemptBarrier;
+
+      await expect(drizzle.transaction(async () => 'late-nested')).rejects.toThrow(
+        'Drizzle transactions are not available during application shutdown.',
+      );
+
+      return 'outer-complete';
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(transactionCalls).toBe(1);
+
+    const shutdown = drizzle.onApplicationShutdown();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    releaseNestedAttempt();
+
+    await expect(outerTransaction).resolves.toBe('outer-complete');
+    await shutdown;
+    expect(transactionCalls).toBe(1);
+  });
+
   it('waits for transaction runner settlement before reporting late request aborts', async () => {
     const events: string[] = [];
     const transactionDatabase = {};


### PR DESCRIPTION
## Summary

Reject ambient/nested `@fluojs/drizzle` transaction calls once application shutdown has begun so nested transaction reuse cannot bypass the documented shutdown boundary.

Linked context: Closes #2142

## Changes

- Apply the shutdown availability check before reusing an active Drizzle transaction context.
- Add a regression test proving nested manual `transaction(...)` calls are rejected during shutdown without opening a second Drizzle transaction runner.
- Add a patch changeset for the public `@fluojs/drizzle` behavior fix.

## Testing

- `lsp_diagnostics` on `packages/drizzle/src/database.ts` — passed, no diagnostics.
- `lsp_diagnostics` on `packages/drizzle/src/module.test.ts` — passed, no diagnostics.
- `pnpm install --frozen-lockfile` — passed.
- `pnpm --filter @fluojs/drizzle test` — passed, 5 files / 42 tests.
- `pnpm exec biome lint packages/drizzle/src/database.ts packages/drizzle/src/module.test.ts .changeset/drizzle-shutdown-nested-transactions.md` — passed.
- `pnpm --filter @fluojs/drizzle... build` — passed.
- `pnpm --filter @fluojs/drizzle typecheck` — passed after building workspace dependencies.
- `pnpm verify:release-readiness` — passed without writing draft artifacts.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/drizzle-shutdown-nested-transactions.md` for `@fluojs/drizzle`.

## Public export documentation

No public exports were added or changed. The existing `DrizzleDatabase` public method surface is unchanged, so source-level public export TSDoc updates are not required.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

The implementation now matches the existing README shutdown contract that new `transaction(...)` and `requestTransaction(...)` calls are rejected once shutdown begins. The PR preserves normal nested transaction reuse while the lifecycle state is `ready` and adds regression coverage for the shutdown edge case.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

No platform/governance SSOT documents were changed. The existing English/Korean `packages/drizzle/README.md` shutdown contract already described the intended behavior, and this PR aligns implementation plus tests with that contract.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
