### PR TITLE
Resolve #2140: harden metrics lifecycle and scrape contracts

### DIFF
--- a/.changeset/metrics-bootstrap-lifecycle-contract.md
+++ b/.changeset/metrics-bootstrap-lifecycle-contract.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/metrics": patch
+---
+
+Harden metrics lifecycle ownership so isolated registries, services, meter providers, and platform telemetry are created at application bootstrap boundaries instead of dynamic module definition time, while preserving shared-registry scrape collision guards.

--- a/packages/metrics/README.ko.md
+++ b/packages/metrics/README.ko.md
@@ -40,7 +40,7 @@ class AppModule {}
 
 `MetricsModule.forRoot()`는 기본적으로 `GET /metrics`를 노출합니다. HTTP request instrumentation middleware를 설치하려면 `http: true` 또는 `http` option object를 전달하세요. HTTP 계측이 활성화되면 request total, error count, request duration을 기록합니다. 운영 환경에서는 scrape endpoint boundary를 명시적으로 다루세요. platform-level proxy가 준비될 때까지 `path: false`로 끄거나 dedicated endpoint middleware를 연결할 수 있습니다.
 
-Scrape endpoint는 active `prom-client` Registry output을 해당 Registry의 Prometheus content type으로 반환합니다. `MetricsModule.forRoot()`는 `registry` option을 전달하지 않는 한 격리된 Registry를 생성합니다. framework metric과 application-defined metric이 하나의 scrape surface를 의도적으로 공유해야 할 때만 shared `Registry`를 전달하세요.
+Scrape endpoint는 active `prom-client` Registry output을 해당 Registry의 Prometheus content type으로 반환합니다. `MetricsModule.forRoot()`는 `registry` option을 전달하지 않는 한 application bootstrap마다 격리된 Registry를 생성합니다. 같은 dynamic module class를 다른 bootstrap에서 재사용해도 격리된 metric state는 새로 만들어집니다. framework metric과 application-defined metric이 하나의 scrape surface를 의도적으로 공유해야 할 때만 shared `Registry`를 전달하세요.
 
 ## 공개 책임
 
