### PR TITLE
Resolve #2152: Harden CLI dev runner and programmatic surface

### DIFF
--- a/.changeset/cli-dev-runner-programmatic-surface.md
+++ b/.changeset/cli-dev-runner-programmatic-surface.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cli': patch
+---
+
+Keep Studio dev-runner restarts aligned with the current sidecar epoch and lazy-load the full CLI dispatcher from the package root programmatic entrypoint.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -2181,6 +2181,79 @@ void bootstrap();
     await expect(runPromise).resolves.toBe(0);
   });
 
+  it('reinjects the current Studio epoch into restarted app children', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const sourceFile = join(sourceDirectory, 'main.ts');
+    mkdirSync(sourceDirectory, { recursive: true });
+    writeFileSync(sourceFile, 'console.log("one");\n');
+    const signalTarget = createSignalTarget();
+    const children: ChildProcess[] = [];
+    const injectedEpochs: Array<string | undefined> = [];
+    const lifecycleEpochs: Array<string | undefined> = [];
+    const watchListeners: Array<(event: string, filename: string | Buffer | null) => void> = [];
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_input, init) => {
+      const body = typeof init?.body === 'string' ? JSON.parse(init.body) as { payload?: { epoch?: string } } : {};
+      lifecycleEpochs.push(body.payload?.epoch);
+
+      return new Response(JSON.stringify({ accepted: true, epoch: body.payload?.epoch ?? 'missing-epoch', sequence: lifecycleEpochs.length }), {
+        headers: { 'content-type': 'application/json' },
+        status: 202,
+      });
+    };
+
+    try {
+      const runPromise = runNodeRestartRunner({
+        debounceMs: 1,
+        env: {
+          FLUO_STUDIO: '1',
+          FLUO_STUDIO_APP_ID: 'test-app',
+          FLUO_STUDIO_EPOCH: 'epoch-1',
+          FLUO_STUDIO_RUNTIME: 'node',
+          FLUO_STUDIO_TOKEN: 'studio-token',
+          FLUO_STUDIO_URL: 'http://127.0.0.1:49152',
+        },
+        projectDirectory: workspaceDirectory,
+        signalTarget: signalTarget.target,
+        spawnChild: (_command, args) => {
+          const injectedSource = decodeURIComponent(String(args[2]).replace('data:text/javascript,', ''));
+          const match = /"FLUO_STUDIO_EPOCH":"([^"]+)"/.exec(injectedSource);
+          injectedEpochs.push(match?.[1]);
+          const child = createMockChild();
+          children.push(child);
+          return child;
+        },
+        watchTarget: (_target, optionsOrListener, listener) => {
+          watchListeners.push(typeof optionsOrListener === 'function' ? optionsOrListener : listener ?? (() => undefined));
+          return { close: () => undefined } as never;
+        },
+      });
+
+      expect(injectedEpochs).toEqual(['epoch-1']);
+
+      writeFileSync(sourceFile, 'console.log("two");\n');
+      for (const listener of watchListeners) {
+        listener('change', 'main.ts');
+      }
+
+      await waitForCondition(() => children[0]?.killed === true);
+      children[0]?.emit('close', 0);
+      await waitForCondition(() => children.length === 2);
+
+      expect(injectedEpochs[1]).toBeDefined();
+      expect(injectedEpochs[1]).not.toBe('epoch-1');
+      expect(lifecycleEpochs).toContain(injectedEpochs[1]);
+
+      children[1]?.emit('close', 0);
+      await expect(runPromise).resolves.toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it('loads .env for each restarted app child instead of only for the supervisor', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);

--- a/packages/cli/src/dev-runner/node-restart-runner.ts
+++ b/packages/cli/src/dev-runner/node-restart-runner.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { existsSync, readdirSync, readFileSync, statSync, watch, type FSWatcher } from 'node:fs';
 import { basename, dirname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -61,6 +61,7 @@ const DEFAULT_IGNORES = [
 const WATCH_FILES = ['.env', 'package.json', 'tsconfig.json', 'tsconfig.build.json'];
 const SHOW_NODE_RESTART_NOTICE_ENV = 'FLUO_DEV_SHOW_RESTART_NOTICE';
 const CLEAR_SCREEN = '\u001B[2J\u001B[3J\u001B[H';
+const STUDIO_EPOCH_ENV = 'FLUO_STUDIO_EPOCH';
 
 type StudioRuntimeName = 'bun' | 'deno' | 'node' | 'unknown' | 'worker';
 
@@ -96,6 +97,39 @@ function resolveStudioIngestEndpoint(env: NodeJS.ProcessEnv): string | undefined
   }
 }
 
