### PR TITLE
Resolve #2293: Separate Discord shutdown cleanup diagnostics

### DIFF
--- a/.changeset/clever-discord-cleanup-diagnostics.md
+++ b/.changeset/clever-discord-cleanup-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/discord": patch
+---
+
+Distinguish Discord bootstrap initialization failures from shutdown cleanup failures in readiness and lifecycle diagnostics.

--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -104,7 +104,7 @@ Behavioral contract 메모:
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, shutdown 전에 시작된 factory 생성 transport가 아직 완료되지 않았더라도 이를 기다린 뒤 factory가 소유한 리소스를 애플리케이션 shutdown 시 닫습니다.
 - send는 bootstrap이 transport를 `ready`로 표시한 뒤에만 허용됩니다. bootstrap 전, startup 중, bootstrap 실패 후, shutdown 중, shutdown 후 시도는 전달 전에 거부됩니다.
 - 서비스가 shutdown 중이거나 이미 stopped 상태라면 cached transport를 재사용하지 않고 send를 거부합니다.
-- `DiscordService.createPlatformStatusSnapshot()`은 `createDiscordPlatformStatusSnapshot(...)`과 같은 status 계약을 노출합니다. 여기에는 lifecycle/readiness, health, transport kind와 ownership, 기본 thread 구성, bootstrap verification 상태, notifications channel dependency details가 포함되어, 호출자가 내부 옵션에 접근하지 않고도 Discord wiring을 관찰할 수 있습니다.
+- `DiscordService.createPlatformStatusSnapshot()`은 `createDiscordPlatformStatusSnapshot(...)`과 같은 status 계약을 노출합니다. 여기에는 lifecycle/readiness, health, transport kind와 ownership, 기본 thread 구성, bootstrap verification 상태, bootstrap initialization 실패와 shutdown cleanup 실패를 구분하는 diagnostics, notifications channel dependency details가 포함되어, 호출자가 내부 옵션에 접근하지 않고도 Discord wiring을 관찰할 수 있습니다.
 - 빈 `defaultThreadId`와 `notifications.channel` 값은 trim 후 무시됩니다. notifications channel은 기본적으로 `discord`입니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.
 

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -104,7 +104,7 @@ Behavioral contract notes:
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown, including any in-flight factory-created transport before shutdown began.
 - Sends are accepted only after bootstrap marks the transport `ready`; attempts before bootstrap, during startup, after failed bootstrap, while shutting down, or after shutdown are rejected before delivery.
 - Sends attempted while the service is shutting down or already stopped are rejected before reusing the cached transport.
-- `DiscordService.createPlatformStatusSnapshot()` exposes the same status contract as `createDiscordPlatformStatusSnapshot(...)`: lifecycle/readiness, health, transport kind and ownership, default thread configuration, bootstrap verification state, and notifications channel dependency details, so callers can observe Discord wiring without reaching into internal options.
+- `DiscordService.createPlatformStatusSnapshot()` exposes the same status contract as `createDiscordPlatformStatusSnapshot(...)`: lifecycle/readiness, health, transport kind and ownership, default thread configuration, bootstrap verification state, distinct bootstrap initialization versus shutdown cleanup failure diagnostics, and notifications channel dependency details, so callers can observe Discord wiring without reaching into internal options.
 - Blank `defaultThreadId` and `notifications.channel` values are trimmed and ignored; the notifications channel defaults to `discord`.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.
 

--- a/packages/discord/src/module.test.ts
+++ b/packages/discord/src/module.test.ts
@@ -1,6 +1,6 @@
-import type { Constructor, Token } from '@fluojs/core';
-import { getModuleMetadata } from '@fluojs/core/internal';
+import { type Constructor, getModuleMetadata, type Token } from '@fluojs/core';
 import { Container, type Provider } from '@fluojs/di';
+import type { NotificationChannel } from '@fluojs/notifications';
 import { NOTIFICATION_CHANNELS, NotificationsModule, NotificationsService } from '@fluojs/notifications';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -95,6 +95,17 @@ class DeferredCloseTransport extends PassiveTransport {
 
   finishClose(): void {
     this.resolveClose?.();
+  }
+}
+
+class FailingCloseTransport extends PassiveTransport {
+  constructor(private readonly closeFailure: Error) {
+    super();
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    throw this.closeFailure;
   }
 }
 