@@ -206,6 +206,7 @@ MetricsModule.forRoot({
 ### 운영 기본값
 
 - `path`의 기본값은 `'/metrics'`입니다. `''`를 포함한 모든 문자열 path는 scrape endpoint를 노출하며, `path: false`로만 scrape endpoint를 완전히 비활성화할 수 있습니다.
+- `registry`를 생략하면 application bootstrap마다 fresh isolated Registry, `MetricsService`, meter provider, telemetry collector set을 소유합니다.
 - scrape response는 active Registry의 Prometheus content type과 Registry contents를 사용합니다.
 - `defaultMetrics`의 기본값은 `true`이며, `defaultMetrics: false`로 해당 Registry의 Prometheus 기본 프로세스/Node.js collector를 끌 수 있습니다.
 - `endpointMiddleware`는 class-based route-scoped middleware를 스크레이프 엔드포인트에만 바인딩합니다. HTTP 계측이 활성화된 경우 endpoint middleware 실패는 내장 HTTP collector에 집계됩니다.

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -40,7 +40,7 @@ class AppModule {}
 
 `MetricsModule.forRoot()` exposes `GET /metrics` by default. Pass `http: true` (or an `http` options object) when you want the module to install HTTP request instrumentation middleware. When HTTP instrumentation is enabled, the module records request totals, error counts, and request duration. For production deployments, make the scrape endpoint boundary explicit: either disable it with `path: false` until a platform-level proxy is in place, or attach dedicated endpoint middleware.
 
-The scrape endpoint returns the active `prom-client` registry output with that registry's Prometheus content type. `MetricsModule.forRoot()` creates an isolated registry unless you pass a `registry` option; pass a shared `Registry` only when framework metrics and application-defined metrics intentionally share one scrape surface.
+The scrape endpoint returns the active `prom-client` registry output with that registry's Prometheus content type. `MetricsModule.forRoot()` creates an isolated registry for each application bootstrap unless you pass a `registry` option; reusing the same dynamic module class for another bootstrap receives fresh isolated metrics state. Pass a shared `Registry` only when framework metrics and application-defined metrics intentionally share one scrape surface.
 
 ## Public Responsibilities
 
@@ -206,6 +206,7 @@ MetricsModule.forRoot({
 ### Operational defaults
 
 - `path` defaults to `'/metrics'`, any string path including `''` exposes a scrape endpoint, and `path: false` disables the scrape endpoint entirely.
+- When `registry` is omitted, each application bootstrap owns a fresh isolated registry, `MetricsService`, meter provider, and telemetry collector set.
 - The scrape response uses the active registry's Prometheus content type and registry contents.
 - `defaultMetrics` defaults to `true`, and `defaultMetrics: false` disables Prometheus default process and Node.js collectors for that registry.
 - `endpointMiddleware` binds class-based route-scoped middleware only to the scrape endpoint; with HTTP instrumentation enabled, endpoint middleware failures are counted by the built-in HTTP collectors.

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -42,6 +42,7 @@
     "test:watch": "pnpm exec vitest -c vitest.config.ts"
   },
   "dependencies": {
+    "@fluojs/core": "workspace:^",
     "@fluojs/di": "workspace:^",
     "@fluojs/http": "workspace:^",
     "@fluojs/runtime": "workspace:^",

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -298,6 +298,51 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
+  it('omits Prometheus default collectors when defaultMetrics is false', async () => {
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('/metrics'), response);
+
+    const metricsText = String(response.body);
+    expect(response.statusCode).toBe(200);
+    expect(metricsText).not.toContain('process_cpu_seconds_total');
+    expect(metricsText).not.toContain('nodejs_heap_size_total_bytes');
+
+    await app.close();
+  });
+
+  it('does not install HTTP collectors until HTTP instrumentation is opted in', async () => {
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
+    });
+
+    const app = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+    const response = createResponse();
+
+    await app.dispatch(createRequest('/metrics'), response);
+
+    const metricsText = String(response.body);
+    expect(response.statusCode).toBe(200);
+    expect(metricsText).not.toContain('http_requests_total');
+    expect(metricsText).not.toContain('http_errors_total');
+    expect(metricsText).not.toContain('http_request_duration_seconds');
+
+    await app.close();
+  });
+
   it('keeps default metrics registration once per shared registry', async () => {
     const sharedRegistry = new Registry();
 
@@ -596,26 +641,58 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
-  it('validates framework-owned HTTP collector label schemas before reuse', () => {
+  it('validates framework-owned HTTP collector label schemas before reuse', async () => {
     const sharedRegistry = new Registry();
 
-    MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-a', registry: sharedRegistry });
+    class FirstAppModule {}
+
+    defineModule(FirstAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-a', registry: sharedRegistry })],
+    });
+
+    const firstApp = await bootstrapApplication({
+      rootModule: FirstAppModule,
+    });
     const requestsCounter = sharedRegistry.getSingleMetric('http_requests_total') as Counter<string> & { labelNames: string[] };
     requestsCounter.labelNames = ['method'];
 
-    expect(() => MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-b', registry: sharedRegistry })).toThrow(
+    await firstApp.close();
+
+    class SecondAppModule {}
+
+    defineModule(SecondAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-b', registry: sharedRegistry })],
+    });
+
+    await expect(bootstrapApplication({ rootModule: SecondAppModule })).rejects.toThrow(
       'Metric name "http_requests_total" is already registered with labels [method]. Built-in HTTP metrics require labels [method,path,status].',
     );
   });
 
-  it('validates framework-owned HTTP duration histogram label schemas before reuse', () => {
+  it('validates framework-owned HTTP duration histogram label schemas before reuse', async () => {
     const sharedRegistry = new Registry();
 
-    MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-a', registry: sharedRegistry });
+    class FirstAppModule {}
+
+    defineModule(FirstAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-a', registry: sharedRegistry })],
+    });
+
+    const firstApp = await bootstrapApplication({
+      rootModule: FirstAppModule,
+    });
     const durationHistogram = sharedRegistry.getSingleMetric('http_request_duration_seconds') as Histogram<string> & { labelNames: string[] };
     durationHistogram.labelNames = ['method', 'path'];
 
-    expect(() => MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-b', registry: sharedRegistry })).toThrow(
+    await firstApp.close();
+
+    class SecondAppModule {}
+
+    defineModule(SecondAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, http: true, path: '/metrics-b', registry: sharedRegistry })],
+    });
+
+    await expect(bootstrapApplication({ rootModule: SecondAppModule })).rejects.toThrow(
       'Metric name "http_request_duration_seconds" is already registered with labels [method,path]. Built-in HTTP metrics require labels [method,path,status].',
     );
   });
@@ -652,7 +729,7 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
-  it('throws when an app predefines a built-in platform telemetry gauge name', () => {
+  it('throws when an app predefines a built-in platform telemetry gauge name', async () => {
     const sharedRegistry = new Registry();
 
     new Gauge({
@@ -662,19 +739,41 @@ describe('MetricsModule', () => {
       registers: [sharedRegistry],
     });
 
-    expect(() => MetricsModule.forRoot({ defaultMetrics: false, registry: sharedRegistry })).toThrow(
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, registry: sharedRegistry })],
+    });
+
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
       'Metric name "fluo_component_ready" is already registered by the application. Built-in platform telemetry requires framework-owned gauges.',
     );
   });
 
-  it('validates framework-owned platform telemetry gauge label schemas before reuse', () => {
+  it('validates framework-owned platform telemetry gauge label schemas before reuse', async () => {
     const sharedRegistry = new Registry();
 
-    MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-a', registry: sharedRegistry });
+    class FirstAppModule {}
+
+    defineModule(FirstAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-a', registry: sharedRegistry })],
+    });
+
+    const firstApp = await bootstrapApplication({
+      rootModule: FirstAppModule,
+    });
     const readinessGauge = sharedRegistry.getSingleMetric('fluo_component_ready') as Gauge<string> & { labelNames: string[] };
     readinessGauge.labelNames = ['component_id'];
 
-    expect(() => MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-b', registry: sharedRegistry })).toThrow(
+    await firstApp.close();
+
+    class SecondAppModule {}
+
+    defineModule(SecondAppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, path: '/metrics-b', registry: sharedRegistry })],
+    });
+
+    await expect(bootstrapApplication({ rootModule: SecondAppModule })).rejects.toThrow(
       'Metric name "fluo_component_ready" is already registered with labels [component_id]. Built-in platform telemetry requires labels [component_id,component_kind,operation,result,env,instance].',
     );
   });
