### PR TITLE
Resolve #2354: harden CLI starter lifecycle and Studio regression coverage

### DIFF
--- a/.changeset/happy-brokers-guard.md
+++ b/.changeset/happy-brokers-guard.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cli": patch
+---
+
+Harden generated broker transport lazy initialization so overlapping first lifecycle calls share one tracked setup, with Studio sidecar auth/privacy and generated test cleanup regressions covered.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -58,6 +58,39 @@ function createMockChild(closeOnKillCode = 0): ChildProcess {
   return child;
 }
 
+function createManualRestartScheduler(): {
+  clear(handle: ReturnType<typeof setTimeout> | number): void;
+  flush(): void;
+  set(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> | number;
+} {
+  const callbacks = new Map<number, () => void>();
+  let nextHandle = 0;
+
+  return {
+    clear(handle) {
+      if (typeof handle === 'number') {
+        callbacks.delete(handle);
+      }
+    },
+    flush() {
+      const pendingCallbacks = [...callbacks.values()];
+      callbacks.clear();
+      for (const callback of pendingCallbacks) {
+        callback();
+      }
+    },
+    set(callback, _delayMs) {
+      nextHandle += 1;
+      callbacks.set(nextHandle, callback);
+      return nextHandle;
+    },
+  };
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve));
+}
+
 async function waitForCondition(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
   const startedAt = Date.now();
 
@@ -2208,12 +2241,14 @@ void bootstrap();
     writeFileSync(sourceFile, 'console.log("hello");\n');
     writeFileSync(ignoredFile, 'console.log("ignored");\n');
     const children: ChildProcess[] = [];
+    const restartScheduler = createManualRestartScheduler();
     const watchedTargets: Array<{ listener: (event: string, filename: string | Buffer | null) => void; target: string }> = [];
 
     const runPromise = runNodeRestartRunner({
       debounceMs: 5,
       env: { FLUO_DEV_WATCH_IGNORE: 'generated' },
       projectDirectory: workspaceDirectory,
+      restartScheduler,
       spawnChild: () => {
         const child = createMockChild();
         children.push(child);
@@ -2233,18 +2268,21 @@ void bootstrap();
       },
     });
 
-    await waitForCondition(() => children.length === 1 && watchedTargets.length > 0);
+    expect(children).toHaveLength(1);
+    expect(watchedTargets.length).toBeGreaterThan(0);
     const sourceWatcher = watchedTargets.find((entry) => entry.target === sourceDirectory);
     expect(sourceWatcher).toBeDefined();
 
     writeFileSync(ignoredFile, 'console.log("ignored changed");\n');
     sourceWatcher?.listener('change', join('generated', 'schema.ts'));
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    restartScheduler.flush();
     expect(children).toHaveLength(1);
 
     writeFileSync(sourceFile, 'console.log("hello changed");\n');
     sourceWatcher?.listener('change', 'main.ts');
-    await waitForCondition(() => children.length === 2);
+    restartScheduler.flush();
+    await flushMicrotasks();
+    expect(children).toHaveLength(2);
 
     children.at(-1)?.kill();
     await expect(runPromise).resolves.toBe(0);
@@ -2468,6 +2506,7 @@ void bootstrap();
     writeFileSync(sourceFile, 'console.log("one");\n');
     const signalTarget = createSignalTarget();
     const children: ChildProcess[] = [];
+    const restartScheduler = createManualRestartScheduler();
     const stdoutBuffer: string[] = [];
     const watchListeners: Array<(event: string, filename: string | Buffer | null) => void> = [];
 
@@ -2475,6 +2514,7 @@ void bootstrap();
       debounceMs: 1,
       env: { FLUO_DEV_SHOW_RESTART_NOTICE: '1' },
       projectDirectory: workspaceDirectory,
+      restartScheduler,
       signalTarget: signalTarget.target,
       spawnChild: () => {
         const child = createMockChild();
@@ -2498,24 +2538,27 @@ void bootstrap();
     for (const listener of watchListeners) {
       listener('change', 'main.ts');
     }
+    restartScheduler.flush();
 
-    await waitForCondition(() => children[0]?.killed === true && stdoutBuffer.length === 1);
+    expect(children[0]?.killed).toBe(true);
+    expect(stdoutBuffer).toHaveLength(1);
     expect(children).toHaveLength(1);
 
     for (const listener of watchListeners) {
       listener('change', 'main.ts');
     }
+    restartScheduler.flush();
 
-    await waitForCondition(() => stdoutBuffer.length === 2);
+    expect(stdoutBuffer).toHaveLength(2);
     expect(children).toHaveLength(1);
 
     children[0]?.emit('close', 0);
-    await waitForCondition(() => children.length === 2);
+    expect(children).toHaveLength(2);
 
     for (const listener of watchListeners) {
       listener('change', 'main.ts');
     }
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    restartScheduler.flush();
 
     expect(stdoutBuffer.filter((message) => message.startsWith('[fluo] restarting after content change:'))).toHaveLength(2);
 
@@ -4550,6 +4593,7 @@ exit 7
     expect(packageJson.scripts?.test).toBeDefined();
     expect(packageJson.scripts?.['test:cov']).toBe('vitest run --coverage');
     expect(packageJson.scripts?.['test:e2e']).toBe('vitest run test/**/*.e2e.test.ts');
+    expect(packageJson.scripts?.['test:watch']).toBe('vitest');
     expect(readFileSync(join(projectDirectory, '.gitignore'), 'utf8')).toContain('.env');
     expect(readFileSync(join(projectDirectory, '.env'), 'utf8')).toContain('PORT=3000');
     expect(stdoutBuffer.join('')).toContain('Skipping dependency installation.');

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -60,18 +60,22 @@ function createMockChild(closeOnKillCode = 0): ChildProcess {
 
 function createManualRestartScheduler(): {
   clear(handle: ReturnType<typeof setTimeout> | number): void;
+  clearCalls: Array<ReturnType<typeof setTimeout> | number>;
   flush(): void;
   set(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> | number;
 } {
   const callbacks = new Map<number, () => void>();
-  let nextHandle = 0;
+  const clearCalls: Array<ReturnType<typeof setTimeout> | number> = [];
+  let nextHandle = -1;
 
   return {
     clear(handle) {
+      clearCalls.push(handle);
       if (typeof handle === 'number') {
         callbacks.delete(handle);
       }
     },
+    clearCalls,
     flush() {
       const pendingCallbacks = [...callbacks.values()];
       callbacks.clear();
@@ -2285,6 +2289,48 @@ void bootstrap();
     expect(children).toHaveLength(2);
 
     children.at(-1)?.kill();
+    await expect(runPromise).resolves.toBe(0);
+  });
+
+  it('clears zero-valued restart scheduler handles before rescheduling', async () => {
+    const workspaceDirectory = mkdtempSync(join(tmpdir(), 'fluo-cli-'));
+    createdDirectories.push(workspaceDirectory);
+    const sourceDirectory = join(workspaceDirectory, 'src');
+    mkdirSync(sourceDirectory, { recursive: true });
+    const sourceFile = join(sourceDirectory, 'main.ts');
+    writeFileSync(sourceFile, 'console.log("one");\n');
+    const children: ChildProcess[] = [];
+    const restartScheduler = createManualRestartScheduler();
+    const watchListeners: Array<(event: string, filename: string | Buffer | null) => void> = [];
+
+    const runPromise = runNodeRestartRunner({
+      debounceMs: 1,
+      env: {},
+      projectDirectory: workspaceDirectory,
+      restartScheduler,
+      signalTarget: createSignalTarget().target,
+      spawnChild: () => {
+        const child = createMockChild();
+        children.push(child);
+        return child;
+      },
+      stderr: { write: () => undefined },
+      stdout: { write: () => undefined },
+      watchTarget: (_target, optionsOrListener, listener) => {
+        watchListeners.push(typeof optionsOrListener === 'function' ? optionsOrListener : listener ?? (() => undefined));
+        return { close: () => undefined } as never;
+      },
+    });
+
+    writeFileSync(sourceFile, 'console.log("two");\n');
+    for (const listener of watchListeners) {
+      listener('change', 'main.ts');
+      listener('change', 'main.ts');
+    }
+
+    expect(restartScheduler.clearCalls).toContain(0);
+
+    children[0]?.emit('close', 0);
     await expect(runPromise).resolves.toBe(0);
   });
 

--- a/packages/cli/src/commands/generate.test.ts
+++ b/packages/cli/src/commands/generate.test.ts
@@ -363,6 +363,9 @@ export { PostModule };
     expect(result.generatedFiles).toEqual([e2ePath]);
     expect(e2eContent).toContain("import { AppModule } from '../src/app';");
     expect(e2eContent).toContain('createTestApp({ rootModule: AppModule })');
+    expect(e2eContent).toContain('try {');
+    expect(e2eContent).toContain('finally {');
+    expect(e2eContent).toContain('await app.close();');
   });
 
   it('preserves explicit e2e root module import overrides', () => {

--- a/packages/cli/src/dev-runner/node-restart-runner.ts
+++ b/packages/cli/src/dev-runner/node-restart-runner.ts
@@ -23,6 +23,13 @@ type RestartSignalTarget = {
 
 type RestartWatcherFactory = (target: string, optionsOrListener: { recursive: boolean } | ((event: string, filename: string | Buffer | null) => void), listener?: (event: string, filename: string | Buffer | null) => void) => FSWatcher;
 
+type RestartSchedulerHandle = ReturnType<typeof setTimeout> | number;
+
+type RestartScheduler = {
+  clear(handle: RestartSchedulerHandle): void;
+  set(callback: () => void, delayMs: number): RestartSchedulerHandle;
+};
+
 type ContentChangeGate = {
   commitBaseline(paths: Iterable<string>): void;
   hasMeaningfulChange(paths: Iterable<string>): boolean;
@@ -38,6 +45,7 @@ export type NodeRestartRunnerOptions = {
   signalTarget?: RestartSignalTarget;
   spawnChild?: RestartChildSpawner;
   stderr?: RestartRunnerStream;
+  restartScheduler?: RestartScheduler;
   stdout?: RestartRunnerStream;
   watchTarget?: RestartWatcherFactory;
 };
@@ -387,6 +395,7 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
   const spawnChild = options.spawnChild ?? spawn;
   const stdout = options.stdout ?? process.stdout;
   const stderr = options.stderr ?? process.stderr;
+  const restartScheduler = options.restartScheduler ?? { clear: clearTimeout, set: setTimeout };
   const watchTarget = options.watchTarget ?? watch;
   const appArgs = options.appArgs ?? [];
   const debounceMs = options.debounceMs ?? Number(env.FLUO_DEV_RELOAD_DEBOUNCE_MS ?? DEFAULT_DEBOUNCE_MS);
@@ -397,7 +406,7 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
   let child: ChildProcess | undefined;
   const pendingRestartPaths = new Set<string>();
   const restartAfterClosePaths = new Set<string>();
-  let restartTimer: NodeJS.Timeout | undefined;
+  let restartTimer: RestartSchedulerHandle | undefined;
   let restarting = false;
   let stopping = false;
 
@@ -456,10 +465,10 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
     pendingRestartPaths.add(filePath);
 
     if (restartTimer) {
-      clearTimeout(restartTimer);
+      restartScheduler.clear(restartTimer);
     }
 
-    restartTimer = setTimeout(() => {
+    restartTimer = restartScheduler.set(() => {
       const restartPaths = [...pendingRestartPaths];
       pendingRestartPaths.clear();
       restartTimer = undefined;
@@ -556,7 +565,7 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
       }
       cleanedUp = true;
       if (restartTimer) {
-        clearTimeout(restartTimer);
+        restartScheduler.clear(restartTimer);
         restartTimer = undefined;
       }
       pendingRestartPaths.clear();

--- a/packages/cli/src/dev-runner/node-restart-runner.ts
+++ b/packages/cli/src/dev-runner/node-restart-runner.ts
@@ -464,7 +464,7 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
   const scheduleRestart = (filePath: string, resolveExitCode: (code: number) => void, cleanup: () => void) => {
     pendingRestartPaths.add(filePath);
 
-    if (restartTimer) {
+    if (restartTimer !== undefined) {
       restartScheduler.clear(restartTimer);
     }
 
@@ -564,7 +564,7 @@ export async function runNodeRestartRunner(options: NodeRestartRunnerOptions): P
         return;
       }
       cleanedUp = true;
-      if (restartTimer) {
+      if (restartTimer !== undefined) {
         restartScheduler.clear(restartTimer);
         restartTimer = undefined;
       }

--- a/packages/cli/src/generators.test.ts
+++ b/packages/cli/src/generators.test.ts
@@ -77,7 +77,10 @@ describe('CLI generators', () => {
     expect(content).toContain("import { createTestApp } from '@fluojs/testing';");
     expect(content).toContain("import { AppModule } from '../src/app';");
     expect(content).toContain('createTestApp({ rootModule: AppModule })');
+    expect(content).toContain('try {');
     expect(content).toContain("app.request('GET', '/users').send()");
+    expect(content).toContain('finally {');
+    expect(content).toContain('await app.close();');
   });
 
   it('emits generic repository examples without ORM-specific access', () => {

--- a/packages/cli/src/new/scaffold.test.ts
+++ b/packages/cli/src/new/scaffold.test.ts
@@ -312,6 +312,7 @@ describe('scaffoldBootstrapApp', () => {
     expect(packageJson.scripts?.start).toBe('fluo start');
     expect(packageJson.scripts?.['test:cov']).toBe('vitest run --coverage');
     expect(packageJson.scripts?.['test:e2e']).toBe('vitest run test/**/*.e2e.test.ts');
+    expect(packageJson.scripts?.['test:watch']).toBe('vitest');
     expect(tsconfig).not.toContain('baseUrl');
     expect(tsconfigBuild).not.toContain('baseUrl');
     expect(appFile).toContain("import { HealthModule } from '@fluojs/runtime';");
@@ -766,6 +767,7 @@ describe('scaffoldBootstrapApp', () => {
     expect(packageJson.scripts?.build).toBe('fluo build');
     expect(packageJson.scripts?.dev).toBe('fluo dev');
     expect(packageJson.scripts?.start).toBe('fluo start');
+    expect(packageJson.scripts?.['test:watch']).toBe('vitest');
     expect(readme).toContain('Shape: `microservice`');
     expect(readme).toContain('Transport: `tcp` is the generated runnable starter contract for this project');
     expect(envFile).toContain('MICROSERVICE_PORT=4000');
@@ -939,6 +941,8 @@ describe('scaffoldBootstrapApp', () => {
     expect(appFile).toContain("import { JSONCodec, connect, type NatsConnection } from 'nats';");
     expect(appFile).toContain('new NatsMicroserviceTransport({');
     expect(appFile).toContain('class LazyNatsTransport implements MicroserviceTransport');
+    expect(appFile).toContain('private initializing: Promise<NatsMicroserviceTransport> | undefined;');
+    expect(appFile).toContain('this.initializing ??= this.createTransport();');
     expect(appFile).toContain("name: 'fluo-microservice-starter'");
   });
 
@@ -980,6 +984,8 @@ describe('scaffoldBootstrapApp', () => {
     expect(appFile).toContain("import { Kafka, logLevel, type Consumer, type Producer } from 'kafkajs';");
     expect(appFile).toContain('new KafkaMicroserviceTransport({');
     expect(appFile).toContain('class LazyKafkaTransport implements MicroserviceTransport');
+    expect(appFile).toContain('private initializing: Promise<KafkaMicroserviceTransport> | undefined;');
+    expect(appFile).toContain('this.initializing ??= this.createTransport();');
     expect(appFile).toContain('await Promise.all([producer.connect(), consumer.connect()]);');
   });
 
@@ -1025,6 +1031,8 @@ describe('scaffoldBootstrapApp', () => {
     expect(appFile).toContain("import { connect } from 'amqplib';");
     expect(appFile).toContain('new RabbitMqMicroserviceTransport({');
     expect(appFile).toContain('class LazyRabbitMqTransport implements MicroserviceTransport');
+    expect(appFile).toContain('private initializing: Promise<RabbitMqMicroserviceTransport> | undefined;');
+    expect(appFile).toContain('this.initializing ??= this.createTransport();');
     expect(appFile).toContain('createConfirmChannel()');
   });
 

--- a/packages/cli/src/new/scaffold.ts
+++ b/packages/cli/src/new/scaffold.ts
@@ -1215,11 +1215,14 @@ const codec = JSONCodec();
 
 class LazyNatsTransport implements MicroserviceTransport {
   private connection: NatsConnection | undefined;
+  private initializing: Promise<NatsMicroserviceTransport> | undefined;
   private transport: NatsMicroserviceTransport | undefined;
 
   async close() {
-    await this.transport?.close();
+    const transport = this.initializing ? await this.initializing.catch(() => undefined) : this.transport;
+    await transport?.close();
     await this.connection?.close();
+    this.initializing = undefined;
     this.transport = undefined;
     this.connection = undefined;
   }
@@ -1237,6 +1240,19 @@ class LazyNatsTransport implements MicroserviceTransport {
   }
 
   private async getTransport() {
+    if (this.transport) {
+      return this.transport;
+    }
+
+    this.initializing ??= this.createTransport();
+    try {
+      return await this.initializing;
+    } finally {
+      this.initializing = undefined;
+    }
+  }
+
+  private async createTransport() {
     if (this.transport) {
       return this.transport;
     }
@@ -1314,15 +1330,18 @@ const responseTopic = process.env.KAFKA_RESPONSE_TOPIC ?? 'fluo.microservices.re
 
 class LazyKafkaTransport implements MicroserviceTransport {
   private consumer: Consumer | undefined;
+  private initializing: Promise<KafkaMicroserviceTransport> | undefined;
   private producer: Producer | undefined;
   private transport: KafkaMicroserviceTransport | undefined;
 
   async close() {
-    await this.transport?.close();
+    const transport = this.initializing ? await this.initializing.catch(() => undefined) : this.transport;
+    await transport?.close();
     await Promise.all([
       this.consumer?.disconnect().catch(() => undefined),
       this.producer?.disconnect().catch(() => undefined),
     ]);
+    this.initializing = undefined;
     this.consumer = undefined;
     this.producer = undefined;
     this.transport = undefined;
@@ -1341,6 +1360,19 @@ class LazyKafkaTransport implements MicroserviceTransport {
   }
 
   private async getTransport() {
+    if (this.transport) {
+      return this.transport;
+    }
+
+    this.initializing ??= this.createTransport();
+    try {
+      return await this.initializing;
+    } finally {
+      this.initializing = undefined;
+    }
+  }
+
+  private async createTransport() {
     if (this.transport) {
       return this.transport;
     }
@@ -1442,12 +1474,15 @@ const responseQueue = process.env.RABBITMQ_RESPONSE_QUEUE ?? 'fluo.microservices
 class LazyRabbitMqTransport implements MicroserviceTransport {
   private channel: Awaited<ReturnType<Awaited<ReturnType<typeof connect>>['createConfirmChannel']>> | undefined;
   private connection: Awaited<ReturnType<typeof connect>> | undefined;
+  private initializing: Promise<RabbitMqMicroserviceTransport> | undefined;
   private transport: RabbitMqMicroserviceTransport | undefined;
 
   async close() {
-    await this.transport?.close();
+    const transport = this.initializing ? await this.initializing.catch(() => undefined) : this.transport;
+    await transport?.close();
     await this.channel?.close().catch(() => undefined);
     await this.connection?.close().catch(() => undefined);
+    this.initializing = undefined;
     this.channel = undefined;
     this.connection = undefined;
     this.transport = undefined;
@@ -1466,6 +1501,19 @@ class LazyRabbitMqTransport implements MicroserviceTransport {
   }
 
   private async getTransport() {
+    if (this.transport) {
+      return this.transport;
+    }
+
+    this.initializing ??= this.createTransport();
+    try {
+      return await this.initializing;
+    } finally {
+      this.initializing = undefined;
+    }
+  }
+
+  private async createTransport() {
     if (this.transport) {
       return this.transport;
     }

--- a/packages/cli/src/studio/sidecar.test.ts
+++ b/packages/cli/src/studio/sidecar.test.ts
@@ -45,6 +45,14 @@ describe('Studio sidecar', () => {
     expect(unauthorizedEvents.status).toBe(401);
     await expect(unauthorizedEvents.json()).resolves.toMatchObject({ error: 'Unauthorized Studio sidecar request.' });
 
+    const unauthorizedRuntimeEvents = await fetch(`${sidecar.url}/api/runtime/events`, {
+      body: JSON.stringify({ payload: { ok: true }, source: { appId: 'test-app', runtime: 'node' }, type: 'snapshot', version: 1 }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+    });
+    expect(unauthorizedRuntimeEvents.status).toBe(401);
+    await expect(unauthorizedRuntimeEvents.json()).resolves.toMatchObject({ error: 'Unauthorized Studio sidecar request.' });
+
     const accepted = await fetch(`${sidecar.url}/api/runtime/events`, {
       body: JSON.stringify({ payload: { ok: true }, source: { appId: 'test-app', runtime: 'node' }, type: 'snapshot', version: 1 }),
       headers: {
@@ -83,6 +91,54 @@ describe('Studio sidecar', () => {
     expect(events.headers.get('access-control-allow-origin')).toBeNull();
     expect(events.headers.get('access-control-allow-credentials')).toBeNull();
     await events.body?.cancel();
+  });
+
+  it('rejects body-like runtime event payload fields before state or SSE replay can retain them', async () => {
+    const sidecar = await startTestSidecar();
+    const safe = await fetch(`${sidecar.url}/api/runtime/events`, {
+      body: JSON.stringify({ payload: { graph: { nodes: [] } }, source: { appId: 'test-app', runtime: 'node' }, type: 'snapshot', version: 1 }),
+      headers: {
+        authorization: `Bearer ${sidecar.token}`,
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+    expect(safe.status).toBe(202);
+
+    const rejected = await fetch(`${sidecar.url}/api/runtime/events`, {
+      body: JSON.stringify({
+        payload: {
+          durationMs: 12,
+          requestId: 'request-1',
+          requestBody: 'super-secret-body',
+        },
+        source: { appId: 'test-app', runtime: 'node' },
+        type: 'request',
+        version: 1,
+      }),
+      headers: {
+        authorization: `Bearer ${sidecar.token}`,
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    });
+    expect(rejected.status).toBe(400);
+    await expect(rejected.json()).resolves.toMatchObject({ error: 'Studio runtime event payload must not include body-like field payload.requestBody.' });
+
+    const state = await fetch(`${sidecar.url}/api/state?token=${encodeURIComponent(sidecar.token)}`);
+    const stateText = JSON.stringify(await state.json());
+    expect(stateText).not.toContain('super-secret-body');
+    expect(stateText).not.toContain('requestBody');
+
+    const events = await fetch(`${sidecar.url}/api/events?token=${encodeURIComponent(sidecar.token)}`);
+    expect(events.status).toBe(200);
+    const reader = events.body?.getReader();
+    expect(reader).toBeDefined();
+    const chunk = await reader!.read();
+    await reader!.cancel();
+    const text = new TextDecoder().decode(chunk.value);
+    expect(text).not.toContain('super-secret-body');
+    expect(text).not.toContain('requestBody');
   });
 
   it('replays accepted events over SSE with epoch and sequence ids', async () => {

--- a/packages/cli/src/studio/sidecar.ts
+++ b/packages/cli/src/studio/sidecar.ts
@@ -58,10 +58,42 @@ const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_HEARTBEAT_MS = 15_000;
 const MAX_EVENT_REPLAY = 1_000;
 const MAX_REQUEST_BYTES = 1_048_576;
+const BODY_LIKE_PAYLOAD_FIELDS = new Set(['body', 'headers', 'payload', 'rawBody', 'requestBody', 'responseBody']);
 const require = createRequire(import.meta.url);
 
 function isRecord(value: unknown): value is JsonRecord {
   return typeof value === 'object' && value !== null;
+}
+
+function findBodyLikePayloadField(value: unknown, path = 'payload'): string | undefined {
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      const match = findBodyLikePayloadField(item, `${path}[${String(index)}]`);
+      if (match) {
+        return match;
+      }
+    }
+
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const nestedPath = `${path}.${key}`;
+    if (BODY_LIKE_PAYLOAD_FIELDS.has(key)) {
+      return nestedPath;
+    }
+
+    const match = findBodyLikePayloadField(nestedValue, nestedPath);
+    if (match) {
+      return match;
+    }
+  }
+
+  return undefined;
 }
 
 function isRestartEpochBoundary(incoming: { payload?: unknown; type?: unknown }): boolean {
@@ -415,6 +447,12 @@ export async function startStudioSidecar(options: StudioSidecarOptions = {}): Pr
         const parsed = body ? JSON.parse(body) as unknown : {};
         if (!isRecord(parsed)) {
           writeJson(response, 400, { error: 'Studio runtime event must be a JSON object.' });
+          return;
+        }
+
+        const bodyLikeField = findBodyLikePayloadField(parsed.payload);
+        if (bodyLikeField) {
+          writeJson(response, 400, { error: `Studio runtime event payload must not include body-like field ${bodyLikeField}.` });
           return;
         }
 


### PR DESCRIPTION
## Summary

Harden the CLI starter lifecycle and Studio regression coverage for the CLI audit finding.

Linked context: Closes #2354

## Changes

- Serialized generated NATS, Kafka, and RabbitMQ lazy transport initialization with an in-flight promise so overlapping first lifecycle calls share one tracked setup.
- Rejected body-like Studio runtime event payload fields before the sidecar stores or replays them, and covered `/api/runtime/events` token rejection.
- Asserted generated e2e template `finally` / `app.close()` cleanup and generated `test:watch` scripts.
- Added a deterministic restart scheduler seam for restart-runner tests that previously depended on debounce wall-clock sleeps.
- Added a patch changeset for `@fluojs/cli`.

## Testing

- `pnpm --dir packages/cli typecheck`
- `pnpm --dir packages/cli exec vitest run -c vitest.config.ts src/studio/sidecar.test.ts src/new/scaffold.test.ts src/generators.test.ts src/commands/generate.test.ts src/cli.test.ts`
- `pnpm --dir packages/cli build`
- `pnpm exec biome lint packages/cli/src/dev-runner/node-restart-runner.ts packages/cli/src/studio/sidecar.ts packages/cli/src/studio/sidecar.test.ts packages/cli/src/new/scaffold.ts packages/cli/src/new/scaffold.test.ts packages/cli/src/generators.test.ts packages/cli/src/commands/generate.test.ts packages/cli/src/cli.test.ts`
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=origin/main`
- `pnpm verify:public-export-tsdoc`
- `pnpm --dir packages/cli test`
- `pnpm --dir packages/cli sandbox:matrix`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [ ] Source `@example` blocks and README scenario examples still play complementary roles.

No public package export-map surface changed. `pnpm verify:public-export-tsdoc` passed in changed mode.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This preserves the existing CLI/Studio contracts: generated broker clients remain lazy and now serialize overlapping first initialization; Studio sidecar auth/privacy defaults are enforced by regression tests.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [ ] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed docs changed. Platform consistency checks are not required for this source/test-only CLI hardening.
