### PR TITLE
Resolve #2291: close Slack factory-owned transports after verification failure

### DIFF
--- a/.changeset/clean-slack-verification-failure.md
+++ b/.changeset/clean-slack-verification-failure.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Close factory-owned Slack transports when bootstrap verification fails after the transport has already been created.

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -204,7 +204,7 @@ Behavioral contract 메모:
 
 - `verifyOnModuleInit`은 선택 사항이며 기본값은 `false`입니다.
 - 검증은 capability 기반입니다. `verify()`를 노출하는 transport만 호출하므로 webhook-only 또는 애플리케이션이 소유한 transport가 no-op verifier를 추가할 필요는 없습니다.
-- `transport.verify()`가 reject되면 bootstrap은 초기화 실패를 감싼 `SlackLifecycleError`로 실패하고, service lifecycle은 `failed`로 이동하며, readiness/status snapshot은 provider를 not ready로 보고합니다.
+- `transport.verify()`가 reject되면 bootstrap은 초기화 실패를 감싼 `SlackLifecycleError`로 실패하고, service lifecycle은 `failed`로 이동하며, readiness/status snapshot은 provider를 not ready로 보고하고, 이미 해석된 factory 소유 transport는 오류를 다시 던지기 전에 닫습니다.
 - `SlackService.createPlatformStatusSnapshot()`은 bootstrap 검증 요청 여부를 health/readiness tooling이 확인할 수 있도록 `verifiedOnModuleInit`을 포함합니다.
 
 ### `@fluojs/notifications`와의 통합

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -204,7 +204,7 @@ Behavioral contract notes:
 
 - `verifyOnModuleInit` is optional and defaults to `false`.
 - Verification is capability-based: only transports that expose `verify()` are called, so webhook-only or app-owned transports do not have to add a no-op verifier.
-- If `transport.verify()` rejects, bootstrap fails with `SlackLifecycleError` wrapping the initialization failure, the service lifecycle moves to `failed`, and readiness/status snapshots report the provider as not ready.
+- If `transport.verify()` rejects, bootstrap fails with `SlackLifecycleError` wrapping the initialization failure, the service lifecycle moves to `failed`, readiness/status snapshots report the provider as not ready, and factory-owned transports that were already resolved are closed before the error is rethrown.
 - `SlackService.createPlatformStatusSnapshot()` includes `verifiedOnModuleInit` so health/readiness tooling can tell whether bootstrap verification was requested.
 
 ### Integration with `@fluojs/notifications`

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -72,6 +72,19 @@ class PassiveTransport implements SlackTransport {
   }
 }
 
+class FailingVerificationTransport extends PassiveTransport {
+  verifyCalls = 0;
+
+  constructor(private readonly failure: Error) {
+    super();
+  }
+
+  async verify(): Promise<void> {
+    this.verifyCalls += 1;
+    throw this.failure;
+  }
+}
+
 class UnsuccessfulTransport implements SlackTransport {
   async send(message: NormalizedSlackMessage) {
     return {
@@ -1199,6 +1212,43 @@ describe('SlackModule', () => {
     expect(createdTransport.verifyCalls).toBe(1);
     expect(verify).toHaveBeenCalledOnce();
     expect(createdTransport.sendCalls).toBe(0);
+  });
+
+  it('closes factory-owned transports when bootstrap verification fails', async () => {
+    const verificationError = new Error('slack auth failed');
+    const transport = new FailingVerificationTransport(verificationError);
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport: {
+        create: async () => transport,
+        ownsResources: true,
+      },
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    await expect(service.onModuleInit()).rejects.toThrowError(
+      new SlackLifecycleError('Slack transport failed to initialize.', { cause: verificationError }),
+    );
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'failed', verifiedOnModuleInit: true },
+      readiness: {
+        reason: 'Slack transport failed to initialize.',
+        status: 'not-ready',
+      },
+    });
+    await expect(service.send({ text: 'After failed bootstrap' })).rejects.toThrowError(
+      new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is failed.'),
+    );
+
+    await service.onApplicationShutdown();
+
+    expect(transport.verifyCalls).toBe(1);
+    expect(transport.closeCalls).toBe(1);
+    expect(transport.sent).toEqual([]);
   });
 
   it('checks notification lifecycle before renderer or validation errors after shutdown', async () => {

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -37,6 +37,13 @@ function createLifecycleError(message: string, cause: unknown): SlackLifecycleEr
   return new SlackLifecycleError(message, { cause });
 }
 
+function createCleanupFailureCause(originalError: unknown, cleanupError: unknown): unknown {
+  return new AggregateError(
+    [originalError, cleanupError],
+    'Slack transport verification failed and the owned transport failed to close.',
+  );
+}
+
 function createDeliveryLifecycleError(state: SlackServiceLifecycleState): SlackLifecycleError {
   return new SlackLifecycleError(`Slack delivery cannot start while the service lifecycle is ${state}.`);
 }
@@ -132,12 +139,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
 
       this.lifecycleState = 'ready';
     } catch (error) {
-      if (isShutdownLifecycleState(this.lifecycleState)) {
-        throw error;
-      }
-
-      this.lifecycleState = 'failed';
-      throw createLifecycleError('Slack transport failed to initialize.', error);
+      await this.handleTransportInitializationFailure(error);
     }
   }
 
