### PR TITLE
Resolve #2372: isolate Slack async configuration

### DIFF
--- a/.changeset/slack-async-option-isolation.md
+++ b/.changeset/slack-async-option-isolation.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/slack": patch
+---
+
+Resolve Slack async module options through each application container so reusing one `SlackModule.forRootAsync(...)` module definition cannot leak resolved or rejected configuration across app boundaries.

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -14,6 +14,8 @@ import type {
   NormalizedSlackMessage,
   Slack,
   SlackFetchLike,
+  SlackTemplateRenderer,
+  SlackTemplateRenderInput,
   SlackTransport,
   SlackTransportFactory,
 } from './types.js';
@@ -418,6 +420,148 @@ describe('SlackModule', () => {
     );
   });
 
+  it('exposes default-global async Slack providers across a real module graph for notifications', async () => {
+    const factoryCalls: string[] = [];
+
+    @Inject(SlackService)
+    class AsyncSlackVisibilityConsumer {
+      constructor(readonly slack: SlackService) {}
+    }
+
+    class AsyncSlackOwnerModule {}
+    defineModule(AsyncSlackOwnerModule, {
+      imports: [
+        SlackModule.forRootAsync({
+          useFactory: async () => {
+            factoryCalls.push('async-default-global');
+
+            return {
+              defaultChannel: '#async-ops',
+              notifications: { channel: 'async-alerts' },
+              transport: createRecordingTransportFactory({ responsePrefix: 'async-graph' }),
+            };
+          },
+        }),
+      ],
+    });
+
+    class AsyncNotificationsOwnerModule {}
+    defineModule(AsyncNotificationsOwnerModule, {
+      imports: [
+        NotificationsModule.forRootAsync({
+          inject: [SLACK_CHANNEL],
+          useFactory: (channel: unknown) => ({
+            channels: [channel as SlackChannel],
+          }),
+        }),
+      ],
+      providers: [AsyncSlackVisibilityConsumer],
+    });
+
+    class AsyncAppModule {}
+    defineModule(AsyncAppModule, {
+      imports: [AsyncSlackOwnerModule, AsyncNotificationsOwnerModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AsyncAppModule });
+
+    try {
+      const consumer = await app.container.resolve(AsyncSlackVisibilityConsumer);
+      const notifications = await app.container.resolve(NotificationsService);
+      const result = await notifications.dispatch({
+        channel: 'async-alerts',
+        payload: { text: 'Async global graph delivery' },
+        recipients: ['#async-release'],
+      });
+
+      expect(consumer.slack).toBeInstanceOf(SlackService);
+      expect(result).toMatchObject({
+        channel: 'async-alerts',
+        deliveryId: 'async-graph-1',
+        queued: false,
+        status: 'delivered',
+      });
+      expect(factoryCalls).toEqual(['async-default-global']);
+      expect(transportState.sent[0]).toMatchObject({
+        channel: '#async-release',
+        text: 'Async global graph delivery',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps global=false async Slack providers local to explicit importers in a real module graph', async () => {
+    @Inject(SlackService)
+    class LocalAsyncSlackConsumer {
+      constructor(readonly slack: SlackService) {}
+    }
+
+    class LocalAsyncSlackFeatureModule {}
+    defineModule(LocalAsyncSlackFeatureModule, {
+      imports: [
+        SlackModule.forRootAsync({
+          global: false,
+          useFactory: async () => ({
+            defaultChannel: '#local-async',
+            transport: createRecordingTransportFactory({ responsePrefix: 'local-async-graph' }),
+          }),
+        }),
+      ],
+      providers: [LocalAsyncSlackConsumer],
+    });
+
+    class LocalAsyncAppModule {}
+    defineModule(LocalAsyncAppModule, {
+      imports: [LocalAsyncSlackFeatureModule],
+    });
+
+    const localApp = await bootstrapApplication({ rootModule: LocalAsyncAppModule });
+
+    try {
+      const consumer = await localApp.container.resolve(LocalAsyncSlackConsumer);
+
+      expect(consumer.slack).toBeInstanceOf(SlackService);
+      await expect(consumer.slack.send({ text: 'Local async graph delivery' })).resolves.toMatchObject({
+        channel: '#local-async',
+      });
+    } finally {
+      await localApp.close();
+    }
+
+    @Inject(SlackService)
+    class HiddenAsyncSlackConsumer {
+      constructor(readonly slack: SlackService) {}
+    }
+
+    class HiddenAsyncSlackOwnerModule {}
+    defineModule(HiddenAsyncSlackOwnerModule, {
+      imports: [
+        SlackModule.forRootAsync({
+          global: false,
+          useFactory: async () => ({
+            defaultChannel: '#hidden-async',
+            transport: createRecordingTransportFactory({ responsePrefix: 'hidden-async-graph' }),
+          }),
+        }),
+      ],
+    });
+
+    class HiddenAsyncConsumerModule {}
+    defineModule(HiddenAsyncConsumerModule, {
+      providers: [HiddenAsyncSlackConsumer],
+    });
+
+    class HiddenAsyncAppModule {}
+    defineModule(HiddenAsyncAppModule, {
+      imports: [HiddenAsyncSlackOwnerModule, HiddenAsyncConsumerModule],
+    });
+
+    await expect(bootstrapApplication({ rootModule: HiddenAsyncAppModule })).rejects.toThrow(
+      /not visible through a global module|SlackService/,
+    );
+  });
+
   it('rejects helper-based registration without an explicit transport contract', () => {
     expect(() =>
       createSlackProviders({
@@ -801,6 +945,116 @@ describe('SlackModule', () => {
       },
       text: 'Payload text wins',
     });
+  });
+
+  it('keeps README template merge precedence exact across payload, rendered, and subject fallbacks', async () => {
+    const container = new Container();
+    const payloadBlocks = [{ type: 'section', text: { text: 'payload block', type: 'mrkdwn' } }];
+    const payloadAttachments = [{ color: '#2eb67d', fallback: 'payload attachment' }];
+    const renderedBlocks = [{ type: 'section', text: { text: 'rendered block', type: 'mrkdwn' } }];
+    const renderedAttachments = [{ color: '#d00000', fallback: 'rendered attachment' }];
+    const renderInputs: SlackTemplateRenderInput[] = [];
+    const renderer: SlackTemplateRenderer = {
+      async render(input) {
+        renderInputs.push(input);
+
+        if (input.template === 'deploy.subject-fallback') {
+          return {};
+        }
+
+        return {
+          attachments: renderedAttachments,
+          blocks: renderedBlocks,
+          text: `Rendered ${input.subject ?? input.template}`,
+        };
+      },
+    };
+    const moduleType = SlackModule.forRoot({
+      renderer,
+      transport: createRecordingTransportFactory({ responsePrefix: 'merge' }),
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await initializeSlackService(container);
+
+    await service.sendNotification({
+      channel: 'slack',
+      locale: 'en',
+      metadata: {
+        requestId: 'dispatch-request',
+        source: 'dispatch',
+        subject: 'dispatch-subject-metadata',
+        template: 'dispatch-template-metadata',
+      },
+      payload: {
+        attachments: payloadAttachments,
+        blocks: payloadBlocks,
+        metadata: {
+          owner: 'payload',
+          requestId: 'payload-request',
+          source: 'payload',
+          subject: 'payload-subject-metadata',
+          template: 'payload-template-metadata',
+        },
+        text: 'Payload text wins',
+      },
+      recipients: ['#ops'],
+      subject: 'Payload subject marker wins',
+      template: 'deploy.payload-wins',
+    });
+    await service.sendNotification({
+      channel: 'slack',
+      metadata: { source: 'dispatch' },
+      payload: {
+        metadata: { source: 'payload' },
+      },
+      recipients: ['#ops'],
+      subject: 'Rendered fallback subject',
+      template: 'deploy.rendered-fallback',
+    });
+    await service.sendNotification({
+      channel: 'slack',
+      payload: {},
+      recipients: ['#ops'],
+      subject: 'Subject fallback text',
+      template: 'deploy.subject-fallback',
+    });
+
+    expect(renderInputs).toHaveLength(3);
+    expect(renderInputs[0]).toMatchObject({
+      locale: 'en',
+      metadata: {
+        requestId: 'dispatch-request',
+        source: 'dispatch',
+        subject: 'dispatch-subject-metadata',
+        template: 'dispatch-template-metadata',
+      },
+      subject: 'Payload subject marker wins',
+      template: 'deploy.payload-wins',
+    });
+    expect(transportState.sent[0]?.attachments).toBe(payloadAttachments);
+    expect(transportState.sent[0]?.blocks).toBe(payloadBlocks);
+    expect(transportState.sent[0]?.metadata).toEqual({
+      owner: 'payload',
+      requestId: 'dispatch-request',
+      source: 'dispatch',
+      subject: 'Payload subject marker wins',
+      template: 'deploy.payload-wins',
+    });
+    expect(transportState.sent[0]?.text).toBe('Payload text wins');
+    expect(transportState.sent[1]?.attachments).toBe(renderedAttachments);
+    expect(transportState.sent[1]?.blocks).toBe(renderedBlocks);
+    expect(transportState.sent[1]?.metadata).toEqual({
+      source: 'dispatch',
+      subject: 'Rendered fallback subject',
+      template: 'deploy.rendered-fallback',
+    });
+    expect(transportState.sent[1]?.text).toBe('Rendered Rendered fallback subject');
+    expect(transportState.sent[2]?.metadata).toEqual({
+      subject: 'Subject fallback text',
+      template: 'deploy.subject-fallback',
+    });
+    expect(transportState.sent[2]?.text).toBe('Subject fallback text');
   });
 
   it('creates a webhook-first transport with an explicit fetch-compatible boundary', async () => {

--- a/packages/slack/src/module.test.ts
+++ b/packages/slack/src/module.test.ts
@@ -546,6 +546,96 @@ describe('SlackModule', () => {
     expect(factoryCalls).toEqual(['#release']);
   });
 
+  it('resolves async options per container when a module definition is reused', async () => {
+    const SLACK_CONFIG = Symbol('isolated-slack-config');
+    const factoryCalls: string[] = [];
+    const moduleType = SlackModule.forRootAsync({
+      inject: [SLACK_CONFIG],
+      useFactory: async (...deps: unknown[]) => {
+        const [defaultChannel] = deps;
+
+        if (typeof defaultChannel !== 'string') {
+          throw new Error('default channel must be a string');
+        }
+
+        factoryCalls.push(defaultChannel);
+
+        return {
+          defaultChannel,
+          transport: createRecordingTransportFactory({ responsePrefix: defaultChannel.slice(1) }),
+        };
+      },
+    });
+    const firstContainer = new Container();
+    const secondContainer = new Container();
+
+    firstContainer.register(
+      { provide: SLACK_CONFIG as Token<string>, useValue: '#first' },
+      ...moduleProviders(moduleType),
+    );
+    secondContainer.register(
+      { provide: SLACK_CONFIG as Token<string>, useValue: '#second' },
+      ...moduleProviders(moduleType),
+    );
+
+    const firstService = await initializeSlackService(firstContainer);
+    const secondService = await initializeSlackService(secondContainer);
+
+    await expect(firstService.send({ text: 'first app' })).resolves.toMatchObject({ channel: '#first' });
+    await expect(secondService.send({ text: 'second app' })).resolves.toMatchObject({ channel: '#second' });
+    expect(factoryCalls).toEqual(['#first', '#second']);
+    expect(transportState.sent).toMatchObject([
+      { channel: '#first', text: 'first app' },
+      { channel: '#second', text: 'second app' },
+    ]);
+  });
+
+  it('does not reuse rejected async options across containers for one module definition', async () => {
+    const SLACK_CONFIG = Symbol('recoverable-slack-config');
+    const configurationFailure = new SlackConfigurationError('Slack config source is unavailable.');
+    const factoryCalls: string[] = [];
+    const moduleType = SlackModule.forRootAsync({
+      inject: [SLACK_CONFIG],
+      useFactory: async (...deps: unknown[]) => {
+        const [defaultChannel] = deps;
+
+        if (typeof defaultChannel !== 'string') {
+          throw new Error('default channel must be a string');
+        }
+
+        factoryCalls.push(defaultChannel);
+
+        if (defaultChannel === '#broken') {
+          throw configurationFailure;
+        }
+
+        return {
+          defaultChannel,
+          transport: createRecordingTransportFactory({ responsePrefix: 'recovered' }),
+        };
+      },
+    });
+    const failingContainer = new Container();
+    const recoveredContainer = new Container();
+
+    failingContainer.register(
+      { provide: SLACK_CONFIG as Token<string>, useValue: '#broken' },
+      ...moduleProviders(moduleType),
+    );
+    recoveredContainer.register(
+      { provide: SLACK_CONFIG as Token<string>, useValue: '#recovered' },
+      ...moduleProviders(moduleType),
+    );
+
+    await expect(initializeSlackService(failingContainer)).rejects.toThrowError(configurationFailure);
+
+    const recoveredService = await initializeSlackService(recoveredContainer);
+
+    await expect(recoveredService.send({ text: 'recovered app' })).resolves.toMatchObject({ channel: '#recovered' });
+    expect(factoryCalls).toEqual(['#broken', '#recovered']);
+    expect(transportState.sent[0]).toMatchObject({ channel: '#recovered', text: 'recovered app' });
+  });
+
   it('wires module-first async Slack and notifications registration through SLACK_CHANNEL', async () => {
     const SLACK_CONFIG = Symbol('slack-config');
     const container = new Container();

--- a/packages/slack/src/module.ts
+++ b/packages/slack/src/module.ts
@@ -98,15 +98,6 @@ function buildSlackModuleAsync(options: SlackAsyncModuleOptions): ModuleType {
   class SlackAsyncModuleDefinition {}
 
   const factory = options.useFactory as (...args: unknown[]) => MaybePromise<SlackModuleOptions>;
-  let cachedResult: Promise<NormalizedSlackModuleOptions> | undefined;
-
-  const memoizedFactory = (...deps: unknown[]): Promise<NormalizedSlackModuleOptions> => {
-    if (!cachedResult) {
-      cachedResult = Promise.resolve(factory(...deps)).then((resolved) => normalizeSlackModuleOptions(resolved));
-    }
-
-    return cachedResult;
-  };
 
   return defineModule(SlackAsyncModuleDefinition, {
     exports: [SlackService, SlackChannel, SLACK, SLACK_CHANNEL],
@@ -115,7 +106,8 @@ function buildSlackModuleAsync(options: SlackAsyncModuleOptions): ModuleType {
       inject: options.inject,
       provide: SLACK_OPTIONS,
       scope: 'singleton',
-      useFactory: (...deps: unknown[]) => memoizedFactory(...deps),
+      useFactory: (...deps: unknown[]) =>
+        Promise.resolve(factory(...deps)).then((resolved) => normalizeSlackModuleOptions(resolved)),
     }),
   });
 }
@@ -146,7 +138,7 @@ export class SlackModule {
    * Registers Slack providers from an async DI factory.
    *
    * @param options Async module options that resolve Slack transport and renderer configuration through DI.
-   * @returns A module definition that memoizes async option resolution per module instance.
+   * @returns A module definition that resolves async options through each active application container.
    *
    * @example
    * ```ts

--- a/packages/slack/src/public-surface.test.ts
+++ b/packages/slack/src/public-surface.test.ts
@@ -82,4 +82,12 @@ describe('@fluojs/slack public API surface', () => {
     expect(slackPublicApi).not.toHaveProperty('SLACK_OPTIONS');
     expect(slackPublicApi).not.toHaveProperty('NormalizedSlackModuleOptions');
   });
+
+  it('keeps named-client migration helpers outside the singleton root barrel', () => {
+    expect(slackPublicApi.SlackModule).not.toHaveProperty('forFeature');
+    expect(slackPublicApi).not.toHaveProperty('createSlackClientToken');
+    expect(slackPublicApi).not.toHaveProperty('getSlackClientToken');
+    expect(slackPublicApi).not.toHaveProperty('SLACK_CLIENTS');
+    expect(slackPublicApi).not.toHaveProperty('SlackClientRegistry');
+  });
 });


### PR DESCRIPTION
## Summary

Linked context: Closes #2372

Fixes the Slack async module configuration leak by resolving `SlackModule.forRootAsync(...)` options through each active application/container singleton provider instead of caching the first resolved or rejected factory result on the reusable module definition.

## Changes

- Removed module-definition-level async option memoization from `SlackModule.forRootAsync(...)` while preserving per-container singleton caching through DI.
- Added regression coverage for reused async module definitions across isolated containers, including both resolved and rejected option factories.
- Added negative public-surface assertions for unsupported named-client migration helpers so the singleton Slack boundary remains explicit.
- Added patch release intent for `@fluojs/slack`.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm --filter @fluojs/slack test`
- `pnpm exec biome lint packages/slack/src/module.ts packages/slack/src/module.test.ts packages/slack/src/public-surface.test.ts .changeset/slack-async-option-isolation.md`
- `pnpm --filter @fluojs/validation build && pnpm --filter @fluojs/http build && pnpm --filter @fluojs/runtime build && pnpm --filter @fluojs/notifications build && pnpm --filter @fluojs/slack typecheck`
- `pnpm --filter @fluojs/slack build`
- `pnpm lint` (passed; Biome reported existing non-failing diagnostics outside the changed Slack files, and public export TSDoc changed-mode passed)
- `pnpm verify:changeset-release-lane`
- `pnpm verify:platform-consistency-governance`
- `pnpm docs:sync-check`
- `pnpm verify:release-readiness`
- `git diff --check`

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/slack-async-option-isolation.md` for `@fluojs/slack`, because async module configuration now remains isolated per application/container boundary.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

Updated the `SlackModule.forRootAsync(...)` return TSDoc to describe per-container option resolution. No new public export was added.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This aligns implementation with the existing README contract that `forRootAsync(...)` derives configuration through DI and keeps Slack singleton/named-client limitations intact. Regression tests cover reused module definitions across isolated containers and rejected async factory recovery.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed platform docs or package README files changed. Governance and docs parity checks passed.