### PR TITLE
test(mongoose): cover transaction module audit gaps

### DIFF
--- a/packages/mongoose/src/module.test.ts
+++ b/packages/mongoose/src/module.test.ts
@@ -904,6 +904,108 @@ describe('@fluojs/mongoose', () => {
     resolveTransaction();
   });
 
+  it('skips late delegated request callbacks and finishes delegated cleanup after startup abort', async () => {
+    const events: string[] = [];
+    const controller = new AbortController();
+    let resolveTransaction!: () => void;
+    let resolveEndSessionStarted!: () => void;
+    let resolveEndSession!: () => void;
+    const transactionReady = new Promise<void>((resolve) => {
+      resolveTransaction = resolve;
+    });
+    const endSessionStarted = new Promise<void>((resolve) => {
+      resolveEndSessionStarted = resolve;
+    });
+    const endSessionDeferred = new Promise<void>((resolve) => {
+      resolveEndSession = resolve;
+    });
+    const session: MongooseSessionLike = {
+      abortTransaction() {
+        events.push('transaction:abort');
+      },
+      commitTransaction() {
+        events.push('transaction:commit');
+      },
+      async endSession() {
+        events.push('session:end:start');
+        resolveEndSessionStarted();
+        await endSessionDeferred;
+        events.push('session:end:done');
+      },
+      startTransaction() {
+        events.push('transaction:start');
+      },
+    };
+
+    const connection: MongooseConnectionLike = {
+      async transaction(fn) {
+        events.push('connection:transaction:start');
+        await transactionReady;
+        await session.startTransaction();
+
+        try {
+          const result = await fn(session);
+          await session.commitTransaction();
+
+          return result;
+        } catch (error) {
+          await session.abortTransaction();
+          throw error;
+        } finally {
+          await session.endSession();
+        }
+      },
+    };
+
+    const mongoose = new MongooseConnection<typeof connection>(connection);
+    const requestTransaction = mongoose.requestTransaction(async () => {
+      events.push('request:work');
+
+      return 'ok';
+    }, controller.signal);
+
+    controller.abort(new Error('client aborted during delegated transaction startup'));
+
+    await expect(requestTransaction).rejects.toThrow('client aborted during delegated transaction startup');
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 0,
+        activeSessions: 1,
+      },
+    });
+    expect(events).toEqual(['connection:transaction:start']);
+
+    resolveTransaction();
+    await endSessionStarted;
+
+    expect(events).toEqual([
+      'connection:transaction:start',
+      'transaction:start',
+      'transaction:abort',
+      'session:end:start',
+    ]);
+
+    resolveEndSession();
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(events).toEqual([
+      'connection:transaction:start',
+      'transaction:start',
+      'transaction:abort',
+      'session:end:start',
+      'session:end:done',
+    ]);
+    expect(events).not.toContain('request:work');
+    expect(mongoose.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        activeRequestTransactions: 0,
+        activeSessions: 0,
+      },
+    });
+  });
+
   it('rejects new manual and request transactions after shutdown begins', async () => {
     const events: string[] = [];
     let resolveDisposeStarted!: () => void;
@@ -1334,6 +1436,42 @@ describe('MongooseModule.forRootAsync', () => {
 
     return { connection, events, session };
   }
+
+  it('makes forRootAsync({ global: true }) providers visible to sibling modules', async () => {
+    const { connection } = makeFakeConnection();
+
+    @Inject(MongooseConnection)
+    class ConsumerService {
+      constructor(readonly mongoose: MongooseConnection<typeof connection>) {}
+
+      currentConnection() {
+        return this.mongoose.current();
+      }
+    }
+
+    class FeatureModule {}
+    defineModule(FeatureModule, {
+      exports: [ConsumerService],
+      providers: [ConsumerService],
+    });
+
+    const mongooseModule = MongooseModule.forRootAsync<typeof connection>({
+      global: true,
+      useFactory: () => ({ connection }),
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [mongooseModule, FeatureModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const consumer = await app.container.resolve(ConsumerService);
+
+    expect(consumer.currentConnection()).toBe(connection);
+
+    await app.close();
+  });
 
   it('factory receives injected token and resolves MongooseConnection', async () => {
     const { connection, events } = makeFakeConnection();

--- a/packages/mongoose/src/transaction-compat.test.ts
+++ b/packages/mongoose/src/transaction-compat.test.ts
@@ -12,6 +12,139 @@ function makeMockMongooseConnection() {
 }
 
 describe('Transaction decorator method semantics', () => {
+  it('uses this.conn as the default transaction resolver first', async () => {
+    const events: string[] = [];
+    const conn = {
+      async transaction<T>(fn: () => Promise<T>): Promise<T> {
+        events.push('this.conn:transaction:start');
+        const result = await fn();
+        events.push('this.conn:transaction:end');
+
+        return result;
+      },
+    };
+
+    class UserService {
+      conn = conn;
+
+      @Transaction()
+      async getValue(): Promise<number> {
+        events.push('service:getValue');
+
+        return 42;
+      }
+    }
+
+    const svc = new UserService();
+
+    await expect(svc.getValue()).resolves.toBe(42);
+    expect(events).toEqual([
+      'this.conn:transaction:start',
+      'service:getValue',
+      'this.conn:transaction:end',
+    ]);
+  });
+
+  it('uses the decorated instance itself when it is transaction-capable and this.conn is absent', async () => {
+    const events: string[] = [];
+
+    class TransactionalService {
+      async transaction<T>(fn: () => Promise<T>): Promise<T> {
+        events.push('self:transaction:start');
+        const result = await fn();
+        events.push('self:transaction:end');
+
+        return result;
+      }
+
+      @Transaction()
+      async getValue(): Promise<string> {
+        events.push('service:getValue');
+
+        return 'self';
+      }
+    }
+
+    const svc = new TransactionalService();
+
+    await expect(svc.getValue()).resolves.toBe('self');
+    expect(events).toEqual([
+      'self:transaction:start',
+      'service:getValue',
+      'self:transaction:end',
+    ]);
+  });
+
+  it('uses one unique nested this.*.conn collaborator when this.conn and self resolver are absent', async () => {
+    const events: string[] = [];
+    const repositoryConn = {
+      async transaction<T>(fn: () => Promise<T>): Promise<T> {
+        events.push('repository.conn:transaction:start');
+        const result = await fn();
+        events.push('repository.conn:transaction:end');
+
+        return result;
+      },
+    };
+
+    class UserService {
+      readonly repository = { conn: repositoryConn };
+
+      @Transaction()
+      async create(): Promise<string> {
+        events.push('service:create');
+
+        return 'created';
+      }
+    }
+
+    const svc = new UserService();
+
+    await expect(svc.create()).resolves.toBe('created');
+    expect(events).toEqual([
+      'repository.conn:transaction:start',
+      'service:create',
+      'repository.conn:transaction:end',
+    ]);
+  });
+
+  it('rejects ambiguous nested this.*.conn default resolver candidates', async () => {
+    const events: string[] = [];
+    const firstConn = {
+      async transaction<T>(fn: () => Promise<T>): Promise<T> {
+        events.push('first:transaction');
+
+        return fn();
+      },
+    };
+    const secondConn = {
+      async transaction<T>(fn: () => Promise<T>): Promise<T> {
+        events.push('second:transaction');
+
+        return fn();
+      },
+    };
+
+    class UserService {
+      readonly primaryRepository = { conn: firstConn };
+      readonly analyticsRepository = { conn: secondConn };
+
+      @Transaction()
+      async create(): Promise<string> {
+        events.push('service:create');
+
+        return 'created';
+      }
+    }
+
+    const svc = new UserService();
+
+    await expect(svc.create()).rejects.toThrow(
+      'Mongoose @Transaction() found multiple nested this.*.conn candidates; pass an accessor.',
+    );
+    expect(events).toEqual([]);
+  });
+
   it('propagates return value from decorated method', async () => {
     const conn = makeMockMongooseConnection();
 


### PR DESCRIPTION
## Summary
- Add @Transaction() default resolver regression coverage for this.conn, self, unique nested collaborator, and ambiguous nested collaborators.
- Add requestTransaction delegated startup abort coverage to verify late callbacks are skipped and delegated cleanup drains.
- Add forRootAsync({ global: true }) sibling module visibility coverage.

## Verification
- lsp_diagnostics: packages/mongoose/src/module.test.ts clean
- lsp_diagnostics: packages/mongoose/src/transaction-compat.test.ts clean
- pnpm --filter @fluojs/mongoose test
- pnpm --filter @fluojs/mongoose typecheck
- pnpm --filter @fluojs/mongoose build

No changeset: test-only regression coverage; no public behavior or release metadata change.

Closes #2147