### PR TITLE
Resolve #2282: align Bun adapter shutdown budget

### DIFF
--- a/.changeset/quiet-buns-drain.md
+++ b/.changeset/quiet-buns-drain.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/platform-bun': patch
+---
+
+Align Bun signal-driven shutdown drain handling with the configured `forceExitTimeoutMs` budget and cover shutdown/raw-body regression paths.

--- a/packages/platform-bun/src/adapter.test.ts
+++ b/packages/platform-bun/src/adapter.test.ts
@@ -567,6 +567,30 @@ describe('@fluojs/platform-bun', () => {
     await expect(response.text()).resolves.toBe('');
   });
 
+  it('preserves byte-exact rawBody values for byte-sensitive custom fetch handlers', async () => {
+    const bytes = Uint8Array.from([0, 10, 13, 195, 40, 255]);
+    const fetch = createBunFetchHandler({
+      dispatcher: {
+        async dispatch(request: FrameworkRequest, response: FrameworkResponse) {
+          expect(request.method).toBe('POST');
+          expect(request.path).toBe('/hooks/binary');
+          expect(Array.from(request.rawBody ?? new Uint8Array())).toEqual([0, 10, 13, 195, 40, 255]);
+
+          response.setStatus(204);
+        },
+      },
+      rawBody: true,
+    });
+
+    const response = await fetch(new Request('https://runtime.test/hooks/binary', {
+      body: bytes,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+      method: 'POST',
+    }));
+
+    expect(response.status).toBe(204);
+  });
+
   it('preserves response parity for simple JSON and non-fast-path responses', async () => {
     @Controller('/responses')
     class ResponsesController {
@@ -1202,7 +1226,7 @@ describe('@fluojs/platform-bun', () => {
 
     try {
       expect(mockBun.lastOptions?.routes).toBeUndefined();
-      expect(Object.prototype.hasOwnProperty.call(mockBun.lastOptions, 'routes')).toBe(false);
+      expect(Object.hasOwn(mockBun.lastOptions ?? {}, 'routes')).toBe(false);
 
       const response = await mockBun.lastServer?.fetch(new Request('http://127.0.0.1:4317/version-gate/legacy-runtime'));
 
@@ -1436,6 +1460,65 @@ describe('@fluojs/platform-bun', () => {
     }
   });
 
+  it('uses forceExitTimeoutMs as the signal-driven Bun close drain budget', async () => {
+    vi.useFakeTimers();
+
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const mockBun = installMockBun();
+    const deferred = createDeferred<void>();
+    const originalExitCode = process.exitCode;
+    let app: Awaited<ReturnType<typeof runBunApplication>> | undefined;
+
+    @Controller('/drain')
+    class DrainController {
+      @Get('/')
+      async drain() {
+        await deferred.promise;
+        return { ok: true };
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, { controllers: [DrainController] });
+
+    try {
+      app = await runBunApplication(AppModule, {
+        forceExitTimeoutMs: 20_000,
+        hostname: '127.0.0.1',
+        port: 4315,
+        shutdownSignals: ['SIGTERM'],
+      });
+
+      const responsePromise = mockBun.lastServer!.fetch(new Request('http://127.0.0.1:4315/drain'));
+      await Promise.resolve();
+
+      process.emit('SIGTERM', 'SIGTERM');
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      expect(process.exitCode).toBe(originalExitCode);
+      expect(errorLog.mock.calls.some(([message]) => String(message).includes('Failed to shut down the application cleanly.'))).toBe(false);
+      expect(errorLog.mock.calls.some(([message]) => String(message).includes('Shutdown timeout exceeded after 20000ms'))).toBe(false);
+
+      deferred.resolve();
+      const response = await responsePromise;
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+
+      expect(response?.status).toBe(200);
+      expect(process.exitCode).toBe(0);
+    } finally {
+      deferred.resolve();
+
+      if (app?.state !== 'closed') {
+        await app?.close();
+      }
+
+      errorLog.mockRestore();
+      process.exitCode = originalExitCode;
+      vi.useRealTimers();
+    }
+  });
+
   it('drains in-flight requests before Bun close resolves', async () => {
     const mockBun = installMockBun();
     const adapter = createBunAdapter() as BunHttpApplicationAdapter;
@@ -1467,6 +1550,41 @@ describe('@fluojs/platform-bun', () => {
 
     expect(closeSettled).toBe(true);
     expect(adapter.getServer()).toBeUndefined();
+  });
+
+  it('returns shutdown 503 for ordinary HTTP ingress during close', async () => {
+    const mockBun = installMockBun();
+    const adapter = createBunAdapter() as BunHttpApplicationAdapter;
+    const deferred = createDeferred<void>();
+    const dispatcher = {
+      dispatch: vi.fn(async (_request: FrameworkRequest, response: FrameworkResponse) => {
+        await deferred.promise;
+        response.setStatus(200);
+        await response.send({ ok: true });
+      }),
+    };
+
+    await adapter.listen(dispatcher);
+
+    const responsePromise = mockBun.lastServer!.fetch(new Request('http://127.0.0.1:3000/drain'));
+    await Promise.resolve();
+
+    const closePromise = adapter.close();
+    const shutdownResponse = await mockBun.lastServer!.fetch(new Request('http://127.0.0.1:3000/new-request'));
+
+    expect(shutdownResponse?.status).toBe(503);
+    await expect(shutdownResponse?.json()).resolves.toMatchObject({
+      error: {
+        code: 'SERVICE_UNAVAILABLE',
+        status: 503,
+      },
+    });
+    expect(dispatcher.dispatch).toHaveBeenCalledTimes(1);
+
+    deferred.resolve();
+
+    await expect(responsePromise).resolves.toBeInstanceOf(Response);
+    await closePromise;
   });
 
   it('does not rebind the live dispatcher when listen() is called more than once', async () => {

--- a/packages/platform-bun/src/adapter.ts
+++ b/packages/platform-bun/src/adapter.ts
@@ -234,8 +234,13 @@ const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 const DEFAULT_FORCE_EXIT_TIMEOUT_MS = 30_000;
 const MINIMUM_BUN_NATIVE_ROUTES_VERSION = '1.2.3';
 const EMPTY_NATIVE_ROUTE_PARAMS: Readonly<Record<string, string>> = Object.freeze({});
+const BUN_ADAPTER_CLOSE_TIMEOUT_MS = Symbol('fluo.bunAdapterCloseTimeoutMs');
 const BUN_WEBSOCKET_SUPPORT_REASON =
   'Bun exposes Bun.serve() + server.upgrade() request-upgrade hosting. Use @fluojs/websockets/bun for the official raw websocket binding.';
+
+type BunAdapterInternalOptions = BunAdapterOptions & {
+  [BUN_ADAPTER_CLOSE_TIMEOUT_MS]?: number;
+};
 
 /** HTTP application adapter backed by native `Bun.serve()`. */
 export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWebSocketBindingHost {
@@ -246,13 +251,18 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   private server?: BunServerLike;
   private realtimeBinding?: BunWebSocketBinding<unknown>;
   private readonly options: BunAdapterOptions;
+  private readonly shutdownTimeoutMs: number;
   private readonly webRequestResponseFactory;
 
   constructor(options: BunAdapterOptions = {}) {
+    const internalOptions = options as BunAdapterInternalOptions;
+
     validateNonNegativeIntegerOption('idleTimeout', options.idleTimeout);
     validateNonNegativeIntegerOption('maxBodySize', options.maxBodySize);
+    validateNonNegativeIntegerOption('shutdownTimeoutMs', internalOptions[BUN_ADAPTER_CLOSE_TIMEOUT_MS]);
     validatePortOption(options.port);
     this.options = options;
+    this.shutdownTimeoutMs = internalOptions[BUN_ADAPTER_CLOSE_TIMEOUT_MS] ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
     this.webRequestResponseFactory = createWebRequestResponseFactory({
       consumeOriginalBody: true,
       maxBodySize: options.maxBodySize,
@@ -350,7 +360,7 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
   /** Stops ingress, waits for in-flight HTTP handlers, and releases adapter state. */
   async close(): Promise<void> {
     if (this.closeInFlight) {
-      await waitForCloseWithTimeout(this.closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+      await waitForCloseWithTimeout(this.closeInFlight, this.shutdownTimeoutMs);
       return;
     }
 
@@ -377,7 +387,7 @@ export class BunHttpApplicationAdapter implements HttpApplicationAdapter, BunWeb
     this.closeInFlight = closeInFlight;
     void closeInFlight.catch(() => {});
 
-    await waitForCloseWithTimeout(closeInFlight, DEFAULT_SHUTDOWN_TIMEOUT_MS);
+    await waitForCloseWithTimeout(closeInFlight, this.shutdownTimeoutMs);
   }
 
   private async dispatchHttpRequest(request: Request): Promise<Response> {
@@ -517,7 +527,7 @@ export async function runBunApplication(
   validateNonNegativeIntegerOption('forceExitTimeoutMs', options.forceExitTimeoutMs);
 
   const logger = createDefaultApplicationLogger();
-  const adapter = createBunAdapter({
+  const adapterOptions: BunAdapterInternalOptions = {
     development: options.development,
     hostname: options.hostname,
     idleTimeout: options.idleTimeout,
@@ -527,7 +537,9 @@ export async function runBunApplication(
     rawBody: options.rawBody,
     stopActiveConnections: options.stopActiveConnections,
     tls: options.tls,
-  }) as BunHttpApplicationAdapter;
+    [BUN_ADAPTER_CLOSE_TIMEOUT_MS]: options.forceExitTimeoutMs ?? DEFAULT_FORCE_EXIT_TIMEOUT_MS,
+  };
+  const adapter = new BunHttpApplicationAdapter(adapterOptions);
 
   return runHttpAdapterApplication(rootModule, {
     ...options,


### PR DESCRIPTION
## Summary

Align the managed Bun adapter close drain timeout with the signal-driven `forceExitTimeoutMs` budget, and add missing regression coverage for shutdown ingress rejection plus custom fetch raw-body byte preservation.

Linked context: Closes #2282

## Changes

- Thread the configured `forceExitTimeoutMs` budget into the managed `runBunApplication(...)` adapter close path through an internal adapter option.
- Add a signal-driven drain regression that proves a longer shutdown budget does not fail at the old 10s adapter close timeout.
- Add ordinary HTTP shutdown ingress coverage that asserts the documented `503` shutdown response while a request is draining.
- Add `createBunFetchHandler(...)` custom-host byte-sensitive `Uint8Array` raw-body preservation coverage.
- Add a patch changeset for `@fluojs/platform-bun`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/platform-bun... build`
- `pnpm --filter @fluojs/platform-bun typecheck`
- `pnpm --filter @fluojs/platform-bun test`
- `pnpm exec biome check "packages/platform-bun/src/adapter.ts" "packages/platform-bun/src/adapter.test.ts" ".changeset/quiet-buns-drain.md"`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/quiet-buns-drain.md`

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports or exported signatures changed. Existing TSDoc remains applicable.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [ ] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This preserves the existing README contract: Bun shutdown stops new ingress with `503`, drains in-flight handlers within the configured signal budget, and preserves byte-exact custom fetch raw bodies. No README contract text changed because the implementation and tests were brought into alignment with the documented behavior.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [ ] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed docs changed. Package-local regression evidence is in `packages/platform-bun/src/adapter.test.ts`, covering the shutdown and raw-body paths named in #2282.