### PR TITLE
Resolve #2290: normalize lazy email transport initialization failures

### DIFF
--- a/.changeset/smooth-mails-retry.md
+++ b/.changeset/smooth-mails-retry.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/email": patch
+---
+
+Normalize lazy email transport factory failures so send-triggered initialization rejects with `EmailLifecycleError` and clears rejected transport state before shutdown.

--- a/packages/email/src/module.test.ts
+++ b/packages/email/src/module.test.ts
@@ -1087,6 +1087,91 @@ describe('EmailModule', () => {
     expect(closeTransport.closeCalls).toBe(1);
   });
 
+  it('normalizes lazy transport factory rejections and clears rejected state before shutdown', async () => {
+    const create = vi.fn(async (): Promise<EmailTransport> => {
+      throw new Error('provider create failed');
+    });
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+
+    await expect(
+      service.send({
+        subject: 'Lazy failure',
+        text: 'hello',
+        to: ['user@example.com'],
+      }),
+    ).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: 'provider create failed' }),
+      message: 'Email transport failed to initialize.',
+      name: 'EmailLifecycleError',
+    });
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'failed' },
+      readiness: { status: 'not-ready' },
+    });
+
+    await expect(service.onApplicationShutdown()).resolves.toBeUndefined();
+    await expect(
+      service.sendNotification({
+        channel: 'email',
+        payload: { text: 'after failed lazy create' },
+        recipients: ['user@example.com'],
+        subject: 'After lazy failure',
+      }),
+    ).rejects.toThrowError(new EmailLifecycleError('Email delivery cannot start while the service lifecycle is stopped.'));
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports pending lazy factory rejection during shutdown as initialization failure', async () => {
+    let rejectTransport!: (error: Error) => void;
+    const create = vi.fn(
+      () =>
+        new Promise<EmailTransport>((_resolve, reject) => {
+          rejectTransport = reject;
+        }),
+    );
+    const container = new Container();
+    const moduleType = EmailModule.forRoot({
+      defaultFrom: 'noreply@example.com',
+      transport: {
+        create,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(EmailService);
+    const delivery = service.send({ subject: 'Shutdown lazy failure', text: 'hello', to: ['user@example.com'] });
+    const shutdown = service.onApplicationShutdown();
+
+    rejectTransport(new Error('provider create failed during shutdown'));
+
+    await expect(delivery).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: 'provider create failed during shutdown' }),
+      message: 'Email transport failed to initialize.',
+      name: 'EmailLifecycleError',
+    });
+    await expect(shutdown).rejects.toMatchObject({
+      cause: expect.objectContaining({ message: 'provider create failed during shutdown' }),
+      message: 'Email transport failed to initialize.',
+      name: 'EmailLifecycleError',
+    });
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'failed' },
+      readiness: { status: 'not-ready' },
+    });
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
   it('blocks shutdown-time delivery from reusing or recreating transports', async () => {
     let resolveTransport!: (transport: DelayedLifecycleTransport) => void;
     const createdTransport = new DelayedLifecycleTransport();

--- a/packages/email/src/service.ts
+++ b/packages/email/src/service.ts
@@ -60,6 +60,10 @@ function createLifecycleError(message: string, cause: unknown): Error {
   return new EmailLifecycleError(message, { cause });
 }
 
+function isTransportInitializationLifecycleError(error: unknown): error is EmailLifecycleError {
+  return error instanceof EmailLifecycleError && error.message === 'Email transport failed to initialize.';
+}
+
 function createDeliveryLifecycleError(state: EmailServiceLifecycleState): EmailLifecycleError {
   return new EmailLifecycleError(`Email delivery cannot start while the service lifecycle is ${state}.`);
 }
@@ -118,9 +122,15 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
   async onApplicationShutdown(): Promise<void> {
     this.lifecycleState = 'stopping';
 
-    try {
-      const transport = this.resolvedTransport ?? (this.transportPromise ? await this.transportPromise : undefined);
+    let transport: EmailTransport | undefined;
 
+    try {
+      transport = this.resolvedTransport ?? (this.transportPromise ? await this.transportPromise : undefined);
+    } catch (error) {
+      await this.handleTransportInitializationFailure(error);
+    }
+
+    try {
       await this.drainInFlightOperations();
 
       if (transport && this.options.transport.ownsResources && transport.close) {
@@ -174,26 +184,7 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
 
       this.lifecycleState = 'ready';
     } catch (error) {
-      if (isShutdownLifecycleState(this.lifecycleState)) {
-        throw error;
-      }
-
-      this.lifecycleState = 'failed';
-
-      let cause: unknown = error;
-      const transport = this.resolvedTransport;
-
-      if (transport && this.options.transport.ownsResources && transport.close) {
-        try {
-          await transport.close();
-        } catch (cleanupError) {
-          cause = createCleanupFailureCause(error, cleanupError);
-        } finally {
-          this.clearResolvedTransport();
-        }
-      }
-
-      throw createLifecycleError('Email transport failed to initialize.', cause);
+      await this.handleTransportInitializationFailure(error, { preserveShutdownState: true });
     }
   }
 
@@ -369,12 +360,46 @@ export class EmailService implements Email, OnModuleInit, OnApplicationShutdown 
       });
     }
 
-    return this.transportPromise;
+    try {
+      return await this.transportPromise;
+    } catch (error) {
+      return await this.handleTransportInitializationFailure(error);
+    }
   }
 
   private clearResolvedTransport(): void {
     this.resolvedTransport = undefined;
     this.transportPromise = undefined;
+  }
+
+  private async handleTransportInitializationFailure(
+    error: unknown,
+    options: { preserveShutdownState?: boolean } = {},
+  ): Promise<never> {
+    if (isTransportInitializationLifecycleError(error)) {
+      throw error;
+    }
+
+    if (options.preserveShutdownState && isShutdownLifecycleState(this.lifecycleState)) {
+      throw error;
+    }
+
+    this.lifecycleState = 'failed';
+
+    let cause: unknown = error;
+    const transport = this.resolvedTransport;
+
+    if (transport && this.options.transport.ownsResources && transport.close) {
+      try {
+        await transport.close();
+      } catch (cleanupError) {
+        cause = createCleanupFailureCause(error, cleanupError);
+      }
+    }
+
+    this.clearResolvedTransport();
+
+    throw createLifecycleError('Email transport failed to initialize.', cause);
   }
 
   private async drainInFlightOperations(): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #2290.

