### PR TITLE
Resolve #2362: enforce cron validation and lifecycle coverage

### DIFF
--- a/.changeset/curly-cron-locks.md
+++ b/.changeset/curly-cron-locks.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/cron": patch
+---
+
+Reject blank decorator scheduling task names, normalize distributed Redis client names, and cover cron lifecycle/status regression paths.

--- a/packages/cron/README.ko.md
+++ b/packages/cron/README.ko.md
@@ -41,7 +41,7 @@ npm install @fluojs/cron croner
 애플리케이션 모듈의 스케줄링 등록은 `CronModule.forRoot(...)`로 구성합니다.
 Cron 표현식은 다섯 필드(`minute hour day month weekday`) 또는 여섯 필드(`second minute hour day month weekday`)를 사용할 수 있습니다. 내장 `CronExpression` preset은 sub-minute 정밀도가 필요할 때 여섯 필드 표현식을 사용합니다. Cron task는 application bootstrap 이후에만 시작되고, 이미 시작된 registry에 동적으로 등록한 cron task는 등록 시점에 시작되며, fluo는 `timezone`과 no-overlap 보호를 scheduler에 전달해 같은 task instance가 자기 자신과 겹쳐 실행되지 않게 합니다.
 
-Scheduling decorator는 public instance method에만 적용됩니다. NestJS에서 사용하던 private scheduled method, static helper, legacy decorator metadata 가정 뒤에 숨은 method name을 그대로 옮기지 마세요. 공개 provider/controller method를 노출하고 private 구현 세부사항은 그 method 뒤에 두세요.
+Scheduling decorator는 public instance method에만 적용됩니다. NestJS에서 사용하던 private scheduled method, static helper, legacy decorator metadata 가정 뒤에 숨은 method name을 그대로 옮기지 마세요. 공개 provider/controller method를 노출하고 private 구현 세부사항은 그 method 뒤에 두세요. 명시적인 decorator `name` 값은 non-empty string이어야 하며, dynamic registry validation contract와 동일하게 검증됩니다.
 
 ```typescript
 import { Module } from '@fluojs/core';
@@ -97,7 +97,7 @@ import { RedisModule } from '@fluojs/redis';
 class AppModule {}
 ```
 
-`distributed.clientName`을 생략하면 위의 기본 Redis 등록을 계속 사용합니다. 분산 락에 기본 Redis가 아닌 다른 연결을 쓰려면 `RedisModule.forRoot({ name, ... })`로 등록한 이름을 `distributed.clientName`에 지정하세요.
+`distributed.clientName`을 생략하면 위의 기본 Redis 등록을 계속 사용합니다. 분산 락에 기본 Redis가 아닌 다른 연결을 쓰려면 `RedisModule.forRoot({ name, ... })`로 등록한 이름을 `distributed.clientName`에 지정하세요. fluo는 module option normalization 중 configured client name을 trim하고, lifecycle 또는 status reporting이 Redis dependency name을 사용하기 전에 blank 값을 거부합니다.
 
 `distributed.lockTtlMs`는 `1_000ms` 이상이어야 합니다. fluo는 최소 지원 경계인 `1_000ms`를 포함해 TTL이 만료되기 전에 Redis 락을 갱신합니다.
 
