### PR TITLE
Resolve #2185: harden Fastify adapter raw-body, request id, and native route coverage

### DIFF
--- a/.changeset/fastify-adapter-request-correlation.md
+++ b/.changeset/fastify-adapter-request-correlation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-fastify": patch
+---
+
+Harden Fastify request correlation and raw-body capture by honoring `x-correlation-id` as the request id fallback on native and wildcard paths, preserving raw-body byte chunks without UTF-8 re-encoding, and documenting direct multipart option configuration.

--- a/packages/platform-fastify/README.ko.md
+++ b/packages/platform-fastify/README.ko.md
@@ -149,7 +149,7 @@ fluo의 Fastify 어댑터는 높은 동시성 시나리오에서 raw Node.js 어
 
 ## 공개 API 개요
 
-- `createFastifyAdapter(options)`: Fastify 어댑터를 위한 권장 팩토리입니다.
+- `createFastifyAdapter(options, multipartOptions?)`: Fastify 어댑터를 위한 권장 팩토리입니다. 선택적 두 번째 인자는 직접 어댑터를 생성할 때 `maxFileSize`, `maxFiles`, `maxTotalSize` 같은 multipart 제한을 설정합니다.
 - `bootstrapFastifyApplication(module, options)`: 암시적 리스닝 없이 수행하는 고급 부트스트랩입니다.
 - `runFastifyApplication(module, options)`: 생명주기 관리를 포함한 빠른 시작 헬퍼입니다. timeout/실패 시에는 해당 상태를 로그와 `process.exitCode`로 보고하고, 최종 프로세스 종료는 주변 호스트에 맡깁니다.
 - `isFastifyMultipartTooLargeError(error)`: Fastify error shape 전반에서 multipart limit error를 감지합니다.

--- a/packages/platform-fastify/README.md
+++ b/packages/platform-fastify/README.md
@@ -149,7 +149,7 @@ The same file also covers Fastify-specific native route registration with wildca
 
 ## Public API Overview
 
-- `createFastifyAdapter(options)`: Recommended factory for the Fastify adapter.
+- `createFastifyAdapter(options, multipartOptions?)`: Recommended factory for the Fastify adapter. The optional second argument configures multipart limits such as `maxFileSize`, `maxFiles`, and `maxTotalSize` for direct adapter construction.
 - `bootstrapFastifyApplication(module, options)`: advanced bootstrap without implicit listening.
 - `runFastifyApplication(module, options)`: Quick-start helper with lifecycle management. On timeout/failure it reports the condition through logging and `process.exitCode`, while leaving final process termination to the surrounding host.
 - `isFastifyMultipartTooLargeError(error)`: Detects multipart limit errors across Fastify error shapes.

--- a/packages/platform-fastify/src/adapter.test.ts
+++ b/packages/platform-fastify/src/adapter.test.ts
@@ -1655,6 +1655,73 @@ describe('@fluojs/platform-fastify', () => {
     }
   });
 
