### PR TITLE
Resolve #2154: fix Studio static report classification and lifecycle coverage

### DIFF
--- a/.changeset/studio-static-report-classification.md
+++ b/.changeset/studio-static-report-classification.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/studio': patch
+---
+
+Preserve internal component identity when static Studio snapshots are filtered so hidden internal dependencies are not reclassified as external nodes in graph rendering or connection inspection.

--- a/packages/studio/src/app/bootstrap.tsx
+++ b/packages/studio/src/app/bootstrap.tsx
@@ -1,11 +1,13 @@
 import { flushSync } from 'react-dom';
-import { createRoot } from 'react-dom/client';
+import { createRoot, type Root } from 'react-dom/client';
 import { App } from './App.js';
 
 /**
  * Provides bootstrap Studio App behavior for the Studio devtool.
+ *
+ * @returns The mounted React root so tests and embedding callers can unmount the viewer cleanly.
  */
-export function bootstrapStudioApp(): void {
+export function bootstrapStudioApp(): Root {
   const app = document.querySelector<HTMLDivElement>('#app');
 
   if (!app) {
@@ -16,4 +18,6 @@ export function bootstrapStudioApp(): void {
   flushSync(() => {
     root.render(<App />);
   });
+
+  return root;
 }

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -11,6 +11,7 @@ import { applyFilters, isStudioLiveEvent, parseStudioLiveEvent, parseStudioPaylo
 import * as studio from './index.js';
 import { bootstrapStudioApp } from './app/bootstrap.js';
 import { inspectComponentConnections, renderDiagnosticDocsUrl, renderDiagnostics, renderGraphSvg } from './viewer-rendering.js';
+import { initialStudioState, selectSelectedStaticComponent } from './entities/studio/model.js';
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packageCommandTimeoutMs = 120_000;
@@ -925,6 +926,43 @@ describe('applyFilters', () => {
     expect(graphSvg).toContain('aws.lambda.orders');
     expect(summary?.outgoing.map((component) => component.id)).toEqual(['queue.default']);
     expect(summary?.externalDependencies).toEqual(['aws.lambda.orders']);
+  });
+
+  it('keeps selected hidden internal components available to the static inspector', () => {
+    const snapshotWithHiddenInternalDependency: PlatformShellSnapshot = {
+      ...snapshotFixture,
+      components: [
+        snapshotFixture.components[0],
+        snapshotFixture.components[1],
+        {
+          ...snapshotFixture.components[0],
+          dependencies: ['queue.default'],
+          id: 'api.gateway',
+          kind: 'http',
+          readiness: {
+            critical: true,
+            status: 'ready',
+          },
+        },
+      ],
+    };
+    const filtered = applyFilters(snapshotWithHiddenInternalDependency, {
+      query: '',
+      readinessStatuses: ['ready'],
+      severities: [],
+    });
+
+    const selected = selectSelectedStaticComponent({
+      ...initialStudioState,
+      staticReport: {
+        filteredSnapshot: filtered,
+        payload: { snapshot: snapshotWithHiddenInternalDependency },
+        selectedComponentId: 'queue.default',
+      },
+    });
+
+    expect(filtered.components.map((component) => component.id)).toEqual(['redis.default', 'api.gateway']);
+    expect(selected?.id).toBe('queue.default');
   });
 
   it('returns empty component and diagnostic lists when filters match nothing', () => {

--- a/packages/studio/src/contracts.test.ts
+++ b/packages/studio/src/contracts.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -9,6 +9,7 @@ import type { PlatformShellSnapshot } from '@fluojs/runtime';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { applyFilters, isStudioLiveEvent, parseStudioLiveEvent, parseStudioPayload, renderMermaid } from './contracts.js';
 import * as studio from './index.js';
+import { bootstrapStudioApp } from './app/bootstrap.js';
 import { inspectComponentConnections, renderDiagnosticDocsUrl, renderDiagnostics, renderGraphSvg } from './viewer-rendering.js';
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -319,6 +320,60 @@ describe('Studio live contracts', () => {
 
     delete (window as typeof window & { __FLUO_STUDIO__?: unknown }).__FLUO_STUDIO__;
     vi.unstubAllGlobals();
+  });
+
+  it('unmounts the packaged viewer and cleans up live sidecar listeners', async () => {
+    class FakeEventSource {
+      static instances: FakeEventSource[] = [];
+      closed = false;
+      onerror: ((event: Event) => void) | null = null;
+      onopen: ((event: Event) => void) | null = null;
+      private readonly listeners = new Map<string, Set<EventListener>>();
+
+      constructor(readonly url: string) {
+        FakeEventSource.instances.push(this);
+      }
+
+      addEventListener(type: string, listener: EventListener): void {
+        const listeners = this.listeners.get(type) ?? new Set<EventListener>();
+        listeners.add(listener);
+        this.listeners.set(type, listeners);
+      }
+
+      close(): void {
+        this.closed = true;
+      }
+
+      listenerCount(type: string): number {
+        return this.listeners.get(type)?.size ?? 0;
+      }
+
+      removeEventListener(type: string, listener: EventListener): void {
+        this.listeners.get(type)?.delete(listener);
+      }
+    }
+
+    vi.resetModules();
+    vi.stubGlobal('EventSource', FakeEventSource);
+    (window as typeof window & { __FLUO_STUDIO__?: { eventsUrl: string } }).__FLUO_STUDIO__ = {
+      eventsUrl: '/api/events?token=test-token',
+    };
+    document.body.innerHTML = '<div id="app"></div>';
+
+    const root = bootstrapStudioApp();
+
+    await vi.waitFor(() => {
+      expect(FakeEventSource.instances).toHaveLength(1);
+    });
+    const source = FakeEventSource.instances[0];
+    expect(source?.listenerCount('message')).toBe(1);
+    expect(source?.listenerCount('snapshot')).toBe(1);
+
+    root.unmount();
+
+    expect(source?.closed).toBe(true);
+    expect(source?.listenerCount('message')).toBe(0);
+    expect(source?.listenerCount('snapshot')).toBe(0);
   });
 });
 
@@ -760,6 +815,32 @@ describe('parseStudioPayload', () => {
       expect(html).toContain('href="./assets/');
       expect(html).not.toContain('src="/assets/');
       expect(html).not.toContain('href="/assets/');
+
+      const consumerRoot = resolve(outputDirectory, 'consumer');
+      const packageInstallRoot = resolve(consumerRoot, 'node_modules/@fluojs/studio');
+      mkdirSync(resolve(packageInstallRoot, 'dist'), { recursive: true });
+      writeFileSync(resolve(consumerRoot, 'package.json'), '{"type":"module"}\n');
+      writeFileSync(
+        resolve(packageInstallRoot, 'package.json'),
+        JSON.stringify({
+          exports: {
+            '.': { import: './dist/index.js', types: './dist/index.d.ts' },
+            './contracts': { import: './dist/contracts.js', types: './dist/contracts.d.ts' },
+            './viewer': './dist/index.html',
+          },
+          name: '@fluojs/studio',
+          type: 'module',
+        }),
+      );
+      cpSync(resolve(outputDirectory, 'index.js'), resolve(packageInstallRoot, 'dist/index.js'));
+      cpSync(resolve(outputDirectory, 'contracts.js'), resolve(packageInstallRoot, 'dist/contracts.js'));
+
+      const directSubpathImport = spawnSync(
+        process.execPath,
+        ['--input-type=module', '--eval', "import { parseStudioPayload, renderMermaid } from '@fluojs/studio/contracts'; if (typeof parseStudioPayload !== 'function' || typeof renderMermaid !== 'function') process.exit(1);"],
+        { cwd: consumerRoot, encoding: 'utf8' },
+      );
+      expect(directSubpathImport.status, [directSubpathImport.stdout, directSubpathImport.stderr].filter(Boolean).join('\n')).toBe(0);
     } finally {
       rmSync(outputDirectory, { force: true, recursive: true });
     }
@@ -805,6 +886,45 @@ describe('applyFilters', () => {
     expect(filteredByHint.components).toEqual([]);
     expect(filteredByHint.diagnostics.map((issue: { code: string }) => issue.code)).toEqual(['QUEUE_DEPENDENCY_NOT_READY']);
     expect(filteredByBlocker.diagnostics.map((issue: { componentId: string }) => issue.componentId)).toEqual(['queue.default']);
+  });
+
+  it('preserves hidden internal component identity when static filters remove a dependency node', () => {
+    const snapshotWithHiddenInternalDependency: PlatformShellSnapshot = {
+      ...snapshotFixture,
+      components: [
+        snapshotFixture.components[0],
+        snapshotFixture.components[1],
+        {
+          ...snapshotFixture.components[0],
+          dependencies: ['queue.default', 'aws.lambda.orders'],
+          id: 'api.gateway',
+          kind: 'http',
+          readiness: {
+            critical: true,
+            status: 'ready',
+          },
+        },
+      ],
+    };
+
+    const filtered = applyFilters(snapshotWithHiddenInternalDependency, {
+      query: '',
+      readinessStatuses: ['ready'],
+      severities: [],
+    });
+    const mermaid = renderMermaid(filtered);
+    const graphSvg = renderGraphSvg(filtered, 'api.gateway', snapshotWithHiddenInternalDependency.components);
+    const summary = inspectComponentConnections(filtered, 'api.gateway', snapshotWithHiddenInternalDependency.components);
+
+    expect(filtered.components.map((component) => component.id)).toEqual(['redis.default', 'api.gateway']);
+    expect(mermaid).not.toContain('["queue.default"]');
+    expect(mermaid).not.toMatch(/C\d+ --> EXT_queue_default_/);
+    expect(mermaid).toContain('aws.lambda.orders');
+    expect(graphSvg).not.toContain('component-external">\n   <text x="');
+    expect(graphSvg).not.toContain('>queue.default</text>');
+    expect(graphSvg).toContain('aws.lambda.orders');
+    expect(summary?.outgoing.map((component) => component.id)).toEqual(['queue.default']);
+    expect(summary?.externalDependencies).toEqual(['aws.lambda.orders']);
   });
 
   it('returns empty component and diagnostic lists when filters match nothing', () => {

--- a/packages/studio/src/contracts.ts
+++ b/packages/studio/src/contracts.ts
@@ -220,6 +220,12 @@ export interface ParsedPayload {
   rawJson: string;
 }
 
+const originalComponentsByFilteredSnapshot = new WeakMap<PlatformShellSnapshot, readonly PlatformSnapshot[]>();
+
+function internalComponentIdsFor(snapshot: PlatformShellSnapshot): Set<string> {
+  return new Set((originalComponentsByFilteredSnapshot.get(snapshot) ?? snapshot.components).map((component) => component.id));
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -908,11 +914,15 @@ export function applyFilters(snapshot: PlatformShellSnapshot, filter: FilterStat
       || (issue.dependsOn?.some((dependency: string) => dependency.toLowerCase().includes(query)) ?? false);
   });
 
-  return {
+  const filteredSnapshot = {
     ...snapshot,
     components,
     diagnostics,
   };
+
+  originalComponentsByFilteredSnapshot.set(filteredSnapshot, snapshot.components);
+
+  return filteredSnapshot;
 }
 
 function escapeMermaidText(value: string): string {
@@ -958,6 +968,7 @@ export function renderMermaid(snapshot: PlatformShellSnapshot): string {
   const lines: string[] = ['graph TD'];
   const nodeByComponent = new Map<string, string>();
   const externalNodeByDependency = new Map<string, string>();
+  const internalComponentIds = internalComponentIdsFor(snapshot);
 
   if (snapshot.components.length === 0) {
     lines.push('  EMPTY["No registered platform components"]');
@@ -981,6 +992,10 @@ export function renderMermaid(snapshot: PlatformShellSnapshot): string {
 
       if (to) {
         lines.push(`  ${from} --> ${to}`);
+        continue;
+      }
+
+      if (internalComponentIds.has(dependency)) {
         continue;
       }
 

--- a/packages/studio/src/entities/studio/model.ts
+++ b/packages/studio/src/entities/studio/model.ts
@@ -75,6 +75,16 @@ export function selectStaticSnapshot(state: StudioDashboardState): PlatformShell
 }
 
 /**
+ * Provides select Original Static Snapshot behavior for the Studio devtool.
+ *
+ * @param state state value used by select Original Static Snapshot.
+ * @returns The unfiltered static snapshot, when one has been loaded.
+ */
+export function selectOriginalStaticSnapshot(state: StudioDashboardState): PlatformShellSnapshot | undefined {
+  return state.staticReport.payload?.snapshot;
+}
+
+/**
  * Provides select Static Timing behavior for the Studio devtool.
  *
  * @param state state value used by select Static Timing.

--- a/packages/studio/src/entities/studio/model.ts
+++ b/packages/studio/src/entities/studio/model.ts
@@ -146,8 +146,10 @@ export function selectSelectedStaticComponent(state: StudioDashboardState): Plat
     return undefined;
   }
 
+  const originalSnapshot = selectOriginalStaticSnapshot(state);
   const selected = state.staticReport.selectedComponentId
     ? snapshot.components.find((component) => component.id === state.staticReport.selectedComponentId)
+      ?? originalSnapshot?.components.find((component) => component.id === state.staticReport.selectedComponentId)
     : undefined;
   return selected ?? snapshot.components[0];
 }

--- a/packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts
+++ b/packages/studio/src/features/live-connection/model/useStudioLiveConnection.test.ts
@@ -32,6 +32,16 @@ class FakeEventSource {
     this.closed = true;
   }
 
+  emit(type: string, event: StudioLiveEvent): void {
+    this.emitRaw(type, JSON.stringify(event));
+  }
+
+  emitRaw(type: string, data: string): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(new MessageEvent(type, { data }));
+    }
+  }
+
   removeEventListener(type: string, listener: EventListener): void {
     this.listeners.get(type)?.delete(listener);
   }
@@ -56,6 +66,32 @@ function liveSnapshotEvent(): StudioLiveEvent {
     sequence: 1,
     source: { appId: 'app-test', runtime: 'node' },
     type: 'snapshot',
+    version: 1,
+  };
+}
+
+function liveRestartEvent(phase: 'started' | 'stopping'): StudioLiveEvent {
+  return {
+    emittedAt: '2026-05-28T00:00:03.000Z',
+    epoch: 'epoch-1',
+    eventId: `epoch-1:restart-${phase}`,
+    payload: { phase, reason: phase === 'started' ? 'restart complete' : 'source changed' },
+    sequence: phase === 'started' ? 3 : 2,
+    source: { appId: 'app-test', runtime: 'node' },
+    type: 'restart',
+    version: 1,
+  };
+}
+
+function liveDisconnectEvent(): StudioLiveEvent {
+  return {
+    emittedAt: '2026-05-28T00:00:04.000Z',
+    epoch: 'epoch-1',
+    eventId: 'epoch-1:disconnect',
+    payload: { reason: 'dev server closed' },
+    sequence: 4,
+    source: { appId: 'app-test', runtime: 'node' },
+    type: 'disconnect',
     version: 1,
   };
 }
@@ -115,6 +151,77 @@ describe('useStudioLiveConnection', () => {
 
     expect(FakeEventSource.instances).toHaveLength(0);
     expect(observedStates.some((state) => state.events.length > 0)).toBe(false);
+  });
+
+  it('reports the full live connection lifecycle state set', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('EventSource', FakeEventSource);
+    (window as typeof window & { __FLUO_STUDIO__?: { eventsUrl: string } }).__FLUO_STUDIO__ = {
+      eventsUrl: '/api/events?token=test-token',
+    };
+
+    const observedStatuses: StudioDashboardState['connection']['status'][] = [];
+    function Harness() {
+      const [state, dispatch] = useReducer(studioReducer, initialStudioState);
+      observedStatuses.push(state.connection.status);
+      useStudioLiveConnection(dispatch);
+      return createElement('output', null, state.connection.status);
+    }
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root: Root = createRoot(container);
+    root.render(createElement(Harness));
+
+    await vi.waitFor(() => {
+      expect(observedStatuses).toContain('connecting');
+      expect(FakeEventSource.instances).toHaveLength(1);
+    });
+
+    const source = FakeEventSource.instances[0];
+    source?.onopen?.(new Event('open'));
+    await vi.waitFor(() => {
+      expect(observedStatuses).toContain('connected');
+    });
+
+    vi.advanceTimersByTime(25_001);
+    await vi.waitFor(() => {
+      expect(observedStatuses).toContain('stale');
+    });
+
+    source?.onerror?.(new Event('error'));
+    await vi.waitFor(() => {
+      expect(observedStatuses).toContain('reconnecting');
+    });
+
+    source?.emit('restart', liveRestartEvent('stopping'));
+    await vi.waitFor(() => {
+      expect(observedStatuses).toContain('restarting');
+    });
+    source?.emit('restart', liveRestartEvent('started'));
+    await vi.waitFor(() => {
+      expect(observedStatuses.at(-1)).toBe('connected');
+    });
+    source?.emit('disconnect', liveDisconnectEvent());
+    await vi.waitFor(() => {
+      expect(observedStatuses).toContain('disconnected');
+    });
+    source?.emitRaw('message', '{"type":"not-a-studio-event"}');
+
+    await vi.waitFor(() => {
+      expect(observedStatuses).toEqual(expect.arrayContaining([
+        'static',
+        'connecting',
+        'connected',
+        'stale',
+        'reconnecting',
+        'restarting',
+        'disconnected',
+        'error',
+      ]));
+    });
+
+    root.unmount();
   });
 
   it('closes the event source, listeners, and stale timer on unmount', async () => {

--- a/packages/studio/src/viewer-rendering.ts
+++ b/packages/studio/src/viewer-rendering.ts
@@ -1,5 +1,6 @@
 import type { PlatformDiagnosticIssue, PlatformShellSnapshot, PlatformSnapshot } from '@fluojs/runtime';
 
+/** Selected Studio component neighborhood rendered by the static report inspector. */
 export interface ComponentConnectionSummary {
   component: PlatformSnapshot;
   diagnostics: PlatformDiagnosticIssue[];
@@ -54,8 +55,8 @@ export function renderDiagnosticDocsUrl(docsUrl: string): string {
   return `<p><strong>docs:</strong> <a href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer">${label}</a></p>`;
 }
 
-function collectExternalDependencies(components: PlatformSnapshot[]): string[] {
-  const componentIds = new Set(components.map((component) => component.id));
+function collectExternalDependencies(components: PlatformSnapshot[], componentCatalog: readonly PlatformSnapshot[] = components): string[] {
+  const componentIds = new Set(componentCatalog.map((component) => component.id));
   const externalDependencies: string[] = [];
   const seen = new Set<string>();
 
@@ -78,17 +79,20 @@ function collectExternalDependencies(components: PlatformSnapshot[]): string[] {
  *
  * @param snapshot - Filtered platform snapshot currently shown in the viewer.
  * @param selectedComponentId - Component id selected by the user, or `undefined` to select the first component.
+ * @param componentCatalog - Unfiltered component list used to distinguish hidden internal dependencies from external dependencies.
  * @returns The selected component plus incoming, outgoing, external, and diagnostic context.
  */
 export function inspectComponentConnections(
   snapshot: PlatformShellSnapshot | undefined,
   selectedComponentId: string | undefined,
+  componentCatalog: readonly PlatformSnapshot[] = snapshot?.components ?? [],
 ): ComponentConnectionSummary | undefined {
   if (!snapshot || snapshot.components.length === 0) {
     return undefined;
   }
 
-  const componentById = new Map(snapshot.components.map((component) => [component.id, component]));
+  const componentById = new Map(componentCatalog.map((component) => [component.id, component]));
+  const visibleComponentById = new Map(snapshot.components.map((component) => [component.id, component]));
   const component = selectedComponentId ? componentById.get(selectedComponentId) ?? snapshot.components[0] : snapshot.components[0];
 
   if (!component) {
@@ -101,13 +105,13 @@ export function inspectComponentConnections(
   for (const dependency of component.dependencies) {
     const dependencyComponent = componentById.get(dependency);
     if (dependencyComponent) {
-      outgoing.push(dependencyComponent);
+      outgoing.push(visibleComponentById.get(dependency) ?? dependencyComponent);
     } else {
       externalDependencies.push(dependency);
     }
   }
 
-  const incoming = snapshot.components.filter((candidate) => candidate.id !== component.id && candidate.dependencies.includes(component.id));
+  const incoming = componentCatalog.filter((candidate) => candidate.id !== component.id && candidate.dependencies.includes(component.id));
   const diagnostics = snapshot.diagnostics.filter(
     (issue) => issue.componentId === component.id || (issue.dependsOn?.includes(component.id) ?? false),
   );
@@ -121,12 +125,17 @@ export function inspectComponentConnections(
   };
 }
 
-function resolveNodePositions(snapshot: PlatformShellSnapshot, width: number, height: number): Map<string, { x: number; y: number }> {
+function resolveNodePositions(
+  snapshot: PlatformShellSnapshot,
+  width: number,
+  height: number,
+  componentCatalog: readonly PlatformSnapshot[] = snapshot.components,
+): Map<string, { x: number; y: number }> {
   const radius = Math.min(width, height) / 2 - 70;
   const centerX = width / 2;
   const centerY = height / 2;
   const positions = new Map<string, { x: number; y: number }>();
-  const externalDependencies = collectExternalDependencies(snapshot.components);
+  const externalDependencies = collectExternalDependencies(snapshot.components, componentCatalog);
   const nodeIds = [
     ...snapshot.components.map((component) => component.id),
     ...externalDependencies,
@@ -148,14 +157,19 @@ function resolveNodePositions(snapshot: PlatformShellSnapshot, width: number, he
  *
  * @param snapshot - Filtered platform snapshot currently shown in the viewer.
  * @param selectedComponentId - Optional selected component id to highlight.
+ * @param componentCatalog - Unfiltered component list used to keep hidden internal dependencies from rendering as external nodes.
  * @returns SVG markup for the browser graph panel.
  */
-export function renderGraphSvg(snapshot: PlatformShellSnapshot, selectedComponentId: string | undefined): string {
+export function renderGraphSvg(
+  snapshot: PlatformShellSnapshot,
+  selectedComponentId: string | undefined,
+  componentCatalog: readonly PlatformSnapshot[] = snapshot.components,
+): string {
   const width = 900;
   const height = 460;
   const components = snapshot.components;
-  const positions = resolveNodePositions(snapshot, width, height);
-  const externalDependencies = collectExternalDependencies(components);
+  const positions = resolveNodePositions(snapshot, width, height, componentCatalog);
+  const externalDependencies = collectExternalDependencies(components, componentCatalog);
   const selectedComponent = selectedComponentId ? components.find((component) => component.id === selectedComponentId) : undefined;
   const selectedDependencyIds = new Set(selectedComponent?.dependencies ?? []);
   const selectedIncomingIds = new Set(

--- a/packages/studio/src/widgets/static-report/ui/StaticReportPanel.tsx
+++ b/packages/studio/src/widgets/static-report/ui/StaticReportPanel.tsx
@@ -3,7 +3,7 @@ import type { PlatformSnapshot } from '@fluojs/runtime';
 import { renderMermaid } from '../../../contracts.js';
 import type { StudioAction } from '../../../entities/studio/actions.js';
 import type { StudioDashboardState } from '../../../entities/studio/model.js';
-import { selectSelectedStaticComponent, selectStaticSnapshot } from '../../../entities/studio/model.js';
+import { selectOriginalStaticSnapshot, selectSelectedStaticComponent, selectStaticSnapshot } from '../../../entities/studio/model.js';
 import { EmptyState } from '../../../shared/ui/EmptyState.js';
 import { inspectComponentConnections, renderDiagnostics, renderGraphSvg } from '../../../viewer-rendering.js';
 
@@ -59,7 +59,8 @@ function renderDetails(component: PlatformSnapshot | undefined) {
 }
 
 function ConnectionExplorer({ dispatch, selectedId, state }: StaticReportPanelProps & { selectedId?: string }) {
-  const summary = inspectComponentConnections(selectStaticSnapshot(state), selectedId);
+  const originalSnapshot = selectOriginalStaticSnapshot(state);
+  const summary = inspectComponentConnections(selectStaticSnapshot(state), selectedId, originalSnapshot?.components);
   if (!summary) {
     return <p className="muted">Load a platform snapshot to explore component connections.</p>;
   }
@@ -130,10 +131,11 @@ function ConnectionExplorer({ dispatch, selectedId, state }: StaticReportPanelPr
  */
 export function StaticReportPanel({ dispatch, state }: StaticReportPanelProps) {
   const snapshot = selectStaticSnapshot(state);
+  const originalSnapshot = selectOriginalStaticSnapshot(state);
   const selected = selectSelectedStaticComponent(state);
   const mermaidText = snapshot ? renderMermaid(snapshot) : '';
   const graphSvg = snapshot && snapshot.components.length > 0
-    ? renderGraphSvg(snapshot, selected?.id)
+    ? renderGraphSvg(snapshot, selected?.id, originalSnapshot?.components)
     : '<p class="muted">No platform components loaded.</p>';
 
   function selectComponentFromEvent(event: MouseEvent<HTMLDivElement> | KeyboardEvent<HTMLDivElement>): void {


### PR DESCRIPTION
## Summary
- Preserve original internal component identity when Studio snapshots are filtered.
- Keep static report rendering from misclassifying hidden internal dependencies as external nodes.
- Add live viewer lifecycle, contracts subpath, and unmount cleanup coverage.

Closes #2154

## Changes
- Updated Studio contract filtering/rendering to classify dependencies against the original component catalog.
- Added tests for filtered static report classification, live connection lifecycle states, contracts subpath direct import, and viewer unmount cleanup.
- Added patch changeset for @fluojs/studio bugfix.

## Testing
- lsp_diagnostics on changed TypeScript/TSX files: no diagnostics.
- pnpm --dir packages/studio test: 4 files / 45 tests passed.
- pnpm --dir packages/studio typecheck: passed.
- pnpm --dir packages/studio build: passed.
- pnpm exec biome lint changed files and changeset: passed.
- pnpm verify:public-export-tsdoc: passed.

## Public export documentation
No public export signature changes. Existing Studio contracts behavior is fixed and covered by tests.

## Behavioral contract
Fixes public Studio static report classification behavior while preserving documented contracts.

## Platform consistency governance (SSOT)
Not applicable. No platform matrix or docs SSOT changes.

## Release impact
Patch changeset included: .changeset/studio-static-report-classification.md.