@@ -149,7 +149,7 @@ class TaskManager {
 }
 ```
 
-Registry는 `addCron`, `addInterval`, `addTimeout`, `remove`, `enable`, `disable`, `get`, `getAll`, `updateCronExpression`, `updateIntervalMs`를 제공합니다. 첫 번째 `name` 인자는 기본 registry key이며, `options.name`을 전달하면 dynamic task의 실제 registry key, scheduler metadata name, 기본 distributed lock key가 이를 사용해 decorator naming semantics와 일치합니다. `get`과 `getAll`은 live `CronJob` handle이 아니라 read-only `SchedulingTaskDescriptor` 값을 반환합니다. Timeout task는 한 번 실행된 뒤 비활성화되지만 registry에는 남아 있어 의도적으로 다시 활성화할 수 있습니다.
+Registry는 `addCron`, `addInterval`, `addTimeout`, `remove`, `enable`, `disable`, `get`, `getAll`, `updateCronExpression`, `updateIntervalMs`를 제공합니다. 첫 번째 `name` 인자는 기본 registry key이며, `options.name`을 전달하면 dynamic task의 실제 registry key, scheduler metadata name, 기본 distributed lock key가 이를 사용해 decorator naming semantics와 일치합니다. Registry와 decorator task name은 non-empty string이어야 합니다. `get`과 `getAll`은 live `CronJob` handle이 아니라 read-only `SchedulingTaskDescriptor` 값을 반환합니다. Timeout task는 한 번 실행된 뒤 비활성화되지만 registry에는 남아 있어 의도적으로 다시 활성화할 수 있습니다.
 
 Dynamic cron 등록은 scheduler startup과 원자적으로 처리됩니다. Scheduler가 새 cron job을 거부하면 registry는 half-registered task를 남기지 않습니다. 실행 중인 cron expression 또는 interval cadence update도 rollback-safe합니다. Rescheduling이 실패하면 이전 expression 또는 interval milliseconds와 scheduled handle이 그대로 유지됩니다. Cron task는 scheduler-level no-overlap protection과 fluo의 in-process running guard를 함께 사용하므로 같은 task instance가 overlapping tick으로 실행되지 않습니다.
 

--- a/packages/cron/README.md
+++ b/packages/cron/README.md
@@ -41,7 +41,7 @@ Register the `CronModule` and use decorators to schedule your methods.
 Use `CronModule.forRoot(...)` to register scheduling for an application module.
 Cron expressions may use either five fields (`minute hour day month weekday`) or six fields (`second minute hour day month weekday`). The built-in `CronExpression` presets use six-field expressions when sub-minute precision is needed. Cron tasks start only after application bootstrap, dynamically registered cron tasks start when added to a started registry, and fluo forwards `timezone` plus no-overlap protection to the scheduler so one task instance does not overlap itself.
 
-Scheduling decorators apply to public instance methods only. Do not migrate NestJS private scheduled methods, static helpers, or method names that are hidden behind legacy decorator metadata assumptions as-is; expose a public provider/controller method and keep any private implementation details behind that method.
+Scheduling decorators apply to public instance methods only. Do not migrate NestJS private scheduled methods, static helpers, or method names that are hidden behind legacy decorator metadata assumptions as-is; expose a public provider/controller method and keep any private implementation details behind that method. Explicit decorator `name` values must be non-empty strings, matching the dynamic registry validation contract.
 
 ```typescript
 import { Module } from '@fluojs/core';
@@ -97,7 +97,7 @@ import { RedisModule } from '@fluojs/redis';
 class AppModule {}
 ```
 
-Leave `distributed.clientName` unset to keep using the default Redis registration above. To use a non-default Redis connection for distributed locks, set `distributed.clientName` to the name registered through `RedisModule.forRoot({ name, ... })`.
+Leave `distributed.clientName` unset to keep using the default Redis registration above. To use a non-default Redis connection for distributed locks, set `distributed.clientName` to the name registered through `RedisModule.forRoot({ name, ... })`. fluo trims the configured client name during module option normalization and rejects blank values before lifecycle or status reporting uses the Redis dependency name.
 
 `distributed.lockTtlMs` must stay at or above `1_000ms`. fluo renews the Redis lock before that TTL expires, including the minimum supported `1_000ms` boundary.
 
@@ -149,7 +149,7 @@ class TaskManager {
 }
 ```
 
-The registry exposes `addCron`, `addInterval`, `addTimeout`, `remove`, `enable`, `disable`, `get`, `getAll`, `updateCronExpression`, and `updateIntervalMs`. The first `name` argument is the default registry key; passing `options.name` overrides the actual registry key, scheduler metadata name, and default distributed lock key for dynamic tasks so dynamic registration matches decorator naming semantics. `get` and `getAll` return read-only `SchedulingTaskDescriptor` values, not live `CronJob` handles. Timeout tasks run once, then disable themselves while remaining in the registry so they can be re-enabled deliberately.
+The registry exposes `addCron`, `addInterval`, `addTimeout`, `remove`, `enable`, `disable`, `get`, `getAll`, `updateCronExpression`, and `updateIntervalMs`. The first `name` argument is the default registry key; passing `options.name` overrides the actual registry key, scheduler metadata name, and default distributed lock key for dynamic tasks so dynamic registration matches decorator naming semantics. Registry and decorator task names must be non-empty strings. `get` and `getAll` return read-only `SchedulingTaskDescriptor` values, not live `CronJob` handles. Timeout tasks run once, then disable themselves while remaining in the registry so they can be re-enabled deliberately.
 
 Dynamic cron registration is atomic with scheduler startup: if the scheduler rejects a new cron job, the registry does not retain a half-registered task. Updating a running cron expression or interval cadence is also rollback-safe. If rescheduling fails, the previous expression or interval milliseconds and scheduled handle remain active. Cron tasks use both scheduler-level no-overlap protection and fluo's in-process running guard, so the same task instance will not run overlapping ticks.
 