@@ -736,7 +835,7 @@ describe('MetricsModule', () => {
 
   it('suppresses only missing platform shell registration errors during scrape refresh', async () => {
     const missingPlatformShellError = new ContainerResolutionError(
-      `No provider registered for token ${String(PLATFORM_SHELL)}.`,
+      'Structured missing provider context should not depend on message wording.',
       {
         hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
         token: PLATFORM_SHELL,
@@ -1057,7 +1156,7 @@ describe('MetricsModule', () => {
     await app.close();
   });
 
-  it('throws when an app predefines a built-in HTTP counter name', () => {
+  it('throws when an app predefines a built-in HTTP counter name', async () => {
     const sharedRegistry = new Registry();
 
     new Counter({
@@ -1066,12 +1165,18 @@ describe('MetricsModule', () => {
       registers: [sharedRegistry],
     });
 
-    expect(() => MetricsModule.forRoot({ defaultMetrics: false, http: true, registry: sharedRegistry })).toThrow(
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, http: true, registry: sharedRegistry })],
+    });
+
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
       'Metric name "http_requests_total" is already registered by the application. Built-in HTTP metrics require framework-owned collectors.',
     );
   });
 
-  it('throws when an app predefines a built-in HTTP error counter name', () => {
+  it('throws when an app predefines a built-in HTTP error counter name', async () => {
     const sharedRegistry = new Registry();
 
     new Counter({
@@ -1080,12 +1185,18 @@ describe('MetricsModule', () => {
       registers: [sharedRegistry],
     });
 
-    expect(() => MetricsModule.forRoot({ defaultMetrics: false, http: true, registry: sharedRegistry })).toThrow(
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, http: true, registry: sharedRegistry })],
+    });
+
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
       'Metric name "http_errors_total" is already registered by the application. Built-in HTTP metrics require framework-owned collectors.',
     );
   });
 
-  it('throws when an app predefines the built-in HTTP duration histogram name', () => {
+  it('throws when an app predefines the built-in HTTP duration histogram name', async () => {
     const sharedRegistry = new Registry();
 
     new Histogram({
@@ -1094,7 +1205,13 @@ describe('MetricsModule', () => {
       registers: [sharedRegistry],
     });
 
-    expect(() => MetricsModule.forRoot({ defaultMetrics: false, http: true, registry: sharedRegistry })).toThrow(
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false, http: true, registry: sharedRegistry })],
+    });
+
+    await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toThrow(
       'Metric name "http_request_duration_seconds" is already registered by the application. Built-in HTTP metrics require framework-owned collectors.',
     );
   });
@@ -1122,5 +1239,41 @@ describe('MetricsModule', () => {
     expect(metrics).toContain('isolated_counter_total');
 
     await app.close();
+  });
+
+  it('creates a fresh isolated registry for each bootstrap of a reused dynamic metrics module', async () => {
+    const MetricsRuntimeModule = MetricsModule.forRoot({ defaultMetrics: false });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsRuntimeModule],
+    });
+
+    const firstApp = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+    const firstMetricsService = (await firstApp.container.resolve(MetricsService)) as MetricsService;
+    const firstRegistry = firstMetricsService.getRegistry();
+
+    firstMetricsService.counter({
+      help: 'Counter scoped to the first bootstrap only',
+      name: 'bootstrap_local_counter_total',
+    });
+
+    expect(await firstRegistry.metrics()).toContain('bootstrap_local_counter_total');
+
+    await firstApp.close();
+
+    const secondApp = await bootstrapApplication({
+      rootModule: AppModule,
+    });
+    const secondMetricsService = (await secondApp.container.resolve(MetricsService)) as MetricsService;
+    const secondRegistry = secondMetricsService.getRegistry();
+
+    expect(secondRegistry).not.toBe(firstRegistry);
+    expect(await secondRegistry.metrics()).not.toContain('bootstrap_local_counter_total');
+
+    await secondApp.close();
   });
 });

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -1,3 +1,4 @@
+import { Inject, type Token } from '@fluojs/core';
 import { ContainerResolutionError, type Provider } from '@fluojs/di';
 import { Controller, Get, forRoutes, type Middleware, type MiddlewareLike, type RequestContext } from '@fluojs/http';
 import { defineModule, type ModuleType, PLATFORM_SHELL, type PlatformShellSnapshot } from '@fluojs/runtime';
