### PR TITLE
Resolve #2224: correct Discord release metadata

### DIFF
--- a/packages/discord/CHANGELOG.md
+++ b/packages/discord/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/discord
 
+## [Unreleased]
+
 ## 1.0.3
 
 ### Patch Changes
@@ -14,9 +16,11 @@
 
 ## 1.0.2
 
-### Patch Changes
+### Major Changes
 
 - [#1867](https://github.com/fluojs/fluo/pull/1867) [`8afb45e`](https://github.com/fluojs/fluo/commit/8afb45ee9a8cbaa21a611079768196e6be0df801) Thanks [@ayden94](https://github.com/ayden94)! - Reject Discord sends until module bootstrap marks the transport ready, preserve failed-bootstrap readiness failures, and allow documented poll-only notification payloads while keeping webhook response exposure documented.
+
+### Patch Changes
 
 - Updated dependencies [[`01ea60e`](https://github.com/fluojs/fluo/commit/01ea60eff7a8d3b30509aff8aaf21649178a9fad), [`5fa7b54`](https://github.com/fluojs/fluo/commit/5fa7b549e760cb6b1be82a7e7e7c1f7e011b0ea2), [`3aa93d9`](https://github.com/fluojs/fluo/commit/3aa93d9bbea28342f225b727f2ec0640acdf7986)]:
   - @fluojs/di@1.0.1


### PR DESCRIPTION
## Summary

Correct `@fluojs/discord` consumer-facing changelog metadata for the lifecycle/readiness behavior entry identified in issue #2224.

Linked context: Closes #2224

## Changes

- Restored the required `## [Unreleased]` section in `packages/discord/CHANGELOG.md`.
- Reclassified the `1.0.2` Discord lifecycle/readiness entry from `Patch Changes` to `Major Changes` so the changelog no longer presents the documented bootstrap/lifecycle gating behavior as patch-only metadata.
- Kept dependency update notes under `Patch Changes`.

## Testing

- `lsp_diagnostics` on `packages/discord/CHANGELOG.md`: no diagnostics found.
- `pnpm install --frozen-lockfile`: completed to provision the isolated worktree for verification; lockfile stayed unchanged.
- `pnpm verify:release-readiness`: passed; output ended with `Release readiness checks passed without writing draft artifacts.`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this PR does not change runtime behavior, public API surface, package contents intended for a new release, or pending release intent. It corrects already-generated historical changelog metadata and restores the standing Unreleased heading required by release governance.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

해당 없음: no source files or public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

No behavioral contract changed in this PR; the existing Discord README lifecycle/readiness contract remains unchanged, and only historical changelog classification was corrected.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs or platform contract docs changed; release-governance evidence was used to scope this changelog-only correction.