+function hasStudioDevtoolsConfig(env: NodeJS.ProcessEnv): boolean {
+  return isEnabledEnvironmentFlag(env.FLUO_STUDIO) && Boolean(env.FLUO_STUDIO_TOKEN);
+}
+
+function createStudioEpoch(): string {
+  return randomUUID();
+}
+
+function ensureStudioEpoch(env: NodeJS.ProcessEnv): string | undefined {
+  if (!hasStudioDevtoolsConfig(env)) {
+    return undefined;
+  }
+
+  env[STUDIO_EPOCH_ENV] ??= createStudioEpoch();
+  return env[STUDIO_EPOCH_ENV];
+}
+
+function advanceStudioEpoch(env: NodeJS.ProcessEnv): string | undefined {
+  if (!hasStudioDevtoolsConfig(env)) {
+    return undefined;
+  }
+
+  const epoch = createStudioEpoch();
+  env[STUDIO_EPOCH_ENV] = epoch;
+  return epoch;
+}
+
+function withStudioEpoch(env: NodeJS.ProcessEnv, payload: Record<string, string>): Record<string, string> {
+  const epoch = ensureStudioEpoch(env);
+
+  return epoch ? { ...payload, epoch } : payload;
+}
+
 function publishStudioLifecycleEvent(
   env: NodeJS.ProcessEnv,
   runtime: DevRunnerRuntime,
@@ -109,7 +143,7 @@ function publishStudioLifecycleEvent(
 
   void globalThis.fetch(endpoint, {
     body: JSON.stringify({
-      payload,
+      payload: withStudioEpoch(env, payload),
       source: {
         appId: env.FLUO_STUDIO_APP_ID ?? basename(process.cwd()),
         runtime: studioRuntimeName(runtime),
@@ -368,6 +402,7 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
   let stopping = false;
 
   const startChild = (resolveExitCode: (code: number) => void, cleanup: () => void) => {
+    ensureStudioEpoch(env);
     const appCommand = buildAppCommand(runnerRuntime, env, appArgs);
     publishStudioLifecycleEvent(env, runnerRuntime, 'restart', {
       phase: 'starting',
@@ -436,6 +471,7 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
       if (env[SHOW_NODE_RESTART_NOTICE_ENV] === '1') {
         stdout.write(`[fluo] restarting after content change: ${relative(projectDirectory, restartPaths[restartPaths.length - 1] ?? projectDirectory)}\n`);
       }
+      advanceStudioEpoch(env);
       publishStudioLifecycleEvent(env, runnerRuntime, 'restart', {
         phase: 'scheduled',
         reason: `content changed: ${relative(projectDirectory, restartPaths[restartPaths.length - 1] ?? projectDirectory)}`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-export { runCli, type CliRuntimeOptions } from './cli.js';
+export { runCli, type CliRuntimeOptions } from './run-cli.js';
 export { runGenerateCommand, type GeneratePlanAction, type GeneratePlanEntry, type GenerateResult } from './commands/generate.js';
 export { inspectUsage, runInspectCommand, type InspectCommandRuntimeOptions } from './commands/inspect.js';
 export { newUsage, runNewCommand, type NewCommandRuntimeOptions } from './commands/new.js';

--- a/packages/cli/src/public-api.test.ts
+++ b/packages/cli/src/public-api.test.ts
@@ -1,18 +1,24 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   inspectUsage,
+  newUsage,
+  runCli,
   runGenerateCommand,
   runInspectCommand,
+  runNewCommand,
+  type CliRuntimeOptions,
   type GeneratePlanAction,
   type GeneratePlanEntry,
   type GenerateResult,
   type InspectCommandRuntimeOptions,
   type ModuleRegistration,
+  type NewCommandRuntimeOptions,
 } from './index.js';
 
 const tempDirectories: string[] = [];
@@ -24,6 +30,20 @@ afterEach(() => {
 });
 
 describe('public CLI package API', () => {
+  it('keeps the root runCli export behind a lazy facade', () => {
+    const sourceRoot = dirname(fileURLToPath(import.meta.url));
+    const rootEntrypoint = readFileSync(join(sourceRoot, 'index.ts'), 'utf8');
+    const runCliFacade = readFileSync(join(sourceRoot, 'run-cli.ts'), 'utf8');
+    const runtimeOptions: CliRuntimeOptions = {
+      ci: true,
+    };
+
+    expect(typeof runCli).toBe('function');
+    expect(runtimeOptions.ci).toBe(true);
+    expect(rootEntrypoint).not.toContain("from './cli.js'");
+    expect(runCliFacade).toContain("await import('./cli.js')");
+  });
+
   it('exports the documented generator and inspect programmatic surface from the root entrypoint', () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-public-api-'));
     tempDirectories.push(workspaceDirectory);
@@ -55,5 +75,28 @@ describe('public CLI package API', () => {
     expect(moduleRegistration.kind).toBe('middleware');
     expect(planEntry.action).toBe('module-create');
     expect(inspectRuntimeOptions.ci).toBe(true);
+  });
+
+  it('exports the documented new command programmatic surface from the root entrypoint', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-public-api-'));
+    tempDirectories.push(workspaceDirectory);
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const runtimeOptions: NewCommandRuntimeOptions = {
+      cwd: workspaceDirectory,
+      interactive: false,
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    };
+
+    const exitCode = await runNewCommand(['starter-app', '--print-plan', '--no-install', '--no-git'], runtimeOptions);
+
+    expect(exitCode).toBe(0);
+    expect(stderrBuffer.join('')).toBe('');
+    expect(newUsage()).toContain('Usage: fluo new|create');
+    expect(stdoutBuffer.join('')).toContain('fluo new scaffold plan');
+    expect(stdoutBuffer.join('')).toContain('Project name: starter-app');
+    expect(stdoutBuffer.join('')).toContain('Side effects: none.');
+    expect(existsSync(join(workspaceDirectory, 'starter-app'))).toBe(false);
   });
 });

--- a/packages/cli/src/run-cli.ts
+++ b/packages/cli/src/run-cli.ts
@@ -1,0 +1,23 @@
+import type { CliRuntimeOptions } from './cli.js';
+import type { InspectCommandRuntimeOptions } from './commands/inspect.js';
+import type { NewCommandRuntimeOptions } from './commands/new.js';
+
+export type { CliRuntimeOptions } from './cli.js';
+
+/**
+ * Runs the top-level CLI command dispatcher through a lazy implementation import.
+ *
+ * This keeps the package root embeddable for tools that only need lightweight helpers while preserving
+ * the same `runCli(...)` behavior as the published `fluo` binary when callers execute it.
+ *
+ * @param argv Argument vector to execute. Defaults to the current process arguments inside the dispatcher.
+ * @param runtime Optional runtime overrides shared by the top-level dispatcher and delegated commands.
+ * @returns `0` when the command completes successfully, otherwise the delegated command exit code.
+ */
+export async function runCli(
+  argv?: string[],
+  runtime: CliRuntimeOptions & NewCommandRuntimeOptions & InspectCommandRuntimeOptions = {},
+): Promise<number> {
+  const { runCli: runCliImplementation } = await import('./cli.js');
+  return runCliImplementation(argv, runtime);
+}

--- a/packages/cli/src/studio/sidecar.test.ts
+++ b/packages/cli/src/studio/sidecar.test.ts
@@ -39,6 +39,10 @@ describe('Studio sidecar', () => {
     const unauthorized = await fetch(`${sidecar.url}/api/state`);
     expect(unauthorized.status).toBe(401);
 
+    const unauthorizedEvents = await fetch(`${sidecar.url}/api/events`);
+    expect(unauthorizedEvents.status).toBe(401);
+    await expect(unauthorizedEvents.json()).resolves.toMatchObject({ error: 'Unauthorized Studio sidecar request.' });
+
     const accepted = await fetch(`${sidecar.url}/api/runtime/events`, {
       body: JSON.stringify({ payload: { ok: true }, source: { appId: 'test-app', runtime: 'node' }, type: 'snapshot', version: 1 }),
       headers: {
@@ -124,5 +128,25 @@ describe('Studio sidecar', () => {
       epoch: sidecar.epoch,
       events: [expect.objectContaining({ epoch: sidecar.epoch, type: 'restart' })],
     });
+  });
+
+  it('honors CLI-provided restart epochs for subsequent child injection', async () => {
+    const sidecar = await startTestSidecar();
+    const initialEpoch = sidecar.epoch;
+    const nextEpoch = 'cli-restart-epoch';
+
+    const accepted = await fetch(`${sidecar.url}/api/runtime/events`, {
+      body: JSON.stringify({ payload: { epoch: nextEpoch, phase: 'scheduled', reason: 'content changed' }, source: { appId: 'test-app', runtime: 'node' }, type: 'restart', version: 1 }),
+      headers: {
+        authorization: `Bearer ${sidecar.token}`,
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+
+    expect(accepted.status).toBe(202);
+    expect(sidecar.epoch).not.toBe(initialEpoch);
+    expect(sidecar.epoch).toBe(nextEpoch);
+    expect(sidecar.env.FLUO_STUDIO_EPOCH).toBe(nextEpoch);
   });
 });

--- a/packages/cli/src/studio/sidecar.ts
+++ b/packages/cli/src/studio/sidecar.ts
@@ -72,6 +72,28 @@ function isRestartEpochBoundary(incoming: { payload?: unknown; type?: unknown })
   return incoming.payload.phase === 'scheduled' || incoming.payload.phase === 'starting';
 }
 
+function resolveRestartEpoch(incoming: { payload?: unknown; type?: unknown }): string | undefined {
+  if (!isRestartEpochBoundary(incoming)) {
+    return undefined;
+  }
+
+  const payload = isRecord(incoming.payload) ? incoming.payload : undefined;
+  const requestedEpoch = payload?.epoch;
+
+  return typeof requestedEpoch === 'string' && requestedEpoch.length > 0 ? requestedEpoch : createEpoch();
+}
+
+function createStudioSidecarEnv(options: { appId: string; epoch: string; runtime: StudioSidecarRuntime; token: string; url: string }): NodeJS.ProcessEnv {
+  return {
+    FLUO_STUDIO: '1',
+    FLUO_STUDIO_APP_ID: options.appId,
+    FLUO_STUDIO_EPOCH: options.epoch,
+    FLUO_STUDIO_RUNTIME: options.runtime,
+    FLUO_STUDIO_TOKEN: options.token,
+    FLUO_STUDIO_URL: options.url,
+  };
+}
+
 function createToken(): string {
   return randomBytes(24).toString('base64url');
 }
@@ -293,8 +315,9 @@ export async function startStudioSidecar(options: StudioSidecarOptions = {}): Pr
   const startedAt = performance.now();
 
   const publish = (incoming: { payload?: unknown; source?: unknown; type?: unknown }): StoredStudioEvent => {
-    if (isRestartEpochBoundary(incoming)) {
-      epoch = createEpoch();
+    const restartEpoch = resolveRestartEpoch(incoming);
+    if (restartEpoch) {
+      epoch = restartEpoch;
     }
 
     sequence += 1;
@@ -442,13 +465,14 @@ export async function startStudioSidecar(options: StudioSidecarOptions = {}): Pr
     get epoch() {
       return epoch;
     },
-    env: {
-      FLUO_STUDIO: '1',
-      FLUO_STUDIO_APP_ID: appId,
-      FLUO_STUDIO_EPOCH: epoch,
-      FLUO_STUDIO_RUNTIME: runtime,
-      FLUO_STUDIO_TOKEN: token,
-      FLUO_STUDIO_URL: url,
+    get env() {
+      return createStudioSidecarEnv({
+        appId,
+        epoch,
+        runtime,
+        token,
+        url,
+      });
     },
     host,
     port: address.port,


### PR DESCRIPTION
## Summary

Linked context: Closes #2152

Harden `@fluojs/cli` Studio dev-runner restart behavior and the root programmatic entrypoint surface.

## Changes

- Keep Studio restart epochs aligned across the dev runner, sidecar state, and newly spawned app child env injection.
- Let the Studio sidecar honor CLI-provided restart epochs and expose a current `env` snapshot after epoch transitions.
- Move root `runCli` through a lazy `run-cli.ts` facade so importing `@fluojs/cli` no longer eagerly loads the full CLI dispatcher from `cli.ts`.
- Add regression coverage for `runNewCommand()`/`newUsage()`, lazy root `runCli`, current restart epoch reinjection, and unauthorized `/api/events` SSE access.
- Add a patch changeset for `@fluojs/cli`.

## Testing

- Changed-file LSP diagnostics: passed for all touched TypeScript files.
- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/runtime... build`
- `pnpm --filter @fluojs/cli typecheck`
- `pnpm --filter @fluojs/cli exec vitest run -c vitest.config.ts src/public-api.test.ts src/studio/sidecar.test.ts src/cli.test.ts`
- `pnpm --filter @fluojs/cli test`
- `pnpm --filter @fluojs/cli build`
- `pnpm lint` (completed; public-export TSDoc changed-mode passed, with existing non-failing Biome warnings outside this change)
- `FLUO_CLI_SANDBOX_ROOT=/var/folders/xj/v8c228rx2ybb4g8pkm1m932r0000gn/T/opencode/fluo-cli-sandbox-2152-a pnpm --dir packages/cli sandbox:matrix`
- `FLUO_CLI_SANDBOX_ROOT=/var/folders/xj/v8c228rx2ybb4g8pkm1m932r0000gn/T/opencode/fluo-cli-sandbox-2152-c pnpm verify:release-readiness`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/cli-dev-runner-programmatic-surface.md` for `@fluojs/cli`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

`runCli(...)` remains the documented public root API; the new facade preserves the API shape while avoiding eager dispatcher loading. `pnpm lint` confirmed changed-mode public export TSDoc.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No README contract wording changed; this PR restores the documented Studio sidecar/restart behavior and keeps the Node-only Studio MVP limitation intact. Regression coverage exercises current epoch reinjection and token-gated SSE denial.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs or package README files changed. Release readiness and CLI sandbox matrix passed with a dedicated sandbox root.
