### PR TITLE
Resolve #2289: close microservice transports during listen/close races

### DIFF
--- a/.changeset/quiet-buses-close.md
+++ b/.changeset/quiet-buses-close.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/microservices": patch
+---
+
+Close NATS, RabbitMQ, and Redis Streams microservice transports consistently when listen and close race, preserving shutdown guards and Redis Streams cleanup before surfacing startup failures.

--- a/packages/microservices/src/transports/nats-transport.test.ts
+++ b/packages/microservices/src/transports/nats-transport.test.ts
@@ -371,4 +371,30 @@ describe('NatsMicroserviceTransport', () => {
       'NATS microservice transport is closing. Wait for close() to complete before emit().',
     );
   });
+
+  it('rejects listen() while close() is still finalizing', async () => {
+    const nats = new InMemoryNatsClient();
+    const codec = {
+      decode(data: Uint8Array) {
+        return new TextDecoder().decode(data);
+      },
+      encode(value: string) {
+        return new TextEncoder().encode(value);
+      },
+    };
+
+    const transport = new NatsMicroserviceTransport({ client: nats, codec });
+    await transport.listen(async () => undefined);
+
+    const closing = transport.close();
+
+    await expect(transport.listen(async () => undefined)).rejects.toThrow(
+      'NATS microservice transport is closing. Wait for close() to complete before listen().',
+    );
+    await expect(transport.emit('still.closing', {})).rejects.toThrow(
+      'NATS microservice transport is closing. Wait for close() to complete before emit().',
+    );
+
+    await closing;
+  });
 });