+  it('rematches a native Fastify handoff when middleware rewrites the framework path', async () => {
+    const lifecycle: string[] = [];
+    const rewriteMiddleware = {
+      async handle(context: MiddlewareContext, next: () => Promise<void>) {
+        lifecycle.push(`middleware:${context.request.path}`);
+
+        if (context.request.path === '/rewrite-source/42') {
+          context.request.path = '/rewrite-target/42';
+          context.request.url = '/rewrite-target/42';
+        }
+
+        await next();
+      },
+    };
+
+    @Controller('/rewrite-source')
+    class RewriteSourceController {
+      @Get('/:id')
+      source(_input: undefined, context: RequestContext) {
+        return { id: context.request.params.id, route: 'source' };
+      }
+    }
+
+    @Controller('/rewrite-target')
+    class RewriteTargetController {
+      @Get('/:id')
+      target(_input: undefined, context: RequestContext) {
+        lifecycle.push(`target:${context.request.params.id}`);
+        return { id: context.request.params.id, path: context.request.path, route: 'target' };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      controllers: [RewriteSourceController, RewriteTargetController],
+    });
+
+    const port = await findAvailablePort();
+    const app = await fluoFactory.create(AppModule, {
+      adapter: createFastifyAdapter({ port }),
+      middleware: [rewriteMiddleware],
+    });
+
+    await app.listen();
+
+    try {
+      const response = await requestHttp({
+        method: 'GET',
+        path: '/rewrite-source/42',
+        port,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toEqual({
+        id: '42',
+        path: '/rewrite-target/42',
+        route: 'target',
+      });
+      expect(lifecycle).toEqual([
+        'middleware:/rewrite-source/42',
+        'target:42',
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('preserves request header passthrough on native and fallback dispatch paths', async () => {
     @Controller('/headers')
     class HeaderController {
@@ -1704,6 +1771,60 @@ describe('@fluojs/platform-fastify', () => {
       expect(JSON.parse(nativeResponse.body)).toEqual({ requestId: 'native-req' });
       expect(fallbackResponse.statusCode).toBe(200);
       expect(JSON.parse(fallbackResponse.body)).toEqual({ requestId: 'fallback-req' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('uses x-correlation-id as request id fallback on native and fallback dispatch paths', async () => {
+    @Controller('/correlation')
+    class CorrelationController {
+      @Get('/native')
+      getNative(_input: undefined, context: RequestContext) {
+        return {
+          requestId: context.request.requestId,
+        };
+      }
+
+      @All('/fallback')
+      getFallback(_input: undefined, context: RequestContext) {
+        return {
+          requestId: context.request.requestId,
+        };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [CorrelationController] });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapFastifyApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    try {
+      const [nativeResponse, fallbackResponse] = await Promise.all([
+        requestHttp({
+          headers: { 'x-correlation-id': 'native-correlation' },
+          method: 'GET',
+          path: '/correlation/native',
+          port,
+        }),
+        requestHttp({
+          headers: { 'x-correlation-id': 'fallback-correlation' },
+          method: 'PATCH',
+          path: '/correlation/fallback',
+          port,
+        }),
+      ]);
+
+      expect(nativeResponse.statusCode).toBe(200);
+      expect(JSON.parse(nativeResponse.body)).toEqual({ requestId: 'native-correlation' });
+      expect(fallbackResponse.statusCode).toBe(200);
+      expect(JSON.parse(fallbackResponse.body)).toEqual({ requestId: 'fallback-correlation' });
     } finally {
       await app.close();
     }

--- a/packages/platform-fastify/src/adapter.ts
+++ b/packages/platform-fastify/src/adapter.ts
@@ -389,7 +389,7 @@ function createNativeFastFrameworkRequest(
     query: readSimpleQueryRecord(request.query),
     queryFactory: () => parseQueryParamsFromSearch(urlParts.search),
     raw: request.raw,
-    requestId: resolvePrimaryRequestIdFromHeaders(request.raw.headers),
+    requestId: resolveRequestIdFromHeaders(request.raw.headers),
     signal: lazySignal.signal,
     url: urlParts.path + urlParts.search,
   }) as FastifyFrameworkRequest;
@@ -874,7 +874,7 @@ function createDeferredFrameworkRequest(
     query: querySnapshot,
     queryFactory: () => parseQueryParamsFromSearch(urlParts.search),
     raw: request.raw,
-    requestId: resolvePrimaryRequestIdFromHeaders(headerSnapshot),
+    requestId: resolveRequestIdFromHeaders(headerSnapshot),
     signal,
     url: urlParts.path + urlParts.search,
   }) as FastifyFrameworkRequest;
@@ -1111,11 +1111,6 @@ function resolveRequestIdFromHeaders(headers: IncomingHttpHeaders): string | und
   return Array.isArray(requestId) ? requestId[0] : requestId;
 }
 
-function resolvePrimaryRequestIdFromHeaders(headers: IncomingHttpHeaders): string | undefined {
-  const requestId = headers['x-request-id'];
-  return Array.isArray(requestId) ? requestId[0] : requestId;
-}
-
 function createFastifyApp(
   httpsOptions: HttpsServerOptions | undefined,
   maxBodySize: number,
@@ -1157,12 +1152,15 @@ function captureRawBodyPreParsingHook(
 
   const chunks: Buffer[] = [];
   const capture = new Transform({
-    transform(chunk, _encoding, callback) {
-      const bufferChunk = Buffer.isBuffer(chunk)
-        ? chunk
-        : chunk instanceof Uint8Array
-          ? Buffer.from(chunk)
-          : Buffer.from(String(chunk), 'utf8');
+    transform(chunk, encoding, callback) {
+      let bufferChunk: Buffer;
+
+      try {
+        bufferChunk = createRawBodyBufferChunk(chunk, encoding);
+      } catch (error: unknown) {
+        callback(error instanceof Error ? error : new Error(String(error)));
+        return;
+      }
 
       chunks.push(bufferChunk);
       capture.receivedEncodedLength += bufferChunk.byteLength;
@@ -1184,6 +1182,22 @@ function captureRawBodyPreParsingHook(
 
   payload.pipe(capture);
   done(null, capture);
+}
+
+function createRawBodyBufferChunk(chunk: unknown, encoding: BufferEncoding): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    return chunk;
+  }
+
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  }
+
+  if (typeof chunk === 'string') {
+    return Buffer.from(chunk, encoding);
+  }
+
+  throw new TypeError(`Fastify raw-body capture received unsupported ${typeof chunk} stream chunk.`);
 }
 
 function isMultipartRequestContentType(contentType: string | string[] | undefined): boolean {


### PR DESCRIPTION
## Summary

Harden the Fastify platform adapter contract for raw-body byte preservation, request correlation fallback, and native route rematch coverage.

Linked context: Closes #2185

## Changes

- Use `x-correlation-id` as the request id fallback for Fastify native and wildcard request wrappers, matching error serialization fallback behavior.
- Preserve raw-body capture from byte chunks without UTF-8 string coercion, while rejecting unsupported stream chunk shapes explicitly.
- Add Fastify regression coverage for native handoff rematching after middleware path rewrites and request id fallback on native/fallback dispatch paths.
- Clarify `createFastifyAdapter(options, multipartOptions?)` in EN/KO package README docs and add a patch changeset for `@fluojs/platform-fastify`.

## Testing

- `pnpm build` ✅
- `pnpm --dir packages/platform-fastify typecheck` ✅
- `pnpm --dir packages/platform-fastify test` ✅ (`52 tests`)
- Changed-file diagnostics: `packages/platform-fastify/src/adapter.ts` ✅, `packages/platform-fastify/src/adapter.test.ts` ✅

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/fastify-adapter-request-correlation.md`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new public exports were added. README public API wording now documents the existing `multipartOptions` factory argument.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The adapter now consistently honors `x-correlation-id` fallback and keeps native handoff stale-rematch behavior covered in `packages/platform-fastify/src/adapter.test.ts`.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

Changed package README mirrors stayed aligned. Platform portability evidence includes the existing Fastify portability harness tests plus focused adapter regression tests.

## Remaining risks

- Full `pnpm verify` was not run; closest package verifier, package test suite, package typecheck, and workspace build passed.
- Existing repository/default-branch dependency vulnerability notice from GitHub is unrelated to this PR.