### PR TITLE
Resolve #2210: test notifications direct dispatch branches

### DIFF
--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -256,6 +256,35 @@ describe('NotificationsModule', () => {
     });
   });
 
+  it('forces single dispatch through direct delivery when queue is explicitly disabled', async () => {
+    const queue = new RecordingQueueAdapter();
+    const deliveries: string[] = [];
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send(notification: NotificationDispatchRequest) {
+            deliveries.push(String(notification.payload.template));
+            return { externalId: 'direct-disabled-queue' };
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 1,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+    const result = await service.dispatch({ channel: 'email', payload: { template: 'single-direct' } }, { queue: false });
+
+    expect(result).toMatchObject({ deliveryId: 'direct-disabled-queue', queued: false, status: 'delivered' });
+    expect(deliveries).toEqual(['single-direct']);
+    expect(queue.jobs).toHaveLength(0);
+  });
+
   it('uses stable queue job ids so queue adapters can deduplicate repeated requests', async () => {
     const queue = new RecordingQueueAdapter();
     const container = new Container();
@@ -406,6 +435,34 @@ describe('NotificationsModule', () => {
       'notification.dispatch.requested',
       'notification.dispatch.delivered',
     ]);
+  });
+
+  it('does not publish lifecycle events when module configuration opts out', async () => {
+    const publisher = new RecordingPublisher();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            return { externalId: 'delivery-events-disabled' };
+          },
+        },
+      ],
+      events: {
+        publishLifecycleEvents: false,
+        publisher,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await expect(service.dispatch({ channel: 'email', payload: { template: 'events-disabled' } })).resolves.toMatchObject({
+      deliveryId: 'delivery-events-disabled',
+      status: 'delivered',
+    });
+    expect(publisher.events).toEqual([]);
   });
 
   it('publishes requested and failed lifecycle events for direct missing-channel dispatch', async () => {
@@ -1314,5 +1371,58 @@ describe('NotificationsModule', () => {
     expect(result.succeeded).toBe(1);
     expect(result.failed).toBe(1);
     expect(result.failures[0]?.error).toBeInstanceOf(NotificationChannelNotFoundError);
+  });
+
+  it('collects provider errors during tolerant direct bulk dispatch', async () => {
+    const providerError = new Error('provider delivery failed');
+    const deliveredPayloads: string[] = [];
+    const queue = new RecordingQueueAdapter();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send(notification: NotificationDispatchRequest) {
+            const template = String(notification.payload.template);
+
+            if (template === 'broken') {
+              throw providerError;
+            }
+
+            deliveredPayloads.push(template);
+            return { externalId: `delivered:${template}` };
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 2,
+      },
+    });
+
+    const notifications = [
+      { channel: 'email', payload: { template: 'first' } },
+      { channel: 'email', payload: { template: 'broken' } },
+      { channel: 'email', payload: { template: 'third' } },
+    ];
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+    const result = await service.dispatchMany(notifications, { continueOnError: true, queue: false });
+
+    expect(queue.jobs).toHaveLength(0);
+    expect(deliveredPayloads).toEqual(['first', 'third']);
+    expect(result).toMatchObject({
+      failed: 1,
+      queued: 0,
+      succeeded: 2,
+    });
+    expect(result.results.map((entry: NotificationDispatchResult) => entry.deliveryId)).toEqual([
+      'delivered:first',
+      'delivered:third',
+    ]);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.notification).toBe(notifications[1]);
+    expect(result.failures[0]?.error).toBe(providerError);
   });
 });


### PR DESCRIPTION
## Summary

Adds package-level regression coverage for documented @fluojs/notifications dispatch branches.

Linked context: Closes #2210

## Changes

- Locks `dispatch(..., { queue: false })` to direct delivery with a configured queue adapter.
- Locks `events.publishLifecycleEvents: false` as a module-level lifecycle publication opt-out.
- Locks direct `dispatchMany(..., { continueOnError: true, queue: false })` provider-error collection without queue handoff.

## Testing

- `pnpm --filter @fluojs/notifications... build`
- `pnpm --filter @fluojs/notifications typecheck`
- `pnpm --filter @fluojs/notifications test`
- `lsp_diagnostics` on `packages/notifications/src/module.test.ts`: no diagnostics

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only coverage for existing documented behavior; no public API, runtime behavior, package contents, or release metadata changes.

## Public export documentation

No public exports changed.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No new behavior is introduced; tests cover the existing README-documented queue override, lifecycle opt-out, and tolerant direct batch failure branches.

## Platform consistency governance (SSOT)

No governance docs or SSOT mirror structures changed.

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.
