### PR TITLE
Resolve #2183: restore package changelog Unreleased sections

### DIFF
--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/http
 
+## [Unreleased]
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/platform-bun/CHANGELOG.md
+++ b/packages/platform-bun/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/platform-bun
 
+## [Unreleased]
+
 ## 1.0.6
 
 ### Patch Changes

--- a/packages/platform-cloudflare-workers/CHANGELOG.md
+++ b/packages/platform-cloudflare-workers/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/platform-cloudflare-workers
 
+## [Unreleased]
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/platform-deno/CHANGELOG.md
+++ b/packages/platform-deno/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/platform-deno
 
+## [Unreleased]
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/platform-express/CHANGELOG.md
+++ b/packages/platform-express/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/platform-express
 
+## [Unreleased]
+
 ## 1.0.6
 
 ### Patch Changes

--- a/packages/platform-fastify/CHANGELOG.md
+++ b/packages/platform-fastify/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/platform-fastify
 
+## [Unreleased]
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/platform-nodejs/CHANGELOG.md
+++ b/packages/platform-nodejs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/platform-nodejs
 
+## [Unreleased]
+
 ## 1.0.5
 
 ### Patch Changes


### PR DESCRIPTION
## Summary

Restore the required `## [Unreleased]` changelog section for the public HTTP runtime packages identified in the release-governance audit.

Linked context: Closes #2183

## Changes

- Added an empty `## [Unreleased]` section at the top of `packages/http/CHANGELOG.md`.
- Added the same generated changelog shape marker for Node-backed adapters: Fastify, Node.js, and Express.
- Added the same generated changelog shape marker for fetch/edge adapters: Bun, Deno, and Cloudflare Workers.
- Preserved all existing released entries and release history exactly as-is.

## Testing

- `pnpm verify:release-readiness`
- LSP diagnostics on all changed `CHANGELOG.md` files: no diagnostics found.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this is a changelog-shape-only documentation artifact cleanup: it restores the required `## [Unreleased]` placeholders without changing public package behavior, API surface, package contents, or semver release metadata.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

해당 없음 — source files and public exports were not changed.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

No runtime behavior or documented package contract changed; this PR only restores the changelog structure required by release governance.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

해당 없음 — governance docs and package README conformance claims were not changed. The affected package changelogs now match `docs/contracts/release-governance.md` requirement that stable package changelogs keep a `## [Unreleased]` section.
