### PR TITLE
Resolve #2347: correct unsupported metrics dashboard-template claim

### DIFF
--- a/book/beginner/ch19-metrics.ko.md
+++ b/book/beginner/ch19-metrics.ko.md
@@ -296,7 +296,7 @@ Prometheus가 `/metrics` 엔드포인트를 스크랩하기 시작하면, Grafan
 ### 19.8.3 Sharing Dashboards: Monitoring as Code
 현대적인 엔지니어링 팀에서 대시보드는 종종 "코드(Code)"로 취급됩니다. Grafana 대시보드를 JSON 파일로 내보내고 Fluo 코드와 함께 버전 관리 시스템(Git)에 저장할 수 있습니다. 이렇게 하면 팀의 모든 개발자가 동일한 시각화 도구에 접근할 수 있고, 모니터링 로직의 변경 사항도 애플리케이션 코드처럼 검토하고 감사할 수 있습니다.
 
-Fluo는 공통적인 사용 사례(예: "API 개요", "데이터베이스 성능")에 대한 **참조 대시보드 템플릿(Reference Dashboard Templates)** 세트를 제공합니다. 이러한 템플릿을 Grafana 인스턴스로 가져와 특정 요구 사항에 맞게 커스터마이징하면, 관측성 스택을 일관된 기준에서 시작할 수 있습니다.
+현재 Fluo 저장소는 Grafana로 가져올 수 있는 대시보드 템플릿 JSON 파일을 배포하지 않습니다. 대시보드는 애플리케이션이 소유하는 모니터링 코드로 다루세요. `@fluojs/metrics`가 노출하는 Prometheus series, operations 예제, 그리고 자체 infrastructure signal을 출발점으로 삼고, 내보낸 Grafana JSON은 애플리케이션과 함께 저장하여 나머지 시스템 변경처럼 검토하고 발전시킬 수 있게 하세요.
 
 ### 19.8.4 Continuous Improvement via Metrics
 모니터링의 장기 목표는 **지속적인 개선(Continuous Improvement)**입니다. 메트릭을 사용하여 팀의 성능 목표를 설정하십시오(예: "다음 분기까지 p99 지연 시간을 20% 단축"). 성능을 가시화하고 측정 가능하게 만들면, 최적화 논의가 추측보다 데이터에 기반하게 됩니다.

--- a/book/beginner/ch19-metrics.md
+++ b/book/beginner/ch19-metrics.md
@@ -296,7 +296,7 @@ Be careful not to make alerts too sensitive. If an alert fires every time traffi
 ### 19.8.3 Sharing Dashboards: Monitoring as Code
 In modern engineering teams, dashboards are often treated as code. You can export Grafana dashboards as JSON files and store them in version control, Git, alongside Fluo code. This gives every developer on the team access to the same visualization tools, and changes to monitoring logic can be reviewed and audited just like application code.
 
-Fluo provides a set of **reference dashboard templates** for common use cases, such as "API overview" and "database performance." You can import these templates into a Grafana instance and customize them for your specific needs, giving your observability stack a consistent baseline.
+The current Fluo repository does not publish Grafana dashboard template JSON files for import. Treat dashboards as application-owned monitoring code: start from the Prometheus series exposed by `@fluojs/metrics`, the operations example, and your own infrastructure signals, then store any exported Grafana JSON alongside your application so it can be reviewed and evolved with the rest of your system.
 
 ### 19.8.4 Continuous Improvement via Metrics
 The long-term goal of monitoring is **continuous improvement**. Use metrics to set team performance goals, for example, "reduce p99 latency by 20% by next quarter." Making performance visible and measurable grounds optimization discussions in data rather than guesses.


### PR DESCRIPTION
## Summary

Linked context: Closes #2347

Correct the beginner metrics tutorial so it no longer claims that the repository ships Grafana reference dashboard template JSON files. The updated wording matches the current @fluojs/metrics package, observability docs, and examples surface: Prometheus metrics endpoints and runnable examples are available, but dashboard JSON assets are application-owned.

## Changes

- Replaced the unsupported dashboard-template claim in `book/beginner/ch19-metrics.md`.
- Applied the same correction to `book/beginner/ch19-metrics.ko.md` to preserve EN/KO parity.
- Clarified that teams should build and version their own Grafana dashboard JSON from `@fluojs/metrics`, the operations example, and their infrastructure signals.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm verify:platform-consistency-governance`
- `pnpm verify:docs`
- `GIT_MASTER=1 git diff --check`
- LSP diagnostics for both changed markdown files: no diagnostics found

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs-only correction; no public package behavior, API surface, package contents, or release metadata changed, so no `.changeset/*.md` file is included.

## Public export documentation

- [x] No public exports changed; source TSDoc requirements are not applicable.
- [x] Source `@example` blocks and README scenario examples are unchanged.

## Behavioral contract

- [x] No runtime behavior or package API contracts changed.
- [x] Intentional documentation boundary is now explicit: the repo exposes metrics signals/examples, not importable Grafana dashboard templates.
- [x] Regression tests are not applicable because this is a book-only documentation correction.

## Platform consistency governance (SSOT)

- [x] EN/KO mirror structure remains synchronized for the changed book pages.
- [x] `pnpm verify:platform-consistency-governance` passed.
- [x] `pnpm verify:docs` passed, including docs locale parity, docs typecheck, and docs build.
