### PR TITLE
Resolve #2179: harden CLI Studio/dev-runner contracts

### DIFF
--- a/.changeset/harden-cli-studio-dev-contracts.md
+++ b/.changeset/harden-cli-studio-dev-contracts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Harden CLI Studio dev-runner contracts by rejecting native/raw-watch Studio combinations, preventing sidecar heartbeat timers from starting on listen failures, and routing fallback update-check prompts through injected IO streams.

--- a/book/beginner/ch02-cli-setup.ko.md
+++ b/book/beginner/ch02-cli-setup.ko.md
@@ -218,14 +218,20 @@ fluo-blog/
 ├── package.json              # Scripts and dependencies
 ├── pnpm-lock.yaml            # Locked dependency versions
 ├── tsconfig.json             # TypeScript configuration
+├── vitest.config.ts          # Unit, slice, e2e test configuration
+├── test/                     # Request-pipeline/e2e tests
+│   └── app.e2e.test.ts
 └── src/                      # Application source
     ├── app.ts                # App assembly
+    ├── app.test.ts           # App dispatch test
     ├── greeting/             # Default greeting feature slice
     │   ├── greeting.controller.ts      # Default HTTP route
     │   ├── greeting.module.ts          # Feature assembly
     │   ├── greeting.repo.ts            # Response payload source
     │   ├── greeting.response.dto.ts    # Response DTO
-    │   └── greeting.service.ts         # Route logic
+    │   ├── greeting.service.ts         # Route logic
+    │   ├── greeting.service.test.ts    # Fast unit test
+    │   └── greeting.slice.test.ts      # Module/provider wiring test
     └── main.ts               # Bootstrap entrypoint
 ```
 
@@ -234,6 +240,7 @@ fluo-blog/
 - 앱은 어디서 시작되는가?
 - 기본 앱은 어디서 조립되는가?
 - 첫 HTTP 응답은 어떤 파일이 담당하는가?
+- 앱 조립, feature slice, request pipeline은 어떤 테스트가 검증하는가?
 - 가장 자주 실행할 스크립트는 무엇인가?
 
 ### src/main.ts
@@ -303,12 +310,16 @@ CLI는 fluo에 최적화된 설정으로 `tsconfig.json`을 대신 구성해 줍
 
 디렉터리 구조를 살펴봤다면, 이제는 이 프로젝트 안에서 매일 어떤 명령으로 작업하게 되는지 이해할 차례입니다.
 
-생성된 프로젝트에는 초기 개발 워크플로 전체를 받쳐 주는 소수의 스크립트가 보통 포함됩니다.
+생성된 Node HTTP 프로젝트에는 초기 개발 워크플로 전체를 받쳐 주는 소수의 스크립트가 포함됩니다.
 
 - **`dev`**: 빠른 피드백을 위한 개발 모드 실행.
 - **`build`**: TypeScript를 프로덕션용 출력으로 컴파일.
 - **`start`**: 빌드된 결과를 실행.
-- **`lint`**: 스타터가 제공하는 경우 코드 품질 점검.
+- **`test`**: 기본 Vitest suite 실행.
+- **`test:watch`**: Vitest watch mode 실행.
+- **`test:cov`**: coverage를 켠 Vitest suite 실행.
+- **`test:e2e`**: `test/**/*.e2e.test.ts` 아래의 request-pipeline test 실행.
+- **`typecheck`**: 파일을 emit하지 않고 TypeScript 검사.
 
 ### Why `dev` matters most right now
 
@@ -363,7 +374,7 @@ fluo restart runner가 process boundary를 소유할 때 `fluo dev`는 `fluo sta
 
 이 CLI reporter는 애플리케이션/런타임 로깅과 별개입니다. 부트스트랩 이후 앱이 내보내는 로그를 조정하려면 코드에서 `ApplicationLogger`를 설정하세요. 예를 들어 `@fluojs/runtime/node`의 `createConsoleApplicationLogger({ mode: 'minimal', level: 'warn' })` 또는 `createJsonApplicationLogger()`를 사용할 수 있습니다.
 
