### PR TITLE
Resolve #2208: preserve notifications lifecycle and queue integrity

### DIFF
--- a/.changeset/fresh-wolves-promise.md
+++ b/.changeset/fresh-wolves-promise.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/notifications": patch
+---
+
+Preserve lifecycle publication failure ordering, reject malformed bulk queue adapter results, and keep deterministic notification IDs distinct for Date, Map, and Set payload values.

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -1248,8 +1248,12 @@ describe('NotificationsModule', () => {
     await service.dispatch({ channel: 'email', payload: { tags: new Set(['three', 'two']) } }, { queue: true });
     await service.dispatch({ channel: 'email', payload: { attributes: new Map([['tier', 'gold']]) } }, { queue: true });
     await service.dispatch({ channel: 'email', payload: { attributes: new Map([['tier', 'silver']]) } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { callbackUrl: new URL('https://example.com/orders/one') } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { callbackUrl: new URL('https://example.com/orders/two') } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { segmentPattern: /vip-.+/i } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { segmentPattern: /trial-.+/i } }, { queue: true });
 
-    expect(new Set(queue.jobs.map((job) => job.id)).size).toBe(6);
+    expect(new Set(queue.jobs.map((job) => job.id)).size).toBe(10);
   });
 
   it('captures missing-channel failures during tolerant bulk dispatch', async () => {

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -65,6 +65,22 @@ class RecordingQueueAdapter implements NotificationsQueueAdapter {
   }
 }
 
+class MalformedEnqueueManyQueueAdapter implements NotificationsQueueAdapter {
+  readonly jobs: NotificationsQueueJob[] = [];
+
+  constructor(private readonly result: unknown) {}
+
+  async enqueue(job: NotificationsQueueJob): Promise<string> {
+    this.jobs.push(job);
+    return `queued:${this.jobs.length}`;
+  }
+
+  async enqueueMany(jobs: readonly NotificationsQueueJob[]): Promise<readonly string[]> {
+    this.jobs.push(...jobs);
+    return this.result as readonly string[];
+  }
+}
+
 class EnqueueOnlyQueueAdapter implements NotificationsQueueAdapter {
   readonly jobs: NotificationsQueueJob[] = [];
 
@@ -421,6 +437,55 @@ describe('NotificationsModule', () => {
     ]);
   });
 
