### PR TITLE
Resolve #2188: tighten Deno adapter signal, websocket, and docs contracts

### DIFF
--- a/.changeset/strong-pumas-wait.md
+++ b/.changeset/strong-pumas-wait.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/platform-deno": patch
+---
+
+Roll back already registered Deno shutdown signal listeners when later signal registration fails, and document the tightened Deno lifecycle and websocket fallback contracts.

--- a/book/intermediate/ch23-deno.ko.md
+++ b/book/intermediate/ch23-deno.ko.md
@@ -113,6 +113,25 @@ export class RealtimeModule {}
 
 게이트웨이 반환값은 WebSocket dispatcher에서 무시됩니다. 위 예시처럼 handler에 전달되는 런타임 socket을 통해 명시적으로 응답을 전송하세요.
 
+`DenoWebSocketModule.forRoot()`를 설정하지 않았다면 `Upgrade: websocket`을 포함한 HTTP 요청도 암묵적으로 upgrade되지 않습니다. 해당 요청은 일반 HTTP dispatch 경로를 계속 따르므로, gateway 활성화는 명시적인 opt-in으로 유지되고 애플리케이션이 Deno websocket binding을 선택하기 전에 플랫폼 네이티브 websocket 동작이 나타나지 않습니다.
+
+### 23.4.1 HTTPS, host alias, shutdown signal
+
+Deno 어댑터는 Deno 네이티브 `hostname`과 이식성 alias인 `host`를 모두 허용합니다. 둘 다 설정하면 `Deno.serve(...)` bind target과 fluo가 보고하는 listen URL에는 `hostname`이 우선합니다. Deno process가 HTTPS startup을 소유해야 한다면 TLS 자료를 `https` option으로 전달하세요.
+
+```typescript
+await runDenoApplication(AppModule, {
+  hostname: '127.0.0.1',
+  https: {
+    cert: await Deno.readTextFile('./cert.pem'),
+    key: await Deno.readTextFile('./key.pem'),
+  },
+  port: 3443,
+});
+```
+
+`runDenoApplication(...)`은 Deno signal API를 사용할 수 있을 때 기본적으로 `SIGINT`와 `SIGTERM` listener를 등록합니다. Host가 process signal을 직접 소유한다면 `shutdownSignals: false`를 사용하고, 배포 profile이 더 좁은 lifecycle contract를 요구한다면 custom signal list를 전달하세요. 한 signal listener를 이미 연결한 뒤 다음 signal 등록이 실패하면 fluo는 실패를 전달하기 전에 앞서 연결한 listener를 제거합니다. Close 중에는 새 유입을 중단하고 active handler가 최대 10초 동안 drain되도록 기다린 다음, shutdown이 아직 끝나지 않았으면 underlying Deno serve signal을 abort합니다.
+
 ## 23.5 Handling Deno Permissions in FluoShop
 
 Deno에서 마이크로서비스를 구축할 때는 최소 권한의 원칙을 따라야 합니다. 광범위한 플래그 대신 구체적인 권한을 지정하세요.
