### PR TITLE
Resolve #2366: strengthen notifications module visibility coverage

### DIFF
--- a/book/intermediate/ch15-notifications.ko.md
+++ b/book/intermediate/ch15-notifications.ko.md
@@ -305,15 +305,20 @@ async onOrderPlaced(event: OrderPlacedEvent) {
 
 ### Services and Tokens
 - `NotificationsService`: `dispatch(...)`, `dispatchMany(...)`, `createPlatformStatusSnapshot()`을 위한 기본 API.
+- `Notifications`: `NOTIFICATIONS` token 값이 구현하는 compatibility facade interface.
 - `NOTIFICATIONS`: `dispatch(...)`와 `dispatchMany(...)`를 노출하는 compatibility facade token.
 - `NOTIFICATION_CHANNELS`: 정규화된 channel list를 위한 token.
 
 ### Dispatch and Channel Contracts
 - `NotificationChannel`: 새로운 delivery Provider를 위한 계약.
+- `NotificationChannelContext`: cancellation signal forwarding을 포함하는 dispatch별 channel context.
+- `NotificationChannelDelivery`: external id, status, provider metadata를 위한 channel return contract.
+- `NotificationPayload`: channel provider로 그대로 전달되는 opaque payload shape.
 - `NotificationDispatchRequest`: dispatch 시도를 위한 스키마.
 - `NotificationDispatchOptions`: queue preference, abort signal, lifecycle publication을 위한 단건 dispatch control.
 - `NotificationDispatchManyOptions`: `continueOnError`를 포함한 batch control.
 - `NotificationDispatchResult`: 직접 또는 queued notification 하나에 대한 정규화된 결과.
+- `NotificationDispatchStatus`: direct 및 queue-backed path의 delivery status union.
 - `NotificationDispatchBatchResult`: `dispatchMany(...)`가 반환하는 요약.
 - `NotificationDispatchFailure`: tolerant batch operation이 반환하는 실패 entry.
 

--- a/book/intermediate/ch15-notifications.md
+++ b/book/intermediate/ch15-notifications.md
@@ -305,15 +305,20 @@ These limitations keep the orchestration layer stable even when the underlying t
 
 ### Services and Tokens
 - `NotificationsService`: The primary API for `dispatch(...)`, `dispatchMany(...)`, and `createPlatformStatusSnapshot()`.
+- `Notifications`: Compatibility facade interface implemented by the `NOTIFICATIONS` token value.
 - `NOTIFICATIONS`: Compatibility facade token exposing `dispatch(...)` and `dispatchMany(...)`.
 - `NOTIFICATION_CHANNELS`: Token for the normalized channel list.
 
 ### Dispatch and Channel Contracts
 - `NotificationChannel`: Contract for a new delivery Provider.
+- `NotificationChannelContext`: Per-dispatch channel context including cancellation signal forwarding.
+- `NotificationChannelDelivery`: Channel return contract for external ids, status, and provider metadata.
+- `NotificationPayload`: Opaque payload shape passed through to channel providers.
 - `NotificationDispatchRequest`: Schema for a dispatch attempt.
 - `NotificationDispatchOptions`: Single-dispatch controls for queue preference, abort signal, and lifecycle publication.
 - `NotificationDispatchManyOptions`: Batch controls, including `continueOnError`.
 - `NotificationDispatchResult`: Normalized result for one direct or queued notification.
+- `NotificationDispatchStatus`: Delivery status union for direct and queue-backed paths.
 - `NotificationDispatchBatchResult`: Summary returned by `dispatchMany(...)`.
 - `NotificationDispatchFailure`: Failure entry returned by tolerant batch operations.
 

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -48,6 +48,7 @@
     "@fluojs/runtime": "workspace:^"
   },
   "devDependencies": {
+    "@fluojs/testing": "workspace:^",
     "vitest": "^3.2.4"
   }
 }

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -1,6 +1,7 @@
-import { type Constructor, Inject, type Token } from '@fluojs/core';
+import { type Constructor, Inject, Module, type Token } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Container, type Provider } from '@fluojs/di';
+import { createTestingModule } from '@fluojs/testing';
 import { describe, expect, it } from 'vitest';
 
 import { NotificationChannelNotFoundError, NotificationQueueNotConfiguredError } from './errors.js';
@@ -65,6 +66,42 @@ class RecordingQueueAdapter implements NotificationsQueueAdapter {
   }
 }
 