+  it('preserves requested lifecycle publication failures when a later direct dispatch fails', async () => {
+    const publisher = new RecordingPublisher();
+    publisher.failOnNames.add('notification.dispatch.requested');
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('channel delivery failed after requested publication failed');
+          },
+        },
+      ],
+      events: {
+        publisher,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+    const dispatch = service.dispatch({ channel: 'email', payload: { template: 'broken-requested' } });
+
+    await expect(dispatch).rejects.toBeInstanceOf(AggregateError);
+    await expect(dispatch).rejects.toThrow(
+      'Notification dispatch failed, and failed lifecycle event publication also failed: channel delivery failed after requested publication failed',
+    );
+
+    try {
+      await dispatch;
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      expect((error as AggregateError).errors).toHaveLength(2);
+      expect((error as AggregateError).errors[0]).toMatchObject({
+        message: 'channel delivery failed after requested publication failed',
+      });
+      expect((error as AggregateError).errors[1]).toMatchObject({
+        message: 'publisher failed:notification.dispatch.requested',
+      });
+    }
+
+    expect(publisher.events).toMatchObject([
+      {
+        channel: 'email',
+        error: { message: 'channel delivery failed after requested publication failed', name: 'Error' },
+        name: 'notification.dispatch.failed',
+      },
+    ]);
+  });
+
   it('validates channels before queueing a single explicit queue dispatch', async () => {
     const queue = new RecordingQueueAdapter();
     const publisher = new RecordingPublisher();
@@ -573,6 +638,76 @@ describe('NotificationsModule', () => {
         name: 'notification.dispatch.queued',
       },
     ]);
+  });
+
+  it('rejects malformed enqueueMany results without fabricating queued successes', async () => {
+    const queue = new MalformedEnqueueManyQueueAdapter(['queued:1']);
+    const publisher = new RecordingPublisher();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not be used for queued bulk dispatch');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+      events: {
+        publisher,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await expect(
+      service.dispatchMany([
+        { channel: 'email', payload: { template: 'digest', userId: 'u1' } },
+        { channel: 'email', payload: { template: 'digest', userId: 'u2' } },
+      ]),
+    ).rejects.toThrow('Notifications queue adapter returned an invalid enqueueMany() result: expected 2 queue ids but received 1.');
+
+    expect(queue.jobs).toHaveLength(2);
+    expect(publisher.events.map((event) => event.name)).toEqual([
+      'notification.dispatch.requested',
+      'notification.dispatch.requested',
+      'notification.dispatch.failed',
+      'notification.dispatch.failed',
+    ]);
+  });
+
+  it('rejects empty enqueueMany ids without substituting fallback delivery ids', async () => {
+    const queue = new MalformedEnqueueManyQueueAdapter(['queued:1', '']);
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not be used for queued bulk dispatch');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await expect(
+      service.dispatchMany([
+        { channel: 'email', payload: { template: 'digest', userId: 'u1' } },
+        { channel: 'email', payload: { template: 'digest', userId: 'u2' } },
+      ]),
+    ).rejects.toThrow('Notifications queue adapter returned an invalid enqueueMany() result: queue id at index 1 must be a non-empty string.');
   });
 
   it('falls back to per-job enqueue calls when the queue adapter omits enqueueMany', async () => {
@@ -1084,6 +1219,37 @@ describe('NotificationsModule', () => {
     expect(first.deliveryId).toMatch(/^fallback:email:/);
     expect(repeated.deliveryId).toBe(first.deliveryId);
     expect(different.deliveryId).not.toBe(first.deliveryId);
+  });
+
+  it('keeps deterministic ids distinct for non-plain payload values', async () => {
+    const queue = new RecordingQueueAdapter();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not run when queue is explicitly requested');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 50,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await service.dispatch({ channel: 'email', payload: { scheduledAt: new Date('2026-01-01T00:00:00.000Z') } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { scheduledAt: new Date('2026-01-02T00:00:00.000Z') } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { tags: new Set(['one', 'two']) } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { tags: new Set(['three', 'two']) } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { attributes: new Map([['tier', 'gold']]) } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { attributes: new Map([['tier', 'silver']]) } }, { queue: true });
+
+    expect(new Set(queue.jobs.map((job) => job.id)).size).toBe(6);
   });
 
   it('captures missing-channel failures during tolerant bulk dispatch', async () => {

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -710,6 +710,35 @@ describe('NotificationsModule', () => {
     ).rejects.toThrow('Notifications queue adapter returned an invalid enqueueMany() result: queue id at index 1 must be a non-empty string.');
   });
 
+  it('rejects sparse enqueueMany results without substituting fallback delivery ids', async () => {
+    const queue = new MalformedEnqueueManyQueueAdapter(new Array<string>(2));
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not be used for queued bulk dispatch');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await expect(
+      service.dispatchMany([
+        { channel: 'email', payload: { template: 'digest', userId: 'u1' } },
+        { channel: 'email', payload: { template: 'digest', userId: 'u2' } },
+      ]),
+    ).rejects.toThrow('Notifications queue adapter returned an invalid enqueueMany() result: queue id at index 0 must be present.');
+  });
+
   it('falls back to per-job enqueue calls when the queue adapter omits enqueueMany', async () => {
     const queue = new EnqueueOnlyQueueAdapter();
     const publisher = new RecordingPublisher();
@@ -1250,10 +1279,13 @@ describe('NotificationsModule', () => {
     await service.dispatch({ channel: 'email', payload: { attributes: new Map([['tier', 'silver']]) } }, { queue: true });
     await service.dispatch({ channel: 'email', payload: { callbackUrl: new URL('https://example.com/orders/one') } }, { queue: true });
     await service.dispatch({ channel: 'email', payload: { callbackUrl: new URL('https://example.com/orders/two') } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { query: new URLSearchParams('a=1') } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { query: new URLSearchParams('a=2') } }, { queue: true });
     await service.dispatch({ channel: 'email', payload: { segmentPattern: /vip-.+/i } }, { queue: true });
+    await service.dispatch({ channel: 'email', payload: { segmentPattern: /vip-.+/g } }, { queue: true });
     await service.dispatch({ channel: 'email', payload: { segmentPattern: /trial-.+/i } }, { queue: true });
 
-    expect(new Set(queue.jobs.map((job) => job.id)).size).toBe(10);
+    expect(new Set(queue.jobs.map((job) => job.id)).size).toBe(13);
   });
 
   it('captures missing-channel failures during tolerant bulk dispatch', async () => {

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -64,13 +64,17 @@ export class NotificationsService implements Notifications {
     notification: TRequest,
     options: NotificationDispatchOptions = {},
   ): Promise<NotificationDispatchResult> {
-    await this.publishLifecycleEventSafely('notification.dispatch.requested', notification, options);
+    const requestedPublicationError = await this.publishLifecycleEventBestEffort(
+      'notification.dispatch.requested',
+      notification,
+      options,
+    );
 
     if (this.shouldQueueSingleDispatch(options)) {
       try {
         this.requireChannel(notification.channel);
       } catch (error) {
-        await this.publishFailureLifecycleEvent(notification, options, error);
+        await this.publishFailureLifecycleEvent(notification, options, error, requestedPublicationError);
         throw error;
       }
 
@@ -84,11 +88,11 @@ export class NotificationsService implements Notifications {
           status: 'queued',
         };
 
-        await this.publishLifecycleEventSafely('notification.dispatch.queued', notification, options, result.deliveryId);
+        await this.publishLifecycleEventBestEffort('notification.dispatch.queued', notification, options, result.deliveryId);
 
         return result;
       } catch (error) {
-        await this.publishFailureLifecycleEvent(notification, options, error);
+        await this.publishFailureLifecycleEvent(notification, options, error, requestedPublicationError);
         throw error;
       }
     }
@@ -98,7 +102,7 @@ export class NotificationsService implements Notifications {
     try {
       channel = this.requireChannel(notification.channel);
     } catch (error) {
-      await this.publishFailureLifecycleEvent(notification, options, error);
+      await this.publishFailureLifecycleEvent(notification, options, error, requestedPublicationError);
       throw error;
     }
 
@@ -112,7 +116,7 @@ export class NotificationsService implements Notifications {
         status: delivery.status ?? 'delivered',
       };
 
-      await this.publishLifecycleEventSafely(
+      await this.publishLifecycleEventBestEffort(
         result.queued ? 'notification.dispatch.queued' : 'notification.dispatch.delivered',
         notification,
         options,
@@ -121,7 +125,7 @@ export class NotificationsService implements Notifications {
 
       return result;
     } catch (error) {
-      await this.publishFailureLifecycleEvent(notification, options, error);
+      await this.publishFailureLifecycleEvent(notification, options, error, requestedPublicationError);
       throw error;
     }
   }
@@ -150,16 +154,14 @@ export class NotificationsService implements Notifications {
     }
 
     if (this.shouldQueue(notifications.length, options)) {
-      for (const notification of notifications) {
-        await this.publishLifecycleEventSafely('notification.dispatch.requested', notification, options);
-      }
+      const requestedPublicationErrors = await this.publishRequestedLifecycleEvents(notifications, options);
 
       let queue: ReturnType<NotificationsService['requireQueueAdapter']>;
 
       try {
         queue = this.requireQueueAdapter();
       } catch (error) {
-        await this.publishFailureLifecycleEvents(notifications, options, error);
+        await this.publishFailureLifecycleEvents(notifications, options, error, requestedPublicationErrors);
         throw error;
       }
 
@@ -168,22 +170,22 @@ export class NotificationsService implements Notifications {
           this.requireChannel(notification.channel);
         }
       } catch (error) {
-        await this.publishFailureLifecycleEvents(notifications, options, error);
+        await this.publishFailureLifecycleEvents(notifications, options, error, requestedPublicationErrors);
         throw error;
       }
 
       const jobs = notifications.map((notification) => this.createQueueJob(notification));
 
       if (!queue.enqueueMany) {
-        return this.dispatchManyThroughSequentialQueueFallback(notifications, jobs, options);
+        return this.dispatchManyThroughSequentialQueueFallback(notifications, jobs, options, requestedPublicationErrors);
       }
 
       let ids: readonly string[];
 
       try {
-        ids = await queue.enqueueMany(jobs);
+        ids = validateQueueBatchDeliveryIds(await queue.enqueueMany(jobs), jobs.length);
       } catch (error) {
-        await this.publishFailureLifecycleEvents(notifications, options, error);
+        await this.publishFailureLifecycleEvents(notifications, options, error, requestedPublicationErrors);
         throw error;
       }
 
@@ -196,7 +198,7 @@ export class NotificationsService implements Notifications {
 
       for (let index = 0; index < notifications.length; index += 1) {
         const notification = notifications[index];
-        await this.publishLifecycleEventSafely('notification.dispatch.queued', notification, options, results[index]?.deliveryId);
+        await this.publishLifecycleEventBestEffort('notification.dispatch.queued', notification, options, results[index]?.deliveryId);
       }
 
       return {
@@ -350,29 +352,38 @@ export class NotificationsService implements Notifications {
     await this.options.events.publisher.publish(event);
   }
 
-  private async publishLifecycleEventSafely<TRequest extends NotificationDispatchRequest>(
+  private async publishLifecycleEventBestEffort<TRequest extends NotificationDispatchRequest>(
     name: NotificationLifecycleEvent['name'],
     notification: TRequest,
     options: NotificationDispatchOptions,
     deliveryId?: string,
     error?: unknown,
-  ): Promise<void> {
+  ): Promise<unknown | undefined> {
     try {
       await this.publishLifecycleEvent(name, notification, options, deliveryId, error);
-    } catch {
-      return;
+    } catch (publicationError) {
+      return publicationError;
     }
+
+    return undefined;
   }
 
   private async publishFailureLifecycleEvent<TRequest extends NotificationDispatchRequest>(
     notification: TRequest,
     options: NotificationDispatchOptions,
     error: unknown,
+    ...precedingPublicationErrors: readonly unknown[]
   ): Promise<void> {
+    const priorPublicationErrors = precedingPublicationErrors.filter((entry) => entry !== undefined);
+
     try {
       await this.publishLifecycleEvent('notification.dispatch.failed', notification, options, undefined, error);
     } catch (publicationError) {
-      throw createLifecyclePublicationFailureError(error, publicationError);
+      throw createLifecyclePublicationFailureError(error, ...priorPublicationErrors, publicationError);
+    }
+
+    if (priorPublicationErrors.length > 0) {
+      throw createLifecyclePublicationFailureError(error, ...priorPublicationErrors);
     }
   }
 
@@ -380,7 +391,9 @@ export class NotificationsService implements Notifications {
     notifications: readonly TRequest[],
     options: NotificationDispatchOptions,
     error: unknown,
+    precedingPublicationErrors: readonly unknown[] = [],
   ): Promise<void> {
+    const priorPublicationErrors = precedingPublicationErrors.filter((entry) => entry !== undefined);
     const failurePublicationResults = await Promise.allSettled(
       notifications.map((notification) =>
         this.publishLifecycleEvent('notification.dispatch.failed', notification, options, undefined, error),
@@ -392,14 +405,38 @@ export class NotificationsService implements Notifications {
       .map((result) => result.reason);
 
     if (publicationFailures.length > 0) {
-      throw createLifecyclePublicationFailureError(error, ...publicationFailures);
+      throw createLifecyclePublicationFailureError(error, ...priorPublicationErrors, ...publicationFailures);
     }
+
+    if (priorPublicationErrors.length > 0) {
+      throw createLifecyclePublicationFailureError(error, ...priorPublicationErrors);
+    }
+  }
+
+  private async publishRequestedLifecycleEvents<TRequest extends NotificationDispatchRequest>(
+    notifications: readonly TRequest[],
+    options: NotificationDispatchOptions,
+  ): Promise<readonly unknown[]> {
+    const publicationErrors: Array<unknown | undefined> = [];
+
+    for (const notification of notifications) {
+      const publicationError = await this.publishLifecycleEventBestEffort(
+        'notification.dispatch.requested',
+        notification,
+        options,
+      );
+
+      publicationErrors.push(publicationError);
+    }
+
+    return publicationErrors;
   }
 
   private async dispatchManyThroughSequentialQueueFallback<TRequest extends NotificationDispatchRequest>(
     notifications: readonly TRequest[],
     jobs: readonly NotificationsQueueJob<TRequest>[],
     options: NotificationDispatchManyOptions,
+    requestedPublicationErrors: readonly unknown[],
   ): Promise<NotificationDispatchBatchResult<TRequest>> {
     const queue = this.requireQueueAdapter();
     const results: NotificationDispatchResult[] = [];
@@ -423,7 +460,7 @@ export class NotificationsService implements Notifications {
         };
 
         results.push(result);
-        await this.publishLifecycleEventSafely('notification.dispatch.queued', notification, options, deliveryId);
+        await this.publishLifecycleEventBestEffort('notification.dispatch.queued', notification, options, deliveryId);
       } catch (error) {
         const failure: { error: Error; notification: TRequest } = {
           error: error instanceof Error ? error : new Error('Notification queue enqueue failed.'),
@@ -431,12 +468,12 @@ export class NotificationsService implements Notifications {
         };
 
         if (!(options.continueOnError ?? false)) {
-          await this.publishFailureLifecycleEvents(notifications.slice(index), options, error);
+          await this.publishFailureLifecycleEvents(notifications.slice(index), options, error, requestedPublicationErrors.slice(index));
           throw error;
         }
 
         try {
-          await this.publishFailureLifecycleEvent(notification, options, error);
+          await this.publishFailureLifecycleEvent(notification, options, error, requestedPublicationErrors[index]);
         } catch (publicationError) {
           failure.error = publicationError instanceof Error
             ? publicationError
@@ -455,6 +492,31 @@ export class NotificationsService implements Notifications {
       succeeded: results.length,
     };
   }
+}
+
+function validateQueueBatchDeliveryIds(value: unknown, expectedCount: number): readonly string[] {
+  if (!Array.isArray(value)) {
+    throw createQueueBatchResultIntegrityError(`expected ${expectedCount} queue ids but received a non-array result`);
+  }
+
+  if (value.length !== expectedCount) {
+    throw createQueueBatchResultIntegrityError(`expected ${expectedCount} queue ids but received ${value.length}`);
+  }
+
+  return value.map((entry, index) => {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      throw createQueueBatchResultIntegrityError(`queue id at index ${index} must be a non-empty string`);
+    }
+
+    return entry;
+  });
+}
+
+function createQueueBatchResultIntegrityError(message: string): Error {
+  const error = new Error(`Notifications queue adapter returned an invalid enqueueMany() result: ${message}.`);
+  error.name = 'NotificationQueueResultIntegrityError';
+
+  return error;
 }
 
 function createLifecyclePublicationFailureError(dispatchError: unknown, ...publicationErrors: unknown[]): AggregateError {
@@ -483,13 +545,35 @@ function stableStringify(value: unknown): string {
     return JSON.stringify(value) ?? String(value);
   }
 
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? 'Date:Invalid' : `Date:${JSON.stringify(value.toISOString())}`;
+  }
+
+  if (value instanceof Map) {
+    const entries = Array.from(value.entries())
+      .map(([key, entry]) => `[${stableStringify(key)},${stableStringify(entry)}]`)
+      .sort();
+
+    return `Map:{${entries.join(',')}}`;
+  }
+
+  if (value instanceof Set) {
+    const entries = Array.from(value.values())
+      .map((entry) => stableStringify(entry))
+      .sort();
+
+    return `Set:[${entries.join(',')}]`;
+  }
+
   if (Array.isArray(value)) {
     return `[${value.map((entry) => stableStringify(entry)).join(',')}]`;
   }
 
+  const prototype = Object.getPrototypeOf(value);
+  const objectTag = prototype && prototype !== Object.prototype ? `${prototype.constructor?.name ?? 'Object'}:` : '';
   const entries = Object.entries(value as Record<string, unknown>)
     .filter(([, entry]) => entry !== undefined)
     .sort(([left], [right]) => left.localeCompare(right));
 
-  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`).join(',')}}`;
+  return `${objectTag}{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`).join(',')}}`;
 }

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -549,6 +549,14 @@ function stableStringify(value: unknown): string {
     return Number.isNaN(value.getTime()) ? 'Date:Invalid' : `Date:${JSON.stringify(value.toISOString())}`;
   }
 
+  if (value instanceof URL) {
+    return `URL:${JSON.stringify(value.href)}`;
+  }
+
+  if (value instanceof RegExp) {
+    return `RegExp:${JSON.stringify(value.source)}/${value.flags}`;
+  }
+
   if (value instanceof Map) {
     const entries = Array.from(value.entries())
       .map(([key, entry]) => `[${stableStringify(key)},${stableStringify(entry)}]`)

--- a/packages/notifications/src/service.ts
+++ b/packages/notifications/src/service.ts
@@ -503,13 +503,23 @@ function validateQueueBatchDeliveryIds(value: unknown, expectedCount: number): r
     throw createQueueBatchResultIntegrityError(`expected ${expectedCount} queue ids but received ${value.length}`);
   }
 
-  return value.map((entry, index) => {
+  const ids: string[] = [];
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (!Object.hasOwn(value, index)) {
+      throw createQueueBatchResultIntegrityError(`queue id at index ${index} must be present`);
+    }
+
+    const entry = value[index];
+
     if (typeof entry !== 'string' || entry.length === 0) {
       throw createQueueBatchResultIntegrityError(`queue id at index ${index} must be a non-empty string`);
     }
 
-    return entry;
-  });
+    ids.push(entry);
+  }
+
+  return ids;
 }
 
 function createQueueBatchResultIntegrityError(message: string): Error {
@@ -551,6 +561,10 @@ function stableStringify(value: unknown): string {
 
   if (value instanceof URL) {
     return `URL:${JSON.stringify(value.href)}`;
+  }
+
+  if (value instanceof URLSearchParams) {
+    return `URLSearchParams:${JSON.stringify(value.toString())}`;
   }
 
   if (value instanceof RegExp) {


### PR DESCRIPTION
## Summary

Fixes notifications lifecycle and queue correctness risks found by the package audit.

Linked context: Closes #2208

## Changes

- Preserve `notification.dispatch.requested` publisher failures when a later dispatch/queue failure occurs, while keeping success-path lifecycle publication best-effort.
- Validate `enqueueMany(...)` runtime results before reporting queued successes so malformed adapter lengths or ids cannot fabricate successful delivery ids.
- Harden deterministic queue/fallback id hashing for `Date`, `Map`, `Set`, and non-plain object payload values.
- Add regression coverage for requested→failed publication ordering, malformed queue batch results, empty queue ids, and non-plain payload id stability.
- Add a patch changeset for `@fluojs/notifications` public behavior fixes.

## Testing

- `pnpm --filter @fluojs/notifications... build`
- `pnpm --filter @fluojs/notifications typecheck`
- `pnpm --filter @fluojs/notifications test`
- `pnpm exec biome check packages/notifications/src/service.ts packages/notifications/src/module.test.ts`
- LSP diagnostics: clean for changed TypeScript files

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. (No public exports were added or changed.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. (No exported function signatures changed.)
- [x] Source `@example` blocks and README scenario examples still play complementary roles. (No README example changes needed for this contract-preserving bug fix.)

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (Existing README contracts around lifecycle failure ordering, queue batch ordering, and deterministic ids are preserved rather than expanded.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. (No governed docs changed.)
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (Not applicable; no platform contract docs changed.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (Not applicable; notifications package behavior is covered by package tests.)