-처음 실행하면 이런 흐름으로 보입니다. 다음과 비슷한 시작 로그를 기대할 수 있습니다.
+처음 실행할 때 기본 CLI reporter는 애플리케이션 stdout/stderr만 전달합니다. `--reporter pretty`로 opt-in하지 않으면 별도의 fluo lifecycle UI를 추가하지 않습니다. 그래도 다음과 비슷한 런타임 시작 로그를 기대할 수 있습니다.
 
 ```text
 [Fluo] Starting application...

--- a/book/beginner/ch02-cli-setup.md
+++ b/book/beginner/ch02-cli-setup.md
@@ -218,14 +218,20 @@ fluo-blog/
 ├── package.json              # Scripts and dependencies
 ├── pnpm-lock.yaml            # Locked dependency versions
 ├── tsconfig.json             # TypeScript configuration
+├── vitest.config.ts          # Unit, slice, and e2e test configuration
+├── test/                     # Request-pipeline/e2e tests
+│   └── app.e2e.test.ts
 └── src/                      # Application source
     ├── app.ts                # App assembly
+    ├── app.test.ts           # App dispatch test
     ├── greeting/             # Default greeting feature slice
     │   ├── greeting.controller.ts      # Default HTTP route
     │   ├── greeting.module.ts          # Feature assembly
     │   ├── greeting.repo.ts            # Response payload source
     │   ├── greeting.response.dto.ts    # Response DTO
-    │   └── greeting.service.ts         # Route logic
+    │   ├── greeting.service.ts         # Route logic
+    │   ├── greeting.service.test.ts    # Fast unit test
+    │   └── greeting.slice.test.ts      # Module/provider wiring test
     └── main.ts               # Bootstrap entrypoint
 ```
 
@@ -234,6 +240,7 @@ At this stage, each file answers questions that naturally come up when opening a
 - Where does the app start?
 - Where is the default app assembled?
 - Which file handles the first HTTP response?
+- Which tests cover the app assembly, feature slice, and request pipeline?
 - Which scripts will you run most often?
 
 ### src/main.ts
@@ -303,12 +310,16 @@ The CLI configures `tsconfig.json` for you with settings optimized for fluo. As 
 
 After looking through the directory structure, the next step is to understand which commands you will use every day inside this project.
 
-The generated project usually includes a small set of scripts that support the full initial development workflow.
+The generated Node HTTP project includes a small set of scripts that support the full initial development workflow.
 
 - **`dev`**: Runs development mode for fast feedback.
 - **`build`**: Compiles TypeScript into production output.
 - **`start`**: Runs the built result.
-- **`lint`**: Checks code quality when the starter provides it.
+- **`test`**: Runs the default Vitest suite.
+- **`test:watch`**: Runs Vitest in watch mode.
+- **`test:cov`**: Runs the Vitest suite with coverage enabled.
+- **`test:e2e`**: Runs the request-pipeline tests under `test/**/*.e2e.test.ts`.
+- **`typecheck`**: Checks TypeScript without emitting compiled files.
 
 ### Why `dev` matters most right now
 
@@ -363,7 +374,7 @@ When the fluo restart runner owns the process boundary, `fluo dev` shows the sam
 
 That CLI reporter is different from application/runtime logging. To tune logs emitted by your app after bootstrap, configure `ApplicationLogger` in code, for example with `createConsoleApplicationLogger({ mode: 'minimal', level: 'warn' })` or `createJsonApplicationLogger()` from `@fluojs/runtime/node`.
 
