### PR TITLE
Resolve #2407: align JWT refresh token provider surface

### DIFF
--- a/.changeset/jwt-sync-refresh-token-surface.md
+++ b/.changeset/jwt-sync-refresh-token-surface.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/jwt": patch
+---
+
+Align `JwtModule.forRoot(...)` with async registration by exposing the `RefreshTokenService` provider/export surface even when sync options omit `refreshToken`, while preserving resolution-time configuration failure for callers that resolve the service without refresh-token options.

--- a/packages/jwt/src/module.refresh-token.test.ts
+++ b/packages/jwt/src/module.refresh-token.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import { Module, type Constructor, type Token } from '@fluojs/core';
+import { getModuleMetadata } from '@fluojs/core/internal';
+import { Container, type Provider } from '@fluojs/di';
+import { FluoFactory } from '@fluojs/runtime';
+
+import { JwtModule } from './module.js';
+import { type RefreshTokenRecord, type RefreshTokenStore, RefreshTokenService } from './refresh/refresh-token.js';
+
+class NoopRefreshTokenStore implements RefreshTokenStore {
+  async save(_: RefreshTokenRecord): Promise<void> {}
+
+  async find(_: string): Promise<RefreshTokenRecord | undefined> {
+    return undefined;
+  }
+
+  async revoke(_: string): Promise<void> {}
+
+  async revokeBySubject(_: string): Promise<void> {}
+
+  async consume(): Promise<'consumed' | 'already_used' | 'expired' | 'not_found' | 'mismatch'> {
+    return 'not_found';
+  }
+}
+
+function isProvider(value: unknown): value is Provider {
+  return typeof value === 'function' || (typeof value === 'object' && value !== null && 'provide' in value);
+}
+
+function isToken(value: unknown): value is Token {
+  return typeof value === 'function' || typeof value === 'string' || typeof value === 'symbol';
+}
+
+function moduleProviders(moduleType: Constructor): Provider[] {
+  const providers = getModuleMetadata(moduleType)?.providers;
+
+  if (!Array.isArray(providers) || !providers.every(isProvider)) {
+    throw new Error('JwtModule did not register providers metadata.');
+  }
+
+  return providers;
+}
+
+function moduleExports(moduleType: Constructor): Token[] {
+  const exports = getModuleMetadata(moduleType)?.exports;
+
+  return Array.isArray(exports) && exports.every(isToken) ? exports : [];
+}
+
+async function createJwtApplicationContext(jwtModule: Constructor) {
+  @Module({ imports: [jwtModule] })
+  class AppModule {}
+
+  return FluoFactory.createApplicationContext(AppModule);
+}
+
+describe('JwtModule refresh token configuration', () => {
+  it('registers refresh token service for async options when refreshToken is configured', async () => {
+    const app = await createJwtApplicationContext(JwtModule.forRootAsync({
+      useFactory: async () => ({
+        algorithms: ['HS256'],
+        refreshToken: {
+          expiresInSeconds: 60,
+          rotation: true,
+          secret: 'refresh-secret',
+          store: new NoopRefreshTokenStore(),
+        },
+        secret: 'jwt-secret',
+      }),
+    }));
+
+    try {
+      expect(app.container.has(RefreshTokenService)).toBe(true);
+      await expect(app.container.resolve(RefreshTokenService)).resolves.toBeInstanceOf(RefreshTokenService);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('fails async bootstrap when refreshToken is configured without any HMAC algorithms', async () => {
+    await expect(createJwtApplicationContext(JwtModule.forRootAsync({
+      useFactory: async () => ({
+        algorithms: ['RS256'],
+        publicKey: '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApseudo\n-----END PUBLIC KEY-----',
+        refreshToken: {
+          expiresInSeconds: 60,
+          rotation: false,
+          secret: 'refresh-secret',
+          store: new NoopRefreshTokenStore(),
+        },
+      }),
+    }))).rejects.toThrow(
+      'JWT refresh token verifier requires at least one HMAC algorithm (HS256/HS384/HS512) in the allowed algorithms list.',
+    );
+  });
+
+  it('registers refresh token service when refresh options are provided', async () => {
+    const container = new Container();
+    const moduleType = JwtModule.forRoot({
+      algorithms: ['HS256'],
+      refreshToken: {
+        expiresInSeconds: 60,
+        rotation: true,
+        secret: 'refresh-secret',
+        store: new NoopRefreshTokenStore(),
+      },
+      secret: 'jwt-secret',
+    });
+
+    container.register(...moduleProviders(moduleType));
+    await expect(container.resolve(RefreshTokenService)).resolves.toBeInstanceOf(RefreshTokenService);
+  });
+
+  it('exports refresh token service from synchronous registration when refresh options are provided', () => {
+    const moduleType = JwtModule.forRoot({
+      algorithms: ['HS256'],
+      refreshToken: {
+        expiresInSeconds: 60,
+        rotation: true,
+        secret: 'refresh-secret',
+        store: new NoopRefreshTokenStore(),
+      },
+      secret: 'jwt-secret',
+    });
+
+    expect(moduleExports(moduleType)).toContain(RefreshTokenService);
+  });
+});

--- a/packages/jwt/src/module.test.ts
+++ b/packages/jwt/src/module.test.ts
@@ -7,26 +7,10 @@ import { FluoFactory } from '@fluojs/runtime';
 
 import * as jwtRootExports from './index.js';
 import { JwtModule } from './module.js';
-import { type RefreshTokenRecord, type RefreshTokenStore, RefreshTokenService } from './refresh/refresh-token.js';
+import { RefreshTokenService } from './refresh/refresh-token.js';
 import { JwtService } from './service.js';
 import { DefaultJwtSigner } from './signing/signer.js';
 import { DefaultJwtVerifier } from './signing/verifier.js';
-
-class NoopRefreshTokenStore implements RefreshTokenStore {
-  async save(_: RefreshTokenRecord): Promise<void> {}
-
-  async find(_: string): Promise<RefreshTokenRecord | undefined> {
-    return undefined;
-  }
-
-  async revoke(_: string): Promise<void> {}
-
-  async revokeBySubject(_: string): Promise<void> {}
-
-  async consume(): Promise<'consumed' | 'already_used' | 'expired' | 'not_found' | 'mismatch'> {
-    return 'not_found';
-  }
-}
 
 @Inject(DefaultJwtSigner, DefaultJwtVerifier)
 class JwtRoundTripService {
@@ -253,28 +237,6 @@ describe('JwtModule', () => {
     }
   });
 
-  it('registers refresh token service for async options when refreshToken is configured', async () => {
-    const app = await createJwtApplicationContext(JwtModule.forRootAsync({
-      useFactory: async () => ({
-        algorithms: ['HS256'],
-        refreshToken: {
-          expiresInSeconds: 60,
-          rotation: true,
-          secret: 'refresh-secret',
-          store: new NoopRefreshTokenStore(),
-        },
-        secret: 'jwt-secret',
-      }),
-    }));
-
-    try {
-      expect(app.container.has(RefreshTokenService)).toBe(true);
-      await expect(app.container.resolve(RefreshTokenService)).resolves.toBeInstanceOf(RefreshTokenService);
-    } finally {
-      await app.close();
-    }
-  });
-
   it('exports refresh token service from async registration metadata to match sync registration parity', () => {
     const moduleType = JwtModule.forRootAsync({
       useFactory: async () => ({
@@ -288,52 +250,30 @@ describe('JwtModule', () => {
     expect(moduleProviders(moduleType).map((provider) => providerToken(provider))).toContain(RefreshTokenService);
   });
 
-  it('fails async bootstrap when refreshToken is configured without any HMAC algorithms', async () => {
-    await expect(createJwtApplicationContext(JwtModule.forRootAsync({
-      useFactory: async () => ({
-        algorithms: ['RS256'],
-        publicKey: '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApseudo\n-----END PUBLIC KEY-----',
-        refreshToken: {
-          expiresInSeconds: 60,
-          rotation: false,
-          secret: 'refresh-secret',
-          store: new NoopRefreshTokenStore(),
-        },
-      }),
-    }))).rejects.toThrow(
-      'JWT refresh token verifier requires at least one HMAC algorithm (HS256/HS384/HS512) in the allowed algorithms list.',
-    );
-  });
-
-  it('registers refresh token service when refresh options are provided', async () => {
-    const container = new Container();
+  it('exports refresh token service from synchronous registration metadata when refresh options are omitted', () => {
     const moduleType = JwtModule.forRoot({
       algorithms: ['HS256'],
-      refreshToken: {
-        expiresInSeconds: 60,
-        rotation: true,
-        secret: 'refresh-secret',
-        store: new NoopRefreshTokenStore(),
-      },
-      secret: 'jwt-secret',
-    });
-
-    container.register(...moduleProviders(moduleType));
-    await expect(container.resolve(RefreshTokenService)).resolves.toBeInstanceOf(RefreshTokenService);
-  });
-
-  it('exports refresh token service from synchronous registration when refresh options are provided', () => {
-    const moduleType = JwtModule.forRoot({
-      algorithms: ['HS256'],
-      refreshToken: {
-        expiresInSeconds: 60,
-        rotation: true,
-        secret: 'refresh-secret',
-        store: new NoopRefreshTokenStore(),
-      },
-      secret: 'jwt-secret',
+      issuer: 'jwt-module-tests',
+      secret: 'sync-secret-without-refresh',
     });
 
     expect(moduleExports(moduleType)).toContain(RefreshTokenService);
+    expect(moduleProviders(moduleType).map((provider) => providerToken(provider))).toContain(RefreshTokenService);
+  });
+
+  it('rejects sync refresh token service resolution when sync options omit refreshToken', async () => {
+    const app = await createJwtApplicationContext(JwtModule.forRoot({
+      algorithms: ['HS256'],
+      issuer: 'jwt-module-tests',
+      secret: 'sync-secret-without-refresh',
+    }));
+
+    try {
+      await expect(app.container.resolve(RefreshTokenService)).rejects.toThrow(
+        'JWT refresh token options are not configured.',
+      );
+    } finally {
+      await app.close();
+    }
   });
 });

--- a/packages/jwt/src/module.ts
+++ b/packages/jwt/src/module.ts
@@ -91,7 +91,7 @@ export class JwtModule {
       provide: JWT_OPTIONS,
       scope: 'singleton',
       useValue: options,
-    }, Boolean(options.refreshToken), Boolean(options.refreshToken), 'singleton', false, options.global ?? false);
+    }, true, true, options.refreshToken ? 'singleton' : 'transient', false, options.global ?? false);
   }
 
   static forRootAsync(options: AsyncModuleOptions<JwtVerifierOptions> & { global?: boolean }): ModuleType {


### PR DESCRIPTION
## Summary

Aligns `JwtModule.forRoot(...)` with the documented JWT module contract so sync registration exposes the same `RefreshTokenService` provider/export surface as async registration.

Linked context: Closes #2407

## Changes

- Expose `RefreshTokenService` from sync `JwtModule.forRoot(...)` metadata even when `refreshToken` options are omitted.
- Preserve resolution-time configuration failure when callers resolve `RefreshTokenService` without `refreshToken` options.
- Move existing refresh-token module tests into a focused `module.refresh-token.test.ts` suite and add sync no-refresh parity regression coverage.
- Add a patch changeset for `@fluojs/jwt`.

## Testing

- `pnpm --filter @fluojs/jwt exec vitest run -c vitest.config.ts src/module.test.ts` — passed, 13 tests
- `pnpm --filter @fluojs/jwt test` — passed, 121 tests
- `pnpm --filter @fluojs/jwt typecheck` — passed
- `pnpm --filter @fluojs/jwt build` — passed
- `pnpm docs:sync-check` — passed
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main` — passed

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

Patch changeset: `.changeset/jwt-sync-refresh-token-surface.md`

## Public export documentation

- [ ] Changed public exports include a source-level summary.
- [ ] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public exports were added or renamed. Existing package README and architecture docs already describe the provider-surface contract this PR restores.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

The existing documented contract says sync and async JWT registration export the same provider surface, including `RefreshTokenService`; resolving that service still requires `refreshToken` options. This PR aligns implementation/tests to that contract without narrowing docs.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No governance docs changed. `pnpm docs:sync-check` passed; package docs were verified as no-op because EN/KO docs already match the target behavior.
