### PR TITLE
Resolve #2214: align EmailChannel failure semantics for empty accepted receipts

### DIFF
--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -240,7 +240,7 @@ export class AppModule {}
 
 Behavioral contract 메모:
 
-- `EmailChannel`은 `pending` 또는 `rejected` 수신자가 하나라도 있으면 전달을 성공으로 보고하지 않고 notification dispatch를 실패로 처리합니다.
+- `EmailChannel`은 수락된 수신자가 0명인 경우(`accepted.length === 0`) 또는 `pending`/`rejected` 수신자가 하나라도 있으면 전달을 성공으로 보고하지 않고 notification dispatch를 실패로 처리합니다.
 - `EmailService.sendNotification(...)`은 렌더링된 template output을 payload 및 notification metadata와 병합합니다. payload 필드는 notification fallback보다 우선합니다.
 - Template rendering에는 notification `payload`, `metadata`, `locale`, `subject`, `template`이 전달되며, payload `text`, `html`과 notification `subject`가 렌더링된 fallback보다 우선합니다.
 

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -240,7 +240,7 @@ Supported notification payload fields:
 
 Behavioral contract notes:
 
-- `EmailChannel` treats any `pending` or `rejected` recipients as a failed notification dispatch instead of reporting the delivery as successful.
+- `EmailChannel` treats zero accepted recipients (`accepted.length === 0`) or any `pending`/`rejected` recipients as a failed notification dispatch instead of reporting the delivery as successful.
 - `EmailService.sendNotification(...)` merges rendered template output with payload and notification metadata; payload fields override notification fallbacks.
 - Template rendering receives notification `payload`, `metadata`, `locale`, `subject`, and `template`; payload `text`, `html`, and notification `subject` override rendered fallbacks.
 


### PR DESCRIPTION
## Summary

Clarify the @fluojs/email README notification integration contract so `EmailChannel` failure semantics explicitly include the zero accepted recipients case (`accepted.length === 0`) alongside existing `pending`/`rejected` recipient failures.

Linked context: Closes #2214

## Changes

- Updated `packages/email/README.md` to document zero accepted recipients as a failed `EmailChannel` notification dispatch.
- Updated `packages/email/README.ko.md` with the matching Korean wording to preserve EN/KO parity.
- Left the queue-backed worker note unchanged because it already documents zero accepted recipients and `pending`/`rejected` failures consistently.

## Testing

- `pnpm verify:platform-consistency-governance` — passed.
- `pnpm --filter @fluojs/email... build` — passed; built email package dependencies before package typechecking.
- `pnpm --filter @fluojs/email typecheck` — passed after dependency build artifacts were present.
- `pnpm --filter @fluojs/email test` — passed, 40 tests.
- Changed-file diagnostics for `packages/email/README.md` and `packages/email/README.ko.md` — no diagnostics found.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this is a docs-only wording alignment with existing implementation and queue documentation; it does not change runtime behavior, public API surface, package contents, or release metadata.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

Not applicable: no public exports or source TSDoc changed.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform contract docs or platform conformance claims changed.