### PR TITLE
Resolve #2284: Drain queue dead-letter writes during startup rollback

### DIFF
--- a/.changeset/bright-queues-drain.md
+++ b/.changeset/bright-queues-drain.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/queue': patch
+---
+
+Drain pending queue dead-letter writes during worker startup rollback before releasing Redis lifecycle state.

--- a/packages/queue/src/module.test.ts
+++ b/packages/queue/src/module.test.ts
@@ -1337,6 +1337,98 @@ describe('@fluojs/queue', () => {
     expect(deadLetters).toHaveLength(1);
   });
 
+  it('drains dead-letter writes during worker startup rollback before Redis state is released', async () => {
+    vi.useFakeTimers();
+    const loggerEvents: string[] = [];
+    const releaseBootstrapReady = createDeferred<void>();
+
+    class StartupRollbackDeadLetterJob {
+      constructor(public readonly id: string) {}
+    }
+
+    class StartupRollbackFailureJob {
+      constructor(public readonly id: string) {}
+    }
+
+    @QueueWorker(StartupRollbackDeadLetterJob, { attempts: 1, jobName: 'startup-rollback-dead-letter-job' })
+    class StartupRollbackDeadLetterWorker {
+      async handle(_job: StartupRollbackDeadLetterJob): Promise<void> {
+        throw new Error('startup rollback terminal failure');
+      }
+    }
+
+    @QueueWorker(StartupRollbackFailureJob, { jobName: 'startup-rollback-failing-start-job' })
+    class StartupRollbackFailureWorker {
+      async handle(_job: StartupRollbackFailureJob): Promise<void> {}
+    }
+
+    class AppModule {}
+
+    const redis = new MockRedisClient();
+    redis.rpush = () => new Promise<number>(() => undefined);
+
+    const container = {
+      has: (token: unknown) => token === REDIS_CLIENT,
+      resolve: async (token: unknown) => {
+        if (token === REDIS_CLIENT) {
+          return redis;
+        }
+
+        if (token === StartupRollbackDeadLetterWorker) {
+          return new StartupRollbackDeadLetterWorker();
+        }
+
+        return new StartupRollbackFailureWorker();
+      },
+    };
+    const service = new QueueLifecycleService(
+      {
+        defaultAttempts: 1,
+        defaultConcurrency: 1,
+        defaultDeadLetterMaxEntries: 1_000,
+        global: true,
+        workerShutdownTimeoutMs: 30_000,
+      },
+      container as never,
+      [
+        {
+          definition: { providers: [StartupRollbackDeadLetterWorker, StartupRollbackFailureWorker] },
+          type: AppModule,
+        },
+      ] as never,
+      createLogger(loggerEvents),
+      { wait: () => releaseBootstrapReady.promise },
+    );
+
+    bullmqState.failWorkerRun.add('startup-rollback-failing-start-job');
+
+    await service.onApplicationBootstrap();
+    await service.enqueue(new StartupRollbackDeadLetterJob('job-1'));
+
+    releaseBootstrapReady.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(service.createPlatformStatusSnapshot().details).toMatchObject({
+      lifecycleState: 'failed',
+      pendingDeadLetterWrites: 1,
+      queuesReady: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(
+      loggerEvents.filter((event) =>
+        event.includes('error:QueueLifecycleService:Dead-letter write did not complete within shutdown timeout.'),
+      ),
+    ).toHaveLength(1);
+    expect(service.createPlatformStatusSnapshot().details).toMatchObject({
+      lifecycleState: 'failed',
+      pendingDeadLetterWrites: 0,
+      queuesReady: 0,
+    });
+  });
+
   it('rolls back partially initialized workers, queues, and connections when startup fails', async () => {
     class StartupFirstJob {
       constructor(public readonly id: string) {}

--- a/packages/queue/src/service.ts
+++ b/packages/queue/src/service.ts
@@ -315,6 +315,7 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
 
   private async handleStartupFailure(): Promise<void> {
     await this.closeInitializedResources();
+    await this.deadLetterManager.drainPendingWrites();
     if (this.lifecycleState === 'starting') {
       this.lifecycleState = 'idle';
     }
@@ -568,10 +569,11 @@ export class QueueLifecycleService implements Queue, OnApplicationBootstrap, OnA
 
   private rollbackAfterWorkerStartupFailure(): void {
     if (!this.startupFailureRollbackPromise) {
-      this.startupFailureRollbackPromise = this.closeInitializedResources()
-        .then(() => {
-          this.redisClient = undefined;
-        })
+      this.startupFailureRollbackPromise = (async () => {
+        await this.closeInitializedResources();
+        await this.deadLetterManager.drainPendingWrites();
+        this.redisClient = undefined;
+      })()
         .catch((rollbackError: unknown) => {
           this.logger.error(
             'Failed to roll back queue resources after worker startup failure.',


### PR DESCRIPTION
## Summary

Closes #2284.

Fixes the Queue worker startup rollback path so pending dead-letter writes are drained after queue-owned resources close and before the Redis lifecycle state is released.

Linked context: https://github.com/fluojs/fluo/issues/2284

## Changes

- Await `deadLetterManager.drainPendingWrites()` during startup failure rollback paths in `QueueLifecycleService`.
- Add regression coverage for a worker startup failure that races with a terminal job failure dead-letter write.
- Add a patch changeset for the public `@fluojs/queue` behavior fix.

## Testing

- PASS: `pnpm install --frozen-lockfile`
- PASS: `pnpm exec biome lint packages/queue/src/service.ts packages/queue/src/module.test.ts`
- PASS: `pnpm --filter @fluojs/queue test` (3 files, 42 tests)
- PASS: `pnpm --filter @fluojs/queue... build`
- PASS: `pnpm --filter @fluojs/queue typecheck`
- PASS: `pnpm verify:changeset-release-lane`
- NOTE: `lsp_diagnostics` for changed TS files could not start because the tool could not find the `biome` executable in its PATH; changed-file lint and package typecheck passed.
- NOTE: `pnpm verify:release-readiness` was attempted and failed in unrelated `packages/cli/src/new/scaffold.test.ts` timeout/temporary package-cache failures while queue tests passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/bright-queues-drain.md` for `@fluojs/queue`.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

해당 없음: no public exports or public signatures changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This preserves the documented Queue dead-letter/lifecycle contract; README text already states shutdown closes resources and drains pending dead-letter writes, so no new API or documentation semantics were introduced.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

해당 없음: no governance docs, platform contract docs, or package README conformance claims changed.