+class LifecycleAwareQueueAdapter extends RecordingQueueAdapter {
+  constructor(private readonly lifecycleCalls: string[]) {
+    super();
+  }
+
+  async close(): Promise<void> {
+    this.lifecycleCalls.push('queue.close');
+  }
+
+  async drain(): Promise<void> {
+    this.lifecycleCalls.push('queue.drain');
+  }
+
+  onDestroy(): void {
+    this.lifecycleCalls.push('queue.onDestroy');
+  }
+}
+
+class LifecycleAwarePublisher extends RecordingPublisher {
+  constructor(private readonly lifecycleCalls: string[]) {
+    super();
+  }
+
+  async close(): Promise<void> {
+    this.lifecycleCalls.push('publisher.close');
+  }
+
+  async drain(): Promise<void> {
+    this.lifecycleCalls.push('publisher.drain');
+  }
+
+  onDestroy(): void {
+    this.lifecycleCalls.push('publisher.onDestroy');
+  }
+}
+
 class MalformedEnqueueManyQueueAdapter implements NotificationsQueueAdapter {
   readonly jobs: NotificationsQueueJob[] = [];
 
@@ -109,6 +146,145 @@ class FailingEnqueueOnlyQueueAdapter implements NotificationsQueueAdapter {
 }
 
 describe('NotificationsModule', () => {
+  it('makes default global providers visible through a real testing module graph', async () => {
+    const deliveries: string[] = [];
+
+    @Inject(NotificationsService)
+    class RootNotificationsProbe {
+      constructor(private readonly notifications: NotificationsService) {}
+
+      send(): Promise<NotificationDispatchResult> {
+        return this.notifications.dispatch({ channel: 'email', payload: { template: 'global-visible' } });
+      }
+    }
+
+    @Module({
+      imports: [
+        NotificationsModule.forRoot({
+          channels: [
+            {
+              channel: 'email',
+              async send(notification: NotificationDispatchRequest) {
+                deliveries.push(String(notification.payload.template));
+
+                return { externalId: 'global-delivery' };
+              },
+            },
+          ],
+        }),
+      ],
+    })
+    class NotificationsOwnerModule {}
+
+    @Module({
+      imports: [NotificationsOwnerModule],
+      providers: [RootNotificationsProbe],
+    })
+    class AppModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AppModule }).compile();
+
+    try {
+      const probe = await testingModule.resolve<RootNotificationsProbe>(RootNotificationsProbe);
+
+      await expect(probe.send()).resolves.toMatchObject({
+        deliveryId: 'global-delivery',
+        queued: false,
+        status: 'delivered',
+      });
+      expect(deliveries).toEqual(['global-visible']);
+    } finally {
+      await testingModule.container.dispose();
+    }
+  });
+
+  it('keeps providers usable inside the importing module when global visibility is disabled', async () => {
+    const deliveries: string[] = [];
+
+    @Inject(NotificationsService)
+    class LocalNotificationsProbe {
+      constructor(private readonly notifications: NotificationsService) {}
+
+      send(): Promise<NotificationDispatchResult> {
+        return this.notifications.dispatch({ channel: 'email', payload: { template: 'local-visible' } });
+      }
+    }
+
+    @Module({
+      imports: [
+        NotificationsModule.forRoot({
+          channels: [
+            {
+              channel: 'email',
+              async send(notification: NotificationDispatchRequest) {
+                deliveries.push(String(notification.payload.template));
+
+                return { externalId: 'local-delivery' };
+              },
+            },
+          ],
+          global: false,
+        }),
+      ],
+      providers: [LocalNotificationsProbe],
+    })
+    class NotificationsOwnerModule {}
+
+    @Module({
+      imports: [NotificationsOwnerModule],
+    })
+    class AppModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AppModule }).compile();
+
+    try {
+      const probe = await testingModule.resolve<LocalNotificationsProbe>(LocalNotificationsProbe);
+
+      await expect(probe.send()).resolves.toMatchObject({
+        deliveryId: 'local-delivery',
+        queued: false,
+        status: 'delivered',
+      });
+      expect(deliveries).toEqual(['local-visible']);
+    } finally {
+      await testingModule.container.dispose();
+    }
+  });
+
+  it('does not expose module-local providers to sibling/root providers in a real testing module graph', async () => {
+    @Inject(NotificationsService)
+    class RootNotificationsProbe {
+      constructor(readonly notifications: NotificationsService) {}
+    }
+
+    @Module({
+      imports: [
+        NotificationsModule.forRoot({
+          channels: [
+            {
+              channel: 'email',
+              async send() {
+                return { externalId: 'local-only' };
+              },
+            },
+          ],
+          global: false,
+        }),
+      ],
+    })
+    class NotificationsOwnerModule {}
+
+    @Module({
+      imports: [NotificationsOwnerModule],
+      providers: [RootNotificationsProbe],
+    })
+    class AppModule {}
+
+    await expect(createTestingModule({ rootModule: AppModule }).compile()).rejects.toThrow(
+      /not visible through a global module|NotificationsService/,
+    );
+  });
+
   it('registers sync providers and dispatches through a configured channel', async () => {
     const deliveries: Array<{ payload: Record<string, unknown>; recipients?: readonly string[] }> = [];
     const container = new Container();
@@ -249,9 +425,9 @@ describe('NotificationsModule', () => {
 
     expect(result).toMatchObject({ deliveryId: 'queued:1', queued: true, status: 'queued' });
     expect(queue.jobs).toHaveLength(1);
+    expect(queue.jobs[0]?.id).toMatch(/^notification:email:[a-z0-9]{7}$/);
     expect(queue.jobs[0]).toMatchObject({
       channel: 'email',
-      id: 'notification:email:1qpsje2',
       notification: { channel: 'email', payload: { template: 'single' } },
     });
   });
@@ -311,11 +487,63 @@ describe('NotificationsModule', () => {
     await service.dispatch(request, { queue: true });
     await service.dispatch({ ...request, id: 'caller-job-id' }, { queue: true });
 
-    expect(queue.jobs.map((job) => job.id)).toEqual([
-      'notification:email:05en8lg',
-      'notification:email:05en8lg',
-      'caller-job-id',
-    ]);
+    const [firstJob, repeatedJob, callerJob] = queue.jobs;
+
+    expect(firstJob?.id).toMatch(/^notification:email:[a-z0-9]{7}$/);
+    expect(repeatedJob?.id).toBe(firstJob?.id);
+    expect(callerJob?.id).toBe('caller-job-id');
+  });
+
+  it('does not close or drain application-owned queue and event publisher resources during testing module disposal', async () => {
+    const lifecycleCalls: string[] = [];
+    const queue = new LifecycleAwareQueueAdapter(lifecycleCalls);
+    const publisher = new LifecycleAwarePublisher(lifecycleCalls);
+
+    @Module({
+      imports: [
+        NotificationsModule.forRoot({
+          channels: [
+            {
+              channel: 'email',
+              async send() {
+                throw new Error('direct delivery should not run when queue is explicitly requested');
+              },
+            },
+          ],
+          events: {
+            publisher,
+          },
+          queue: {
+            adapter: queue,
+            bulkThreshold: 1,
+          },
+        }),
+      ],
+    })
+    class AppModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AppModule }).compile();
+
+    try {
+      const service = await testingModule.resolve<NotificationsService>(NotificationsService);
+
+      await expect(
+        service.dispatch({ channel: 'email', payload: { template: 'queued-owned-by-app' } }, { queue: true }),
+      ).resolves.toMatchObject({
+        deliveryId: 'queued:1',
+        queued: true,
+        status: 'queued',
+      });
+      expect(queue.jobs).toHaveLength(1);
+      expect(publisher.events.map((event) => event.name)).toEqual([
+        'notification.dispatch.requested',
+        'notification.dispatch.queued',
+      ]);
+    } finally {
+      await testingModule.container.dispose();
+    }
+
+    expect(lifecycleCalls).toEqual([]);
   });
 
   it('publishes a failed lifecycle event when explicit queue dispatch enqueue fails', async () => {

--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -1,6 +1,7 @@
 import { type Constructor, Inject, Module, type Token } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Container, type Provider } from '@fluojs/di';
+import { FluoFactory } from '@fluojs/runtime';
 import { createTestingModule } from '@fluojs/testing';
 import { describe, expect, it } from 'vitest';
 
@@ -494,10 +495,21 @@ describe('NotificationsModule', () => {
     expect(callerJob?.id).toBe('caller-job-id');
   });
 
-  it('does not close or drain application-owned queue and event publisher resources during testing module disposal', async () => {
-    const lifecycleCalls: string[] = [];
-    const queue = new LifecycleAwareQueueAdapter(lifecycleCalls);
-    const publisher = new LifecycleAwarePublisher(lifecycleCalls);
+  it('does not close or drain application-owned queue and event publisher resources during runtime app close', async () => {
+    const resourceLifecycleCalls: string[] = [];
+    const runtimeShutdownCalls: string[] = [];
+    const queue = new LifecycleAwareQueueAdapter(resourceLifecycleCalls);
+    const publisher = new LifecycleAwarePublisher(resourceLifecycleCalls);
+
+    class RuntimeShutdownProbe {
+      onModuleDestroy(): void {
+        runtimeShutdownCalls.push('app.onModuleDestroy');
+      }
+
+      onApplicationShutdown(signal?: string): void {
+        runtimeShutdownCalls.push(`app.onApplicationShutdown:${signal ?? 'none'}`);
+      }
+    }
 
     @Module({
       imports: [
@@ -519,13 +531,14 @@ describe('NotificationsModule', () => {
           },
         }),
       ],
+      providers: [RuntimeShutdownProbe],
     })
     class AppModule {}
 
-    const testingModule = await createTestingModule({ rootModule: AppModule }).compile();
+    const app = await FluoFactory.createApplicationContext(AppModule);
 
     try {
-      const service = await testingModule.resolve<NotificationsService>(NotificationsService);
+      const service = await app.get<NotificationsService>(NotificationsService);
 
       await expect(
         service.dispatch({ channel: 'email', payload: { template: 'queued-owned-by-app' } }, { queue: true }),
@@ -540,10 +553,14 @@ describe('NotificationsModule', () => {
         'notification.dispatch.queued',
       ]);
     } finally {
-      await testingModule.container.dispose();
+      await app.close('notifications-shutdown-test');
     }
 
-    expect(lifecycleCalls).toEqual([]);
+    expect(runtimeShutdownCalls).toEqual([
+      'app.onModuleDestroy',
+      'app.onApplicationShutdown:notifications-shutdown-test',
+    ]);
+    expect(resourceLifecycleCalls).toEqual([]);
   });
 
   it('publishes a failed lifecycle event when explicit queue dispatch enqueue fails', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,9 @@ importers:
         specifier: workspace:^
         version: link:../runtime
     devDependencies:
+      '@fluojs/testing':
+        specifier: workspace:^
+        version: link:../testing
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(happy-dom@20.9.0)(tsx@4.21.0)


### PR DESCRIPTION
## Summary

Linked context: Closes #2366

Strengthens @fluojs/notifications coverage for real module-graph visibility, application-owned queue/event publisher shutdown ownership, deterministic hash contracts, and book API summary parity.

## Changes

- Added createTestingModule({ rootModule }) integration coverage for default global visibility and global: false local visibility.
- Added disposal coverage proving application-owned queue adapters and lifecycle event publishers are not closed or drained by the notifications foundation package.
- Hardened deterministic queue job id assertions to verify prefix/stability/caller-supplied id behavior without pinning opaque hash literals.
- Aligned Chapter 15 EN/KO public API summaries with the notifications root exports.
- Added @fluojs/testing as a devDependency for the notifications package tests.

## Testing

- pnpm install --frozen-lockfile: blocked by a pre-existing lockfile/package mismatch in packages/cache-manager; reran pnpm install --no-frozen-lockfile inside the dedicated worktree and confirmed the lockfile diff only adds @fluojs/testing to packages/notifications.
- pnpm --filter @fluojs/notifications... build: passed.
- pnpm --filter @fluojs/notifications typecheck: passed after dependency dist outputs were built.
- pnpm --filter @fluojs/notifications test: passed, 43 tests across 3 files.
- pnpm exec biome lint packages/notifications/src/module.test.ts packages/notifications/package.json book/intermediate/ch15-notifications.md book/intermediate/ch15-notifications.ko.md pnpm-lock.yaml: passed for the Biome-targeted changed TS file.
- pnpm docs:sync-check: passed, 42 en/ko page pairs and 10 navigation metadata pairs.
- pnpm lint: completed; Biome reported existing warnings in unrelated packages and verify:public-export-tsdoc passed in changed mode.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset: this is test/docs coverage plus a devDependency for the package test harness; no public runtime behavior, API surface, package exports, or release metadata changed.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

No public exports changed. The book summary now lists the existing root exports already present in packages/notifications/src/index.ts and packages/notifications/README.md.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The PR reinforces existing documented contracts: global-by-default visibility with global: false opt-out, deterministic id stability without exact hash pinning, and no queue/event-bus resource ownership by @fluojs/notifications.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.

No governance/platform contract docs or package README conformance claims changed. EN/KO book parity was verified with pnpm docs:sync-check.