### PR TITLE
Resolve #2211: drain email shutdown operations

### DIFF
--- a/.changeset/email-drain-in-flight-shutdown.md
+++ b/.changeset/email-drain-in-flight-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Drain in-flight transport verify and send operations before closing owned email transports during shutdown.

--- a/packages/email/README.ko.md
+++ b/packages/email/README.ko.md
@@ -195,7 +195,7 @@ Behavioral contract 메모:
 - `EmailService.createPlatformStatusSnapshot()`은 diagnostics를 위해 lifecycle, readiness, health, transport ownership details를 노출합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하며, `verifyOnModuleInit: true`인 경우 bootstrap 검증이 성공적으로 끝날 때까지 delivery가 transport handoff로 진행되지 않습니다.
 - 거부된 `forRootAsync(...)` 옵션 factory 결과는 영구 memoize되지 않으며, 다음 provider resolution에서 configuration lookup을 다시 시도할 수 있습니다.
-- shutdown이 시작된 뒤에는 `EmailService.send(...)`와 `EmailService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `EmailLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다린 뒤 닫습니다.
+- shutdown이 시작된 뒤에는 `EmailService.send(...)`와 `EmailService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `EmailLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다리고, 활성 transport `verify()` / `send()` 호출을 drain한 뒤 소유 transport를 닫습니다.
 - transport `verify()`와 `close()`에서 발생한 provider error는 diagnostics를 위해 lifecycle failure의 `cause`로 보존됩니다.
 - 모듈 옵션은 provider wiring 전에 trim 및 normalize됩니다. 여기에는 sender 기본값, notification channel 이름, transport factory 소유권이 포함됩니다.
 - `EmailModule.forRoot(...)`와 `EmailModule.forRootAsync(...)`는 기본적으로 global입니다. module-local visibility가 필요할 때만 `global: false`를 사용합니다.

--- a/packages/email/README.md
+++ b/packages/email/README.md
@@ -195,7 +195,7 @@ Behavioral contract notes:
 - `EmailService.createPlatformStatusSnapshot()` exposes lifecycle, readiness, health, and transport ownership details for diagnostics.
 - The service initializes the configured transport during module bootstrap and, when `verifyOnModuleInit: true`, delivery waits until bootstrap verification has completed successfully before transport handoff.
 - Rejected `forRootAsync(...)` option factories are not memoized permanently; the next provider resolution can retry configuration lookup.
