### PR TITLE
Resolve #2368: enforce Slack readiness gating and coverage

### DIFF
--- a/.changeset/slack-readiness-gating.md
+++ b/.changeset/slack-readiness-gating.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Gate Slack direct and notification-backed delivery on completed module readiness so bootstrap transport creation and optional verification finish before any provider handoff.

--- a/packages/slack/README.ko.md
+++ b/packages/slack/README.ko.md
@@ -138,7 +138,8 @@ Behavioral contract 메모:
 - `SlackService.sendMany(...)`는 메시지를 순차적으로 보내며, fail-fast 대신 batch result가 필요한 호출자를 위해 `continueOnError`를 지원합니다.
 - `SlackService.send(...)`, `SlackService.sendMany(...)`, `SlackService.sendNotification(...)`은 provider handoff 전에 이미 abort된 signal을 존중하며, 같은 signal을 transport 호출로 전달합니다.
 - 서비스는 모듈 bootstrap 시 transport를 초기화하고, factory가 소유한 리소스만 애플리케이션 shutdown 시 닫습니다.
-- shutdown이 시작된 뒤에는 `SlackService.send(...)`와 `SlackService.sendNotification(...)`이 transport를 재사용하거나 lazy 생성하지 않고 `SlackLifecycleError`로 실패합니다. 진행 중인 factory 소유 transport 생성은 shutdown이 기다린 뒤 닫습니다.
+- 직접 전달과 notifications 기반 전달은 lifecycle이 `ready`일 때만 허용됩니다. `onModuleInit()`이 끝나기 전, 초기화 실패 뒤, 또는 shutdown 중 호출하면 transport를 lazy 생성하거나 재사용하지 않고 `SlackLifecycleError`로 실패합니다.
+- shutdown은 진행 중인 factory 소유 transport 생성을 기다린 뒤 닫고 완료됩니다.
 - `SlackService.createPlatformStatusSnapshot()`은 호출자가 내부 옵션에 접근하지 않아도 lifecycle, readiness, transport 소유권을 보고합니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.
 
@@ -388,7 +389,7 @@ Slack 패키지는 의도적으로 다음을 **포함하지 않습니다**:
 - `SlackLifecycleState`
 - `SlackStatusAdapterInput`
 - `SlackConfigurationError`
-- `SlackLifecycleError`: lifecycle로 차단된 전달, transport 초기화, 소유 리소스 shutdown 실패에서 발생합니다. 애플리케이션 teardown과 전송이 경합할 수 있다면 이 에러를 catch하세요.
+- `SlackLifecycleError`: readiness 전, 초기화 실패 뒤, 또는 shutdown 중 lifecycle로 차단된 전달과 transport 초기화, 소유 리소스 shutdown 실패에서 발생합니다. bootstrap 또는 애플리케이션 teardown과 전송이 경합할 수 있다면 이 에러를 catch하세요.
 - `SlackMessageValidationError`
 - `SlackTransportError`
 

--- a/packages/slack/README.md
+++ b/packages/slack/README.md
@@ -138,7 +138,8 @@ Behavioral contract notes:
 - `SlackService.sendMany(...)` sends messages sequentially and supports `continueOnError` when callers need a batch result instead of fail-fast behavior.
 - `SlackService.send(...)`, `SlackService.sendMany(...)`, and `SlackService.sendNotification(...)` honor already-aborted signals before provider handoff, and the same signal is propagated to transport calls.
 - The service initializes the configured transport during module bootstrap and closes factory-owned resources during application shutdown.
-- Once shutdown starts, `SlackService.send(...)` and `SlackService.sendNotification(...)` fail with `SlackLifecycleError` instead of reusing or lazily creating transports; any in-flight factory-owned transport creation is awaited and closed by shutdown.
+- Direct and notification-backed delivery require the lifecycle to be `ready`; calls before `onModuleInit()` finishes, after initialization failure, or during shutdown fail with `SlackLifecycleError` instead of lazily creating or reusing transports.
+- Shutdown awaits any in-flight factory-owned transport creation and closes it before completion.
 - `SlackService.createPlatformStatusSnapshot()` reports lifecycle, readiness, and transport ownership without requiring callers to reach into internal options.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.
 
