### PR TITLE
Resolve #2273: Preserve GraphQL portable HTTP/SSE bootstrap path

### DIFF
--- a/.changeset/polite-lions-serve.md
+++ b/.changeset/polite-lions-serve.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Preserve the documented portable GraphQL HTTP/SSE bootstrap path by loading core GraphQL/Yoga dependencies through runtime-neutral imports and keeping the Node-only `graphql-ws`/`ws` upgrade transport behind the opt-in websocket subscription path.

--- a/packages/graphql/src/node/graphql-websocket-transport.ts
+++ b/packages/graphql/src/node/graphql-websocket-transport.ts
@@ -1,0 +1,244 @@
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
+
+import type { FrameworkRequest, HttpApplicationAdapter } from '@fluojs/http';
+import type {
+  ExecutionArgs,
+  GraphQLError as GraphQLErrorType,
+  execute as executeGraphql,
+  subscribe as subscribeGraphql,
+} from 'graphql';
+import { handleProtocols, type CompleteMessage, type Context as GraphqlWsServerContext, type SubscribeMessage } from 'graphql-ws';
+import { useServer, type Extra as GraphqlWsExtra } from 'graphql-ws/lib/use/ws';
+import { WebSocketServer, type WebSocket } from 'ws';
+
+import { isGraphqlPath } from '../transport/transport.js';
+
+type NodeUpgradeListener = (request: IncomingMessage, socket: Duplex, head: Buffer) => void;
+
+type GraphqlWebSocketContext = GraphqlWsServerContext<Record<string, unknown>, GraphqlWsExtra>;
+
+interface NodeUpgradeServer {
+  off(event: 'upgrade', listener: NodeUpgradeListener): this;
+  on(event: 'upgrade', listener: NodeUpgradeListener): this;
+}
+
+interface GraphqlNodeWebSocketLimits {
+  maxConnections: number;
+  maxOperationsPerConnection: number;
+  maxPayloadBytes: number;
+}
+
+interface GraphqlSubscribePayload {
+  operationName?: string | null;
+  query: string;
+  variables?: Record<string, unknown> | null;
+}
+
+export interface GraphqlNodeWebSocketSubscribeRequest {
+  connectionParams?: Record<string, unknown>;
+  operationId: string;
+  payload: GraphqlSubscribePayload;
+  request: FrameworkRequest;
+  socket: object;
+}
+
+export interface GraphqlNodeWebSocketTransport {
+  dispose(): Promise<void>;
+}
+
+interface GraphqlNodeWebSocketTransportOptions {
+  adapter: HttpApplicationAdapter;
+  connectionInitWaitTimeoutMs?: number;
+  execute: typeof executeGraphql;
+  keepAliveMs?: number;
+  limits?: GraphqlNodeWebSocketLimits;
+  onComplete: (socketKey: object, operationId: string) => Promise<void> | void;
+  onDisconnect: (socketKey: object) => Promise<void> | void;
+  onSubscribe: (request: GraphqlNodeWebSocketSubscribeRequest) => Promise<ExecutionArgs | readonly GraphQLErrorType[]>;
+  subscribe: typeof subscribeGraphql;
+}
+
+function hasNodeUpgradeServer(value: unknown): value is NodeUpgradeServer {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const server = value as { off?: unknown; on?: unknown };
+
+  return typeof server.on === 'function' && typeof server.off === 'function';
+}
+
+function isConnectionParamsRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function buildFrameworkRequestFromIncomingMessage(request: IncomingMessage): FrameworkRequest {
+  const requestUrl = new URL(request.url ?? '/graphql', 'http://localhost');
+
+  return {
+    cookies: {},
+    headers: request.headers,
+    method: request.method ?? 'GET',
+    params: {},
+    path: requestUrl.pathname,
+    query: Object.fromEntries(requestUrl.searchParams.entries()),
+    raw: request,
+    url: requestUrl.pathname + requestUrl.search,
+  };
+}
+
+function closeWebSocketServer(server: WebSocketServer): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    server.close((error?: Error) => {
+      if (error?.message === 'The server is not running') {
+        resolve();
+        return;
+      }
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function resolveUpgradeServer(adapter: HttpApplicationAdapter): NodeUpgradeServer {
+  if (typeof adapter.getServer !== 'function') {
+    throw new Error(
+      'GraphQL websocket subscriptions require an HTTP adapter with getServer(). Use the Node HTTP adapter or provide a compatible adapter implementation.',
+    );
+  }
+
+  const server = adapter.getServer();
+
+  if (!hasNodeUpgradeServer(server)) {
+    throw new Error(
+      'GraphQL websocket subscriptions require adapter.getServer() to return a Node HTTP/S server that supports upgrade listeners.',
+    );
+  }
+
+  return server;
+}
+
+function rejectWebSocketUpgrade(socket: Duplex, statusCode: number, message: string): void {
+  if (!socket.writable) {
+    socket.destroy();
+    return;
+  }
+
+  const body = `${message}\n`;
+  socket.write(
+    [
+      `HTTP/1.1 ${String(statusCode)} ${statusCode === 503 ? 'Service Unavailable' : 'Bad Request'}`,
+      'Connection: close',
+      'Content-Type: text/plain; charset=utf-8',
+      `Content-Length: ${String(new TextEncoder().encode(body).byteLength)}`,
+      '',
+      body,
+    ].join('\r\n'),
+  );
+  socket.destroy();
+}
+
+function createUpgradeListener(websocketServer: WebSocketServer, limits: GraphqlNodeWebSocketLimits | undefined): NodeUpgradeListener {
+  return (request, socket, head) => {
+    const targetPath = new URL(request.url ?? '/', 'http://localhost').pathname;
+
+    if (!isGraphqlPath(targetPath)) {
+      return;
+    }
+
+    if (limits && websocketServer.clients.size >= limits.maxConnections) {
+      rejectWebSocketUpgrade(
+        socket,
+        503,
+        'GraphQL websocket connection count exceeds the configured limit.',
+      );
+      return;
+    }
+
+    websocketServer.handleUpgrade(request, socket, head, (websocket: WebSocket) => {
+      websocketServer.emit('connection', websocket, request);
+    });
+  };
+}
+
+function createSubscribeRequest(
+  context: GraphqlWebSocketContext,
+  message: SubscribeMessage,
+): GraphqlNodeWebSocketSubscribeRequest {
+  return {
+    connectionParams: isConnectionParamsRecord(context.connectionParams) ? context.connectionParams : undefined,
+    operationId: message.id,
+    payload: message.payload,
+    request: buildFrameworkRequestFromIncomingMessage(context.extra.request),
+    socket: context.extra.socket,
+  };
+}
+
+export async function createNodeGraphqlWebSocketTransport(
+  options: GraphqlNodeWebSocketTransportOptions,
+): Promise<GraphqlNodeWebSocketTransport> {
+  const upgradeServer = resolveUpgradeServer(options.adapter);
+  const websocketServer = new WebSocketServer({
+    handleProtocols: (protocols: Set<string>) => handleProtocols(protocols),
+    maxPayload: options.limits?.maxPayloadBytes ?? 0,
+    noServer: true,
+  });
+  const upgradeListener = createUpgradeListener(websocketServer, options.limits);
+  const websocketDisposable = useServer(
+    {
+      connectionInitWaitTimeout: options.connectionInitWaitTimeoutMs,
+      execute: options.execute,
+      onComplete: async (context: GraphqlWebSocketContext, message: CompleteMessage) => {
+        await options.onComplete(context.extra.socket, message.id);
+      },
+      onDisconnect: async (context: GraphqlWebSocketContext) => {
+        await options.onDisconnect(context.extra.socket);
+      },
+      onSubscribe: async (context: GraphqlWebSocketContext, message: SubscribeMessage) =>
+        options.onSubscribe(createSubscribeRequest(context, message)),
+      subscribe: options.subscribe,
+    },
+    websocketServer,
+    options.keepAliveMs,
+  );
+
+  upgradeServer.on('upgrade', upgradeListener);
+
+  return {
+    async dispose() {
+      let disposeError: unknown;
+
+      upgradeServer.off('upgrade', upgradeListener);
+
+      for (const client of websocketServer.clients) {
+        client.terminate();
+      }
+
+      try {
+        await websocketDisposable.dispose();
+      } catch (error) {
+        disposeError = error;
+      }
+
+      try {
+        await closeWebSocketServer(websocketServer);
+      } catch (error) {
+        disposeError ??= error;
+      }
+
+      if (disposeError instanceof Error) {
+        throw disposeError;
+      }
+
+      if (disposeError !== undefined) {
+        throw new Error(String(disposeError));
+      }
+    },
+  };
+}

--- a/packages/graphql/src/schema/schema.test.ts
+++ b/packages/graphql/src/schema/schema.test.ts
@@ -31,6 +31,7 @@ const deps = {
   GraphQLString,
   GraphQLUnionType,
   buildSchema,
+  createGraphQLError: (message: string, options: { extensions?: Record<string, unknown> }) => new GraphQLError(message, options),
 };
 
 const fakeContainer = {} as unknown as Container;

--- a/packages/graphql/src/schema/schema.ts
+++ b/packages/graphql/src/schema/schema.ts
@@ -40,6 +40,7 @@ type YogaGraphqlDeps = {
   GraphQLString: GraphQLScalarType;
   GraphQLUnionType: typeof GraphQLUnionTypeType;
   buildSchema: (source: string) => GraphQLSchemaType;
+  createGraphQLError: (message: string, options: { extensions?: Record<string, unknown> }) => GraphQLErrorType;
 };
 
 function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
@@ -56,7 +57,6 @@ function scalarByName(deps: YogaGraphqlDeps, scalar: 'string' | 'int' | 'float' 
       return deps.GraphQLBoolean;
     case 'id':
       return deps.GraphQLID;
-    case 'string':
     default:
       return deps.GraphQLString;
   }
@@ -343,25 +343,34 @@ function isGraphQLSchemaLike(value: unknown): boolean {
   );
 }
 
-function toGraphqlValidationError(deps: YogaGraphqlDeps, error: DtoValidationError): GraphQLErrorType {
-  return new deps.GraphQLError('Validation failed.', {
+function toGraphqlValidationError(
+  deps: YogaGraphqlDeps,
+  error: DtoValidationError,
+  markAllowedCrossRealmGraphqlObjects: (value: unknown) => void,
+): GraphQLErrorType {
+  const graphqlError = deps.createGraphQLError('Validation failed.', {
     extensions: {
       code: 'BAD_USER_INPUT',
       issues: error.issues,
     },
   });
+
+  markAllowedCrossRealmGraphqlObjects(graphqlError);
+
+  return graphqlError;
 }
 
 async function createResolverInput(
   deps: YogaGraphqlDeps,
   handler: ResolverHandlerDescriptor,
   args: Record<string, unknown>,
+  markAllowedCrossRealmGraphqlObjects: (value: unknown) => void,
 ): Promise<unknown> {
   try {
     return await createGraphqlInput(handler.inputClass, args, handler.argFields);
   } catch (error) {
     if (error instanceof DtoValidationError) {
-      throw toGraphqlValidationError(deps, error);
+      throw toGraphqlValidationError(deps, error, markAllowedCrossRealmGraphqlObjects);
     }
 
     throw error;
@@ -385,6 +394,7 @@ function resolveResolverMethod(
 function createResolverInvoker(
   deps: YogaGraphqlDeps,
   runtimeContainer: Container,
+  markAllowedCrossRealmGraphqlObjects: (value: unknown) => void,
 ): (
   descriptor: ResolverDescriptor,
   handler: ResolverHandlerDescriptor,
@@ -400,7 +410,7 @@ function createResolverInvoker(
     if (descriptor.scope === 'singleton') {
       const instance = await runtimeContainer.resolve(descriptor.token);
       const resolverMethod = resolveResolverMethod(instance, descriptor, handler);
-      const input = await createResolverInput(deps, handler, args);
+      const input = await createResolverInput(deps, handler, args, markAllowedCrossRealmGraphqlObjects);
       return resolverMethod.call(instance, input, contextValue);
     }
 
@@ -410,7 +420,7 @@ function createResolverInvoker(
     try {
       const instance = await operationContainer.resolve(descriptor.token);
       const resolverMethod = resolveResolverMethod(instance, descriptor, handler);
-      const input = await createResolverInput(deps, handler, args);
+      const input = await createResolverInput(deps, handler, args, markAllowedCrossRealmGraphqlObjects);
       return await resolverMethod.call(instance, input, contextValue);
     } finally {
       if (disposeOperationContainer) {
@@ -503,7 +513,7 @@ export function createCodeFirstSchema(
     throw new Error('GraphQL module requires either schema or at least one resolver decorated with @Resolver().');
   }
 
-  const invokeResolver = createResolverInvoker(deps, runtimeContainer);
+  const invokeResolver = createResolverInvoker(deps, runtimeContainer, markAllowedCrossRealmGraphqlObjects);
   const outputTypeCache = new Map<string, GraphQLOutputType>();
 
   const queryFields = pickFieldsByType(
@@ -535,9 +545,13 @@ export function createCodeFirstSchema(
   const mutationType = createOptionalRootType(deps, 'Mutation', mutationFields);
   const subscriptionType = createOptionalRootType(deps, 'Subscription', subscriptionFields);
 
-  return new deps.GraphQLSchema({
+  const schema = new deps.GraphQLSchema({
     mutation: mutationType,
     query: queryType,
     subscription: subscriptionType,
   });
+
+  markAllowedCrossRealmGraphqlObjects(schema);
+
+  return schema;
 }

--- a/packages/graphql/src/service.test.ts
+++ b/packages/graphql/src/service.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
 
 import type { HttpApplicationAdapter } from '@fluojs/http';
 import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
@@ -26,6 +27,20 @@ function createService(options: GraphqlModuleOptions): GraphqlLifecycleService {
     adapter,
     options,
   );
+}
+
+function createPortableSchema(): GraphQLSchema {
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({
+      fields: {
+        ping: {
+          resolve: () => 'pong',
+          type: GraphQLString,
+        },
+      },
+      name: 'Query',
+    }),
+  });
 }
 
 function resolveGraphiqlEnabled(service: GraphqlLifecycleService): boolean {
@@ -67,6 +82,25 @@ function resolveWebSocketLimits(service: GraphqlLifecycleService): {
 }
 
 describe('GraphqlLifecycleService graphiql defaults', () => {
+  afterEach(() => {
+    vi.doUnmock('node:module');
+  });
+
+  it('bootstraps portable HTTP and SSE paths without Node createRequire', async () => {
+    vi.doMock('node:module', () => ({
+      createRequire() {
+        throw new Error('portable GraphQL HTTP/SSE bootstrap must not call createRequire.');
+      },
+    }));
+
+    const service = createService({
+      schema: createPortableSchema(),
+    });
+
+    await expect(service.onApplicationBootstrap()).resolves.toBeUndefined();
+    await service.onApplicationShutdown();
+  });
+
   it('defaults to false when graphiql option is not set', () => {
     const service = createService({});
 

--- a/packages/graphql/src/service.ts
+++ b/packages/graphql/src/service.ts
@@ -1,6 +1,3 @@
-import type { IncomingMessage } from 'node:http';
-import type { Duplex } from 'node:stream';
-
 import { Controller, Get, Post, type FrameworkRequest, type HttpApplicationAdapter, type Middleware, type MiddlewareContext, type Next } from '@fluojs/http';
 import { Inject } from '@fluojs/core';
 import type { Container } from '@fluojs/di';
@@ -19,14 +16,14 @@ import type {
   GraphQLUnionType as GraphQLUnionTypeType,
   DocumentNode,
   ExecutionArgs,
+  execute as executeGraphql,
+  subscribe as subscribeGraphql,
 } from 'graphql';
-import type { CompleteMessage, Context as GraphqlWsServerContext, OperationResult, SubscribeMessage } from 'graphql-ws';
-import type { Extra as GraphqlWsExtra } from 'graphql-ws/lib/use/ws';
-import type { WebSocket, WebSocketServer } from 'ws';
 
 import { discoverResolverDescriptors } from './discovery.js';
 import { createGraphqlValidationPlugin, resolveGraphqlRequestLimits } from './guardrails.js';
 import { GRAPHQL_INTERNAL_MODULE_OPTIONS_TOKEN } from './internal-tokens.js';
+import type { GraphqlNodeWebSocketSubscribeRequest, GraphqlNodeWebSocketTransport } from './node/graphql-websocket-transport.js';
 import { createCodeFirstSchema, resolveSchema } from './schema/schema.js';
 import { isGraphqlPath, toFetchRequest, writeFetchResponse } from './transport/transport.js';
 import { GRAPHQL_OPERATION_CONTAINER } from './types.js';
@@ -57,21 +54,6 @@ type GraphqlInstanceOfModule = {
   instanceOf: GraphqlInstanceOf;
 };
 
-type NodeUpgradeListener = (request: IncomingMessage, socket: Duplex, head: Buffer) => void;
-
-interface NodeUpgradeServer {
-  off(event: 'upgrade', listener: NodeUpgradeListener): this;
-  on(event: 'upgrade', listener: NodeUpgradeListener): this;
-}
-
-type GraphqlWebSocketContext = GraphqlWsServerContext<Record<string, unknown>, GraphqlWsExtra>;
-
-interface GraphqlSubscribePayload {
-  operationName?: string | null;
-  query: string;
-  variables?: Record<string, unknown> | null;
-}
-
 interface GraphqlWebSocketLimits {
   maxConnections: number;
   maxOperationsPerConnection: number;
@@ -83,16 +65,6 @@ const DEFAULT_GRAPHQL_WEBSOCKET_LIMITS: GraphqlWebSocketLimits = {
   maxOperationsPerConnection: 25,
   maxPayloadBytes: 64 * 1024,
 };
-
-function hasNodeUpgradeServer(value: unknown): value is NodeUpgradeServer {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  const server = value as { off?: unknown; on?: unknown };
-
-  return typeof server.on === 'function' && typeof server.off === 'function';
-}
 
 function buildFrameworkRequestFromFetchRequest(request: Request): FrameworkRequest {
   const requestUrl = new URL(request.url);
@@ -110,43 +82,6 @@ function buildFrameworkRequestFromFetchRequest(request: Request): FrameworkReque
   };
 }
 
-function buildFrameworkRequestFromIncomingMessage(request: IncomingMessage): FrameworkRequest {
-  const requestUrl = new URL(request.url ?? '/graphql', 'http://localhost');
-
-  return {
-    cookies: {},
-    headers: request.headers,
-    method: request.method ?? 'GET',
-    params: {},
-    path: requestUrl.pathname,
-    query: Object.fromEntries(requestUrl.searchParams.entries()),
-    raw: request,
-    url: requestUrl.pathname + requestUrl.search,
-  };
-}
-
-function isConnectionParamsRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function closeWebSocketServer(server: WebSocketServer): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    server.close((error?: Error) => {
-      if (error?.message === 'The server is not running') {
-        resolve();
-        return;
-      }
-
-      if (error) {
-        reject(error);
-        return;
-      }
-
-      resolve();
-    });
-  });
-}
-
 interface GraphqlDeps {
   GraphQLError: typeof GraphQLErrorType;
   GraphQLBoolean: typeof GraphQLBooleanType;
@@ -159,10 +94,11 @@ interface GraphqlDeps {
   GraphQLString: typeof GraphQLStringType;
   GraphQLUnionType: typeof GraphQLUnionTypeType;
   buildSchema: (source: string) => GraphQLSchemaType;
+  createGraphQLError: (message: string, options: { extensions?: Record<string, unknown> }) => GraphQLErrorType;
   createYoga: (options: Record<string, unknown>) => YogaLike;
-  execute: (args: ExecutionArgs) => OperationResult;
+  execute: typeof executeGraphql;
   instanceOfModule: GraphqlInstanceOfModule;
-  subscribe: (args: ExecutionArgs) => OperationResult;
+  subscribe: typeof subscribeGraphql;
 }
 
 let graphqlInstanceOfPatchRefCount = 0;
@@ -186,7 +122,8 @@ export class GraphqlEndpointController {
 }
 
 function getCrossRealmGraphqlTag(value: unknown, constructor: GraphqlConstructor): string | undefined {
-  const className = constructor.prototype?.[Symbol.toStringTag];
+  const prototypeTag = constructor.prototype?.[Symbol.toStringTag];
+  const className = typeof prototypeTag === 'string' ? prototypeTag : constructor.name;
 
   if (typeof className !== 'string' || !className.startsWith('GraphQL')) {
     return undefined;
@@ -196,10 +133,10 @@ function getCrossRealmGraphqlTag(value: unknown, constructor: GraphqlConstructor
     return undefined;
   }
 
-  if (Symbol.toStringTag in value) {
-    const valueClassName = (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag];
+  const valueTag = (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag];
 
-    return valueClassName === className ? className : undefined;
+  if (typeof valueTag === 'string') {
+    return valueTag === className ? className : undefined;
   }
 
   const valueClassName = (value as { constructor?: { name?: string } }).constructor?.name;
@@ -219,8 +156,12 @@ function markAllowedCrossRealmGraphqlObjects(value: unknown, visited = new WeakS
   visited.add(value);
 
   const tag = (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag];
+  const constructorName = (value as { constructor?: { name?: unknown } }).constructor?.name;
 
-  if (typeof tag === 'string' && tag.startsWith('GraphQL')) {
+  if (
+    (typeof tag === 'string' && tag.startsWith('GraphQL')) ||
+    (typeof constructorName === 'string' && constructorName.startsWith('GraphQL'))
+  ) {
     allowedCrossRealmGraphqlObjects.add(value);
   }
 
@@ -301,11 +242,14 @@ function releaseGraphqlInstanceOfPatch(): void {
 }
 
 async function loadGraphqlDeps(): Promise<GraphqlDeps> {
-  const { createRequire } = await import('node:module');
-  const runtimeRequire = createRequire(import.meta.url);
-  const graphqlMod = runtimeRequire('graphql') as typeof import('graphql');
-  const yogaMod = runtimeRequire('graphql-yoga') as typeof import('graphql-yoga');
-  const instanceOfModule = runtimeRequire('graphql/jsutils/instanceOf.js') as GraphqlInstanceOfModule;
+  const graphqlSpecifier = 'graphql';
+  const yogaSpecifier = 'graphql-yoga';
+  const instanceOfSpecifier = 'graphql/jsutils/instanceOf.js';
+  const [graphqlMod, yogaMod, instanceOfModule] = await Promise.all([
+    import(/* @vite-ignore */ graphqlSpecifier) as Promise<typeof import('graphql')>,
+    import(/* @vite-ignore */ yogaSpecifier) as Promise<typeof import('graphql-yoga')>,
+    import(/* @vite-ignore */ instanceOfSpecifier) as Promise<GraphqlInstanceOfModule>,
+  ]);
 
   return {
     GraphQLError: graphqlMod.GraphQLError,
@@ -319,6 +263,10 @@ async function loadGraphqlDeps(): Promise<GraphqlDeps> {
     GraphQLString: graphqlMod.GraphQLString,
     GraphQLUnionType: graphqlMod.GraphQLUnionType,
     buildSchema: graphqlMod.buildSchema,
+    createGraphQLError: yogaMod.createGraphQLError as (
+      message: string,
+      options: { extensions?: Record<string, unknown> },
+    ) => GraphQLErrorType,
     createYoga: yogaMod.createYoga as (options: Record<string, unknown>) => YogaLike,
     execute: graphqlMod.execute,
     instanceOfModule,
@@ -336,13 +284,10 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   private readonly operationContainers = new WeakMap<Request, Container>();
   private readonly requestContexts = new WeakMap<Request, GraphqlRequestContext>();
   private readonly websocketOperationContainers = new Map<object, Map<string, Container>>();
-  private websocketDisposable: { dispose(): Promise<void> | void } | undefined;
-  private websocketServer: WebSocketServer | undefined;
-  private websocketUpgradeListener: NodeUpgradeListener | undefined;
-  private websocketUpgradeServer: NodeUpgradeServer | undefined;
-  private executeGraphqlOperation: ((args: ExecutionArgs) => OperationResult) | undefined;
+  private websocketTransport: GraphqlNodeWebSocketTransport | undefined;
+  private executeGraphqlOperation: typeof executeGraphql | undefined;
   private releaseGraphqlInstanceOfPatch: (() => void) | undefined;
-  private subscribeGraphqlOperation: ((args: ExecutionArgs) => OperationResult) | undefined;
+  private subscribeGraphqlOperation: typeof subscribeGraphql | undefined;
   private yoga: YogaLike | undefined;
 
   private readonly middleware: Middleware = {
@@ -561,114 +506,47 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
   }
 
   private async registerWebSocketTransport(): Promise<void> {
-    if (!this.isWebSocketTransportEnabled() || this.yoga === undefined || this.websocketUpgradeListener !== undefined) {
+    if (!this.isWebSocketTransportEnabled() || this.yoga === undefined || this.websocketTransport !== undefined) {
       return;
     }
 
-    const [{ handleProtocols }, { useServer }, { WebSocketServer }] = await Promise.all([
-      import('graphql-ws'),
-      import('graphql-ws/lib/use/ws'),
-      import('ws'),
-    ]);
-    const upgradeServer = this.resolveUpgradeServer();
-    const websocketLimits = this.resolveWebSocketLimits();
-    const websocketServer = new WebSocketServer({
-      handleProtocols: (protocols: Set<string>) => handleProtocols(protocols),
-      maxPayload: websocketLimits?.maxPayloadBytes ?? 0,
-      noServer: true,
-    });
-    const upgradeListener: NodeUpgradeListener = (request, socket, head) => {
-      const targetPath = new URL(request.url ?? '/', 'http://localhost').pathname;
+    const { createNodeGraphqlWebSocketTransport } = await import('./node/graphql-websocket-transport.js');
 
-      if (!isGraphqlPath(targetPath)) {
-        return;
-      }
+    this.websocketTransport = await createNodeGraphqlWebSocketTransport({
+      adapter: this.adapter,
+      connectionInitWaitTimeoutMs: this.options.subscriptions?.websocket?.connectionInitWaitTimeoutMs,
+      execute: (args: ExecutionArgs) => {
+        if (!this.executeGraphqlOperation) {
+          throw new Error('GraphQL execute function not initialized.');
+        }
 
-      if (websocketLimits && websocketServer.clients.size >= websocketLimits.maxConnections) {
-        this.rejectWebSocketUpgrade(
-          socket,
-          503,
-          'GraphQL websocket connection count exceeds the configured limit.',
-        );
-        return;
-      }
-
-      websocketServer.handleUpgrade(request, socket, head, (websocket: WebSocket) => {
-        websocketServer.emit('connection', websocket, request);
-      });
-    };
-
-    const websocketDisposable = useServer(
-      {
-        connectionInitWaitTimeout: this.options.subscriptions?.websocket?.connectionInitWaitTimeoutMs,
-        execute: (args: ExecutionArgs) => {
-          if (!this.executeGraphqlOperation) {
-            throw new Error('GraphQL execute function not initialized.');
-          }
-
-          return this.executeGraphqlOperation(args);
-        },
-        onComplete: async (context: GraphqlWebSocketContext, message: CompleteMessage) => {
-          await this.disposeWebSocketOperationContainer(context.extra.socket, message.id);
-        },
-        onDisconnect: async (context: GraphqlWebSocketContext) => {
-          await this.disposeAllWebSocketOperationContainers(context.extra.socket);
-        },
-        onSubscribe: async (context: GraphqlWebSocketContext, message: SubscribeMessage) =>
-          this.handleWebSocketSubscribe(context, message.id, message.payload),
-        subscribe: (args: ExecutionArgs) => {
-          if (!this.subscribeGraphqlOperation) {
-            throw new Error('GraphQL subscribe function not initialized.');
-          }
-
-          return this.subscribeGraphqlOperation(args);
-        },
+        return this.executeGraphqlOperation(args);
       },
-      websocketServer,
-      this.options.subscriptions?.websocket?.keepAliveMs,
-    );
+      keepAliveMs: this.options.subscriptions?.websocket?.keepAliveMs,
+      limits: this.resolveWebSocketLimits(),
+      onComplete: (socketKey, operationId) => this.disposeWebSocketOperationContainer(socketKey, operationId),
+      onDisconnect: (socketKey) => this.disposeAllWebSocketOperationContainers(socketKey),
+      onSubscribe: (request) => this.handleWebSocketSubscribe(request),
+      subscribe: (args: ExecutionArgs) => {
+        if (!this.subscribeGraphqlOperation) {
+          throw new Error('GraphQL subscribe function not initialized.');
+        }
 
-    upgradeServer.on('upgrade', upgradeListener);
-
-    this.websocketDisposable = websocketDisposable;
-    this.websocketServer = websocketServer;
-    this.websocketUpgradeListener = upgradeListener;
-    this.websocketUpgradeServer = upgradeServer;
+        return this.subscribeGraphqlOperation(args);
+      },
+    });
   }
 
   private async unregisterWebSocketTransport(): Promise<void> {
-    if (this.websocketUpgradeListener && this.websocketUpgradeServer) {
-      this.websocketUpgradeServer.off('upgrade', this.websocketUpgradeListener);
-    }
-
-    this.websocketUpgradeListener = undefined;
-    this.websocketUpgradeServer = undefined;
-
-    if (this.websocketServer) {
-      for (const client of this.websocketServer.clients) {
-        client.terminate();
-      }
-    }
-
-    if (this.websocketDisposable) {
+    if (this.websocketTransport) {
       try {
-        await this.websocketDisposable.dispose();
+        await this.websocketTransport.dispose();
       } catch (error) {
         this.logger.error('Failed to dispose GraphQL websocket transport.', error, 'GraphqlLifecycleService');
       }
     }
 
-    this.websocketDisposable = undefined;
-
-    if (this.websocketServer) {
-      try {
-        await closeWebSocketServer(this.websocketServer);
-      } catch (error) {
-        this.logger.error('Failed to close GraphQL websocket server.', error, 'GraphqlLifecycleService');
-      }
-    }
-
-    this.websocketServer = undefined;
+    this.websocketTransport = undefined;
 
     for (const socketKey of this.websocketOperationContainers.keys()) {
       await this.disposeAllWebSocketOperationContainers(socketKey);
@@ -679,50 +557,27 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     return this.options.subscriptions?.websocket?.enabled === true;
   }
 
-  private resolveUpgradeServer(): NodeUpgradeServer {
-    if (typeof this.adapter.getServer !== 'function') {
-      throw new Error(
-        'GraphQL websocket subscriptions require an HTTP adapter with getServer(). Use the Node HTTP adapter or provide a compatible adapter implementation.',
-      );
-    }
-
-    const server = this.adapter.getServer();
-
-    if (!hasNodeUpgradeServer(server)) {
-      throw new Error(
-        'GraphQL websocket subscriptions require adapter.getServer() to return a Node HTTP/S server that supports upgrade listeners.',
-      );
-    }
-
-    return server;
-  }
-
-  private async handleWebSocketSubscribe(
-    context: GraphqlWsServerContext<Record<string, unknown>, GraphqlWsExtra>,
-    operationId: string,
-    payload: GraphqlSubscribePayload,
-  ): Promise<ExecutionArgs | readonly GraphQLErrorType[]> {
+  private async handleWebSocketSubscribe(request: GraphqlNodeWebSocketSubscribeRequest): Promise<ExecutionArgs | readonly GraphQLErrorType[]> {
     const yoga = this.yoga;
 
     if (!yoga) {
       throw new Error('GraphQL server not initialized.');
     }
 
-    const websocketLimitError = this.createWebSocketOperationLimitError(context.extra.socket, operationId);
+    const websocketLimitError = this.createWebSocketOperationLimitError(request.socket, request.operationId);
 
     if (websocketLimitError) {
       return [websocketLimitError];
     }
 
-    const frameworkRequest = buildFrameworkRequestFromIncomingMessage(context.extra.request);
-    const fetchRequest = toFetchRequest(frameworkRequest);
-    const operationContainer = this.getOrCreateWebSocketOperationContainer(context.extra.socket, operationId);
+    const fetchRequest = toFetchRequest(request.request);
+    const operationContainer = this.getOrCreateWebSocketOperationContainer(request.socket, request.operationId);
     const graphqlContext = this.buildGraphqlContext(
       fetchRequest,
       {
-        connectionParams: isConnectionParamsRecord(context.connectionParams) ? context.connectionParams : undefined,
-        request: frameworkRequest,
-        socket: context.extra.socket,
+        connectionParams: request.connectionParams,
+        request: request.request,
+        socket: request.socket,
       },
       operationContainer,
     );
@@ -732,23 +587,23 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
         request: fetchRequest,
         [GRAPHQL_CONTEXT_OVERRIDE]: graphqlContext,
       });
-      const document = parse(payload.query);
+      const document = parse(request.payload.query);
       const validationErrors = validate(schema, document);
 
       if (validationErrors.length > 0) {
-        await this.disposeWebSocketOperationContainer(context.extra.socket, operationId);
+        await this.disposeWebSocketOperationContainer(request.socket, request.operationId);
         return validationErrors;
       }
 
       return {
         contextValue: await contextFactory(),
         document,
-        operationName: payload.operationName ?? undefined,
+        operationName: request.payload.operationName ?? undefined,
         schema,
-        variableValues: payload.variables,
+        variableValues: request.payload.variables,
       };
     } catch (error) {
-      await this.disposeWebSocketOperationContainer(context.extra.socket, operationId);
+      await this.disposeWebSocketOperationContainer(request.socket, request.operationId);
       throw error;
     }
   }
@@ -775,26 +630,6 @@ export class GraphqlLifecycleService implements OnApplicationBootstrap, OnApplic
     return new GraphQLError(
       `GraphQL websocket active operation count exceeds the configured limit of ${String(limits.maxOperationsPerConnection)}.`,
     );
-  }
-
-  private rejectWebSocketUpgrade(socket: Duplex, statusCode: number, message: string): void {
-    if (!socket.writable) {
-      socket.destroy();
-      return;
-    }
-
-    const body = `${message}\n`;
-    socket.write(
-      [
-        `HTTP/1.1 ${String(statusCode)} ${statusCode === 503 ? 'Service Unavailable' : 'Bad Request'}`,
-        'Connection: close',
-        'Content-Type: text/plain; charset=utf-8',
-        `Content-Length: ${String(new TextEncoder().encode(body).byteLength)}`,
-        '',
-        body,
-      ].join('\r\n'),
-    );
-    socket.destroy();
   }
 
   private getOrCreateWebSocketOperationContainer(socketKey: object, operationId: string): Container {


### PR DESCRIPTION
## Summary

Closes #2273

Preserve the documented portable GraphQL HTTP/SSE bootstrap path by removing Node-only bootstrap requirements from the default GraphQL lifecycle. Websocket subscription support remains behind the opt-in Node-specific transport path.

## Changes

- Replaced node:module/createRequire GraphQL dependency loading with runtime-neutral dynamic imports for the HTTP/SSE bootstrap path.
- Moved graphql-ws, ws, Node upgrade listener wiring, and Node HTTP stream types into packages/graphql/src/node/graphql-websocket-transport.ts.
- Kept websocket subscriptions gated behind subscriptions.websocket.enabled === true and the existing Node adapter upgrade-listener contract.
- Normalized cross-realm GraphQL schema/error handling introduced by runtime-neutral loading.
- Added regression coverage for non-websocket bootstrap when node:module.createRequire throws.
- Added a patch changeset for the public runtime behavior fix.

## Testing

- pnpm --filter @fluojs/graphql typecheck — passed
- pnpm --filter @fluojs/graphql build — passed
- pnpm --filter @fluojs/graphql test — passed (86 tests)
- pnpm exec biome lint packages/graphql/src/service.ts packages/graphql/src/service.test.ts packages/graphql/src/schema/schema.ts packages/graphql/src/schema/schema.test.ts packages/graphql/src/node/graphql-websocket-transport.ts .changeset/polite-lions-serve.md — passed
- pnpm verify:release-readiness — passed
- pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main — passed

Note: LSP diagnostics could not run in this worktree because the language server attempted to invoke a missing global biome executable; repository-local Biome lint/typecheck/build/test verifiers passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary. N/A: no public exports were added or changed.
- [x] Changed exported functions document matching @param / @returns tags where applicable. N/A.
- [x] Source @example blocks and README scenario examples still play complementary roles. N/A.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. N/A: existing HTTP/SSE portable and websocket Node-only boundary is preserved.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs. N/A: no docs changed.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. N/A.
- [x] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests. N/A.