@@ -157,15 +176,21 @@ Deno 네이티브한 저장소가 필요하다면 Deno의 내장 KV 저장소를
 ```typescript
 import { OnModuleInit } from '@fluojs/runtime';
 
+declare const Deno: {
+  openKv(): Promise<{
+    set(key: string[], value: unknown): Promise<void>;
+    get(key: string[]): Promise<{ value: unknown }>;
+  }>;
+};
+
 export class CacheService implements OnModuleInit {
-  private kv: any; // Deno.Kv 타입
+  private kv!: Awaited<ReturnType<typeof Deno.openKv>>;
 
   async onModuleInit() {
-    // @ts-ignore: Deno 전역 객체
     this.kv = await Deno.openKv();
   }
 
-  async set(key: string, value: any) {
+  async set(key: string, value: unknown) {
     await this.kv.set([key], value);
   }
 

--- a/book/intermediate/ch23-deno.md
+++ b/book/intermediate/ch23-deno.md
@@ -113,6 +113,25 @@ export class RealtimeModule {}
 
 Gateway return values are ignored by the WebSocket dispatcher. Send replies explicitly through the runtime socket passed to the handler, as shown above.
 
+If `DenoWebSocketModule.forRoot()` is not configured, an HTTP request that carries `Upgrade: websocket` is not upgraded implicitly. It continues through normal HTTP dispatch, which keeps gateway activation explicit and prevents platform-native websocket behavior from appearing before the application opts into the Deno websocket binding.
+
+### 23.4.1 HTTPS, host aliases, and shutdown signals
+
+The Deno adapter accepts Deno-native `hostname` and a portable `host` alias. When both are set, `hostname` wins for the `Deno.serve(...)` bind target and the listen URL reported by fluo. Pass TLS material through the `https` option when the Deno process should own HTTPS startup:
+
+```typescript
+await runDenoApplication(AppModule, {
+  hostname: '127.0.0.1',
+  https: {
+    cert: await Deno.readTextFile('./cert.pem'),
+    key: await Deno.readTextFile('./key.pem'),
+  },
+  port: 3443,
+});
+```
+
+`runDenoApplication(...)` registers `SIGINT` and `SIGTERM` listeners by default when the Deno signal APIs are available. Use `shutdownSignals: false` for hosts that own process signals themselves, or pass a custom signal list when a deployment profile needs a narrower lifecycle contract. If one signal registration fails after another listener was already attached, fluo removes the earlier listener before surfacing the failure. During close, the adapter stops new ingress, lets active handlers drain for up to 10 seconds, and then aborts the underlying Deno serve signal if shutdown has not settled.
+
 ## 23.5 Handling Deno Permissions in FluoShop
 
 When building microservices on Deno, follow the principle of least privilege. Specify concrete permissions instead of broad flags.

--- a/packages/platform-deno/README.ko.md
+++ b/packages/platform-deno/README.ko.md
@@ -49,6 +49,7 @@ await runDenoApplication(AppModule, {
 테스트나 커스텀 `Deno.serve` 구현을 위해 어댑터의 `handle` 메서드를 사용하여 네이티브 웹 요청을 수동으로 디스패치할 수 있습니다. 다만 `handle(...)`은 런타임 dispatcher가 바인딩된 뒤에만 동작하므로, 먼저 `app.listen()`(또는 `runDenoApplication(...)`)으로 부트스트랩을 완료해야 합니다.
 
 ```typescript
+import { createDenoAdapter } from '@fluojs/platform-deno';
 import { fluoFactory } from '@fluojs/runtime';
 
 const adapter = createDenoAdapter({ port: 3000 });
