### PR TITLE
Resolve #2197: fix Queue worker lifecycle

### DIFF
--- a/.changeset/queue-scoped-worker-rollback.md
+++ b/.changeset/queue-scoped-worker-rollback.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/queue": patch
+---
+
+Fix non-global queue worker discovery so scoped registrations only start workers visible to the importing module graph, and roll back queue-owned BullMQ resources immediately when worker startup fails after bootstrap readiness.

--- a/packages/queue/src/helpers.ts
+++ b/packages/queue/src/helpers.ts
@@ -20,6 +20,9 @@ export interface DiscoveryCandidate {
   token: Token;
 }
 
+/** Selects whether one compiled module participates in worker discovery. */
+export type DiscoveryModuleFilter = (compiledModule: CompiledModule) => boolean;
+
 /**
  * Scope from provider.
  *
@@ -54,10 +57,17 @@ export function isClassProvider(provider: Provider): provider is Extract<Provide
  * @param compiledModules The compiled modules.
  * @returns The collect discovery candidates result.
  */
-export function collectDiscoveryCandidates(compiledModules: readonly CompiledModule[]): DiscoveryCandidate[] {
+export function collectDiscoveryCandidates(
+  compiledModules: readonly CompiledModule[],
+  moduleFilter: DiscoveryModuleFilter = () => true,
+): DiscoveryCandidate[] {
   const candidates: DiscoveryCandidate[] = [];
 
   for (const compiledModule of compiledModules) {
+    if (!moduleFilter(compiledModule)) {
+      continue;
+    }
+
     for (const provider of compiledModule.definition.providers ?? []) {
       if (typeof provider === 'function') {
         candidates.push({

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -374,11 +374,65 @@ function createDeferred<T = void>() {
   return { promise, reject, resolve };
 }
 
-async function waitForQueueWorkers(): Promise<void> {
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, 0);
-  });
-  await Promise.resolve();
+function snapshotDetailNumber(service: QueueLifecycleService, key: string): number {
+  const value = service.createPlatformStatusSnapshot().details[key];
+
+  return typeof value === 'number' ? value : 0;
+}
+
+async function waitForQueueWorkers(service: QueueLifecycleService): Promise<void> {
+  const expectedReady = snapshotDetailNumber(service, 'workersDiscovered');
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const snapshot = service.createPlatformStatusSnapshot();
+    const workersReady = snapshotDetailNumber(service, 'workersReady');
+    const workerStartFailures = snapshotDetailNumber(service, 'workerStartFailures');
+
+    if (snapshot.details.lifecycleState === 'started' && workersReady === expectedReady && workerStartFailures === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  throw new Error('Queue workers did not reach started readiness.');
+}
+
+async function waitForApplicationQueueWorkers(app: { container: { resolve<T>(token: unknown): Promise<T> } }): Promise<void> {
+  await waitForQueueWorkers(await app.container.resolve(QueueLifecycleService));
+}
+
+async function waitForFailedQueueRollback(service: QueueLifecycleService): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const snapshot = service.createPlatformStatusSnapshot();
+    const queuesReady = snapshotDetailNumber(service, 'queuesReady');
+
+    if (snapshot.details.lifecycleState === 'failed' && queuesReady === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  throw new Error('Queue startup failure did not roll back initialized resources.');
+}
+
+async function waitForRedisDuplicatesClosed(redis: MockRedisClient): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (redis.duplicates.length > 0 && redis.duplicates.every((connection) => connection.status === 'end')) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  }
+
+  throw new Error('Queue-owned Redis duplicates did not close.');
 }
 
 describe('@fluojs/queue', () => {
@@ -492,7 +546,7 @@ describe('@fluojs/queue', () => {
     });
     const userService = await app.container.resolve(UserService);
     const workerStore = await app.container.resolve(WorkerStore);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     const jobId = await userService.register('user-1');
 
@@ -546,7 +600,7 @@ describe('@fluojs/queue', () => {
     });
     const userService = await app.container.resolve(UserService);
     const workerStore = await app.container.resolve(WorkerStore);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     await expect(userService.enqueue('user-9')).resolves.toBe('1');
     expect(workerStore.handled).toEqual(['user-9']);
@@ -585,11 +639,24 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
+    const service = await app.container.resolve(QueueLifecycleService);
     const workerStore = await app.container.resolve(WorkerStore);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     await expect(queue.enqueue(new BullMqStartupJob('ready'))).resolves.toBe('1');
     expect(workerStore.handled).toEqual(['ready']);
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        dependencies: ['redis.default'],
+        queuesReady: 1,
+        workersDiscovered: 1,
+        workersReady: 1,
+      },
+      ownership: {
+        externallyManaged: false,
+        ownsResources: true,
+      },
+    });
     expect(redis.duplicateOptions).toEqual([
       { maxRetriesPerRequest: null },
       { maxRetriesPerRequest: null },
@@ -599,6 +666,73 @@ describe('@fluojs/queue', () => {
     await app.close();
 
     expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
+  });
+
+  it('restricts non-global queue worker discovery to modules that can see the queue provider', async () => {
+    class VisibleJob {
+      constructor(public readonly id: string) {}
+    }
+
+    class HiddenJob {
+      constructor(public readonly id: string) {}
+    }
+
+    class WorkerStore {
+      handled: string[] = [];
+    }
+
+    @Inject(WorkerStore)
+    @QueueWorker(VisibleJob)
+    class VisibleWorker {
+      constructor(private readonly store: WorkerStore) {}
+
+      async handle(job: VisibleJob): Promise<void> {
+        this.store.handled.push(`visible:${job.id}`);
+      }
+    }
+
+    @QueueWorker(HiddenJob)
+    class HiddenWorker {
+      async handle(_job: HiddenJob): Promise<void> {}
+    }
+
+    class VisibleModule {}
+    defineModule(VisibleModule, {
+      imports: [QueueModule.forRoot({ global: false })],
+      providers: [VisibleWorker, WorkerStore],
+    });
+
+    class HiddenModule {}
+    defineModule(HiddenModule, {
+      providers: [HiddenWorker],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [VisibleModule, HiddenModule],
+    });
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const queue = await app.container.resolve<Queue>(QUEUE);
+    const service = await app.container.resolve(QueueLifecycleService);
+    const workerStore = await app.container.resolve(WorkerStore);
+    await waitForApplicationQueueWorkers(app);
+
+    await expect(queue.enqueue(new VisibleJob('1'))).resolves.toBe('1');
+    await expect(queue.enqueue(new HiddenJob('2'))).rejects.toThrow('No @QueueWorker() registered for job type HiddenJob.');
+    expect(workerStore.handled).toEqual(['visible:1']);
+    expect(service.createPlatformStatusSnapshot().details).toMatchObject({
+      queuesReady: 1,
+      workersDiscovered: 1,
+      workersReady: 1,
+    });
+    expect(bullmqState.workers.has('HiddenJob')).toBe(false);
+
+    await app.close();
   });
 
   it('warns and skips @QueueWorker() classes registered with non-singleton scopes', async () => {
@@ -687,7 +821,7 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     const jobId = await queue.enqueue(new FailingJob('invoice-1'));
 
@@ -745,7 +879,7 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     await queue.enqueue(new MutableFailingJob({ role: 'original' }));
 
@@ -786,7 +920,7 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     await queue.enqueue(new TrimmedDeadLetterJob('job-1'));
     await queue.enqueue(new TrimmedDeadLetterJob('job-2'));
@@ -824,7 +958,7 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     await queue.enqueue(new UnboundedDeadLetterJob('job-1'));
     await queue.enqueue(new UnboundedDeadLetterJob('job-2'));
@@ -884,7 +1018,7 @@ describe('@fluojs/queue', () => {
     });
     const workerStore = await app.container.resolve(WorkerStore);
 
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
     expect(workerStore.received).toEqual(['bootstrapped']);
     expect(workerStore.receivedDuringBootstrap).toBe(false);
 
@@ -946,7 +1080,7 @@ describe('@fluojs/queue', () => {
     });
     const workerStore = await app.container.resolve(WorkerStore);
 
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
     expect(workerStore.received).toEqual(['queued-before-later-hook']);
     expect(workerStore.receivedDuringLaterBootstrap).toBe(false);
 
@@ -983,6 +1117,7 @@ describe('@fluojs/queue', () => {
         defaultAttempts: 1,
         defaultConcurrency: 1,
         defaultDeadLetterMaxEntries: 1_000,
+        global: true,
         workerShutdownTimeoutMs: 30_000,
       },
       container as never,
@@ -1016,7 +1151,7 @@ describe('@fluojs/queue', () => {
     });
 
     releaseBootstrapReady.resolve();
-    await waitForQueueWorkers();
+    await waitForQueueWorkers(service);
 
     expect(service.createPlatformStatusSnapshot()).toMatchObject({
       details: {
@@ -1059,12 +1194,13 @@ describe('@fluojs/queue', () => {
     });
     const service = await app.container.resolve(QueueLifecycleService);
 
-    await waitForQueueWorkers();
+    await waitForFailedQueueRollback(service);
 
     expect(service.createPlatformStatusSnapshot()).toMatchObject({
       details: {
         lastWorkerStartFailure: 'worker run fail:RunFailureJob',
         lifecycleState: 'failed',
+        queuesReady: 0,
         workerStartFailures: 1,
         workersDiscovered: 1,
         workersReady: 0,
@@ -1083,6 +1219,10 @@ describe('@fluojs/queue', () => {
         event.includes('error:QueueLifecycleService:Failed to start queue worker RunFailureWorker after application bootstrap.'),
       ),
     ).toBe(true);
+    expect(bullmqState.queues.get('RunFailureJob')?.closeCalls).toBe(1);
+    expect(bullmqState.workers.get('RunFailureJob')?.closeCalls).toBe(1);
+    await waitForRedisDuplicatesClosed(redis);
+    expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
     await expect(service.enqueue(new RunFailureJob('after-failure'))).rejects.toThrow('Queue lifecycle state is failed.');
 
     await app.close();
@@ -1124,7 +1264,7 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     const enqueuePromise = queue.enqueue(new ShutdownFailingJob('job-1'));
     await Promise.resolve();
@@ -1233,6 +1373,7 @@ describe('@fluojs/queue', () => {
         defaultAttempts: 1,
         defaultConcurrency: 1,
         defaultDeadLetterMaxEntries: 1_000,
+        global: true,
         workerShutdownTimeoutMs: 30_000,
       },
       container as never,
@@ -1306,6 +1447,7 @@ describe('@fluojs/queue', () => {
         defaultAttempts: 1,
         defaultConcurrency: 1,
         defaultDeadLetterMaxEntries: 1_000,
+        global: true,
         workerShutdownTimeoutMs: 30_000,
       },
       container as never,
@@ -1437,13 +1579,18 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
+    const service = await app.container.resolve(QueueLifecycleService);
     await vi.advanceTimersByTimeAsync(0);
 
     void queue.enqueue(new HangingProcessorJob('job-1'));
     await Promise.resolve();
 
     const closePromise = app.close();
-    await vi.advanceTimersByTimeAsync(25);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(service.createPlatformStatusSnapshot().details).toMatchObject({ lifecycleState: 'stopping' });
+    await expect(queue.enqueue(new HangingProcessorJob('job-while-stopping'))).rejects.toThrow('Queue lifecycle state is stopping.');
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(26);
     await closePromise;
 
     const worker = bullmqState.workers.get('hanging-processor-job');
@@ -1475,7 +1622,7 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     await expect(queue.enqueue(new ArrayPayloadJob())).rejects.toThrow(
       'Queue payload must be a plain object after JSON serialization.',
@@ -1504,7 +1651,7 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     await expect(queue.enqueue(new MissingHandleJob('job-1'))).resolves.toBe('1');
 
@@ -1669,7 +1816,7 @@ describe('@fluojs/queue', () => {
       rootModule: AppModule,
     });
     const queue = await app.container.resolve<Queue>(QUEUE);
-    await waitForQueueWorkers();
+    await waitForApplicationQueueWorkers(app);
 
     await queue.enqueue(new DefaultedJob('ok'));
 

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -158,17 +158,15 @@ const bullmqState = vi.hoisted(() => {
     async dispatch(name: string, job: MockQueueJob) {
       await dispatch(name, job);
     },
-    async runWorker(worker: MockWorkerState) {
+    runWorker(worker: MockWorkerState): Promise<void> {
       worker.running = true;
       const queue = queues.get(worker.name);
 
       if (!queue) {
-        return;
+        return Promise.resolve();
       }
 
-      for (const job of queue.jobs) {
-        await dispatch(worker.name, job);
-      }
+      return Promise.all(queue.jobs.map((job) => dispatch(worker.name, job))).then(() => undefined);
     },
   };
 });
@@ -249,12 +247,12 @@ vi.mock('bullmq', () => ({
       this.worker.closed = true;
     }
 
-    async run(): Promise<void> {
+    run(): Promise<void> {
       if (bullmqState.failWorkerRun.has(this.worker.name)) {
         throw new Error(`worker run fail:${this.worker.name}`);
       }
 
-      await bullmqState.runWorker(this.worker);
+      return bullmqState.runWorker(this.worker);
     }
 
     async waitUntilReady(): Promise<void> {
@@ -1224,6 +1222,63 @@ describe('@fluojs/queue', () => {
     await waitForRedisDuplicatesClosed(redis);
     expect(redis.duplicates.every((connection) => connection.status === 'end')).toBe(true);
     await expect(service.enqueue(new RunFailureJob('after-failure'))).rejects.toThrow('Queue lifecycle state is failed.');
+
+    await app.close();
+  });
+
+  it('does not start later workers after an earlier worker startup failure', async () => {
+    const loggerEvents: string[] = [];
+
+    class FirstFailureJob {
+      constructor(public readonly id: string) {}
+    }
+
+    class LaterStartJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(FirstFailureJob)
+    class FirstFailureWorker {
+      async handle(_job: FirstFailureJob): Promise<void> {}
+    }
+
+    @QueueWorker(LaterStartJob)
+    class LaterStartWorker {
+      async handle(_job: LaterStartJob): Promise<void> {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [QueueModule.forRoot()],
+      providers: [FirstFailureWorker, LaterStartWorker],
+    });
+
+    bullmqState.failWorkerRun.add('FirstFailureJob');
+
+    const redis = new MockRedisClient();
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const service = await app.container.resolve(QueueLifecycleService);
+
+    await waitForFailedQueueRollback(service);
+
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        lastWorkerStartFailure: 'worker run fail:FirstFailureJob',
+        lifecycleState: 'failed',
+        queuesReady: 0,
+        workerStartFailures: 1,
+        workersDiscovered: 2,
+        workersReady: 0,
+      },
+    });
+    expect(bullmqState.workers.get('FirstFailureJob')?.running).toBe(false);
+    expect(bullmqState.workers.get('LaterStartJob')?.running).toBe(false);
+    expect(bullmqState.workers.get('FirstFailureJob')?.closeCalls).toBe(1);
+    expect(bullmqState.workers.get('LaterStartJob')?.closeCalls).toBe(1);
 
     await app.close();
   });

--- a/packages/queue/src/module.ts
+++ b/packages/queue/src/module.ts
@@ -21,6 +21,7 @@ function normalizeQueueModuleOptions(options: QueueModuleOptions = {}): Normaliz
     defaultConcurrency: normalizePositiveInteger(options.defaultConcurrency, 1),
     defaultDeadLetterMaxEntries: normalizePositiveIntegerOrFalse(options.defaultDeadLetterMaxEntries, 1_000),
     defaultRateLimiter,
+    global: options.global ?? true,
     workerShutdownTimeoutMs: normalizePositiveInteger(options.workerShutdownTimeoutMs, 30_000),
   };
 }

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -458,7 +458,15 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
       }
 
       for (const { descriptor, worker } of workers) {
+        if (this.lifecycleState !== 'started') {
+          break;
+        }
+
         this.runWorker(descriptor, worker);
+
+        if (this.lifecycleState !== 'started') {
+          break;
+        }
       }
     }).catch((error: unknown) => {
       if (this.lifecycleState !== 'started') {

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -25,7 +25,7 @@ import {
   type QueueLifecycleState,
   type QueuePlatformStatusSnapshot,
 } from './status.js';
-import { QUEUE_OPTIONS } from './tokens.js';
+import { QUEUE, QUEUE_OPTIONS } from './tokens.js';
 import { discoverQueueWorkerDescriptors } from './worker-discovery.js';
 import type {
   NormalizedQueueModuleOptions,
@@ -180,6 +180,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
   private redisClient: QueueRedisClient | undefined;
   private startPromise: Promise<void> | undefined;
   private shutdownPromise: Promise<void> | undefined;
+  private startupFailureRollbackPromise: Promise<void> | undefined;
 
   constructor(
     private readonly options: NormalizedQueueModuleOptions,
@@ -288,7 +289,12 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     this.redisClient = redis;
     this.descriptorsByJobType.clear();
 
-    for (const [jobType, descriptor] of discoverQueueWorkerDescriptors(this.compiledModules, this.options, this.logger)) {
+    for (const [jobType, descriptor] of discoverQueueWorkerDescriptors(
+      this.compiledModules,
+      this.options,
+      this.logger,
+      (compiledModule) => this.shouldDiscoverWorkersInModule(compiledModule),
+    )) {
       this.descriptorsByJobType.set(jobType, descriptor);
     }
 
@@ -297,6 +303,14 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
       this.lifecycleState = 'started';
       this.scheduleReadyWorkers();
     }
+  }
+
+  private shouldDiscoverWorkersInModule(compiledModule: CompiledModule): boolean {
+    if (this.options.global) {
+      return true;
+    }
+
+    return compiledModule.accessibleTokens.has(QueueLifecycleService) || compiledModule.accessibleTokens.has(QUEUE);
   }
 
   private async handleStartupFailure(): Promise<void> {
@@ -462,6 +476,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
         error,
         'QueueLifecycleService',
       );
+      this.rollbackAfterWorkerStartupFailure();
     });
   }
 
@@ -540,6 +555,23 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
       error,
       'QueueLifecycleService',
     );
+    this.rollbackAfterWorkerStartupFailure();
+  }
+
+  private rollbackAfterWorkerStartupFailure(): void {
+    if (!this.startupFailureRollbackPromise) {
+      this.startupFailureRollbackPromise = this.closeInitializedResources()
+        .then(() => {
+          this.redisClient = undefined;
+        })
+        .catch((rollbackError: unknown) => {
+          this.logger.error(
+            'Failed to roll back queue resources after worker startup failure.',
+            rollbackError,
+            'QueueLifecycleService',
+          );
+        });
+    }
   }
 
   private toErrorMessage(error: unknown): string {
@@ -635,6 +667,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
 
     this.shutdownPromise = (async () => {
       await this.waitForInFlightStartup();
+      await this.waitForStartupFailureRollback();
 
       await this.closeInitializedResources();
       await this.deadLetterManager.drainPendingWrites();
@@ -644,6 +677,15 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
     })();
 
     await this.shutdownPromise;
+  }
+
+  private async waitForStartupFailureRollback(): Promise<void> {
+    if (!this.startupFailureRollbackPromise) {
+      return;
+    }
+
+    await this.startupFailureRollbackPromise;
+    this.startupFailureRollbackPromise = undefined;
   }
 
   private async waitForInFlightStartup(): Promise<void> {

--- a/packages/queue/src/status.test.ts
+++ b/packages/queue/src/status.test.ts
@@ -31,8 +31,15 @@ describe('createQueuePlatformStatusSnapshot', () => {
 
     expect(snapshot.readiness).toEqual({ critical: true, status: 'ready' });
     expect(snapshot.health).toEqual({ status: 'healthy' });
+    expect(snapshot.ownership).toEqual({
+      externallyManaged: false,
+      ownsResources: true,
+    });
     expect(snapshot.details).toMatchObject({
+      deadLetterDrainTimeoutMs: 5_000,
       dependencies: ['redis.jobs'],
+      queuesReady: 2,
+      workerStartFailures: 0,
       workerShutdownTimeoutMs: 30_000,
       workersDiscovered: 2,
       workersReady: 2,

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -56,6 +56,7 @@ export interface NormalizedQueueModuleOptions {
   defaultConcurrency: number;
   defaultDeadLetterMaxEntries: number | false;
   defaultRateLimiter?: QueueRateLimiterOptions;
+  global: boolean;
   workerShutdownTimeoutMs: number;
 }
 

--- a/packages/queue/src/worker-discovery.ts
+++ b/packages/queue/src/worker-discovery.ts
@@ -1,7 +1,7 @@
 import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
 
 import { getQueueWorkerMetadata } from './metadata.js';
-import { collectDiscoveryCandidates, normalizePositiveInteger, normalizeRateLimiter } from './helpers.js';
+import { collectDiscoveryCandidates, type DiscoveryModuleFilter, normalizePositiveInteger, normalizeRateLimiter } from './helpers.js';
 import type { NormalizedQueueModuleOptions, QueueJobType, QueueWorkerDescriptor, QueueWorkerMetadata } from './types.js';
 
 /**
@@ -16,11 +16,12 @@ export function discoverQueueWorkerDescriptors(
   compiledModules: readonly CompiledModule[],
   options: NormalizedQueueModuleOptions,
   logger: ApplicationLogger,
+  moduleFilter?: DiscoveryModuleFilter,
 ): Map<QueueJobType, QueueWorkerDescriptor> {
   const descriptorsByJobType = new Map<QueueJobType, QueueWorkerDescriptor>();
   const seenJobNames = new Set<string>();
 
-  for (const candidate of collectDiscoveryCandidates(compiledModules)) {
+  for (const candidate of collectDiscoveryCandidates(compiledModules, moduleFilter)) {
     const metadata = getQueueWorkerMetadata(candidate.targetType);
 
     if (!metadata) {


### PR DESCRIPTION
## Summary

Fix `@fluojs/queue` scoped worker discovery and startup rollback behavior for the Queue package audit finding.

Linked context: Closes #2197

## Changes

- Restrict non-global `QueueModule.forRoot({ global: false })` worker discovery to providers visible from the importing module graph.
- Roll back queue-owned BullMQ workers, queues, and duplicate Redis connections when worker startup fails after bootstrap readiness.
- Stop starting later workers once an earlier worker startup failure transitions Queue away from `started`.
- Add regression coverage for scoped worker discovery, startup rollback, shutdown enqueue rejection, Redis duplicate ownership/status details, and state-based worker readiness.
- Add a patch changeset for the public `@fluojs/queue` runtime behavior fix.

## Testing

- LSP diagnostics: no errors for modified Queue source files (`service.ts`, `module.test.ts`, and Queue src directory); one non-blocking hint in `module.test.ts`
- Forbidden pattern scan: no `as any`, `@ts-ignore`, `@ts-expect-error`, or empty catch blocks in `packages/queue/src`
- `pnpm --filter @fluojs/queue test` — passed (`41 passed`)
- `pnpm --filter @fluojs/queue... build` — passed
- `pnpm --filter @fluojs/queue typecheck` — passed after dependency build
- Oracle read-only review — initial blocker fixed; follow-up PASS

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/queue-scoped-worker-rollback.md`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public export was added. The changed runtime behavior aligns existing Queue module/lifecycle options and status contracts with the documented README behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The existing Queue README already documents scoped `global: false` module visibility, bootstrap-ready worker handoff, failed worker-start status, shared Redis ownership boundaries, and shutdown enqueue rejection. This PR aligns implementation and regression tests to those contracts.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs or package README files changed. Regression evidence is the Queue package lifecycle test suite above.
