### PR TITLE
Resolve #2144: add Drizzle transaction and status regression coverage

### DIFF
--- a/packages/drizzle/src/module.test.ts
+++ b/packages/drizzle/src/module.test.ts
@@ -1,14 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
-
 import { Global, Inject, Module } from '@fluojs/core';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
-  DRIZZLE_OPTIONS,
-  DRIZZLE_DATABASE,
-  DrizzleModule,
   createDrizzlePlatformStatusSnapshot,
+  DRIZZLE_DATABASE,
+  DRIZZLE_HANDLE_PROVIDER,
+  DRIZZLE_OPTIONS,
   DrizzleDatabase,
+  DrizzleModule,
 } from './index.js';
 
 describe('@fluojs/drizzle', () => {
@@ -997,6 +997,25 @@ describe('@fluojs/drizzle', () => {
     expect(snapshot.readiness.status).toBe('not-ready');
     expect(snapshot.health.status).toBe('degraded');
   });
+
+  it('marks stopped state as not-ready and unhealthy', () => {
+    const snapshot = createDrizzlePlatformStatusSnapshot({
+      activeRequestTransactions: 0,
+      lifecycleState: 'stopped',
+      strictTransactions: false,
+      supportsTransaction: true,
+    });
+
+    expect(snapshot.readiness).toEqual({
+      critical: true,
+      reason: 'Drizzle integration is stopped.',
+      status: 'not-ready',
+    });
+    expect(snapshot.health).toEqual({
+      reason: 'Drizzle integration has been disposed.',
+      status: 'unhealthy',
+    });
+  });
 });
 
 describe('DrizzleModule.forRootAsync', () => {
@@ -1046,6 +1065,27 @@ describe('DrizzleModule.forRootAsync', () => {
 
     void db;
     void events;
+
+    await app.close();
+  });
+
+  it('resolves DRIZZLE_HANDLE_PROVIDER as the lifecycle-aware DrizzleDatabase alias', async () => {
+    const { database, transactionDatabase } = makeFakeDatabase();
+
+    const drizzleModule = DrizzleModule.forRoot<typeof database, typeof transactionDatabase>({ database });
+
+    class AppModule {}
+
+    defineModule(AppModule, { imports: [drizzleModule] });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const drizzle = await app.container.resolve(DrizzleDatabase);
+    const handleProvider = await app.container.resolve(DRIZZLE_HANDLE_PROVIDER);
+
+    expect(handleProvider).toBe(drizzle);
+    expect((handleProvider as DrizzleDatabase<typeof database, typeof transactionDatabase>).createPlatformStatusSnapshot()).toEqual(
+      drizzle.createPlatformStatusSnapshot(),
+    );
 
     await app.close();
   });

--- a/packages/drizzle/src/transaction-decorator.red.test.ts
+++ b/packages/drizzle/src/transaction-decorator.red.test.ts
@@ -2,7 +2,7 @@ import { Inject } from '@fluojs/core';
 import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { describe, expect, it } from 'vitest';
 
-import { DrizzleDatabase, DrizzleModule, Transaction, type DrizzleDatabaseFacade } from './index.js';
+import { DrizzleDatabase, type DrizzleDatabaseFacade, DrizzleModule, Transaction } from './index.js';
 
 describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 impl)', () => {
   it('exports Transaction and opens a transaction for current-less repository calls', async () => {
@@ -274,6 +274,45 @@ describe('@fluojs/drizzle Transaction decorator contract (RED - pending Task 8 i
 
     await app.close();
   });
+
+  it('forwards @Transaction(...) options to the outer transaction boundary', async () => {
+    const optionsCalls: Array<{ isolationLevel: string } | undefined> = [];
+    const transactionDatabase = { kind: 'transaction' as const };
+    const database = {
+      async transaction<T>(
+        callback: (value: typeof transactionDatabase) => Promise<T>,
+        options?: { isolationLevel: string },
+      ): Promise<T> {
+        optionsCalls.push(options);
+        return callback(transactionDatabase);
+      },
+    };
+
+    @Inject(DrizzleDatabase)
+    class UserService {
+      constructor(private readonly db: DrizzleDatabase<typeof database, typeof transactionDatabase, { isolationLevel: string }>) {}
+
+      @Transaction({ isolationLevel: 'Serializable' })
+      async create() {
+        return this.db.current();
+      }
+    }
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [DrizzleModule.forRoot<typeof database, typeof transactionDatabase, { isolationLevel: string }>({ database })],
+      providers: [UserService],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const service = await app.container.resolve(UserService);
+
+    await expect(service.create()).resolves.toBe(transactionDatabase);
+    expect(optionsCalls).toEqual([{ isolationLevel: 'Serializable' }]);
+
+    await app.close();
+  });
 });
 
 describe('@fluojs/drizzle Transaction decorator — named/accessor contract', () => {
@@ -323,7 +362,7 @@ describe('@fluojs/drizzle Transaction decorator — named/accessor contract', ()
     class MultiDatabaseService {
       readonly analyticsDb = analyticsDatabase;
 
-      constructor(private readonly db: DrizzleDatabase<typeof primaryDatabase, typeof primaryTransactionDatabase>) {}
+      constructor(readonly _db: DrizzleDatabase<typeof primaryDatabase, typeof primaryTransactionDatabase>) {}
 
       @Transaction((self: MultiDatabaseService) => self.analyticsDb)
       async loadAnalytics() {
@@ -390,7 +429,7 @@ describe('@fluojs/drizzle Transaction decorator — named/accessor contract', ()
     class IsolatedService {
       readonly analyticsDb = analyticsDatabase;
 
-      constructor(private readonly db: DrizzleDatabase<typeof primaryDatabase, typeof primaryTransactionDatabase2>) {}
+      constructor(readonly _db: DrizzleDatabase<typeof primaryDatabase, typeof primaryTransactionDatabase2>) {}
 
       @Transaction((self: IsolatedService) => self.analyticsDb)
       async analyticsWork() {


### PR DESCRIPTION
## Summary
- Add @fluojs/drizzle regression coverage for documented transaction options and lifecycle status contracts.
- Cover DRIZZLE_HANDLE_PROVIDER alias resolution against the lifecycle-aware DrizzleDatabase.

Closes #2144

## Changes
- Added @Transaction(...) option forwarding regression coverage.
- Added stopped/not-ready/unhealthy platform status snapshot coverage.
- Added DRIZZLE_HANDLE_PROVIDER alias resolution coverage.

## Testing
- lsp_diagnostics packages/drizzle/src/module.test.ts: no diagnostics.
- lsp_diagnostics packages/drizzle/src/transaction-decorator.red.test.ts: no diagnostics.
- pnpm exec biome check packages/drizzle/src/module.test.ts packages/drizzle/src/transaction-decorator.red.test.ts: passed.
- pnpm --filter @fluojs/drizzle test: 5 files / 45 tests passed.
- pnpm --filter @fluojs/drizzle typecheck: passed.
- pnpm --filter @fluojs/drizzle build: passed.

## Public export documentation
Not applicable. This PR adds regression tests only and does not change public exports or docs.

## Behavioral contract
Strengthens regression coverage for documented Drizzle transaction/status contracts without changing implementation behavior.

## Platform consistency governance (SSOT)
Not applicable. No platform matrix or docs SSOT change.

## Release impact
No changeset. Test-only change; no public behavior, API, package contents, or release metadata changed.