@@ -94,11 +95,11 @@ await runDenoApplication(AppModule, {
 
 `hostname`은 Deno 네이티브 옵션 이름으로 유지됩니다. 공유 HTTP 어댑터 테스트와 교차 런타임 설정 헬퍼를 위해 `host`도 이식성 alias로 허용하며, 둘 다 제공하면 `Deno.serve(...)` bind target과 보고되는 listen URL에는 `hostname`이 우선합니다.
 
-Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve`, `upgradeWebSocket` seam, `rawBody`, `maxBodySize`, `multipart`, `shutdownSignals`가 포함됩니다. Seam을 주입하지 않으면 어댑터는 listen/upgrade 시점에 `globalThis.Deno.serve`와 `globalThis.Deno.upgradeWebSocket`으로 fallback합니다. `runDenoApplication(...)`은 기본적으로 `SIGINT`/`SIGTERM`을 연결하고, `shutdownSignals: false`는 signal registration을 끕니다. Close는 Deno serve signal을 abort하기 전에 active request drain을 최대 10초 기다립니다. `handle(...)`은 `listen()`이 dispatcher를 bind하기 전에는 JSON `500`, shutdown 진행 중에는 JSON `503`을 반환합니다.
+Advanced option에는 test 또는 non-hosted runtime을 위한 injectable `serve`, `upgradeWebSocket` seam, `rawBody`, `maxBodySize`, `multipart`, `shutdownSignals`가 포함됩니다. Seam을 주입하지 않으면 어댑터는 listen/upgrade 시점에 `globalThis.Deno.serve`와 `globalThis.Deno.upgradeWebSocket`으로 fallback합니다. `runDenoApplication(...)`은 기본적으로 `SIGINT`/`SIGTERM`을 연결하고, `shutdownSignals: false`는 signal registration을 끄며, 여러 signal을 등록하다 실패하면 이미 연결한 listener를 rollback합니다. Close는 Deno serve signal을 abort하기 전에 active request drain을 최대 10초 기다립니다. `handle(...)`은 `listen()`이 dispatcher를 bind하기 전에는 JSON `500`, shutdown 진행 중에는 JSON `503`을 반환합니다.
 
 ## Conformance 커버리지
 
-`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, HTTPS startup forwarding, `host` alias 및 `hostname` 우선순위 listen-target handling, `SIGINT`/`SIGTERM` signal listener 등록과 정리, websocket upgrade binding, global Deno serve/upgrade fallback seam, listen 전 `500` 처리, shutdown 중 `503` 처리, serve-signal abort 전 in-flight request drain, bounded 10초 close timeout을 검증합니다.
+`packages/platform-deno/src/adapter.test.ts`는 문서화된 Deno 계약을 검증하는 package-local regression 대상입니다. 이 파일은 shared Web dispatch delegation, HTTPS startup forwarding, `host` alias 및 `hostname` 우선순위 listen-target handling, 기본 `SIGINT`/`SIGTERM` signal listener 등록, `shutdownSignals: false`, partial signal-registration failure 이후 listener rollback, websocket upgrade binding 및 no-binding HTTP fallback, global Deno serve/upgrade fallback seam, listen 전 `500` 처리, shutdown 중 `503` 처리, serve-signal abort 전 in-flight request drain, bounded 10초 close timeout을 검증합니다.
 
 공유 edge portability suite인 `packages/testing/src/portability/web-runtime-adapter-portability.test.ts`는 Deno를 Bun 및 Cloudflare Workers와 함께 실행해 malformed cookie 보존, query decoding, JSON/text raw-body capture, multipart raw-body 제외, SSE framing을 검증합니다. 패키지 테스트의 README parity assertion은 이 edge-runtime 커버리지 문서가 한국어 mirror와 계속 동기화되도록 확인합니다.
 

--- a/packages/platform-deno/README.md
+++ b/packages/platform-deno/README.md
@@ -49,6 +49,7 @@ await runDenoApplication(AppModule, {
 For testing or custom `Deno.serve` implementations, you can use the adapter's `handle` method to dispatch native web requests manually. Bind the dispatcher first via `app.listen()` (or `runDenoApplication(...)`), because `handle(...)` only works after the runtime has been bootstrapped.
 
 ```typescript
+import { createDenoAdapter } from '@fluojs/platform-deno';
 import { fluoFactory } from '@fluojs/runtime';
 
 const adapter = createDenoAdapter({ port: 3000 });
@@ -94,11 +95,11 @@ await runDenoApplication(AppModule, {
 
 `hostname` remains the Deno-native option name. The adapter also accepts `host` as a portability alias for shared HTTP adapter tests and cross-runtime configuration helpers; when both are provided, `hostname` wins for the `Deno.serve(...)` bind target and reported listen URL.
 
-Advanced options include injectable `serve` and `upgradeWebSocket` seams for tests or non-hosted runtimes, `rawBody`, `maxBodySize`, `multipart`, and `shutdownSignals`. When a seam is not injected, the adapter falls back to `globalThis.Deno.serve` and `globalThis.Deno.upgradeWebSocket` at listen/upgrade time. `runDenoApplication(...)` wires `SIGINT`/`SIGTERM` by default, `shutdownSignals: false` disables signal registration, and close waits up to 10 seconds for active requests to drain before aborting the Deno serve signal. `handle(...)` returns a JSON `500` before `listen()` binds the dispatcher and a JSON `503` while shutdown is in progress.
+Advanced options include injectable `serve` and `upgradeWebSocket` seams for tests or non-hosted runtimes, `rawBody`, `maxBodySize`, `multipart`, and `shutdownSignals`. When a seam is not injected, the adapter falls back to `globalThis.Deno.serve` and `globalThis.Deno.upgradeWebSocket` at listen/upgrade time. `runDenoApplication(...)` wires `SIGINT`/`SIGTERM` by default, `shutdownSignals: false` disables signal registration, and failed multi-signal registration rolls back listeners that were already attached. Close waits up to 10 seconds for active requests to drain before aborting the Deno serve signal. `handle(...)` returns a JSON `500` before `listen()` binds the dispatcher and a JSON `503` while shutdown is in progress.
 
 ## Conformance Coverage
 
-`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, HTTPS startup forwarding, `host` alias and `hostname` precedence listen-target handling, `SIGINT`/`SIGTERM` signal listener registration and cleanup, websocket upgrade binding, global Deno serve/upgrade fallback seams, pre-listen `500` handling, shutdown `503` handling, in-flight request drain before serve-signal abort, and the bounded 10-second close timeout.
+`packages/platform-deno/src/adapter.test.ts` is the package-local regression target for the documented Deno contract. It covers shared Web dispatch delegation, HTTPS startup forwarding, `host` alias and `hostname` precedence listen-target handling, default `SIGINT`/`SIGTERM` signal listener registration, `shutdownSignals: false`, listener rollback after partial signal-registration failure, websocket upgrade binding and no-binding HTTP fallback, global Deno serve/upgrade fallback seams, pre-listen `500` handling, shutdown `503` handling, in-flight request drain before serve-signal abort, and the bounded 10-second close timeout.
 
 The shared edge portability suite in `packages/testing/src/portability/web-runtime-adapter-portability.test.ts` exercises Deno beside Bun and Cloudflare Workers for malformed cookie preservation, query decoding, JSON/text raw-body capture, multipart raw-body exclusion, and SSE framing. The README parity assertion in the package test keeps these documented edge-runtime coverage claims synchronized with the Korean mirror.
 

--- a/packages/platform-deno/src/adapter.test.ts
+++ b/packages/platform-deno/src/adapter.test.ts
@@ -220,10 +220,14 @@ function createUpgradeWebSocketStub() {
   };
 }
 
-function installDenoSignalMock() {
+function installDenoSignalMock(options: { throwOnAdd?: string } = {}) {
   const originalDeno = (globalThis as typeof globalThis & { Deno?: unknown }).Deno;
   const listeners = new Map<string, () => void>();
   const addSignalListener = vi.fn((signal: string, handler: () => void) => {
+    if (signal === options.throwOnAdd) {
+      throw new Error(`failed to register ${signal}`);
+    }
+
     listeners.set(signal, handler);
   });
   const removeSignalListener = vi.fn((signal: string, handler: () => void) => {
@@ -630,6 +634,73 @@ describe('@fluojs/platform-deno', () => {
     }
   });
 
+  it('registers default Deno shutdown signals through the run helper', async () => {
+    const signals = installDenoSignalMock();
+
+    try {
+      class AppModule {}
+      defineModule(AppModule, {});
+
+      const server = createServeStub();
+      const app = await runDenoApplication(AppModule, {
+        serve: server.serve,
+      });
+
+      expect(signals.addSignalListener).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+      expect(signals.addSignalListener).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+
+      await app.close();
+
+      expect(signals.removeSignalListener).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+      expect(signals.removeSignalListener).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+    } finally {
+      signals.restore();
+    }
+  });
+
+  it('skips Deno shutdown signal registration when shutdownSignals is false', async () => {
+    const signals = installDenoSignalMock();
+
+    try {
+      class AppModule {}
+      defineModule(AppModule, {});
+
+      const server = createServeStub();
+      const app = await runDenoApplication(AppModule, {
+        serve: server.serve,
+        shutdownSignals: false,
+      });
+
+      expect(signals.addSignalListener).not.toHaveBeenCalled();
+      await app.close();
+      expect(signals.removeSignalListener).not.toHaveBeenCalled();
+    } finally {
+      signals.restore();
+    }
+  });
+
+  it('rolls back already registered Deno signal listeners when later registration fails', async () => {
+    const signals = installDenoSignalMock({ throwOnAdd: 'SIGTERM' });
+
+    try {
+      class AppModule {}
+      defineModule(AppModule, {});
+
+      const server = createServeStub();
+
+      await expect(runDenoApplication(AppModule, {
+        serve: server.serve,
+      })).rejects.toThrow(/failed to register SIGTERM/);
+
+      expect(signals.addSignalListener).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+      expect(signals.addSignalListener).toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+      expect(signals.removeSignalListener).toHaveBeenCalledWith('SIGINT', expect.any(Function));
+      expect(signals.removeSignalListener).not.toHaveBeenCalledWith('SIGTERM', expect.any(Function));
+    } finally {
+      signals.restore();
+    }
+  });
+
   it('closes the Deno application when a registered shutdown signal fires', async () => {
     const signals = installDenoSignalMock();
 
@@ -1019,6 +1090,34 @@ describe('@fluojs/platform-deno', () => {
     expect(bindingFetch).toHaveBeenCalledTimes(1);
     expect(upgraded.upgrade).toHaveBeenCalledTimes(1);
     expect(httpResponse?.status).toBe(200);
+  });
+
+  it('keeps websocket upgrade requests on HTTP dispatch when no Deno websocket binding is configured', async () => {
+    const server = createServeStub();
+    const upgraded = createUpgradeWebSocketStub();
+    const adapter = new DenoHttpApplicationAdapter({
+      hostname: '0.0.0.0',
+      port: 3000,
+      serve: server.serve,
+      upgradeWebSocket: upgraded.upgrade,
+    });
+    const dispatcher = {
+      dispatch: vi.fn(async (_request: FrameworkRequest, response: FrameworkResponse) => {
+        response.setStatus(204);
+      }),
+    };
+
+    await adapter.listen(dispatcher);
+
+    const response = await server.handler?.(new Request('https://runtime.test/chat', {
+      headers: { upgrade: 'websocket' },
+    }));
+
+    expect(response?.status).toBe(204);
+    expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
+    expect(upgraded.upgrade).not.toHaveBeenCalled();
+
+    await adapter.close();
   });
 
   it('falls back to global Deno.upgradeWebSocket for configured websocket bindings', async () => {

--- a/packages/platform-deno/src/adapter.ts
+++ b/packages/platform-deno/src/adapter.ts
@@ -376,26 +376,40 @@ function createDenoShutdownSignalRegistration(
     const bindings: Array<{ handler: () => void; signal: DenoApplicationSignal }> = [];
     const seen = new Set<DenoApplicationSignal>();
 
-    for (const signal of signals) {
-      if (seen.has(signal)) {
-        continue;
+    try {
+      for (const signal of signals) {
+        if (seen.has(signal)) {
+          continue;
+        }
+
+        seen.add(signal);
+        const handler = () => {
+          void closeDenoApplicationFromSignal(app, logger, signal);
+        };
+
+        denoGlobal.addSignalListener(signal, handler);
+        bindings.push({ handler, signal });
       }
-
-      seen.add(signal);
-      const handler = () => {
-        void closeDenoApplicationFromSignal(app, logger, signal);
-      };
-
-      bindings.push({ handler, signal });
-      denoGlobal.addSignalListener(signal, handler);
+    } catch (error: unknown) {
+      removeDenoSignalBindings(denoGlobal, bindings);
+      throw error;
     }
 
     return () => {
-      for (const binding of bindings) {
-        denoGlobal.removeSignalListener(binding.signal, binding.handler);
-      }
+      removeDenoSignalBindings(denoGlobal, bindings);
     };
   };
+}
+
+function removeDenoSignalBindings(
+  denoGlobal: {
+    removeSignalListener: (signal: DenoApplicationSignal, handler: () => void) => void;
+  },
+  bindings: readonly { handler: () => void; signal: DenoApplicationSignal }[],
+): void {
+  for (const binding of bindings) {
+    denoGlobal.removeSignalListener(binding.signal, binding.handler);
+  }
 }
 
 function createListenTarget(hostname: string, port: number, usesHttps: boolean): HttpAdapterListenTarget {


### PR DESCRIPTION
## Summary

Tighten the Deno adapter lifecycle, websocket fallback, and documentation contracts from the package audit.

Linked context: Closes #2188

## Changes

- Roll back already registered Deno shutdown signal listeners if a later signal registration fails.
- Add Deno adapter regressions for default SIGINT/SIGTERM registration, shutdownSignals: false, partial signal-registration rollback, and websocket upgrade no-binding HTTP fallback.
- Align @fluojs/platform-deno README EN/KO examples and coverage claims.
- Expand Deno book EN/KO companion guidance for websocket opt-in fallback, HTTPS, host/hostname precedence, shutdown signals, and Deno KV typing parity.
- Add a patch changeset for @fluojs/platform-deno.

## Testing

- lsp_diagnostics on changed source/book files: passed after worktree dependency setup.
- pnpm --filter @fluojs/platform-deno... build: passed.
- pnpm --filter @fluojs/platform-deno typecheck: passed.
- pnpm --filter @fluojs/platform-deno test: passed (31 tests).
- pnpm verify:platform-consistency-governance: passed.
- GIT_MASTER=1 git diff --check: passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: .changeset/strong-pumas-wait.md for @fluojs/platform-deno.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

No public export surface was added or renamed; existing TSDoc remains intact.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The Deno signal rollback behavior is covered by package-local tests, and websocket upgrade remains explicit unless the Deno websocket binding is configured.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.

Changed EN/KO package README and book companion pages together. Governance verifier passed; package tests back the README coverage claims.