-On the first run, the flow looks like this. You can expect startup logs similar to the following.
+On the first run, the default CLI reporter forwards application stdout and stderr only; it does not add a separate fluo lifecycle UI unless you opt in with `--reporter pretty`. You can still expect runtime startup logs similar to the following.
 
 ```text
 [Fluo] Starting application...

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -251,6 +251,8 @@ fluo migrate ./src --skip tests
 
 CI 작업, 대시보드, migration report에서 안정적인 machine-readable 결과가 필요하면 `--json`을 사용하세요. 사람을 위한 출력은 기본값으로 유지됩니다. JSON 모드는 성공 시 stdout에 structured report만 기록하고, parser 오류나 잘못된 flag 조합은 기존처럼 stderr에 메시지를 기록한 뒤 exit code `1`을 반환하며 partial JSON을 출력하지 않습니다. Report에는 `mode`(`dry-run` 또는 `apply`), `dryRun`, `apply`, 활성화된 `transforms`, `scannedFiles`, `changedFiles`, 전체 `warningCount`, 그리고 `filePath`, `changed`, `appliedTransforms`, `warningCount`, category label과 source line number가 포함된 warnings per-file metadata가 포함됩니다.
 
+`--apply`로 다시 실행하기 전에는 모든 warning을 검토하세요. Warning은 자동 rewrite를 그대로 수락해도 된다는 뜻이 아니라 수동 follow-up 항목입니다. Warning category별 post-codemod checklist는 [NestJS migration guide](../../docs/getting-started/migrate-from-nestjs.ko.md)를 기준으로 확인하세요.
+
 **주요 변환 사항:**
 - `@nestjs/common` 임포트를 `@fluojs/core` 또는 `@fluojs/http`로 재작성합니다.
 - bootstrap 패턴을 재작성하고 지원되는 `listen(port)` 호출을 fluo runtime startup 규칙으로 접습니다.

--- a/packages/cli/README.ko.md
+++ b/packages/cli/README.ko.md
@@ -32,7 +32,7 @@ pnpm dlx @fluojs/cli new my-app
 
 - `@fluojs/cli`는 intended publish surface에 포함되는 공개 패키지입니다.
 - 지원되는 설치 경로는 전역 패키지(`npm install -g @fluojs/cli`, `pnpm add -g @fluojs/cli`, `bun add -g @fluojs/cli`, `yarn global add @fluojs/cli`)와 무설치 실행 경로(`pnpm dlx @fluojs/cli ...`)입니다.
-- 배포되는 `fluo` bin은 `package.json`에 선언된 dist 빌드 CLI 엔트리포인트를 기준으로 동작합니다.
+- 배포되는 `fluo` bin은 `package.json`에 선언된 `./bin/fluo.mjs` wrapper이며, 이 wrapper가 dist 빌드 CLI 엔트리포인트인 `../dist/cli.js`를 로드합니다.
 
 ## 버전 확인
 
@@ -194,7 +194,7 @@ fluo dev --studio --studio-port 51234
 fluo dev --studio --dry-run
 ```
 
-CLI는 local Studio sidecar를 시작하고, tokenized URL을 출력하며, restart lifecycle event를 sidecar로 계속 전달하고, 앱이 `@fluojs/runtime`을 import하기 전에 명시적인 Studio config를 Node 앱 child에 주입합니다. Optional package인 `@fluojs/studio`가 설치되어 있으면 sidecar는 패키징된 `@fluojs/studio/viewer` React app을 제공합니다. Runtime package source는 `process.env`를 직접 읽지 않으며, CLI가 주입한 Studio config가 있을 때만 live graph/routes/request/timing/diagnostic event를 전송합니다.
+CLI는 local Studio sidecar를 시작하고, tokenized URL을 출력하며, restart lifecycle event를 sidecar로 계속 전달하고, 앱이 `@fluojs/runtime`을 import하기 전에 명시적인 Studio config를 Node 앱 child에 주입합니다. Studio live mode는 fluo가 소유한 Node restart runner를 요구합니다. 따라서 lifecycle event가 CLI restart boundary와 분리되지 않도록 `fluo dev --studio`는 `--raw-watch`, `--runner native`, `FLUO_DEV_RUNNER=native`를 거부합니다. Optional package인 `@fluojs/studio`가 설치되어 있으면 sidecar는 패키징된 `@fluojs/studio/viewer` React app을 제공합니다. Runtime package source는 `process.env`를 직접 읽지 않으며, CLI가 주입한 Studio config가 있을 때만 live graph/routes/request/timing/diagnostic event를 전송합니다.
 
 보안 기본값은 local-only입니다. Sidecar는 `127.0.0.1`에 bind되고, runtime ingestion 및 browser state/SSE API는 generated token을 요구하며, CORS는 기본적으로 활성화하지 않고, request body는 기본적으로 수집하지 않습니다.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -251,6 +251,8 @@ fluo migrate ./src --skip tests
 
 Use `--json` when CI jobs, dashboards, or migration reports need a stable machine-readable result. Human output remains the default. JSON mode writes only the structured report to stdout on success, while parser errors and invalid flag combinations still write their message to stderr and return exit code `1` without partial JSON output. The report includes `mode` (`dry-run` or `apply`), `dryRun`, `apply`, enabled `transforms`, `scannedFiles`, `changedFiles`, aggregate `warningCount`, and per-file metadata with `filePath`, `changed`, `appliedTransforms`, `warningCount`, and warnings including category labels and source line numbers.
 
+Review every warning before rerunning with `--apply`. Warnings are manual follow-up items rather than permission for an automatic rewrite to be accepted blindly; use the [NestJS migration guide](../../docs/getting-started/migrate-from-nestjs.md) as the post-codemod checklist for each warning category.
+
 **Key Transformations:**
 - Rewrites imports from `@nestjs/common` to `@fluojs/core` or `@fluojs/http`.
 - Rewrites bootstrap patterns and folds supported `listen(port)` calls into fluo runtime startup conventions.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -32,7 +32,7 @@ pnpm dlx @fluojs/cli new my-app
 
 - `@fluojs/cli` is a public package in the intended publish surface.
 - The supported install paths are the global package (`npm install -g @fluojs/cli`, `pnpm add -g @fluojs/cli`, `bun add -g @fluojs/cli`, or `yarn global add @fluojs/cli`) and the no-install runner (`pnpm dlx @fluojs/cli ...`).
