### PR TITLE
Resolve #2286: Detect duplicate CQRS handlers registered under different tokens

### DIFF
--- a/.changeset/rare-owls-detect.md
+++ b/.changeset/rare-owls-detect.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/cqrs': patch
+---
+
+Detect duplicate command and query handlers when the same handler class is registered under different singleton provider tokens.

--- a/packages/cqrs/src/buses/command-bus.ts
+++ b/packages/cqrs/src/buses/command-bus.ts
@@ -1,7 +1,7 @@
 import { Inject, InvariantError } from '@fluojs/core';
 import type { OnApplicationBootstrap } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
-import { CqrsBusBase, createDuplicateHandlerMessage } from '../discovery.js';
+import { CqrsBusBase, createDuplicateHandlerMessage, isSameHandlerRegistration } from '../discovery.js';
 import { CommandHandlerNotFoundException, DuplicateCommandHandlerError } from '../errors.js';
 import { getCommandHandlerMetadata } from '../metadata.js';
 import type {
@@ -97,7 +97,6 @@ export class CommandBusLifecycleService extends CqrsBusBase implements CommandBu
 
   private discoverCommandDescriptors(): Map<CommandType, CommandHandlerDescriptor> {
     const descriptors = new Map<CommandType, CommandHandlerDescriptor>();
-    const seenByTarget = new WeakMap<Function, Set<CommandType>>();
 
     for (const candidate of this.discoveryCandidates()) {
       const metadata = getCommandHandlerMetadata(candidate.targetType);
@@ -114,34 +113,27 @@ export class CommandBusLifecycleService extends CqrsBusBase implements CommandBu
         continue;
       }
 
-      const seenCommandTypes = seenByTarget.get(candidate.targetType) ?? new Set<CommandType>();
-
-      if (seenCommandTypes.has(metadata.commandType)) {
-        continue;
-      }
-
-      seenCommandTypes.add(metadata.commandType);
-      seenByTarget.set(candidate.targetType, seenCommandTypes);
-
       const existing = descriptors.get(metadata.commandType);
+      const nextDescriptor = {
+        moduleName: candidate.moduleName,
+        targetType: candidate.targetType,
+        token: candidate.token,
+      };
 
-      if (existing && existing.targetType !== candidate.targetType) {
+      if (existing) {
+        if (isSameHandlerRegistration(existing, nextDescriptor)) {
+          continue;
+        }
+
         throw new DuplicateCommandHandlerError(
-          createDuplicateHandlerMessage('command', metadata.commandType, existing, {
-            moduleName: candidate.moduleName,
-            targetType: candidate.targetType,
-          }),
+          createDuplicateHandlerMessage('command', metadata.commandType, existing, nextDescriptor),
         );
       }
 
-      if (!existing) {
-        descriptors.set(metadata.commandType, {
-          commandType: metadata.commandType,
-          moduleName: candidate.moduleName,
-          targetType: candidate.targetType,
-          token: candidate.token,
-        });
-      }
+      descriptors.set(metadata.commandType, {
+        commandType: metadata.commandType,
+        ...nextDescriptor,
+      });
     }
 
     return descriptors;

--- a/packages/cqrs/src/buses/query-bus.ts
+++ b/packages/cqrs/src/buses/query-bus.ts
@@ -3,7 +3,7 @@ import type {
   OnApplicationBootstrap,
 } from '@fluojs/runtime';
 import { APPLICATION_LOGGER, COMPILED_MODULES, RUNTIME_CONTAINER } from '@fluojs/runtime/internal';
-import { CqrsBusBase, createDuplicateHandlerMessage } from '../discovery.js';
+import { CqrsBusBase, createDuplicateHandlerMessage, isSameHandlerRegistration } from '../discovery.js';
 import { DuplicateQueryHandlerError, QueryHandlerNotFoundException } from '../errors.js';
 import { getQueryHandlerMetadata } from '../metadata.js';
 import type {
@@ -99,7 +99,6 @@ export class QueryBusLifecycleService extends CqrsBusBase implements QueryBus, O
 
   private discoverQueryDescriptors(): Map<QueryType, QueryHandlerDescriptor> {
     const descriptors = new Map<QueryType, QueryHandlerDescriptor>();
-    const seenByTarget = new WeakMap<Function, Set<QueryType>>();
 
     for (const candidate of this.discoveryCandidates()) {
       const metadata = getQueryHandlerMetadata(candidate.targetType);
@@ -116,34 +115,27 @@ export class QueryBusLifecycleService extends CqrsBusBase implements QueryBus, O
         continue;
       }
 
-      const seenQueryTypes = seenByTarget.get(candidate.targetType) ?? new Set<QueryType>();
-
-      if (seenQueryTypes.has(metadata.queryType)) {
-        continue;
-      }
-
-      seenQueryTypes.add(metadata.queryType);
-      seenByTarget.set(candidate.targetType, seenQueryTypes);
-
       const existing = descriptors.get(metadata.queryType);
+      const nextDescriptor = {
+        moduleName: candidate.moduleName,
+        targetType: candidate.targetType,
+        token: candidate.token,
+      };
 
-      if (existing && existing.targetType !== candidate.targetType) {
+      if (existing) {
+        if (isSameHandlerRegistration(existing, nextDescriptor)) {
+          continue;
+        }
+
         throw new DuplicateQueryHandlerError(
-          createDuplicateHandlerMessage('query', metadata.queryType, existing, {
-            moduleName: candidate.moduleName,
-            targetType: candidate.targetType,
-          }),
+          createDuplicateHandlerMessage('query', metadata.queryType, existing, nextDescriptor),
         );
       }
 
-      if (!existing) {
-        descriptors.set(metadata.queryType, {
-          moduleName: candidate.moduleName,
-          queryType: metadata.queryType,
-          targetType: candidate.targetType,
-          token: candidate.token,
-        });
-      }
+      descriptors.set(metadata.queryType, {
+        queryType: metadata.queryType,
+        ...nextDescriptor,
+      });
     }
 
     return descriptors;

--- a/packages/cqrs/src/discovery.ts
+++ b/packages/cqrs/src/discovery.ts
@@ -1,4 +1,4 @@
-import { type Token } from '@fluojs/core';
+import { formatTokenName, type Token } from '@fluojs/core';
 import { getClassDiMetadata } from '@fluojs/core/internal';
 import type { Container, Provider } from '@fluojs/di';
 import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
@@ -41,10 +41,28 @@ function isClassProvider(provider: Provider): provider is Extract<Provider, { pr
 export function createDuplicateHandlerMessage(
   kind: 'command' | 'query' | 'event',
   messageType: Function,
-  first: { moduleName: string; targetType: Function },
-  second: { moduleName: string; targetType: Function },
+  first: { moduleName: string; targetType: Function; token: Token },
+  second: { moduleName: string; targetType: Function; token: Token },
 ): string {
-  return `Duplicate ${kind} handler for ${messageType.name} was discovered in ${first.moduleName}.${first.targetType.name} and ${second.moduleName}.${second.targetType.name}.`;
+  return `Duplicate ${kind} handler for ${messageType.name} was discovered in ${describeHandlerRegistration(first)} and ${describeHandlerRegistration(second)}.`;
+}
+
+function describeHandlerRegistration(registration: { moduleName: string; targetType: Function; token: Token }): string {
+  return `${registration.moduleName}.${registration.targetType.name} [token: ${formatTokenName(registration.token)}]`;
+}
+
+/**
+ * Checks whether two discovered handler candidates refer to the same provider registration.
+ *
+ * @param first The first handler registration.
+ * @param second The second handler registration.
+ * @returns Whether both target type and provider token match.
+ */
+export function isSameHandlerRegistration(
+  first: { targetType: Function; token: Token },
+  second: { targetType: Function; token: Token },
+): boolean {
+  return first.targetType === second.targetType && first.token === second.token;
 }
 
 /**

--- a/packages/cqrs/src/module.test.ts
+++ b/packages/cqrs/src/module.test.ts
@@ -251,6 +251,33 @@ describe('@fluojs/cqrs', () => {
     await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toBeInstanceOf(DuplicateCommandHandlerError);
   });
 
+  it('fails bootstrap when one command handler class is registered under different singleton tokens', async () => {
+    const FIRST_CREATE_USER_HANDLER = Symbol('FIRST_CREATE_USER_HANDLER');
+    const SECOND_CREATE_USER_HANDLER = Symbol('SECOND_CREATE_USER_HANDLER');
+
+    @CommandHandler(CreateUserCommand)
+    class SharedCreateUserHandler {
+      execute(_command: CreateUserCommand) {
+        return 'shared';
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [
+        { provide: FIRST_CREATE_USER_HANDLER, useClass: SharedCreateUserHandler },
+        { provide: SECOND_CREATE_USER_HANDLER, useClass: SharedCreateUserHandler },
+      ],
+    });
+
+    const error = await bootstrapApplication({ rootModule: AppModule }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DuplicateCommandHandlerError);
+    expect(error).toEqual(expect.objectContaining({ message: expect.stringContaining('Symbol(FIRST_CREATE_USER_HANDLER)') }));
+    expect(error).toEqual(expect.objectContaining({ message: expect.stringContaining('Symbol(SECOND_CREATE_USER_HANDLER)') }));
+  });
+
   it('fails bootstrap when duplicate query handlers are registered for one query type', async () => {
     @QueryHandler(GetUserQuery)
     class FirstGetUserHandler {
@@ -273,6 +300,33 @@ describe('@fluojs/cqrs', () => {
     });
 
     await expect(bootstrapApplication({ rootModule: AppModule })).rejects.toBeInstanceOf(DuplicateQueryHandlerError);
+  });
+
+  it('fails bootstrap when one query handler class is registered under different singleton tokens', async () => {
+    const FIRST_GET_USER_HANDLER = Symbol('FIRST_GET_USER_HANDLER');
+    const SECOND_GET_USER_HANDLER = Symbol('SECOND_GET_USER_HANDLER');
+
+    @QueryHandler(GetUserQuery)
+    class SharedGetUserHandler {
+      execute(_query: GetUserQuery) {
+        return 'shared';
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CqrsModule.forRoot()],
+      providers: [
+        { provide: FIRST_GET_USER_HANDLER, useClass: SharedGetUserHandler },
+        { provide: SECOND_GET_USER_HANDLER, useClass: SharedGetUserHandler },
+      ],
+    });
+
+    const error = await bootstrapApplication({ rootModule: AppModule }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(DuplicateQueryHandlerError);
+    expect(error).toEqual(expect.objectContaining({ message: expect.stringContaining('Symbol(FIRST_GET_USER_HANDLER)') }));
+    expect(error).toEqual(expect.objectContaining({ message: expect.stringContaining('Symbol(SECOND_GET_USER_HANDLER)') }));
   });
 
   it('delegates publish and publishAll to the underlying event bus when no CQRS event handlers are registered', async () => {


### PR DESCRIPTION
## Summary

Detect duplicate CQRS command/query handler registrations when the same handler class is registered under different singleton provider tokens.

Linked context: Closes #2286

## Changes

- Compare discovered command/query handler claims by provider registration identity (`targetType` + `token`) instead of `targetType` alone.
- Keep identical repeated registrations deduplicated, but throw `DuplicateCommandHandlerError` / `DuplicateQueryHandlerError` when different tokens claim the same command/query type.
- Include provider token names in duplicate handler error messages to make tokenized registration conflicts diagnosable.
- Add regression coverage for command and query handlers registered under two different `symbol` tokens.
- Add `.changeset/rare-owls-detect.md` for the public `@fluojs/cqrs` behavior fix.

## Testing

- `pnpm exec biome lint "packages/cqrs/src/discovery.ts" "packages/cqrs/src/buses/command-bus.ts" "packages/cqrs/src/buses/query-bus.ts" "packages/cqrs/src/module.test.ts"` — passed.
- `pnpm --filter @fluojs/cqrs test` — passed: 5 files, 50 tests.
- `pnpm --filter @fluojs/cqrs... build` — passed.
- `pnpm --filter @fluojs/cqrs typecheck` — passed.
- `pnpm lint` — passed; existing repository warnings remain outside this change, and `verify-public-export-tsdoc` passed in changed mode.
- `pnpm verify:release-readiness` — passed without writing draft artifacts.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Changeset: `.changeset/rare-owls-detect.md` (`@fluojs/cqrs`: patch), because duplicate handler detection behavior changes for public CQRS bootstrap semantics.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No root public API export was added. The new internal exported discovery helper includes TSDoc, and `pnpm lint` ran `verify-public-export-tsdoc` successfully in changed mode.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

`packages/cqrs/README.md` already documents `DuplicateCommandHandlerError` / `DuplicateQueryHandlerError` when different singleton providers claim the same command or query type. This change aligns runtime discovery with that existing contract and adds regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform/governance docs or platform conformance claims changed. CQRS package behavior is covered by package regression tests and release-readiness verification.