@@ -287,7 +298,7 @@ describe('DiscordModule', () => {
 
     const notifications = await container.resolve(NotificationsService);
     const service = await container.resolve(DiscordService);
-    const channels = await container.resolve(NOTIFICATION_CHANNELS);
+    const channels = await container.resolve<readonly NotificationChannel[]>(NOTIFICATION_CHANNELS);
     await service.onModuleInit();
 
     const result = await notifications.dispatch({
@@ -1000,6 +1011,47 @@ describe('DiscordModule', () => {
     await expect(service.send({ content: 'After failed bootstrap' })).rejects.toThrowError(
       new DiscordTransportError('Discord transport failed to initialize.'),
     );
+  });
+
+  it('reports shutdown cleanup failures separately from failed bootstrap diagnostics', async () => {
+    const closeFailure = new Error('webhook close failed');
+    const transport = new FailingCloseTransport(closeFailure);
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      transport: {
+        create: async () => transport,
+        kind: 'failing-close-factory',
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    await service.onModuleInit();
+
+    await expect(service.onApplicationShutdown()).rejects.toMatchObject({
+      cause: closeFailure,
+      message: 'Discord transport failed to close cleanly.',
+    });
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: {
+        lifecycleFailurePhase: 'shutdown-cleanup',
+        lifecycleState: 'failed',
+      },
+      health: {
+        reason: 'Discord transport failed during shutdown cleanup.',
+        status: 'unhealthy',
+      },
+      readiness: {
+        reason: 'Discord transport failed during shutdown cleanup.',
+        status: 'not-ready',
+      },
+    });
+    await expect(service.send({ content: 'After failed shutdown cleanup' })).rejects.toThrowError(
+      new DiscordTransportError('Discord transport failed during shutdown cleanup.'),
+    );
+    expect(transport.closeCalls).toBe(1);
+    expect(transport.sent).toEqual([]);
   });
 
   it('rejects aborted notification sends before rendering templates', async () => {

--- a/packages/discord/src/public-surface.test.ts
+++ b/packages/discord/src/public-surface.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
-
-import * as discordPublicApi from './index.js';
 import type {
   Discord,
   DiscordFetchLike,
@@ -13,6 +11,7 @@ import type {
   DiscordTransportFactory,
   DiscordWebhookTransportOptions,
 } from './index.js';
+import * as discordPublicApi from './index.js';
 
 describe('@fluojs/discord public API surface', () => {
   it('keeps documented root-barrel exports stable', () => {
@@ -43,6 +42,7 @@ describe('@fluojs/discord public API surface', () => {
     expectTypeOf<DiscordFetchLike>().toBeFunction();
     expectTypeOf<DiscordTemplateRenderer>().toHaveProperty('render');
     expectTypeOf<DiscordStatusAdapterInput>().toHaveProperty('channelName');
+    expectTypeOf<DiscordStatusAdapterInput>().toHaveProperty('lifecycleFailurePhase');
     expectTypeOf<DiscordStatusAdapterInput>().toHaveProperty('transportKind');
   });
 

--- a/packages/discord/src/service.ts
+++ b/packages/discord/src/service.ts
@@ -2,7 +2,7 @@ import { Inject } from '@fluojs/core';
 import type { OnApplicationShutdown, OnModuleInit } from '@fluojs/runtime';
 
 import { DiscordMessageValidationError, DiscordTransportError } from './errors.js';
-import { createDiscordPlatformStatusSnapshot } from './status.js';
+import { createDiscordPlatformStatusSnapshot, type DiscordStatusAdapterInput } from './status.js';
 import { DISCORD_OPTIONS } from './tokens.js';
 import type {
   Discord,
@@ -29,8 +29,17 @@ function createStoppedTransportError(): DiscordTransportError {
   return new DiscordTransportError('Discord transport is shutting down or already stopped.');
 }
 
-function createLifecycleReadinessError(lifecycleState: DiscordServiceLifecycleState): DiscordTransportError {
+type DiscordServiceLifecycleFailurePhase = NonNullable<DiscordStatusAdapterInput['lifecycleFailurePhase']>;
+
+function createLifecycleReadinessError(
+  lifecycleState: DiscordServiceLifecycleState,
+  lifecycleFailurePhase: DiscordServiceLifecycleFailurePhase | undefined,
+): DiscordTransportError {
   if (lifecycleState === 'failed') {
+    if (lifecycleFailurePhase === 'shutdown-cleanup') {
+      return new DiscordTransportError('Discord transport failed during shutdown cleanup.');
+    }
+
     return new DiscordTransportError('Discord transport failed to initialize.');
   }
 
@@ -74,6 +83,7 @@ type DiscordServiceLifecycleState = 'created' | 'starting' | 'ready' | 'stopping
  */
 @Inject(DISCORD_OPTIONS)
 export class DiscordService implements Discord, OnModuleInit, OnApplicationShutdown {
+  private lifecycleFailurePhase: DiscordServiceLifecycleFailurePhase | undefined;
   private lifecycleState: DiscordServiceLifecycleState = 'created';
   private resolvedTransport: DiscordTransport | undefined;
   private shutdownPromise: Promise<void> | undefined;
@@ -91,6 +101,7 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
     }
 
     this.lifecycleState = 'stopping';
+    this.lifecycleFailurePhase = undefined;
 
     this.shutdownPromise = this.closeOwnedTransport();
 
@@ -106,8 +117,10 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
       }
 
       this.lifecycleState = 'stopped';
+      this.lifecycleFailurePhase = undefined;
     } catch (error) {
       this.lifecycleState = 'failed';
+      this.lifecycleFailurePhase = 'shutdown-cleanup';
       throw new Error('Discord transport failed to close cleanly.', { cause: error });
     }
   }
@@ -118,6 +131,7 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
     }
 
     this.lifecycleState = 'starting';
+    this.lifecycleFailurePhase = undefined;
 
     try {
       const transport = await this.ensureTransport();
@@ -135,12 +149,14 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
       }
 
       this.lifecycleState = 'ready';
+      this.lifecycleFailurePhase = undefined;
     } catch (error) {
       if (isShutdownLifecycleState(this.lifecycleState)) {
         throw error;
       }
 
       this.lifecycleState = 'failed';
+      this.lifecycleFailurePhase = 'initialization';
       throw new Error('Discord transport failed to initialize.', { cause: error });
     }
   }
@@ -154,6 +170,7 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
     return createDiscordPlatformStatusSnapshot({
       channelName: this.options.notifications.channel,
       defaultThreadConfigured: this.options.defaultThreadId !== undefined,
+      lifecycleFailurePhase: this.lifecycleFailurePhase,
       lifecycleState: this.lifecycleState,
       ownsTransportResources: this.options.transport.ownsResources,
       transportKind: this.options.transport.kind,
@@ -303,7 +320,7 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
     }
 
     if (this.lifecycleState === 'failed') {
-      throw createLifecycleReadinessError(this.lifecycleState);
+      throw createLifecycleReadinessError(this.lifecycleState, this.lifecycleFailurePhase);
     }
 
     if (this.resolvedTransport) {
@@ -326,7 +343,7 @@ export class DiscordService implements Discord, OnModuleInit, OnApplicationShutd
     }
 
     if (this.lifecycleState !== 'ready') {
-      throw createLifecycleReadinessError(this.lifecycleState);
+      throw createLifecycleReadinessError(this.lifecycleState, this.lifecycleFailurePhase);
     }
   }
 

--- a/packages/discord/src/status.test.ts
+++ b/packages/discord/src/status.test.ts
@@ -35,7 +35,34 @@ describe('createDiscordPlatformStatusSnapshot', () => {
     });
 
     expect(snapshot.readiness.status).toBe('not-ready');
+    expect(snapshot.readiness.reason).toBe('Discord transport failed to initialize.');
     expect(snapshot.health.status).toBe('unhealthy');
     expect(snapshot.ownership.externallyManaged).toBe(true);
+  });
+
+  it('distinguishes shutdown cleanup failures from bootstrap initialization failures', () => {
+    const snapshot = createDiscordPlatformStatusSnapshot({
+      channelName: 'discord',
+      defaultThreadConfigured: false,
+      lifecycleFailurePhase: 'shutdown-cleanup',
+      lifecycleState: 'failed',
+      ownsTransportResources: true,
+      transportKind: 'owned-factory',
+      verifiedOnModuleInit: true,
+    });
+
+    expect(snapshot.details).toMatchObject({
+      lifecycleFailurePhase: 'shutdown-cleanup',
+      lifecycleState: 'failed',
+    });
+    expect(snapshot.readiness).toEqual({
+      critical: true,
+      reason: 'Discord transport failed during shutdown cleanup.',
+      status: 'not-ready',
+    });
+    expect(snapshot.health).toEqual({
+      reason: 'Discord transport failed during shutdown cleanup.',
+      status: 'unhealthy',
+    });
   });
 });

--- a/packages/discord/src/status.ts
+++ b/packages/discord/src/status.ts
@@ -7,6 +7,7 @@ export type DiscordLifecycleState = 'created' | 'starting' | 'ready' | 'stopping
 export interface DiscordStatusAdapterInput {
   channelName: string;
   defaultThreadConfigured: boolean;
+  lifecycleFailurePhase?: 'initialization' | 'shutdown-cleanup';
   lifecycleState: DiscordLifecycleState;
   ownsTransportResources: boolean;
   transportKind: string;
@@ -48,7 +49,10 @@ function createReadiness(input: DiscordStatusAdapterInput): PlatformReadinessRep
   if (input.lifecycleState === 'failed') {
     return {
       critical: true,
-      reason: 'Discord transport failed to initialize.',
+      reason:
+        input.lifecycleFailurePhase === 'shutdown-cleanup'
+          ? 'Discord transport failed during shutdown cleanup.'
+          : 'Discord transport failed to initialize.',
       status: 'not-ready',
     };
   }
@@ -63,7 +67,10 @@ function createReadiness(input: DiscordStatusAdapterInput): PlatformReadinessRep
 function createHealth(input: DiscordStatusAdapterInput): PlatformHealthReport {
   if (input.lifecycleState === 'failed' || input.lifecycleState === 'stopped') {
     return {
-      reason: 'Discord transport is unavailable.',
+      reason:
+        input.lifecycleState === 'failed' && input.lifecycleFailurePhase === 'shutdown-cleanup'
+          ? 'Discord transport failed during shutdown cleanup.'
+          : 'Discord transport is unavailable.',
       status: 'unhealthy',
     };
   }
@@ -92,6 +99,7 @@ export function createDiscordPlatformStatusSnapshot(input: DiscordStatusAdapterI
       channelName: input.channelName,
       defaultThreadConfigured: input.defaultThreadConfigured,
       dependencies: ['notifications.channel', 'discord.transport'],
+      ...(input.lifecycleFailurePhase ? { lifecycleFailurePhase: input.lifecycleFailurePhase } : {}),
       lifecycleState: input.lifecycleState,
       transportKind: input.transportKind,
       verifiedOnModuleInit: input.verifiedOnModuleInit,


### PR DESCRIPTION
## Summary
- Closes #2293.
- Distinguishes Discord bootstrap initialization failures from shutdown cleanup failures while preserving the public lifecycle state union.
- Adds status/service regression coverage and documents the diagnostics contract in EN/KO README files.
- Adds a patch changeset for the public @fluojs/discord diagnostics behavior change.

## Testing
- pnpm exec biome check packages/discord/src/service.ts packages/discord/src/status.ts packages/discord/src/module.test.ts packages/discord/src/status.test.ts packages/discord/src/public-surface.test.ts packages/discord/README.md packages/discord/README.ko.md .changeset/clever-discord-cleanup-diagnostics.md
- pnpm --filter @fluojs/discord test
- pnpm --filter @fluojs/discord typecheck
- pnpm --filter @fluojs/discord build
- pnpm --filter @fluojs/discord... build
- pnpm verify:release-readiness
- GIT_MASTER=1 git diff --check

## Notes
- This PR salvages the implementation worktree after issue-to-pr workers timed out before opening a PR.
- No worktree cleanup, branch deletion, issue close, or merge was performed by the worker.