### PR TITLE
Resolve #2275: Serialize cache lifecycle operations

### DIFF
--- a/.changeset/quiet-caches-reset.md
+++ b/.changeset/quiet-caches-reset.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cache-manager": patch
+---
+
+Serialize cache reset and shutdown boundaries so in-flight `remember(...)` loaders cannot repopulate stale entries and closed stores are not touched by later cache operations.

--- a/packages/cache-manager/README.ko.md
+++ b/packages/cache-manager/README.ko.md
@@ -170,7 +170,7 @@ HTTP 인터셉터는 나중에 재사용할 수 있는 값이 있는 성공한, 
 
 ### 캐시 소유권과 reset 범위
 
-`CacheService.reset()`은 관련 없는 애플리케이션 상태가 아니라 설정된 store가 소유한 엔트리만 삭제합니다. 또한 진행 중인 `remember(...)` bookkeeping을 제거하므로 reset 전에 시작된 loader가 reset 완료 후 stale 엔트리를 다시 채우지 못합니다. 내장 메모리 저장소에서는 해당 store 인스턴스가 보유한 in-process 엔트리를 의미합니다. Redis에서는 설정된 `keyPrefix` namespace가 소유권 경계입니다. 공유 Redis 배포에서는 기본 `fluo:cache:`를 유지하거나 `myapp:cache:`처럼 전용 prefix를 선택하세요.
+`CacheService.reset()`은 관련 없는 애플리케이션 상태가 아니라 설정된 store가 소유한 엔트리만 삭제합니다. 또한 reset 경계에서 store read/write를 직렬화하고 진행 중인 `remember(...)` loader를 무효화하므로, reset 전에 시작된 loader가 reset 완료 후 stale 엔트리를 다시 채우지 못합니다. 내장 메모리 저장소에서는 해당 store 인스턴스가 보유한 in-process 엔트리를 의미합니다. Redis에서는 설정된 `keyPrefix` namespace가 소유권 경계입니다. 공유 Redis 배포에서는 기본 `fluo:cache:`를 유지하거나 `myapp:cache:`처럼 전용 prefix를 선택하세요.
 
 ```typescript
 CacheModule.forRoot({
@@ -181,7 +181,7 @@ CacheModule.forRoot({
 
 Redis cache prefix를 cache가 아닌 데이터와 공유하지 마세요. `del(key)`은 이 패키지가 해석한 정확한 캐시 키를 삭제하고, `reset()`은 위에서 설명한 store 소유 캐시 namespace만 삭제합니다.
 
-애플리케이션이 종료될 때 `CacheService`는 `close()` 또는 `dispose()`를 노출하는 custom store로 shutdown을 전달합니다. store가 socket, pool, timer 또는 기타 외부 리소스를 소유한다면 이 optional hook 중 하나를 사용하세요.
+애플리케이션이 종료될 때 `CacheService`는 새 store read/write를 중단하고 이미 시작된 store 작업을 기다린 뒤, `close()` 또는 `dispose()`를 노출하는 custom store로 shutdown을 전달합니다. store가 socket, pool, timer 또는 기타 외부 리소스를 소유한다면 이 optional hook 중 하나를 사용하세요.
 
 `CacheStore` 계약을 구현한 custom store는 `store` 옵션에 직접 전달할 수 있습니다. in-process LRU store, Redis 외 원격 캐시, 또는 cache operation을 관찰해야 하는 테스트 더블에 적합합니다.
 

--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -170,7 +170,7 @@ The HTTP interceptor caches only successful, uncommitted GET handler results wit
 
 ### Cache Ownership and Reset Scope
 
-`CacheService.reset()` clears entries owned by the configured store, not unrelated application state. It also drops in-flight `remember(...)` bookkeeping so loaders that started before the reset cannot repopulate stale entries after the reset completes. For the built-in memory store that means the in-process entries held by that store instance. For Redis, ownership is the configured `keyPrefix` namespace; keep the default `fluo:cache:` or choose a dedicated prefix such as `myapp:cache:` for shared Redis deployments.
+`CacheService.reset()` clears entries owned by the configured store, not unrelated application state. It also serializes store reads/writes across the reset boundary and invalidates in-flight `remember(...)` loaders so loaders that started before the reset cannot repopulate stale entries after the reset completes. For the built-in memory store that means the in-process entries held by that store instance. For Redis, ownership is the configured `keyPrefix` namespace; keep the default `fluo:cache:` or choose a dedicated prefix such as `myapp:cache:` for shared Redis deployments.
 
 ```typescript
 CacheModule.forRoot({
@@ -181,7 +181,7 @@ CacheModule.forRoot({
 
 Avoid sharing a Redis cache prefix with non-cache data. `del(key)` removes the exact cache key resolved by this package, while `reset()` removes only the store-owned cache namespace described above.
 
-When the application closes, `CacheService` forwards shutdown to custom stores that expose `close()` or `dispose()`. Use one of those optional hooks when a store owns sockets, pools, timers, or other external resources.
+When the application closes, `CacheService` stops new store reads/writes, waits for already-started store operations, and then forwards shutdown to custom stores that expose `close()` or `dispose()`. Use one of those optional hooks when a store owns sockets, pools, timers, or other external resources.
 
 Custom stores can be passed directly through `store` when they implement the `CacheStore` contract. This is the right option for in-process LRU stores, remote caches other than Redis, or test doubles that need to observe cache operations.
 

--- a/packages/cache-manager/src/cache-service.test.ts
+++ b/packages/cache-manager/src/cache-service.test.ts
@@ -101,6 +101,29 @@ class PaginatedRedisClient extends MockRedisClient {
   }
 }
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveDeferred: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve;
+  });
+
+  return {
+    promise,
+    resolve(value: T) {
+      if (!resolveDeferred) {
+        throw new Error('Deferred resolver was not initialized.');
+      }
+
+      resolveDeferred(value);
+    },
+  };
+}
+
 function createCacheService(store: CacheStore, options: Partial<NormalizedCacheModuleOptions> = {}) {
   const mergedOptions: NormalizedCacheModuleOptions = {
     ...baseOptions,
@@ -520,5 +543,124 @@ describe('CacheService — general cache contract (outside HTTP interceptor)', (
     await cache.close();
 
     expect(store.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write a remember value after close starts while the loader is in flight', async () => {
+    const loaderDeferred = createDeferred<{ computed: boolean }>();
+    const store: CacheStore = {
+      close: vi.fn(async () => undefined),
+      del: vi.fn(async () => undefined),
+      get: vi.fn(async () => undefined),
+      reset: vi.fn(async () => undefined),
+      set: vi.fn(async () => undefined),
+    };
+    const cache = createCacheService(store);
+    const pending = cache.remember('key', () => loaderDeferred.promise);
+
+    await vi.waitFor(() => {
+      expect(store.get).toHaveBeenCalledTimes(1);
+    });
+
+    await cache.close();
+    loaderDeferred.resolve({ computed: true });
+
+    await expect(pending).resolves.toEqual({ computed: true });
+    expect(store.close).toHaveBeenCalledTimes(1);
+    expect(store.set).not.toHaveBeenCalled();
+    expect(store.del).not.toHaveBeenCalled();
+    await expect(cache.get('key')).resolves.toBeUndefined();
+    await cache.set('key', { ignored: true });
+    await cache.del('key');
+    await cache.reset();
+    expect(store.get).toHaveBeenCalledTimes(1);
+    expect(store.set).not.toHaveBeenCalled();
+    expect(store.del).not.toHaveBeenCalled();
+    expect(store.reset).not.toHaveBeenCalled();
+  });
+
+  it('serializes reset between already-started and later store operations', async () => {
+    const events: string[] = [];
+    const getDeferred = createDeferred<void>();
+    const store: CacheStore = {
+      async del() {
+        events.push('del');
+      },
+      async get<T>() {
+        events.push('get:start');
+        await getDeferred.promise;
+        events.push('get:end');
+        return 'before-reset' as T;
+      },
+      async reset() {
+        events.push('reset');
+      },
+      async set() {
+        events.push('set');
+      },
+    };
+    const cache = createCacheService(store);
+    const pendingGet = cache.get('key');
+
+    await vi.waitFor(() => {
+      expect(events).toEqual(['get:start']);
+    });
+
+    const pendingReset = cache.reset();
+    const pendingSet = cache.set('key', 'after-reset');
+
+    await Promise.resolve();
+    expect(events).toEqual(['get:start']);
+
+    getDeferred.resolve();
+
+    await expect(pendingGet).resolves.toBe('before-reset');
+    await pendingReset;
+    await pendingSet;
+    expect(events).toEqual(['get:start', 'get:end', 'reset', 'set']);
+  });
+
+  it('does not let a reset-interrupted remember register stale inflight work for later callers', async () => {
+    const events: string[] = [];
+    const getDeferred = createDeferred<void>();
+    const oldLoaderDeferred = createDeferred<{ source: 'old' }>();
+    const store: CacheStore = {
+      async del() {
+        events.push('del');
+      },
+      async get<T>() {
+        events.push('get:start');
+        await getDeferred.promise;
+        events.push('get:end');
+        return undefined as T | undefined;
+      },
+      async reset() {
+        events.push('reset');
+      },
+      async set() {
+        events.push('set');
+      },
+    };
+    const cache = createCacheService(store);
+    const oldLoader = vi.fn(() => oldLoaderDeferred.promise);
+    const newLoader = vi.fn(async () => ({ source: 'new' as const }));
+
+    const oldPending = cache.remember('key', oldLoader);
+
+    await vi.waitFor(() => {
+      expect(events).toEqual(['get:start']);
+    });
+
+    const pendingReset = cache.reset();
+
+    getDeferred.resolve();
+    await pendingReset;
+
+    await expect(cache.remember('key', newLoader)).resolves.toEqual({ source: 'new' });
+    expect(newLoader).toHaveBeenCalledTimes(1);
+    expect(oldLoader).toHaveBeenCalledTimes(1);
+
+    oldLoaderDeferred.resolve({ source: 'old' });
+    await expect(oldPending).resolves.toEqual({ source: 'old' });
+    expect(events).toEqual(['get:start', 'get:end', 'reset', 'get:start', 'get:end', 'set']);
   });
 });

--- a/packages/cache-manager/src/service.ts
+++ b/packages/cache-manager/src/service.ts
@@ -20,6 +20,18 @@ export class CacheService {
   private readonly invalidatedInflight = new Set<string>();
   private closed = false;
   private resetVersion = 0;
+  private storeOperationTail: Promise<void> = Promise.resolve();
+
+  private async runStoreOperation<T>(operation: () => Promise<T> | T): Promise<T> {
+    const result = this.storeOperationTail.then(operation, operation);
+
+    this.storeOperationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return result;
+  }
 
   private beginPendingLoad(key: string, generation: number): void {
     const generations = this.pendingLoads.get(key) ?? new Map<number, number>();
@@ -61,7 +73,17 @@ export class CacheService {
    * @returns The cached value, or `undefined` when the key is missing or expired.
    */
   get<T = unknown>(key: string): Promise<T | undefined> {
-    return Promise.resolve(this.store.get<T>(key));
+    if (this.closed) {
+      return Promise.resolve(undefined);
+    }
+
+    return this.runStoreOperation(() => {
+      if (this.closed) {
+        return undefined;
+      }
+
+      return this.store.get<T>(key);
+    });
   }
 
   /**
@@ -75,11 +97,17 @@ export class CacheService {
   async set<T = unknown>(key: string, value: T, ttlSeconds?: number): Promise<void> {
     const resolvedTtl = ttlSeconds ?? this.options.ttl;
 
-    if (!Number.isFinite(resolvedTtl) || resolvedTtl < 0) {
+    if (this.closed || !Number.isFinite(resolvedTtl) || resolvedTtl < 0) {
       return;
     }
 
-    await this.store.set<T>(key, value, resolvedTtl);
+    await this.runStoreOperation(async () => {
+      if (this.closed) {
+        return;
+      }
+
+      await this.store.set<T>(key, value, resolvedTtl);
+    });
   }
 
   /**
@@ -95,6 +123,10 @@ export class CacheService {
     loader: () => Promise<T>,
     ttlSeconds?: number,
   ): Promise<T> {
+    if (this.closed) {
+      return loader();
+    }
+
     const resetVersion = this.resetVersion;
     this.beginPendingLoad(key, resetVersion);
 
@@ -105,10 +137,18 @@ export class CacheService {
         return cached;
       }
 
+      if (this.closed || this.resetVersion !== resetVersion) {
+        return loader();
+      }
+
       const existing = this.inflight.get(key) as InflightLoad<T> | undefined;
 
-      if (existing) {
+      if (existing && existing.generation === resetVersion) {
         return existing.promise;
+      }
+
+      if (existing) {
+        this.inflight.delete(key);
       }
 
       const entry: InflightLoad<T> = {
@@ -118,14 +158,14 @@ export class CacheService {
       };
 
       const promise = loader().then(async (value) => {
-        if (entry.invalidated || this.resetVersion !== resetVersion) {
+        if (this.closed || entry.invalidated || this.resetVersion !== resetVersion) {
           return value;
         }
 
         await this.set(key, value, ttlSeconds);
 
-        if (entry.invalidated || this.resetVersion !== resetVersion) {
-          await this.store.del(key);
+        if (!this.closed && (entry.invalidated || this.resetVersion !== resetVersion)) {
+          await this.deleteFromStore(key);
         }
 
         return value;
@@ -155,6 +195,10 @@ export class CacheService {
    * @returns A promise that resolves after the entry is removed.
    */
   async del(key: string): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
     const entry = this.inflight.get(key);
 
     if (entry) {
@@ -165,7 +209,7 @@ export class CacheService {
       this.invalidatedInflight.add(key);
     }
 
-    await this.store.del(key);
+    await this.deleteFromStore(key);
   }
 
   /**
@@ -174,12 +218,22 @@ export class CacheService {
    * @returns A promise that resolves after the store reset completes.
    */
   async reset(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+
     this.resetVersion += 1;
     this.inflight.clear();
     this.pendingLoads.clear();
     this.pendingInvalidations.clear();
     this.invalidatedInflight.clear();
-    await this.store.reset();
+    await this.runStoreOperation(async () => {
+      if (this.closed) {
+        return;
+      }
+
+      await this.store.reset();
+    });
   }
 
   /**
@@ -193,19 +247,32 @@ export class CacheService {
     }
 
     this.closed = true;
+    this.resetVersion += 1;
     this.inflight.clear();
     this.pendingLoads.clear();
     this.pendingInvalidations.clear();
     this.invalidatedInflight.clear();
 
-    if (this.store.close) {
-      await this.store.close();
-      return;
-    }
+    await this.runStoreOperation(async () => {
+      if (this.store.close) {
+        await this.store.close();
+        return;
+      }
 
-    if (this.store.dispose) {
-      await this.store.dispose();
-    }
+      if (this.store.dispose) {
+        await this.store.dispose();
+      }
+    });
+  }
+
+  private async deleteFromStore(key: string): Promise<void> {
+    await this.runStoreOperation(async () => {
+      if (this.closed) {
+        return;
+      }
+
+      await this.store.del(key);
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Serialize cache close/reset operations behind a lifecycle queue and barrier.
- Prevent stale in-flight remember() work from being reused after reset.
- Document close/reset semantics in EN/KO README and add a patch changeset.

Closes #2275

## Verification
- pnpm --filter @fluojs/cache-manager typecheck
- pnpm --filter @fluojs/cache-manager test
- pnpm exec biome lint packages/cache-manager/src/service.ts packages/cache-manager/src/cache-service.test.ts packages/cache-manager/README.md packages/cache-manager/README.ko.md .changeset/quiet-caches-reset.md
- pnpm --filter @fluojs/cache-manager... build
- pnpm docs:sync-check
- pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main
- pnpm verify:release-readiness