### PR TITLE
Resolve #2410: Resolve Passport AuthHandledResult contract mismatch

### DIFF
--- a/.changeset/passport-handled-result-terminal.md
+++ b/.changeset/passport-handled-result-terminal.md
@@ -1,0 +1,5 @@
+---
+"@fluojs/passport": patch
+---
+
+Preserve the documented `AuthHandledResult` contract so every `handled:true` result remains terminal after the strategy commits a response, including results that also include a principal.

--- a/packages/passport/README.ko.md
+++ b/packages/passport/README.ko.md
@@ -120,7 +120,7 @@ export class AuthModule {}
 
 이 bridge helper는 third-party Passport.js strategy instance를 `AuthGuard`가 실행하기 전에 provider로 바인딩해야 하므로 Passport.js adapter에 대해 공식적으로 허용되는 module-facade 예외입니다. 애플리케이션-facing 인증 표면은 계속 `PassportModule`, `@UseAuth(...)`, `AuthGuard`이며, 이 helper가 이를 대체하지 않습니다.
 
-브릿지는 각 Passport.js 전략 실행을 정확히 한 번만 정착(settle)시킵니다. 전략은 바인딩된 Passport 액션(`success`, `fail`, `redirect`, `pass`, `error`) 중 하나를 호출해야 하며, promise rejection, 액션 없이 완료된 promise, 그리고 제한된 action timeout을 초과한 callback-style 실행은 요청을 미해결 상태로 두지 않고 인증 실패로 처리됩니다. 커스텀 `mapPrincipal` 함수는 비어 있지 않은 `subject`와 객체 형태의 `claims`를 포함한 유효한 fluo `Principal`을 반환해야 합니다.
+브릿지는 각 Passport.js 전략 실행을 정확히 한 번만 정착(settle)시킵니다. 전략은 바인딩된 Passport 액션(`success`, `fail`, `redirect`, `pass`, `error`) 중 하나를 호출해야 하며, promise rejection, 액션 없이 완료된 promise, 그리고 제한된 action timeout을 초과한 callback-style 실행은 요청을 미해결 상태로 두지 않고 인증 실패로 처리됩니다. `handled: true`를 포함한 모든 `AuthStrategyResult`는 전략이 response를 commit한 뒤에는 `principal`을 함께 포함하더라도 완전히 terminal입니다. 이때 `AuthGuard`는 principal validation, scope check, `requestContext.principal` 할당, protected handler 실행을 모두 건너뜁니다. 커스텀 `mapPrincipal` 함수는 비어 있지 않은 `subject`와 객체 형태의 `claims`를 포함한 유효한 fluo `Principal`을 반환해야 합니다.
 
 ### 쿠키 인증 프리셋
 
