### PR TITLE
Resolve #2151: clarify Throttler NestJS migration boundaries

### DIFF
--- a/book/beginner/ch16-throttler.ko.md
+++ b/book/beginner/ch16-throttler.ko.md
@@ -111,6 +111,8 @@ export class AuthController {
 
 클러스터 전체 총량 제한처럼 더 높은 수준의 보호가 필요하다면, 내장된 앱 전체 quota 레이어가 있다고 가정하지 말고 애플리케이션 middleware, 커스텀 store, 또는 커스텀 guard wrapper로 명시적으로 모델링하십시오.
 
+이 차이는 NestJS 마이그레이션에서 특히 중요합니다. 기존 `@nestjs/throttler` 전역 설정이 있었다고 해서 모든 fluo route가 보호된다고 보지 말고, `ThrottlerGuard` 활성화 여부를 확인하세요. Forwarded header는 신뢰 가능한 proxy 뒤에서만 `trustProxyHeaders`로 opt-in하고, multi-window 정책은 middleware, store, 또는 guard-wrapper 조합으로 명시적으로 설계해야 합니다. Throttling된 응답에서 보장되는 metadata는 `429` status와 `Retry-After`이며, 추가 header나 JSON body 규칙은 애플리케이션의 error handling layer에서 더하십시오.
+
 전역 규칙이 생기면 이제 경로 성격에 맞게 조정할 수 있습니다. 글로벌 설정을 재정의하거나 특정 컨트롤러나 메서드에 대해 속도 제한을 건너뛸 수 있습니다.
 
 ### 16.3.2 Multiple Throttling Definitions

--- a/book/beginner/ch16-throttler.md
+++ b/book/beginner/ch16-throttler.md
@@ -111,6 +111,8 @@ export class AuthController {
 
 If you need aggregate cluster-wide quotas or other higher-level protection, model that explicitly with application middleware, a custom store, or a custom guard wrapper instead of assuming one built-in app-wide quota layer.
 
+This distinction is especially important during NestJS migrations. Do not treat a previous `@nestjs/throttler` global setup as proof that every fluo route is protected: confirm `ThrottlerGuard` activation, opt in to forwarded headers with `trustProxyHeaders` only behind a trusted proxy, and plan any multi-window policy as explicit middleware, store, or guard-wrapper composition. The guaranteed throttled response metadata is the `429` status plus `Retry-After`; add any extra headers or JSON body conventions in your application error handling layer.
+
 Once you have global rules, you can tune them for each route's character. You can override global settings or skip rate limiting for specific Controllers or methods.
 
 ### 16.3.2 Multiple Throttling Definitions

--- a/docs/getting-started/migrate-from-nestjs.ko.md
+++ b/docs/getting-started/migrate-from-nestjs.ko.md
@@ -22,6 +22,7 @@
 | NestJS 요청 transaction interceptor | 영속성 패키지의 서비스 `@Transaction()` 또는 controller/request 경계의 명시적 `requestTransaction(...)` | fluo는 Drizzle `*TransactionInterceptor` export를 제공하지 않는다. 비즈니스 transaction은 서비스에 두고, 전체 요청이 하나의 경계를 공유해야 할 때만 `DrizzleDatabase.requestTransaction(...)`을 사용한다. |
 | `HealthCheckService.check([...])`를 호출하는 `@HealthCheck()` 컨트롤러 메서드 | `@fluojs/terminus`의 `TerminusModule.forRoot({ indicators, indicatorProviders, readinessChecks })` | Module-level registration이 기본 API이므로 runtime `/health`와 `/ready` route가 indicator 및 platform diagnostics를 일관되게 포함한다. |
 | NestJS Terminus memory/disk 또는 Redis check | `@fluojs/terminus/node`와 `@fluojs/terminus/redis` | Node.js memory/disk helper와 Redis helper는 전용 subpath에 있다. Root package는 Redis peer나 Node filesystem access를 기본 import 경계에 포함하지 않는다. |
+| `@nestjs/throttler` 전역 throttler 설정 | `@fluojs/throttler` / `@fluojs/http`의 `ThrottlerModule.forRoot(...)`와 명시적 `@UseGuards(ThrottlerGuard)` | Module registration은 정책과 guard provider를 제공한다. Route enforcement는 guard를 붙인 위치에서만 시작된다. |
 
 ## Breaking Differences
 
@@ -36,6 +37,10 @@
 - Drizzle은 등록된 handle에 `database.transaction(...)`이 없고 `strictTransactions`가 `false`이면 fail-open direct execution을 기본값으로 사용한다. rollback 보장이 필요한 production migration 흐름에서는 `strictTransactions: true`를 설정해, transaction 지원 누락이 원자성 없이 조용히 실행되지 않고 readiness 및 helper 호출 실패로 드러나게 한다.
 - NestJS Terminus의 controller-level `@HealthCheck()` handler는 `TerminusModule.forRoot(...)` 기반 indicator 및 readiness registration으로 옮기는 것이 좋다. 직접 `TerminusHealthService.check()` 호출은 test나 custom code에서 사용할 수 있지만, 기본 endpoint registration API는 아니다.
 - `@fluojs/terminus`는 별도의 process-only liveness route를 기본으로 만들지 않는다. 기본 `GET /health` aggregated health route와 `GET /ready` readiness gate를 유지하고, 더 좁은 process probe가 필요하면 애플리케이션 또는 배포 계층에서 정의한다.
+- Throttler migration은 global module을 global enforcement로 치환하는 방식이 아니다. `ThrottlerModule.forRoot(...)`는 default를 등록하고, `ThrottlerGuard`는 보호할 controller나 handler의 guard metadata로 활성화해야 한다.
+- `@fluojs/throttler`는 하나의 module default와 class/method `@Throttle({ ttl, limit })` override를 제공한다. burst와 sustained limit 같은 multi-window 정책은 HTTP middleware, custom `ThrottlerStore`, 또는 애플리케이션이 소유한 guard wrapper로 명시적으로 구현해야 한다.
+- Forwarded client IP header는 `Forwarded`, `X-Forwarded-For`, `X-Real-IP`를 신뢰 가능한 proxy가 덮어쓰는 배포에서 `trustProxyHeaders: true`를 설정한 경우에만 사용된다.
+- Throttling된 응답에서 보장되는 metadata는 HTTP `429`와 `Retry-After`다. 추가 rate-limit header나 body shape는 애플리케이션 경계에서 더한다.
 
 ## Removed Concepts
 
@@ -45,6 +50,7 @@
 - 프레임워크 요구 사항으로서의 레거시 데코레이터 컴파일러 모드.
 - 문서화된 모든 플랫폼이 `fluo new`에 포함된다고 가정하는 방식. 스타터 범위는 별도 지원 매트릭스에서 정의된다.
 - `@nestjs/terminus` controller decorator나 별도 default liveness route가 Terminus의 일대일 마이그레이션 대상이라고 가정하는 방식.
+- `@nestjs/throttler`의 named definition, global guard registration, proxy header trust가 명시적인 Fluo wiring 없이 그대로 유지된다고 가정하는 방식.
 
 ## CLI Starter and Generator Limits
 

--- a/docs/getting-started/migrate-from-nestjs.md
+++ b/docs/getting-started/migrate-from-nestjs.md
@@ -22,6 +22,7 @@ Apply the fluo construct in the second column, not the NestJS source pattern, wh
 | NestJS request transaction interceptor | Service `@Transaction()` from the persistence package, or explicit `requestTransaction(...)` at the controller/request boundary | fluo does not provide Drizzle `*TransactionInterceptor` exports. Keep business transactions on services; use `DrizzleDatabase.requestTransaction(...)` only when the entire request must share one boundary. |
 | `@HealthCheck()` controller method with `HealthCheckService.check([...])` | `TerminusModule.forRoot({ indicators, indicatorProviders, readinessChecks })` from `@fluojs/terminus` | Module-level registration is the primary API so runtime `/health` and `/ready` routes include indicator and platform diagnostics consistently. |
 | NestJS Terminus memory/disk or Redis checks | `@fluojs/terminus/node` and `@fluojs/terminus/redis` | Node.js memory/disk helpers and Redis helpers live on dedicated subpaths. The root package does not make Redis peers or Node filesystem access part of the default import boundary. |
+| `@nestjs/throttler` global throttler setup | `ThrottlerModule.forRoot(...)` plus explicit `@UseGuards(ThrottlerGuard)` from `@fluojs/throttler` / `@fluojs/http` | Module registration provides the policy and guard provider; route enforcement starts only where the guard is attached. |
 
 ## Breaking Differences
 
@@ -36,6 +37,10 @@ Apply the fluo construct in the second column, not the NestJS source pattern, wh
 - Drizzle defaults to fail-open direct execution when the registered handle lacks `database.transaction(...)` and `strictTransactions` is `false`. Set `strictTransactions: true` for migrated production flows that require rollback guarantees so missing transaction support fails readiness and helper calls instead of silently running without atomicity.
 - NestJS Terminus controller-level `@HealthCheck()` handlers SHOULD be migrated to `TerminusModule.forRoot(...)` indicator and readiness registration. Direct `TerminusHealthService.check()` calls are available for tests or custom code, but they are not the primary endpoint registration API.
 - `@fluojs/terminus` does not create a separate process-only liveness route by default. Keep the default `GET /health` aggregated health route and `GET /ready` readiness gate, and define any narrower process probe at the application or deployment layer.
+- Throttler migration is not a global-module-for-global-enforcement replacement. `ThrottlerModule.forRoot(...)` registers defaults, while `ThrottlerGuard` must be activated with guard metadata on protected controllers or handlers.
+- `@fluojs/throttler` exposes one module default plus class/method `@Throttle({ ttl, limit })` overrides. Multi-window policies such as burst plus sustained limits require explicit HTTP middleware, a custom `ThrottlerStore`, or an application-owned guard wrapper.
+- Forwarded client IP headers are ignored unless `trustProxyHeaders: true` is set behind a trusted proxy that overwrites `Forwarded`, `X-Forwarded-For`, or `X-Real-IP`.
+- The guaranteed throttled response metadata is HTTP `429` with `Retry-After`; add any extra rate-limit headers or body shape at the application boundary.
 
 ## Removed Concepts
 
@@ -45,6 +50,7 @@ Apply the fluo construct in the second column, not the NestJS source pattern, wh
 - Legacy decorator compiler mode as a framework requirement.
 - Assuming every documented platform is part of `fluo new`; starter coverage is defined separately in the support matrix.
 - Assuming `@nestjs/terminus` controller decorators or a separate default liveness route are one-to-one Terminus migration targets.
+- Assuming `@nestjs/throttler` named definitions, global guard registration, or proxy header trust carry over without explicit Fluo wiring.
 
 ## CLI Starter and Generator Limits
 

--- a/packages/throttler/README.ko.md
+++ b/packages/throttler/README.ko.md
@@ -12,6 +12,7 @@
 - [공통 패턴](#공통-패턴)
   - [Redis 저장소 사용](#redis-저장소-사용)
   - [커스텀 키 생성](#커스텀-키-생성)
+- [NestJS 마이그레이션 경계](#nestjs-마이그레이션-경계)
 - [공개 API 개요](#공개-api-개요)
 - [관련 패키지](#관련-패키지)
 - [예제 소스](#예제-소스)
@@ -120,6 +121,15 @@ ThrottlerModule.forRoot({
   },
 });
 ```
+
+## NestJS 마이그레이션 경계
+
+`@nestjs/throttler`에서 마이그레이션할 때 `@fluojs/throttler`는 drop-in 전역 limiter가 아니라 명시적인 guard-stage 패키지로 다뤄야 합니다:
+
+- `ThrottlerModule.forRoot(...)`는 검증된 옵션과 provider를 등록하지만, 모든 route에 throttling을 자동으로 강제하지 않습니다. 보호가 필요한 곳마다 `@UseGuards(ThrottlerGuard)` 같은 Fluo guard metadata로 `ThrottlerGuard`를 활성화하세요.
+- 공개 정책 shape는 하나의 module default와 class 또는 method 수준 `@Throttle({ ttl, limit })` override입니다. burst와 sustained limit을 함께 두는 named multi-window definition은 HTTP middleware, custom `ThrottlerStore`, 또는 애플리케이션이 소유한 guard wrapper로 명시적으로 조합해야 합니다.
+- Forwarded client IP header는 기본적으로 무시됩니다. `Forwarded`, `X-Forwarded-For`, `X-Real-IP`를 신뢰 가능한 proxy가 덮어쓰는 배포에서만 `trustProxyHeaders: true`를 활성화하세요.
+- 제한 초과 시 보장되는 응답 계약은 HTTP `429`와 `Retry-After`입니다. 추가 rate-limit header나 response body는 exception filter 같은 애플리케이션 경계에서 더하세요.
 
 ## 공개 API 개요
 

--- a/packages/throttler/README.md
+++ b/packages/throttler/README.md
@@ -12,6 +12,7 @@ Decorator-based rate limiting for fluo applications with in-memory and Redis sto
 - [Common Patterns](#common-patterns)
   - [Redis Storage](#redis-storage)
   - [Custom Key Generation](#custom-key-generation)
+- [NestJS Migration Boundaries](#nestjs-migration-boundaries)
 - [Public API Overview](#public-api-overview)
 - [Related Packages](#related-packages)
 - [Example Sources](#example-sources)
@@ -120,6 +121,15 @@ ThrottlerModule.forRoot({
   },
 });
 ```
+
+## NestJS Migration Boundaries
+
+When migrating from `@nestjs/throttler`, treat `@fluojs/throttler` as an explicit guard-stage package rather than a drop-in global limiter:
+
+- `ThrottlerModule.forRoot(...)` registers validated options and providers, but it does not automatically enforce throttling on every route. Activate `ThrottlerGuard` with Fluo guard metadata such as `@UseGuards(ThrottlerGuard)` wherever enforcement is required.
+- The public policy shape is one module default plus class- or method-level `@Throttle({ ttl, limit })` overrides. Named multi-window definitions such as burst plus sustained limits require explicit composition through HTTP middleware, a custom `ThrottlerStore`, or an application-owned guard wrapper.
+- Forwarded client IP headers are ignored by default. Enable `trustProxyHeaders: true` only behind a trusted proxy that overwrites `Forwarded`, `X-Forwarded-For`, or `X-Real-IP`.
+- The guaranteed limit-exceeded response contract is HTTP `429` with `Retry-After`. Additional rate-limit headers or response bodies should be added at the application boundary, for example with an exception filter.
 
 ## Public API Overview
 


### PR DESCRIPTION
## Summary

Clarifies the NestJS migration boundaries for `@fluojs/throttler` so users do not assume `@nestjs/throttler` global enforcement, named multi-window definitions, or proxy-header trust carry over implicitly.

Linked context: Closes #2151

## Changes

- Added package README EN/KO migration notes for explicit `ThrottlerGuard` activation, multi-window composition, `trustProxyHeaders`, and `429` + `Retry-After` response guarantees.
- Added the same Throttler row and breaking-difference bullets to the NestJS migration map in EN/KO.
- Added companion guidance to the beginner Throttler chapter in EN/KO.

## Testing

- `pnpm docs:sync-check`
- `git diff --check`
- LSP diagnostics for the worktree Markdown files: 0 errors

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
