### PR TITLE
Resolve #2198: harden Cron distributed locks

### DIFF
--- a/.changeset/harden-cron-distributed-locks.md
+++ b/.changeset/harden-cron-distributed-locks.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cron": patch
+---
+
+Harden distributed lock readiness and shutdown retry semantics so Redis lock I/O outages no longer report ready/healthy and timed-out task lock releases can be retried after the task settles.

--- a/packages/cron/src/distributed-lock-manager.ts
+++ b/packages/cron/src/distributed-lock-manager.ts
@@ -68,6 +68,7 @@ async function resolveRedisPeerModule(): Promise<RedisPeerModule> {
 /** Coordinates Redis lock acquisition, renewal, and release for scheduled cron tasks. */
 export class CronDistributedLockManager {
   private readonly ownedLockKeys = new Set<string>();
+  private lockIoError: Error | undefined;
   private redisClient: RedisLockClient | undefined;
   private lockOwnershipLosses = 0;
   private lockRenewalFailures = 0;
@@ -84,6 +85,14 @@ export class CronDistributedLockManager {
 
   get ownedLocks(): number {
     return this.ownedLockKeys.size;
+  }
+
+  get lockIoAvailable(): boolean {
+    if (!this.options.distributed.enabled) {
+      return true;
+    }
+
+    return this.redisClient !== undefined && this.lockIoError === undefined;
   }
 
   get ownershipLosses(): number {
@@ -113,9 +122,11 @@ export class CronDistributedLockManager {
     }
 
     this.redisClient = redisClient;
+    await this.verifyLockIoAvailability();
   }
 
   reset(): void {
+    this.lockIoError = undefined;
     this.redisClient = undefined;
   }
 
@@ -135,12 +146,15 @@ export class CronDistributedLockManager {
         'NX',
       );
 
+      this.markLockIoAvailable();
+
       if (result === 'OK') {
         this.ownedLockKeys.add(descriptor.lockKey);
       }
 
       return result === 'OK';
     } catch (error) {
+      this.markLockIoUnavailable(error);
       this.logger.error(
         `Failed to acquire distributed cron lock for ${descriptor.taskName}.`,
         error,
@@ -180,8 +194,8 @@ export class CronDistributedLockManager {
     };
   }
 
-  async releaseLock(descriptor: CronTaskDescriptor): Promise<void> {
-    await this.releaseLockKey(descriptor.lockKey, descriptor.taskName);
+  async releaseLock(descriptor: CronTaskDescriptor): Promise<boolean> {
+    return await this.releaseLockKey(descriptor.lockKey, descriptor.taskName);
   }
 
   async releaseOwnedLocks(excludedLockKeys: ReadonlySet<string> = new Set()): Promise<void> {
@@ -278,6 +292,7 @@ export class CronDistributedLockManager {
       );
 
       if (typeof result === 'number' && result <= 0) {
+        this.markLockIoAvailable();
         this.logger.warn(
           `Distributed cron lock ownership was lost for ${descriptor.taskName}.`,
           'CronLifecycleService',
@@ -285,6 +300,7 @@ export class CronDistributedLockManager {
         return 'ownership-lost';
       }
 
+      this.markLockIoAvailable();
       this.logger.log(
         `Renewed distributed cron lock for ${descriptor.taskName}.`,
         'CronLifecycleService',
@@ -292,6 +308,7 @@ export class CronDistributedLockManager {
 
       return 'renewed';
     } catch (error) {
+      this.markLockIoUnavailable(error);
       this.logger.error(
         `Failed to renew distributed cron lock for ${descriptor.taskName}.`,
         error,
@@ -301,37 +318,69 @@ export class CronDistributedLockManager {
     }
   }
 
-  private async releaseLockKey(lockKey: string, taskName: string): Promise<void> {
+  private async releaseLockKey(lockKey: string, taskName: string): Promise<boolean> {
     const redis = this.redisClient;
 
     if (!redis) {
-      return;
+      return true;
     }
 
     try {
       const result = await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, this.options.distributed.ownerId);
 
       if (typeof result === 'number' && result <= 0) {
+        this.markLockIoAvailable();
         this.logger.warn(
           `Distributed cron lock for ${taskName} was already released or owned by another node.`,
           'CronLifecycleService',
         );
         this.ownedLockKeys.delete(lockKey);
-        return;
+        return true;
       }
 
+      this.markLockIoAvailable();
       this.logger.log(
         `Released distributed cron lock for ${taskName}.`,
         'CronLifecycleService',
       );
       this.ownedLockKeys.delete(lockKey);
+      return true;
     } catch (error) {
+      this.markLockIoUnavailable(error);
       this.logger.error(
         `Failed to release distributed cron lock for ${taskName}.`,
         error,
         'CronLifecycleService',
       );
+      return false;
     }
+  }
+
+  private async verifyLockIoAvailability(): Promise<void> {
+    const redis = this.redisClient;
+
+    if (!redis) {
+      return;
+    }
+
+    const probeKey = `${this.options.distributed.keyPrefix}:__probe:${this.options.distributed.ownerId}`;
+
+    try {
+      await redis.set(probeKey, this.options.distributed.ownerId, 'PX', 1_000, 'NX');
+      await redis.eval(RELEASE_LOCK_SCRIPT, 1, probeKey, this.options.distributed.ownerId);
+      this.markLockIoAvailable();
+    } catch (error) {
+      this.markLockIoUnavailable(error);
+      throw new Error('Cron distributed mode requires Redis lock I/O to be available.');
+    }
+  }
+
+  private markLockIoAvailable(): void {
+    this.lockIoError = undefined;
+  }
+
+  private markLockIoUnavailable(error: unknown): void {
+    this.lockIoError = error instanceof Error ? error : new Error('Redis lock I/O failed.');
   }
 }
 

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -31,6 +31,10 @@ class InMemoryLockRedisClient {
   private readonly locks = new Map<string, string>();
   renewalCalls = 0;
 
+  hasLock(key: string): boolean {
+    return this.locks.has(key);
+  }
+
   async set(key: string, value: string, _mode: 'PX', _ttl: number, _existence: 'NX'): Promise<'OK' | null> {
     if (this.locks.has(key)) {
       return null;
@@ -167,7 +171,7 @@ class ReleaseErrorOnceRedisClient extends InMemoryLockRedisClient {
   releaseAttempts = 0;
 
   override async eval(script: string, keysLength: number, key: string, owner: string, ttl?: string): Promise<number> {
-    if (script.includes('DEL')) {
+    if (script.includes('DEL') && !key.includes('__probe')) {
       this.releaseAttempts += 1;
 
       if (this.releaseAttempts === 1) {
@@ -176,6 +180,26 @@ class ReleaseErrorOnceRedisClient extends InMemoryLockRedisClient {
     }
 
     return await super.eval(script, keysLength, key, owner, ttl);
+  }
+}
+
+class AcquireFailureAfterProbeRedisClient extends InMemoryLockRedisClient {
+  lockAcquireAttempts = 0;
+  failNextAcquire = true;
+
+  override async set(key: string, value: string, mode: 'PX', ttl: number, existence: 'NX'): Promise<'OK' | null> {
+    if (key.includes('__probe')) {
+      return await super.set(key, value, mode, ttl, existence);
+    }
+
+    this.lockAcquireAttempts += 1;
+
+    if (this.failNextAcquire) {
+      this.failNextAcquire = false;
+      throw new Error('redis unavailable');
+    }
+
+    return await super.set(key, value, mode, ttl, existence);
   }
 }
 
@@ -679,6 +703,74 @@ describe('@fluojs/cron', () => {
     await appTwo.close();
   });
 
+  it('reports distributed Redis lock I/O outages as not-ready and unhealthy', async () => {
+    const scheduled = createManualScheduler();
+    const redis = new AcquireFailureAfterProbeRedisClient();
+
+    class Store {
+      runs = 0;
+    }
+
+    @Inject(Store)
+    class DistributedTaskService {
+      constructor(private readonly store: Store) {}
+
+      @Cron(CronExpression.EVERY_SECOND, { name: 'distributed-io-status' })
+      run() {
+        this.store.runs += 1;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        CronModule.forRoot({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-io-status',
+            lockTtlMs: 60_000,
+          },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService, Store],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const registry = await app.container.resolve(SCHEDULING_REGISTRY);
+    const statusService = registry as CronLifecycleService;
+
+    expect(statusService.createPlatformStatusSnapshot().readiness.status).toBe('ready');
+
+    await scheduled.records[0]!.tick();
+
+    const snapshot = statusService.createPlatformStatusSnapshot();
+    expect(redis.lockAcquireAttempts).toBe(1);
+    expect(snapshot.details.redisDependencyResolved).toBe(true);
+    expect(snapshot.details.redisLockIoAvailable).toBe(false);
+    expect(snapshot.readiness.status).toBe('not-ready');
+    expect(snapshot.health.status).toBe('unhealthy');
+    expect((await app.container.resolve(Store)).runs).toBe(0);
+
+    const attemptsAfterFailure = redis.lockAcquireAttempts;
+    await redis.set('cron-io-status:distributed-io-status', 'other-owner', 'PX', 60_000, 'NX');
+    const attemptsAfterSeedingContention = redis.lockAcquireAttempts;
+    await scheduled.records[0]!.tick();
+
+    const recoveredSnapshot = statusService.createPlatformStatusSnapshot();
+    expect(attemptsAfterFailure).toBe(1);
+    expect(redis.lockAcquireAttempts).toBe(attemptsAfterSeedingContention + 1);
+    expect(recoveredSnapshot.details.redisLockIoAvailable).toBe(true);
+    expect(recoveredSnapshot.readiness.status).toBe('ready');
+    expect(recoveredSnapshot.health.status).toBe('healthy');
+    expect((await app.container.resolve(Store)).runs).toBe(0);
+
+    await closeApplication(app);
+  });
+
   it('fails bootstrap before scheduling jobs when the configured Redis client is missing', async () => {
     const scheduler = createManualScheduler();
 
@@ -1069,6 +1161,57 @@ describe('@fluojs/cron', () => {
     await scheduled.records[0]!.tick();
 
     expect(events).toEqual(['before', 'run', 'error:hook boom', 'after']);
+
+    await closeApplication(app);
+  });
+
+  it('releases distributed locks from the finally path when the task body throws', async () => {
+    const scheduled = createManualScheduler();
+    const redis = new InMemoryLockRedisClient();
+    const events: string[] = [];
+
+    class DistributedFailingTaskService {
+      @Cron(CronExpression.EVERY_SECOND, {
+        distributed: true,
+        lockTtlMs: 60_000,
+        name: 'distributed-throw-release',
+        onError: (error) => {
+          events.push(`error:${error instanceof Error ? error.message : 'unknown'}`);
+        },
+      })
+      run() {
+        events.push('run');
+        throw new Error('task body boom');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        CronModule.forRoot({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-throw-release',
+            lockTtlMs: 60_000,
+          },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+      providers: [DistributedFailingTaskService],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const registry = await app.container.resolve(SCHEDULING_REGISTRY);
+    const statusService = registry as CronLifecycleService;
+
+    await scheduled.records[0]!.tick();
+
+    expect(events).toEqual(['run', 'error:task body boom']);
+    expect(redis.hasLock('cron-throw-release:distributed-throw-release')).toBe(false);
+    expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(0);
 
     await closeApplication(app);
   });
@@ -1709,6 +1852,80 @@ describe('@fluojs/cron', () => {
     await closeApplication(app);
   });
 
+  it('stops and resumes dynamic cron execution while cleaning up old scheduler handles', async () => {
+    const scheduled = createManualScheduler();
+    const events: string[] = [];
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CronModule.forRoot({ scheduler: scheduled.scheduler })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const registry = await app.container.resolve<SchedulingRegistry>(SCHEDULING_REGISTRY);
+
+    registry.addCron('dynamic-execution-control', CronExpression.EVERY_SECOND, () => {
+      events.push('run');
+    });
+
+    const firstRecord = scheduled.records[0]!;
+    await firstRecord.tick();
+    expect(events).toEqual(['run']);
+
+    expect(registry.disable('dynamic-execution-control')).toBe(true);
+    expect(firstRecord.stop).toHaveBeenCalledTimes(1);
+    await firstRecord.tick();
+    expect(events).toEqual(['run']);
+
+    expect(registry.enable('dynamic-execution-control')).toBe(true);
+    const secondRecord = scheduled.records[1]!;
+    expect(secondRecord.options.name).toBe('dynamic-execution-control');
+    await secondRecord.tick();
+    expect(events).toEqual(['run', 'run']);
+
+    expect(registry.remove('dynamic-execution-control')).toBe(true);
+    expect(secondRecord.stop).toHaveBeenCalledTimes(1);
+    await secondRecord.tick();
+    expect(events).toEqual(['run', 'run']);
+    expect(registry.get('dynamic-execution-control')).toBeUndefined();
+
+    await closeApplication(app);
+  });
+
+  it('cleans up dynamic interval and timeout timers when disabled or removed', async () => {
+    vi.useFakeTimers();
+    const events: string[] = [];
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CronModule.forRoot()],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const registry = await app.container.resolve<SchedulingRegistry>(SCHEDULING_REGISTRY);
+
+    registry.addInterval('dynamic-interval-cleanup', 100, () => {
+      events.push('interval');
+    });
+    registry.addTimeout('dynamic-timeout-cleanup', 250, () => {
+      events.push('timeout');
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(events).toEqual(['interval']);
+
+    expect(registry.disable('dynamic-interval-cleanup')).toBe(true);
+    expect(registry.remove('dynamic-timeout-cleanup')).toBe(true);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(events).toEqual(['interval']);
+
+    expect(registry.enable('dynamic-interval-cleanup')).toBe(true);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(events).toEqual(['interval', 'interval']);
+
+    await app.close();
+  });
+
   it('honors dynamic task option names for registry keys and scheduler metadata', async () => {
     const scheduled = createManualScheduler();
 
@@ -1775,13 +1992,16 @@ describe('@fluojs/cron', () => {
 
   it('rolls back cron expression updates when rescheduling fails', async () => {
     const firstStop = vi.fn();
-    const scheduler = vi.fn<CronScheduler>((_expression, _options, _callback) => {
+    let firstCallback: (() => Promise<void>) | undefined;
+    const scheduler = vi.fn<CronScheduler>((_expression, _options, callback) => {
       if (scheduler.mock.calls.length === 1) {
+        firstCallback = callback;
         return { stop: firstStop };
       }
 
       throw new Error('reschedule failed');
     });
+    const events: string[] = [];
 
     class AppModule {}
     defineModule(AppModule, {
@@ -1791,13 +2011,23 @@ describe('@fluojs/cron', () => {
     const app = await bootstrapApplication({ rootModule: AppModule });
     const registry = await app.container.resolve<SchedulingRegistry>(SCHEDULING_REGISTRY);
 
-    registry.addCron('dynamic-cron', CronExpression.EVERY_SECOND, () => {});
+    registry.addCron('dynamic-cron', CronExpression.EVERY_SECOND, () => {
+      events.push('previous-schedule-run');
+    });
 
     expect(() => registry.updateCronExpression('dynamic-cron', CronExpression.EVERY_5_SECONDS)).toThrow(
       'reschedule failed',
     );
     expect(registry.get('dynamic-cron')?.expression).toBe(CronExpression.EVERY_SECOND);
     expect(firstStop).not.toHaveBeenCalled();
+    expect(firstCallback).toBeDefined();
+
+    if (!firstCallback) {
+      throw new Error('expected previous cron callback to remain registered');
+    }
+
+    await firstCallback();
+    expect(events).toEqual(['previous-schedule-run']);
 
     await closeApplication(app);
     expect(firstStop).toHaveBeenCalledTimes(1);
@@ -2056,6 +2286,65 @@ describe('@fluojs/cron', () => {
     expect(secondStore.count).toBe(1);
 
     await appTwo.close();
+  });
+
+  it('retries distributed lock release on a later shutdown call after a timed-out task settles', async () => {
+    const scheduled = createManualScheduler();
+    const redis = new ReleaseErrorOnceRedisClient();
+    const started = createDeferred<void>();
+    const release = createDeferred<void>();
+    const loggerEvents: string[] = [];
+
+    class DistributedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, { name: 'distributed-timeout-release-retry' })
+      async run() {
+        started.resolve();
+        await release.promise;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        CronModule.forRoot({
+          distributed: {
+            enabled: true,
+            keyPrefix: 'cron-timeout-release-retry',
+            lockTtlMs: 60_000,
+          },
+          scheduler: scheduled.scheduler,
+          shutdown: {
+            timeoutMs: 1,
+          },
+        }),
+      ],
+      providers: [DistributedTaskService],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      providers: [{ provide: REDIS_CLIENT, useValue: redis }],
+      rootModule: AppModule,
+    });
+    const registry = await app.container.resolve(SCHEDULING_REGISTRY);
+    const statusService = registry as CronLifecycleService;
+
+    const tickPromise = scheduled.records[0]!.tick();
+    await started.promise;
+    await app.close();
+    expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(1);
+
+    release.resolve();
+    await tickPromise;
+
+    expect(redis.releaseAttempts).toBe(2);
+    expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(0);
+    expect(loggerEvents.some((event) => event.includes('Failed to release distributed cron lock for distributed-timeout-release-retry.'))).toBe(true);
+
+    await app.close();
+
+    expect(redis.releaseAttempts).toBe(2);
+    expect(statusService.createPlatformStatusSnapshot().details.ownedLocks).toBe(0);
   });
 
   it('preserves active dynamic distributed locks after remove when bounded shutdown times out', async () => {

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -397,6 +397,7 @@ export class CronLifecycleService
       lockRenewalFailures: this.distributedLocks.renewalFailures,
       ownedLocks: this.distributedLocks.ownedLocks,
       redisDependencyResolved: this.distributedLocks.resolvedClient !== undefined,
+      redisLockIoAvailable: this.distributedLocks.lockIoAvailable,
       runningTasks,
       totalTasks: this.tasks.size,
     });
@@ -423,12 +424,21 @@ export class CronLifecycleService
   private async shutdown(): Promise<void> {
     if (this.shutdownPromise) {
       await this.shutdownPromise;
+      await this.retryReleasedDistributedLocksAfterShutdown();
       return;
     }
 
     this.shutdownPromise = this.runShutdownLifecycle();
 
     await this.shutdownPromise;
+  }
+
+  private async retryReleasedDistributedLocksAfterShutdown(): Promise<void> {
+    if (this.lifecycleState !== 'stopped' || this.activeTasks.size > 0) {
+      return;
+    }
+
+    await this.distributedLocks.releaseOwnedLocks();
   }
 
   private async startLifecycle(): Promise<void> {
@@ -661,8 +671,12 @@ export class CronLifecycleService
       });
     } finally {
       lockRenewalMonitor.stop();
-      await this.distributedLocks.releaseLock(descriptor);
       this.runningDistributedLockKeys.delete(descriptor.lockKey);
+      const released = await this.distributedLocks.releaseLock(descriptor);
+
+      if (!released && this.lifecycleState === 'stopped') {
+        await this.distributedLocks.releaseOwnedLocks();
+      }
     }
   }
 

--- a/packages/cron/src/status.test.ts
+++ b/packages/cron/src/status.test.ts
@@ -119,4 +119,23 @@ describe('createCronPlatformStatusSnapshot', () => {
       status: 'unhealthy',
     });
   });
+
+  it('keeps existing status adapter callers compatible when Redis lock I/O is omitted', () => {
+    const snapshot = createCronPlatformStatusSnapshot({
+      activeTicks: 0,
+      distributedEnabled: true,
+      enabledTasks: 1,
+      lifecycleState: 'ready',
+      lockOwnershipLosses: 0,
+      lockRenewalFailures: 0,
+      ownedLocks: 0,
+      redisDependencyResolved: true,
+      runningTasks: 0,
+      totalTasks: 1,
+    });
+
+    expect(snapshot.details.redisLockIoAvailable).toBe(true);
+    expect(snapshot.readiness.status).toBe('ready');
+    expect(snapshot.health.status).toBe('healthy');
+  });
 });

--- a/packages/cron/src/status.test.ts
+++ b/packages/cron/src/status.test.ts
@@ -12,6 +12,7 @@ function createCronInput(overrides: Partial<CronStatusAdapterInput> = {}): CronS
     lockRenewalFailures: 0,
     ownedLocks: 0,
     redisDependencyResolved: false,
+    redisLockIoAvailable: false,
     runningTasks: 0,
     totalTasks: 0,
     ...overrides,
@@ -30,6 +31,7 @@ describe('createCronPlatformStatusSnapshot', () => {
       lockRenewalFailures: 0,
       ownedLocks: 1,
       redisDependencyResolved: true,
+      redisLockIoAvailable: true,
       runningTasks: 1,
       totalTasks: 3,
     });
@@ -54,6 +56,7 @@ describe('createCronPlatformStatusSnapshot', () => {
       lockRenewalFailures: 1,
       ownedLocks: 0,
       redisDependencyResolved: true,
+      redisLockIoAvailable: true,
       runningTasks: 0,
       totalTasks: 1,
     });
@@ -92,6 +95,28 @@ describe('createCronPlatformStatusSnapshot', () => {
       reason: 'Distributed cron mode requires a ready Redis lock client.',
       status: 'not-ready',
     });
-    expect(snapshot.health).toEqual({ status: 'healthy' });
+    expect(snapshot.health).toEqual({
+      reason: 'Distributed cron Redis lock I/O is unavailable.',
+      status: 'unhealthy',
+    });
+  });
+
+  it('marks distributed cron not-ready and unhealthy when Redis lock I/O is unavailable', () => {
+    const snapshot = createCronPlatformStatusSnapshot(createCronInput({
+      distributedEnabled: true,
+      lifecycleState: 'ready',
+      redisDependencyResolved: true,
+      redisLockIoAvailable: false,
+    }));
+
+    expect(snapshot.readiness).toEqual({
+      critical: true,
+      reason: 'Distributed cron mode requires a ready Redis lock client.',
+      status: 'not-ready',
+    });
+    expect(snapshot.health).toEqual({
+      reason: 'Distributed cron Redis lock I/O is unavailable.',
+      status: 'unhealthy',
+    });
   });
 });

--- a/packages/cron/src/status.ts
+++ b/packages/cron/src/status.ts
@@ -14,6 +14,7 @@ export interface CronStatusAdapterInput {
   lockRenewalFailures: number;
   ownedLocks: number;
   redisDependencyResolved: boolean;
+  redisLockIoAvailable: boolean;
   runningTasks: number;
   totalTasks: number;
 }
@@ -28,7 +29,7 @@ export interface CronPlatformStatusSnapshot {
 
 function createReadiness(input: CronStatusAdapterInput): PlatformReadinessReport {
   if (input.lifecycleState === 'ready') {
-    if (input.distributedEnabled && !input.redisDependencyResolved) {
+    if (input.distributedEnabled && (!input.redisDependencyResolved || !input.redisLockIoAvailable)) {
       return {
         critical: true,
         reason: 'Distributed cron mode requires a ready Redis lock client.',
@@ -96,6 +97,13 @@ function createHealth(input: CronStatusAdapterInput): PlatformHealthReport {
     };
   }
 
+  if (input.distributedEnabled && (!input.redisDependencyResolved || !input.redisLockIoAvailable)) {
+    return {
+      reason: 'Distributed cron Redis lock I/O is unavailable.',
+      status: 'unhealthy',
+    };
+  }
+
   if (input.lockRenewalFailures > 0 || input.lockOwnershipLosses > 0) {
     return {
       reason: 'Distributed cron lock renewal reported recoverable failures.',
@@ -126,6 +134,7 @@ export function createCronPlatformStatusSnapshot(input: CronStatusAdapterInput):
       lockRenewalFailures: input.lockRenewalFailures,
       ownedLocks: input.ownedLocks,
       redisDependencyResolved: input.redisDependencyResolved,
+      redisLockIoAvailable: input.redisLockIoAvailable,
       runningTasks: input.runningTasks,
       totalTasks: input.totalTasks,
     },

--- a/packages/cron/src/status.ts
+++ b/packages/cron/src/status.ts
@@ -14,7 +14,7 @@ export interface CronStatusAdapterInput {
   lockRenewalFailures: number;
   ownedLocks: number;
   redisDependencyResolved: boolean;
-  redisLockIoAvailable: boolean;
+  redisLockIoAvailable?: boolean;
   runningTasks: number;
   totalTasks: number;
 }
@@ -28,8 +28,10 @@ export interface CronPlatformStatusSnapshot {
 }
 
 function createReadiness(input: CronStatusAdapterInput): PlatformReadinessReport {
+  const redisLockIoAvailable = resolveRedisLockIoAvailable(input);
+
   if (input.lifecycleState === 'ready') {
-    if (input.distributedEnabled && (!input.redisDependencyResolved || !input.redisLockIoAvailable)) {
+    if (input.distributedEnabled && (!input.redisDependencyResolved || !redisLockIoAvailable)) {
       return {
         critical: true,
         reason: 'Distributed cron mode requires a ready Redis lock client.',
@@ -83,6 +85,8 @@ function createReadiness(input: CronStatusAdapterInput): PlatformReadinessReport
 }
 
 function createHealth(input: CronStatusAdapterInput): PlatformHealthReport {
+  const redisLockIoAvailable = resolveRedisLockIoAvailable(input);
+
   if (input.lifecycleState === 'failed' || input.lifecycleState === 'stopped') {
     return {
       reason: 'Cron scheduler is unavailable.',
@@ -97,7 +101,7 @@ function createHealth(input: CronStatusAdapterInput): PlatformHealthReport {
     };
   }
 
-  if (input.distributedEnabled && (!input.redisDependencyResolved || !input.redisLockIoAvailable)) {
+  if (input.distributedEnabled && (!input.redisDependencyResolved || !redisLockIoAvailable)) {
     return {
       reason: 'Distributed cron Redis lock I/O is unavailable.',
       status: 'unhealthy',
@@ -116,6 +120,14 @@ function createHealth(input: CronStatusAdapterInput): PlatformHealthReport {
   };
 }
 
+function resolveRedisLockIoAvailable(input: CronStatusAdapterInput): boolean {
+  if (!input.distributedEnabled) {
+    return true;
+  }
+
+  return input.redisLockIoAvailable ?? input.redisDependencyResolved;
+}
+
 /**
  * Creates the cron platform snapshot consumed by status reporters.
  *
@@ -123,6 +135,8 @@ function createHealth(input: CronStatusAdapterInput): PlatformHealthReport {
  * @returns Readiness, health, ownership, and cron detail fields.
  */
 export function createCronPlatformStatusSnapshot(input: CronStatusAdapterInput): CronPlatformStatusSnapshot {
+  const redisLockIoAvailable = resolveRedisLockIoAvailable(input);
+
   return {
     details: {
       activeTicks: input.activeTicks,
@@ -134,7 +148,7 @@ export function createCronPlatformStatusSnapshot(input: CronStatusAdapterInput):
       lockRenewalFailures: input.lockRenewalFailures,
       ownedLocks: input.ownedLocks,
       redisDependencyResolved: input.redisDependencyResolved,
-      redisLockIoAvailable: input.redisLockIoAvailable,
+      redisLockIoAvailable,
       runningTasks: input.runningTasks,
       totalTasks: input.totalTasks,
     },


### PR DESCRIPTION
## Summary

Hardens @fluojs/cron distributed locking readiness and shutdown semantics.

Linked context: Closes #2198

## Changes

- Treat successful Redis lock I/O responses as available even when SET NX returns null due normal lock contention.
- Keep active distributed lock ownership during bounded shutdown timeouts and retry release after tasks settle.
- Add regression coverage for task failure release, dynamic registry cleanup/resume, rollback-safe rescheduling, and Redis lock I/O status recovery.
- Add a patch changeset for @fluojs/cron behavior changes.

## Testing

- LSP diagnostics on packages/cron/src: 0 errors
- pnpm --filter @fluojs/cron test: 64 passed
- pnpm --filter @fluojs/cron... build: passed
- pnpm --filter @fluojs/cron typecheck: passed
- Oracle read-only review: PASS after blocker fix

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform governance docs or package README alignment claims were changed.