### PR TITLE
Resolve #2292: Reject Slack notification fan-out hidden by payload channel

### DIFF
--- a/.changeset/reject-slack-hidden-fan-out.md
+++ b/.changeset/reject-slack-hidden-fan-out.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Reject Slack notification dispatches that include multiple non-empty recipients even when the payload also supplies a channel, preserving the documented one-destination boundary.

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -678,6 +678,29 @@ describe('SlackModule', () => {
     );
   });
 
+  it('rejects multi-recipient notification fan-out even when payload channel is set', async () => {
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      transport: createRecordingTransportFactory(),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    await expect(
+      service.sendNotification({
+        channel: 'slack',
+        payload: { channel: '#ops', text: 'Fan-out not allowed' },
+        recipients: ['#eng', '#platform'],
+      }),
+    ).rejects.toThrowError(
+      new SlackMessageValidationError(
+        'Slack notifications accept exactly one target channel per dispatch. Use `sendMany(...)` for fan-out delivery.',
+      ),
+    );
+    expect(transportState.sent).toHaveLength(0);
+  });
+
   it('surfaces an unsuccessful transport receipt as a notifications channel failure', async () => {
     const container = new Container();
     const moduleType = SlackModule.forRoot({

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -369,18 +369,18 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
   }
 
   private resolveNotificationChannel(notification: SlackNotificationDispatchRequest): string | undefined {
-    const payloadChannel = normalizeOptionalString(notification.payload.channel);
-
-    if (payloadChannel) {
-      return payloadChannel;
-    }
-
     const recipients = notification.recipients?.map((entry) => entry.trim()).filter((entry) => entry.length > 0) ?? [];
 
     if (recipients.length > 1) {
       throw new SlackMessageValidationError(
         'Slack notifications accept exactly one target channel per dispatch. Use `sendMany(...)` for fan-out delivery.',
       );
+    }
+
+    const payloadChannel = normalizeOptionalString(notification.payload.channel);
+
+    if (payloadChannel) {
+      return payloadChannel;
     }
 
     return recipients[0] ?? this.options.defaultChannel;


### PR DESCRIPTION
## Summary

Closes #2292.

Reject Slack notification dispatches that try to hide multi-recipient fan-out behind `payload.channel`, preserving the documented one-destination Slack notification boundary.

Linked context: https://github.com/fluojs/fluo/issues/2292

## Changes

- Validate non-empty `recipients` cardinality before selecting `payload.channel` in `SlackService.sendNotification(...)`.
- Add regression coverage for `payload.channel` plus multiple recipients throwing `SlackMessageValidationError` without transport delivery.
- Add a patch changeset for the consumer-visible `@fluojs/slack` bug fix.

## Testing

- `pnpm install --frozen-lockfile` — passed, installed dependencies in the dedicated worktree for verification.
- `pnpm exec biome check packages/slack/src/service.ts packages/slack/src/module.test.ts .changeset/reject-slack-hidden-fan-out.md` — passed (`Checked 2 files in 15ms. No fixes applied.`).
- `pnpm --filter @fluojs/slack... build` — passed, including Slack dependency graph and `@fluojs/slack` build.
- `pnpm --filter @fluojs/slack test` — passed (`3 passed`, `46 passed`).
- `pnpm --filter @fluojs/slack typecheck` — passed.
- `pnpm verify:release-readiness` — passed (`Release readiness checks passed without writing draft artifacts.`).

Note: LSP diagnostics for changed TypeScript files were attempted but the diagnostics tool could not locate `biome` in its own PATH. The markdown changeset diagnostics reported no diagnostics; changed-file validation was covered with the explicit `pnpm exec biome check` command above.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Changeset: `.changeset/reject-slack-hidden-fan-out.md` (`@fluojs/slack`: patch).

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports or signatures changed. Existing README contract text already states that one notification dispatch maps to exactly one Slack destination and multi-destination fan-out should use `sendMany(...)`.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This preserves the existing `@fluojs/slack` contract that one notification dispatch maps to exactly one Slack destination, with regression coverage for the previously hidden fan-out path.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform/governance docs changed. Package README alignment was checked before implementation; no README wording change was required because the documented one-destination limitation already covered this behavior.