@@ -78,51 +79,66 @@ export class MetricsModule {
 
     const httpOptions = resolveHttpOptions(options.http);
     const metricsPath = options.path === undefined ? '/metrics' : options.path;
-    const registry = options.registry ?? new PrometheusRegistry();
-    const metricsService = new MetricsService(registry);
-    const meterProvider = new PrometheusMeterProvider(registry);
-    const platformTelemetry = new RuntimePlatformTelemetry(
-      registry,
-      options.registry ? 'shared' : 'isolated',
-      options.platformTelemetry,
-    );
 
-    if (options.defaultMetrics !== false && !MetricsModule.registeredRegistries.has(registry)) {
-      MetricsModule.registeredRegistries.add(registry);
-      collectDefaultMetrics({ register: registry });
-    }
+    const registryToken: Token<Registry> = Symbol('MetricsModule.registry');
+    const platformTelemetryToken: Token<RuntimePlatformTelemetry> = Symbol('MetricsModule.platformTelemetry');
+    const httpMetricsMiddleware = httpOptions
+      ? createHttpMetricsMiddleware(registryToken, httpOptions)
+      : undefined;
 
     const endpointMiddleware = typeof metricsPath === 'string'
       ? (options.endpointMiddleware ?? []).map((middlewareClass) => forRoutes(middlewareClass, metricsPath))
       : [];
     const middleware = [
-      ...(httpOptions ? [new HttpMetricsMiddleware(registry, httpOptions)] : []),
+      ...(httpMetricsMiddleware ? [httpMetricsMiddleware] : []),
       ...endpointMiddleware,
       ...(options.middleware ?? []),
     ];
 
     const providers: Provider[] = [
+      ...(httpMetricsMiddleware ? [httpMetricsMiddleware] : []),
+      {
+        provide: registryToken,
+        useFactory: () => MetricsModule.createRegistry(options),
+      },
       {
         provide: MetricsService,
-        useValue: metricsService,
+        inject: [registryToken],
+        useFactory: (registry: unknown) => new MetricsService(assertPrometheusRegistry(registry)),
       },
       {
         provide: METER_PROVIDER,
-        useValue: meterProvider,
+        inject: [registryToken],
+        useFactory: (registry: unknown) => new PrometheusMeterProvider(assertPrometheusRegistry(registry)),
+      },
+      {
+        provide: platformTelemetryToken,
+        inject: [registryToken],
+        useFactory: (registry: unknown) => new RuntimePlatformTelemetry(
+          assertPrometheusRegistry(registry),
+          options.registry ? 'shared' : 'isolated',
+          options.platformTelemetry,
+        ),
       },
     ];
 
-    const controllers: Array<new () => object> = [];
+    const controllers: ModuleType[] = [];
 
     if (typeof metricsPath === 'string') {
       const metricsRoutePath = metricsPath;
 
+      @Inject(registryToken, platformTelemetryToken)
       @Controller('')
       class MetricsController {
+        constructor(
+          private readonly registry: Registry,
+          private readonly platformTelemetry: RuntimePlatformTelemetry,
+        ) {}
+
         @Get(metricsRoutePath)
         async getMetrics(_input: undefined, ctx: RequestContext): Promise<string> {
-          ctx.response.setHeader('content-type', registry.contentType);
-          return platformTelemetry.collectMetrics(ctx, registry);
+          ctx.response.setHeader('content-type', this.registry.contentType);
+          return this.platformTelemetry.collectMetrics(ctx, this.registry);
         }
       }
 
@@ -138,6 +154,17 @@ export class MetricsModule {
     });
 
     return MetricsRuntimeModule;
+  }
+
+  private static createRegistry(options: MetricsModuleOptions): Registry {
+    const registry = options.registry ?? new PrometheusRegistry();
+
+    if (options.defaultMetrics !== false && !MetricsModule.registeredRegistries.has(registry)) {
+      MetricsModule.registeredRegistries.add(registry);
+      collectDefaultMetrics({ register: registry });
+    }
+
+    return registry;
   }
 }
 
