### PR TITLE
Resolve #2288: discover factory and value event handlers

### DIFF
--- a/.changeset/calm-event-bus-discovery.md
+++ b/.changeset/calm-event-bus-discovery.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/event-bus': patch
+---
+
+Discover `@OnEvent()` handlers declared on singleton factory and value provider instances.

--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -1,9 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { Inject, Scope } from '@fluojs/core';
 import { defineControllerMetadata } from '@fluojs/core/internal';
 import { Container } from '@fluojs/di';
-import { bootstrapApplication, defineModule, type ApplicationLogger } from '@fluojs/runtime';
+import { type ApplicationLogger, bootstrapApplication, defineModule } from '@fluojs/runtime';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OnEvent } from './decorators.js';
 import { getEventHandlerMetadataEntries } from './metadata.js';
@@ -774,6 +773,87 @@ describe('@fluojs/event-bus', () => {
     await eventBus.publish(new UserCreatedEvent('user-7'));
 
     expect(SharedHandler.calls).toBe(1);
+
+    await app.close();
+  });
+
+  it('discovers handlers from singleton factory and value provider instances', async () => {
+    const VALUE_HANDLER = Symbol('value-handler');
+    const FACTORY_HANDLER = Symbol('factory-handler');
+    const calls: string[] = [];
+
+    class ValueProviderHandler {
+      @OnEvent(UserCreatedEvent)
+      onUserCreated(event: UserCreatedEvent) {
+        calls.push(`value:${event.userId}`);
+      }
+    }
+
+    class FactoryProviderHandler {
+      @OnEvent(UserCreatedEvent)
+      onUserCreated(event: UserCreatedEvent) {
+        calls.push(`factory:${event.userId}`);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [EventBusModule.forRoot()],
+      providers: [
+        { provide: VALUE_HANDLER, useValue: new ValueProviderHandler() },
+        { provide: FACTORY_HANDLER, useFactory: () => new FactoryProviderHandler() },
+      ],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+    const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+
+    await eventBus.publish(new UserCreatedEvent('user-factory-value'));
+
+    expect(calls).toEqual(['value:user-factory-value', 'factory:user-factory-value']);
+
+    await app.close();
+  });
+
+  it('keeps non-singleton factory provider handlers out of event discovery', async () => {
+    const loggerEvents: string[] = [];
+    const calls: string[] = [];
+
+    class RequestFactoryHandler {
+      @OnEvent(UserCreatedEvent)
+      onUserCreated(event: UserCreatedEvent) {
+        calls.push(event.userId);
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [EventBusModule.forRoot()],
+      providers: [
+        {
+          provide: RequestFactoryHandler,
+          scope: 'request',
+          useFactory: () => new RequestFactoryHandler(),
+        },
+      ],
+    });
+
+    const app = await bootstrapApplication({
+      logger: createLogger(loggerEvents),
+      rootModule: AppModule,
+    });
+    const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+
+    await eventBus.publish(new UserCreatedEvent('user-request-factory'));
+
+    expect(calls).toEqual([]);
+    expect(
+      loggerEvents.some((event) =>
+        event.includes(
+          'warn:EventBusLifecycleService:RequestFactoryHandler in module AppModule declares @OnEvent() methods but is registered with request scope.',
+        ),
+      ),
+    ).toBe(true);
 
     await app.close();
   });

--- a/packages/event-bus/src/service.ts
+++ b/packages/event-bus/src/service.ts
@@ -23,6 +23,11 @@ interface DiscoveryCandidate {
   token: Token;
 }
 
+interface ProviderDiscoveryCandidate {
+  moduleName: string;
+  provider: Provider;
+}
+
 interface ResolvedPublishOptions {
   signal: AbortSignal | undefined;
   timeoutMs: number | undefined;
@@ -76,6 +81,10 @@ function methodKeyToName(methodKey: MetadataPropertyKey): string {
 
 function isClassProvider(provider: Provider): provider is Extract<Provider, { provide: Token; useClass: Function }> {
   return typeof provider === 'object' && provider !== null && 'useClass' in provider;
+}
+
+function isFactoryOrValueProvider(provider: Provider): provider is Extract<Provider, { useFactory: unknown } | { useValue: unknown }> {
+  return typeof provider === 'object' && provider !== null && ('useFactory' in provider || 'useValue' in provider);
 }
 
 /**
@@ -359,7 +368,7 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
 
   private async discoverHandlers(): Promise<void> {
     try {
-      this.descriptors = this.discoverHandlerDescriptors();
+      this.descriptors = await this.discoverHandlerDescriptors();
       this.handlerInstances.clear();
       await this.preloadHandlerInstances(this.descriptors);
       this.discovered = true;
@@ -729,11 +738,11 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     };
   }
 
-  private discoverHandlerDescriptors(): EventHandlerDescriptor[] {
+  private async discoverHandlerDescriptors(): Promise<EventHandlerDescriptor[]> {
     const seen = new Map<Token, Map<MetadataPropertyKey, Set<EventType>>>();
     const descriptors: EventHandlerDescriptor[] = [];
 
-    for (const candidate of this.discoveryCandidates()) {
+    for (const candidate of await this.discoveryCandidates()) {
       const entries = getEventHandlerMetadataEntries(candidate.targetType.prototype);
 
       if (this.shouldSkipNonSingletonCandidate(candidate, entries.length)) {
@@ -812,8 +821,9 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
     };
   }
 
-  private discoveryCandidates(): DiscoveryCandidate[] {
+  private async discoveryCandidates(): Promise<DiscoveryCandidate[]> {
     const candidates: DiscoveryCandidate[] = [];
+    const providerCandidates: ProviderDiscoveryCandidate[] = [];
 
     for (const compiledModule of this.compiledModules) {
       for (const provider of compiledModule.definition.providers ?? []) {
@@ -834,6 +844,11 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
             targetType: provider.useClass,
             token: provider.provide,
           });
+          continue;
+        }
+
+        if (isFactoryOrValueProvider(provider)) {
+          providerCandidates.push({ moduleName: compiledModule.type.name, provider });
         }
       }
 
@@ -847,7 +862,75 @@ export class EventBusLifecycleService implements EventBus, OnApplicationBootstra
       }
     }
 
+    for (const candidate of providerCandidates) {
+      const resolvedCandidate = await this.resolveProviderDiscoveryCandidate(candidate);
+
+      if (resolvedCandidate) {
+        candidates.push(resolvedCandidate);
+      }
+    }
+
     return candidates;
+  }
+
+  private async resolveProviderDiscoveryCandidate(candidate: ProviderDiscoveryCandidate): Promise<DiscoveryCandidate | undefined> {
+    const provider = candidate.provider;
+
+    if (!('provide' in provider)) {
+      return undefined;
+    }
+
+    const scope = scopeFromProvider(provider);
+    const token = provider.provide;
+
+    if (scope !== 'singleton') {
+      return this.createUnresolvedProviderDiscoveryCandidate(candidate.moduleName, token, scope);
+    }
+
+    const instance = await this.resolveHandlerInstance({
+      eventType: Object,
+      methodKey: 'constructor',
+      methodName: 'constructor',
+      moduleName: candidate.moduleName,
+      targetName: 'EventHandlerProvider',
+      token,
+    });
+
+    if (typeof instance !== 'object' || instance === null) {
+      return undefined;
+    }
+
+    const targetType = instance.constructor;
+
+    if (typeof targetType !== 'function') {
+      return undefined;
+    }
+
+    return {
+      moduleName: candidate.moduleName,
+      scope,
+      targetType,
+      token,
+    };
+  }
+
+  private createUnresolvedProviderDiscoveryCandidate(
+    moduleName: string,
+    token: Token,
+    scope: 'request' | 'transient',
+  ): DiscoveryCandidate | undefined {
+    const tokenType = typeof token === 'function' ? token : undefined;
+
+    if (!tokenType) {
+      return undefined;
+    }
+
+    return {
+      moduleName,
+      scope,
+      targetType: tokenType,
+      token,
+    };
   }
 
   private async invokeHandler(descriptor: EventHandlerDescriptor, event: object): Promise<void> {


### PR DESCRIPTION
## Summary

Discover `@OnEvent()` handlers declared on singleton `useFactory` and `useValue` provider instances so event-bus discovery matches its singleton provider contract.

Linked context: Closes #2288

## Changes

- Resolve singleton factory/value provider instances during event handler discovery.
- Keep request/transient factory handlers out of discovery with the existing non-singleton warning path.
- Add regression coverage for factory/value discovery and non-singleton factory exclusion.

## Testing

- `pnpm --filter @fluojs/event-bus... build`
- `pnpm exec biome check packages/event-bus/src/service.ts packages/event-bus/src/module.test.ts .changeset/calm-event-bus-discovery.md`
- `pnpm --filter @fluojs/event-bus test`
- `pnpm --filter @fluojs/event-bus typecheck`
- `pnpm --filter @fluojs/event-bus build`
- `pnpm verify:release-readiness`
- `GIT_MASTER=1 git diff --check`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.