### PR TITLE
Resolve #2279: harden DI request scope lifecycle and introspection ownership

### DIFF
--- a/.changeset/soft-pandas-guard.md
+++ b/.changeset/soft-pandas-guard.md
@@ -1,0 +1,6 @@
+---
+"@fluojs/di": patch
+"@fluojs/testing": patch
+---
+
+Harden DI request-scope lifecycle and introspection ownership by recursively disposing nested request scopes from their owners, returning read-only introspection state, and keeping testing cache adoption on controlled container-owned APIs.

--- a/.changeset/soft-pandas-guard.md
+++ b/.changeset/soft-pandas-guard.md
@@ -1,6 +1,8 @@
 ---
-"@fluojs/di": patch
+"@fluojs/di": major
 "@fluojs/testing": patch
 ---
 
 Harden DI request-scope lifecycle and introspection ownership by recursively disposing nested request scopes from their owners, returning read-only introspection state, and keeping testing cache adoption on controlled container-owned APIs.
+
+Migration note: callers that used `inspectResolutionState()` as a mutable escape hatch must stop mutating returned registration/cache maps or normalized provider records. Framework-owned tooling should use the returned `cacheOwner` helpers for controlled cache adoption instead of writing to the maps directly.

--- a/packages/di/README.ko.md
+++ b/packages/di/README.ko.md
@@ -76,7 +76,7 @@ const service = await container.resolve(UserService);
 - **request**: `createRequestScope()`마다 새로 생성됩니다.
 - **transient**: resolve할 때마다 새 인스턴스를 만듭니다.
 
-dispose 중에는 루트 컨테이너가 먼저 살아 있는 request scope 자식을 정리한 뒤, 자식 dispose 중 하나 이상이 실패하더라도 루트가 소유한 singleton 정리를 계속 수행합니다. 자식/루트 dispose 실패가 여러 개 발생하면 `dispose()`는 모든 shutdown 실패를 확인할 수 있도록 `AggregateError`로 보고합니다.
+dispose 중에는 각 컨테이너가 자신이 소유한 살아 있는 request scope 자식을 먼저 재귀적으로 정리하므로, 루트가 아닌 request scope를 dispose해도 중첩 request scope를 닫은 뒤 자신의 request cache를 정리합니다. 이후 루트 dispose는 자식 dispose 중 하나 이상이 실패하더라도 루트가 소유한 singleton 정리를 계속 수행합니다. 자식/루트 dispose 실패가 여러 개 발생하면 `dispose()`는 모든 shutdown 실패를 확인할 수 있도록 `AggregateError`로 보고합니다.
 
 ### provider override
 
@@ -163,7 +163,7 @@ const service = await container.resolve(DataService);
 | `register(...providers)` | 하나 이상의 프로바이더를 등록합니다. |
 | `override(...providers)` | 기존 provider를 교체하고 cached instance를 무효화하며 오래된 instance를 dispose합니다. |
 | `resolve<T>(token)` | 토큰을 인스턴스로 비동기 해석합니다. |
-| `inspectResolutionState()` | cache ownership을 보존해야 하는 testing/tooling helper를 위한 지원 대상 framework-owned container introspection seam을 노출합니다. 애플리케이션 코드는 `has(...)`와 `resolve(...)`를 우선 사용하세요. |
+| `inspectResolutionState()` | read-only map view, frozen provider record, controlled cache adoption을 통해 cache ownership을 보존해야 하는 testing/tooling helper를 위한 지원 대상 framework-owned container introspection seam을 노출합니다. 애플리케이션 코드는 `has(...)`와 `resolve(...)`를 우선 사용하세요. |
 | `createRequestScope()` | 요청 스코프 의존성을 위한 자식 컨테이너를 생성합니다. |
 | `has(token)` | 컨테이너나 부모에 토큰이 등록되어 있는지 확인합니다. |
 | `hasRequestScopedDependency(token)` | 토큰 해석 시 provider 그래프에 request-scoped 의존성이나 순환이 있어 request-scope 컨테이너가 필요할 수 있는지 확인합니다. |
@@ -176,7 +176,7 @@ const service = await container.resolve(DataService);
 | Provider types | `Provider`, `ClassProvider`, `FactoryProvider`, `ValueProvider`, `ExistingProvider`는 `register(...)`와 `override(...)`가 받는 공개 registration shape를 설명합니다. |
 | Token wrapper types | `ForwardRefFn`과 `OptionalToken`은 `forwardRef(...)`와 `optional(...)`이 반환하는 wrapper 값을 설명합니다. |
 | Container helper types | `ClassType`, `Disposable`, `RequestScopeContainer`는 typed provider 선언, teardown hook, request-scope helper 경계를 지원합니다. |
-| `ContainerResolutionState` | framework testing/tooling integration을 위해 `inspectResolutionState()`가 반환하는 공개 introspection record입니다. |
+| Container introspection helper types | `ContainerResolutionState`, `ContainerResolutionCacheOwner`, `ContainerFactoryResolutionState`는 `inspectResolutionState()`가 반환하는 read-only graph/cache view와 controlled cache adoption helper를 설명합니다. |
 | `NormalizedProvider` | 컨테이너가 검증한 provider record shape를 위한 compatibility-only 공개 타입입니다. provider를 작성할 때는 `Provider`나 구체 provider interface를 우선 사용하세요. normalized record 생성은 컨테이너가 소유합니다. |
 | `DiErrorContext` | DI error에 붙는 구조화된 context입니다. 로그와 테스트가 token, scope, module, dependency chain, hint를 검사할 수 있게 합니다. |
 | 에러 클래스 | `InvalidProviderError`, `ContainerResolutionError`, `RequestScopeResolutionError`, `ScopeMismatchError`, `CircularDependencyError`, `DuplicateProviderError`. |

--- a/packages/di/README.md
+++ b/packages/di/README.md
@@ -75,7 +75,7 @@ fluo DI supports four provider shapes:
 - **Request**: Instance is created once per `createRequestScope()` call.
 - **Transient**: A new instance is created every time it is resolved.
 
-During disposal, the root container first tears down live request-scope children and then continues with root-owned singleton cleanup even if one or more child disposals fail. When multiple child/root disposals fail, `dispose()` reports an `AggregateError` so callers can inspect every shutdown failure without losing cleanup progress.
+During disposal, each container first recursively tears down live request-scope children it owns, so disposing a non-root request scope also closes nested request scopes before its own request cache. Root disposal then continues with root-owned singleton cleanup even if one or more child disposals fail. When multiple child/root disposals fail, `dispose()` reports an `AggregateError` so callers can inspect every shutdown failure without losing cleanup progress.
 
 ### Provider Overrides
 
@@ -163,7 +163,7 @@ Ensure all required providers are registered in the container. If you use `creat
 | `register(...providers)` | Registers one or more providers. |
 | `override(...providers)` | Replaces existing providers, invalidates cached instances, and disposes stale instances. |
 | `resolve<T>(token)` | Asynchronously resolves a token to an instance. |
-| `inspectResolutionState()` | Exposes the supported framework-owned container introspection seam for testing/tooling helpers that must preserve cache ownership. Prefer `has(...)` and `resolve(...)` for application code. |
+| `inspectResolutionState()` | Exposes the supported framework-owned container introspection seam for testing/tooling helpers that must preserve cache ownership through read-only map views, frozen provider records, and controlled cache adoption. Prefer `has(...)` and `resolve(...)` for application code. |
 | `createRequestScope()` | Creates a child container for request-scoped dependencies. |
 | `has(token)` | Checks if a token is registered in the container or its parents. |
 | `hasRequestScopedDependency(token)` | Checks whether resolving a token may require a request-scope container because its provider graph contains request-scoped dependencies or is cyclic. |
@@ -176,7 +176,7 @@ Ensure all required providers are registered in the container. If you use `creat
 | Provider types | `Provider`, `ClassProvider`, `FactoryProvider`, `ValueProvider`, and `ExistingProvider` describe the public registration shapes accepted by `register(...)` and `override(...)`. |
 | Token wrapper types | `ForwardRefFn` and `OptionalToken` describe the wrapper values returned by `forwardRef(...)` and `optional(...)`. |
 | Container helper types | `ClassType`, `Disposable`, and `RequestScopeContainer` support typed provider declarations, teardown hooks, and request-scope helper boundaries. |