@@ -308,6 +310,34 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
     }
 
     return this.transportPromise;
+  }
+
+  private clearResolvedTransport(): void {
+    this.resolvedTransport = undefined;
+    this.transportPromise = undefined;
+  }
+
+  private async handleTransportInitializationFailure(error: unknown): Promise<never> {
+    if (isShutdownLifecycleState(this.lifecycleState)) {
+      throw error;
+    }
+
+    this.lifecycleState = 'failed';
+
+    let cause: unknown = error;
+    const transport = this.resolvedTransport;
+
+    if (transport && this.options.transport.ownsResources && transport.close) {
+      try {
+        await transport.close();
+      } catch (cleanupError) {
+        cause = createCleanupFailureCause(error, cleanupError);
+      }
+    }
+
+    this.clearResolvedTransport();
+
+    throw createLifecycleError('Slack transport failed to initialize.', cause);
   }
 
   private assertCanCreateOrUseTransport(): void {


### PR DESCRIPTION
## Summary

Close factory-owned Slack transports when `verifyOnModuleInit` resolves the transport and then `transport.verify()` rejects.

Linked context: Closes #2291.

## Changes

- Close already-resolved factory-owned Slack transports during bootstrap verification failure cleanup before rethrowing `SlackLifecycleError`.
- Clear failed resolved transport state so later shutdown does not close the same factory-owned transport twice.
- Add regression coverage for the verification failure cleanup path.
- Align English and Korean Slack README contract notes and add a patch changeset for `@fluojs/slack`.

## Testing

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm exec biome check packages/slack/src/service.ts packages/slack/src/module.test.ts packages/slack/README.md packages/slack/README.ko.md .changeset/clean-slack-verification-failure.md`
- [x] `pnpm --filter @fluojs/slack test`
- [x] `pnpm --filter @fluojs/slack... build`
- [x] `pnpm --filter @fluojs/slack typecheck`
- [x] `GIT_MASTER=1 git diff --check`
- [ ] `pnpm verify:release-readiness` was attempted but failed in the existing CLI sandbox matrix after generator output with `Config file contains no configuration data` / `Cannot find module ./utils.js`; Slack package tests, build, typecheck, and changed-file checks passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

No public exports were added or changed.

- [x] Changed public exports include a source-level summary. Not applicable because no public exports changed.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable. Not applicable because no exported signatures changed.
- [x] Source `@example` blocks and README scenario examples still play complementary roles. README contract notes were updated without adding new examples.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated and unchanged.
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. No governance docs changed; Slack README EN/KO package docs were updated together.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. Not applicable; no platform contract docs changed.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. Not applicable; this is Slack lifecycle cleanup, not platform conformance.