### PR TITLE
Resolve #2272: strengthen serialization regression tests

### DIFF
--- a/packages/serialization/src/serialize.test.ts
+++ b/packages/serialization/src/serialize.test.ts
@@ -385,7 +385,10 @@ describe('serialize', () => {
     }
 
     class DerivedView extends BaseView {
-      @Transform((value) => String(value).toUpperCase())
+      @Transform((value) => {
+        const label = String(value);
+        return label.startsWith('[') && label.endsWith(']') ? label : `[${label}]`;
+      })
       override label: string;
 
       constructor(label: string) {
@@ -394,7 +397,7 @@ describe('serialize', () => {
       }
     }
 
-    expect(serialize(new DerivedView('  fluo  '))).toEqual({ label: 'FLUO' });
+    expect(serialize(new DerivedView('  fluo  '))).toEqual({ label: '[fluo]' });
   });
 
   it('does not emit undecorated undefined fields when excludeExtraneous is enabled', () => {

--- a/packages/serialization/src/serializer-interceptor.test.ts
+++ b/packages/serialization/src/serializer-interceptor.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
-
+import type {
+  CallHandler,
+  FrameworkRequest,
+  FrameworkResponse,
+  InterceptorContext,
+  RequestContext,
+} from '@fluojs/http';
 import {
   Controller,
   createDispatcher,
@@ -7,7 +12,7 @@ import {
   Get,
   UseInterceptors,
 } from '@fluojs/http';
-import type { CallHandler, FrameworkRequest, FrameworkResponse, InterceptorContext, RequestContext } from '@fluojs/http';
+import { describe, expect, it } from 'vitest';
 
 import { Exclude } from './decorators/exclude.js';
 import { SerializerInterceptor } from './serializer-interceptor.js';
@@ -150,6 +155,46 @@ describe('SerializerInterceptor', () => {
     };
 
     await expect(interceptor.intercept(context, next)).resolves.toBe(owner);
+  });
+
+  it('preserves handler-owned responses committed through RequestContext.response in the real HTTP request pipeline', async () => {
+    class StreamOwner {
+      id = 'stream-1';
+
+      @Exclude()
+      internalState = 'owned-by-handler';
+    }
+
+    const owner = new StreamOwner();
+    let observedSuccess: unknown;
+    const observer = {
+      onRequestSuccess(_context: unknown, value: unknown) {
+        observedSuccess = value;
+      },
+    };
+
+    @Controller('/streams')
+    @UseInterceptors(SerializerInterceptor)
+    class StreamsController {
+      @Get('/owned')
+      async getOwned(_input: undefined, context: RequestContext) {
+        await context.response.send(owner);
+        return owner;
+      }
+    }
+
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: StreamsController }]),
+      observers: [observer],
+      rootContainer: createTestContainer() as never,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/streams/owned'), response);
+
+    expect(response.committed).toBe(true);
+    expect(response.body).toBe(owner);
+    expect(observedSuccess).toBe(owner);
   });
 
   it('serializes responses through the real HTTP request pipeline', async () => {


### PR DESCRIPTION
## Summary

Strengthen serialization regression coverage for documented transform ordering and handler-owned HTTP response preservation.

Linked context: Closes #2272

## Changes

- Make base/derived transform ordering coverage order-sensitive.
- Add a real request-pipeline regression where a handler commits through RequestContext.response.send(...).

## Testing

- pnpm exec biome check packages/serialization/src/serialize.test.ts packages/serialization/src/serializer-interceptor.test.ts
- pnpm --filter @fluojs/serialization typecheck
- pnpm --filter @fluojs/serialization test

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only regression coverage for existing documented behavior; no .changeset/*.md file is required.

## Public export documentation

No public exports changed.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

## Behavioral contract

This PR preserves existing documented serialization behavior by strengthening regression tests only.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

No platform contract or governance docs changed.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.