@@ -158,6 +185,34 @@ const HEALTH_STATUSES = ['healthy', 'unhealthy', 'degraded'] as const satisfies 
 const READINESS_STATUSES = ['ready', 'not-ready', 'degraded'] as const satisfies readonly PlatformReadinessStatus[];
 const PLATFORM_SHELL_TOKEN_NAME = 'PLATFORM_SHELL';
 const PLATFORM_SHELL_TOKEN_NAMES = new Set([PLATFORM_SHELL_TOKEN_NAME, String(PLATFORM_SHELL)]);
+
+function createHttpMetricsMiddleware(
+  registryToken: Token<Registry>,
+  httpOptions: HttpMetricsMiddlewareOptions,
+): new (registry: Registry) => Middleware {
+  @Inject(registryToken)
+  class MetricsHttpMiddleware implements Middleware {
+    private readonly delegate: HttpMetricsMiddleware;
+
+    constructor(registry: Registry) {
+      this.delegate = new HttpMetricsMiddleware(registry, httpOptions);
+    }
+
+    handle(context: Parameters<Middleware['handle']>[0], next: Parameters<Middleware['handle']>[1]): ReturnType<Middleware['handle']> {
+      return this.delegate.handle(context, next);
+    }
+  }
+
+  return MetricsHttpMiddleware;
+}
+
+function assertPrometheusRegistry(value: unknown): Registry {
+  if (!(value instanceof PrometheusRegistry)) {
+    throw new Error('MetricsModule registry provider resolved an invalid Prometheus registry.');
+  }
+
+  return value;
+}
 
 function toReadinessValue(status: PlatformShellSnapshot['readiness']['status']): number {
   return status === 'ready' ? 1 : 0;
@@ -428,19 +483,12 @@ function isMissingPlatformShellResolutionError(error: unknown): error is Contain
   }
 
   const containerError = error as ContainerResolutionError & { meta?: Record<string, unknown> };