Normalize lazy `@fluojs/email` transport factory failures so send-triggered initialization follows the same `EmailLifecycleError` path as bootstrap initialization failures instead of caching a rejected transport promise.

Linked context: https://github.com/fluojs/fluo/issues/2290

## Changes

- Route rejected lazy transport factory promises through email lifecycle initialization failure handling.
- Clear rejected transport state after initialization failures so shutdown does not later misclassify the failure as a close error.
- Preserve shutdown-time bootstrap behavior for already-stopping lifecycle transitions while avoiding double-wrapped initialization errors.
- Add regression coverage for lazy send failures and pending lazy factory rejection during shutdown.
- Add a patch changeset for `@fluojs/email`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm test -- src/module.test.ts` from `packages/email` — 4 files / 47 tests passed.
- `pnpm typecheck` from `packages/email` — passed.
- `pnpm exec biome lint packages/email/src/service.ts packages/email/src/module.test.ts .changeset/smooth-mails-retry.md` — passed for changed TS files.
- `GIT_MASTER=1 git diff --check` — passed.
- `pnpm --filter @fluojs/email... build` — passed.
- `pnpm verify:changeset-release-lane` — passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Rationale: this is a public `@fluojs/email` lifecycle failure semantics bug fix. Added `.changeset/smooth-mails-retry.md` with patch intent.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary. Not applicable; no public exports or signatures changed.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable. Not applicable; no exported function signatures changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. No examples changed.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README. Not applicable; this preserves and normalizes the existing lifecycle-error contract.
- [x] Intentional limitations are explicitly stated (not silently removed). No limitations changed.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. No governance docs changed.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable; no platform contract docs changed.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable; no platform README conformance claims changed.