### PR TITLE
Resolve #2370: cover event-bus per-call transport timeout

### DIFF
--- a/packages/event-bus/src/module.test.ts
+++ b/packages/event-bus/src/module.test.ts
@@ -1141,6 +1141,52 @@ describe('@fluojs/event-bus', () => {
       await closeApplication(app);
     });
 
+    it('allows a per-call publish timeout to bound awaited transport publish work', async () => {
+      vi.useFakeTimers();
+      const loggerEvents: string[] = [];
+      const gate = createDeferred<void>();
+      const transport = {
+        publishStarted: false,
+        async publish(_channel: string, _payload: unknown) {
+          this.publishStarted = true;
+          await gate.promise;
+        },
+        async subscribe(_channel: string, _handler: (payload: unknown) => Promise<void>) {},
+        async close() {},
+      } satisfies EventBusTransport & { publishStarted: boolean };
+
+      class AppModule {}
+      defineModule(AppModule, {
+        imports: [EventBusModule.forRoot({ publish: { timeoutMs: 120 }, transport })],
+      });
+
+      const app = await bootstrapApplication({
+        logger: createLogger(loggerEvents),
+        rootModule: AppModule,
+      });
+      const eventBus = await app.container.resolve<EventBus>(EVENT_BUS);
+
+      const publishPromise = eventBus.publish(new UserCreatedEvent('transport-user-per-call-timeout'), {
+        timeoutMs: 12,
+      });
+
+      await flushAsyncWork();
+      expect(transport.publishStarted).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(12);
+      await expect(publishPromise).resolves.toBeUndefined();
+
+      expect(
+        loggerEvents.some((event) =>
+          event.includes('EventBusTransport publish to channel "UserCreatedEvent" exceeded publish timeout of 12ms.'),
+        ),
+      ).toBe(true);
+      expect(loggerEvents.some((event) => event.includes('exceeded publish timeout of 120ms.'))).toBe(false);
+
+      gate.resolve();
+      await closeApplication(app);
+    });
+
     it('applies timeout bounds to awaited transport publish calls', async () => {
       vi.useFakeTimers();
       const loggerEvents: string[] = [];


### PR DESCRIPTION
## Summary

Linked context: Closes #2370

Preserve the just-merged #2364 event-bus public-surface docs and transport regression coverage, then close the remaining #2370 executable gap for per-call transport publish timeout coverage.

## Changes

- Add an `@fluojs/event-bus` transport regression test proving `publish(event, { timeoutMs })` bounds awaited `transport.publish(...)` work.
- Cover the per-call timeout overriding the module default by asserting the 12ms diagnostic is emitted and the 120ms module default is not used for that publish call.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm exec biome lint packages/event-bus/src/module.test.ts`
- `pnpm --filter @fluojs/event-bus... build`
- `pnpm --filter @fluojs/event-bus typecheck`
- `pnpm --filter @fluojs/event-bus test` — 5 files / 71 tests passed
- `pnpm verify:platform-consistency-governance`

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset: this is test-only regression hardening. It does not change public package behavior, API surface, published package contents, docs, or release metadata.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The README already documents that awaited local handler and transport publishes share per-call timeout bounds. This PR adds the missing transport-side executable regression without changing behavior.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by `createPlatformConformanceHarness(...)` tests.

No governed docs changed in this PR. `pnpm verify:platform-consistency-governance` passed, and #2364 package-surface/docs coverage remains on `origin/main`.