-  const message = String((containerError as { message?: unknown }).message ?? '');
-  const token = typeof containerError.meta?.['token'] === 'string' ? containerError.meta['token'] : undefined;
-  if (token && PLATFORM_SHELL_TOKEN_NAMES.has(token)) {
-    return message.startsWith(`No provider registered for token ${token}.`);
-  }
+  const token = typeof containerError.meta?.token === 'string' ? containerError.meta.token : undefined;
+  const hint = typeof containerError.meta?.hint === 'string' ? containerError.meta.hint : undefined;
 
-  for (const tokenName of PLATFORM_SHELL_TOKEN_NAMES) {
-    if (message.startsWith(`No provider registered for token ${tokenName}.`)) {
-      return true;
-    }
-  }
-
-  return false;
+  return token !== undefined
+    && PLATFORM_SHELL_TOKEN_NAMES.has(token)
+    && hint === 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.';
 }
 
 function resolveHttpOptions(http: MetricsModuleOptions['http']): HttpMetricsMiddlewareOptions | undefined {
@@ -450,6 +498,12 @@ function resolveHttpOptions(http: MetricsModuleOptions['http']): HttpMetricsMidd
 
   if (http === true) {
     return {};
+  }
+
+  if (http.pathLabelMode === 'raw' && http.allowUnsafeRawPathLabelMode !== true) {
+    throw new Error(
+      'HttpMetricsMiddleware pathLabelMode "raw" is disabled by default. Pass allowUnsafeRawPathLabelMode: true only when you have bounded path cardinality.',
+    );
   }
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,6 +489,9 @@ importers:
 
   packages/metrics:
     dependencies:
+      '@fluojs/core':
+        specifier: workspace:^
+        version: link:../core
       '@fluojs/di':
         specifier: workspace:^
         version: link:../di


### PR DESCRIPTION
## Summary

Closes #2140

Harden `@fluojs/metrics` lifecycle and scrape contracts so isolated registry, `MetricsService`, meter provider, HTTP middleware, and platform telemetry ownership are created at application bootstrap/provider boundaries instead of dynamic module definition time.

## Changes

- Move `MetricsModule.forRoot(...)` registry, meter, service, HTTP middleware, and runtime telemetry ownership behind app-local providers with injected controller/middleware boundaries.
- Preserve shared-registry HTTP/platform telemetry reuse guards and app-owned duplicate collector failures at bootstrap.
- Stop classifying missing `PLATFORM_SHELL` by DI message text; use structured `ContainerResolutionError.meta` token/hint context instead.
- Add regression coverage for `defaultMetrics: false`, HTTP opt-in negative paths, shared-registry collector/telemetry guards, and reused dynamic module bootstrap isolation.
- Document bootstrap-local isolated registry ownership in `packages/metrics/README.md` and `packages/metrics/README.ko.md`.
- Add a patch changeset for `@fluojs/metrics`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/metrics... build`
- `pnpm --filter @fluojs/metrics build`
- `pnpm --filter @fluojs/metrics typecheck`
- `pnpm exec biome lint "packages/metrics/src/metrics-module.ts" "packages/metrics/src/metrics-module.test.ts" "packages/metrics/package.json"`
- `pnpm --filter @fluojs/metrics test`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `lsp_diagnostics` on `packages/metrics/src/metrics-module.ts` and `packages/metrics/src/metrics-module.test.ts`: no diagnostics
- `pnpm verify:release-readiness` was attempted and failed in unrelated `packages/cli/src/cli.test.ts` (`keeps the local sandbox outside the repo workspace`, expected status `0` but received `1`); the metrics package tests passed within this run.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Changeset: `.changeset/metrics-bootstrap-lifecycle-contract.md` (`@fluojs/metrics` patch).

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added. The existing `MetricsModule.forRoot(...)` TSDoc remains applicable, and package README/KO text now states bootstrap-local isolated registry ownership.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Regression tests cover per-bootstrap isolated registry ownership, `defaultMetrics: false`, HTTP instrumentation opt-in behavior, structured `PLATFORM_SHELL` missing-provider handling, and shared-registry collision guards.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs changed. The affected package README and Korean mirror were updated together; `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` passed.