### PR TITLE
Resolve #2274: add GraphQL lifecycle guardrails

### DIFF
--- a/.changeset/clean-graphql-websocket-disconnects.md
+++ b/.changeset/clean-graphql-websocket-disconnects.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/graphql": patch
+---
+
+Dispose request-scoped websocket operation providers when GraphQL clients disconnect before subscription completion.

--- a/packages/graphql/src/module.test.ts
+++ b/packages/graphql/src/module.test.ts
@@ -1,15 +1,13 @@
 import { createRequire } from 'node:module';
 import { createServer } from 'node:net';
-
-import { describe, expect, it } from 'vitest';
-import { WebSocket } from 'ws';
-
 import { Inject, Scope } from '@fluojs/core';
 import type { MiddlewareContext, Next } from '@fluojs/http';
-import { IsInt, MinLength } from '@fluojs/validation';
 import { defineModule } from '@fluojs/runtime';
 import { bootstrapNodeApplication } from '@fluojs/runtime/node';
+import { IsInt, MinLength } from '@fluojs/validation';
 import { GraphQLObjectType, GraphQLSchema, GraphQLString, GraphQLUnionType } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
 
 import { Arg, Mutation, Query, Resolver, Subscription } from './decorators.js';
 import { GraphqlModule } from './module.js';
@@ -246,6 +244,20 @@ async function readGraphqlWebSocketMessages(socket: WebSocket, count: number): P
     socket.on('error', handleError);
     socket.on('message', handleMessage);
   });
