### PR TITLE
Resolve #2371: harden notifications executable coverage

### DIFF
--- a/packages/notifications/src/module.test.ts
+++ b/packages/notifications/src/module.test.ts
@@ -103,6 +103,10 @@ class LifecycleAwarePublisher extends RecordingPublisher {
   }
 }
 
+function expectGeneratedQueueJobId(value: string | undefined): void {
+  expect(value).toMatch(/^notification:email:[a-z0-9]{7}$/);
+}
+
 class MalformedEnqueueManyQueueAdapter implements NotificationsQueueAdapter {
   readonly jobs: NotificationsQueueJob[] = [];
 
@@ -286,6 +290,109 @@ describe('NotificationsModule', () => {
     );
   });
 
+  it('makes async default global providers and tokens visible through a real testing module graph', async () => {
+    const deliveries: string[] = [];
+
+    @Inject(NOTIFICATIONS, NOTIFICATION_CHANNELS)
+    class RootNotificationsTokenProbe {
+      constructor(
+        private readonly notifications: Notifications,
+        private readonly channels: readonly NotificationChannel[],
+      ) {}
+
+      async send(): Promise<{ channelNames: readonly string[]; result: NotificationDispatchResult }> {
+        const result = await this.notifications.dispatch({
+          channel: 'email',
+          payload: { template: 'async-global-visible' },
+        });
+
+        return {
+          channelNames: this.channels.map((channel) => channel.channel),
+          result,
+        };
+      }
+    }
+
+    @Module({
+      imports: [
+        NotificationsModule.forRootAsync({
+          useFactory: async () => ({
+            channels: [
+              {
+                channel: 'email',
+                async send(notification: NotificationDispatchRequest) {
+                  deliveries.push(String(notification.payload.template));
+
+                  return { externalId: 'async-global-delivery' };
+                },
+              },
+            ],
+          }),
+        }),
+      ],
+    })
+    class NotificationsOwnerModule {}
+
+    @Module({
+      imports: [NotificationsOwnerModule],
+      providers: [RootNotificationsTokenProbe],
+    })
+    class AppModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AppModule }).compile();
+
+    try {
+      const probe = await testingModule.resolve<RootNotificationsTokenProbe>(RootNotificationsTokenProbe);
+      const dispatch = await probe.send();
+
+      expect(dispatch.channelNames).toEqual(['email']);
+      expect(dispatch.result).toMatchObject({
+        deliveryId: 'async-global-delivery',
+        queued: false,
+        status: 'delivered',
+      });
+      expect(deliveries).toEqual(['async-global-visible']);
+    } finally {
+      await testingModule.container.dispose();
+    }
+  });
+
+  it('keeps async module-local providers hidden from sibling/root providers in a real testing module graph', async () => {
+    @Inject(NOTIFICATIONS)
+    class RootNotificationsTokenProbe {
+      constructor(readonly notifications: Notifications) {}
+    }
+
+    @Module({
+      imports: [
+        NotificationsModule.forRootAsync({
+          global: false,
+          useFactory: async () => ({
+            channels: [
+              {
+                channel: 'email',
+                async send() {
+                  return { externalId: 'async-local-only' };
+                },
+              },
+            ],
+          }),
+        }),
+      ],
+    })
+    class NotificationsOwnerModule {}
+
+    @Module({
+      imports: [NotificationsOwnerModule],
+      providers: [RootNotificationsTokenProbe],
+    })
+    class AppModule {}
+
+    await expect(createTestingModule({ rootModule: AppModule }).compile()).rejects.toThrow(
+      /not visible through a global module|NOTIFICATIONS/,
+    );
+  });
+
   it('registers sync providers and dispatches through a configured channel', async () => {
     const deliveries: Array<{ payload: Record<string, unknown>; recipients?: readonly string[] }> = [];
     const container = new Container();
@@ -426,7 +533,7 @@ describe('NotificationsModule', () => {
 
     expect(result).toMatchObject({ deliveryId: 'queued:1', queued: true, status: 'queued' });
     expect(queue.jobs).toHaveLength(1);
-    expect(queue.jobs[0]?.id).toMatch(/^notification:email:[a-z0-9]{7}$/);
+    expectGeneratedQueueJobId(queue.jobs[0]?.id);
     expect(queue.jobs[0]).toMatchObject({
       channel: 'email',
       notification: { channel: 'email', payload: { template: 'single' } },
@@ -490,9 +597,53 @@ describe('NotificationsModule', () => {
 
     const [firstJob, repeatedJob, callerJob] = queue.jobs;
 
-    expect(firstJob?.id).toMatch(/^notification:email:[a-z0-9]{7}$/);
+    expectGeneratedQueueJobId(firstJob?.id);
     expect(repeatedJob?.id).toBe(firstJob?.id);
     expect(callerJob?.id).toBe('caller-job-id');
+  });
+
+  it('derives queue job ids from canonical notification content without pinning opaque hash literals', async () => {
+    const queue = new RecordingQueueAdapter();
+    const container = new Container();
+    const moduleType = NotificationsModule.forRoot({
+      channels: [
+        {
+          channel: 'email',
+          async send() {
+            throw new Error('direct delivery should not run when queue is explicitly requested');
+          },
+        },
+      ],
+      queue: {
+        adapter: queue,
+        bulkThreshold: 50,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(NotificationsService);
+
+    await service.dispatch(
+      {
+        channel: 'email',
+        payload: { template: 'digest', userId: 'u1' },
+        recipients: ['user@example.com'],
+      },
+      { queue: true },
+    );
+    await service.dispatch(
+      {
+        recipients: ['user@example.com'],
+        payload: { userId: 'u1', template: 'digest' },
+        channel: 'email',
+      },
+      { queue: true },
+    );
+
+    const [canonicalJob, reorderedJob] = queue.jobs;
+
+    expectGeneratedQueueJobId(canonicalJob?.id);
+    expect(reorderedJob?.id).toBe(canonicalJob?.id);
   });
 
   it('does not close or drain application-owned queue and event publisher resources during runtime app close', async () => {
@@ -560,6 +711,58 @@ describe('NotificationsModule', () => {
       'app.onModuleDestroy',
       'app.onApplicationShutdown:notifications-shutdown-test',
     ]);
+    expect(resourceLifecycleCalls).toEqual([]);
+  });
+
+  it('does not close or drain application-owned queue and event publisher resources during testing module disposal', async () => {
+    const resourceLifecycleCalls: string[] = [];
+    const queue = new LifecycleAwareQueueAdapter(resourceLifecycleCalls);
+    const publisher = new LifecycleAwarePublisher(resourceLifecycleCalls);
+
+    @Module({
+      imports: [
+        NotificationsModule.forRoot({
+          channels: [
+            {
+              channel: 'email',
+              async send() {
+                throw new Error('direct delivery should not run when queue is explicitly requested');
+              },
+            },
+          ],
+          events: {
+            publisher,
+          },
+          queue: {
+            adapter: queue,
+            bulkThreshold: 1,
+          },
+        }),
+      ],
+    })
+    class AppModule {}
+
+    const testingModule = await createTestingModule({ rootModule: AppModule }).compile();
+
+    try {
+      const service = await testingModule.resolve<NotificationsService>(NotificationsService);
+
+      await expect(
+        service.dispatch({ channel: 'email', payload: { template: 'queued-owned-by-app' } }, { queue: true }),
+      ).resolves.toMatchObject({
+        deliveryId: 'queued:1',
+        queued: true,
+        status: 'queued',
+      });
+      expect(queue.jobs).toHaveLength(1);
+      expect(publisher.events.map((event) => event.name)).toEqual([
+        'notification.dispatch.requested',
+        'notification.dispatch.queued',
+      ]);
+    } finally {
+      await testingModule.container.dispose();
+    }
+
     expect(resourceLifecycleCalls).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Linked context: Closes #2371

Hardens @fluojs/notifications executable coverage on top of the just-merged #2366 visibility/shutdown work. The new coverage keeps async module visibility, deterministic queue id assertions, and application-owned queue/event publisher disposal boundaries guarded without changing runtime behavior.

## Changes

- Added createTestingModule({ rootModule }) coverage for forRootAsync default global visibility through the NOTIFICATIONS and NOTIFICATION_CHANNELS tokens.
- Added createTestingModule({ rootModule }) coverage proving forRootAsync({ global: false }) keeps module-local providers hidden from sibling/root providers.
- Added a canonical-notification-content queue id regression so tests assert deterministic properties without pinning an opaque hash literal.
- Added testing-module disposal coverage proving application-owned queue adapters and event publishers are not closed or drained by @fluojs/notifications.

## Testing

- pnpm install --frozen-lockfile: passed.
- pnpm exec biome lint packages/notifications/src/module.test.ts: passed.
- pnpm --filter @fluojs/notifications... build: passed.
- pnpm --filter @fluojs/notifications typecheck: passed after dependent workspace packages were built.
- pnpm --filter @fluojs/notifications test: passed, 47 tests across 3 files.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

No changeset: this is package test coverage only. It does not change public runtime behavior, API surface, package exports, package contents, release metadata, or docs shipped to consumers.

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching @param / @returns tags where applicable.
- [x] Source @example blocks and README scenario examples still play complementary roles.

No public exports changed. The existing README and book public API summaries from #2366 remain unchanged.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [ ] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

No new runtime behavior is introduced. The added regression tests reinforce existing documented contracts: default global visibility, global: false local visibility, deterministic queue job ids without exact hash pinning, and no foundation-package ownership of concrete queue/event-bus resources.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [ ] Any package README alignment/conformance claims are backed by createPlatformConformanceHarness(...) tests.

No governance docs, platform contract docs, package README alignment claims, or localized docs changed. Closest package verifier coverage was run instead.