### PR TITLE
Resolve #2223: serialize Discord startup and shutdown lifecycle

### DIFF
--- a/.changeset/soft-turkeys-promise.md
+++ b/.changeset/soft-turkeys-promise.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/discord": patch
+---
+
+Serialize Discord startup and shutdown transport lifecycle transitions so shutdown drains in-flight factory-owned transport creation and closes owned resources exactly once.

--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -101,7 +101,7 @@ Behavioral contract 메모:
 - `DiscordModule.forRoot(...)`와 `DiscordModule.forRootAsync(...)`는 `DiscordService`, `DiscordChannel`, `DISCORD`, `DISCORD_CHANNEL`을 기본 global로 export합니다. fluo 옵션인 `global?: boolean`을 사용하고, migrated code가 Discord provider를 importing module 안에만 유지해야 할 때만 `global: false`를 설정하세요. NestJS `isGlobal`은 지원하지 않습니다.
 - `DiscordService.send(...)`는 전달 전에 `defaultThreadId`를 해석합니다.
 - `DiscordService.sendMany(...)`는 `DiscordMessage[]`를 직접 순차 전송하는 batch API이며 `continueOnError`를 지원합니다. 이는 multi-recipient `@fluojs/notifications` dispatch shortcut이 아닙니다.
-- 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
+- 서비스는 모듈 bootstrap 시 transport를 초기화하고, shutdown 전에 시작된 factory 생성 transport가 아직 완료되지 않았더라도 이를 기다린 뒤 factory가 소유한 리소스를 애플리케이션 shutdown 시 닫습니다.
 - send는 bootstrap이 transport를 `ready`로 표시한 뒤에만 허용됩니다. bootstrap 전, startup 중, bootstrap 실패 후, shutdown 중, shutdown 후 시도는 전달 전에 거부됩니다.
 - 서비스가 shutdown 중이거나 이미 stopped 상태라면 cached transport를 재사용하지 않고 send를 거부합니다.
 - `DiscordService.createPlatformStatusSnapshot()`은 `createDiscordPlatformStatusSnapshot(...)`과 같은 status 계약을 노출합니다. 여기에는 lifecycle/readiness, health, transport kind와 ownership, 기본 thread 구성, bootstrap verification 상태, notifications channel dependency details가 포함되어, 호출자가 내부 옵션에 접근하지 않고도 Discord wiring을 관찰할 수 있습니다.

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -101,7 +101,7 @@ Behavioral contract notes:
 - `DiscordModule.forRoot(...)` and `DiscordModule.forRootAsync(...)` export `DiscordService`, `DiscordChannel`, `DISCORD`, and `DISCORD_CHANNEL` globally by default. Use the fluo `global?: boolean` option and set `global: false` only when migrated code must keep Discord providers local to importing modules; NestJS `isGlobal` is not supported.
 - `DiscordService.send(...)` resolves `defaultThreadId` before delivery.
 - `DiscordService.sendMany(...)` is a direct `DiscordMessage[]` batch API that sends messages sequentially and supports `continueOnError`; it is not a multi-recipient `@fluojs/notifications` dispatch shortcut.
-- The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
+- The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown, including any in-flight factory-created transport before shutdown began.
 - Sends are accepted only after bootstrap marks the transport `ready`; attempts before bootstrap, during startup, after failed bootstrap, while shutting down, or after shutdown are rejected before delivery.
 - Sends attempted while the service is shutting down or already stopped are rejected before reusing the cached transport.
 - `DiscordService.createPlatformStatusSnapshot()` exposes the same status contract as `createDiscordPlatformStatusSnapshot(...)`: lifecycle/readiness, health, transport kind and ownership, default thread configuration, bootstrap verification state, and notifications channel dependency details, so callers can observe Discord wiring without reaching into internal options.

--- a/packages/discord/src/module.test.ts
+++ b/packages/discord/src/module.test.ts
@@ -784,6 +784,78 @@ describe('DiscordModule', () => {
     expect(transport.sent).toEqual(['App-owned transport']);
   });
 
