### PR TITLE
Resolve #2325: close Terminus indicator gaps

### DIFF
--- a/.changeset/sharp-rings-terminus-timeouts.md
+++ b/.changeset/sharp-rings-terminus-timeouts.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/terminus": patch
+---
+
+Harden Terminus health indicators by rejecting invalid indicator timeout budgets and cancelling HTTP probe response bodies after status checks.

--- a/packages/terminus/src/indicators/drizzle.test.ts
+++ b/packages/terminus/src/indicators/drizzle.test.ts
@@ -18,6 +18,26 @@ describe('DrizzleHealthIndicator', () => {
     expect(execute).toHaveBeenCalledWith('select 1');
   });
 
+  it('rejects invalid timeoutMs before starting the Drizzle probe', async () => {
+    const execute = vi.fn(async (_query: unknown) => undefined);
+    const indicator = createDrizzleHealthIndicator({
+      database: { execute },
+      timeoutMs: Number.POSITIVE_INFINITY,
+    });
+
+    await expect(indicator.check('drizzle')).rejects.toMatchObject({
+      causes: {
+        drizzle: {
+          message: 'drizzle health indicator timeoutMs must be a positive finite number.',
+          status: 'down',
+        },
+      },
+      message: 'Drizzle health check failed.',
+      name: 'HealthCheckError',
+    } satisfies Partial<HealthCheckError>);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it('maps Drizzle lifecycle readiness before pinging', async () => {
     const execute = vi.fn(async (_query: unknown) => undefined);
     const indicator = createDrizzleHealthIndicator({

--- a/packages/terminus/src/indicators/drizzle.ts
+++ b/packages/terminus/src/indicators/drizzle.ts
@@ -1,6 +1,6 @@
 import { optional, type Provider } from '@fluojs/di';
 
-import { createDownResult, createUpResult, resolveIndicatorKey, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
+import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
 
 const DRIZZLE_DATABASE = Symbol.for('fluo.drizzle.database');
@@ -143,9 +143,9 @@ export class DrizzleHealthIndicator implements HealthIndicator {
 
   async check(key: string): Promise<HealthIndicatorResult> {
     const indicatorKey = resolveIndicatorKey('drizzle', this.options.key ?? key);
-    const timeoutMs = this.options.timeoutMs ?? DEFAULT_DRIZZLE_TIMEOUT_MS;
 
     try {
+      const timeoutMs = resolveIndicatorTimeoutMs(this.options.timeoutMs, DEFAULT_DRIZZLE_TIMEOUT_MS, indicatorKey);
       const snapshot = createDrizzleLifecycleSnapshot(this.options.handleProvider);
       const lifecycleDownResult = snapshot
         ? createDrizzleLifecycleDownResult(indicatorKey, snapshot)

--- a/packages/terminus/src/indicators/http.test.ts
+++ b/packages/terminus/src/indicators/http.test.ts
@@ -3,6 +3,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { HealthCheckError } from '../errors.js';
 import { createHttpHealthIndicator, HttpHealthIndicator } from './http.js';
 
+function createTrackedBodyResponse(status: number) {
+  const cancel = vi.fn();
+  const body = new ReadableStream<Uint8Array>({
+    cancel() {
+      cancel();
+    },
+  });
+
+  return {
+    cancel,
+    response: new Response(body, { status }),
+  };
+}
+
 describe('HttpHealthIndicator', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -25,6 +39,23 @@ describe('HttpHealthIndicator', () => {
         url: 'https://example.com/health',
       },
     });
+  });
+
+  it('cancels successful response bodies after checking status', async () => {
+    const { cancel, response } = createTrackedBodyResponse(200);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
+
+    const indicator = new HttpHealthIndicator({
+      url: 'https://example.com/health',
+    });
+
+    await expect(indicator.check('upstream')).resolves.toMatchObject({
+      upstream: {
+        status: 'up',
+        statusCode: 200,
+      },
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 
   it('throws HealthCheckError for unexpected codes and transport failures', async () => {
@@ -58,6 +89,25 @@ describe('HttpHealthIndicator', () => {
       message: 'HTTP health check failed.',
       name: 'HealthCheckError',
     } satisfies Partial<HealthCheckError>);
+  });
+
+  it('cancels unexpected-status response bodies before reporting down', async () => {
+    const { cancel, response } = createTrackedBodyResponse(500);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
+
+    const indicator = createHttpHealthIndicator({ url: 'https://example.com/health' });
+
+    await expect(indicator.check('upstream')).rejects.toMatchObject({
+      causes: {
+        upstream: {
+          message: 'Unexpected status code 500 from https://example.com/health.',
+          status: 'down',
+        },
+      },
+      message: 'HTTP health check failed.',
+      name: 'HealthCheckError',
+    } satisfies Partial<HealthCheckError>);
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 
   it('aborts timed out HTTP probes and reports the timeout as down', async () => {
@@ -94,5 +144,25 @@ describe('HttpHealthIndicator', () => {
     }));
     expect(observedSignal?.aborted).toBe(true);
     expect(observedSignal?.reason).toEqual(new Error('HTTP health check timed out after 5ms.'));
+  });
+
+  it('rejects invalid timeoutMs before starting fetch', async () => {
+    const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+    const indicator = new HttpHealthIndicator({
+      timeoutMs: 0,
+      url: 'https://example.com/health',
+    });
+
+    await expect(indicator.check('upstream')).rejects.toMatchObject({
+      causes: {
+        upstream: {
+          message: 'upstream health indicator timeoutMs must be a positive finite number.',
+          status: 'down',
+        },
+      },
+      message: 'HTTP health check failed.',
+      name: 'HealthCheckError',
+    } satisfies Partial<HealthCheckError>);
+    expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/terminus/src/indicators/http.ts
+++ b/packages/terminus/src/indicators/http.ts
@@ -1,6 +1,6 @@
 import type { Provider } from '@fluojs/di';
 
-import { createDownResult, createUpResult, resolveIndicatorKey, throwHealthCheckError } from './utils.js';
+import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError } from './utils.js';
 import { HealthCheckError } from '../errors.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
 
@@ -30,6 +30,16 @@ function isExpectedStatus(status: number, expected?: HttpHealthIndicatorOptions[
   }
 
   return status >= 200 && status < 300;
+}
+
+function cancelResponseBody(response: Response): void {
+  const body = response.body;
+
+  if (!body) {
+    return;
+  }
+
+  void body.cancel().catch(() => undefined);
 }
 
 /**
@@ -67,36 +77,44 @@ export class HttpHealthIndicator implements HealthIndicator {
 
   async check(key: string): Promise<HealthIndicatorResult> {
     const indicatorKey = resolveIndicatorKey('http', this.options.key ?? key);
-    const timeoutMs = this.options.timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS;
     const method = this.options.method ?? 'GET';
 
-    const abortController = new AbortController();
-    const startedAt = Date.now();
-    const timeout = setTimeout(() => {
-      abortController.abort(new Error(`HTTP health check timed out after ${String(timeoutMs)}ms.`));
-    }, timeoutMs);
-
     try {
-      const response = await fetch(this.options.url, {
-        headers: this.options.headers,
-        method,
-        signal: abortController.signal,
-      });
-      const responseTimeMs = Date.now() - startedAt;
+      const timeoutMs = resolveIndicatorTimeoutMs(this.options.timeoutMs, DEFAULT_HTTP_TIMEOUT_MS, indicatorKey);
+      const abortController = new AbortController();
+      const startedAt = Date.now();
+      const timeout = setTimeout(() => {
+        abortController.abort(new Error(`HTTP health check timed out after ${String(timeoutMs)}ms.`));
+      }, timeoutMs);
 
-      if (!isExpectedStatus(response.status, this.options.expectedStatus)) {
-        throwHealthCheckError('HTTP health check failed.', createDownResult(indicatorKey, `Unexpected status code ${String(response.status)} from ${this.options.url}.`, {
-          responseTimeMs,
-          statusCode: response.status,
-          url: this.options.url,
-        }));
+      try {
+        const response = await fetch(this.options.url, {
+          headers: this.options.headers,
+          method,
+          signal: abortController.signal,
+        });
+        const responseTimeMs = Date.now() - startedAt;
+
+        try {
+          if (!isExpectedStatus(response.status, this.options.expectedStatus)) {
+            throwHealthCheckError('HTTP health check failed.', createDownResult(indicatorKey, `Unexpected status code ${String(response.status)} from ${this.options.url}.`, {
+              responseTimeMs,
+              statusCode: response.status,
+              url: this.options.url,
+            }));
+          }
+
+          return createUpResult(indicatorKey, {
+            responseTimeMs,
+            statusCode: response.status,
+            url: this.options.url,
+          });
+        } finally {
+          cancelResponseBody(response);
+        }
+      } finally {
+        clearTimeout(timeout);
       }
-
-      return createUpResult(indicatorKey, {
-        responseTimeMs,
-        statusCode: response.status,
-        url: this.options.url,
-      });
     } catch (error: unknown) {
       if (error instanceof HealthCheckError) {
         throw error;
@@ -106,8 +124,6 @@ export class HttpHealthIndicator implements HealthIndicator {
         indicatorKey,
         error instanceof Error ? error.message : `HTTP health check failed for ${this.options.url}.`,
       ));
-    } finally {
-      clearTimeout(timeout);
     }
   }
 }

--- a/packages/terminus/src/indicators/prisma.test.ts
+++ b/packages/terminus/src/indicators/prisma.test.ts
@@ -48,4 +48,24 @@ describe('PrismaHealthIndicator', () => {
       name: 'HealthCheckError',
     } satisfies Partial<HealthCheckError>);
   });
+
+  it('rejects invalid timeoutMs before starting the Prisma probe', async () => {
+    const ping = vi.fn(async () => undefined);
+    const indicator = createPrismaHealthIndicator({
+      ping,
+      timeoutMs: -1,
+    });
+
+    await expect(indicator.check('prisma')).rejects.toMatchObject({
+      causes: {
+        prisma: {
+          message: 'prisma health indicator timeoutMs must be a positive finite number.',
+          status: 'down',
+        },
+      },
+      message: 'Prisma health check failed.',
+      name: 'HealthCheckError',
+    } satisfies Partial<HealthCheckError>);
+    expect(ping).not.toHaveBeenCalled();
+  });
 });

--- a/packages/terminus/src/indicators/prisma.ts
+++ b/packages/terminus/src/indicators/prisma.ts
@@ -1,6 +1,6 @@
 import type { Provider } from '@fluojs/di';
 
-import { createDownResult, createUpResult, resolveIndicatorKey, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
+import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
 
 const PRISMA_CLIENT = Symbol.for('fluo.prisma.client');
@@ -93,9 +93,10 @@ export class PrismaHealthIndicator implements HealthIndicator {
 
   async check(key: string): Promise<HealthIndicatorResult> {
     const indicatorKey = resolveIndicatorKey('prisma', this.options.key ?? key);
-    const timeoutMs = this.options.timeoutMs ?? DEFAULT_PRISMA_TIMEOUT_MS;
 
     try {
+      const timeoutMs = resolveIndicatorTimeoutMs(this.options.timeoutMs, DEFAULT_PRISMA_TIMEOUT_MS, indicatorKey);
+
       await withIndicatorTimeout(runPrismaPing(this.options), timeoutMs, indicatorKey);
       return createUpResult(indicatorKey);
     } catch (error: unknown) {

--- a/packages/terminus/src/indicators/redis.test.ts
+++ b/packages/terminus/src/indicators/redis.test.ts
@@ -1,9 +1,47 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { getRedisClientToken } from '@fluojs/redis';
+import { getRedisClientToken, type RedisStatusAdapterInput } from '@fluojs/redis';
 
 import type { HealthCheckError } from '../errors.js';
 import { createRedisHealthIndicator, createRedisHealthIndicatorProvider, RedisHealthIndicator } from './redis.js';
+
+const unavailableRedisStates = [
+  {
+    healthStatus: 'degraded',
+    message: 'Redis client is still in lazyConnect wait state.',
+    readinessStatus: 'not-ready',
+    status: 'wait',
+  },
+  {
+    healthStatus: 'degraded',
+    message: 'Redis client is connecting.',
+    readinessStatus: 'degraded',
+    status: 'connecting',
+  },
+  {
+    healthStatus: 'degraded',
+    message: 'Redis client is reconnecting.',
+    readinessStatus: 'degraded',
+    status: 'reconnecting',
+  },
+  {
+    healthStatus: 'unhealthy',
+    message: 'Redis client is close.',
+    readinessStatus: 'not-ready',
+    status: 'close',
+  },
+  {
+    healthStatus: 'unhealthy',
+    message: 'Redis client is end.',
+    readinessStatus: 'not-ready',
+    status: 'end',
+  },
+] satisfies ReadonlyArray<{
+  healthStatus: 'degraded' | 'unhealthy';
+  message: string;
+  readinessStatus: 'degraded' | 'not-ready';
+  status: RedisStatusAdapterInput['status'];
+}>;
 
 describe('RedisHealthIndicator', () => {
   it('uses redis ping methods when present', async () => {
@@ -27,23 +65,45 @@ describe('RedisHealthIndicator', () => {
     expect(ping).toHaveBeenCalledTimes(1);
   });
 
-  it('maps Redis lifecycle readiness before pinging', async () => {
+  for (const state of unavailableRedisStates) {
+    it(`maps Redis ${state.status} lifecycle readiness before pinging`, async () => {
+      const ping = vi.fn(async () => 'PONG');
+      const indicator = createRedisHealthIndicator({
+        client: { ping, status: state.status },
+      });
+
+      await expect(indicator.check('redis')).rejects.toMatchObject({
+        causes: {
+          redis: {
+            details: {
+              componentId: 'redis.default',
+              connectionState: state.status,
+              lazyConnect: true,
+            },
+            healthStatus: state.healthStatus,
+            message: state.message,
+            readinessStatus: state.readinessStatus,
+            status: 'down',
+          },
+        },
+        message: 'Redis health check failed.',
+        name: 'HealthCheckError',
+      } satisfies Partial<HealthCheckError>);
+      expect(ping).not.toHaveBeenCalled();
+    });
+  }
+
+  it('rejects invalid timeoutMs before starting the Redis probe', async () => {
     const ping = vi.fn(async () => 'PONG');
     const indicator = createRedisHealthIndicator({
-      client: { ping, status: 'end' },
+      client: { ping, status: 'ready' },
+      timeoutMs: Number.NaN,
     });
 
     await expect(indicator.check('redis')).rejects.toMatchObject({
       causes: {
         redis: {
-          details: {
-            componentId: 'redis.default',
-            connectionState: 'end',
-            lazyConnect: true,
-          },
-          healthStatus: 'unhealthy',
-          message: 'Redis client is end.',
-          readinessStatus: 'not-ready',
+          message: 'redis health indicator timeoutMs must be a positive finite number.',
           status: 'down',
         },
       },

--- a/packages/terminus/src/indicators/redis.ts
+++ b/packages/terminus/src/indicators/redis.ts
@@ -1,7 +1,7 @@
 import type { Provider } from '@fluojs/di';
 import { createRedisPlatformStatusSnapshot, getRedisClientToken, getRedisComponentId, type RedisStatusAdapterInput } from '@fluojs/redis';
 
-import { createDownResult, createUpResult, resolveIndicatorKey, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
+import { createDownResult, createUpResult, resolveIndicatorKey, resolveIndicatorTimeoutMs, throwHealthCheckError, withIndicatorTimeout } from './utils.js';
 import type { HealthIndicator, HealthIndicatorResult } from '../types.js';
 
 interface RedisClientLike {
@@ -136,9 +136,9 @@ export class RedisHealthIndicator implements HealthIndicator {
 
   async check(key: string): Promise<HealthIndicatorResult> {
     const indicatorKey = resolveIndicatorKey('redis', this.options.key ?? key);
-    const timeoutMs = this.options.timeoutMs ?? DEFAULT_REDIS_TIMEOUT_MS;
 
     try {
+      const timeoutMs = resolveIndicatorTimeoutMs(this.options.timeoutMs, DEFAULT_REDIS_TIMEOUT_MS, indicatorKey);
       const lifecycleDownResult = createRedisLifecycleDownResult(indicatorKey, this.options);
 
       if (lifecycleDownResult) {

--- a/packages/terminus/src/indicators/utils.test.ts
+++ b/packages/terminus/src/indicators/utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveIndicatorTimeoutMs, withIndicatorTimeout } from './utils.js';
+
+describe('indicator timeout utilities', () => {
+  it('normalizes omitted and fractional timeout budgets to positive integer milliseconds', () => {
+    expect(resolveIndicatorTimeoutMs(undefined, 2_000, 'redis')).toBe(2_000);
+    expect(resolveIndicatorTimeoutMs(5.9, 2_000, 'redis')).toBe(5);
+    expect(resolveIndicatorTimeoutMs(0.5, 2_000, 'redis')).toBe(1);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])('rejects invalid timeout budget %s', (timeoutMs) => {
+    expect(() => resolveIndicatorTimeoutMs(timeoutMs, 2_000, 'redis')).toThrow(
+      'redis health indicator timeoutMs must be a positive finite number.',
+    );
+  });
+
+  it('rejects invalid timeout budgets before scheduling a race timer', async () => {
+    await expect(withIndicatorTimeout(Promise.resolve('ok'), Number.NEGATIVE_INFINITY, 'redis')).rejects.toThrow(
+      'redis health indicator timeoutMs must be a positive finite number.',
+    );
+  });
+});

--- a/packages/terminus/src/indicators/utils.ts
+++ b/packages/terminus/src/indicators/utils.ts
@@ -6,6 +6,31 @@ export interface IndicatorTimeoutOptions {
   timeoutMs?: number;
 }
 
+function normalizePositiveFiniteTimeoutMs(timeoutMs: number, indicatorName: string): number {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(`${indicatorName} health indicator timeoutMs must be a positive finite number.`);
+  }
+
+  return Math.max(1, Math.floor(timeoutMs));
+}
+
+/**
+ * Resolve an indicator timeout budget before it reaches timeout scheduling.
+ *
+ * @param timeoutMs Caller-provided timeout budget in milliseconds.
+ * @param defaultTimeoutMs Default timeout budget used when `timeoutMs` is omitted.
+ * @param indicatorName Indicator name used in timeout validation errors.
+ * @returns A positive integer timeout budget in milliseconds.
+ * @throws {Error} When the resolved timeout is zero, negative, `NaN`, or infinite.
+ */
+export function resolveIndicatorTimeoutMs(
+  timeoutMs: number | undefined,
+  defaultTimeoutMs: number,
+  indicatorName: string,
+): number {
+  return normalizePositiveFiniteTimeoutMs(timeoutMs ?? defaultTimeoutMs, indicatorName);
+}
+
 /**
  * Create an `up` indicator result payload.
  *
@@ -57,10 +82,18 @@ export function withIndicatorTimeout<T>(
   timeoutMs: number,
   indicatorName: string,
 ): Promise<T> {
+  let normalizedTimeoutMs: number;
+
+  try {
+    normalizedTimeoutMs = normalizePositiveFiniteTimeoutMs(timeoutMs, indicatorName);
+  } catch (error: unknown) {
+    return Promise.reject(error);
+  }
+
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
-      reject(new Error(`${indicatorName} health indicator timed out after ${String(timeoutMs)}ms.`));
-    }, timeoutMs);
+      reject(new Error(`${indicatorName} health indicator timed out after ${String(normalizedTimeoutMs)}ms.`));
+    }, normalizedTimeoutMs);
 
     promise.then(
       (value) => {


### PR DESCRIPTION
## Summary

Closes #2325.

Linked context: https://github.com/fluojs/fluo/issues/2325

## Changes

- Added shared positive-finite timeout normalization for Terminus indicator-level `timeoutMs` values before timeout machinery receives them.
- Updated HTTP, Prisma, Drizzle, and Redis indicators to reject invalid indicator timeout budgets as down diagnostics before starting downstream work.
- Cancelled HTTP probe response bodies after status checks so repeated probes do not leave fetch response resources unread.
- Expanded Redis lifecycle regression coverage for documented unavailable states: `wait`, `connecting`, `reconnecting`, `close`, and `end`.
- Added a patch changeset for consumer-visible `@fluojs/terminus` runtime hardening.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/terminus test` — 12 files / 69 tests passed
- `pnpm --filter @fluojs/terminus... build`
- `pnpm --filter @fluojs/terminus typecheck`
- `pnpm exec biome lint packages/terminus/src/indicators/utils.ts packages/terminus/src/indicators/utils.test.ts packages/terminus/src/indicators/http.ts packages/terminus/src/indicators/http.test.ts packages/terminus/src/indicators/prisma.ts packages/terminus/src/indicators/prisma.test.ts packages/terminus/src/indicators/drizzle.ts packages/terminus/src/indicators/drizzle.test.ts packages/terminus/src/indicators/redis.ts packages/terminus/src/indicators/redis.test.ts`
- `pnpm lint` — passed with existing repo warnings/info; `verify:public-export-tsdoc` passed
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `git diff --check origin/main...HEAD`
- Type-suppression search for `as any`, `@ts-ignore`, `@ts-expect-error` in changed Terminus indicator files — no matches

Note: `lsp_diagnostics` could not run because the tool environment could not find the `biome` executable; package typecheck plus targeted Biome lint covered the changed files.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/sharp-rings-terminus-timeouts.md`

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or removed; implementation hardens existing indicator behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The Redis lifecycle behavior was already documented in `packages/terminus/README.md`; this PR adds direct coverage for every documented unavailable state. Invalid timeout hardening and HTTP response-body cleanup preserve the existing health-check contract by failing invalid indicator configuration deterministically and releasing response resources.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governance docs or package README files changed; package regression tests and release-lane verification cover this Terminus behavior hardening.