-- The published `fluo` bin is backed by the dist-built CLI entrypoint declared in `package.json`.
+- The published `fluo` bin is the `./bin/fluo.mjs` wrapper declared in `package.json`; that wrapper loads the dist-built CLI entrypoint at `../dist/cli.js`.
 
 ## Version Inspection
 
@@ -194,7 +194,7 @@ fluo dev --studio --studio-port 51234
 fluo dev --studio --dry-run
 ```
 
-The CLI starts a local Studio sidecar, prints a tokenized URL, keeps restart lifecycle events flowing through the sidecar, and injects an explicit Studio config into the Node app child before the app imports `@fluojs/runtime`. The sidecar serves the packaged `@fluojs/studio/viewer` React app when that optional package is installed. Runtime package source never reads `process.env` directly; it publishes live graph/routes/request/timing/diagnostic events only when CLI-injected Studio config is present.
+The CLI starts a local Studio sidecar, prints a tokenized URL, keeps restart lifecycle events flowing through the sidecar, and injects an explicit Studio config into the Node app child before the app imports `@fluojs/runtime`. Studio live mode requires the fluo-owned Node restart runner; `fluo dev --studio` rejects `--raw-watch`, `--runner native`, and `FLUO_DEV_RUNNER=native` so lifecycle events cannot be split from the CLI restart boundary. The sidecar serves the packaged `@fluojs/studio/viewer` React app when that optional package is installed. Runtime package source never reads `process.env` directly; it publishes live graph/routes/request/timing/diagnostic events only when CLI-injected Studio config is present.
 
 Security defaults are local-only: the sidecar binds `127.0.0.1`, runtime ingestion and browser state/SSE APIs require generated tokens, CORS is not enabled by default, and request bodies are not captured by default.
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawnSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, type FSWatcher, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -1853,9 +1853,20 @@ void bootstrap();
       stderr: { write: (message) => stderrBuffer.push(message) },
       stdout: { write: () => undefined },
     });
+    const nativeEnvExitCode = await runCli(['dev', '--dry-run', '--studio'], {
+      cwd: workspaceDirectory,
+      env: { FLUO_DEV_RUNNER: 'native' },
+      spawnCommand: async (command) => {
+        spawnedCommands.push(command);
+        return 0;
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
 
     expect(rawWatchExitCode).toBe(1);
     expect(nativeRunnerExitCode).toBe(1);
+    expect(nativeEnvExitCode).toBe(1);
     expect(spawnedCommands).toEqual([]);
     expect(stderrBuffer.join('')).toContain('fluo dev --studio requires the fluo-owned Node restart runner.');
   });
@@ -2184,6 +2195,59 @@ void bootstrap();
     gate.commitBaseline([sourceFile]);
     expect(gate.hasMeaningfulChange([sourceFile])).toBe(false);
     expect(gate.hasMeaningfulChange([ignoredFile])).toBe(false);
+  });
+
+  it('honors FLUO_DEV_WATCH_IGNORE before restarting the fluo Node child', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    const ignoredDirectory = join(sourceDirectory, 'generated');
+    mkdirSync(ignoredDirectory, { recursive: true });
+    const sourceFile = join(sourceDirectory, 'main.ts');
+    const ignoredFile = join(ignoredDirectory, 'schema.ts');
+    writeFileSync(sourceFile, 'console.log("hello");\n');
+    writeFileSync(ignoredFile, 'console.log("ignored");\n');
+    const children: ChildProcess[] = [];
+    const watchedTargets: Array<{ listener: (event: string, filename: string | Buffer | null) => void; target: string }> = [];
+
+    const runPromise = runNodeRestartRunner({
+      debounceMs: 5,
+      env: { FLUO_DEV_WATCH_IGNORE: 'generated' },
+      projectDirectory: workspaceDirectory,
+      spawnChild: () => {
+        const child = createMockChild();
+        children.push(child);
+        return child;
+      },
+      stderr: { write: () => undefined },
+      stdout: { write: () => undefined },
+      watchTarget: (target, optionsOrListener, maybeListener) => {
+        const listener = typeof optionsOrListener === 'function' ? optionsOrListener : maybeListener;
+        if (!listener) {
+          throw new Error('Expected watch listener to be registered.');
+        }
+        watchedTargets.push({ listener, target });
+        const watcher = new EventEmitter() as FSWatcher;
+        watcher.close = () => undefined;
+        return watcher;
+      },
+    });
+
+    await waitForCondition(() => children.length === 1 && watchedTargets.length > 0);
+    const sourceWatcher = watchedTargets.find((entry) => entry.target === sourceDirectory);
+    expect(sourceWatcher).toBeDefined();
+
+    writeFileSync(ignoredFile, 'console.log("ignored changed");\n');
+    sourceWatcher?.listener('change', join('generated', 'schema.ts'));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(children).toHaveLength(1);
+
+    writeFileSync(sourceFile, 'console.log("hello changed");\n');
+    sourceWatcher?.listener('change', 'main.ts');
+    await waitForCondition(() => children.length === 2);
+
+    children.at(-1)?.kill();
+    await expect(runPromise).resolves.toBe(0);
   });
 
   it('dedupes change-then-revert bursts until the debounce baseline is committed', () => {
@@ -3836,6 +3900,25 @@ exit 7
     expect(stdoutBuffer.join('')).toBe('graph TD\n  STUDIO["components: 0"]\n');
   });
 
+  it('writes inspect --mermaid output to explicit artifact paths', async () => {
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'fluo-inspect-'));
+    createdDirectories.push(outputDirectory);
+    const outputPath = join(outputDirectory, 'artifacts', 'graph.mmd');
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--mermaid', '--output', outputPath], {
+      cwd: process.cwd(),
+      loadStudioMermaidRenderer: async () => (snapshot) => `graph TD\n  STUDIO["components: ${snapshot.components.length}"]`,
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expectCliCommandSuccess(exitCode, stdoutBuffer, stderrBuffer);
+    expect(stdoutBuffer.join('')).toBe('');
+    expect(readFileSync(outputPath, 'utf8')).toBe('graph TD\n  STUDIO["components: 0"]\n');
+  });
+
   it('fails inspect --mermaid without prompting when Studio is missing in non-interactive mode', async () => {
     const stdoutBuffer: string[] = [];
     const stderrBuffer: string[] = [];
@@ -3888,6 +3971,40 @@ exit 7
     expect(promptMessages).toEqual(['Install @fluojs/studio before rendering Mermaid output?']);
     expect(stdoutBuffer.join('')).toBe('');
     expect(stderrBuffer.join('')).toContain('Installation declined; no package-manager command was run.');
+  });
+
+  it('fails inspect --mermaid without installing when Studio installation is approved', async () => {
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    const promptMessages: string[] = [];
+
+    const exitCode = await runCli(['inspect', inspectFixtureModulePath, '--mermaid'], {
+      ci: true,
+      cwd: process.cwd(),
+      interactive: true,
+      loadStudioMermaidRenderer: async () => undefined,
+      prompt: {
+        confirm: async (message) => {
+          promptMessages.push(message);
+          return true;
+        },
+        select: async () => {
+          throw new Error('inspect should not request select prompts');
+        },
+        text: async () => {
+          throw new Error('inspect should not request text prompts');
+        },
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdin: { isTTY: true },
+      stdout: { write: (message) => stdoutBuffer.push(message) },
+    });
+
+    expect(exitCode).toBe(1);
+    expect(promptMessages).toEqual(['Install @fluojs/studio before rendering Mermaid output?']);
+    expect(stdoutBuffer.join('')).toBe('');
+    expect(stderrBuffer.join('')).toContain('Automatic installation is not run by fluo inspect.');
+    expect(stderrBuffer.join('')).toContain('Install @fluojs/studio explicitly, then rerun the command.');
   });
 
   it('returns success for cancelled inspect prompts without terminating the host process', async () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -185,6 +186,34 @@ describe('CLI command runner', () => {
     expect(confirmMessage).toBe('Install @fluojs/cli@1.0.0-beta.2 now and restart this command?');
     expect(confirmDefault).toBe(false);
     expect(stdoutBuffer.join('')).toContain('fluo analyze');
+  });
+
+  it('routes the default update-check prompt through injected TTY streams', async () => {
+    const stdout = Object.assign(new PassThrough(), { isTTY: true as const });
+    const stdin = Object.assign(new PassThrough(), { isTTY: true as const });
+    const stdoutBuffer: string[] = [];
+    const stderrBuffer: string[] = [];
+    stdout.on('data', (chunk: Buffer) => stdoutBuffer.push(chunk.toString('utf8')));
+
+    const runPromise = runCli(['analyze'], {
+      env: updateCheckEnv,
+      stderr: createTtyBufferStream(stderrBuffer),
+      stdin,
+      stdout,
+      updateCheck: {
+        cacheFile: createUpdateCacheFile(),
+        currentVersion: '1.0.0-beta.1',
+        fetchLatestVersion: async () => '1.0.0-beta.2',
+      },
+    });
+    stdin.write('n\n');
+
+    const exitCode = await runPromise;
+
+    expect(exitCode).toBe(0);
+    expect(stdoutBuffer.join('')).toContain('Install @fluojs/cli@1.0.0-beta.2 now and restart this command? (y/N)');
+    expect(stdoutBuffer.join('')).toContain('fluo analyze');
+    expect(stderrBuffer.join('')).toContain('Continuing with @fluojs/cli@1.0.0-beta.1.');
   });
 
   it('installs the accepted update and reruns the same CLI argv with update checks suppressed', async () => {

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1797,6 +1797,40 @@ void bootstrap();
     expect(spawned[0]?.env.FLUO_STUDIO_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
   });
 
+  it('rejects Studio dev when the Node restart runner is bypassed', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    writeFileSync(join(workspaceDirectory, 'package.json'), JSON.stringify({ name: 'test-app', scripts: { dev: 'fluo dev' } }, null, 2));
+    const stderrBuffer: string[] = [];
+    const spawnedCommands: string[] = [];
+
+    const rawWatchExitCode = await runCli(['dev', '--dry-run', '--studio', '--raw-watch'], {
+      cwd: workspaceDirectory,
+      env: {},
+      spawnCommand: async (command) => {
+        spawnedCommands.push(command);
+        return 0;
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+    const nativeRunnerExitCode = await runCli(['dev', '--dry-run', '--studio', '--runner', 'native'], {
+      cwd: workspaceDirectory,
+      env: {},
+      spawnCommand: async (command) => {
+        spawnedCommands.push(command);
+        return 0;
+      },
+      stderr: { write: (message) => stderrBuffer.push(message) },
+      stdout: { write: () => undefined },
+    });
+
+    expect(rawWatchExitCode).toBe(1);
+    expect(nativeRunnerExitCode).toBe(1);
+    expect(spawnedCommands).toEqual([]);
+    expect(stderrBuffer.join('')).toContain('fluo dev --studio requires the fluo-owned Node restart runner.');
+  });
+
   it('keeps Studio dev support Node-only until non-Node bridges are verified', async () => {
     const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
     createdDirectories.push(workspaceDirectory);

--- a/packages/cli/src/commands/scripts.ts
+++ b/packages/cli/src/commands/scripts.ts
@@ -415,7 +415,7 @@ function projectDisplayName(project: { directory: string; manifest: JsonRecord }
     : project.directory.split(/[\\/]/).filter(Boolean).at(-1) ?? 'fluo-app';
 }
 
-function assertStudioSupport(command: ScriptCommand, studio: boolean, projectRuntime: ProjectRuntime, _devRunner: DevRunnerPreference): void {
+function assertStudioSupport(command: ScriptCommand, studio: boolean, projectRuntime: ProjectRuntime, devRunner: DevRunnerPreference, rawWatch: boolean): void {
   if (!studio) {
     return;
   }
@@ -426,6 +426,10 @@ function assertStudioSupport(command: ScriptCommand, studio: boolean, projectRun
 
   if (projectRuntime !== 'node') {
     throw new Error(`fluo dev --studio currently supports Node dev runner projects only. ${projectRuntime} Studio support remains experimental until a dedicated bridge is implemented and verified.`);
+  }
+
+  if (devRunner !== 'fluo' || rawWatch) {
+    throw new Error('fluo dev --studio requires the fluo-owned Node restart runner. Remove --raw-watch and use --runner fluo so Studio lifecycle events stay attached to the CLI restart boundary.');
   }
 }
 
@@ -693,7 +697,7 @@ export async function runScriptCommand(command: ScriptCommand, argv: string[], r
     throw new Error('--runner is only supported for fluo dev. Use -- to forward --runner to the child command.');
   }
   const devRunner = command === 'dev' ? resolveDevRunnerPreference(parsed, env, projectRuntime) : 'fluo';
-  assertStudioSupport(command, parsed.studio, projectRuntime, devRunner);
+  assertStudioSupport(command, parsed.studio, projectRuntime, devRunner, rawWatch);
   const runnerSteps = buildProjectRunner(command, projectRuntime, parsed.passThrough, { devRunner, rawWatch });
   const reporterMode = resolveReporterMode(parsed, { ...runtime, env, stdout });
   const verbose = parsed.verbose || isEnabledEnvironmentFlag(env.FLUO_VERBOSE);

--- a/packages/cli/src/studio/sidecar.test.ts
+++ b/packages/cli/src/studio/sidecar.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { startStudioSidecar, type StudioSidecar } from './sidecar.js';
 
@@ -106,6 +108,30 @@ describe('Studio sidecar', () => {
 
     expect(response.status).toBe(401);
     await expect(response.json()).resolves.toMatchObject({ error: 'Unauthorized Studio sidecar request.' });
+  });
+
+  it('does not start heartbeat timers when the sidecar fails to listen', async () => {
+    const occupiedServer = createServer((_request, response) => {
+      response.end('occupied');
+    });
+    await new Promise<void>((resolve, reject) => {
+      occupiedServer.once('error', reject);
+      occupiedServer.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = occupiedServer.address();
+    if (!address || typeof address === 'string') {
+      await new Promise<void>((resolve, reject) => occupiedServer.close((error) => error ? reject(error) : resolve()));
+      throw new Error('Failed to allocate occupied test port.');
+    }
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+
+    try {
+      await expect(startStudioSidecar({ appId: 'test-app', heartbeatMs: 1, port: address.port, runtime: 'node' })).rejects.toMatchObject({ code: 'EADDRINUSE' });
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+    } finally {
+      setIntervalSpy.mockRestore();
+      await new Promise<void>((resolve, reject) => occupiedServer.close((error) => error ? reject(error) : resolve()));
+    }
   });
 
   it('moves to a new app epoch when restart lifecycle events arrive', async () => {

--- a/packages/cli/src/studio/sidecar.test.ts
+++ b/packages/cli/src/studio/sidecar.test.ts
@@ -65,6 +65,26 @@ describe('Studio sidecar', () => {
     });
   });
 
+  it('keeps browser APIs same-origin by omitting CORS headers by default', async () => {
+    const sidecar = await startTestSidecar();
+
+    const state = await fetch(`${sidecar.url}/api/state?token=${encodeURIComponent(sidecar.token)}`, {
+      headers: { origin: 'https://example.com' },
+    });
+    expect(state.status).toBe(200);
+    expect(state.headers.get('access-control-allow-origin')).toBeNull();
+    expect(state.headers.get('access-control-allow-credentials')).toBeNull();
+    await state.text();
+
+    const events = await fetch(`${sidecar.url}/api/events?token=${encodeURIComponent(sidecar.token)}`, {
+      headers: { origin: 'https://example.com' },
+    });
+    expect(events.status).toBe(200);
+    expect(events.headers.get('access-control-allow-origin')).toBeNull();
+    expect(events.headers.get('access-control-allow-credentials')).toBeNull();
+    await events.body?.cancel();
+  });
+
   it('replays accepted events over SSE with epoch and sequence ids', async () => {
     const sidecar = await startTestSidecar();
     await fetch(`${sidecar.url}/api/runtime/events`, {

--- a/packages/cli/src/studio/sidecar.ts
+++ b/packages/cli/src/studio/sidecar.ts
@@ -433,17 +433,6 @@ export async function startStudioSidecar(options: StudioSidecarOptions = {}): Pr
     writeJson(response, 404, { error: 'Unknown Studio sidecar route.' });
   });
 
-  const heartbeat = options.heartbeatMs === 0
-    ? undefined
-    : setInterval(() => {
-        publish({
-          payload: { uptimeMs: Number((performance.now() - startedAt).toFixed(3)) },
-          source: { appId, runtime },
-          type: 'heartbeat',
-        });
-      }, options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS);
-  heartbeat?.unref();
-
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
     server.listen(options.port ?? 0, host, () => {
@@ -454,11 +443,22 @@ export async function startStudioSidecar(options: StudioSidecarOptions = {}): Pr
 
   const address = server.address();
   if (!address || typeof address === 'string') {
-    await closeServer(server, clients, heartbeat);
+    await closeServer(server, clients, undefined);
     throw new Error('Failed to resolve Studio sidecar address.');
   }
 
   const url = `http://${host}:${String(address.port)}`;