+  it('keeps shutdown state when startup resolves after shutdown begins', async () => {
+    const transport = new PassiveTransport();
+    let resolveTransport: (transport: DiscordTransport) => void = () => {};
+    const transportPromise = new Promise<DiscordTransport>((resolve) => {
+      resolveTransport = resolve;
+    });
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      transport: {
+        create: () => transportPromise,
+        kind: 'deferred-factory',
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    const startup = service.onModuleInit();
+    const shutdown = service.onApplicationShutdown();
+
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'stopping' },
+      readiness: {
+        reason: 'Discord transport is shutting down or already stopped.',
+        status: 'not-ready',
+      },
+    });
+
+    resolveTransport(transport);
+
+    await expect(startup).resolves.toBeUndefined();
+    await shutdown;
+
+    expect(transport.closeCalls).toBe(1);
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'stopped' },
+      readiness: {
+        reason: 'Discord transport is shutting down or already stopped.',
+        status: 'not-ready',
+      },
+    });
+    await expect(service.send({ content: 'After shutdown' })).rejects.toThrowError(
+      new DiscordTransportError('Discord transport is shutting down or already stopped.'),
+    );
+    expect(transport.sent).toEqual([]);
+  });
+
+  it('closes a factory-owned transport exactly once across repeated shutdown hooks', async () => {
+    const transport = new PassiveTransport();
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      transport: {
+        create: async () => transport,
+        kind: 'owned-factory',
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    await service.onModuleInit();
+
+    await Promise.all([service.onApplicationShutdown(), service.onApplicationShutdown()]);
+    await service.onApplicationShutdown();
+
+    expect(transport.closeCalls).toBe(1);
+    await expect(service.send({ content: 'After shutdown' })).rejects.toThrowError(
+      new DiscordTransportError('Discord transport is shutting down or already stopped.'),
+    );
+    expect(transport.sent).toEqual([]);
+  });
+
   it('preserves the cause when bootstrap verification fails', async () => {
     const cause = new Error('webhook credentials revoked');
     const transport: DiscordTransport = {

--- a/packages/discord/src/service.ts
+++ b/packages/discord/src/service.ts
@@ -37,6 +37,12 @@ function createLifecycleReadinessError(lifecycleState: DiscordServiceLifecycleSt
   return new DiscordTransportError('Discord transport is not ready for delivery.');
 }
 
+function isShutdownLifecycleState(
+  state: DiscordServiceLifecycleState,
+): state is Extract<DiscordServiceLifecycleState, 'stopping' | 'stopped'> {
+  return state === 'stopping' || state === 'stopped';
+}
+
 function normalizeOptionalString(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : undefined;
@@ -70,16 +76,33 @@ type DiscordServiceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping
 export class DiscordService implements Discord, OnModuleInit, OnApplicationShutdown {
   private lifecycleState: DiscordServiceLifecycleState = 'created';
   private resolvedTransport: DiscordTransport | undefined;
+  private shutdownPromise: Promise<void> | undefined;
   private transportPromise: Promise<DiscordTransport> | undefined;
 
   constructor(private readonly options: NormalizedDiscordModuleOptions) {}
 
   async onApplicationShutdown(): Promise<void> {
+    if (this.lifecycleState === 'stopped') {
+      return;
+    }
+
+    if (this.shutdownPromise) {
+      return this.shutdownPromise;
+    }
+
     this.lifecycleState = 'stopping';
 
+    this.shutdownPromise = this.closeOwnedTransport();
+
+    return this.shutdownPromise;
+  }
+
+  private async closeOwnedTransport(): Promise<void> {
     try {
-      if (this.resolvedTransport && this.options.transport.ownsResources && this.resolvedTransport.close) {
-        await this.resolvedTransport.close();
+      const transport = this.resolvedTransport ?? (this.transportPromise ? await this.transportPromise : undefined);
+
+      if (transport && this.options.transport.ownsResources && transport.close) {
+        await transport.close();
       }
 
       this.lifecycleState = 'stopped';
@@ -90,17 +113,33 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
   }
 
   async onModuleInit(): Promise<void> {
+    if (isShutdownLifecycleState(this.lifecycleState)) {
+      return;
+    }
+
     this.lifecycleState = 'starting';
 
     try {
       const transport = await this.ensureTransport();
 
+      if (this.lifecycleState !== 'starting') {
+        return;
+      }
+
       if (this.options.verifyOnModuleInit && transport.verify) {
         await transport.verify();
       }
 
+      if (this.lifecycleState !== 'starting') {
+        return;
+      }
+
       this.lifecycleState = 'ready';
     } catch (error) {
+      if (isShutdownLifecycleState(this.lifecycleState)) {
+        throw error;
+      }
+
       this.lifecycleState = 'failed';
       throw new Error('Discord transport failed to initialize.', { cause: error });
     }
@@ -145,6 +184,7 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
     this.assertReadyForSend();
 
     const transport = await this.ensureTransport();
+    this.assertReadyForSend();
     const normalized = this.normalizeMessage(message);
     assertMessageContent(normalized);
     const result = await transport.send(normalized, options);
@@ -258,6 +298,14 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
   }
 
   private async ensureTransport(): Promise<DiscordTransport> {
+    if (this.lifecycleState === 'stopping' || this.lifecycleState === 'stopped') {
+      throw createStoppedTransportError();
+    }
+
+    if (this.lifecycleState === 'failed') {
+      throw createLifecycleReadinessError(this.lifecycleState);
+    }
+
     if (this.resolvedTransport) {
       return this.resolvedTransport;
     }


### PR DESCRIPTION
## Summary

Serialize `@fluojs/discord` startup/shutdown transport lifecycle transitions so shutdown cannot be overwritten by late startup completion and factory-owned transport creation is drained before owned resources close.

Linked context: Closes #2223

## Changes

- Guard Discord transport creation/reuse once shutdown or failure begins.
- Make shutdown idempotent and await in-flight factory-created transports before closing owned resources.
- Prevent `onModuleInit()` from restoring `ready` after shutdown starts.
- Add Discord lifecycle race regression coverage for startup/shutdown overlap and repeated shutdown.
- Document EN/KO lifecycle behavior and add a patch changeset for `@fluojs/discord`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/discord test`
- `pnpm --filter @fluojs/discord... build && pnpm --filter @fluojs/discord typecheck`
- `pnpm lint` (completed; existing repo-wide Biome warnings reported outside changed Discord files, `verify:public-export-tsdoc` passed)
- LSP diagnostics: no diagnostics for `packages/discord/src/service.ts` and `packages/discord/src/module.test.ts` after dependency build.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/soft-turkeys-promise.md`

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public API surface was added or changed; existing TSDoc remains applicable.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The Discord README and README.ko now state shutdown drains in-flight factory-created transports before closing factory-owned resources. Regression tests cover the startup/shutdown race and close-once behavior.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform/governance SSOT docs changed. Package README EN/KO lifecycle wording was updated together; regression evidence is in `packages/discord/src/module.test.ts`.
