### PR TITLE
Resolve #2369: document Discord bootstrap verification and visibility coverage

### DIFF
--- a/packages/discord/README.ko.md
+++ b/packages/discord/README.ko.md
@@ -12,7 +12,9 @@ fluo를 위한 webhook-first, transport-agnostic Discord 전달 코어 패키지
 - [사용 시점](#사용-시점)
 - [빠른 시작](#빠른-시작)
 - [일반적인 패턴](#일반적인-패턴)
+  - [모듈 visibility와 migration 경계](#모듈-visibility와-migration-경계)
   - [`DiscordService`를 이용한 standalone 전달](#discordservice를-이용한-standalone-전달)
+  - [`verifyOnModuleInit` bootstrap verification](#verifyonmoduleinit-bootstrap-verification)
   - [`@fluojs/notifications`와의 통합](#fluojs-notifications와의-통합)
   - [명시적 fetch 주입을 사용하는 webhook-first 전달](#명시적-fetch-주입을-사용하는-webhook-first-전달)
   - [의도적인 제한 사항](#의도적인-제한-사항)
@@ -77,6 +79,12 @@ export class DeployNotifier {
 
 ## 일반적인 패턴
 
+### 모듈 visibility와 migration 경계
+
+`DiscordModule.forRoot(...)`와 `DiscordModule.forRootAsync(...)`는 기본적으로 global module을 반환합니다. 이 모듈은 `DiscordService`, `DiscordChannel`, `DISCORD`, `DISCORD_CHANNEL`을 export합니다. 반환된 모듈을 명시적으로 import한 모듈에서만 이 provider들을 보이게 해야 하는 migrated code가 있을 때만 `global: false`를 전달하세요. 이 옵션은 NestJS `isGlobal`이 아니라 `global?: boolean`입니다.
+
+패키지 수준 registration surface는 의도적으로 singleton 중심입니다. `DISCORD`와 `DISCORD_CHANNEL`은 하나의 구성된 Discord service와 notifications channel을 위한 compatibility token입니다. 여러 Discord client가 필요한 애플리케이션은 private provider helper를 import하지 말고 서로 다른 `DiscordTransport` 인스턴스를 감싼 app-owned module/provider 또는 app-owned facade를 구성해야 합니다.
+
 ### `DiscordService`를 이용한 standalone 전달
 
 notifications foundation을 거치지 않고 직접 Discord 전달을 하고 싶다면 `DiscordService`를 사용합니다.
@@ -107,6 +115,24 @@ Behavioral contract 메모:
 - `DiscordService.createPlatformStatusSnapshot()`은 `createDiscordPlatformStatusSnapshot(...)`과 같은 status 계약을 노출합니다. 여기에는 lifecycle/readiness, health, transport kind와 ownership, 기본 thread 구성, bootstrap verification 상태, bootstrap initialization 실패와 shutdown cleanup 실패를 구분하는 diagnostics, notifications channel dependency details가 포함되어, 호출자가 내부 옵션에 접근하지 않고도 Discord wiring을 관찰할 수 있습니다.
 - 빈 `defaultThreadId`와 `notifications.channel` 값은 trim 후 무시됩니다. notifications channel은 기본적으로 `discord`입니다.
 - 이 패키지는 절대로 `process.env`를 직접 읽지 않습니다. 모든 설정은 명시적인 옵션 또는 DI를 통해 들어와야 합니다.
+
+### `verifyOnModuleInit` bootstrap verification
+
+선택한 transport가 애플리케이션 bootstrap 중 자체 readiness를 검증할 수 있다면 `DiscordModuleOptions.verifyOnModuleInit?: boolean`을 `true`로 설정하세요. `DiscordService.onModuleInit()`은 항상 구성된 transport를 먼저 해석합니다. `verifyOnModuleInit`이 켜져 있고 해석된 transport가 optional `verify()` 메서드를 노출하면, 서비스는 Discord provider를 ready로 표시하기 전에 `transport.verify()`를 await합니다. `verify`를 구현하지 않은 transport도 유효하며 verification 단계를 건너뜁니다.
+
+```typescript
+DiscordModule.forRoot({
+  transport: customDiscordTransport,
+  verifyOnModuleInit: true,
+});
+```
+
+Behavioral contract 메모:
+
+- `verifyOnModuleInit`은 optional이며 기본값은 `false`입니다.
+- Verification은 capability 기반입니다. `verify()`를 노출한 transport만 호출하므로 webhook-only 또는 app-owned transport가 no-op verifier를 추가할 필요는 없습니다.
+- `transport.verify()`가 reject하면 bootstrap은 initialization failure로 실패하고, service lifecycle은 `failed`로 이동하며, readiness/status snapshot은 provider를 not ready로 보고합니다.
+- `DiscordService.createPlatformStatusSnapshot()`은 `verifiedOnModuleInit`과 bootstrap verification 상태를 포함하므로 health/readiness tooling이 내부 옵션에 접근하지 않고도 bootstrap verification 요청 여부를 확인할 수 있습니다.
 
 ### `@fluojs/notifications`와의 통합
 

--- a/packages/discord/README.md
+++ b/packages/discord/README.md
@@ -12,7 +12,9 @@ Migration boundary: the module API is intentionally Nest-like but not a NestJS d
 - [When to Use](#when-to-use)
 - [Quick Start](#quick-start)
 - [Common Patterns](#common-patterns)
+  - [Module visibility and migration boundaries](#module-visibility-and-migration-boundaries)
   - [Standalone delivery with `DiscordService`](#standalone-delivery-with-discordservice)
+  - [Bootstrap verification with `verifyOnModuleInit`](#bootstrap-verification-with-verifyonmoduleinit)
   - [Integration with `@fluojs/notifications`](#integration-with-fluojs-notifications)
   - [Webhook-first delivery with explicit fetch injection](#webhook-first-delivery-with-explicit-fetch-injection)
   - [Intentional limitations](#intentional-limitations)
@@ -77,6 +79,12 @@ export class DeployNotifier {
 
 ## Common Patterns
 
+### Module visibility and migration boundaries
+
+`DiscordModule.forRoot(...)` and `DiscordModule.forRootAsync(...)` return a global module by default. The module exports `DiscordService`, `DiscordChannel`, `DISCORD`, and `DISCORD_CHANNEL`; pass `global: false` only when migrated code needs those providers to remain visible only to modules that explicitly import the returned module. The option is `global?: boolean`, not NestJS `isGlobal`.
+
+The package-level registration surface is intentionally singleton-oriented. `DISCORD` and `DISCORD_CHANNEL` are compatibility tokens for the one configured Discord service and notifications channel. Applications that need multiple Discord clients should compose app-owned modules/providers around distinct `DiscordTransport` instances or expose app-owned facades instead of importing private provider helpers.
+
 ### Standalone delivery with `DiscordService`
 
 Use `DiscordService` when your application wants direct Discord delivery without routing through the notifications foundation.
@@ -107,6 +115,24 @@ Behavioral contract notes:
 - `DiscordService.createPlatformStatusSnapshot()` exposes the same status contract as `createDiscordPlatformStatusSnapshot(...)`: lifecycle/readiness, health, transport kind and ownership, default thread configuration, bootstrap verification state, distinct bootstrap initialization versus shutdown cleanup failure diagnostics, and notifications channel dependency details, so callers can observe Discord wiring without reaching into internal options.
 - Blank `defaultThreadId` and `notifications.channel` values are trimmed and ignored; the notifications channel defaults to `discord`.
 - The package never reads `process.env` directly. All configuration must enter through explicit options or DI.
+
+### Bootstrap verification with `verifyOnModuleInit`
+
+Set `DiscordModuleOptions.verifyOnModuleInit?: boolean` to `true` when the selected transport can verify its own readiness during application bootstrap. `DiscordService.onModuleInit()` always resolves the configured transport first; if `verifyOnModuleInit` is enabled **and** the resolved transport exposes an optional `verify()` method, the service awaits `transport.verify()` before marking the Discord provider ready. Transports that do not implement `verify` are still valid and simply skip the verification step.
+
+```typescript
+DiscordModule.forRoot({
+  transport: customDiscordTransport,
+  verifyOnModuleInit: true,
+});
+```
+
+Behavioral contract notes:
+
+- `verifyOnModuleInit` is optional and defaults to `false`.
+- Verification is capability-based: only transports that expose `verify()` are called, so webhook-only or app-owned transports do not have to add a no-op verifier.
+- If `transport.verify()` rejects, bootstrap fails with the initialization failure, the service lifecycle moves to `failed`, and readiness/status snapshots report the provider as not ready.
+- `DiscordService.createPlatformStatusSnapshot()` includes `verifiedOnModuleInit` and bootstrap verification state so health/readiness tooling can tell whether bootstrap verification was requested without reaching into internal options.
 
 ### Integration with `@fluojs/notifications`
 

--- a/packages/discord/src/module.test.ts
+++ b/packages/discord/src/module.test.ts
@@ -1,7 +1,8 @@
-import { type Constructor, getModuleMetadata, type Token } from '@fluojs/core';
+import { type Constructor, getModuleMetadata, Inject, type Token } from '@fluojs/core';
 import { Container, type Provider } from '@fluojs/di';
 import type { NotificationChannel } from '@fluojs/notifications';
 import { NOTIFICATION_CHANNELS, NotificationsModule, NotificationsService } from '@fluojs/notifications';
+import { bootstrapApplication, defineModule } from '@fluojs/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DiscordChannel } from './channel.js';
@@ -189,6 +190,135 @@ describe('DiscordModule', () => {
     transportState.sent.length = 0;
     transportState.sequence = 0;
     transportState.verifyCalls = 0;
+  });
+
+  it('exposes default-global Discord providers across a real module graph for notifications', async () => {
+    @Inject(DiscordService)
+    class DiscordVisibilityConsumer {
+      constructor(readonly discord: DiscordService) {}
+    }
+
+    class DiscordOwnerModule {}
+    defineModule(DiscordOwnerModule, {
+      imports: [
+        DiscordModule.forRoot({
+          defaultThreadId: 'thread-ops',
+          notifications: { channel: 'alerts' },
+          transport: createRecordingTransportFactory({ responsePrefix: 'graph' }),
+        }),
+      ],
+    });
+
+    class NotificationsOwnerModule {}
+    defineModule(NotificationsOwnerModule, {
+      imports: [
+        NotificationsModule.forRootAsync({
+          inject: [DISCORD_CHANNEL],
+          useFactory: (channel: unknown) => ({
+            channels: [channel as DiscordChannel],
+          }),
+        }),
+      ],
+      providers: [DiscordVisibilityConsumer],
+    });
+
+    class AppModule {}
+    defineModule(AppModule, {
+      imports: [DiscordOwnerModule, NotificationsOwnerModule],
+    });
+
+    const app = await bootstrapApplication({ rootModule: AppModule });
+
+    try {
+      const consumer = await app.container.resolve(DiscordVisibilityConsumer);
+      const notifications = await app.container.resolve(NotificationsService);
+      const result = await notifications.dispatch({
+        channel: 'alerts',
+        payload: { content: 'Global graph delivery' },
+        recipients: ['thread-release'],
+      });
+
+      expect(consumer.discord).toBeInstanceOf(DiscordService);
+      expect(result).toMatchObject({
+        channel: 'alerts',
+        deliveryId: 'graph-1',
+        queued: false,
+        status: 'delivered',
+      });
+      expect(transportState.sent[0]).toMatchObject({
+        content: 'Global graph delivery',
+        threadId: 'thread-release',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('keeps global=false Discord providers local to explicit importers in a real module graph', async () => {
+    @Inject(DiscordService)
+    class LocalDiscordConsumer {
+      constructor(readonly discord: DiscordService) {}
+    }
+
+    class LocalDiscordFeatureModule {}
+    defineModule(LocalDiscordFeatureModule, {
+      imports: [
+        DiscordModule.forRoot({
+          defaultThreadId: 'thread-local',
+          global: false,
+          transport: createRecordingTransportFactory({ responsePrefix: 'local-graph' }),
+        }),
+      ],
+      providers: [LocalDiscordConsumer],
+    });
+
+    class LocalAppModule {}
+    defineModule(LocalAppModule, {
+      imports: [LocalDiscordFeatureModule],
+    });
+
+    const localApp = await bootstrapApplication({ rootModule: LocalAppModule });
+
+    try {
+      const consumer = await localApp.container.resolve(LocalDiscordConsumer);
+
+      expect(consumer.discord).toBeInstanceOf(DiscordService);
+      await expect(consumer.discord.send({ content: 'Local graph delivery' })).resolves.toMatchObject({
+        threadId: 'thread-local',
+      });
+    } finally {
+      await localApp.close();
+    }
+
+    @Inject(DiscordService)
+    class HiddenDiscordConsumer {
+      constructor(readonly discord: DiscordService) {}
+    }
+
+    class HiddenDiscordOwnerModule {}
+    defineModule(HiddenDiscordOwnerModule, {
+      imports: [
+        DiscordModule.forRoot({
+          defaultThreadId: 'thread-hidden',
+          global: false,
+          transport: createRecordingTransportFactory({ responsePrefix: 'hidden-graph' }),
+        }),
+      ],
+    });
+
+    class HiddenConsumerModule {}
+    defineModule(HiddenConsumerModule, {
+      providers: [HiddenDiscordConsumer],
+    });
+
+    class HiddenAppModule {}
+    defineModule(HiddenAppModule, {
+      imports: [HiddenDiscordOwnerModule, HiddenConsumerModule],
+    });
+
+    await expect(bootstrapApplication({ rootModule: HiddenAppModule })).rejects.toThrow(
+      /not visible through a global module|DiscordService/,
+    );
   });
 
   it('registers sync providers and delivers Discord messages through an injected transport factory', async () => {
@@ -488,6 +618,45 @@ describe('DiscordModule', () => {
     expect(transportState.sent).toEqual([]);
   });
 
+  it('rejects sends while module bootstrap is still resolving the transport', async () => {
+    const transport = new PassiveTransport();
+    let resolveTransport: (transport: DiscordTransport) => void = () => {};
+    const transportPromise = new Promise<DiscordTransport>((resolve) => {
+      resolveTransport = resolve;
+    });
+    const container = new Container();
+    const moduleType = DiscordModule.forRoot({
+      transport: {
+        create: () => transportPromise,
+        kind: 'deferred-startup-factory',
+        ownsResources: true,
+      },
+    });
+
+    container.register(...moduleProviders(moduleType));
+    const service = await container.resolve(DiscordService);
+    const startup = service.onModuleInit();
+
+    expect(service.createPlatformStatusSnapshot()).toMatchObject({
+      details: { lifecycleState: 'starting' },
+      readiness: {
+        reason: 'Discord transport is still starting.',
+        status: 'degraded',
+      },
+    });
+    await expect(service.send({ content: 'During startup' })).rejects.toThrowError(
+      new DiscordTransportError('Discord transport is not ready for delivery.'),
+    );
+    expect(transport.sent).toEqual([]);
+
+    resolveTransport(transport);
+    await startup;
+    await service.onApplicationShutdown();
+
+    expect(transport.closeCalls).toBe(1);
+    expect(transport.sent).toEqual([]);
+  });
+
   it('accepts poll-only Discord payloads documented by the notifications contract', async () => {
     const container = new Container();
     const moduleType = DiscordModule.forRoot({
@@ -680,6 +849,50 @@ describe('DiscordModule', () => {
 
       await expect(pending).resolves.toMatchObject({ messageId: 'msg-1', ok: true, statusCode: 200, threadId: 'thread-ops' });
       expect(fetchLike).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('retries HTTP 408 webhook responses before succeeding', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const fetchLike = vi
+        .fn<DiscordFetchLike>()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 408,
+          statusText: 'Request Timeout',
+          async text() {
+            return 'request timed out';
+          },
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          async text() {
+            return JSON.stringify({ id: 'msg-timeout', thread_id: 'thread-ops' });
+          },
+        });
+      const transport = createDiscordWebhookTransport({
+        fetch: fetchLike,
+        webhookUrl: 'https://discord.com/api/webhooks/123/abc',
+      });
+
+      const pending = transport.send(
+        { attachments: [], components: [], content: 'Retry timeout path', embeds: [], threadId: 'thread-ops' },
+        {},
+      );
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toMatchObject({
+        messageId: 'msg-timeout',
+        ok: true,
+        statusCode: 200,
+        threadId: 'thread-ops',
+      });
+      expect(fetchLike).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Summary

Closes #2369.

Document the Discord bootstrap verification contract and add executable regression coverage for module visibility, startup send rejection, and HTTP 408 retry behavior.

Linked context: https://github.com/fluojs/fluo/issues/2369

## Changes

- Added Discord README EN/KO sections for module visibility and `verifyOnModuleInit` bootstrap verification.
- Covered default-global Discord provider visibility through a real `bootstrapApplication(...)` module graph with `NotificationsModule` integration.
- Covered `global: false` local visibility and hidden-consumer rejection through a real module graph.
- Added regression coverage for sends rejected while bootstrap is still resolving the transport.
- Added dedicated webhook retry coverage for transient HTTP 408 responses.
- Left `src/internal` relocation untouched because this issue treats it as secondary without additional public-surface evidence.

## Testing

- `pnpm install --frozen-lockfile` — passed; installed worktree dependencies without lockfile changes.
- `pnpm exec biome check packages/discord/src/module.test.ts packages/discord/README.md packages/discord/README.ko.md` — passed; no fixes applied.
- `pnpm --filter @fluojs/discord... build` — passed; built Discord and dependency packages needed for workspace type resolution.
- `pnpm --filter @fluojs/discord test` — passed; 3 test files, 40 tests.
- `pnpm --filter @fluojs/discord typecheck` — passed.

## Release impact

- [ ] This PR has consumer-visible release impact and includes a changeset.
- [x] This PR has no consumer-visible release impact.

Docs and regression tests only; no public API, runtime behavior, package contents, or release metadata changed.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports changed.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The PR documents the existing `verifyOnModuleInit` option and adds executable regression coverage for visibility, startup readiness gating, and HTTP 408 retry behavior.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

Only `packages/discord/README.md` and `packages/discord/README.ko.md` changed; no platform governance docs changed. EN/KO package README updates are mirrored, and the new claims are backed by `packages/discord/src/module.test.ts`.