-| `ContainerResolutionState` | Public introspection record returned by `inspectResolutionState()` for framework testing/tooling integrations. |
+| Container introspection helper types | `ContainerResolutionState`, `ContainerResolutionCacheOwner`, and `ContainerFactoryResolutionState` describe the read-only graph/cache views and controlled cache adoption helpers returned by `inspectResolutionState()`. |
 | `NormalizedProvider` | Compatibility-only public type for the container's validated provider record shape. Prefer authoring providers with `Provider` or the specific provider interfaces; the container owns normalized record construction. |
 | `DiErrorContext` | Structured context attached to DI errors so logs and tests can inspect tokens, scopes, modules, dependency chains, and hints. |
 | Error classes | `InvalidProviderError`, `ContainerResolutionError`, `RequestScopeResolutionError`, `ScopeMismatchError`, `CircularDependencyError`, `DuplicateProviderError`. |

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { Inject, Scope as ScopeDecorator } from '@fluojs/core';
+import { Inject, Scope as ScopeDecorator, type Token } from '@fluojs/core';
 
 import { Container } from './container.js';
 import { CircularDependencyError, ContainerResolutionError, DuplicateProviderError, InvalidProviderError, RequestScopeResolutionError, ScopeMismatchError } from './errors.js';
@@ -877,6 +877,90 @@ describe('Container', () => {
     });
   });
 
