### PR TITLE
Resolve #2215: restore email changelog Unreleased section

### DIFF
--- a/packages/email/CHANGELOG.md
+++ b/packages/email/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @fluojs/email
 
+## [Unreleased]
+
 ## 1.0.1
 
 ### Patch Changes


### PR DESCRIPTION
## Summary

Restore the required `## [Unreleased]` placeholder in `packages/email/CHANGELOG.md` so the email package changelog stays aligned with release governance.

Linked context: Closes #2215

## Changes

- Added the missing `## [Unreleased]` section above the latest `1.0.1` entry in `packages/email/CHANGELOG.md`.

## Testing

- `lsp_diagnostics` on `packages/email/CHANGELOG.md`: No diagnostics found.
- `pnpm verify:release-readiness`: passed after installing worktree dependencies with `pnpm install --frozen-lockfile`.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this only restores a governed changelog placeholder and does not change public package behavior, API surface, package contents, or release metadata consumed by Changesets.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

해당 없음 — no public exports or source files changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [ ] Intentional limitations are explicitly stated (not silently removed).
- [ ] Runtime invariants are covered by regression tests.

해당 없음 — this is a changelog governance placeholder restoration and does not alter runtime behavior or documented package contracts.

## Platform consistency governance (SSOT)

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

해당 없음 — no governed SSOT docs, platform contract docs, or package README conformance claims changed.