@@ -279,7 +279,7 @@ Identity-link 결정을 모델링하려면 `createConservativeAccountLinkPolicy(
 - `createPassportPlatformDiagnosticIssues(...)`: Empty registry, 누락된 default strategy, cookie preset readiness, refresh-token backing store readiness 문제에 대한 diagnostic issue를 생성합니다.
 - `PassportPlatformStatusSnapshot`, `PassportStatusAdapterInput`: Status helper input/output 계약입니다.
 
-`UseOptionalAuth`는 scope가 필요 없는 route에서만 credential 누락을 우회합니다. Scoped route에는 여전히 principal이 필요합니다. Passport.js bridge의 `redirect()`는 response를 commit하고 protected handler를 건너뛰며, `pass()`와 Passport action 없이 완료된 strategy는 인증 실패입니다. Refresh-token backing store status 및 diagnostic surface는 readiness, health, details, diagnostic cause를 노출하기 전에 secret처럼 보이는 reason 문자열을 redact합니다.
+`UseOptionalAuth`는 scope가 필요 없는 route에서만 credential 누락을 우회합니다. Scoped route에는 여전히 principal이 필요합니다. `handled: true`를 포함한 `AuthHandledResult`는 strategy가 response를 commit한 뒤에만 terminal이며, `principal`을 함께 포함한 결과도 여기에 포함됩니다. Passport.js bridge의 `redirect()`는 response를 commit하고 protected handler를 건너뛰며, `pass()`와 Passport action 없이 완료된 strategy는 인증 실패입니다. Refresh-token backing store status 및 diagnostic surface는 readiness, health, details, diagnostic cause를 노출하기 전에 secret처럼 보이는 reason 문자열을 redact합니다.
 
 ## 관련 패키지
 

--- a/packages/passport/README.md
+++ b/packages/passport/README.md
@@ -120,7 +120,7 @@ export class AuthModule {}
 
 This bridge helper is the official exception to the module-facade rule for Passport.js adapters because third-party strategy instances must be bound as providers before `AuthGuard` can execute them. It does not replace `PassportModule`, `@UseAuth(...)`, or `AuthGuard` as the application-facing authentication surface.
 
-The bridge settles each Passport.js strategy execution exactly once. A strategy must call one of the bound Passport actions (`success`, `fail`, `redirect`, `pass`, or `error`); promise rejections, promise completion without an action, and callback-style executions that exceed the bounded action timeout become authentication failures instead of leaving the request unresolved. Custom `mapPrincipal` functions must return a valid fluo `Principal` with a non-empty `subject` and object `claims`.
+The bridge settles each Passport.js strategy execution exactly once. A strategy must call one of the bound Passport actions (`success`, `fail`, `redirect`, `pass`, or `error`); promise rejections, promise completion without an action, and callback-style executions that exceed the bounded action timeout become authentication failures instead of leaving the request unresolved. Any `AuthStrategyResult` with `handled: true` is fully terminal after the strategy commits a response, even if it also includes a `principal`; `AuthGuard` skips principal validation, scope checks, `requestContext.principal` assignment, and the protected handler. Custom `mapPrincipal` functions must return a valid fluo `Principal` with a non-empty `subject` and object `claims`.
 
 ### Cookie Auth Preset
 
@@ -279,7 +279,7 @@ Use `createConservativeAccountLinkPolicy(...)` and `resolveAccountLinking(...)` 
 - `createPassportPlatformDiagnosticIssues(...)`: Emits diagnostic issues for empty registries, missing default strategies, cookie preset readiness, and refresh-token backing store readiness.
 - `PassportPlatformStatusSnapshot`, `PassportStatusAdapterInput`: Status helper input/output contracts.
 
-`UseOptionalAuth` only bypasses missing credentials when no scopes are required; scoped routes still need a principal. Passport.js bridge `redirect()` commits the response and skips the protected handler, while `pass()` and strategy completion without a Passport action are authentication failures. Refresh-token backing store status and diagnostic surfaces redact secret-like reason strings before exposing readiness, health, details, or diagnostic causes.
+`UseOptionalAuth` only bypasses missing credentials when no scopes are required; scoped routes still need a principal. `AuthHandledResult` with `handled: true` is terminal only after the strategy commits the response, including results that also carry a `principal`. Passport.js bridge `redirect()` commits the response and skips the protected handler, while `pass()` and strategy completion without a Passport action are authentication failures. Refresh-token backing store status and diagnostic surfaces redact secret-like reason strings before exposing readiness, health, details, or diagnostic causes.
 
 ## Related Packages
 

--- a/packages/passport/src/guard.test.ts
+++ b/packages/passport/src/guard.test.ts
@@ -13,7 +13,7 @@ import { AuthGuard } from './guard.js';
 import { PassportModule } from './module.js';
 import { createPassportJsStrategyBridge } from './adapters/passport-js.js';
 import { REFRESH_TOKEN_SERVICE, RefreshTokenStrategy, type RefreshTokenService } from './refresh/refresh-token.js';
-import type { AuthStrategy } from './types.js';
+import type { AuthStrategy, AuthStrategyResult } from './types.js';
 
 function createPassportModuleProviders(
   options: Parameters<typeof PassportModule.forRoot>[0],
@@ -948,6 +948,102 @@ describe('AuthGuard', () => {
     await dispatcher.dispatch(createRequest('/protected', { 'x-request-id': 'req-handled-bypass' }), response);
 
     expect(response.statusCode).toBe(401);
+  });
+
+  it('treats handled:true with a committed response and principal as terminal', async () => {
+    let handlerCalled = false;
+
+    class CommittedHandledStrategy implements AuthStrategy {
+      async authenticate(context: GuardContext): Promise<AuthStrategyResult> {
+        context.requestContext.response.setStatus(202);
+        context.requestContext.response.send({ outcome: 'strategy' });
+
+        return {
+          handled: true,
+          principal: {
+            claims: { source: 'handled' },
+            scopes: ['profile:read'],
+            subject: 'handled-user',
+          },
+        };
+      }
+    }
+
+    @Controller('/protected')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth('handled')
+      @RequireScopes('profile:read')
+      getResource() {
+        handlerCalled = true;
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      CommittedHandledStrategy,
+      ...createPassportModuleProviders({ defaultStrategy: 'handled' }, [{ name: 'handled', token: CommittedHandledStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/protected'), response);
+
+    expect(handlerCalled).toBe(false);
+    expect(response.statusCode).toBe(202);
+    expect(response.body).toEqual({ outcome: 'strategy' });
+  });
+
+  it('rejects handled:true with a principal when the strategy does not commit a response', async () => {
+    class BrokenHandledStrategy implements AuthStrategy {
+      async authenticate(): Promise<AuthStrategyResult> {
+        return {
+          handled: true,
+          principal: {
+            claims: { source: 'handled' },
+            subject: 'handled-user',
+          },
+        };
+      }
+    }
+
+    @Controller('/protected')
+    class ProtectedController {
+      @Get('/')
+      @UseAuth('broken')
+      getResource() {
+        return { ok: true };
+      }
+    }
+
+    const root = new Container().register(
+      ProtectedController,
+      BrokenHandledStrategy,
+      ...createPassportModuleProviders({ defaultStrategy: 'broken' }, [{ name: 'broken', token: BrokenHandledStrategy }]),
+    );
+    const dispatcher = createDispatcher({
+      handlerMapping: createHandlerMapping([{ controllerToken: ProtectedController }]),
+      rootContainer: root,
+    });
+    const response = createResponse();
+
+    await dispatcher.dispatch(createRequest('/protected', { 'x-request-id': 'req-handled-principal-no-commit' }), response);
+
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toEqual({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: undefined,
+        message: 'Authentication required.',
+        meta: undefined,
+        requestId: 'req-handled-principal-no-commit',
+        status: 401,
+      },
+    });
   });
 
   it('supports Passport.js redirect flow without executing the protected handler', async () => {

--- a/packages/passport/src/guard.ts
+++ b/packages/passport/src/guard.ts
@@ -170,17 +170,18 @@ export class AuthGuard implements AuthGuardContract {
 
     try {
       const result = await strategy.authenticate(context);
-      const principal = resolvePrincipal(result);
 
-      if (isAuthHandledResult(result) && !principal) {
+      if (isAuthHandledResult(result)) {
         if (!context.requestContext.response.committed) {
           throw new AuthenticationFailedError(
-            'Auth strategy returned handled:true without a principal but did not commit a response.',
+            'Auth strategy returned handled:true but did not commit a response.',
           );
         }
 
-       return true;
+        return true;
       }
+
+      const principal = resolvePrincipal(result);
 
       if (!principal) {
         if (isAuthOptionalResult(result) && requirement?.optional && !requirement.scopes?.length) {


### PR DESCRIPTION
## Summary

Preserve the documented `@fluojs/passport` `AuthHandledResult` contract so every `handled: true` strategy result is terminal after the strategy commits a response, including results that also carry a `principal`.

Linked context: Closes #2410

## Changes

- Make `AuthGuard` short-circuit all committed `handled: true` results before principal validation, scope checks, `requestContext.principal` assignment, or protected handler execution.
- Add guard regression coverage for principal-bearing handled results and no-commit rejection.
- Document the terminal handled-result contract in `packages/passport` README EN/KO.
- Add a patch changeset for `@fluojs/passport`.

## Testing

- `pnpm --filter @fluojs/passport exec vitest run -c vitest.config.ts src/guard.test.ts` — 28 passed
- `pnpm --filter @fluojs/passport test` — 101 passed
- `pnpm --filter @fluojs/passport typecheck` — passed
- `pnpm --filter @fluojs/passport build` — passed
- `pnpm docs:sync-check` — passed
- `pnpm verify:changeset-release-lane -- --lane=stable --base-ref=main` — passed

## Release impact

- [x] This PR has consumer-visible release impact and includes a changeset.
- [ ] This PR has no consumer-visible release impact.

## Public export documentation

- [x] Changed public exports include a source-level summary.
- [x] Changed exported functions document matching `@param` / `@returns` tags where applicable.
- [x] Source `@example` blocks and README scenario examples still play complementary roles.

No public export shape was changed; existing `AuthHandledResult` and `AuthGuard` documentation remains in place and README contract wording was clarified.

## Behavioral contract

- [x] No documented behavioral contracts were removed without migration notes.
- [x] New behavioral contracts are documented in the affected package README.
- [x] Intentional limitations are explicitly stated (not silently removed).
- [x] Runtime invariants are covered by regression tests.

This preserves the existing documented behavior rather than narrowing the public API.

## Platform consistency governance (SSOT)

- [x] SSOT English/Korean mirror structure remains synchronized for changed governance docs.
- [x] If platform contract docs changed, companion updates include discoverability/docs index, tooling or CI enforcement, and regression-test evidence.
- [x] Any package README alignment/conformance claims are backed by the applicable platform harness tests, such as `createPlatformConformanceHarness(...)` for platform component contracts or `createHttpAdapterPortabilityHarness(...)` for HTTP adapter portability contracts.

No platform contract docs changed. Package README EN/KO parity is covered by `pnpm docs:sync-check`, and the behavior is covered by `packages/passport/src/guard.test.ts`.