+
+  const heartbeat = options.heartbeatMs === 0
+    ? undefined
+    : setInterval(() => {
+        publish({
+          payload: { uptimeMs: Number((performance.now() - startedAt).toFixed(3)) },
+          source: { appId, runtime },
+          type: 'heartbeat',
+        });
+      }, options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS);
+  heartbeat?.unref();
 
   return {
     appId,

--- a/packages/cli/src/update-check.ts
+++ b/packages/cli/src/update-check.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, join, sep } from 'node:path';
 import { createInterface } from 'node:readline/promises';
+import type { Readable, Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 
 type CliStream = {
@@ -98,6 +99,30 @@ const UPDATE_PACKAGE_MANAGERS = new Set<UpdatePackageManager>(['bun', 'npm', 'pn
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function isReadableStream(value: CliReadableStream | undefined): value is CliReadableStream & Readable {
+  if (!value || !isRecord(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.on === 'function'
+    && typeof candidate.pause === 'function'
+    && typeof candidate.resume === 'function';
+}
+
+function isWritableStream(value: CliStream | undefined): value is CliStream & Writable {
+  if (!value || !isRecord(value)) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.write === 'function'
+    && typeof candidate.on === 'function'
+    && typeof candidate.once === 'function'
+    && typeof candidate.emit === 'function'
+    && typeof candidate.removeListener === 'function';
 }
 
 function isTruthyEnvValue(value: string | undefined): boolean {
@@ -474,11 +499,11 @@ function resolveInstallCommand(
   };
 }
 
-async function defaultPromptConfirm(message: string, defaultValue: boolean): Promise<boolean> {
+async function defaultPromptConfirm(message: string, defaultValue: boolean, io: { stdin?: CliReadableStream; stdout?: CliStream } = {}): Promise<boolean> {
   const promptSuffix = defaultValue ? 'Y/n' : 'y/N';
   const readline = createInterface({
-    input: process.stdin,
-    output: process.stdout,
+    input: isReadableStream(io.stdin) ? io.stdin : process.stdin,
+    output: isWritableStream(io.stdout) ? io.stdout : process.stdout,
   });
 
   try {
@@ -609,7 +634,7 @@ export async function runCliUpdateCheck(argv: string[], options: CliUpdateCheckR
   }
 
   stderr.write(`A newer ${packageName} version is available: ${currentVersion} -> ${latestVersion}.\n`);
-  const prompt = options.prompt ?? { confirm: defaultPromptConfirm };
+  const prompt = options.prompt ?? { confirm: (message, defaultValue) => defaultPromptConfirm(message, defaultValue, { stdin: options.stdin, stdout }) };
   const shouldInstall = await prompt.confirm(`Install ${packageName}@${latestVersion} now and restart this command?`, false);
 
   if (!shouldInstall) {


### PR DESCRIPTION
## Summary

Resolve #2179 by hardening the public `@fluojs/cli` Studio/dev-runner contracts and adding focused regressions for the highest-priority CLI audit findings.

Linked context: Closes #2179

## Changes

- Reject `fluo dev --studio` when the Node restart runner is bypassed via `--raw-watch`, `--runner native`, or `FLUO_DEV_RUNNER=native`, preserving the documented Studio lifecycle-event boundary.
- Start Studio sidecar heartbeat timers only after `server.listen()` succeeds, preventing timer leaks on listen failures.
- Route the default update-check confirmation prompt through caller-injected `stdin`/`stdout` streams when they are real Node streams.
- Align `packages/cli` EN/KO README docs for the Studio runner limitation and the published bin wrapper contract.
- Add a patch changeset for the public `@fluojs/cli` behavior hardening.

## Testing

- `lsp_diagnostics` clean for changed TypeScript files:
  - `packages/cli/src/update-check.ts`
  - `packages/cli/src/commands/scripts.ts`
  - `packages/cli/src/studio/sidecar.ts`
  - `packages/cli/src/cli.test.ts`
  - `packages/cli/src/studio/sidecar.test.ts`
- `pnpm exec vitest run packages/cli/src/cli.test.ts packages/cli/src/studio/sidecar.test.ts` — passed (`217 passed`).
- Note: `pnpm --filter @fluojs/cli exec vitest run -c vitest.config.ts ...` could not resolve unbuilt workspace package entrypoints in this fresh worktree, so the equivalent root Vitest invocation with workspace aliases was used.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/harden-cli-studio-dev-contracts.md` for `@fluojs/cli`.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed; this PR changes CLI runtime behavior, tests, README contract text, and release metadata.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or conformance harness claims changed. Package README EN/KO mirrors were updated together with direct CLI regressions.