### PR TITLE
Resolve #2319: align metrics example boundaries

### DIFF
--- a/.changeset/clean-metrics-telemetry.md
+++ b/.changeset/clean-metrics-telemetry.md
@@ -1,0 +1,5 @@
+---
+'@fluojs/metrics': patch
+---
+
+Harden platform telemetry scrapes so missing platform-shell registration uses container presence checks, registered shell resolution failures still surface, and component ids or kinds containing separator-like text keep distinct Prometheus series.

--- a/apps/docs/content/docs/examples/ops-metrics-terminus.ko.mdx
+++ b/apps/docs/content/docs/examples/ops-metrics-terminus.ko.mdx
@@ -8,7 +8,8 @@ Production observability를 준비할 때 `examples/ops-metrics-terminus`를 사
 ## 보여주는 것
 
 - Health와 readiness routes.
-- Metrics exposure.
+- HTTP 계측, template-normalized label, route-scoped scrape endpoint 보호를 포함한 metrics exposure.
+- Shared `Registry` 위에서 `MetricsService`로 등록하는 custom application metric.
 - Operations module composition.
 - Ops endpoint를 위한 E2E check.
 

--- a/apps/docs/content/docs/examples/ops-metrics-terminus.mdx
+++ b/apps/docs/content/docs/examples/ops-metrics-terminus.mdx
@@ -8,7 +8,8 @@ Use `examples/ops-metrics-terminus` when preparing an application for production
 ## Shows
 
 - Health and readiness routes.
-- Metrics exposure.
+- Metrics exposure with HTTP instrumentation, template-normalized labels, and route-scoped scrape endpoint protection.
+- Custom application metrics registered through `MetricsService` on a shared `Registry`.
 - Operations module composition.
 - E2E checks for ops endpoints.
 

--- a/apps/docs/content/docs/guides/operations.ko.mdx
+++ b/apps/docs/content/docs/guides/operations.ko.mdx
@@ -179,7 +179,8 @@ node -p "require.resolve('@fluojs/studio/viewer')"
 
 - `MetricsModule.forRoot()` 기반 `GET /metrics`
 - `TerminusModule.forRoot(...)` 기반 `GET /health`, `GET /ready`
-- Shared `Registry`에 등록된 custom Prometheus counter
+- Template-normalized label과 route-scoped scrape endpoint middleware를 사용하는 HTTP request instrumentation
+- Shared `Registry` 위에서 `MetricsService`로 등록한 custom Prometheus counter
 - Runtime-aligned health/readiness semantics
 - `createTestApp(...).request(...).send()` 기반 tests
 

--- a/apps/docs/content/docs/guides/operations.mdx
+++ b/apps/docs/content/docs/guides/operations.mdx
@@ -179,7 +179,8 @@ Open the printed `dist/index.html` path and drag a snapshot file into the viewer
 
 - `GET /metrics` through `MetricsModule.forRoot()`
 - `GET /health` and `GET /ready` through `TerminusModule.forRoot(...)`
-- one custom Prometheus counter registered on a shared `Registry`
+- HTTP request instrumentation with template-normalized labels and route-scoped scrape endpoint middleware
+- one custom Prometheus counter registered through `MetricsService` on a shared `Registry`
 - runtime-aligned health/readiness semantics
 - tests through `createTestApp(...).request(...).send()`
 