@@ -388,7 +389,7 @@ These limitations are part of the package contract so runtime choice, provider c
 - `SlackLifecycleState`
 - `SlackStatusAdapterInput`
 - `SlackConfigurationError`
-- `SlackLifecycleError`: thrown by lifecycle-gated delivery, transport initialization, and owned-resource shutdown failures. Catch this error when sends can race with application teardown.
+- `SlackLifecycleError`: thrown by lifecycle-gated delivery before readiness, after initialization failure, or during shutdown, plus transport initialization and owned-resource shutdown failures. Catch this error when sends can race with bootstrap or application teardown.
 - `SlackMessageValidationError`
 - `SlackTransportError`
 

--- a/packages/slack/src/errors.ts
+++ b/packages/slack/src/errors.ts
@@ -19,7 +19,11 @@ export class SlackMessageValidationError extends Error {
 }
 
 /**
- * Thrown when Slack delivery is requested after the service lifecycle has started shutting down.
+ * Thrown when Slack delivery, transport initialization, verification, or cleanup is blocked by lifecycle state.
+ *
+ * @remarks
+ * Direct and notification-backed delivery require a ready service. Calls made before module initialization finishes,
+ * after initialization fails, or after shutdown starts surface this error instead of lazily creating or reusing a transport.
  */
 export class SlackLifecycleError extends Error {
   constructor(message: string, options?: ErrorOptions) {

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -1,7 +1,8 @@
-import type { Constructor, Token } from '@fluojs/core';
+import { Inject, type Constructor, type Token } from '@fluojs/core';
 import { getModuleMetadata } from '@fluojs/core/internal';
 import { Container, type Provider } from '@fluojs/di';
 import { NOTIFICATION_CHANNELS, NotificationsModule, NotificationsService } from '@fluojs/notifications';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SlackChannel } from './channel.js';
@@ -172,6 +173,13 @@ function providerToken(provider: Provider): unknown {
   return typeof provider === 'function' ? provider : provider.provide;
 }
 
+async function initializeSlackService(container: Container): Promise<SlackService> {
+  const service = await container.resolve(SlackService);
+  await service.onModuleInit();
+
+  return service;
+}
+
 describe('SlackModule', () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
@@ -190,8 +198,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
-    await service.onModuleInit();
+    const service = await initializeSlackService(container);
 
     const result = await service.send({
       text: 'Deploy finished.',
@@ -280,6 +287,135 @@ describe('SlackModule', () => {
     expect(moduleChannelToken).toBe(moduleChannel);
     expect(helperChannel.channel).toBe('slack');
     expect(helperChannelToken).toBe(helperChannel);
+  });
+
+  it('exposes default-global Slack providers across a real module graph for notifications', async () => {
+    @Inject(SlackService)
+    class SlackVisibilityConsumer {
+      constructor(readonly slack: SlackService) {}
+    }
+
+    class SlackOwnerModule {}
+    defineModule(SlackOwnerModule, {
+      imports: [
+        SlackModule.forRoot({
+          defaultChannel: '#ops',
+          notifications: { channel: 'alerts' },
+          transport: createRecordingTransportFactory({ responsePrefix: 'graph' }),
+        }),
+      ],
+    });
+
+    class NotificationsOwnerModule {}
+    defineModule(NotificationsOwnerModule, {
+      imports: [
+        NotificationsModule.forRootAsync({
+          inject: [SLACK_CHANNEL],
+          useFactory: (channel: unknown) => ({
+            channels: [channel as SlackChannel],
+          }),
+        }),
+      ],
+      providers: [SlackVisibilityConsumer],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [SlackOwnerModule, NotificationsOwnerModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const consumer = await app.container.resolve(SlackVisibilityConsumer);
+      const notifications = await app.container.resolve(NotificationsService);
+      const result = await notifications.dispatch({
+        channel: 'alerts',
+        payload: { text: 'Global graph delivery' },
+        recipients: ['#release'],
+      });
+
+      expect(consumer.slack).toBeInstanceOf(SlackService);
+      expect(result).toMatchObject({
+        channel: 'alerts',
+        deliveryId: 'graph-1',
+        queued: false,
+        status: 'delivered',
+      });
+      expect(transportState.sent[0]).toMatchObject({
+        channel: '#release',
+        text: 'Global graph delivery',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps global=false Slack providers local to explicit importers in a real module graph', async () => {
+    @Inject(SlackService)
+    class LocalSlackConsumer {
+      constructor(readonly slack: SlackService) {}
+    }
+
+    class LocalSlackFeatureModule {}
+    defineModule(LocalSlackFeatureModule, {
+      imports: [
+        SlackModule.forRoot({
+          defaultChannel: '#local',
+          global: false,
+          transport: createRecordingTransportFactory({ responsePrefix: 'local-graph' }),
+        }),
+      ],
+      providers: [LocalSlackConsumer],
+    });
+
+    class LocalAppModule {}
+    defineModule(LocalAppModule, {
+      imports: [LocalSlackFeatureModule],
+    });
+
+    const localApp = await bootstrapApplication({ rootModule: LocalAppModule });
+
+    try {
+      const consumer = await localApp.container.resolve(LocalSlackConsumer);
+
+      expect(consumer.slack).toBeInstanceOf(SlackService);
+      await expect(consumer.slack.send({ text: 'Local graph delivery' })).resolves.toMatchObject({
+        channel: '#local',
+      });
+    } finally {
+      await localApp.close();
+    }
+
+    @Inject(SlackService)
+    class HiddenSlackConsumer {
+      constructor(readonly slack: SlackService) {}
+    }
+
+    class HiddenSlackOwnerModule {}
+    defineModule(HiddenSlackOwnerModule, {
+      imports: [
+        SlackModule.forRoot({
+          defaultChannel: '#hidden',
+          global: false,
+          transport: createRecordingTransportFactory({ responsePrefix: 'hidden-graph' }),
+        }),
+      ],
+    });
+
+    class HiddenConsumerModule {}
+    defineModule(HiddenConsumerModule, {
+      providers: [HiddenSlackConsumer],
+    });
+
+    class HiddenAppModule {}
+    defineModule(HiddenAppModule, {
+      imports: [HiddenSlackOwnerModule, HiddenConsumerModule],
+    });
+
+    await expect(bootstrapApplication({ rootModule: HiddenAppModule })).rejects.toThrow(
+      /not visible through a global module|SlackService/,
+    );
   });
 
   it('rejects helper-based registration without an explicit transport contract', () => {
@@ -400,6 +536,7 @@ describe('SlackModule', () => {
 
     container.register({ provide: SLACK_CONFIG as Token<string>, useValue: '#release' }, ...moduleProviders(moduleType));
 
+    await initializeSlackService(container);
     const facade = await container.resolve<Slack>(SLACK);
     const channel = await container.resolve(SlackChannel);
     const result = await facade.send({ text: 'Shipped' });
@@ -445,6 +582,7 @@ describe('SlackModule', () => {
       ...moduleProviders(notificationsModuleType),
     );
 
+    await initializeSlackService(container);
     const notifications = await container.resolve(NotificationsService);
     const channels = await container.resolve(NOTIFICATION_CHANNELS);
     const result = await notifications.dispatch({
@@ -488,6 +626,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
+    await initializeSlackService(container);
     const channel = await container.resolve(SlackChannel);
 
     const result = await channel.send(
@@ -513,6 +652,65 @@ describe('SlackModule', () => {
       text: 'Fallback Welcome',
     });
     expect(transportState.sent[0]?.blocks).toHaveLength(1);
+  });
+
+  it('applies Slack notification payload precedence over rendered template fields and metadata collisions', async () => {
+    const container = new Container();
+    const payloadBlocks = [{ type: 'section', text: { text: 'payload block', type: 'mrkdwn' } }];
+    const payloadAttachments = [{ color: '#2eb67d', fallback: 'payload attachment' }];
+    const moduleType = SlackModule.forRoot({
+      renderer: {
+        async render() {
+          return {
+            attachments: [{ color: '#d00000', fallback: 'rendered attachment' }],
+            blocks: [{ type: 'section', text: { text: 'rendered block', type: 'mrkdwn' } }],
+            text: 'Rendered fallback',
+          };
+        },
+      },
+      transport: createRecordingTransportFactory({ responsePrefix: 'template' }),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await initializeSlackService(container);
+
+    await service.sendNotification({
+      channel: 'slack',
+      metadata: {
+        requestId: 'dispatch-request',
+        source: 'dispatch',
+        subject: 'dispatch-subject-metadata',
+        template: 'dispatch-template-metadata',
+      },
+      payload: {
+        attachments: payloadAttachments,
+        blocks: payloadBlocks,
+        metadata: {
+          owner: 'payload',
+          requestId: 'payload-request',
+          source: 'payload',
+          subject: 'payload-subject-metadata',
+          template: 'payload-template-metadata',
+        },
+        text: 'Payload text wins',
+      },
+      recipients: ['#ops'],
+      subject: 'Dispatch subject wins',
+      template: 'deploy.finished',
+    });
+
+    expect(transportState.sent[0]).toMatchObject({
+      attachments: payloadAttachments,
+      blocks: payloadBlocks,
+      metadata: {
+        owner: 'payload',
+        requestId: 'dispatch-request',
+        source: 'dispatch',
+        subject: 'Dispatch subject wins',
+        template: 'deploy.finished',
+      },
+      text: 'Payload text wins',
+    });
   });
 
   it('creates a webhook-first transport with an explicit fetch-compatible boundary', async () => {
@@ -663,7 +861,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
+    const service = await initializeSlackService(container);
 
     await expect(
       service.sendNotification({
@@ -685,7 +883,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
+    const service = await initializeSlackService(container);
 
     await expect(
       service.sendNotification({
@@ -701,6 +899,29 @@ describe('SlackModule', () => {
     expect(transportState.sent).toHaveLength(0);
   });
 
+  it('prefers payload channel over recipients and default channel for notification routing', async () => {
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#default',
+      transport: createRecordingTransportFactory({ responsePrefix: 'route' }),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await initializeSlackService(container);
+
+    const result = await service.sendNotification({
+      channel: 'slack',
+      payload: { channel: ' #payload ', text: 'Route precedence' },
+      recipients: ['#recipient'],
+    });
+
+    expect(result).toMatchObject({ channel: '#payload', messageTs: 'route-1' });
+    expect(transportState.sent[0]).toMatchObject({
+      channel: '#payload',
+      text: 'Route precedence',
+    });
+  });
+
   it('surfaces an unsuccessful transport receipt as a notifications channel failure', async () => {
     const container = new Container();
     const moduleType = SlackModule.forRoot({
@@ -708,6 +929,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
+    await initializeSlackService(container);
     const channel = await container.resolve(SlackChannel);
 
     await expect(
@@ -730,7 +952,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
+    const service = await initializeSlackService(container);
 
     const result = await service.sendMany([{ text: 'one' }, { text: 'two' }, { text: 'three' }]);
 
@@ -748,7 +970,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
+    const service = await initializeSlackService(container);
 
     await expect(service.sendMany([{ text: 'ok-1' }, { text: 'fail-2' }, { text: 'ok-3' }])).rejects.toThrowError(
       'provider rejected fail-2',
@@ -765,7 +987,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
+    const service = await initializeSlackService(container);
 
     const result = await service.sendMany([{ text: 'ok-1' }, { text: 'fail-2' }, { text: 'ok-3' }], {
       continueOnError: true,
@@ -800,7 +1022,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
+    const service = await initializeSlackService(container);
 
     const result = await service.sendMany([{ text: 'first' }, { text: 'second' }], {
       continueOnError: true,
@@ -1022,7 +1244,76 @@ describe('SlackModule', () => {
     expect(fetchLike).toHaveBeenCalledTimes(1);
   });
 
-  it('accepts custom provider-backed transports without bootstrap verification', async () => {
+  it('requires module readiness before direct or notification-backed delivery', async () => {
+    const create = vi.fn(async () => new PassiveTransport());
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      transport: {
+        create,
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+
+    await expect(service.send({ text: 'Before readiness' })).rejects.toThrowError(
+      new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is created.'),
+    );
+    await expect(
+      service.sendNotification({
+        channel: 'slack',
+        payload: { text: 'Before readiness' },
+        recipients: ['#ops'],
+      }),
+    ).rejects.toThrowError(new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is created.'));
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('blocks delivery while bootstrap verification is still pending', async () => {
+    let resolveVerify!: () => void;
+    let resolveVerifyStarted!: () => void;
+    const verifyDelay = new Promise<void>((resolve) => {
+      resolveVerify = resolve;
+    });
+    const verifyStarted = new Promise<void>((resolve) => {
+      resolveVerifyStarted = resolve;
+    });
+    const transport = new DelayedLifecycleTransport(verifyDelay);
+    const verify = vi.spyOn(transport, 'verify').mockImplementation(async () => {
+      transport.verifyCalls += 1;
+      resolveVerifyStarted();
+      await verifyDelay;
+    });
+    const container = new Container();
+    const moduleType = SlackModule.forRoot({
+      defaultChannel: '#ops',
+      transport: {
+        create: async () => transport,
+        ownsResources: true,
+      },
+      verifyOnModuleInit: true,
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(SlackService);
+    const bootstrap = service.onModuleInit();
+    await verifyStarted;
+
+    await expect(service.send({ text: 'During verification' })).rejects.toThrowError(
+      new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is starting.'),
+    );
+    expect(transport.sendCalls).toBe(0);
+
+    resolveVerify();
+    await bootstrap;
+
+    await expect(service.send({ text: 'After readiness' })).resolves.toMatchObject({ channel: '#ops' });
+    expect(transport.sendCalls).toBe(1);
+    expect(verify).toHaveBeenCalledOnce();
+  });
+
+  it('accepts custom provider-backed transports after bootstrap without verification', async () => {
     const transport = new PassiveTransport();
     const container = new Container();
     const moduleType = SlackModule.forRoot({
@@ -1031,6 +1322,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
+    await initializeSlackService(container);
     const facade = await container.resolve<Slack>(SLACK);
     const result = await facade.send({ text: 'Provider transport' });
 
@@ -1049,9 +1341,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
-
-    await service.onModuleInit();
+    const service = await initializeSlackService(container);
     expect(service.createPlatformStatusSnapshot()).toMatchObject({
       details: {
         lifecycleState: 'ready',
@@ -1103,14 +1393,12 @@ describe('SlackModule', () => {
 
     container.register(...moduleProviders(moduleType));
     const service = await container.resolve(SlackService);
-    const sendDuringCreate = service.send({ text: 'Shutdown race' });
+    const bootstrap = service.onModuleInit();
     const shutdown = service.onApplicationShutdown();
 
     resolveTransport(createdTransport);
 
-    await expect(sendDuringCreate).rejects.toThrowError(
-      new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is stopped.'),
-    );
+    await bootstrap;
     await shutdown;
     await expect(service.send({ text: 'After shutdown' })).rejects.toThrowError(
       new SlackLifecycleError('Slack delivery cannot start while the service lifecycle is stopped.'),
@@ -1127,8 +1415,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
-    await service.onModuleInit();
+    const service = await initializeSlackService(container);
     await service.onApplicationShutdown();
     await service.onApplicationShutdown();
 
@@ -1146,8 +1433,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
-    await service.onModuleInit();
+    const service = await initializeSlackService(container);
     await Promise.all([service.onApplicationShutdown(), service.onApplicationShutdown()]);
 
     expect(transport.closeCalls).toBe(1);
@@ -1177,8 +1463,7 @@ describe('SlackModule', () => {
     });
 
     container.register(...moduleProviders(moduleType));
-    const service = await container.resolve(SlackService);
-    await service.onModuleInit();
+    const service = await initializeSlackService(container);
 
     await expect(service.onApplicationShutdown()).rejects.toThrowError(
       new SlackLifecycleError('Slack transport failed to close cleanly.', { cause: closeError }),

--- a/packages/slack/src/module.ts
+++ b/packages/slack/src/module.ts
@@ -126,7 +126,7 @@ export class SlackModule {
    * Registers Slack providers using static options.
    *
    * @param options Static Slack module options including transport wiring and optional template rendering behavior.
-   * @returns A global module definition that exports {@link SlackService}, {@link SlackChannel}, and compatibility tokens.
+   * @returns A module definition that exports {@link SlackService}, {@link SlackChannel}, and compatibility tokens.
    *
    * @example
    * ```ts
@@ -146,7 +146,7 @@ export class SlackModule {
    * Registers Slack providers from an async DI factory.
    *
    * @param options Async module options that resolve Slack transport and renderer configuration through DI.
-   * @returns A global module definition that memoizes async option resolution per module instance.
+   * @returns A module definition that memoizes async option resolution per module instance.
    *
    * @example
    * ```ts

--- a/packages/slack/src/public-surface.test.ts
+++ b/packages/slack/src/public-surface.test.ts
@@ -28,6 +28,7 @@ describe('@fluojs/slack public API surface', () => {
     expect(slackPublicApi).toHaveProperty('SLACK_CHANNEL');
     expect(slackPublicApi).toHaveProperty('createSlackPlatformStatusSnapshot');
     expect(slackPublicApi).toHaveProperty('SlackConfigurationError');
+    expect(slackPublicApi).toHaveProperty('SlackLifecycleError');
     expect(slackPublicApi).toHaveProperty('SlackMessageValidationError');
     expect(slackPublicApi).toHaveProperty('SlackTransportError');
   });

--- a/packages/slack/src/service.ts
+++ b/packages/slack/src/service.ts
@@ -166,6 +166,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
    * @param options Optional abort signal propagated to the transport.
    * @returns A normalized delivery receipt describing the transport response.
    * @throws {SlackMessageValidationError} When the resolved message does not include Slack-visible content.
+   * @throws {SlackLifecycleError} When delivery is requested before readiness, after initialization failure, or during shutdown.
    *
    * @example
    * ```ts
@@ -203,6 +204,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
    * @param messages Ordered message list to deliver through the configured transport.
    * @param options Optional tolerant batch controls such as `continueOnError`.
    * @returns A batch summary containing successes and any captured failures.
+   * @throws {SlackLifecycleError} When delivery is requested before readiness, after initialization failure, or during shutdown.
    *
    * @example
    * ```ts
@@ -212,6 +214,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
    */
   async sendMany(messages: readonly SlackMessage[], options: SlackSendManyOptions = {}): Promise<SlackSendBatchResult> {
     assertNotAborted(options.signal);
+    this.assertCanDeliver();
 
     const results: SlackSendResult[] = [];
     const failures: SlackSendFailure[] = [];
@@ -248,6 +251,7 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
    * @param options Optional abort signal propagated to rendering and transport work.
    * @returns A normalized delivery receipt for the resulting Slack message.
    * @throws {SlackMessageValidationError} When the notification cannot resolve one target channel or any Slack-visible content.
+   * @throws {SlackLifecycleError} When delivery is requested before readiness, after initialization failure, or during shutdown.
    *
    * @example
    * ```ts
@@ -347,7 +351,9 @@ export class SlackService implements Slack, OnModuleInit, OnApplicationShutdown 
   }
 
   private assertCanDeliver(): void {
-    this.assertCanCreateOrUseTransport();
+    if (this.lifecycleState !== 'ready') {
+      throw createDeliveryLifecycleError(this.lifecycleState);
+    }
   }
 
   private normalizeMessage(message: SlackMessage): NormalizedSlackMessage {

--- a/packages/slack/src/types.ts
+++ b/packages/slack/src/types.ts
@@ -221,13 +221,23 @@ export interface SlackSendManyOptions extends SlackSendOptions {
 /** Module options accepted by {@link SlackModule.forRoot} and `forRootAsync`. */
 export interface SlackModuleOptions {
   defaultChannel?: string;
-  /** Whether Slack providers should be visible globally. Defaults to `true`. */
+  /**
+   * Controls whether Slack providers are visible through the whole module graph.
+   *
+   * @remarks
+   * Defaults to `true` for Nest-like root registration. Set `false` when migrated code needs `SlackService`,
+   * `SlackChannel`, `SLACK`, and `SLACK_CHANNEL` to stay visible only to modules that explicitly import the returned
+   * module definition.
+   */
   global?: boolean;
   notifications?: {
     channel?: string;
   };
   renderer?: SlackTemplateRenderer;
   transport: SlackTransport | SlackTransportFactory;
+  /**
+   * Verifies the configured transport during `onModuleInit()` before the service becomes ready for delivery.
+   */
   verifyOnModuleInit?: boolean;
 }
 
@@ -257,6 +267,7 @@ export interface Slack {
    * @param message Caller-supplied Slack message with text and/or block content.
    * @param options Optional abort signal propagated to the transport.
    * @returns A normalized delivery receipt describing the transport response.
+   * @throws {SlackLifecycleError} When delivery is requested before readiness, after initialization failure, or during shutdown.
    */
   send(message: SlackMessage, options?: SlackSendOptions): Promise<SlackSendResult>;
 
@@ -266,6 +277,7 @@ export interface Slack {
    * @param messages Ordered message list to deliver through the configured transport.
    * @param options Optional tolerant batch controls such as `continueOnError`.
    * @returns A batch summary containing successes and any captured failures.
+   * @throws {SlackLifecycleError} When delivery is requested before readiness, after initialization failure, or during shutdown.
    */
   sendMany(messages: readonly SlackMessage[], options?: SlackSendManyOptions): Promise<SlackSendBatchResult>;
 
@@ -275,6 +287,7 @@ export interface Slack {
    * @param notification Shared notification envelope interpreted by the Slack package.
    * @param options Optional abort signal propagated to rendering and transport work.
    * @returns A normalized delivery receipt for the resulting Slack message.
+   * @throws {SlackLifecycleError} When delivery is requested before readiness, after initialization failure, or during shutdown.
    */
   sendNotification(
     notification: SlackNotificationDispatchRequest,


### PR DESCRIPTION
## Summary

Linked context: Closes #2368

Enforces Slack delivery readiness gating so direct and notification-backed sends wait for completed module bootstrap and optional transport verification before provider handoff.

## Changes

- Require `SlackService.send(...)`, `sendMany(...)`, and `sendNotification(...)` to run only when the service lifecycle is `ready`.
- Keep transport creation and `verifyOnModuleInit` verification inside `onModuleInit()`.
- Add real module-graph coverage for default-global Slack visibility and `global: false` local visibility.
- Add notification routing precedence and template merge-order regression coverage.
- Align Slack README EN/KO docs and public TSDoc for lifecycle gating, global opt-out, and error contracts.
- Add a patch changeset for the public behavior fix.

## Testing

- `pnpm --filter @fluojs/slack test`
- `pnpm --filter @fluojs/validation build && pnpm --filter @fluojs/http build && pnpm --filter @fluojs/runtime build && pnpm --filter @fluojs/notifications build && pnpm --filter @fluojs/slack typecheck`
- `pnpm --filter @fluojs/slack build`
- `pnpm lint` (completed; public export TSDoc changed-mode check passed, Biome emitted non-failing existing diagnostics)
- `pnpm exec biome lint packages/slack/src/service.ts packages/slack/src/errors.ts packages/slack/src/module.ts packages/slack/src/types.ts packages/slack/src/module.test.ts packages/slack/src/public-surface.test.ts`
- `pnpm verify:changeset-release-lane`
- `pnpm docs:sync-check`
- `pnpm verify:platform-consistency-governance`
- `git diff --check`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/slack-readiness-gating.md` for `@fluojs/slack`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

Updated public TSDoc for lifecycle errors, `global?: boolean`, and `verifyOnModuleInit` readiness behavior.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

`@fluojs/slack` now fails delivery before readiness instead of creating or reusing transports before `onModuleInit()` completes.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No platform conformance docs were changed. Package README EN/KO lifecycle text was kept aligned and verified with docs/governance checks.