--- a/packages/cron/src/decorators.ts
+++ b/packages/cron/src/decorators.ts
@@ -48,6 +48,10 @@ function assertMethodIsPublic(context: ClassMethodDecoratorContext, decoratorNam
   if (context.private) {
     throw new Error(`${decoratorName}() cannot be used on private methods.`);
   }
+
+  if (context.static) {
+    throw new Error(`${decoratorName}() cannot be used on static methods.`);
+  }
 }
 
 /**

--- a/packages/cron/src/module.test.ts
+++ b/packages/cron/src/module.test.ts
@@ -386,6 +386,95 @@ describe('@fluojs/cron', () => {
     }).toThrow('@Timeout() cannot be used on private methods.');
   });
 
+  it('rejects private and static methods for @Cron()', () => {
+    expect(() => {
+      class InvalidPrivateCronTask {
+        @Cron(CronExpression.EVERY_SECOND)
+        // biome-ignore lint/correctness/noUnusedPrivateClassMembers: private decorator targets are the validation fixture under test.
+        #run() {}
+      }
+
+      return InvalidPrivateCronTask;
+    }).toThrow('@Cron() cannot be used on private methods.');
+
+    expect(() => {
+      class InvalidStaticCronTask {
+        @Cron(CronExpression.EVERY_SECOND)
+        static run() {}
+      }
+
+      return InvalidStaticCronTask;
+    }).toThrow('@Cron() cannot be used on static methods.');
+  });
+
+  it('rejects static methods for @Interval() and @Timeout()', () => {
+    expect(() => {
+      class InvalidStaticIntervalTask {
+        @Interval(1_000)
+        static run() {}
+      }
+
+      return InvalidStaticIntervalTask;
+    }).toThrow('@Interval() cannot be used on static methods.');
+
+    expect(() => {
+      class InvalidStaticTimeoutTask {
+        @Timeout(1_000)
+        static run() {}
+      }
+
+      return InvalidStaticTimeoutTask;
+    }).toThrow('@Timeout() cannot be used on static methods.');
+  });
+
+  it('rejects blank decorator task names during discovery before scheduling', async () => {
+    const scheduled = createManualScheduler();
+
+    class BlankCronNameTask {
+      @Cron(CronExpression.EVERY_SECOND, { name: '   ' })
+      run() {}
+    }
+
+    class BlankIntervalNameTask {
+      @Interval(1_000, { name: '' })
+      run() {}
+    }
+
+    class BlankTimeoutNameTask {
+      @Timeout(1_000, { name: '\t' })
+      run() {}
+    }
+
+    class CronAppModule {}
+    defineModule(CronAppModule, {
+      imports: [CronModule.forRoot({ scheduler: scheduled.scheduler })],
+      providers: [BlankCronNameTask],
+    });
+
+    class IntervalAppModule {}
+    defineModule(IntervalAppModule, {
+      imports: [CronModule.forRoot({ scheduler: scheduled.scheduler })],
+      providers: [BlankIntervalNameTask],
+    });
+
+    class TimeoutAppModule {}
+    defineModule(TimeoutAppModule, {
+      imports: [CronModule.forRoot({ scheduler: scheduled.scheduler })],
+      providers: [BlankTimeoutNameTask],
+    });
+
+    await expect(bootstrapApplication({ rootModule: CronAppModule })).rejects.toThrow(
+      'Scheduling task name must be a non-empty string.',
+    );
+    await expect(bootstrapApplication({ rootModule: IntervalAppModule })).rejects.toThrow(
+      'Scheduling task name must be a non-empty string.',
+    );
+    await expect(bootstrapApplication({ rootModule: TimeoutAppModule })).rejects.toThrow(
+      'Scheduling task name must be a non-empty string.',
+    );
+    expect(scheduled.records).toHaveLength(0);
+  });
+
   it('discovers cron tasks across imported modules and resolves DI-backed instances', async () => {
     const scheduled = createManualScheduler();
 
@@ -865,6 +954,61 @@ describe('@fluojs/cron', () => {
       'Cron distributed mode requires the configured Redis client to be registered.',
     );
     expect(scheduler.records).toHaveLength(0);
+  });
+
+  it('normalizes distributed clientName before Redis lookup and status dependency reporting', async () => {
+    const scheduled = createManualScheduler();
+    const redis = new InMemoryLockRedisClient();
+
+    class DistributedTaskService {
+      @Cron(CronExpression.EVERY_SECOND, { name: 'client-name-normalized' })
+      run() {}
+    }
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [
+        CronModule.forRoot({
+          distributed: {
+            clientName: ' locks ',
+            enabled: true,
+            keyPrefix: 'cron-client-name-normalized',
+            lockTtlMs: 60_000,
+          },
+          scheduler: scheduled.scheduler,
+        }),
+      ],
+      providers: [DistributedTaskService],
+    });
+
+    const app = await bootstrapApplication({
+      providers: [{ provide: getRedisClientToken('locks'), useValue: redis }],
+      rootModule: AppModule,
+    });
+
+    try {
+      const registry = await app.container.resolve(SCHEDULING_REGISTRY);
+      const statusService = registry as CronLifecycleService;
+      const snapshot = statusService.createPlatformStatusSnapshot();
+
+      expect(snapshot.details.dependencies).toEqual(['redis.locks']);
+      expect(snapshot.details.redisDependencyResolved).toBe(true);
+      expect(snapshot.readiness.status).toBe('ready');
+      expect(scheduled.records[0]?.options.name).toBe('client-name-normalized');
+    } finally {
+      await closeApplication(app);
+    }
+  });
+
+  it('rejects blank distributed clientName during module option normalization', () => {
+    expect(() =>
+      normalizeCronModuleOptions({
+        distributed: {
+          clientName: '   ',
+          enabled: true,
+        },
+      }),
+    ).toThrow('Cron distributed clientName must be a non-empty string when provided.');
   });
 
   it('fails bootstrap before scheduling jobs when the configured Redis client cannot perform lock operations', async () => {
@@ -1834,20 +1978,23 @@ describe('@fluojs/cron', () => {
     });
 
     const app = await bootstrapApplication({ rootModule: AppModule });
-    const store = await app.container.resolve(TickStore);
 
-    await vi.advanceTimersByTimeAsync(100);
-    expect(store.intervalCount).toBe(1);
-    expect(store.timeoutCount).toBe(0);
+    try {
+      const store = await app.container.resolve(TickStore);
 
-    await vi.advanceTimersByTimeAsync(150);
-    expect(store.intervalCount).toBe(2);
-    expect(store.timeoutCount).toBe(1);
+      await vi.advanceTimersByTimeAsync(100);
+      expect(store.intervalCount).toBe(1);
+      expect(store.timeoutCount).toBe(0);
 
-    await vi.advanceTimersByTimeAsync(1_000);
-    expect(store.timeoutCount).toBe(1);
+      await vi.advanceTimersByTimeAsync(150);
+      expect(store.intervalCount).toBe(2);
+      expect(store.timeoutCount).toBe(1);
 
-    await closeApplication(app);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(store.timeoutCount).toBe(1);
+    } finally {
+      await closeApplication(app);
+    }
   });
 
   it('fails bootstrap on duplicate task names across cron/interval/timeout decorators', async () => {

--- a/packages/cron/src/module.ts
+++ b/packages/cron/src/module.ts
@@ -1,8 +1,8 @@
 import type { Provider } from '@fluojs/di';
 import { defineModule, type ModuleType } from '@fluojs/runtime';
 
-import { CronLifecycleService } from './service.js';
 import { defaultCronScheduler } from './scheduler.js';
+import { CronLifecycleService } from './service.js';
 import { CRON_OPTIONS, SCHEDULING_REGISTRY } from './tokens.js';
 import type { CronModuleOptions, NormalizedCronModuleOptions } from './types.js';
 
@@ -16,6 +16,20 @@ function randomId(): string {
   }
 
   return `cron-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function normalizeRedisClientName(clientName: string | undefined): string | undefined {
+  if (clientName === undefined) {
+    return undefined;
+  }
+
+  const normalizedClientName = clientName.trim();
+
+  if (normalizedClientName.length === 0) {
+    throw new Error('Cron distributed clientName must be a non-empty string when provided.');
+  }
+
+  return normalizedClientName;
 }
 
 function normalizeDistributedOptions(distributed: CronModuleOptions['distributed']): NormalizedCronModuleOptions['distributed'] {
@@ -40,7 +54,7 @@ function normalizeDistributedOptions(distributed: CronModuleOptions['distributed
   }
 
   return {
-    clientName: distributed.clientName,
+    clientName: normalizeRedisClientName(distributed.clientName),
     enabled: distributed.enabled ?? true,
     keyPrefix: distributed.keyPrefix ?? 'fluo:cron:lock',
     lockTtlMs: distributed.lockTtlMs ?? 30_000,

--- a/packages/cron/src/optional-redis-peer.test.ts
+++ b/packages/cron/src/optional-redis-peer.test.ts
@@ -46,6 +46,46 @@ describe('optional Redis peer contract', () => {
     await app.close();
   });
 
+  it('does not load Redis while creating non-distributed status snapshots', async () => {
+    vi.doMock('@fluojs/redis', () => {
+      throw createMissingRedisPeerError();
+    });
+
+    const [
+      { bootstrapApplication, defineModule },
+      { CronModule },
+      { CronLifecycleService },
+      { SCHEDULING_REGISTRY },
+    ] = await Promise.all([
+      import('@fluojs/runtime'),
+      import('./module.js'),
+      import('./service.js'),
+      import('./tokens.js'),
+    ]);
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [CronModule.forRoot({ distributed: { enabled: false } })],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const registry = await app.container.resolve(SCHEDULING_REGISTRY);
+
+      if (!(registry instanceof CronLifecycleService)) {
+        throw new Error('Expected the scheduling registry to expose cron status snapshots.');
+      }
+
+      const snapshot = registry.createPlatformStatusSnapshot();
+
+      expect(snapshot.details.distributedEnabled).toBe(false);
+      expect(snapshot.details.dependencies).toEqual([]);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('loads Redis only when distributed scheduling is enabled', async () => {
     const redisTokenRequests: string[] = [];
 

--- a/packages/cron/src/service.ts
+++ b/packages/cron/src/service.ts
@@ -12,7 +12,12 @@ import { Cron as CronValidator } from 'croner';
 
 import { CronDistributedLockManager } from './distributed-lock-manager.js';
 import { createCronPlatformStatusSnapshot } from './status.js';
-import { createLockKey, discoverCronTaskDescriptors } from './task-discovery.js';
+import {
+  assertValidSchedulingTaskName,
+  createLockKey,
+  discoverCronTaskDescriptors,
+  resolveSchedulingTaskName,
+} from './task-discovery.js';
 import { CronTaskRunner } from './task-runner.js';
 import { CRON_OPTIONS } from './tokens.js';
 import type {
@@ -44,21 +49,8 @@ function assertValidLockTtlMs(lockTtlMs: number): void {
   }
 }
 
-function assertValidTaskName(name: string): void {
-  if (name.trim().length === 0) {
-    throw new Error('Scheduling task name must be a non-empty string.');
-  }
-}
-
 function resolveDynamicTaskName(name: string, optionName?: string): string {
-  assertValidTaskName(name);
-
-  if (optionName !== undefined) {
-    assertValidTaskName(optionName);
-    return optionName;
-  }
-
-  return name;
+  return resolveSchedulingTaskName(name, optionName);
 }
 
 function assertValidMs(ms: number, context: string): void {
@@ -569,6 +561,7 @@ export class CronLifecycleService
   }
 
   private registerTask(descriptor: CronTaskDescriptor, source: 'decorator' | 'dynamic'): void {
+    assertValidSchedulingTaskName(descriptor.taskName);
     this.assertTaskNameAvailable(descriptor.taskName);
 
     if (descriptor.distributed) {

--- a/packages/cron/src/task-discovery.ts
+++ b/packages/cron/src/task-discovery.ts
@@ -1,4 +1,4 @@
-import { type MetadataPropertyKey, type Token } from '@fluojs/core';
+import type { MetadataPropertyKey, Token } from '@fluojs/core';
 import { getClassDiMetadata } from '@fluojs/core/internal';
 import type { Provider } from '@fluojs/di';
 import type { ApplicationLogger, CompiledModule } from '@fluojs/runtime';
@@ -33,6 +33,35 @@ export function buildDefaultTaskName(targetName: string, methodName: string): st
  */
 export function createLockKey(prefix: string, taskName: string): string {
   return `${prefix}:${taskName}`;
+}
+
+/**
+ * Asserts that a scheduling task name can be used as a registry key.
+ *
+ * @param name Scheduling task name supplied by a decorator or registry call.
+ */
+export function assertValidSchedulingTaskName(name: string): void {
+  if (name.trim().length === 0) {
+    throw new Error('Scheduling task name must be a non-empty string.');
+  }
+}
+
+/**
+ * Resolves the effective scheduling task name while preserving authored names.
+ *
+ * @param defaultName Name derived from the decorated target or registry argument.
+ * @param optionName Optional name override supplied in scheduling options.
+ * @returns The effective task name used by the scheduler registry.
+ */
+export function resolveSchedulingTaskName(defaultName: string, optionName?: string): string {
+  assertValidSchedulingTaskName(defaultName);
+
+  if (optionName !== undefined) {
+    assertValidSchedulingTaskName(optionName);
+    return optionName;
+  }
+
+  return defaultName;
 }
 
 /**
@@ -77,7 +106,10 @@ export function discoverCronTaskDescriptors(
 
     for (const entry of entries) {
       const methodName = methodKeyToName(entry.propertyKey);
-      const taskName = entry.metadata.options.name ?? buildDefaultTaskName(candidate.targetType.name, methodName);
+      const taskName = resolveSchedulingTaskName(
+        buildDefaultTaskName(candidate.targetType.name, methodName),
+        entry.metadata.options.name,
+      );
       const seenMethods = seen.get(candidate.targetType) ?? new Set<string>();
       const lockTtlMs = entry.metadata.options.lockTtlMs ?? options.distributed.lockTtlMs;
 


### PR DESCRIPTION
## Summary

Linked context: Closes #2362.

This PR tightens `@fluojs/cron` validation so decorator-discovered tasks and dynamic registry tasks share the same non-empty task-name contract. It also normalizes distributed Redis `clientName` values before lifecycle/status code uses dependency names and adds regression coverage for lifecycle teardown, optional Redis peer status snapshots, and decorator target validation.

## Changes

- Reject `@Cron`, `@Interval`, and `@Timeout` on static methods; keep private-method rejection explicit for all scheduling decorators.
- Share scheduling task-name validation between decorator discovery and dynamic registry registration.
- Trim `distributed.clientName` during `CronModule` option normalization and reject blank values before Redis lookup/status reporting.
- Add cron module and optional-peer regression tests for blank decorator names, normalized Redis dependency reporting, finally-style teardown, non-distributed status snapshots without Redis peer loading, and `@Cron` private/static targets.
- Update EN/KO `packages/cron` README guidance and add a patch changeset for `@fluojs/cron`.

## Testing

- `pnpm install --frozen-lockfile` — passed.
- `pnpm exec biome check packages/cron/src/decorators.ts packages/cron/src/module.ts packages/cron/src/service.ts packages/cron/src/task-discovery.ts packages/cron/src/module.test.ts packages/cron/src/optional-redis-peer.test.ts` — passed, checked 6 files with no fixes applied.
- `pnpm --filter @fluojs/cron... build` — passed, including cron dependencies and `@fluojs/cron`.
- `pnpm --filter @fluojs/cron typecheck` — passed.
- `pnpm --filter @fluojs/cron test` — passed, 4 test files / 73 tests.
- `pnpm lint` — passed; `biome lint` reported existing warnings/infos outside this PR scope and `verify:public-export-tsdoc` passed in changed mode.
- `pnpm verify:platform-consistency-governance` — passed.

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/curly-cron-locks.md` for `@fluojs/cron`.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No new root package exports were added. Internal exported helpers in `packages/cron/src/task-discovery.ts` include TSDoc, and `packages/cron/README.md` / `README.ko.md` document the caller-visible validation contract.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

Decorator task names now fail closed when blank, static scheduling decorator targets are rejected, and `distributed.clientName` normalization is covered before Redis lookup/status snapshot paths depend on it.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform contract docs changed. EN/KO package README mirror guidance was updated together, and regression evidence is in `packages/cron/src/module.test.ts` plus `packages/cron/src/optional-redis-peer.test.ts`.