--- a/book/beginner/ch19-metrics.ko.md
+++ b/book/beginner/ch19-metrics.ko.md
@@ -128,7 +128,7 @@ MetricsModule.forRoot({
 ```
 
 ### 19.4.1 Bucket Tuning for Latency
-히스토그램은 "버킷(buckets)"을 사용하여 서로 다른 시간 범위(예: <100ms, <500ms, <1s)에 얼마나 많은 요청이 속하는지 계산합니다. Fluo는 합리적인 기본값을 제공하지만, 초저지연 API의 경우 커스텀 버킷을 정의하고 싶을 수 있습니다. 예를 들어 목표가 50ms 미만 응답이라면 0-100ms 범위에서 더 세분화된 버킷을 갖도록 설정할 수 있습니다. 이러한 정밀함을 통해 성능 저하가 정확히 어디에서 발생하는지 확인할 수 있습니다.
+히스토그램은 "버킷(buckets)"을 사용하여 서로 다른 시간 범위(예: <100ms, <500ms, <1s)에 얼마나 많은 요청이 속하는지 계산합니다. 현재 내장 HTTP 히스토그램은 패키지 기본값을 사용하며 `MetricsModule.forRoot(...)` bucket option을 노출하지 않습니다. 초저지연 API에서 custom bucket boundary가 필요하다면 `MetricsService.histogram(...)`으로 애플리케이션 전용 히스토그램을 만들거나 별도 middleware가 소유하는 히스토그램을 추가해 custom bucket 계약을 명시적으로 유지하세요.
 
 ### 19.4.2 Response Size Tracking
 지연 시간 외에 응답 크기까지 보고 싶을 때가 많지만, 현재 기본 HTTP 메트릭 계약은 `http_requests_total`, `http_errors_total`, `http_request_duration_seconds`에 한정됩니다. 응답 크기 분포를 추적하고 싶다면 애플리케이션 전용 커스텀 메트릭이나 별도 미들웨어 계층으로 추가하는 편이 맞습니다.

--- a/book/beginner/ch19-metrics.md
+++ b/book/beginner/ch19-metrics.md
@@ -128,7 +128,7 @@ MetricsModule.forRoot({
 ```
 
 ### 19.4.1 Bucket Tuning for Latency
-Histograms use buckets to count how many requests fall into different time ranges, for example, <100ms, <500ms, and <1s. Fluo provides reasonable defaults, but for ultra-low-latency APIs, you may want to define custom buckets. For example, if your target response time is under 50ms, you can configure more granular buckets in the 0-100ms range. This precision lets you see exactly where performance degradation occurs.
+Histograms use buckets to count how many requests fall into different time ranges, for example, <100ms, <500ms, and <1s. The built-in HTTP histogram currently uses the package defaults and does not expose a `MetricsModule.forRoot(...)` bucket option. For ultra-low-latency APIs that need custom bucket boundaries, create an application-specific `MetricsService.histogram(...)` or a dedicated middleware-owned histogram so the custom bucket contract stays explicit.
 
 ### 19.4.2 Response Size Tracking
 In addition to latency, you often want to see response size, but the current default HTTP metrics contract is limited to `http_requests_total`, `http_errors_total`, and `http_request_duration_seconds`. If you want to track response size distribution, it is better to add it as an application-specific custom metric or through a separate Middleware layer.

--- a/examples/ops-metrics-terminus/README.ko.md
+++ b/examples/ops-metrics-terminus/README.ko.md
@@ -6,16 +6,17 @@
 
 ## 이 예제가 보여주는 것
 
-- `MetricsModule.forRoot()`를 통한 `/metrics`
+- HTTP 계측과 endpoint middleware를 포함한 `MetricsModule.forRoot(...)` 기반 `/metrics`
 - `TerminusModule.forRoot(...)`를 통한 `/health`, `/ready`
-- `MetricsModule`이 scrape하는 의도적으로 shared Registry에 등록한 custom Prometheus counter 하나
+- 의도적으로 shared Registry 위에서 application-facing `MetricsService`를 통해 등록한 custom Prometheus counter 하나
+- Template-normalized HTTP request label과 token-protected metrics scraping
 - terminus와 metrics에 함께 노출되는 runtime-aligned health/readiness semantics
 - `@fluojs/testing`을 사용한 unit / integration / e2e 스타일 검증
 
 ## 라우트
 
 - `GET /ops/jobs/trigger` — 예제용 custom counter 증가
-- `GET /metrics` — Prometheus scrape endpoint
+- `GET /metrics` — 이 runnable 예제에서 `x-metrics-token: secret-token`으로 보호되는 Prometheus scrape endpoint
 - `GET /health`
 - `GET /ready`
 
@@ -47,9 +48,9 @@ examples/ops-metrics-terminus/
 
 ## 권장 읽기 순서
 
-1. `src/app.ts` — metrics + terminus 등록
-2. `src/ops/metrics-registry.ts` — shared Registry와 custom metric 등록
-3. `src/ops/ops-metrics.service.ts` — counter를 증가시키는 비즈니스 액션
+1. `src/app.ts` — metrics + terminus 등록, HTTP 계측, scrape endpoint 보호
+2. `src/ops/metrics-registry.ts` — `MetricsModule.forRoot({ registry })`에 전달하는 shared Registry ownership
+3. `src/ops/ops-metrics.service.ts` — application-facing `MetricsService` custom counter 등록과 재사용
 4. `src/ops/ops.controller.ts` — metrics 상태를 바꾸는 라우트
 5. `src/app.test.ts` — `createTestApp(...).request(...).send()` 기반 `/health`, `/ready`, `/metrics`, custom route 검증
 

--- a/examples/ops-metrics-terminus/README.md
+++ b/examples/ops-metrics-terminus/README.md
@@ -6,16 +6,17 @@ Runnable fluo operations example focused on `@fluojs/metrics` and `@fluojs/termi
 
 ## what this example demonstrates
 
-- `/metrics` via `MetricsModule.forRoot()`
+- `/metrics` via `MetricsModule.forRoot(...)` with HTTP instrumentation and endpoint middleware
 - `/health` and `/ready` via `TerminusModule.forRoot(...)`
-- one custom Prometheus counter registered on an intentionally shared Registry that is scraped through `MetricsModule`
+- one custom Prometheus counter registered through the application-facing `MetricsService` on an intentionally shared Registry
+- template-normalized HTTP request labels and token-protected metrics scraping
 - runtime-aligned health/readiness semantics exposed through terminus and metrics
 - unit, integration, and e2e-style verification with `@fluojs/testing`
 
 ## routes
 
 - `GET /ops/jobs/trigger` — increments the example custom counter
-- `GET /metrics` — Prometheus scrape endpoint
+- `GET /metrics` — Prometheus scrape endpoint protected by `x-metrics-token: secret-token` in this runnable example
 - `GET /health`
 - `GET /ready`
 
@@ -47,9 +48,9 @@ examples/ops-metrics-terminus/
 
 ## recommended reading order
 
-1. `src/app.ts` — metrics + terminus registration
-2. `src/ops/metrics-registry.ts` — shared Registry and custom metric registration
-3. `src/ops/ops-metrics.service.ts` — business action that increments the counter
+1. `src/app.ts` — metrics + terminus registration, HTTP instrumentation, and scrape endpoint protection
+2. `src/ops/metrics-registry.ts` — shared Registry ownership passed into `MetricsModule.forRoot({ registry })`
+3. `src/ops/ops-metrics.service.ts` — application-facing `MetricsService` custom counter registration and reuse
 4. `src/ops/ops.controller.ts` — route that mutates metrics state
 5. `src/app.test.ts` — `/health`, `/ready`, `/metrics`, and custom route verification through `createTestApp(...).request(...).send()`
 

--- a/examples/ops-metrics-terminus/src/app.test.ts
+++ b/examples/ops-metrics-terminus/src/app.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import { createTestApp } from '@fluojs/testing';
+import { MetricsService, Registry } from '@fluojs/metrics';
 
 import { AppModule } from './app';
 import { OpsMetricsService } from './ops/ops-metrics.service';
 
 describe('OpsMetricsService', () => {
   it('returns the trigger acknowledgement shape', () => {
-    const service = new OpsMetricsService();
+    const service = new OpsMetricsService(new MetricsService(new Registry()));
 
     expect(service.triggerJob()).toEqual({
       accepted: true,
@@ -17,29 +18,36 @@ describe('OpsMetricsService', () => {
 });
 
 describe('AppModule e2e', () => {
-  it('serves health, ready, metrics, and ops routes through createTestApp request helpers', async () => {
+  it('serves protected metrics and ops routes through createTestApp request helpers', async () => {
     const app = await createTestApp({ rootModule: AppModule });
 
-    await expect(app.request('GET', '/health').send()).resolves.toMatchObject({
-      status: 200,
-    });
+    try {
+      await expect(app.request('GET', '/health').send()).resolves.toMatchObject({
+        status: 200,
+      });
 
-    await expect(app.request('GET', '/ready').send()).resolves.toMatchObject({
-      status: 200,
-    });
+      await expect(app.request('GET', '/ready').send()).resolves.toMatchObject({
+        status: 200,
+      });
 
-    const triggerResult = await app.request('GET', '/ops/jobs/trigger').send();
-    expect(triggerResult.status).toBe(200);
-    expect(triggerResult.body).toEqual({
-      accepted: true,
-      metric: 'example_ops_jobs_triggered_total',
-    });
+      const triggerResult = await app.request('GET', '/ops/jobs/trigger').send();
+      expect(triggerResult.status).toBe(200);
+      expect(triggerResult.body).toEqual({
+        accepted: true,
+        metric: 'example_ops_jobs_triggered_total',
+      });
 
-    const metricsResult = await app.request('GET', '/metrics').send();
-    expect(metricsResult.status).toBe(200);
-    expect(metricsResult.body).toContain('example_ops_jobs_triggered_total');
-    expect(metricsResult.body).toContain('fluo_component_ready');
+      const forbiddenMetricsResult = await app.request('GET', '/metrics').send();
+      expect(forbiddenMetricsResult.status).toBe(403);
 
-    await app.close();
+      const metricsResult = await app.request('GET', '/metrics').header('x-metrics-token', 'secret-token').send();
+      expect(metricsResult.status).toBe(200);
+      expect(metricsResult.body).toContain('example_ops_jobs_triggered_total');
+      expect(metricsResult.body).toContain('fluo_component_ready');
+      expect(metricsResult.body).toContain('http_requests_total{method="GET",path="/metrics",status="403"} 1');
+      expect(metricsResult.body).toContain('http_errors_total{method="GET",path="/metrics",status="403"} 1');
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/examples/ops-metrics-terminus/src/app.test.ts
+++ b/examples/ops-metrics-terminus/src/app.test.ts
@@ -50,4 +50,26 @@ describe('AppModule e2e', () => {
       await app.close();
     }
   });
+
+  it('reuses the shared custom counter across repeated app bootstraps', async () => {
+    const firstApp = await createTestApp({ rootModule: AppModule });
+
+    try {
+      await expect(firstApp.request('GET', '/ops/jobs/trigger').send()).resolves.toMatchObject({
+        status: 200,
+      });
+    } finally {
+      await firstApp.close();
+    }
+
+    const secondApp = await createTestApp({ rootModule: AppModule });
+
+    try {
+      await expect(secondApp.request('GET', '/metrics').header('x-metrics-token', 'secret-token').send()).resolves.toMatchObject({
+        status: 200,
+      });
+    } finally {
+      await secondApp.close();
+    }
+  });
 });

--- a/examples/ops-metrics-terminus/src/app.ts
+++ b/examples/ops-metrics-terminus/src/app.ts
@@ -1,14 +1,13 @@
 import { Module } from '@fluojs/core';
-import { MetricsModule } from '@fluojs/metrics';
 import { TerminusModule } from '@fluojs/terminus';
 import { MemoryHealthIndicator } from '@fluojs/terminus/node';
 
 import { OpsModule } from './ops/ops.module';
-import { sharedRegistry } from './ops/metrics-registry';
+import { opsMetricsModule } from './ops/metrics-registry';
 
 @Module({
   imports: [
-    MetricsModule.forRoot({ registry: sharedRegistry }),
+    opsMetricsModule,
     TerminusModule.forRoot({
       indicators: [new MemoryHealthIndicator({ key: 'memory', rssThresholdBytes: Number.MAX_SAFE_INTEGER })],
     }),

--- a/examples/ops-metrics-terminus/src/ops/metrics-registry.ts
+++ b/examples/ops-metrics-terminus/src/ops/metrics-registry.ts
@@ -1,9 +1,23 @@
-import { PrometheusMeterProvider, Registry } from '@fluojs/metrics';
+import { ForbiddenException, type MiddlewareContext, type Next } from '@fluojs/http';
+import { MetricsModule, Registry } from '@fluojs/metrics';
+
+class MetricsTokenMiddleware {
+  async handle(context: MiddlewareContext, next: Next): Promise<void> {
+    if (context.request.headers['x-metrics-token'] !== 'secret-token') {
+      throw new ForbiddenException('Metrics endpoint requires x-metrics-token.');
+    }
+
+    await next();
+  }
+}
 
 export const sharedRegistry = new Registry();
-const meter = new PrometheusMeterProvider(sharedRegistry);
 
-export const exampleJobsTriggeredCounter = meter.createCounter(
-  'example_ops_jobs_triggered_total',
-  'Total number of example ops job trigger requests.',
-);
+export const opsMetricsModule = MetricsModule.forRoot({
+  endpointMiddleware: [MetricsTokenMiddleware],
+  http: {
+    pathLabelMode: 'template',
+    unknownPathLabel: 'UNKNOWN',
+  },
+  registry: sharedRegistry,
+});

--- a/examples/ops-metrics-terminus/src/ops/ops-metrics.service.ts
+++ b/examples/ops-metrics-terminus/src/ops/ops-metrics.service.ts
@@ -1,10 +1,21 @@
-import { exampleJobsTriggeredCounter } from './metrics-registry';
+import { Inject } from '@fluojs/core';
+import { MetricsService } from '@fluojs/metrics';
 
+const JOBS_TRIGGERED_METRIC = 'example_ops_jobs_triggered_total';
+
+@Inject(MetricsService)
 export class OpsMetricsService {
-  constructor() {}
+  private readonly jobsTriggered: ReturnType<MetricsService['counter']>;
+
+  constructor(metrics: MetricsService) {
+    this.jobsTriggered = metrics.counter({
+      help: 'Total number of example ops job trigger requests.',
+      name: JOBS_TRIGGERED_METRIC,
+    });
+  }
 
   triggerJob() {
-    exampleJobsTriggeredCounter.inc();
-    return { accepted: true, metric: 'example_ops_jobs_triggered_total' };
+    this.jobsTriggered.inc();
+    return { accepted: true, metric: JOBS_TRIGGERED_METRIC };
   }
 }

--- a/examples/ops-metrics-terminus/src/ops/ops-metrics.service.ts
+++ b/examples/ops-metrics-terminus/src/ops/ops-metrics.service.ts
@@ -3,15 +3,32 @@ import { MetricsService } from '@fluojs/metrics';
 
 const JOBS_TRIGGERED_METRIC = 'example_ops_jobs_triggered_total';
 
+const jobsTriggeredCounters = new WeakMap<
+  ReturnType<MetricsService['getRegistry']>,
+  ReturnType<MetricsService['counter']>
+>();
+
+function getJobsTriggeredCounter(metrics: MetricsService): ReturnType<MetricsService['counter']> {
+  const registry = metrics.getRegistry();
+  let counter = jobsTriggeredCounters.get(registry);
+
+  if (!counter) {
+    counter = metrics.counter({
+      help: 'Total number of example ops job trigger requests.',
+      name: JOBS_TRIGGERED_METRIC,
+    });
+    jobsTriggeredCounters.set(registry, counter);
+  }
+
+  return counter;
+}
+
 @Inject(MetricsService)
 export class OpsMetricsService {
   private readonly jobsTriggered: ReturnType<MetricsService['counter']>;
 
   constructor(metrics: MetricsService) {
-    this.jobsTriggered = metrics.counter({
-      help: 'Total number of example ops job trigger requests.',
-      name: JOBS_TRIGGERED_METRIC,
-    });
+    this.jobsTriggered = getJobsTriggeredCounter(metrics);
   }
 
   triggerJob() {

--- a/examples/ops-metrics-terminus/src/ops/ops.module.ts
+++ b/examples/ops-metrics-terminus/src/ops/ops.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@fluojs/core';
 
+import { opsMetricsModule } from './metrics-registry';
 import { OpsController } from './ops.controller';
 import { OpsMetricsService } from './ops-metrics.service';
 
 @Module({
   controllers: [OpsController],
+  imports: [opsMetricsModule],
   providers: [OpsMetricsService],
 })
 export class OpsModule {}

--- a/packages/metrics/src/metrics-module.test.ts
+++ b/packages/metrics/src/metrics-module.test.ts
@@ -16,6 +16,8 @@ import { MetricsService } from './metrics-service.js';
 import { PrometheusMeterProvider } from './providers/prometheus-meter-provider.js';
 
 type TestResponse = FrameworkResponse & { body?: unknown };
+type TestPlatformHealthStatus = 'healthy' | 'unhealthy' | 'degraded';
+type TestPlatformReadinessStatus = 'ready' | 'not-ready' | 'degraded';
 
 function createRequest(path: string, headers: FrameworkRequest['headers'] = {}): FrameworkRequest {
   return {
@@ -57,6 +59,50 @@ function createResponse(): TestResponse {
   };
 }
 
+function createPlatformComponent({
+  health = 'healthy',
+  id,
+  kind,
+  readiness = 'ready',
+}: {
+  health?: TestPlatformHealthStatus;
+  id: string;
+  kind: string;
+  readiness?: TestPlatformReadinessStatus;
+}): PlatformComponent {
+  return {
+    async health() {
+      return { status: health };
+    },
+    id,
+    kind,
+    async ready() {
+      return { critical: false, status: readiness };
+    },
+    snapshot() {
+      return {
+        dependencies: [],
+        details: {},
+        health: { status: health },
+        id,
+        kind,
+        ownership: { externallyManaged: false, ownsResources: true },
+        readiness: { critical: false, status: readiness },
+        state: readiness === 'ready' ? 'ready' : 'starting',
+        telemetry: { namespace: kind, tags: {} },
+      };
+    },
+    async start() {},
+    state() {
+      return readiness === 'ready' ? 'ready' : 'starting';
+    },
+    async stop() {},
+    async validate() {
+      return { issues: [], ok: health !== 'unhealthy' };
+    },
+  };
+}
+
 describe('MetricsModule', () => {
   it('can disable the scrape endpoint explicitly', async () => {
     class AppModule {}
@@ -69,12 +115,14 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const response = createResponse();
-    await app.dispatch(createRequest('/metrics'), response);
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/metrics'), response);
 
-    expect(response.statusCode).toBe(404);
-
-    await app.close();
+      expect(response.statusCode).toBe(404);
+    } finally {
+      await app.close();
+    }
   });
 
   it('supports route-scoped endpoint middleware for scrape protection', async () => {
@@ -103,17 +151,19 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const forbiddenResponse = createResponse();
-    await app.dispatch(createRequest('/metrics'), forbiddenResponse);
-    expect(forbiddenResponse.statusCode).toBe(403);
+    try {
+      const forbiddenResponse = createResponse();
+      await app.dispatch(createRequest('/metrics'), forbiddenResponse);
+      expect(forbiddenResponse.statusCode).toBe(403);
 
-    const metricsResponse = createResponse();
-    await app.dispatch(createRequest('/metrics', { 'x-metrics-token': 'secret-token' }), metricsResponse);
+      const metricsResponse = createResponse();
+      await app.dispatch(createRequest('/metrics', { 'x-metrics-token': 'secret-token' }), metricsResponse);
 
-    expect(metricsResponse.statusCode).toBe(200);
-    expect(String(metricsResponse.body)).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
-
-    await app.close();
+      expect(metricsResponse.statusCode).toBe(200);
+      expect(String(metricsResponse.body)).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
+    } finally {
+      await app.close();
+    }
   });
 
   it('binds endpoint middleware when the scrape endpoint path is empty', async () => {
@@ -314,19 +364,22 @@ describe('MetricsModule', () => {
     const app = await bootstrapApplication({
       rootModule: AppModule,
     });
-    const response = createResponse();
 
-    await app.dispatch(createRequest('/metrics'), response);
+    try {
+      const response = createResponse();
 
-    expect(response.statusCode).toBe(200);
-    expect(response.headers['content-type']).toBe(Registry.PROMETHEUS_CONTENT_TYPE);
-    expect(response.body).toEqual(expect.stringContaining('fluo_metrics_registry_mode{mode="isolated"} 1'));
-    expect(response.body).toEqual(expect.stringContaining('fluo_component_ready{component_id="runtime.shell",component_kind="runtime",operation="readiness",result="ready",env="unknown",instance="local"} 1'));
-    expect(response.body).toEqual(expect.stringContaining('fluo_component_health{component_id="runtime.shell",component_kind="runtime",operation="health",result="healthy",env="unknown",instance="local"} 1'));
-    expect(response.body).toEqual(expect.stringContaining('process_cpu_seconds_total'));
-    expect(response.body).toEqual(expect.stringContaining('nodejs_heap_size_total_bytes'));
+      await app.dispatch(createRequest('/metrics'), response);
 
-    await app.close();
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toBe(Registry.PROMETHEUS_CONTENT_TYPE);
+      expect(response.body).toEqual(expect.stringContaining('fluo_metrics_registry_mode{mode="isolated"} 1'));
+      expect(response.body).toEqual(expect.stringContaining('fluo_component_ready{component_id="runtime.shell",component_kind="runtime",operation="readiness",result="ready",env="unknown",instance="local"} 1'));
+      expect(response.body).toEqual(expect.stringContaining('fluo_component_health{component_id="runtime.shell",component_kind="runtime",operation="health",result="healthy",env="unknown",instance="local"} 1'));
+      expect(response.body).toEqual(expect.stringContaining('process_cpu_seconds_total'));
+      expect(response.body).toEqual(expect.stringContaining('nodejs_heap_size_total_bytes'));
+    } finally {
+      await app.close();
+    }
   });
 
   it('omits Prometheus default collectors when defaultMetrics is false', async () => {
@@ -853,36 +906,70 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const response = createResponse();
-    await app.dispatch(createRequest('/metrics'), response);
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/metrics'), response);
 
-    const metricsText = String(response.body);
-    expect(response.statusCode).toBe(200);
-    expect(metricsText).toContain('fluo_component_ready{component_id="cache.default",component_kind="cache",operation="readiness",result="degraded"');
-    expect(metricsText).toContain('fluo_component_health{component_id="cache.default",component_kind="cache",operation="health",result="degraded"');
-
-    await app.close();
+      const metricsText = String(response.body);
+      expect(response.statusCode).toBe(200);
+      expect(metricsText).toContain('fluo_component_ready{component_id="cache.default",component_kind="cache",operation="readiness",result="degraded"');
+      expect(metricsText).toContain('fluo_component_health{component_id="cache.default",component_kind="cache",operation="health",result="degraded"');
+    } finally {
+      await app.close();
+    }
   });
 
-  it('suppresses only missing platform shell registration errors during scrape refresh', async () => {
-    const missingPlatformShellError = new ContainerResolutionError(
-      'Structured missing provider context should not depend on message wording.',
-      {
-        hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
-        token: PLATFORM_SHELL,
-      },
-    );
+  it('preserves platform telemetry components whose ids and kinds contain key separators', async () => {
+    const firstComponent = createPlatformComponent({
+      id: 'cache::default',
+      kind: 'redis',
+    });
+    const secondComponent = createPlatformComponent({
+      health: 'degraded',
+      id: 'cache',
+      kind: 'default::redis',
+      readiness: 'degraded',
+    });
+
+    class AppModule {}
+
+    defineModule(AppModule, {
+      imports: [MetricsModule.forRoot({ defaultMetrics: false })],
+    });
+
+    const app = await bootstrapApplication({
+      platform: { components: [firstComponent, secondComponent] },
+      rootModule: AppModule,
+    });
+
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/metrics'), response);
+
+      const metricsText = String(response.body);
+      expect(response.statusCode).toBe(200);
+      expect(metricsText).toContain('fluo_component_ready{component_id="cache::default",component_kind="redis",operation="readiness",result="ready"');
+      expect(metricsText).toContain('fluo_component_health{component_id="cache::default",component_kind="redis",operation="health",result="healthy"');
+      expect(metricsText).toContain('fluo_component_ready{component_id="cache",component_kind="default::redis",operation="readiness",result="degraded"');
+      expect(metricsText).toContain('fluo_component_health{component_id="cache",component_kind="default::redis",operation="health",result="degraded"');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('omits platform telemetry when the platform shell token is absent during scrape refresh', async () => {
     const missingPlatformShellMiddleware = {
       async handle(context: MiddlewareContext, next: Next): Promise<void> {
-        const originalResolve = context.requestContext.container.resolve.bind(context.requestContext.container);
+        const container = context.requestContext.container as typeof context.requestContext.container & { has?: (token: unknown) => boolean };
+        const originalHas = container.has?.bind(container);
 
-        context.requestContext.container.resolve = (async (token: Parameters<typeof originalResolve>[0]) => {
+        container.has = (token: unknown) => {
           if (token === PLATFORM_SHELL) {
-            throw missingPlatformShellError;
+            return false;
           }
 
-          return await originalResolve(token);
-        }) as typeof context.requestContext.container.resolve;
+          return originalHas?.(token) ?? true;
+        };
 
         await next();
       },
@@ -898,39 +985,35 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const response = createResponse();
-    await app.dispatch(createRequest('/metrics'), response);
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/metrics'), response);
 
-    const metricsText = String(response.body);
+      const metricsText = String(response.body);
 
-    expect(response.statusCode).toBe(200);
-    expect(metricsText).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
-    expect(metricsText).not.toContain('fluo_component_ready{');
-    expect(metricsText).not.toContain('fluo_component_health{');
-
-    await app.close();
+      expect(response.statusCode).toBe(200);
+      expect(metricsText).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
+      expect(metricsText).not.toContain('fluo_component_ready{');
+      expect(metricsText).not.toContain('fluo_component_health{');
+    } finally {
+      await app.close();
+    }
   });
 
   it('clears stale platform telemetry series when the platform shell becomes unavailable', async () => {
-    const missingPlatformShellError = new ContainerResolutionError(
-      `No provider registered for token ${String(PLATFORM_SHELL)}.`,
-      {
-        hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
-        token: PLATFORM_SHELL,
-      },
-    );
     let platformShellAvailable = true;
     const intermittentPlatformShellMiddleware = {
       async handle(context: MiddlewareContext, next: Next): Promise<void> {
-        const originalResolve = context.requestContext.container.resolve.bind(context.requestContext.container);
+        const container = context.requestContext.container as typeof context.requestContext.container & { has?: (token: unknown) => boolean };
+        const originalHas = container.has?.bind(container);
 
-        context.requestContext.container.resolve = (async (token: Parameters<typeof originalResolve>[0]) => {
-          if (token === PLATFORM_SHELL && !platformShellAvailable) {
-            throw missingPlatformShellError;
+        container.has = (token: unknown) => {
+          if (token === PLATFORM_SHELL) {
+            return platformShellAvailable;
           }
 
-          return await originalResolve(token);
-        }) as typeof context.requestContext.container.resolve;
+          return originalHas?.(token) ?? true;
+        };
 
         await next();
       },
@@ -946,35 +1029,40 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const initialResponse = createResponse();
-    await app.dispatch(createRequest('/metrics'), initialResponse);
-    expect(String(initialResponse.body)).toContain('fluo_component_ready{');
-    expect(String(initialResponse.body)).toContain('fluo_component_health{');
+    try {
+      const initialResponse = createResponse();
+      await app.dispatch(createRequest('/metrics'), initialResponse);
+      expect(String(initialResponse.body)).toContain('fluo_component_ready{');
+      expect(String(initialResponse.body)).toContain('fluo_component_health{');
 
-    platformShellAvailable = false;
-    const missingShellResponse = createResponse();
-    await app.dispatch(createRequest('/metrics'), missingShellResponse);
+      platformShellAvailable = false;
+      const missingShellResponse = createResponse();
+      await app.dispatch(createRequest('/metrics'), missingShellResponse);
 
-    const metricsText = String(missingShellResponse.body);
-    expect(missingShellResponse.statusCode).toBe(200);
-    expect(metricsText).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
-    expect(metricsText).not.toContain('fluo_component_ready{');
-    expect(metricsText).not.toContain('fluo_component_health{');
-
-    await app.close();
+      const metricsText = String(missingShellResponse.body);
+      expect(missingShellResponse.statusCode).toBe(200);
+      expect(metricsText).toContain('fluo_metrics_registry_mode{mode="isolated"} 1');
+      expect(metricsText).not.toContain('fluo_component_ready{');
+      expect(metricsText).not.toContain('fluo_component_health{');
+    } finally {
+      await app.close();
+    }
   });
 
-  it('surfaces unexpected platform shell resolution failures during scrape refresh', async () => {
+  it('surfaces platform shell resolution failures even when diagnostics use a missing-provider hint', async () => {
     const resolutionFailure = new ContainerResolutionError(
-      `Failed to resolve token ${String(PLATFORM_SHELL)} because the provider factory threw an unexpected error.`,
+      'Structured missing provider context should not be treated as absence when the token is registered.',
       {
-        hint: 'Inspect the PLATFORM_SHELL provider registration and its factory dependencies.',
+        hint: 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.',
         token: PLATFORM_SHELL,
       },
     );
     const unexpectedPlatformShellMiddleware = {
       async handle(context: MiddlewareContext, next: Next): Promise<void> {
+        const container = context.requestContext.container as typeof context.requestContext.container & { has?: (token: unknown) => boolean };
         const originalResolve = context.requestContext.container.resolve.bind(context.requestContext.container);
+
+        container.has = (token: unknown) => token === PLATFORM_SHELL;
 
         context.requestContext.container.resolve = (async (token: Parameters<typeof originalResolve>[0]) => {
           if (token === PLATFORM_SHELL) {
@@ -998,20 +1086,22 @@ describe('MetricsModule', () => {
       rootModule: AppModule,
     });
 
-    const response = createResponse();
-    await app.dispatch(createRequest('/metrics'), response);
+    try {
+      const response = createResponse();
+      await app.dispatch(createRequest('/metrics'), response);
 
-    expect(response.statusCode).toBe(500);
-    expect(response.body).toEqual(
-      expect.objectContaining({
-        error: expect.objectContaining({
-          message: 'Internal server error.',
-          status: 500,
+      expect(response.statusCode).toBe(500);
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: 'Internal server error.',
+            status: 500,
+          }),
         }),
-      }),
-    );
-
-    await app.close();
+      );
+    } finally {
+      await app.close();
+    }
   });
 
   it('serializes overlapping scrapes and removes stale platform status series', async () => {

--- a/packages/metrics/src/metrics-module.ts
+++ b/packages/metrics/src/metrics-module.ts
@@ -149,6 +149,7 @@ export class MetricsModule {
 
     defineModule(MetricsRuntimeModule, {
       controllers,
+      exports: [MetricsService, METER_PROVIDER],
       middleware,
       providers,
     });
@@ -177,14 +178,20 @@ type RuntimeTelemetryComponent = {
   health: PlatformHealthStatus;
   readiness: PlatformReadinessStatus;
 };
+type ComponentStatusMap<TStatus extends string> = Map<string, Map<string, TStatus>>;
+type ComponentStatusEntry<TStatus extends string> = {
+  componentId: string;
+  componentKind: string;
+  status: TStatus;
+};
+type ContainerPresenceProbe = RequestContext['container'] & { has?: (token: Token) => boolean };
 
 const PLATFORM_COMPONENT_LABELS = ['component_id', 'component_kind', 'operation', 'result', 'env', 'instance'] as const;
 const REGISTRY_MODE_LABELS = ['mode'] as const;
 const FRAMEWORK_PLATFORM_GAUGES = new WeakSet<Gauge<string>>();
 const HEALTH_STATUSES = ['healthy', 'unhealthy', 'degraded'] as const satisfies readonly PlatformHealthStatus[];
 const READINESS_STATUSES = ['ready', 'not-ready', 'degraded'] as const satisfies readonly PlatformReadinessStatus[];
-const PLATFORM_SHELL_TOKEN_NAME = 'PLATFORM_SHELL';
-const PLATFORM_SHELL_TOKEN_NAMES = new Set([PLATFORM_SHELL_TOKEN_NAME, String(PLATFORM_SHELL)]);
+const PLATFORM_SHELL_TOKEN_NAMES = new Set([String(PLATFORM_SHELL)]);
 
 function createHttpMetricsMiddleware(
   registryToken: Token<Registry>,
@@ -274,8 +281,8 @@ class RuntimePlatformTelemetry {
   private readonly readinessGauge: Gauge<string>;
   private readonly healthGauge: Gauge<string>;
   private readonly registryModeGauge: Gauge<string>;
-  private readonly lastHealthStatuses = new Map<string, PlatformHealthStatus>();
-  private readonly lastReadinessStatuses = new Map<string, PlatformReadinessStatus>();
+  private readonly lastHealthStatuses: ComponentStatusMap<PlatformHealthStatus> = new Map();
+  private readonly lastReadinessStatuses: ComponentStatusMap<PlatformReadinessStatus> = new Map();
   private scrapeChain: Promise<unknown> = Promise.resolve();
 
   constructor(
@@ -343,7 +350,7 @@ class RuntimePlatformTelemetry {
     ];
 
     this.syncGaugeStatuses({
-      currentStatuses: new Map(components.map((component) => [this.toComponentKey(component.id, component.kind), component.health])),
+      currentStatuses: this.toComponentStatusMap(components, (component) => component.health),
       env,
       gauge: this.healthGauge,
       instance,
@@ -353,7 +360,7 @@ class RuntimePlatformTelemetry {
       toMetricValue: toHealthValue,
     });
     this.syncGaugeStatuses({
-      currentStatuses: new Map(components.map((component) => [this.toComponentKey(component.id, component.kind), component.readiness])),
+      currentStatuses: this.toComponentStatusMap(components, (component) => component.readiness),
       env,
       gauge: this.readinessGauge,
       instance,
@@ -394,13 +401,11 @@ class RuntimePlatformTelemetry {
     env: string;
     gauge: Gauge<string>;
     instance: string;
-    lastStatuses: Map<string, TStatus>;
+    lastStatuses: ComponentStatusMap<TStatus>;
     operation: 'health' | 'readiness';
     statuses: readonly TStatus[];
   }): void {
-    for (const componentKey of lastStatuses.keys()) {
-      const [componentId, componentKind] = this.fromComponentKey(componentKey);
-
+    for (const { componentId, componentKind } of this.componentStatusEntries(lastStatuses)) {
       for (const status of statuses) {
         gauge.remove(componentId, componentKind, operation, status, env, instance);
       }
@@ -419,22 +424,21 @@ class RuntimePlatformTelemetry {
     statuses,
     toMetricValue,
   }: {
-    currentStatuses: Map<string, TStatus>;
+    currentStatuses: ComponentStatusMap<TStatus>;
     env: string;
     gauge: Gauge<string>;
     instance: string;
-    lastStatuses: Map<string, TStatus>;
+    lastStatuses: ComponentStatusMap<TStatus>;
     operation: 'health' | 'readiness';
     statuses: readonly TStatus[];
     toMetricValue(status: TStatus): number;
   }): void {
-    for (const [componentKey, previousStatus] of lastStatuses) {
-      const nextStatus = currentStatuses.get(componentKey);
+    for (const { componentId, componentKind, status: previousStatus } of this.componentStatusEntries(lastStatuses)) {
+      const nextStatus = this.getComponentStatus(currentStatuses, componentId, componentKind);
       if (nextStatus === previousStatus) {
         continue;
       }
 
-      const [componentId, componentKind] = this.fromComponentKey(componentKey);
       for (const status of statuses) {
         if (status !== previousStatus) {
           continue;
@@ -444,37 +448,88 @@ class RuntimePlatformTelemetry {
       }
     }
 
-    for (const [componentKey, currentStatus] of currentStatuses) {
-      const [componentId, componentKind] = this.fromComponentKey(componentKey);
+    for (const { componentId, componentKind, status: currentStatus } of this.componentStatusEntries(currentStatuses)) {
       gauge.labels(componentId, componentKind, operation, currentStatus, env, instance).set(toMetricValue(currentStatus));
     }
 
     lastStatuses.clear();
-    for (const [componentKey, currentStatus] of currentStatuses) {
-      lastStatuses.set(componentKey, currentStatus);
+    for (const { componentId, componentKind, status: currentStatus } of this.componentStatusEntries(currentStatuses)) {
+      this.setComponentStatus(lastStatuses, componentId, componentKind, currentStatus);
     }
   }
 
-  private fromComponentKey(componentKey: string): [string, string] {
-    const separatorIndex = componentKey.indexOf('::');
-    return [componentKey.slice(0, separatorIndex), componentKey.slice(separatorIndex + 2)];
+  private toComponentStatusMap<TStatus extends string>(
+    components: readonly RuntimeTelemetryComponent[],
+    getStatus: (component: RuntimeTelemetryComponent) => TStatus,
+  ): ComponentStatusMap<TStatus> {
+    const statuses: ComponentStatusMap<TStatus> = new Map();
+
+    for (const component of components) {
+      this.setComponentStatus(statuses, component.id, component.kind, getStatus(component));
+    }
+
+    return statuses;
   }
 
-  private toComponentKey(componentId: string, componentKind: string): string {
-    return `${componentId}::${componentKind}`;
+  private setComponentStatus<TStatus extends string>(
+    statuses: ComponentStatusMap<TStatus>,
+    componentId: string,
+    componentKind: string,
+    status: TStatus,
+  ): void {
+    let statusByKind = statuses.get(componentId);
+    if (!statusByKind) {
+      statusByKind = new Map();
+      statuses.set(componentId, statusByKind);
+    }
+
+    statusByKind.set(componentKind, status);
+  }
+
+  private getComponentStatus<TStatus extends string>(
+    statuses: ComponentStatusMap<TStatus>,
+    componentId: string,
+    componentKind: string,
+  ): TStatus | undefined {
+    return statuses.get(componentId)?.get(componentKind);
+  }
+
+  private *componentStatusEntries<TStatus extends string>(
+    statuses: ComponentStatusMap<TStatus>,
+  ): Iterable<ComponentStatusEntry<TStatus>> {
+    for (const [componentId, statusByKind] of statuses) {
+      for (const [componentKind, status] of statusByKind) {
+        yield { componentId, componentKind, status };
+      }
+    }
   }
 
   private async resolvePlatformShell(ctx: RequestContext): Promise<{ snapshot(): Promise<PlatformShellSnapshot> } | undefined> {
+    const hasPlatformShell = hasContainerToken(ctx.container, PLATFORM_SHELL);
+    if (hasPlatformShell === false) {
+      return undefined;
+    }
+
     try {
       return await ctx.container.resolve(PLATFORM_SHELL);
     } catch (error) {
-      if (isMissingPlatformShellResolutionError(error)) {
+      if (hasPlatformShell !== true && isMissingPlatformShellResolutionError(error)) {
         return undefined;
       }
 
       throw error;
     }
   }
+}
+
+function hasContainerToken(container: RequestContext['container'], token: Token): boolean | undefined {
+  const has = (container as ContainerPresenceProbe).has;
+
+  if (typeof has !== 'function') {
+    return undefined;
+  }
+
+  return has.call(container, token);
 }
 
 function isMissingPlatformShellResolutionError(error: unknown): error is ContainerResolutionError {
@@ -484,11 +539,8 @@ function isMissingPlatformShellResolutionError(error: unknown): error is Contain
 
   const containerError = error as ContainerResolutionError & { meta?: Record<string, unknown> };
   const token = typeof containerError.meta?.token === 'string' ? containerError.meta.token : undefined;
-  const hint = typeof containerError.meta?.hint === 'string' ? containerError.meta.hint : undefined;
 
-  return token !== undefined
-    && PLATFORM_SHELL_TOKEN_NAMES.has(token)
-    && hint === 'Ensure the provider is registered in a module\'s providers array, or that the module exporting it is imported by the consuming module.';
+  return token !== undefined && PLATFORM_SHELL_TOKEN_NAMES.has(token);
 }
 
 function resolveHttpOptions(http: MetricsModuleOptions['http']): HttpMetricsMiddlewareOptions | undefined {


### PR DESCRIPTION
## Summary

Align the `@fluojs/metrics` operations example and docs with the app-facing metrics boundary, and harden runtime platform telemetry regressions found in the package audit.

Linked context: Closes #2319

## Changes

- Export `MetricsService`/`METER_PROVIDER` from the runtime `MetricsModule` so feature modules importing the same configured metrics module can consume application-facing metrics services.
- Replace lossy `id::kind` platform telemetry keys with nested component status maps, preserving component ids/kinds that contain separator-like text.
- Use container presence checks for missing `PLATFORM_SHELL` handling while still surfacing registered shell resolution failures.
- Wrap request-facing metrics app tests in `try/finally` cleanup and add telemetry regression coverage.
- Update `examples/ops-metrics-terminus` to register the custom counter through `MetricsService`, enable template-normalized HTTP instrumentation, and protect `/metrics` with route-scoped endpoint middleware.
- Align EN/KO docs, example docs, and book text around the supported app-facing metrics path and the current lack of built-in HTTP bucket configuration.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm --filter @fluojs/metrics test`
- `pnpm exec vitest run examples/ops-metrics-terminus`
- `pnpm --filter @fluojs/metrics typecheck`
- `pnpm typecheck`
- `pnpm verify:platform-consistency-governance`
- `pnpm lint` (passed; repository-wide Biome warning/info diagnostics remain in unrelated existing files)
- `pnpm verify:docs`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `git diff --check`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

See [docs/contracts/public-export-tsdoc-baseline.md](docs/contracts/public-export-tsdoc-baseline.md) for the repo-wide authoring baseline.

- [x] Changed public exports include a source-level summary. (`pnpm verify:public-export-tsdoc` passed in changed mode; no new TypeScript export was added.)
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

## Behavioral contract

See [docs/contracts/behavioral-contract-policy.md](docs/contracts/behavioral-contract-policy.md) for full details.

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README. (No new package-level README contract; example/docs/book clarify existing behavior.)
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

## Platform consistency governance (SSOT)

See [docs/architecture/platform-consistency-design.md](docs/architecture/platform-consistency-design.md) and [docs/contracts/release-governance.md](docs/contracts/release-governance.md).

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence. (No platform contract docs changed.)
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests. (No new conformance claim added.)