-- Once shutdown starts, `EmailService.send(...)` and `EmailService.sendNotification(...)` fail with `EmailLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited and closed by shutdown.
+- Once shutdown starts, `EmailService.send(...)` and `EmailService.sendNotification(...)` fail with `EmailLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited, active transport `verify()` / `send()` calls are drained, and then owned transports are closed by shutdown.
 - Transport `verify()` and `close()` provider errors are preserved as the `cause` of lifecycle failures for diagnostics.
 - Module options are trimmed and normalized before provider wiring, including sender defaults, notification channel names, and transport factory ownership.
 - `EmailModule.forRoot(...)` and `EmailModule.forRootAsync(...)` are global by default. Use `global: false` to opt into module-local visibility.

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -271,7 +271,11 @@ class DelayedLifecycleTransport implements EmailTransport {
   sendCalls = 0;
   verifyCalls = 0;
 
-  constructor(private readonly verifyDelay: Promise<void> | undefined = undefined) {}
+  constructor(
+    private readonly verifyDelay: Promise<void> | undefined = undefined,
+    private readonly sendDelay: Promise<void> | undefined = undefined,
+    private readonly onSendStarted: (() => void) | undefined = undefined,
+  ) {}
 
   async close(): Promise<void> {
     this.closeCalls += 1;
@@ -279,6 +283,8 @@ class DelayedLifecycleTransport implements EmailTransport {
 
   async send(): Promise<{ accepted: string[]; messageId: string; pending: []; rejected: [] }> {
     this.sendCalls += 1;
+    this.onSendStarted?.();
+    await this.sendDelay;
 
     return {
       accepted: ['user@example.com'],
@@ -958,7 +964,7 @@ describe('EmailModule', () => {
     resolveTransport(createdTransport);
 
     await expect(sendDuringCreate).rejects.toThrowError(
-      new EmailLifecycleError('Email delivery cannot start while the service lifecycle is stopped.'),
+      new EmailLifecycleError('Email delivery cannot start while the service lifecycle is stopping.'),
     );
     await shutdown;
     await expect(
@@ -969,7 +975,7 @@ describe('EmailModule', () => {
     expect(createdTransport.sendCalls).toBe(0);
   });
 
-  it('does not mark the service ready when shutdown interrupts bootstrap verification', async () => {
+  it('drains bootstrap verification before closing owned transports during shutdown', async () => {
     let resolveVerify!: () => void;
     let resolveVerifyStarted!: () => void;
     const verifyDelay = new Promise<void>((resolve) => {
@@ -1001,9 +1007,12 @@ describe('EmailModule', () => {
     const bootstrap = service.onModuleInit();
     await verifyStarted;
     const shutdown = service.onApplicationShutdown();
+    await Promise.resolve();
 
-    await shutdown;
+    expect(createdTransport.closeCalls).toBe(0);
+
     resolveVerify();
+    await shutdown;
     await bootstrap;
 
     expect(service.createPlatformStatusSnapshot()).toMatchObject({
@@ -1022,6 +1031,42 @@ describe('EmailModule', () => {
     expect(createdTransport.verifyCalls).toBe(1);
     expect(verify).toHaveBeenCalledOnce();
     expect(createdTransport.sendCalls).toBe(0);
+  });
+
+  it('drains in-flight sends before closing owned transports during shutdown', async () => {
+    let resolveSend!: () => void;
+    let resolveSendStarted!: () => void;
+    const sendDelay = new Promise<void>((resolve) => {
+      resolveSend = resolve;
+    });
+    const sendStarted = new Promise<void>((resolve) => {
+      resolveSendStarted = resolve;
+    });
+    const createdTransport = new DelayedLifecycleTransport(undefined, sendDelay, resolveSendStarted);
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create: async () => createdTransport,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+    const delivery = service.send({ subject: 'Drain send', text: 'hello', to: ['user@example.com'] });
+    await sendStarted;
+    const shutdown = service.onApplicationShutdown();
+    await Promise.resolve();
+
+    expect(createdTransport.sendCalls).toBe(1);
+    expect(createdTransport.closeCalls).toBe(0);
+
+    resolveSend();
+
+    await expect(delivery).resolves.toMatchObject({ messageId: 'delayed-1' });
+    await shutdown;
+    expect(createdTransport.closeCalls).toBe(1);
   });
 
   it('waits for bootstrap transport verification before delivery proceeds', async () => {

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -109,6 +109,7 @@ function assertMessageContent(message: NormalizedEmailMessage): void {
 export class EmailService implements Email, OnModuleInit, OnApplicationShutdown {
   private lifecycleState: EmailServiceLifecycleState = 'created';
   private bootstrapPromise: Promise<void> | undefined;
+  private readonly inFlightOperations = new Set<Promise<unknown>>();
   private resolvedTransport: EmailTransport | undefined;
   private transportPromise: Promise<EmailTransport> | undefined;
 
@@ -119,6 +120,8 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
 
     try {
       const transport = this.resolvedTransport ?? (this.transportPromise ? await this.transportPromise : undefined);
+
+      await this.drainInFlightOperations();
 
       if (transport && this.options.transport.ownsResources && transport.close) {
         await transport.close();
@@ -162,7 +165,7 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
       }
 
       if (this.options.verifyOnModuleInit && transport.verify) {
-        await transport.verify();
+        await this.trackInFlightOperation(Promise.resolve(transport.verify()));
       }
 
       if (this.lifecycleState !== 'starting') {
@@ -246,7 +249,7 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
     } else {
       this.assertCanDeliver();
     }
-    const result = await transport.send(normalized, options);
+    const result = await this.trackInFlightOperation(Promise.resolve(transport.send(normalized, options)));
 
     return {
       accepted: result.accepted ?? [],
@@ -372,6 +375,22 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
   private clearResolvedTransport(): void {
     this.resolvedTransport = undefined;
     this.transportPromise = undefined;
+  }
+
+  private async drainInFlightOperations(): Promise<void> {
+    while (this.inFlightOperations.size > 0) {
+      await Promise.allSettled(Array.from(this.inFlightOperations));
+    }
+  }
+
+  private async trackInFlightOperation<T>(operation: Promise<T>): Promise<T> {
+    this.inFlightOperations.add(operation);
+
+    try {
+      return await operation;
+    } finally {
+      this.inFlightOperations.delete(operation);
+    }
   }
 
   private async ensureReadyForDelivery(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes the @fluojs/email shutdown race where owned transports could close while verify() or send() calls were still in flight.

Linked context: Closes #2211

## Changes

- Track active transport verify() and send() operations inside EmailService.
- Drain active operations before closing owned transports during shutdown.
- Add regression coverage for concurrent shutdown during bootstrap verification and direct sends.
- Document the shutdown drain contract in English and Korean READMEs.
- Add a patch changeset for @fluojs/email.

## Testing

- lsp_diagnostics on packages/email/src/service.ts: no diagnostics.
- lsp_diagnostics on packages/email/src/module.test.ts: no diagnostics.
- pnpm --filter @fluojs/email test: passed (4 files, 41 tests).
- pnpm --filter @fluojs/email typecheck: passed.
- pnpm --filter @fluojs/email build: passed after workspace dependency build artifacts were prepared with pnpm build.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

No public exports were added or changed; this updates internal lifecycle behavior and README contract notes.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Shutdown now waits for active transport verify()/send() operations before owned transport close, preserving lifecycle ordering.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.

Platform contract docs were not changed; package README EN/KO mirrors were updated together and package regression tests cover the lifecycle behavior.