+}
+
+async function waitForGraphqlRuntimeEffect(predicate: () => boolean, description: string): Promise<void> {
+  const timeoutAt = Date.now() + 1_000;
+
+  while (Date.now() < timeoutAt) {
+    if (predicate()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for GraphQL runtime effect: ${description}`);
 }
 
 @Inject()
@@ -840,6 +852,36 @@ describe('@fluojs/graphql', () => {
     await app.close();
   });
 
+  it('allows selected operations to exceed request budgets when limits are explicitly disabled', async () => {
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          limits: false,
+          schema: createGuardrailSchema(),
+        }),
+      ],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, {
+      cors: false,
+      port,
+    });
+
+    await app.listen();
+
+    await expect(postGraphql(port, 'query WideOp { a: greeting b: greeting c: greeting }')).resolves.toEqual({
+      data: {
+        a: 'hello',
+        b: 'hello',
+        c: 'hello',
+      },
+    });
+
+    await app.close();
+  });
+
   it('supports named object output types for root query/mutation/subscription', async () => {
     class AppModule {}
     defineModule(AppModule, {
@@ -1351,6 +1393,166 @@ describe('@fluojs/graphql', () => {
     releaseOperation?.();
     socket.close();
     await onceWebSocketClosed(socket);
+    await app.close();
+  });
+
+  it('allows concurrent websocket operations when websocket limits are explicitly disabled', async () => {
+    let releaseOperation: (() => void) | undefined;
+    const waitForRelease = new Promise<void>((resolve) => {
+      releaseOperation = resolve;
+    });
+
+    @Inject()
+    @Resolver('UnboundedSubscriptionResolver')
+    class UnboundedSubscriptionResolver {
+      @Subscription()
+      async *slowStream(): AsyncGenerator<string, void, void> {
+        yield 'tick';
+        await waitForRelease;
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [UnboundedSubscriptionResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+              limits: false,
+            },
+          },
+        }),
+      ],
+      providers: [UnboundedSubscriptionResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+    await app.listen();
+
+    const socket = await connectGraphqlWebSocket(port);
+    socket.send(JSON.stringify({
+      id: 'sub-1',
+      payload: {
+        query: 'subscription { slowStream }',
+      },
+      type: 'subscribe',
+    }));
+    socket.send(JSON.stringify({
+      id: 'sub-2',
+      payload: {
+        query: 'subscription { slowStream }',
+      },
+      type: 'subscribe',
+    }));
+
+    await expect(readGraphqlWebSocketMessages(socket, 2)).resolves.toEqual([
+      {
+        id: 'sub-1',
+        payload: {
+          data: {
+            slowStream: 'tick',
+          },
+        },
+        type: 'next',
+      },
+      {
+        id: 'sub-2',
+        payload: {
+          data: {
+            slowStream: 'tick',
+          },
+        },
+        type: 'next',
+      },
+    ]);
+
+    releaseOperation?.();
+    socket.close();
+    await onceWebSocketClosed(socket);
+    await app.close();
+  });
+
+  it('disposes websocket operation-scoped providers when the client disconnects before completion', async () => {
+    const lifecycleEvents: string[] = [];
+    let releaseOperation: (() => void) | undefined;
+    const waitForRelease = new Promise<void>((resolve) => {
+      releaseOperation = resolve;
+    });
+
+    @Inject()
+    @Scope('request')
+    class WebSocketOperationState {
+      onDestroy(): void {
+        lifecycleEvents.push('state:destroy');
+      }
+    }
+
+    @Inject(WebSocketOperationState)
+    @Scope('request')
+    @Resolver('DisconnectLifecycleResolver')
+    class DisconnectLifecycleResolver {
+      constructor(private readonly state: WebSocketOperationState) {}
+
+      @Subscription()
+      async *disconnectStream(): AsyncGenerator<string, void, void> {
+        lifecycleEvents.push(this.state instanceof WebSocketOperationState ? 'resolver:started' : 'resolver:missing-state');
+        yield 'tick';
+        await waitForRelease;
+      }
+
+      onDestroy(): void {
+        lifecycleEvents.push('resolver:destroy');
+      }
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        GraphqlModule.forRoot({
+          resolvers: [DisconnectLifecycleResolver],
+          subscriptions: {
+            websocket: {
+              enabled: true,
+            },
+          },
+        }),
+      ],
+      providers: [WebSocketOperationState, DisconnectLifecycleResolver],
+    });
+
+    const port = await findAvailablePort();
+    const app = await bootstrapNodeApplication(AppModule, { cors: false, port });
+    await app.listen();
+
+    const socket = await connectGraphqlWebSocket(port);
+    socket.send(JSON.stringify({
+      id: 'sub-1',
+      payload: {
+        query: 'subscription { disconnectStream }',
+      },
+      type: 'subscribe',
+    }));
+
+    await expect(onceGraphqlWebSocketMessage(socket)).resolves.toEqual({
+      id: 'sub-1',
+      payload: {
+        data: {
+          disconnectStream: 'tick',
+        },
+      },
+      type: 'next',
+    });
+
+    socket.close();
+    await onceWebSocketClosed(socket);
+    await waitForGraphqlRuntimeEffect(() => lifecycleEvents.includes('state:destroy'), 'websocket operation container disposal');
+
+    expect(lifecycleEvents).toEqual(expect.arrayContaining(['resolver:started', 'resolver:destroy', 'state:destroy']));
+
+    releaseOperation?.();
     await app.close();
   });
 

--- a/packages/graphql/src/node/graphql-websocket-transport.ts
+++ b/packages/graphql/src/node/graphql-websocket-transport.ts
@@ -4,13 +4,13 @@ import type { Duplex } from 'node:stream';
 import type { FrameworkRequest, HttpApplicationAdapter } from '@fluojs/http';
 import type {
   ExecutionArgs,
-  GraphQLError as GraphQLErrorType,
   execute as executeGraphql,
+  GraphQLError as GraphQLErrorType,
   subscribe as subscribeGraphql,
 } from 'graphql';
-import { handleProtocols, type CompleteMessage, type Context as GraphqlWsServerContext, type SubscribeMessage } from 'graphql-ws';
-import { useServer, type Extra as GraphqlWsExtra } from 'graphql-ws/lib/use/ws';
-import { WebSocketServer, type WebSocket } from 'ws';
+import { type CompleteMessage, type Context as GraphqlWsServerContext, handleProtocols, type SubscribeMessage } from 'graphql-ws';
+import { type Extra as GraphqlWsExtra, useServer } from 'graphql-ws/lib/use/ws';
+import { type WebSocket, WebSocketServer } from 'ws';
 
 import { isGraphqlPath } from '../transport/transport.js';
 
@@ -184,12 +184,27 @@ export async function createNodeGraphqlWebSocketTransport(
   options: GraphqlNodeWebSocketTransportOptions,
 ): Promise<GraphqlNodeWebSocketTransport> {
   const upgradeServer = resolveUpgradeServer(options.adapter);
+  const disconnectErrors: unknown[] = [];
+  const pendingDisconnects = new Set<Promise<void>>();
   const websocketServer = new WebSocketServer({
     handleProtocols: (protocols: Set<string>) => handleProtocols(protocols),
     maxPayload: options.limits?.maxPayloadBytes ?? 0,
     noServer: true,
   });
   const upgradeListener = createUpgradeListener(websocketServer, options.limits);
+  const trackDisconnect = (socketKey: object) => {
+    const pendingDisconnect = Promise.resolve(options.onDisconnect(socketKey))
+      .catch((error: unknown) => {
+        disconnectErrors.push(error);
+      })
+      .finally(() => {
+        pendingDisconnects.delete(pendingDisconnect);
+      });
+    pendingDisconnects.add(pendingDisconnect);
+  };
+  const trackConnection = (websocket: WebSocket) => {
+    websocket.once('close', () => trackDisconnect(websocket));
+  };
   const websocketDisposable = useServer(
     {
       connectionInitWaitTimeout: options.connectionInitWaitTimeoutMs,
@@ -208,16 +223,28 @@ export async function createNodeGraphqlWebSocketTransport(
     options.keepAliveMs,
   );
 
+  websocketServer.on('connection', trackConnection);
   upgradeServer.on('upgrade', upgradeListener);
 
   return {
     async dispose() {
       let disposeError: unknown;
 
+      websocketServer.off('connection', trackConnection);
       upgradeServer.off('upgrade', upgradeListener);
 
       for (const client of websocketServer.clients) {
         client.terminate();
+      }
+
+      const disconnectResults = await Promise.allSettled(pendingDisconnects);
+      for (const error of disconnectErrors) {
+        disposeError ??= error;
+      }
+      for (const result of disconnectResults) {
+        if (result.status === 'rejected') {
+          disposeError ??= result.reason;
+        }
       }
 
       try {


### PR DESCRIPTION
## Summary

Close GraphQL lifecycle and guardrail regression gaps from #2274.

Closes #2274

## Changes

- Add an HTTP request `limits: false` integration success path for selected operations that would otherwise exceed request budgets.
- Add a websocket `subscriptions.websocket.limits = false` runtime success path for concurrent operations on the same socket.
- Add a client-disconnect-before-completion regression for websocket operation-scoped provider disposal.
- Fix websocket disconnect cleanup so socket close disposes active operation-scoped containers even when subscriptions have not completed.
- Add a patch changeset for the documented websocket lifecycle behavior fix.

## Testing

- pnpm exec biome check packages/graphql/src/module.test.ts packages/graphql/src/node/graphql-websocket-transport.ts .changeset/clean-graphql-websocket-disconnects.md
- pnpm --filter @fluojs/graphql... build
- pnpm --filter @fluojs/graphql typecheck
- pnpm --filter @fluojs/graphql test -- src/module.test.ts
- pnpm verify:changeset-release-lane
- pnpm verify:release-readiness

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

The original issue expected test-only preservation, but the new disconnect regression exposed a documented websocket lifecycle bug. `.changeset/clean-graphql-websocket-disconnects.md` records the patch release impact.

## Public export documentation

No public exports changed.

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

## Behavioral contract

This PR preserves the documented GraphQL lifecycle and guardrail contracts: request/websocket `limits: false` opt-outs work at runtime, and websocket operation-scoped providers are disposed when clients disconnect before subscription completion.

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

No platform contract or governance docs changed.

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.