--- a/packages/microservices/src/transports/nats-transport.ts
+++ b/packages/microservices/src/transports/nats-transport.ts
@@ -53,6 +53,7 @@ interface PendingRequest {
  * preserving JSON framing and NATS request timeout behavior.
  */
 export class NatsMicroserviceTransport implements MicroserviceTransport {
+  private closePromise: Promise<void> | undefined;
   private closing = false;
   private handler: TransportHandler | undefined;
   private logger: MicroserviceTransportLogger | undefined;
@@ -95,7 +96,14 @@ export class NatsMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once subscriptions are active.
    */
   async listen(handler: TransportHandler): Promise<void> {
-    this.closing = false;
+    if (this.closing) {
+      if (this.closePromise) {
+        throw new Error('NATS microservice transport is closing. Wait for close() to complete before listen().');
+      }
+
+      this.closing = false;
+    }
+
     this.handler = handler;
 
     if (this.listening) {
@@ -243,28 +251,41 @@ export class NatsMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once shutdown cleanup completes.
    */
   async close(): Promise<void> {
-    this.closing = true;
-    let closeError: unknown;
-
-    try {
-      for (const subscription of this.subscriptions) {
-        subscription.unsubscribe();
-      }
-
-    } catch (error) {
-      closeError = error;
-    } finally {
-      this.subscriptions = [];
-      this.listening = false;
-      this.handler = undefined;
-
-      for (const pending of [...this.pending.values()]) {
-        pending.reject(new Error('NATS microservice transport closed before response.'));
-      }
+    if (this.closePromise) {
+      await this.closePromise;
+      return;
     }
 
-    if (closeError) {
-      throw closeError;
+    this.closing = true;
+    this.closePromise = (async () => {
+      let closeError: unknown;
+
+      try {
+        for (const subscription of this.subscriptions) {
+          subscription.unsubscribe();
+        }
+
+      } catch (error) {
+        closeError = error;
+      } finally {
+        this.subscriptions = [];
+        this.listening = false;
+        this.handler = undefined;
+
+        for (const pending of [...this.pending.values()]) {
+          pending.reject(new Error('NATS microservice transport closed before response.'));
+        }
+      }
+
+      if (closeError) {
+        throw closeError;
+      }
+    })();
+
+    try {
+      await this.closePromise;
+    } finally {
+      this.closePromise = undefined;
     }
   }
 

--- a/packages/microservices/src/transports/rabbitmq-transport.test.ts
+++ b/packages/microservices/src/transports/rabbitmq-transport.test.ts
@@ -521,6 +521,54 @@ describe('RabbitMqMicroserviceTransport', () => {
     expect(published.filter((message) => (JSON.parse(message) as { kind?: string }).kind === 'message')).toHaveLength(0);
   });
 
+  it('rejects listen() during close() without reopening the shutdown state', async () => {
+    const bus = new InMemoryQueueBus();
+    let releaseCancel: (() => void) | undefined;
+    let resolveCancelStarted: (() => void) | undefined;
+    let cancelBlocked = false;
+    const cancelStarted = new Promise<void>((resolve) => {
+      resolveCancelStarted = resolve;
+    });
+    const transport = new RabbitMqMicroserviceTransport({
+      consumer: {
+        async cancel(queue) {
+          if (!cancelBlocked) {
+            cancelBlocked = true;
+            resolveCancelStarted?.();
+            await new Promise<void>((resolve) => {
+              releaseCancel = resolve;
+            });
+          }
+
+          await bus.unsubscribe(queue);
+        },
+        async consume(queue, handler) {
+          await bus.subscribe(queue, handler);
+        },
+      },
+      publisher: {
+        async publish(queue, message) {
+          await bus.publish(queue, message);
+        },
+      },
+    });
+
+    await transport.listen(async () => 'ok');
+
+    const closing = transport.close();
+    await cancelStarted;
+
+    await expect(transport.listen(async () => undefined)).rejects.toThrow(
+      'RabbitMqMicroserviceTransport is closing. Wait for close() to complete before listen().',
+    );
+    await expect(transport.emit('still.closing', {})).rejects.toThrow(
+      'RabbitMqMicroserviceTransport is closing. Wait for close() to complete before emit().',
+    );
+
+    releaseCancel?.();
+    await closing;
+  });
+
   it('rejects emit() after close() starts', async () => {
     const bus = new InMemoryQueueBus();
     const transport = new RabbitMqMicroserviceTransport({

--- a/packages/microservices/src/transports/rabbitmq-transport.ts
+++ b/packages/microservices/src/transports/rabbitmq-transport.ts
@@ -35,6 +35,7 @@ export interface RabbitMqMicroserviceTransportOptions {
  * a queue-oriented topology while still consuming the generic Fluo transport API.
  */
 export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
+  private closePromise: Promise<void> | undefined;
   private closing = false;
   private handler: TransportHandler | undefined;
   private listening = false;
@@ -69,7 +70,14 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once queue consumers are registered.
    */
   async listen(handler: TransportHandler): Promise<void> {
-    this.closing = false;
+    if (this.closing) {
+      if (this.closePromise) {
+        throw new Error('RabbitMqMicroserviceTransport is closing. Wait for close() to complete before listen().');
+      }
+
+      this.closing = false;
+    }
+
     this.handler = handler;
 
     if (this.listening) {
@@ -256,32 +264,54 @@ export class RabbitMqMicroserviceTransport implements MicroserviceTransport {
    * @returns A promise that resolves once shutdown cleanup completes.
    */
   async close(): Promise<void> {
-    this.closing = true;
-    let closeError: unknown;
-
-    if (this.listenPromise) {
-      await this.listenPromise;
+    if (this.closePromise) {
+      await this.closePromise;
+      return;
     }
 
-    try {
-      if (this.listening) {
-        for (const queue of this.subscribedQueues) {
-          try {
-            await this.options.consumer.cancel(queue);
-          } catch (error) {
-            closeError ??= error;
-          }
+    this.closing = true;
+    this.closePromise = (async () => {
+      let closeError: unknown;
+      let listenError: unknown;
+
+      if (this.listenPromise) {
+        try {
+          await this.listenPromise;
+        } catch (error) {
+          listenError = error;
         }
       }
-    } finally {
-      this.subscribedQueues.clear();
-      this.rejectPendingRequests(new Error('RabbitMQ microservice transport closed before response.'));
-      this.listening = false;
-      this.handler = undefined;
-    }
 
-    if (closeError) {
-      throw closeError;
+      try {
+        if (this.listening) {
+          for (const queue of this.subscribedQueues) {
+            try {
+              await this.options.consumer.cancel(queue);
+            } catch (error) {
+              closeError ??= error;
+            }
+          }
+        }
+      } finally {
+        this.subscribedQueues.clear();
+        this.rejectPendingRequests(new Error('RabbitMQ microservice transport closed before response.'));
+        this.listening = false;
+        this.handler = undefined;
+      }
+
+      if (listenError) {
+        throw listenError;
+      }
+
+      if (closeError) {
+        throw closeError;
+      }
+    })();
+
+    try {
+      await this.closePromise;
+    } finally {
+      this.closePromise = undefined;
     }
   }
 

--- a/packages/microservices/src/transports/redis-streams-transport.test.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  RedisStreamsMicroserviceTransport,
-  type RedisStreamWriteOptions,
-  type RedisStreamsMicroserviceTransportOptions,
   type RedisStreamClientLike,
+  RedisStreamsMicroserviceTransport,
+  type RedisStreamsMicroserviceTransportOptions,
+  type RedisStreamWriteOptions,
 } from './redis-streams-transport.js';
 
 interface InMemoryStreamEntry {
@@ -1160,6 +1160,65 @@ describe('RedisStreamsMicroserviceTransport', () => {
 
     releaseDestroy?.();
     await closing;
+  });
+
+  it('cleans up stream resources before rethrowing a failed in-flight listen during close()', async () => {
+    const bus = new InMemoryStreamBus();
+    const namespace = 'fluo:streams:listen-close-failure';
+    const startupError = new Error('response group failed');
+    const values = new Map<string, string>();
+    const destroyedGroups: string[] = [];
+    const deletedKeys: string[] = [];
+    let releaseResponseCreate: (() => void) | undefined;
+    let resolveResponseCreateStarted: (() => void) | undefined;
+    const responseCreateStarted = new Promise<void>((resolve) => {
+      resolveResponseCreateStarted = resolve;
+    });
+    const leaseAwareClient = createLeaseAwareClient(bus, values, destroyedGroups);
+    const readerClient = {
+      ...leaseAwareClient,
+      del: async (key: string) => {
+        deletedKeys.push(key);
+
+        if (leaseAwareClient.del) {
+          await leaseAwareClient.del(key);
+        }
+      },
+      xgroupCreate: async (stream: string, group: string, startId: string, mkstream: boolean) => {
+        if (stream.startsWith(`${namespace}:responses:`)) {
+          resolveResponseCreateStarted?.();
+          await new Promise<void>((resolve) => {
+            releaseResponseCreate = resolve;
+          });
+          throw startupError;
+        }
+
+        await leaseAwareClient.xgroupCreate(stream, group, startId, mkstream);
+      },
+    } satisfies RedisStreamClientLike;
+    const { transport } = createTransport(bus, {
+      namespace,
+      readerClient,
+    });
+
+    const listening = transport.listen(async () => undefined);
+    const listenResult = listening.catch((error: unknown) => error);
+    await responseCreateStarted;
+
+    const closing = transport.close();
+    releaseResponseCreate?.();
+
+    await expect(closing).rejects.toBe(startupError);
+    await expect(listenResult).resolves.toBe(startupError);
+    expect(values.get(`${namespace}:groups:fluo-handlers:owner`)).toBeUndefined();
+    expect(values.get(`${namespace}:groups:fluo-handlers:listeners`)).toBeUndefined();
+    expect(destroyedGroups.some((entry) => entry.startsWith(`${namespace}:events::fluo-handlers:events:`))).toBe(true);
+    expect(
+      destroyedGroups.some((entry) => (
+        entry.startsWith(`${namespace}:responses:`) && entry.includes('::fluo-handlers:responses:')
+      )),
+    ).toBe(true);
+    expect(deletedKeys.some((key) => key.startsWith(`${namespace}:responses:`))).toBe(true);
   });
 
   it('still rejects pending requests when group destroy fails during close', async () => {

--- a/packages/microservices/src/transports/redis-streams-transport.ts
+++ b/packages/microservices/src/transports/redis-streams-transport.ts
@@ -311,14 +311,25 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
     this.closing = true;
     this.closePromise = (async () => {
       let closeError: unknown;
+      let listenError: unknown;
 
       if (this.listenPromise) {
-        await this.listenPromise;
+        try {
+          await this.listenPromise;
+        } catch (error) {
+          listenError = error;
+        }
       }
 
       try {
         const settled = await Promise.allSettled(this.pollPromises);
-        const shouldDestroyMessageGroup = await this.releaseMessageGroupLease();
+        let shouldDestroyMessageGroup = false;
+
+        try {
+          shouldDestroyMessageGroup = await this.releaseMessageGroupLease();
+        } catch (error) {
+          closeError ??= error;
+        }
 
         for (const result of settled) {
           if (result.status === 'rejected') {
@@ -361,6 +372,10 @@ export class RedisStreamsMicroserviceTransport implements MicroserviceTransport 
         for (const pending of [...this.pending.values()]) {
           pending.reject(new Error('Redis Streams microservice transport closed before response.'));
         }
+      }
+
+      if (listenError) {
+        throw listenError;
       }
 
       if (closeError) {


### PR DESCRIPTION
## Summary

Linked context: https://github.com/fluojs/fluo/issues/2289

Closes #2289

Close the NATS, RabbitMQ, and Redis Streams transport lifecycle races called out in issue 2289 while preserving the documented shutdown contract for caller-owned broker resources.

## Changes

- Added closePromise-backed shutdown gates to `NatsMicroserviceTransport` so `listen()` cannot reopen or clear shutdown state while `close()` is still finalizing.
- Added the same closePromise-backed guard to `RabbitMqMicroserviceTransport`, with close cleanup still running after an in-flight listen startup error is observed.
- Updated `RedisStreamsMicroserviceTransport.close()` to capture failed in-flight startup, still run poll, lease, group, response-stream, and pending-request cleanup, then rethrow the captured startup error.
- Added transport-specific regression coverage for NATS, RabbitMQ, and Redis Streams listen/close races.
- Added `.changeset/quiet-buses-close.md` for the public `@fluojs/microservices` behavior fix.

## Testing

- `pnpm exec biome check "packages/microservices/src/transports/nats-transport.ts" "packages/microservices/src/transports/nats-transport.test.ts" "packages/microservices/src/transports/rabbitmq-transport.ts" "packages/microservices/src/transports/rabbitmq-transport.test.ts" "packages/microservices/src/transports/redis-streams-transport.ts" "packages/microservices/src/transports/redis-streams-transport.test.ts" ".changeset/quiet-buses-close.md"`
- `pnpm --filter @fluojs/microservices... build`
- `pnpm --filter @fluojs/microservices typecheck`
- `pnpm --filter @fluojs/microservices exec vitest run -c vitest.config.ts src/transports/nats-transport.test.ts src/transports/rabbitmq-transport.test.ts src/transports/redis-streams-transport.test.ts`
- `pnpm --filter @fluojs/microservices test`
- `pnpm --filter @fluojs/cli exec vitest run -c vitest.config.ts src/new/scaffold.test.ts -t "keeps generated broker starter modules import-safe for inspect-style tooling without a live broker"`
- `pnpm verify:release-readiness`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/quiet-buses-close.md` for `@fluojs/microservices`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports or signatures changed; existing TSDoc remains valid.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The existing `packages/microservices/README.md` shutdown/listen-race guarantees are preserved and now covered for the affected transports.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform/governance docs changed. Package README alignment is backed by the added transport-level regression tests and release-readiness verification.