### PR TITLE
Resolve cron optional peer CI timeout

### DIFF
--- a/packages/cron/src/optional-redis-peer.test.ts
+++ b/packages/cron/src/optional-redis-peer.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const OPTIONAL_PEER_IMPORT_TIMEOUT_MS = 15_000;
+
 afterEach(() => {
   vi.doUnmock('@fluojs/redis');
   vi.resetModules();
@@ -22,7 +24,7 @@ describe('optional Redis peer contract', () => {
     expect(cronPublicApi).toHaveProperty('CronModule');
     expect(cronPublicApi).toHaveProperty('Cron');
     expect(cronPublicApi).toHaveProperty('SCHEDULING_REGISTRY');
-  });
+  }, OPTIONAL_PEER_IMPORT_TIMEOUT_MS);
 
   it('does not load Redis while bootstrapping non-distributed scheduling', async () => {
     vi.doMock('@fluojs/redis', () => {


### PR DESCRIPTION
## Summary

Stabilize the cron optional Redis peer root-barrel import contract test that timed out twice in CI while blocking PR #2314.

Linked context: follow-up for PR #2314 CI blocker.

## Changes

- Give the root-barrel optional peer dynamic import test an explicit timeout budget.
- Keep the existing assertions and optional Redis peer contract unchanged.

## Testing

- pnpm exec biome check packages/cron/src/optional-redis-peer.test.ts
- pnpm --filter @fluojs/cron... build
- pnpm --filter @fluojs/cron typecheck
- pnpm --filter @fluojs/cron test -- src/optional-redis-peer.test.ts

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Test-only CI stabilization; no .changeset/*.md file is required.

## Public export documentation

No public exports changed.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

## Behavioral contract

This PR preserves the existing optional Redis peer root-import contract and only adjusts the test timeout budget.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

No platform contract or governance docs changed.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.