### PR TITLE
Resolve #2216: cover Slack retry, abort, and channel fallback edges

### DIFF
--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -238,6 +238,37 @@ describe('SlackModule', () => {
     expect(transportState.closeCalls).toBe(1);
   });
 
+  it('normalizes missing notification channel fallbacks for module and manual provider registration', async () => {
+    const moduleContainer = new Container();
+    const helperContainer = new Container();
+
+    moduleContainer.register(
+      ...moduleProviders(
+        SlackModule.forRoot({
+          defaultChannel: '#ops',
+          transport: createRecordingTransportFactory(),
+        }),
+      ),
+    );
+    helperContainer.register(
+      ...createSlackProviders({
+        defaultChannel: '#ops',
+        notifications: { channel: '   ' },
+        transport: createRecordingTransportFactory(),
+      }),
+    );
+
+    const moduleChannel = await moduleContainer.resolve(SlackChannel);
+    const moduleChannelToken = await moduleContainer.resolve(SLACK_CHANNEL);
+    const helperChannel = await helperContainer.resolve(SlackChannel);
+    const helperChannelToken = await helperContainer.resolve(SLACK_CHANNEL);
+
+    expect(moduleChannel.channel).toBe('slack');
+    expect(moduleChannelToken).toBe(moduleChannel);
+    expect(helperChannel.channel).toBe('slack');
+    expect(helperChannelToken).toBe(helperChannel);
+  });
+
   it('rejects helper-based registration without an explicit transport contract', () => {
     expect(() =>
       createSlackProviders({
@@ -307,6 +338,27 @@ describe('SlackModule', () => {
     controller.abort();
 
     await expect(service.sendMany([], { signal: controller.signal })).rejects.toMatchObject({ name: 'AbortError' });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('honors an already-aborted signal before sending a non-empty sendMany batch', async () => {
+    const controller = new AbortController();
+    const create = vi.fn(async () => new PassiveTransport());
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      transport: {
+        create,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+    controller.abort();
+
+    await expect(service.sendMany([{ text: 'Already aborted batch item' }], { signal: controller.signal })).rejects.toMatchObject({
+      name: 'AbortError',
+    });
     expect(create).not.toHaveBeenCalled();
   });
 
@@ -761,6 +813,42 @@ describe('SlackModule', () => {
       expect(fetchLike).toHaveBeenCalledTimes(3);
       expect(rateLimitedText).not.toHaveBeenCalled();
       expect(outageText).not.toHaveBeenCalled();
+      expect(successText).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries request-timeout webhook failures before succeeding', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const requestTimeoutText = vi.fn(async () => 'request timeout');
+      const successText = vi.fn(async () => 'ok');
+      const fetchLike = vi
+        .fn<SlackFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 408,
+          statusText: 'Request Timeout',
+          text: requestTimeoutText,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          text: successText,
+        });
+      const transport = createSlackWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://hooks.slack.test/services/T000/B000/XXXX',
+      });
+
+      const pending = transport.send({ attachments: [], blocks: [], channel: '#ops', text: 'Request timeout retry path' }, {});
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toMatchObject({ ok: true, response: 'ok', statusCode: 200 });
+      expect(fetchLike).toHaveBeenCalledTimes(2);
+      expect(requestTimeoutText).not.toHaveBeenCalled();
       expect(successText).toHaveBeenCalledOnce();
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Summary

Closes #2216

Add focused Slack regression coverage for the package audit gaps around retry, abort, and notification channel fallback behavior.

## Changes

- Added direct webhook retry coverage for transient `408 Request Timeout` responses.
- Added non-empty `SlackService.sendMany(...)` coverage for pre-aborted signals before transport creation/provider handoff.
- Added notification channel fallback normalization coverage for both `SlackModule.forRoot(...)` and manual `createSlackProviders(...)` registration.

## Testing

- Changed-file LSP diagnostics for `packages/slack/src/module.test.ts`: passed.
- `pnpm --filter @fluojs/slack test`: passed, 3 test files / 44 tests.
- `pnpm --filter @fluojs/slack... build`: passed, prepared workspace dependency build outputs for package type resolution.
- `pnpm --filter @fluojs/slack typecheck`: passed.
- `pnpm --filter @fluojs/slack build`: passed.
- `pnpm exec biome lint packages/slack/src/module.test.ts`: passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset is included because this is test-only regression coverage with no public API, runtime behavior, package contents, or release metadata change.

## Public export documentation

해당 없음 — no public exports or package source APIs changed. Only `packages/slack/src/module.test.ts` was updated.

## Behavioral contract

- No documented Slack behavioral contracts were removed or changed.
- Regression tests now directly cover documented transient `408` retry behavior, pre-aborted `sendMany(...)` cancellation, and notification channel fallback normalization.
- The no implicit `process.env` reads and explicit transport boundary contracts remain unchanged.

## Platform consistency governance (SSOT)

해당 없음 — no governed docs or EN/KO SSOT surfaces changed. The change is package-local test coverage that preserves the documented Slack runtime-portable transport contract.