### PR TITLE
Resolve #2206: restore notifications changelog Unreleased section

### DIFF
--- a/packages/notifications/CHANGELOG.md
+++ b/packages/notifications/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/notifications
 
+## [Unreleased]
+
 ## 1.0.1
 
 ### Patch Changes


### PR DESCRIPTION
## Summary

Restore the required `## [Unreleased]` section in `packages/notifications/CHANGELOG.md` so `@fluojs/notifications` remains aligned with `docs/contracts/release-governance.md`.

Linked context: Closes #2206

## Changes

- Added the missing `## [Unreleased]` heading at the top of `packages/notifications/CHANGELOG.md`.
- Did not add a changeset because this is a generated changelog governance restoration only; it does not change public package behavior, API surface, package contents, or release intent.

## Testing

- `lsp_diagnostics packages/notifications/CHANGELOG.md` — passed, no diagnostics.
- `python3` changelog heading assertion — passed; line 3 is `## [Unreleased]`.
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main` — passed.
- `pnpm verify:release-readiness` — initially failed because the fresh worktree had no `node_modules` and `babel` was unavailable; after `pnpm install --frozen-lockfile`, reran and passed: `Release readiness checks passed without writing draft artifacts.`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included: this restores required changelog structure for governance compliance and does not introduce consumer-visible behavior/API/package content changes or new release metadata.

## Public export documentation

해당 없음 — no public exports or source files changed.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

해당 없음 — no runtime behavior, documented package behavior, or intentional limitation changed.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [ ] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. No governance docs were changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable; no platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable; no README alignment/conformance claims changed.