+  describe('inject wrapper immutability', () => {
+    it('returns frozen forwardRef and optional wrapper tokens', () => {
+      class Logger {}
+      class MutatedLogger {}
+
+      const forwardLogger = forwardRef(() => Logger);
+      const optionalLogger = optional(Logger);
+
+      expect(Object.isFrozen(forwardLogger)).toBe(true);
+      expect(Object.isFrozen(optionalLogger)).toBe(true);
+      expect(Reflect.set(forwardLogger, 'forwardRef', () => MutatedLogger)).toBe(false);
+      expect(Reflect.set(optionalLogger, 'token', MutatedLogger)).toBe(false);
+      expect(forwardLogger.forwardRef()).toBe(Logger);
+      expect(optionalLogger.token).toBe(Logger);
+    });
+
+    it('snapshots and freezes provider inject wrappers before caller mutations can affect resolution', async () => {
+      type MutableForwardRefToken<T = unknown> = {
+        __forwardRef__: true;
+        forwardRef: () => Token<T>;
+      };
+      type MutableOptionalInjectToken<T = unknown> = {
+        __optional__: true;
+        token: Token<T>;
+      };
+
+      class Logger {}
+      class MutatedLogger {}
+      const CONSUMER = Symbol('Consumer');
+      const resolveLogger = () => Logger;
+      const forwardLogger: MutableForwardRefToken<Logger | MutatedLogger> = {
+        __forwardRef__: true,
+        forwardRef: resolveLogger,
+      };
+      const optionalLogger: MutableOptionalInjectToken<Logger | MutatedLogger> = {
+        __optional__: true,
+        token: Logger,
+      };
+
+      const container = new Container().register(
+        Logger,
+        {
+          provide: CONSUMER,
+          useFactory: (forwardDependency, optionalDependency) => [forwardDependency, optionalDependency],
+          inject: [forwardLogger, optionalLogger],
+        },
+      );
+
+      forwardLogger.forwardRef = () => MutatedLogger;
+      optionalLogger.token = MutatedLogger;
+
+      const provider = container.inspectResolutionState().registrations.get(CONSUMER);
+
+      if (!provider) {
+        expect.unreachable('expected introspection state to expose the normalized provider');
+      }
+
+      const storedForwardToken = provider.inject[0];
+      const storedOptionalToken = provider.inject[1];
+
+      expect(storedForwardToken).not.toBe(forwardLogger);
+      expect(storedOptionalToken).not.toBe(optionalLogger);
+      expect(Object.isFrozen(storedForwardToken)).toBe(true);
+      expect(Object.isFrozen(storedOptionalToken)).toBe(true);
+
+      if (typeof storedForwardToken !== 'object' || storedForwardToken === null || !('__forwardRef__' in storedForwardToken)) {
+        expect.unreachable('expected the first normalized inject entry to be a forwardRef wrapper');
+      }
+      if (typeof storedOptionalToken !== 'object' || storedOptionalToken === null || !('__optional__' in storedOptionalToken)) {
+        expect.unreachable('expected the second normalized inject entry to be an optional wrapper');
+      }
+
+      expect(Reflect.set(storedForwardToken, 'forwardRef', () => MutatedLogger)).toBe(false);
+      expect(Reflect.set(storedOptionalToken, 'token', MutatedLogger)).toBe(false);
+      expect(storedForwardToken.forwardRef()).toBe(Logger);
+      expect(storedOptionalToken.token).toBe(Logger);
+
+      const resolvedDependencies = await container.resolve<unknown[]>(CONSUMER);
+
+      expect(resolvedDependencies[0]).toBeInstanceOf(Logger);
+      expect(resolvedDependencies[1]).toBeInstanceOf(Logger);
+    });
+  });
+
   describe('optional injection', () => {
     it('injects undefined when an optional token is not registered', async () => {
       const LOGGER = Symbol('Logger');
@@ -1488,9 +1572,17 @@ describe('Container', () => {
       expect(Object.isFrozen(provider.inject)).toBe(true);
       expect(Object.isFrozen(multiProviders)).toBe(true);
       expect(Reflect.get(state.registrations, 'set')).toBeUndefined();
+      expect(Reflect.get(state.registrations, 'source')).toBeUndefined();
       expect(Reflect.get(state.multiRegistrations, 'clear')).toBeUndefined();
+      expect(Reflect.get(state.multiRegistrations, 'source')).toBeUndefined();
       expect(Reflect.get(state.singletonCache, 'delete')).toBeUndefined();
+      expect(Reflect.get(state.singletonCache, 'source')).toBeUndefined();
       expect(Reflect.get(state.multiSingletonCache, 'set')).toBeUndefined();
+      expect(Reflect.get(state.multiSingletonCache, 'source')).toBeUndefined();
+      expect(Reflect.ownKeys(state.registrations).map((key) => Reflect.get(state.registrations, key)).some((value) => value instanceof Map)).toBe(false);
+      expect(Reflect.ownKeys(state.multiRegistrations).map((key) => Reflect.get(state.multiRegistrations, key)).some((value) => value instanceof Map)).toBe(false);
+      expect(Reflect.ownKeys(state.singletonCache).map((key) => Reflect.get(state.singletonCache, key)).some((value) => value instanceof Map)).toBe(false);
+      expect(Reflect.ownKeys(state.multiSingletonCache).map((key) => Reflect.get(state.multiSingletonCache, key)).some((value) => value instanceof Map)).toBe(false);
       await expect(container.resolve(token)).resolves.toBe('value');
       await expect(container.resolve<string[]>(plugins)).resolves.toEqual(['plugin']);
     });

--- a/packages/di/src/container.test.ts
+++ b/packages/di/src/container.test.ts
@@ -666,6 +666,31 @@ describe('Container', () => {
       expect(afterOverride).not.toBe(beforeOverride);
     });
 
+    it('invalidates nested request-scope descendants when an ancestor dependency is overridden', async () => {
+      const CONFIG = Symbol('NestedConfig');
+
+      class RequestConsumer {
+        constructor(readonly config: string) {}
+      }
+
+      const root = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: RequestConsumer, scope: Scope.REQUEST, useClass: RequestConsumer, inject: [CONFIG] },
+      );
+      const parentScope = root.createRequestScope();
+      const descendantScope = parentScope.createRequestScope();
+
+      const beforeOverride = await descendantScope.resolve<RequestConsumer>(RequestConsumer);
+
+      root.override({ provide: CONFIG, useValue: 'after-override' });
+
+      const afterOverride = await descendantScope.resolve<RequestConsumer>(RequestConsumer);
+
+      expect(beforeOverride.config).toBe('before-override');
+      expect(afterOverride.config).toBe('after-override');
+      expect(afterOverride).not.toBe(beforeOverride);
+    });
+
     it('replaces existing multi providers when overriding a token', async () => {
       const token = Symbol('plugins');
       const container = new Container().register(
@@ -803,6 +828,20 @@ describe('Container', () => {
 
       expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
       expect(() => new Container().register(provider)).toThrow('provide token');
+    });
+
+    it('throws InvalidProviderError when an object provider uses null provide', () => {
+      const provider = { provide: null, useValue: 'missing-token' } as unknown as Provider;
+
+      expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
+      expect(() => new Container().register(provider)).toThrow('provide token');
+    });
+
+    it('throws InvalidProviderError when an object provider has no strategy', () => {
+      const provider = { provide: Symbol('strategy-less-provider') } as unknown as Provider;
+
+      expect(() => new Container().register(provider)).toThrow(InvalidProviderError);
+      expect(() => new Container().register(provider)).toThrow('exactly one');
     });
 
     it('throws InvalidProviderError when an object provider has more than one strategy', () => {
@@ -1425,6 +1464,38 @@ describe('Container', () => {
     });
   });
 
+  describe('resolution introspection', () => {
+    it('returns read-only map views and frozen provider records', async () => {
+      const token = Symbol('introspection-token');
+      const plugins = Symbol('introspection-plugins');
+      const container = new Container().register(
+        { provide: token, useValue: 'value' },
+        { provide: plugins, useValue: 'plugin', multi: true },
+      );
+
+      await container.resolve(token);
+      await container.resolve(plugins);
+
+      const state = container.inspectResolutionState();
+      const provider = state.registrations.get(token);
+      const multiProviders = state.multiRegistrations.get(plugins);
+
+      if (!provider || !multiProviders) {
+        expect.unreachable('expected introspection state to expose registered providers');
+      }
+
+      expect(Object.isFrozen(provider)).toBe(true);
+      expect(Object.isFrozen(provider.inject)).toBe(true);
+      expect(Object.isFrozen(multiProviders)).toBe(true);
+      expect(Reflect.get(state.registrations, 'set')).toBeUndefined();
+      expect(Reflect.get(state.multiRegistrations, 'clear')).toBeUndefined();
+      expect(Reflect.get(state.singletonCache, 'delete')).toBeUndefined();
+      expect(Reflect.get(state.multiSingletonCache, 'set')).toBeUndefined();
+      await expect(container.resolve(token)).resolves.toBe('value');
+      await expect(container.resolve<string[]>(plugins)).resolves.toEqual(['plugin']);
+    });
+  });
+
   describe('dispose', () => {
     it('calls onDestroy for resolved singleton instances in reverse creation order', async () => {
       const events: string[] = [];
@@ -1481,6 +1552,40 @@ describe('Container', () => {
       await root.dispose();
 
       expect(events).toEqual(['request', 'singleton']);
+    });
+
+    it('recursively disposes nested request scopes when a non-root request scope is disposed', async () => {
+      const events: string[] = [];
+
+      class ParentRequestService {
+        onDestroy() {
+          events.push('parent');
+        }
+      }
+
+      class ChildRequestService {
+        onDestroy() {
+          events.push('child');
+        }
+      }
+
+      const root = new Container().register(
+        { provide: ParentRequestService, scope: Scope.REQUEST, useClass: ParentRequestService },
+        { provide: ChildRequestService, scope: Scope.REQUEST, useClass: ChildRequestService },
+      );
+      const parentScope = root.createRequestScope();
+      const childScope = parentScope.createRequestScope();
+
+      await parentScope.resolve(ParentRequestService);
+      await childScope.resolve(ChildRequestService);
+
+      await parentScope.dispose();
+
+      expect(events).toEqual(['child', 'parent']);
+
+      await root.dispose();
+
+      expect(events).toEqual(['child', 'parent']);
     });
 
     it('removes materialized request scopes from the root child scope registry on dispose', async () => {
@@ -1703,6 +1808,39 @@ describe('Container', () => {
       await Promise.resolve();
       await container.resolve(Consumer);
       await container.dispose();
+
+      expect(events).toEqual(['consumer:before-override', 'consumer:after-override']);
+    });
+
+    it('disposes stale nested request-scope consumers invalidated by ancestor overrides exactly once', async () => {
+      const events: string[] = [];
+      const CONFIG = Symbol('NestedDisposableConsumerConfig');
+
+      class RequestConsumer {
+        constructor(readonly config: string) {}
+
+        onDestroy() {
+          events.push(`consumer:${this.config}`);
+        }
+      }
+
+      const root = new Container().register(
+        { provide: CONFIG, useValue: 'before-override' },
+        { provide: RequestConsumer, scope: Scope.REQUEST, useClass: RequestConsumer, inject: [CONFIG] },
+      );
+      const parentScope = root.createRequestScope();
+      const descendantScope = parentScope.createRequestScope();
+
+      await descendantScope.resolve(RequestConsumer);
+
+      root.override({ provide: CONFIG, useValue: 'after-override' });
+      await Promise.resolve();
+
+      expect(events).toEqual(['consumer:before-override']);
+
+      await descendantScope.resolve(RequestConsumer);
+      await parentScope.dispose();
+      await root.dispose();
 
       expect(events).toEqual(['consumer:before-override', 'consumer:after-override']);
     });

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -33,6 +33,9 @@ type ProviderObjectInput = {
 
 type ValidatedProviderObject = ProviderObjectInput & { readonly provide: Token };
 
+/**
+ * Factory provider resolution mode recorded after a factory returns either synchronously or through a promise.
+ */
 export type FactoryResolutionKind = 'async' | 'sync';
 
 interface CachedResolutionPlan<T> {
@@ -78,38 +81,42 @@ export interface ContainerResolutionState {
 }
 
 class ReadonlyMapView<K, V> implements ReadonlyMap<K, V> {
+  readonly #source: ReadonlyMap<K, V>;
+
   readonly [Symbol.toStringTag] = 'Map';
 
-  constructor(private readonly source: ReadonlyMap<K, V>) {}
+  constructor(source: ReadonlyMap<K, V>) {
+    this.#source = source;
+  }
 
   get size(): number {
-    return this.source.size;
+    return this.#source.size;
   }
 
   entries(): IterableIterator<[K, V]> {
-    return this.source.entries();
+    return this.#source.entries();
   }
 
   forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: unknown): void {
-    for (const [key, value] of this.source) {
+    for (const [key, value] of this.#source) {
       callbackfn.call(thisArg, value, key, this);
     }
   }
 
   get(key: K): V | undefined {
-    return this.source.get(key);
+    return this.#source.get(key);
   }
 
   has(key: K): boolean {
-    return this.source.has(key);
+    return this.#source.has(key);
   }
 
   keys(): IterableIterator<K> {
-    return this.source.keys();
+    return this.#source.keys();
   }
 
   values(): IterableIterator<V> {
-    return this.source.values();
+    return this.#source.values();
   }
 
   [Symbol.iterator](): IterableIterator<[K, V]> {
@@ -118,16 +125,20 @@ class ReadonlyMapView<K, V> implements ReadonlyMap<K, V> {
 }
 
 class ReadonlyMultiRegistrationMapView implements ReadonlyMap<Token, readonly NormalizedProvider[]> {
+  readonly #source: ReadonlyMap<Token, readonly NormalizedProvider[]>;
+
   readonly [Symbol.toStringTag] = 'Map';
 
-  constructor(private readonly source: ReadonlyMap<Token, readonly NormalizedProvider[]>) {}
+  constructor(source: ReadonlyMap<Token, readonly NormalizedProvider[]>) {
+    this.#source = source;
+  }
 
   get size(): number {
-    return this.source.size;
+    return this.#source.size;
   }
 
   *entries(): IterableIterator<[Token, readonly NormalizedProvider[]]> {
-    for (const [token, providers] of this.source) {
+    for (const [token, providers] of this.#source) {
       yield [token, Object.freeze([...providers])];
     }
   }
@@ -139,20 +150,20 @@ class ReadonlyMultiRegistrationMapView implements ReadonlyMap<Token, readonly No
   }
 
   get(key: Token): readonly NormalizedProvider[] | undefined {
-    const providers = this.source.get(key);
+    const providers = this.#source.get(key);
     return providers ? Object.freeze([...providers]) : undefined;
   }
 
   has(key: Token): boolean {
-    return this.source.has(key);
+    return this.#source.has(key);
   }
 
   keys(): IterableIterator<Token> {
-    return this.source.keys();
+    return this.#source.keys();
   }
 
   *values(): IterableIterator<readonly NormalizedProvider[]> {
-    for (const providers of this.source.values()) {
+    for (const providers of this.#source.values()) {
       yield Object.freeze([...providers]);
     }
   }
@@ -208,6 +219,20 @@ function assertObjectProvider(provider: ProviderObjectInput): asserts provider i
 function normalizeInjectToken(token: Token | ForwardRefFn | OptionalToken): Token | ForwardRefFn | OptionalToken {
   if (token == null) {
     throw new InvalidProviderError('Inject token must not be null or undefined. Check that all tokens in @Inject(...) are defined at the point of decoration (forward-reference cycles require forwardRef()).');
+  }
+
+  if (isForwardRef(token)) {
+    return Object.freeze<ForwardRefFn>({
+      __forwardRef__: true,
+      forwardRef: token.forwardRef,
+    });
+  }
+
+  if (isOptionalToken(token)) {
+    return Object.freeze<OptionalToken>({
+      __optional__: true,
+      token: token.token,
+    });
   }
 
   return token;

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -33,7 +33,7 @@ type ProviderObjectInput = {
 
 type ValidatedProviderObject = ProviderObjectInput & { readonly provide: Token };
 
-type FactoryResolutionKind = 'async' | 'sync';
+export type FactoryResolutionKind = 'async' | 'sync';
 
 interface CachedResolutionPlan<T> {
   readonly lineageRevision: string;
@@ -47,6 +47,7 @@ interface CachedResolutionPlan<T> {
 export interface ContainerResolutionCacheOwner {
   readonly deleteMultiSingleton: (provider: NormalizedProvider) => void;
   readonly deleteSingleton: (token: Token) => void;
+  readonly recordFactoryResolution: (provider: NormalizedProvider, kind: FactoryResolutionKind) => void;
   readonly setMultiSingleton: (provider: NormalizedProvider, promise: Promise<unknown>) => void;
   readonly setSingleton: (token: Token, promise: Promise<unknown>) => void;
 }
@@ -502,6 +503,9 @@ export class Container {
       },
       deleteSingleton: (token: Token) => {
         this.singletonCache.delete(token);
+      },
+      recordFactoryResolution: (provider: NormalizedProvider, kind: FactoryResolutionKind) => {
+        this.root().factoryResolutionKinds.set(provider, kind);
       },
       setMultiSingleton: (provider: NormalizedProvider, promise: Promise<unknown>) => {
         this.multiSingletonCache.set(provider, promise);

--- a/packages/di/src/container.ts
+++ b/packages/di/src/container.ts
@@ -11,19 +11,29 @@ import {
 } from './errors.js';
 import type {
   ClassType,
-  ClassProvider,
   Disposable,
-  ExistingProvider,
-  FactoryProvider,
   ForwardRefFn,
   NormalizedProvider,
   OptionalToken,
   Provider,
-  ValueProvider,
 } from './types.js';
 import { Scope, isForwardRef, isOptionalToken } from './types.js';
 
-type ObjectProvider = ClassProvider | ExistingProvider | FactoryProvider | ValueProvider;
+type ProviderObjectInput = {
+  readonly inject?: readonly (Token | ForwardRefFn | OptionalToken)[];
+  readonly multi?: boolean;
+  readonly provide?: Token | null;
+  readonly resolverClass?: ClassType;
+  readonly scope?: Scope;
+  readonly useClass?: unknown;
+  readonly useExisting?: Token | null;
+  readonly useFactory?: unknown;
+  readonly useValue?: unknown;
+};
+
+type ValidatedProviderObject = ProviderObjectInput & { readonly provide: Token };
+
+type FactoryResolutionKind = 'async' | 'sync';
 
 interface CachedResolutionPlan<T> {
   readonly lineageRevision: string;
@@ -31,46 +41,157 @@ interface CachedResolutionPlan<T> {
 }
 
 /**
- * Public read/write seam for framework-owned testing and tooling that need to
+ * Controlled cache adoption seam for framework-owned testing and tooling that
+ * need synchronous helpers to preserve container-owned singleton disposal.
+ */
+export interface ContainerResolutionCacheOwner {
+  readonly deleteMultiSingleton: (provider: NormalizedProvider) => void;
+  readonly deleteSingleton: (token: Token) => void;
+  readonly setMultiSingleton: (provider: NormalizedProvider, promise: Promise<unknown>) => void;
+  readonly setSingleton: (token: Token, promise: Promise<unknown>) => void;
+}
+
+/**
+ * Read-only factory resolution diagnostics recorded by container-owned factory
+ * instantiation paths.
+ */
+export interface ContainerFactoryResolutionState {
+  readonly get: (provider: NormalizedProvider) => FactoryResolutionKind | undefined;
+  readonly has: (provider: NormalizedProvider) => boolean;
+}
+
+/**
+ * Public read-only seam for framework-owned testing and tooling that need to
  * inspect a container's resolved provider graph without depending on private
  * field names or structural casts.
  */
 export interface ContainerResolutionState {
+  readonly cacheOwner: ContainerResolutionCacheOwner;
+  readonly factoryResolutionKinds: ContainerFactoryResolutionState;
   readonly parent?: ContainerResolutionState;
-  readonly registrations: Map<Token, NormalizedProvider>;
-  readonly multiRegistrations: Map<Token, NormalizedProvider[]>;
-  readonly multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>;
+  readonly registrations: ReadonlyMap<Token, NormalizedProvider>;
+  readonly multiRegistrations: ReadonlyMap<Token, readonly NormalizedProvider[]>;
+  readonly multiSingletonCache: ReadonlyMap<NormalizedProvider, Promise<unknown>>;
   readonly requestScopeEnabled: boolean;
-  readonly singletonCache: Map<Token, Promise<unknown>>;
+  readonly singletonCache: ReadonlyMap<Token, Promise<unknown>>;
+}
+
+class ReadonlyMapView<K, V> implements ReadonlyMap<K, V> {
+  readonly [Symbol.toStringTag] = 'Map';
+
+  constructor(private readonly source: ReadonlyMap<K, V>) {}
+
+  get size(): number {
+    return this.source.size;
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.source.entries();
+  }
+
+  forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: unknown): void {
+    for (const [key, value] of this.source) {
+      callbackfn.call(thisArg, value, key, this);
+    }
+  }
+
+  get(key: K): V | undefined {
+    return this.source.get(key);
+  }
+
+  has(key: K): boolean {
+    return this.source.has(key);
+  }
+
+  keys(): IterableIterator<K> {
+    return this.source.keys();
+  }
+
+  values(): IterableIterator<V> {
+    return this.source.values();
+  }
+
+  [Symbol.iterator](): IterableIterator<[K, V]> {
+    return this.entries();
+  }
+}
+
+class ReadonlyMultiRegistrationMapView implements ReadonlyMap<Token, readonly NormalizedProvider[]> {
+  readonly [Symbol.toStringTag] = 'Map';
+
+  constructor(private readonly source: ReadonlyMap<Token, readonly NormalizedProvider[]>) {}
+
+  get size(): number {
+    return this.source.size;
+  }
+
+  *entries(): IterableIterator<[Token, readonly NormalizedProvider[]]> {
+    for (const [token, providers] of this.source) {
+      yield [token, Object.freeze([...providers])];
+    }
+  }
+
+  forEach(callbackfn: (value: readonly NormalizedProvider[], key: Token, map: ReadonlyMap<Token, readonly NormalizedProvider[]>) => void, thisArg?: unknown): void {
+    for (const [key, value] of this.entries()) {
+      callbackfn.call(thisArg, value, key, this);
+    }
+  }
+
+  get(key: Token): readonly NormalizedProvider[] | undefined {
+    const providers = this.source.get(key);
+    return providers ? Object.freeze([...providers]) : undefined;
+  }
+
+  has(key: Token): boolean {
+    return this.source.has(key);
+  }
+
+  keys(): IterableIterator<Token> {
+    return this.source.keys();
+  }
+
+  *values(): IterableIterator<readonly NormalizedProvider[]> {
+    for (const providers of this.source.values()) {
+      yield Object.freeze([...providers]);
+    }
+  }
+
+  [Symbol.iterator](): IterableIterator<[Token, readonly NormalizedProvider[]]> {
+    return this.entries();
+  }
 }
 
 function isClassConstructor(value: Provider): value is ClassType {
   return typeof value === 'function';
 }
 
-function isValueProvider(value: Provider): value is ValueProvider {
-  return typeof value === 'object' && value !== null && 'useValue' in value;
+function isProviderObject(value: unknown): value is ProviderObjectInput {
+  return typeof value === 'object' && value !== null;
 }
 
-function isFactoryProvider(value: Provider): value is FactoryProvider {
-  return typeof value === 'object' && value !== null && 'useFactory' in value;
+function isClassType(value: unknown): value is ClassType {
+  return typeof value === 'function';
 }
 
-function isClassProvider(value: Provider): value is ClassProvider {
-  return typeof value === 'object' && value !== null && 'useClass' in value;
+function isFactoryFunction(value: unknown): value is (...deps: unknown[]) => unknown {
+  return typeof value === 'function';
 }
 
-function isExistingProvider(value: Provider): value is ExistingProvider {
-  return typeof value === 'object' && value !== null && 'useExisting' in value;
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' || typeof value === 'function') &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
 }
 
-function assertProviderToken(provider: ObjectProvider): void {
+function assertProviderToken(provider: ProviderObjectInput): asserts provider is ValidatedProviderObject {
   if (!('provide' in provider) || provider.provide == null) {
     throw new InvalidProviderError('Provider object must include a non-null provide token.');
   }
 }
 
-function assertProviderStrategy(provider: ObjectProvider): void {
+function assertProviderStrategy(provider: ProviderObjectInput): void {
   const strategyCount = Number('useValue' in provider) + Number('useFactory' in provider) + Number('useClass' in provider) + Number('useExisting' in provider);
 
   if (strategyCount !== 1) {
@@ -78,7 +199,7 @@ function assertProviderStrategy(provider: ObjectProvider): void {
   }
 }
 
-function assertObjectProvider(provider: ObjectProvider): void {
+function assertObjectProvider(provider: ProviderObjectInput): asserts provider is ValidatedProviderObject {
   assertProviderToken(provider);
   assertProviderStrategy(provider);
 }
@@ -91,87 +212,93 @@ function normalizeInjectToken(token: Token | ForwardRefFn | OptionalToken): Toke
   return token;
 }
 
+function freezeNormalizedProvider<T>(provider: NormalizedProvider<T>): NormalizedProvider<T> {
+  return Object.freeze({
+    ...provider,
+    inject: Object.freeze([...provider.inject]),
+  });
+}
+
 function normalizeProvider(provider: Provider): NormalizedProvider {
   if (isClassConstructor(provider)) {
     const metadata = getClassDiMetadata(provider);
 
-    return {
+    return freezeNormalizedProvider({
       inject: (metadata?.inject ?? []).map(normalizeInjectToken),
       provide: provider,
       scope: metadata?.scope ?? Scope.DEFAULT,
       type: 'class',
       useClass: provider,
-    };
+    });
   }
 
-  if (isValueProvider(provider)) {
-    assertObjectProvider(provider);
+  if (!isProviderObject(provider)) {
+    throw new InvalidProviderError('Unsupported provider type.');
+  }
 
-    return {
+  const objectProvider: ProviderObjectInput = provider;
+  assertObjectProvider(objectProvider);
+
+  if ('useValue' in objectProvider) {
+    return freezeNormalizedProvider({
       inject: [],
-      multi: provider.multi,
-      provide: provider.provide,
+      multi: objectProvider.multi,
+      provide: objectProvider.provide,
       scope: Scope.DEFAULT,
       type: 'value',
-      useValue: provider.useValue,
-    };
+      useValue: objectProvider.useValue,
+    });
   }
 
-  if (isFactoryProvider(provider)) {
-    assertObjectProvider(provider);
-
-    if (typeof provider.useFactory !== 'function') {
-      throw new InvalidProviderError('Factory provider useFactory must be a function.', { token: provider.provide });
+  if ('useFactory' in objectProvider) {
+    if (!isFactoryFunction(objectProvider.useFactory)) {
+      throw new InvalidProviderError('Factory provider useFactory must be a function.', { token: objectProvider.provide });
     }
 
-    const metadata = provider.resolverClass ? getClassDiMetadata(provider.resolverClass) : undefined;
+    const metadata = objectProvider.resolverClass ? getClassDiMetadata(objectProvider.resolverClass) : undefined;
 
-    return {
-      inject: (provider.inject ?? []).map(normalizeInjectToken),
-      multi: provider.multi,
-      provide: provider.provide,
-      scope: provider.scope ?? metadata?.scope ?? Scope.DEFAULT,
+    return freezeNormalizedProvider({
+      inject: (objectProvider.inject ?? []).map(normalizeInjectToken),
+      multi: objectProvider.multi,
+      provide: objectProvider.provide,
+      scope: objectProvider.scope ?? metadata?.scope ?? Scope.DEFAULT,
       type: 'factory',
-      useFactory: provider.useFactory,
-    };
+      useFactory: objectProvider.useFactory,
+    });
   }
 
-  if (isClassProvider(provider)) {
-    assertObjectProvider(provider);
-
-    if (typeof provider.useClass !== 'function') {
-      throw new InvalidProviderError('Class provider useClass must be a constructor.', { token: provider.provide });
+  if ('useClass' in objectProvider) {
+    if (!isClassType(objectProvider.useClass)) {
+      throw new InvalidProviderError('Class provider useClass must be a constructor.', { token: objectProvider.provide });
     }
 
-    const metadata = getClassDiMetadata(provider.useClass);
+    const metadata = getClassDiMetadata(objectProvider.useClass);
 
-    return {
-      inject: (provider.inject ?? metadata?.inject ?? []).map(normalizeInjectToken),
-      multi: provider.multi,
-      provide: provider.provide,
-      scope: provider.scope ?? metadata?.scope ?? Scope.DEFAULT,
+    return freezeNormalizedProvider({
+      inject: (objectProvider.inject ?? metadata?.inject ?? []).map(normalizeInjectToken),
+      multi: objectProvider.multi,
+      provide: objectProvider.provide,
+      scope: objectProvider.scope ?? metadata?.scope ?? Scope.DEFAULT,
       type: 'class',
-      useClass: provider.useClass,
-    };
+      useClass: objectProvider.useClass,
+    });
   }
 
-  if (isExistingProvider(provider)) {
-    assertObjectProvider(provider);
-
-    if (provider.useExisting == null) {
-      throw new InvalidProviderError('Alias provider useExisting must be a non-null token.', { token: provider.provide });
+  if ('useExisting' in objectProvider) {
+    if (objectProvider.useExisting == null) {
+      throw new InvalidProviderError('Alias provider useExisting must be a non-null token.', { token: objectProvider.provide });
     }
 
-    return {
+    return freezeNormalizedProvider({
       inject: [],
-      provide: provider.provide,
+      provide: objectProvider.provide,
       scope: Scope.DEFAULT,
       type: 'existing',
-      useExisting: provider.useExisting,
-    };
+      useExisting: objectProvider.useExisting,
+    });
   }
 
-  throw new InvalidProviderError('Unsupported provider type.');
+  throw new InvalidProviderError('Provider object must declare exactly one of useValue, useFactory, useClass, or useExisting.');
 }
 
 /**
@@ -188,6 +315,7 @@ export class Container {
   private readonly staleDisposalErrors: unknown[] = [];
   private readonly singletonCache: Map<Token, Promise<unknown>>;
   private readonly forwardRefTokenCache = new WeakMap<ForwardRefFn, Token>();
+  private readonly factoryResolutionKinds = new WeakMap<NormalizedProvider, FactoryResolutionKind>();
   private readonly providerLookupPlanCache = new Map<Token, CachedResolutionPlan<NormalizedProvider | undefined>>();
   private readonly multiProviderPlanCache = new Map<Token, CachedResolutionPlan<readonly NormalizedProvider[]>>();
   private readonly requestScopeVerdictPlanCache = new Map<Token, CachedResolutionPlan<boolean>>();
@@ -195,7 +323,7 @@ export class Container {
   private childScopes: Set<Container> | undefined;
   private disposePromise: Promise<void> | undefined;
   private disposed = false;
-  private trackedByRoot = false;
+  private trackedByParent = false;
   private graphRevision = 0;
 
   constructor(
@@ -347,20 +475,50 @@ export class Container {
    *
    * This method is the supported introspection seam for packages such as
    * `@fluojs/testing`; callers should prefer ordinary `has(...)` and
-   * `resolve(...)` unless they need to preserve container cache ownership while
-   * implementing a framework-level helper.
+   * `resolve(...)` unless they need read-only graph/cache visibility while
+   * implementing a framework-level helper. Cache adoption for synchronous
+   * helpers goes through `cacheOwner`; the returned maps are not mutable
+   * container internals.
    *
-   * @returns Provider registrations and resolution caches for this container scope.
+   * @returns Read-only provider registrations and resolution caches for this container scope.
    */
   inspectResolutionState(): ContainerResolutionState {
     return {
+      cacheOwner: this.createCacheOwner(),
+      factoryResolutionKinds: this.createFactoryResolutionState(),
       parent: this.parent?.inspectResolutionState(),
-      registrations: this.registrations,
-      multiRegistrations: this.multiRegistrations,
-      multiSingletonCache: this.multiSingletonCache,
+      registrations: new ReadonlyMapView(this.registrations),
+      multiRegistrations: new ReadonlyMultiRegistrationMapView(this.multiRegistrations),
+      multiSingletonCache: new ReadonlyMapView(this.multiSingletonCache),
       requestScopeEnabled: this.requestScopeEnabled,
-      singletonCache: this.singletonCache,
+      singletonCache: new ReadonlyMapView(this.singletonCache),
     };
+  }
+
+  private createCacheOwner(): ContainerResolutionCacheOwner {
+    return Object.freeze({
+      deleteMultiSingleton: (provider: NormalizedProvider) => {
+        this.multiSingletonCache.delete(provider);
+      },
+      deleteSingleton: (token: Token) => {
+        this.singletonCache.delete(token);
+      },
+      setMultiSingleton: (provider: NormalizedProvider, promise: Promise<unknown>) => {
+        this.multiSingletonCache.set(provider, promise);
+      },
+      setSingleton: (token: Token, promise: Promise<unknown>) => {
+        this.singletonCache.set(token, promise);
+      },
+    });
+  }
+
+  private createFactoryResolutionState(): ContainerFactoryResolutionState {
+    const root = this.root();
+
+    return Object.freeze({
+      get: (provider: NormalizedProvider) => root.factoryResolutionKinds.get(provider),
+      has: (provider: NormalizedProvider) => root.factoryResolutionKinds.has(provider),
+    });
   }
 
   /**
@@ -449,8 +607,8 @@ export class Container {
     const errors: unknown[] = [];
 
     try {
-      // Dispose all live request-scope children first (root only)
-      if (!this.parent && this.childScopes && this.childScopes.size > 0) {
+      // Dispose all live request-scope children before tearing down this scope's cache.
+      if (this.childScopes && this.childScopes.size > 0) {
         const childResults = await Promise.allSettled(Array.from(this.childScopes).map((child) => child.dispose()));
 
         for (const result of childResults) {
@@ -470,9 +628,9 @@ export class Container {
 
       this.throwDisposalErrors(errors);
     } finally {
-      if (this.parent && this.trackedByRoot) {
-        this.root().childScopes?.delete(this);
-        this.trackedByRoot = false;
+      if (this.parent && this.trackedByParent) {
+        this.parent.childScopes?.delete(this);
+        this.trackedByParent = false;
       }
     }
   }
@@ -591,7 +749,7 @@ export class Container {
       return true;
     }
 
-    return (metadata?.inject ?? []).some((depEntry) => this.dependencyEntryRequiresRequestScope(depEntry, visited));
+    return (metadata?.inject ?? []).some((depEntry: Token | ForwardRefFn | OptionalToken) => this.dependencyEntryRequiresRequestScope(depEntry, visited));
   }
 
   private normalizedProviderRequiresRequestScope(provider: NormalizedProvider, visited: Set<Token>): boolean {
@@ -852,14 +1010,14 @@ export class Container {
   }
 
   private ensureTrackedRequestScope(): void {
-    if (!this.requestScopeEnabled || !this.parent || this.trackedByRoot) {
+    if (!this.requestScopeEnabled || !this.parent || this.trackedByParent) {
       return;
     }
 
-    const root = this.root();
-    root.childScopes ??= new Set<Container>();
-    root.childScopes.add(this);
-    this.trackedByRoot = true;
+    this.parent.ensureTrackedRequestScope();
+    this.parent.childScopes ??= new Set<Container>();
+    this.parent.childScopes.add(this);
+    this.trackedByParent = true;
   }
 
   private requestCacheForWrite(): Map<Token, Promise<unknown>> {
@@ -1131,9 +1289,11 @@ export class Container {
           throw new InvariantError('Factory provider is missing useFactory.');
         }
 
-          const deps = await this.resolveProviderDeps(provider, chain, activeTokens);
+        const deps = await this.resolveProviderDeps(provider, chain, activeTokens);
+        const value = provider.useFactory(...deps);
+        this.root().factoryResolutionKinds.set(provider, isPromiseLike(value) ? 'async' : 'sync');
 
-        return provider.useFactory(...deps);
+        return value as T;
       }
       case 'class': {
         if (!provider.useClass) {
@@ -1305,31 +1465,9 @@ export class Container {
   private invalidateAffectedCachedEntriesInHierarchy(token: Token): void {
     this.invalidateAffectedCachedEntries(token);
 
-    const childScopes = this.root().childScopes;
-
-    if (!childScopes) {
-      return;
+    for (const childScope of this.childScopes ?? []) {
+      childScope.invalidateAffectedCachedEntriesInHierarchy(token);
     }
-
-    for (const childScope of childScopes) {
-      if (this.isAncestorOf(childScope)) {
-        childScope.invalidateAffectedCachedEntries(token);
-      }
-    }
-  }
-
-  private isAncestorOf(container: Container): boolean {
-    let current = container.parent;
-
-    while (current) {
-      if (current === this) {
-        return true;
-      }
-
-      current = current.parent;
-    }
-
-    return false;
   }
 
   private invalidateAffectedCachedEntries(token: Token): void {

--- a/packages/di/src/types.ts
+++ b/packages/di/src/types.ts
@@ -114,15 +114,15 @@ export interface RequestScopeContainer {
  * {@link ValueProvider}, or {@link ExistingProvider}. The container owns construction of normalized records.
  */
 export interface NormalizedProvider<T = unknown> {
-  inject: InjectionToken[];
-  provide: Token<T>;
-  scope: Scope;
-  type: 'class' | 'factory' | 'value' | 'existing';
-  useClass?: ClassType<T>;
-  useFactory?: (...deps: unknown[]) => MaybePromise<T>;
-  useValue?: T;
-  useExisting?: Token;
-  multi?: boolean;
+  readonly inject: readonly InjectionToken[];
+  readonly provide: Token<T>;
+  readonly scope: Scope;
+  readonly type: 'class' | 'factory' | 'value' | 'existing';
+  readonly useClass?: ClassType<T>;
+  readonly useFactory?: (...deps: unknown[]) => MaybePromise<T>;
+  readonly useValue?: T;
+  readonly useExisting?: Token;
+  readonly multi?: boolean;
 }
 
 /**

--- a/packages/di/src/types.ts
+++ b/packages/di/src/types.ts
@@ -140,7 +140,7 @@ export interface NormalizedProvider<T = unknown> {
  * ```
  */
 export function forwardRef<T = unknown>(fn: () => Token<T>): ForwardRefFn<T> {
-  return { __forwardRef__: true, forwardRef: fn };
+  return Object.freeze<ForwardRefFn<T>>({ __forwardRef__: true, forwardRef: fn });
 }
 
 /**
@@ -160,7 +160,7 @@ export function isForwardRef(value: unknown): value is ForwardRefFn {
  * @returns An optional-token wrapper understood by container resolution.
  */
 export function optional<T = unknown>(token: Token<T>): OptionalToken<T> {
-  return { __optional__: true, token };
+  return Object.freeze<OptionalToken<T>>({ __optional__: true, token });
 }
 
 /**

--- a/packages/runtime/src/module-graph.test.ts
+++ b/packages/runtime/src/module-graph.test.ts
@@ -194,11 +194,18 @@ describe('module graph cache-key prerequisites', () => {
       expect.unreachable('expected a factory provider with explicit inject metadata');
     }
 
+    const poisonedReplacement = forwardRef(() => MissingDependency);
+    expect(Object.isFrozen(poisonedReplacement)).toBe(true);
+    expect(Reflect.set(poisonedReplacement, 'forwardRef', () => Logger)).toBe(false);
+    expect(poisonedReplacement.forwardRef()).toBe(MissingDependency);
+
     factoryProvider.provide = POISONED_TOKEN;
-    factoryProvider.inject.splice(0, factoryProvider.inject.length, forwardRef(() => MissingDependency));
+    factoryProvider.inject.splice(0, factoryProvider.inject.length, poisonedReplacement);
     const poisonedWrapper = factoryProvider.inject[0];
     if (isMutableRuntimeForwardRef(poisonedWrapper)) {
-      poisonedWrapper.forwardRef = () => MissingDependency;
+      expect(Object.isFrozen(poisonedWrapper)).toBe(true);
+      expect(Reflect.set(poisonedWrapper, 'forwardRef', () => Logger)).toBe(false);
+      expect(poisonedWrapper.forwardRef()).toBe(MissingDependency);
     }
 
     const secondCompile = compileModuleGraph(AppModule, { moduleGraphCache: true });

--- a/packages/testing/src/module.test.ts
+++ b/packages/testing/src/module.test.ts
@@ -532,6 +532,37 @@ describe('@fluojs/testing', () => {
     expect(syncConsumer).toBe(resolved);
   });
 
+  it('preserves sync factory promotion when the dependency is first materialized through get()', async () => {
+    const TOKEN = Symbol('sync-first-factory-dependency-token');
+    const dependency = { name: 'sync-first-dependency' };
+
+    @Inject(TOKEN)
+    class SyncFirstFactoryConsumer {
+      constructor(readonly value: typeof dependency) {}
+    }
+
+    @Module({
+      providers: [
+        {
+          provide: TOKEN,
+          useFactory: () => dependency,
+        },
+        SyncFirstFactoryConsumer,
+      ],
+    })
+    class SyncFirstFactoryConsumerModule {}
+
+    const testingModule = await createTestingModule({ rootModule: SyncFirstFactoryConsumerModule }).compile();
+
+    const syncDependency = testingModule.get<typeof dependency>(TOKEN);
+    const resolved = await testingModule.resolve<SyncFirstFactoryConsumer>(SyncFirstFactoryConsumer);
+    const syncConsumer = testingModule.get<SyncFirstFactoryConsumer>(SyncFirstFactoryConsumer);
+
+    expect(syncDependency).toBe(dependency);
+    expect(resolved.value).toBe(syncDependency);
+    expect(syncConsumer).toBe(resolved);
+  });
+
   it('keeps classes depending on useExisting aliases to async factories resolve-only after resolve()', async () => {
     const SOURCE = Symbol('async-factory-source-token');
     const ALIAS = Symbol('async-factory-alias-token');

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -151,11 +151,12 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
 }
 
 interface SyncResolverState {
-  factoryResolutionKinds: WeakMap<NormalizedProvider, 'async' | 'sync'>;
+  cacheOwner: ContainerResolutionState['cacheOwner'];
+  factoryResolutionKinds: ContainerResolutionState['factoryResolutionKinds'];
   introspection: ContainerIntrospection;
-  multiSingletonCache: Map<NormalizedProvider, Promise<unknown>>;
+  multiSingletonCache: ReadonlyMap<NormalizedProvider, Promise<unknown>>;
   resolutionChain: Set<Token>;
-  singletonCache: Map<Token, Promise<unknown>>;
+  singletonCache: ReadonlyMap<Token, Promise<unknown>>;
   syncMultiSingletonValues: Map<NormalizedProvider, unknown>;
   syncSingletonValues: Map<Token, unknown>;
 }
@@ -235,19 +236,19 @@ async function resolveMultiLifecycleProvider(
   bootstrapped: BootstrapResult,
   introspection: ContainerIntrospection,
 ): Promise<unknown> {
-  const cache = rootContainerIntrospection(introspection).multiSingletonCache;
-  const cached = cache.get(provider);
+  const rootIntrospection = rootContainerIntrospection(introspection);
+  const cached = rootIntrospection.multiSingletonCache.get(provider);
 
   if (cached) {
     return cached;
   }
 
   const instance = instantiateLifecycleProvider(provider, bootstrapped, introspection).catch((error: unknown) => {
-    cache.delete(provider);
+    rootIntrospection.cacheOwner.deleteMultiSingleton(provider);
     throw error;
   });
 
-  cache.set(provider, instance);
+  rootIntrospection.cacheOwner.setMultiSingleton(provider, instance);
   return instance;
 }
 
@@ -361,41 +362,6 @@ function dependencyToken(entry: Token | ForwardRefFn | OptionalToken): Token {
   }
 
   return entry as Token;
-}
-
-function trackFactoryResolutionKind(
-  provider: NormalizedProvider,
-  factoryResolutionKinds: WeakMap<NormalizedProvider, 'async' | 'sync'>,
-): void {
-  if (provider.type !== 'factory' || !provider.useFactory) {
-    return;
-  }
-
-  const originalFactory = provider.useFactory;
-  provider.useFactory = (...deps: unknown[]) => {
-    const value = originalFactory(...deps);
-    factoryResolutionKinds.set(provider, isPromiseLike(value) ? 'async' : 'sync');
-    return value;
-  };
-}
-
-function installFactoryResolutionTracking(
-  target: ContainerIntrospection,
-  factoryResolutionKinds: WeakMap<NormalizedProvider, 'async' | 'sync'>,
-): void {
-  if (target.parent) {
-    installFactoryResolutionTracking(target.parent, factoryResolutionKinds);
-  }
-
-  for (const provider of target.registrations.values()) {
-    trackFactoryResolutionKind(provider, factoryResolutionKinds);
-  }
-
-  for (const providers of target.multiRegistrations.values()) {
-    for (const provider of providers) {
-      trackFactoryResolutionKind(provider, factoryResolutionKinds);
-    }
-  }
 }
 
 function providerGraphIsSyncResolvable(state: SyncResolverState, token: Token, visited = new Set<Token>()): boolean {
@@ -539,7 +505,7 @@ function resolveSyncProvider(provider: NormalizedProvider, state: SyncResolverSt
 
   const instance = instantiateSyncProvider(provider, state);
   state.syncSingletonValues.set(provider.provide, instance);
-  state.singletonCache.set(provider.provide, Promise.resolve(instance));
+  state.cacheOwner.setSingleton(provider.provide, Promise.resolve(instance));
   return instance;
 }
 
@@ -564,7 +530,7 @@ function resolveSyncMultiProvider(provider: NormalizedProvider, state: SyncResol
 
   const instance = instantiateSyncProvider(provider, state);
   state.syncMultiSingletonValues.set(provider, instance);
-  state.multiSingletonCache.set(provider, Promise.resolve(instance));
+  state.cacheOwner.setMultiSingleton(provider, Promise.resolve(instance));
   return instance;
 }
 
@@ -596,16 +562,15 @@ function resolveSyncToken(token: Token, state: SyncResolverState): unknown {
 
 function createSyncResolver(container: BootstrapResult['container']): SyncResolver {
   const introspection = toContainerIntrospection(container);
-  const factoryResolutionKinds = new WeakMap<NormalizedProvider, 'async' | 'sync'>();
-
-  installFactoryResolutionTracking(introspection, factoryResolutionKinds);
+  const rootIntrospection = rootContainerIntrospection(introspection);
 
   const state: SyncResolverState = {
-    factoryResolutionKinds,
+    cacheOwner: rootIntrospection.cacheOwner,
+    factoryResolutionKinds: rootIntrospection.factoryResolutionKinds,
     introspection,
-    multiSingletonCache: rootContainerIntrospection(introspection).multiSingletonCache,
+    multiSingletonCache: rootIntrospection.multiSingletonCache,
     resolutionChain: new Set<Token>(),
-    singletonCache: rootContainerIntrospection(introspection).singletonCache,
+    singletonCache: rootIntrospection.singletonCache,
     syncMultiSingletonValues: new Map<NormalizedProvider, unknown>(),
     syncSingletonValues: new Map<Token, unknown>(),
   };

--- a/packages/testing/src/module.ts
+++ b/packages/testing/src/module.ts
@@ -468,6 +468,7 @@ function instantiateSyncProvider(provider: NormalizedProvider, state: SyncResolv
         );
       }
 
+      state.cacheOwner.recordFactoryResolution(provider, 'sync');
       return value;
     }
     case 'class': {
@@ -711,8 +712,8 @@ class DefaultTestingModuleBuilder implements TestingModuleBuilder {
       ...bootstrapped,
       has: (token) => bootstrapped.container.has(token),
       get: (token) => syncResolver.get(token),
-      resolve: async (token) => {
-        const value = await bootstrapped.container.resolve(token);
+      resolve: async <T>(token: Token<T>) => {
+        const value = await bootstrapped.container.resolve<T>(token);
         await syncResolver.syncFromContainer();
         return value;
       },


### PR DESCRIPTION
## Summary

Harden `@fluojs/di` request-scope lifecycle ownership and framework introspection boundaries.

Linked context: Closes #2279

## Changes

- Recursively track and dispose nested request scopes from each owning request-scope container before clearing that owner cache.
- Replace mutable `inspectResolutionState()` map exposure with read-only map views, frozen normalized provider records, and controlled cache adoption for framework tooling.
- Move `@fluojs/testing` sync cache adoption off direct `Map` mutation and onto the new container-owned cache adoption seam.
- Record sync factory resolution kind when `@fluojs/testing` first materializes a sync factory through `get()`, so later async sync-points can safely promote dependent sync graphs.
- Add targeted DI regression tests for nested request-scope disposal, nested descendant override invalidation, stale nested request-scope instance disposal, read-only introspection state, `provide: null`, and zero-strategy provider validation.
- Add a testing regression for the sync-first factory path: `get(A)` materializes a sync factory, `resolve(B)` follows where `B` depends on `A`, then `get(B)` preserves identity instead of throwing a false async-only error.
- Update `packages/di` EN/KO README lifecycle and introspection contract text.
- Add `.changeset/soft-pandas-guard.md` for `@fluojs/di` major release impact and `@fluojs/testing` patch release impact.

## Testing

- `lsp_diagnostics` attempted for changed TS files; unavailable in this environment because `biome` executable was not found by the LSP tool.
- `pnpm install --frozen-lockfile`
- `pnpm --dir packages/di typecheck`
- `pnpm --dir packages/di test`
- `pnpm --dir packages/di build`
- `pnpm --dir packages/testing typecheck`
- `pnpm --dir packages/testing test`
- `pnpm exec biome lint packages/di/src/container.ts packages/testing/src/module.ts packages/testing/src/module.test.ts`
- `pnpm build`
- `pnpm verify:release-readiness`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Changeset: `.changeset/soft-pandas-guard.md` records `@fluojs/di` as `major` and `@fluojs/testing` as `patch`.

Migration note: callers that used `inspectResolutionState()` as a mutable escape hatch must stop mutating returned registration/cache maps or normalized provider records. Framework-owned tooling should use the returned `cacheOwner` helpers for controlled cache adoption instead of writing to the maps directly. Ordinary application code should continue using `has(...)`, `resolve(...)`, and documented container APIs instead of the introspection seam.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (N/A: no platform contract docs changed.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (N/A: no platform conformance claim changed.)